### PR TITLE
Refactor AI guidance: extract detailed docs into .ai/ directory

### DIFF
--- a/.ai/ARCHITECTURE.md
+++ b/.ai/ARCHITECTURE.md
@@ -1,0 +1,261 @@
+# Architecture
+
+## Pattern Overview
+
+**Overall:** Microkernel with plugin system and layered rendering engine
+
+**Key Characteristics:**
+- Constructor-function-based Core class (`Core`) that exposes the entire public API as instance methods
+- Plugin system where all features extend `BasePlugin` and hook into the core via an event/hook bus
+- Separate rendering engine (Walkontable) embedded as a "3rd party" module, bridged through `TableView`
+- Three coordinate systems (physical, visual, renderable) managed by `IndexMapper`
+- Cascading metadata system (GlobalMeta -> TableMeta -> ColumnMeta -> CellMeta) for configuration
+- Registry pattern for all extensible components (plugins, editors, renderers, validators, cell types, themes)
+- Two entry points: `base.js` (tree-shakeable, minimal) and `index.js` (full, registers everything)
+
+## Layers
+
+**Public API (Core):**
+- Purpose: Exposes all grid methods (getData, setData, selectCell, updateSettings, etc.)
+- Location: `handsontable/src/core.js` (~5656 lines)
+- Contains: The `Core` constructor function with all public API methods defined on `this`
+- Depends on: Every subsystem (Selection, DataMap, MetaManager, IndexMapper, TableView, EditorManager, Hooks, ShortcutManager, FocusManager, ThemeManager)
+- Used by: Framework wrappers (React, Angular, Vue), end users
+
+**View Layer (TableView + Walkontable):**
+- Purpose: Bridges Core to the DOM rendering engine (Walkontable)
+- Location: `handsontable/src/tableView.js` (TableView), `handsontable/src/3rdparty/walkontable/src/` (Walkontable)
+- Contains: DOM element creation, event delegation (mouse/touch/keyboard), scroll handling, overlay management
+- Depends on: Walkontable engine, Core instance for data callbacks
+- Used by: Core (via `this.view`)
+
+**Walkontable Rendering Engine:**
+- Purpose: Low-level table rendering, viewport calculation, scroll synchronization, overlays for frozen rows/columns
+- Location: `handsontable/src/3rdparty/walkontable/src/`
+- Contains: Table renderers (`renderer/`), overlay managers (`overlay/`), viewport calculators (`calculator/`), cell/range coordinate primitives (`cell/`), scroll logic (`scroll.js`), selection rendering (`selection/`)
+- Depends on: Settings object provided by TableView, DOM APIs
+- Used by: TableView exclusively (via Facade pattern in `facade/core.js`)
+- Key submodules:
+  - `core/_base.js`, `core/core.js`, `core/clone.js` - Walkontable core and clone instances
+  - `table/master.js` - Master table, `table/top.js`, `table/bottom.js`, etc. - Overlay tables
+  - `overlay/` - 6 overlay types (top, bottom, inlineStart, topInlineStartCorner, bottomInlineStartCorner, plus base)
+  - `calculator/` - Viewport row/column calculators
+  - `renderer/` - Low-level cell/row/colgroup/header renderers
+  - `scroll.js` - Scroll position management
+  - `viewport.js` - Viewport state
+
+**Data Layer (DataMap + DataSource):**
+- Purpose: Manages source data, data transformations, and the mapping between data and grid cells
+- Location: `handsontable/src/dataMap/`
+- Contains: `DataMap` (row/column data access), `DataSource` (raw data wrapper), `replaceData` (data replacement logic), `sourceDataValidator` (validation)
+- Depends on: MetaManager for cell metadata
+- Used by: Core (via `datamap` and `dataSource` internal variables)
+
+**Metadata Layer (MetaManager):**
+- Purpose: Cascading configuration system - GlobalMeta -> TableMeta -> ColumnMeta -> CellMeta
+- Location: `handsontable/src/dataMap/metaManager/`
+- Contains: Four meta layers (`metaLayers/globalMeta.js`, `tableMeta.js`, `columnMeta.js`, `cellMeta.js`), meta schema (`metaSchema.js`), modifier mods (`mods/`)
+- Depends on: Helpers
+- Used by: Core, plugins (via `hot.getCellMeta()`, `hot.getSettings()`)
+- Pattern: Prototype chain inheritance. GlobalMeta is the prototype of ColumnMeta, which is the prototype of CellMeta. TableMeta is a direct instance of GlobalMeta. This allows cascading: cell-level settings override column-level, which override table-level, which override global defaults.
+
+**Index Translation Layer:**
+- Purpose: Manages the three coordinate systems (physical, visual, renderable) and index maps (hiding, trimming)
+- Location: `handsontable/src/translations/`
+- Contains: `IndexMapper` (main class), `maps/` (HidingMap, TrimmingMap, IndexesSequence, PhysicalIndexToValueMap, LinkedPhysicalIndexToValueMap), `mapCollections/` (AggregatedCollection, MapCollection), `changesObservable/`
+- Depends on: Helpers, mixins
+- Used by: Core (`hot.rowIndexMapper`, `hot.columnIndexMapper`), plugins that modify row/column visibility
+
+**Selection Layer:**
+- Purpose: Manages cell/range selection, multi-selection, focus, and selection transformations
+- Location: `handsontable/src/selection/`
+- Contains: `Selection` class (`selection.js`), `SelectionRange` (`range.js`), `Highlight` system (`highlight/`), transformation modules (`transformation/`), mouse event handler (`mouseEventHandler.js`), utilities (`utils.js`)
+- Depends on: IndexMapper (for coordinate translation), Walkontable Selection (for rendering highlights)
+- Used by: Core (via `selection` internal variable), EditorManager, plugins
+
+**Plugin System:**
+- Purpose: All grid features are implemented as plugins that extend `BasePlugin`
+- Location: `handsontable/src/plugins/`
+- Contains: 40+ plugins, each in its own directory with an `index.js` barrel export
+- Depends on: Core (via `this.hot`), Hooks system, IndexMapper
+- Used by: Core instantiates all registered plugins
+- Key plugins: `autoColumnSize`, `autoRowSize`, `columnSorting`, `filters`, `formulas`, `hiddenColumns`, `hiddenRows`, `mergeCells`, `nestedHeaders`, `nestedRows`, `undoRedo`, `contextMenu`, `copyPaste`, `comments`, `stretchColumns`
+
+**Hooks System:**
+- Purpose: Event bus for inter-component communication (before/after patterns)
+- Location: `handsontable/src/core/hooks/`
+- Contains: `Hooks` class (singleton), `HooksBucket`, hook constants (`constants.js` with REGISTERED_HOOKS, REMOVED_HOOKS, DEPRECATED_HOOKS)
+- Depends on: Helpers
+- Used by: Core, all plugins, EditorManager, Selection
+- Pattern: Global singleton + per-instance buckets. Hooks can be added globally or per-instance. Plugins use `this.addHook()` (auto-cleaned on disable) vs `this.hot.addHook()` (manual cleanup).
+
+**Editor System:**
+- Purpose: Manages cell editors (text input, dropdown, date picker, etc.)
+- Location: `handsontable/src/editors/`, `handsontable/src/editorManager.js`
+- Contains: `EditorManager` (orchestrates editor lifecycle), `BaseEditor` (abstract base), 15+ editor types
+- Depends on: Selection (to know which cell is active), MetaManager (for cell type config)
+- Used by: Core
+
+**Renderer System:**
+- Purpose: Cell rendering functions that produce HTML content for cells
+- Location: `handsontable/src/renderers/`
+- Contains: `baseRenderer`, `textRenderer`, `numericRenderer`, `checkboxRenderer`, `htmlRenderer`, etc.
+- Depends on: MetaManager (for cell configuration)
+- Used by: Walkontable (calls renderer functions during table render)
+
+**Validator System:**
+- Purpose: Cell value validation
+- Location: `handsontable/src/validators/`
+- Contains: `autocompleteValidator`, `dateValidator`, `numericValidator`, `timeValidator`, etc.
+- Used by: Core (triggered on data changes)
+
+**Cell Type System:**
+- Purpose: Bundles an editor + renderer + validator into a named cell type
+- Location: `handsontable/src/cellTypes/`
+- Contains: Composite types like `textType`, `numericType`, `checkboxType`, `dateType`, `dropdownType`, etc.
+- Used by: MetaManager (resolves cell type to editor/renderer/validator)
+
+**Shortcut System:**
+- Purpose: Keyboard shortcut management with context-based scoping
+- Location: `handsontable/src/shortcuts/` (manager, recorder, context), `handsontable/src/shortcutContexts/` (predefined contexts)
+- Used by: Core, plugins
+
+**Focus Management:**
+- Purpose: Manages browser focus and focus scoping for accessibility
+- Location: `handsontable/src/focusManager/`
+- Contains: `FocusGridManager`, scope manager, predefined scopes
+- Used by: Core
+
+**Theme System:**
+- Purpose: CSS theme management with CSS variables
+- Location: `handsontable/src/themes/` (engine, registry, static themes), `handsontable/src/styles/` (SCSS sources)
+- Contains: Theme engine (`engine/`), theme registry (`registry.js`), static theme definitions (`static/`), theme class (`theme/`)
+- Used by: Core (via `stylesHandler` and `themeManager`)
+
+## Data Flow
+
+**Initialization Flow:**
+
+1. User calls `new Handsontable(element, settings)` which calls `base.js` -> `Core(element, settings, rootInstanceSymbol)`
+2. Core creates: `MetaManager`, `IndexMapper` (row + column), `DataSource`, `Selection`, `EditorManager`, `ShortcutManager`, `FocusGridManager`, `StylesHandler`, `ThemeManager`
+3. Core creates `TableView` which creates `Walkontable` instance
+4. All registered plugins are instantiated (each calls `constructor(hotInstance)`)
+5. `afterPluginsInitialized` hook fires, each plugin's `isEnabled()` is checked, and `enablePlugin()` called if true
+6. `init()` triggers initial data load and render
+
+**Render Flow:**
+
+1. Core calls `this.view.render()` (or plugin triggers render via hooks)
+2. `TableView` delegates to Walkontable's `draw()` method
+3. Walkontable calculates visible viewport using `ViewportRowsCalculator` and `ViewportColumnsCalculator`
+4. Walkontable iterates visible rows/columns, calls renderer functions from the renderer registry for each cell
+5. Each overlay (top frozen, left frozen, corner) renders its own clone table synchronized with the master table
+6. Selection highlights are rendered via Walkontable's `Selection` rendering system
+
+**Data Change Flow:**
+
+1. User edits a cell or calls `setDataAtCell(row, col, value)`
+2. Core fires `beforeChange` hook (plugins can modify/cancel)
+3. `DataMap.set()` updates the source data
+4. Core fires `afterChange` hook
+5. If validation is configured, `validateCells()` runs validators
+6. `render()` is called to update the DOM
+
+**Settings Update Flow:**
+
+1. User calls `updateSettings(newSettings)`
+2. Core fires `beforeUpdateSettings` hook
+3. `MetaManager` updates cascading meta layers
+4. Each plugin's `onUpdateSettings()` is called; if the changed key is in `SETTING_KEYS`, `updatePlugin()` runs
+5. Core fires `afterUpdateSettings` hook
+6. Re-render
+
+**Coordinate Translation Flow:**
+
+1. User provides visual coordinates (e.g., `selectCell(2, 3)`)
+2. Core uses `rowIndexMapper.getRenderableFromVisualIndex()` to get renderable index for DOM operations
+3. Core uses `rowIndexMapper.getPhysicalFromVisualIndex()` to get physical index for data operations
+4. Plugins like `hiddenRows`/`hiddenColumns` register `HidingMap` instances that affect visual-to-renderable translation
+5. Plugins like `trimRows` register `TrimmingMap` instances that affect physical-to-visual translation
+
+**State Management:**
+- Source data: Held in `DataSource` (reference to user's array/object)
+- Cell metadata: Cascading prototype chain in `MetaManager`
+- Index state: `IndexMapper` with registered `HidingMap`/`TrimmingMap` instances per plugin
+- Selection state: `Selection` class with `SelectionRange` tracking visual coordinates
+- Plugin state: Each plugin manages its own internal state
+
+## Key Abstractions
+
+**CellCoords / CellRange:**
+- Purpose: Coordinate and range primitives used throughout the codebase
+- Examples: `handsontable/src/3rdparty/walkontable/src/cell/coords.js`, `handsontable/src/3rdparty/walkontable/src/cell/range.js`
+- Pattern: Value objects with methods like `isEqual()`, `includes()`, `getTopStartCorner()`, etc.
+
+**IndexMapper:**
+- Purpose: Single source of truth for row/column index translations between physical, visual, and renderable coordinate systems
+- Examples: `handsontable/src/translations/indexMapper.js`
+- Pattern: Maintains collections of maps (trimming, hiding, value) and caches translations. Plugins register named maps.
+
+**BasePlugin:**
+- Purpose: Abstract base for all plugin implementations with standardized lifecycle
+- Examples: `handsontable/src/plugins/base/base.js`
+- Pattern: Template method pattern with `isEnabled()` -> `enablePlugin()` -> `updatePlugin()` -> `disablePlugin()` -> `destroy()`
+
+**Hooks (Event Bus):**
+- Purpose: Decoupled communication between Core, plugins, and user code
+- Examples: `handsontable/src/core/hooks/index.js`
+- Pattern: Observer/pub-sub with global singleton and per-instance buckets. Supports ordered callbacks via `orderIndex`.
+
+**MetaManager (Cascading Config):**
+- Purpose: Configuration inheritance chain from global defaults to individual cell settings
+- Examples: `handsontable/src/dataMap/metaManager/index.js`
+- Pattern: Prototype-chain inheritance: GlobalMeta (prototype) -> ColumnMeta (prototype) -> CellMeta (instance). TableMeta is a separate instance of GlobalMeta.
+
+**Registry Pattern:**
+- Purpose: Dynamic registration and lookup of components by string key
+- Examples: `handsontable/src/plugins/registry.js`, `handsontable/src/editors/registry.js`, `handsontable/src/renderers/registry.js`, `handsontable/src/validators/registry.js`, `handsontable/src/cellTypes/registry.js`, `handsontable/src/themes/registry.js`
+- Pattern: Map-based registries with `register()` / `get()` / `getNames()` methods. The `registry.js` module in `src/` aggregates all `registerAll*()` calls.
+
+## Entry Points
+
+**Full Entry (`index.js`):**
+- Location: `handsontable/src/index.js`
+- Triggers: `registerAllModules()` which registers all editors, renderers, validators, cell types, and plugins
+- Responsibilities: Creates the full Handsontable namespace with all modules pre-registered. Used for UMD/CDN builds.
+
+**Base Entry (`base.js`):**
+- Location: `handsontable/src/base.js`
+- Triggers: Registers only `TextCellType` and `baseRenderer` (minimal defaults)
+- Responsibilities: Tree-shakeable entry point. Users import and register only needed modules.
+
+**Core Constructor:**
+- Location: `handsontable/src/core.js` (exported as `Core`)
+- Triggers: Called by `Handsontable()` wrapper in `base.js`
+- Responsibilities: Instantiates all subsystems, creates DOM structure, sets up hooks
+
+## Error Handling
+
+**Strategy:** Custom error helper with cause tracking
+
+**Patterns:**
+- Use `throwWithCause(message, cause)` from `handsontable/src/helpers/errors.js` instead of `throw new Error()`. Enforced by ESLint rule `handsontable/no-native-error-throw`.
+- Hooks use before/after pattern where `before*` hooks can return `false` to cancel operations
+- Validators use callback pattern (async-capable): `validator(value, callback)` where `callback(true/false)` signals validity
+- Console warnings use helpers from `handsontable/src/helpers/console.js` (never raw `console`)
+
+## Cross-Cutting Concerns
+
+**Logging:** Via `handsontable/src/helpers/console.js` helpers (`warn`, `log`, `error`). Raw `console` is banned by ESLint.
+
+**Validation:** Cell validators in `handsontable/src/validators/`. Source data validators in `handsontable/src/dataMap/sourceDataValidator.js`. Triggered on data changes and via `validateCells()` API.
+
+**Authentication:** Not applicable (frontend-only library, no auth).
+
+**Internationalization:** `handsontable/src/i18n/` with language dictionaries and a registry. RTL layout support via `layoutDirection` setting and `isRtl()`/`isLtr()` Core methods.
+
+**Accessibility:** ARIA attributes applied via helpers in `handsontable/src/helpers/a11y.js`. Announcer utility in `handsontable/src/utils/a11yAnnouncer.js`. Focus management in `handsontable/src/focusManager/`. Two navigation modes: spreadsheet mode and data grid mode.
+
+**DOM Abstraction:** All DOM access goes through `handsontable/src/helpers/dom/element.js` and `handsontable/src/helpers/dom/event.js`. Global `window`/`document` are banned; use `this.hot.rootWindow`/`this.hot.rootDocument`.
+
+**Event Management:** `handsontable/src/eventManager.js` provides centralized DOM event listener management with automatic cleanup.

--- a/.ai/CONCERNS.md
+++ b/.ai/CONCERNS.md
@@ -1,0 +1,211 @@
+# Codebase Concerns
+
+## Tech Debt
+
+**Walkontable DAO Layer (Data Access Objects):**
+- Issue: The Walkontable rendering engine uses a DAO (Data Access Object) pattern with deeply nested getter properties that should be replaced with proper dependency injection (IOC). Over 20 TODO comments across Walkontable files acknowledge this debt.
+- Files: `handsontable/src/3rdparty/walkontable/src/core/_base.js`, `handsontable/src/3rdparty/walkontable/src/core/core.js`, `handsontable/src/3rdparty/walkontable/src/table.js`
+- Impact: Makes Walkontable difficult to test in isolation, creates tight coupling between components, and hinders refactoring. Every overlay, table, and viewport component reaches through DAOs rather than receiving dependencies explicitly.
+- Fix approach: Introduce constructor-based dependency injection. Replace DAO getter objects with direct parameter passing. Start with `createScrollDao()` and `getTableDao()` in `_base.js`.
+
+**Broken Plugin Initialization Abstraction (#6806):**
+- Issue: Multiple plugins contain explicit workarounds for a broken plugin initialization order. Plugins must guard against uninitialized state (`!this.hot.view`) and force `updatePlugin()` calls during `enablePlugin()`.
+- Files: `handsontable/src/plugins/nestedHeaders/nestedHeaders.js`, `handsontable/src/plugins/collapsibleColumns/collapsibleColumns.js`
+- Impact: Every new plugin that depends on rendering state risks hitting the same initialization timing bug. The workarounds obscure the actual plugin lifecycle and make the code fragile.
+- Fix approach: Refactor the plugin initialization sequence in `handsontable/src/plugins/base/base.js` and the core plugin registry to guarantee that `this.hot.view` is available before `enablePlugin()` is called. Remove all `#6806` workarounds once fixed.
+
+**EventManager Shared Listener Array:**
+- Issue: `EventManager` mutates an external object's `eventListeners` array, and all `EventManager` instances sharing the same context share the same listener list.
+- Files: `handsontable/src/eventManager.js`
+- Impact: Makes it hard to reason about listener ownership. Clearing one manager's listeners requires filtering by manager identity, which is inefficient and error-prone.
+- Fix approach: Each `EventManager` instance should maintain its own listener list. Provide a central registry only for debugging/leak detection purposes.
+
+**Redundant Render Cycle Calls:**
+- Issue: Several plugins independently trigger operations that should be batched per render cycle. The TODO comments are explicit: "Should call once per render cycle, currently fired separately in different plugins."
+- Files: `handsontable/src/plugins/hiddenColumns/hiddenColumns.js`, `handsontable/src/plugins/autoColumnSize/autoColumnSize.js`, `handsontable/src/plugins/autoRowSize/autoRowSize.js`
+- Impact: Unnecessary re-renders degrade performance, especially with large datasets. Each redundant call triggers layout recalculations.
+- Fix approach: Consolidate these operations into a single per-render-cycle hook. Use the existing `batchRender()` / `suspendRender()` / `resumeRender()` infrastructure to coalesce these calls.
+
+**core.js Monolith:**
+- Issue: `core.js` is covering initialization, data manipulation, rendering coordination, selection management, and the entire public API surface. Functions use `this` binding via closure (constructor function pattern), not class syntax.
+- Files: `handsontable/src/core.js`
+- Impact: Any change to core behavior requires understanding the entire file. High risk of unintended side effects. The large number of eslint-disable comments indicates code that does not conform to the project's own standards.
+- Fix approach: Extract logical groups into separate modules (data operations, rendering coordination, public API facade). The existing `handsontable/src/core/` directory already contains some extractions (`hooks/`, `coordsMapper/`); continue this pattern.
+
+**NestedRows ManualRowMove Reimplementation:**
+- Issue: The `rowMoveController.js` in `nestedRows` contains three TODO comments about "mocking real work" of the `ManualRowMove` plugin and reimplementing its internal function.
+- Files: `handsontable/src/plugins/nestedRows/utils/rowMoveController.js`
+- Impact: Logic duplication between `NestedRows` and `ManualRowMove` plugins. Bugs fixed in one may not be fixed in the other.
+- Fix approach: Extract shared row-move logic into a reusable utility or expose the necessary methods from `ManualRowMove` as a proper API.
+
+**CustomBorders Plugin Bugs:**
+- Issue: Test files contain 14+ TODO comments documenting behaviors that "look like a bug." Tests explicitly assert buggy values with comments like "I would expect false" or "I think this should be 5 * 5." One test is flagged as flaky.
+- Files: `handsontable/src/plugins/customBorders/__tests__/customBorders.spec.js`, `handsontable/src/plugins/customBorders/__tests__/hidingColumns.spec.js`
+- Impact: Tests encode known-wrong behavior. When these bugs are fixed, the tests will break, creating confusion about whether the fix is correct.
+- Fix approach: File issues for each documented bug. Replace TODO comments with issue references. Fix bugs and update test assertions.
+
+**DOMPurify Deprecation In Progress:**
+- Issue: The built-in DOMPurify-based HTML sanitization is deprecated and scheduled for removal in the next major release. A migration path to a user-provided `sanitizer` option exists but the old path is still the default.
+- Files: `handsontable/src/helpers/dom/element.js`, `handsontable/src/helpers/string.js`
+- Impact: `dompurify` remains a runtime dependency (listed in `package.json` dependencies). Until removal, bundle size includes DOMPurify even when users provide a custom sanitizer.
+- Fix approach: Complete the migration in the next major release. Remove `dompurify` from `dependencies`. Make `sanitizer` option required or provide a lightweight built-in default.
+
+## Known Bugs
+
+**CustomBorders Enable/Disable State Mismatch:**
+- Symptoms: `getPlugin('customBorders').isEnabled()` returns `true` when it should be `false` (and vice versa) after certain `updateSettings()` calls.
+- Files: `handsontable/src/plugins/customBorders/__tests__/customBorders.spec.js`
+- Trigger: Initialize with `customBorders: true`, then call `updateSettings({ customBorders: false })`.
+- Workaround: None documented.
+
+**CustomBorders Border Count Incorrect:**
+- Symptoms: `countVisibleCustomBorders()` and `countCustomBorders()` return values that do not match expected counts. For a 5x5 selection, the test expects `10 * 5` borders and notes "I think this should be 5 * 5."
+- Files: `handsontable/src/plugins/customBorders/__tests__/customBorders.spec.js`
+- Trigger: Apply custom borders to a cell range and count rendered border elements.
+- Workaround: Redundant invisible borders are rendered in the DOM.
+
+**Flaky CustomBorders Test:**
+- Symptoms: `getCellMeta(0, 0).borders` is sometimes `undefined`, causing `Cannot read property 'hasOwnProperty' of undefined`.
+- Files: `handsontable/src/plugins/customBorders/__tests__/customBorders.spec.js`
+- Trigger: Race condition in test setup; timing-dependent.
+- Workaround: Retry the test.
+
+## Security Considerations
+
+**HTML Sanitization Transition Period:**
+- Risk: During the DOMPurify deprecation transition, HTML content injected via `innerHTML` is sanitized by default using DOMPurify. If a user passes `sanitizer: false` or a weak custom sanitizer, XSS is possible in cell content.
+- Files: `handsontable/src/helpers/dom/element.js`, `handsontable/src/helpers/string.js`
+- Current mitigation: DOMPurify is the default sanitizer. The `fastInnerHTML` function checks for HTML characters before applying innerHTML.
+- Recommendations: Document clearly that `sanitizer: false` disables XSS protection. Add a console warning when sanitizer is set to a non-function falsy value. Consider keeping a lightweight built-in sanitizer after DOMPurify removal.
+
+**innerHTML Usage in Template Literal Tag:**
+- Risk: The `templateLiteralTag.js` helper uses `template.innerHTML` to parse tagged template literals. If user-supplied data flows into the template, it could introduce XSS.
+- Files: `handsontable/src/helpers/templateLiteralTag.js`
+- Current mitigation: The function is used internally for UI element construction, not directly with user data.
+- Recommendations: Add a comment documenting that this function must not be used with unsanitized user input. Consider using `DOMParser` or `textContent` where possible.
+
+**innerHTML in Mixed Helper:**
+- Risk: `helpers/mixed.js` uses `messageNode.innerHTML` to render domain-specific messages.
+- Files: `handsontable/src/helpers/mixed.js`
+- Current mitigation: The messages are internally generated string templates, not user input.
+- Recommendations: Switch to `textContent` or DOM API construction to eliminate the innerHTML call entirely.
+
+## Performance Bottlenecks
+
+**Spread Operator with Potentially Large Arrays:**
+- Problem: At least 28 instances of `array.push(...otherArray)` exist in production source code. With arrays of 10k+ elements, this causes stack overflow due to argument count limits.
+- Files: `handsontable/src/dataMap/metaManager/metaLayers/cellMeta.js`, `handsontable/src/plugins/nestedRows/nestedRows.js`, `handsontable/src/plugins/nestedRows/ui/collapsing.js`, `handsontable/src/plugins/collapsibleColumns/collapsibleColumns.js`, `handsontable/src/plugins/hiddenRows/contextMenuItem/showRow.js`, `handsontable/src/plugins/hiddenColumns/contextMenuItem/showColumn.js`, `handsontable/src/core.js`
+- Cause: `Function.prototype.apply` (which spread desugars to) has a maximum argument count (~65k in V8, lower in other engines).
+- Improvement path: Replace `arr.push(...largeArr)` with `for` or `forEach` loops in all code paths that may handle large datasets. Priority: `cellMeta.js` handles per-cell metadata and scales with table size.
+
+**Walkontable Filter Object Recreation:**
+- Problem: `rowFilter` and `columnFilter` are set to `null` and recreated on every render pass instead of updating state in place. Two TODO comments acknowledge this.
+- Files: `handsontable/src/3rdparty/walkontable/src/table.js`
+- Cause: The filter objects are recreated rather than having their state updated incrementally.
+- Improvement path: Refactor filter objects to support state updates without full reconstruction.
+
+**Limited requestAnimationFrame Batching:**
+- Problem: `requestAnimationFrame` is used in only 7 source files, primarily in `autoRowSize`, `autoColumnSize`, and the overlay system. Scroll events and resize operations in other areas may not be batched.
+- Files: `handsontable/src/helpers/feature.js`, `handsontable/src/utils/interval.js`, `handsontable/src/3rdparty/walkontable/src/overlays.js`, `handsontable/src/plugins/autoRowSize/autoRowSize.js`, `handsontable/src/plugins/autoColumnSize/autoColumnSize.js`
+- Cause: Not all rendering-triggering events are routed through a rAF-based scheduler.
+- Improvement path: Introduce a central render scheduler that batches all render-triggering events through `requestAnimationFrame`.
+
+## Fragile Areas
+
+**Selection + MergeCells Interaction:**
+- Files: `handsontable/src/selection/highlight/visualSelection.js`, `handsontable/src/selection/selection.js`, `handsontable/src/plugins/mergeCells/mergeCells.js`
+- Why fragile: Visual selection coordinate adjustments interact with MergeCells coordinate adjustments in overlapping ways. TODO comments indicate uncertainty about the correct responsibility boundary. The `selection.clear()` method has a TODO noting that `selectedByColumnHeader` and `selectedByRowHeader` collections should be cleared but are not.
+- Safe modification: When modifying selection logic, test all combinations of: merged cells, hidden rows/columns, frozen rows/columns, and navigable headers. Run both `selectAll` and `selectCells` spec suites.
+- Test coverage: Extensive E2E tests exist but the visual selection highlight logic is under-tested at the unit level.
+
+**NestedHeaders + CollapsibleColumns:**
+- Files: `handsontable/src/plugins/nestedHeaders/nestedHeaders.js`, `handsontable/src/plugins/collapsibleColumns/collapsibleColumns.js`
+- Why fragile: Both plugins contain workarounds for the broken plugin initialization abstraction (#6806). `NestedHeaders` has 4 workaround sites, `CollapsibleColumns` has 3. These workarounds involve conditional state checks and forced `updatePlugin()` calls that mask timing issues.
+- Safe modification: Always test with both plugins enabled simultaneously. Verify expand/collapse behavior with hidden columns. Run the full `collapsibleColumns.spec.js` and `hidingColumns.spec.js` in nested headers.
+- Test coverage: Good E2E coverage exists but the workarounds themselves are not directly tested.
+
+**Overlay System (Walkontable):**
+- Files: `handsontable/src/3rdparty/walkontable/src/overlays.js`, `handsontable/src/3rdparty/walkontable/src/overlay/top.js`, `handsontable/src/3rdparty/walkontable/src/overlay/inlineStart.js`, `handsontable/src/3rdparty/walkontable/src/overlay/bottom.js`
+- Why fragile: The overlay system manages 6 overlay types (top, bottom, left, and 3 corners) with complex positioning logic. TODO comments indicate a workaround for `innerBorderTop` that is documented to be clearable only after SVG borders are merged. Lazy creation of corner overlays adds initialization complexity.
+- Safe modification: Test with combinations of `fixedRowsTop`, `fixedRowsBottom`, `fixedColumnsStart`. Test RTL layout. Verify no visual artifacts at overlay boundaries.
+- Test coverage: Walkontable has its own test pipeline (`npm run test:walkontable`), separate from the main E2E tests.
+
+## Scaling Limits
+
+**Cell Metadata Storage:**
+- Current capacity: Linear growth with row * column count.
+- Limit: The `cellMeta.js` layer uses `push(...values())` to collect metadata, which risks stack overflow at large scales (50k+ rows with many columns).
+- Scaling path: Replace spread-based collection with iterative approach. Consider lazy metadata initialization.
+
+## Dependencies at Risk
+
+**moment.js (pinned at 2.30.1):**
+- Risk: moment.js is in maintenance mode (no new features). The library is 67KB minified and has known issues with tree-shaking. It is used in 22 source files across date editors, validators, renderers, and filter conditions.
+- Impact: Bundle size penalty. The deprecation of `dateFormat` string options (using moment format patterns) is already underway.
+- Migration plan: The codebase is migrating date handling away from moment-based string formats. Complete the migration by removing all moment.js imports and replacing with a user-configurable date formatting approach or a lightweight alternative.
+
+**numbro (pinned at 2.5.0):**
+- Risk: numbro is used in 5 files for numeric formatting. The `numericFormat.pattern` and `numericFormat.culture` options using numbro are deprecated.
+- Impact: Bundle size; numbro adds significant weight for locale-aware number formatting.
+- Migration plan: The deprecation of numbro-based formatting is documented in `handsontable/src/dataMap/metaManager/metaSchema.js` (line 4098). Complete migration to native `Intl.NumberFormat`.
+
+**TypeScript 3.8.2:**
+- Risk: TypeScript 3.8 is severely outdated (released March 2020). The `.d.ts` type definitions in `handsontable/types/` are limited to TS 3.8 features.
+- Impact: Cannot use modern TypeScript features in type definitions (template literal types, conditional types improvements, etc.). Users with newer TS versions may encounter compatibility issues.
+- Migration plan: Upgrade the TypeScript dev dependency and modernize type definitions incrementally. Test against multiple TS versions.
+
+**@typescript-eslint/parser and plugin (^4.33.0):**
+- Risk: Version 4.x is several major versions behind current (8.x). Compatibility with newer ESLint versions is limited.
+- Impact: Cannot adopt new linting rules and may miss detection of new TypeScript anti-patterns.
+- Migration plan: Upgrade alongside ESLint (currently ^7.25.0, also outdated).
+
+**ESLint ^7.25.0:**
+- Risk: ESLint 7 is end-of-life. Current stable is ESLint 9. The flat config format is not adopted.
+- Impact: Missing newer rule categories. Community plugin ecosystem is moving to ESLint 8/9.
+- Migration plan: Migrate to ESLint 9 flat config. Update `@typescript-eslint` packages simultaneously.
+
+**Jest ^27.5.1 and jasmine-core ^3.4.0:**
+- Risk: Jest 27 is two major versions behind current (30). Jasmine 3.4 is significantly behind current (5.x).
+- Impact: Missing performance improvements, better error messages, and modern testing features (e.g., better async handling in Jest 29+).
+- Migration plan: Upgrade Jest to 29+ (requires updating `babel-jest` and potentially test configuration). Evaluate Jasmine upgrade separately due to API changes.
+
+**@handsontable/pikaday (^1.0.0):**
+- Risk: A forked date picker library maintained by Handsontable. The `dateEditor` is being deprecated (string-based `dateFormat` with Pikaday). Only 6 source files reference it.
+- Impact: Maintenance burden for a forked dependency.
+- Migration plan: Complete the date editor modernization. Remove Pikaday dependency when the legacy date editor path is removed.
+
+## Missing Critical Features
+
+**No Centralized Render Scheduler:**
+- Problem: Rendering is triggered from multiple points (plugins, core, selection) without a central coordinator. The `batchRender()`/`suspendRender()`/`resumeRender()` API exists but is opt-in and used in only 4 source files.
+- Blocks: Predictable rendering performance. Plugins must individually manage render batching.
+
+**No Plugin Integration Testing Framework:**
+- Problem: Plugin interactions (e.g., `MergeCells` + `HiddenColumns` + `NestedHeaders`) are tested via E2E specs but lack a structured integration test approach. Each combination must be manually tested.
+- Blocks: Confident refactoring of plugin initialization. The broken initialization abstraction (#6806) persists partly because testing all combinations is expensive.
+
+## Test Coverage Gaps
+
+**TouchScroll Plugin:**
+- What's not tested: The `touchScroll` plugin has 2 source files and 0 test files. Touch-specific scrolling behavior is entirely untested.
+- Files: `handsontable/src/plugins/touchScroll/`
+- Risk: Touch scrolling regressions on mobile browsers go undetected.
+- Priority: Medium (mobile usage is increasing).
+
+**Walkontable DAO Layer:**
+- What's not tested: The DAO objects in `_base.js` are not unit tested. They are exercised only indirectly through higher-level integration tests.
+- Files: `handsontable/src/3rdparty/walkontable/src/core/_base.js`
+- Risk: Refactoring the DAO layer could break property access patterns without test detection.
+- Priority: Medium (blocks the DAO refactoring effort).
+
+**Visual Selection Highlight Internals:**
+- What's not tested: The coordinate adjustment logic in `visualSelection.js` with MergeCells interaction has TODO comments but no dedicated unit tests.
+- Files: `handsontable/src/selection/highlight/visualSelection.js`
+- Risk: Selection highlight bugs with merged cells in hidden row/column scenarios.
+- Priority: High (user-visible behavior).
+
+**Event Manager Scope Filtering:**
+- What's not tested: The scope-based event filtering logic lacks unit tests for the multi-instance same-context scenario.
+- Files: `handsontable/src/eventManager.js`
+- Risk: Memory leaks when multiple EventManager instances share a context and are destroyed in unexpected order.
+- Priority: Medium.

--- a/.ai/CONVENTIONS.md
+++ b/.ai/CONVENTIONS.md
@@ -1,0 +1,295 @@
+# Coding Conventions
+
+## Naming Patterns
+
+**Files:**
+- Source files: `camelCase.js` (e.g., `hiddenColumns.js`, `conditionCollection.js`, `editorManager.js`)
+- Plugin directories: `camelCase/` (e.g., `src/plugins/hiddenColumns/`, `src/plugins/copyPaste/`)
+- Helper files: `camelCase.js` in `src/helpers/` (e.g., `array.js`, `object.js`, `unicode.js`)
+- Test files: `*.unit.js` for Jest unit tests, `*.spec.js` for Jasmine E2E tests
+- Type definition files: `*.types.ts` in `handsontable/test/types/`
+- Each plugin directory has an `index.js` barrel that re-exports `PLUGIN_KEY`, `PLUGIN_PRIORITY`, and the class
+
+**Functions:**
+- Use `camelCase` for all functions and methods: `getActiveEditor()`, `createSpreadsheetData()`
+- Private methods use `#` prefix (JavaScript private class fields): `#onAfterDocumentKeyDown()`
+- Use full names, never abbreviations: `row` and `columns` (not `cols`)
+- All exported functions require JSDoc comments (enforced by ESLint `jsdoc/require-jsdoc: 'error'`)
+- Factory functions follow naming pattern: `handsontableMethodFactory()`, `handsontableMouseTriggerFactory()`
+
+**Variables:**
+- Use `camelCase` for all variables: `activeEditor`, `tableMeta`, `cellProperties`
+- `hot` for Handsontable instance references throughout the codebase
+- Use `this.hot.rootWindow` and `this.hot.rootDocument` instead of global `window` or `document` (enforced by ESLint rule `no-restricted-globals`)
+- Constants: `UPPER_SNAKE_CASE` (e.g., `PLUGIN_KEY`, `PLUGIN_PRIORITY`, `SETTING_KEYS`, `BROWSERS_LIST`)
+
+**Types:**
+- Class names: `PascalCase` (e.g., `BasePlugin`, `HiddenColumns`, `CellMeta`, `EditorManager`)
+- Type annotations in JSDoc use `@type {TypeName}` or `@private` tags
+- TypeScript `.d.ts` files use PascalCase for types and interfaces
+- Never create `.ts` files in `handsontable/src/` -- core is JavaScript only
+
+## Code Style
+
+**Formatting:**
+- Modified Airbnb JavaScript style (extends `airbnb-base`)
+- Indentation: 2 spaces (`SwitchCase: 1`, function params aligned to first)
+- Quotes: Single quotes only (`'string'` not `"string"`)
+- Max line length: 120 characters (ignores comments and long `it()` test names matching `^\s*x?it\s*\(`)
+- Space before function parens: never (`function foo()` not `function foo ()`)
+- Arrow parens: as-needed, required for block body
+- Curly braces: always required (`curly: ['error', 'all']`)
+- Trailing comma: off (`comma-dangle: 'off'`)
+- No `++`/`--` except in for loop afterthoughts
+- No multiple empty lines (max 1)
+- `no-eq-null: 'error'` -- never use `== null` or `!= null`
+
+**Padding/Blank Lines (enforced by `padding-line-between-statements`):**
+- Always a blank line before `return`
+- Always a blank line before control flow (`if`, `for`, `switch`, `while`) unless preceded by another block-like statement
+- Always a blank line after variable declarations (`const`, `let`, `var`) unless followed by another declaration
+
+**Linting:**
+- ESLint with `@babel/eslint-parser` and JSX support
+- Root config: `.eslintrc.js` (extends `airbnb-base`)
+- Handsontable-specific config: `handsontable/.eslintrc.js` (extends root, adds custom plugin rules)
+- Browser compatibility enforced via `eslint-plugin-compat` against browser targets from `browser-targets.js`
+- JSDoc validation with `eslint-plugin-jsdoc` at error level
+- CSS/SCSS linted via Stylelint: `stylelint --cache "src/**/*.{css,scss}" "test/**/*.{css,scss}"`
+
+## Handsontable-Specific ESLint Rules
+
+| Rule | Enforcement |
+|---|---|
+| `handsontable/no-native-error-throw` | Use `throwWithCause()` from `src/helpers/errors.js`, never `throw new Error()` |
+| `handsontable/restricted-module-imports` | No imports from barrel index files (`plugins/index`, `editors/index`, `renderers/index`, `validators/index`, `cellTypes/index`, `i18n/index`). Import from specific submodule paths. Only exception: `src/registry.js` |
+| `handsontable/require-async-in-it` | All `it()` callbacks in `*.spec.js` must be `async`. Disabled for `*.unit.js` |
+| `handsontable/require-await` | Specific HOT API calls must be `await`-ed in `*.spec.js` (full list in `handsontable/.eslintrc.js` lines 84-151) |
+| `no-restricted-globals` | Source: `window`, `document`, `console`, `Handsontable` banned. Tests: only `fit`, `fdescribe` banned |
+| `compat/compat` | Browser API compatibility check (off in test files) |
+
+**Test file overrides (relaxed rules in `handsontable/.eslintrc.js`):**
+- `jsdoc/require-jsdoc`: off in `*.unit.js` and `*.spec.js`
+- `handsontable/no-native-error-throw`: off in test files
+- `handsontable/require-async-in-it`: off in `*.unit.js` (only enforced in `*.spec.js`)
+- `handsontable/require-await`: off in `*.unit.js`
+- `no-undef`: off in test files (globals available from bootstrap)
+- `no-await-in-loop`: off in test files
+
+## Import Organization
+
+**Order:**
+1. Third-party libraries
+2. Internal modules from parent/helper directories (relative paths like `../../helpers/`)
+3. Local modules from sibling/child directories
+4. Constants and configurations
+
+**Example from `src/plugins/hiddenColumns/hiddenColumns.js`:**
+```javascript
+import { BasePlugin } from '../base';
+import { addClass } from '../../helpers/dom/element';
+import { rangeEach } from '../../helpers/number';
+import { arrayEach, arrayMap, arrayReduce } from '../../helpers/array';
+import { SEPARATOR } from '../contextMenu/predefinedItems';
+import { Hooks } from '../../core/hooks';
+import hideColumnItem from './contextMenuItem/hideColumn';
+import showColumnItem from './contextMenuItem/showColumn';
+import { HidingMap } from '../../translations';
+```
+
+**Path Aliases (Jest/test only):**
+- `'handsontable'` maps to `<rootDir>/src`
+- `'walkontable'` maps to `<rootDir>/src/3rdparty/walkontable/src`
+
+**Critical Rule: No barrel imports in source code.**
+- Wrong: `import { HiddenColumns } from '../plugins'`
+- Correct: `import { HiddenColumns } from '../plugins/hiddenColumns/hiddenColumns'`
+- Only `src/registry.js` may import from barrel indices
+
+## Error Handling
+
+**Pattern -- Always use `throwWithCause()`:**
+```javascript
+import { throwWithCause } from '../helpers/errors';
+
+// Instead of: throw new Error('message')
+throwWithCause('The `fixedColumnsLeft` is not supported for RTL. Please use option `fixedColumnsStart`.');
+```
+
+**Error Cause identification:**
+- All errors include `cause: { handsontable: true }` for programmatic recognition
+- Check with `error.cause?.handsontable === true`
+
+**Implementation in `src/helpers/errors.js`:**
+```javascript
+export function throwWithCause(message) {
+  throw new Error(message, {
+    cause: { handsontable: true }
+  });
+}
+```
+
+## Logging
+
+**Framework:** Custom wrappers in `src/helpers/console.js`
+
+**Available Functions:**
+- `log(...args)` -- General logging
+- `warn(...args)` -- Warning messages
+- `deprecatedWarn(message)` -- Deprecated feature warnings (prefixed with "Deprecated: ")
+- `info(...args)` -- Informational messages
+- `error(...args)` -- Error messages
+
+**Usage Pattern:**
+```javascript
+import { warn, deprecatedWarn } from './helpers/console';
+
+warn('Both `rowHeights` and `minRowHeights` are defined. The `minRowHeights` will be ignored.');
+deprecatedWarn('The `getTotalRows()` method is deprecated. Use `countRows()` instead.');
+```
+
+**Why not `console` directly:**
+- Enforced by ESLint `no-restricted-globals` with custom error message
+- Safely handles missing console in older browsers
+- Provides consistent logging interface
+
+## Comments
+
+**When to Comment:**
+- Explain *why* code exists, not *what* it does
+- Non-obvious algorithmic decisions
+- Workarounds and temporary solutions (mark with `// TODO:` or `// FIXME:`)
+- Complex coordinate system transformations (physical/visual/renderable)
+
+**JSDoc/Typedoc Requirements:**
+- All exported functions must have JSDoc (`jsdoc/require-jsdoc: 'error'`)
+- Parameters: `@param {type} name - Description.`
+- Returns: `@returns {type} Description.`
+- Private: `@private` tag
+- Newline required after description (`jsdoc/newline-after-description: 'error'`)
+- Check param names, types, property names, access level (all at error level)
+
+**JSDoc Template:**
+```javascript
+/**
+ * Brief description of the method.
+ *
+ * Additional notes if needed.
+ *
+ * @param {string} paramName - Description of the parameter.
+ * @param {number} anotherParam - Description.
+ *
+ * @fires [[eventName]] when triggered.
+ *
+ * @throws [[ErrorType]] when condition is met.
+ *
+ * @returns {string} Description of the return value.
+ *
+ * @category CategoryName
+ */
+```
+
+**Allowed Custom JSDoc Tags:**
+`@plugin`, `@util`, `@experimental`, `@deprecated`, `@preserve`, `@core`, `@TODO`, `@category`, `@package`, `@template`
+
+**Typedoc Formatting Rules:**
+- No HTML tags in descriptions -- use Markdown
+- Line breaks: use empty line, never `<br>`
+- Links: `[[MY_LINK]]` syntax, not `{@link MY_LINK}`
+- End every sentence with a full stop
+- No blank line below `/**` or above `*/`
+
+## Function Design
+
+**Size:** Aim for functions under 100 lines. Extract complex logic into helper functions in `src/helpers/`.
+
+**Parameters:**
+- Use object destructuring for multiple related parameters
+- `no-param-reassign` is off, but prefer immutable patterns
+
+**Return Values:**
+- `consistent-return` is off -- functions may return different types in branches
+- Document return type in JSDoc `@returns` tag
+
+## Module Design
+
+**Exports:**
+- Named exports preferred (`import/prefer-default-export: 'off'`)
+- Plugin index pattern from `src/plugins/hiddenColumns/index.js`:
+```javascript
+export {
+  PLUGIN_KEY,
+  PLUGIN_PRIORITY,
+  HiddenColumns,
+} from './hiddenColumns';
+```
+
+**Plugin Static Properties:**
+```javascript
+class MyPlugin extends BasePlugin {
+  static get PLUGIN_KEY() { return 'myPlugin'; }
+  static get PLUGIN_PRIORITY() { return 150; }
+  static get SETTING_KEYS() { return ['myPlugin']; }
+  static get DEFAULT_SETTINGS() { return {}; }
+  static get SETTINGS_VALIDATORS() { return null; }
+  static get PLUGIN_DEPS() { return ['plugin:AutoRowSize']; }
+}
+```
+
+**Plugin Lifecycle Methods (in order):**
+1. `constructor(hotInstance)` -- receives HOT instance as `this.hot`
+2. `isEnabled()` -- return truthy/falsy based on `this.hot.getSettings()[PLUGIN_KEY]`
+3. `enablePlugin()` -- set up hooks via `this.addHook()`, register IndexMapper maps. Call `super.enablePlugin()` at the end
+4. `updatePlugin()` -- typical: `this.disablePlugin(); this.enablePlugin(); super.updatePlugin();`
+5. `disablePlugin()` -- Call `super.disablePlugin()` first (clears EventManager and hooks). Then clean up
+6. `destroy()` -- final teardown. Call `super.destroy()` at the end
+
+**Hooks Registration at Module Level (outside the class):**
+```javascript
+import { Hooks } from '../../core/hooks';
+
+Hooks.getSingleton().register('beforeMyAction');
+Hooks.getSingleton().register('afterMyAction');
+```
+
+**Important:** `this.addHook()` (BasePlugin method) auto-cleans hooks on `disablePlugin()`. `this.hot.addHook()` does not.
+
+## Plugin Directory Structure Convention
+
+```
+src/plugins/{pluginName}/
+├── index.js              # Re-exports PLUGIN_KEY, PLUGIN_PRIORITY, ClassName
+├── {pluginName}.js       # Main plugin class extending BasePlugin
+├── __tests__/            # Tests (*.spec.js for E2E, *.unit.js for unit)
+│   └── helpers/          # Optional plugin-specific test helpers (auto-loaded for E2E)
+└── {submodules}/         # Additional subdirectories as needed
+```
+
+## DOM and Window Access
+
+- Always use `this.hot.rootWindow` instead of global `window`
+- Always use `this.hot.rootDocument` instead of global `document`
+- This enables multi-instance support and air-gapped environments
+
+```javascript
+const element = this.hot.rootDocument.createElement('div');
+const width = this.hot.rootWindow.innerWidth;
+```
+
+## Optional Chaining Policy
+
+Use `?.` only when a value is genuinely optional by design. Do not use as a blanket safety net. If a value is guaranteed by the data contract (e.g., parallel arrays from the same iterator, `getCellMeta()` always returns an object), access directly without `?.`. Unnecessary optional chaining hides bugs.
+
+## Performance Conventions
+
+- Never use `arr.push(...largeArray)` with arrays that could exceed 10k elements -- use `forEach` loop
+- Use `batch()` / `batchRender()` / `suspendRender()` / `resumeRender()` for multiple operations that trigger rendering
+- Use `requestAnimationFrame` for batching scroll events
+- Target 60fps with 100k+ row datasets
+
+## CSS Conventions
+
+- CSS and JavaScript are strictly separated -- never mix CSS into JavaScript files
+- Theme CSS uses CSS custom properties (variables) as the public API for customization
+- Three themes: `ht-theme-main`, `ht-theme-classic`, `ht-theme-horizon` (each with `-no-icons` variants)
+- Theme class is applied to the root container element

--- a/.ai/INTEGRATIONS.md
+++ b/.ai/INTEGRATIONS.md
@@ -1,0 +1,141 @@
+# External Integrations
+
+## APIs & External Services
+
+Handsontable is a frontend-only library with no built-in external API integrations. It runs entirely in the browser and makes no network requests unless explicitly configured by the user. The library supports air-gapped environments. There is no built-in telemetry.
+
+**Formula Engine (Optional):**
+- HyperFormula - Spreadsheet formula calculation engine
+  - Package: `hyperformula` ^3.0.0 (optional dependency)
+  - Integration: Plugin-based via `handsontable/src/plugins/formulas/`
+  - Engine setup: `handsontable/src/plugins/formulas/engine/register.js`
+  - No network calls; runs entirely in-browser
+  - Bundled in `handsontable.full.js` variant; external in `handsontable.js`
+
+## Data Storage
+
+**Databases:**
+- Not applicable. Handsontable operates on in-memory JavaScript arrays/objects passed by the consumer application.
+- Data is managed through `handsontable/src/dataMap/` (DataMap, MetaManager).
+
+**File Storage:**
+- Local filesystem only (during development/build).
+- No runtime file storage; the library is browser-only.
+
+**Caching:**
+- None at the library level. Internal caching of cell metadata and rendering state is handled in-memory.
+
+## Authentication & Identity
+
+**Auth Provider:**
+- Not applicable. Handsontable is a UI component library with no authentication layer.
+- License validation is handled internally (no network calls).
+
+## Monitoring & Observability
+
+**Error Tracking:**
+- None built-in. No telemetry or error reporting services.
+- Errors use custom handler: `handsontable/src/helpers/errors.js` with `throwWithCause(error, cause)` utility.
+
+**Logs:**
+- Console helpers via `handsontable/src/helpers/console.js` (wraps `console` to avoid direct global access).
+- No external logging service integration.
+
+## CI/CD & Deployment
+
+**Hosting:**
+- npm registry (published as `handsontable`, `@handsontable/react-wrapper`, `@handsontable/angular-wrapper`, `@handsontable/vue3`)
+- CDN: jsDelivr and unpkg (automatic from npm publish)
+- Documentation: Netlify (`docs/netlify/`)
+
+**CI Pipeline:**
+- GitHub Actions (`.github/workflows/`)
+- Key workflows: `test.yml`, `build-all.yml`, `code-quality.yml`, `publish.yml`
+
+**Visual Regression Testing:**
+- Argos CI (`@argos-ci/core` ^5.1.1) - Screenshot comparison service used in `visual-tests/`
+- Playwright for screenshot capture
+
+**Documentation Search:**
+- Algolia - Docs search reindexing (`.github/workflows/docs-algolia-reindex.yml`)
+
+## Environment Configuration
+
+**Required env vars:**
+- None for library consumers.
+- Build-time variables defined in `hot.config.js` (root):
+  - `HOT_FILENAME` - Output filename (`handsontable`)
+  - `HOT_VERSION` - Library version string (`17.0.0`)
+  - `HOT_PACKAGE_NAME` - npm package name (`handsontable`)
+  - `HOT_BUILD_DATE` - Build timestamp (generated via `moment().format()`)
+  - `HOT_RELEASE_DATE` - Release date string
+- Build mode variables: `NODE_ENV`, `BABEL_ENV`
+
+**Secrets location:**
+- No secrets in the repository. No `.env` files present.
+- CI secrets managed via GitHub Actions secrets (for npm publish, Netlify deploy, Algolia reindex).
+
+## Webhooks & Callbacks
+
+**Incoming:**
+- None. Handsontable is a client-side library with no server endpoints.
+
+**Outgoing:**
+- None. No telemetry, analytics, or network requests.
+
+## Third-Party Libraries (Runtime)
+
+These are the only external libraries bundled or referenced at runtime:
+
+| Library | Version | Purpose | Integration Point |
+|---|---|---|---|
+| `dompurify` | ^3.1.7 | XSS sanitization of HTML content | Used internally for cell content sanitization |
+| `numbro` | 2.5.0 | Number formatting | Used by numeric cell type and renderers |
+| `moment` | 2.30.1 | Date parsing/formatting | Used by date cell type and Pikaday editor |
+| `@handsontable/pikaday` | ^1.0.0 | Date picker UI | Date editor plugin (forked from original Pikaday) |
+| `hyperformula` | ^3.0.0 | Formula engine | Optional; integrated via Formulas plugin (`src/plugins/formulas/`) |
+
+**Note:** Numbro locale files and Moment locale files are excluded from the build via empty-loader (`handsontable/.config/loader/empty-loader.js`) to reduce bundle size. Only the base libraries are included.
+
+## Framework Wrapper Integration Points
+
+**React (`wrappers/react-wrapper/`):**
+- Peer dependency: `handsontable` ^17.0.0
+- Build tool: Rollup 4
+- Core component: `wrappers/react-wrapper/src/hotTableInner.tsx`
+- Supports React 18
+- Selection state preservation via `selection.exportSelection()` / `selection.importSelection()` during `updateSettings()`
+
+**Angular (`wrappers/angular-wrapper/`):**
+- Peer dependency: `handsontable` ^17.0.0, `@angular/core` >=16.0.0
+- Build tool: ng-packagr 16
+- Core component: `wrappers/angular-wrapper/projects/hot-table/src/lib/`
+- Runtime deps: `rxjs` ^7.8.1, `tslib` ^2.3.0, `zone.js` ~0.13.0
+- Tests require `NODE_OPTIONS=--openssl-legacy-provider`
+
+**Vue 3 (`wrappers/vue3/`):**
+- Peer dependency: `handsontable` ^17.0.0, `vue` ^3.2.22
+- Build tool: Rollup 4 with `rollup-plugin-vue`
+- No additional runtime dependencies
+
+## Import/Export Capabilities
+
+**Supported formats (client-side only):**
+- CSV - Parsed via `handsontable/src/utils/parseTable.js`
+- HTML tables - HTML parsing utility for copy/paste and export
+- JSON - Data structure is plain arrays/objects
+- Excel formulas - When Formulas plugin enabled via HyperFormula
+
+**No built-in database synchronization.** Applications must implement their own save/load mechanisms.
+
+## Hooks System (Internal Event Bus)
+
+Handsontable provides an extensive hook system for component lifecycle and user interactions (not external webhooks). Hooks are defined in `handsontable/src/core/hooks/`. Plugins register hooks globally at module level:
+
+```js
+import Hooks from '../../core/hooks';
+Hooks.getSingleton().register('beforeMyAction');
+Hooks.getSingleton().register('afterMyAction');
+```
+
+Key hook categories: lifecycle (`beforeInit`/`afterInit`, `beforeRender`/`afterRender`), data (`beforeChange`/`afterChange`, `beforeLoadData`/`afterLoadData`), selection, editor/renderer, and plugin-specific hooks.

--- a/.ai/STACK.md
+++ b/.ai/STACK.md
@@ -1,0 +1,178 @@
+# Technology Stack
+
+## Languages
+
+**Primary:**
+- JavaScript (ES2015+) - Core library (`handsontable/src/`), all source code
+- SCSS/CSS - Styling and themes (`handsontable/src/**/*.scss`, `handsontable/styles/`)
+
+**Secondary:**
+- TypeScript - Framework wrappers (`wrappers/react-wrapper/src/`, `wrappers/angular-wrapper/`, `wrappers/vue3/src/`) and hand-authored type definitions (`handsontable/types/`)
+- HTML - Test runners (`handsontable/test/E2ERunner.html`, `handsontable/src/3rdparty/walkontable/test/SpecRunner.html`)
+
+**Important:** The core package (`handsontable/`) is JavaScript only. Do not create `.ts` files in `handsontable/src/`. TypeScript definitions live in `handsontable/types/` as `.d.ts` files.
+
+## Runtime
+
+**Environment:**
+- Node.js 22 (specified in `.nvmrc`)
+- Browser-only library at runtime (no server-side logic)
+
+**Package Manager:**
+- pnpm 10.30.2 (specified in root `package.json` `packageManager` field)
+- Activate via: `corepack enable && corepack prepare pnpm@10.30.2 --activate`
+- Lockfile: `pnpm-lock.yaml` present
+- Workspace config: `pnpm-workspace.yaml`
+
+## Frameworks
+
+**Core:**
+- No framework - vanilla JavaScript data grid library
+- Walkontable - internal rendering engine (`handsontable/src/3rdparty/walkontable/src/`)
+
+**Framework Wrappers:**
+- React 18 - `wrappers/react-wrapper/` (`@handsontable/react-wrapper`)
+- Angular 16+ - `wrappers/angular-wrapper/` (`@handsontable/angular-wrapper`)
+- Vue 3.2+ - `wrappers/vue3/` (`@handsontable/vue3`)
+
+**Testing:**
+- Jest 27 - Unit tests (`handsontable/jest.config.js`, `*.unit.js` files, jsdom environment, `jest-jasmine2` runner)
+- Jasmine 3.4 - E2E browser tests (`*.spec.js` files, run via Puppeteer)
+- Puppeteer 24 - Headless Chrome for E2E tests
+- Playwright 1.58 - Visual regression tests (`visual-tests/`)
+- `@testing-library/react` 14 - React wrapper tests
+- `@vue/test-utils` 2.0.0-rc.16 - Vue 3 wrapper tests
+- `jest-preset-angular` 14 - Angular wrapper tests (requires `NODE_OPTIONS=--openssl-legacy-provider`)
+
+**Build/Dev:**
+- Webpack 5 - Core library bundling (`handsontable/.config/`)
+- Rollup 4 - React and Vue 3 wrapper bundling
+- Babel 7 - JavaScript transpilation (`handsontable/babel.config.js`)
+- ng-packagr 16 - Angular library packaging
+- Sass 1.58 - SCSS compilation
+- TypeScript 3.8.2 (core types), 5.1.6 (Angular), 4.x (Vue 3)
+
+## Key Dependencies
+
+**Critical (runtime):**
+- `dompurify` ^3.1.7 - XSS prevention, HTML sanitization for cell content
+- `numbro` 2.5.0 - Number formatting in cells
+- `moment` 2.30.1 - Date formatting and manipulation
+- `@handsontable/pikaday` ^1.0.0 - Date picker editor (forked Pikaday)
+
+**Optional (runtime):**
+- `hyperformula` ^3.0.0 - Spreadsheet formula engine (optional dependency, integrated via `handsontable/src/plugins/formulas/`)
+
+**Angular wrapper runtime:**
+- `rxjs` ^7.8.1 - Reactive extensions for Angular
+- `tslib` ^2.3.0 - TypeScript runtime helpers
+- `zone.js` ~0.13.0 - Angular change detection
+
+**Build tooling (key devDependencies):**
+- `eslint` 7 (core) / 8 (wrappers) - Linting with Airbnb base config
+- `eslint-plugin-handsontable` - Custom ESLint rules (`handsontable/.config/plugin/eslint/`)
+- `eslint-plugin-compat` - Browser API compatibility enforcement
+- `stylelint` 16 - CSS/SCSS linting
+- `env-cmd` 9 - Injects environment variables from `hot.config.js` during build
+- `cross-env` 7 - Cross-platform environment variable setting
+- `mini-css-extract-plugin` - CSS extraction from webpack bundles
+- `css-minimizer-webpack-plugin` - CSS minification
+
+## Configuration
+
+**Environment:**
+- Build environment variables defined in `hot.config.js` (root): `HOT_FILENAME`, `HOT_VERSION`, `HOT_PACKAGE_NAME`, `HOT_BUILD_DATE`, `HOT_RELEASE_DATE`
+- Injected via `env-cmd -f ../hot.config.js` in all build/test scripts
+- No `.env` files in the repository (air-gapped environment support)
+
+**Webpack configs (`handsontable/.config/`):**
+- `base.js` - Base configuration (UMD output, library name `Handsontable`, babel-loader, empty-loader for numbro/moment locales)
+- `development.js` / `production.js` - Dev and production build configs
+- `styles-development.js` / `styles-production.js` - CSS build configs
+- `themes-css-development.js` / `themes-css-production.js` - Theme CSS builds
+- `themes-umd-development.js` / `themes-umd-production.js` - Theme UMD builds
+- `languages-development.js` / `languages-production.js` - i18n language pack builds
+- `walkontable.js` - Walkontable standalone build
+- `test-e2e.js` / `test-production.js` / `test-walkontable.js` - Test bundle configs
+
+**Babel environments (`handsontable/babel.config.js`):**
+- `commonjs` - Unit testing, source code, and UMD builds via webpack
+- `commonjs_dist` - Transpiling to CommonJS for `tmp/` output
+- `es` - Transpiling to ES modules (`.mjs`) for `tmp/` output
+- `es_languages` - Language packs as ES modules with auto-registration
+- `commonjs_e2e` - E2E test bundles (includes `babel-plugin-forbidden-imports` to restrict imports)
+
+**Linting:**
+- `.eslintrc.js` (root) - Monorepo-level ESLint config
+- `handsontable/.eslintrc.js` - Core-specific ESLint with custom rules
+- Custom ESLint plugin at `handsontable/.config/plugin/eslint/` with rules:
+  - `no-native-error-throw` - Must use `throwWithCause()` from `src/helpers/errors.js`
+  - `restricted-module-imports` - No imports from barrel index files
+  - `require-async-in-it` - `it()` callbacks in spec files must be `async`
+  - `require-await` - Specific HOT API calls must be `await`-ed
+
+**Testing:**
+- `handsontable/jest.config.js` - Jest config (jsdom environment, `jest-jasmine2` runner, `*.unit.js` pattern)
+- Module aliases in Jest: `handsontable` -> `src/`, `walkontable` -> `src/3rdparty/walkontable/src/`
+- CSS/SCSS mocked via `handsontable/test/__mocks__/styleMock.js`
+- E2E test dump scripts use webpack to bundle test helpers and spec files before Puppeteer execution
+
+## Build Outputs
+
+| Output | Path | Format |
+|---|---|---|
+| UMD bundles | `handsontable/dist/handsontable.js`, `handsontable/dist/handsontable.full.js` | UMD |
+| Minified bundles | `handsontable/dist/handsontable.min.js`, `handsontable/dist/handsontable.full.min.js` | UMD (minified) |
+| CommonJS modules | `handsontable/tmp/*.js` | CJS |
+| ES modules | `handsontable/tmp/*.mjs` | ESM |
+| Compiled CSS | `handsontable/styles/` | CSS |
+| Language packs | `handsontable/dist/languages/`, `handsontable/languages/` | UMD + ESM |
+| Theme bundles | `handsontable/dist/themes/` | UMD + CSS |
+
+**Two build variants:**
+- `handsontable.js` - Base build, external dependencies not bundled
+- `handsontable.full.js` - Includes HyperFormula bundled in
+
+**Wrappers consume `tmp/` output** via pnpm workspace linking (`"handsontable": "workspace:^"` override in root `package.json`).
+
+## CSS Themes
+
+- `ht-theme-main` - Default modern theme
+- `ht-theme-classic` - Legacy Handsontable theme
+- `ht-theme-horizon` - Alternative design theme
+- Each theme has `-no-icons` variant
+- Themes use CSS custom property tokens (design system) declared in Figma
+
+## Platform Requirements
+
+**Development:**
+- Node.js 22 (enforced via `.nvmrc`)
+- pnpm 10.30.2 (via corepack)
+- No Docker, databases, or external services required
+
+**Production (browser targets):**
+- Chrome (two latest major versions)
+- Firefox (two latest major versions)
+- Safari (two latest major versions)
+- Edge (two latest major versions)
+- Enforced via `eslint-plugin-compat`
+
+**CDN distribution:**
+- jsDelivr: `dist/handsontable.full.min.js`
+- unpkg: `dist/handsontable.full.min.js`
+
+## CI/CD
+
+**Platform:** GitHub Actions (`.github/workflows/`)
+
+**Key workflows:**
+- `test.yml` - Main test pipeline (unit, E2E, Walkontable, wrapper tests)
+- `build-all.yml` - Full build verification
+- `code-quality.yml` - Linting and code quality checks
+- `linter.yml` - ESLint checks
+- `publish.yml` - Package publishing pipeline to npm
+- `docs-staging.yml` / `docs-production.yml` - Documentation deployment (Netlify)
+- `docs-visual-tests.yml` - Visual regression testing for docs
+- `changelog.yml` - Changelog verification
+- `audit.yml` - Security audit
+- `pkg-pr-new.yml` - PR package preview

--- a/.ai/STRUCTURE.md
+++ b/.ai/STRUCTURE.md
@@ -1,0 +1,476 @@
+# Codebase Structure
+
+## Directory Layout
+
+```
+handsontable-develop/
+├── handsontable/               # Core data grid package (vanilla JS)
+│   ├── src/                    # Source code
+│   ├── test/                   # E2E tests and test infrastructure
+│   ├── types/                  # Hand-authored TypeScript .d.ts definitions
+│   ├── dist/                   # UMD/minified build output
+│   ├── tmp/                    # ES/CJS module build output (used by wrappers)
+│   ├── styles/                 # Compiled CSS output
+│   ├── languages/              # Compiled language files
+│   ├── .config/                # Webpack configs
+│   ├── scripts/                # Build scripts
+│   ├── dev.html                # Dev playground (LTR)
+│   ├── dev-rtl.html            # Dev playground (RTL)
+│   └── dev-ltr-rtl.html        # Dev playground (both)
+├── wrappers/
+│   ├── react-wrapper/          # @handsontable/react-wrapper
+│   ├── angular-wrapper/        # @handsontable/angular-wrapper
+│   └── vue3/                   # @handsontable/vue3
+├── docs/                       # VuePress documentation site (Node 20)
+├── examples/                   # Code examples
+├── visual-tests/               # Playwright visual regression tests
+├── .changelogs/                # Changelog entry mechanism
+├── bin/                        # CLI tools (changelog)
+├── scripts/                    # Monorepo-level scripts
+├── resources/                  # Shared resources
+├── .github/                    # GitHub workflows and CI
+├── hot.config.js               # Build environment variables
+├── pnpm-workspace.yaml         # pnpm workspace definition
+├── package.json                # Root package.json (pnpm 10.30.2)
+├── babel.config.js             # Root Babel config
+├── .eslintrc.js                # Root ESLint config
+├── .eslintignore               # ESLint ignore patterns
+├── browser-targets.js          # Supported browser targets
+├── .nvmrc                      # Node.js version (22)
+└── CHANGELOG.md                # Release changelog
+```
+
+## Core Source Directory (`handsontable/src/`)
+
+```
+handsontable/src/
+├── core.js                     # Core class (~5656 lines) - main public API
+├── base.js                     # Tree-shakeable entry point (minimal)
+├── index.js                    # Full entry point (registers all modules)
+├── registry.js                 # Aggregated registerAll*() for all module types
+├── tableView.js                # Bridge between Core and Walkontable
+├── editorManager.js            # Manages cell editor lifecycle
+├── eventManager.js             # Centralized DOM event listener management
+│
+├── core/                       # Core submodules
+│   ├── hooks/                  # Hooks (event bus) system
+│   │   ├── index.js            # Hooks class (singleton)
+│   │   ├── bucket.js           # HooksBucket storage
+│   │   └── constants.js        # REGISTERED_HOOKS, REMOVED_HOOKS, DEPRECATED_HOOKS
+│   ├── coordsMapper/           # CellRange to renderable coordinate mapping
+│   └── viewportScroll/         # Viewport scroll management
+│
+├── plugins/                    # All feature plugins (~40 plugins)
+│   ├── base/                   # BasePlugin abstract class
+│   │   └── base.js             # Plugin lifecycle template
+│   ├── registry.js             # Plugin registry (register/get/getNames)
+│   ├── index.js                # Barrel export + registerAllPlugins()
+│   ├── autoColumnSize/         # Auto column sizing
+│   ├── autoRowSize/            # Auto row sizing
+│   ├── autofill/               # Drag-to-fill
+│   ├── bindRowsWithHeaders/    # Row-header binding
+│   ├── collapsibleColumns/     # Column collapsing (nested headers)
+│   ├── columnSorting/          # Single-column sorting
+│   ├── columnSummary/          # Column summary calculations
+│   ├── comments/               # Cell comments
+│   ├── contextMenu/            # Right-click context menu
+│   ├── copyPaste/              # Copy/paste support
+│   ├── customBorders/          # Custom cell borders
+│   ├── dialog/                 # Dialog/modal support
+│   ├── dragToScroll/           # Drag-to-scroll viewport
+│   ├── dropdownMenu/           # Column header dropdown menus
+│   ├── emptyDataState/         # Empty state display
+│   ├── exportFile/             # CSV export
+│   ├── filters/                # Column filters
+│   ├── formulas/               # HyperFormula integration
+│   ├── hiddenColumns/          # Column hiding
+│   ├── hiddenRows/             # Row hiding
+│   ├── loading/                # Loading indicator
+│   ├── manualColumnFreeze/     # Manual column freezing
+│   ├── manualColumnMove/       # Column drag-to-move
+│   ├── manualColumnResize/     # Column drag-to-resize
+│   ├── manualRowMove/          # Row drag-to-move
+│   ├── manualRowResize/        # Row drag-to-resize
+│   ├── mergeCells/             # Cell merging
+│   ├── multiColumnSorting/     # Multi-column sorting
+│   ├── multipleSelectionHandles/ # Mobile selection handles
+│   ├── nestedHeaders/          # Multi-level column headers
+│   ├── nestedRows/             # Hierarchical row data
+│   ├── pagination/             # Data pagination
+│   ├── search/                 # Cell search
+│   ├── stretchColumns/         # Column stretching strategies
+│   │   └── strategies/         # 'all' and 'last' strategies
+│   ├── touchScroll/            # Touch device scrolling
+│   ├── trimRows/               # Row trimming (removes from DataMap)
+│   └── undoRedo/               # Undo/redo support
+│
+├── editors/                    # Cell editor implementations
+│   ├── baseEditor/             # Abstract BaseEditor class
+│   ├── textEditor/             # Text input editor (base for most editors)
+│   ├── autocompleteEditor/     # Autocomplete dropdown
+│   ├── checkboxEditor/         # Checkbox toggle
+│   ├── dateEditor/             # Date picker
+│   ├── dropdownEditor/         # Dropdown select
+│   ├── handsontableEditor/     # Embedded Handsontable editor
+│   ├── intlDateEditor/         # Internationalized date editor
+│   ├── intlTimeEditor/         # Internationalized time editor
+│   ├── multiSelectEditor/      # Multi-select editor
+│   ├── numericEditor/          # Numeric input
+│   ├── passwordEditor/         # Password input
+│   ├── selectEditor/           # Native select editor
+│   ├── timeEditor/             # Time input
+│   ├── registry.js             # Editor registry
+│   ├── factory.js              # Editor factory
+│   └── index.js                # Barrel export + registerAllEditors()
+│
+├── renderers/                  # Cell renderer functions
+│   ├── baseRenderer/           # Base decorator renderer
+│   ├── textRenderer/           # Text cell renderer
+│   ├── autocompleteRenderer/   # Autocomplete cell renderer
+│   ├── checkboxRenderer/       # Checkbox renderer
+│   ├── dateRenderer/           # Date renderer
+│   ├── htmlRenderer/           # HTML content renderer
+│   ├── numericRenderer/        # Numeric renderer
+│   ├── passwordRenderer/       # Password mask renderer
+│   ├── registry.js             # Renderer registry
+│   ├── factory.js              # Renderer factory
+│   └── index.js                # Barrel export + registerAllRenderers()
+│
+├── validators/                 # Cell value validators
+│   ├── autocompleteValidator/  # Autocomplete validation
+│   ├── dateValidator/          # Date validation
+│   ├── numericValidator/       # Numeric validation
+│   ├── timeValidator/          # Time validation
+│   ├── registry.js             # Validator registry
+│   └── index.js                # Barrel export + registerAllValidators()
+│
+├── cellTypes/                  # Composite cell types (editor+renderer+validator)
+│   ├── textType/               # Default text type
+│   ├── numericType/            # Numeric type
+│   ├── checkboxType/           # Checkbox type
+│   ├── dateType/               # Date type
+│   ├── dropdownType/           # Dropdown type
+│   ├── autocompleteType/       # Autocomplete type
+│   ├── handsontableType/       # Embedded grid type
+│   ├── intlDateType/           # Internationalized date type
+│   ├── intlTimeType/           # Internationalized time type
+│   ├── multiSelectType/        # Multi-select type
+│   ├── passwordType/           # Password type
+│   ├── selectType/             # Select type
+│   ├── timeType/               # Time type
+│   ├── registry.js             # Cell type registry
+│   └── index.js                # Barrel export + registerAllCellTypes()
+│
+├── dataMap/                    # Data management layer
+│   ├── dataMap.js              # DataMap - row/column data access
+│   ├── dataSource.js           # DataSource - raw data wrapper
+│   ├── replaceData.js          # Data replacement logic
+│   ├── sourceDataValidator.js  # Source data validation
+│   ├── metaManager/            # Cascading metadata system
+│   │   ├── index.js            # MetaManager class
+│   │   ├── metaSchema.js       # Default meta schema (all settings defaults)
+│   │   ├── lazyFactoryMap.js   # Lazy map for meta objects
+│   │   ├── metaLayers/         # Four meta layers
+│   │   │   ├── globalMeta.js   # Global defaults (prototype)
+│   │   │   ├── tableMeta.js    # Table-level overrides (instance)
+│   │   │   ├── columnMeta.js   # Column-level overrides (prototype)
+│   │   │   └── cellMeta.js     # Cell-level overrides (instance)
+│   │   ├── mods/               # Meta modifier modules
+│   │   │   ├── dynamicCellMeta.js     # Dynamic cell meta from `cells()` function
+│   │   │   └── extendMetaProperties.js # Extends meta with type-resolved properties
+│   │   └── utils.js            # Meta utilities
+│   └── index.js                # Barrel export
+│
+├── translations/               # Index mapping (3 coordinate systems)
+│   ├── indexMapper.js           # IndexMapper - main translation class
+│   ├── maps/                    # Map implementations
+│   │   ├── hidingMap.js         # HidingMap (hidden but in DataMap)
+│   │   ├── trimmingMap.js       # TrimmingMap (removed from DataMap)
+│   │   ├── indexesSequence.js   # IndexesSequence (ordering)
+│   │   └── ...                  # PhysicalIndexToValueMap, LinkedPhysicalIndexToValueMap
+│   ├── mapCollections/          # Map collection types
+│   │   ├── mapCollection.js     # MapCollection base
+│   │   └── aggregatedCollection.js # AggregatedCollection (aggregates multiple maps)
+│   ├── changesObservable/       # Observable for index changes
+│   └── index.js                 # Barrel export
+│
+├── selection/                  # Selection management
+│   ├── selection.js            # Selection class (main)
+│   ├── range.js                # SelectionRange data layer
+│   ├── highlight/              # Selection highlight rendering
+│   │   └── highlight.js        # Highlight class with type constants
+│   ├── transformation/         # Selection transformation modules
+│   │   ├── extender.js         # ExtenderTransformation (extend selection)
+│   │   └── focus.js            # FocusTransformation (move focus)
+│   ├── mouseEventHandler.js    # Mouse event -> selection actions
+│   └── utils.js                # Selection utilities
+│
+├── 3rdparty/walkontable/       # Walkontable rendering engine
+│   ├── src/
+│   │   ├── core/               # Walkontable core classes
+│   │   │   ├── _base.js        # Base Walkontable class
+│   │   │   ├── core.js         # Main Walkontable core
+│   │   │   └── clone.js        # Clone Walkontable (for overlays)
+│   │   ├── facade/             # Facade pattern for external access
+│   │   │   └── core.js         # Public Walkontable API
+│   │   ├── table/              # Table implementations
+│   │   │   ├── master.js       # Master (main) table
+│   │   │   ├── top.js          # Top frozen overlay table
+│   │   │   ├── bottom.js       # Bottom frozen overlay table
+│   │   │   ├── inlineStart.js  # Left/right frozen overlay table
+│   │   │   ├── topInlineStartCorner.js    # Top-left corner table
+│   │   │   └── bottomInlineStartCorner.js # Bottom-left corner table
+│   │   ├── overlay/            # Overlay system (frozen rows/cols)
+│   │   │   ├── _base.js        # Base overlay
+│   │   │   ├── top.js          # Top overlay
+│   │   │   ├── bottom.js       # Bottom overlay
+│   │   │   ├── inlineStart.js  # Inline-start (left/right) overlay
+│   │   │   ├── topInlineStartCorner.js    # Corner overlays
+│   │   │   └── bottomInlineStartCorner.js
+│   │   ├── renderer/           # Low-level DOM renderers
+│   │   │   ├── _base.js        # Base renderer
+│   │   │   ├── table.js        # Table renderer orchestrator
+│   │   │   ├── rows.js         # Row renderer
+│   │   │   ├── cells.js        # Cell renderer
+│   │   │   ├── columnHeaders.js # Column header renderer
+│   │   │   ├── rowHeaders.js   # Row header renderer
+│   │   │   └── colGroup.js     # ColGroup renderer
+│   │   ├── calculator/         # Viewport calculators
+│   │   ├── cell/               # CellCoords and CellRange
+│   │   ├── selection/          # Selection rendering in Walkontable
+│   │   ├── filter/             # Row/column filters for rendering
+│   │   ├── utils/              # Walkontable utilities
+│   │   ├── scroll.js           # Scroll position management
+│   │   ├── viewport.js         # Viewport state
+│   │   ├── overlays.js         # Overlay manager
+│   │   ├── settings.js         # Walkontable settings adapter
+│   │   ├── event.js            # Walkontable event handling
+│   │   └── table.js            # Table abstraction
+│   └── test/                   # Walkontable-specific tests
+│
+├── shortcuts/                  # Keyboard shortcut system
+│   ├── manager.js              # ShortcutManager
+│   ├── context.js              # ShortcutContext
+│   ├── recorder.js             # Key recorder
+│   ├── keyObserver.js          # Key observer
+│   └── utils.js                # Shortcut utilities
+│
+├── shortcutContexts/           # Predefined shortcut contexts
+│
+├── focusManager/               # Focus management for accessibility
+│   ├── index.js                # FocusGridManager, scope manager
+│   ├── grid.js                 # Grid focus manager
+│   ├── scope.js                # Focus scope
+│   ├── scopeManager.js         # Scope manager
+│   ├── scopes/                 # Predefined focus scopes
+│   ├── eventListener.js        # Focus event listener
+│   ├── constants.js            # Focus constants
+│   └── utils/                  # Focus utilities
+│
+├── themes/                     # Theme system
+│   ├── engine/                 # Theme engine (runtime)
+│   ├── registry.js             # Theme registry
+│   ├── static/                 # Static theme definitions
+│   ├── theme/                  # Theme class
+│   └── index.js                # Barrel export
+│
+├── styles/                     # SCSS source files
+│   ├── handsontable.scss       # Main stylesheet
+│   ├── handsontableStyles.js   # Style injection
+│   ├── base/                   # Base styles
+│   ├── components/             # Component styles
+│   └── utils/                  # Style utilities
+│
+├── i18n/                       # Internationalization
+│   ├── registry.js             # Language registry
+│   └── utils.js                # i18n utilities
+│
+├── helpers/                    # Shared utility functions
+│   ├── dom/                    # DOM helpers
+│   │   ├── element.js          # Element manipulation (addClass, empty, etc.)
+│   │   └── event.js            # Event helpers (isImmediatePropagationStopped, etc.)
+│   ├── a11y.js                 # Accessibility ARIA helpers
+│   ├── array.js                # Array utilities
+│   ├── browser.js              # Browser detection
+│   ├── console.js              # Console wrappers (use instead of raw console)
+│   ├── constants.js            # Shared constants
+│   ├── data.js                 # Data helpers (spreadsheetColumnLabel, etc.)
+│   ├── dateTime.js             # Date/time utilities
+│   ├── errors.js               # throwWithCause (use instead of throw new Error)
+│   ├── feature.js              # Feature detection
+│   ├── function.js             # Function utilities
+│   ├── mixed.js                # Mixed type utilities
+│   ├── moves.js                # Movement helpers
+│   ├── number.js               # Number utilities (rangeEach, clamp)
+│   ├── object.js               # Object utilities (deepClone, mixin, etc.)
+│   ├── string.js               # String utilities
+│   ├── templateLiteralTag.js   # Template literal helpers
+│   ├── themes.js               # Theme helpers
+│   ├── unicode.js              # Unicode/keyboard key helpers
+│   └── wrappers/               # Framework wrappers (jQuery)
+│
+├── mixins/                     # Object mixins
+│   ├── localHooks.js           # Local hooks mixin (used by IndexMapper, Selection, etc.)
+│   └── hooksRefRegisterer.js   # Hooks reference registerer mixin
+│
+└── utils/                      # Utility classes
+    ├── autoResize.js            # Auto-resize textarea utility
+    ├── ghostTable.js            # Ghost table for measuring
+    ├── interval.js              # Interval helper
+    ├── paginator.js             # Pagination utility
+    ├── parseTable.js            # HTML table parsing (instanceToHTML, etc.)
+    ├── rootInstance.js          # Root instance management
+    ├── samplesGenerator.js      # Sample data generator (for auto-sizing)
+    ├── staticRegister.js        # Static registration utility
+    ├── stylesHandler.js         # Runtime CSS style handler
+    ├── valueAccessors.js        # Value getter/setter utilities
+    ├── a11yAnnouncer.js         # Accessibility announcer
+    └── dataStructures/          # Data structure utilities
+        └── uniqueMap.js         # UniqueMap implementation
+```
+
+## Directory Purposes
+
+**`handsontable/src/plugins/`:**
+- Purpose: All grid features as self-contained plugins
+- Contains: Each plugin in its own directory with `index.js` barrel export
+- Key files: `base/base.js` (BasePlugin), `registry.js` (plugin registry)
+- Convention: Each plugin directory exports `{ PLUGIN_KEY, PLUGIN_PRIORITY, PluginClassName }` from `index.js`
+
+**`handsontable/src/3rdparty/walkontable/`:**
+- Purpose: Self-contained rendering engine with its own test suite
+- Contains: DOM rendering, viewport calculation, overlay management, scroll handling
+- Key files: `src/facade/core.js` (public API), `src/core/core.js` (internal core)
+- Note: Has its own test runner (`npm run test:walkontable`). Do not mix with main E2E tests.
+
+**`handsontable/src/dataMap/metaManager/`:**
+- Purpose: Cascading configuration through prototype chain
+- Contains: Four meta layers, meta schema with all default settings, modifier mods
+
+**`handsontable/types/`:**
+- Purpose: Hand-authored TypeScript definitions for the public API
+- Contains: `.d.ts` files only. Do NOT create `.ts` files in the core package.
+
+## Key File Locations
+
+**Entry Points:**
+- `handsontable/src/index.js`: Full entry - registers all modules, used for UMD builds
+- `handsontable/src/base.js`: Tree-shakeable entry - minimal registration, users add modules
+- `handsontable/src/core.js`: Core constructor function (~5656 lines)
+- `handsontable/src/registry.js`: Aggregated `registerAllModules()` function
+
+**Configuration:**
+- `hot.config.js`: Build environment variables (HOT_VERSION, HOT_BUILD_DATE, etc.)
+- `handsontable/webpack.config.js`: Main webpack config
+- `handsontable/.config/`: Additional webpack configs (base, languages, etc.)
+- `handsontable/babel.config.js`: Babel config
+- `handsontable/jest.config.js`: Jest config for unit tests
+- `.eslintrc.js`: Root ESLint config
+- `handsontable/.eslintrc.js`: Package-level ESLint config
+- `browser-targets.js`: Supported browser list
+- `.nvmrc`: Node.js version (22)
+
+**Core Logic:**
+- `handsontable/src/core.js`: All public API methods
+- `handsontable/src/tableView.js`: Core-to-Walkontable bridge
+- `handsontable/src/editorManager.js`: Editor lifecycle
+- `handsontable/src/eventManager.js`: DOM event management
+- `handsontable/src/dataMap/metaManager/metaSchema.js`: All default settings and their documentation
+
+**Testing:**
+- `handsontable/test/e2e/`: E2E test specs (Jasmine/Puppeteer)
+- `handsontable/test/helpers/`: Test helper functions (globally available in specs)
+- `handsontable/test/bootstrap.js`: Test environment bootstrap
+- `handsontable/test/types/`: TypeScript type tests
+- `handsontable/src/**/__tests__/`: Co-located unit tests (Jest) and some E2E specs
+- `visual-tests/`: Playwright visual regression tests
+- `handsontable/src/3rdparty/walkontable/test/`: Walkontable-specific tests
+
+## Naming Conventions
+
+**Files:**
+- Source files: `camelCase.js` (e.g., `dataMap.js`, `indexMapper.js`, `baseEditor/`)
+- Test files: `*.unit.js` (Jest unit), `*.spec.js` (Jasmine E2E)
+- Type files: `*.d.ts` in `handsontable/types/`, `*.types.ts` for type tests
+- Plugin directories: `camelCase` matching the plugin key (e.g., `hiddenColumns/`, `contextMenu/`)
+
+**Directories:**
+- Plugin directories: `camelCase` (e.g., `autoColumnSize/`, `manualRowMove/`)
+- Feature modules: `camelCase` (e.g., `dataMap/`, `focusManager/`, `shortcutContexts/`)
+- Walkontable subdirectories: `camelCase` (e.g., `calculator/`, `renderer/`, `overlay/`)
+
+**Exports:**
+- Plugin barrel files export: `{ PLUGIN_KEY, PLUGIN_PRIORITY, PluginClassName }`
+- Registry modules export: `register*`, `get*`, `getRegistered*Names`
+- Editor/renderer/validator directories: `camelCase` directory name, `PascalCase` class name
+
+## Where to Add New Code
+
+**New Plugin:**
+- Create directory: `handsontable/src/plugins/myPlugin/`
+- Implementation: `handsontable/src/plugins/myPlugin/myPlugin.js`
+- Barrel export: `handsontable/src/plugins/myPlugin/index.js` (export `PLUGIN_KEY`, `PLUGIN_PRIORITY`, class)
+- Register in: `handsontable/src/plugins/index.js` (add to `registerAllPlugins()`)
+- E2E tests: `handsontable/src/plugins/myPlugin/__tests__/myPlugin.spec.js`
+- Unit tests: `handsontable/src/plugins/myPlugin/__tests__/myPlugin.unit.js`
+- Types: `handsontable/types/plugins/myPlugin/myPlugin.d.ts`
+
+**New Editor:**
+- Create directory: `handsontable/src/editors/myEditor/`
+- Register in: `handsontable/src/editors/index.js`
+- Types: `handsontable/types/editors/myEditor.d.ts`
+
+**New Renderer:**
+- Create directory: `handsontable/src/renderers/myRenderer/`
+- Register in: `handsontable/src/renderers/index.js`
+
+**New Cell Type:**
+- Create directory: `handsontable/src/cellTypes/myType/`
+- Register in: `handsontable/src/cellTypes/index.js`
+
+**New Helper/Utility:**
+- Shared helpers: `handsontable/src/helpers/myHelper.js`
+- Utility classes: `handsontable/src/utils/myUtil.js`
+- DOM helpers: `handsontable/src/helpers/dom/myDomHelper.js`
+
+**New Walkontable Feature:**
+- Implementation: `handsontable/src/3rdparty/walkontable/src/`
+- Tests: `handsontable/src/3rdparty/walkontable/test/`
+- Note: Walkontable has its own test runner, separate from main E2E
+
+**New Framework Wrapper Feature:**
+- React: `wrappers/react-wrapper/src/`
+- Angular: `wrappers/angular-wrapper/projects/hot-table/src/lib/`
+- Vue 3: `wrappers/vue3/src/`
+
+## Special Directories
+
+**`handsontable/dist/`:**
+- Purpose: UMD and minified bundle output
+- Generated: Yes (via build)
+- Committed: Yes (published to npm)
+
+**`handsontable/tmp/`:**
+- Purpose: ES and CJS module output consumed by wrapper packages via workspace linking
+- Generated: Yes (via build)
+- Committed: No
+
+**`handsontable/styles/`:**
+- Purpose: Compiled CSS output (themes, base styles)
+- Generated: Yes (via build from `src/styles/`)
+- Committed: Yes (published to npm)
+
+**`handsontable/types/`:**
+- Purpose: Hand-authored TypeScript `.d.ts` definitions
+- Generated: No (manually maintained)
+- Committed: Yes
+
+**`handsontable/languages/`:**
+- Purpose: Compiled language dictionary files
+- Generated: Yes (via build)
+- Committed: Yes
+
+**`node_modules/`:**
+- Purpose: Dependencies
+- Generated: Yes (via `pnpm install`)
+- Committed: No

--- a/.ai/TESTING.md
+++ b/.ai/TESTING.md
@@ -1,0 +1,527 @@
+# Testing Patterns
+
+## Test Framework
+
+**Runner:**
+- Jest for unit tests (configured in `handsontable/jest.config.js`)
+- Jasmine with Puppeteer for E2E tests (browser-based, headless Chrome via `test/scripts/run-puppeteer.mjs`)
+- Separate test runner for Walkontable (`npm run test:walkontable`)
+- Test runner: `jest-jasmine2` (not the default Jest runner)
+
+**Assertion Library:**
+- Jest's built-in `expect()` for unit tests
+- Jasmine's `expect()` for E2E tests
+- Custom matchers from `test/helpers/custom-matchers.js` (shared between unit and E2E)
+
+**Run Commands:**
+```bash
+# From handsontable/ directory:
+npm run test:unit                  # Run all Jest unit tests (~216 files)
+npm run test:e2e                   # Build + run Jasmine E2E tests (~946 spec files)
+npm run test:walkontable           # Run Walkontable-specific tests
+npm run test:e2e.watch             # Watch mode for E2E tests
+npm run test:types                 # TypeScript type checking only
+npm run test                       # Full pipeline: lint + unit + types + walkontable + e2e + production
+
+# From monorepo root (pnpm):
+pnpm --filter handsontable run test:unit
+pnpm --filter handsontable run test:e2e
+
+# Run specific unit test pattern:
+npm run test:unit -- --testPathPattern=cellMeta
+
+# Coverage:
+npm run test:unit -- --coverage
+```
+
+**Test Environment:**
+- Unit tests: jsdom (JavaScript DOM implementation)
+- E2E tests: Puppeteer with real headless Chrome
+- Default Jasmine timeout: 15000ms (set in `test/bootstrap.js`)
+
+## Test File Organization
+
+**Location:**
+- **Unit tests**: Co-located with source in `src/**/__tests__/` directories
+- **E2E core tests**: `handsontable/test/e2e/` (top-level core tests)
+- **E2E core API tests**: `handsontable/test/e2e/core/` (per-method tests like `selectCell.spec.js`)
+- **E2E settings tests**: `handsontable/test/e2e/settings/` (per-setting tests like `colWidths.spec.js`)
+- **Plugin E2E tests**: `src/plugins/{pluginName}/__tests__/` (alongside plugin source)
+
+**Naming:**
+- Unit tests: `{feature}.unit.js` (e.g., `cellMeta.unit.js`, `dataFilter.unit.js`)
+- E2E tests: `{Feature}.spec.js` or `Core_{feature}.spec.js` (e.g., `Core_dataSchema.spec.js`, `filters.spec.js`)
+- Type tests: `*.types.ts` in `test/types/`
+
+**Structure Examples:**
+```
+src/dataMap/metaManager/metaLayers/
+├── cellMeta.js
+├── columnMeta.js
+├── globalMeta.js
+├── tableMeta.js
+└── __tests__/
+    ├── cellMeta.unit.js
+    ├── columnMeta.unit.js
+    ├── globalMeta.unit.js
+    └── tableMeta.unit.js
+```
+
+```
+src/plugins/filters/
+├── filters.js
+├── index.js
+├── conditionCollection.js
+└── __tests__/
+    ├── filters.spec.js
+    ├── filtersUI.spec.js
+    ├── conditionCollection.unit.js
+    ├── dataFilter.unit.js
+    ├── filters.types.ts
+    ├── helpers/
+    │   ├── fixtures.js          # Test data factories
+    │   └── utils.js             # Plugin-specific helpers (auto-loaded)
+    ├── hooks/
+    ├── methods/
+    ├── component/
+    └── a11y/
+```
+
+```
+test/e2e/
+├── Core_dataSchema.spec.js      # Core feature tests
+├── Core_render.spec.js
+├── core/                         # Per-method API tests
+│   ├── selectCell.spec.js
+│   ├── getData.spec.js
+│   └── alter/
+├── settings/                     # Per-setting tests
+│   ├── colWidths.spec.js
+│   ├── fixedColumnsStart.spec.js
+│   └── validator.spec.js
+├── hooks/                        # Hook-specific tests
+└── i18n/                         # Internationalization tests
+```
+
+## Test Structure
+
+**E2E Suite Organization (Jasmine) -- Standard Boilerplate:**
+```javascript
+describe('MyPlugin', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should do something', async() => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      myPlugin: true,
+    });
+
+    await selectCell(0, 0);
+
+    expect(getDataAtCell(0, 0)).toBe('A1');
+  });
+});
+```
+
+**Critical patterns:**
+- `beforeEach` uses `function()` (not arrow) to access `this` for `$container`
+- `afterEach` always calls `destroy()` then `this.$container.remove()`
+- `it()` callbacks must be `async` in `*.spec.js` (ESLint enforced)
+- All HOT API calls must be `await`-ed (ESLint enforced)
+- No imports needed for test helpers -- they are global
+
+**Unit Test Structure (Jest):**
+```javascript
+import GlobalMeta from '../globalMeta';
+import ColumnMeta from '../columnMeta';
+import CellMeta from '../cellMeta';
+import { registerAllCellTypes } from '../../../../cellTypes';
+
+registerAllCellTypes();
+
+describe('CellMeta', () => {
+  it('should reflect changes when global meta properties changed', () => {
+    const globalMeta = new GlobalMeta();
+    const columnMeta = new ColumnMeta(globalMeta);
+    const meta = new CellMeta(columnMeta);
+
+    globalMeta.getMeta().copyable = false;
+
+    expect(meta.getMeta(2, 0)).toHaveProperty('copyable', false);
+  });
+});
+```
+
+**Key differences between unit and E2E tests:**
+- Unit tests use explicit imports; E2E tests use global helpers
+- Unit tests are synchronous; E2E tests must be async
+- Unit tests test classes/functions in isolation; E2E tests create full HOT instances
+
+## Async Testing
+
+**E2E Tests Must Be `async`:**
+Enforced by ESLint rule `handsontable/require-async-in-it` in `*.spec.js`:
+
+```javascript
+// CORRECT
+it('should do something', async() => {
+  handsontable(config);
+  await render();
+  await selectCell(0, 0);
+  expect(getDataAtCell(0, 0)).toBe('A1');
+});
+
+// INCORRECT -- ESLint error
+it('should do something', () => {
+  handsontable(config);
+  render(); // Must be await-ed
+});
+```
+
+**HOT Methods Requiring `await` (from `handsontable/.eslintrc.js`):**
+
+Core API: `alter`, `clear`, `deselectCell`, `emptySelectedCells`, `listen`, `loadData`, `populateFromArray`, `refreshDimensions`, `render`, `scrollToFocusedCell`, `scrollViewportTo`, `unlisten`
+
+Selection: `selectAll`, `selectCell`, `selectColumns`, `selectRows`
+
+Data mutation: `setDataAtCell`, `setDataAtRowProp`, `spliceCellsMeta`, `spliceCol`, `spliceRow`
+
+Settings: `updateData`, `updateSettings`, `useTheme`
+
+Validation: `validateCell`, `validateCells`, `validateColumns`, `validateRows`
+
+Rendering control: `suspendExecution`, `suspendRender`
+
+Scroll helpers: `scrollViewportVertically`, `scrollViewportHorizontally`, `scrollWindowTo`, `scrollWindowBy`
+
+Context menu: `contextMenu`, `selectContextMenuOption`, `openContextSubmenuOption`, `selectContextSubmenuOption`
+
+Dropdown menu: `dropdownMenu`, `selectDropdownMenuOption`, `openDropdownSubmenuOption`, `openDropdownByConditionMenu`, `selectDropdownByConditionMenuOption`
+
+Column/row operations: `resizeColumn`, `resizeRow`, `moveSecondDisplayedRowBeforeFirstRow`, `moveFirstDisplayedRowAfterSecondRow`, `swapDisplayedColumns`
+
+Mouse events: `simulateTouch`, `triggerTouchEvent`, `mouseDown`, `mouseOver`, `mouseUp`, `mouseClick`, `contextMenuEvent`, `simulateClick`, `mouseDoubleClick`, `mouseRightDown`, `mouseRightUp`
+
+Keyboard events: `keyDownUp`, `keyDown`, `keyUp`
+
+**Scroll-Awaiting Pattern (`test/helpers/utils.js`):**
+Many helpers (e.g., `selectCell`, `scrollViewportTo`, `selectAll`) are wrapped with `waitOnScroll()`, which returns a Promise that resolves after any triggered scroll completes. This is why they must be `await`-ed.
+
+**Delay Pattern:**
+```javascript
+await sleep(100); // Wait for async validation or animation
+await sleep(200); // Wait for dropdown menus to render
+```
+
+**Unit tests are synchronous:** `handsontable/require-async-in-it` and `handsontable/require-await` are both off for `*.unit.js`.
+
+## Mocking
+
+**Framework:** Mocks provided via Jest config and test bootstrap
+
+**Available Mocks** in `test/__mocks__/`:
+- `resizeObserverMock.js` -- `ResizeObserverMock` class with no-op `observe()`, `unobserve()`, `disconnect()`
+- `intersectionObserverMock.js` -- `IntersectionObserverMock` class
+- `styleMock.js` -- Returns empty object `{}` for CSS/SCSS imports (Jest `moduleNameMapper`)
+- `cssPolyfill.js` -- CSS polyfill mock
+
+**Mock Setup in `test/bootstrap.js`:**
+```javascript
+import { ResizeObserverMock } from './__mocks__/resizeObserverMock';
+import { IntersectionObserverMock } from './__mocks__/intersectionObserverMock';
+
+beforeAll(() => {
+  window.IntersectionObserver = window.IntersectionObserver ?? IntersectionObserverMock;
+  window.ResizeObserver = window.ResizeObserver ?? ResizeObserverMock;
+});
+```
+
+**Spy Pattern for Hooks:**
+```javascript
+const onAfterValidate = jasmine.createSpy('onAfterValidate');
+
+handsontable({
+  data: arrayOfObjects(),
+  columns: [{ data: 'id', validator(value, cb) { cb(true); } }],
+  afterValidate: onAfterValidate
+});
+
+await setDataAtCell(2, 0, 123);
+await sleep(100);
+
+expect(onAfterValidate).toHaveBeenCalledWith(true, 123, 2, 'id');
+```
+
+**What to Mock:**
+- Browser APIs not in jsdom (ResizeObserver, IntersectionObserver)
+- CSS imports (handled by styleMock.js)
+- Callbacks and hooks (use Jasmine spies)
+
+**What NOT to Mock:**
+- Core Handsontable code and logic
+- Plugin implementations
+- Selection and rendering engine
+- Data mutation and state management
+
+## Fixtures and Factories
+
+**Test Data Creation:**
+```javascript
+// Generate spreadsheet data with cell coordinates as values
+const data = createSpreadsheetData(5, 5);
+// Returns: [['A1', 'B1', 'C1', ...], ['A2', 'B2', 'C2', ...], ...]
+
+handsontable({
+  data: createSpreadsheetData(10, 10),
+  colHeaders: true
+});
+```
+
+**Plugin-Specific Test Data:**
+Plugins define their own fixtures in `src/plugins/{name}/__tests__/helpers/fixtures.js`:
+```javascript
+// Example: src/plugins/filters/__tests__/helpers/fixtures.js
+export function getDataForFilters() { /* ... */ }
+export function getColumnsForFilters() { /* ... */ }
+```
+
+**Auto-Loading of Plugin Helpers:**
+`test/helpers/index.js` uses `require.context` to auto-discover and export all files in `src/plugins/**/helpers/*.js` to the global scope:
+```javascript
+[
+  require.context('./../../src/plugins', true, /^\.\/.*\/helpers\/.*\.js$/),
+].forEach((req) => {
+  req.keys().forEach((key) => {
+    exportToWindow(req(key));
+  });
+});
+```
+
+**Location Summary:**
+- `test/helpers/common.js` -- Core test helpers (HOT API wrappers, data factories)
+- `test/helpers/mouseEvents.js` -- Mouse event simulation
+- `test/helpers/keyboardEvents.js` -- Keyboard event simulation
+- `test/helpers/asciiTable.js` -- ASCII table generation for selection assertions
+- `test/helpers/custom-matchers.js` -- Custom Jasmine/Jest matchers
+- `test/helpers/utils.js` -- `waitOnScroll()` decorator and utilities
+- `test/helpers/focusNavigator.js` -- Focus navigation helpers
+- `test/helpers/htmlNormalize.js` -- HTML normalization for assertions
+- `test/helpers/it-themes-extension.js` -- Theme-specific test extensions
+- `src/plugins/{name}/__tests__/helpers/` -- Plugin-specific test data and utilities
+
+## Custom Matchers
+
+**From `test/helpers/custom-matchers.js`:**
+
+- `toBeInArray(expected)` -- Check if value is in an array
+- `toBeFunction()` -- Check if value is a function
+- `toEqualCellRange(pattern)` -- Compact cell range comparison:
+  ```javascript
+  expect(hot.getSelectedRangeLast()).toEqualCellRange('highlight: 3,2 from: 3,2 to: 5,5');
+  expect(hot.getSelectedRange()).toEqualCellRange([
+    'highlight: 2,3 from: 1,2 to: 4,4',
+    'highlight: 3,2 from: 3,2 to: 5,5',
+  ]);
+  ```
+- `toBeVisible()` -- Check CSS visibility/display of element
+- `toBeAroundValue(expected, diff)` -- Fuzzy numeric comparison within margin
+- `toBeVisibleAsSelection()` -- ASCII table-based selection visualization assertion
+
+**ASCII Table Selection Testing** (from `test/helpers/asciiTable.js`):
+Tests selection patterns by rendering an ASCII representation of the table's selection state using symbols like `#` (current), `0` (area), `r` (row), `c` (column).
+
+## Coverage
+
+**Requirements:** No enforced minimum coverage target
+
+**View Coverage:**
+```bash
+npm run test:unit -- --coverage    # Show coverage after Jest run
+```
+
+**Coverage Output:**
+- Formats: json, lcov, clover
+- Location: `handsontable/coverage/`
+- Covers only `src/` directory
+
+**Coverage Goals:**
+- Aim for 100% coverage of new or modified code
+- Test all possible states including edge cases
+
+## Test Types
+
+**Unit Tests (`*.unit.js`):**
+- Framework: Jest with jsdom (`jest-jasmine2` runner)
+- Location: `src/**/__tests__/`
+- Scope: Individual functions and classes in isolation
+- Synchronous (no async/await required)
+- Explicit imports needed
+- ~216 test files
+
+**E2E Tests (`*.spec.js`):**
+- Framework: Jasmine with Puppeteer (headless Chrome)
+- Location: `test/e2e/` and `src/plugins/{name}/__tests__/`
+- Scope: Full HOT instances with real DOM rendering
+- Must be async with await on HOT API calls
+- Global helpers available (no imports needed)
+- ~946 spec files
+
+**Type Tests (`*.types.ts`):**
+- Tool: tsc (TypeScript compiler only)
+- Location: `test/types/`
+- Purpose: Verify TypeScript type definitions in `handsontable/types/`
+
+**Walkontable Tests:**
+- Separate test pipeline (`npm run test:walkontable`)
+- Location: `src/3rdparty/walkontable/test/`
+- Has its own spec runner (`SpecRunner.html`)
+- Do not mix with main E2E tests
+
+**Visual Regression Tests:**
+- Framework: Playwright
+- Location: `visual-tests/`
+- Config: `visual-tests/playwright.config.ts` and `playwright-cross-browser.config.ts`
+- Screenshots stored in `visual-tests/screenshots/`
+
+## Plugin Testing Requirements
+
+**Test against all lifecycle states:**
+```javascript
+// 1. Enable via settings
+it('should enable plugin when option is true', async() => {
+  handsontable({ data: createSpreadsheetData(5, 5), myPlugin: true });
+  expect(getPlugin('myPlugin').isEnabled()).toBe(true);
+});
+
+// 2. Disable via updateSettings
+it('should disable plugin via updateSettings', async() => {
+  handsontable({ data: createSpreadsheetData(5, 5), myPlugin: true });
+  await updateSettings({ myPlugin: false });
+  expect(getPlugin('myPlugin').isEnabled()).toBe(false);
+});
+
+// 3. Enable/disable programmatically
+it('should re-enable after programmatic disable', async() => {
+  handsontable({ data: createSpreadsheetData(5, 5), myPlugin: true });
+  getPlugin('myPlugin').disablePlugin();
+  await render();
+  getPlugin('myPlugin').enablePlugin();
+  await render();
+  expect(getPlugin('myPlugin').isEnabled()).toBe(true);
+});
+```
+
+## Large Dataset Testing
+
+When fixing bugs or adding features handling data arrays, include tests with **50k+ rows** to catch stack overflow and performance issues:
+```javascript
+it('should handle 50k rows without stack overflow', () => {
+  const largeData = createSpreadsheetData(50000, 10);
+  largeData.forEach(row => processRow(row)); // forEach, not spread
+  expect(largeData.length).toBe(50000);
+});
+```
+
+## Selection Testing
+
+Test non-consecutive selections, header selections, and active layers:
+```javascript
+it('should maintain selections after render', async() => {
+  handsontable(config);
+  await selectCell(0, 0);
+  await keyDown('ctrl');
+  await selectCell(2, 2);
+  await keyUp('ctrl');
+  await render();
+  const selected = getSelected();
+  expect(selected.length).toBe(2);
+});
+```
+
+## Global Test Helpers Reference
+
+**HOT API Helpers** (from `test/helpers/common.js`, available globally):
+- Instance: `handsontable(options)`, `getInstance()`, `destroy()`, `spec()`
+- Rendering: `render()`, `refreshDimensions()`
+- Selection: `selectCell()`, `selectCells()`, `selectColumns()`, `selectRows()`, `selectAll()`, `deselectCell()`
+- Data read: `getData()`, `getDataAtCell()`, `getDataAtCol()`, `getDataAtRow()`, `getSourceData()`
+- Data write: `setDataAtCell()`, `setDataAtRowProp()`, `loadData()`, `updateData()`, `clear()`
+- Settings: `updateSettings()`, `getSettings()`, `useTheme()`
+- Cell info: `getCell()`, `getCellMeta()`, `getCellEditor()`, `getCellRenderer()`, `getCellValidator()`
+- Plugins: `getPlugin(name)`
+- Counts: `countRows()`, `countCols()`, `countRenderedRows()`, `countRenderedCols()`
+- Structure: `alter()`, `spliceCol()`, `spliceRow()`, `spliceCellsMeta()`
+- Validation: `validateCell()`, `validateCells()`, `validateColumns()`, `validateRows()`
+- Headers: `getColHeader()`, `getRowHeader()`, `countColHeaders()`, `countRowHeaders()`
+- Scrolling: `scrollViewportTo()`, `scrollToFocusedCell()`
+- Coordinates: `toPhysicalRow()`, `toPhysicalColumn()`, `toVisualRow()`, `toVisualColumn()`
+
+**Data Generation:**
+- `createSpreadsheetData(rows, cols)` -- Grid with coordinates as values ('A1', 'B2', etc.)
+
+**Async Utilities:**
+- `sleep(delay = 100)` -- Promise-based delay
+- `promisfy(fn)` -- Convert callback to Promise
+
+**DOM Event Helpers** (from `test/helpers/mouseEvents.js`):
+- `mouseDown(element, button, eventProps)`
+- `mouseUp(element, button, eventProps)`
+- `mouseOver(element, button, eventProps)`
+- `mouseClick(element, button, eventProps)`
+- `mouseMove(element, button, eventProps)`
+- `contextMenuEvent(element)`
+- `simulateClick(element, buttonKey, eventProps)` -- Full click sequence (mousedown + mouseup + click + focus)
+- `mouseDoubleClick(element, buttonKey, eventProps)`
+- `mouseRightDown(element)`, `mouseRightUp(element)`
+
+**Keyboard Event Helpers** (from `test/helpers/keyboardEvents.js`):
+- `keyDown(key)` -- Simulate keydown event
+- `keyUp(key)` -- Simulate keyup event
+- `keyDownUp(key)` -- Simulate full keydown+keyup sequence
+- Key names: `'enter'`, `'esc'`, `'tab'`, `'arrowdown'`, `'arrowup'`, `'arrowleft'`, `'arrowright'`, `'ctrl'`, `'shift'`, `'space'`, `'backspace'`, `'delete'`, etc.
+
+## Bootstrap and Setup
+
+**Test Bootstrap** (`handsontable/test/bootstrap.js`):
+- Sets Jasmine timeout to 15000ms
+- Polyfills `ResizeObserver` and `IntersectionObserver` if missing
+- Exports global test helpers via `exportToGlobal()`
+- Imports custom matchers
+
+**E2E Bootstrap** (`handsontable/test/helpers/index.js`):
+- Imports and runs `test/bootstrap.js`
+- Exports all helpers from `common.js`, `mouseEvents.js`, `keyboardEvents.js` to `window`
+- Auto-discovers and exports all plugin test helpers via `require.context`
+
+**E2E Common Bootstrap** (`handsontable/test/helpers/common.js`):
+- Provides `beforeEach`/`afterEach` for scroll reset and spec context management
+- Wraps `$.fn.handsontable` to auto-inject theme in E2E tests
+- Contains `handsontableMethodFactory()` that creates global wrappers for all HOT instance methods
+- Some methods (scroll-related) are wrapped with `waitOnScroll()` from `test/helpers/utils.js`
+
+**Jest Configuration** (`handsontable/jest.config.js`):
+```javascript
+{
+  testEnvironment: 'jsdom',
+  roots: ['<rootDir>/src'],
+  setupFilesAfterEnv: ['<rootDir>/test/bootstrap.js'],
+  testRegex: '\\.unit\\.js$',
+  testRunner: 'jest-jasmine2',
+  moduleNameMapper: {
+    '^handsontable(.*)$': '<rootDir>/src$1',
+    '^walkontable(.*)$': '<rootDir>/src/3rdparty/walkontable/src$1',
+    '\\.(css|scss)$': '<rootDir>/test/__mocks__/styleMock.js',
+  }
+}
+```

--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -1,6 +1,6 @@
 # Bugbot review context (Handsontable)
 
-Use this policy for PR reviews in this monorepo.
+All coding rules and conventions are in `/AGENTS.md`. Apply those rules to every review. This file adds **review-specific checks** only.
 
 ## Scope
 
@@ -9,13 +9,7 @@ Use this policy for PR reviews in this monorepo.
 
 ## Repository-level checks
 
-1. Changelog requirement:
-   - If package source code changes, require a new `/.changelogs/*.json` file.
-   - If the PR description contains `[skip changelog]`, skip this check.
-2. Breaking-change:
-   - If a PR introduces a breaking change, require the `Breaking change` label on that PR.
-   - If the change is breaking, require migration guide updates in `/docs/content/guides/upgrade-and-migration/**`.
-3. User-facing behavior docs requirement:
-   - For user-facing behavior or UX changes, require matching docs updates in `/docs/content/**`.
-4. Agent guidance maintenance:
-   - If a PR introduces new coding conventions, constraints, or gotchas for future agents, require an `AGENTS.md` update.
+- **Changelog**: If package source code changes, require a new `/.changelogs/*.json` file. Skip if the PR description contains `[skip changelog]`.
+- **Breaking change**: If a PR introduces a breaking change, require the `Breaking change` label on that PR and migration guide updates in `/docs/content/guides/upgrade-and-migration/**`.
+- **Docs**: For user-facing behavior or UX changes, require matching docs updates in `/docs/content/**`.
+- **Agent guidance**: If a PR introduces new conventions, constraints, or gotchas, require an `/AGENTS.md` update.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Handsontable is a JavaScript/TypeScript data grid monorepo (pnpm workspace). It contains the core library plus React, Angular, and Vue 3 wrappers. It operates entirely in the browser (frontend-only, no server-side logic) and cannot access the internet unless explicitly configured (air-gapped environment support). There is no built-in telemetry.
+Handsontable is a JavaScript data grid monorepo (pnpm workspace). It contains the core library plus React, Angular, and Vue 3 wrappers. It operates entirely in the browser (frontend-only, no server-side logic) and cannot access the internet unless explicitly configured (air-gapped environment support). There is no built-in telemetry.
 
 **The core package (`handsontable/`) is JavaScript, not TypeScript.** Type definitions are hand-authored `.d.ts` files in `handsontable/types/`. Do not create `.ts` files in the core package.
 
@@ -14,14 +14,17 @@ These are the most frequent mistakes. Read this section first.
 
 | Pitfall | What to do instead |
 |---|---|
-| `throw new Error('...')` | Use `throwWithCause('...', cause)` from `src/helpers/errors.js`. Enforced by ESLint rule `handsontable/no-native-error-throw`. |
-| Using `window`, `document`, `console` as globals | Use `this.hot.rootWindow`, `this.hot.rootDocument`, and helpers from `src/helpers/console.js`. Enforced by ESLint rule `no-restricted-globals`. |
-| Importing from barrel index files (`plugins/index`, `editors/index`, `renderers/index`, `validators/index`, `cellTypes/index`, `i18n/index`) | Import from the specific submodule path (e.g., `import { HiddenColumns } from '../plugins/hiddenColumns/hiddenColumns'`). Enforced by ESLint rule `handsontable/restricted-module-imports`. The only exception is `src/registry.js`. |
-| Writing `it('should ...', () => { ... })` in spec files | All `it()` callbacks in `*.spec.js` that call HOT rendering APIs **must** be `async` and the API calls must be `await`-ed. Enforced by ESLint rule `handsontable/require-async-in-it`. |
+| `throw new Error('...')` | Use `throwWithCause('...', cause)` from `src/helpers/errors.js`. Enforced by ESLint. |
+| Using `window`, `document`, `console` as globals | Use `this.hot.rootWindow`, `this.hot.rootDocument`, and helpers from `src/helpers/console.js`. Enforced by ESLint. |
+| Importing from barrel index files (`plugins/index`, `editors/index`, `renderers/index`, `validators/index`, `cellTypes/index`, `i18n/index`) | Import from the specific submodule path (e.g., `import { HiddenColumns } from '../plugins/hiddenColumns/hiddenColumns'`). Only exception: `src/registry.js`. |
+| Writing `it('should ...', () => { ... })` in spec files | All `it()` callbacks in `*.spec.js` that call HOT rendering APIs **must** be `async` and the API calls must be `await`-ed. |
 | `arr.push(...largeArray)` with large arrays | Causes stack overflow with 10k+ elements. Use `forEach` loop instead. |
 | Confusing physical, visual, and renderable coordinates | See [Three coordinate systems](#three-coordinate-systems). |
 | Creating `.ts` files in `handsontable/src/` | Core is JavaScript. TypeScript definitions live in `handsontable/types/` as `.d.ts` files. |
 | Forgetting `super.enablePlugin()` / `super.disablePlugin()` in plugins | See [Plugin lifecycle](#plugin-lifecycle). |
+| Hardcoding user-visible text in source code | Add language constants in `src/i18n/constants.js` and update all language files in `src/i18n/languages/`. |
+| Using `.bind(this)` for hook/event callbacks | Use arrow-function class fields (`#onAfterX = () => { ... }`) instead. |
+| Direct cross-plugin imports | Use hooks for inter-plugin communication or `hot.getPlugin('{Name}')` if API access is required. |
 
 ---
 
@@ -48,58 +51,45 @@ These are the most frequent mistakes. Read this section first.
 
 ## Build, lint, test
 
-**Monorepo-level commands** use `pnpm` from the workspace root:
+From the workspace root:
 
-- **Build core**: `pnpm --filter handsontable run build` (must be done before wrapper tests, since wrappers depend on the built `tmp/` output)
+- **Build core**: `pnpm --filter handsontable run build` (must be done before wrapper tests)
 - **Lint core**: `pnpm --filter handsontable run eslint` and `pnpm --filter handsontable run stylelint`
 - **Unit tests (core)**: `pnpm --filter handsontable run test:unit` (Jest, ~2200 tests)
 - **E2E tests (core)**: `pnpm --filter handsontable run test:e2e` (Puppeteer/Jasmine, headless Chrome)
 - **Walkontable tests**: `pnpm --filter handsontable run test:walkontable` (separate pipeline)
-- **React tests**: `pnpm --filter @handsontable/react-wrapper run test`
-- **Vue3 tests**: `pnpm --filter @handsontable/vue3 run test`
-- **Angular tests**: `pnpm --filter @handsontable/angular-wrapper run test` (uses `--openssl-legacy-provider` automatically)
+- **Wrapper tests**: `pnpm --filter @handsontable/react-wrapper run test`, `pnpm --filter @handsontable/vue3 run test`, `pnpm --filter @handsontable/angular-wrapper run test`
 
-**Inside individual packages** (e.g., `cd handsontable`), use `npm run ...` directly.
+Inside individual packages (e.g., `cd handsontable`), use `npm run ...` directly.
 
 ### Build outputs
-
-The library outputs ES Modules and UMD bundles (UMD as legacy support). Two build variants exist:
-
-- `handsontable.js` — base build, external dependencies not bundled
-- `handsontable.full.js` — includes HyperFormula bundled in
-
-Build scripts require environment variables injected via `env-cmd -f ../hot.config.js`.
 
 | Output | Path |
 |---|---|
 | UMD / minified bundles | `handsontable/dist/` |
-| ES and CJS modules (used by wrappers via workspace linking) | `handsontable/tmp/` |
+| ES and CJS modules (used by wrappers) | `handsontable/tmp/` |
 | Compiled CSS | `handsontable/styles/` |
 
-### CSS themes
-
-Three themes are available: `ht-theme-main`, `ht-theme-classic`, `ht-theme-horizon` (each with `-no-icons` variants). The theme CSS class is applied to the root container element.
+Two build variants: `handsontable.js` (base, external deps) and `handsontable.full.js` (includes HyperFormula).
 
 ---
 
 ## Breaking changes policy
 
-**Agents must try to avoid introducing breaking changes.** This is the single most important constraint. Existing customers depend on API stability. When a solution requires a Breaking Change, it must be stated in **bold**.
-
-### What counts as a breaking change
+**Agents must try to avoid introducing breaking changes.** This is the single most important constraint.
 
 | Change | Why it breaks | What to do instead |
 |---|---|---|
-| Renaming a CSS class produced by Handsontable | Breaks custom stylesheets | Keep the legacy class name in the DOM. Add tests verifying the old name still works. |
-| Renaming APIs (methods, configuration options, hooks) | Breaks customer integrations | Keep the legacy API working and translate it to the new API internally. Legacy APIs do not produce console warnings. |
-| Changing API signatures or behavior | Breaks customer integrations | Keep the deprecated API working until the next stable release. Deprecated APIs produce a console warning (fired only once). |
-| Removing hooks or configuration options | May go completely undetected by customers | Add the hook/option to the list of removed hooks so an error is shown when someone uses it in configuration. |
-| Changing a default setting value | 🚫 **Strictly forbidden** — this is considered a "really bad" breaking change. | Never change defaults. |
+| Renaming a CSS class | Breaks custom stylesheets | Keep the legacy class name in the DOM. Test old name still works. |
+| Renaming APIs (methods, options, hooks) | Breaks customer integrations | Keep the legacy API working. No console warnings for legacy APIs. |
+| Changing API signatures or behavior | Breaks customer integrations | Deprecated API works until next stable release. One-time console warning. |
+| Removing hooks or options | May go undetected by customers | Add to removed hooks list so an error is shown. |
+| Changing a default setting value | **Strictly forbidden** | Never change defaults. |
 
 ### Legacy vs deprecated
 
-- **Legacy**: Old API is kept working forever alongside the new API. No console warnings. Feature set of the legacy API may be frozen. Tests must verify the old name continues to work.
-- **Deprecated**: Old API works until the next stable release, then is removed. Produces a one-time console warning. Tests must verify the old name continues to work until removal.
+- **Legacy**: Old API kept working forever. No console warnings. Tests must verify old name works.
+- **Deprecated**: Old API works until next stable release, then removed. One-time console warning. Tests must verify old name works until removal.
 
 ### What is NOT considered breaking
 
@@ -109,190 +99,72 @@ Changes to JavaScript APIs that are **not listed in the public API reference** (
 
 ## Mandatory checklist for every change
 
-Every code change produced by an agent **must** satisfy all of the following:
-
-1. **Tests are required.** Every change must include both **unit tests** (Jest, `*.unit.js`) and **E2E tests** (Jasmine/Puppeteer, `*.spec.js`). No change is considered complete without test coverage for the new or modified behavior.
-2. **Documentation must be updated.** If a change affects the public API, configuration options, hooks, behavior, or user-facing experience, the corresponding documentation (guides, API reference via JSDoc/Typedoc, migration guide) **must** be updated as part of the same change.
-3. **Update AGENTS.md.** If a change introduces new conventions, patterns, constraints, file locations, or gotchas that future agents should know about, this `AGENTS.md` file **must** be updated to reflect them.
-4. **Use red–green TDD for every bug fix and minor feature.** First, reproduce the problem or expected behavior with a test and confirm it fails (red). Only after that, implement the code change and make the same test pass (green). Do not start a fix or behavior change before you have a failing test.
+1. **Tests are required.** Include both **unit tests** (`*.unit.js`) and **E2E tests** (`*.spec.js`).
+2. **Documentation must be updated.** If a change affects public API, hooks, behavior, or UX, update JSDoc/Typedoc comments and guides.
+3. **Update AGENTS.md.** If a change introduces new conventions, constraints, or gotchas.
+4. **Use red-green TDD.** Write a failing test first, then implement the fix.
 
 ---
 
 ## Code style and conventions
 
-### Formatting rules (enforced by ESLint)
+### Formatting (enforced by ESLint)
 
-- **Style base**: Modified [Airbnb JavaScript style](https://github.com/airbnb/javascript)
+- **Style base**: Modified Airbnb JavaScript style
 - **Indentation**: 2 spaces
 - **Quotes**: Single quotes only
 - **Max line length**: 120 characters (ignores comments and long `it()` test names)
-- **JSDoc**: `jsdoc/require-jsdoc` is set to `error` — all exported functions require JSDoc comments
+- **JSDoc**: `jsdoc/require-jsdoc` is set to `error` for all exported functions
 
-### Handsontable-specific ESLint rules
-
-These custom rules are enforced and will cause lint failures if violated:
+### Custom ESLint rules
 
 | Rule | What it enforces |
 |---|---|
-| `handsontable/no-native-error-throw` | Must use `throwWithCause()` from `src/helpers/errors.js`, not `throw new Error()` |
-| `handsontable/restricted-module-imports` | No imports from barrel index files (`plugins/index`, `editors/index`, `renderers/index`, `validators/index`, `cellTypes/index`, `i18n/index`) |
-| `handsontable/require-async-in-it` | All `it()` in `*.spec.js` calling HOT rendering APIs must be `async` |
+| `handsontable/no-native-error-throw` | Must use `throwWithCause()`, not `throw new Error()` |
+| `handsontable/restricted-module-imports` | No imports from barrel index files |
+| `handsontable/require-async-in-it` | All `it()` in `*.spec.js` must be `async` |
 | `handsontable/require-await` | Specific HOT API calls must be `await`-ed |
-| `no-restricted-globals` | `window`, `document`, `console`, `Handsontable` are banned as globals |
-| `compat/compat` | Browser API compatibility enforced against supported browser list |
+| `no-restricted-globals` | `window`, `document`, `console`, `Handsontable` are banned |
+| `compat/compat` | Browser API compatibility against `browser-targets.js` |
 
 ### General conventions
 
-- **Separate CSS and JS**: Do not mix CSS into JavaScript files.
-- **DRY**: Reuse existing helpers and mixins. Do not duplicate code. If a piece of code repeats, create a new helper. Write generic code that can be reused across modules and plugins.
-- **Method ordering**: Public methods first, then `@private` listeners.
+- **Separate CSS and JS**: Never mix CSS into JavaScript files.
+- **DRY**: Reuse existing helpers and mixins. Extract duplicated code into shared methods.
+- **Method ordering**: Public methods first, then private listeners.
 - **Destructors**: Remove all variables in destructors (after `hot.destroy()`).
-- **Browser compatibility**: Ensure chosen CSS and JS APIs are supported in all supported browsers (Chrome, Firefox, Safari — two latest major versions, Edge).
-- **Optional chaining (`?.`)**: Use only when a value is genuinely optional by design, not as a blanket safety net. If a value is guaranteed by the data contract (e.g., parallel arrays from the same iterator, or APIs like `getCellMeta()` that always return an object), access it directly without `?.`. Unnecessary optional chaining hides bugs and misleads contributors into assuming a value can be null when it cannot.
+- **Browser compatibility**: Ensure CSS and JS APIs are supported in all browsers listed in `browser-targets.js`.
+- **Bundle size**: Prefer grammar that produces smaller output in compressed bundles (e.g., `===` over verbose helpers, short-circuit evaluation over full `if` blocks).
+- **Silent `catch` blocks**: Must include a comment explaining why the error is swallowed.
+- **Optional chaining (`?.`)**: Use only when a value is genuinely optional by design, not as a blanket safety net. If a value is guaranteed by the data contract, access it directly without `?.`.
+
+### Private fields and methods
+
+- Use the `#` prefix for private class fields/methods instead of `@private` JSDoc tags.
+- Exception: when `#` is avoided for performance reasons, `@private` JSDoc tag is acceptable.
 
 ### Naming conventions
 
-- Always use `Handsontable` in text, never `HOT`. Exception: instances of the Handsontable class are usually called `hot`.
+- Always use `Handsontable` in text, never `HOT`. Exception: instances are usually called `hot`.
 - Use full names: `row` and `columns` (not `cols`).
+- **Public API names** (options, hooks, methods) must be generic and self-explanatory. Avoid internal jargon or abbreviations. Check for collisions with existing API names before approving.
 
 ### JSDoc / Typedoc
 
-Both public and private APIs must be documented with JSDoc/Typedoc comments. The public API reference is generated automatically from these comments. Allowed custom tags: `@plugin`, `@util`, `@experimental`, `@deprecated`, `@preserve`, `@core`, `@TODO`, `@category`.
+- All public and private APIs must have JSDoc comments.
+- New hooks and configuration options must include a `@since` tag.
+- Allowed custom tags: `@plugin`, `@util`, `@experimental`, `@deprecated`, `@preserve`, `@core`, `@TODO`, `@category`.
+- No HTML tags in descriptions -- use Markdown. Line breaks use empty lines, never `<br>`.
+- Links: `[[MY_LINK]]` syntax, not `{@link MY_LINK}`. End every sentence with a full stop.
 
-#### Typedoc formatting rules
+### TypeScript definitions (`handsontable/types/`)
 
-- Avoid HTML tags (`<strong>`, `<br>`, etc.) inside descriptions — use Markdown instead.
-- For line breaks use an **empty line**, never `<br>`.
-- Links must use `[[MY_LINK]]` syntax, not `{@link MY_LINK}`.
-- End every sentence with a full stop.
-- Comment blocks start with `/**` — do not leave a blank line below the opening.
-- Comment blocks end with `*/` — do not leave a blank line above the closing.
-- Do not hardcode parameter values in descriptions — use `@param` tags.
-- Group tags of the same type on consecutive lines.
-
-#### Typedoc template
-
-```
-/**
- * Brief description of the method.
- *
- * Additional notes if needed.
- *
- * @param {string} paramName - description of the parameter
- * @param {number} anotherParam - description
- *
- * @fires [[eventName]] when triggered
- *
- * @throws [[ErrorType]] when condition is met
- *
- * @returns description of the return value
- *
- * @category CategoryName
- */
-```
+- Avoid bare `object` in `.d.ts` files -- use or import specific types.
+- Do not duplicate type definitions across plugins. Import from their source.
 
 ---
 
-## Documentation rules
-
-### What counts as documentation
-
-Handsontable documentation includes: guides and code examples on the docs portal, the API reference (generated from JSDoc/Typedoc), code comments, changelog entries, release notes, migration guides, and README files across the monorepo.
-
-### When documentation is required
-
-- Any change to a public API (methods, options, hooks, plugins, typings, errors) **must** update the corresponding JSDoc/Typedoc comments and guides.
-- Any change to user-facing behavior or look-and-feel **must** be documented.
-- Any breaking change **must** include a migration guide step (see below).
-- New documentation pages should be included in the changelog (do not use `[skip changelog]` for new pages).
-
-### Documentation branch conventions
-
-- Documentation branches for features: `docs/issue-xxxx` (e.g., `docs/issue-9024`), branched from the feature branch or `develop`.
-- Documentation branches for releases: `release/x.y.z-docs`, branched from `release/x.y.z`.
-- Documentation-only PRs use `[skip changelog]` in the PR description, **unless** the PR adds a new documentation page.
-
-### Writing style rules
-
-All documentation text (guides, JSDoc comments, changelog entries, migration guides, PR descriptions) must follow these rules:
-
-1. **Short sentences.** Split longer sentences in two.
-2. **Active voice.** Never passive. ("Configure the parameters" not "The parameters should be configured.")
-3. **Simple verb syntax.** ("To ensure performance…" not "In order to ensure that the system will be capable of…")
-4. **American English spelling.** (`recognize`, `program`, `behavior`, not `recognise`, `programme`, `behaviour`.)
-5. **Commonized forms.** `frontend`, `backend`, `webhook`, `internet` (not `front-end`, `back end`, `web hook`, `Internet`).
-6. **Use "you" not "we".** ("In this example, you can see…" not "In this example, we can see…")
-7. **Oxford comma.** Use a comma before `and`/`or` in lists of 3+ items. ("berries, apples, and bacon.")
-8. **No evaluative adjectives.** Eliminate "easy", "simple", "obvious", "straightforward" from explanations.
-9. **Do not assume user background knowledge.** Bridge the gap between specialists and non-specialists.
-10. **Max 3 adjectives before a noun.**
-11. **Use en dashes (–) to separate clauses**, not hyphens.
-12. **Consistent 3rd-party naming.** Use official capitalization: `Node.js`, `webpack`, `GitLab`, `TypeScript`.
-13. **PR descriptions**: Use plain, concise language. Avoid literary wording — developers need to parse it quickly.
-
-### Migration guide requirements
-
-A migration guide is required for every major release and some minor releases. Each breaking change must have a separate migration guide step that includes:
-
-1. Who the breaking change affects.
-2. A brief reason for the change (what the user gains).
-3. A brief description of the change itself.
-4. What the user needs to do (step-by-step, with substeps if needed).
-5. Code examples (before/after).
-6. Links to more detailed information (new pages, PRs).
-
-The structure must follow previous migration guides for consistency.
-
-### Trademark rules
-
-- Any documentation page mentioning "Excel" must include the Microsoft/Excel trademark disclaimer.
-- If the page also mentions "Google Sheets", use the expanded disclaimer covering both trademarks.
-- Avoid third-party trademarks in documentation unless practically necessary (e.g., to describe compatibility or integration).
-
-### Documentation file locations
-
-| Content | Location |
-|---|---|
-| Guides and examples | `docs/content/` |
-| API reference source | JSDoc/Typedoc comments in source files |
-| Changelog | `CHANGELOG.md` (root) |
-| Changelog entry mechanism | `.changelogs/README.md` |
-| Changelog CLI | `bin/changelog` |
-| Docs editing guide | `docs/README-EDITING.md` |
-| Docs deployment guide | `docs/README-DEPLOYMENT.md` |
-| Broken link redirects | `docs/netlify/netlify/edge-functions/` |
-| Migration guides | `docs/content/guides/upgrade-and-migration/` |
-
----
-
-## Three coordinate systems
-
-This is fundamental to working with the codebase. Three distinct index spaces exist:
-
-| Coordinate type | Description | Example |
-|---|---|---|
-| **Physical** | Position in the source data array | Row 5 in the original dataset |
-| **Visual** | Position in the DataMap (after trimming) | Row 3 if rows 0-1 were trimmed |
-| **Renderable** | Position in the DOM (after hiding) | Row 2 if one visual row is hidden |
-
-Plugins must correctly translate between these systems using `IndexMapper` (`hot.rowIndexMapper` / `hot.columnIndexMapper`).
-
-### HidingMap vs TrimmingMap
-
-| Map type | Effect |
-|---|---|
-| `HidingMap` | Index stays in DataMap but is **not rendered** in the DOM |
-| `TrimmingMap` | Index is **removed from DataMap** entirely |
-
-Plugins register maps via:
-```js
-hot.rowIndexMapper.registerMap('pluginName', new TrimmingMap());
-hot.columnIndexMapper.registerMap('pluginName', new HidingMap());
-```
-
----
-
-## Plugin lifecycle
+## Plugin architecture
 
 All plugins extend `BasePlugin` from `src/plugins/base/base.js`.
 
@@ -300,58 +172,80 @@ All plugins extend `BasePlugin` from `src/plugins/base/base.js`.
 
 ```js
 class MyPlugin extends BasePlugin {
-  static get PLUGIN_KEY() { return 'myPlugin'; }          // Key in settings
-  static get PLUGIN_PRIORITY() { return 150; }             // Init order (lower = first)
-  static get SETTING_KEYS() { return ['myPlugin']; }       // Keys that trigger updatePlugin()
-  static get PLUGIN_DEPS() { return ['plugin:AutoRowSize']; } // Dependencies
+  static get PLUGIN_KEY() { return 'myPlugin'; }
+  static get PLUGIN_PRIORITY() { return 150; }
+  static get SETTING_KEYS() { return ['myPlugin']; }
+  static get PLUGIN_DEPS() { return ['plugin:AutoRowSize']; }
 }
 ```
 
 ### Method lifecycle (in order)
 
-1. `constructor(hotInstance)` — receives HOT instance as `this.hot`
-2. `isEnabled()` — return truthy/falsy based on `this.hot.getSettings()[PLUGIN_KEY]`
-3. `enablePlugin()` — set up hooks via `this.addHook()`, register IndexMapper maps. **Call `super.enablePlugin()` at the end.**
-4. `updatePlugin()` — typical pattern: `this.disablePlugin(); this.enablePlugin(); super.updatePlugin();`
-5. `disablePlugin()` — **Call `super.disablePlugin()` (clears EventManager and hooks).** Then clean up plugin-specific state.
-6. `destroy()` — final teardown. **Call `super.destroy()` at the end.**
+1. `constructor(hotInstance)` -- receives HOT instance as `this.hot`
+2. `isEnabled()` -- return truthy/falsy based on `this.hot.getSettings()[PLUGIN_KEY]`
+3. `enablePlugin()` -- set up hooks via `this.addHook()`, register IndexMapper maps. **Call `super.enablePlugin()` at the end.**
+4. `updatePlugin()` -- typical: `this.disablePlugin(); this.enablePlugin(); super.updatePlugin();`
+5. `disablePlugin()` -- **Call `super.disablePlugin()` (clears EventManager and hooks).** Then clean up.
+6. `destroy()` -- final teardown. **Call `super.destroy()` at the end.**
 
 ### Hook registration
 
-Plugins that introduce new hooks register them globally **at module level, outside the class**:
+Plugins that introduce new hooks register them at module level, outside the class:
 
 ```js
 import Hooks from '../../core/hooks';
-
 Hooks.getSingleton().register('beforeMyAction');
 Hooks.getSingleton().register('afterMyAction');
-
-export class MyPlugin extends BasePlugin {
-  // ...
-}
 ```
 
-### Important distinction
+**Important:** `this.addHook()` (BasePlugin method) auto-cleans hooks on `disablePlugin()`. `this.hot.addHook()` does not.
 
-`this.addHook()` in a plugin context (BasePlugin) is different from `this.hot.addHook()`. The plugin version auto-cleans hooks on `disablePlugin()`.
+### Plugin registration
 
-### File structure convention
+New plugins must be wired through `src/plugins/index.js` and exported from their own `index.js`:
 
-Each plugin directory exports from an `index.js`:
 ```js
 export { PLUGIN_KEY, PLUGIN_PRIORITY, MyPlugin } from './myPlugin';
 ```
+
+### Plugin decoupling rules
+
+- Plugins must **not** directly import or check for the presence of other plugins. Use hooks (event-driven communication) instead.
+- If access to another plugin's API is required, use `hot.getPlugin('{Name}')`.
+- No circular dependencies between plugins.
+- Do not re-implement another plugin's methods. Listen to hooks and react.
+
+### Conflict ownership
+
+When a plugin is incompatible with another, the plugin that introduces the conflict owns the disabling/blocking logic. Other plugins should not contain awareness checks.
+
+### Configuration rules
+
+- New options should be **disabled by default** in `src/dataMap/metaManager/metaSchema.js`.
+- New options should support the cascading configuration model (`cell` -> `column` -> `global`) when applicable. If table-level only, document this in JSDoc.
+
+---
+
+## Three coordinate systems
+
+| Coordinate type | Description | Example |
+|---|---|---|
+| **Physical** | Position in the source data array | Row 5 in the original dataset |
+| **Visual** | Position in the DataMap (after trimming) | Row 3 if rows 0-1 were trimmed |
+| **Renderable** | Position in the DOM (after hiding) | Row 2 if one visual row is hidden |
+
+Plugins must translate between these systems using `IndexMapper` (`hot.rowIndexMapper` / `hot.columnIndexMapper`).
+
+| Map type | Effect |
+|---|---|
+| `HidingMap` | Index stays in DataMap but is **not rendered** in the DOM |
+| `TrimmingMap` | Index is **removed from DataMap** entirely |
 
 ---
 
 ## Testing requirements
 
-Handsontable uses three test pipelines:
-- **Jest** for unit tests (`*.unit.js` files, `__tests__/` directories next to source files)
-- **Jasmine** (with Puppeteer, headless Chrome) for browser E2E tests (`*.spec.js` files, `handsontable/test/e2e/`)
-- **Walkontable** has its own separate test pipeline (`npm run test:walkontable`)
-
-### Test file naming
+Three test pipelines: **Jest** (unit), **Jasmine/Puppeteer** (E2E), **Walkontable** (separate).
 
 | Type | Pattern | Framework | Location |
 |---|---|---|---|
@@ -383,7 +277,6 @@ describe('MyPlugin', () => {
     });
 
     await selectCell(0, 0);
-
     expect(getDataAtCell(0, 0)).toBe('A1');
   });
 });
@@ -391,122 +284,99 @@ describe('MyPlugin', () => {
 
 ### Global test helpers
 
-`test/helpers/common.js` exposes all HOT API methods as global test functions — **no imports needed** in spec files:
+`test/helpers/common.js` exposes all HOT API methods as globals -- **no imports needed** in spec files: `handsontable()`, `createSpreadsheetData()`, `selectCell()`, `getCell()`, `getDataAtCell()`, `getData()`, `getPlugin()`, `render()`, `destroy()`, `updateSettings()`, `spec()`.
 
-- `handsontable(options)` — creates a HOT instance
-- `createSpreadsheetData(rows, cols)` — generates mock data (`'A1'`, `'B2'`, etc.)
-- `selectCell()`, `getCell()`, `getDataAtCell()`, `getData()`, `getPlugin()`, `render()`, `destroy()`, `updateSettings()`, etc.
-- `spec()` — returns the current test's HOT instance
-
-Additional helpers: `test/helpers/mouseEvents.js`, `test/helpers/keyboardEvents.js` (DOM event simulation), `test/helpers/asciiTable.js` (selection pattern assertions).
+Additional helpers: `mouseEvents.js`, `keyboardEvents.js`, `asciiTable.js`.
 
 ### What to test
 
-- Aim for 100% code coverage of new or modified code.
+- 100% coverage of new or modified code.
 - Test all possible states including edge cases.
-- Plugins, renderers, and editors must be tested against:
-  - `hot.updateSettings()`
-  - `hot.getPlugin('{PluginName}').enablePlugin(); hot.render();`
-  - `hot.getPlugin('{PluginName}').disablePlugin(); hot.render();`
-- Verify no regressions in related functionality.
-- Check that no exceptions are displayed in the console.
+- Plugins must be tested against: `updateSettings()`, programmatic `enablePlugin()`/`disablePlugin()`.
+- Add unit tests with **50k+ rows** when handling data arrays.
+- Test non-consecutive selections and header selections when modifying selection code.
 
-### Large dataset testing
+---
 
-When fixing bugs or adding features that handle data arrays, add unit tests with **50k+ rows** to catch stack overflow and performance issues.
+## Documentation rules
 
-### Selection testing
+### When documentation is required
 
-Test non-consecutive selections (Ctrl/Cmd+click), row/column header selections, and active selection layers when modifying selection-related code.
+- Any change to public API, options, hooks, or user-facing behavior **must** update JSDoc/Typedoc comments and guides.
+- Any breaking change **must** include a migration guide step.
+- New documentation pages should be included in the changelog.
 
-### Visual regression tests
+### Writing style
 
-Playwright visual regression tests are in `visual-tests/`.
+1. Short sentences. Active voice. American English spelling.
+2. Use "you" not "we". Oxford comma.
+3. No evaluative adjectives ("easy", "simple", "obvious").
+4. Use en dashes (-) to separate clauses, not hyphens.
+5. Consistent naming: `Node.js`, `webpack`, `TypeScript`.
+
+### Trademark rules
+
+- Pages mentioning "Excel" must include the Microsoft/Excel trademark disclaimer.
+- Pages also mentioning "Google Sheets" use the expanded disclaimer.
 
 ---
 
 ## Architecture constraints
 
-- **Frontend-only**: No server-side logic. Everything runs in the browser. No network requests unless explicitly configured by the user.
-- **Microkernel plugin system**: All extensions hook into the core through the plugin API. Respect the plugin lifecycle (see [Plugin lifecycle](#plugin-lifecycle)).
-- **Cascading configuration**: All feature configuration must work with Handsontable's cascading configuration model (`cell` → `column` → `global`).
-- **Design system theming**: CSS variables are the public API for theme customization. The design system uses a token hierarchy declared in Figma and exported as CSS variables.
-- **Framework wrapper parity**: Official wrappers (React, Angular, Vue) must be idiomatic for each framework and maintain feature parity.
-- **XSS prevention**: Strict input sanitization on user-facing cell content, custom formulas, and cell scripts. Safe plugin architecture to minimize attack surfaces.
-- **Internationalization**: Must handle RTL layouts, Unicode input (IME), and translations.
-- **No global namespace pollution**: Integration via NPM/CDN must not pollute the global namespace.
-- **Minimal dependencies**: Avoid adding third-party libraries. If you must, discuss with the team first. All dependencies must have permissive open-source licenses (MIT, BSD, Apache, etc.) and be actively maintained. This applies transitively to sub-dependencies.
-- **Functional continuity**: Each release must include no less functionality than its predecessor.
+- **Frontend-only**: No server-side logic. No network requests unless user-configured.
+- **Microkernel plugin system**: All extensions hook into the core through the plugin API.
+- **Cascading configuration**: `cell` -> `column` -> `global`.
+- **Design system theming**: CSS variables are the public API for theme customization.
+- **Framework wrapper parity**: React, Angular, Vue wrappers must be idiomatic and maintain feature parity.
+- **XSS prevention**: Strict input sanitization on user-facing cell content.
+- **Internationalization**: RTL layouts, Unicode input (IME), translations. All user-facing strings go through `src/i18n/`.
+- **No global namespace pollution**.
+- **Minimal dependencies**: Discuss with the team before adding any third-party dependency. Must have permissive licenses (MIT, BSD, Apache). Applies transitively.
 
 ---
 
 ## Performance rules
 
-- **Avoid spread operator with large arrays**: When working with potentially large arrays (10k+ elements), never use `arr.push(...largeArray)`. This causes stack overflow. Use `forEach` loops instead.
-- **Batch scroll events**: Use `requestAnimationFrame` to batch scroll event updates and prevent excessive redraws. Target smooth 60fps with 100k+ row datasets.
-- **Use `batch()` / `batchRender()` / `suspendRender()` / `resumeRender()`** when performing multiple operations that trigger rendering to avoid unnecessary redraws.
-- **Performance must not degrade**: Measured in library size, rendering performance, and memory consumption. Performance should gradually improve over time.
+- **No spread with large arrays**: Never `arr.push(...largeArray)` with 10k+ elements. Use `forEach`.
+- **Batch rendering**: Use `batch()` / `batchRender()` / `suspendRender()` / `resumeRender()` for multiple operations.
+- **Batch scroll events**: Use `requestAnimationFrame`.
+- **No degradation**: Library size, rendering performance, and memory consumption must not degrade.
 
 ---
 
 ## Git and branching
 
-### Branch naming
-
-- Feature branches: `feature/issue-xxxx` (e.g., `feature/issue-9024`)
-- Documentation branches: `docs/issue-xxxx` (e.g., `docs/issue-9024`)
+- Feature branches: `feature/issue-xxxx`
+- Documentation branches: `docs/issue-xxxx`
 - Release branches: `release/x.y.z`
-- LTS branches: `lts/[major].x`
-
-### Git rules
-
-- **Never force-push** to `master`, `develop`, or feature branches bound to Pull Requests. Force-pushing diverges history in other people's clones and makes PR review history incomprehensible.
-- Follow the **Git flow** branching strategy.
-
-### Versioning
-
-- Uses **SemVer**. Patch releases are for critical fixes only.
-- Even-numbered major releases (16, 18, 20, 22) become **LTS releases**.
-- Odd-numbered major releases (17, 19, 21) are **Current-only** (6-month lifecycle).
-- No more than 4 major releases per year (preferably 0). If multiple breaking changes are needed, bulk them into a single major release.
+- **Never force-push** to `master`, `develop`, or PR-bound branches.
+- **SemVer**: Even-numbered majors (16, 18, 20) become LTS.
 
 ---
 
 ## Pull requests and changelog
 
-### PR requirements
-
 - Every PR must be connected to a GitHub issue.
-- Every PR that changes package source code must include a changelog entry.
-- To create a changelog entry, run: `bin/changelog entry` (interactive CLI).
-- To skip changelog (for non-source-code changes only), write `[skip changelog]` in the PR description.
-- PRs are merged using **"Squash and merge"** in the GitHub UI by the PR author after full approval.
-- The PR author is responsible for addressing reviewer comments. The reviewer confirms resolution by clicking **Resolve conversation**.
-
-### Changelog format
-
-Follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format. See `.changelogs/README.md` for full details.
-
-### Visibility of work
-
-- If a task spans multiple days, create a draft PR and commit daily.
-- All work must be tracked as a GitHub issue. If no issue exists, create one.
+- Every PR that changes source code must include a changelog entry (`bin/changelog entry`).
+- Use `[skip changelog]` only for non-source-code changes.
+- PRs are merged using **"Squash and merge"**.
 
 ---
 
-## API design guidelines
+## Accessibility (a11y)
 
-- Make all necessary methods available in the public API.
-- APIs must be discoverable, documented in guides, and usable in real-world applications.
-- All configuration options must fit into the cascading configuration model.
-- TypeScript typings in `handsontable/types/` must be maintained and accurate.
-- The public API must provide good code completion in IDEs and AI coding assistants.
+- Preserve WCAG 2.1 AA conformance.
+- Do not regress keyboard navigation. Both modes must work:
+  - Spreadsheet mode: `navigableHeaders: false`, `tabNavigation: true`.
+  - Data grid mode: `navigableHeaders: true`, `tabNavigation: false`.
+- Verify ARIA semantics after changes to rendering, selection, headers, frozen areas, or merged cells.
+- New UI elements must use semantic HTML with sufficient color contrast.
 
 ---
 
 ## React wrapper specifics
 
-- When calling `updateSettings()` in the React wrapper, **preserve and restore selection state** using `selection.exportSelection()` and `selection.importSelection()` to maintain non-consecutive selections, active layers, and focus positions across React re-renders.
+When calling `updateSettings()` in the React wrapper, **preserve and restore selection state** using `selection.exportSelection()` and `selection.importSelection()`.
 
 ---
 
@@ -514,45 +384,10 @@ Follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format. See `.c
 
 - Always respect defined column widths as **minimum values**.
 - If a column would shrink below its base width, disable stretching entirely.
-- Different stretching strategies (`'all'`, `'last'`) must behave consistently regarding minimum width handling.
-
----
-
-## Dependency management
-
-- **Discuss with the team before adding any third-party dependency.**
-- All dependencies must have permissive open-source licenses (MIT, BSD, Apache, etc.).
-- All dependencies must be actively maintained.
-- These rules apply transitively to all sub-dependencies.
-- Adding dependencies under non-permissive licenses requires notifying clients through the Sales team.
-
----
-
-## Security
-
-- Strict XSS prevention in user-facing cell content.
-- Input sanitization on custom formulas and cell scripts.
-- Safe plugin architecture to minimize attack surfaces.
-- CLA must be signed before merging external contributions.
-
----
-
-## Accessibility (a11y) policy
-
-- Preserve conformance with WCAG 2.1 AA. This is the baseline for global accessibility standards used by our users.
-- Do not regress keyboard-only navigation. Keep both navigation modes working:
-  - Spreadsheet mode (default): `navigableHeaders: false`, `tabNavigation: true`.
-  - Data grid mode: `navigableHeaders: true`, `tabNavigation: false`.
-- Protect screen reader behavior (NVDA, JAWS, VoiceOver). When changing rendering, selection, headers, frozen areas, hidden rows/columns, or merged cells, verify ARIA semantics are still correct.
-- For accessibility-critical flows, prefer complete DOM rendering (`renderAllRows: true`, `renderAllColumns: true`) and document the performance tradeoff.
-- Custom plugins, renderers, and cell types must remain accessible: semantic HTML, sufficient color contrast, no flashing/blinking content, and extra ARIA attributes where required.
-- Accessibility-sensitive changes require tests. Add automated coverage and validate keyboard navigation paths.
 
 ---
 
 ## File locations reference
-
-### Core
 
 | Area | Path |
 |---|---|
@@ -560,102 +395,36 @@ Follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format. See `.c
 | Full entry point | `handsontable/src/index.js` |
 | Base (tree-shakeable) entry | `handsontable/src/base.js` |
 | Module registry | `handsontable/src/registry.js` |
-| TableView (Core ↔ Walkontable bridge) | `handsontable/src/tableView.js` |
-
-### Plugins
-
-| Area | Path |
-|---|---|
+| TableView (Core-Walkontable bridge) | `handsontable/src/tableView.js` |
 | Plugin base class | `handsontable/src/plugins/base/base.js` |
 | Plugin registry | `handsontable/src/plugins/registry.js` |
-| All plugins index | `handsontable/src/plugins/index.js` |
-| Column stretching strategies | `handsontable/src/plugins/stretchColumns/strategies/` |
-
-### Data and meta
-
-| Area | Path |
-|---|---|
-| Data mapping | `handsontable/src/dataMap/` |
-| Cell meta system | `handsontable/src/dataMap/metaManager/` |
-| Index translations (IndexMapper) | `handsontable/src/translations/` |
-
-### Selection
-
-| Area | Path |
-|---|---|
+| Meta schema (defaults) | `handsontable/src/dataMap/metaManager/metaSchema.js` |
+| Index translations | `handsontable/src/translations/` |
 | Selection logic | `handsontable/src/selection/` |
-| Highlight system | `handsontable/src/selection/highlight/` |
-| Selection transformations | `handsontable/src/selection/transformation/` |
-
-### Rendering (Walkontable)
-
-| Area | Path |
-|---|---|
 | Walkontable engine | `handsontable/src/3rdparty/walkontable/src/` |
-| Overlays | `handsontable/src/3rdparty/walkontable/src/overlay/` |
-| Viewport calculators | `handsontable/src/3rdparty/walkontable/src/calculator/` |
-| Scroll handling | `handsontable/src/3rdparty/walkontable/src/scroll.js` |
-| Walkontable tests | `handsontable/src/3rdparty/walkontable/test/` |
-
-### Hooks and helpers
-
-| Area | Path |
-|---|---|
 | Hooks system | `handsontable/src/core/hooks/` |
-| Error helpers (`throwWithCause`) | `handsontable/src/helpers/errors.js` |
+| Error helpers | `handsontable/src/helpers/errors.js` |
 | Console helpers | `handsontable/src/helpers/console.js` |
-| HTML parsing | `handsontable/src/utils/parseTable.js` |
-
-### Types and config
-
-| Area | Path |
-|---|---|
+| i18n constants | `handsontable/src/i18n/constants.js` |
+| i18n language files | `handsontable/src/i18n/languages/` |
 | TypeScript definitions | `handsontable/types/` |
-| Webpack configs | `handsontable/.config/` |
-| Babel config | `handsontable/babel.config.js` |
-| Build env variables | `hot.config.js` (root) |
-| ESLint config | `.eslintrc.js` (root) and `handsontable/.eslintrc.js` |
-
-### Tests
-
-| Area | Path |
-|---|---|
 | E2E tests | `handsontable/test/e2e/` |
 | Test helpers | `handsontable/test/helpers/` |
-| Test bootstrap | `handsontable/test/bootstrap.js` |
-| Type tests | `handsontable/test/types/` |
 | Visual regression tests | `visual-tests/` |
-
-### Wrappers
-
-| Area | Path |
-|---|---|
-| React wrapper core | `wrappers/react-wrapper/src/hotTableInner.tsx` |
-| Angular wrapper core | `wrappers/angular-wrapper/projects/hot-table/src/lib/` |
-| Vue 3 wrapper | `wrappers/vue3/` |
-
-### CI/CD, changelog, and docs
-
-| Area | Path |
-|---|---|
-| CI workflows | `.github/workflows/` |
 | Changelog entries | `.changelogs/` |
 | Changelog CLI | `bin/changelog` |
 | Guides and examples | `docs/content/` |
-| Docs editing guide | `docs/README-EDITING.md` |
-| Docs deployment guide | `docs/README-DEPLOYMENT.md` |
-| Broken link redirects | `docs/netlify/netlify/edge-functions/` |
 | Migration guides | `docs/content/guides/upgrade-and-migration/` |
+| Browser targets | `browser-targets.js` (root) |
+| ESLint config | `.eslintrc.js` (root) and `handsontable/.eslintrc.js` |
 
 ---
 
 ## Gotchas
 
-- The core build outputs to `handsontable/tmp/` (not `dist/` for wrappers' consumption). The UMD/minified builds go to `handsontable/dist/` and CSS to `handsontable/styles/`. Wrapper packages reference the `tmp/` build via workspace linking.
-- Two Handsontable builds exist: `handsontable.js` (base, external deps) and `handsontable.full.js` (includes HyperFormula). When testing, ensure both variants work.
-- The Angular wrapper tests use `NODE_OPTIONS=--openssl-legacy-provider`; this is already wired into the `test` script.
-- The `pnpm-workspace.yaml` has `ignoredBuiltDependencies` and `onlyBuiltDependencies` lists. If pnpm warns about ignored build scripts (e.g., `less`), this is expected.
-- Root-level `npm run lint` and `npm run test` scripts use a custom `translate-to-native-npm.mjs` script to fan out across all workspace packages.
-- The docs site (`docs/`) uses Node 20 (its own `.nvmrc`) and is not needed for core library development.
-- Walkontable (the rendering engine) lives inside `src/3rdparty/walkontable/` and has its **own test runner** — do not mix Walkontable tests with main E2E tests.
+- Wrappers consume `handsontable/tmp/` (not `dist/`). Build core before running wrapper tests.
+- Two builds: `handsontable.js` (base) and `handsontable.full.js` (includes HyperFormula). Test both.
+- Angular wrapper tests use `NODE_OPTIONS=--openssl-legacy-provider` (already in the `test` script).
+- The docs site (`docs/`) uses Node 20 and is not needed for core development.
+- Walkontable has its **own test runner** -- do not mix with main E2E tests.
 - No Docker, databases, or external services are required.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,18 @@ Handsontable is a JavaScript data grid monorepo (pnpm workspace). It contains th
 
 **The core package (`handsontable/`) is JavaScript, not TypeScript.** Type definitions are hand-authored `.d.ts` files in `handsontable/types/`. Do not create `.ts` files in the core package.
 
+For deeper context on specific topics, see the `.ai/` directory:
+
+| File | Topic |
+|---|---|
+| `.ai/STACK.md` | Technology stack and dependencies |
+| `.ai/ARCHITECTURE.md` | System architecture and design patterns |
+| `.ai/STRUCTURE.md` | Repository structure and file organization |
+| `.ai/CONVENTIONS.md` | Coding conventions and style guidelines |
+| `.ai/INTEGRATIONS.md` | Framework wrappers and integration details |
+| `.ai/TESTING.md` | Testing strategy and infrastructure |
+| `.ai/CONCERNS.md` | Known issues, technical debt, and constraints |
+
 ---
 
 ## Common pitfalls

--- a/handsontable/.cursor/BUGBOT.md
+++ b/handsontable/.cursor/BUGBOT.md
@@ -1,6 +1,6 @@
 # Handsontable core review notes
 
-Apply these checks when changed files are in `/handsontable/**`.
+All coding rules and conventions are in `/AGENTS.md`. Apply those rules to every review. This file adds **review-specific checks** for files under `/handsontable/**`.
 
 ---
 


### PR DESCRIPTION
### Context
Streamline AGENTS.md by extracting detailed architecture, conventions, testing, stack, structure, integrations, and concerns documentation into dedicated `.ai/` files. These files are auto-discovered by Claude and Cursor. BUGBOT.md files updated to reference AGENTS.md as the canonical source of truth.

_[skip changelog]_

### How has this been tested?
Manual review of content preservation across all extracted files. No source code changes.

### Types of changes
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):

### Affected project(s):
- [x] `handsontable`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only refactor that adds new markdown reference files and updates internal guidance pointers; no runtime code paths or build outputs are affected.
> 
> **Overview**
> Moves extensive contributor/agent guidance out of `AGENTS.md` into a new `.ai/` documentation set (`ARCHITECTURE`, `STRUCTURE`, `STACK`, `CONVENTIONS`, `TESTING`, `INTEGRATIONS`, `CONCERNS`) intended for tool/agent discovery.
> 
> Updates `AGENTS.md` to be a slimmer entry point linking to those `.ai/` docs, and adjusts both `.cursor/BUGBOT.md` files to treat `AGENTS.md` as the canonical rules source while keeping only review-specific checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e78e2b452e1836d2c6910f1f8d8fe0ec86eb64b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->