### PR TITLE
Update the Cell Editor guide and the examples

### DIFF
--- a/docs/content/guides/cell-functions/cell-editor/cell-editor.md
+++ b/docs/content/guides/cell-functions/cell-editor/cell-editor.md
@@ -18,56 +18,19 @@ menuTag: updated
 
 # Cell editor
 
-Create a custom cell editor function, to have full control over how editing works in the cells of your data grid.
+Create custom cell editors to fully control how values are entered in your data grid.
+
+Each cell can have one editor — a class that manages the editor's DOM element, its value, and the lifecycle from opening to saving. Handsontable's [`EditorManager`](@/api/baseEditor.md) selects and drives the editor automatically. You create editors by extending [`BaseEditor`](@/api/baseEditor.md) or any of the [built-in editor classes](#built-in-editors).
 
 [[toc]]
-
-## Overview
-
-Handsontable separates the process of displaying the cell value from the process of changing the value. Renderers are responsible for presenting the data and Editors for altering it. As a renderer has only one simple task: _get actual value of the cell and return its representation as a HTML code_ they can be a single function. Editors, however, need to handle user input (that is, mouse and keyboard events), validate data and behave according to validation results, so putting all those functionalities into a single function wouldn't be a good idea. That's why Handsontable editors are represented by editor classes.
-
-This tutorial will give you a comprehensive understanding of how the whole process of cell editing works, how Handsontable Core manages editors, how editor life cycle looks like and finally - how to create your own editors.
 
 ::: only-for react
 
 ## Component-based editors
 
-You can use React components to create custom editors. To do so, you'll need to create a functional component using the `useHotEditor` hook.
+Use React components as editors with the `useHotEditor` hook. The hook returns `value`, `setValue`, and `finishEditing`, plus callbacks for the editor lifecycle (`onOpen`, `onClose`, `onPrepare`, `onFocus`).
 
-In the simplest case:
-
-```js
-import { useHotEditor } from "@handsontable/react-wrapper";
-
-const EditorComponent = () => {
-  const { value, setValue, finishEditing } = useHotEditor({
-    onOpen: () => {
-      // Open logic
-    },
-    onClose: () => {
-      // Close logic
-    },
-  });
-
-  // Component logic here
-
-  // Any elements that should be rendered within the editor
-  return (
-    <div>
-      <button onClick={finishEditing}>Apply</button>
-    </div>
-  );
-};
-
-// ...
-
-<HotTable editor={EditorComponent} />;
-```
-
-It's also worth noting that by default, the editors in Handsontable will close after clicking on them if the `outsideClickDeselects` option is enabled.
-To prevent that, the `mousedown` event on the editor container must call `event.stopPropagation()`.
-
-If you are using React 17 and newer, `event.stopPropagation()` should work for you as expected. See the [React 17 release notes](https://reactjs.org/blog/2020/08/10/react-v17-rc.html#changes-to-event-delegation) for details about event delegation.
+To prevent the editor from closing when clicked (due to `outsideClickDeselects`), call `event.stopPropagation()` on the `mousedown` event of the editor's root element.
 
 ::: example #example1 :react --js 1 --ts 2
 
@@ -78,9 +41,7 @@ If you are using React 17 and newer, `event.stopPropagation()` should work for y
 
 ## Class-based editors
 
-You can also declare a custom editor for the `HotTable` component by declaring it as a class and passing it to the Handsontable options as `hotEditor` (or simply `editor` when used in a `columns` config array).
-
-The following example implements the `@handsontable/react-wrapper` component with a custom editor added, utilizing the `placeholder` attribute in the editor's `input` element.
+Declare the editor as a class that extends a built-in editor (e.g., `TextEditor`) and pass it to the `editor` option in column configuration.
 
 ::: example #example2 :react --js 1 --ts 2
 
@@ -91,8 +52,7 @@ The following example implements the `@handsontable/react-wrapper` component wit
 
 ::: tip
 
-All the sections below describe how to utilize the features available for the Handsontable class-based editors.
-This information is applicable in React when using the non-component editor approach.
+The sections below describe the class-based editor API. All of it applies to React when using the class-based approach.
 
 :::
 
@@ -102,7 +62,7 @@ This information is applicable in React when using the non-component editor appr
 
 ## Component-based editors
 
-You can use Angular components to create custom editors. To do so, you'll need to create a component that extends from `HotCellEditorComponent<T>`, where `T` is a type of `number`, `boolean`, or `string`. Below is implementation of custom editor:
+Create an Angular component that extends `HotCellEditorComponent<T>` (where `T` is `string`, `number`, or `boolean`). The only method you must implement is `onFocus()`. Use the `finishEdit` and `cancelEdit` outputs to trigger editing completion.
 
 ```ts
 @Component({
@@ -111,24 +71,13 @@ You can use Angular components to create custom editors. To do so, you'll need t
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div style="width: 100%; overflow: hidden">
-      <input
-        #inputElement
-        type="text"
-        [value]="getValue()"
-        (keydown)="onKeyDown($event)"
-        style="width: 100%; box-sizing: border-box"
-      />
+    <div>
+      <input #inputElement type="text" [value]="getValue()" (keydown)="onKeyDown($event)" />
     </div>
   `,
 })
-export class CustomEditorComponent extends HotCellEditorComponent<number> {
+export class CustomEditorComponent extends HotCellEditorComponent<string> {
   @ViewChild('inputElement') inputElement!: ElementRef;
-
-  onKeyDown(event: KeyboardEvent): void {
-    const target = event.target as HTMLInputElement;
-    this.setValue(Number(target.value));
-  }
 
   onFocus(): void {
     this.inputElement.nativeElement.select();
@@ -136,27 +85,13 @@ export class CustomEditorComponent extends HotCellEditorComponent<number> {
 }
 ```
 
-In the base class, we also have the outputs `finishEdit` and `cancelEdit`. Using them triggers the Angular wrapper to call the corresponding methods from the base class in Handsontable: `finishEditing()` and `cancelChanges()`. The `onOpen()` and `onClose()` functions are invoked by the Angular wrapper after the base class methods `open()` and `close()` in Handsontable are called. The values for `@Input` are automatically set by the Angular wrapper and should not be overridden.
-By inheriting from this class, the only function you need to implement is `onFocus()`. Once your custom editor is ready, the final step is to pass it to the `HotTableComponent` using the settings object in the column definition:
+Pass the component as the `editor` property in column configuration:
 
 ```ts
 settings = {
-  columns: [
-    {
-      title: "Custom Editor",
-      editor: CustomEditorComponent,
-    },
-  ],
+  columns: [{ editor: CustomEditorComponent }],
 };
 ```
-
-```html
-<hot-table [settings]="settings" />
-```
-
-In this way, the Angular wrapper will understand that you want to use a custom editor defined through your component. The library will then properly prepare the provided component to display it when you enter the edit mode for a specific cell in the column.
-
-Example:
 
 ::: example #example1 :angular --ts 1 --html 2
 
@@ -167,9 +102,7 @@ Example:
 
 ## Class-based editors
 
-You can also declare a custom editor for the `HotTable` component by declaring it as a class and passing it to the Handsontable settings as `editor` when used in a `columns` config array.
-
-The following example implements the `@handsontable/angular-wrapper` component with a custom editor added, utilizing the `placeholder` attribute in the editor's `input` element.
+Declare the editor as a class that extends a built-in editor (e.g., `TextEditor`) and pass it to the `editor` option in column configuration.
 
 ::: example #example2 :angular --ts 1 --html 2
 
@@ -180,402 +113,203 @@ The following example implements the `@handsontable/angular-wrapper` component w
 
 ::: tip
 
-All the sections below describe how to utilize the features available for the Handsontable class-based editors.
-This information is applicable in Angular when using the non-component editor approach.
+The sections below describe the class-based editor API. All of it applies to Angular when using the class-based approach.
 
 :::
+
 :::
 
-### EditorManager
+## How editing works
 
-[`EditorManager`](@/api/baseEditor.md) is a class responsible for handling all editors available in Handsontable. If `Handsontable` needs to interact with editors it uses [`EditorManager`](@/api/baseEditor.md) object. [`EditorManager`](@/api/baseEditor.md) object is instantiated in [`init()`](@/api/baseEditor.md#init) method which is run, after you invoke `Handsontable()` constructor for the first time. The reference for [`EditorManager`](@/api/baseEditor.md) object is kept private in Handsontable instance and you cannot access it. However, there are ways to alter the default behaviour of [`EditorManager`](@/api/baseEditor.md), more on that later.
+Handsontable separates rendering (displaying cell values) from editing (changing them). Renderers are stateless functions; editors are stateful classes that own a DOM element and manage the full editing flow.
 
-#### EditorManager tasks
+### EditorManager lifecycle
 
-[`EditorManager`](@/api/baseEditor.md) has 4 main tasks:
+`EditorManager` orchestrates all editors. For each cell interaction it runs four steps in order:
 
-- Selecting proper editor for an active cell
-- Preparing editor to be displayed
-- Displaying editor (based on user behavior)
-- Closing editor (based on user behavior).
+| Step | When it runs | What it does |
+| --- | --- | --- |
+| **Select editor** | Cell is selected | Looks up the editor class from the `editor` config option |
+| **Prepare** | Cell is selected | Calls `prepare()` to configure the editor for the selected cell |
+| **Open** | User triggers editing | Calls `beginEditing()` → `open()` |
+| **Close** | User confirms or cancels | Calls `finishEditing()` → `close()` or `focus()` |
 
-We will discuss each of those tasks in detail.
+**Editing opens on:** <kbd>**Enter**</kbd>, <kbd>**Shift**</kbd>+<kbd>**Enter**</kbd>, <kbd>**F2**</kbd>, double-click.
 
-##### Select proper editor for an active cell
+**Editing closes on:**
 
-When user selects a cell [`EditorManager`](@/api/baseEditor.md) finds the editor class assigned to this cell, examining the value of the [`editor`](@/api/options.md#editor) configuration option. You can define the [`editor`](@/api/options.md#editor) configuration option globally (for all cells in table), per column (for all cells in column) or for each cell individually. For more details, see the [Configuration options](@/guides/getting-started/configuration-options/configuration-options.md#cascading-configuration) guide.
-
-The value of the [`editor`](@/api/options.md#editor) configuration option can be either a string representing an editor (such as 'text', 'autocomplete', 'checkbox' etc.), or an editor class. [`EditorManager`](@/api/baseEditor.md) will then get an instance of editor class and the first very important thing to remember is: **there is always one instance of certain editor class in a single table**, in other words each editor class object **is a singleton** within a single table, which means that its constructor will be invoked only once per table. If you have 3 tables on a page, each table will have its own instance of editor class. This has some important implications that you have to consider creating your own editor.
-
-##### Prepare editor to be displayed
-
-When [`EditorManager`](@/api/baseEditor.md) obtain editor class instance (editor object) it invokes its [`prepare()`](@/api/baseEditor.md#prepare) method. The [`prepare()`](@/api/baseEditor.md#prepare) method sets editor objects properties related to the selected cell, but does not display the editor. [`prepare()`](@/api/baseEditor.md#prepare) is called each time user selects a cell. In some cases it can be invoked multiple times for the same cell, without changing the selection.
-
-##### Display editor
-
-When editor is prepared the [`EditorManager`](@/api/baseEditor.md) waits for user event that triggers cell edition. Those events are:
-
-- Pressing <kbd>**Enter**</kbd>
-- Pressing <kbd>**Shift**</kbd>+<kbd>**Enter**</kbd>
-- double clicking cell
-- Pressing <kbd>**F2**</kbd>
-
-If any of those events is triggered, [`EditorManager`](@/api/baseEditor.md) calls editor's [`beginEditing()`](@/api/baseEditor.md#beginediting) method, which should display the editor.
+| Key / action | Result |
+| --- | --- |
+| Click another cell | Saves changes |
+| <kbd>**Enter**</kbd> / <kbd>**Shift**</kbd>+<kbd>**Enter**</kbd> | Saves and moves selection down / up |
+| <kbd>**Tab**</kbd> / <kbd>**Shift**</kbd>+<kbd>**Tab**</kbd> | Saves and moves selection right / left |
+| <kbd>**Ctrl**</kbd>/<kbd>**Cmd**</kbd>+<kbd>**Enter**</kbd> or <kbd>**Alt**</kbd>/<kbd>**Option**</kbd>+<kbd>**Enter**</kbd> | Inserts a line break |
+| <kbd>**Page Up**</kbd> / <kbd>**Page Down**</kbd> | Saves and scrolls one screen |
+| <kbd>**Escape**</kbd> | Cancels without saving |
 
 ::: tip
 
-**IME support:** When using languages that require IME (Input Method Editor), such as Chinese, Japanese, or Korean, the editor opens through the standard edit mode (pressing Enter, F2, or double-clicking). To enable immediate typing into a selected cell without explicitly opening the editor, enable the [`imeFastEdit`](@/api/options.md#imefastedit) option. For more information, see the [IME support](@/guides/internationalization/ime-support/ime-support.md) guide.
+**IME support:** For Chinese, Japanese, or Korean input, enable [`imeFastEdit`](@/api/options.md#imefastedit) to let users start typing immediately without pressing <kbd>**Enter**</kbd> or <kbd>**F2**</kbd>. See the [IME support](@/guides/internationalization/ime-support/ime-support.md) guide.
 
 :::
 
-##### Close editor
+**Overriding keyboard behavior:** Register a [`beforeKeyDown`](@/api/hooks.md#beforekeydown) hook listener and call `event.stopImmediatePropagation()` to prevent `EditorManager` from processing a specific key. Register the listener in `open()` and remove it in `close()` so it only intercepts events while your editor is active.
 
-When editor is opened the [`EditorManager`](@/api/baseEditor.md) waits for user event that should end cell edition. Those events are:
+**Editor singleton:** Each editor class has exactly one instance per table. The constructor and `init()` run once per table; `prepare()` runs every time the user selects a cell that uses that editor.
 
-- Clicking on another cell (saves changes)
-- Pressing <kbd>**Enter**</kbd> (saves changes and moves selection one cell down)
-- Pressing <kbd>**Shift**</kbd>+<kbd>**Enter**</kbd> (saves changes and moves selection one cell up)
-- Pressing <kbd>**Ctrl**</kbd>/<kbd>**Cmd**</kbd>+<kbd>**Enter**</kbd> or <kbd>**Alt**</kbd>/<kbd>**Option**</kbd>+<kbd>**Enter**</kbd> (adds a new line inside the cell)
-- Pressing <kbd>**Escape**</kbd> (aborts changes)
-- Pressing <kbd>**Tab**</kbd> (saves changes and moves one cell to the right or to the left, depending on your [layout direction](@/guides/internationalization/layout-direction/layout-direction.md#elements-affected-by-layout-direction))
-- Pressing <kbd>**Shift**</kbd>+<kbd>**Tab**</kbd> (saves changes and moves one cell to the left or to the right, depending on your [layout direction](@/guides/internationalization/layout-direction/layout-direction.md#elements-affected-by-layout-direction))
-- Pressing <kbd>**Page Up**</kbd>, <kbd>**Page Down**</kbd> (saves changes and moves one screen up/down)
+## BaseEditor API
 
-If any of those events is triggered, [`EditorManager`](@/api/baseEditor.md) calls editor's [`finishEditing()`](@/api/baseEditor.md#finishediting) method, which should try to save changes (unless ESC key has been pressed) and close the editor.
+All custom editors extend `Handsontable.editors.BaseEditor`. In an ESM project, import it from `handsontable/editors/baseEditor`. In a script-tag (UMD) project, access it as `Handsontable.editors.BaseEditor`.
 
-#### Overriding EditorManager default behaviour
+### Common methods
 
-You may want to change the default events that causes editor to open or close. For example, your editor might use <kbd>**Arrow Up**</kbd> and <kbd>**Arrow Down**</kbd> events to perform some actions (for example increasing or decreasing cell value) and you don't want [`EditorManager`](@/api/baseEditor.md) to close the editor when user press those keys. That's why [`EditorManager`](@/api/baseEditor.md) runs [`beforeKeyDown`](@/api/hooks.md#beforekeydown) hook before processing user events. If you register a listener for [`beforeKeyDown`](@/api/hooks.md#beforekeydown), that call `stopImmediatePropagation()` on `event` object [`EditorManager`](@/api/baseEditor.md) won perform its default action. More on overriding [`EditorManager`](@/api/baseEditor.md)'s behaviour in section "SelectEditor - creating editor from scratch".
+These methods are already implemented in `BaseEditor`. Override them only when necessary — always call `super.method()` first when you do.
 
-You should now have a better understanding on how [`EditorManager`](@/api/baseEditor.md) works. Let's go a bit deeper and see what methods every editor class must implement and what those methods do.
+| Method | Description |
+| --- | --- |
+| `prepare()` | Configures the editor for the selected cell. Sets `this.row`, `this.col`, `this.prop`, `this.TD`, and `this.cellProperties`. Parameters: `(row, col, prop, td, originalValue, cellProperties)`. |
+| `beginEditing()` | Sets the initial editor value and calls `open()`. Uses the original cell value when `newInitialValue` is `undefined`. Parameters: `(newInitialValue, event)`. |
+| `finishEditing()` | Validates and saves the value, or restores the original when `restoreOriginalValue` is `true`. When `ctrlDown` is `true`, applies the value to all selected cells. Calls `close()` on success or `focus()` when validation fails. Parameters: `(restoreOriginalValue?, ctrlDown?, callback?)`. |
+| `discardEditor()` | Called after validation. If valid, calls `close()`; if invalid, calls `focus()` to keep the editor open. Parameter: `(result)`. |
+| `saveValue()` | Validates and saves `value`. Applies to all selected cells when `ctrlDown` is `true`. Parameters: `(value, ctrlDown)`. |
+| `isOpened()` | Returns `true` if the editor is currently open. |
+| `extend()` | Returns a new subclass of the current editor. Overriding methods on the returned class does not affect the original. Useful for ES5 environments; in ES6+ prefer `class MyEditor extends BaseEditor {}`. |
 
-### [`BaseEditor`](@/api/baseEditor.md)
+### Abstract methods
 
-`Handsontable.editors.BaseEditor` is an abstract class from which all editor classes should inherit. It implements some of the basic editor methods as well as declares some methods that should be implemented by each editor class. In this section we examine all of those methods.
+You must implement all of these in your custom editor class.
 
-#### Common methods
+| Method | Description |
+| --- | --- |
+| `init()` | Called once when the editor object is created. Build the editor's DOM here. |
+| `getValue()` | Returns the current editor value to be saved as the new cell value. |
+| `setValue()` | Updates the editor to display the new value. Parameter: `(newValue)`. |
+| `open()` | Shows the editor. |
+| `close()` | Hides the editor after editing ends. |
+| `focus()` | Focuses the editor input. Called when validation fails and the editor must stay open. |
 
-Common methods, are methods implemented by [`BaseEditor`](@/api/baseEditor.md) class. They contain some core logic that every editor should have. Most of the time, you shouldn't bother with those methods. However, if you are creating some more complex editors, you might want to override some of the common methods, in which case you should always invoke the original method and then perform other operations, specific to your editor.
+### Editor instance properties
 
-**Example** - overriding common method
+Available as `this.property` inside any editor method.
 
-```js
-// CustomEditor is a class, inheriting from BaseEditor
-class CustomEditor extends BaseEditor {
-  prepare(row, col, prop, td, originalValue, cellProperties) {
-    // Invoke the original method...
-    super.prepare(row, col, prop, td, originalValue, cellProperties);
-    // ...and then do some stuff specific to your CustomEditor
-    this.customEditorSpecificProperty = "foo";
-  }
-}
-```
+| Property | Type | Description |
+| --- | --- | --- |
+| `hot` | `Handsontable.Core` | The Handsontable instance this editor belongs to. Set once in the constructor; never changes. |
+| `row` | `number` | Visual row index of the active cell. Updated by `prepare()`. |
+| `col` | `number` | Visual column index of the active cell. Updated by `prepare()`. |
+| `prop` | `string` | Data property name for the active cell (for object data sources). Updated by `prepare()`. |
+| `TD` | `HTMLTableCellElement` | DOM node of the active cell. Updated by `prepare()`. |
+| `cellProperties` | `object` | Configuration of the active cell. Updated by `prepare()`. Includes all standard cell options and any custom properties (e.g., `selectOptions`). |
 
-There are 7 common methods. All of them are described below.
+## Built-in editors
+
+| Alias | Editor class |
+| --- | --- |
+| `autocomplete` | `Handsontable.editors.AutocompleteEditor` |
+| `checkbox` | `Handsontable.editors.CheckboxEditor` |
+| `date` | `Handsontable.editors.DateEditor` |
+| `dropdown` | `Handsontable.editors.DropdownEditor` |
+| `handsontable` | `Handsontable.editors.HandsontableEditor` |
+| `numeric` | `Handsontable.editors.NumericEditor` |
+| `password` | `Handsontable.editors.PasswordEditor` |
+| `select` | `Handsontable.editors.SelectEditor` |
+| `text` | `Handsontable.editors.TextEditor` |
+| `time` | `Handsontable.editors.TimeEditor` |
+
+## Creating a custom editor
+
+Two approaches are available:
+
+- **Extend an existing editor** when you want most of its behavior and only need to change a few details (e.g., swap the input element type).
+- **Extend `BaseEditor` directly** when you need an entirely different UI (e.g., a dropdown list, a date picker, a color picker).
+
+### Extending an existing editor
+
+Override only the methods you need. The `PasswordEditor` below extends `TextEditor` and replaces the `<textarea>` with `<input type="password">`. Since both elements share the same DOM API, only `createElements()` needs to change.
 
 ::: only-for javascript
 
-#### prepare(row: `Number`, col: `Number`, prop: `Number|String`, td: `HTMLTableCellElement`, originalValue: `Mixed`, cellProperties: `Object`)
+::: example #example1 --js 1 --ts 2
+
+@[code](@/content/guides/cell-functions/cell-editor/javascript/example1.js)
+@[code](@/content/guides/cell-functions/cell-editor/javascript/example1.ts)
+
+:::
 
 :::
 
 ::: only-for react
 
-##### prepare(row: `Number`, col: `Number`, prop: `Number|String`, td: `HTMLTableCellElement`, originalValue: `Mixed`, cellProperties: `Object`)
+::: example #example3 :react --js 1 --ts 2
+
+@[code](@/content/guides/cell-functions/cell-editor/react/example2.jsx)
+@[code](@/content/guides/cell-functions/cell-editor/react/example2.tsx)
+
+:::
 
 :::
 
 ::: only-for angular
 
-##### prepare(row: `number`, col: `number`, prop: `number | string`, td: `HTMLTableCellElement`, originalValue: `any`, cellProperties: `Object`)
+::: example #example3 :angular --ts 1 --html 2
+
+@[code](@/content/guides/cell-functions/cell-editor/angular/example2.ts)
+@[code](@/content/guides/cell-functions/cell-editor/angular/example2.html)
 
 :::
 
-Prepares editor to be displayed for given cell. Sets most of the instance properties.
+:::
 
-Returns: `undefined`
+### Building an editor from scratch
+
+Extend `BaseEditor` directly for full control. The `SelectEditor` below renders a `<select>` dropdown. It also overrides keyboard behavior so <kbd>**Arrow Up**</kbd> / <kbd>**Arrow Down**</kbd> cycle through options rather than closing the editor.
+
+Key implementation decisions:
+- **`init()`** - DOM is created here (runs once), not in `prepare()` or `open()`.
+- **`data-hot-input="true"`** - Required on the editor element. Without it, Handsontable treats clicks on the editor as clicks outside it and closes the editor immediately.
+- **`prepare()`** - Options are populated here so each cell can have its own list via `selectOptions`.
+- **`open()` / `close()`** - The `beforeKeyDown` hook is registered when opening and cleared when closing, scoping key interception to this editor only.
 
 ::: only-for javascript
 
-#### beginEditing(newInitialValue: `Mixed`, event: `Mixed`)
+::: example #example2 --js 1 --ts 2 --css 3
+
+@[code](@/content/guides/cell-functions/cell-editor/javascript/example2.js)
+@[code](@/content/guides/cell-functions/cell-editor/javascript/example2.ts)
+@[code](@/content/guides/cell-functions/cell-editor/javascript/example2.css)
+
+:::
 
 :::
 
 ::: only-for react
 
-##### beginEditing(newInitialValue: `Mixed`, event: `Mixed`)
+To use a class-based editor from scratch in React, pass the editor class as the `editor` prop in a column configuration object. See the [class-based editors](#class-based-editors) section for an example.
 
 :::
 
 ::: only-for angular
 
-##### beginEditing(newInitialValue: `any`, event: `Event`)
+To use a class-based editor from scratch in Angular, pass the editor class as the `editor` property in a column configuration object. See the [class-based editors](#class-based-editors) section for an example.
 
 :::
 
-Sets editor value to `newInitialValue`. If `newInitialValue` is undefined, the editor value is set to original cell value. Calls [`open()`](@/api/baseEditor.md#open) method internally.
+## Registering an editor
 
-Returns: `undefined`
-
-::: only-for javascript
-
-#### finishEditing(restoreOriginalValue: 'Boolean' _\[optional\]_, ctrlDown: `Boolean` _\[optional\]_, callback: `Function`)
-
-:::
-
-::: only-for react
-
-##### finishEditing(restoreOriginalValue: 'Boolean' _\[optional\]_, ctrlDown: `Boolean` _\[optional\]_, callback: `Function`)
-
-:::
-
-::: only-for angular
-
-##### finishEditing(restoreOriginalValue?: 'boolean', ctrlDown?: `boolean`, callback?: `Function`)
-
-:::
-
-Tries to finish cell edition. Calls [`saveValue()`](@/api/baseEditor.md#savevalue) and `discardEditor()` internally. If `restoreOriginalValue` is set to `true` cell value is being set to its original value (from before the edition). `ctrlDown` value is passed to [`saveValue()`](@/api/baseEditor.md#savevalue) as the second argument.
-
-Callback function contains a boolean parameter - if new value is valid or the [`allowInvalid`](@/api/options.md#allowinvalid) configuration option is set to `true`, otherwise the parameter is `false`.
-
-::: only-for javascript
-
-#### discardEditor(result: `Boolean`)
-
-:::
-
-::: only-for react
-
-##### discardEditor(result: `Boolean`)
-
-:::
-
-::: only-for angular
-
-##### discardEditor(result: `boolean`)
-
-:::
-
-Called when cell validation ends. If new value is saved successfully (`result` is set to `true` or [`allowInvalid`](@/api/options.md#allowinvalid) property is `true`) it calls [`close()`](@/api/baseEditor.md#close) method, otherwise calls [`focus()`](@/api/baseEditor.md#focus) method and keeps editor opened.
-
-Returns: `undefined`
-
-::: only-for javascript
-
-#### saveValue(value: `Mixed`, ctrlDown: `Boolean`)
-
-:::
-
-::: only-for react
-
-##### saveValue(value: `Mixed`, ctrlDown: `Boolean`)
-
-:::
-
-::: only-for angular
-
-##### saveValue(value: `any`, ctrlDown: `boolean`)
-
-:::
-
-Tries to save `value` as new cell value. Performs validation internally. If `ctrlDown` is set to true the new value will be set to all selected cells.
-
-Returns: `undefined`
-
-##### isOpened()
-
-Returns `true` if editor is opened or `false` if editor is closed. Editor is considered to be opened after [`open()`](@/api/baseEditor.md#open) has been called. Editor is considered closed [`close()`](@/api/baseEditor.md#close) after method has been called.
-
-Returns: `Boolean`
-
-##### extend()
-
-Returns: `Function` - a class function that inherits from the current class. The `prototype` methods of the returned class can be safely overwritten, without a danger of altering the parent's `prototype`.
-
-**Example** - inheriting from [`BaseEditor`](@/api/baseEditor.md) and overriding its method
+Register your editor under a string alias so it can be referenced by name in configuration instead of passing the class directly:
 
 ```js
-const CustomEditor = Handsontable.editors.BaseEditor.prototype.extend();
-
-// This won't alter BaseEditor.prototype.beginEditing()
-CustomEditor.prototype.beginEditing = function () {};
+Handsontable.editors.registerEditor('myEditor', MyEditor);
 ```
 
-**Example** - inheriting from another editor
-
-```js
-const CustomTextEditor = Handsontable.editors.TextEditor.prototype.extend();
-
-// CustomTextEditor uses all methods implemented by TextEditor.
-// You can safely override any method without affecting original
-// TextEditor.
-```
-
-**Note:** This is an utility method not related to the process of editing cell.
-
-#### Editor specific methods
-
-Editor specific methods are methods not implemented in [`BaseEditor`](@/api/baseEditor.md). In order to work, every editor class has to implement those methods.
-
-##### init()
-
-Method called when new instance of editor class is created. That happens at most once per table instance, as all used editors as **singletons** within table instance. You should use this methods to perform tasks which results can be reused during editor's lifecycle. The most common operation is creating HTML structure of editor.
-
-Method does not need to return any value.
-
-##### getValue()
-
-Method should act return the current editor value, that is value that should be saved as a new cell value.
-
-::: only-for javascript
-
-#### setValue(newValue: `Mixed`)
-
-:::
-
-::: only-for react
-
-##### setValue(newValue: `Mixed`)
-
-:::
-
-::: only-for angular
-
-##### setValue(newValue: `any`)
-
-:::
-
-Method should set editor value to `newValue`.
-
-**Example** Let's say we are implementing a DateEditor, which helps selecting date, by displaying a calendar. [`getvalue()`](@/api/baseEditor.md#getvalue) and [`setvalue()`](@/api/baseEditor.md#setvalue) method could work like so:
-
-```js
-class CalendarEditor extends TextEditor {
-  constructor(hotInstance) {
-    super(hotInstance);
-  }
-
-  getValue() {
-    // returns currently selected date, for example "2023/09/15"
-    return calendar.getDate();
-  }
-
-  setValue(newValue) {
-    // highlights given date on calendar
-    calendar.highlightDate(newValue);
-  }
-}
-```
-
-##### open()
-
-Displays the editor. In most cases this method can be as simple as:
-
-```js
-class CustomEditor extends TextEditor {
-  open() {
-    this.editorDiv.style.display = "";
-  }
-}
-```
-
-This method does not need to return any value.
-
-##### close()
-
-Hides the editor after cell value has been changed. In most cases this method can be as simple as:
-
-```js
-class CustomEditor extends TextEditor {
-  close() {
-    this.editorDiv.style.display = "none";
-  }
-}
-```
-
-This method does not need to return any value.
-
-##### focus()
-
-Focuses the editor. This method is called when user wants to close the editor by selecting another cell and the value in editor does not validate (and [`allowInvalid`](@/api/options.md#allowinvalid) is `false`). In most cases this method can be as simple as:
-
-```js
-class CustomEditor extends TextEditor {
-  focus() {
-    this.editorInput.focus();
-  }
-}
-```
-
-This method does not need to return any value.
-
-#### Common editor properties
-
-All the undermentioned properties are available in editor instance through `this` object (e.g., `this.instance`).
-
-| Property       | Type                | Description                                                                                                                                                                     |
-| -------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| instance       | `Handsontable.Core` | The instance of Handsontable to which this editor object belongs. Set in class constructor, immutable thorough the whole lifecycle of editor.                                   |
-| row            | `Number`            | The active cell row index. Updated on every [`prepare()`](@/api/baseEditor.md#prepare) method call.                                                                             |
-| col            | `Number`            | The active cell col index. Updated on every [`prepare()`](@/api/baseEditor.md#prepare) method call.                                                                             |
-| prop           | `String`            | The property name associated with active cell (relevant only when data source is an array of objects). Updated on every [`prepare()`](@/api/baseEditor.md#prepare) method call. |
-| TD             | `HTMLTableCellNode` | Node object of active cell. Updated on every [`prepare()`](@/api/baseEditor.md#prepare) method call.                                                                            |
-| cellProperties | `Object`            | An object representing active cell properties. Updated on every [`prepare()`](@/api/baseEditor.md#prepare) method call.                                                         |
-
-### How to create a custom editor?
-
-Now you know the philosophy behind the Handsontable editors and you're ready to write your own editor. Basically, you can build a new editor from scratch, by creating a new editor class, which inherits from [`BaseEditor`](@/api/baseEditor.md), or if you just want to enhance an existing editor, you can extend its class and override only a few of its methods.
-
-In this tutorial we will examine both approaches. We will create a completely new `SelectEditor` which uses `<select>` list to alter the value of cell. We will also create a `PasswordEditor` which works exactly like regular `TextEditor` except that it displays a password input instead of textarea.
-
-Let's begin with `PasswordEditor` as it is a bit easier.
-
-#### `PasswordEditor` - extending an existing editor
-
-`TextEditor` is the most complex editor available in Handsontable by default. It displays a `<textarea>` which automatically changes its size to accommodate its content. We would like to create a `PasswordEditor` which preserves all those capabilities but displays `<input type="password">` field instead of `<textarea>`.
-
-As you may have guessed, we need to create a new editor class, that inherits from `TextEditor` and then override some of its methods to replace `<textarea>` with `input:password`. Luckily, textarea and password input have the same API, so all we have to do is replace the code responsible for creating HTML elements. If you take a look at `TextEditor` [`init()`](@/api/baseEditor.md#init) method, you'll notice that it calls internal `createElements()` method, which creates `<textarea>` node and append it to DOM during editor initialization - BINGO!
-
-Here is the code
-
-```js
-import Handsontable from "handsontable";
-
-class PasswordEditor extends Handsontable.editors.TextEditor {
-  createElements() {
-    super.createElements();
-
-    this.TEXTAREA = this.hot.rootDocument.createElement("input");
-    this.TEXTAREA.setAttribute("type", "password");
-    this.TEXTAREA.setAttribute("data-hot-input", true); // Makes the element recognizable by HOT as its own component's element.
-    this.textareaStyle = this.TEXTAREA.style;
-    this.textareaStyle.width = 0;
-    this.textareaStyle.height = 0;
-
-    this.TEXTAREA_PARENT.innerText = "";
-    this.TEXTAREA_PARENT.appendChild(this.TEXTAREA);
-  }
-}
-```
-
-That's it! You can now use your new editor:
+After registration, use the alias in column configuration:
 
 ::: only-for javascript
 
 ```js
-const container = document.querySelector("#container");
-const hot = new Handsontable(container, {
+new Handsontable(container, {
   columns: [
-    {
-      type: "text",
-    },
-    {
-      editor: PasswordEditor,
-      // If you want to use string 'password' instead of passing
-      // the actual editor class check out section "Registering
-      // editor"
-    },
+    { editor: 'myEditor' },
   ],
 });
 ```
@@ -585,19 +319,7 @@ const hot = new Handsontable(container, {
 ::: only-for react
 
 ```jsx
-<HotTable
-  columns={[
-    {
-      type: "text",
-    },
-    {
-      editor: PasswordEditor,
-      // If you want to use string 'password' instead of passing
-      // the actual editor class check out section "Registering
-      // editor"
-    },
-  ]}
-/>
+<HotTable columns={[{ editor: 'myEditor' }]} />
 ```
 
 :::
@@ -605,18 +327,7 @@ const hot = new Handsontable(container, {
 ::: only-for angular
 
 ```ts
-settings = {
-  columns: [
-    {
-      type: "text",
-    },
-    {
-      editor: PasswordEditor,
-      // If you want to use string 'password' instead of passing
-      // the actual editor class check out section "Registering editor"
-    },
-  ],
-};
+settings = { columns: [{ editor: 'myEditor' }] };
 ```
 
 ```html
@@ -625,629 +336,63 @@ settings = {
 
 :::
 
-Let's try something more complex: we'll build a new editor from the ground up.
+Handsontable defines these aliases by default: `autocomplete`, `base`, `checkbox`, `date`, `dropdown`, `handsontable`, `numeric`, `password`, `select`, `text`, `time`.
 
-#### `SelectEditor` - creating editor from scratch
+Choose a unique alias (e.g., `'myorg.select'`) to avoid overwriting built-in editors. Registering under an existing alias silently overwrites the previous mapping.
 
-We're going to build a full featured editor, that lets user choose a cell value from predefined list of options, using standard `<select>` input. As an extra feature, we'll add an ability to change currently selected option with <kbd>**ARROW_UP**</kbd> and <kbd>**ARROW_DOWN**</kbd> keys.
+## Publishing a custom editor
 
-Things to do:
+If you intend to distribute your editor as a library, two extra steps make it easy for others to discover and extend it.
 
-1. Create a new class that inherits from `Handsontable.editors.BaseEditor`.
-2. Add function creating `<select>` input and attaching to DOM.
-3. Add function that populates `<select>` with options array passed in the cell properties.
-4. Implement methods:
-   - [`getvalue()`](@/api/baseEditor.md#getvalue)
-   - [`setvalue()`](@/api/baseEditor.md#setvalue)
-   - [`open()`](@/api/baseEditor.md#open)
-   - [`close()`](@/api/baseEditor.md#close)
-   - [`focus()`](@/api/baseEditor.md#focus)
-5. Override the default [`EditorManager`](@/api/baseEditor.md) behaviour, so that pressing <kbd>**Arrow Up**</kbd> and <kbd>**Arrow Down**</kbd> keys won't close the editor, but instead change the currently selected value.
-6. Register editor.
-
-##### Create new editor
-
-That's probably the easiest part. All we have to do is call `BaseEditor.prototype.extend()` function which will return a new function class that inherits from [`BaseEditor`](@/api/baseEditor.md).
+**Step 1: Register the alias** (covered above) so users can reference the editor by name:
 
 ```js
-const SelectEditor = Handsontable.editors.BaseEditor.prototype.extend();
+Handsontable.editors.registerEditor('myorg.select', MySelectEditor);
 ```
 
-Task one: **DONE**
-
-##### Create `<select>` input and attaching it to DOM
-
-There are three potential places where we can put the function that will create `<select>` element and put it in the DOM:
-
-- [`init()`](@/api/baseEditor.md#init) method
-- [`prepare()`](@/api/baseEditor.md#prepare) method
-- [`open()`](@/api/baseEditor.md#open) method
-
-The key to choose the best solution is to understand when each of those methods are called.
-
-[`init()`](@/api/baseEditor.md#init) method is called during creation of editor class object. That happens at most one per table instance, because once the object is created it is reused every time [`EditorManager`](@/api/baseEditor.md) asks for this editor class instance (see [Singleton pattern](http://en.wikipedia.org/wiki/Singleton_pattern) for details).
-
-[`prepare()`](@/api/baseEditor.md#prepare) method is called every time the user selects a cell that has this particular editor class set as the [`editor`](@/api/options.md#editor) configuration option. So, if we set `SelectEditor` as editor for an entire column, then selecting any cell in this column will invoke [`prepare()`](@/api/baseEditor.md#prepare) method of `SelectEditor`. In other words, this method can be called hundreds of times during table life, especially when working with large data. Another important aspect of [`prepare()`](@/api/baseEditor.md#prepare) is that it should not display the editor (it's `open's` job). Displaying editor is triggered by user event such as pressing ENTER, F2 or double clicking a cell, so there is some time between calling [`prepare()`](@/api/baseEditor.md#prepare) and actually displaying the editor. Nevertheless, operations performed by [`prepare()`](@/api/baseEditor.md#prepare) should be completed as fast as possible, to provide the best user experience.
-
-[`open()`](@/api/baseEditor.md#open) method is called when editor needs to be displayed. In most cases this method should change the CSS `display` property to `block` or perform something similar. User expects that editor will be displayed right after the event (pressing appropriate key or double clicking a cell) has been triggered, so [`open()`](@/api/baseEditor.md#open) method should work as fast as possible.
-
-Knowing all this, the most reasonable place to put the code responsible for creating `<select>` input is somewhere in [`init()`](@/api/baseEditor.md#init) method. DOM manipulation is considered to be quite expensive (regarding the resource consumption) operation, so it's best to perform it once and reuse the produced HTML nodes throughout the life of editor.
+**Step 2: Expose the class on `Handsontable.editors`** so users can retrieve and extend it without importing from your source module:
 
 ```js
-import Handsontable from "handsontable";
+Handsontable.editors.MySelectEditor = MySelectEditor;
+```
 
-class SelectEditor extends Handsontable.editors.BaseEditor {
-  /**
-   * Initializes editor instance, DOM Element and mount hooks.
-   */
-  init() {
-    // Create detached node, add CSS class and make sure its not
-    // visible
-    this.select = this.hot.rootDocument.createElement("SELECT");
-    this.select.classList.add("htSelectEditor");
-    this.select.style.display = "none";
+To extend a published editor, retrieve it with `getEditor()`:
 
-    // Attach node to DOM, by appending it to the container holding
-    // the table
-    this.hot.rootElement.appendChild(this.select);
-  }
+```js
+const MySelectEditor = Handsontable.editors.getEditor('myorg.select');
+
+class ExtendedSelectEditor extends MySelectEditor {
+  // override methods as needed
 }
 ```
 
-```css
-.htSelectEditor {
-  /*
-   * This hack enables to change <select> dimensions in WebKit browsers
-   */
-  -webkit-appearance: menulist-button !important;
-  position: absolute;
-  width: auto;
-  z-index: 300;
-}
-```
+::: tip
 
-Task two: **DONE**
-
-##### Populate `<select>` with options
-
-In the previous step we implemented a function that creates the `<select>` input and attaches it to the DOM. You probably noticed that we haven't written any code that would create the `<option>` elements, therefore if we displayed the list, it would be empty.
-
-We want to be able to define an option list like this:
-
-::: only-for javascript
-
-```js
-const container = document.querySelector("#container");
-const hot = new Handsontable(container, {
-  columns: [
-    {
-      editor: SelectEditor,
-      selectOptions: ["option1", "option2", "option3"],
-    },
-  ],
-});
-```
-
-:::
-
-::: only-for react
-
-```jsx
-<HotTable
-  columns={[
-    {
-      editor: SelectEditor,
-      selectOptions: ["option1", "option2", "option3"],
-    },
-  ]}
-/>
-```
-
-:::
-
-::: only-for angular
-
-```ts
-settings = {
-  columns: [
-    {
-      editor: SelectEditor,
-      selectOptions: ["option1", "option2", "option3"],
-    },
-  ],
-};
-```
-
-```html
-<hot-table [settings]="settings"></hot-table>
-```
-
-:::
-
-There is no (easy) way to get to the value of [`selectOptions`](@/api/options.md#selectoptions). Even if we could get to this array we could only populate the list with options once, if we do this in the 'init' function. What if we have more than one column using `SelectEditor` and each of them has it's own option list? It's even possible that two cells in the same column can have different option lists (cascade configuration - remember?) It's clear that we have to find a better place for the code that creates items for our list.
-
-We are left with two places [`prepare()`](@/api/baseEditor.md#prepare) and [`open()`](@/api/baseEditor.md#open). The latter one is simpler to implement, but as we previously stated, [`setvalue()`](@/api/baseEditor.md#setvalue) should work as fast as possible and creating `<option>` nodes and attaching them to DOM might be time consuming, if [`selectOptions`](@/api/options.md#selectoptions) contains long list of options. Therefore, [`prepare()`](@/api/baseEditor.md#prepare) seems to be a safer place to do this kind of work. The only thing to keep in mind is that we should always invoke [`BaseEditor`](@/api/baseEditor.md)'s original method when overriding [`prepare()`](@/api/baseEditor.md#prepare). `BaseEditor.prototype.prepare()` sets some important properties, which are used by other editor methods.
-
-```js
-// Create options in prepare() method
-prepare(row, col, prop, td, originalValue, cellProperties) {
-  // Remember to invoke parent's method
-  super.prepare(row, col, prop, td, originalValue, cellProperties);
-
-  const selectOptions = this.cellProperties.selectOptions;
-  let options;
-
-  if (typeof selectOptions === 'function') {
-    options = this.prepareOptions(selectOptions(this.row, this.col, this.prop));
-  } else {
-    options = this.prepareOptions(selectOptions);
-  }
-
-  this.select.innerText = '';
-
-  Object.keys(options).forEach((key) => {
-    const optionElement = this.hot.rootDocument.createElement('OPTION');
-    optionElement.value = key;
-    optionElement.innerText = options[key];
-    this.select.appendChild(optionElement);
-  });
-}
-```
-
-Where the `prepareOptions` is:
-
-```js
-prepareOptions(optionsToPrepare) {
-  let preparedOptions = {};
-
-  if (Array.isArray(optionsToPrepare)) {
-    for (let i = 0, len = optionsToPrepare.length; i < len; i++) {
-      preparedOptions[optionsToPrepare[i]] = optionsToPrepare[i];
-    }
-
-  } else if (typeof optionsToPrepare === 'object') {
-    preparedOptions = optionsToPrepare;
-  }
-
-  return preparedOptions;
-}
-```
-
-Task three: **DONE**
-
-##### Implement editor specific methods
-
-Most of the work is done. Now we just need to implement all the editor specific methods. Luckily, our editor is quite simple so those methods will be only few lines of code.
-
-```js
-getValue() {
-  return this.select.value;
-}
-
-setValue(value) {
-  this.select.value = value;
-}
-
-open() {
-  const {
-    top,
-    start,
-    width,
-    height,
-  } = this.getEditedCellRect();
-  const selectStyle = this.select.style;
-
-  this._opened = true;
-
-  selectStyle.height = `${height}px`;
-  selectStyle.minWidth = `${width}px`;
-  selectStyle.top = `${top}px`;
-  selectStyle[this.hot.isRtl() ? 'right' : 'left'] = `${start}px`;
-  selectStyle.margin = '0px';
-  selectStyle.display = '';
-}
-
-focus() {
-  this.select.focus();
-}
-
-close() {
-  this._opened = false;
-  this.select.style.display = 'none';
-}
-```
-
-The implementations of [`getvalue()`](@/api/baseEditor.md#getvalue), [`setvalue()`](@/api/baseEditor.md#setvalue) and [`close()`](@/api/baseEditor.md#close) are self-explanatory, but [`open()`](@/api/baseEditor.md#open) requires a few words of comment. First of all, the implementation assumes that code responsible for populating the list with options is placed in [`prepare()`](@/api/baseEditor.md#prepare). Secondly, before displaying the list, we sets its `height` and `min-width` so that it matches the size of corresponding cell. It's an optional step, but without it the editor will have different sizes depending on the browser. Probably a good idea would be also to limit the maximum height of `<select>`. Finally, as the `<select>` has been appended to the end of the table container, we have to change its position so that it could be displayed above the cell that is being edited. Again, this is an optional step, but it seems quite reasonable to put the editor next to the appropriate cell.
-
-Task four: **DONE**
-
-At this point we should have an editor that is ready to use. Put the code somewhere in your page and pass `SelectEditor` class function as value of the [`editor`](@/api/options.md#editor) configuration option.
-
-::: only-for javascript
-
-```js
-const container = document.querySelector("#container");
-const hot = new Handsontable(container, {
-  columns: [
-    {},
-    {
-      editor: SelectEditor,
-      selectOptions: ["option1", "option2", "option3"],
-    },
-  ],
-});
-```
-
-:::
-
-::: only-for react
-
-```jsx
-<HotTable
-  columns={[
-    {},
-    {
-      editor: SelectEditor,
-      selectOptions: ["option1", "option2", "option3"],
-    },
-  ]}
-/>
-```
-
-:::
-
-::: only-for angular
-
-```ts
-settings = {
-  columns: [
-    {},
-    {
-      editor: SelectEditor,
-      selectOptions: ["option1", "option2", "option3"],
-    },
-  ],
-};
-```
-
-```html
-<hot-table [settings]="settings"></hot-table>
-```
-
-:::
-
-##### Use <kbd>**Arrow Up**</kbd> and <kbd>**Arrow Down**</kbd> to change selected value
-
-We know that our editor works, but let's add one more tweak to it. Currently, when editor is opened and user presses <kbd>**Arrow Up**</kbd> or <kbd>**Arrow Down**</kbd> editor closes and the selection moves one cell up or down. Wouldn't it be nice, if pressing up and down arrow keys changed the currently selected value? User could navigate to the cell, hit <kbd>**Enter**</kbd>, choose the desired value and save changes by hitting <kbd>**Enter**</kbd> again. It would be possible to work with the table without even laying your hand on a mouse. Sounds pretty good, but how to override the default behavior? After all, it's the [`EditorManager`](@/api/baseEditor.md) who decides when to close the editor.
-
-Don't worry. Although, you don't have a direct access to [`EditorManager`](@/api/baseEditor.md) instance, you can still override its behaviour. Before [`EditorManager`](@/api/baseEditor.md) starts to process keyboard events it triggers [`beforeKeyDown`](@/api/hooks.md#beforekeydown) hook. If any of the listening functions invoke `stopImmediatePropagation()` method on an `event` object [`EditorManager`](@/api/baseEditor.md) won't process this event any further. Therefore, all we have to do is register a [`beforeKeyDown`](@/api/hooks.md#beforekeydown) listener function that checks whether <kbd>**Arrow Up**</kbd> or <kbd>**Arrow Down**</kbd> has been pressed and if so, stops event propagation and changes the currently selected value in `<select>` list accordingly.
-
-The thing that we need to keep in mind is that our listener should work only, when our editor is opened. We want to preserve the default behaviour for other editors, as well as when no editor is opened. That's why the most reasonable place to register our listener would be the [`open()`](@/api/baseEditor.md#open) method and the [`close()`](@/api/baseEditor.md#close) method should contain code that will remove our listener.
-
-Here's how the listener function could look like:
-
-```js
-onBeforeKeyDown() {
-  const previousOptionIndex = this.select.selectedIndex - 1;
-  const nextOptionIndex = this.select.selectedIndex + 1;
-
-  switch (event.keyCode) {
-    case 38: // Arrow Up
-      if (previousOptionIndex >= 0) {
-        this.select[previousOptionIndex].selected = true;
-      }
-
-      event.stopImmediatePropagation();
-      event.preventDefault();
-      break;
-
-    case 40: // Arrow Down
-      if (nextOptionIndex <= this.select.length - 1){
-        this.select[nextOptionIndex].selected=true;
-      }
-
-      event.stopImmediatePropagation();
-      event.preventDefault();
-      break;
-
-    default:
-      break;
-  }
-}
-```
-
-Active editor is the editor which [`prepare()`](@/api/baseEditor.md#prepare) method was called most recently. For example, if you select a cell which editor is `Handsontable.TextEditor`, then `getActiveEditor()` will return an object of this editor class. If then select a cell (presumably in another column) which editor is `Handsontable.DateEditor`, the active editor changes and now `getActiveEditor()` will return an object of `DateEditor` class.
-
-The rest of the code should be quite clear. Now all we have to do is register our listener.
-
-```js
-open() {
-  this.addHook('beforeKeyDown', () => this.onBeforeKeyDown());
-}
-
-close() {
-  this.clearHooks();
-}
-```
-
-Go ahead and test it!
-
-## Registering an editor
-
-When you create an editor, a good idea is to assign it an alias that will refer to this particular editor class. Handsontable defines 11 aliases by default:
-
-- `autocomplete` for `Handsontable.editors.AutocompleteEditor`
-- `base` for `Handsontable.editors.BaseEditor`
-- `checkbox` for `Handsontable.editors.CheckboxEditor`
-- `date` for `Handsontable.editors.DateEditor`
-- `dropdown` for `Handsontable.editors.DropdownEditor`
-- `handsontable` for `Handsontable.editors.HandsontableEditor`
-- `numeric` for `Handsontable.editors.NumericEditor`
-- `password` for `Handsontable.editors.PasswordEditor`
-- `select` for `Handsontable.editors.SelectEditor`
-- `text` for `Handsontable.editors.TextEditor`
-- `time` for `Handsontable.editors.TimeEditor`
-
-It gives users a convenient way for defining which editor should be use when changing value of certain cells. User doesn't need to know which class is responsible for displaying the editor, he does not even need to know that there is any class at all. What is more, you can change the class associated with an alias without a need to change code that defines a table.
-
-To register your own alias use `Handsontable.editors.registerEditor()` function. It takes two arguments:
-
-- `editorName` - a string representing an editor
-- `editorClass` - a class that will be represented by `editorName`
-
-If you'd like to register `SelectEditor` under alias `select` you have to call:
-
-```js
-Handsontable.editors.registerEditor("select", SelectEditor);
-```
-
-Choose aliases wisely. If you register your editor under name that is already registered, the target class will be overwritten:
-
-```js
-Handsontable.editors.registerEditor("text", MyNewTextEditor);
-```
-
-Now 'text' alias points to MyNewTextEditor class, not `Handsontable.editors.TextEditor`.
-
-So, unless you intentionally want to overwrite an existing alias, try to choose a unique name. A good practice is prefixing your aliases with some custom name (for example your GitHub username) to minimize the possibility of name collisions. This is especially important if you want to publish your editor, because you never know aliases has been registered by the user who uses your editor.
-
-```js
-Handsontable.editors.registerEditor("select", SelectEditor);
-```
-
-Someone might already registered such alias.
-
-```js
-Handsontable.editors.registerEditor("my.select", SelectEditor);
-```
-
-That's better.
-
-::: only-for javascript
-
-## Prepare editor for publication
-
-If you plan to publish your editor or just want to keep your code nice and clean (as we all do :) there are 3 simple steps that will help you to organize your code.
-
-:::
-
-::: only-for react
-
-### Prepare editor for publication
-
-If you plan to publish your editor or just want to keep your code nice and clean (as we all do :) there are 3 simple steps that will help you to organize your code.
-
-:::
-
-::: only-for javascript
-
-### Enclose in IIFE
-
-Put your code in a module, to avoid polluting the global namespace. You can use AMD, CommonJS or any other module pattern, but the easiest way to isolate your code is to use plain immediately invoked function expression (IIFE).
-
-```js
-((Handsontable) => {
-  const CustomEditor = Handsontable.editors.BaseEditor.prototype.extend();
-
-  // ...rest of the editor code
-})(Handsontable);
-```
-
-Passing `Handsontable` namespace as argument is optional (as it is defined globally), but it's a good practice to use as few global objects as possible, to make modularisation and dependency management easier.
-:::
-
-::: only-for react
-
-#### Enclose in IIFE
-
-Put your code in a module, to avoid polluting the global namespace. You can use AMD, CommonJS or any other module pattern, but the easiest way to isolate your code is to use plain immediately invoked function expression (IIFE).
-
-```js
-((Handsontable) => {
-  const CustomEditor = Handsontable.editors.BaseEditor.prototype.extend();
-
-  // ...rest of the editor code
-})(Handsontable);
-```
-
-Passing `Handsontable` namespace as argument is optional (as it is defined globally), but it's a good practice to use as few global objects as possible, to make modularisation and dependency management easier.
-:::
-
-::: only-for javascript
-
-### Add editor to dedicated namespace
-
-Code enclosed in IIFE cannot be accessed from outside, unless it's intentionally exposed. To keep things well organized register your editor to the collection of editors using `Handsontable.editors.registerEditor` method. This way you can use your editor during table definition and other users will have an easy access to your editor, in case they would like to extend it.
-
-```js
-((Handsontable) => {
-  const CustomEditor = Handsontable.editors.BaseEditor.prototype.extend();
-
-  // ...rest of the editor code
-
-  // And at the end
-  Handsontable.editors.registerEditor("custom", CustomEditor);
-})(Handsontable);
-```
-
-From now on, you can use `CustomEditor` like so:
-
-```js
-const container = document.querySelector("#container");
-const hot = new Handsontable(container, {
-  columns: [
-    {
-      editor: Handsontable.editors.CustomEditor,
-    },
-  ],
-});
-```
-
-Extending your `CustomEditor` is also easy.
-
-```js
-const AnotherEditor = Handsontable.editors
-  .getEditor("custom")
-  .prototype.extend();
-```
-
-Keep in mind, that there are no restrictions to the name you choose, but choose wisely and do not overwrite existing editors. Try to keep the names unique.
-:::
-
-::: only-for react
-
-#### Add editor to dedicated namespace
-
-Code enclosed in IIFE cannot be accessed from outside, unless it's intentionally exposed. To keep things well organized register your editor to the collection of editors using `Handsontable.editors.registerEditor` method. This way you can use your editor during table definition and other users will have an easy access to your editor, in case they would like to extend it.
-
-```js
-((Handsontable) => {
-  const CustomEditor = Handsontable.editors.BaseEditor.prototype.extend();
-
-  // ...rest of the editor code
-
-  // And at the end
-  Handsontable.editors.registerEditor("custom", CustomEditor);
-})(Handsontable);
-```
-
-From now on, you can use `CustomEditor` like so:
-
-```jsx
-<HotTable
-  columns={[
-    {
-      editor: Handsontable.editors.CustomEditor,
-    },
-  ]}
-/>
-```
-
-Extending your `CustomEditor` is also easy.
-
-```js
-const AnotherEditor = Handsontable.editors
-  .getEditor("custom")
-  .prototype.extend();
-```
-
-Keep in mind, that there are no restrictions to the name you choose, but choose wisely and do not overwrite existing editors. Try to keep the names unique.
-:::
-
-::: only-for javascript
-
-### Register an alias
-
-The final touch is to register your editor under some alias, so that users can easily refer to it without the need to now the actual class name. See Registering editor for details.
-
-To sum up, a well prepared editor should look like this:
-
-```js
-((Handsontable) => {
-  const CustomEditor = Handsontable.editors.BaseEditor.prototype.extend();
-
-  // ...rest of the editor code
-
-  // Put editor in dedicated namespace
-  Handsontable.editors.CustomEditor = CustomEditor;
-
-  // Register alias
-  Handsontable.editors.registerEditor("theBestEditor", CustomEditor);
-})(Handsontable);
-```
-
-From now on, you can use `CustomEditor` like so:
-
-```js
-const container = document.querySelector("#container");
-const hot = new Handsontable(container, {
-  columns: [
-    {
-      editor: "theBestEditor",
-    },
-  ],
-});
-```
-
-:::
-
-::: only-for react
-
-#### Register an alias
-
-The final touch is to register your editor under some alias, so that users can easily refer to it without the need to now the actual class name. See Registering editor for details.
-
-To sum up, a well prepared editor should look like this:
-
-```js
-((Handsontable) => {
-  const CustomEditor = Handsontable.editors.BaseEditor.prototype.extend();
-
-  // ...rest of the editor code
-
-  // Put editor in dedicated namespace
-  Handsontable.editors.CustomEditor = CustomEditor;
-
-  // Register alias
-  Handsontable.editors.registerEditor("theBestEditor", CustomEditor);
-})(Handsontable);
-```
-
-From now on, you can use `CustomEditor` like so:
-
-```jsx
-<HotTable
-  columns={[
-    {
-      editor: "theBestEditor",
-    },
-  ]}
-/>
-```
+`getEditor('alias')` returns the class itself, not an instance. It is the recommended way to retrieve a class by alias because it works regardless of whether the class is accessible in the current module scope.
 
 :::
 
 ## Related keyboard shortcuts
 
-| Windows                                               | macOS                                                       | Action                                                             |  Excel  | Sheets  |
-| ----------------------------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------ | :-----: | :-----: |
-| Arrow keys                                            | Arrow keys                                                  | Move the cursor through the text                                   | &check; | &check; |
-| Alphanumeric keys                                     | Alphanumeric keys                                           | Enter the pressed key's value into the cell                        | &check; | &check; |
-| <kbd>**Enter**</kbd>                                  | <kbd>**Enter**</kbd>                                        | Complete the cell entry and move to the cell below                 | &check; | &check; |
-| <kbd>**Shift**</kbd>+<kbd>**Enter**</kbd>             | <kbd>**Shift**</kbd>+<kbd>**Enter**</kbd>                   | Complete the cell entry and move to the cell above                 | &check; | &check; |
-| <kbd>**Tab**</kbd>                                    | <kbd>**Tab**</kbd>                                          | Complete the cell entry and move to the next cell<sup>\*</sup>     | &check; | &check; |
-| <kbd>**Shift**</kbd>+<kbd>**Tab**</kbd>               | <kbd>**Shift**</kbd>+<kbd>**Tab**</kbd>                     | Complete the cell entry and move to the previous cell<sup>\*</sup> | &check; | &check; |
-| <kbd>**Delete**</kbd>                                 | <kbd>**Delete**</kbd>                                       | Delete one character after the cursor<sup>\*</sup>                 | &check; | &check; |
-| <kbd>**Backspace**</kbd>                              | <kbd>**Backspace**</kbd>                                    | Delete one character before the cursor<sup>\*</sup>                | &check; | &check; |
-| <kbd>**Home**</kbd>                                   | <kbd>**Home**</kbd>                                         | Move the cursor to the beginning of the text<sup>\*</sup>          | &check; | &check; |
-| <kbd>**End**</kbd>                                    | <kbd>**End**</kbd>                                          | Move the cursor to the end of the text<sup>\*</sup>                | &check; | &check; |
-| <kbd>**Ctrl**</kbd> + Arrow keys                      | <kbd>**Cmd**</kbd> + Arrow keys                             | Move the cursor to the beginning or to the end of the text         | &check; | &check; |
-| <kbd>**Ctrl**</kbd>+<kbd>**Shift**</kbd> + Arrow keys | <kbd>**Cmd**</kbd>+<kbd>**Shift**</kbd> + Arrow keys        | Extend the selection to the beginning or to the end of the text    | &check; | &check; |
-| <kbd>**Page Up**</kbd>                                | <kbd>**Page Up**</kbd>                                      | Complete the cell entry and move one screen up                     | &check; | &check; |
-| <kbd>**Page Down**</kbd>                              | <kbd>**Page Down**</kbd>                                    | Complete the cell entry and move one screen down                   | &check; | &check; |
-| <kbd>**Alt**</kbd>+<kbd>**Enter**</kbd>               | <kbd>**Option**</kbd>+<kbd>**Enter**</kbd>                  | Insert a line break                                                | &cross; | &check; |
-| <kbd>**Ctrl**</kbd>+<kbd>**Enter**</kbd>              | <kbd>**Ctrl**</kbd>/<kbd>**Cmd**</kbd>+<kbd>**Enter**</kbd> | Insert a line break                                                | &cross; | &check; |
-| <kbd>**Escape**</kbd>                                 | <kbd>**Escape**</kbd>                                       | Cancel the cell entry and exit the editing mode                    | &check; | &check; |
+| Windows | macOS | Action | Excel | Sheets |
+| --- | --- | --- | :---: | :---: |
+| Arrow keys | Arrow keys | Move the cursor through the text | &check; | &check; |
+| Alphanumeric keys | Alphanumeric keys | Enter the pressed key's value into the cell | &check; | &check; |
+| <kbd>**Enter**</kbd> | <kbd>**Enter**</kbd> | Complete the cell entry and move to the cell below | &check; | &check; |
+| <kbd>**Shift**</kbd>+<kbd>**Enter**</kbd> | <kbd>**Shift**</kbd>+<kbd>**Enter**</kbd> | Complete the cell entry and move to the cell above | &check; | &check; |
+| <kbd>**Tab**</kbd> | <kbd>**Tab**</kbd> | Complete the cell entry and move to the next cell<sup>\*</sup> | &check; | &check; |
+| <kbd>**Shift**</kbd>+<kbd>**Tab**</kbd> | <kbd>**Shift**</kbd>+<kbd>**Tab**</kbd> | Complete the cell entry and move to the previous cell<sup>\*</sup> | &check; | &check; |
+| <kbd>**Delete**</kbd> | <kbd>**Delete**</kbd> | Delete one character after the cursor<sup>\*</sup> | &check; | &check; |
+| <kbd>**Backspace**</kbd> | <kbd>**Backspace**</kbd> | Delete one character before the cursor<sup>\*</sup> | &check; | &check; |
+| <kbd>**Home**</kbd> | <kbd>**Home**</kbd> | Move the cursor to the beginning of the text<sup>\*</sup> | &check; | &check; |
+| <kbd>**End**</kbd> | <kbd>**End**</kbd> | Move the cursor to the end of the text<sup>\*</sup> | &check; | &check; |
+| <kbd>**Ctrl**</kbd> + Arrow keys | <kbd>**Cmd**</kbd> + Arrow keys | Move the cursor to the beginning or to the end of the text | &check; | &check; |
+| <kbd>**Ctrl**</kbd>+<kbd>**Shift**</kbd> + Arrow keys | <kbd>**Cmd**</kbd>+<kbd>**Shift**</kbd> + Arrow keys | Extend the selection to the beginning or to the end of the text | &check; | &check; |
+| <kbd>**Page Up**</kbd> | <kbd>**Page Up**</kbd> | Complete the cell entry and move one screen up | &check; | &check; |
+| <kbd>**Page Down**</kbd> | <kbd>**Page Down**</kbd> | Complete the cell entry and move one screen down | &check; | &check; |
+| <kbd>**Alt**</kbd>+<kbd>**Enter**</kbd> | <kbd>**Option**</kbd>+<kbd>**Enter**</kbd> | Insert a line break | &cross; | &check; |
+| <kbd>**Ctrl**</kbd>+<kbd>**Enter**</kbd> | <kbd>**Ctrl**</kbd>/<kbd>**Cmd**</kbd>+<kbd>**Enter**</kbd> | Insert a line break | &cross; | &check; |
+| <kbd>**Escape**</kbd> | <kbd>**Escape**</kbd> | Cancel the cell entry and exit the editing mode | &check; | &check; |
 
 <sup>\*</sup> This action depends on your [layout direction](@/guides/internationalization/layout-direction/layout-direction.md).
 
@@ -1261,7 +406,6 @@ From now on, you can use `CustomEditor` like so:
 
 - [Custom editor in React](@/react/guides/cell-functions/cell-editor/cell-editor.md)
 - [Custom editor in Angular](@/angular/guides/cell-functions/cell-editor/cell-editor.md)
-- [Custom editor in Vue](@/guides/integrate-with-vue3/vue3-custom-editor-example/vue3-custom-editor-example.md)
 - [Custom editor in Vue 3](@/guides/integrate-with-vue3/vue3-custom-editor-example/vue3-custom-editor-example.md)
 
 </div>

--- a/docs/content/guides/cell-functions/cell-editor/javascript/example1.js
+++ b/docs/content/guides/cell-functions/cell-editor/javascript/example1.js
@@ -11,28 +11,33 @@ class PasswordEditor extends TextEditor {
     this.TEXTAREA.setAttribute('type', 'password');
     this.TEXTAREA.setAttribute('data-hot-input', 'true');
     this.textareaStyle = this.TEXTAREA.style;
-    this.textareaStyle.width = 0;
-    this.textareaStyle.height = 0;
+    this.textareaStyle.width = '0';
+    this.textareaStyle.height = '0';
     this.TEXTAREA_PARENT.innerText = '';
     this.TEXTAREA_PARENT.appendChild(this.TEXTAREA);
   }
+}
+
+function maskedRenderer(hotInstance, td, row, col, prop, value) {
+  td.innerText = value ? '●●●●●●●●' : '—';
+  td.style.letterSpacing = value ? '2px' : 'normal';
+
+  return td;
 }
 
 const container = document.querySelector('#example1');
 
 new Handsontable(container, {
   data: [
-    ['Alice', 'abc123'],
-    ['Bob', 'letmein'],
-    ['Carol', 'hunter2'],
-    ['Dave', 'p@ssword'],
-    ['Eve', 'qwerty'],
+    ['Alice Chen', 'alice@example.com', 'Admin', 'Wh1stl3!2024'],
+    ['Bob Garcia', 'bob@example.com', 'Editor', 'P@ssw0rd42'],
+    ['Carol Smith', 'carol@example.com', 'Viewer', 'Tr0ub4dor&3'],
+    ['Dave Kim', 'dave@example.com', 'Editor', 'c0rrectH0rs3'],
+    ['Eve Johnson', 'eve@example.com', 'Admin', 'Sup3rS3cr3t!'],
   ],
-  colHeaders: ['Username', 'Password'],
-  columns: [
-    { type: 'text' },
-    { editor: PasswordEditor },
-  ],
+  colHeaders: ['Name', 'Email', 'Role', 'Password'],
+  columns: [{ type: 'text' }, { type: 'text' }, { type: 'text' }, { editor: PasswordEditor, renderer: maskedRenderer }],
+  colWidths: [130, 190, 70, 130],
   rowHeaders: true,
   height: 'auto',
   autoWrapRow: true,

--- a/docs/content/guides/cell-functions/cell-editor/javascript/example1.js
+++ b/docs/content/guides/cell-functions/cell-editor/javascript/example1.js
@@ -1,0 +1,41 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+import { TextEditor } from 'handsontable/editors/textEditor';
+
+registerAllModules();
+
+class PasswordEditor extends TextEditor {
+  createElements() {
+    super.createElements();
+    this.TEXTAREA = this.hot.rootDocument.createElement('input');
+    this.TEXTAREA.setAttribute('type', 'password');
+    this.TEXTAREA.setAttribute('data-hot-input', 'true');
+    this.textareaStyle = this.TEXTAREA.style;
+    this.textareaStyle.width = 0;
+    this.textareaStyle.height = 0;
+    this.TEXTAREA_PARENT.innerText = '';
+    this.TEXTAREA_PARENT.appendChild(this.TEXTAREA);
+  }
+}
+
+const container = document.querySelector('#example1');
+
+new Handsontable(container, {
+  data: [
+    ['Alice', 'abc123'],
+    ['Bob', 'letmein'],
+    ['Carol', 'hunter2'],
+    ['Dave', 'p@ssword'],
+    ['Eve', 'qwerty'],
+  ],
+  colHeaders: ['Username', 'Password'],
+  columns: [
+    { type: 'text' },
+    { editor: PasswordEditor },
+  ],
+  rowHeaders: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/cell-functions/cell-editor/javascript/example1.ts
+++ b/docs/content/guides/cell-functions/cell-editor/javascript/example1.ts
@@ -5,7 +5,7 @@ import { TextEditor } from 'handsontable/editors/textEditor';
 registerAllModules();
 
 class PasswordEditor extends TextEditor {
-  createElements(): void {
+  override createElements(): void {
     super.createElements();
     this.TEXTAREA = this.hot.rootDocument.createElement('input') as HTMLInputElement;
     this.TEXTAREA.setAttribute('type', 'password');
@@ -18,21 +18,38 @@ class PasswordEditor extends TextEditor {
   }
 }
 
+function maskedRenderer(
+  hotInstance: Handsontable.Core,
+  td: HTMLTableCellElement,
+  row: number,
+  col: number,
+  prop: string | number,
+  value: any
+): HTMLTableCellElement {
+  td.innerText = value ? '●●●●●●●●' : '—';
+  td.style.letterSpacing = value ? '2px' : 'normal';
+
+  return td;
+}
+
 const container = document.querySelector('#example1') as HTMLElement;
 
 new Handsontable(container, {
   data: [
-    ['Alice', 'abc123'],
-    ['Bob', 'letmein'],
-    ['Carol', 'hunter2'],
-    ['Dave', 'p@ssword'],
-    ['Eve', 'qwerty'],
+    ['Alice Chen', 'alice@example.com', 'Admin', 'Wh1stl3!2024'],
+    ['Bob Garcia', 'bob@example.com', 'Editor', 'P@ssw0rd42'],
+    ['Carol Smith', 'carol@example.com', 'Viewer', 'Tr0ub4dor&3'],
+    ['Dave Kim', 'dave@example.com', 'Editor', 'c0rrectH0rs3'],
+    ['Eve Johnson', 'eve@example.com', 'Admin', 'Sup3rS3cr3t!'],
   ],
-  colHeaders: ['Username', 'Password'],
+  colHeaders: ['Name', 'Email', 'Role', 'Password'],
   columns: [
     { type: 'text' },
-    { editor: PasswordEditor as typeof TextEditor },
+    { type: 'text' },
+    { type: 'text' },
+    { editor: PasswordEditor as typeof TextEditor, renderer: maskedRenderer },
   ],
+  colWidths: [130, 190, 70, 130],
   rowHeaders: true,
   height: 'auto',
   autoWrapRow: true,

--- a/docs/content/guides/cell-functions/cell-editor/javascript/example1.ts
+++ b/docs/content/guides/cell-functions/cell-editor/javascript/example1.ts
@@ -1,0 +1,41 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+import { TextEditor } from 'handsontable/editors/textEditor';
+
+registerAllModules();
+
+class PasswordEditor extends TextEditor {
+  createElements(): void {
+    super.createElements();
+    this.TEXTAREA = this.hot.rootDocument.createElement('input') as HTMLInputElement;
+    this.TEXTAREA.setAttribute('type', 'password');
+    this.TEXTAREA.setAttribute('data-hot-input', 'true');
+    this.textareaStyle = this.TEXTAREA.style;
+    this.textareaStyle.width = '0';
+    this.textareaStyle.height = '0';
+    this.TEXTAREA_PARENT.innerText = '';
+    this.TEXTAREA_PARENT.appendChild(this.TEXTAREA);
+  }
+}
+
+const container = document.querySelector('#example1') as HTMLElement;
+
+new Handsontable(container, {
+  data: [
+    ['Alice', 'abc123'],
+    ['Bob', 'letmein'],
+    ['Carol', 'hunter2'],
+    ['Dave', 'p@ssword'],
+    ['Eve', 'qwerty'],
+  ],
+  colHeaders: ['Username', 'Password'],
+  columns: [
+    { type: 'text' },
+    { editor: PasswordEditor as typeof TextEditor },
+  ],
+  rowHeaders: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/cell-functions/cell-editor/javascript/example2.css
+++ b/docs/content/guides/cell-functions/cell-editor/javascript/example2.css
@@ -5,3 +5,14 @@
   width: auto;
   z-index: 300;
 }
+
+.htSelectBadge {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 600;
+  color: #fff;
+  letter-spacing: 0.3px;
+  white-space: nowrap;
+}

--- a/docs/content/guides/cell-functions/cell-editor/javascript/example2.css
+++ b/docs/content/guides/cell-functions/cell-editor/javascript/example2.css
@@ -1,0 +1,7 @@
+.htSelectEditor {
+  /* Enables dimension changes for <select> in WebKit browsers */
+  -webkit-appearance: menulist-button !important;
+  position: absolute;
+  width: auto;
+  z-index: 300;
+}

--- a/docs/content/guides/cell-functions/cell-editor/javascript/example2.js
+++ b/docs/content/guides/cell-functions/cell-editor/javascript/example2.js
@@ -12,14 +12,11 @@ class SelectEditor extends BaseEditor {
     this.select.style.display = 'none';
     this.hot.rootElement.appendChild(this.select);
   }
-
   prepare(row, col, prop, td, originalValue, cellProperties) {
     super.prepare(row, col, prop, td, originalValue, cellProperties);
 
     const rawOptions = this.cellProperties.selectOptions ?? [];
-    const options = Array.isArray(rawOptions)
-      ? Object.fromEntries(rawOptions.map((v) => [v, v]))
-      : rawOptions;
+    const options = Array.isArray(rawOptions) ? Object.fromEntries(rawOptions.map((v) => [v, v])) : rawOptions;
 
     this.select.innerText = '';
     Object.keys(options).forEach((key) => {
@@ -30,15 +27,12 @@ class SelectEditor extends BaseEditor {
       this.select.appendChild(option);
     });
   }
-
   getValue() {
     return this.select.value;
   }
-
   setValue(value) {
     this.select.value = value;
   }
-
   open() {
     const { top, start, width, height } = this.getEditedCellRect();
     const s = this.select.style;
@@ -49,7 +43,6 @@ class SelectEditor extends BaseEditor {
     s[this.hot.isRtl() ? 'right' : 'left'] = `${start}px`;
     s.margin = '0px';
     s.display = '';
-
     this.addHook('beforeKeyDown', (event) => {
       const { selectedIndex, length } = this.select;
 
@@ -64,35 +57,72 @@ class SelectEditor extends BaseEditor {
       }
     });
   }
-
   close() {
     this.select.style.display = 'none';
     this.clearHooks();
   }
-
   focus() {
     this.select.focus();
   }
+}
+const PRIORITY_COLORS = {
+  Low: '#22c55e',
+  Medium: '#f59e0b',
+  High: '#ef4444',
+  Critical: '#7c3aed',
+};
+
+const STATUS_COLORS = {
+  'To Do': '#6b7280',
+  'In Progress': '#3b82f6',
+  Review: '#f59e0b',
+  Done: '#22c55e',
+};
+
+function badgeRenderer(colorMap) {
+  return (hotInstance, td, row, col, prop, value) => {
+    td.innerText = '';
+
+    if (value) {
+      const badge = hotInstance.rootDocument.createElement('span');
+
+      badge.className = 'htSelectBadge';
+      badge.style.background = colorMap[value] ?? '#6b7280';
+      badge.innerText = value;
+      td.appendChild(badge);
+    }
+
+    return td;
+  };
 }
 
 const container = document.querySelector('#example2');
 
 new Handsontable(container, {
   data: [
-    ['Tesla', 'black'],
-    ['Nissan', 'white'],
-    ['Toyota', 'red'],
-    ['Honda', 'blue'],
-    ['Ford', 'silver'],
+    ['Migrate database schema', 'High', 'In Progress'],
+    ['Update API documentation', 'Medium', 'To Do'],
+    ['Fix authentication bug', 'Critical', 'Review'],
+    ['Add dark mode support', 'Low', 'Done'],
+    ['Improve test coverage', 'Medium', 'In Progress'],
+    ['Deploy to staging server', 'High', 'To Do'],
+    ['Refactor billing module', 'Medium', 'Done'],
   ],
-  colHeaders: ['Car', 'Color'],
+  colHeaders: ['Task', 'Priority', 'Status'],
   columns: [
     { type: 'text' },
     {
       editor: SelectEditor,
-      selectOptions: ['black', 'white', 'red', 'blue', 'silver'],
+      renderer: badgeRenderer(PRIORITY_COLORS),
+      selectOptions: ['Low', 'Medium', 'High', 'Critical'],
+    },
+    {
+      editor: SelectEditor,
+      renderer: badgeRenderer(STATUS_COLORS),
+      selectOptions: ['To Do', 'In Progress', 'Review', 'Done'],
     },
   ],
+  colWidths: [220, 110, 130],
   rowHeaders: true,
   height: 'auto',
   autoWrapRow: true,

--- a/docs/content/guides/cell-functions/cell-editor/javascript/example2.js
+++ b/docs/content/guides/cell-functions/cell-editor/javascript/example2.js
@@ -1,0 +1,101 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+import { BaseEditor } from 'handsontable/editors/baseEditor';
+
+registerAllModules();
+
+class SelectEditor extends BaseEditor {
+  init() {
+    this.select = this.hot.rootDocument.createElement('SELECT');
+    this.select.setAttribute('data-hot-input', 'true');
+    this.select.classList.add('htSelectEditor');
+    this.select.style.display = 'none';
+    this.hot.rootElement.appendChild(this.select);
+  }
+
+  prepare(row, col, prop, td, originalValue, cellProperties) {
+    super.prepare(row, col, prop, td, originalValue, cellProperties);
+
+    const rawOptions = this.cellProperties.selectOptions ?? [];
+    const options = Array.isArray(rawOptions)
+      ? Object.fromEntries(rawOptions.map((v) => [v, v]))
+      : rawOptions;
+
+    this.select.innerText = '';
+    Object.keys(options).forEach((key) => {
+      const option = this.hot.rootDocument.createElement('OPTION');
+
+      option.value = key;
+      option.innerText = options[key];
+      this.select.appendChild(option);
+    });
+  }
+
+  getValue() {
+    return this.select.value;
+  }
+
+  setValue(value) {
+    this.select.value = value;
+  }
+
+  open() {
+    const { top, start, width, height } = this.getEditedCellRect();
+    const s = this.select.style;
+
+    s.height = `${height}px`;
+    s.minWidth = `${width}px`;
+    s.top = `${top}px`;
+    s[this.hot.isRtl() ? 'right' : 'left'] = `${start}px`;
+    s.margin = '0px';
+    s.display = '';
+
+    this.addHook('beforeKeyDown', (event) => {
+      const { selectedIndex, length } = this.select;
+
+      if (event.keyCode === 38 && selectedIndex > 0) {
+        this.select[selectedIndex - 1].selected = true;
+        event.stopImmediatePropagation();
+        event.preventDefault();
+      } else if (event.keyCode === 40 && selectedIndex < length - 1) {
+        this.select[selectedIndex + 1].selected = true;
+        event.stopImmediatePropagation();
+        event.preventDefault();
+      }
+    });
+  }
+
+  close() {
+    this.select.style.display = 'none';
+    this.clearHooks();
+  }
+
+  focus() {
+    this.select.focus();
+  }
+}
+
+const container = document.querySelector('#example2');
+
+new Handsontable(container, {
+  data: [
+    ['Tesla', 'black'],
+    ['Nissan', 'white'],
+    ['Toyota', 'red'],
+    ['Honda', 'blue'],
+    ['Ford', 'silver'],
+  ],
+  colHeaders: ['Car', 'Color'],
+  columns: [
+    { type: 'text' },
+    {
+      editor: SelectEditor,
+      selectOptions: ['black', 'white', 'red', 'blue', 'silver'],
+    },
+  ],
+  rowHeaders: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/cell-functions/cell-editor/javascript/example2.ts
+++ b/docs/content/guides/cell-functions/cell-editor/javascript/example2.ts
@@ -1,0 +1,110 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+import { BaseEditor } from 'handsontable/editors/baseEditor';
+
+registerAllModules();
+
+class SelectEditor extends BaseEditor {
+  declare select: HTMLSelectElement;
+
+  init(): void {
+    this.select = this.hot.rootDocument.createElement('SELECT') as HTMLSelectElement;
+    this.select.setAttribute('data-hot-input', 'true');
+    this.select.classList.add('htSelectEditor');
+    this.select.style.display = 'none';
+    this.hot.rootElement.appendChild(this.select);
+  }
+
+  override prepare(
+    row: number,
+    col: number,
+    prop: number | string,
+    td: HTMLTableCellElement,
+    originalValue: any,
+    cellProperties: object
+  ): void {
+    super.prepare(row, col, prop, td, originalValue, cellProperties);
+
+    const rawOptions = (this.cellProperties as any).selectOptions ?? [];
+    const options: Record<string, string> = Array.isArray(rawOptions)
+      ? Object.fromEntries(rawOptions.map((v: any) => [v, v]))
+      : rawOptions;
+
+    this.select.innerText = '';
+    Object.keys(options).forEach((key) => {
+      const option = this.hot.rootDocument.createElement('OPTION') as HTMLOptionElement;
+
+      option.value = key;
+      option.innerText = options[key];
+      this.select.appendChild(option);
+    });
+  }
+
+  getValue(): string {
+    return this.select.value;
+  }
+
+  setValue(value: string): void {
+    this.select.value = value;
+  }
+
+  open(): void {
+    const { top, start, width, height } = this.getEditedCellRect();
+    const s = this.select.style;
+
+    s.height = `${height}px`;
+    s.minWidth = `${width}px`;
+    s.top = `${top}px`;
+    (s as any)[this.hot.isRtl() ? 'right' : 'left'] = `${start}px`;
+    s.margin = '0px';
+    s.display = '';
+
+    this.addHook('beforeKeyDown', (event: KeyboardEvent) => {
+      const { selectedIndex, length } = this.select;
+
+      if (event.keyCode === 38 && selectedIndex > 0) {
+        (this.select[selectedIndex - 1] as HTMLOptionElement).selected = true;
+        event.stopImmediatePropagation();
+        event.preventDefault();
+      } else if (event.keyCode === 40 && selectedIndex < length - 1) {
+        (this.select[selectedIndex + 1] as HTMLOptionElement).selected = true;
+        event.stopImmediatePropagation();
+        event.preventDefault();
+      }
+    });
+  }
+
+  close(): void {
+    this.select.style.display = 'none';
+    this.clearHooks();
+  }
+
+  focus(): void {
+    this.select.focus();
+  }
+}
+
+const container = document.querySelector('#example2') as HTMLElement;
+
+new Handsontable(container, {
+  data: [
+    ['Tesla', 'black'],
+    ['Nissan', 'white'],
+    ['Toyota', 'red'],
+    ['Honda', 'blue'],
+    ['Ford', 'silver'],
+  ],
+  colHeaders: ['Car', 'Color'],
+  columns: [
+    { type: 'text' },
+    {
+      editor: SelectEditor as typeof BaseEditor,
+      selectOptions: ['black', 'white', 'red', 'blue', 'silver'],
+    } as any,
+  ],
+  rowHeaders: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/cell-functions/cell-editor/javascript/example2.ts
+++ b/docs/content/guides/cell-functions/cell-editor/javascript/example2.ts
@@ -84,24 +84,71 @@ class SelectEditor extends BaseEditor {
   }
 }
 
+const PRIORITY_COLORS: Record<string, string> = {
+  Low: '#22c55e',
+  Medium: '#f59e0b',
+  High: '#ef4444',
+  Critical: '#7c3aed',
+};
+
+const STATUS_COLORS: Record<string, string> = {
+  'To Do': '#6b7280',
+  'In Progress': '#3b82f6',
+  Review: '#f59e0b',
+  Done: '#22c55e',
+};
+
+function badgeRenderer(colorMap: Record<string, string>) {
+  return (
+    hotInstance: Handsontable.Core,
+    td: HTMLTableCellElement,
+    row: number,
+    col: number,
+    prop: string | number,
+    value: any
+  ): HTMLTableCellElement => {
+    td.innerText = '';
+
+    if (value) {
+      const badge = hotInstance.rootDocument.createElement('span');
+
+      badge.className = 'htSelectBadge';
+      badge.style.background = colorMap[value] ?? '#6b7280';
+      badge.innerText = value as string;
+      td.appendChild(badge);
+    }
+
+    return td;
+  };
+}
+
 const container = document.querySelector('#example2') as HTMLElement;
 
 new Handsontable(container, {
   data: [
-    ['Tesla', 'black'],
-    ['Nissan', 'white'],
-    ['Toyota', 'red'],
-    ['Honda', 'blue'],
-    ['Ford', 'silver'],
+    ['Migrate database schema', 'High', 'In Progress'],
+    ['Update API documentation', 'Medium', 'To Do'],
+    ['Fix authentication bug', 'Critical', 'Review'],
+    ['Add dark mode support', 'Low', 'Done'],
+    ['Improve test coverage', 'Medium', 'In Progress'],
+    ['Deploy to staging server', 'High', 'To Do'],
+    ['Refactor billing module', 'Medium', 'Done'],
   ],
-  colHeaders: ['Car', 'Color'],
+  colHeaders: ['Task', 'Priority', 'Status'],
   columns: [
     { type: 'text' },
     {
       editor: SelectEditor as typeof BaseEditor,
-      selectOptions: ['black', 'white', 'red', 'blue', 'silver'],
+      renderer: badgeRenderer(PRIORITY_COLORS),
+      selectOptions: ['Low', 'Medium', 'High', 'Critical'],
+    } as any,
+    {
+      editor: SelectEditor as typeof BaseEditor,
+      renderer: badgeRenderer(STATUS_COLORS),
+      selectOptions: ['To Do', 'In Progress', 'Review', 'Done'],
     } as any,
   ],
+  colWidths: [220, 110, 130],
   rowHeaders: true,
   height: 'auto',
   autoWrapRow: true,


### PR DESCRIPTION
### Context

This PR updated the Cell Editor guide for JavaScript and added missing code examples. The content has been made more compact and optimised for LLMs.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/261

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; adds example code snippets without modifying runtime library behavior.
> 
> **Overview**
> Updates the `Cell editor` guide to be significantly more compact and task-oriented, with clearer explanations of the `EditorManager` lifecycle, `BaseEditor` API surface, built-in editor aliases, and guidance for registering/publishing editors.
> 
> Adds missing JavaScript code examples (JS/TS) for two common custom editor patterns: a `PasswordEditor` that extends `TextEditor` and a `SelectEditor` built from `BaseEditor` (including CSS and `beforeKeyDown` handling for arrow-key navigation).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2d245b915aa8c7b6b3fde799a51bd02b217af87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->