### PR TITLE
Update the Cell functions guide and add the code example

### DIFF
--- a/docs/.vuepress/containers/examples/examples.js
+++ b/docs/.vuepress/containers/examples/examples.js
@@ -203,6 +203,7 @@ module.exports = function(docsVersion, base) {
         );
         const activeTab = `${args.match(/--tab (code|html|css|preview)/)?.[1] ?? 'preview'}-tab-${id}`;
         const noEdit = !!args.match(/--no-edit/)?.[0];
+        const noJsfiddle = !!args.match(/--no-jsfiddle/)?.[0];
         const depsMatch = args.match(/--deps\s+(\S+(?:\s+\S+)*)/);
         const extraDeps = (depsMatch ? depsMatch[1].trim().split(/\s+/) : []).map((spec) => {
           const at = spec.lastIndexOf('@');
@@ -250,7 +251,7 @@ module.exports = function(docsVersion, base) {
       extraDeps
     )
     : ''}
-                  ${!noEdit
+                  ${!noEdit && !noJsfiddle
     ? jsfiddle(
       id,
       htmlContent,
@@ -275,7 +276,7 @@ module.exports = function(docsVersion, base) {
       extraDeps
     )
     : ''}
-                  ${!noEdit && !isReact
+                  ${!noEdit && !isReact && !noJsfiddle
     ? jsfiddle(
       id,
       htmlContent,

--- a/docs/.vuepress/containers/examples/examples.js
+++ b/docs/.vuepress/containers/examples/examples.js
@@ -203,7 +203,6 @@ module.exports = function(docsVersion, base) {
         );
         const activeTab = `${args.match(/--tab (code|html|css|preview)/)?.[1] ?? 'preview'}-tab-${id}`;
         const noEdit = !!args.match(/--no-edit/)?.[0];
-        const noJsfiddle = !!args.match(/--no-jsfiddle/)?.[0];
         const depsMatch = args.match(/--deps\s+(\S+(?:\s+\S+)*)/);
         const extraDeps = (depsMatch ? depsMatch[1].trim().split(/\s+/) : []).map((spec) => {
           const at = spec.lastIndexOf('@');
@@ -251,7 +250,7 @@ module.exports = function(docsVersion, base) {
       extraDeps
     )
     : ''}
-                  ${!noEdit && !noJsfiddle
+                  ${!noEdit
     ? jsfiddle(
       id,
       htmlContent,
@@ -276,7 +275,7 @@ module.exports = function(docsVersion, base) {
       extraDeps
     )
     : ''}
-                  ${!noEdit && !isReact && !noJsfiddle
+                  ${!noEdit && !isReact
     ? jsfiddle(
       id,
       htmlContent,

--- a/docs/content/guides/cell-functions/cell-function/angular/example1.html
+++ b/docs/content/guides/cell-functions/cell-function/angular/example1.html
@@ -1,0 +1,3 @@
+<div>
+    <app-example1></app-example1>
+</div>

--- a/docs/content/guides/cell-functions/cell-function/angular/example1.ts
+++ b/docs/content/guides/cell-functions/cell-function/angular/example1.ts
@@ -38,7 +38,6 @@ const stockRenderer = (
 
   label.className = 'htStockBarLabel';
   label.innerText = valid ? `${num}` : '—';
-
   track.appendChild(fill);
   wrapper.appendChild(track);
   wrapper.appendChild(label);
@@ -96,12 +95,12 @@ const stockValidator = (value: Handsontable.CellValue, callback: (valid: boolean
 })
 export class AppComponent implements OnInit {
   readonly hotData = [
-    ['Apple', 1.20, 820],
-    ['Banana', 0.50, 280],
-    ['Cherry', 3.00, 45],
-    ['Mango', 2.50, 960],
-    ['Pear', 0.80, 170],
-    ['Blueberry', 4.50, 15],
+    ['Apple', 1.2, 820],
+    ['Banana', 0.5, 280],
+    ['Cherry', 3.0, 45],
+    ['Mango', 2.5, 960],
+    ['Pear', 0.8, 170],
+    ['Blueberry', 4.5, 15],
   ];
 
   hotSettings!: GridSettings;
@@ -113,7 +112,7 @@ export class AppComponent implements OnInit {
         // Built-in type bundles renderer + editor + no validator
         { type: 'text' },
         // Built-in type bundles renderer + editor + validator with custom format
-        { type: 'numeric', numericFormat: { pattern: '$0,0.00' } },
+        { type: 'numeric', locale: 'en-US', numericFormat: { style: 'currency', currency: 'USD', minimumFractionDigits: 2 } },
         // Mixed: custom renderer, built-in numeric editor, custom validator
         {
           renderer: stockRenderer,

--- a/docs/content/guides/cell-functions/cell-function/angular/example1.ts
+++ b/docs/content/guides/cell-functions/cell-function/angular/example1.ts
@@ -1,0 +1,170 @@
+/* file: app.component.ts */
+import { Component, OnInit, ViewEncapsulation } from '@angular/core';
+import { GridSettings } from '@handsontable/angular-wrapper';
+import Handsontable from 'handsontable/base';
+
+// Custom renderer: visualizes stock level as a progress bar with a numeric label.
+// Demonstrates using a renderer independently from the editor and validator.
+const stockRenderer = (
+  hotInstance: Handsontable.Core,
+  td: HTMLTableCellElement,
+  _row: number,
+  _col: number,
+  _prop: string | number,
+  value: Handsontable.CellValue
+): HTMLTableCellElement => {
+  const num = parseInt(value as string, 10);
+  const valid = !isNaN(num) && num >= 0;
+  const pct = valid ? Math.min(100, (num / 1000) * 100) : 0;
+  const color = pct > 60 ? '#22c55e' : pct > 20 ? '#f59e0b' : '#ef4444';
+
+  td.innerText = '';
+
+  const wrapper = hotInstance.rootDocument.createElement('div');
+
+  wrapper.className = 'htStockBar';
+
+  const track = hotInstance.rootDocument.createElement('div');
+
+  track.className = 'htStockBarTrack';
+
+  const fill = hotInstance.rootDocument.createElement('div');
+
+  fill.className = 'htStockBarFill';
+  fill.style.width = `${pct}%`;
+  fill.style.background = color;
+
+  const label = hotInstance.rootDocument.createElement('span');
+
+  label.className = 'htStockBarLabel';
+  label.innerText = valid ? `${num}` : '—';
+
+  track.appendChild(fill);
+  wrapper.appendChild(track);
+  wrapper.appendChild(label);
+  td.appendChild(wrapper);
+
+  return td;
+};
+
+// Custom validator: accepts integers in the range 0–1000.
+// Demonstrates using a validator independently from the renderer and editor.
+const stockValidator = (value: Handsontable.CellValue, callback: (valid: boolean) => void): void => {
+  const num = Number(value);
+
+  callback(Number.isInteger(num) && num >= 0 && num <= 1000);
+};
+
+@Component({
+  selector: 'app-example1',
+  template: `
+    <hot-table [settings]="hotSettings!" [data]="hotData"></hot-table>
+  `,
+  // ViewEncapsulation.None makes these styles global so they apply to DOM
+  // elements created by the Handsontable renderer outside Angular's component tree.
+  styles: [`
+    .htStockBar {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 0 4px;
+      height: 100%;
+      box-sizing: border-box;
+    }
+    .htStockBarTrack {
+      flex: 1;
+      height: 8px;
+      background: #e5e7eb;
+      border-radius: 4px;
+      overflow: hidden;
+    }
+    .htStockBarFill {
+      height: 100%;
+      border-radius: 4px;
+      min-width: 2px;
+    }
+    .htStockBarLabel {
+      font-size: 11px;
+      font-variant-numeric: tabular-nums;
+      min-width: 28px;
+      text-align: right;
+      white-space: nowrap;
+    }
+  `],
+  encapsulation: ViewEncapsulation.None,
+  standalone: false,
+})
+export class AppComponent implements OnInit {
+  readonly hotData = [
+    ['Apple', 1.20, 820],
+    ['Banana', 0.50, 280],
+    ['Cherry', 3.00, 45],
+    ['Mango', 2.50, 960],
+    ['Pear', 0.80, 170],
+    ['Blueberry', 4.50, 15],
+  ];
+
+  hotSettings!: GridSettings;
+
+  ngOnInit() {
+    this.hotSettings = {
+      colHeaders: ['Product', 'Price', 'Stock'],
+      columns: [
+        // Built-in type bundles renderer + editor + no validator
+        { type: 'text' },
+        // Built-in type bundles renderer + editor + validator with custom format
+        { type: 'numeric', numericFormat: { pattern: '$0,0.00' } },
+        // Mixed: custom renderer, built-in numeric editor, custom validator
+        {
+          renderer: stockRenderer,
+          editor: 'numeric',
+          validator: stockValidator,
+          allowInvalid: false,
+        },
+      ],
+      colWidths: [120, 90, 200],
+      rowHeaders: true,
+      height: 'auto',
+      autoWrapRow: true,
+      autoWrapCol: true,
+    };
+  }
+}
+/* end-file */
+
+
+/* file: app.module.ts */
+import { NgModule, ApplicationConfig } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, HotTableModule } from '@handsontable/angular-wrapper';
+import { CommonModule } from '@angular/common';
+import { NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+/* start:skip-in-compilation */
+import { AppComponent } from './app.component';
+/* end:skip-in-compilation */
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: {
+        license: NON_COMMERCIAL_LICENSE,
+      } as HotGlobalConfig
+    }
+  ],
+};
+
+@NgModule({
+  imports: [BrowserModule, HotTableModule, CommonModule],
+  declarations: [AppComponent],
+  providers: [...appConfig.providers],
+  bootstrap: [AppComponent]
+})
+
+export class AppModule { }
+/* end-file */

--- a/docs/content/guides/cell-functions/cell-function/cell-function.md
+++ b/docs/content/guides/cell-functions/cell-function/cell-function.md
@@ -28,9 +28,9 @@ Every Handsontable cell has three associated functions that handle distinct conc
 
 | Function | Role | Implemented as |
 | --- | --- | --- |
-| `renderer` | Controls how a cell looks: DOM structure, CSS classes, HTML content | A plain function |
-| `editor` | Controls how a cell is edited: input element, keyboard handling, open/close lifecycle | A class extending `BaseEditor` |
-| `validator` | Decides whether a cell value is acceptable | A function or `RegExp` |
+| [`renderer`](@/guides/cell-functions/cell-renderer/cell-renderer.md) | Controls how a cell looks: DOM structure, CSS classes, HTML content | A plain function |
+| [`editor`](@/guides/cell-functions/cell-editor/cell-editor.md) | Controls how a cell is edited: input element, keyboard handling, open/close lifecycle | A class extending `BaseEditor` |
+| [`validator`](@/guides/cell-functions/cell-validator/cell-validator.md) | Decides whether a cell value is acceptable | A function or `RegExp` |
 
 The three functions are **independent**. You can mix and match any combination: use the built-in numeric editor with a custom renderer, override just the validator while keeping a built-in type, or write all three from scratch.
 

--- a/docs/content/guides/cell-functions/cell-function/cell-function.md
+++ b/docs/content/guides/cell-functions/cell-function/cell-function.md
@@ -18,102 +18,158 @@ menuTag: updated
 
 # Cell functions
 
-Render, edit, and validate the contents of your cells, using Handsontable's cell functions. Quickly set up your cells, using cell types.
+Render, edit, and validate cell contents using Handsontable's three independent cell functions.
 
 [[toc]]
 
 ## Overview
 
-With every cell in the Handsontable there are 3 associated functions:
+Every Handsontable cell has three associated functions that handle distinct concerns:
 
-- [Renderer](#renderer)
-- [Editor](#editor)
-- [Validator](#validator)
+| Function | Role | Implemented as |
+| --- | --- | --- |
+| `renderer` | Controls how a cell looks: DOM structure, CSS classes, HTML content | A plain function |
+| `editor` | Controls how a cell is edited: input element, keyboard handling, open/close lifecycle | A class extending `BaseEditor` |
+| `validator` | Decides whether a cell value is acceptable | A function or `RegExp` |
 
-Each of those functions are responsible for a different cell behavior. You can define them separately or use a [cell type](#cell-type) to define all three at once.
+The three functions are **independent**. You can mix and match any combination: use the built-in numeric editor with a custom renderer, override just the validator while keeping a built-in type, or write all three from scratch.
 
-## Renderer
+## Cell types bundle all three
 
-Handsontable does not display the values stored in the data source directly. Instead, every time a value from data source needs to be displayed in a table cell, it is passed to the cell `renderer` function, together with the table cell object of type `HTMLTableCellElement` (DOM node), along with other useful information.
+A [cell type](@/guides/cell-types/cell-type/cell-type.md) is a preset that assigns a matching `renderer`, `editor`, and `validator` together under a single `type` alias. Using `type: 'numeric'` is shorthand for:
 
-`Renderer` is expected to format the passed value and place it as a content of the cell object. `Renderer` can also alter the cell class list, i.e. it can add a `htInvalid` class to let the user know, that the displayed value is invalid.
+```js
+{
+  renderer: Handsontable.renderers.NumericRenderer,
+  editor:   Handsontable.editors.NumericEditor,
+  validator: Handsontable.validators.NumericValidator,
+}
+```
 
-## Editor
+Built-in types: `text`, `numeric`, `checkbox`, `date`, `time`, `dropdown`, `autocomplete`, `password`, `handsontable`.
 
-Cell editors are the most complex cell functions. We have prepared a separate page [custom cell editor](@/guides/cell-functions/cell-editor/cell-editor.md) explaining how cell edit works and how to write your own cell editor.
+When you set an explicit `renderer`, `editor`, or `validator` alongside a `type`, the explicit function always takes precedence over the type for that function only:
 
-## Validator
+```js
+columns: [{
+  type: 'numeric',      // sets NumericEditor + NumericValidator
+  renderer: myRenderer, // overrides only NumericRenderer; editor and validator stay numeric
+}]
+```
 
-Cell validator can be either a function or a regular expression. A cell is considered valid, when the validator function calls a `callback` (passed as one of the `validator` arguments) with `true` or the validation regex [`test()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test) method returns `true`. Because the validity of a value is determined only by the argument that is passed to `callback`, `validator` function can be synchronous or asynchronous.
+## Configuration priority
 
-Contrary to `renderer` and `editor` functions, the `validator` function doesn't have to be defined for each cell. If the `validator` function is not defined, then a cell value is always valid.
+Cell functions resolve using the cascading configuration model. The most specific level wins:
 
-## Cell type
+```
+cell[row][col]  >  column  >  global (root settings)
+```
 
-Manually defining those functions for cells or columns would be tedious, so to simplify the configuration, Handsontable introduced [cell types](@/guides/cell-types/cell-type/cell-type.md).
+```js
+new Handsontable(container, {
+  type: 'text',               // global fallback for all cells
+  columns: [
+    { type: 'numeric' },      // overrides global for all cells in column 0
+    { type: 'text' },         // same as global for column 1
+  ],
+  cell: [
+    { row: 0, col: 0, type: 'checkbox' }, // overrides column setting for cell [0, 0] only
+  ],
+});
+```
 
-## Cell functions getters
+## Mixing renderer, editor, and validator
+
+The example below shows a product inventory table. Each column uses a different function configuration:
+
+- **Product** — `type: 'text'` bundles text renderer, text editor, and no validator.
+- **Price** — `type: 'numeric'` bundles numeric renderer (formatted as currency), numeric editor, and numeric validator.
+- **Stock** — custom `renderer` (progress bar), built-in `'numeric'` editor, and a custom range `validator`. All three come from different sources.
+
+::: only-for javascript
+
+::: example #example1 --js 1 --ts 2 --css 3
+
+@[code](@/content/guides/cell-functions/cell-function/javascript/example1.js)
+@[code](@/content/guides/cell-functions/cell-function/javascript/example1.ts)
+@[code](@/content/guides/cell-functions/cell-function/javascript/example1.css)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #example1 :react --css 1 --js 2 --ts 3
+
+@[code](@/content/guides/cell-functions/cell-function/react/example1.css)
+@[code](@/content/guides/cell-functions/cell-function/react/example1.jsx)
+@[code](@/content/guides/cell-functions/cell-function/react/example1.tsx)
+
+:::
+
+:::
+
+::: only-for angular
+
+::: example #example1 :angular --ts 1 --html 2
+
+@[code](@/content/guides/cell-functions/cell-function/angular/example1.ts)
+@[code](@/content/guides/cell-functions/cell-function/angular/example1.html)
+
+:::
+
+:::
+
+Double-click any **Stock** cell to edit it with the numeric editor. The bar renderer updates on save. Enter a value outside 0–1000 to see the validator reject it (cell turns red when `allowInvalid: false`).
+
+## Getting cell functions programmatically
+
+Use [`getCellMeta(row, col)`](@/api/core.md#getcellmeta) to read all properties of a cell at once, or the dedicated getters for individual functions:
+
+```js
+const cellProperties = hot.getCellMeta(0, 0);
+
+cellProperties.renderer;   // renderer function
+cellProperties.editor;     // editor class
+cellProperties.validator;  // validator function or RegExp
+cellProperties.type;       // cell type string
+```
+
+Dedicated getters:
+
+| Method | Returns |
+| --- | --- |
+| [`getCellRenderer(row, col)`](@/api/core.md#getcellrenderer) | The resolved renderer function for the cell |
+| [`getCellEditor(row, col)`](@/api/core.md#getcelleditor) | The resolved editor class for the cell |
+| [`getCellValidator(row, col)`](@/api/core.md#getcellvalidator) | The resolved validator function or `RegExp` for the cell |
+
+If a cell's functions are defined through a cell type, the getters return the resolved functions, not the type string:
+
+::: only-for javascript
+
+```js
+const hot = new Handsontable(container, {
+  columns: [{ type: 'numeric' }],
+});
+
+const cellProperties = hot.getCellMeta(0, 0);
+
+cellProperties.renderer;   // numericRenderer function
+cellProperties.editor;     // NumericEditor class
+cellProperties.validator;  // numericValidator function
+cellProperties.type;       // 'numeric'
+```
+
+:::
 
 ::: only-for react
 
 ::: tip
 
-To use the Handsontable API, you'll need access to the Handsontable instance. You can do that by utilizing a reference to the `HotTable` component, and reading its `hotInstance` property.
-
-For more information, see the [Instance methods](@/guides/getting-started/react-methods/react-methods.md) page.
+To call these methods, access the Handsontable instance through the `HotTable` ref's `hotInstance` property. See [Instance methods](@/guides/getting-started/react-methods/react-methods.md) for details.
 
 :::
-
-:::
-
-If, for some reason, you need to get the `renderer`, `editor` or `validator` function of a specific cell,
-you can use the standard [`getCellMeta()`](@/api/core.md#getcellmeta) method to get all properties of a cell,
-and then refer to the cell functions like this:
-
-```js
-// get cell properties for cell [0, 0]
-const cellProperties = hot.getCellMeta(0, 0);
-
-cellProperties.renderer; // get cell renderer
-cellProperties.editor; // get cell editor
-cellProperties.validator; // get cell validator
-cellProperties.type; // get cell type
-```
-
-You can also get specific cell functions by using the following getters:
-
-- [`getCellRenderer(row, col)`](@/api/core.md#getcellrenderer)
-- [`getCellEditor(row, col)`](@/api/core.md#getcelleditor)
-- [`getCellValidator(row, col)`](@/api/core.md#getcellvalidator)
-
-If a cell's functions are defined through a [cell type](#cell-type), the getters will return
-the `renderer`, `editor` or `validator` functions defined for that cell type. For example:
-
-::: only-for javascript
-
-```js
-import Handsontable from 'handsontable';
-
-const container = document.querySelector('#container');
-const hot = new Handsontable(container, {
-  columns: [{
-    // set a cell type for the entire grid
-    type: 'numeric'
-  }]
-});
-
-// get cell properties for cell [0, 0]
-const cellProperties = hot.getCellMeta(0, 0);
-
-cellProperties.renderer; // numericRenderer
-cellProperties.editor; // NumericEditor
-cellProperties.validator; // numericValidator
-cellProperties.type; // numeric
-```
-
-:::
-
-::: only-for react
 
 ```jsx
 const ExampleComponent = () => {
@@ -121,23 +177,15 @@ const ExampleComponent = () => {
 
   useEffect(() => {
     const hot = hotRef.current.hotInstance;
-
-    // get cell properties for cell [0, 0]
     const cellProperties = hot.getCellMeta(0, 0);
 
-    cellProperties.renderer; // "numeric"
-    cellProperties.editor; // "numeric"
-    cellProperties.validator; // "numeric"
-    cellProperties.type; // "numeric"
+    cellProperties.renderer;   // numericRenderer function
+    cellProperties.editor;     // NumericEditor class
+    cellProperties.validator;  // numericValidator function
+    cellProperties.type;       // 'numeric'
   });
 
-  return (
-    <HotTable
-      ref={hotRef}
-      // set a cell type for the entire grid
-      type="numeric"
-    />
-  );
+  return <HotTable ref={hotRef} columns={[{ type: 'numeric' }]} />;
 };
 ```
 

--- a/docs/content/guides/cell-functions/cell-function/cell-function.md
+++ b/docs/content/guides/cell-functions/cell-function/cell-function.md
@@ -204,6 +204,8 @@ Renderers are called separately for every displayed cell on every table render. 
 
 Use [`getCellMeta(row, col)`](@/api/core.md#getcellmeta) to read all properties of a cell at once, or the dedicated getters for individual functions:
 
+::: only-for javascript
+
 ```js
 const cellProperties = hot.getCellMeta(0, 0);
 
@@ -212,6 +214,35 @@ cellProperties.editor;     // editor class
 cellProperties.validator;  // validator function or RegExp
 cellProperties.type;       // cell type string
 ```
+
+:::
+
+::: only-for react
+
+```jsx
+const hot = hotRef.current.hotInstance;
+const cellProperties = hot.getCellMeta(0, 0);
+
+cellProperties.renderer;   // renderer function
+cellProperties.editor;     // editor class
+cellProperties.validator;  // validator function or RegExp
+cellProperties.type;       // cell type string
+```
+
+:::
+
+::: only-for angular
+
+```ts
+const cellProperties = this.hotTable.hotInstance.getCellMeta(0, 0);
+
+const renderer = cellProperties.renderer;   // renderer function
+const editor = cellProperties.editor;       // editor class
+const validator = cellProperties.validator; // validator function or RegExp
+const type = cellProperties.type;           // cell type string
+```
+
+:::
 
 Dedicated getters:
 

--- a/docs/content/guides/cell-functions/cell-function/cell-function.md
+++ b/docs/content/guides/cell-functions/cell-function/cell-function.md
@@ -123,6 +123,10 @@ The example below shows a product inventory table. Each column uses a different 
 
 Double-click any **Stock** cell to edit it with the numeric editor. The bar renderer updates on save. Enter a value outside 0–1000 to see the validator reject it (cell turns red when `allowInvalid: false`).
 
+## Performance
+
+Renderers are called separately for every displayed cell on every table render. A table can render many times during its lifetime — after scrolling, sorting, editing, and more. Keep `renderer` functions as simple and fast as possible to avoid performance drops, especially with large datasets.
+
 ## Getting cell functions programmatically
 
 Use [`getCellMeta(row, col)`](@/api/core.md#getcellmeta) to read all properties of a cell at once, or the dedicated getters for individual functions:

--- a/docs/content/guides/cell-functions/cell-function/cell-function.md
+++ b/docs/content/guides/cell-functions/cell-function/cell-function.md
@@ -34,14 +34,42 @@ Every Handsontable cell has three associated functions that handle distinct conc
 
 The three functions are **independent**. You can mix and match any combination: use the built-in numeric editor with a custom renderer, override just the validator while keeping a built-in type, or write all three from scratch.
 
+### Function signatures
+
+```js
+// renderer — called for every visible cell on every render
+renderer(hotInstance, td, row, col, prop, value, cellProperties)
+// hotInstance  – Handsontable instance
+// td           – HTMLTableCellElement to modify
+// row, col     – visual row and column indexes
+// prop         – data property name (string) or column index (number)
+// value        – current cell value
+// cellProperties – merged cell configuration object
+
+// validator — may be synchronous or asynchronous
+validator(value, callback)
+// value    – value to validate
+// callback – call with true (valid) or false (invalid)
+// RegExp alternative: /pattern/.test(value) must return true
+
+// editor — a class; see the Cell editor guide for the full lifecycle API
+class MyEditor extends BaseEditor { ... }
+```
+
+`validator` is **optional**. If no validator is defined for a cell, the value is always considered valid.
+
+### `allowInvalid`
+
+By default, `allowInvalid: true` — invalid cells are accepted into the data source but marked with the `htInvalid` CSS class. Set `allowInvalid: false` to reject invalid values and keep the editor open until a valid value is entered.
+
 ## Cell types bundle all three
 
 A [cell type](@/guides/cell-types/cell-type/cell-type.md) is a preset that assigns a matching `renderer`, `editor`, and `validator` together under a single `type` alias. Using `type: 'numeric'` is shorthand for:
 
 ```js
 {
-  renderer: Handsontable.renderers.NumericRenderer,
-  editor:   Handsontable.editors.NumericEditor,
+  renderer:  Handsontable.renderers.NumericRenderer,
+  editor:    Handsontable.editors.NumericEditor,
   validator: Handsontable.validators.NumericValidator,
 }
 ```
@@ -56,6 +84,12 @@ columns: [{
   renderer: myRenderer, // overrides only NumericRenderer; editor and validator stay numeric
 }]
 ```
+
+**When to use a type vs individual functions:**
+
+- Use `type` when you want the standard, bundled behavior for a data kind (numbers, dates, checkboxes).
+- Override a single function from a type when one aspect needs customizing but the rest is fine as-is.
+- Set individual `renderer`/`editor`/`validator` directly when no built-in type fits or you need full control.
 
 ## Configuration priority
 
@@ -112,7 +146,7 @@ The example below shows a product inventory table. Each column uses a different 
 
 ::: only-for angular
 
-::: example #example1 :angular --ts 1 --html 2
+::: example #example1 :angular --ts 1 --html 2 --no-jsfiddle
 
 @[code](@/content/guides/cell-functions/cell-function/angular/example1.ts)
 @[code](@/content/guides/cell-functions/cell-function/angular/example1.html)
@@ -195,6 +229,20 @@ const ExampleComponent = () => {
 
 :::
 
+::: only-for angular
+
+```ts
+// Access the instance via ViewChild on the HotTableComponent
+const cellProperties = this.hotTableComponent.hotInstance.getCellMeta(0, 0);
+
+cellProperties.renderer;   // numericRenderer function
+cellProperties.editor;     // NumericEditor class
+cellProperties.validator;  // numericValidator function
+cellProperties.type;       // 'numeric'
+```
+
+:::
+
 ## Related articles
 
 ### Related guides
@@ -215,6 +263,7 @@ const ExampleComponent = () => {
   - [`renderer`](@/api/options.md#renderer)
   - [`type`](@/api/options.md#type)
   - [`validator`](@/api/options.md#validator)
+  - [`allowInvalid`](@/api/options.md#allowinvalid)
   - [`valueFormatter`](@/api/options.md#valueformatter)
 - Core methods:
   - [`destroyEditor()`](@/api/core.md#destroyeditor)

--- a/docs/content/guides/cell-functions/cell-function/cell-function.md
+++ b/docs/content/guides/cell-functions/cell-function/cell-function.md
@@ -56,7 +56,7 @@ validator(value, callback)
 class MyEditor extends BaseEditor { ... }
 ```
 
-`validator` is **optional**. If no validator is defined for a cell, the value is always considered valid.
+`validator` is **optional**. If no validator is defined for a cell, the cell is skipped entirely during validation — afterValidate will not fire for it, and it will not contribute to the validation cycle.
 
 ### `allowInvalid`
 

--- a/docs/content/guides/cell-functions/cell-function/cell-function.md
+++ b/docs/content/guides/cell-functions/cell-function/cell-function.md
@@ -99,6 +99,8 @@ Cell functions resolve using the cascading configuration model. The most specifi
 cell[row][col]  >  column  >  global (root settings)
 ```
 
+::: only-for javascript
+
 ```js
 new Handsontable(container, {
   type: 'text',               // global fallback for all cells
@@ -111,6 +113,43 @@ new Handsontable(container, {
   ],
 });
 ```
+
+:::
+
+::: only-for react
+
+```jsx
+<HotTable
+  type="text"
+  columns={[
+    { type: 'numeric' },      // overrides global for all cells in column 0
+    { type: 'text' },         // same as global for column 1
+  ]}
+  cell={[
+    { row: 0, col: 0, type: 'checkbox' }, // overrides column setting for cell [0, 0] only
+  ]}
+/>
+```
+
+:::
+
+::: only-for angular
+
+```ts
+settings: GridSettings = {
+  type: 'text',               // global fallback for all cells
+  columns: [
+    { type: 'numeric' },      // overrides global for all cells in column 0
+    { type: 'text' },         // same as global for column 1
+  ],
+  cell: [
+    { row: 0, col: 0, type: 'checkbox' }, // overrides column setting for cell [0, 0] only
+  ],
+};
+```
+
+:::
+
 
 ## Mixing renderer, editor, and validator
 
@@ -146,7 +185,7 @@ The example below shows a product inventory table. Each column uses a different 
 
 ::: only-for angular
 
-::: example #example1 :angular --ts 1 --html 2 --no-jsfiddle
+::: example #example1 :angular --ts 1 --html 2
 
 @[code](@/content/guides/cell-functions/cell-function/angular/example1.ts)
 @[code](@/content/guides/cell-functions/cell-function/angular/example1.html)
@@ -232,13 +271,31 @@ const ExampleComponent = () => {
 ::: only-for angular
 
 ```ts
-// Access the instance via ViewChild on the HotTableComponent
-const cellProperties = this.hotTableComponent.hotInstance.getCellMeta(0, 0);
+import { Component, AfterViewInit, ViewChild } from '@angular/core';
+import { HotTableComponent } from '@handsontable/angular-wrapper';
 
-cellProperties.renderer;   // numericRenderer function
-cellProperties.editor;     // NumericEditor class
-cellProperties.validator;  // numericValidator function
-cellProperties.type;       // 'numeric'
+@Component({
+  selector: 'app-example',
+  template: '<hot-table [settings]="settings"></hot-table>',
+  standalone: false,
+})
+export class AppComponent implements AfterViewInit {
+  @ViewChild(HotTableComponent) hotTable!: HotTableComponent;
+
+  settings = {
+    columns: [{ type: 'numeric' }],
+  };
+
+  ngAfterViewInit() {
+    const hot = this.hotTable.hotInstance;
+    const cellProperties = hot.getCellMeta(0, 0);
+
+    const renderer = cellProperties.renderer;   // numericRenderer function
+    const editor = cellProperties.editor;       // NumericEditor class
+    const validator = cellProperties.validator; // numericValidator function
+    const type = cellProperties.type;           // 'numeric'
+  }
+}
 ```
 
 :::

--- a/docs/content/guides/cell-functions/cell-function/javascript/example1.css
+++ b/docs/content/guides/cell-functions/cell-function/javascript/example1.css
@@ -1,0 +1,30 @@
+.htStockBar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 4px;
+  height: 100%;
+  box-sizing: border-box;
+}
+
+.htStockBarTrack {
+  flex: 1;
+  height: 8px;
+  background: #e5e7eb;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.htStockBarFill {
+  height: 100%;
+  border-radius: 4px;
+  min-width: 2px;
+}
+
+.htStockBarLabel {
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  min-width: 28px;
+  text-align: right;
+  white-space: nowrap;
+}

--- a/docs/content/guides/cell-functions/cell-function/javascript/example1.js
+++ b/docs/content/guides/cell-functions/cell-function/javascript/example1.js
@@ -31,7 +31,6 @@ function stockRenderer(hotInstance, td, row, col, prop, value) {
 
   label.className = 'htStockBarLabel';
   label.innerText = valid ? `${num}` : '—';
-
   track.appendChild(fill);
   wrapper.appendChild(track);
   wrapper.appendChild(label);
@@ -52,19 +51,23 @@ const container = document.querySelector('#example1');
 
 new Handsontable(container, {
   data: [
-    ['Apple', 1.20, 820],
-    ['Banana', 0.50, 280],
-    ['Cherry', 3.00, 45],
-    ['Mango', 2.50, 960],
-    ['Pear', 0.80, 170],
-    ['Blueberry', 4.50, 15],
+    ['Apple', 1.2, 820],
+    ['Banana', 0.5, 280],
+    ['Cherry', 3.0, 45],
+    ['Mango', 2.5, 960],
+    ['Pear', 0.8, 170],
+    ['Blueberry', 4.5, 15],
   ],
   colHeaders: ['Product', 'Price', 'Stock'],
   columns: [
     // Built-in type bundles renderer + editor + no validator
     { type: 'text' },
     // Built-in type bundles renderer + editor + validator with custom format
-    { type: 'numeric', numericFormat: { pattern: '$0,0.00' } },
+    {
+      type: 'numeric',
+      locale: 'en-US',
+      numericFormat: { style: 'currency', currency: 'USD', minimumFractionDigits: 2 },
+    },
     // Mixed: custom renderer, built-in numeric editor, custom validator
     {
       renderer: stockRenderer,

--- a/docs/content/guides/cell-functions/cell-function/javascript/example1.js
+++ b/docs/content/guides/cell-functions/cell-function/javascript/example1.js
@@ -1,0 +1,82 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+// Custom renderer: visualizes stock level as a progress bar with a numeric label.
+// Demonstrates using a renderer independently from the editor and validator.
+function stockRenderer(hotInstance, td, row, col, prop, value) {
+  const num = parseInt(value, 10);
+  const valid = !isNaN(num) && num >= 0;
+  const pct = valid ? Math.min(100, (num / 1000) * 100) : 0;
+  const color = pct > 60 ? '#22c55e' : pct > 20 ? '#f59e0b' : '#ef4444';
+
+  td.innerText = '';
+
+  const wrapper = hotInstance.rootDocument.createElement('div');
+
+  wrapper.className = 'htStockBar';
+
+  const track = hotInstance.rootDocument.createElement('div');
+
+  track.className = 'htStockBarTrack';
+
+  const fill = hotInstance.rootDocument.createElement('div');
+
+  fill.className = 'htStockBarFill';
+  fill.style.width = `${pct}%`;
+  fill.style.background = color;
+
+  const label = hotInstance.rootDocument.createElement('span');
+
+  label.className = 'htStockBarLabel';
+  label.innerText = valid ? `${num}` : '—';
+
+  track.appendChild(fill);
+  wrapper.appendChild(track);
+  wrapper.appendChild(label);
+  td.appendChild(wrapper);
+
+  return td;
+}
+
+// Custom validator: accepts integers in the range 0–1000.
+// Demonstrates using a validator independently from the renderer and editor.
+function stockValidator(value, callback) {
+  const num = Number(value);
+
+  callback(Number.isInteger(num) && num >= 0 && num <= 1000);
+}
+
+const container = document.querySelector('#example1');
+
+new Handsontable(container, {
+  data: [
+    ['Apple', 1.20, 820],
+    ['Banana', 0.50, 280],
+    ['Cherry', 3.00, 45],
+    ['Mango', 2.50, 960],
+    ['Pear', 0.80, 170],
+    ['Blueberry', 4.50, 15],
+  ],
+  colHeaders: ['Product', 'Price', 'Stock'],
+  columns: [
+    // Built-in type bundles renderer + editor + no validator
+    { type: 'text' },
+    // Built-in type bundles renderer + editor + validator with custom format
+    { type: 'numeric', numericFormat: { pattern: '$0,0.00' } },
+    // Mixed: custom renderer, built-in numeric editor, custom validator
+    {
+      renderer: stockRenderer,
+      editor: 'numeric',
+      validator: stockValidator,
+      allowInvalid: false,
+    },
+  ],
+  colWidths: [120, 90, 200],
+  rowHeaders: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/cell-functions/cell-function/javascript/example1.ts
+++ b/docs/content/guides/cell-functions/cell-function/javascript/example1.ts
@@ -1,0 +1,89 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+// Custom renderer: visualizes stock level as a progress bar with a numeric label.
+// Demonstrates using a renderer independently from the editor and validator.
+function stockRenderer(
+  hotInstance: Handsontable.Core,
+  td: HTMLTableCellElement,
+  row: number,
+  col: number,
+  prop: string | number,
+  value: any
+): HTMLTableCellElement {
+  const num = parseInt(value as string, 10);
+  const valid = !isNaN(num) && num >= 0;
+  const pct = valid ? Math.min(100, (num / 1000) * 100) : 0;
+  const color = pct > 60 ? '#22c55e' : pct > 20 ? '#f59e0b' : '#ef4444';
+
+  td.innerText = '';
+
+  const wrapper = hotInstance.rootDocument.createElement('div');
+
+  wrapper.className = 'htStockBar';
+
+  const track = hotInstance.rootDocument.createElement('div');
+
+  track.className = 'htStockBarTrack';
+
+  const fill = hotInstance.rootDocument.createElement('div');
+
+  fill.className = 'htStockBarFill';
+  fill.style.width = `${pct}%`;
+  fill.style.background = color;
+
+  const label = hotInstance.rootDocument.createElement('span');
+
+  label.className = 'htStockBarLabel';
+  label.innerText = valid ? `${num}` : '—';
+
+  track.appendChild(fill);
+  wrapper.appendChild(track);
+  wrapper.appendChild(label);
+  td.appendChild(wrapper);
+
+  return td;
+}
+
+// Custom validator: accepts integers in the range 0–1000.
+// Demonstrates using a validator independently from the renderer and editor.
+function stockValidator(value: any, callback: (valid: boolean) => void): void {
+  const num = Number(value);
+
+  callback(Number.isInteger(num) && num >= 0 && num <= 1000);
+}
+
+const container = document.querySelector('#example1') as HTMLElement;
+
+new Handsontable(container, {
+  data: [
+    ['Apple', 1.20, 820],
+    ['Banana', 0.50, 280],
+    ['Cherry', 3.00, 45],
+    ['Mango', 2.50, 960],
+    ['Pear', 0.80, 170],
+    ['Blueberry', 4.50, 15],
+  ],
+  colHeaders: ['Product', 'Price', 'Stock'],
+  columns: [
+    // Built-in type bundles renderer + editor + no validator
+    { type: 'text' },
+    // Built-in type bundles renderer + editor + validator with custom format
+    { type: 'numeric', numericFormat: { pattern: '$0,0.00' } },
+    // Mixed: custom renderer, built-in numeric editor, custom validator
+    {
+      renderer: stockRenderer,
+      editor: 'numeric',
+      validator: stockValidator,
+      allowInvalid: false,
+    } as any,
+  ],
+  colWidths: [120, 90, 200],
+  rowHeaders: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/cell-functions/cell-function/javascript/example1.ts
+++ b/docs/content/guides/cell-functions/cell-function/javascript/example1.ts
@@ -38,7 +38,6 @@ function stockRenderer(
 
   label.className = 'htStockBarLabel';
   label.innerText = valid ? `${num}` : '—';
-
   track.appendChild(fill);
   wrapper.appendChild(track);
   wrapper.appendChild(label);
@@ -59,19 +58,19 @@ const container = document.querySelector('#example1') as HTMLElement;
 
 new Handsontable(container, {
   data: [
-    ['Apple', 1.20, 820],
-    ['Banana', 0.50, 280],
-    ['Cherry', 3.00, 45],
-    ['Mango', 2.50, 960],
-    ['Pear', 0.80, 170],
-    ['Blueberry', 4.50, 15],
+    ['Apple', 1.2, 820],
+    ['Banana', 0.5, 280],
+    ['Cherry', 3.0, 45],
+    ['Mango', 2.5, 960],
+    ['Pear', 0.8, 170],
+    ['Blueberry', 4.5, 15],
   ],
   colHeaders: ['Product', 'Price', 'Stock'],
   columns: [
     // Built-in type bundles renderer + editor + no validator
     { type: 'text' },
     // Built-in type bundles renderer + editor + validator with custom format
-    { type: 'numeric', numericFormat: { pattern: '$0,0.00' } },
+    { type: 'numeric', locale: 'en-US', numericFormat: { style: 'currency', currency: 'USD', minimumFractionDigits: 2 } },
     // Mixed: custom renderer, built-in numeric editor, custom validator
     {
       renderer: stockRenderer,

--- a/docs/content/guides/cell-functions/cell-function/react/example1.css
+++ b/docs/content/guides/cell-functions/cell-function/react/example1.css
@@ -1,0 +1,30 @@
+.htStockBar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 4px;
+  height: 100%;
+  box-sizing: border-box;
+}
+
+.htStockBarTrack {
+  flex: 1;
+  height: 8px;
+  background: #e5e7eb;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.htStockBarFill {
+  height: 100%;
+  border-radius: 4px;
+  min-width: 2px;
+}
+
+.htStockBarLabel {
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  min-width: 28px;
+  text-align: right;
+  white-space: nowrap;
+}

--- a/docs/content/guides/cell-functions/cell-function/react/example1.jsx
+++ b/docs/content/guides/cell-functions/cell-function/react/example1.jsx
@@ -32,7 +32,6 @@ function stockRenderer(hotInstance, td, row, col, prop, value) {
 
   label.className = 'htStockBarLabel';
   label.innerText = valid ? `${num}` : '—';
-
   track.appendChild(fill);
   wrapper.appendChild(track);
   wrapper.appendChild(label);
@@ -53,19 +52,23 @@ const ExampleComponent = () => {
   return (
     <HotTable
       data={[
-        ['Apple', 1.20, 820],
-        ['Banana', 0.50, 280],
-        ['Cherry', 3.00, 45],
-        ['Mango', 2.50, 960],
-        ['Pear', 0.80, 170],
-        ['Blueberry', 4.50, 15],
+        ['Apple', 1.2, 820],
+        ['Banana', 0.5, 280],
+        ['Cherry', 3.0, 45],
+        ['Mango', 2.5, 960],
+        ['Pear', 0.8, 170],
+        ['Blueberry', 4.5, 15],
       ]}
       colHeaders={['Product', 'Price', 'Stock']}
       columns={[
         // Built-in type bundles renderer + editor + no validator
         { type: 'text' },
         // Built-in type bundles renderer + editor + validator with custom format
-        { type: 'numeric', numericFormat: { pattern: '$0,0.00' } },
+        {
+          type: 'numeric',
+          locale: 'en-US',
+          numericFormat: { style: 'currency', currency: 'USD', minimumFractionDigits: 2 },
+        },
         // Mixed: custom renderer, built-in numeric editor, custom validator
         {
           renderer: stockRenderer,

--- a/docs/content/guides/cell-functions/cell-function/react/example1.jsx
+++ b/docs/content/guides/cell-functions/cell-function/react/example1.jsx
@@ -1,0 +1,87 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+// Custom renderer: visualizes stock level as a progress bar with a numeric label.
+// Demonstrates using a renderer independently from the editor and validator.
+function stockRenderer(hotInstance, td, row, col, prop, value) {
+  const num = parseInt(value, 10);
+  const valid = !isNaN(num) && num >= 0;
+  const pct = valid ? Math.min(100, (num / 1000) * 100) : 0;
+  const color = pct > 60 ? '#22c55e' : pct > 20 ? '#f59e0b' : '#ef4444';
+
+  td.innerText = '';
+
+  const wrapper = hotInstance.rootDocument.createElement('div');
+
+  wrapper.className = 'htStockBar';
+
+  const track = hotInstance.rootDocument.createElement('div');
+
+  track.className = 'htStockBarTrack';
+
+  const fill = hotInstance.rootDocument.createElement('div');
+
+  fill.className = 'htStockBarFill';
+  fill.style.width = `${pct}%`;
+  fill.style.background = color;
+
+  const label = hotInstance.rootDocument.createElement('span');
+
+  label.className = 'htStockBarLabel';
+  label.innerText = valid ? `${num}` : '—';
+
+  track.appendChild(fill);
+  wrapper.appendChild(track);
+  wrapper.appendChild(label);
+  td.appendChild(wrapper);
+
+  return td;
+}
+
+// Custom validator: accepts integers in the range 0–1000.
+// Demonstrates using a validator independently from the renderer and editor.
+function stockValidator(value, callback) {
+  const num = Number(value);
+
+  callback(Number.isInteger(num) && num >= 0 && num <= 1000);
+}
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={[
+        ['Apple', 1.20, 820],
+        ['Banana', 0.50, 280],
+        ['Cherry', 3.00, 45],
+        ['Mango', 2.50, 960],
+        ['Pear', 0.80, 170],
+        ['Blueberry', 4.50, 15],
+      ]}
+      colHeaders={['Product', 'Price', 'Stock']}
+      columns={[
+        // Built-in type bundles renderer + editor + no validator
+        { type: 'text' },
+        // Built-in type bundles renderer + editor + validator with custom format
+        { type: 'numeric', numericFormat: { pattern: '$0,0.00' } },
+        // Mixed: custom renderer, built-in numeric editor, custom validator
+        {
+          renderer: stockRenderer,
+          editor: 'numeric',
+          validator: stockValidator,
+          allowInvalid: false,
+        },
+      ]}
+      colWidths={[120, 90, 200]}
+      rowHeaders={true}
+      height="auto"
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/cell-functions/cell-function/react/example1.tsx
+++ b/docs/content/guides/cell-functions/cell-function/react/example1.tsx
@@ -1,0 +1,95 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+// Custom renderer: visualizes stock level as a progress bar with a numeric label.
+// Demonstrates using a renderer independently from the editor and validator.
+function stockRenderer(
+  hotInstance: Handsontable.Core,
+  td: HTMLTableCellElement,
+  row: number,
+  col: number,
+  prop: string | number,
+  value: Handsontable.CellValue
+): HTMLTableCellElement {
+  const num = parseInt(value as string, 10);
+  const valid = !isNaN(num) && num >= 0;
+  const pct = valid ? Math.min(100, (num / 1000) * 100) : 0;
+  const color = pct > 60 ? '#22c55e' : pct > 20 ? '#f59e0b' : '#ef4444';
+
+  td.innerText = '';
+
+  const wrapper = hotInstance.rootDocument.createElement('div');
+
+  wrapper.className = 'htStockBar';
+
+  const track = hotInstance.rootDocument.createElement('div');
+
+  track.className = 'htStockBarTrack';
+
+  const fill = hotInstance.rootDocument.createElement('div');
+
+  fill.className = 'htStockBarFill';
+  fill.style.width = `${pct}%`;
+  fill.style.background = color;
+
+  const label = hotInstance.rootDocument.createElement('span');
+
+  label.className = 'htStockBarLabel';
+  label.innerText = valid ? `${num}` : '—';
+
+  track.appendChild(fill);
+  wrapper.appendChild(track);
+  wrapper.appendChild(label);
+  td.appendChild(wrapper);
+
+  return td;
+}
+
+// Custom validator: accepts integers in the range 0–1000.
+// Demonstrates using a validator independently from the renderer and editor.
+function stockValidator(value: Handsontable.CellValue, callback: (valid: boolean) => void): void {
+  const num = Number(value);
+
+  callback(Number.isInteger(num) && num >= 0 && num <= 1000);
+}
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={[
+        ['Apple', 1.20, 820],
+        ['Banana', 0.50, 280],
+        ['Cherry', 3.00, 45],
+        ['Mango', 2.50, 960],
+        ['Pear', 0.80, 170],
+        ['Blueberry', 4.50, 15],
+      ]}
+      colHeaders={['Product', 'Price', 'Stock']}
+      columns={[
+        // Built-in type bundles renderer + editor + no validator
+        { type: 'text' },
+        // Built-in type bundles renderer + editor + validator with custom format
+        { type: 'numeric', numericFormat: { pattern: '$0,0.00' } },
+        // Mixed: custom renderer, built-in numeric editor, custom validator
+        {
+          renderer: stockRenderer,
+          editor: 'numeric',
+          validator: stockValidator,
+          allowInvalid: false,
+        } as Handsontable.ColumnSettings,
+      ]}
+      colWidths={[120, 90, 200]}
+      rowHeaders={true}
+      height="auto"
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/cell-functions/cell-function/react/example1.tsx
+++ b/docs/content/guides/cell-functions/cell-function/react/example1.tsx
@@ -40,7 +40,6 @@ function stockRenderer(
 
   label.className = 'htStockBarLabel';
   label.innerText = valid ? `${num}` : '—';
-
   track.appendChild(fill);
   wrapper.appendChild(track);
   wrapper.appendChild(label);
@@ -61,19 +60,19 @@ const ExampleComponent = () => {
   return (
     <HotTable
       data={[
-        ['Apple', 1.20, 820],
-        ['Banana', 0.50, 280],
-        ['Cherry', 3.00, 45],
-        ['Mango', 2.50, 960],
-        ['Pear', 0.80, 170],
-        ['Blueberry', 4.50, 15],
+        ['Apple', 1.2, 820],
+        ['Banana', 0.5, 280],
+        ['Cherry', 3.0, 45],
+        ['Mango', 2.5, 960],
+        ['Pear', 0.8, 170],
+        ['Blueberry', 4.5, 15],
       ]}
       colHeaders={['Product', 'Price', 'Stock']}
       columns={[
         // Built-in type bundles renderer + editor + no validator
         { type: 'text' },
         // Built-in type bundles renderer + editor + validator with custom format
-        { type: 'numeric', numericFormat: { pattern: '$0,0.00' } },
+        { type: 'numeric', locale: 'en-US', numericFormat: { style: 'currency', currency: 'USD', minimumFractionDigits: 2 } },
         // Mixed: custom renderer, built-in numeric editor, custom validator
         {
           renderer: stockRenderer,


### PR DESCRIPTION
### Context

This PR updated the Cell functions guide for JavaScript, Angular, and React and added missing code examples. The content has been optimised for LLMs.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/259

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes plus new example snippets; no runtime/library code is modified.
> 
> **Overview**
> Updates the `Cell functions` guide to clarify the separation and precedence of `renderer`/`editor`/`validator`, document `allowInvalid`, add configuration priority and programmatic access examples, and include basic performance guidance.
> 
> Adds a new inventory-table code example for JavaScript, React, and Angular that demonstrates mixing a custom stock-level progress-bar `renderer`, built-in numeric editor, and a range `validator` (plus shared CSS and Angular wrapper/module setup).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12df99eee666227678a17377e16ec097c5e97d1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->