### PR TITLE
Add the description and example for the `filter` and `filteringCaseSenstive` options

### DIFF
--- a/docs/content/guides/cell-types/autocomplete-cell-type/angular/example6.html
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/angular/example6.html
@@ -1,0 +1,3 @@
+<div>
+  <example6-autocomplete-cell-type></example6-autocomplete-cell-type>
+</div>

--- a/docs/content/guides/cell-types/autocomplete-cell-type/angular/example6.ts
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/angular/example6.ts
@@ -1,0 +1,99 @@
+/* file: app.component.ts */
+import { Component } from '@angular/core';
+import { GridSettings } from '@handsontable/angular-wrapper';
+
+@Component({
+  selector: 'example6-autocomplete-cell-type',
+  standalone: false,
+  template: ` <div>
+    <hot-table [data]="data" [settings]="gridSettings"></hot-table>
+  </div>`
+})
+export class Example6AutocompleteCellTypeComponent {
+  readonly fruits = [
+    'Apple',
+    'Apricot',
+    'Avocado',
+    'Banana',
+    'Blueberry',
+    'Cherry',
+    'Grape',
+    'Lemon',
+    'Lime',
+    'Mango',
+    'Orange',
+    'Peach',
+    'Pear',
+    'Pineapple',
+    'Plum',
+    'Raspberry',
+    'Strawberry',
+    'Watermelon',
+  ];
+
+  readonly data = [
+    ['Apple', 'Apple'],
+    ['Banana', 'Banana'],
+    ['Cherry', 'Cherry'],
+    ['Mango', 'Mango'],
+    ['Orange', 'Orange'],
+  ];
+
+  readonly gridSettings: GridSettings = {
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true,
+    colHeaders: ['Filter: true (default)', 'Filter: false'],
+    columns: [
+      {
+        type: 'autocomplete',
+        source: this.fruits,
+        strict: false,
+      },
+      {
+        type: 'autocomplete',
+        source: this.fruits,
+        strict: false,
+        // don't hide options that don't match the search query
+        filter: false,
+      },
+    ],
+  };
+}
+/* end-file */
+
+
+/* file: app.module.ts */
+import { NgModule, ApplicationConfig } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, HotTableModule } from '@handsontable/angular-wrapper';
+import { CommonModule } from '@angular/common';
+import { NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+/* start:skip-in-compilation */
+import { Example6AutocompleteCellTypeComponent } from './app.component';
+/* end:skip-in-compilation */
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: {
+        license: NON_COMMERCIAL_LICENSE,
+      } as HotGlobalConfig
+    }
+  ],
+};
+
+@NgModule({
+  imports: [ BrowserModule, HotTableModule, CommonModule ],
+  declarations: [ Example6AutocompleteCellTypeComponent ],
+  providers: [...appConfig.providers],
+  bootstrap: [ Example6AutocompleteCellTypeComponent ]
+})
+
+export class AppModule { }
+/* end-file */

--- a/docs/content/guides/cell-types/autocomplete-cell-type/angular/example7.html
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/angular/example7.html
@@ -1,0 +1,3 @@
+<div>
+  <example7-autocomplete-cell-type></example7-autocomplete-cell-type>
+</div>

--- a/docs/content/guides/cell-types/autocomplete-cell-type/angular/example7.ts
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/angular/example7.ts
@@ -1,0 +1,99 @@
+/* file: app.component.ts */
+import { Component } from '@angular/core';
+import { GridSettings } from '@handsontable/angular-wrapper';
+
+@Component({
+  selector: 'example7-autocomplete-cell-type',
+  standalone: false,
+  template: ` <div>
+    <hot-table [data]="data" [settings]="gridSettings"></hot-table>
+  </div>`
+})
+export class Example7AutocompleteCellTypeComponent {
+  readonly colors = [
+    'Black',
+    'Blue',
+    'brown',
+    'cyan',
+    'Gray',
+    'green',
+    'Lime',
+    'Magenta',
+    'Navy',
+    'olive',
+    'orange',
+    'Pink',
+    'Purple',
+    'Red',
+    'silver',
+    'Teal',
+    'White',
+    'Yellow',
+  ];
+
+  readonly data = [
+    ['Black', 'Black'],
+    ['Blue', 'Blue'],
+    ['Gray', 'Gray'],
+    ['Red', 'Red'],
+    ['White', 'White'],
+  ];
+
+  readonly gridSettings: GridSettings = {
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true,
+    colHeaders: ['Case-insensitive (default)', 'Case-sensitive'],
+    columns: [
+      {
+        type: 'autocomplete',
+        source: this.colors,
+        strict: false,
+      },
+      {
+        type: 'autocomplete',
+        source: this.colors,
+        strict: false,
+        // match case while searching autocomplete options
+        filteringCaseSensitive: true,
+      },
+    ],
+  };
+}
+/* end-file */
+
+
+/* file: app.module.ts */
+import { NgModule, ApplicationConfig } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, HotTableModule } from '@handsontable/angular-wrapper';
+import { CommonModule } from '@angular/common';
+import { NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+/* start:skip-in-compilation */
+import { Example7AutocompleteCellTypeComponent } from './app.component';
+/* end:skip-in-compilation */
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: {
+        license: NON_COMMERCIAL_LICENSE,
+      } as HotGlobalConfig
+    }
+  ],
+};
+
+@NgModule({
+  imports: [ BrowserModule, HotTableModule, CommonModule ],
+  declarations: [ Example7AutocompleteCellTypeComponent ],
+  providers: [...appConfig.providers],
+  bootstrap: [ Example7AutocompleteCellTypeComponent ]
+})
+
+export class AppModule { }
+/* end-file */

--- a/docs/content/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md
@@ -236,6 +236,84 @@ When working with object-based autocomplete data, you can use methods like [`get
 :::
 
 
+## The `filter` option
+
+By default, the autocomplete dropdown hides options that don't match what the user is typing. Set `filter: false` to always show the full list of source options, regardless of the current input. This is useful when you want to give users a visual reference of all available choices while they type.
+
+The left column uses the default behavior (`filter: true`) — options are narrowed as you type. The right column has `filter: false` — all options remain visible no matter what you enter.
+
+::: only-for javascript
+
+::: example #example6 .docs-height-small --js 1 --ts 2
+
+@[code](@/content/guides/cell-types/autocomplete-cell-type/javascript/example6.js)
+@[code](@/content/guides/cell-types/autocomplete-cell-type/javascript/example6.ts)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #example6 .docs-height-small :react --js 1 --ts 2
+
+@[code](@/content/guides/cell-types/autocomplete-cell-type/react/example6.jsx)
+@[code](@/content/guides/cell-types/autocomplete-cell-type/react/example6.tsx)
+
+:::
+
+:::
+
+::: only-for angular
+
+::: example #example6 .docs-height-small :angular --ts 1 --html 2
+
+@[code](@/content/guides/cell-types/autocomplete-cell-type/angular/example6.ts)
+@[code](@/content/guides/cell-types/autocomplete-cell-type/angular/example6.html)
+
+:::
+
+:::
+
+## The `filteringCaseSensitive` option
+
+By default, the autocomplete search is case-insensitive — typing `"bl"` matches both `"Black"` and `"blue"`. Set `filteringCaseSensitive: true` to require an exact case match when filtering suggestions.
+
+The left column uses the default case-insensitive behavior. The right column has `filteringCaseSensitive: true` — only options whose case matches the typed characters are shown.
+
+::: only-for javascript
+
+::: example #example7 .docs-height-small --js 1 --ts 2
+
+@[code](@/content/guides/cell-types/autocomplete-cell-type/javascript/example7.js)
+@[code](@/content/guides/cell-types/autocomplete-cell-type/javascript/example7.ts)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #example7 .docs-height-small :react --js 1 --ts 2
+
+@[code](@/content/guides/cell-types/autocomplete-cell-type/react/example7.jsx)
+@[code](@/content/guides/cell-types/autocomplete-cell-type/react/example7.tsx)
+
+:::
+
+:::
+
+::: only-for angular
+
+::: example #example7 .docs-height-small :angular --ts 1 --html 2
+
+@[code](@/content/guides/cell-types/autocomplete-cell-type/angular/example7.ts)
+@[code](@/content/guides/cell-types/autocomplete-cell-type/angular/example7.html)
+
+:::
+
+:::
+
 ## Related articles
 
 ### Related guides
@@ -248,6 +326,7 @@ When working with object-based autocomplete data, you can use methods like [`get
 
 - Configuration options:
   - [`allowHtml`](@/api/options.md#allowhtml)
+  - [`filter`](@/api/options.md#filter)
   - [`filteringCaseSensitive`](@/api/options.md#filteringcasesensitive)
   - [`sortByRelevance`](@/api/options.md#sortbyrelevance)
   - [`source`](@/api/options.md#source)

--- a/docs/content/guides/cell-types/autocomplete-cell-type/javascript/example6.js
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/javascript/example6.js
@@ -1,0 +1,57 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+// Register all Handsontable's modules.
+registerAllModules();
+
+const fruits = [
+  'Apple',
+  'Apricot',
+  'Avocado',
+  'Banana',
+  'Blueberry',
+  'Cherry',
+  'Grape',
+  'Lemon',
+  'Lime',
+  'Mango',
+  'Orange',
+  'Peach',
+  'Pear',
+  'Pineapple',
+  'Plum',
+  'Raspberry',
+  'Strawberry',
+  'Watermelon',
+];
+
+const container = document.querySelector('#example6');
+
+new Handsontable(container, {
+  licenseKey: 'non-commercial-and-evaluation',
+  data: [
+    ['Apple', 'Apple'],
+    ['Banana', 'Banana'],
+    ['Cherry', 'Cherry'],
+    ['Mango', 'Mango'],
+    ['Orange', 'Orange'],
+  ],
+  colHeaders: ['Filter: true (default)', 'Filter: false'],
+  columns: [
+    {
+      type: 'autocomplete',
+      source: fruits,
+      strict: false,
+      // filter: true is the default — only matching options are shown
+    },
+    {
+      type: 'autocomplete',
+      source: fruits,
+      strict: false,
+      // don't hide options that don't match the search query
+      filter: false,
+    },
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+});

--- a/docs/content/guides/cell-types/autocomplete-cell-type/javascript/example6.ts
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/javascript/example6.ts
@@ -1,0 +1,57 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+// Register all Handsontable's modules.
+registerAllModules();
+
+const fruits: string[] = [
+  'Apple',
+  'Apricot',
+  'Avocado',
+  'Banana',
+  'Blueberry',
+  'Cherry',
+  'Grape',
+  'Lemon',
+  'Lime',
+  'Mango',
+  'Orange',
+  'Peach',
+  'Pear',
+  'Pineapple',
+  'Plum',
+  'Raspberry',
+  'Strawberry',
+  'Watermelon',
+];
+
+const container = document.querySelector('#example6')!;
+
+new Handsontable(container, {
+  licenseKey: 'non-commercial-and-evaluation',
+  data: [
+    ['Apple', 'Apple'],
+    ['Banana', 'Banana'],
+    ['Cherry', 'Cherry'],
+    ['Mango', 'Mango'],
+    ['Orange', 'Orange'],
+  ],
+  colHeaders: ['Filter: true (default)', 'Filter: false'],
+  columns: [
+    {
+      type: 'autocomplete',
+      source: fruits,
+      strict: false,
+      // filter: true is the default — only matching options are shown
+    },
+    {
+      type: 'autocomplete',
+      source: fruits,
+      strict: false,
+      // don't hide options that don't match the search query
+      filter: false,
+    },
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+});

--- a/docs/content/guides/cell-types/autocomplete-cell-type/javascript/example7.js
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/javascript/example7.js
@@ -1,0 +1,57 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+// Register all Handsontable's modules.
+registerAllModules();
+
+const colors = [
+  'Black',
+  'Blue',
+  'brown',
+  'cyan',
+  'Gray',
+  'green',
+  'Lime',
+  'Magenta',
+  'Navy',
+  'olive',
+  'orange',
+  'Pink',
+  'Purple',
+  'Red',
+  'silver',
+  'Teal',
+  'White',
+  'Yellow',
+];
+
+const container = document.querySelector('#example7');
+
+new Handsontable(container, {
+  licenseKey: 'non-commercial-and-evaluation',
+  data: [
+    ['Black', 'Black'],
+    ['Blue', 'Blue'],
+    ['Gray', 'Gray'],
+    ['Red', 'Red'],
+    ['White', 'White'],
+  ],
+  colHeaders: ['Case-insensitive (default)', 'Case-sensitive'],
+  columns: [
+    {
+      type: 'autocomplete',
+      source: colors,
+      strict: false,
+      // filteringCaseSensitive: false is the default — typing "bl" matches "Black" and "blue"
+    },
+    {
+      type: 'autocomplete',
+      source: colors,
+      strict: false,
+      // match case while searching autocomplete options
+      filteringCaseSensitive: true,
+    },
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+});

--- a/docs/content/guides/cell-types/autocomplete-cell-type/javascript/example7.ts
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/javascript/example7.ts
@@ -1,0 +1,57 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+// Register all Handsontable's modules.
+registerAllModules();
+
+const colors: string[] = [
+  'Black',
+  'Blue',
+  'brown',
+  'cyan',
+  'Gray',
+  'green',
+  'Lime',
+  'Magenta',
+  'Navy',
+  'olive',
+  'orange',
+  'Pink',
+  'Purple',
+  'Red',
+  'silver',
+  'Teal',
+  'White',
+  'Yellow',
+];
+
+const container = document.querySelector('#example7')!;
+
+new Handsontable(container, {
+  licenseKey: 'non-commercial-and-evaluation',
+  data: [
+    ['Black', 'Black'],
+    ['Blue', 'Blue'],
+    ['Gray', 'Gray'],
+    ['Red', 'Red'],
+    ['White', 'White'],
+  ],
+  colHeaders: ['Case-insensitive (default)', 'Case-sensitive'],
+  columns: [
+    {
+      type: 'autocomplete',
+      source: colors,
+      strict: false,
+      // filteringCaseSensitive: false is the default — typing "bl" matches "Black" and "blue"
+    },
+    {
+      type: 'autocomplete',
+      source: colors,
+      strict: false,
+      // match case while searching autocomplete options
+      filteringCaseSensitive: true,
+    },
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+});

--- a/docs/content/guides/cell-types/autocomplete-cell-type/react/example6.jsx
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/react/example6.jsx
@@ -1,0 +1,61 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const fruits = [
+  'Apple',
+  'Apricot',
+  'Avocado',
+  'Banana',
+  'Blueberry',
+  'Cherry',
+  'Grape',
+  'Lemon',
+  'Lime',
+  'Mango',
+  'Orange',
+  'Peach',
+  'Pear',
+  'Pineapple',
+  'Plum',
+  'Raspberry',
+  'Strawberry',
+  'Watermelon',
+];
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+      data={[
+        ['Apple', 'Apple'],
+        ['Banana', 'Banana'],
+        ['Cherry', 'Cherry'],
+        ['Mango', 'Mango'],
+        ['Orange', 'Orange'],
+      ]}
+      colHeaders={['Filter: true (default)', 'Filter: false']}
+      columns={[
+        {
+          type: 'autocomplete',
+          source: fruits,
+          strict: false,
+          // filter: true is the default — only matching options are shown
+        },
+        {
+          type: 'autocomplete',
+          source: fruits,
+          strict: false,
+          // don't hide options that don't match the search query
+          filter: false,
+        },
+      ]}
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/cell-types/autocomplete-cell-type/react/example6.tsx
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/react/example6.tsx
@@ -1,0 +1,61 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const fruits: string[] = [
+  'Apple',
+  'Apricot',
+  'Avocado',
+  'Banana',
+  'Blueberry',
+  'Cherry',
+  'Grape',
+  'Lemon',
+  'Lime',
+  'Mango',
+  'Orange',
+  'Peach',
+  'Pear',
+  'Pineapple',
+  'Plum',
+  'Raspberry',
+  'Strawberry',
+  'Watermelon',
+];
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+      data={[
+        ['Apple', 'Apple'],
+        ['Banana', 'Banana'],
+        ['Cherry', 'Cherry'],
+        ['Mango', 'Mango'],
+        ['Orange', 'Orange'],
+      ]}
+      colHeaders={['Filter: true (default)', 'Filter: false']}
+      columns={[
+        {
+          type: 'autocomplete',
+          source: fruits,
+          strict: false,
+          // filter: true is the default — only matching options are shown
+        },
+        {
+          type: 'autocomplete',
+          source: fruits,
+          strict: false,
+          // don't hide options that don't match the search query
+          filter: false,
+        },
+      ]}
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/cell-types/autocomplete-cell-type/react/example7.jsx
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/react/example7.jsx
@@ -1,0 +1,61 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const colors = [
+  'Black',
+  'Blue',
+  'brown',
+  'cyan',
+  'Gray',
+  'green',
+  'Lime',
+  'Magenta',
+  'Navy',
+  'olive',
+  'orange',
+  'Pink',
+  'Purple',
+  'Red',
+  'silver',
+  'Teal',
+  'White',
+  'Yellow',
+];
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+      data={[
+        ['Black', 'Black'],
+        ['Blue', 'Blue'],
+        ['Gray', 'Gray'],
+        ['Red', 'Red'],
+        ['White', 'White'],
+      ]}
+      colHeaders={['Case-insensitive (default)', 'Case-sensitive']}
+      columns={[
+        {
+          type: 'autocomplete',
+          source: colors,
+          strict: false,
+          // filteringCaseSensitive: false is the default — typing "bl" matches "Black" and "blue"
+        },
+        {
+          type: 'autocomplete',
+          source: colors,
+          strict: false,
+          // match case while searching autocomplete options
+          filteringCaseSensitive: true,
+        },
+      ]}
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/cell-types/autocomplete-cell-type/react/example7.tsx
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/react/example7.tsx
@@ -1,0 +1,61 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const colors: string[] = [
+  'Black',
+  'Blue',
+  'brown',
+  'cyan',
+  'Gray',
+  'green',
+  'Lime',
+  'Magenta',
+  'Navy',
+  'olive',
+  'orange',
+  'Pink',
+  'Purple',
+  'Red',
+  'silver',
+  'Teal',
+  'White',
+  'Yellow',
+];
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+      data={[
+        ['Black', 'Black'],
+        ['Blue', 'Blue'],
+        ['Gray', 'Gray'],
+        ['Red', 'Red'],
+        ['White', 'White'],
+      ]}
+      colHeaders={['Case-insensitive (default)', 'Case-sensitive']}
+      columns={[
+        {
+          type: 'autocomplete',
+          source: colors,
+          strict: false,
+          // filteringCaseSensitive: false is the default — typing "bl" matches "Black" and "blue"
+        },
+        {
+          type: 'autocomplete',
+          source: colors,
+          strict: false,
+          // match case while searching autocomplete options
+          filteringCaseSensitive: true,
+        },
+      ]}
+    />
+  );
+};
+
+export default ExampleComponent;


### PR DESCRIPTION
### Context

This PR adds the missing description and example for the `filter` and `filteringCaseSensitive` options in the `Autocomplete cell type` guide. 


### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/257
2. https://github.com/handsontable/dev-handsontable/issues/256

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes adding new examples and guide text; no runtime/library behavior is modified.
> 
> **Overview**
> Adds new sections to the `Autocomplete cell type` guide documenting the `filter` and `filteringCaseSensitive` options, including how they affect dropdown filtering behavior.
> 
> Introduces new runnable examples (`example6`/`example7`) for JavaScript, React, and Angular demonstrating default vs `filter: false` and case-insensitive vs `filteringCaseSensitive: true`, and updates the related options list to include `filter`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7243dd8280e04d971f59a644b50e910dff41fbd6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->