### PR TITLE
Add the missing info to the `customBorders` API

### DIFF
--- a/handsontable/src/plugins/customBorders/customBorders.js
+++ b/handsontable/src/plugins/customBorders/customBorders.js
@@ -45,48 +45,45 @@ const SUPPORTED_STYLES = ['dashed', 'dotted', 'solid'];
  * To initialize Handsontable with predefined custom borders, provide cell coordinates and border styles in a form
  * of an array.
  *
+ * When a border property is set to an empty object `{}` or an empty string `''`, the default style is applied:
+ * **1px solid black**.
+ *
+ * The plugin also integrates with the [[ContextMenu]] plugin. Adding `'borders'` to the
+ * [`contextMenu`](@/api/options.md#contextmenu) items enables users to apply or remove borders on selected cells
+ * directly from the right-click menu.
+ *
  * See [`customBorders` configuration option](@/api/options.md#customBorders) or go to
  * [Custom cell borders demo](@/guides/cell-features/formatting-cells/formatting-cells.md#custom-cell-borders) for more examples.
  *
  * @example
  * ```js
- * customBorders: [
- *   {
- *    range: {
- *      from: {
- *        row: 1,
- *        col: 1
- *      },
- *      to: {
- *        row: 3,
- *        col: 4
- *      },
- *    },
- *    start: {},
- *    end: {},
- *    top: {},
- *    bottom: {},
- *   },
- * ],
- *
- * // or
- * customBorders: [
- *   { row: 2,
- *     col: 2,
- *     start: {
- *       width: 2,
- *       color: 'red',
- *       style: 'dotted'
+ * // Enable custom borders with context menu integration.
+ * // When a border property is an empty object, the default style (1px solid black) is applied.
+ * new Handsontable(container, {
+ *   customBorders: [
+ *     {
+ *       range: {
+ *         from: { row: 1, col: 1 },
+ *         to: { row: 3, col: 4 },
+ *       },
+ *       top: {},    // default: 1px solid black
+ *       bottom: {}, // default: 1px solid black
+ *       start: {},  // default: 1px solid black
+ *       end: {},    // default: 1px solid black
  *     },
- *     end: {
- *       width: 1,
- *       color: 'green',
- *       style: 'dashed'
+ *     {
+ *       row: 2,
+ *       col: 2,
+ *       start: { width: 2, color: 'red', style: 'dotted' },
+ *       end: { width: 1, color: 'green', style: 'dashed' },
+ *       top: '',    // default: 1px solid black
+ *       bottom: '', // default: 1px solid black
  *     },
- *     top: '',
- *     bottom: '',
- *   }
- * ],
+ *   ],
+ *   // Enable the 'borders' item in the context menu so users can
+ *   // apply or remove borders from the right-click menu.
+ *   contextMenu: ['borders'],
+ * });
  * ```
  */
 export class CustomBorders extends BasePlugin {


### PR DESCRIPTION
### Context

This PR adds the missing information to the `customBorders` API description about the possibility to add the custom border from the context menu level.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/255

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates JSDoc/API documentation and examples, with no runtime logic changes.
> 
> **Overview**
> Clarifies the `CustomBorders` plugin documentation by explicitly describing **default border styling** when a side is set to `{}` or `''` (defaults to `1px solid black`).
> 
> Updates the `@example` to show **context menu integration**, including enabling the `'borders'` item via `contextMenu: ['borders']` so users can apply/remove borders from the right-click menu.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c374f58c8dd5ef1899308c5bc7c21b1c5783fb06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->