### PR TITLE
Fix legacy Angular docs version redirects below 16.0

### DIFF
--- a/.changelogs/12208.json
+++ b/.changelogs/12208.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Redirect legacy Angular docs versions below 16.0 to JavaScript docs homepage",
+  "type": "fixed",
+  "issueOrPR": 12208,
+  "breaking": false,
+  "framework": "angular"
+}

--- a/.changelogs/12208.json
+++ b/.changelogs/12208.json
@@ -1,8 +1,0 @@
-{
-  "issuesOrigin": "private",
-  "title": "Redirect legacy Angular docs versions below 16.0 to JavaScript docs homepage",
-  "type": "fixed",
-  "issueOrPR": 12208,
-  "breaking": false,
-  "framework": "angular"
-}

--- a/docs/netlify/_redirects
+++ b/docs/netlify/_redirects
@@ -4,28 +4,6 @@
 /docs/redirect pageId=:pageId /docs 301
 
 # Angular docs are available from 16.0+ only.
-/15.3/angular-data-grid/* /docs/javascript-data-grid/ 301
-/15.2/angular-data-grid/* /docs/javascript-data-grid/ 301
-/15.1/angular-data-grid/* /docs/javascript-data-grid/ 301
-/15.0/angular-data-grid/* /docs/javascript-data-grid/ 301
-/14.6/angular-data-grid/* /docs/javascript-data-grid/ 301
-/14.5/angular-data-grid/* /docs/javascript-data-grid/ 301
-/14.4/angular-data-grid/* /docs/javascript-data-grid/ 301
-/14.3/angular-data-grid/* /docs/javascript-data-grid/ 301
-/14.2/angular-data-grid/* /docs/javascript-data-grid/ 301
-/14.1/angular-data-grid/* /docs/javascript-data-grid/ 301
-/14.0/angular-data-grid/* /docs/javascript-data-grid/ 301
-/13.1/angular-data-grid/* /docs/javascript-data-grid/ 301
-/13.0/angular-data-grid/* /docs/javascript-data-grid/ 301
-/12.4/angular-data-grid/* /docs/javascript-data-grid/ 301
-/12.3/angular-data-grid/* /docs/javascript-data-grid/ 301
-/12.2/angular-data-grid/* /docs/javascript-data-grid/ 301
-/12.1/angular-data-grid/* /docs/javascript-data-grid/ 301
-/12.0/angular-data-grid/* /docs/javascript-data-grid/ 301
-/11.1/angular-data-grid/* /docs/javascript-data-grid/ 301
-/11.0/angular-data-grid/* /docs/javascript-data-grid/ 301
-/10.0/angular-data-grid/* /docs/javascript-data-grid/ 301
-/9.0/angular-data-grid/* /docs/javascript-data-grid/ 301
 /docs/15.3/angular-data-grid/* /docs/javascript-data-grid/ 301
 /docs/15.2/angular-data-grid/* /docs/javascript-data-grid/ 301
 /docs/15.1/angular-data-grid/* /docs/javascript-data-grid/ 301

--- a/docs/netlify/_redirects
+++ b/docs/netlify/_redirects
@@ -3,6 +3,52 @@
 /docs/:version/redirect pageId=:pageId /docs/:version
 /docs/redirect pageId=:pageId /docs 301
 
+# Angular docs are available from 16.0+ only.
+/15.3/angular-data-grid/* /docs/javascript-data-grid/ 301
+/15.2/angular-data-grid/* /docs/javascript-data-grid/ 301
+/15.1/angular-data-grid/* /docs/javascript-data-grid/ 301
+/15.0/angular-data-grid/* /docs/javascript-data-grid/ 301
+/14.6/angular-data-grid/* /docs/javascript-data-grid/ 301
+/14.5/angular-data-grid/* /docs/javascript-data-grid/ 301
+/14.4/angular-data-grid/* /docs/javascript-data-grid/ 301
+/14.3/angular-data-grid/* /docs/javascript-data-grid/ 301
+/14.2/angular-data-grid/* /docs/javascript-data-grid/ 301
+/14.1/angular-data-grid/* /docs/javascript-data-grid/ 301
+/14.0/angular-data-grid/* /docs/javascript-data-grid/ 301
+/13.1/angular-data-grid/* /docs/javascript-data-grid/ 301
+/13.0/angular-data-grid/* /docs/javascript-data-grid/ 301
+/12.4/angular-data-grid/* /docs/javascript-data-grid/ 301
+/12.3/angular-data-grid/* /docs/javascript-data-grid/ 301
+/12.2/angular-data-grid/* /docs/javascript-data-grid/ 301
+/12.1/angular-data-grid/* /docs/javascript-data-grid/ 301
+/12.0/angular-data-grid/* /docs/javascript-data-grid/ 301
+/11.1/angular-data-grid/* /docs/javascript-data-grid/ 301
+/11.0/angular-data-grid/* /docs/javascript-data-grid/ 301
+/10.0/angular-data-grid/* /docs/javascript-data-grid/ 301
+/9.0/angular-data-grid/* /docs/javascript-data-grid/ 301
+/docs/15.3/angular-data-grid/* /docs/javascript-data-grid/ 301
+/docs/15.2/angular-data-grid/* /docs/javascript-data-grid/ 301
+/docs/15.1/angular-data-grid/* /docs/javascript-data-grid/ 301
+/docs/15.0/angular-data-grid/* /docs/javascript-data-grid/ 301
+/docs/14.6/angular-data-grid/* /docs/javascript-data-grid/ 301
+/docs/14.5/angular-data-grid/* /docs/javascript-data-grid/ 301
+/docs/14.4/angular-data-grid/* /docs/javascript-data-grid/ 301
+/docs/14.3/angular-data-grid/* /docs/javascript-data-grid/ 301
+/docs/14.2/angular-data-grid/* /docs/javascript-data-grid/ 301
+/docs/14.1/angular-data-grid/* /docs/javascript-data-grid/ 301
+/docs/14.0/angular-data-grid/* /docs/javascript-data-grid/ 301
+/docs/13.1/angular-data-grid/* /docs/javascript-data-grid/ 301
+/docs/13.0/angular-data-grid/* /docs/javascript-data-grid/ 301
+/docs/12.4/angular-data-grid/* /docs/javascript-data-grid/ 301
+/docs/12.3/angular-data-grid/* /docs/javascript-data-grid/ 301
+/docs/12.2/angular-data-grid/* /docs/javascript-data-grid/ 301
+/docs/12.1/angular-data-grid/* /docs/javascript-data-grid/ 301
+/docs/12.0/angular-data-grid/* /docs/javascript-data-grid/ 301
+/docs/11.1/angular-data-grid/* /docs/javascript-data-grid/ 301
+/docs/11.0/angular-data-grid/* /docs/javascript-data-grid/ 301
+/docs/10.0/angular-data-grid/* /docs/javascript-data-grid/ 301
+/docs/9.0/angular-data-grid/* /docs/javascript-data-grid/ 301
+
 /docs/ActionBarComponent.html /docs/javascript-data-grid/api/action-bar-component/
 /docs/AlterManager.html /docs/javascript-data-grid/api/alter-manager/
 /docs/AutoColumnSize.html /docs/javascript-data-grid/api/auto-column-size/

--- a/docs/netlify/netlify/edge-functions/readme.md
+++ b/docs/netlify/netlify/edge-functions/readme.md
@@ -123,6 +123,22 @@ const getFrameworkFromCookie = (cookieValue: string) => {
 - `/docs/12.1` → **Redirect** to `/docs/12.1/react-data-grid/`
 - `/docs/13.0` → **Redirect** to `/docs/13.0/javascript-data-grid/`
 
+### 7. `redirect_legacy_angular_docs_versions.mts`
+
+**Purpose:** Redirects versioned Angular docs URLs for versions below 16.0 to the JavaScript docs homepage.
+
+**Path Pattern:** `/docs/(\\d+).(\\d+)/angular-data-grid(/.*)?`
+
+**Functionality:**
+- Redirects `/docs/:major.:minor/angular-data-grid/...` requests to `/docs/javascript-data-grid/` when `major < 16`
+- Leaves versions `16.0+` unchanged
+- Acts as a fallback for legacy Angular version paths that don't have dedicated Angular docs content
+
+**Examples:**
+- `/docs/15.3/angular-data-grid/` → `/docs/javascript-data-grid/`
+- `/docs/14.6/angular-data-grid/installation/` → `/docs/javascript-data-grid/`
+- `/docs/16.0/angular-data-grid/` → no redirect
+
 ## Framework Override Rules
 
 Certain URL patterns override the user's cookie preference:
@@ -135,5 +151,6 @@ Certain URL patterns override the user's cookie preference:
 - **Versions < 12.1**: Content is served directly (rewrite behavior)
 - **Versions 12.1+**: Framework-specific redirects are applied
 - **Versions 13+**: Full framework-aware routing is enabled
+- **Angular URLs for versions < 16.0**: Redirected to `/docs/javascript-data-grid/`
 
 This system ensures backward compatibility while providing modern framework-specific documentation routing for newer versions.	

--- a/docs/netlify/netlify/edge-functions/readme.md
+++ b/docs/netlify/netlify/edge-functions/readme.md
@@ -127,11 +127,11 @@ const getFrameworkFromCookie = (cookieValue: string) => {
 
 **Purpose:** Redirects versioned Angular docs URLs for versions below 16.0 to the JavaScript docs homepage.
 
-**Path Pattern:** `/docs/(\\d+).(\\d+)/angular-data-grid(/.*)?`
+**Path Pattern:** `/docs/(15.3|15.2|...|9.0)/angular-data-grid(/.*)?`
 
 **Functionality:**
-- Redirects `/docs/:major.:minor/angular-data-grid/...` requests to `/docs/javascript-data-grid/` when `major < 16`
-- Leaves versions `16.0+` unchanged
+- Redirects versioned legacy Angular docs paths to `/docs/javascript-data-grid/`
+- Scoped to released pre-16 docs versions (`15.3` down to `9.0`)
 - Acts as a fallback for legacy Angular version paths that don't have dedicated Angular docs content
 
 **Examples:**

--- a/docs/netlify/netlify/edge-functions/redirect_legacy_angular_docs_versions.mts
+++ b/docs/netlify/netlify/edge-functions/redirect_legacy_angular_docs_versions.mts
@@ -1,0 +1,18 @@
+/* eslint-disable no-unused-vars */
+import { Config, Context } from '@netlify/edge-functions';
+
+export default async(req: Request, context: Context) => {
+  const major = parseInt(context.params['0'], 10);
+
+  if (major >= 16) {
+    return context.next();
+  }
+
+  const url = new URL('/docs/javascript-data-grid/', req.url);
+
+  return Response.redirect(url, 301);
+};
+
+export const config: Config = {
+  path: '/docs/(\\d+).(\\d+)/angular-data-grid(/.*)?'
+};

--- a/docs/netlify/netlify/edge-functions/redirect_legacy_angular_docs_versions.mts
+++ b/docs/netlify/netlify/edge-functions/redirect_legacy_angular_docs_versions.mts
@@ -2,17 +2,11 @@
 import { Config, Context } from '@netlify/edge-functions';
 
 export default async(req: Request, context: Context) => {
-  const major = parseInt(context.params['0'], 10);
-
-  if (major >= 16) {
-    return context.next();
-  }
-
   const url = new URL('/docs/javascript-data-grid/', req.url);
 
   return Response.redirect(url, 301);
 };
 
 export const config: Config = {
-  path: '/docs/(\\d+).(\\d+)/angular-data-grid(/.*)?'
+  path: '/docs/(15\\.3|15\\.2|15\\.1|15\\.0|14\\.6|14\\.5|14\\.4|14\\.3|14\\.2|14\\.1|14\\.0|13\\.1|13\\.0|12\\.4|12\\.3|12\\.2|12\\.1|12\\.0|11\\.1|11\\.0|10\\.0|9\\.0)/angular-data-grid(/.*)?'
 };

--- a/docs/netlify/netlify/edge-functions/redirect_legacy_angular_docs_versions.mts
+++ b/docs/netlify/netlify/edge-functions/redirect_legacy_angular_docs_versions.mts
@@ -1,6 +1,31 @@
 /* eslint-disable no-unused-vars */
 import { Config, Context } from '@netlify/edge-functions';
 
+const LEGACY_ANGULAR_VERSIONS = [
+  '15\\.3',
+  '15\\.2',
+  '15\\.1',
+  '15\\.0',
+  '14\\.6',
+  '14\\.5',
+  '14\\.4',
+  '14\\.3',
+  '14\\.2',
+  '14\\.1',
+  '14\\.0',
+  '13\\.1',
+  '13\\.0',
+  '12\\.4',
+  '12\\.3',
+  '12\\.2',
+  '12\\.1',
+  '12\\.0',
+  '11\\.1',
+  '11\\.0',
+  '10\\.0',
+  '9\\.0'
+];
+
 export default async(req: Request, context: Context) => {
   const url = new URL('/docs/javascript-data-grid/', req.url);
 
@@ -8,5 +33,5 @@ export default async(req: Request, context: Context) => {
 };
 
 export const config: Config = {
-  path: '/docs/(15\\.3|15\\.2|15\\.1|15\\.0|14\\.6|14\\.5|14\\.4|14\\.3|14\\.2|14\\.1|14\\.0|13\\.1|13\\.0|12\\.4|12\\.3|12\\.2|12\\.1|12\\.0|11\\.1|11\\.0|10\\.0|9\\.0)/angular-data-grid(/.*)?'
+  path: `/docs/(${LEGACY_ANGULAR_VERSIONS.join('|')})/angular-data-grid(/.*)?`
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- remove duplicate Angular legacy redirect rules that omitted the `/docs/` prefix
- keep only the functional `/docs/:version/angular-data-grid/*` redirects
- reduce maintenance surface for future version additions

## Validation
- `node -e "const fs=require('fs');const lines=fs.readFileSync('docs/netlify/_redirects','utf8').split(/\\r?\\n/);const nonDocs=lines.filter((l)=>/^\\/(?:\\d+\\.\\d+)\\/angular-data-grid\\/\\*/.test(l));const docs=lines.filter((l)=>/^\\/docs\\/(?:\\d+\\.\\d+)\\/angular-data-grid\\/\\*/.test(l));console.log('non_docs_versioned_angular_rules=',nonDocs.length);console.log('docs_prefixed_versioned_angular_rules=',docs.length);if(nonDocs.length!==0||docs.length!==22){process.exit(1);}"`
  - expected result: `non_docs_versioned_angular_rules= 0` and `docs_prefixed_versioned_angular_rules= 22`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8e0e83c-874f-44fe-9b4a-bf5c6ea8b30b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8e0e83c-874f-44fe-9b4a-bf5c6ea8b30b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

[skip changelog]

