### PR TITLE
Fix nested headers null highlight crash on header sorting

### DIFF
--- a/.changelogs/12211.json
+++ b/.changelogs/12211.json
@@ -2,7 +2,7 @@
   "issuesOrigin": "public",
   "title": "Fixed nested headers crash when sorting with disabled current highlight.",
   "type": "fixed",
-  "issueOrPR": 3107,
+  "issueOrPR": 12211,
   "breaking": false,
   "framework": "none"
 }

--- a/.changelogs/3107.json
+++ b/.changelogs/3107.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed nested headers crash when sorting with disabled current highlight.",
+  "type": "fixed",
+  "issueOrPR": 3107,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/nestedHeaders/__tests__/nestedHeaders.spec.js
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/nestedHeaders.spec.js
@@ -73,5 +73,29 @@ describe('NestedHeaders', () => {
 
       expect(getPlugin('dropdownMenu').menu.container.style.display).not.toBe('block');
     });
+
+    it('should not throw after sorting when current highlight is disabled', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 11),
+        colHeaders: true,
+        rowHeaders: true,
+        columnSorting: true,
+        navigableHeaders: true,
+        disableVisualSelection: 'current',
+        nestedHeaders: [
+          ['A', { label: 'B', colspan: 8 }, 'C'],
+        ],
+      });
+
+      const $headerWithSortAction = spec().$container.find(
+        '.ht_master table.htCore thead tr:last-of-type th:nth-of-type(2) span.columnSorting'
+      );
+
+      $headerWithSortAction.simulate('mousedown');
+      $headerWithSortAction.simulate('mouseup');
+      $headerWithSortAction.simulate('click');
+
+      expect(getPlugin('columnSorting').isSorted()).toBe(true);
+    });
   });
 });

--- a/handsontable/src/plugins/nestedHeaders/nestedHeaders.js
+++ b/handsontable/src/plugins/nestedHeaders/nestedHeaders.js
@@ -481,11 +481,16 @@ export class NestedHeaders extends BasePlugin {
     if (isNestedHeadersRange) {
       const columnIndex = this.#stateManager.findLeftMostColumnIndex(highlight.row, highlight.col);
       const focusHighlight = this.hot.selection.highlight.getFocus();
+      const focusVisualCellRange = focusHighlight.visualCellRange;
+
+      if (focusVisualCellRange === null) {
+        return;
+      }
 
       // Correct the highlight/focus selection to highlight the correct TH element
-      focusHighlight.visualCellRange.highlight.col = columnIndex;
-      focusHighlight.visualCellRange.from.col = columnIndex;
-      focusHighlight.visualCellRange.to.col = columnIndex;
+      focusVisualCellRange.highlight.col = columnIndex;
+      focusVisualCellRange.from.col = columnIndex;
+      focusVisualCellRange.to.col = columnIndex;
       focusHighlight.commit();
     }
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Context
Fixes a Sentry-reported crash (`Cannot read properties of null (reading 'highlight')`) in `NestedHeaders`.

Root cause: the `cacheUpdated` callback (`#updateFocusHighlightPosition`) assumes `focusHighlight.visualCellRange` always exists, but with `disableVisualSelection: 'current'` the focus highlight is intentionally cleared (`null`). Sorting a nested header triggers mapper cache updates and the callback dereferenced `null.highlight`.

### How has this been tested?
- Reproduced the crash with a focused regression E2E scenario (nested headers + sorting + `disableVisualSelection: 'current'`) before the fix.
- Added a regression E2E test: `should not throw after sorting when current highlight is disabled`.
- Rebuilt UMD bundle and reran the focused E2E scenario after the fix.
- Ran focused unit tests for nested headers state manager.
- Ran ESLint on changed files.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/3107
2.
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42dd6b0f-b117-42c6-969b-016f2032a10f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42dd6b0f-b117-42c6-969b-016f2032a10f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

