### PR TITLE
Improve the description of the checkbox cell type guide

### DIFF
--- a/docs/content/guides/cell-types/checkbox-cell-type/angular/example4.html
+++ b/docs/content/guides/cell-types/checkbox-cell-type/angular/example4.html
@@ -1,0 +1,3 @@
+<div>
+  <example4-checkbox-cell-type></example4-checkbox-cell-type>
+</div>

--- a/docs/content/guides/cell-types/checkbox-cell-type/angular/example4.ts
+++ b/docs/content/guides/cell-types/checkbox-cell-type/angular/example4.ts
@@ -1,0 +1,94 @@
+/* file: app.component.ts */
+import { Component } from '@angular/core';
+import { GridSettings } from '@handsontable/angular-wrapper';
+
+@Component({
+  selector: 'example4-checkbox-cell-type',
+  standalone: false,
+  template: ` <div>
+    <hot-table [data]="data" [settings]="gridSettings"></hot-table>
+  </div>`,
+})
+export class Example4CheckboxCellTypeComponent {
+
+  readonly data = [
+    { car: 'Mercedes A 160', year: 2017, comesInBlack: 'yes' },
+    { car: 'Citroen C4 Coupe', year: 2018, comesInBlack: 'yes' },
+    { car: 'Audi A4 Avant', year: 2019, comesInBlack: 'no' },
+    { car: 'Opel Astra', year: 2020, comesInBlack: 'yes' },
+    { car: 'BMW 320i Coupe', year: 2021, comesInBlack: 'no' },
+  ];
+
+  readonly gridSettings: GridSettings = {
+    colHeaders: ['Car model', 'Year', 'Comes in black'],
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true,
+    columns: [
+      {
+        data: 'car',
+      },
+      {
+        data: 'year',
+      },
+      {
+        data: 'comesInBlack',
+        type: 'checkbox',
+        checkedTemplate: 'yes',
+        uncheckedTemplate: 'no',
+        label: {
+          position: 'after',
+          value: function(
+            _row: number,
+            _column: number,
+            _prop: string | number,
+            value: string
+          ) {
+            if (value === 'yes') {
+              return 'In black';
+            } else {
+              return 'Not in black';
+            }
+          },
+        },
+      },
+    ]
+  };
+}
+/* end-file */
+
+
+/* file: app.module.ts */
+import { NgModule, ApplicationConfig } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, HotTableModule } from '@handsontable/angular-wrapper';
+import { CommonModule } from '@angular/common';
+import { NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+/* start:skip-in-compilation */
+import { Example4CheckboxCellTypeComponent } from './app.component';
+/* end:skip-in-compilation */
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: {
+        license: NON_COMMERCIAL_LICENSE,
+      } as HotGlobalConfig
+    }
+  ],
+};
+
+@NgModule({
+  imports: [ BrowserModule, HotTableModule, CommonModule ],
+  declarations: [ Example4CheckboxCellTypeComponent ],
+  providers: [...appConfig.providers],
+  bootstrap: [ Example4CheckboxCellTypeComponent ]
+})
+
+export class AppModule { }
+/* end-file */

--- a/docs/content/guides/cell-types/checkbox-cell-type/angular/example4.ts
+++ b/docs/content/guides/cell-types/checkbox-cell-type/angular/example4.ts
@@ -39,9 +39,9 @@ export class Example4CheckboxCellTypeComponent {
         label: {
           position: 'after',
           value: function(
-            _row: number,
-            _column: number,
-            _prop: string | number,
+            row: number,
+            column: number,
+            prop: string | number,
             value: string
           ) {
             if (value === 'yes') {

--- a/docs/content/guides/cell-types/checkbox-cell-type/checkbox-cell-type.md
+++ b/docs/content/guides/cell-types/checkbox-cell-type/checkbox-cell-type.md
@@ -142,6 +142,43 @@ To add a label to the checkbox, use the [`label`](@/api/options.md#label) option
 
 :::
 
+### Label value as a function
+
+The `value` property of the `label` option can also be a function. The function receives four arguments: `row`, `column`, `prop`, and `value`, where `value` is the current cell value. This lets you generate label text dynamically based on the cell's state.
+
+::: only-for javascript
+
+::: example #example4 --js 1 --ts 2
+
+@[code](@/content/guides/cell-types/checkbox-cell-type/javascript/example4.js)
+@[code](@/content/guides/cell-types/checkbox-cell-type/javascript/example4.ts)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #example4 :react --js 1 --ts 2
+
+@[code](@/content/guides/cell-types/checkbox-cell-type/react/example4.jsx)
+@[code](@/content/guides/cell-types/checkbox-cell-type/react/example4.tsx)
+
+:::
+
+:::
+
+::: only-for angular
+
+::: example #example4 :angular --ts 1 --html 2
+
+@[code](@/content/guides/cell-types/checkbox-cell-type/angular/example4.ts)
+@[code](@/content/guides/cell-types/checkbox-cell-type/angular/example4.html)
+
+:::
+
+:::
+
 ## Related keyboard shortcuts
 
 | Windows                  | macOS                    | Action                        |  Excel  | Sheets  |

--- a/docs/content/guides/cell-types/checkbox-cell-type/javascript/example4.js
+++ b/docs/content/guides/cell-types/checkbox-cell-type/javascript/example4.js
@@ -1,0 +1,48 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+// Register all Handsontable's modules.
+registerAllModules();
+
+const container = document.querySelector('#example4');
+
+new Handsontable(container, {
+  data: [
+    { car: 'Mercedes A 160', year: 2017, comesInBlack: 'yes' },
+    { car: 'Citroen C4 Coupe', year: 2018, comesInBlack: 'yes' },
+    { car: 'Audi A4 Avant', year: 2019, comesInBlack: 'no' },
+    { car: 'Opel Astra', year: 2020, comesInBlack: 'yes' },
+    { car: 'BMW 320i Coupe', year: 2021, comesInBlack: 'no' },
+  ],
+  colHeaders: ['Car model', 'Year', 'Comes in black'],
+  height: 'auto',
+  columns: [
+    {
+      data: 'car',
+    },
+    {
+      data: 'year',
+    },
+    {
+      data: 'comesInBlack',
+      type: 'checkbox',
+      checkedTemplate: 'yes',
+      uncheckedTemplate: 'no',
+      label: {
+        position: 'after',
+        value: function() {
+          const checkboxState = arguments[3];
+
+          if (checkboxState === 'yes') {
+            return 'In black';
+          } else {
+            return 'Not in black';
+          }
+        },
+      },
+    },
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/cell-types/checkbox-cell-type/javascript/example4.js
+++ b/docs/content/guides/cell-types/checkbox-cell-type/javascript/example4.js
@@ -30,10 +30,8 @@ new Handsontable(container, {
       uncheckedTemplate: 'no',
       label: {
         position: 'after',
-        value: function() {
-          const checkboxState = arguments[3];
-
-          if (checkboxState === 'yes') {
+        value(row, column, prop, value) {
+          if (value === 'yes') {
             return 'In black';
           } else {
             return 'Not in black';

--- a/docs/content/guides/cell-types/checkbox-cell-type/javascript/example4.ts
+++ b/docs/content/guides/cell-types/checkbox-cell-type/javascript/example4.ts
@@ -1,0 +1,51 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+// Register all Handsontable's modules.
+registerAllModules();
+
+const container = document.querySelector('#example4')!;
+
+new Handsontable(container, {
+  data: [
+    { car: 'Mercedes A 160', year: 2017, comesInBlack: 'yes' },
+    { car: 'Citroen C4 Coupe', year: 2018, comesInBlack: 'yes' },
+    { car: 'Audi A4 Avant', year: 2019, comesInBlack: 'no' },
+    { car: 'Opel Astra', year: 2020, comesInBlack: 'yes' },
+    { car: 'BMW 320i Coupe', year: 2021, comesInBlack: 'no' },
+  ],
+  colHeaders: ['Car model', 'Year', 'Comes in black'],
+  height: 'auto',
+  columns: [
+    {
+      data: 'car',
+    },
+    {
+      data: 'year',
+    },
+    {
+      data: 'comesInBlack',
+      type: 'checkbox',
+      checkedTemplate: 'yes',
+      uncheckedTemplate: 'no',
+      label: {
+        position: 'after',
+        value: function(
+          _row: number,
+          _column: number,
+          _prop: string | number,
+          value: string
+        ) {
+          if (value === 'yes') {
+            return 'In black';
+          } else {
+            return 'Not in black';
+          }
+        },
+      },
+    },
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/cell-types/checkbox-cell-type/javascript/example4.ts
+++ b/docs/content/guides/cell-types/checkbox-cell-type/javascript/example4.ts
@@ -30,12 +30,7 @@ new Handsontable(container, {
       uncheckedTemplate: 'no',
       label: {
         position: 'after',
-        value: function(
-          _row: number,
-          _column: number,
-          _prop: string | number,
-          value: string
-        ) {
+        value(row: number, column: number, prop: string | number, value: string) {
           if (value === 'yes') {
             return 'In black';
           } else {

--- a/docs/content/guides/cell-types/checkbox-cell-type/react/example4.jsx
+++ b/docs/content/guides/cell-types/checkbox-cell-type/react/example4.jsx
@@ -1,0 +1,52 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={[
+        { car: 'Mercedes A 160', year: 2017, comesInBlack: 'yes' },
+        { car: 'Citroen C4 Coupe', year: 2018, comesInBlack: 'yes' },
+        { car: 'Audi A4 Avant', year: 2019, comesInBlack: 'no' },
+        { car: 'Opel Astra', year: 2020, comesInBlack: 'yes' },
+        { car: 'BMW 320i Coupe', year: 2021, comesInBlack: 'no' },
+      ]}
+      colHeaders={['Car model', 'Year', 'Comes in black']}
+      height="auto"
+      columns={[
+        {
+          data: 'car',
+        },
+        {
+          data: 'year',
+        },
+        {
+          data: 'comesInBlack',
+          type: 'checkbox',
+          checkedTemplate: 'yes',
+          uncheckedTemplate: 'no',
+          label: {
+            position: 'after',
+            value: function() {
+              const checkboxState = arguments[3];
+
+              if (checkboxState === 'yes') {
+                return 'In black';
+              } else {
+                return 'Not in black';
+              }
+            },
+          },
+        },
+      ]}
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/cell-types/checkbox-cell-type/react/example4.jsx
+++ b/docs/content/guides/cell-types/checkbox-cell-type/react/example4.jsx
@@ -30,10 +30,8 @@ const ExampleComponent = () => {
           uncheckedTemplate: 'no',
           label: {
             position: 'after',
-            value: function() {
-              const checkboxState = arguments[3];
-
-              if (checkboxState === 'yes') {
+            value(row, column, prop, value) {
+              if (value === 'yes') {
                 return 'In black';
               } else {
                 return 'Not in black';

--- a/docs/content/guides/cell-types/checkbox-cell-type/react/example4.tsx
+++ b/docs/content/guides/cell-types/checkbox-cell-type/react/example4.tsx
@@ -30,12 +30,7 @@ const ExampleComponent = () => {
           uncheckedTemplate: 'no',
           label: {
             position: 'after',
-            value: function(
-              _row: number,
-              _column: number,
-              _prop: string | number,
-              value: string
-            ) {
+            value(row: number, column: number, prop: string | number, value: string) {
               if (value === 'yes') {
                 return 'In black';
               } else {

--- a/docs/content/guides/cell-types/checkbox-cell-type/react/example4.tsx
+++ b/docs/content/guides/cell-types/checkbox-cell-type/react/example4.tsx
@@ -1,0 +1,55 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={[
+        { car: 'Mercedes A 160', year: 2017, comesInBlack: 'yes' },
+        { car: 'Citroen C4 Coupe', year: 2018, comesInBlack: 'yes' },
+        { car: 'Audi A4 Avant', year: 2019, comesInBlack: 'no' },
+        { car: 'Opel Astra', year: 2020, comesInBlack: 'yes' },
+        { car: 'BMW 320i Coupe', year: 2021, comesInBlack: 'no' },
+      ]}
+      colHeaders={['Car model', 'Year', 'Comes in black']}
+      height="auto"
+      columns={[
+        {
+          data: 'car',
+        },
+        {
+          data: 'year',
+        },
+        {
+          data: 'comesInBlack',
+          type: 'checkbox',
+          checkedTemplate: 'yes',
+          uncheckedTemplate: 'no',
+          label: {
+            position: 'after',
+            value: function(
+              _row: number,
+              _column: number,
+              _prop: string | number,
+              value: string
+            ) {
+              if (value === 'yes') {
+                return 'In black';
+              } else {
+                return 'Not in black';
+              }
+            },
+          },
+        },
+      ]}
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+
+export default ExampleComponent;


### PR DESCRIPTION
### Context
This PR adds the information that the label's value property of the checkbox cell type can also be a function. It also adds the corresponding example for JS, React, and Angular.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/252

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds a new guide section and sample snippets; no runtime/library behavior is modified.
> 
> **Overview**
> Adds a new **"Label value as a function"** section to the checkbox cell type guide, documenting that `label.value` can be a function receiving `row`, `column`, `prop`, and the current cell `value`.
> 
> Includes new `example4` snippets for JavaScript, React, and Angular demonstrating dynamically generated checkbox labels (e.g., returning "In black" vs "Not in black" based on `checkedTemplate`/`uncheckedTemplate`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a694014d5872f8fd2e7f945a2d46029d9867325b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->