### PR TITLE
Add the examples for the open() method for `contextMenu` and `dropdownMenu`

### DIFF
--- a/handsontable/src/plugins/contextMenu/contextMenu.js
+++ b/handsontable/src/plugins/contextMenu/contextMenu.js
@@ -244,6 +244,13 @@ export class ContextMenu extends BasePlugin {
    * the offset to the menu position.
    * @fires Hooks#beforeContextMenuShow
    * @fires Hooks#afterContextMenuShow
+   * @example
+   * ```js
+   * const menu = hot.getPlugin('contextMenu');
+   *
+   * hot.selectCell(0, 0);
+   * menu.open({ top: 50, left: 50 });
+   * ```
    */
   open(position, offset = { above: 0, below: 0, left: 0, right: 0 }) {
     if (this.menu?.isOpened()) {

--- a/handsontable/src/plugins/dropdownMenu/dropdownMenu.js
+++ b/handsontable/src/plugins/dropdownMenu/dropdownMenu.js
@@ -349,6 +349,13 @@ export class DropdownMenu extends BasePlugin {
    * the offset to the menu position.
    * @fires Hooks#beforeDropdownMenuShow
    * @fires Hooks#afterDropdownMenuShow
+   * @example
+   * ```js
+   * const menu = hot.getPlugin('dropdownMenu');
+   *
+   * hot.selectCell(0, 0);
+   * menu.open({ top: 50, left: 50 });
+   * ```
    */
   open(position, offset = { above: 0, below: 0, left: 0, right: 0 }) {
     if (this.menu?.isOpened()) {


### PR DESCRIPTION
### Context
This PR adds the missing code snipptets to the `contextMenu` and `dropdownMenu` plugins' description of the `open()` method.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/248
2. https://github.com/handsontable/dev-handsontable/issues/246

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that doesn’t affect runtime behavior. Only JSDoc comments are updated.
> 
> **Overview**
> Adds JSDoc `@example` code snippets for `contextMenu.open()` and `dropdownMenu.open()` to show how to programmatically open each menu after selecting a cell.
> 
> No functional code changes; only documentation/comments are updated.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2221b822aabc00bdc7c2cfcf40a977095f7d22b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->