### PR TITLE
Fix release workflow: protected branch push, tag update, and merge conflicts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1025,18 +1025,17 @@ jobs:
               echo "::warning::Conflicts merging release to develop — creating a PR for manual resolution."
               git merge --abort
 
-              # Push the release branch as a merge branch and create a PR for human review
+              # Check if a merge PR already exists before pushing (idempotent for workflow re-runs)
               MERGE_BRANCH="merge/${RELEASE_BRANCH##*/}-to-develop"
-              git checkout -b "${MERGE_BRANCH}" origin/${RELEASE_BRANCH}
-              git push -u origin "${MERGE_BRANCH}"
-
-              # Check if a PR already exists (idempotent for workflow re-runs)
               EXISTING_PR=$(gh pr list --base develop --head "${MERGE_BRANCH}" --json url --jq '.[0].url // empty')
 
               if [ -n "$EXISTING_PR" ]; then
                 PR_URL="$EXISTING_PR"
                 echo "::notice::Merge PR already exists: ${PR_URL}"
               else
+                git checkout -b "${MERGE_BRANCH}" origin/${RELEASE_BRANCH}
+                git push -u origin "${MERGE_BRANCH}"
+
                 PR_URL=$(gh pr create \
                   --base develop \
                   --head "${MERGE_BRANCH}" \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -944,7 +944,15 @@ jobs:
     outputs:
       version: ${{ needs.stable-prepare.outputs.version }}
       release-branch: ${{ needs.stable-prepare.outputs.release-branch }}
+      develop-merge-pr: ${{ steps.merge-develop.outputs.pr-url }}
     steps:
+      - name: Generate release bot token
+        id: release-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # https://github.com/actions/create-github-app-token/releases/tag/v1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # https://github.com/actions/checkout/releases/tag/v6.0.2
         with:
           ref: ${{ needs.stable-prepare.outputs.release-branch }}
@@ -962,45 +970,42 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Check merge compatibility
+      - name: Check merge compatibility (master)
         run: |
           RELEASE_BRANCH='${{ needs.stable-prepare.outputs.release-branch }}'
 
           git fetch origin develop master
 
-          FAILED=0
-          for TARGET in develop master; do
-            git checkout -b _dry_${TARGET} origin/${TARGET}
+          # Only dry-run master — develop conflicts are handled gracefully via PR.
+          git checkout -b _dry_master origin/master
 
-            if ! git merge --no-commit --no-ff origin/${RELEASE_BRANCH} 2>/dev/null; then
-              CONFLICTS=$(git diff --name-only --diff-filter=U)
-              UNEXPECTED=$(echo "$CONFLICTS" | grep -v '^pnpm-lock.yaml$' || true)
+          if ! git merge --no-commit --no-ff origin/${RELEASE_BRANCH} 2>/dev/null; then
+            CONFLICTS=$(git diff --name-only --diff-filter=U)
+            UNEXPECTED=$(echo "$CONFLICTS" | grep -v '^pnpm-lock.yaml$' || true)
 
-              if [ -n "$UNEXPECTED" ]; then
-                echo "::error::Conflicts with ${TARGET} require human attention:"
-                echo "$UNEXPECTED" | while IFS= read -r f; do echo "  - $f"; done
-                FAILED=1
-              else
-                echo "::notice::${TARGET}: pnpm-lock.yaml conflict will be auto-resolved"
-              fi
-
+            if [ -n "$UNEXPECTED" ]; then
+              echo "::error::Conflicts with master require human attention:"
+              echo "$UNEXPECTED" | while IFS= read -r f; do echo "  - $f"; done
               git merge --abort 2>/dev/null || true
+              git checkout -
+              git branch -D _dry_master
+              exit 1
             else
-              git reset --merge
+              echo "::notice::master: pnpm-lock.yaml conflict will be auto-resolved"
             fi
 
-            git checkout -
-            git branch -D _dry_${TARGET}
-          done
-
-          if [ "$FAILED" -ne 0 ]; then
-            echo "::error::Fix the conflicts on the release branch or develop, then re-run this job."
-            exit 1
+            git merge --abort 2>/dev/null || true
+          else
+            git reset --merge
           fi
 
+          git checkout -
+          git branch -D _dry_master
+
       - name: Merge to develop
+        id: merge-develop
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.release-token.outputs.token }}
         run: |
           RELEASE_BRANCH='${{ needs.stable-prepare.outputs.release-branch }}'
 
@@ -1015,24 +1020,40 @@ jobs:
             UNEXPECTED=$(echo "$UNRESOLVED" | grep -v '^pnpm-lock.yaml$' || true)
 
             if [ -n "$UNEXPECTED" ]; then
-              echo "::error::Unexpected conflicts during merge to develop: $UNEXPECTED"
+              echo "::warning::Conflicts merging release to develop — creating a PR for manual resolution."
               git merge --abort
-              exit 1
+
+              # Push the release branch as a merge branch and create a PR for human review
+              MERGE_BRANCH="merge/${RELEASE_BRANCH##*/}-to-develop"
+              git checkout -b "${MERGE_BRANCH}" origin/${RELEASE_BRANCH}
+              git push origin "${MERGE_BRANCH}"
+
+              PR_URL=$(gh pr create \
+                --base develop \
+                --head "${MERGE_BRANCH}" \
+                --title "Merge ${RELEASE_BRANCH} back to develop" \
+                --body "Automatic merge from the release workflow had conflicts that need manual resolution.")
+
+              echo "pr-url=${PR_URL}" >> $GITHUB_OUTPUT
+              echo "::notice::PR created for manual merge to develop: ${PR_URL}"
+            else
+              git checkout --ours pnpm-lock.yaml
+              pnpm install --lockfile-only
+              git add pnpm-lock.yaml
+              git commit --no-edit
+              git push origin develop
             fi
-
-            git checkout --ours pnpm-lock.yaml
-            pnpm install --lockfile-only
-            git add pnpm-lock.yaml
-            git commit --no-edit
+          else
+            git push origin develop
           fi
-
-          git push origin develop
 
       - name: Merge to master
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TOKEN: ${{ steps.release-token.outputs.token }}
         run: |
           RELEASE_BRANCH='${{ needs.stable-prepare.outputs.release-branch }}'
+
+          git remote set-url origin "https://x-access-token:${RELEASE_TOKEN}@github.com/${{ github.repository }}.git"
 
           git checkout master
 
@@ -1056,7 +1077,7 @@ jobs:
 
       - name: Move version tag to post-merge master commit
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.release-token.outputs.token }}
         run: |
           VERSION='${{ needs.stable-prepare.outputs.version }}'
           NEW_SHA=$(git rev-parse HEAD) # HEAD is master after the merge step
@@ -1120,6 +1141,7 @@ jobs:
     outputs:
       version: ${{ needs.stable-merge.outputs.version }}
       release-branch: ${{ needs.stable-merge.outputs.release-branch }}
+      develop-merge-pr: ${{ needs.stable-merge.outputs.develop-merge-pr }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # https://github.com/actions/checkout/releases/tag/v6.0.2
         with:
@@ -1298,6 +1320,16 @@ jobs:
         continue-on-error: true
         run: node .github/scripts/purge-jsdelivr-cache.mjs '${{ needs.stable-build.outputs.version }}'
 
+      - name: Extract changelog for docs
+        id: docs-changelog-content
+        continue-on-error: true
+        run: |
+          VERSION='${{ needs.stable-build.outputs.version }}'
+          CONTENT=$(node .github/scripts/extract-changelog.mjs "$VERSION")
+          echo "content<<DOCS_CHANGELOG_EOF" >> $GITHUB_OUTPUT
+          echo "$CONTENT" >> $GITHUB_OUTPUT
+          echo "DOCS_CHANGELOG_EOF" >> $GITHUB_OUTPUT
+
       - name: Install dependencies
         id: docs-deps
         continue-on-error: true
@@ -1365,6 +1397,13 @@ jobs:
             exit 1
           fi
 
+      - name: Update docs changelog
+        id: docs-changelog
+        continue-on-error: true
+        env:
+          CHANGELOG_CONTENT: ${{ steps.docs-changelog-content.outputs.content }}
+        run: node .github/scripts/update-docs-changelog.mjs '${{ needs.stable-build.outputs.version }}'
+
       - name: Commit and push docs branch
         id: docs-commit
         continue-on-error: true
@@ -1383,16 +1422,20 @@ jobs:
         id: docs-result
         if: always()
         run: |
-          if [ "${{ steps.docs-deps.outcome }}" = "failure" ] || \
+          if [ "${{ steps.docs-changelog-content.outcome }}" = "failure" ] || \
+             [ "${{ steps.docs-deps.outcome }}" = "failure" ] || \
              [ "${{ steps.docs-branch.outcome }}" = "failure" ] || \
              [ "${{ steps.docs-api.outcome }}" = "failure" ] || \
              [ "${{ steps.docs-angular.outcome }}" = "failure" ] || \
+             [ "${{ steps.docs-changelog.outcome }}" = "failure" ] || \
              [ "${{ steps.docs-commit.outcome }}" = "failure" ]; then
             echo "result=failure" >> $GITHUB_OUTPUT
-          elif [ "${{ steps.docs-deps.outcome }}" = "success" ] && \
+          elif [ "${{ steps.docs-changelog-content.outcome }}" = "success" ] && \
+               [ "${{ steps.docs-deps.outcome }}" = "success" ] && \
                [ "${{ steps.docs-branch.outcome }}" = "success" ] && \
                [ "${{ steps.docs-api.outcome }}" = "success" ] && \
                [ "${{ steps.docs-angular.outcome }}" = "success" ] && \
+               [ "${{ steps.docs-changelog.outcome }}" = "success" ] && \
                [ "${{ steps.docs-commit.outcome }}" = "success" ]; then
             echo "result=success" >> $GITHUB_OUTPUT
           else
@@ -1463,6 +1506,7 @@ jobs:
           NPM_RESULT: ${{ needs.stable-publish.result }}
           NUGET_RESULT: ${{ needs.stable-publish-nuget.result }}
           DOCS_RESULT: ${{ needs.stable-publish.outputs.docs-result }}
+          DEVELOP_MERGE_PR: ${{ needs.stable-build.outputs.develop-merge-pr }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           REPO_URL: ${{ github.server_url }}/${{ github.repository }}
         run: |
@@ -1479,6 +1523,11 @@ jobs:
           else
             DOCS_STATUS=":x: :chrome: *Docs*"
           fi
+          if [ -n "$DEVELOP_MERGE_PR" ]; then
+            GITHUB_STATUS=":x: :github: *GitHub*"
+          else
+            GITHUB_STATUS=":white_check_mark: :github: *GitHub*"
+          fi
           NL=$'\n'
           FAILURE_NOTES=""
           if [ "$NUGET_RESULT" != "success" ]; then
@@ -1486,6 +1535,9 @@ jobs:
           fi
           if [ "$DOCS_RESULT" = "failure" ]; then
             FAILURE_NOTES="${FAILURE_NOTES}• *Docs*: branch update failed. Manual intervention required — check the <${RUN_URL}|Actions run> and update the docs branch manually.${NL}"
+          fi
+          if [ -n "$DEVELOP_MERGE_PR" ]; then
+            FAILURE_NOTES="${FAILURE_NOTES}• *GitHub*: merge to develop had conflicts. A <${DEVELOP_MERGE_PR}|PR was created> for manual resolution.${NL}"
           fi
           CHANGELOG_URL="${REPO_URL}/blob/master/CHANGELOG.md"
 
@@ -1496,6 +1548,7 @@ jobs:
             --arg npm_ok        "$NPM_OK" \
             --arg nuget_status  "$NUGET_STATUS" \
             --arg docs_status   "$DOCS_STATUS" \
+            --arg github_status "$GITHUB_STATUS" \
             --arg failure_notes "$FAILURE_NOTES" \
             --arg changelog_url "$CHANGELOG_URL" \
             --arg repo_url      "${REPO_URL}" \
@@ -1521,7 +1574,7 @@ jobs:
               {
                 type: "section",
                 fields: [
-                  { type: "mrkdwn", text: ":white_check_mark: :github: *GitHub*" },
+                  { type: "mrkdwn", text: $github_status },
                   { type: "mrkdwn", text: $npm_status },
                   { type: "mrkdwn", text: $nuget_status },
                   { type: "mrkdwn", text: $docs_status }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1026,16 +1026,24 @@ jobs:
               # Push the release branch as a merge branch and create a PR for human review
               MERGE_BRANCH="merge/${RELEASE_BRANCH##*/}-to-develop"
               git checkout -b "${MERGE_BRANCH}" origin/${RELEASE_BRANCH}
-              git push origin "${MERGE_BRANCH}"
+              git push -u origin "${MERGE_BRANCH}"
 
-              PR_URL=$(gh pr create \
-                --base develop \
-                --head "${MERGE_BRANCH}" \
-                --title "Merge ${RELEASE_BRANCH} back to develop" \
-                --body "Automatic merge from the release workflow had conflicts that need manual resolution.")
+              # Check if a PR already exists (idempotent for workflow re-runs)
+              EXISTING_PR=$(gh pr list --base develop --head "${MERGE_BRANCH}" --json url --jq '.[0].url // empty')
+
+              if [ -n "$EXISTING_PR" ]; then
+                PR_URL="$EXISTING_PR"
+                echo "::notice::Merge PR already exists: ${PR_URL}"
+              else
+                PR_URL=$(gh pr create \
+                  --base develop \
+                  --head "${MERGE_BRANCH}" \
+                  --title "Merge ${RELEASE_BRANCH} back to develop" \
+                  --body "Automatic merge from the release workflow had conflicts that need manual resolution.")
+                echo "::notice::PR created for manual merge to develop: ${PR_URL}"
+              fi
 
               echo "pr-url=${PR_URL}" >> $GITHUB_OUTPUT
-              echo "::notice::PR created for manual merge to develop: ${PR_URL}"
             else
               git checkout --ours pnpm-lock.yaml
               pnpm install --lockfile-only

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1062,6 +1062,10 @@ jobs:
         run: |
           RELEASE_BRANCH='${{ needs.stable-prepare.outputs.release-branch }}'
 
+          # Clean up any leftover merge/dirty state from the develop step
+          git merge --abort 2>/dev/null || true
+          git reset --hard HEAD
+
           git remote set-url origin "https://x-access-token:${RELEASE_TOKEN}@github.com/${{ github.repository }}.git"
 
           git checkout master

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -945,6 +945,7 @@ jobs:
       version: ${{ needs.stable-prepare.outputs.version }}
       release-branch: ${{ needs.stable-prepare.outputs.release-branch }}
       develop-merge-pr: ${{ steps.merge-develop.outputs.pr-url }}
+      develop-merge-result: ${{ steps.merge-develop.outcome }}
     steps:
       - name: Generate release bot token
         id: release-token
@@ -1004,6 +1005,7 @@ jobs:
 
       - name: Merge to develop
         id: merge-develop
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ steps.release-token.outputs.token }}
         run: |
@@ -1150,6 +1152,7 @@ jobs:
       version: ${{ needs.stable-merge.outputs.version }}
       release-branch: ${{ needs.stable-merge.outputs.release-branch }}
       develop-merge-pr: ${{ needs.stable-merge.outputs.develop-merge-pr }}
+      develop-merge-result: ${{ needs.stable-merge.outputs.develop-merge-result }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # https://github.com/actions/checkout/releases/tag/v6.0.2
         with:
@@ -1515,6 +1518,7 @@ jobs:
           NUGET_RESULT: ${{ needs.stable-publish-nuget.result }}
           DOCS_RESULT: ${{ needs.stable-publish.outputs.docs-result }}
           DEVELOP_MERGE_PR: ${{ needs.stable-build.outputs.develop-merge-pr }}
+          DEVELOP_MERGE_RESULT: ${{ needs.stable-build.outputs.develop-merge-result }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           REPO_URL: ${{ github.server_url }}/${{ github.repository }}
         run: |
@@ -1531,7 +1535,7 @@ jobs:
           else
             DOCS_STATUS=":x: :chrome: *Docs*"
           fi
-          if [ -n "$DEVELOP_MERGE_PR" ]; then
+          if [ -n "$DEVELOP_MERGE_PR" ] || [ "$DEVELOP_MERGE_RESULT" = "failure" ]; then
             GITHUB_STATUS=":x: :github: *GitHub*"
           else
             GITHUB_STATUS=":white_check_mark: :github: *GitHub*"
@@ -1546,6 +1550,8 @@ jobs:
           fi
           if [ -n "$DEVELOP_MERGE_PR" ]; then
             FAILURE_NOTES="${FAILURE_NOTES}• *GitHub*: merge to develop had conflicts. A <${DEVELOP_MERGE_PR}|PR was created> for manual resolution.${NL}"
+          elif [ "$DEVELOP_MERGE_RESULT" = "failure" ]; then
+            FAILURE_NOTES="${FAILURE_NOTES}• *GitHub*: merge to develop failed. Check the <${RUN_URL}|Actions run> and merge manually.${NL}"
           fi
           CHANGELOG_URL="${REPO_URL}/blob/master/CHANGELOG.md"
 


### PR DESCRIPTION
### Context
Fixes three issues encountered during the 17.0.1 release:

- **Protected `master` branch push failed.** The default `GITHUB_TOKEN` cannot bypass branch protection rules. Now uses a GitHub App token (Handsontable Release Bot) for pushing to `master` and updating version tags.
- **Tag update blocked by signature rules.** Same fix — the app token has bypass permissions on tag protection rulesets.
- **Merge conflicts blocked the entire workflow.** A revert/revert-the-revert flow on `develop` caused conflicts when merging the release branch back. Instead of failing the whole workflow (blocking master merge and npm publish), the workflow now creates a PR for manual conflict resolution and continues with the release. The Slack notification reflects this with a `:x:` on GitHub status and a link to the merge PR under non-critical failures.

Also adds docs changelog extraction and update steps to the stable publish job.

[skip changelog]

### How has this been tested?
Manual verification of workflow YAML structure. Will be validated on the next release cycle.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the stable release workflow’s merge/push/tag-update logic and authentication; mistakes could break automated releases or push incorrect refs despite being limited to CI config.
> 
> **Overview**
> Improves the stable release pipeline in `publish.yml` by generating a GitHub App token and using it for protected `master` pushes and post-merge version tag moves.
> 
> Makes merge handling more resilient: only dry-runs merge compatibility against `master`, and if merging the release branch back to `develop` hits non-lockfile conflicts it now creates/uses an idempotent PR (`merge/<version>-to-develop`) instead of failing the whole workflow, surfacing the PR URL and merge outcome as job outputs.
> 
> Enhances stable release notifications and docs publishing: Slack status now reflects `develop` merge issues and links the conflict PR, and stable docs publishing now extracts changelog content and runs an explicit docs changelog update step that is included in the docs success/failure gating.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41af8ad2814ba81843e0890c9cfecc2f5a36c215. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->