### PR TITLE
 Improve afterGetRow/ColumnHeaderRenderers description

### DIFF
--- a/handsontable/src/core/hooks/constants.js
+++ b/handsontable/src/core/hooks/constants.js
@@ -2432,6 +2432,34 @@ export const REGISTERED_HOOKS = [
   /**
    * Fired after getting the column header renderers.
    *
+   * The `renderers` array initially contains one renderer function when [`colHeaders`](@/api/options.md#colheaders)
+   * is enabled, or zero functions when it is disabled. Each function in the array renders one layer of
+   * column headers above the grid. By pushing additional renderer functions to the array, you can display
+   * more than one layer of column headers simultaneously.
+   *
+   * Each renderer function receives the following arguments:
+   *
+   * | Argument               | Type                    | Description                                |
+   * | ---------------------- | ----------------------- | ------------------------------------------ |
+   * | `renderedColumnIndex`  | `number`                | The renderable index of the column.        |
+   * | `TH`                   | `HTMLTableCellElement`  | The `<th>` element to modify.              |
+   *
+   * ```js
+   * new Handsontable(container, {
+   *   colHeaders: true,
+   *   afterGetColumnHeaderRenderers(renderers) {
+   *     // Add a second layer of column headers above the default one.
+   *     renderers.push((renderedColumnIndex, TH) => {
+   *       TH.innerText = `Extra: ${renderedColumnIndex}`;
+   *     });
+   *   },
+   * });
+   * ```
+   *
+   * Read more:
+   * - [Options: `colHeaders`](@/api/options.md#colheaders)
+   * - [Guides: Column header](@/guides/columns/column-header/column-header.md)
+   *
    * @event Hooks#afterGetColumnHeaderRenderers
    * @param {Function[]} renderers An array of the column header renderers.
    */
@@ -2439,6 +2467,34 @@ export const REGISTERED_HOOKS = [
 
   /**
    * Fired after getting the row header renderers.
+   *
+   * The `renderers` array initially contains one renderer function when [`rowHeaders`](@/api/options.md#rowheaders)
+   * is enabled, or zero functions when it is disabled. Each function in the array renders one layer of
+   * row headers to the left of the grid. By pushing additional renderer functions to the array, you can display
+   * more than one layer of row headers simultaneously.
+   *
+   * Each renderer function receives the following arguments:
+   *
+   * | Argument              | Type                    | Description                             |
+   * | --------------------- | ----------------------- | --------------------------------------- |
+   * | `renderableRowIndex`  | `number`                | The renderable index of the row.        |
+   * | `TH`                  | `HTMLTableCellElement`  | The `<th>` element to modify.           |
+   *
+   * ```js
+   * new Handsontable(container, {
+   *   rowHeaders: true,
+   *   afterGetRowHeaderRenderers(renderers) {
+   *     // Add a second layer of row headers next to the default one.
+   *     renderers.push((renderableRowIndex, TH) => {
+   *       TH.innerText = `Extra: ${renderableRowIndex}`;
+   *     });
+   *   },
+   * });
+   * ```
+   *
+   * Read more:
+   * - [Options: `rowHeaders`](@/api/options.md#rowheaders)
+   * - [Guides: Row header](@/guides/rows/row-header/row-header.md)
    *
    * @event Hooks#afterGetRowHeaderRenderers
    * @param {Function[]} renderers An array of the row header renderers.


### PR DESCRIPTION
### Context

This PR adds the missing information about the possibility of using `afterGetRowHeaderRenders` and `afterGetColumnHeaderRenderers` to add an additional layer of row or column headers, along with a code snippet.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/429#issuecomment-4125215267

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to JSDoc comments for two hooks and don’t affect runtime behavior.
> 
> **Overview**
> Improves the hook docs for `afterGetColumnHeaderRenderers` and `afterGetRowHeaderRenderers` by explaining how the `renderers` array can be extended to render *multiple header layers*, including the expected renderer function signature.
> 
> Adds small usage examples and links to related `colHeaders`/`rowHeaders` options and header guides to make the hooks’ intended customization clearer.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29a8be52f9b7b54ef6ab5f62a189bb1470d0dc1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->