### PR TITLE
Add the missing information to the `manualRowMove` and `manualColumnMove` guides

### DIFF
--- a/docs/content/guides/columns/column-moving/column-moving.md
+++ b/docs/content/guides/columns/column-moving/column-moving.md
@@ -132,6 +132,23 @@ But, if you configure the [`colHeaders`](@/api/options.md#colheaders) option wit
 
 :::
 
+## Set a pre-defined column order
+
+Instead of setting [`manualColumnMove`](@/api/options.md#manualcolumnmove) to `true`, you can pass an **array of physical column indexes** to define the initial visual order of columns on render.
+
+Each position in the array corresponds to a visual (display) position, and the value at that position is the physical (source data) column index. For example:
+
+```js
+manualColumnMove: [1, 0, 2]
+```
+
+This renders the columns in the following order:
+- Visual position 0 → physical column `1`
+- Visual position 1 → physical column `0`
+- Visual position 2 → physical column `2`
+
+The array must contain all physical column indexes (its length must equal the total number of columns). After the initial render, users can still drag columns to change the order further.
+
 ## Drag and move actions of the [`ManualColumnMove`](@/api/manualColumnMove.md) plugin
 
 There are significant differences between the plugin's [`dragColumns`](@/api/manualColumnMove.md#dragcolumns) and [`moveColumns`](@/api/manualColumnMove.md#movecolumns) API functions. Both of them change the order of columns, but they rely on different kinds of indexes. The differences between them are shown in the diagrams below.

--- a/docs/content/guides/rows/row-moving/row-moving.md
+++ b/docs/content/guides/rows/row-moving/row-moving.md
@@ -60,6 +60,23 @@ A draggable move handle appears above the selected row header. You can click and
 
 :::
 
+## Set a pre-defined row order
+
+Instead of setting [`manualRowMove`](@/api/options.md#manualrowmove) to `true`, you can pass an **array of physical row indexes** to define the initial visual order of rows on render.
+
+Each position in the array corresponds to a visual (display) position, and the value at that position is the physical (source data) row index. For example:
+
+```js
+manualRowMove: [2, 0, 1]
+```
+
+This renders the rows in the following order:
+- Visual position 0 → physical row `2`
+- Visual position 1 → physical row `0`
+- Visual position 2 → physical row `1`
+
+The array must contain all physical row indexes (its length must equal the total number of rows). After the initial render, users can still drag rows to change the order further.
+
 ## Drag and move actions of `manualRowMove` plugin
 
 There are significant differences between the plugin's [`dragRows`](@/api/manualRowMove.md#dragrows) and [`moveRows`](@/api/manualRowMove.md#moverows) API functions. Both of them change the order of rows, but they rely on different kinds of indexes. The differences between them are shown in the diagrams below.


### PR DESCRIPTION
### Context
This PR adds the missing information to the `manualRowMove` and `manualColumnMove` guides about the possibility of setting both to an array of predefined index orders along with the code snippets.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/66

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that doesn’t affect runtime behavior; risk is limited to potential confusion if index semantics are misstated.
> 
> **Overview**
> Adds documentation to the `manualColumnMove` and `manualRowMove` guides explaining that these options can be initialized with an array of **physical** indexes to set the initial visual order.
> 
> Includes short examples and clarifies the visual-position-to-physical-index mapping, plus the requirement that the array cover all rows/columns while still allowing user drag-reordering after render.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30e1b0bff0f9bcb7d0fd541f40244bc53e498e3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->