### PR TITLE
Specify the limitation of the filter predefined options in the dropdown menu

### DIFF
--- a/docs/content/guides/columns/column-filter/column-filter.md
+++ b/docs/content/guides/columns/column-filter/column-filter.md
@@ -885,6 +885,9 @@ At the moment, filtering comes with the following limitations:
 - There is no easy way to add custom filter operators to the user interface.
 - The list of values that you can filter by is generated automatically and there's no supported way
   of modifying it.
+- The filter's dropdown menu supports at most two conditions per column. If you add more conditions
+  programmatically via [`addCondition()`](@/api/filters.md), the extra conditions are applied to the
+  data but are not visible or editable in the dropdown menu.
 
 ## Related keyboard shortcuts
 

--- a/docs/content/guides/columns/column-filter/column-filter.md
+++ b/docs/content/guides/columns/column-filter/column-filter.md
@@ -885,9 +885,10 @@ At the moment, filtering comes with the following limitations:
 - There is no easy way to add custom filter operators to the user interface.
 - The list of values that you can filter by is generated automatically and there's no supported way
   of modifying it.
-- The filter's dropdown menu supports at most two conditions per column. If you add more conditions
-  programmatically via [`addCondition()`](@/api/filters.md), the extra conditions are applied to the
-  data but are not visible or editable in the dropdown menu.
+- The filter's dropdown menu has a limited capacity per column: at most 2 regular conditions and 1
+  "filter by value" condition. If you add more conditions programmatically via
+  [`addCondition()`](@/api/filters.md), the extra conditions are applied to the data but are not
+  visible or editable in the dropdown menu.
 
 ## Related keyboard shortcuts
 

--- a/handsontable/src/plugins/filters/__tests__/filters.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/filters.spec.js
@@ -200,15 +200,15 @@ describe('Filters', () => {
     plugin.filter();
 
     expect(warnSpy.calls.mostRecent().args).toEqual(['The filter conditions have been applied properly, ' +
-      'but couldn’t be displayed visually. The overall amount of conditions exceed the capability of the ' +
-      'dropdown menu. For more details see the documentation.']);
+      'but couldn’t be displayed visually. The dropdown menu supports a maximum of 2 conditions per column, ' +
+      'but more were provided. For more details see the documentation.']);
 
     plugin.addCondition(0, 'contains', ['o']);
     plugin.filter();
 
     expect(warnSpy.calls.mostRecent().args).toEqual(['The filter conditions have been applied properly, ' +
-      'but couldn’t be displayed visually. The overall amount of conditions exceed the capability of the ' +
-      'dropdown menu. For more details see the documentation.']);
+      'but couldn’t be displayed visually. The dropdown menu supports a maximum of 2 conditions per column, ' +
+      'but more were provided. For more details see the documentation.']);
     expect(warnSpy.calls.count()).toBe(2);
   });
 

--- a/handsontable/src/plugins/filters/__tests__/filters.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/filters.spec.js
@@ -201,7 +201,7 @@ describe('Filters', () => {
 
     expect(warnSpy.calls.mostRecent().args).toEqual(['The filter conditions have been applied properly, ' +
       'but couldn’t be displayed visually. The dropdown menu supports at most 2 regular conditions and 1 ' +
-      "'filter by value' condition per column, but more were provided. " +
+      '\'filter by value\' condition per column, but more were provided. ' +
       'For more details see the documentation.']);
 
     plugin.addCondition(0, 'contains', ['o']);
@@ -209,7 +209,7 @@ describe('Filters', () => {
 
     expect(warnSpy.calls.mostRecent().args).toEqual(['The filter conditions have been applied properly, ' +
       'but couldn’t be displayed visually. The dropdown menu supports at most 2 regular conditions and 1 ' +
-      "'filter by value' condition per column, but more were provided. " +
+      '\'filter by value\' condition per column, but more were provided. ' +
       'For more details see the documentation.']);
     expect(warnSpy.calls.count()).toBe(2);
   });

--- a/handsontable/src/plugins/filters/__tests__/filters.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/filters.spec.js
@@ -200,15 +200,17 @@ describe('Filters', () => {
     plugin.filter();
 
     expect(warnSpy.calls.mostRecent().args).toEqual(['The filter conditions have been applied properly, ' +
-      'but couldn’t be displayed visually. The dropdown menu supports a maximum of 2 conditions per column, ' +
-      'but more were provided. For more details see the documentation.']);
+      'but couldn’t be displayed visually. The dropdown menu supports at most 2 regular conditions and 1 ' +
+      "'filter by value' condition per column, but more were provided. " +
+      'For more details see the documentation.']);
 
     plugin.addCondition(0, 'contains', ['o']);
     plugin.filter();
 
     expect(warnSpy.calls.mostRecent().args).toEqual(['The filter conditions have been applied properly, ' +
-      'but couldn’t be displayed visually. The dropdown menu supports a maximum of 2 conditions per column, ' +
-      'but more were provided. For more details see the documentation.']);
+      'but couldn’t be displayed visually. The dropdown menu supports at most 2 regular conditions and 1 ' +
+      "'filter by value' condition per column, but more were provided. " +
+      'For more details see the documentation.']);
     expect(warnSpy.calls.count()).toBe(2);
   });
 

--- a/handsontable/src/plugins/filters/filters.js
+++ b/handsontable/src/plugins/filters/filters.js
@@ -446,6 +446,10 @@ export class Filters extends BasePlugin {
    *
    * **Note**: Mind that you cannot mix different types of operations (for instance, if you use `conjunction`, use it consequently for a particular column).
    *
+   * **Note**: If the number of conditions added programmatically via `addCondition()` exceeds the number supported by
+   * the filter's dropdown UI (two conditions per column), the extra conditions will be applied to the data but will
+   * not be visible or editable in the dropdown menu.
+   *
    * @example
    * ::: only-for javascript
    * ```js
@@ -1300,7 +1304,7 @@ export class Filters extends BasePlugin {
 
     if (conditionsByValue.length >= 2 || conditionsWithoutByValue.length >= 3) {
       warn(toSingleLine`The filter conditions have been applied properly, but couldn’t be displayed visually.\x20
-        The overall amount of conditions exceed the capability of the dropdown menu.\x20
+        The dropdown menu supports a maximum of 2 conditions per column, but more were provided.\x20
         For more details see the documentation.`);
 
     } else {

--- a/handsontable/src/plugins/filters/filters.js
+++ b/handsontable/src/plugins/filters/filters.js
@@ -1303,8 +1303,8 @@ export class Filters extends BasePlugin {
     const conditionsWithoutByValue = conditions.filter(condition => condition.name !== CONDITION_BY_VALUE);
 
     if (conditionsByValue.length >= 2 || conditionsWithoutByValue.length >= 3) {
-      warn(toSingleLine`The filter conditions have been applied properly, but couldn’t be displayed visually. 
-        The dropdown menu supports at most 2 regular conditions and 1 'filter by value' condition per column, 
+      warn(toSingleLine`The filter conditions have been applied properly, but couldn’t be displayed visually.\x20
+        The dropdown menu supports at most 2 regular conditions and 1 'filter by value' condition per column,\x20
         but more were provided. For more details see the documentation.`);
 
     } else {

--- a/handsontable/src/plugins/filters/filters.js
+++ b/handsontable/src/plugins/filters/filters.js
@@ -446,9 +446,9 @@ export class Filters extends BasePlugin {
    *
    * **Note**: Mind that you cannot mix different types of operations (for instance, if you use `conjunction`, use it consequently for a particular column).
    *
-   * **Note**: If the number of conditions added programmatically via `addCondition()` exceeds the number supported by
-   * the filter's dropdown UI (two conditions per column), the extra conditions will be applied to the data but will
-   * not be visible or editable in the dropdown menu.
+   * **Note**: If the number of conditions added programmatically via `addCondition()` exceeds the capacity of the
+   * filter's dropdown UI (at most 2 regular conditions and 1 `by_value` condition per column), the extra conditions
+   * will be applied to the data but will not be visible or editable in the dropdown menu.
    *
    * @example
    * ::: only-for javascript
@@ -1303,9 +1303,9 @@ export class Filters extends BasePlugin {
     const conditionsWithoutByValue = conditions.filter(condition => condition.name !== CONDITION_BY_VALUE);
 
     if (conditionsByValue.length >= 2 || conditionsWithoutByValue.length >= 3) {
-      warn(toSingleLine`The filter conditions have been applied properly, but couldn’t be displayed visually.\x20
-        The dropdown menu supports a maximum of 2 conditions per column, but more were provided.\x20
-        For more details see the documentation.`);
+      warn(toSingleLine`The filter conditions have been applied properly, but couldn’t be displayed visually. 
+        The dropdown menu supports at most 2 regular conditions and 1 'filter by value' condition per column, 
+        but more were provided. For more details see the documentation.`);
 
     } else {
       const operationType = this.conditionCollection.getOperation(column);


### PR DESCRIPTION
### Context
This PR specifies the limit on the options displayed in the filter dropdown menu when the filters plugin is enabled, and predefined conditions are used. It also modifies the warning message for better readability and specifies that the display limit is 2 options.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/242

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation wording, JSDoc notes, and a more explicit console warning message plus updated tests; filtering behavior is unchanged.
> 
> **Overview**
> Clarifies the **Filters dropdown UI limitation** that per column it can display *at most 2 regular conditions plus 1 `by_value` condition*, and that extra conditions added via `addCondition()` still apply but aren’t shown/editable.
> 
> Updates the plugin’s console warning to explicitly state those limits, and adjusts the related unit test expectations to match the new message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b21a0007fdb4ae07eb1b1c90beb839c4446196b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->