### PR TITLE
Correct the batch operations methods description

### DIFF
--- a/docs/content/guides/optimization/batch-operations/batch-operations.md
+++ b/docs/content/guides/optimization/batch-operations/batch-operations.md
@@ -166,7 +166,7 @@ hot.batchRender(() => {
 
 #### batchExecution
 
-The [`batchExecution()`](@/api/core.md#batchexecution) is a callback function. Excessive renders can be skipped by placing the API calls inside of it. The table will be rendered after executing the callback. It is less prone to errors as you don't have to remember to resume the operations. The only drawback to this method is that it doesn't support async operations.
+The [`batchExecution()`](@/api/core.md#batchexecution) method aggregates multi-line API calls into a callback and postpones the table execution process. After the execution of the operations, the internal table cache is recalculated once. As a result, it improves the performance of wrapped operations. Without batching, a similar case could trigger multiple table cache rebuilds. It is less prone to errors as you don't have to remember to resume the operations. The only drawback to this method is that it doesn't support async operations.
 
 ```js
 hot.batchExecution(() => {
@@ -197,7 +197,9 @@ hot.resumeRender(); // remember to resume rendering
 
 #### suspendExecution and resumeExecution
 
-To suspend the rendering process, you can call the [`suspendExecution()`](@/api/core.md#suspendexecution) method just before the actions you want to batch. This is a manual approach. After suspending, you must remember to resume the process with the [`resumeExecution()`](@/api/core.md#resumeexecution) method.
+The [`suspendExecution()`](@/api/core.md#suspendexecution) method suspends the execution process. It's helpful to wrap the table logic changes such as index changes into one call after which the cache is updated. The method is intended to be used by advanced users. Suspending the execution process could cause visual glitches caused by not updating the internal table cache.
+
+To suspend, call [`suspendExecution()`](@/api/core.md#suspendexecution) just before the actions you want to batch. This is a manual approach. After suspending, you must remember to resume the process with the [`resumeExecution()`](@/api/core.md#resumeexecution) method. In combination, these two methods allow aggregating the table logic changes after which the cache is updated. Resuming the state automatically invokes the table cache updating process.
 
 ```js
 hot.suspendExecution();


### PR DESCRIPTION
### Context
This PR corrects the wrong description of the batch operations methods:
- `batchExecution`
- `suspendExecution`
- `resumeExecution`

Now they match their correct descriptions from the Core API.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/211

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording updates; no runtime or API behavior changes, so risk is limited to potential confusion if the new descriptions are still inaccurate.
> 
> **Overview**
> Updates the batch operations guide to **correct and clarify** the descriptions of `batchExecution()` and `suspendExecution()`/`resumeExecution()`.
> 
> The docs now emphasize that `batchExecution()` postpones execution and rebuilds the internal table cache once, and that `suspendExecution()` is an advanced manual mechanism that can cause visual glitches until `resumeExecution()` is called (which triggers the cache update).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c7e6d06b13fd832fbaea0e342f39fd7171960eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->