### PR TITLE
Correct the `getActiveEditor` method description

### DIFF
--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -5048,9 +5048,13 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
   /**
    * Returns the active editor class instance.
    *
+   * The active editor is the editor instance associated with the currently selected cell.
+   * An editor becomes active when a cell is selected and the editor is prepared (but not
+   * necessarily open). If no cell is selected, the method returns `undefined`.
+   *
    * @memberof Core#
    * @function getActiveEditor
-   * @returns {BaseEditor} The active editor instance.
+   * @returns {BaseEditor | undefined} The active editor instance, or `undefined` if no cell is selected.
    */
   this.getActiveEditor = function() {
     return editorManager.getActiveEditor();


### PR DESCRIPTION
### Context
This PR adds the missing information about what an active editor is in the description of the `getActiveEditor` method.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/238

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that doesn’t modify runtime behavior; main risk is minor API-doc mismatch if wording is inaccurate.
> 
> **Overview**
> Updates the `Core#getActiveEditor` JSDoc to define what “active editor” means (editor prepared for the currently selected cell, not necessarily opened) and to document that the method can return `undefined` when no cell is selected.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7dd664da3e6a89808e329560fd8bc2abbeefbf32. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->