### PR TITLE
Add it.flaky() API for retrying flaky E2E tests

### DIFF
--- a/.ai/TESTING.md
+++ b/.ai/TESTING.md
@@ -183,7 +183,7 @@ describe('CellMeta', () => {
 ## Async Testing
 
 **E2E Tests Must Be `async`:**
-Enforced by ESLint rule `handsontable/require-async-in-it` in `*.spec.js`:
+Enforced by ESLint rule `handsontable/require-async-in-it` in `*.spec.js` (applies to `it()`, `it.flaky()`, and `fit.flaky()` calls):
 
 ```javascript
 // CORRECT
@@ -200,6 +200,19 @@ it('should do something', () => {
   render(); // Must be await-ed
 });
 ```
+
+**Flaky Test Retries:**
+Use `it.flaky()` (or `fit.flaky()`) to mark tests that fail intermittently due to timing or environment issues. The test is retried up to 3 times before reporting a failure. Between retries, any existing Handsontable instance is destroyed and the container is cleaned up.
+
+```javascript
+it.flaky('should handle a timing-sensitive operation', async() => {
+  handsontable({ data: createSpreadsheetData(5, 5) });
+  await selectCell(0, 0);
+  expect(getDataAtCell(0, 0)).toBe('A1');
+});
+```
+
+The test description is prefixed with `[flaky]` in CI output for visibility. Defined in `test/helpers/it-themes-extension.js`.
 
 **HOT Methods Requiring `await` (from `handsontable/.eslintrc.js`):**
 
@@ -329,7 +342,7 @@ export function getColumnsForFilters() { /* ... */ }
 - `test/helpers/utils.js` -- `waitOnScroll()` decorator and utilities
 - `test/helpers/focusNavigator.js` -- Focus navigation helpers
 - `test/helpers/htmlNormalize.js` -- HTML normalization for assertions
-- `test/helpers/it-themes-extension.js` -- Theme-specific test extensions
+- `test/helpers/it-themes-extension.js` -- Theme-specific and flaky test extensions
 - `src/plugins/{name}/__tests__/helpers/` -- Plugin-specific test data and utilities
 
 ## Custom Matchers

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,7 +50,7 @@ module.exports = {
       {
         code: 120,
         ignoreComments: true,
-        ignorePattern: '^\\s*x?it\\s*\\(', // Ignore long test names (e.q: `it("something long")`).
+        ignorePattern: '^\\s*x?(?:f?it)(?:\\.\\w+)?\\s*\\(', // Ignore long test names (e.g. `it("...")`, `it.flaky("...")`).
       }
     ],
     'newline-per-chained-call': 'off',

--- a/handsontable/.config/plugin/eslint/rules/require-async-in-it.js
+++ b/handsontable/.config/plugin/eslint/rules/require-async-in-it.js
@@ -11,10 +11,35 @@ module.exports = {
   },
 
   create(context) {
+    /**
+     * Checks if a CallExpression node is a call to `it`, `it.flaky`, `fit.flaky`,
+     * or similar member expressions on `it`/`fit`.
+     *
+     * @param {object} callee The callee node of the CallExpression.
+     * @returns {boolean}
+     */
+    function isItCall(callee) {
+      // Direct `it(...)` call.
+      if (callee.name === 'it') {
+        return true;
+      }
+
+      // Member expression like `it.flaky(...)` or `fit.flaky(...)`.
+      if (
+        callee.type === 'MemberExpression' &&
+        callee.object.type === 'Identifier' &&
+        (callee.object.name === 'it' || callee.object.name === 'fit')
+      ) {
+        return true;
+      }
+
+      return false;
+    }
+
     return {
       CallExpression(node) {
         if (
-          node.callee.name === 'it' &&
+          isItCall(node.callee) &&
           node.arguments[1] &&
           (node.arguments[1].type === 'ArrowFunctionExpression' || node.arguments[1].type === 'FunctionExpression') &&
           node.arguments[1].async !== true

--- a/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
+++ b/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
@@ -666,7 +666,7 @@ describe('AutocompleteEditor', () => {
       });
     });
 
-    it('should not take excessive time to open the editor if the choice list is very long (dev-handsontable#2313)', async() => {
+    it.flaky('should not take excessive time to open the editor if the choice list is very long (dev-handsontable#2313)', async() => {
       const options = new Array(50000).fill().map(() => Math.random());
       let startTime;
       let endTime;

--- a/handsontable/test/helpers/it-themes-extension.js
+++ b/handsontable/test/helpers/it-themes-extension.js
@@ -88,7 +88,7 @@ function runFlakyFn(originalFn, description, specDefinitions) {
   return originalFn(`[flaky] ${description}`, async function() {
     const origAddExpectationResult = jasmine.Spec.prototype.addExpectationResult;
 
-    for (let attempt = 1; attempt < FLAKY_MAX_RETRIES; attempt++) {
+    for (let attempt = 1; attempt <= FLAKY_MAX_RETRIES; attempt++) {
       let expectationFailed = false;
       let caughtError = null;
 

--- a/handsontable/test/helpers/it-themes-extension.js
+++ b/handsontable/test/helpers/it-themes-extension.js
@@ -52,8 +52,10 @@ function cleanUpBetweenRetries() {
   const container = document.querySelector('#testContainer');
 
   if (container) {
+    const $container = $(container);
+
     try {
-      const instance = $(container).handsontable('getInstance');
+      const instance = $container.data('handsontable');
 
       if (instance && !instance.isDestroyed) {
         instance.destroy();
@@ -62,6 +64,7 @@ function cleanUpBetweenRetries() {
       // No instance to destroy - container may not have a HOT instance.
     }
 
+    $container.removeData();
     container.innerHTML = '';
   }
 }

--- a/handsontable/test/helpers/it-themes-extension.js
+++ b/handsontable/test/helpers/it-themes-extension.js
@@ -1,17 +1,22 @@
 /**
- * This extension allows to run specs only for a specific theme.
- * If the currently loaded theme doesn't match the specified one, the spec will be marked as pending.
+ * This extension allows to run specs only for a specific theme and to mark specs as flaky.
  *
  * @example
  * ```
  * it.forTheme('main')('should do something', () => {
  *  // your spec
  * });
+ *
+ * it.flaky('should eventually pass', async() => {
+ *  // flaky spec - retried up to 3 times before reporting failure
+ * });
  * ```
  */
 const originalIt = global.it;
 const originalFit = global.fit;
 const originalXit = global.xit;
+
+const FLAKY_MAX_RETRIES = 3;
 
 /**
  * Runs the original function with the provided description and spec definitions.
@@ -40,6 +45,53 @@ function runOriginalFnUnderConditions(originalFn, themeName, description, specDe
 }
 
 /**
+ * Wraps a spec function with retry logic for flaky tests. If the spec fails, it is retried
+ * up to {@link FLAKY_MAX_RETRIES} times. Between retries, any existing Handsontable instance
+ * is destroyed and the test container is re-created.
+ *
+ * @param {Function} originalFn - The original Jasmine `it` or `fit` function.
+ * @param {string} description - The description of the spec.
+ * @param {Function} specDefinitions - The async function containing the spec definitions.
+ * @returns {*} The result of the original function execution.
+ */
+function runFlakyFn(originalFn, description, specDefinitions) {
+  return originalFn(`[flaky] ${description}`, async function() {
+    let lastError;
+
+    for (let attempt = 1; attempt <= FLAKY_MAX_RETRIES; attempt++) {
+      try {
+        await specDefinitions.call(this);
+
+        return;
+      } catch (error) {
+        lastError = error;
+
+        if (attempt < FLAKY_MAX_RETRIES) {
+          // Clean up between retries by destroying any HOT instance and re-creating the container.
+          const container = document.querySelector('#testContainer');
+
+          if (container) {
+            try {
+              const instance = $(container).handsontable('getInstance');
+
+              if (instance && !instance.isDestroyed) {
+                instance.destroy();
+              }
+            } catch (_e) {
+              // No instance to destroy - container may not have a HOT instance.
+            }
+
+            container.innerHTML = '';
+          }
+        }
+      }
+    }
+
+    throw lastError;
+  });
+}
+
+/**
  * Helper function allowing to run specs only for a specific theme.
  * If no "chained" call of `it.forTheme()` is used, it will behave as the original `it` function.
  *
@@ -59,6 +111,9 @@ fit.forTheme = themeName => (description, specDefinition) =>
 
 xit.forTheme = themeName => (description, specDefinition) =>
   runOriginalFnUnderConditions(originalXit, themeName, description, specDefinition);
+
+it.flaky = (description, specDefinitions) => runFlakyFn(originalIt, description, specDefinitions);
+fit.flaky = (description, specDefinitions) => runFlakyFn(originalFit, description, specDefinitions);
 
 global.it = it;
 global.fit = fit;

--- a/handsontable/test/helpers/it-themes-extension.js
+++ b/handsontable/test/helpers/it-themes-extension.js
@@ -45,9 +45,36 @@ function runOriginalFnUnderConditions(originalFn, themeName, description, specDe
 }
 
 /**
+ * Cleans up the test container between flaky test retries by destroying any existing
+ * Handsontable instance and clearing the container's contents.
+ */
+function cleanUpBetweenRetries() {
+  const container = document.querySelector('#testContainer');
+
+  if (container) {
+    try {
+      const instance = $(container).handsontable('getInstance');
+
+      if (instance && !instance.isDestroyed) {
+        instance.destroy();
+      }
+    } catch (_e) {
+      // No instance to destroy - container may not have a HOT instance.
+    }
+
+    container.innerHTML = '';
+  }
+}
+
+/**
  * Wraps a spec function with retry logic for flaky tests. If the spec fails, it is retried
  * up to {@link FLAKY_MAX_RETRIES} times. Between retries, any existing Handsontable instance
- * is destroyed and the test container is re-created.
+ * is destroyed and the test container is cleared.
+ *
+ * On non-final attempts, Jasmine's `Spec.prototype.addExpectationResult` is intercepted so that
+ * expectation failures are swallowed (not recorded in the spec result) and can be detected for
+ * retry. On the final attempt, the spec runs with standard Jasmine behavior so failures are
+ * reported normally.
  *
  * @param {Function} originalFn - The original Jasmine `it` or `fit` function.
  * @param {string} description - The description of the spec.
@@ -56,38 +83,40 @@ function runOriginalFnUnderConditions(originalFn, themeName, description, specDe
  */
 function runFlakyFn(originalFn, description, specDefinitions) {
   return originalFn(`[flaky] ${description}`, async function() {
-    let lastError;
+    const origAddExpectationResult = jasmine.Spec.prototype.addExpectationResult;
 
-    for (let attempt = 1; attempt <= FLAKY_MAX_RETRIES; attempt++) {
+    for (let attempt = 1; attempt < FLAKY_MAX_RETRIES; attempt++) {
+      let expectationFailed = false;
+      let caughtError = null;
+
+      // Intercept expectation results so failures are swallowed during non-final attempts.
+      jasmine.Spec.prototype.addExpectationResult = function(passed, data, isError) {
+        if (!passed) {
+          expectationFailed = true;
+
+          return;
+        }
+
+        origAddExpectationResult.call(this, passed, data, isError);
+      };
+
       try {
         await specDefinitions.call(this);
-
-        return;
       } catch (error) {
-        lastError = error;
-
-        if (attempt < FLAKY_MAX_RETRIES) {
-          // Clean up between retries by destroying any HOT instance and re-creating the container.
-          const container = document.querySelector('#testContainer');
-
-          if (container) {
-            try {
-              const instance = $(container).handsontable('getInstance');
-
-              if (instance && !instance.isDestroyed) {
-                instance.destroy();
-              }
-            } catch (_e) {
-              // No instance to destroy - container may not have a HOT instance.
-            }
-
-            container.innerHTML = '';
-          }
-        }
+        caughtError = error;
+      } finally {
+        jasmine.Spec.prototype.addExpectationResult = origAddExpectationResult;
       }
+
+      if (!expectationFailed && !caughtError) {
+        return;
+      }
+
+      cleanUpBetweenRetries();
     }
 
-    throw lastError;
+    // Final attempt - run with standard Jasmine behavior so failures are reported normally.
+    await specDefinitions.call(this);
   });
 }
 

--- a/handsontable/test/helpers/it-themes-extension.js
+++ b/handsontable/test/helpers/it-themes-extension.js
@@ -92,15 +92,12 @@ function runFlakyFn(originalFn, description, specDefinitions) {
       let expectationFailed = false;
       let caughtError = null;
 
-      // Intercept expectation results so failures are swallowed during non-final attempts.
-      jasmine.Spec.prototype.addExpectationResult = function(passed, data, isError) {
+      // Suppress all expectation results during non-final attempts to avoid duplicates
+      // across retries and to keep retry internals invisible to Jasmine's result tracking.
+      jasmine.Spec.prototype.addExpectationResult = function(passed) {
         if (!passed) {
           expectationFailed = true;
-
-          return;
         }
-
-        origAddExpectationResult.call(this, passed, data, isError);
       };
 
       try {


### PR DESCRIPTION
### Context

- Adds `it.flaky` and `fit.flaky` in the E2E harness (`test/helpers/it-themes-extension.js`). Failed specs retry up to 3 times. Between attempts the `#testContainer` is cleared and any Handsontable instance is destroyed. Descriptions are prefixed with `[flaky]` in output.
- Updates the custom ESLint rule `handsontable/require-async-in-it` so member-style calls (`it.flaky`, `fit.flaky`) still require `async` callbacks like plain `it(...)`.
- Relaxes root `max-len` `ignorePattern` so long names on `it.flaky` / `fit.flaky` are ignored the same way as `it(...)`.
- Adjusts `.ai/TESTING.md` to describe flaky retries and the helper.
- Marks the long-list autocomplete editor timing spec with `it.flaky` to reduce intermittent CI noise.

_[skip changelog]_

### How has this been tested?

I tested the changes locally

### Types of changes

- [x] New feature or improvement (non-breaking change which adds functionality)

### Affected project(s):

- [x] `handsontable`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the E2E test harness by intercepting Jasmine expectation reporting during retries, which could hide or alter failure reporting if misapplied. Production code is unaffected, but test signal/CI behavior may change.
> 
> **Overview**
> Adds a new `it.flaky()`/`fit.flaky()` E2E test helper that retries failing Jasmine specs up to 3 times, cleaning `#testContainer` and destroying any existing Handsontable instance between attempts and prefixing output with `[flaky]`.
> 
> Updates linting/docs to support the new API: extends `handsontable/require-async-in-it` to also require async callbacks for member-style `it.*` calls, relaxes root `max-len` for `it.flaky(...)` names, documents the retry behavior in `.ai/TESTING.md`, and marks one timing-sensitive autocomplete editor spec as `it.flaky`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b38c27821d2e2d0ed9c48e4c87f0a8cfb4d93a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->