### PR TITLE
Fix highlight class names not updating via updateSettings

### DIFF
--- a/.changelogs/12247.json
+++ b/.changelogs/12247.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed an issue where `currentRowClassName` and `currentColClassName` could not be changed dynamically using `updateSettings`.",
+  "type": "fixed",
+  "issueOrPR": 12247,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -3065,6 +3065,7 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
         instance.view.invalidateIndexSizesCache();
       }
 
+      selection.updateHighlightClassNames();
       instance.runHooks('afterUpdateSettings', settings);
     }
 

--- a/handsontable/src/selection/highlight/__tests__/highlight.unit.js
+++ b/handsontable/src/selection/highlight/__tests__/highlight.unit.js
@@ -1,0 +1,144 @@
+import Highlight from '../highlight';
+
+function createHighlightInstance(options = {}) {
+  return new Highlight({
+    rowClassName: 'rowClass',
+    columnClassName: 'columnClass',
+    headerClassName: 'headerClass',
+    activeHeaderClassName: 'activeHeaderClass',
+    cellAttributes: [],
+    rowIndexMapper: null,
+    columnIndexMapper: null,
+    disabledCellSelection: () => false,
+    cellCornerVisible: () => false,
+    areaCornerVisible: () => false,
+    visualToRenderableCoords: coords => coords,
+    renderableToVisualCoords: coords => coords,
+    createCellCoords: (row, column) => ({ row, column }),
+    createCellRange: (highlight, from, to) => ({ highlight, from, to }),
+    ...options,
+  });
+}
+
+describe('Highlight', () => {
+  describe('updateHighlightClassNames()', () => {
+    it('should update the rowClassName option and all cached row highlights', () => {
+      const highlight = createHighlightInstance();
+
+      // Create and cache a row highlight at layer level 0
+      highlight.createRowHighlight();
+
+      const [cachedRowHighlight] = highlight.getRowHighlights();
+
+      expect(cachedRowHighlight.settings.className).toBe('rowClass');
+
+      highlight.updateHighlightClassNames({ rowClassName: 'newRowClass' });
+
+      expect(highlight.options.rowClassName).toBe('newRowClass');
+      expect(cachedRowHighlight.settings.className).toBe('newRowClass');
+    });
+
+    it('should update the columnClassName option and all cached column highlights', () => {
+      const highlight = createHighlightInstance();
+
+      // Create and cache a column highlight at layer level 0
+      highlight.createColumnHighlight();
+
+      const [cachedColumnHighlight] = highlight.getColumnHighlights();
+
+      expect(cachedColumnHighlight.settings.className).toBe('columnClass');
+
+      highlight.updateHighlightClassNames({ columnClassName: 'newColumnClass' });
+
+      expect(highlight.options.columnClassName).toBe('newColumnClass');
+      expect(cachedColumnHighlight.settings.className).toBe('newColumnClass');
+    });
+
+    it('should update the headerClassName option and all cached row/column header highlights', () => {
+      const highlight = createHighlightInstance();
+
+      // Create and cache header highlights at layer level 0
+      highlight.createRowHeader();
+      highlight.createColumnHeader();
+
+      const [cachedRowHeader] = highlight.getRowHeaders();
+      const [cachedColumnHeader] = highlight.getColumnHeaders();
+
+      expect(cachedRowHeader.settings.className).toBe('headerClass');
+      expect(cachedColumnHeader.settings.className).toBe('headerClass');
+
+      highlight.updateHighlightClassNames({ headerClassName: 'newHeaderClass' });
+
+      expect(highlight.options.headerClassName).toBe('newHeaderClass');
+      expect(cachedRowHeader.settings.className).toBe('newHeaderClass');
+      expect(cachedColumnHeader.settings.className).toBe('newHeaderClass');
+    });
+
+    it('should update the activeHeaderClassName option and all cached active header highlights', () => {
+      const highlight = createHighlightInstance();
+
+      // Create and cache active header highlights at layer level 0
+      highlight.createActiveRowHeader();
+      highlight.createActiveColumnHeader();
+      highlight.createActiveCornerHeader();
+
+      const [cachedActiveRowHeader] = highlight.getActiveRowHeaders();
+      const [cachedActiveColumnHeader] = highlight.getActiveColumnHeaders();
+      const [cachedActiveCornerHeader] = highlight.getActiveCornerHeaders();
+
+      expect(cachedActiveRowHeader.settings.className).toBe('activeHeaderClass');
+      expect(cachedActiveColumnHeader.settings.className).toBe('activeHeaderClass');
+      expect(cachedActiveCornerHeader.settings.className).toBe('activeHeaderClass');
+
+      highlight.updateHighlightClassNames({ activeHeaderClassName: 'newActiveHeaderClass' });
+
+      expect(highlight.options.activeHeaderClassName).toBe('newActiveHeaderClass');
+      expect(cachedActiveRowHeader.settings.className).toBe('newActiveHeaderClass');
+      expect(cachedActiveColumnHeader.settings.className).toBe('newActiveHeaderClass');
+      expect(cachedActiveCornerHeader.settings.className).toBe('newActiveHeaderClass');
+    });
+
+    it('should set className to undefined when a class name is explicitly unset', () => {
+      const highlight = createHighlightInstance();
+
+      highlight.createRowHighlight();
+
+      const [cachedRowHighlight] = highlight.getRowHighlights();
+
+      expect(cachedRowHighlight.settings.className).toBe('rowClass');
+
+      highlight.updateHighlightClassNames({ rowClassName: undefined });
+
+      expect(highlight.options.rowClassName).toBeUndefined();
+      expect(cachedRowHighlight.settings.className).toBeUndefined();
+    });
+
+    it('should only update the specified class names, leaving others unchanged', () => {
+      const highlight = createHighlightInstance();
+
+      highlight.createRowHighlight();
+      highlight.createColumnHighlight();
+
+      const [cachedRowHighlight] = highlight.getRowHighlights();
+      const [cachedColumnHighlight] = highlight.getColumnHighlights();
+
+      highlight.updateHighlightClassNames({ rowClassName: 'updatedRowClass' });
+
+      expect(cachedRowHighlight.settings.className).toBe('updatedRowClass');
+      expect(cachedColumnHighlight.settings.className).toBe('columnClass'); // unchanged
+    });
+
+    it('should update newly created highlights with the new class name after updateHighlightClassNames is called', () => {
+      const highlight = createHighlightInstance();
+
+      highlight.updateHighlightClassNames({ rowClassName: 'newRowClass' });
+
+      // Create a row highlight after the update
+      highlight.createRowHighlight();
+
+      const [cachedRowHighlight] = highlight.getRowHighlights();
+
+      expect(cachedRowHighlight.settings.className).toBe('newRowClass');
+    });
+  });
+});

--- a/handsontable/src/selection/highlight/highlight.js
+++ b/handsontable/src/selection/highlight/highlight.js
@@ -404,6 +404,38 @@ class Highlight {
   }
 
   /**
+   * Updates the CSS class names used for row, column, header, and active header highlights.
+   * Necessary when the related settings change at runtime (e.g. via `updateSettings()`).
+   *
+   * @param {object} options Options with updated class names.
+   * @param {string} [options.rowClassName] The new class name for row highlights.
+   * @param {string} [options.columnClassName] The new class name for column highlights.
+   * @param {string} [options.headerClassName] The new class name for header highlights.
+   * @param {string} [options.activeHeaderClassName] The new class name for active header highlights.
+   */
+  updateHighlightClassNames(options) {
+    if ('rowClassName' in options) {
+      this.options.rowClassName = options.rowClassName;
+      arrayEach(this.rowHighlights.values(), highlight => void (highlight.settings.className = options.rowClassName));
+    }
+    if ('columnClassName' in options) {
+      this.options.columnClassName = options.columnClassName;
+      arrayEach(this.columnHighlights.values(), highlight => void (highlight.settings.className = options.columnClassName));
+    }
+    if ('headerClassName' in options) {
+      this.options.headerClassName = options.headerClassName;
+      arrayEach(this.rowHeaders.values(), highlight => void (highlight.settings.className = options.headerClassName));
+      arrayEach(this.columnHeaders.values(), highlight => void (highlight.settings.className = options.headerClassName));
+    }
+    if ('activeHeaderClassName' in options) {
+      this.options.activeHeaderClassName = options.activeHeaderClassName;
+      arrayEach(this.activeRowHeaders.values(), highlight => void (highlight.settings.className = options.activeHeaderClassName));
+      arrayEach(this.activeColumnHeaders.values(), highlight => void (highlight.settings.className = options.activeHeaderClassName));
+      arrayEach(this.activeCornerHeaders.values(), highlight => void (highlight.settings.className = options.activeHeaderClassName));
+    }
+  }
+
+  /**
    * Perform cleaning visual highlights for the whole table.
    */
   clear() {

--- a/handsontable/src/selection/highlight/highlight.js
+++ b/handsontable/src/selection/highlight/highlight.js
@@ -416,22 +416,22 @@ class Highlight {
   updateHighlightClassNames(options) {
     if ('rowClassName' in options) {
       this.options.rowClassName = options.rowClassName;
-      arrayEach(this.rowHighlights.values(), highlight => void (highlight.settings.className = options.rowClassName));
+      arrayEach(this.rowHighlights.values(), (h) => { h.settings.className = options.rowClassName; });
     }
     if ('columnClassName' in options) {
       this.options.columnClassName = options.columnClassName;
-      arrayEach(this.columnHighlights.values(), highlight => void (highlight.settings.className = options.columnClassName));
+      arrayEach(this.columnHighlights.values(), (h) => { h.settings.className = options.columnClassName; });
     }
     if ('headerClassName' in options) {
       this.options.headerClassName = options.headerClassName;
-      arrayEach(this.rowHeaders.values(), highlight => void (highlight.settings.className = options.headerClassName));
-      arrayEach(this.columnHeaders.values(), highlight => void (highlight.settings.className = options.headerClassName));
+      arrayEach(this.rowHeaders.values(), (h) => { h.settings.className = options.headerClassName; });
+      arrayEach(this.columnHeaders.values(), (h) => { h.settings.className = options.headerClassName; });
     }
     if ('activeHeaderClassName' in options) {
       this.options.activeHeaderClassName = options.activeHeaderClassName;
-      arrayEach(this.activeRowHeaders.values(), highlight => void (highlight.settings.className = options.activeHeaderClassName));
-      arrayEach(this.activeColumnHeaders.values(), highlight => void (highlight.settings.className = options.activeHeaderClassName));
-      arrayEach(this.activeCornerHeaders.values(), highlight => void (highlight.settings.className = options.activeHeaderClassName));
+      arrayEach(this.activeRowHeaders.values(), (h) => { h.settings.className = options.activeHeaderClassName; });
+      arrayEach(this.activeColumnHeaders.values(), (h) => { h.settings.className = options.activeHeaderClassName; });
+      arrayEach(this.activeCornerHeaders.values(), (h) => { h.settings.className = options.activeHeaderClassName; });
     }
   }
 

--- a/handsontable/src/selection/selection.js
+++ b/handsontable/src/selection/selection.js
@@ -189,6 +189,19 @@ class Selection {
   }
 
   /**
+   * Updates the CSS class names used for row, column, header, and active header highlights based on
+   * the current settings. Call this after settings change via `updateSettings()`.
+   */
+  updateHighlightClassNames() {
+    this.highlight.updateHighlightClassNames({
+      rowClassName: this.settings.currentRowClassName,
+      columnClassName: this.settings.currentColClassName,
+      headerClassName: this.settings.currentHeaderClassName,
+      activeHeaderClassName: this.settings.activeHeaderClassName,
+    });
+  }
+
+  /**
    * Gets all selection range layers of the selection.
    *
    * @returns {SelectionRange}

--- a/handsontable/test/e2e/settings/currentRowClassName.spec.js
+++ b/handsontable/test/e2e/settings/currentRowClassName.spec.js
@@ -35,6 +35,42 @@ describe('settings', () => {
 
       expect(spec().$container.find('td.currentRowClassName').length).toEqual(0);
     });
+
+    it('should apply a new currentRowClassName set via updateSettings', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 7),
+        currentRowClassName: 'oldRowClass'
+      });
+
+      await selectCell(2, 2);
+
+      expect(spec().$container.find('td.oldRowClass').length).toEqual(7);
+      expect(spec().$container.find('td.newRowClass').length).toEqual(0);
+
+      await updateSettings({ currentRowClassName: 'newRowClass' });
+
+      await selectCell(2, 2);
+
+      expect(spec().$container.find('td.oldRowClass').length).toEqual(0);
+      expect(spec().$container.find('td.newRowClass').length).toEqual(7);
+    });
+
+    it('should remove the row highlight when currentRowClassName is unset via updateSettings', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 7),
+        currentRowClassName: 'myRowClass'
+      });
+
+      await selectCell(2, 2);
+
+      expect(spec().$container.find('td.myRowClass').length).toEqual(7);
+
+      await updateSettings({ currentRowClassName: undefined });
+
+      await selectCell(2, 2);
+
+      expect(spec().$container.find('td.myRowClass').length).toEqual(0);
+    });
   });
 
   describe('currentColClassName', () => {
@@ -59,6 +95,42 @@ describe('settings', () => {
       await deselectCell();
 
       expect(spec().$container.find('td.currentColClassName').length).toEqual(0);
+    });
+
+    it('should apply a new currentColClassName set via updateSettings', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 7),
+        currentColClassName: 'oldColClass'
+      });
+
+      await selectCell(2, 2);
+
+      expect(spec().$container.find('td.oldColClass').length).toEqual(5);
+      expect(spec().$container.find('td.newColClass').length).toEqual(0);
+
+      await updateSettings({ currentColClassName: 'newColClass' });
+
+      await selectCell(2, 2);
+
+      expect(spec().$container.find('td.oldColClass').length).toEqual(0);
+      expect(spec().$container.find('td.newColClass').length).toEqual(5);
+    });
+
+    it('should remove the column highlight when currentColClassName is unset via updateSettings', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 7),
+        currentColClassName: 'myColClass'
+      });
+
+      await selectCell(2, 2);
+
+      expect(spec().$container.find('td.myColClass').length).toEqual(5);
+
+      await updateSettings({ currentColClassName: undefined });
+
+      await selectCell(2, 2);
+
+      expect(spec().$container.find('td.myColClass').length).toEqual(0);
     });
   });
 });


### PR DESCRIPTION
### Context
When `currentRowClassName`, `currentColClassName`, `currentHeaderClassName`, or `activeHeaderClassName` settings were changed via `updateSettings()`, the visual highlights in the table were not updated to use the new class names. The old class names remained applied to the DOM elements, causing the highlights to display incorrectly or not at all.

This fix ensures that highlight class names are properly updated whenever settings change at runtime.

### How has this been tested?
Added comprehensive end-to-end tests covering:
- Updating `currentRowClassName` via `updateSettings()` and verifying the new class is applied
- Removing `currentRowClassName` by setting it to `undefined` and verifying highlights are removed
- Updating `currentColClassName` via `updateSettings()` and verifying the new class is applied
- Removing `currentColClassName` by setting it to `undefined` and verifying highlights are removed

All new tests pass and verify that class names are properly switched when settings are updated.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. (Issue number not provided in diff)

### Affected project(s):
- [x] `handsontable`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

https://github.com/handsontable/handsontable/issues/468

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped bug fix to selection highlight CSS class propagation with added unit/E2E coverage; minimal impact outside visual selection rendering.
> 
> **Overview**
> Fixes selection highlighting so CSS class names for current row/column (and related header highlights) update correctly when changed at runtime via `updateSettings()`.
> 
> Adds `Highlight.updateHighlightClassNames()` (and a `Selection.updateHighlightClassNames()` wrapper) to update cached highlight instances’ `className` values, and wires this into `Core.updateSettings()` so existing highlights switch class names (or are removed when unset) without requiring a full reinit. Adds new unit tests for highlight cache updates plus E2E coverage for updating/unsetting `currentRowClassName` and `currentColClassName`, and includes a changelog entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fcbfd22da77d93fd0b770f0a102738f88b6b32c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->