### PR TITLE
Add documentation for context menu vs column menu distinction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ These are the most frequent mistakes. Read this section first.
 | Hardcoding user-visible text in source code | Add language constants in `src/i18n/constants.js` and update all language files in `src/i18n/languages/`. |
 | Using `.bind(this)` for hook/event callbacks | Use arrow-function class fields (`#onAfterX = () => { ... }`) instead. |
 | Direct cross-plugin imports | Use hooks for inter-plugin communication or `hot.getPlugin('{Name}')` if API access is required. |
+| Confusing the context menu with the column (dropdown) menu | These are two separate plugins. See [Context menu vs column menu](#context-menu-vs-column-menu). |
 
 ---
 
@@ -429,6 +430,26 @@ When calling `updateSettings()` in the React wrapper, **preserve and restore sel
 
 ---
 
+## Context menu vs column menu
+
+Handsontable has two distinct menu plugins that are frequently confused. Always use the correct plugin name, option key, and hook prefix.
+
+| | Context menu | Column menu (dropdown menu) |
+|---|---|---|
+| **User-facing name** | Context menu | Column menu / dropdown menu |
+| **Plugin class** | `ContextMenu` | `DropdownMenu` |
+| **PLUGIN_KEY** | `'contextMenu'` | `'dropdownMenu'` |
+| **Config option** | `contextMenu: true\|false\|array\|object` | `dropdownMenu: true\|false\|array\|object` |
+| **Trigger** | Right-click (or `Ctrl+Shift+\` / `Shift+F10`) on any cell or header | Click the button rendered inside a column header (or `Shift+Alt+ArrowDown` when a header is focused) |
+| **Scope** | Cells and headers across rows and columns | Column-specific operations only |
+| **Default items** | Row/column insert and remove, undo, redo, alignment, read-only | Column insert and remove, clear column, alignment, read-only |
+| **Hook prefix** | `beforeContextMenu*`, `afterContextMenu*` | `beforeDropdownMenu*`, `afterDropdownMenu*` |
+| **Source directory** | `src/plugins/contextMenu/` | `src/plugins/dropdownMenu/` |
+
+**Important:** `DropdownMenu` is built on top of the shared `Menu` class from `contextMenu`, so they look similar internally - but they are configured and triggered independently. When a task mentions "column menu", "column header menu", or "dropdown menu", it always refers to `dropdownMenu`, not `contextMenu`.
+
+---
+
 ## File locations reference
 
 | Area | Path |
@@ -482,6 +503,7 @@ When running unit tests for a specific plugin:
 - The docs site (`docs/`) uses Node 20 and is not needed for core development.
 - Walkontable has its **own test runner** -- do not mix with main E2E tests.
 - No Docker, databases, or external services are required.
+- **Context menu vs column (dropdown) menu**: "Context menu" (`contextMenu` option, right-click triggered) and "column menu" (`dropdownMenu` option, column header button triggered) are separate plugins with separate hook prefixes and config keys. Never mix them up. See [Context menu vs column menu](#context-menu-vs-column-menu).
 - **Filters plugin visual/physical column index**: When working with the filters plugin in combination with `manualColumnMove`, always ensure proper conversion between visual and physical column indexes. The `conditionCollection` and `conditionUpdateObserver` operate on physical indexes, while `getDataAtCol()` requires visual indexes. See issue #11832 for details.
 - For hook signature/behavior fixes, add both a runtime regression (`handsontable/src/**/__tests__/*.spec.js` or `handsontable/test/e2e/hooks/*.spec.js`) and a TypeScript regression (`handsontable/src/__tests__/core/settings.types.ts`) when types are changed.
 


### PR DESCRIPTION
### Context
Developers frequently confuse Handsontable&#39;s two distinct menu plugins: the context menu (triggered by right-click) and the column/dropdown menu (triggered by clicking a column header button). This confusion leads to incorrect plugin usage, wrong configuration keys, and misapplied hooks. The AGENTS.md documentation needed clarification to prevent these common mistakes.

### How has this been tested?
Documentation-only change. No testing required.

### Types of changes
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
N/A

### Affected project(s):
- [x] `handsontable`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

### Summary
This PR adds comprehensive documentation to AGENTS.md to clarify the distinction between Handsontable&#39;s two menu plugins:

1. **Added to "Common pitfalls" section**: A new entry directing developers to the detailed comparison
2. **New "Context menu vs column menu" section**: A detailed reference table comparing:
   - User-facing names
   - Plugin class names (`ContextMenu` vs `DropdownMenu`)
   - Configuration keys (`contextMenu` vs `dropdownMenu`)
   - Trigger mechanisms (right-click vs column header button)
   - Scope and default menu items
   - Hook prefixes (`beforeContextMenu*`/`afterContextMenu*` vs `beforeDropdownMenu*`/`afterDropdownMenu*`)
   - Source directories
3. **Added to "Gotchas" section**: A reminder about the distinction to reinforce the concept

This documentation will help developers avoid mixing up these plugins and use the correct configuration keys and hooks for their use cases.

https://claude.ai/code/session_01GJEGvz1NVHAvjmeZNSg7dM