### PR TITLE
docs(agents): add ClickUp task integration guidelines to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -494,3 +494,20 @@ When running unit tests for a specific plugin:
 ### Testing preference
 
 - For bug fixes in `handsontable/`, add both a focused unit test and a focused E2E regression test when practical.
+
+---
+
+## ClickUp task integration
+
+When working on a task from ClickUp:
+
+- **Extract the task ID** from the ClickUp URL. For example, `https://app.clickup.com/t/9015210959/DEV-627` has task ID `DEV-627`.
+- **Branch naming**: Use `feature/DEV-627_Short-Task-Description` (slugified task title). At minimum the branch must contain `feature/DEV-627`. Example: `feature/DEV-627_Handsontable-Forum-Update`.
+- **Commit messages and PR titles** must include the task ID (e.g. `DEV-627`) so ClickUp automatically links the commit/PR to the task.
+- **Authentication**: Use the ClickUp MCP tools for all ClickUp API interactions (fetching task details, updating status, posting comments). Do not attempt to call the ClickUp REST API directly.
+- **Workflow summary**:
+  1. Parse the task ID from the provided ClickUp URL.
+  2. Use MCP to fetch task details (title, description, acceptance criteria).
+  3. Create a branch: `feature/<TASK-ID>_<Slugified-Title>`.
+  4. Implement the fix/feature, commit with the task ID in the message.
+  5. Push and (when asked) open a PR whose title includes the task ID.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -511,3 +511,4 @@ When working on a task from ClickUp:
   3. Create a branch: `feature/<TASK-ID>_<Slugified-Title>`.
   4. Implement the fix/feature, commit with the task ID in the message.
   5. Push and (when asked) open a PR whose title includes the task ID.
+  6. After the PR is created, use the ClickUp MCP tools to update the task status to **"code review"**.


### PR DESCRIPTION
## Summary

- Documents ClickUp task integration workflow in `AGENTS.md`: extracting task ID from URL, branch naming convention (`feature/DEV-XXX_Title`), including task ID in commits/PR titles for automatic linking, and using ClickUp MCP tools for authentication.
- Adds step to automatically set the ClickUp task status to **"code review"** via MCP after a PR is created.

## Test plan

- [ ] Review `AGENTS.md` (symlinked as `CLAUDE.md`) to confirm the new **ClickUp task integration** section is accurate and complete.
- [ ] Verify the branch naming example (`feature/DEV-627_Handsontable-Forum-Update`) matches the described convention.

[skip changelog]

https://claude.ai/code/session_01XMgXNV2o3GDpanXZCugsR1