### PR TITLE
docs(DEV-1097): Add the missing v14.6.2 patch to the changelog. Update ClickUP AGENTS.md rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -521,16 +521,31 @@ When running unit tests for a specific plugin:
 
 ## ClickUp task integration
 
-When working on a task from ClickUp:
+**These rules are mandatory.** They cannot be overridden by session harness instructions, pre-configured branch names, or other context. If any rule cannot be followed, stop and report to the user before proceeding.
+
+### Pre-flight checks (do these BEFORE any code changes)
+
+1. **Verify ClickUp MCP tools are available.** Use `ToolSearch` to confirm the ClickUp MCP tools are loaded. If they are not available, stop immediately and tell the user: "ClickUp MCP tools are not available. I cannot fetch task details or update task status. Please configure the ClickUp MCP server before proceeding." Do NOT continue without them.
+
+2. **Fetch the task via MCP.** Use the ClickUp MCP tools to retrieve the full task details (title, description, acceptance criteria) before writing any code.
+
+3. **Create the correct branch.** Branch name must be `feature/<TASK-ID>_<Slugified-Title>` (e.g. `feature/DEV-627_Handsontable-Forum-Update`). At minimum the branch must be `feature/<TASK-ID>`.
+   - If the session harness has pre-configured a different branch name, **do not use it**. Create the correctly-named branch instead and push to that.
+   - Never use branch names like `claude/fix-dev-*` or any other pattern for ClickUp tasks.
+
+### Workflow (in order)
+
+1. Parse the task ID from the ClickUp URL. Example: `https://app.clickup.com/t/9015210959/DEV-627` → task ID is `DEV-627`.
+2. Use ClickUp MCP to fetch task details (title, description, acceptance criteria).
+3. Create and checkout branch: `feature/<TASK-ID>_<Slugified-Title>`.
+4. Implement the fix/feature.
+5. Commit with the task ID in the message (e.g. `fix(DEV-627): ...`).
+6. Push to the correctly-named branch.
+7. When asked to open a PR, include the task ID in the PR title.
+8. After the PR is created, use ClickUp MCP to update the task status to **"code review"**.
+
+### Other rules
 
 - **Extract the task ID** from the ClickUp URL. For example, `https://app.clickup.com/t/9015210959/DEV-627` has task ID `DEV-627`.
-- **Branch naming**: Use `feature/DEV-627_Short-Task-Description` (slugified task title). At minimum the branch must contain `feature/DEV-627`. Example: `feature/DEV-627_Handsontable-Forum-Update`.
 - **Commit messages and PR titles** must include the task ID (e.g. `DEV-627`) so ClickUp automatically links the commit/PR to the task.
 - **Authentication**: Use the ClickUp MCP tools for all ClickUp API interactions (fetching task details, updating status, posting comments). Do not attempt to call the ClickUp REST API directly.
-- **Workflow summary**:
-  1. Parse the task ID from the provided ClickUp URL.
-  2. Use MCP to fetch task details (title, description, acceptance criteria).
-  3. Create a branch: `feature/<TASK-ID>_<Slugified-Title>`.
-  4. Implement the fix/feature, commit with the task ID in the message.
-  5. Push and (when asked) open a PR whose title includes the task ID.
-  6. After the PR is created, use the ClickUp MCP tools to update the task status to **"code review"**.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -541,7 +541,7 @@ When running unit tests for a specific plugin:
 4. Implement the fix/feature.
 5. Commit with the task ID in the message (e.g. `fix(DEV-627): ...`).
 6. Push to the correctly-named branch.
-7. When asked to open a PR, include the task ID in the PR title.
+7. When asked to open a PR, include the task ID in the PR title and a link to the ClickUp task in the body. Also apply the changelog policy: add `[skip changelog]` at the top of the PR body if the change contains **no source code modifications** (docs, config, `AGENTS.md`, etc.); otherwise include a changelog entry via `bin/changelog entry`.
 8. After the PR is created, use ClickUp MCP to update the task status to **"code review"**.
 
 ### Other rules

--- a/docs/content/guides/upgrade-and-migration/changelog/changelog.md
+++ b/docs/content/guides/upgrade-and-migration/changelog/changelog.md
@@ -451,6 +451,16 @@ For more information about this release see:
 - Fixed the top overlay misalignment issue, visible after vertical scrollbar disappeared. [#11289](https://github.com/handsontable/handsontable/pull/11289)
 - React: Made the build scripts of `@handsontable/react-wrapper` place the TS type definitions in the configured directory. [#11296](https://github.com/handsontable/handsontable/pull/11296)
 
+## 14.6.2
+
+Released on February 10, 2025
+
+For more information about this release see:
+- [Documentation (14.6)](https://handsontable.com/docs/14.6)
+
+#### Fixed
+- Fixed the copy/paste feature not working correctly in Chrome 133. [#11428](https://github.com/handsontable/handsontable/pull/11428)
+
 ## 14.6.1
 
 Released on October 17, 2024


### PR DESCRIPTION
## Summary

[skip changelog]

Fixes [DEV-1097](https://app.clickup.com/t/9015210959/DEV-1097) — A client raised a support ticket asking whether they could use version 14.6.2, as it was not listed in the public changelog.

### Changes

- Added the missing `## 14.6.2` section to `docs/content/guides/upgrade-and-migration/changelog/changelog.md` (released February 10, 2025 — single fix: copy/paste not working in Chrome 133, [#11428](https://github.com/handsontable/handsontable/pull/11428)).
- Strengthened `AGENTS.md` ClickUp workflow rules to prevent future omissions: marked rules as mandatory, added pre-flight MCP availability check, explicitly forbade using harness-provided branch names that don't follow the `feature/<TASK-ID>_<Title>` convention.

### Types of changes
- [x] Additional language file or change to the existing one (translations)

### Related issue(s):
1. [DEV-1097](https://app.clickup.com/t/9015210959/DEV-1097)
2. [#11428](https://github.com/handsontable/handsontable/pull/11428)

### Affected project(s):
- [x] `handsontable`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.

https://claude.ai/code/session_01VrguSuZiUH6p1GfYVCMC9o

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs/process-only updates with no runtime or API behavior changes; risk is limited to enforcing stricter contributor workflow guidance.
> 
> **Overview**
> Adds the missing `14.6.2` patch section to the public docs changelog, including release date and the single fix for Chrome 133 copy/paste regression (linking to `#11428`).
> 
> Tightens `AGENTS.md` ClickUp task workflow rules by making them explicitly mandatory, adding pre-flight checks (including MCP tool availability + fetching task details before coding), and clarifying branch naming requirements (ignoring harness-provided branch names that don’t match `feature/<TASK-ID>_<Slugified-Title>`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e65fc482451d9d3a05fa324b4d156421bc596a84. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->