### PR TITLE
Fix dropdown button when filters are enabled and the active header is shown

### DIFF
--- a/.changelogs/12253.json
+++ b/.changelogs/12253.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed column menu dropdown button styling when a filtered column header is also active",
+  "type": "fixed",
+  "issueOrPR": 12253,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/styles/components/plugins/_dropdown-menu.scss
+++ b/handsontable/src/styles/components/plugins/_dropdown-menu.scss
@@ -104,12 +104,6 @@
             var(--ht-header-active-background-color),
             var(--ht-header-filter-background-color) 20%
           );
-
-          .changeType {
-            &::after {
-              background-color: var(--ht-header-active-foreground-color);
-            }
-          }
         }
       }
     }


### PR DESCRIPTION
### Context

When **Filters** and the **column menu (dropdown menu)** are enabled, a column header can be both **active** (selected) and show the filter state. A rule in `_dropdown-menu.scss` forced the `.changeType` control’s `::after` to use `--ht-header-active-foreground-color` in that combined state, which broke the intended look of the dropdown button. That override is removed so the column menu affordance stays correct.

### How has this been tested?

Manual check: table with `filters: true` and `dropdownMenu: true`, select a column header so it is active and verify the dropdown control still looks right. (Add whatever you actually ran—e.g. style build / visual spot-check.)

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue))

### Related issue(s):

1. https://app.clickup.com/t/9015210959/DEV-1203

### Affected project(s):

- [x] `handsontable`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CSS change removing a conflicting override for the column menu button in a specific active+filtered header state; low risk aside from potential minor visual regressions in related header states.
> 
> **Overview**
> Fixes a styling regression where the column menu dropdown button appearance was overridden when a header was *both* filter-active and active-highlighted.
> 
> Removes the `.changeType::after` foreground-color override under `th.htFiltersActive.ht__active_highlight`, letting the button use the standard icon/button color variables, and adds a changelog entry (`.changelogs/12253.json`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26e929ab7927b9b7d04e67b29628c8437dc883d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->