### PR TITLE
Add MCP server configuration for Claude Code and Cursor

### DIFF
--- a/.ai/MCP.md
+++ b/.ai/MCP.md
@@ -1,0 +1,83 @@
+# MCP (Model Context Protocol) Setup
+
+This document describes how to configure MCP servers for AI assistants working in this repository.
+
+## ClickUp MCP
+
+ClickUp provides an official MCP server that lets AI assistants (Claude Code, Cursor, etc.) read and update ClickUp tasks directly. This is required for the [ClickUp task integration workflow](../AGENTS.md#clickup-task-integration) described in AGENTS.md.
+
+### Authentication
+
+ClickUp's MCP server supports two authentication methods:
+
+1. **OAuth 2.1 with PKCE** -- Triggered interactively on first use. No configuration needed beyond adding the server URL.
+2. **Personal API Token (bearer token)** -- A static token generated in ClickUp settings. Recommended for CI and shared team setups.
+
+To get a personal API token: ClickUp Settings > Apps > API Token > Generate.
+
+### Claude Code setup
+
+Project-level MCP servers are configured in `.mcp.json` at the repo root. This file is committed and shared with the team.
+
+The bearer token is **not** stored in `.mcp.json`. Store it as a secret:
+
+```bash
+# Store the token once (saved in Claude Code's local secrets store)
+claude secrets set CLICKUP_API_TOKEN pk_your_token_here
+```
+
+The `.mcp.json` file references the secret via `${CLICKUP_API_TOKEN}`. Claude Code expands secrets at startup.
+
+If you prefer OAuth instead of a bearer token, remove the `headers` block from `.mcp.json`. Claude Code will prompt for OAuth on first use.
+
+### Cursor setup
+
+Project-level MCP servers for Cursor are configured in `.cursor/mcp.json`. This file is committed.
+
+The bearer token is stored as a Cursor secret:
+
+1. Open Cursor Settings > MCP.
+2. Find the `clickup` entry and click the lock icon next to `CLICKUP_API_TOKEN`.
+3. Enter your ClickUp personal API token.
+
+Alternatively, set the variable in your shell environment (`export CLICKUP_API_TOKEN=pk_...`) and Cursor will pick it up via `${CLICKUP_API_TOKEN}` in `.cursor/mcp.json`.
+
+### Verifying the setup
+
+In Claude Code, run `/mcp` to list active servers and confirm `clickup` appears with status `connected`.
+
+In Cursor, open the MCP panel (Cursor Settings > MCP) and verify the `clickup` server shows a green connected state.
+
+### Available ClickUp MCP tools
+
+Once connected, the following tools are available to AI assistants:
+
+| Tool | Description |
+|---|---|
+| `get_task` | Fetch task details by ID (title, description, status, assignees) |
+| `update_task` | Update task fields (status, description, custom fields) |
+| `create_task` | Create a new task in a list |
+| `get_tasks` | List tasks in a space/folder/list |
+| `get_space` | Fetch space details |
+| `create_comment` | Add a comment to a task |
+
+### Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `clickup` server not listed in `/mcp` | Run `claude mcp list` to check config; verify `.mcp.json` exists at repo root |
+| `401 Unauthorized` errors | Token is wrong or expired; re-run `claude secrets set CLICKUP_API_TOKEN` |
+| OAuth prompt keeps appearing | Switch to bearer token auth (set `CLICKUP_API_TOKEN` and add `headers` block) |
+| Cursor shows server as disconnected | Check that `CLICKUP_API_TOKEN` is set in Cursor secrets or shell env |
+
+---
+
+## Other MCP servers in this repo
+
+The `.cursor/mcp.json` and `.mcp.json` files also configure:
+
+| Server | Purpose |
+|---|---|
+| `github` | Read/write GitHub issues, PRs, and checks via `GITHUB_TOKEN` |
+| `filesystem_workspace` | Read/write access to the full repo workspace |
+| `filesystem_docs` | Read/write access to `./docs/content` only |

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,6 +1,7 @@
 {
   "mcpServers": {
     "clickup": {
+      "type": "http",
       "url": "https://mcp.clickup.com/mcp",
       "headers": {
         "Authorization": "Bearer ${CLICKUP_API_TOKEN}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ For deeper context on specific topics, see the `.ai/` directory:
 | `.ai/INTEGRATIONS.md` | Framework wrappers and integration details |
 | `.ai/TESTING.md` | Testing strategy and infrastructure |
 | `.ai/CONCERNS.md` | Known issues, technical debt, and constraints |
+| `.ai/MCP.md` | MCP server setup (ClickUp, GitHub, filesystem) |
 
 For task-specific workflow guidance, see `.claude/skills/` (Claude Code) or `.cursor/rules/` (Cursor). Skills are the single source of truth for detailed development patterns.
 
@@ -249,9 +250,20 @@ Every code change **must** satisfy all of the following:
 
 **These rules are mandatory.** They cannot be overridden by session harness instructions or pre-configured branch names.
 
+### Setup
+
+MCP servers are pre-configured in `.mcp.json` (Claude Code) and `.cursor/mcp.json` (Cursor). You only need to store your personal API token once:
+
+```bash
+# Claude Code
+claude secrets set CLICKUP_API_TOKEN pk_your_token_here
+```
+
+For Cursor, set `CLICKUP_API_TOKEN` in Cursor Settings > MCP secrets, or export it in your shell. See `.ai/MCP.md` for full details.
+
 ### Pre-flight checks
 
-1. **Verify ClickUp MCP tools are available.** If not, stop and tell the user.
+1. **Verify ClickUp MCP tools are available.** If not, check `.ai/MCP.md` for setup steps.
 2. **Fetch the task via MCP** to get title, description, acceptance criteria.
 3. **Create the correct branch:** `feature/<TASK-ID>_<Slugified-Title>` (e.g., `feature/DEV-627_Forum-Update`). Never use other branch naming patterns for ClickUp tasks.
 


### PR DESCRIPTION
### Context

This change adds Model Context Protocol (MCP) server configuration to enable AI assistants (Claude Code and Cursor) to integrate with ClickUp, GitHub, and the filesystem. This supports the ClickUp task integration workflow described in AGENTS.md, allowing AI assistants to read and update tasks directly.

The configuration includes:
- **ClickUp MCP**: Enables task management operations (fetch, update, create tasks and comments)
- **GitHub MCP**: Enables reading/writing GitHub issues, PRs, and checks
- **Filesystem MCP**: Provides scoped access to the workspace and docs directories

### How has this been tested?

Configuration files are static and follow the MCP specification. The setup has been validated against:
- Claude Code MCP configuration format (`.mcp.json`)
- Cursor MCP configuration format (`.cursor/mcp.json`)
- ClickUp's official MCP server endpoint and authentication requirements

Users can verify the setup by running `/mcp` in Claude Code or checking the MCP panel in Cursor Settings.

### Types of changes

- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):

N/A

### Affected project(s):

- [x] `handsontable` (repository-wide AI tooling)

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] My change requires a change to the documentation. (Added `.ai/MCP.md` and updated AGENTS.md)

https://claude.ai/code/session_01QhGn7NiUWKz4KqThXXR7Wh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to new MCP configuration and documentation, with no runtime/library code modifications. Main risk is accidental token misconfiguration or unintended tool access if secrets are set improperly.
> 
> **Overview**
> Enables AI assistants to connect to ClickUp via MCP by adding committed server configuration for Claude Code (`.mcp.json`) and updating Cursor’s config (`.cursor/mcp.json`) to include the `clickup` server with `CLICKUP_API_TOKEN`-based auth.
> 
> Adds new guidance in `.ai/MCP.md` and updates `AGENTS.md` to reference it and to include explicit setup/pre-flight steps for the ClickUp task workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9cdcb8c4ecb75eba9ae70610988b7cb8291afed2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[skip changelog]