### PR TITLE
Add server-data SVG icon and update sidebar

### DIFF
--- a/docs/.vuepress/public/img/svg/server-data.svg
+++ b/docs/.vuepress/public/img/svg/server-data.svg
@@ -1,0 +1,15 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_server_data)">
+<rect x="2" y="2.5" width="12" height="3" rx="0.5" stroke="#1A42E8" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12.5 3.5h1.5M12.5 4.5h1.5" stroke="#1A42E8" stroke-linecap="round"/>
+<rect x="2" y="6.5" width="12" height="3" rx="0.5" stroke="#1A42E8" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12.5 7.5h1.5M12.5 8.5h1.5" stroke="#1A42E8" stroke-linecap="round"/>
+<rect x="2" y="10.5" width="12" height="3" rx="0.5" stroke="#1A42E8" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12.5 11.5h1.5M12.5 12.5h1.5" stroke="#1A42E8" stroke-linecap="round"/>
+</g>
+<defs>
+<clipPath id="clip0_server_data">
+<rect width="16" height="16" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/docs/.vuepress/theme/styles/base/icons.styl
+++ b/docs/.vuepress/theme/styles/base/icons.styl
@@ -45,23 +45,24 @@ i.Logo {
 
 .sidebar .sidebar-nav > .sidebar-links > li {
     &:nth-child(1)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/rocket.svg'); background-size: 18px }               // Getting started
-    &:nth-child(2)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/paint.svg'); background-size: 18px }               // Styling
-    &:nth-child(3)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/layout-columns.svg'); background-size: 18px }       // Columns
-    &:nth-child(4)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/layout-columns2.svg'); background-size: 18px }      // Rows
-    &:nth-child(5)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/forms.svg'); background-size: 18px }                // Cell features
-    &:nth-child(6)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/function.svg'); background-size: 18px }             // Cell functions
-    &:nth-child(7)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/settings-2.svg'); background-size: 18px }           // Cell types
-    &:nth-child(8)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/math-function.svg'); background-size: 18px }        // Formulas
-    &:nth-child(9)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/keyboard.svg'); background-size: 18px }             // Navigation
-    &:nth-child(10)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/accessible.svg'); background-size: 18px }           // Accessibility
-    &:nth-child(11)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/layout-list.svg'); background-size: 18px }         // Accessories and menus
-    &:nth-child(12)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/dialog.svg'); background-size: 18px }         // Dialog
-    &:nth-child(13)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/language.svg'); background-size: 18px }            // Internationalization
-    &:nth-child(14)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/brand-vue.svg'); background-size: 18px }           // Integrate with Vue 3
-    &:nth-child(15)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/tools.svg'); background-size: 18px }               // Tools and building
-    &:nth-child(16)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/chart-line.svg'); background-size: 18px }          // Optimization
-    &:nth-child(17)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/shield-half.svg'); background-size: 18px }         // Security
-    &:nth-child(18)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/code.svg'); background-size: 18px }                // Technical specification
-    &:nth-child(19)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/git-branch.svg'); background-size: 18px }          // Upgrade and migration
+    &:nth-child(2)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/server-data.svg'); background-size: 18px }               // Server-side data 
+    &:nth-child(3)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/paint.svg'); background-size: 18px }               // Styling
+    &:nth-child(4)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/layout-columns.svg'); background-size: 18px }       // Columns
+    &:nth-child(5)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/layout-columns2.svg'); background-size: 18px }      // Rows
+    &:nth-child(6)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/forms.svg'); background-size: 18px }                // Cell features
+    &:nth-child(7)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/function.svg'); background-size: 18px }             // Cell functions
+    &:nth-child(8)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/settings-2.svg'); background-size: 18px }           // Cell types
+    &:nth-child(9)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/math-function.svg'); background-size: 18px }        // Formulas
+    &:nth-child(10)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/keyboard.svg'); background-size: 18px }             // Navigation
+    &:nth-child(11)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/accessible.svg'); background-size: 18px }           // Accessibility
+    &:nth-child(12)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/layout-list.svg'); background-size: 18px }         // Accessories and menus
+    &:nth-child(13)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/dialog.svg'); background-size: 18px }         // Dialog
+    &:nth-child(14)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/language.svg'); background-size: 18px }            // Internationalization
+    &:nth-child(15)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/brand-vue.svg'); background-size: 18px }           // Integrate with Vue 3
+    &:nth-child(16)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/tools.svg'); background-size: 18px }               // Tools and building
+    &:nth-child(17)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/chart-line.svg'); background-size: 18px }          // Optimization
+    &:nth-child(18)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/shield-half.svg'); background-size: 18px }         // Security
+    &:nth-child(19)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/code.svg'); background-size: 18px }                // Technical specification
+    &:nth-child(20)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/git-branch.svg'); background-size: 18px }          // Upgrade and migration
     > section a i:first-child { background:  url('{{$basePath}}/img/svg/plugin.svg'); background-size: 18px }                               // Plugin
 } 


### PR DESCRIPTION
### Context
The docs sidebar includes a **Server-side data** section (second group under Getting started), but the VuePress theme mapped section icons with `nth-child` rules that did not account for that group. Icons from **Styling** onward were shifted by one. This change adds `server-data.svg` and updates `icons.styl` so each sidebar section uses the correct icon.

### How has this been tested?
- Ran the docs site locally and checked the sidebar: **Getting started** and **Server-side data** show the right icons

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Affected project(s):
- [x] `handsontable`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that updates static assets and CSS selectors; main risk is minor visual mismatch if sidebar ordering differs from the `nth-child` mapping.
> 
> **Overview**
> Fixes the docs sidebar icon mapping by inserting a dedicated icon for the **Server-side data** section and shifting subsequent `nth-child` icon rules so each sidebar group displays the intended icon.
> 
> Adds a new `server-data.svg` asset and wires it into the VuePress theme’s `icons.styl`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b23a84f4d76cc0f3418529fd336d7264a2a9cc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->