### PR TITLE
fix(wrappers): skip init-only settings in updateSettings (#12242)

### DIFF
--- a/.changelogs/12242.json
+++ b/.changelogs/12242.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed framework wrappers crashing when init-only settings (renderAllRows, renderAllColumns, layoutDirection, ariaTags) changed after initialization.",
+  "type": "fixed",
+  "issueOrPR": 12242,
+  "breaking": false,
+  "framework": "none"
+}

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.spec.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.spec.ts
@@ -149,6 +149,32 @@ describe('HotTableComponent', () => {
       component.ngOnChanges(changes);
       expect(updateDataSpy).not.toHaveBeenCalledWith(newData);
     });
+
+    it('should not pass init-only settings to updateSettings after initialization', () => {
+      fixture = TestBed.createComponent(HotTableComponent);
+      fixture.componentInstance.settings = {
+        renderAllRows: false,
+        width: 300,
+      };
+      fixture.detectChanges();
+      const component = fixture.componentInstance;
+      const updateSettingsSpy = jest.spyOn(component.hotInstance, 'updateSettings');
+
+      const changes: SimpleChanges = {
+        settings: new SimpleChange(
+          { renderAllRows: false, width: 300 },
+          { renderAllRows: true, width: 500 },
+          false
+        ),
+      };
+
+      component.ngOnChanges(changes);
+
+      const passedSettings = updateSettingsSpy.mock.calls[0][0];
+
+      expect(passedSettings.renderAllRows).toBe(void 0);
+      expect(passedSettings.width).toBe(500);
+    });
   });
 
   describe('ngOnDestroy', () => {

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.ts
@@ -156,8 +156,18 @@ export class HotTableComponent implements AfterViewInit, OnChanges, OnDestroy {
       return;
     }
 
+    const initOnlySettingKeys: string[] =
+      (this.hotInstance.getSettings() as any)?._initOnlySettings || [];
+    const filteredSettings: Handsontable.GridSettings = {};
+
+    for (const key of Object.keys(newSettings)) {
+      if (!initOnlySettingKeys.includes(key)) {
+        (filteredSettings as any)[key] = (newSettings as any)[key];
+      }
+    }
+
     this.ngZone.runOutsideAngular(() => {
-      this.hotInstance?.updateSettings(newSettings, false);
+      this.hotInstance?.updateSettings(filteredSettings, false);
     });
   }
 

--- a/wrappers/react-wrapper/src/settingsMapper.ts
+++ b/wrappers/react-wrapper/src/settingsMapper.ts
@@ -36,9 +36,8 @@ export class SettingsMapper {
         return areEquivalentSettingsValue(prevProps[key], properties[key]);
       }
 
-      // Omit settings that can be set only during initialization and are intentionally modified.
       if (!isInit && initOnlySettingKeys.includes(key)) {
-        return prevProps[key] === properties[key];
+        return true;
       }
       return false;
     };

--- a/wrappers/react-wrapper/test/hotTable.spec.tsx
+++ b/wrappers/react-wrapper/test/hotTable.spec.tsx
@@ -123,8 +123,18 @@ describe('Updating the Handsontable settings', () => {
     expect(JSON.stringify(hotInstance.getSettings().data)).toEqual('[[2]]');
   });
 
-  it('should throw an error when trying to update init-only settings after inializing the component', async () => {
-    console.error = jest.fn();
+  it('should NOT throw an error when trying to update init-only settings after initializing the component', async () => {
+    const errorMock = jest.fn();
+    const originalError = console.error;
+
+    console.error = (...args: unknown[]) => {
+      const message = args[0];
+
+      if (typeof message === 'string' && message.includes('Could not parse CSS stylesheet')) {
+        return;
+      }
+      errorMock(...args);
+    };
 
     let updateState = null;
 
@@ -150,11 +160,11 @@ describe('Updating the Handsontable settings', () => {
 
     const updateStateAndRender = () => act(() => (updateState as any)(true));
 
-    await expect(updateStateAndRender).toThrowError(
-      'The `renderAllRows` option can not be updated after the Handsontable is initialized.'
-    );
+    await expect(updateStateAndRender).not.toThrowError();
 
-    expect(console.error).toHaveBeenCalled();
+    expect(errorMock).not.toHaveBeenCalled();
+
+    console.error = originalError;
   });
 
   it('should NOT throw an error when trying to update settings after inializing the component if the other settings' +

--- a/wrappers/react-wrapper/test/settingsMapper.spec.tsx
+++ b/wrappers/react-wrapper/test/settingsMapper.spec.tsx
@@ -184,5 +184,49 @@ describe('Settings mapper unit tests', () => {
 
       expect(result.columns).toEqual(nextProps.columns);
     });
+
+    it('should always skip init-only settings when not initializing, even if the value changed', () => {
+      const prevProps: HotTableProps = {
+        renderAllRows: false,
+        renderAllColumns: false,
+        layoutDirection: 'ltr',
+        ariaTags: true,
+        width: 300,
+      };
+      const nextProps: HotTableProps = {
+        renderAllRows: true,
+        renderAllColumns: true,
+        layoutDirection: 'rtl',
+        ariaTags: false,
+        width: 500,
+      };
+
+      const result = SettingsMapper.getSettings(nextProps, {
+        prevProps,
+        isInit: false,
+        initOnlySettingKeys: ['renderAllRows', 'renderAllColumns', 'layoutDirection', 'ariaTags'] as any,
+      });
+
+      expect(result.renderAllRows).toBe(void 0);
+      expect(result.renderAllColumns).toBe(void 0);
+      expect(result.layoutDirection).toBe(void 0);
+      expect(result.ariaTags).toBe(void 0);
+      expect(result.width).toBe(500);
+    });
+
+    it('should include init-only settings during initialization', () => {
+      const nextProps: HotTableProps = {
+        renderAllRows: true,
+        width: 300,
+      };
+
+      const result = SettingsMapper.getSettings(nextProps, {
+        isInit: true,
+        initOnlySettingKeys: ['renderAllRows'] as any,
+      });
+
+      expect(result.renderAllRows).toBe(true);
+      expect(result.width).toBe(300);
+    });
   });
 });

--- a/wrappers/vue3/src/helpers.ts
+++ b/wrappers/vue3/src/helpers.ts
@@ -99,6 +99,8 @@ export function prepareSettings(props: HotTableProps, currentSettings?: Handsont
   const assignedProps: VueProps<HotTableProps> = filterPassedProps(props);
   const hotSettingsInProps: Handsontable.GridSettings = props.settings ? props.settings : assignedProps;
   const additionalHotSettingsInProps: Handsontable.GridSettings = props.settings ? assignedProps : null;
+  const initOnlySettingKeys: string[] =
+    (currentSettings as any)?._initOnlySettings || [];
   const newSettings: Handsontable.GridSettings = {};
 
   // eslint-disable-next-line no-restricted-syntax
@@ -106,6 +108,7 @@ export function prepareSettings(props: HotTableProps, currentSettings?: Handsont
     if (
       hasOwnProperty(hotSettingsInProps, key) &&
       hotSettingsInProps[key] !== void 0 &&
+      !initOnlySettingKeys.includes(key) &&
       ((currentSettings && key !== 'data') ? !simpleEqual(currentSettings[key], hotSettingsInProps[key]) : true)
     ) {
       newSettings[key] = hotSettingsInProps[key];
@@ -119,6 +122,7 @@ export function prepareSettings(props: HotTableProps, currentSettings?: Handsont
       key !== 'id' &&
       key !== 'settings' &&
       additionalHotSettingsInProps[key] !== void 0 &&
+      !initOnlySettingKeys.includes(key) &&
       ((currentSettings && key !== 'data')
         ? !simpleEqual(currentSettings[key], additionalHotSettingsInProps[key]) : true)
     ) {

--- a/wrappers/vue3/test/hotTableHelpers.spec.ts
+++ b/wrappers/vue3/test/hotTableHelpers.spec.ts
@@ -72,4 +72,42 @@ describe('prepareSettings', () => {
     expect(preparedSettings.mergeCells).toBe(undefined);
     expect(Object.keys(preparedSettings).length).toBe(0);
   });
+
+  it('should skip init-only settings when current settings contain _initOnlySettings', () => {
+    const currentSettings = {
+      renderAllRows: false,
+      renderAllColumns: false,
+      layoutDirection: 'ltr' as const,
+      ariaTags: true,
+      width: 300,
+      _initOnlySettings: ['renderAllRows', 'renderAllColumns', 'layoutDirection', 'ariaTags'],
+    } as GridSettings;
+    const propsMock = {
+      renderAllRows: true,
+      renderAllColumns: true,
+      layoutDirection: 'rtl' as const,
+      ariaTags: false,
+      width: 500,
+    };
+
+    const preparedSettings = prepareSettings(propsMock, currentSettings);
+
+    expect(preparedSettings.renderAllRows).toBe(void 0);
+    expect(preparedSettings.renderAllColumns).toBe(void 0);
+    expect(preparedSettings.layoutDirection).toBe(void 0);
+    expect(preparedSettings.ariaTags).toBe(void 0);
+    expect(preparedSettings.width).toBe(500);
+  });
+
+  it('should include init-only settings during initial call (no currentSettings)', () => {
+    const propsMock = {
+      renderAllRows: true,
+      width: 300,
+    };
+
+    const preparedSettings = prepareSettings(propsMock);
+
+    expect(preparedSettings.renderAllRows).toBe(true);
+    expect(preparedSettings.width).toBe(300);
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Context

Fixes #12242

When using framework wrappers (React, Vue, Angular), changing an init-only setting prop (e.g., `renderAllRows`, `renderAllColumns`, `layoutDirection`, `ariaTags`) after initialization causes the application to crash with:

```
Uncaught Error: The `renderAllRows` option can not be updated after the Handsontable is initialized.
```

The root cause: all three framework wrappers passed init-only settings through to `updateSettings()` when the prop value changed between renders. Handsontable Core then threw because these settings are marked as `initOnly: true`.

**Fix:** All three wrappers now silently skip init-only settings when calling `updateSettings()` after initialization. The list of init-only settings is read from the Handsontable instance's `_initOnlySettings` metadata, so it stays in sync with Core automatically.

### How has this been tested?

- **React wrapper**: Updated existing test and added new unit tests for `SettingsMapper.getSettings()` verifying init-only keys are excluded after init, but included during init.
- **Vue wrapper**: Added unit tests for `prepareSettings()` verifying init-only keys are filtered when `currentSettings` contains `_initOnlySettings`.
- **Angular wrapper**: Added integration test verifying init-only settings are stripped before reaching `updateSettings()`.

All wrapper test suites pass:
- `pnpm --filter @handsontable/react-wrapper run test` -- 65/65 passed
- `pnpm --filter @handsontable/vue3 run test` -- 20/20 passed
- `pnpm --filter @handsontable/angular-wrapper run test` -- 94/94 passed

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #12242

### Affected project(s):
- [ ] `handsontable`
- [x] `@handsontable/angular-wrapper`
- [x] `@handsontable/react-wrapper`
- [x] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a05b0d7b-f893-4d2b-b89b-240b1bb0ccc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a05b0d7b-f893-4d2b-b89b-240b1bb0ccc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

