### PR TITLE
Fix documentation bug

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -17,7 +17,7 @@ report-check-links.xlsx
 
 /.vuepress/public/handsontable
 /.vuepress/public/@handsontable
-/.vuepress/public/data/
+/.vuepress/public/data/canonicals-raw.json
 /.vuepress/public/scripts/prebuilt-umd/
 /.build-tmp/
 

--- a/docs/.vuepress/public/data/common.json
+++ b/docs/.vuepress/public/data/common.json
@@ -1,0 +1,1 @@
+{"versions":["next"],"latestVersion":"next","urls":[],"versionsWithPatches":[["next",[]]]}


### PR DESCRIPTION
https://claude.ai/code/session_01EPFiTG5rQLyjz7MMpDEmGJ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that affects which VuePress public data files are committed vs ignored. Main risk is unintentionally committing/omitting generated data, impacting doc builds if expected files differ.
> 
> **Overview**
> Fixes a docs build/source-control issue by changing `docs/.gitignore` to stop ignoring the entire `/.vuepress/public/data/` directory and instead ignore only `canonicals-raw.json`.
> 
> Adds `docs/.vuepress/public/data/common.json` with version metadata (e.g., `latestVersion` and `versionsWithPatches`) so this data is now tracked in the repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfdb725647b6e1720d0baf55bf77faba1f87d8d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->