### PR TITLE
Fix documentation regression

### DIFF
--- a/docs/.vuepress/theme/styles/base/icons.styl
+++ b/docs/.vuepress/theme/styles/base/icons.styl
@@ -45,23 +45,24 @@ i.Logo {
 
 .sidebar .sidebar-nav > .sidebar-links > li {
     &:nth-child(1)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/rocket.svg'); background-size: 18px }               // Getting started
-    &:nth-child(2)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/paint.svg'); background-size: 18px }               // Styling
-    &:nth-child(3)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/layout-columns.svg'); background-size: 18px }       // Columns
-    &:nth-child(4)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/layout-columns2.svg'); background-size: 18px }      // Rows
-    &:nth-child(5)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/forms.svg'); background-size: 18px }                // Cell features
-    &:nth-child(6)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/function.svg'); background-size: 18px }             // Cell functions
-    &:nth-child(7)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/settings-2.svg'); background-size: 18px }           // Cell types
-    &:nth-child(8)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/math-function.svg'); background-size: 18px }        // Formulas
-    &:nth-child(9)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/keyboard.svg'); background-size: 18px }             // Navigation
-    &:nth-child(10)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/accessible.svg'); background-size: 18px }           // Accessibility
-    &:nth-child(11)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/layout-list.svg'); background-size: 18px }         // Accessories and menus
-    &:nth-child(12)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/dialog.svg'); background-size: 18px }         // Dialog
-    &:nth-child(13)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/language.svg'); background-size: 18px }            // Internationalization
-    &:nth-child(14)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/brand-vue.svg'); background-size: 18px }           // Integrate with Vue 3
-    &:nth-child(15)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/tools.svg'); background-size: 18px }               // Tools and building
-    &:nth-child(16)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/chart-line.svg'); background-size: 18px }          // Optimization
-    &:nth-child(17)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/shield-half.svg'); background-size: 18px }         // Security
-    &:nth-child(18)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/code.svg'); background-size: 18px }                // Technical specification
-    &:nth-child(19)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/git-branch.svg'); background-size: 18px }          // Upgrade and migration
+    &:nth-child(2)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/report.svg'); background-size: 18px }               // Server-side data
+    &:nth-child(3)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/paint.svg'); background-size: 18px }               // Styling
+    &:nth-child(4)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/layout-columns.svg'); background-size: 18px }       // Columns
+    &:nth-child(5)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/layout-columns2.svg'); background-size: 18px }      // Rows
+    &:nth-child(6)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/forms.svg'); background-size: 18px }                // Cell features
+    &:nth-child(7)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/function.svg'); background-size: 18px }             // Cell functions
+    &:nth-child(8)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/settings-2.svg'); background-size: 18px }           // Cell types
+    &:nth-child(9)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/math-function.svg'); background-size: 18px }        // Formulas
+    &:nth-child(10)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/keyboard.svg'); background-size: 18px }            // Navigation
+    &:nth-child(11)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/accessible.svg'); background-size: 18px }          // Accessibility
+    &:nth-child(12)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/layout-list.svg'); background-size: 18px }         // Accessories and menus
+    &:nth-child(13)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/dialog.svg'); background-size: 18px }              // Dialog
+    &:nth-child(14)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/language.svg'); background-size: 18px }            // Internationalization
+    &:nth-child(15)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/brand-vue.svg'); background-size: 18px }           // Integrate with Vue 3
+    &:nth-child(16)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/tools.svg'); background-size: 18px }               // Tools and building
+    &:nth-child(17)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/chart-line.svg'); background-size: 18px }          // Optimization
+    &:nth-child(18)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/shield-half.svg'); background-size: 18px }         // Security
+    &:nth-child(19)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/code.svg'); background-size: 18px }                // Technical specification
+    &:nth-child(20)  > section p i:first-child { background:  url('{{$basePath}}/img/svg/git-branch.svg'); background-size: 18px }          // Upgrade and migration
     > section a i:first-child { background:  url('{{$basePath}}/img/svg/plugin.svg'); background-size: 18px }                               // Plugin
 } 


### PR DESCRIPTION
https://claude.ai/code/session_018tZ5vfnLPtxEfh6mb2TAtw

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates VuePress theme Stylus rules that map sidebar sections to SVG icons; no runtime or data/auth logic changes.
> 
> **Overview**
> Fixes a documentation theme regression by updating the `.sidebar` `:nth-child(...)` icon mappings in `icons.styl` to match the current sidebar order.
> 
> This inserts a **new second section icon** for *Server-side data* (using `report.svg`) and shifts all subsequent section indices (including moving *Upgrade and migration* to `:nth-child(20)`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a753b03b2130eba863894ecb9b594c6d83bbe32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->