### PR TITLE
Fix Ctrl+A selecting grid instead of comment text (#12193)

### DIFF
--- a/.changelogs/12193.json
+++ b/.changelogs/12193.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed Ctrl+A selecting the entire grid instead of the comment text when the comment textarea was focused.",
+  "type": "fixed",
+  "issueOrPR": 12193,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/comments/__tests__/keyboardShortcuts.spec.js
+++ b/handsontable/src/plugins/comments/__tests__/keyboardShortcuts.spec.js
@@ -275,6 +275,65 @@ describe('Comments keyboard shortcut', () => {
     });
   });
 
+  describe('"Cmd/Ctrl" + "A"', () => {
+    it('should not trigger grid "select all" when the comment textarea is focused (#12193)', async() => {
+      handsontable({
+        data: createSpreadsheetData(4, 4),
+        rowHeaders: true,
+        colHeaders: true,
+        comments: true,
+        contextMenu: true,
+      });
+
+      await selectCell(1, 1);
+      await keyDownUp(['control', 'alt', 'm']);
+      await waitForNextAnimationFrames(1);
+
+      const plugin = getPlugin('comments');
+      const editor = plugin.getEditorInputElement();
+
+      editor.value = 'hello';
+      editor.setSelectionRange(2, 2);
+
+      expect(document.activeElement).toBe(editor);
+      expect(getShortcutManager().getActiveContextName()).toBe('plugin:comments');
+
+      await keyDownUp(['control', 'a']);
+
+      expect(document.activeElement).toBe(editor);
+      expect(getShortcutManager().getActiveContextName()).toBe('plugin:comments');
+      expect(getSelectedRange()).toEqualCellRange(['highlight: 1,1 from: 1,1 to: 1,1']);
+    });
+
+    it('should not trigger grid "select all" when the comment is opened via context menu (#12193)', async() => {
+      handsontable({
+        data: createSpreadsheetData(4, 4),
+        rowHeaders: true,
+        colHeaders: true,
+        comments: true,
+        contextMenu: true,
+      });
+
+      await selectCell(1, 1);
+      await contextMenu();
+      await selectContextMenuOption('Add comment');
+      await waitForNextAnimationFrames(1);
+
+      const plugin = getPlugin('comments');
+      const editor = plugin.getEditorInputElement();
+
+      editor.value = 'hello';
+      editor.setSelectionRange(2, 2);
+
+      expect(document.activeElement).toBe(editor);
+
+      await keyDownUp(['control', 'a']);
+
+      expect(document.activeElement).toBe(editor);
+      expect(getSelectedRange()).toEqualCellRange(['highlight: 1,1 from: 1,1 to: 1,1']);
+    });
+  });
+
   describe('"Cmd/Ctrl" + "Enter"', () => {
     it('should close the comment and save the value (comment opened by keyboard shortcut)', async() => {
       handsontable({

--- a/handsontable/src/plugins/comments/comments.js
+++ b/handsontable/src/plugins/comments/comments.js
@@ -397,6 +397,7 @@ export class Comments extends BasePlugin {
     this.eventManager.addEventListener(rootDocument, 'mouseup', () => this.#onMouseUp());
     this.eventManager.addEventListener(editorElement, 'focus', () => this.#onEditorFocus());
     this.eventManager.addEventListener(editorElement, 'blur', () => this.#onEditorBlur());
+    this.eventManager.addEventListener(editorElement, 'keydown', event => this.#onEditorKeyDown(event));
 
     this.eventManager.addEventListener(
       this.getEditorInputElement(),
@@ -835,6 +836,30 @@ export class Comments extends BasePlugin {
     this.#commentValueBeforeSave = this.getComment();
     this.hot.listen();
     this.hot.getShortcutManager().setActiveContextName(SHORTCUTS_CONTEXT_NAME);
+  }
+
+  /**
+   * Stops keyboard events from propagating to the grid's shortcut system while the comment
+   * textarea is focused. Without this, keys like Ctrl+A trigger grid-level actions (e.g.
+   * "select all cells") instead of native textarea behavior. Shortcuts registered in the
+   * `plugin:comments` context (Escape, Ctrl+Enter, Tab) are allowed through.
+   *
+   * @param {KeyboardEvent} event The keydown event from the comment textarea.
+   */
+  #onEditorKeyDown(event) {
+    if (!this.#editor.isVisible()) {
+      return;
+    }
+
+    const { key, ctrlKey, metaKey } = event;
+
+    const isEscape = key === 'Escape';
+    const isCtrlEnter = (ctrlKey || metaKey) && key === 'Enter';
+    const isTab = key === 'Tab';
+
+    if (!isEscape && !isCtrlEnter && !isTab) {
+      event.stopPropagation();
+    }
   }
 
   /**

--- a/handsontable/src/plugins/comments/comments.js
+++ b/handsontable/src/plugins/comments/comments.js
@@ -13,6 +13,7 @@ import { deepClone, deepExtend } from '../../helpers/object';
 import { CellRange } from '../../3rdparty/walkontable/src';
 import { BasePlugin } from '../base';
 import { throwWithCause } from '../../helpers/errors';
+import { normalizeEventKey } from '../../shortcuts/utils';
 import CommentEditor from './commentEditor';
 import DisplaySwitch from './displaySwitch';
 import { getEditorAnchorWidth } from './utils';
@@ -840,9 +841,9 @@ export class Comments extends BasePlugin {
 
   /**
    * Stops keyboard events from propagating to the grid's shortcut system while the comment
-   * textarea is focused. Without this, keys like Ctrl+A trigger grid-level actions (e.g.
-   * "select all cells") instead of native textarea behavior. Shortcuts registered in the
-   * `plugin:comments` context (Escape, Ctrl+Enter, Tab) are allowed through.
+   * textarea is visible. Without this, keys like Ctrl+A trigger grid-level actions (e.g.
+   * "select all cells") instead of native textarea behavior. Events matching shortcuts
+   * registered in the `plugin:comments` context are allowed through.
    *
    * @param {KeyboardEvent} event The keydown event from the comment textarea.
    */
@@ -851,15 +852,56 @@ export class Comments extends BasePlugin {
       return;
     }
 
-    const { key, ctrlKey, metaKey } = event;
-
-    const isEscape = key === 'Escape';
-    const isCtrlEnter = (ctrlKey || metaKey) && key === 'Enter';
-    const isTab = key === 'Tab';
-
-    if (!isEscape && !isCtrlEnter && !isTab) {
+    if (!this.#isCommentsContextShortcut(event)) {
       event.stopPropagation();
     }
+  }
+
+  /**
+   * Checks whether the keyboard event matches any shortcut registered in the
+   * `plugin:comments` shortcut context. Uses the same key normalization logic
+   * as the shortcut recorder so this check stays in sync automatically.
+   *
+   * @param {KeyboardEvent} event The keyboard event to check.
+   * @returns {boolean}
+   */
+  #isCommentsContextShortcut(event) {
+    const shortcutContext = this.hot.getShortcutManager().getContext(SHORTCUTS_CONTEXT_NAME);
+
+    if (!shortcutContext || typeof event.key !== 'string') {
+      return false;
+    }
+
+    const key = normalizeEventKey(event);
+    const modifiers = [];
+
+    if (event.altKey) {
+      modifiers.push('alt');
+    }
+    if (event.ctrlKey) {
+      modifiers.push('control');
+    }
+    if (event.metaKey) {
+      modifiers.push('meta');
+    }
+    if (event.shiftKey) {
+      modifiers.push('shift');
+    }
+
+    if (shortcutContext.hasShortcut([key, ...modifiers])) {
+      return true;
+    }
+
+    if (event.ctrlKey || event.metaKey) {
+      const unified = modifiers
+        .filter(m => m !== 'control' && m !== 'meta');
+
+      unified.push('control/meta');
+
+      return shortcutContext.hasShortcut([key, ...unified]);
+    }
+
+    return false;
   }
 
   /**

--- a/handsontable/src/plugins/comments/comments.js
+++ b/handsontable/src/plugins/comments/comments.js
@@ -13,7 +13,6 @@ import { deepClone, deepExtend } from '../../helpers/object';
 import { CellRange } from '../../3rdparty/walkontable/src';
 import { BasePlugin } from '../base';
 import { throwWithCause } from '../../helpers/errors';
-import { normalizeEventKey } from '../../shortcuts/utils';
 import CommentEditor from './commentEditor';
 import DisplaySwitch from './displaySwitch';
 import { getEditorAnchorWidth } from './utils';
@@ -852,56 +851,9 @@ export class Comments extends BasePlugin {
       return;
     }
 
-    if (!this.#isCommentsContextShortcut(event)) {
+    if (!this.hot.getShortcutManager().hasEventShortcut(SHORTCUTS_CONTEXT_NAME, event)) {
       event.stopPropagation();
     }
-  }
-
-  /**
-   * Checks whether the keyboard event matches any shortcut registered in the
-   * `plugin:comments` shortcut context. Uses the same key normalization logic
-   * as the shortcut recorder so this check stays in sync automatically.
-   *
-   * @param {KeyboardEvent} event The keyboard event to check.
-   * @returns {boolean}
-   */
-  #isCommentsContextShortcut(event) {
-    const shortcutContext = this.hot.getShortcutManager().getContext(SHORTCUTS_CONTEXT_NAME);
-
-    if (!shortcutContext || typeof event.key !== 'string') {
-      return false;
-    }
-
-    const key = normalizeEventKey(event);
-    const modifiers = [];
-
-    if (event.altKey) {
-      modifiers.push('alt');
-    }
-    if (event.ctrlKey) {
-      modifiers.push('control');
-    }
-    if (event.metaKey) {
-      modifiers.push('meta');
-    }
-    if (event.shiftKey) {
-      modifiers.push('shift');
-    }
-
-    if (shortcutContext.hasShortcut([key, ...modifiers])) {
-      return true;
-    }
-
-    if (event.ctrlKey || event.metaKey) {
-      const unified = modifiers
-        .filter(m => m !== 'control' && m !== 'meta');
-
-      unified.push('control/meta');
-
-      return shortcutContext.hasShortcut([key, ...unified]);
-    }
-
-    return false;
   }
 
   /**

--- a/handsontable/src/shortcuts/manager.js
+++ b/handsontable/src/shortcuts/manager.js
@@ -3,6 +3,7 @@ import { throwWithCause } from '../helpers/errors';
 import { stopImmediatePropagation } from '../helpers/dom/event';
 import { createContext, isContextObject } from './context';
 import { useRecorder } from './recorder';
+import { getEventKeyCombinations } from './utils';
 import { toSingleLine } from '../helpers/templateLiteralTag';
 
 /* eslint-disable jsdoc/require-description-complete-sentence */
@@ -196,12 +197,35 @@ export const createShortcutManager = ({ ownerWindow, handleEvent, beforeKeyDown,
 
   keyRecorder.mount();
 
+  /**
+   * Check if any shortcut in the given context matches the keyboard event.
+   * Uses the same key normalization as the shortcut recorder, including
+   * the unified `control/meta` form.
+   *
+   * @memberof ShortcutManager#
+   * @param {string} contextName The name of the shortcut context to check against.
+   * @param {KeyboardEvent} event The keyboard event to match.
+   * @returns {boolean}
+   */
+  const hasEventShortcut = (contextName, event) => {
+    const context = getContext(contextName);
+
+    if (!context) {
+      return false;
+    }
+
+    const combinations = getEventKeyCombinations(event);
+
+    return combinations.some(keys => context.hasShortcut(keys));
+  };
+
   return {
     addContext,
     getActiveContextName,
     getContext,
     getOrCreateContext,
     setActiveContextName,
+    hasEventShortcut,
     /**
      * Returns whether `control` or `meta` keys are pressed.
      *

--- a/handsontable/src/shortcuts/manager.js
+++ b/handsontable/src/shortcuts/manager.js
@@ -1,6 +1,7 @@
 import { createUniqueMap } from '../utils/dataStructures/uniqueMap';
 import { throwWithCause } from '../helpers/errors';
 import { stopImmediatePropagation } from '../helpers/dom/event';
+import { isMacOS } from '../helpers/browser';
 import { createContext, isContextObject } from './context';
 import { useRecorder } from './recorder';
 import { getEventKeyCombinations } from './utils';
@@ -214,7 +215,7 @@ export const createShortcutManager = ({ ownerWindow, handleEvent, beforeKeyDown,
       return false;
     }
 
-    const combinations = getEventKeyCombinations(event);
+    const combinations = getEventKeyCombinations(event, isMacOS);
 
     return combinations.some(keys => context.hasShortcut(keys));
   };

--- a/handsontable/src/shortcuts/recorder.js
+++ b/handsontable/src/shortcuts/recorder.js
@@ -1,10 +1,9 @@
 import { createKeysObserver } from './keyObserver';
-import { normalizeEventKey } from './utils';
+import { normalizeEventKey, isModifierKey, getPressedModifierKeys } from './utils';
 import { isImmediatePropagationStopped } from '../helpers/dom/event';
 import { getParentWindow } from '../helpers/dom/element';
 import { isMacOS } from '../helpers/browser';
 
-const MODIFIER_KEYS = ['meta', 'alt', 'shift', 'control'];
 const modifierKeysObserver = createKeysObserver();
 const modKeyListeners = [];
 let instanceCounter = 0;
@@ -22,55 +21,6 @@ let instanceCounter = 0;
  * @returns {object}
  */
 export function useRecorder(ownerWindow, handleEvent, beforeKeyDown, afterKeyDown, callback) {
-  /**
-   * Check if a pressed key is tracked or not.
-   *
-   * @param {string} pressedKey A pressed key
-   * @returns {boolean}
-   */
-  const isModifierKey = (pressedKey) => {
-    return MODIFIER_KEYS.includes(pressedKey);
-  };
-
-  /**
-   * Get every pressed modifier key from the performed `KeyboardEvent`.
-   *
-   * @private
-   * @param {KeyboardEvent} event The event object.
-   * @param {boolean} [mergeMetaKeys=false] If `true,` the function will return the "control" and "meta"
-   *                                        modifiers keys as the "control/meta" name. This allows creating
-   *                                        keyboard shortcuts with modifier key that trigger the shortcut
-   *                                        actions depend on the OS keyboard layout (the Meta key for macOS
-   *                                        and Control for non macOS system).
-   * @returns {string[]}
-   */
-  const getPressedModifierKeys = (event, mergeMetaKeys = false) => {
-    const pressedModifierKeys = [];
-
-    if (event.altKey) {
-      pressedModifierKeys.push('alt');
-    }
-
-    if (mergeMetaKeys && (event.ctrlKey || event.metaKey)) {
-      pressedModifierKeys.push('control/meta');
-
-    } else {
-      if (event.ctrlKey) {
-        pressedModifierKeys.push('control');
-      }
-
-      if (event.metaKey) {
-        pressedModifierKeys.push('meta');
-      }
-    }
-
-    if (event.shiftKey) {
-      pressedModifierKeys.push('shift');
-    }
-
-    return pressedModifierKeys;
-  };
-
   /**
    * `KeyboardEvent`'s callback function
    *

--- a/handsontable/src/shortcuts/utils.js
+++ b/handsontable/src/shortcuts/utils.js
@@ -120,17 +120,30 @@ export const normalizeEventKey = ({ which, key }) => {
   return key.toLowerCase();
 };
 
-const MODIFIER_KEYS = ['meta', 'alt', 'shift', 'control'];
+export const MODIFIER_KEYS = ['meta', 'alt', 'shift', 'control'];
 
 /**
- * Get the pressed modifier keys from a keyboard event.
+ * Check if a pressed key is a modifier key.
  *
- * @param {KeyboardEvent} event The keyboard event.
+ * @param {string} pressedKey A pressed key.
+ * @returns {boolean}
+ */
+export const isModifierKey = (pressedKey) => {
+  return MODIFIER_KEYS.includes(pressedKey);
+};
+
+/**
+ * Get every pressed modifier key from the performed `KeyboardEvent`.
+ *
+ * @param {KeyboardEvent} event The event object.
  * @param {boolean} [mergeMetaKeys=false] If `true`, the function returns "control" and "meta"
- *                                        as the unified "control/meta" name.
+ *                                        modifiers keys as the "control/meta" name. This allows creating
+ *                                        keyboard shortcuts with modifier key that trigger the shortcut
+ *                                        actions depend on the OS keyboard layout (the Meta key for macOS
+ *                                        and Control for non macOS system).
  * @returns {string[]}
  */
-const getPressedModifierKeys = (event, mergeMetaKeys = false) => {
+export const getPressedModifierKeys = (event, mergeMetaKeys = false) => {
   const pressedModifierKeys = [];
 
   if (event.altKey) {
@@ -159,26 +172,33 @@ const getPressedModifierKeys = (event, mergeMetaKeys = false) => {
 
 /**
  * Get all key combinations that a keyboard event can match against registered shortcuts.
- * Returns an array of key arrays: the literal form and (when Ctrl or Meta is pressed)
- * the unified `control/meta` form. This mirrors the matching logic used by the
- * shortcut recorder.
+ * Returns an array of key arrays: the literal form and -- when the OS-native modifier
+ * is pressed (Meta on macOS, Control on other systems) -- the unified `control/meta` form.
+ * This mirrors the matching logic used by the shortcut recorder.
  *
  * @param {KeyboardEvent} event The keyboard event.
+ * @param {Function} platformCheck A function that returns `true` on macOS.
+ *                                 Defaults to `isMacOS` from `helpers/browser`.
  * @returns {Array<string[]>}
  */
-export const getEventKeyCombinations = (event) => {
+export const getEventKeyCombinations = (event, platformCheck) => {
   if (typeof event.key !== 'string') {
     return [];
   }
 
   const pressedKey = normalizeEventKey(event);
-  const isModifier = MODIFIER_KEYS.includes(pressedKey);
-  const modifiers = isModifier ? [] : getPressedModifierKeys(event);
+  const modifier = isModifierKey(pressedKey);
+  const modifiers = modifier ? [] : getPressedModifierKeys(event);
   const literal = [pressedKey].concat(modifiers);
   const combinations = [literal];
 
-  if (!isModifier && (event.ctrlKey || event.metaKey)) {
-    combinations.push([pressedKey].concat(getPressedModifierKeys(event, true)));
+  if (!modifier) {
+    const isMac = typeof platformCheck === 'function' ? platformCheck() : false;
+    const hasOsNativeModifier = isMac ? modifiers.includes('meta') : modifiers.includes('control');
+
+    if (hasOsNativeModifier) {
+      combinations.push([pressedKey].concat(getPressedModifierKeys(event, true)));
+    }
   }
 
   return combinations;

--- a/handsontable/src/shortcuts/utils.js
+++ b/handsontable/src/shortcuts/utils.js
@@ -119,3 +119,67 @@ export const normalizeEventKey = ({ which, key }) => {
 
   return key.toLowerCase();
 };
+
+const MODIFIER_KEYS = ['meta', 'alt', 'shift', 'control'];
+
+/**
+ * Get the pressed modifier keys from a keyboard event.
+ *
+ * @param {KeyboardEvent} event The keyboard event.
+ * @param {boolean} [mergeMetaKeys=false] If `true`, the function returns "control" and "meta"
+ *                                        as the unified "control/meta" name.
+ * @returns {string[]}
+ */
+const getPressedModifierKeys = (event, mergeMetaKeys = false) => {
+  const pressedModifierKeys = [];
+
+  if (event.altKey) {
+    pressedModifierKeys.push('alt');
+  }
+
+  if (mergeMetaKeys && (event.ctrlKey || event.metaKey)) {
+    pressedModifierKeys.push('control/meta');
+
+  } else {
+    if (event.ctrlKey) {
+      pressedModifierKeys.push('control');
+    }
+
+    if (event.metaKey) {
+      pressedModifierKeys.push('meta');
+    }
+  }
+
+  if (event.shiftKey) {
+    pressedModifierKeys.push('shift');
+  }
+
+  return pressedModifierKeys;
+};
+
+/**
+ * Get all key combinations that a keyboard event can match against registered shortcuts.
+ * Returns an array of key arrays: the literal form and (when Ctrl or Meta is pressed)
+ * the unified `control/meta` form. This mirrors the matching logic used by the
+ * shortcut recorder.
+ *
+ * @param {KeyboardEvent} event The keyboard event.
+ * @returns {Array<string[]>}
+ */
+export const getEventKeyCombinations = (event) => {
+  if (typeof event.key !== 'string') {
+    return [];
+  }
+
+  const pressedKey = normalizeEventKey(event);
+  const isModifier = MODIFIER_KEYS.includes(pressedKey);
+  const modifiers = isModifier ? [] : getPressedModifierKeys(event);
+  const literal = [pressedKey].concat(modifiers);
+  const combinations = [literal];
+
+  if (!isModifier && (event.ctrlKey || event.metaKey)) {
+    combinations.push([pressedKey].concat(getPressedModifierKeys(event, true)));
+  }
+
+  return combinations;
+};

--- a/handsontable/types/shortcuts/manager.d.ts
+++ b/handsontable/types/shortcuts/manager.d.ts
@@ -6,6 +6,7 @@ export interface ShortcutManager {
   getContext(contextName: string): Context | undefined;
   getOrCreateContext(contextName: string): Context;
   setActiveContextName(contextName: string): void;
+  hasEventShortcut(contextName: string, event: KeyboardEvent): boolean;
   isCtrlPressed(): boolean;
   destroy(): void;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Context

Fixes #12193. When a user opens a comment editor (via context menu or Ctrl+Alt+M), types text, repositions the cursor inside the text, and presses Ctrl+A (or Cmd+A on Mac), the entire grid is selected instead of the text within the comment textarea.

**Root cause:** The Comments plugin's `#onAfterDocumentKeyDown` handler calls `stopImmediatePropagation(event)` in the `afterDocumentKeyDown` hook, which fires _after_ the shortcut system has already processed the event. The grid context's `Ctrl+A` shortcut (`selectAllCells()`) executes before the Comments plugin can block it.

**Fix:** Added a `keydown` event listener directly on the comment textarea element that calls `event.stopPropagation()` to prevent keyboard events from bubbling up to the grid's shortcut system (which listens on `document.documentElement`). Events matching shortcuts registered in the `plugin:comments` context are allowed through via the new `ShortcutManager.hasEventShortcut()` API.

**Architecture:** To avoid duplicating the recorder's internal key matching logic, `MODIFIER_KEYS`, `isModifierKey`, and `getPressedModifierKeys` were extracted from `recorder.js` into `shortcuts/utils.js` as shared exports. A new `getEventKeyCombinations(event, platformCheck)` utility builds key combination arrays from a `KeyboardEvent` (with the OS-aware `isMacOS` guard for `control/meta` unification), and `hasEventShortcut(contextName, event)` was added to `ShortcutManager` as the public API. The Comments plugin calls this single method instead of reimplementing any shortcut matching.

### How has this been tested?

- Added two new E2E tests to `keyboardShortcuts.spec.js` verifying that Ctrl+A does not trigger grid "select all" when the comment textarea is focused (both via keyboard shortcut and context menu).
- Ran all 133 Comments plugin E2E specs -- 0 failures.
- Ran all 31 ShortcutManager E2E specs -- 0 failures.
- Ran ESLint -- 0 errors.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #12193

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-286b165e-8a9f-4bd2-972f-df522e5be43b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-286b165e-8a9f-4bd2-972f-df522e5be43b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

