### PR TITLE
Fix columnHeaderHeight overriding actual content height (#12198)

### DIFF
--- a/.changelogs/12198.json
+++ b/.changelogs/12198.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed `columnHeaderHeight` overriding the actual content height, causing overlay THEAD misalignment when header text wraps.",
+  "type": "fixed",
+  "issueOrPR": 12198,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/src/table.js
+++ b/handsontable/src/3rdparty/walkontable/src/table.js
@@ -366,6 +366,10 @@ class Table {
 
         this.adjustColumnHeaderHeights();
 
+        if (this.isMaster) {
+          this.syncOversizedColumnHeadersWithDOM();
+        }
+
         if (this.isMaster || this.is(CLONE_BOTTOM)) {
           this.markOversizedRows();
         }
@@ -489,6 +493,33 @@ class Table {
           return;
         }
         children[i].childNodes[0].style.height = `${oversizedColumnHeaders[i]}px`;
+      }
+    }
+  }
+
+  /**
+   * After the master table applies `oversizedColumnHeaders` via `adjustColumnHeaderHeights`,
+   * the actual THEAD row heights may exceed the stored values when header content (e.g.,
+   * wrapping text) pushes cells taller than the configured `columnHeaderHeight`. This method
+   * re-reads the rendered THEAD row heights and updates `oversizedColumnHeaders` so that
+   * overlay tables receive the correct values during their own `adjustColumnHeaderHeights`.
+   */
+  syncOversizedColumnHeadersWithDOM() {
+    const { wtSettings } = this;
+    const children = this.THEAD.childNodes;
+    const oversizedColumnHeaders = this.dataAccessObject.wtViewport.oversizedColumnHeaders;
+    const columnHeaders = wtSettings.getSetting('columnHeaders');
+    const borderCompensation = 1;
+
+    for (let i = 0, len = columnHeaders.length; i < len; i++) {
+      if (!children[i] || !oversizedColumnHeaders[i]) {
+        continue;
+      }
+
+      const actualRowHeight = innerHeight(children[i]);
+
+      if (actualRowHeight > oversizedColumnHeaders[i] + borderCompensation) {
+        oversizedColumnHeaders[i] = actualRowHeight;
       }
     }
   }

--- a/handsontable/test/e2e/ColHeader.spec.js
+++ b/handsontable/test/e2e/ColHeader.spec.js
@@ -384,6 +384,93 @@ describe('ColHeader', () => {
     expect(topHeaderExample.height()).toEqual(masterHeaderExample.height());
   });
 
+  it('should not let columnHeaderHeight override the actual measured height when content is taller (#12198)', async() => {
+    const style = document.createElement('style');
+
+    style.textContent = '.wrapHeader { white-space: normal !important; overflow: visible !important; }';
+    document.head.appendChild(style);
+
+    spec().$container.css('width', '600px');
+
+    handsontable({
+      data: createSpreadsheetData(3, 11),
+      colWidths: 80,
+      rowHeaders: true,
+      colHeaders(index) {
+        return `Col ${index + 1} really long header`;
+      },
+      columnHeaderHeight: 50,
+      height: 'auto',
+      headerClassName: 'wrapHeader',
+    });
+
+    await sleep(100);
+
+    const masterThead = spec().$container.find('.ht_master thead')[0];
+    const inlineStartThead = spec().$container.find('.ht_clone_inline_start thead')[0];
+
+    expect(masterThead.offsetHeight).toBeGreaterThan(50);
+    expect(Math.abs(inlineStartThead.offsetHeight - masterThead.offsetHeight)).toBeLessThanOrEqual(1);
+
+    style.remove();
+  });
+
+  it('should align row headers when columnHeaderHeight is larger than content height (#12198)', async() => {
+    const style = document.createElement('style');
+
+    style.textContent = '.wrapHeader { white-space: normal !important; overflow: visible !important; }';
+    document.head.appendChild(style);
+
+    spec().$container.css('width', '600px');
+
+    handsontable({
+      data: createSpreadsheetData(3, 11),
+      colWidths: 80,
+      rowHeaders: true,
+      colHeaders(index) {
+        return `Col ${index + 1} really long header`;
+      },
+      columnHeaderHeight: 132,
+      height: 'auto',
+      headerClassName: 'wrapHeader',
+    });
+
+    await sleep(100);
+
+    const masterThead = spec().$container.find('.ht_master thead')[0];
+    const inlineStartThead = spec().$container.find('.ht_clone_inline_start thead')[0];
+
+    expect(Math.abs(inlineStartThead.offsetHeight - masterThead.offsetHeight)).toBeLessThanOrEqual(1);
+
+    const masterFirstRow = spec().$container.find('.ht_master tbody tr:first-child')[0];
+    const inlineStartFirstRow = spec().$container.find('.ht_clone_inline_start tbody tr:first-child')[0];
+
+    if (masterFirstRow && inlineStartFirstRow) {
+      expect(Math.abs(
+        masterFirstRow.getBoundingClientRect().top - inlineStartFirstRow.getBoundingClientRect().top
+      )).toBeLessThan(2);
+    }
+
+    style.remove();
+  });
+
+  it('should keep the tallest header height even when shorter columns are processed after it (#12198)', async() => {
+    handsontable({
+      data: createSpreadsheetData(3, 5),
+      colWidths: 80,
+      rowHeaders: true,
+      colHeaders: ['a<br>b<br>c<br>d', 'B', 'C', 'D', 'E'],
+      columnHeaderHeight: 30,
+      height: 'auto',
+    });
+
+    const masterThead = spec().$container.find('.ht_master thead')[0];
+    const inlineStartThead = spec().$container.find('.ht_clone_inline_start thead')[0];
+
+    expect(masterThead.offsetHeight).toBeGreaterThan(30);
+    expect(Math.abs(inlineStartThead.offsetHeight - masterThead.offsetHeight)).toBeLessThanOrEqual(1);
+  });
+
   it('should allow defining custom column header height using the columnHeaderHeight config option', async() => {
     handsontable({
       startCols: 3,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Context

Fixes #12198. When `columnHeaderHeight` is set and header content wraps (e.g., via `white-space: normal`), the overlay THEADs (inline-start, corner) do not match the master THEAD height, causing row misalignment.

**Root cause:** `markIfOversizedColumnHeader()` computes `oversizedColumnHeaders[level]` and `adjustColumnHeaderHeights()` applies it to the first TH of each header row. But the master's header row can grow beyond the stored value because *other* TH cells in the same row have wrapping content that pushes the row taller. Overlay tables have fewer columns (e.g., only the row header), so their header rows don't grow -- creating the mismatch.

**Fix:** After the master table calls `adjustColumnHeaderHeights()`, a new `syncOversizedColumnHeadersWithDOM()` method re-measures the actual rendered THEAD row heights and updates `oversizedColumnHeaders` to match. When overlays later call `adjustColumnHeaderHeights()`, they receive the correct (actual) master heights. A 1px border-compensation threshold avoids triggering on sub-pixel rounding differences.

**Before fix:**
[Before fix - row 1 hidden behind header, THEAD mismatch](https://cursor.com/agents/bc-8a5c7e36-92fb-4448-b2be-7518286f0a80/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbug_before_fix.webp)

**After fix:**
[After fix - all rows aligned, THEAD heights match](https://cursor.com/agents/bc-8a5c7e36-92fb-4448-b2be-7518286f0a80/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffix_verified_console.webp)

### How has this been tested?

- Added E2E tests in `ColHeader.spec.js`:
  1. `columnHeaderHeight: 50` (lower than content) with wrapping headers -- verifies overlay THEAD matches master.
  2. `columnHeaderHeight: 132` (higher than content) with wrapping headers -- verifies alignment preserved.
  3. Tall header in first column followed by short headers -- verifies tallest height is preserved.
- Ran ColHeader, RowHeader, autoRowSize, and nestedHeaders E2E tests (276 specs, 0 failures).
- Ran full Walkontable test suite (659 specs, 0 failures).
- Ran nestedHeaders rowspan test (passes -- fix does not interfere with rowspan equalization).

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #12198

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a5c7e36-92fb-4448-b2be-7518286f0a80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a5c7e36-92fb-4448-b2be-7518286f0a80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

