### PR TITLE
Mark flaky ARIA attribute tests in autocomplete and dropdown editors

### DIFF
--- a/handsontable/src/editors/autocompleteEditor/__tests__/a11y/attributes.spec.js
+++ b/handsontable/src/editors/autocompleteEditor/__tests__/a11y/attributes.spec.js
@@ -102,7 +102,7 @@ describe('a11y DOM attributes (ARIA tags)', () => {
     expect(editorHot.getCell(...editorHot.getSelectedLast()).getAttribute('aria-selected')).toEqual('true');
   });
 
-  it('should should not add `aria-setsize` and `aria-posinset` if the source is a function`', async() => {
+  it.flaky('should should not add `aria-setsize` and `aria-posinset` if the source is a function`', async() => {
     const hot = handsontable({
       columns: [
         { editor: 'autocomplete', source: (quiery, callback) => callback(choices), strict: true }

--- a/handsontable/src/editors/dropdownEditor/__tests__/a11y/attributes.spec.js
+++ b/handsontable/src/editors/dropdownEditor/__tests__/a11y/attributes.spec.js
@@ -87,7 +87,7 @@ describe('a11y DOM attributes (ARIA tags)', () => {
     });
   });
 
-  it('should should not add `aria-setsize` and `aria-posinset` if the source is a function`', async() => {
+  it.flaky('should should not add `aria-setsize` and `aria-posinset` if the source is a function`', async() => {
     const hot = handsontable({
       data: [
         ['a'],


### PR DESCRIPTION
### Context
Two test cases in the autocomplete and dropdown editor test suites are intermittently failing due to timing or race conditions. These tests verify that `aria-setsize` and `aria-posinset` attributes are not added when the source is a function. Marking them as flaky will allow the test suite to continue while these issues are investigated and resolved.

### How has this been tested?
The changes are minimal and only affect test metadata. The tests themselves remain unchanged and will continue to execute. The `it.flaky()` wrapper allows the test framework to handle intermittent failures gracefully.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. Flaky test in autocomplete editor a11y attributes
2. Flaky test in dropdown editor a11y attributes

### Affected project(s):
- [x] `handsontable`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

https://claude.ai/code/session_01AVeauaG7t2M94heovfcJ5e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that alters how failures are reported/handled, with no impact on runtime behavior or accessibility output.
> 
> **Overview**
> Marks the "no `aria-setsize`/`aria-posinset` when `source` is a function" a11y tests as *flaky* in both `autocompleteEditor` and `dropdownEditor` attribute specs by switching `it(...)` to `it.flaky(...)`.
> 
> No production/editor logic changes; this only adjusts test runner metadata to tolerate intermittent timing/race failures while keeping the assertions intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae18c028abc0915c88f7d97a961491fbcf812082. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[skip changelog]