### PR TITLE
fix: correct JSDoc type annotations for modifyAutofillRange hook

### DIFF
--- a/.changelogs/11862.json
+++ b/.changelogs/11862.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed incorrect JSDoc type annotations for the `modifyAutofillRange` hook parameters. The parameters `entireArea` and `startArea` are now correctly documented as `number[]` (a flat 4-element array) instead of the generic `Array` type, and the `@returns` type annotation has been added.",
+  "type": "fixed",
+  "issueOrPR": 11862,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/core/hooks/constants.js
+++ b/handsontable/src/core/hooks/constants.js
@@ -2064,12 +2064,13 @@ export const REGISTERED_HOOKS = [
   'afterColumnSort',
 
   /**
-   * Fired by {@link Autofill} plugin after setting range of autofill. This hook is fired when {@link Options#fillHandle}
+   * Fired by {@link Autofill} plugin to allow modifying the autofill range. This hook is fired when {@link Options#fillHandle}
    * option is enabled.
    *
    * @event Hooks#modifyAutofillRange
-   * @param {Array} entireArea Array of visual coordinates of the entire area of the drag-down operation (`[startRow, startColumn, endRow, endColumn]`).
-   * @param {Array} startArea Array of visual coordinates of the starting point for the drag-down operation (`[startRow, startColumn, endRow, endColumn]`).
+   * @param {number[]} entireArea Visual coordinates of the entire area of the drag-down operation (`[startRow, startColumn, endRow, endColumn]`).
+   * @param {number[]} startArea Visual coordinates of the starting point for the drag-down operation (`[startRow, startColumn, endRow, endColumn]`).
+   * @returns {number[]} The modified autofill range (`[startRow, startColumn, endRow, endColumn]`).
    */
   'modifyAutofillRange',
 

--- a/handsontable/src/plugins/mergeCells/mergeCells.js
+++ b/handsontable/src/plugins/mergeCells/mergeCells.js
@@ -1284,9 +1284,9 @@ export class MergeCells extends BasePlugin {
   /**
    * The `modifyAutofillRange` hook callback.
    *
-   * @param {Array} fullArea The drag + base area coordinates.
-   * @param {Array} baseArea The selection information.
-   * @returns {Array} The new drag area.
+   * @param {number[]} fullArea The drag + base area coordinates (`[startRow, startColumn, endRow, endColumn]`).
+   * @param {number[]} baseArea The selection area coordinates (`[startRow, startColumn, endRow, endColumn]`).
+   * @returns {number[]} The new drag area (`[startRow, startColumn, endRow, endColumn]`).
    */
   #onModifyAutofillRange(fullArea, baseArea) {
     const dragDirection = this.autofillCalculations.getDirection(baseArea, fullArea);


### PR DESCRIPTION
Update the @param type annotations for the modifyAutofillRange hook from the generic {Array} to the accurate {number[]} (a flat 4-element tuple), and add the missing @returns {number[]} annotation to reflect how the hook system uses the callback return value.

Also update the matching JSDoc on MergeCells#onModifyAutofillRange.

Fixes #11862

Update the @param type annotations for the modifyAutofillRange hook from
the generic {Array} to the accurate {number[]} (a flat 4-element tuple),
and add the missing @returns {number[]} annotation.

Also updates the matching JSDoc on MergeCells#onModifyAutofillRange.

Fixes #11862

https://claude.ai/code/session_01UxA81trKxSESf1KTqLLkPm

### Context
<!--- Why is this change required? What problem does it solve? -->

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only JSDoc updates (no runtime behavior changes). Main risk is minor API-doc mismatch if any downstream tooling relied on the previous generic `Array` typing.
> 
> **Overview**
> Clarifies the `modifyAutofillRange` hook documentation by typing `entireArea`/`startArea` as `number[]` (4-element coordinate arrays) and documenting the `number[]` return value in `core/hooks/constants.js`.
> 
> Updates the matching JSDoc for `MergeCells#onModifyAutofillRange` to use the same `number[]` parameter/return annotations, and adds a changelog entry (`.changelogs/11862.json`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0db1c78e7e24eb64712bc60194dec331c8bfa60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->