### PR TITLE
DEV-1210: docs: add MUI theme recipe

### DIFF
--- a/docs/content/recipes/sidebar.js
+++ b/docs/content/recipes/sidebar.js
@@ -18,6 +18,7 @@ const cellTypesItems = [
 
 const themesItems = [
   { path: 'themes/custom-theme/custom-theme', title: 'Handsontable with shadcn/ui', onlyFor: ['react', 'javascript', 'angular'] },
+  { path: 'themes/mui-theme/mui-theme', title: 'Handsontable with MUI', onlyFor: ['react'] },
 ];
 
 module.exports = {

--- a/docs/content/recipes/themes/mui-theme/mui-theme.md
+++ b/docs/content/recipes/themes/mui-theme/mui-theme.md
@@ -1,0 +1,206 @@
+---
+id: f2a7b9c1
+title: Handsontable with MUI
+metaTitle: Handsontable with MUI - React Data Grid | Handsontable
+description: Integrate Handsontable into a React app with MUI so your grid follows Material UI colors, typography, and spacing.
+permalink: /recipes/themes/mui-theme
+canonicalUrl: /recipes/themes/mui-theme
+tags:
+  - guides
+  - tutorial
+  - recipes
+  - MUI
+  - Material UI
+  - design system
+  - React
+  - themes
+  - Theme API
+react:
+  id: d4e8a6f2
+  metaTitle: Handsontable with MUI - React Data Grid | Handsontable
+searchCategory: Recipes
+category: Themes
+---
+
+## Overview
+
+This recipe shows how to integrate Handsontable into a React app that uses [MUI](https://mui.com/) by registering a custom theme with Theme API colors and tokens. The grid follows your Material UI design language.
+
+**Difficulty:** Beginner  
+**Time:** ~15 minutes  
+**Stack:** React, MUI, Handsontable, `@handsontable/react-wrapper`
+
+## What You'll Get
+
+- A reusable Handsontable theme (`registerTheme('mui-data-grid', { colors, tokens })`) that maps to your MUI palette.
+- A React grid component that uses the custom theme and keeps your MUI typography and spacing.
+- A base setup you can extend with dark mode and custom icons.
+
+## Prerequisites
+
+- A React app with MUI configured.
+- Handsontable and the React wrapper installed.
+- A `ThemeProvider` at your app root.
+
+## Step 1: Install dependencies
+
+In your project root:
+
+```bash
+npm install handsontable @handsontable/react-wrapper @mui/material @emotion/react @emotion/styled
+```
+
+## Step 2: Register Handsontable modules
+
+Register Handsontable modules once in your grid module:
+
+```tsx
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+```
+
+## Step 3: Create MUI color mapping for Theme API
+
+Handsontable's Theme API expects a specific `colors` shape. Create a mapping helper that reads from your MUI theme.
+
+**File: `src/theme/handsontableMuiColors.ts`**
+
+```ts
+import type { Theme } from '@mui/material/styles';
+
+export function createHandsontableMuiColors(theme: Theme) {
+  return {
+    palette: {
+      50: theme.palette.grey[50],
+      100: theme.palette.grey[100],
+      200: theme.palette.grey[200],
+      300: theme.palette.grey[300],
+      400: theme.palette.grey[400],
+      500: theme.palette.grey[500],
+      600: theme.palette.grey[600],
+      700: theme.palette.grey[700],
+      800: theme.palette.grey[800],
+      900: theme.palette.grey[900],
+      950: theme.palette.grey[900],
+    },
+    primary: {
+      100: theme.palette.primary.light,
+      200: theme.palette.primary.light,
+      300: theme.palette.primary.main,
+      400: theme.palette.primary.main,
+      500: theme.palette.primary.dark,
+      600: theme.palette.primary.dark,
+    },
+    white: theme.palette.background.paper,
+    black: theme.palette.text.primary,
+    transparent: 'transparent',
+  };
+}
+```
+
+## Step 4: Register your MUI Handsontable theme
+
+Register a custom Handsontable theme that uses your mapped colors and Horizon tokens.
+
+**File: `src/theme/muiDataGridTheme.ts`**
+
+```ts
+import type { Theme } from '@mui/material/styles';
+import { registerTheme } from 'handsontable/themes';
+import tokensHorizon from 'handsontable/themes/static/variables/tokens/horizon';
+import { createHandsontableMuiColors } from './handsontableMuiColors';
+
+export function createMuiDataGridTheme(theme: Theme) {
+  return registerTheme('mui-data-grid', {
+    colors: createHandsontableMuiColors(theme),
+    tokens: tokensHorizon,
+  }).params({
+    tokens: {
+      // Match MUI's default rounded corners.
+      wrapperBorderRadius: '4px',
+    },
+  });
+}
+```
+
+## Step 5: Build a themed grid component
+
+Use `useTheme()` to read MUI palette values, then register and apply your custom Handsontable theme.
+
+**File: `src/components/MuiHotTable.tsx`**
+
+```tsx
+import { useMemo } from 'react';
+import { useTheme } from '@mui/material/styles';
+import { HotTable, HotColumn } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import { createMuiDataGridTheme } from '../theme/muiDataGridTheme';
+
+registerAllModules();
+
+const data = [
+  { name: 'Alice', age: 28, country: 'USA', status: true },
+  { name: 'Bob', age: 34, country: 'UK', status: false },
+  { name: 'Carla', age: 41, country: 'Germany', status: true },
+];
+
+export default function MuiHotTable() {
+  const theme = useTheme();
+  const hotTheme = useMemo(() => createMuiDataGridTheme(theme), [theme]);
+
+  return (
+    <HotTable
+      theme={hotTheme}
+      data={data}
+      colHeaders={['Name', 'Age', 'Country', 'Active']}
+      rowHeaders={true}
+      autoWrapRow={true}
+      width="100%"
+      height="auto"
+      licenseKey="non-commercial-and-evaluation"
+    >
+      <HotColumn data="name" width={160} />
+      <HotColumn data="age" type="numeric" width={100} />
+      <HotColumn data="country" width={160} />
+      <HotColumn data="status" type="checkbox" className="htCenter" width={120} />
+    </HotTable>
+  );
+}
+```
+
+## Step 6: Render inside MUI `ThemeProvider`
+
+Wrap your app with MUI's `ThemeProvider`, then render the table component.
+
+```tsx
+import { ThemeProvider, createTheme, CssBaseline } from '@mui/material';
+import MuiHotTable from './components/MuiHotTable';
+
+const theme = createTheme({
+  palette: {
+    mode: 'light',
+  },
+});
+
+export default function App() {
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <MuiHotTable />
+    </ThemeProvider>
+  );
+}
+```
+
+## Optional enhancements
+
+- Add a dark mode toggle in MUI, then re-create your Handsontable theme when MUI mode changes.
+- Add custom `icons` in `registerTheme()` to align sort/menu/filter icons with Material Symbols.
+- Override more Theme API tokens (for example spacing and border styles) to match your component library standards.
+
+## Related
+
+- [Themes](@/guides/styling/themes/themes.md) - Built-in themes and Theme API.
+- [Theme customization](@/guides/styling/theme-customization/theme-customization.md) - Theme API parameters and CSS variable reference.
+- [Theme Recipes](/recipes/themes) - Practical design-system recipes for Handsontable.

--- a/docs/content/recipes/themes/mui-theme/mui-theme.md
+++ b/docs/content/recipes/themes/mui-theme/mui-theme.md
@@ -22,7 +22,12 @@ searchCategory: Recipes
 category: Themes
 ---
 
-<iframe src="https://codesandbox.io/p/sandbox/y4vsfq" title="Handsontable with MUI demo" width="100%" height="500" frameborder="0" allowfullscreen style="border-radius: 8px; min-height: 500px;"></iframe>
+<iframe src="https://codesandbox.io/embed/y4vsfq?view=preview"
+  style="width:100%; height: 500px; border:0; border-radius: 4px; overflow:hidden;"
+  title="Handsontable with MUI recipe (icons fixed)"
+  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+></iframe>
 
 [**Open in CodeSandbox**](https://codesandbox.io/p/sandbox/y4vsfq)
 

--- a/docs/content/recipes/themes/mui-theme/mui-theme.md
+++ b/docs/content/recipes/themes/mui-theme/mui-theme.md
@@ -22,9 +22,9 @@ searchCategory: Recipes
 category: Themes
 ---
 
-<iframe src="https://codesandbox.io/p/sandbox/y6llzl" title="Handsontable with MUI demo" width="100%" height="500" frameborder="0" allowfullscreen style="border-radius: 8px; min-height: 500px;"></iframe>
+<iframe src="https://codesandbox.io/p/sandbox/y4vsfq" title="Handsontable with MUI demo" width="100%" height="500" frameborder="0" allowfullscreen style="border-radius: 8px; min-height: 500px;"></iframe>
 
-[**Open in CodeSandbox**](https://codesandbox.io/p/sandbox/y6llzl)
+[**Open in CodeSandbox**](https://codesandbox.io/p/sandbox/y4vsfq)
 
 ## Overview
 
@@ -36,7 +36,7 @@ This recipe shows how to integrate Handsontable into a React app that uses [MUI]
 
 ## What You'll Get
 
-- A reusable Handsontable theme (`registerTheme('mui-data-grid', { colors, tokens })`) that maps to your MUI palette.
+- A reusable Handsontable theme (`registerTheme('mui-data-grid', { icons, colors, tokens })`) that maps to your MUI palette.
 - A React grid component that uses the custom theme and keeps your MUI typography and spacing.
 - A base setup you can extend with dark mode and custom icons.
 
@@ -112,11 +112,13 @@ Register a custom Handsontable theme that uses your mapped colors and Horizon to
 ```ts
 import type { Theme } from '@mui/material/styles';
 import { registerTheme } from 'handsontable/themes';
+import iconsHorizon from 'handsontable/themes/static/variables/icons/horizon';
 import tokensHorizon from 'handsontable/themes/static/variables/tokens/horizon';
 import { createHandsontableMuiColors } from './handsontableMuiColors';
 
 export function createMuiDataGridTheme(theme: Theme) {
   return registerTheme('mui-data-grid', {
+    icons: iconsHorizon,
     colors: createHandsontableMuiColors(theme),
     tokens: tokensHorizon,
   }).params({

--- a/docs/content/recipes/themes/mui-theme/mui-theme.md
+++ b/docs/content/recipes/themes/mui-theme/mui-theme.md
@@ -22,9 +22,9 @@ searchCategory: Recipes
 category: Themes
 ---
 
-<iframe src="https://codesandbox.io/p/sandbox/72nz56" title="Handsontable with MUI demo" width="100%" height="500" frameborder="0" allowfullscreen style="border-radius: 8px; min-height: 500px;"></iframe>
+<iframe src="https://codesandbox.io/p/sandbox/y6llzl" title="Handsontable with MUI demo" width="100%" height="500" frameborder="0" allowfullscreen style="border-radius: 8px; min-height: 500px;"></iframe>
 
-[**Open in CodeSandbox**](https://codesandbox.io/p/sandbox/72nz56)
+[**Open in CodeSandbox**](https://codesandbox.io/p/sandbox/y6llzl)
 
 ## Overview
 

--- a/docs/content/recipes/themes/mui-theme/mui-theme.md
+++ b/docs/content/recipes/themes/mui-theme/mui-theme.md
@@ -22,6 +22,10 @@ searchCategory: Recipes
 category: Themes
 ---
 
+<iframe src="https://codesandbox.io/p/sandbox/72nz56" title="Handsontable with MUI demo" width="100%" height="500" frameborder="0" allowfullscreen style="border-radius: 8px; min-height: 500px;"></iframe>
+
+[**Open in CodeSandbox**](https://codesandbox.io/p/sandbox/72nz56)
+
 ## Overview
 
 This recipe shows how to integrate Handsontable into a React app that uses [MUI](https://mui.com/) by registering a custom theme with Theme API colors and tokens. The grid follows your Material UI design language.

--- a/docs/content/recipes/themes/themes.md
+++ b/docs/content/recipes/themes/themes.md
@@ -32,4 +32,9 @@ Our recipes cover common use cases and demonstrate best practices for:
 - **Design system integration** – Match the grid to shadcn/ui, Tailwind, or other design systems
 - **Theme API** – Register and configure themes with colors, density, and dark mode
 
+Current recipes:
+
+- [Handsontable with shadcn/ui](/recipes/themes/custom-theme)
+- [Handsontable with MUI](/recipes/themes/mui-theme)
+
 Each recipe includes complete code examples, configuration options, and troubleshooting tips to help you integrate Handsontable with your app's look and feel.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Context
Add a new recipe for implementing a design system with Handsontable using MUI (Material UI), based on the existing custom-theme recipe format.

### How has this been tested?
- Created a CodeSandbox using the CodeSandbox SDK API token flow and a React+MUI+Handsontable example pinned to `handsontable@0.0.0-next-deba76c-20260408`.
- Fixed sandbox runtime error by including required `icons` in `registerTheme(...)` (using Horizon icons).
- Updated recipe iframe to embed format with preview mode visible:
  - `https://codesandbox.io/embed/y4vsfq?view=preview`
- Kept Open in CodeSandbox link:
  - `https://codesandbox.io/p/sandbox/y4vsfq`
- Ran docs lint successfully in `docs/`.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. N/A
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed22fc9f-866f-456b-96c4-56d1167c581a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed22fc9f-866f-456b-96c4-56d1167c581a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

