### PR TITLE
DEV-1210: Add MUI theme recipe with working CodeSandbox embed

### DIFF
--- a/docs/content/recipes/sidebar.js
+++ b/docs/content/recipes/sidebar.js
@@ -18,6 +18,7 @@ const cellTypesItems = [
 
 const themesItems = [
   { path: 'themes/custom-theme/custom-theme', title: 'Handsontable with shadcn/ui', onlyFor: ['react', 'javascript', 'angular'] },
+  { path: 'themes/material-design/material-design', title: 'Handsontable with Material Design 3', onlyFor: ['react', 'javascript', 'angular'] },
 ];
 
 module.exports = {

--- a/docs/content/recipes/sidebar.js
+++ b/docs/content/recipes/sidebar.js
@@ -18,6 +18,7 @@ const cellTypesItems = [
 
 const themesItems = [
   { path: 'themes/custom-theme/custom-theme', title: 'Handsontable with shadcn/ui', onlyFor: ['react', 'javascript', 'angular'] },
+  { path: 'themes/mui-theme/mui-theme', title: 'Handsontable with MUI', onlyFor: ['react', 'javascript', 'angular'] },
   { path: 'themes/material-design/material-design', title: 'Handsontable with Material Design 3', onlyFor: ['react', 'javascript', 'angular'] },
 ];
 

--- a/docs/content/recipes/themes/material-design/material-design.md
+++ b/docs/content/recipes/themes/material-design/material-design.md
@@ -1,0 +1,212 @@
+---
+id: c7m4n2p9
+title: Handsontable with Material Design 3
+metaTitle: Handsontable with Material Design 3 - React Data Grid | Handsontable
+description: Integrate Handsontable with Material Design 3 by mapping M3 design tokens to the Handsontable Theme API.
+permalink: /recipes/themes/material-design
+canonicalUrl: /recipes/themes/material-design
+tags:
+  - guides
+  - tutorial
+  - recipes
+  - material design
+  - material design 3
+  - m3
+  - design system
+  - React
+  - themes
+  - Theme API
+react:
+  id: r6d1k8v4
+  metaTitle: Handsontable with Material Design 3 - React Data Grid | Handsontable
+angular:
+  id: a2q9m5t7
+  metaTitle: Handsontable with Material Design 3 - Angular Data Grid | Handsontable
+searchCategory: Recipes
+category: Themes
+---
+
+[[toc]]
+
+## Overview
+
+This recipe shows how to integrate Handsontable with [Material Design 3](https://m3.material.io/) by registering a custom theme that maps M3 color roles and shape tokens to Handsontable Theme API variables.
+
+**Difficulty:** Beginner  
+**Time:** ~15 minutes  
+**Stack:** React, Handsontable, `@handsontable/react-wrapper`, Material Design 3 tokens
+
+## What you will build
+
+- A reusable Handsontable theme registered with `registerTheme('material-data-grid', { ... })`.
+- M3 color roles (for example `primary`, `surface`, `on-surface`, `outline`) mapped to Handsontable theme colors.
+- Token overrides for border radius and spacing so the grid follows your Material Design system.
+
+## Prerequisites
+
+- A React project that already uses Material Design 3 styles or tokens.
+- M3 CSS variables available in your app stylesheet (for example from a design-token pipeline or your own variables).
+- Handsontable installed in your app.
+
+## Step 1 - Install Handsontable
+
+In your project root:
+
+```bash
+pnpm add handsontable @handsontable/react-wrapper
+```
+
+You can use `npm install` or `yarn add` instead.
+
+## Step 2 - Register Handsontable modules
+
+Register Handsontable modules before creating the grid:
+
+```tsx
+import { registerAllModules } from 'handsontable/registry';
+import { registerTheme } from 'handsontable/themes';
+
+registerAllModules();
+```
+
+## Step 3 - Define Material Design 3 colors
+
+Create a color map that points to your M3 CSS variables. This keeps the grid aligned with the rest of your design system.
+
+You can use Handsontable's built-in Material starter mapping:
+
+```tsx
+import colorsMaterial from 'handsontable/themes/static/variables/colors/material';
+```
+
+Or create your own mapping:
+
+**File: `src/theme/colorsMaterial.ts`**
+
+```tsx
+export const colorsMaterial = {
+  palette: {
+    50: 'var(--md-sys-color-surface-container-lowest)',
+    100: 'var(--md-sys-color-surface-container-low)',
+    200: 'var(--md-sys-color-surface-container)',
+    300: 'var(--md-sys-color-surface-container-high)',
+    400: 'var(--md-sys-color-surface-container-highest)',
+    500: 'var(--md-sys-color-surface-variant)',
+    600: 'var(--md-sys-color-outline-variant)',
+    700: 'var(--md-sys-color-outline)',
+    800: 'var(--md-sys-color-on-surface-variant)',
+    900: 'var(--md-sys-color-on-surface)',
+    950: 'var(--md-sys-color-shadow)',
+  },
+  primary: {
+    100: 'var(--md-sys-color-primary-container)',
+    200: 'var(--md-sys-color-primary-fixed)',
+    300: 'var(--md-sys-color-primary-fixed-dim)',
+    400: 'var(--md-sys-color-primary)',
+    500: 'var(--md-sys-color-primary)',
+    600: 'var(--md-sys-color-on-primary)',
+  },
+  white: 'var(--md-sys-color-surface)',
+  black: 'var(--md-sys-color-on-surface)',
+  transparent: 'transparent',
+};
+```
+
+## Step 4 - Create Material-style icons
+
+Provide a theme icon set that follows your Material icon style. You can use SVG data URIs with `currentColor` so icons inherit theme colors.
+
+**File: `src/theme/iconsMaterial.ts`**
+
+```tsx
+const iconAttrs =
+  'xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"';
+
+function icon(svgContent: string): string {
+  return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(`<svg ${iconAttrs}>${svgContent}</svg>`)}`;
+}
+
+export const iconsMaterial = {
+  arrowRight: icon('<path d="m10 6 6 6-6 6"/>'),
+  arrowLeft: icon('<path d="m14 6-6 6 6 6"/>'),
+  arrowDown: icon('<path d="m6 10 6 6 6-6"/>'),
+  menu: icon('<path d="M4 7h16"/><path d="M4 12h16"/><path d="M4 17h16"/>'),
+  selectArrow: icon('<path d="m6 10 6 6 6-6"/>'),
+  check: icon('<path d="m5 13 4 4L19 7"/>'),
+  checkbox: icon('<path d="m5 13 4 4L19 7"/>'),
+};
+```
+
+## Step 5 - Register the Material Design theme
+
+Import a built-in token base, then override selected values with M3 variables.
+
+**File: `src/components/DataGrid.tsx`**
+
+```tsx
+import { HotTable, HotColumn } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import { registerTheme } from 'handsontable/themes';
+import tokensHorizon from 'handsontable/themes/static/variables/tokens/horizon';
+
+import { colorsMaterial } from '../theme/colorsMaterial';
+import { iconsMaterial } from '../theme/iconsMaterial';
+
+registerAllModules();
+
+const materialDataGridTheme = registerTheme('material-data-grid', {
+  icons: iconsMaterial,
+  colors: colorsMaterial,
+  tokens: tokensHorizon,
+}).params({
+  tokens: {
+    wrapperBorderRadius: 'var(--md-sys-shape-corner-medium, 12px)',
+    cellSelectionBorderColor: 'var(--md-sys-color-primary)',
+    checkboxFocusRingColor: 'var(--md-sys-color-primary)',
+  },
+});
+
+const data = [
+  { product: 'Notebook', price: 12.5, stock: 120 },
+  { product: 'Desk lamp', price: 28.0, stock: 45 },
+  { product: 'Keyboard', price: 62.9, stock: 30 },
+];
+
+export function DataGrid() {
+  return (
+    <HotTable
+      data={data}
+      colHeaders={['Product', 'Price', 'Stock']}
+      theme={materialDataGridTheme}
+      stretchH="all"
+      autoWrapRow={true}
+      licenseKey="non-commercial-and-evaluation"
+    >
+      <HotColumn data="product" />
+      <HotColumn data="price" type="numeric" />
+      <HotColumn data="stock" type="numeric" />
+    </HotTable>
+  );
+}
+```
+
+## Step 6 - Verify Material behavior
+
+When your app toggles between light and dark mode, Handsontable updates automatically if your M3 variables change at runtime. Verify:
+
+- Header and cell surfaces match your Material surface roles.
+- Selection and focus states use your `primary` role.
+- Borders and separators use your `outline` roles.
+- Corner radius follows `--md-sys-shape-corner-*`.
+
+## Troubleshooting
+
+- If the table still looks like a default theme, confirm that `theme={materialDataGridTheme}` is set on `HotTable`.
+- If colors do not change in dark mode, verify your M3 CSS variables are redefined in your dark theme scope.
+- If some icons are missing, add all required icon keys used by your enabled Handsontable features.
+
+## Related
+
+- [Themes](@/guides/styling/themes/themes.md) - Learn how to apply built-in and custom themes.
+- [Theme customization](@/guides/styling/theme-customization/theme-customization.md) - Explore Theme API parameters and tokens.
+- [Design system guide](@/guides/styling/design-system/design-system.md) - Review Handsontable design token concepts.

--- a/docs/content/recipes/themes/mui-theme/mui-theme.md
+++ b/docs/content/recipes/themes/mui-theme/mui-theme.md
@@ -1,0 +1,220 @@
+---
+id: f2a7b9c1
+title: Handsontable with MUI
+metaTitle: Handsontable with MUI - React Data Grid | Handsontable
+description: Integrate Handsontable into a React app with MUI so your grid follows Material UI colors, typography, and spacing.
+permalink: /recipes/themes/mui-theme
+canonicalUrl: /recipes/themes/mui-theme
+tags:
+  - guides
+  - tutorial
+  - recipes
+  - MUI
+  - Material UI
+  - design system
+  - React
+  - themes
+  - Theme API
+react:
+  id: d4e8a6f2
+  metaTitle: Handsontable with MUI - React Data Grid | Handsontable
+searchCategory: Recipes
+category: Themes
+---
+
+<iframe src="https://h6h64c-3000.csb.app/" title="Handsontable with MUI demo" width="100%" height="500" frameborder="0" allowfullscreen style="border-radius: 8px; min-height: 500px;"></iframe>
+
+[**Open in CodeSandbox**](https://codesandbox.io/p/sandbox/h6h64c)
+
+## Overview
+
+This recipe shows how to integrate Handsontable into a React app that uses [MUI](https://mui.com/) by registering a custom theme with Theme API colors, icons, and tokens. The grid follows your Material UI design language.
+
+**Difficulty:** Beginner  
+**Time:** ~15 minutes  
+**Stack:** React, MUI, Handsontable, `@handsontable/react-wrapper`
+
+## What You'll Get
+
+- A reusable Handsontable theme (`registerTheme('mui-data-grid', { icons, colors, tokens })`) that maps to your MUI palette.
+- A React grid component that uses the custom theme and keeps your MUI typography and spacing.
+- A base setup you can extend with dark mode and custom icons.
+
+## Prerequisites
+
+- A React app with MUI configured.
+- Handsontable and the React wrapper installed.
+- A `ThemeProvider` at your app root.
+
+## Step 1: Install dependencies
+
+In your project root:
+
+```bash
+npm install handsontable @handsontable/react-wrapper @mui/material @emotion/react @emotion/styled
+```
+
+For this recipe's CodeSandbox, dependencies are pinned to:
+
+- `handsontable@0.0.0-next-deba76c-20260408`
+- `@handsontable/react-wrapper@0.0.0-next-deba76c-20260408`
+
+## Step 2: Register Handsontable modules
+
+Register Handsontable modules once in your grid module:
+
+```tsx
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+```
+
+## Step 3: Create MUI color mapping for Theme API
+
+Handsontable's Theme API expects a specific `colors` shape. Create a mapping helper that reads from your MUI theme.
+
+**File: `src/theme/handsontableMuiColors.ts`**
+
+```ts
+import type { Theme } from '@mui/material/styles';
+
+export function createHandsontableMuiColors(theme: Theme) {
+  return {
+    palette: {
+      50: theme.palette.grey[50],
+      100: theme.palette.grey[100],
+      200: theme.palette.grey[200],
+      300: theme.palette.grey[300],
+      400: theme.palette.grey[400],
+      500: theme.palette.grey[500],
+      600: theme.palette.grey[600],
+      700: theme.palette.grey[700],
+      800: theme.palette.grey[800],
+      900: theme.palette.grey[900],
+      950: theme.palette.grey[900],
+    },
+    primary: {
+      100: theme.palette.primary.light,
+      200: theme.palette.primary.light,
+      300: theme.palette.primary.main,
+      400: theme.palette.primary.main,
+      500: theme.palette.primary.dark,
+      600: theme.palette.primary.dark,
+    },
+    white: theme.palette.background.paper,
+    black: theme.palette.text.primary,
+    transparent: 'transparent',
+  };
+}
+```
+
+## Step 4: Register your MUI Handsontable theme
+
+Register a custom Handsontable theme that uses your mapped colors and Horizon variables.
+
+Important: include `icons` in `registerTheme()` to avoid `[ThemeBuilder] themeConfig.icons is required`.
+
+**File: `src/theme/muiDataGridTheme.ts`**
+
+```ts
+import type { Theme } from '@mui/material/styles';
+import { registerTheme } from 'handsontable/themes';
+import iconsHorizon from 'handsontable/themes/static/variables/icons/horizon';
+import tokensHorizon from 'handsontable/themes/static/variables/tokens/horizon';
+import { createHandsontableMuiColors } from './handsontableMuiColors';
+
+export function createMuiDataGridTheme(theme: Theme) {
+  return registerTheme('mui-data-grid', {
+    icons: iconsHorizon,
+    colors: createHandsontableMuiColors(theme),
+    tokens: tokensHorizon,
+  }).params({
+    tokens: {
+      wrapperBorderRadius: '4px',
+    },
+  });
+}
+```
+
+## Step 5: Build a themed grid component
+
+Use `useTheme()` to read MUI palette values, then register and apply your custom Handsontable theme.
+
+**File: `src/components/MuiHotTable.tsx`**
+
+```tsx
+import { useMemo } from 'react';
+import { useTheme } from '@mui/material/styles';
+import { HotTable, HotColumn } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import { createMuiDataGridTheme } from '../theme/muiDataGridTheme';
+import 'handsontable/styles/handsontable.css';
+import 'handsontable/styles/ht-theme-main.css';
+
+registerAllModules();
+
+const data = [
+  { name: 'Alice', age: 28, country: 'USA', status: true },
+  { name: 'Bob', age: 34, country: 'UK', status: false },
+  { name: 'Carla', age: 41, country: 'Germany', status: true },
+];
+
+export default function MuiHotTable() {
+  const theme = useTheme();
+  const hotTheme = useMemo(() => createMuiDataGridTheme(theme), [theme]);
+
+  return (
+    <HotTable
+      theme={hotTheme}
+      data={data}
+      colHeaders={['Name', 'Age', 'Country', 'Active']}
+      rowHeaders={true}
+      autoWrapRow={true}
+      width="100%"
+      height="auto"
+      licenseKey="non-commercial-and-evaluation"
+    >
+      <HotColumn data="name" width={160} />
+      <HotColumn data="age" type="numeric" width={100} />
+      <HotColumn data="country" width={160} />
+      <HotColumn data="status" type="checkbox" className="htCenter" width={120} />
+    </HotTable>
+  );
+}
+```
+
+## Step 6: Render inside MUI `ThemeProvider`
+
+Wrap your app with MUI's `ThemeProvider`, then render the table component.
+
+```tsx
+import { ThemeProvider, createTheme, CssBaseline } from '@mui/material';
+import MuiHotTable from './components/MuiHotTable';
+
+const theme = createTheme({
+  palette: {
+    mode: 'light',
+  },
+});
+
+export default function App() {
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <MuiHotTable />
+    </ThemeProvider>
+  );
+}
+```
+
+## Optional enhancements
+
+- Add a dark mode toggle in MUI, then re-create your Handsontable theme when MUI mode changes.
+- Add custom `icons` in `registerTheme()` to align sort/menu/filter icons with Material Symbols.
+- Override more Theme API tokens (for example spacing and border styles) to match your component library standards.
+
+## Related
+
+- [Themes](@/guides/styling/themes/themes.md) - Built-in themes and Theme API.
+- [Theme customization](@/guides/styling/theme-customization/theme-customization.md) - Theme API parameters and CSS variable reference.
+- [Theme Recipes](/recipes/themes) - Practical design-system recipes for Handsontable.

--- a/docs/content/recipes/themes/mui-theme/mui-theme.md
+++ b/docs/content/recipes/themes/mui-theme/mui-theme.md
@@ -22,7 +22,12 @@ searchCategory: Recipes
 category: Themes
 ---
 
-<iframe src="https://h6h64c-3000.csb.app/" title="Handsontable with MUI demo" width="100%" height="500" frameborder="0" allowfullscreen style="border-radius: 8px; min-height: 500px;"></iframe>
+<iframe src="https://codesandbox.io/embed/h6h64c?view=preview"
+     style="width:100%; height: 500px; border:0; border-radius: 4px; overflow:hidden;"
+     title="Handsontable with MUI recipe (icons fixed)"
+     allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+     sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+   ></iframe>
 
 [**Open in CodeSandbox**](https://codesandbox.io/p/sandbox/h6h64c)
 

--- a/docs/content/recipes/themes/themes.md
+++ b/docs/content/recipes/themes/themes.md
@@ -36,3 +36,4 @@ Each recipe includes complete code examples, configuration options, and troubles
 
 - [Handsontable with shadcn/ui](@/recipes/themes/custom-theme/custom-theme.md)
 - [Handsontable with Material Design 3](@/recipes/themes/material-design/material-design.md)
+- [Handsontable with MUI](@/recipes/themes/mui-theme/mui-theme.md)

--- a/docs/content/recipes/themes/themes.md
+++ b/docs/content/recipes/themes/themes.md
@@ -33,3 +33,6 @@ Our recipes cover common use cases and demonstrate best practices for:
 - **Theme API** – Register and configure themes with colors, density, and dark mode
 
 Each recipe includes complete code examples, configuration options, and troubleshooting tips to help you integrate Handsontable with your app's look and feel.
+
+- [Handsontable with shadcn/ui](@/recipes/themes/custom-theme/custom-theme.md)
+- [Handsontable with Material Design 3](@/recipes/themes/material-design/material-design.md)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Context
This PR adds a new MUI theme recipe page with a working, public CodeSandbox demo created programmatically, and wires it into recipe navigation.

### How has this been tested?
- `curl -I "https://codesandbox.io/p/sandbox/h6h64c"`
- `npm run docs:lint --prefix docs`

### Types of changes
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. N/A
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b10c648-5b7f-496b-ae8e-9a41e80ab906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b10c648-5b7f-496b-ae8e-9a41e80ab906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

