### PR TITLE
DEV-1214: docs: add Base Web theme recipe

### DIFF
--- a/docs/content/recipes/sidebar.js
+++ b/docs/content/recipes/sidebar.js
@@ -17,6 +17,7 @@ const cellTypesItems = [
 ];
 
 const themesItems = [
+  { path: 'themes/base-theme/base-theme', title: 'Handsontable with Base Web', onlyFor: ['react', 'javascript', 'angular'] },
   { path: 'themes/custom-theme/custom-theme', title: 'Handsontable with shadcn/ui', onlyFor: ['react', 'javascript', 'angular'] },
 ];
 

--- a/docs/content/recipes/themes/base-theme/base-theme.md
+++ b/docs/content/recipes/themes/base-theme/base-theme.md
@@ -25,14 +25,14 @@ searchCategory: Recipes
 category: Themes
 ---
 
-<iframe src="https://codesandbox.io/embed/k3vmf8?view=preview"
+<iframe src="https://codesandbox.io/embed/57v662?view=preview"
   style="width:100%; height: 500px; border:0; border-radius: 4px; overflow:hidden;"
   title="Handsontable with Base Web recipe"
   allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
 ></iframe>
 
-[**Open in CodeSandbox**](https://codesandbox.io/p/sandbox/k3vmf8)
+[**Open in CodeSandbox**](https://codesandbox.io/p/sandbox/57v662)
 
 ## Overview
 

--- a/docs/content/recipes/themes/base-theme/base-theme.md
+++ b/docs/content/recipes/themes/base-theme/base-theme.md
@@ -25,14 +25,14 @@ searchCategory: Recipes
 category: Themes
 ---
 
-<iframe src="https://codesandbox.io/embed/qr6x9m?view=preview"
+<iframe src="https://codesandbox.io/embed/2mmgyv?view=preview"
   style="width:100%; height: 500px; border:0; border-radius: 4px; overflow:hidden;"
   title="Handsontable with Base Web recipe"
   allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
 ></iframe>
 
-[**Open in CodeSandbox**](https://codesandbox.io/p/sandbox/qr6x9m)
+[**Open in CodeSandbox**](https://codesandbox.io/p/sandbox/2mmgyv)
 
 ## Overview
 

--- a/docs/content/recipes/themes/base-theme/base-theme.md
+++ b/docs/content/recipes/themes/base-theme/base-theme.md
@@ -25,6 +25,10 @@ searchCategory: Recipes
 category: Themes
 ---
 
+<iframe src="https://codesandbox.io/p/sandbox/qr6x9m" title="Handsontable with Base Web demo" width="100%" height="500" frameborder="0" allowfullscreen style="border-radius: 8px; min-height: 500px;"></iframe>
+
+[**Open in CodeSandbox**](https://codesandbox.io/p/sandbox/qr6x9m)
+
 ## Overview
 
 This recipe shows how to integrate Handsontable into a React app that uses [Base Web](https://baseweb.design/). You register a custom Handsontable theme that maps Base Web design tokens to Handsontable colors and tokens, so the grid follows your system styles.
@@ -50,7 +54,7 @@ This recipe shows how to integrate Handsontable into a React app that uses [Base
 Install Handsontable and the React wrapper in your project root:
 
 ```bash
-pnpm add handsontable @handsontable/react-wrapper
+pnpm add handsontable@0.0.0-next-deba76c-20260408 @handsontable/react-wrapper@0.0.0-next-deba76c-20260408
 ```
 
 If you are creating a new Base setup, install Base Web and Styletron as well:

--- a/docs/content/recipes/themes/base-theme/base-theme.md
+++ b/docs/content/recipes/themes/base-theme/base-theme.md
@@ -25,14 +25,14 @@ searchCategory: Recipes
 category: Themes
 ---
 
-<iframe src="https://codesandbox.io/embed/2mmgyv?view=preview"
+<iframe src="https://codesandbox.io/embed/k3vmf8?view=preview"
   style="width:100%; height: 500px; border:0; border-radius: 4px; overflow:hidden;"
   title="Handsontable with Base Web recipe"
   allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
 ></iframe>
 
-[**Open in CodeSandbox**](https://codesandbox.io/p/sandbox/2mmgyv)
+[**Open in CodeSandbox**](https://codesandbox.io/p/sandbox/k3vmf8)
 
 ## Overview
 

--- a/docs/content/recipes/themes/base-theme/base-theme.md
+++ b/docs/content/recipes/themes/base-theme/base-theme.md
@@ -1,0 +1,216 @@
+---
+id: q7n4k2p9
+title: Handsontable with Base Web
+metaTitle: Handsontable with Base Web - React Data Grid | Handsontable
+description: Integrate Handsontable into a React app using Base Web and style a custom theme with your design tokens so the grid matches your design system.
+permalink: /recipes/themes/base-theme
+canonicalUrl: /recipes/themes/base-theme
+tags:
+  - guides
+  - tutorial
+  - recipes
+  - base web
+  - design system
+  - React
+  - themes
+  - Theme API
+  - custom theme
+react:
+  id: t3m8v6c1
+  metaTitle: Handsontable with Base Web - React Data Grid | Handsontable
+angular:
+  id: w5r2d8h4
+  metaTitle: Handsontable with Base Web - Angular Data Grid | Handsontable
+searchCategory: Recipes
+category: Themes
+---
+
+## Overview
+
+This recipe shows how to integrate Handsontable into a React app that uses [Base Web](https://baseweb.design/). You register a custom Handsontable theme that maps Base Web design tokens to Handsontable colors and tokens, so the grid follows your system styles.
+
+**Difficulty:** Beginner  
+**Time:** ~20 minutes  
+**Stack:** React, Base Web, Styletron, Handsontable, `@handsontable/react-wrapper`
+
+## What You'll Get
+
+- A Handsontable grid with a custom theme registered through `registerTheme('base-data-grid', { icons, colors, tokens })`.
+- A color mapping layer that uses your Base token variables, such as `--bds-primary-a`, `--bds-background-primary`, and `--bds-content-primary`.
+- Theme token overrides for spacing and radius, so the grid matches Base Web's component shape and density.
+
+## Prerequisites
+
+- A React app with Base Web set up (including `BaseProvider` and Styletron engine).
+- Base design tokens exposed as CSS variables in your global stylesheet.
+- Handsontable and the React wrapper installed.
+
+## Step 1: Install dependencies
+
+Install Handsontable and the React wrapper in your project root:
+
+```bash
+pnpm add handsontable @handsontable/react-wrapper
+```
+
+If you are creating a new Base setup, install Base Web and Styletron as well:
+
+```bash
+pnpm add baseui styletron-engine-atomic styletron-react
+```
+
+## Step 2: Register Handsontable modules
+
+Register Handsontable modules once before rendering the grid.
+
+```tsx
+import { registerAllModules } from 'handsontable/registry';
+import { registerTheme } from 'handsontable/themes';
+
+registerAllModules();
+```
+
+## Step 3: Map Base design tokens to Handsontable colors
+
+Create a colors object that maps Handsontable color keys to your Base CSS variables.
+
+**File: `src/theme/colorsBase.ts`**
+
+```tsx
+/**
+ * Maps Handsontable theme colors to Base Web design tokens.
+ * Keep this object focused on color variables so you can swap brands by changing token values only.
+ */
+export const colorsBase = {
+  palette: {
+    50: 'var(--bds-background-tertiary)',
+    100: 'var(--bds-background-secondary)',
+    200: 'var(--bds-background-primary)',
+    300: 'var(--bds-border-opaque)',
+    400: 'var(--bds-content-tertiary)',
+    500: 'var(--bds-content-secondary)',
+    600: 'var(--bds-content-primary)',
+    700: 'var(--bds-content-inverse-secondary)',
+    800: 'var(--bds-content-inverse-primary)',
+    900: 'var(--bds-background-inverse-primary)',
+    950: 'var(--bds-background-inverse-secondary)',
+  },
+  primary: {
+    100: 'var(--bds-primary-a)',
+    200: 'var(--bds-primary-b)',
+    300: 'var(--bds-primary)',
+    400: 'var(--bds-primary-hover)',
+    500: 'var(--bds-primary-active)',
+    600: 'var(--bds-content-primary)',
+  },
+  white: 'var(--bds-background-primary)',
+  black: 'var(--bds-content-primary)',
+  transparent: 'transparent',
+};
+```
+
+If your app does not yet expose token variables, define them in your global stylesheet and keep names consistent with your design system naming convention.
+
+## Step 4: Define icons and tokens
+
+You can reuse Handsontable's built-in icon and token sets, then override only what you need.
+
+```tsx
+import iconsMain from 'handsontable/themes/static/variables/icons/main';
+import tokensHorizon from 'handsontable/themes/static/variables/tokens/horizon';
+```
+
+For most Base Web integrations, start with the built-ins and only override shape and spacing tokens:
+
+```tsx
+const baseThemeTokenOverrides = {
+  wrapperBorderRadius: 'var(--bds-radius-200)',
+  buttonBorderRadius: 'var(--bds-radius-200)',
+  menuBorderRadius: 'var(--bds-radius-300)',
+  inputBorderRadius: 'var(--bds-radius-200)',
+};
+```
+
+## Step 5: Register and use the Base theme
+
+Create and register your theme, then pass it to `HotTable`.
+
+```tsx
+import React from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerTheme } from 'handsontable/themes';
+import { registerAllModules } from 'handsontable/registry';
+import iconsMain from 'handsontable/themes/static/variables/icons/main';
+import tokensHorizon from 'handsontable/themes/static/variables/tokens/horizon';
+import { colorsBase } from './theme/colorsBase';
+
+registerAllModules();
+
+const baseDataGridTheme = registerTheme('base-data-grid', {
+  icons: iconsMain,
+  colors: colorsBase,
+  tokens: tokensHorizon,
+}).params({
+  tokens: {
+    wrapperBorderRadius: 'var(--bds-radius-200)',
+    buttonBorderRadius: 'var(--bds-radius-200)',
+    menuBorderRadius: 'var(--bds-radius-300)',
+    inputBorderRadius: 'var(--bds-radius-200)',
+  },
+});
+
+const data = [
+  { name: 'Alice', role: 'Designer', location: 'New York', active: true },
+  { name: 'Jon', role: 'Engineer', location: 'Berlin', active: false },
+  { name: 'Lina', role: 'Product Manager', location: 'Warsaw', active: true },
+];
+
+export default function BaseThemeExample() {
+  return (
+    <HotTable
+      theme={baseDataGridTheme}
+      data={data}
+      width="100%"
+      height="auto"
+      rowHeaders={true}
+      colHeaders={['Name', 'Role', 'Location', 'Active']}
+      columns={[
+        { data: 'name' },
+        { data: 'role' },
+        { data: 'location' },
+        { data: 'active', type: 'checkbox' },
+      ]}
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+}
+```
+
+## Step 6: Keep styles consistent with Base Web
+
+When you tune the grid, follow this order:
+
+1. Update Base token values in one place.
+2. Reuse those tokens through your `colorsBase` object.
+3. Override only the minimum Handsontable tokens with `.params({ tokens: ... })`.
+
+This keeps the grid aligned with system-level style updates and avoids one-off CSS overrides.
+
+## Troubleshooting
+
+### Theme does not apply.
+
+- Confirm the registered theme object is passed to `theme`, not a string class name.
+- Make sure `registerAllModules()` runs before rendering `HotTable`.
+- Check that your CSS variables are available on the grid container.
+
+### Colors look incorrect in dark mode.
+
+- Verify your app switches the same token variables that `colorsBase` uses.
+- Avoid hardcoded hex values in `colorsBase` when your app relies on dynamic themes.
+
+## Related
+
+- [Themes](/themes) - Built-in themes and Theme API.
+- [Theme customization](/theme-customization) - Theme API parameters and CSS variable reference.
+- [Design system (Figma)](/handsontable-design-system) - Figma kit and design tokens.

--- a/docs/content/recipes/themes/base-theme/base-theme.md
+++ b/docs/content/recipes/themes/base-theme/base-theme.md
@@ -25,14 +25,14 @@ searchCategory: Recipes
 category: Themes
 ---
 
-<iframe src="https://codesandbox.io/embed/57v662?view=preview"
+<iframe src="https://codesandbox.io/embed/3ctq7w?view=preview"
   style="width:100%; height: 500px; border:0; border-radius: 4px; overflow:hidden;"
   title="Handsontable with Base Web recipe"
   allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
 ></iframe>
 
-[**Open in CodeSandbox**](https://codesandbox.io/p/sandbox/57v662)
+[**Open in CodeSandbox**](https://codesandbox.io/p/sandbox/3ctq7w)
 
 ## Overview
 

--- a/docs/content/recipes/themes/base-theme/base-theme.md
+++ b/docs/content/recipes/themes/base-theme/base-theme.md
@@ -25,7 +25,12 @@ searchCategory: Recipes
 category: Themes
 ---
 
-<iframe src="https://codesandbox.io/p/sandbox/qr6x9m" title="Handsontable with Base Web demo" width="100%" height="500" frameborder="0" allowfullscreen style="border-radius: 8px; min-height: 500px;"></iframe>
+<iframe src="https://codesandbox.io/embed/qr6x9m?view=preview"
+  style="width:100%; height: 500px; border:0; border-radius: 4px; overflow:hidden;"
+  title="Handsontable with Base Web recipe"
+  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+></iframe>
 
 [**Open in CodeSandbox**](https://codesandbox.io/p/sandbox/qr6x9m)
 

--- a/docs/content/recipes/themes/themes.md
+++ b/docs/content/recipes/themes/themes.md
@@ -33,3 +33,6 @@ Our recipes cover common use cases and demonstrate best practices for:
 - **Theme API** – Register and configure themes with colors, density, and dark mode
 
 Each recipe includes complete code examples, configuration options, and troubleshooting tips to help you integrate Handsontable with your app's look and feel.
+
+- [Handsontable with shadcn/ui](/recipes/themes/custom-theme)
+- [Handsontable with Base Web](/recipes/themes/base-theme)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Context
Adds a new recipe page for implementing a custom Handsontable theme with Base Web, using the existing custom-theme recipe structure as reference.

[skip changelog]

### How has this been tested?
- `python3` + CodeSandbox Define API (`https://codesandbox.io/api/v1/sandboxes/define?json=1`) - created public sandbox `qr6x9m` with pinned Handsontable next versions.
- `python3` check against `https://codesandbox.io/api/v1/sandboxes/qr6x9m` - confirmed `id`, `alias`, and `registerTheme('base-data-grid', { icons, colors, tokens })` in source.
- `curl -I -sS https://codesandbox.io/p/sandbox/qr6x9m` - URL resolves (`HTTP/2 200`).
- `npm run docs:lint --prefix docs` - pass.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. N/A
2. 
3. 

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0acc5b19-a07f-407f-bf2e-60fa39beb537"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0acc5b19-a07f-407f-bf2e-60fa39beb537"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

