### PR TITLE
DEV-1209: Add Ant Design theme recipe documentation

### DIFF
--- a/docs/content/recipes/sidebar.js
+++ b/docs/content/recipes/sidebar.js
@@ -18,6 +18,7 @@ const cellTypesItems = [
 
 const themesItems = [
   { path: 'themes/custom-theme/custom-theme', title: 'Handsontable with shadcn/ui', onlyFor: ['react', 'javascript', 'angular'] },
+  { path: 'themes/ant-design/ant-design', title: 'Handsontable with Ant Design', onlyFor: ['react', 'javascript', 'angular'] },
 ];
 
 module.exports = {

--- a/docs/content/recipes/themes/ant-design/ant-design.md
+++ b/docs/content/recipes/themes/ant-design/ant-design.md
@@ -24,6 +24,15 @@ searchCategory: Recipes
 category: Themes
 ---
 
+<iframe src="https://codesandbox.io/embed/ylxwyx?view=preview"
+  style="width:100%; height: 500px; border:0; border-radius: 4px; overflow:hidden;"
+  title="Handsontable with Ant Design recipe (icons fixed)"
+  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+></iframe>
+
+[**Open in CodeSandbox**](https://codesandbox.io/p/sandbox/ylxwyx)
+
 ## Overview
 
 This recipe shows how to integrate Handsontable into a React app that uses [Ant Design](https://ant.design/) by registering a custom theme. You map Handsontable theme colors and tokens to Ant Design tokens, so the grid follows your UI system.
@@ -34,7 +43,7 @@ This recipe shows how to integrate Handsontable into a React app that uses [Ant 
 
 ## What You'll Get
 
-- A Handsontable grid with a custom theme registered through `registerTheme('ant-data-grid', ...)`.
+- A Handsontable grid with a custom theme registered through `registerTheme('ant-data-grid', { icons, colors, tokens })`.
 - Theme colors based on Handsontable's built-in Ant palette (`colors/ant`) with token-based overrides.
 - Spacing, typography, and border radius aligned with Ant Design tokens.
 
@@ -48,7 +57,7 @@ This recipe shows how to integrate Handsontable into a React app that uses [Ant 
 In your project root:
 
 ```bash
-pnpm add handsontable @handsontable/react-wrapper antd
+npm install handsontable@0.0.0-next-deba76c-20260408 @handsontable/react-wrapper@0.0.0-next-deba76c-20260408 antd
 ```
 
 (or `npm install` / `yarn add`).
@@ -61,11 +70,13 @@ Create a shared theme module, and register all Handsontable modules.
 import { registerAllModules } from 'handsontable/registry';
 import { registerTheme } from 'handsontable/themes';
 import colorsAnt from 'handsontable/themes/static/variables/colors/ant';
+import iconsHorizon from 'handsontable/themes/static/variables/icons/horizon';
 import tokensHorizon from 'handsontable/themes/static/variables/tokens/horizon';
 
 registerAllModules();
 
 export const antDataGridTheme = registerTheme('ant-data-grid', {
+  icons: iconsHorizon,
   colors: colorsAnt,
   tokens: tokensHorizon,
 }).params({

--- a/docs/content/recipes/themes/ant-design/ant-design.md
+++ b/docs/content/recipes/themes/ant-design/ant-design.md
@@ -1,0 +1,186 @@
+---
+id: f2a9c4d1
+title: Handsontable with Ant Design
+metaTitle: Handsontable with Ant Design - React Data Grid | Handsontable
+description: Integrate Handsontable into a React app that uses Ant Design, and align the grid with your design system tokens through the Theme API.
+permalink: /recipes/themes/ant-design
+canonicalUrl: /recipes/themes/ant-design
+tags:
+  - guides
+  - tutorial
+  - recipes
+  - ant design
+  - design system
+  - React
+  - themes
+  - Theme API
+react:
+  id: a8d3e6f2
+  metaTitle: Handsontable with Ant Design - React Data Grid | Handsontable
+angular:
+  id: c4b7e1a9
+  metaTitle: Handsontable with Ant Design - Angular Data Grid | Handsontable
+searchCategory: Recipes
+category: Themes
+---
+
+## Overview
+
+This recipe shows how to integrate Handsontable into a React app that uses [Ant Design](https://ant.design/) by registering a custom theme. You map Handsontable theme colors and tokens to Ant Design tokens, so the grid follows your UI system.
+
+**Difficulty:** Beginner  
+**Time:** ~15 minutes  
+**Stack:** React, Ant Design, Handsontable, `@handsontable/react-wrapper`
+
+## What You'll Get
+
+- A Handsontable grid with a custom theme registered through `registerTheme('ant-data-grid', ...)`.
+- Theme colors based on Handsontable's built-in Ant palette (`colors/ant`) with token-based overrides.
+- Spacing, typography, and border radius aligned with Ant Design tokens.
+
+## Prerequisites
+
+- A React app with Ant Design already configured.
+- `handsontable` and `@handsontable/react-wrapper` installed in your app.
+
+## Step 1: Install dependencies
+
+In your project root:
+
+```bash
+pnpm add handsontable @handsontable/react-wrapper antd
+```
+
+(or `npm install` / `yarn add`).
+
+## Step 2: Register modules and create a base Ant theme
+
+Create a shared theme module, and register all Handsontable modules.
+
+```tsx
+import { registerAllModules } from 'handsontable/registry';
+import { registerTheme } from 'handsontable/themes';
+import colorsAnt from 'handsontable/themes/static/variables/colors/ant';
+import tokensHorizon from 'handsontable/themes/static/variables/tokens/horizon';
+
+registerAllModules();
+
+export const antDataGridTheme = registerTheme('ant-data-grid', {
+  colors: colorsAnt,
+  tokens: tokensHorizon,
+}).params({
+  tokens: {
+    wrapperBorderRadius: '8px',
+    fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
+  },
+});
+```
+
+## Step 3: Map Ant Design tokens to Handsontable theme params
+
+Use Ant Design's token hook to keep Handsontable in sync with your active Ant Design theme.
+
+```tsx
+import { theme as antdTheme } from 'antd';
+import colorsAnt from 'handsontable/themes/static/variables/colors/ant';
+import { antDataGridTheme } from './theme';
+
+export function useAntHandsontableTheme() {
+  const { token } = antdTheme.useToken();
+
+  return antDataGridTheme.params({
+    colors: {
+      ...colorsAnt,
+      primary: {
+        ...colorsAnt.primary,
+        500: token.colorPrimary,
+        600: token.colorPrimaryHover,
+      },
+      white: token.colorBgContainer,
+      black: token.colorText,
+    },
+    tokens: {
+      backgroundColor: token.colorBgContainer,
+      foregroundColor: token.colorText,
+      borderColor: token.colorBorder,
+      accentColor: token.colorPrimary,
+      wrapperBorderRadius: `${token.borderRadius}px`,
+      fontFamily: token.fontFamily,
+      fontSize: `${token.fontSize}px`,
+    },
+  });
+}
+```
+
+## Step 4: Create the grid component
+
+Pass the mapped theme to `HotTable`.
+
+```tsx
+import { HotTable } from '@handsontable/react-wrapper';
+import { useMemo } from 'react';
+import { useAntHandsontableTheme } from './useAntHandsontableTheme';
+
+const data = [
+  { name: 'Alice', role: 'Designer', country: 'USA' },
+  { name: 'Bob', role: 'Engineer', country: 'Germany' },
+  { name: 'Carla', role: 'Product', country: 'UK' },
+];
+
+export function AntDesignGrid() {
+  const theme = useAntHandsontableTheme();
+  const columns = useMemo(() => ([
+    { data: 'name', title: 'Name' },
+    { data: 'role', title: 'Role' },
+    { data: 'country', title: 'Country' },
+  ]), []);
+
+  return (
+    <HotTable
+      data={data}
+      colHeaders
+      columns={columns}
+      theme={theme}
+      height="auto"
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+}
+```
+
+## Step 5: Wrap with `ConfigProvider`
+
+Control your Ant Design theme (light, dark, custom brand), and Handsontable will reuse those values through your token mapping.
+
+```tsx
+import { ConfigProvider, theme as antdTheme } from 'antd';
+import { AntDesignGrid } from './AntDesignGrid';
+
+export function App() {
+  return (
+    <ConfigProvider
+      theme={{
+        algorithm: antdTheme.defaultAlgorithm,
+        token: {
+          colorPrimary: '#1677ff',
+          borderRadius: 8,
+        },
+      }}
+    >
+      <AntDesignGrid />
+    </ConfigProvider>
+  );
+}
+```
+
+## Tips
+
+- Keep one source of truth - prefer Ant Design tokens as your source, and map Handsontable theme params from those tokens.
+- Start with `colors/ant`, then override only the values you need.
+- Use the same token map for dark mode, and switch it through Ant Design's `ConfigProvider`.
+
+## Related
+
+- [Themes](/themes) - Built-in themes and Theme API.
+- [Theme customization](/theme-customization) - Theme API params and CSS variable reference.
+- [Theme Recipes](/recipes/themes) - More recipes for design-system integration.

--- a/docs/content/recipes/themes/themes.md
+++ b/docs/content/recipes/themes/themes.md
@@ -29,7 +29,7 @@ Before diving into specific recipes, we recommend reading our [Themes guide](@/g
 
 Our recipes cover common use cases and demonstrate best practices for:
 
-- **Design system integration** – Match the grid to shadcn/ui, Tailwind, or other design systems
+- **Design system integration** – Match the grid to Ant Design, shadcn/ui, Tailwind, or other design systems
 - **Theme API** – Register and configure themes with colors, density, and dark mode
 
 Each recipe includes complete code examples, configuration options, and troubleshooting tips to help you integrate Handsontable with your app's look and feel.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Context
This PR adds and finalizes a new Ant Design theme recipe for Handsontable under Recipes -> Themes.

The update now includes a public, programmatically created CodeSandbox example embedded at the top of the recipe page.

### How has this been tested?
- Created sandbox programmatically through CodeSandbox API (`define`) with public privacy (`privacy: 0`) and verified metadata includes `id` and `alias`.
- Verified sandbox endpoints resolve:
  - `https://codesandbox.io/p/sandbox/ylxwyx`
  - `https://codesandbox.io/embed/ylxwyx?view=preview`
- Ran docs lint:
  - `npm run docs:lint --prefix docs`

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. N/A
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed9a17df-1779-4a67-bd69-6827849a1d9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed9a17df-1779-4a67-bd69-6827849a1d9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

