### PR TITLE
Fix setDataAtRowProp ignoring source parameter in array-form calls

### DIFF
--- a/.changelogs/12300.json
+++ b/.changelogs/12300.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed `setDataAtRowProp` ignoring the `source` parameter in array-form calls, causing `beforeChange` and `afterChange` hooks to always receive `'edit'` instead of the provided source string.",
+  "type": "fixed",
+  "issueOrPR": 12300,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -1891,7 +1891,7 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
       changeSource = prop;
     }
 
-    const processedChanges = processChanges(changes, source);
+    const processedChanges = processChanges(changes, changeSource);
 
     instance.runHooks('afterSetDataAtRowProp', processedChanges, changeSource);
 

--- a/handsontable/test/e2e/core/setDataAtRowProp.spec.js
+++ b/handsontable/test/e2e/core/setDataAtRowProp.spec.js
@@ -197,4 +197,53 @@ describe('Core.setDataAtRowProp', () => {
     expect(getActiveEditor().getValue()).toBe('typed value');
     expect(getDataAtRowProp(0, 'b')).toBe(42);
   });
+
+  it('should pass the source argument to the `beforeChange` and `afterChange` hooks when called with' +
+  ' a single change', async() => {
+    const beforeChange = jasmine.createSpy('beforeChange');
+    const afterChange = jasmine.createSpy('afterChange');
+
+    handsontable({
+      data: spec().datasetAoO,
+      beforeChange,
+      afterChange,
+    });
+
+    beforeChange.calls.reset();
+    afterChange.calls.reset();
+
+    await setDataAtRowProp(0, 'a', 'changed!', 'my-source');
+
+    expect(beforeChange).toHaveBeenCalledWith([[0, 'a', 1, 'changed!']], 'my-source');
+    expect(afterChange).toHaveBeenCalledWith([[0, 'a', 1, 'changed!']], 'my-source');
+  });
+
+  it('should pass the source argument to the `beforeChange` and `afterChange` hooks when called with' +
+  ' an array of changes', async() => {
+    const beforeChange = jasmine.createSpy('beforeChange');
+    const afterChange = jasmine.createSpy('afterChange');
+
+    handsontable({
+      data: spec().datasetAoO,
+      beforeChange,
+      afterChange,
+    });
+
+    beforeChange.calls.reset();
+    afterChange.calls.reset();
+
+    await setDataAtRowProp([
+      [0, 'a', 'changed!'],
+      [0, 'b', 'changed too!']
+    ], 'my-source');
+
+    expect(beforeChange).toHaveBeenCalledWith([
+      [0, 'a', 1, 'changed!'],
+      [0, 'b', 2, 'changed too!']
+    ], 'my-source');
+    expect(afterChange).toHaveBeenCalledWith([
+      [0, 'a', 1, 'changed!'],
+      [0, 'b', 2, 'changed too!']
+    ], 'my-source');
+  });
 });


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
When `setDataAtRowProp` is called with an array of changes and a source string (e.g. `setDataAtRowProp([[row, prop, val]], 'mySource')`), the source is correctly reassigned to the local `changeSource` var, but `processChanges()` was called with the original `source` param instead of `changeSource`. Since `source` would be undefined when only passing two params `processChanges` falls back to `'edit'` — silently discarding the caller's source string.

The sibling method `setDataAtCell` handles this identically but correctly passes `changeSource` to `processChanges()`. The remaining other functions called within `setDataAtRowProp` itself (`afterSetDataAtRowProp`, `validateChanges`, `applyChanges`) already use `changeSource` correctly — only the `processChanges` call was missed.

The fix changes so that we now send `changeSource` to the `procesChanges` func.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

Added E2E tests verifying the source argument reaches `beforeChange` and `afterChange` hooks for both the single-change and array-of-changes call forms.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. N/A

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core change-processing for `setDataAtRowProp`, which can affect downstream integrations that rely on hook `source` values, but the behavioral change is narrowly scoped and covered by added E2E tests.
> 
> **Overview**
> Fixes `setDataAtRowProp` so that when invoked in array-form (and related call paths), the provided `source` is no longer dropped during `processChanges()`, ensuring `beforeChange`/`afterChange` receive the caller’s source instead of defaulting to `'edit'`.
> 
> Adds E2E coverage asserting the `source` argument is propagated to `beforeChange` and `afterChange` for both single-change and multi-change invocations, and includes a public changelog entry for the bug fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 307d3119a4da7a0b8020bcd4d40577071301bf57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->