### PR TITLE
Fix multiple HOT tables with shared HyperFormula engine and auto-sizing becoming unresponsive (#12301)

### DIFF
--- a/.changelogs/12301.json
+++ b/.changelogs/12301.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed multiple Handsontable tables with shared HyperFormula engine and auto-sizing becoming unresponsive due to cross-table formula update interference.",
+  "type": "fixed",
+  "issueOrPR": 12301,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/12305.json
+++ b/.changelogs/12305.json
@@ -2,7 +2,7 @@
   "issuesOrigin": "public",
   "title": "Fixed multiple Handsontable tables with shared HyperFormula engine and auto-sizing becoming unresponsive due to cross-table formula update interference.",
   "type": "fixed",
-  "issueOrPR": 12301,
+  "issueOrPR": 12305,
   "breaking": false,
   "framework": "none"
 }

--- a/handsontable/src/plugins/autoColumnSize/__tests__/autoColumnSize.spec.js
+++ b/handsontable/src/plugins/autoColumnSize/__tests__/autoColumnSize.spec.js
@@ -12,6 +12,18 @@ describe('AutoColumnSize', () => {
       destroy();
       this.$container.remove();
     }
+    if (this.$container2) {
+      try {
+        if (this.$container2.handsontable('getInstance')) {
+          this.$container2.handsontable('getInstance').destroy();
+        }
+      } catch (e) {
+        if (!e.message.includes('instance has been destroyed')) {
+          throw e;
+        }
+      }
+      this.$container2.remove();
+    }
   });
 
   const arrayOfObjects = function() {
@@ -1540,6 +1552,70 @@ describe('AutoColumnSize', () => {
         main.toBe(75);
         horizon.toBe(83);
       });
+    });
+
+    it('should not throw when two tables with different layouts share a HyperFormula engine (#12301)', async() => {
+      spec().$container2 = $('<div id="testContainer-2"></div>').appendTo('body');
+
+      const hot1 = handsontable({
+        data: [['a', 'b']],
+        autoRowSize: true,
+        autoColumnSize: true,
+        formulas: {
+          engine: HyperFormula,
+          sheetName: 'Sheet1',
+        },
+      });
+
+      spec().$container2.handsontable({
+        data: [['c'], ['d']],
+        autoRowSize: true,
+        autoColumnSize: true,
+        formulas: {
+          engine: hot1.getPlugin('formulas').engine,
+          sheetName: 'Sheet2',
+        },
+      });
+
+      const hot2 = spec().$container2.handsontable('getInstance');
+
+      expect(() => {
+        hot2.setDataAtCell(0, 0, 'test');
+      }).not.toThrow();
+
+      expect(() => {
+        hot1.setDataAtCell(0, 0, 'test2');
+      }).not.toThrow();
+    });
+
+    it('should only refresh columns belonging to the current sheet after formula values update (#12301)', async() => {
+      spec().$container2 = $('<div id="testContainer-2"></div>').appendTo('body');
+
+      const hot1 = handsontable({
+        data: [['a', '=A1']],
+        autoColumnSize: true,
+        formulas: {
+          engine: HyperFormula,
+          sheetName: 'Sheet1',
+        },
+      });
+
+      spec().$container2.handsontable({
+        data: [['c'], ['d'], ['e']],
+        autoColumnSize: true,
+        formulas: {
+          engine: hot1.getPlugin('formulas').engine,
+          sheetName: 'Sheet2',
+        },
+      });
+
+      const hot2 = spec().$container2.handsontable('getInstance');
+
+      const addColumnSpy = spyOn(hot1.getPlugin('autoColumnSize').ghostTable, 'addColumn').and.callThrough();
+
+      hot2.setDataAtCell(2, 0, 'new value');
+
+      expect(addColumnSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/handsontable/src/plugins/autoColumnSize/__tests__/autoColumnSize.spec.js
+++ b/handsontable/src/plugins/autoColumnSize/__tests__/autoColumnSize.spec.js
@@ -1588,7 +1588,7 @@ describe('AutoColumnSize', () => {
       }).not.toThrow();
     });
 
-    it('should only refresh columns belonging to the current sheet after formula values update (#12301)', async() => {
+    it('should not queue column refresh for changes belonging to another sheet (#12301)', async() => {
       spec().$container2 = $('<div id="testContainer-2"></div>').appendTo('body');
 
       const hot1 = handsontable({
@@ -1600,22 +1600,24 @@ describe('AutoColumnSize', () => {
         },
       });
 
-      spec().$container2.handsontable({
-        data: [['c'], ['d'], ['e']],
+      const hot2Instance = spec().$container2.handsontable({
+        data: [['=Sheet1!A1'], ['d'], ['e']],
         autoColumnSize: true,
         formulas: {
           engine: hot1.getPlugin('formulas').engine,
           sheetName: 'Sheet2',
         },
-      });
+      }).data('handsontable');
 
-      const hot2 = spec().$container2.handsontable('getInstance');
+      const sheet2Id = hot2Instance.getPlugin('formulas').sheetId;
+      const toVisualColumnSpy = spyOn(hot1, 'toVisualColumn').and.callThrough();
 
-      const addColumnSpy = spyOn(hot1.getPlugin('autoColumnSize').ghostTable, 'addColumn').and.callThrough();
+      hot1.runHooks('afterFormulasValuesUpdate', [
+        { address: { sheet: sheet2Id, row: 0, col: 0 }, newValue: 'test' },
+        { address: { sheet: sheet2Id, row: 2, col: 0 }, newValue: 'test2' },
+      ]);
 
-      hot2.setDataAtCell(2, 0, 'new value');
-
-      expect(addColumnSpy).not.toHaveBeenCalled();
+      expect(toVisualColumnSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/handsontable/src/plugins/autoColumnSize/autoColumnSize.js
+++ b/handsontable/src/plugins/autoColumnSize/autoColumnSize.js
@@ -732,7 +732,14 @@ export class AutoColumnSize extends BasePlugin {
       return;
     }
 
+    const formulasPlugin = this.hot.getPlugin('formulas');
+    const sheetId = formulasPlugin?.sheetId;
+
     const changedColumns = changes.reduce((acc, change) => {
+      if (sheetId !== null && sheetId !== undefined && change.address?.sheet !== sheetId) {
+        return acc;
+      }
+
       const physicalColumn = change.address?.col;
 
       if (Number.isInteger(physicalColumn)) {

--- a/handsontable/src/plugins/autoRowSize/__tests__/autoRowSize.spec.js
+++ b/handsontable/src/plugins/autoRowSize/__tests__/autoRowSize.spec.js
@@ -1103,7 +1103,7 @@ describe('AutoRowSize', () => {
       }).not.toThrow();
     });
 
-    it('should only refresh rows belonging to the current sheet after formula values update (#12301)', async() => {
+    it('should not queue row refresh for changes belonging to another sheet (#12301)', async() => {
       spec().$container2 = $('<div id="testContainer-2"></div>').appendTo('body');
 
       const hot1 = handsontable({
@@ -1115,22 +1115,24 @@ describe('AutoRowSize', () => {
         },
       });
 
-      spec().$container2.handsontable({
-        data: [['c'], ['d'], ['e']],
+      const hot2Instance = spec().$container2.handsontable({
+        data: [['=Sheet1!A1'], ['d'], ['e']],
         autoRowSize: true,
         formulas: {
           engine: hot1.getPlugin('formulas').engine,
           sheetName: 'Sheet2',
         },
-      });
+      }).data('handsontable');
 
-      const hot2 = spec().$container2.handsontable('getInstance');
+      const sheet2Id = hot2Instance.getPlugin('formulas').sheetId;
+      const toVisualRowSpy = spyOn(hot1, 'toVisualRow').and.callThrough();
 
-      const addRowSpy = spyOn(hot1.getPlugin('autoRowSize').ghostTable, 'addRow').and.callThrough();
+      hot1.runHooks('afterFormulasValuesUpdate', [
+        { address: { sheet: sheet2Id, row: 0, col: 0 }, newValue: 'test' },
+        { address: { sheet: sheet2Id, row: 2, col: 0 }, newValue: 'test2' },
+      ]);
 
-      hot2.setDataAtCell(2, 0, 'new value');
-
-      expect(addRowSpy).not.toHaveBeenCalled();
+      expect(toVisualRowSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/handsontable/src/plugins/autoRowSize/__tests__/autoRowSize.spec.js
+++ b/handsontable/src/plugins/autoRowSize/__tests__/autoRowSize.spec.js
@@ -12,6 +12,18 @@ describe('AutoRowSize', () => {
       destroy();
       this.$container.remove();
     }
+    if (this.$container2) {
+      try {
+        if (this.$container2.handsontable('getInstance')) {
+          this.$container2.handsontable('getInstance').destroy();
+        }
+      } catch (e) {
+        if (!e.message.includes('instance has been destroyed')) {
+          throw e;
+        }
+      }
+      this.$container2.remove();
+    }
   });
 
   /**
@@ -1055,6 +1067,70 @@ describe('AutoRowSize', () => {
 
       expect(getPlugin('autoRowSize').ghostTable.addRow).toHaveBeenCalledTimes(1);
       Handsontable.hooks.remove('beforeInit', beforeInit);
+    });
+
+    it('should not throw when two tables with different layouts share a HyperFormula engine (#12301)', async() => {
+      spec().$container2 = $('<div id="testContainer-2"></div>').appendTo('body');
+
+      const hot1 = handsontable({
+        data: [['a', 'b']],
+        autoRowSize: true,
+        autoColumnSize: true,
+        formulas: {
+          engine: HyperFormula,
+          sheetName: 'Sheet1',
+        },
+      });
+
+      spec().$container2.handsontable({
+        data: [['c'], ['d']],
+        autoRowSize: true,
+        autoColumnSize: true,
+        formulas: {
+          engine: hot1.getPlugin('formulas').engine,
+          sheetName: 'Sheet2',
+        },
+      });
+
+      const hot2 = spec().$container2.handsontable('getInstance');
+
+      expect(() => {
+        hot2.setDataAtCell(0, 0, 'test');
+      }).not.toThrow();
+
+      expect(() => {
+        hot1.setDataAtCell(0, 0, 'test2');
+      }).not.toThrow();
+    });
+
+    it('should only refresh rows belonging to the current sheet after formula values update (#12301)', async() => {
+      spec().$container2 = $('<div id="testContainer-2"></div>').appendTo('body');
+
+      const hot1 = handsontable({
+        data: [['a', '=A1']],
+        autoRowSize: true,
+        formulas: {
+          engine: HyperFormula,
+          sheetName: 'Sheet1',
+        },
+      });
+
+      spec().$container2.handsontable({
+        data: [['c'], ['d'], ['e']],
+        autoRowSize: true,
+        formulas: {
+          engine: hot1.getPlugin('formulas').engine,
+          sheetName: 'Sheet2',
+        },
+      });
+
+      const hot2 = spec().$container2.handsontable('getInstance');
+
+      const addRowSpy = spyOn(hot1.getPlugin('autoRowSize').ghostTable, 'addRow').and.callThrough();
+
+      hot2.setDataAtCell(2, 0, 'new value');
+
+      expect(addRowSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/handsontable/src/plugins/autoRowSize/autoRowSize.js
+++ b/handsontable/src/plugins/autoRowSize/autoRowSize.js
@@ -764,7 +764,14 @@ export class AutoRowSize extends BasePlugin {
       return;
     }
 
+    const formulasPlugin = this.hot.getPlugin('formulas');
+    const sheetId = formulasPlugin?.sheetId;
+
     const changedRows = changes.reduce((acc, change) => {
+      if (sheetId !== null && sheetId !== undefined && change.address?.sheet !== sheetId) {
+        return acc;
+      }
+
       const physicalRow = change.address?.row;
 
       if (Number.isInteger(physicalRow)) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Context

Fixes #12301.

When multiple Handsontable instances on the same page share a HyperFormula engine and have `autoRowSize`/`autoColumnSize` enabled, the first table becomes completely unresponsive. Clicking any cell throws a TypeError in the console.

**Root cause:** The `afterFormulasValuesUpdate` hook is broadcast to every Handsontable instance that shares the same HyperFormula engine. The `AutoRowSize` and `AutoColumnSize` plugins process the `changes` array without filtering by `change.address.sheet`, causing row/column indices from one sheet to be incorrectly applied to another table with a different layout. When the indices are out of range for the receiving table, `toVisualRow`/`toVisualColumn` returns `null`, which propagates into GhostTable sampling and causes TypeErrors.

**Fix:** In both `AutoRowSize#onAfterFormulasValuesUpdate` and `AutoColumnSize#onAfterFormulasValuesUpdate`, filter changes to only include entries where `change.address.sheet` matches the current instance's Formulas plugin `sheetId`. Changes for other sheets are skipped. This mirrors the filtering pattern already used in `Formulas#renderDependentSheets` and `Formulas#validateDependentCells`.

### How has this been tested?

- Added E2E tests to both `autoRowSize.spec.js` and `autoColumnSize.spec.js` that:
  1. Create two HOT instances with different layouts (1x2 and 2x1) sharing a HyperFormula engine with auto-sizing enabled, and verify no errors are thrown when editing cells in either table.
  2. Directly fire `afterFormulasValuesUpdate` with synthetic Sheet2 changes on hot1, then spy on `toVisualRow`/`toVisualColumn` to verify cross-sheet changes are filtered BEFORE any index translation occurs.
- Confirmed all 4 new tests **fail** without the fix and **pass** with the fix (proper red-green TDD verification).
- All existing E2E tests for both plugins continue to pass (43 autoRowSize specs, 50 autoColumnSize specs).
- ESLint passes with no errors.
- **Manual GUI testing**: Created a reproduction page matching the user's demo (two tables with different layouts sharing HyperFormula engine), confirmed both tables are responsive and no console errors occur.

[demo_multi_table_autosize_fix_12301.mp4](https://cursor.com/agents/bc-764404ab-9a42-4c35-a611-452e6609df68/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_multi_table_autosize_fix_12301.mp4)

[Both tables working with no console errors](https://cursor.com/agents/bc-764404ab-9a42-4c35-a611-452e6609df68/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_both_tables_working_no_errors.webp)

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/12301

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-764404ab-9a42-4c35-a611-452e6609df68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-764404ab-9a42-4c35-a611-452e6609df68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

