### PR TITLE
Add long-press gesture to open context menu on touch devices (#12302)

### DIFF
--- a/.changelogs/12302.json
+++ b/.changelogs/12302.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Added long-press gesture detection on touch devices to open the context menu.",
+  "type": "added",
+  "issueOrPR": 12302,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/12306.json
+++ b/.changelogs/12306.json
@@ -2,7 +2,7 @@
   "issuesOrigin": "public",
   "title": "Added long-press gesture detection on touch devices to open the context menu.",
   "type": "added",
-  "issueOrPR": 12302,
+  "issueOrPR": 12306,
   "breaking": false,
   "framework": "none"
 }

--- a/docs/content/guides/accessories-and-menus/context-menu/context-menu.md
+++ b/docs/content/guides/accessories-and-menus/context-menu/context-menu.md
@@ -31,7 +31,7 @@ Enable the context menu with the default configuration:
 contextMenu: true,
 ```
 
-To see the context menu, right-click on a cell:
+To see the context menu, right-click on a cell. On touch devices, long-press a cell to open the context menu.
 
 ::: only-for javascript
 
@@ -110,7 +110,7 @@ You can define the items in the menu by passing the [`contextMenu`](@/api/option
 | [`filter_action_bar`](@/api/contextMenu.md)              | Apply the configured filter. Requires: [`Filters`](@/api/filters.md)                                                                                                 |
 | [`export_file`](@/api/contextMenu.md)                    | Open the Export submenu with "To CSV" and "To Excel" items. Requires: [`ExportFile`](@/api/exportFile.md). The Excel item is hidden when no XLSX engine is configured. |
 
-To see the context menu, right-click on a cell:
+To see the context menu, right-click on a cell. On touch devices, long-press a cell to open the context menu.
 
 ::: only-for javascript
 
@@ -151,7 +151,7 @@ To see the context menu, right-click on a cell:
 
 In addition to built-in options, you can equip your context menu with custom options.
 
-To see the context menu, right-click on a cell:
+To see the context menu, right-click on a cell. On touch devices, long-press a cell to open the context menu.
 
 ::: example #example4 :react --js 1 --ts 2
 
@@ -220,7 +220,7 @@ The following example shows how to:
 - Use a custom renderer
 
 
-To see the context menu, right-click on a cell:
+To see the context menu, right-click on a cell. On touch devices, long-press a cell to open the context menu.
 
 ::: only-for javascript
 
@@ -255,11 +255,12 @@ To see the context menu, right-click on a cell:
 
 :::
 
-## Related keyboard shortcuts
+## Related keyboard shortcuts and gestures
 
 | Windows                                                                                               | macOS                                                                                                | Action                                                        |  Excel  | Sheets  |
 | ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- | :-----: | :-----: |
 | <kbd>**Ctrl**</kbd>+<kbd>**Shift**</kbd>+<kbd>**\\**</kbd> or <kbd>**Shift**</kbd>+<kbd>**F10**</kbd> | <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>**\\**</kbd> or <kbd>⇧</kbd>+<kbd>**F10**</kbd> | Open the context menu                                         | &cross; | &check; |
+| Long-press (touch devices)                                                                            | Long-press (touch devices)                                                                           | Open the context menu                                         | &cross; | &check; |
 | Arrow keys                                                                                            | Arrow keys                                                                                           | Move one available menu item up, down, left, or right         | &check; | &check; |
 | <kbd>**Page Up**</kbd>                                                                                | <kbd>**Page Up**</kbd>                                                                               | Move to the first visible item of the context menu or submenu | &check; | &cross; |
 | <kbd>**Page Down**</kbd>                                                                              | <kbd>**Page Down**</kbd>                                                                             | Move to the last visible item of the context menu or submenu  | &check; | &cross; |

--- a/handsontable/src/3rdparty/walkontable/src/event.js
+++ b/handsontable/src/3rdparty/walkontable/src/event.js
@@ -240,6 +240,8 @@ class Event {
    * @param {MouseEvent} event The mouse event object.
    */
   onContextMenu(event) {
+    this.#cancelLongPressTimer();
+
     if (this.#wtSettings.has('onCellContextMenu')) {
       const cell = this.parentCell(event.target);
 

--- a/handsontable/src/3rdparty/walkontable/src/event.js
+++ b/handsontable/src/3rdparty/walkontable/src/event.js
@@ -103,6 +103,7 @@ class Event {
         this.momentumScrolling = {};
       }
       this.#eventManager.addEventListener(this.#wtTable.holder, 'scroll', () => {
+        this.#cancelLongPressTimer();
         clearTimeout(this.momentumScrolling._timeout);
 
         if (!this.momentumScrolling.ongoing) {

--- a/handsontable/src/3rdparty/walkontable/src/event.js
+++ b/handsontable/src/3rdparty/walkontable/src/event.js
@@ -416,6 +416,11 @@ class Event {
       this.#longPressTimeout = null;
       this.#touchStartCoords = null;
 
+      this.#dblClickOrigin[0] = null;
+      this.#dblClickOrigin[1] = null;
+      clearTimeout(this.#dblClickTimeout[0]);
+      clearTimeout(this.#dblClickTimeout[1]);
+
       const target = event.target;
       const contextMenuEvent = new MouseEvent('contextmenu', {
         bubbles: true,

--- a/handsontable/src/3rdparty/walkontable/src/event.js
+++ b/handsontable/src/3rdparty/walkontable/src/event.js
@@ -9,6 +9,9 @@ import { isTouchSupported } from '../../../helpers/feature';
 import { isMobileBrowser, isChromeWebKit, isFirefoxWebKit, isIOS } from '../../../helpers/browser';
 import { isDefined } from '../../../helpers/mixed';
 
+const LONG_PRESS_DELAY = 500;
+const LONG_PRESS_MOVE_THRESHOLD = 10;
+
 /**
  * @class Event
  */
@@ -47,6 +50,18 @@ class Event {
    * @type {number[]}
    */
   #dblClickOrigin = [null, null];
+  /**
+   * Timer ID for the long-press gesture detection.
+   *
+   * @type {number|null}
+   */
+  #longPressTimeout = null;
+  /**
+   * Starting coordinates of a touch gesture (used to detect movement that cancels long-press).
+   *
+   * @type {{ x: number, y: number }|null}
+   */
+  #touchStartCoords = null;
 
   /**
    * @param {FacadeGetter} facadeGetter Gets an instance facade.
@@ -82,6 +97,7 @@ class Event {
     const initTouchEvents = () => {
       this.#eventManager.addEventListener(this.#wtTable.holder, 'touchstart', event => this.onTouchStart(event));
       this.#eventManager.addEventListener(this.#wtTable.holder, 'touchend', event => this.onTouchEnd(event));
+      this.#eventManager.addEventListener(this.#wtTable.holder, 'touchmove', event => this.#onTouchMove(event));
 
       if (!this.momentumScrolling) {
         this.momentumScrolling = {};
@@ -322,22 +338,25 @@ class Event {
    * OnTouchStart callback. Simulates mousedown event.
    *
    * @private
-   * @param {MouseEvent} event The mouse event object.
+   * @param {TouchEvent} event The touch event object.
    */
   onTouchStart(event) {
     this.#selectedCellBeforeTouchEnd = this.#selectionManager.getFocusSelection().cellRange;
     this.touchApplied = true;
 
     this.onMouseDown(event);
+    this.#startLongPressTimer(event);
   }
 
   /**
    * OnTouchEnd callback. Simulates mouseup event.
    *
    * @private
-   * @param {MouseEvent} event The mouse event object.
+   * @param {TouchEvent} event The touch event object.
    */
   onTouchEnd(event) {
+    this.#cancelLongPressTimer();
+
     const target = event.target;
     const parentCellCoords = this.parentCell(target)?.coords;
     const isCellsRange = isDefined(parentCellCoords) && (parentCellCoords.row >= 0 && parentCellCoords.col >= 0);
@@ -374,6 +393,83 @@ class Event {
   }
 
   /**
+   * Starts the long-press timer. When the timer fires, a synthetic `contextmenu` event is
+   * dispatched on the original touch target so that the existing contextmenu hook chain
+   * (and ContextMenu plugin) work without changes.
+   *
+   * @private
+   * @param {TouchEvent} event The original `touchstart` event.
+   */
+  #startLongPressTimer(event) {
+    this.#cancelLongPressTimer();
+
+    const touch = event.touches[0];
+
+    if (!touch) {
+      return;
+    }
+
+    this.#touchStartCoords = { x: touch.clientX, y: touch.clientY };
+
+    this.#longPressTimeout = setTimeout(() => {
+      this.#longPressTimeout = null;
+      this.#touchStartCoords = null;
+
+      const target = event.target;
+      const contextMenuEvent = new MouseEvent('contextmenu', {
+        bubbles: true,
+        cancelable: true,
+        clientX: touch.clientX,
+        clientY: touch.clientY,
+        screenX: touch.screenX,
+        screenY: touch.screenY,
+      });
+
+      target.dispatchEvent(contextMenuEvent);
+    }, LONG_PRESS_DELAY);
+  }
+
+  /**
+   * Cancels the pending long-press timer.
+   *
+   * @private
+   */
+  #cancelLongPressTimer() {
+    if (this.#longPressTimeout !== null) {
+      clearTimeout(this.#longPressTimeout);
+      this.#longPressTimeout = null;
+    }
+    this.#touchStartCoords = null;
+  }
+
+  /**
+   * OnTouchMove callback. Cancels the long-press timer if the finger moves beyond the threshold.
+   *
+   * @private
+   * @param {TouchEvent} event The touch event object.
+   */
+  #onTouchMove(event) {
+    if (this.#longPressTimeout === null || this.#touchStartCoords === null) {
+      return;
+    }
+
+    const touch = event.touches[0];
+
+    if (!touch) {
+      this.#cancelLongPressTimer();
+
+      return;
+    }
+
+    const dx = Math.abs(touch.clientX - this.#touchStartCoords.x);
+    const dy = Math.abs(touch.clientY - this.#touchStartCoords.y);
+
+    if (dx > LONG_PRESS_MOVE_THRESHOLD || dy > LONG_PRESS_MOVE_THRESHOLD) {
+      this.#cancelLongPressTimer();
+    }
+  }
+
+  /**
    * Call listener with backward compatibility.
    *
    * @private
@@ -396,6 +492,7 @@ class Event {
   destroy() {
     clearTimeout(this.#dblClickTimeout[0]);
     clearTimeout(this.#dblClickTimeout[1]);
+    this.#cancelLongPressTimer();
 
     this.#eventManager.destroy();
   }

--- a/handsontable/test/e2e/mobile/events.spec.js
+++ b/handsontable/test/e2e/mobile/events.spec.js
@@ -179,4 +179,132 @@ describe('Events', () => {
 
     expect($('.htDropdownMenu').is(':visible')).toBe(true);
   });
+
+  describe('long-press', () => {
+    it('should open context menu after long-pressing a cell (#12302)', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        contextMenu: true,
+        width: 400,
+        height: 400,
+      });
+
+      const cell = getCell(1, 1);
+
+      await triggerTouchEvent('touchstart', cell);
+      await sleep(600);
+
+      expect($('.htContextMenu').is(':visible')).toBe(true);
+
+      await triggerTouchEvent('touchend', cell);
+    });
+
+    it('should fire `beforeOnCellContextMenu` and `afterOnCellContextMenu` hooks on long-press (#12302)', async() => {
+      const beforeOnCellContextMenu = jasmine.createSpy('beforeOnCellContextMenu');
+      const afterOnCellContextMenu = jasmine.createSpy('afterOnCellContextMenu');
+
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        contextMenu: true,
+        width: 400,
+        height: 400,
+        beforeOnCellContextMenu,
+        afterOnCellContextMenu,
+      });
+
+      const cell = getCell(1, 1);
+
+      await triggerTouchEvent('touchstart', cell);
+      await sleep(600);
+
+      expect(beforeOnCellContextMenu).toHaveBeenCalledTimes(1);
+      expect(afterOnCellContextMenu).toHaveBeenCalledTimes(1);
+
+      await triggerTouchEvent('touchend', cell);
+    });
+
+    it('should not open context menu if touch ends before long-press threshold (#12302)', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        contextMenu: true,
+        width: 400,
+        height: 400,
+      });
+
+      const cell = getCell(1, 1);
+
+      await triggerTouchEvent('touchstart', cell);
+      await sleep(100);
+      await triggerTouchEvent('touchend', cell);
+      await sleep(500);
+
+      expect($('.htContextMenu').is(':visible')).toBeFalse();
+    });
+
+    it('should not open context menu if finger moves during touch (#12302)', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        contextMenu: true,
+        width: 400,
+        height: 400,
+      });
+
+      const cell = getCell(1, 1);
+      const cellRect = cell.getBoundingClientRect();
+
+      await triggerTouchEvent('touchstart', cell);
+      await sleep(100);
+
+      // Simulate finger moving 50px away from the initial position.
+      await triggerTouchEvent('touchmove', cell,
+        parseInt(cellRect.left, 10) + 60,
+        parseInt(cellRect.top, 10) + 60
+      );
+
+      await sleep(500);
+
+      expect($('.htContextMenu').is(':visible')).toBeFalse();
+
+      await triggerTouchEvent('touchend', cell);
+    });
+
+    it('should not open context menu if contextMenu option is disabled (#12302)', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        contextMenu: false,
+        width: 400,
+        height: 400,
+      });
+
+      const cell = getCell(1, 1);
+
+      await triggerTouchEvent('touchstart', cell);
+      await sleep(600);
+
+      expect($('.htContextMenu').is(':visible')).toBeFalse();
+
+      await triggerTouchEvent('touchend', cell);
+    });
+
+    it('should select the cell before opening context menu on long-press (#12302)', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        contextMenu: true,
+        width: 400,
+        height: 400,
+      });
+
+      const cell = getCell(2, 3);
+
+      expect(getSelected()).toBeUndefined();
+
+      await triggerTouchEvent('touchstart', cell);
+      await sleep(600);
+
+      expect(getSelected()).toEqual([[2, 3, 2, 3]]);
+      expect($('.htContextMenu').is(':visible')).toBe(true);
+
+      await triggerTouchEvent('touchend', cell);
+    });
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Context

Long-pressing a cell on mobile devices does not open the context menu. The `contextmenu` event never fires because mobile browsers (particularly iOS Safari) do not natively dispatch `contextmenu` events on long-press within Handsontable's table elements.

This PR adds long-press gesture detection in the Walkontable event layer. When the user holds their finger on a cell for 500ms without moving, a synthetic `contextmenu` event is dispatched on the touch target. This flows through the existing Walkontable → TableView → ContextMenu plugin hook chain (`onCellContextMenu` → `beforeOnCellContextMenu` → `afterOnCellContextMenu`) without any changes to the ContextMenu plugin itself.

**How it works:**
- `touchstart`: starts a 500ms timer and records the starting finger coordinates
- `touchmove`: cancels the timer if the finger moves more than 10px from the starting position (prevents accidental context menu while scrolling)
- `touchend`: cancels the timer (short taps don't trigger context menu)
- `scroll`: cancels the timer (prevents dispatching `contextmenu` on recycled/detached DOM nodes after Walkontable virtualizes cells)
- `contextmenu` (native): cancels the timer (on browsers like Android Chrome that natively fire `contextmenu` on long-press, the native event is used and the synthetic dispatch is suppressed -- prevents duplicate events)
- Timer fires: resets double-click detection state, then dispatches a synthetic `MouseEvent('contextmenu')` on the original touch target with correct coordinates
- `destroy()`: cleans up the timer

### How has this been tested?

- All 586 context menu E2E tests pass (`npm run test:e2e --testPathPattern=contextMenu`)
- All 659 Walkontable tests pass (`npm run test:walkontable`)
- ESLint passes with zero errors
- Added 6 E2E tests in `test/e2e/mobile/events.spec.js` covering:
  - Context menu opens after long-press on a cell
  - `beforeOnCellContextMenu` and `afterOnCellContextMenu` hooks fire
  - Context menu does NOT open if touch ends before 500ms threshold
  - Context menu does NOT open if finger moves during touch
  - Context menu does NOT open if `contextMenu` option is disabled
  - Cell is selected before context menu opens

Note: The positive long-press tests depend on the mobile test runner's touch emulation, which has pre-existing failures in the CI Puppeteer environment (all existing mobile event tests also fail). The negative tests (verifying context menu does NOT appear) pass.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/12302 - Long-press on mobile does not trigger context menu
2. https://github.com/handsontable/handsontable/issues/5171 - Long-touch doesn't trigger Context-Menu
3. https://github.com/handsontable/handsontable/issues/4833 - Context menu not working with mobiles
4. https://github.com/handsontable/handsontable/issues/7520 - Interoperability problems using Mobile devices

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c2d6160-2d27-4eef-a3fe-5e82add3fe86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c2d6160-2d27-4eef-a3fe-5e82add3fe86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

