### PR TITLE
Fix disableVisualSelection treating undefined as true (#12304)

### DIFF
--- a/.changelogs/12304.json
+++ b/.changelogs/12304.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed `disableVisualSelection` treating `undefined` as `true` instead of falling back to the default (`false`).",
+  "type": "fixed",
+  "issueOrPR": 12304,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/12307.json
+++ b/.changelogs/12307.json
@@ -2,7 +2,7 @@
   "issuesOrigin": "public",
   "title": "Fixed `disableVisualSelection` treating `undefined` as `true` instead of falling back to the default (`false`).",
   "type": "fixed",
-  "issueOrPR": 12304,
+  "issueOrPR": 12307,
   "breaking": false,
   "framework": "none"
 }

--- a/handsontable/src/selection/__tests__/selection/isDisabledCellSelection.spec.js
+++ b/handsontable/src/selection/__tests__/selection/isDisabledCellSelection.spec.js
@@ -13,6 +13,70 @@ describe('Selection', () => {
   });
 
   describe('`isDisabledCellSelection` option', () => {
+    it('should not disable any selection when set as `undefined` (should fall back to default `false`) (#12304)', async() => {
+      handsontable({
+        rowHeaders: true,
+        colHeaders: true,
+        startRows: 5,
+        startCols: 5,
+        navigableHeaders: true,
+        disableVisualSelection: undefined,
+      });
+
+      await selectColumns(1, 1, -1);
+      await keyDown('control/meta');
+      await selectRows(1, 1, -1);
+      await keyUp('control/meta');
+
+      expect(getSelectedRange()).toEqualCellRange([
+        'highlight: -1,1 from: -1,1 to: 4,1',
+        'highlight: 1,-1 from: 1,-1 to: 1,4',
+      ]);
+      expect(`
+        |   ║ - : * : - : - : - |
+        |===:===:===:===:===:===|
+        | - ║   : 0 :   :   :   |
+        | # ║ 0 : 1 : 0 : 0 : 0 |
+        | - ║   : 0 :   :   :   |
+        | - ║   : 0 :   :   :   |
+        | - ║   : 0 :   :   :   |
+        `).toBeMatchToSelectionPattern();
+    });
+
+    it('should not disable any selection when updated via `updateSettings` to `undefined` (#12304)', async() => {
+      handsontable({
+        rowHeaders: true,
+        colHeaders: true,
+        startRows: 5,
+        startCols: 5,
+        navigableHeaders: true,
+        disableVisualSelection: true,
+      });
+
+      await updateSettings({
+        disableVisualSelection: undefined,
+      });
+
+      await selectColumns(1, 1, -1);
+      await keyDown('control/meta');
+      await selectRows(1, 1, -1);
+      await keyUp('control/meta');
+
+      expect(getSelectedRange()).toEqualCellRange([
+        'highlight: -1,1 from: -1,1 to: 4,1',
+        'highlight: 1,-1 from: 1,-1 to: 1,4',
+      ]);
+      expect(`
+        |   ║ - : * : - : - : - |
+        |===:===:===:===:===:===|
+        | - ║   : 0 :   :   :   |
+        | # ║ 0 : 1 : 0 : 0 : 0 |
+        | - ║   : 0 :   :   :   |
+        | - ║   : 0 :   :   :   |
+        | - ║   : 0 :   :   :   |
+        `).toBeMatchToSelectionPattern();
+    });
+
     it('should disable any kind of selection when set as `true` on table settings layer', async() => {
       handsontable({
         rowHeaders: true,

--- a/handsontable/src/selection/highlight/__tests__/highlight.unit.js
+++ b/handsontable/src/selection/highlight/__tests__/highlight.unit.js
@@ -21,6 +21,58 @@ function createHighlightInstance(options = {}) {
 }
 
 describe('Highlight', () => {
+  describe('isEnabledFor()', () => {
+    it('should treat `undefined` the same as `false` (selection enabled)', () => {
+      const highlight = createHighlightInstance({
+        disabledCellSelection: () => undefined,
+      });
+
+      expect(highlight.isEnabledFor('focus', { row: 0, col: 0 })).toBe(true);
+      expect(highlight.isEnabledFor('area', { row: 0, col: 0 })).toBe(true);
+      expect(highlight.isEnabledFor('header', { row: 0, col: 0 })).toBe(true);
+    });
+
+    it('should return `true` when `disabledCellSelection` returns `false`', () => {
+      const highlight = createHighlightInstance({
+        disabledCellSelection: () => false,
+      });
+
+      expect(highlight.isEnabledFor('focus', { row: 0, col: 0 })).toBe(true);
+      expect(highlight.isEnabledFor('area', { row: 0, col: 0 })).toBe(true);
+      expect(highlight.isEnabledFor('header', { row: 0, col: 0 })).toBe(true);
+    });
+
+    it('should return `false` when `disabledCellSelection` returns `true`', () => {
+      const highlight = createHighlightInstance({
+        disabledCellSelection: () => true,
+      });
+
+      expect(highlight.isEnabledFor('focus', { row: 0, col: 0 })).toBe(false);
+      expect(highlight.isEnabledFor('area', { row: 0, col: 0 })).toBe(false);
+      expect(highlight.isEnabledFor('header', { row: 0, col: 0 })).toBe(false);
+    });
+
+    it('should selectively disable highlight types when `disabledCellSelection` returns a string', () => {
+      const highlight = createHighlightInstance({
+        disabledCellSelection: () => 'current',
+      });
+
+      expect(highlight.isEnabledFor('focus', { row: 0, col: 0 })).toBe(false);
+      expect(highlight.isEnabledFor('area', { row: 0, col: 0 })).toBe(true);
+      expect(highlight.isEnabledFor('header', { row: 0, col: 0 })).toBe(true);
+    });
+
+    it('should selectively disable highlight types when `disabledCellSelection` returns an array', () => {
+      const highlight = createHighlightInstance({
+        disabledCellSelection: () => ['current', 'header'],
+      });
+
+      expect(highlight.isEnabledFor('focus', { row: 0, col: 0 })).toBe(false);
+      expect(highlight.isEnabledFor('area', { row: 0, col: 0 })).toBe(true);
+      expect(highlight.isEnabledFor('header', { row: 0, col: 0 })).toBe(false);
+    });
+  });
+
   describe('updateHighlightClassNames()', () => {
     it('should update the rowClassName option and all cached row highlights', () => {
       const highlight = createHighlightInstance();

--- a/handsontable/src/selection/highlight/highlight.js
+++ b/handsontable/src/selection/highlight/highlight.js
@@ -177,7 +177,7 @@ class Highlight {
       disableHighlight = [disableHighlight];
     }
 
-    return disableHighlight === false || Array.isArray(disableHighlight) && !disableHighlight.includes(type);
+    return !disableHighlight || Array.isArray(disableHighlight) && !disableHighlight.includes(type);
   }
 
   /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Context

Fixes #12304. Passing `disableVisualSelection={undefined}` (or not setting the prop in a framework wrapper, which passes `undefined`) incorrectly disables visual selection instead of falling back to the documented default of `false`.

**Root cause:** In `Highlight.isEnabledFor()`, the check `disableHighlight === false` uses strict equality, so `undefined === false` evaluates to `false`, causing the method to return `false` (selection disabled). The fix changes the check to `!disableHighlight`, which correctly treats both `undefined` and `false` as "selection enabled".

### How has this been tested?

- Added unit tests for `Highlight.isEnabledFor()` covering `undefined`, `false`, `true`, string, and array values.
- Added 2 E2E tests verifying that `disableVisualSelection: undefined` at init time and via `updateSettings` keeps visual selection enabled.
- Ran the full selection E2E test suite (899 specs, 0 failures).
- Ran ESLint with 0 errors.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #12304

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66e5aaa2-a2f1-4ec0-b341-8cabceb0ad47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66e5aaa2-a2f1-4ec0-b341-8cabceb0ad47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

