### PR TITLE
fix: incorrect return types for in some hooks

### DIFF
--- a/.changelogs/12309.json
+++ b/.changelogs/12309.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed incorrect return types for in some hooks",
+  "type": "fixed",
+  "issueOrPR": 12309,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/types/core/hooks/index.d.ts
+++ b/handsontable/types/core/hooks/index.d.ts
@@ -229,7 +229,7 @@ export interface Events {
   beforeRemoveRow?: (index: number, amount: number, physicalColumns: number[], source?: ChangeSource) => void;
   beforeRender?: (isForced: boolean) => void;
   beforeRenderer?: (TD: HTMLTableCellElement, row: number, column: number, prop: string | number, value: CellValue, cellProperties: CellProperties) => void;
-  beforeRowMove?: (movedRows: number[], finalIndex: number, dropIndex: number | undefined, movePossible: boolean) => void;
+  beforeRowMove?: (movedRows: number[], finalIndex: number, dropIndex: number | undefined, movePossible: boolean) => void | boolean;
   beforeRowResize?: (newSize: number, row: number, isDoubleClick: boolean) => number | void;
   beforeRowWrap?: (isActionInterrupted: { value: boolean }, newCoords: CellCoords, isRowFlipped: boolean) => void;
   beforeSelectAll?: (from: CellCoords, to: CellCoords, highlight?: CellCoords) => void;
@@ -267,7 +267,7 @@ export interface Events {
   modifyColHeader?: (column: number) => void;
   modifyColumnHeaderHeight?: () => void;
   modifyColumnHeaderValue?: (headerValue: string, visualColumnIndex: number, headerLevel: number) => void | string;
-  modifyColWidth?: (width: number, column: number, source?: string) => void;
+  modifyColWidth?: (width: number, column: number, source?: string) => void | number;
   modifyCopyableRange?: (copyableRanges: RangeType[]) => void;
   modifyFiltersMultiSelectValue?: (value: string, meta: CellProperties) => void | CellValue;
   modifyFocusedElement?: (row: number, column: number, focusedElement: HTMLElement) => void | HTMLElement;
@@ -277,7 +277,7 @@ export interface Events {
   modifyGetCoordsElement?: (row: number, column: number) => void | [number, number];
   modifyRowData?: (row: number) => void;
   modifyRowHeader?: (row: number) => void;
-  modifyRowHeaderWidth?: (rowHeaderWidth: number) => void;
+  modifyRowHeaderWidth?: (rowHeaderWidth: number) => void | number;
   modifyRowHeight?: (height: number, row: number, source?: string) => void | number;
   modifyRowHeightByOverlayName?: (height: number, row: number, overlayType: OverlayType) => void | number;
   modifySourceData?: (row: number, column: number, valueHolder: { value: CellValue }, ioMode: 'get' | 'set') => void;


### PR DESCRIPTION
### Context

Three hook type definitions in `handsontable/types/core/hooks/index.d.ts` had incorrect return types that didn't match the runtime behavior:
- `beforeRowMove` returned void but the source checks for false to cancel the move - fixed to `void | boolean`
- `modifyColWidth` returned void but the hook is expected to return a modified width - fixed to `void | number`
- `modifyRowHeaderWidth` returned void but the return value is used to override the row header width - fixed to `void | number`

### How has this been tested?

Verified each hook's return value usage in the source code to confirm the correct types. No
  runtime changes - type definitions only.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

none found

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only updates to hook signatures; low runtime risk but may surface new TypeScript errors for consumers whose hook implementations returned incompatible types.
> 
> **Overview**
> Fixes Handsontable hook type definitions to match runtime behavior by allowing `beforeRowMove` to return `boolean` (to cancel a move) and allowing `modifyColWidth`/`modifyRowHeaderWidth` to return a `number` (to override computed widths).
> 
> Adds a changelog entry (`.changelogs/12309.json`) documenting the typing fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd17258a2129dffef90a17089daabe480c63cfb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->