### PR TITLE
Fix Column / Row hook return value being ignored during drag resize

### DIFF
--- a/.changelogs/10593.json
+++ b/.changelogs/10593.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed beforeColumnResize and beforeRowResize hook return value being ignored during drag resize",
+  "type": "fixed",
+  "issueOrPR": 10593,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/manualColumnResize/__tests__/manualColumnResize.spec.js
+++ b/handsontable/src/plugins/manualColumnResize/__tests__/manualColumnResize.spec.js
@@ -619,6 +619,21 @@ describe('manualColumnResize', () => {
     expect(colWidth(spec().$container, 0)).toEqual(100);
   });
 
+  it('should apply the return value of beforeColumnResize when drag resizing', async() => {
+    handsontable({
+      data: createSpreadsheetData(3, 3),
+      colHeaders: true,
+      manualColumnResize: true,
+      beforeColumnResize: () => 150
+    });
+
+    expect(colWidth(spec().$container, 0)).toEqual(50);
+
+    await resizeColumn(0, 100);
+
+    expect(colWidth(spec().$container, 0)).toEqual(150);
+  });
+
   it('should appropriate resize colWidth after beforeColumnResize call a few times', async() => {
     handsontable({
       data: createSpreadsheetData(3, 3),

--- a/handsontable/src/plugins/manualColumnResize/manualColumnResize.js
+++ b/handsontable/src/plugins/manualColumnResize/manualColumnResize.js
@@ -525,7 +525,12 @@ export class ManualColumnResize extends BasePlugin {
       this.hot.render();
     };
     const resize = (column, forceRender) => {
-      this.hot.runHooks('beforeColumnResize', this.#newSize, column, false);
+      const hookNewSize = this.hot.runHooks('beforeColumnResize', this.#newSize, column, false);
+
+      if (hookNewSize !== undefined) {
+        this.#newSize = hookNewSize;
+        this.setManualSize(column, this.#newSize);
+      }
 
       if (forceRender) {
         render();

--- a/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
+++ b/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
@@ -445,6 +445,19 @@ describe('manualRowResize', () => {
     expect(rowHeight(spec().$container, 0)).toEqual(100);
   });
 
+  it('should apply the return value of beforeRowResize when drag resizing', async() => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      rowHeaders: true,
+      manualRowResize: true,
+      beforeRowResize: () => 150
+    });
+
+    await resizeRow(0, 100);
+
+    expect(rowHeight(spec().$container, 0)).toEqual(150);
+  });
+
   it('should appropriate resize rowHeight after beforeRowResize call a few times', async() => {
     handsontable({
       data: createSpreadsheetData(3, 3),

--- a/handsontable/src/plugins/manualRowResize/manualRowResize.js
+++ b/handsontable/src/plugins/manualRowResize/manualRowResize.js
@@ -515,7 +515,12 @@ export class ManualRowResize extends BasePlugin {
       this.hot.render();
     };
     const runHooks = (row, forceRender) => {
-      this.hot.runHooks('beforeRowResize', this.getActualRowHeight(row), row, false);
+      const hookNewSize = this.hot.runHooks('beforeRowResize', this.getActualRowHeight(row), row, false);
+
+      if (hookNewSize !== undefined) {
+        this.#newSize = hookNewSize;
+        this.setManualSize(row, this.#newSize);
+      }
 
       if (forceRender) {
         render();


### PR DESCRIPTION
### Context
The beforeColumnResize and beforeRowResize hooks allow returning a number to override the new size. This worked correctly when triggered by a double-click (auto-size), but the return value was silently ignored when triggered by a drag resize. This fix makes both code paths handle the hook return value consistently

fixes https://github.com/handsontable/handsontable/issues/10593

### How has this been tested?

Added E2E tests for both manualColumnResize and manualRowResize that verify the hook return value is applied during drag resize. Ran the full E2E suite - no regressions.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #10593

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes resize finalization logic in `manualColumnResize` and `manualRowResize`, which can affect persisted row/column dimensions during user interactions. Risk is limited to these plugins and is covered by new regression tests.
> 
> **Overview**
> Ensures drag-based resizing respects the numeric return value from `beforeColumnResize`/`beforeRowResize` by applying the hook result (when provided) as the final manual size before firing the corresponding `after*Resize` hook.
> 
> Adds regression tests for both manual resize plugins verifying that drag resize applies the hook override, and includes a changelog entry for #10593.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22086175d77c657ce7508b13fdce9d582fb53ecf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->