### PR TITLE
docs: improve recipes and fix server-side data duplicate headings

### DIFF
--- a/docs/content/guides/getting-started/server-side-data/server-side-data-configuration.md
+++ b/docs/content/guides/getting-started/server-side-data/server-side-data-configuration.md
@@ -19,8 +19,6 @@ searchCategory: Guides
 category: Server-side data
 ---
 
-# Server-side configuration
-
 How to wire [`dataProvider`](@/api/options.md#dataprovider) with [`pagination`](@/api/options.md#pagination), sorting, and filters, and what `fetchRows` receives in each request. Start with [Server-side data](@/guides/getting-started/server-side-data/server-side-data.md) if you need the overview or demo.
 
 [[toc]]

--- a/docs/content/guides/getting-started/server-side-data/server-side-data-crud.md
+++ b/docs/content/guides/getting-started/server-side-data/server-side-data-crud.md
@@ -19,8 +19,6 @@ searchCategory: Guides
 category: Server-side data
 ---
 
-# Server-side CRUD
-
 With a complete [`dataProvider`](@/api/options.md#dataprovider) configuration, Handsontable sends **create**, **update**, and **remove** operations to your backend. For loading and `fetchRows`, see [Configuration and query parameters](@/guides/getting-started/server-side-data/server-side-data-configuration.md) and [Fetching, hooks, and examples](@/guides/getting-started/server-side-data/server-side-data-fetching.md).
 
 [[toc]]

--- a/docs/content/guides/getting-started/server-side-data/server-side-data-fetching.md
+++ b/docs/content/guides/getting-started/server-side-data/server-side-data-fetching.md
@@ -20,8 +20,6 @@ searchCategory: Guides
 category: Server-side data
 ---
 
-# Server-side fetching and examples
-
 Hooks around `fetchRows`, loading and error UI, and the DataProvider plugin API. For CRUD callbacks, see [Server-side CRUD](@/guides/getting-started/server-side-data/server-side-data-crud.md). For query fields passed into `fetchRows`, see [Server-side configuration](@/guides/getting-started/server-side-data/server-side-data-configuration.md).
 
 [[toc]]

--- a/docs/content/guides/getting-started/server-side-data/server-side-data-migration.md
+++ b/docs/content/guides/getting-started/server-side-data/server-side-data-migration.md
@@ -19,8 +19,6 @@ searchCategory: Guides
 category: Server-side data
 ---
 
-# Migrate to server-side data
-
 Use this checklist when moving from a full in-memory `data` array and hooks such as [`afterChange`](@/api/hooks.md#afterchange) to `dataProvider`. For an overview and demo, see [Server-side data](@/guides/getting-started/server-side-data/server-side-data.md).
 
 [[toc]]

--- a/docs/content/recipes/sidebar.js
+++ b/docs/content/recipes/sidebar.js
@@ -18,7 +18,7 @@ const cellTypesItems = [
 
 const themesItems = [
   { path: 'themes/custom-theme/custom-theme', title: 'Handsontable with shadcn/ui', onlyFor: ['react', 'javascript', 'angular'] },
-  { path: 'themes/mui-theme/mui-theme', title: 'Handsontable with MUI', onlyFor: ['react'] },
+  { path: 'themes/mui-theme/mui-theme', title: 'Handsontable with MUI', onlyFor: ['react', 'javascript', 'angular'] },
 ];
 
 module.exports = {

--- a/docs/content/recipes/themes/custom-theme/custom-theme.md
+++ b/docs/content/recipes/themes/custom-theme/custom-theme.md
@@ -321,9 +321,11 @@ const DataGrid = forwardRef<HotTableRef, unknown>(function DataGrid(_, ref) {
 });
 ```
 
-Use the grid in your page (e.g. **`app/page.tsx`**): `import DataGrid from "@/components/DataGrid"` and render `<DataGrid />`. The full example exports a `DataGridWrapper` that wires the grid ref to URL search params for filtering (see Complete example below).
+Use the grid in your page (e.g. **`app/page.tsx`**): `import DataGrid from "@/components/DataGrid"` and render `<DataGrid />`.
 
 ## Complete example (minimal single-file shape)
+
+The complete example adds a `DataGridWrapper` that wires the grid ref to URL search params for filtering. It uses the same `DataGrid` component from Step 5, wrapped with `memo` and `forwardRef`.
 
 ```tsx
 "use client";
@@ -332,127 +334,26 @@ import { useSearchParams } from "next/navigation";
 import { HotTable, HotColumn, HotTableRef } from "@handsontable/react-wrapper";
 import { registerTheme } from "handsontable/themes";
 import { registerAllModules } from "handsontable/registry";
-
 import tokensHorizon from 'handsontable/themes/static/variables/tokens/horizon';
-
 import { colorsShadcn } from "@/lib/theme/colorsShadcn";
 import { iconsShadcn } from "@/lib/theme/iconsShadcn";
 import { data, config } from "@/lib/helpers";
 
 registerAllModules();
 
+// Theme registration and DataGrid component (same as Step 5)
 const shadcnDataGridTheme = registerTheme('shadcn-data-grid', {
   icons: iconsShadcn,
   colors: colorsShadcn,
   tokens: tokensHorizon,
-}).params({
-  tokens: {
-    wrapperBorderRadius: "var(--radius)",
-  },
-})
+}).params({ tokens: { wrapperBorderRadius: "var(--radius)" } });
 
 const DataGrid = forwardRef<HotTableRef, unknown>(function DataGrid(_, ref) {
-  return (<HotTable
-    ref={ref}
-    theme={shadcnDataGridTheme}
-    data={data}
-    {...config}
-  >
-    <HotColumn data="name" width={160} />
-    <HotColumn data="age" type="numeric" width={100} />
-    <HotColumn
-      data="country"
-      type="autocomplete"
-      source={[
-        "Germany",
-        "China",
-        "France",
-        "Netherlands",
-        "Switzerland",
-        "USA",
-        "Canada",
-        "UK",
-        "Australia",
-        "Spain",
-        "Japan",
-        "Brazil",
-        "South Korea",
-        "Mexico",
-      ]}
-      strict={true}
-      allowInvalid={true}
-      width={160}
-    />
-    <HotColumn
-      data="city"
-      type="dropdown"
-      source={[
-        "Walldorf",
-        "Shenzhen",
-        "Lyon",
-        "Amsterdam",
-        "Zurich",
-        "New York",
-        "Toronto",
-        "London",
-        "Sydney",
-        "Los Angeles",
-        "Barcelona",
-        "Tokyo",
-        "Manchester",
-        "Sao Paulo",
-        "Miami",
-        "Madrid",
-        "Seoul",
-        "Vancouver",
-        "Valencia",
-        "Chicago",
-        "Mexico City",
-        "Houston",
-      ]}
-      width={160}
-    />
-    <HotColumn
-      data="isActive"
-      type="checkbox"
-      className="htCenter"
-      width={120}
-    />
-    <HotColumn
-      data="interest"
-      type="dropdown"
-      source={[
-        "Electronics",
-        "Fashion",
-        "Tech Gadgets",
-        "Home Decor",
-        "Sports & Fitness",
-        "Books & Literature",
-        "Beauty & Personal Care",
-        "Food & Cooking",
-        "Travel & Adventure",
-        "Art & Collectibles",
-      ]}
-      width={220}
-    />
-    <HotColumn data="favoriteProduct" width={220} />
-    <HotColumn
-      data="lastLoginDate"
-      type="date"
-      className="htRight"
-      correctFormat={true}
-      dateFormat="MMM DD, YYYY"
-      width={180}
-    />
-    <HotColumn
-      data="lastLoginTime"
-      type="time"
-      className="htRight"
-      correctFormat={true}
-      timeFormat="HH:mm"
-      width={180}
-    />
-  </HotTable>);
+  return (
+    <HotTable ref={ref} theme={shadcnDataGridTheme} data={data} {...config}>
+      {/* HotColumn definitions (see Step 5) */}
+    </HotTable>
+  );
 });
 
 const MemoizedDataGrid = memo(DataGrid);
@@ -471,9 +372,9 @@ function DataGridWrapper() {
       if (filtersPlugin) {
         filtersPlugin.clearConditions();
 
-        if (params.q) filtersPlugin.addCondition(0, 'begins_with', [params.q]); // Name
-        if (params.country) filtersPlugin.addCondition(2, 'contains', [params.country]); // Country
-        if (params.status) filtersPlugin.addCondition(4, 'eq', [params.status === 'active']); // Active (checkbox)
+        if (params.q) filtersPlugin.addCondition(0, 'begins_with', [params.q]);
+        if (params.country) filtersPlugin.addCondition(2, 'contains', [params.country]);
+        if (params.status) filtersPlugin.addCondition(4, 'eq', [params.status === 'active']);
 
         filtersPlugin.filter();
         hot?.render();
@@ -481,9 +382,7 @@ function DataGridWrapper() {
     }
   }, [searchParams]);
 
-  return (
-    <MemoizedDataGrid ref={hotTableRef} />
-  );
+  return <MemoizedDataGrid ref={hotTableRef} />;
 }
 
 export default DataGridWrapper;
@@ -493,6 +392,10 @@ export default DataGridWrapper;
 
 ## Related
 
-- [Themes](/themes) – Built-in themes and Theme API
-- [Theme customization](/theme-customization) – Theme API parameters and CSS variable reference
-- [Design system (Figma)](/handsontable-design-system) – Figma kit and design tokens
+<div class="boxes-list">
+
+- [Themes](@/guides/styling/themes/themes.md)
+- [Theme customization](@/guides/styling/theme-customization/theme-customization.md)
+- [Design system](@/guides/styling/design-system/design-system.md)
+
+</div>

--- a/docs/content/recipes/themes/mui-theme/mui-theme.md
+++ b/docs/content/recipes/themes/mui-theme/mui-theme.md
@@ -1,7 +1,7 @@
 ---
 id: f2a7b9c1
 title: Handsontable with MUI
-metaTitle: Handsontable with MUI - React Data Grid | Handsontable
+metaTitle: Handsontable with MUI - JavaScript Data Grid | Handsontable
 description: Integrate Handsontable into a React app with MUI so your grid follows Material UI colors, typography, and spacing.
 permalink: /recipes/themes/mui-theme
 canonicalUrl: /recipes/themes/mui-theme
@@ -18,6 +18,9 @@ tags:
 react:
   id: d4e8a6f2
   metaTitle: Handsontable with MUI - React Data Grid | Handsontable
+angular:
+  id: a3b7c9e1
+  metaTitle: Handsontable with MUI - Angular Data Grid | Handsontable
 searchCategory: Recipes
 category: Themes
 ---
@@ -212,6 +215,10 @@ export default function App() {
 
 ## Related
 
-- [Themes](@/guides/styling/themes/themes.md) - Built-in themes and Theme API.
-- [Theme customization](@/guides/styling/theme-customization/theme-customization.md) - Theme API parameters and CSS variable reference.
-- [Theme Recipes](/recipes/themes) - Practical design-system recipes for Handsontable.
+<div class="boxes-list">
+
+- [Themes](@/guides/styling/themes/themes.md)
+- [Theme customization](@/guides/styling/theme-customization/theme-customization.md)
+- [Design system](@/guides/styling/design-system/design-system.md)
+
+</div>

--- a/docs/content/recipes/themes/themes.md
+++ b/docs/content/recipes/themes/themes.md
@@ -34,7 +34,11 @@ Our recipes cover common use cases and demonstrate best practices for:
 
 Current recipes:
 
-- [Handsontable with shadcn/ui](/recipes/themes/custom-theme)
-- [Handsontable with MUI](/recipes/themes/mui-theme)
+<div class="boxes-list">
+
+- [Handsontable with shadcn/ui](@/content/recipes/themes/custom-theme/custom-theme.md)
+- [Handsontable with MUI](@/content/recipes/themes/mui-theme/mui-theme.md)
+
+</div>
 
 Each recipe includes complete code examples, configuration options, and troubleshooting tips to help you integrate Handsontable with your app's look and feel.

--- a/docs/src/styles/components/code.css
+++ b/docs/src/styles/components/code.css
@@ -67,6 +67,7 @@
 :root[data-theme='light'] .expressive-code {
   --ec-frm-shdCol: transparent;
   --ec-frm-frameBoxShdCssVal: none;
+  --ec-frm-trmTtbBrdBtmCol: var(--sl-color-gray-5);
 }
 
 :root[data-theme='light'] .expressive-code .copy button {


### PR DESCRIPTION
- Make MUI recipe available for all frameworks (JS, React, Angular)
- Shorten shadcn Complete example to avoid duplicating Step 5 code
- Fix Related sections: use boxes-list pattern with correct @/ links
- Fix terminal code block border color in light mode (use CSS variable)
- Fix theme recipes index page: use boxes-list with correct links
- Remove duplicate H1 headings from 4 server-side data pages

### Context
<!--- Why is this change required? What problem does it solve? -->

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation and styling tweaks; main potential impact is broken navigation/SEO metadata if links or frontmatter targets are incorrect.
> 
> **Overview**
> Removes duplicate top-level headings from four Server-side data guide pages so the frontmatter `title` is the single H1.
> 
> Updates theme recipes to use the `boxes-list` “Related”/index pattern with corrected `@/` links, shortens the shadcn/ui recipe’s complete example to avoid duplicating Step 5 code, and broadens the MUI theme recipe’s availability/metadata (adds Angular frontmatter and exposes it in the recipes sidebar for JS/React/Angular).
> 
> Adjusts `Expressive Code` light-mode styling to set the terminal tab bar bottom border color via `--ec-frm-trmTtbBrdBtmCol`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b72d9e929cb77f77ccfd6ffd47b4fa1cf031d8cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[skip changelog]