### PR TITLE
Add dynamic docs version resolution for staging/dev builds

### DIFF
--- a/docs/src/plugins/docs-version.mjs
+++ b/docs/src/plugins/docs-version.mjs
@@ -1,0 +1,98 @@
+/**
+ * Computes the Handsontable version string to embed in documentation pages.
+ *
+ * - Production (BUILD_MODE=production): reads the version from
+ *   handsontable/package.json (e.g. "17.0.1").
+ * - Staging/dev: derives a pre-release version from the current git commit
+ *   in the format "0.0.0-next-{shortSHA}-{YYYYMMDD}" so that CodeSandbox
+ *   links on the Introduction page resolve to the correct in-progress build.
+ *   When GITHUB_SHA is set (CI environment) it is preferred over `git rev-parse`
+ *   to avoid requiring a git binary at build time.
+ */
+
+import { createRequire } from 'module';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import { execSync } from 'child_process';
+
+const _require = createRequire(import.meta.url);
+const _dir = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Returns the 7-character short SHA for the current HEAD commit.
+ * Prefers the GITHUB_SHA environment variable (available in GitHub Actions)
+ * and falls back to `git rev-parse --short HEAD`. Returns 'dev' when neither
+ * is available.
+ *
+ * @returns {string}
+ */
+function getShortSha() {
+  const envSha = process.env.GITHUB_SHA;
+
+  if (envSha && envSha.length >= 7) {
+    return envSha.slice(0, 7);
+  }
+
+  try {
+    return execSync('git rev-parse --short HEAD', {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return 'dev';
+  }
+}
+
+/**
+ * Returns the commit date for HEAD in YYYYMMDD format.
+ * Falls back to the current wall-clock date when git is unavailable.
+ *
+ * @returns {string}
+ */
+function getCommitDate() {
+  try {
+    return execSync('git log -1 --format=%cd --date=format:%Y%m%d', {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    const now = new Date();
+
+    return [
+      now.getFullYear(),
+      String(now.getMonth() + 1).padStart(2, '0'),
+      String(now.getDate()).padStart(2, '0'),
+    ].join('');
+  }
+}
+
+/**
+ * Computes the version string used in docs page links (e.g. CodeSandbox URLs).
+ *
+ * @returns {string}
+ */
+function computeDocsVersion() {
+  if (process.env.BUILD_MODE === 'production') {
+    try {
+      const pkg = _require(join(_dir, '../../../handsontable/package.json'));
+
+      return pkg.version ?? 'next';
+    } catch {
+      return 'next';
+    }
+  }
+
+  // Staging / dev: 0.0.0-next-{shortSHA}-{YYYYMMDD}
+  const shortSha = getShortSha();
+  const date = getCommitDate();
+
+  return `0.0.0-next-${shortSha}-${date}`;
+}
+
+/**
+ * The resolved Handsontable version for this docs build.
+ * Evaluated once at module load time so all imports share the same value.
+ *
+ * @type {string}
+ */
+export const CURRENT_DOCS_VERSION = computeDocsVersion();

--- a/docs/src/plugins/framework-loader.mjs
+++ b/docs/src/plugins/framework-loader.mjs
@@ -12,6 +12,7 @@ import { join, relative, dirname } from 'path';
 import { createRequire } from 'module';
 import { fileURLToPath } from 'url';
 import matter from 'gray-matter';
+import { CURRENT_DOCS_VERSION } from './docs-version.mjs';
 
 // Read the current handsontable library version for StackBlitz package.json.
 const _require = createRequire(import.meta.url);
@@ -401,7 +402,7 @@ const PREFIXES = {
 
 // Bump this when the loader logic changes to force Astro's data store to
 // re-process all entries (the store skips entries whose digest hasn't changed).
-const LOADER_VERSION = 'v28';
+const LOADER_VERSION = 'v29';
 
 // ---------------------------------------------------------------------------
 // File listing (recursive, no external glob)
@@ -1064,6 +1065,12 @@ function applyVuepressPreprocessing(content, prefix, contentDir) {
 
   // Fix {{$basePath}} → '' (VuePress versioned-base template variable)
   result = result.replace(/\{\{\s*\$basePath\s*\}\}/g, '');
+
+  // Fix {{$currentVersion}} → resolved Handsontable version string.
+  // Production builds use the package.json version (e.g. "17.0.1").
+  // Staging/dev builds use "0.0.0-next-{shortSHA}-{YYYYMMDD}" so that
+  // CodeSandbox links resolve to the correct in-progress build artifact.
+  result = result.replace(/\{\{\s*\$currentVersion\s*\}\}/g, CURRENT_DOCS_VERSION);
 
   // Transform @/framework/path.md links to absolute Starlight URLs using permalinks.
   // When prefix/contentDir are available (framework pages), do full permalink resolution.

--- a/docs/src/plugins/vuepress-preprocessor.mjs
+++ b/docs/src/plugins/vuepress-preprocessor.mjs
@@ -10,9 +10,12 @@
  * - ::: example / ::: example-without-tabs  (strip markers, keep code blocks)
  * - ::: source-code-link URL  (convert to <a> tag)
  * - $withBase('/path') → /path
+ * - {{$currentVersion}} → resolved Handsontable version string
  * - @/framework/path links  → /path (cross-framework alias)
  * - <div class="boxes-list"> ... </div>  → Starlight-styled card grid HTML
  */
+
+import { CURRENT_DOCS_VERSION } from './docs-version.mjs';
 
 /**
  * @param {{ framework?: string }} options
@@ -77,6 +80,12 @@ function preprocessMarkdown(content, framework) {
   //     base prefix is added automatically; dropping the placeholder preserves
   //     the correct root-relative path (e.g. /img/pages/... or /cert.pdf).
   result = result.replace(/\{\{\s*\$basePath\s*\}\}/g, '');
+
+  // 6c. Fix {{$currentVersion}} → resolved Handsontable version string.
+  //     Production builds use the package.json version (e.g. "17.0.1").
+  //     Staging/dev builds use "0.0.0-next-{shortSHA}-{YYYYMMDD}" so that
+  //     CodeSandbox links resolve to the correct in-progress build artifact.
+  result = result.replace(/\{\{\s*\$currentVersion\s*\}\}/g, CURRENT_DOCS_VERSION);
 
   // 7. Transform @/framework/... cross-framework alias links to absolute paths.
   //    e.g. @/react/guides/foo/foo.md → /guides/foo/foo


### PR DESCRIPTION
### Context
Documentation pages (particularly CodeSandbox links on the Introduction page) need to reference the correct Handsontable version. For production builds, this should be the actual package version (e.g., "17.0.1"). For staging/dev builds, it should be a pre-release version derived from the current git commit so that links resolve to the correct in-progress build artifact.

This change introduces a centralized version resolution module that:
- Reads the package version for production builds (`BUILD_MODE=production`)
- Generates a pre-release version string (`0.0.0-next-{shortSHA}-{YYYYMMDD}`) for staging/dev builds
- Prefers `GITHUB_SHA` environment variable (available in CI) over `git rev-parse` to avoid requiring git at build time
- Falls back gracefully when git is unavailable

### How has this been tested?
The implementation includes fallback mechanisms for all external dependencies:
- `GITHUB_SHA` environment variable is preferred in CI environments
- `git rev-parse --short HEAD` is used as fallback for local development
- Returns 'dev' if neither is available
- Current date is used as fallback for commit date when git is unavailable

The version string is computed once at module load time and shared across all imports, ensuring consistency throughout the build.

### Types of changes
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
N/A

### Affected project(s):
- [x] `handsontable`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)

https://claude.ai/code/session_01KQw7rk5nPi9LTTB6p8M7qA

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes docs build-time preprocessing and introduces git/CI-dependent version resolution that could affect builds or generated links if environment assumptions differ.
> 
> **Overview**
> Adds a centralized docs version resolver (`docs-version.mjs`) that uses the real `handsontable/package.json` version in production, and otherwise generates a `0.0.0-next-{shortSHA}-{YYYYMMDD}` version derived from `GITHUB_SHA`/git metadata.
> 
> Updates both the Astro `framework-loader` and the Vite `vuepress-preprocessor` to replace VuePress template token `{{$currentVersion}}` with this resolved version, and bumps the loader cache key (`LOADER_VERSION` `v28`→`v29`) so existing content is reprocessed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 922ca8ec4772f25a6c3d0bd0081dc5ba90ec107d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[skip changelog]