### PR TITLE
DEV-1194: Fix multiselect overflow indicator ignoring chip padding tokens

### DIFF
--- a/.changelogs/12316.json
+++ b/.changelogs/12316.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed multiselect overflow indicator not responding to chip padding token changes",
+  "type": "fixed",
+  "issueOrPR": 12316,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/styles/components/renderers/_multi-select-renderer.scss
+++ b/handsontable/src/styles/components/renderers/_multi-select-renderer.scss
@@ -73,7 +73,7 @@
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      padding: 0 calc(var(--ht-gap-size) * 2);
+      padding: var(--ht-chip-vertical-padding) var(--ht-chip-horizontal-padding);
       background: var(--ht-chip-background);
       border-radius: var(--ht-chip-border-radius);
       color: var(--ht-foreground-color);


### PR DESCRIPTION
### Context

The `.ht-multi-select-overflow` element (the "+N" more tags indicator in multiselect cells) was using hardcoded padding `0 calc(var(--ht-gap-size) * 2)` instead of the chip padding CSS custom properties. This caused the overflow indicator to not respond to `--ht-chip-vertical-padding` and `--ht-chip-horizontal-padding` changes — making it visually misaligned with chips when padding is customized via the Theme Builder.

The fix changes the overflow indicator's padding to use `var(--ht-chip-vertical-padding) var(--ht-chip-horizontal-padding)`, matching the chip elements.

### How has this been tested?

- Stylelint: `npm run stylelint --prefix handsontable` — passed
- Unit tests: `npm run test:unit --prefix handsontable --testPathPattern=multiSelectRenderer` — passed
- Manual testing: Used the Theme Builder to change chip Vertical/Horizontal Padding values and verified via Chrome DevTools that both `.ht-multi-select-chip` and `.ht-multi-select-overflow` now respond to the same CSS custom properties

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. DEV-1194

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CSS-only change to a renderer style; low risk aside from minor visual/layout differences in themed multiselect cells.
> 
> **Overview**
> Fixes the multiselect overflow indicator (`.ht-multi-select-overflow`, the "+N" chip) to use the chip padding design tokens (`--ht-chip-vertical-padding`/`--ht-chip-horizontal-padding`) instead of a hardcoded `--ht-gap-size`-based value, so it stays aligned when chip padding is customized.
> 
> Adds a changelog entry documenting the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb5f9b61f087d7c28979bc45f634efb273de290f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->