### PR TITLE
fix(DEV-1262): Fix changelog JSON files for PRs with wrong/missing descriptions

### DIFF
--- a/.changelogs/12117.json
+++ b/.changelogs/12117.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "public",
-  "title": "Fixed filters plugin applying conditions to wrong columns after using manualColumnMove",
+  "title": "Fixed the Filters plugin incorrectly applying filter conditions after columns were moved with the ManualColumnMove plugin.",
   "type": "fixed",
   "issueOrPR": 11832,
   "breaking": false,

--- a/.changelogs/12118.json
+++ b/.changelogs/12118.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "public",
-  "title": "Fixed manual column resizing in scaled containers by aligning the guide and normalizing drag width changes.",
+  "title": "Fixed column resizing being misaligned and calculating incorrect widths when the grid container has a CSS `transform: scale()` applied.",
   "type": "fixed",
   "issueOrPR": 11838,
   "breaking": false,

--- a/.changelogs/12123.json
+++ b/.changelogs/12123.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed the `stretchH: 'last'` option ignoring the defined column width and shrinking the last column to 0px when the viewport was too narrow.",
+  "type": "fixed",
+  "issueOrPR": 11761,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/12129.json
+++ b/.changelogs/12129.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Added `rowspan` support to the NestedHeaders plugin, allowing column headers to span multiple header rows.",
+  "type": "added",
+  "issueOrPR": 191,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/12143.json
+++ b/.changelogs/12143.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed `setSourceDataAtCell()` updating a parent row instead of the intended nested child row when the `nestedRows` option was enabled.",
+  "type": "fixed",
+  "issueOrPR": 10657,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/12144.json
+++ b/.changelogs/12144.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed `setDataAtRowProp()` incorrectly canceling an active editor session when the programmatic update targeted a different cell in the same row.",
+  "type": "fixed",
+  "issueOrPR": 4305,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/12205.json
+++ b/.changelogs/12205.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a one-pixel horizontal misalignment of the left pagination caret in the Pagination plugin.",
+  "type": "fixed",
+  "issueOrPR": 2791,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/12207.json
+++ b/.changelogs/12207.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "private",
-  "title": "Fixed validator state reset after first paste when using dataSchema in React wrapper",
+  "title": "Fixed the React wrapper skipping settings updates when `dataSchema` or `columns` contains non-plain objects such as `Date`, `Set`, or `Map`.",
   "type": "fixed",
   "issueOrPR": 12207,
   "breaking": false,

--- a/.changelogs/12289.json
+++ b/.changelogs/12289.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed incorrect JSDoc type annotations for the `modifyAutofillRange` hook's `entireArea` and `startArea` parameters, and added the missing `@returns` annotation.",
+  "type": "fixed",
+  "issueOrPR": 11862,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -13,6 +13,10 @@ on:
       - opened
       - reopened
       - synchronize
+    paths:
+      - 'handsontable/**'
+      - 'performance-tests/**'
+      - '.github/workflows/performance-tests.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -10,6 +10,10 @@ on:
       - opened
       - synchronize
       - reopened
+    paths:
+      - 'handsontable/**'
+      - 'wrappers/**'
+      - '.github/workflows/pkg-pr-new.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

- Corrected wrong `title` fields in three existing changelog files -- they contained descriptions that did not match the actual changes in those PRs:
  - `12207.json`: was "Fixed validator state reset after first paste..." -- now correctly describes the React wrapper deep equality fix for non-plain objects (`Date`, `Set`, `Map`)
  - `12118.json`: replaced implementation-focused wording with a user-facing description of the CSS `transform: scale()` column resize fix
  - `12117.json`: improved wording and added missing period for the Filters + ManualColumnMove fix
- Created 6 missing PR-numbered changelog entries -- the changelog endpoint looks up files by PR number, and these PRs only had issue-numbered files:
  - `12289.json` -- JSDoc type fix for `modifyAutofillRange` hook
  - `12129.json` -- `rowspan` support added to NestedHeaders plugin
  - `12123.json` -- `stretchH: 'last'` column width fix
  - `12144.json` -- `setDataAtRowProp()` editor session fix
  - `12143.json` -- `setSourceDataAtCell()` with nestedRows fix
  - `12205.json` -- Pagination left caret alignment fix
- Added `paths` filters to the `pull_request` trigger in `performance-tests.yml` and `pkg-pr-new.yml` so those expensive CI jobs are skipped on PRs that only touch docs, config, or changelog files.

## CI workflow path filters

| Workflow | Triggers on PR when paths match |
|---|---|
| Performance tests | `handsontable/**`, `performance-tests/**`, `.github/workflows/performance-tests.yml` |
| Preview packages | `handsontable/**`, `wrappers/**`, `.github/workflows/pkg-pr-new.yml` |

## Test plan

- [ ] Verify `https://handsontable.com/api/changelog-prs` shows correct entries for #12207, #12118, #12117, #12289, #12129, #12123, #12144, #12143, #12205 after merge.
- [ ] Open a changelog-only PR and confirm Performance tests and Preview packages CI jobs are skipped.
- [ ] Open a PR touching `handsontable/src/` and confirm both CI jobs run normally.

ClickUp task: https://app.clickup.com/t/86c9az9hz

[skip changelog]

https://claude.ai/code/session_01LnWPMsBNS7QKVXMPhtYdYH