### PR TITLE
DEV-1266: Remove broken reset demo button from docs examples

### DIFF
--- a/docs/src/plugins/framework-loader.mjs
+++ b/docs/src/plugins/framework-loader.mjs
@@ -273,7 +273,6 @@ function buildExampleHtml(id, directive, fileRefs, contentDir, fileMeta = {}) {
   // ── SVG icons (inlined to keep no external dependencies) ──────────────────
   const iconCode = `<svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>`;
   const iconChevron = `<svg class="hot-example-source-chevron" aria-hidden="true" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6l6 -6"/></svg>`;
-  const iconReset = `<svg aria-hidden="true" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 1 3 6.36"/><polyline points="3 22 3 16 9 16"/></svg>`;
   const iconStackBlitz = `<svg aria-hidden="true" width="13" height="13" viewBox="0 0 28 28" fill="currentColor"><path d="M15.245 0L0 15.556h10.976L7.757 28 28 12.444H17.024L15.245 0z"/></svg>`;
   const iconGitHub = `<svg aria-hidden="true" width="13" height="13" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>`;
 
@@ -293,9 +292,6 @@ function buildExampleHtml(id, directive, fileRefs, contentDir, fileMeta = {}) {
     ${iconCode} Source code ${iconChevron}
   </button>
   <div class="hot-example-actions">
-    <button class="hot-example-reset-btn" type="button" title="Reset demo" aria-label="Reset demo">
-      ${iconReset}
-    </button>
     <button class="hot-example-stackblitz-btn" type="button" title="Edit on StackBlitz" aria-label="Edit on StackBlitz">
       ${iconStackBlitz}
     </button>

--- a/docs/src/scripts/example-runner.ts
+++ b/docs/src/scripts/example-runner.ts
@@ -110,8 +110,6 @@ async function runExamples(): Promise<void> {
 
         const root = createRoot(container);
         root.render(createElement(Component));
-        if (!(el as any).__reactRoots) (el as any).__reactRoots = [];
-        (el as any).__reactRoots.push(root);
         markLoaded(el);
       } catch (err) {
         console.error('[hot-example] JSX failed:', src, err);

--- a/docs/src/scripts/example-runner.ts
+++ b/docs/src/scripts/example-runner.ts
@@ -35,139 +35,6 @@ function markLoaded(el: Element): void {
   el.querySelector('.hot-example-preview')?.classList.remove('hot-example-preview--loading');
 }
 
-/** Store original preview HTML for reset. */
-const originalPreviews = new WeakMap<Element, string>();
-
-/** Saves the initial preview HTML so we can restore it on reset. */
-function savePreview(el: Element): void {
-  const preview = el.querySelector('.hot-example-preview');
-  if (preview && !originalPreviews.has(el)) {
-    originalPreviews.set(el, preview.innerHTML);
-  }
-}
-
-/** Destroys all Handsontable instances inside a container. */
-function destroyInstances(container: Element): void {
-  // @ts-expect-error — Handsontable is loaded globally by examples
-  const Handsontable = (window as any).Handsontable;
-  if (!Handsontable?.instances) return;
-
-  const instances = [...Handsontable.instances];
-  for (const hot of instances) {
-    try {
-      if (container.contains(hot.rootElement)) {
-        hot.destroy();
-      }
-    } catch { /* already destroyed */ }
-  }
-}
-
-// ── Reset handler ─────────────────────────────────────────────────────────
-
-function setupResetButtons(): void {
-  document.addEventListener('click', async (e) => {
-    const btn = (e.target as Element).closest('.hot-example-reset-btn');
-    if (!btn) return;
-
-    const wrapper = btn.closest('.hot-example') as HTMLElement | null;
-    if (!wrapper) return;
-
-    const preview = wrapper.querySelector('.hot-example-preview');
-    if (!preview) return;
-
-    // Destroy existing Handsontable instances
-    destroyInstances(preview);
-
-    // Unmount React roots
-    const reactRoots = (wrapper as any).__reactRoots as any[];
-    if (reactRoots) {
-      for (const root of reactRoots) {
-        try { root.unmount(); } catch { /* ok */ }
-      }
-      (wrapper as any).__reactRoots = [];
-    }
-
-    // Restore original preview HTML
-    const original = originalPreviews.get(wrapper);
-    if (original) {
-      preview.innerHTML = original;
-    }
-
-    // Re-run the example
-    const jsSrc = wrapper.dataset.exampleJs;
-    const jsxSrc = wrapper.dataset.exampleJsx;
-    const vueSrc = wrapper.dataset.exampleVue;
-    const ngSrc = wrapper.dataset.exampleAngular;
-    const id = wrapper.dataset.exampleId;
-    const cacheBust = `?t=${Date.now()}`;
-
-    if (jsSrc) {
-      try {
-        await import(/* @vite-ignore */ jsSrc + cacheBust);
-      } catch (err) {
-        console.error('[hot-example] Reset JS failed:', jsSrc, err);
-      }
-    } else if (jsxSrc && id) {
-      try {
-        const [{ createRoot }, { createElement }] = await Promise.all([
-          import('react-dom/client'),
-          import('react'),
-        ]);
-        const mod = await import(/* @vite-ignore */ jsxSrc + cacheBust) as { default: React.ComponentType };
-        const container = document.getElementById(id);
-        if (container) {
-          const root = createRoot(container);
-          root.render(createElement(mod.default));
-          if (!(wrapper as any).__reactRoots) (wrapper as any).__reactRoots = [];
-          (wrapper as any).__reactRoots.push(root);
-        }
-      } catch (err) {
-        console.error('[hot-example] Reset JSX failed:', jsxSrc, err);
-      }
-    } else if (vueSrc && id) {
-      try {
-        const { createApp } = await import('vue');
-        const htmlSrc = wrapper.dataset.exampleHtml;
-        const container = document.getElementById(id);
-        if (container && htmlSrc) {
-          const htmlLoader = htmlTemplates[htmlSrc];
-          if (htmlLoader) {
-            container.innerHTML = await htmlLoader() as string;
-          }
-        }
-        const mod = await import(/* @vite-ignore */ vueSrc + cacheBust) as { default: any };
-        if (container) {
-          createApp(mod.default).mount(container);
-        }
-      } catch (err) {
-        console.error('[hot-example] Reset Vue failed:', vueSrc, err);
-      }
-    } else if (ngSrc && id) {
-      try {
-        const htmlSrc = wrapper.dataset.exampleHtml;
-        const container = document.getElementById(id);
-        if (container && htmlSrc) {
-          const htmlLoader = htmlTemplates[htmlSrc];
-          if (htmlLoader) {
-            container.innerHTML = await htmlLoader() as string;
-          }
-        }
-        await ensureZone();
-        await import('@angular/compiler');
-        const { platformBrowserDynamic } = await import('@angular/platform-browser-dynamic');
-        const mod = await import(/* @vite-ignore */ ngSrc + cacheBust) as { AppModule: unknown };
-        if (mod.AppModule) {
-          await platformBrowserDynamic().bootstrapModule(mod.AppModule as never, {
-            ngZoneEventCoalescing: true,
-          });
-        }
-      } catch (err) {
-        console.error('[hot-example] Reset Angular failed:', ngSrc, err);
-      }
-    }
-  });
-}
-
 // ── Main runner ───────────────────────────────────────────────────────────
 
 async function runExamples(): Promise<void> {
@@ -191,7 +58,6 @@ async function runExamples(): Promise<void> {
 
   // ── Vanilla JS examples ────────────────────────────────────────────────
   for (const el of document.querySelectorAll('[data-example-js]')) {
-    savePreview(el);
     const src = (el as HTMLElement).dataset.exampleJs!;
     const loader = jsModules[src];
 
@@ -220,7 +86,6 @@ async function runExamples(): Promise<void> {
     ]);
 
     for (const el of jsxEls) {
-      savePreview(el);
       const src = el.dataset.exampleJsx!;
       const id  = el.dataset.exampleId;
       const loader = jsxModules[src];
@@ -262,7 +127,6 @@ async function runExamples(): Promise<void> {
     const { createApp } = await import('vue');
 
     for (const el of vueEls) {
-      savePreview(el);
       const src     = el.dataset.exampleVue!;
       const htmlSrc = el.dataset.exampleHtml;
       const id      = el.dataset.exampleId;
@@ -317,7 +181,6 @@ async function runExamples(): Promise<void> {
     const { platformBrowserDynamic } = await import('@angular/platform-browser-dynamic');
 
     for (const el of ngEls) {
-      savePreview(el);
       const src     = el.dataset.exampleAngular!;
       const htmlSrc = el.dataset.exampleHtml;
       const id      = el.dataset.exampleId;
@@ -366,8 +229,6 @@ async function runExamples(): Promise<void> {
     }
   }
 }
-
-setupResetButtons();
 
 if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', runExamples);

--- a/docs/src/styles/interactive-example.css
+++ b/docs/src/styles/interactive-example.css
@@ -272,7 +272,6 @@
 }
 
 /* Icon-only action buttons (StackBlitz, GitHub) — merged as cells */
-.hot-example-reset-btn,
 .hot-example-stackblitz-btn,
 .hot-example-github-btn {
   appearance: none;
@@ -290,14 +289,12 @@
   transition: color 0.15s, background-color 0.15s;
 }
 
-.hot-example-reset-btn:hover,
 .hot-example-stackblitz-btn:hover,
 .hot-example-github-btn:hover {
   color: var(--sl-color-white);
   background: var(--sl-color-gray-6);
 }
 
-.hot-example-reset-btn:focus-visible,
 .hot-example-stackblitz-btn:focus-visible,
 .hot-example-github-btn:focus-visible {
   outline: none;


### PR DESCRIPTION
### Context
The "Reset demo" button in documentation examples breaks the demo when pressed -- after clicking it, the example stops working. This PR removes the button and its entire implementation (HTML, event handler, helper functions, and CSS).

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1266

### How has this been tested?
This is a docs-only change. Verified by code inspection that:
- The reset button HTML is removed from the example toolbar template in `framework-loader.mjs`
- The `setupResetButtons`, `destroyInstances`, and `savePreview` functions are removed from `example-runner.ts`
- The `.hot-example-reset-btn` CSS selectors are removed from `interactive-example.css`

No library source code was changed.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. DEV-1266

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that removes a non-functional UI control and its associated client-side reset logic; the main example loading paths remain unchanged.
> 
> **Overview**
> Removes the **broken “Reset demo” control** from interactive documentation examples.
> 
> This deletes the reset button from the example toolbar template (`framework-loader.mjs`), drops the corresponding reset implementation in the client runner (`example-runner.ts`), and removes the now-unused `.hot-example-reset-btn` styling from `interactive-example.css`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad8ef0fc462ffc458c2e2ba4923f118ad5c51e00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->