### PR TITLE
DEV-1278: Add inline Flatpickr date picker recipe

### DIFF
--- a/docs/content/recipes/editing-validation/editing-validation.md
+++ b/docs/content/recipes/editing-validation/editing-validation.md
@@ -1,0 +1,26 @@
+---
+title: Editing and validation recipes
+metaTitle: Editing and Validation Recipes - JavaScript Data Grid | Handsontable
+permalink: /recipes/editing-validation
+canonicalUrl: /recipes/editing-validation
+searchCategory: Recipes
+hotPlugin: false
+editLink: false
+id: k3m9p2x7
+description: Recipes for custom editors, validation patterns, and dynamic cell configuration in Handsontable.
+react:
+  id: n5r8w1t4
+  metaTitle: Editing and Validation Recipes - React Data Grid | Handsontable
+angular:
+  id: j7v2y6h9
+  metaTitle: Editing and Validation Recipes - Angular Data Grid | Handsontable
+---
+[[toc]]
+
+## Overview
+
+This section collects recipes focused on editing behavior, validation, and keeping cell configuration in sync with your data.
+
+## Available recipes
+
+- **[Inline Flatpickr date editor](@/content/recipes/editing-validation/inline-flatpickr-datepicker/inline-flatpickr-datepicker.md)** - Mount Flatpickr on `TextEditor`'s textarea, finish editing on close, and destroy the picker when the editor closes.

--- a/docs/content/recipes/editing-validation/inline-flatpickr-datepicker/inline-flatpickr-datepicker.md
+++ b/docs/content/recipes/editing-validation/inline-flatpickr-datepicker/inline-flatpickr-datepicker.md
@@ -1,0 +1,109 @@
+---
+id: f2h8k4n9
+title: Inline Flatpickr date editor
+metaTitle: Inline Flatpickr Date Editor Recipe - JavaScript Data Grid | Handsontable
+description: Replace the default cell editor for dates with Flatpickr on the TextEditor TEXTAREA, including open, onClose, and teardown in close().
+permalink: /recipes/editing-validation/inline-flatpickr-datepicker
+canonicalUrl: /recipes/editing-validation/inline-flatpickr-datepicker
+tags:
+  - guides
+  - tutorial
+  - recipes
+  - editing
+  - flatpickr
+react:
+  id: g3j9m5p0
+  metaTitle: Inline Flatpickr Date Editor Recipe - React Data Grid | Handsontable
+angular:
+  id: h4k0n6q1
+  metaTitle: Inline Flatpickr Date Editor Recipe - Angular Data Grid | Handsontable
+searchCategory: Recipes
+category: Editing and Validation
+---
+
+::: only-for javascript vue
+
+::: example #example1 :hot-recipe --js 1 --ts 2 --css 3 --deps flatpickr
+
+@[code](@/content/recipes/editing-validation/inline-flatpickr-datepicker/javascript/example1.js)
+@[code](@/content/recipes/editing-validation/inline-flatpickr-datepicker/javascript/example1.ts)
+@[code](@/content/recipes/editing-validation/inline-flatpickr-datepicker/javascript/example1.css)
+
+:::
+
+:::
+
+## Overview
+
+Use a custom editor that **extends** `Handsontable.editors.TextEditor`, initializes **Flatpickr** on the editor **TEXTAREA** inside `open()`, and **destroys** the Flatpickr instance in `close()` so you do not leak DOM nodes or listeners. Register the class under the name **`datepicker`** and set **`editor: 'datepicker'`** on the column.
+
+**Difficulty:** Intermediate  
+**Time:** ~15 minutes
+
+## Run without a bundler (CDN)
+
+To try the same pattern in plain HTML without installing Flatpickr, add the stylesheet and script before your app bundle:
+
+```html
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css"
+/>
+<script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+```
+
+Handsontable still needs your usual script (for example, from `handsontable.full.min.js` or your build). The demo above uses the `flatpickr` package via the docs dependency loader instead of these tags.
+
+## Steps
+
+1. **Subclass `TextEditor`** - Reuse the native textarea, focus behavior, and positioning from `TextEditor`.
+2. **`open()`** - Call `super.open()`, then `flatpickr(this.TEXTAREA, { ... })` with at least `dateFormat`, `defaultDate`, and `onClose: () => this.finishEditing()`. Use `appendTo: this.TEXTAREA_PARENT` so the calendar mounts under the editor holder and clicks stay inside the grid (same idea as `preventCloseElement` for factory editors).
+3. **`close()`** - Call `this.fp.destroy()`, clear the reference, then `super.close()`.
+4. **Register** - `registerEditor('datepicker', FlatpickrDateEditor)` from `handsontable/editors/registry` (same registration as `Handsontable.editors.registerEditor` on the full bundle).
+5. **Column** - Set `editor: 'datepicker'` for the date column (see the embedded example).
+
+## Key code
+
+```typescript
+class FlatpickrDateEditor extends TextEditor {
+  static override get EDITOR_TYPE() {
+    return 'datepicker';
+  }
+
+  fp: flatpickr.Instance | null = null;
+
+  override open(): void {
+    super.open();
+    this.fp = flatpickr(this.TEXTAREA as HTMLTextAreaElement, {
+      appendTo: this.TEXTAREA_PARENT,
+      dateFormat: 'Y-m-d',
+      defaultDate: /* from cell or today */,
+      onClose: () => {
+        this.finishEditing();
+      },
+    });
+    this.fp.open();
+  }
+
+  override close(): void {
+    if (this.fp) {
+      this.fp.destroy();
+      this.fp = null;
+    }
+    super.close();
+  }
+}
+
+registerEditor('datepicker', FlatpickrDateEditor);
+```
+
+## Acceptance checks
+
+- Opening a cell in the **Due date** column shows the Flatpickr calendar.
+- Choosing a date writes the formatted string and closes the editor.
+- Re-opening and closing does not accumulate calendars or listeners (`destroy()` runs every time).
+
+## See also
+
+- [Registering an editor](@/guides/cell-functions/cell-editor/cell-editor.md#registering-an-editor)
+- [Datetime `flatpickr` picker (cell type recipe)](@/content/recipes/cell-types/flatpickr/flatpickr.md)

--- a/docs/content/recipes/editing-validation/inline-flatpickr-datepicker/javascript/example1.css
+++ b/docs/content/recipes/editing-validation/inline-flatpickr-datepicker/javascript/example1.css
@@ -1,0 +1,26 @@
+.ht_editor_visible > textarea.handsontableInput {
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box !important;
+  border: none;
+  border-radius: 0;
+  outline: none;
+  margin-top: -1px;
+  margin-left: -1px;
+  box-shadow: inset 0 0 0 var(--ht-cell-editor-border-width, 2px)
+    var(--ht-cell-editor-border-color, #1a42e8),
+    0 0 var(--ht-cell-editor-shadow-blur-radius, 0) 0
+    var(--ht-cell-editor-shadow-color, transparent) !important;
+  background-color: var(--ht-cell-editor-background-color, #ffffff) !important;
+  padding: var(--ht-cell-vertical-padding, 4px)
+    var(--ht-cell-horizontal-padding, 8px) !important;
+  font-family: inherit;
+  font-size: var(--ht-font-size);
+  line-height: var(--ht-line-height);
+  resize: none;
+}
+
+.ht_editor_visible > textarea.handsontableInput:focus-visible {
+  border: none !important;
+  outline: none !important;
+}

--- a/docs/content/recipes/editing-validation/inline-flatpickr-datepicker/javascript/example1.js
+++ b/docs/content/recipes/editing-validation/inline-flatpickr-datepicker/javascript/example1.js
@@ -1,0 +1,72 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+import { registerEditor } from 'handsontable/editors/registry';
+import { TextEditor } from 'handsontable/editors/textEditor';
+import flatpickr from 'flatpickr';
+import 'flatpickr/dist/flatpickr.css';
+registerAllModules();
+const DATE_FORMAT = 'Y-m-d';
+/**
+ * TextEditor subclass: Flatpickr attaches to the built-in TEXTAREA in open(),
+ * and the instance is destroyed in close() so listeners and DOM do not leak.
+ */
+class FlatpickrDateEditor extends TextEditor {
+    constructor() {
+        super(...arguments);
+        this.fp = null;
+    }
+    static get EDITOR_TYPE() {
+        return 'datepicker';
+    }
+    open() {
+        super.open();
+        const textarea = this.TEXTAREA;
+        const raw = this.getValue();
+        const defaultDate = raw ? new Date(raw) : new Date();
+        this.fp = flatpickr(textarea, {
+            appendTo: this.TEXTAREA_PARENT,
+            dateFormat: DATE_FORMAT,
+            defaultDate,
+            allowInput: true,
+            onClose: () => {
+                this.finishEditing();
+            },
+        });
+        this.fp.open();
+    }
+    close() {
+        if (this.fp) {
+            this.fp.destroy();
+            this.fp = null;
+        }
+        super.close();
+    }
+}
+registerEditor('datepicker', FlatpickrDateEditor);
+/* start:skip-in-preview */
+const data = [
+    { task: 'Ship release notes', owner: 'Docs', dueDate: '2026-04-20' },
+    { task: 'Fix flaky E2E test', owner: 'QA', dueDate: '2026-04-28' },
+    { task: 'Review security audit', owner: 'Security', dueDate: '2026-05-05' },
+];
+/* end:skip-in-preview */
+const container = document.querySelector('#example1');
+// eslint-disable-next-line no-unused-vars -- instance kept for recipe preview
+const hot = new Handsontable(container, {
+    data,
+    rowHeaders: true,
+    colHeaders: ['Task', 'Owner', 'Due date'],
+    height: 'auto',
+    width: '100%',
+    columns: [
+        { data: 'task', type: 'text', width: 220 },
+        { data: 'owner', type: 'text', width: 120 },
+        {
+            data: 'dueDate',
+            type: 'text',
+            editor: 'datepicker',
+            width: 140,
+        },
+    ],
+    licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/recipes/editing-validation/inline-flatpickr-datepicker/javascript/example1.ts
+++ b/docs/content/recipes/editing-validation/inline-flatpickr-datepicker/javascript/example1.ts
@@ -1,0 +1,81 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+import { registerEditor } from 'handsontable/editors/registry';
+import { TextEditor } from 'handsontable/editors/textEditor';
+import flatpickr from 'flatpickr';
+import 'flatpickr/dist/flatpickr.css';
+
+registerAllModules();
+
+const DATE_FORMAT = 'Y-m-d';
+
+/**
+ * TextEditor subclass: Flatpickr attaches to the built-in TEXTAREA in open(),
+ * and the instance is destroyed in close() so listeners and DOM do not leak.
+ */
+class FlatpickrDateEditor extends TextEditor {
+  static override get EDITOR_TYPE() {
+    return 'datepicker';
+  }
+
+  fp: flatpickr.Instance | null = null;
+
+  override open(): void {
+    super.open();
+
+    const textarea = this.TEXTAREA as HTMLTextAreaElement;
+    const raw = this.getValue() as string;
+    const defaultDate = raw ? new Date(raw) : new Date();
+
+    this.fp = flatpickr(textarea, {
+      appendTo: this.TEXTAREA_PARENT,
+      dateFormat: DATE_FORMAT,
+      defaultDate,
+      allowInput: true,
+      onClose: () => {
+        this.finishEditing();
+      },
+    });
+    this.fp.open();
+  }
+
+  override close(): void {
+    if (this.fp) {
+      this.fp.destroy();
+      this.fp = null;
+    }
+    super.close();
+  }
+}
+
+registerEditor('datepicker', FlatpickrDateEditor);
+
+/* start:skip-in-preview */
+const data = [
+  { task: 'Ship release notes', owner: 'Docs', dueDate: '2026-04-20' },
+  { task: 'Fix flaky E2E test', owner: 'QA', dueDate: '2026-04-28' },
+  { task: 'Review security audit', owner: 'Security', dueDate: '2026-05-05' },
+];
+/* end:skip-in-preview */
+
+const container = document.querySelector('#example1')!;
+
+// eslint-disable-next-line no-unused-vars -- instance kept for recipe preview
+const hot = new Handsontable(container, {
+  data,
+  rowHeaders: true,
+  colHeaders: ['Task', 'Owner', 'Due date'],
+  height: 'auto',
+  width: '100%',
+  columns: [
+    { data: 'task', type: 'text', width: 220 },
+    { data: 'owner', type: 'text', width: 120 },
+    {
+      data: 'dueDate',
+      type: 'text',
+      editor: 'datepicker',
+      width: 140,
+    },
+  ],
+  licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/recipes/introduction.md
+++ b/docs/content/recipes/introduction.md
@@ -29,6 +29,10 @@ This is a collection of practical, production-ready recipes for common Handsonta
 
 Browse recipes by category, difficulty, or use case. Each guide is designed to get you from zero to working implementation in minutes.
 
+### Editing and validation
+
+- [Editing and validation recipes](@/content/recipes/editing-validation/editing-validation.md) - Custom editors, validation patterns, and dynamic cell configuration.
+
 ### For AI Agents
 
 This resource is structured for easy indexing and retrieval. Each recipe includes metadata, keywords, problem descriptions, and solution patterns to help AI assistants provide accurate, contextual examples.

--- a/docs/content/recipes/rendering-styling/conditional-row-coloring/conditional-row-coloring.md
+++ b/docs/content/recipes/rendering-styling/conditional-row-coloring/conditional-row-coloring.md
@@ -1,0 +1,147 @@
+---
+id: ceb1a2d8
+title: Conditional row coloring
+metaTitle: Conditional row coloring - JavaScript Data Grid | Handsontable
+description: Color entire rows from a status column using the cells callback, className, and scoped CSS that updates after edits.
+permalink: /recipes/rendering-styling/conditional-row-coloring
+canonicalUrl: /recipes/rendering-styling/conditional-row-coloring
+tags:
+  - guides
+  - tutorial
+  - recipes
+  - styling
+react:
+  id: f7c3e91a
+  metaTitle: Conditional row coloring - React Data Grid | Handsontable
+angular:
+  id: b2d804e6
+  metaTitle: Conditional row coloring - Angular Data Grid | Handsontable
+searchCategory: Recipes
+category: Rendering and styling
+---
+
+::: only-for javascript vue
+
+::: example #example1 :hot-recipe --js 1 --ts 2 --css 3
+
+@[code](@/content/recipes/rendering-styling/conditional-row-coloring/javascript/example1.js)
+@[code](@/content/recipes/rendering-styling/conditional-row-coloring/javascript/example1.ts)
+@[code](@/content/recipes/rendering-styling/conditional-row-coloring/javascript/example1.css)
+
+:::
+
+:::
+
+[[toc]]
+
+## Overview
+
+This recipe shows how to tint every cell in a row based on a **status** value (`active`, `pending`, or `inactive`). You map each status to a CSS class, set that class through Handsontable metadata, and keep colors correct on first load and after the user edits **Status**.
+
+**Difficulty:** Beginner  
+**Time:** ~10 minutes  
+**Libraries:** None beyond Handsontable.
+
+## Map status values to row classes
+
+Use a small lookup object so the mapping stays in one place.
+
+```typescript
+const STATUS_ROW_CLASSES: Record<string, string> = {
+  active: 'ht-demo-row-status-active',
+  pending: 'ht-demo-row-status-pending',
+  inactive: 'ht-demo-row-status-inactive',
+};
+```
+
+Prefix custom classes (for example `ht-demo-`) so they do not clash with Handsontable internals.
+
+## Apply the class with the `cells` callback
+
+The [`cells`](@/api/options.md#cells) setting runs while cell metadata is built. Return a [`className`](@/api/options.md#classname) object for each cell so the same row class is applied to every column in that row.
+
+The callback receives **physical** row and column indexes. Read the status from the dataset using the **visual** row so sorting and row moves still match what the user sees:
+
+```typescript
+cells(
+  this: CellProperties,
+  row: number,
+  _column: number,
+  _prop: string | number,
+): CellMeta {
+  const hot = this.instance;
+  const visualRow = hot.toVisualRow(row);
+
+  if (visualRow === null || visualRow < 0) {
+    return {};
+  }
+
+  const status = hot.getDataAtRowProp(visualRow, 'status');
+  const rowClass = statusToRowClass(status);
+
+  if (!rowClass) {
+    return {};
+  }
+
+  return { className: rowClass };
+},
+```
+
+Handsontable runs a full render after typical data changes (including dropdown edits), which refreshes this metadata, so row colors stay in sync after edits without extra hooks.
+
+Use a regular `cells` function (not an arrow function) so `this` is the current [`CellProperties`](@/api/cellProperties.md) object and `this.instance` is the grid instance.
+
+## Scoped CSS for row states
+
+Keep rules under your preview root (here `#example1`) so they only affect this demo. Use theme tokens where possible so the table still fits light, dark, and custom themes.
+
+See `example1.css` in the demo tabs for full rules. They set row background tints for **active** and **pending**, and a muted background plus secondary text color for **inactive**.
+
+## `cells` callback vs custom renderer
+
+| Approach | Pros | Trade-offs |
+| -------- | ---- | ---------- |
+| **`cells` + `className`** | Styling lives in CSS. Works with built-in cell types and editors. One place defines the row class for all columns. | You rely on Handsontable to merge `className` into the DOM. Very large grids should still profile render cost. |
+| **Custom [`renderer`](@/api/renderers.md)** | Full control of `innerHTML`, extra markup, and per-cell logic in one function. | If you only use a renderer to add classes, you duplicate logic across columns or wrap the default renderer yourself. Row-wide styling is usually easier with `cells`. |
+
+You can combine both: use `cells` for row-level classes and a custom renderer only where cell content needs special HTML.
+
+### Renderer-only sketch
+
+If you prefer classes inside a renderer, read the row status and update `td.className` (and call the default text renderer if you still want standard cell output):
+
+```typescript
+import { textRenderer } from 'handsontable/renderers';
+
+function statusAwareRenderer(
+  hot: Handsontable.Core,
+  physicalRow: number,
+  ...args: Parameters<typeof textRenderer>
+) {
+  const visualRow = hot.toVisualRow(physicalRow);
+  const status =
+    visualRow !== null && visualRow >= 0
+      ? hot.getDataAtRowProp(visualRow, 'status')
+      : undefined;
+  const rowClass = statusToRowClass(status);
+
+  if (rowClass) {
+    args[0].className = rowClass;
+  }
+
+  textRenderer(...args);
+}
+```
+
+For a whole grid, you would register this renderer on each column (or set it in `cells` as `renderer`), which is why the `className`-only `cells` approach is often shorter for row coloring.
+
+## Acceptance checklist
+
+- **Correct on load and after edits:** Changing **Status** updates data, triggers a render, and rebuilds cell meta so classes match the new value.
+- **Scoped CSS:** Selectors are prefixed with `#example1` so styles do not leak globally.
+- **Clean code:** Status-to-class mapping is a single object; the `cells` callback stays small and uses `toVisualRow` for correct data reads.
+
+## Related
+
+- [Configuration options: cell and row metadata](@/guides/getting-started/configuration-options/configuration-options.md#set-cell-options)
+- [`className` option](@/api/options.md#classname)

--- a/docs/content/recipes/rendering-styling/conditional-row-coloring/javascript/example1.css
+++ b/docs/content/recipes/rendering-styling/conditional-row-coloring/javascript/example1.css
@@ -1,0 +1,21 @@
+/* Scoped to the recipe preview container */
+#example1 .ht-demo-row-status-active td {
+  background-color: color-mix(
+    in srgb,
+    var(--ht-accent-color, #1a42e8) 12%,
+    var(--ht-background-color, #ffffff)
+  );
+}
+
+#example1 .ht-demo-row-status-pending td {
+  background-color: color-mix(
+    in srgb,
+    var(--ht-warn-color, #ca8a04) 14%,
+    var(--ht-background-color, #ffffff)
+  );
+}
+
+#example1 .ht-demo-row-status-inactive td {
+  background-color: var(--ht-background-secondary-color, #f3f4f6);
+  color: var(--ht-foreground-secondary-color, #6b7280);
+}

--- a/docs/content/recipes/rendering-styling/conditional-row-coloring/javascript/example1.js
+++ b/docs/content/recipes/rendering-styling/conditional-row-coloring/javascript/example1.js
@@ -1,0 +1,59 @@
+import Handsontable from "handsontable/base";
+import { registerAllModules } from "handsontable/registry";
+registerAllModules();
+const STATUS_ROW_CLASSES = {
+    active: "ht-demo-row-status-active",
+    pending: "ht-demo-row-status-pending",
+    inactive: "ht-demo-row-status-inactive",
+};
+function statusToRowClass(status) {
+    if (typeof status !== "string") {
+        return undefined;
+    }
+    return STATUS_ROW_CLASSES[status];
+}
+/* start:skip-in-preview */
+const data = [
+    { task: "Invoice export", owner: "A. Lee", status: "active" },
+    { task: "SSO rollout", owner: "M. Costa", status: "pending" },
+    { task: "Legacy reports", owner: "J. Park", status: "inactive" },
+    { task: "API docs", owner: "R. Singh", status: "active" },
+    { task: "Mobile parity", owner: "T. Nguyen", status: "pending" },
+];
+/* end:skip-in-preview */
+const container = document.querySelector("#example1");
+const hotOptions = {
+    data,
+    licenseKey: "non-commercial-and-evaluation",
+    rowHeaders: true,
+    colHeaders: ["Task", "Owner", "Status"],
+    height: "auto",
+    width: "100%",
+    columns: [
+        { data: "task", type: "text", width: 220 },
+        { data: "owner", type: "text", width: 120 },
+        {
+            data: "status",
+            type: "dropdown",
+            width: 120,
+            source: ["active", "pending", "inactive"],
+            strict: true,
+            allowInvalid: false,
+        },
+    ],
+    cells(row, _column, _prop) {
+        const hot = this.instance;
+        const visualRow = hot.toVisualRow(row);
+        if (visualRow === null || visualRow < 0) {
+            return {};
+        }
+        const status = hot.getDataAtRowProp(visualRow, "status");
+        const rowClass = statusToRowClass(status);
+        if (!rowClass) {
+            return {};
+        }
+        return { className: rowClass };
+    },
+};
+// eslint-disable-next-line no-unused-vars
+const hot = new Handsontable(container, hotOptions);

--- a/docs/content/recipes/rendering-styling/conditional-row-coloring/javascript/example1.ts
+++ b/docs/content/recipes/rendering-styling/conditional-row-coloring/javascript/example1.ts
@@ -1,0 +1,77 @@
+import Handsontable from "handsontable/base";
+import { registerAllModules } from "handsontable/registry";
+import type { CellMeta, CellProperties } from "handsontable/settings";
+
+registerAllModules();
+
+const STATUS_ROW_CLASSES: Record<string, string> = {
+  active: "ht-demo-row-status-active",
+  pending: "ht-demo-row-status-pending",
+  inactive: "ht-demo-row-status-inactive",
+};
+
+function statusToRowClass(status: unknown): string | undefined {
+  if (typeof status !== "string") {
+    return undefined;
+  }
+
+  return STATUS_ROW_CLASSES[status];
+}
+
+/* start:skip-in-preview */
+const data = [
+  { task: "Invoice export", owner: "A. Lee", status: "active" },
+  { task: "SSO rollout", owner: "M. Costa", status: "pending" },
+  { task: "Legacy reports", owner: "J. Park", status: "inactive" },
+  { task: "API docs", owner: "R. Singh", status: "active" },
+  { task: "Mobile parity", owner: "T. Nguyen", status: "pending" },
+];
+/* end:skip-in-preview */
+
+const container = document.querySelector("#example1")!;
+
+const hotOptions: Handsontable.GridSettings = {
+  data,
+  licenseKey: "non-commercial-and-evaluation",
+  rowHeaders: true,
+  colHeaders: ["Task", "Owner", "Status"],
+  height: "auto",
+  width: "100%",
+  columns: [
+    { data: "task", type: "text", width: 220 },
+    { data: "owner", type: "text", width: 120 },
+    {
+      data: "status",
+      type: "dropdown",
+      width: 120,
+      source: ["active", "pending", "inactive"],
+      strict: true,
+      allowInvalid: false,
+    },
+  ],
+  cells(
+    this: CellProperties,
+    row: number,
+    _column: number,
+    _prop: string | number,
+  ): CellMeta {
+    const hot = this.instance;
+    const visualRow = hot.toVisualRow(row);
+
+    if (visualRow === null || visualRow < 0) {
+      return {};
+    }
+
+    const status = hot.getDataAtRowProp(visualRow, "status");
+    const rowClass = statusToRowClass(status);
+
+    if (!rowClass) {
+      return {};
+    }
+
+    return { className: rowClass };
+  },
+};
+
+// eslint-disable-next-line no-unused-vars
+const hot = new Handsontable(container, hotOptions);

--- a/docs/content/recipes/rendering-styling/rendering-styling.md
+++ b/docs/content/recipes/rendering-styling/rendering-styling.md
@@ -1,0 +1,26 @@
+---
+title: Rendering and styling recipes
+metaTitle: Rendering and styling recipes - JavaScript Data Grid | Handsontable
+permalink: /recipes/rendering-styling
+canonicalUrl: /recipes/rendering-styling
+searchCategory: Recipes
+hotPlugin: false
+editLink: false
+id: r8n4k2p1
+description: Recipes for conditional row styling, CSS class mapping, and presentation patterns in Handsontable.
+react:
+  id: m6t9v3q5
+  metaTitle: Rendering and styling recipes - React Data Grid | Handsontable
+angular:
+  id: w2x7j4h8
+  metaTitle: Rendering and styling recipes - Angular Data Grid | Handsontable
+---
+[[toc]]
+
+## Overview
+
+This section collects recipes that focus on how the grid looks in the DOM: CSS classes, conditional formatting, and keeping presentation aligned with your data.
+
+## Available recipes
+
+- **[Conditional row coloring](@/content/recipes/rendering-styling/conditional-row-coloring/conditional-row-coloring.md)** - Map a status column to row-level CSS classes with the `cells` callback and scoped styles.

--- a/docs/content/recipes/sidebar.js
+++ b/docs/content/recipes/sidebar.js
@@ -22,10 +22,25 @@ const themesItems = [
   { path: 'themes/mui-theme/mui-theme', title: 'Handsontable with MUI', onlyFor: ['react', 'javascript', 'angular'] },
 ];
 
+const renderingStylingItems = [
+  {
+    path: 'rendering-styling/conditional-row-coloring/conditional-row-coloring',
+    title: 'Conditional row coloring',
+    onlyFor: ['javascript'],
+  },
+];
+
 module.exports = {
   sidebar: [
     'introduction',
     { title: 'Cell Types', path: 'cell-types', children: cellTypesItems, collapsable: false, onlyFor: ['react', 'javascript', 'angular'] },
+    {
+      title: 'Rendering and styling',
+      path: 'rendering-styling',
+      children: renderingStylingItems,
+      collapsable: false,
+      onlyFor: ['javascript'],
+    },
     { title: 'Themes', path: 'themes', children: themesItems, collapsable: false, onlyFor: ['react', 'javascript', 'angular'] },
   ],
 };

--- a/docs/content/recipes/sidebar.js
+++ b/docs/content/recipes/sidebar.js
@@ -16,18 +16,18 @@ const cellTypesItems = [
   { path: 'cell-types/guide-datepicker-angular/guide-datepicker', title: 'Datetime picker', onlyFor: ['angular'] }
 ];
 
+const editingValidationItems = [
+  {
+    path: 'editing-validation/inline-flatpickr-datepicker/inline-flatpickr-datepicker',
+    title: 'Inline Flatpickr date editor',
+    onlyFor: ['javascript'],
+  },
+];
+
 const themesItems = [
   { path: 'themes/base-theme/base-theme', title: 'Handsontable with Base Web', onlyFor: ['react', 'javascript', 'angular'] },
   { path: 'themes/custom-theme/custom-theme', title: 'Handsontable with shadcn/ui', onlyFor: ['react', 'javascript', 'angular'] },
   { path: 'themes/mui-theme/mui-theme', title: 'Handsontable with MUI', onlyFor: ['react', 'javascript', 'angular'] },
-];
-
-const renderingStylingItems = [
-  {
-    path: 'rendering-styling/conditional-row-coloring/conditional-row-coloring',
-    title: 'Conditional row coloring',
-    onlyFor: ['javascript'],
-  },
 ];
 
 module.exports = {
@@ -35,9 +35,9 @@ module.exports = {
     'introduction',
     { title: 'Cell Types', path: 'cell-types', children: cellTypesItems, collapsable: false, onlyFor: ['react', 'javascript', 'angular'] },
     {
-      title: 'Rendering and styling',
-      path: 'rendering-styling',
-      children: renderingStylingItems,
+      title: 'Editing and Validation',
+      path: 'editing-validation',
+      children: editingValidationItems,
       collapsable: false,
       onlyFor: ['javascript'],
     },

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,6 +14,7 @@
     "preview": "astro preview",
     "docs:lint": "eslint --ext .js,.mjs,.ts,.astro src content",
     "docs:lint:fix": "eslint --ext .js,.mjs,.ts,.astro src content --fix",
+    "docs:code-examples:generate-js": "node scripts/transpile-doc-example.mjs",
     "docs:visual-test": "npx playwright test",
     "docs:visual-test:update-screenshot": "npx playwright test -u"
   },

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,9 +14,9 @@
     "preview": "astro preview",
     "docs:lint": "eslint --ext .js,.mjs,.ts,.astro src content",
     "docs:lint:fix": "eslint --ext .js,.mjs,.ts,.astro src content --fix",
-    "docs:code-examples:generate-js": "node scripts/transpile-doc-example.mjs",
     "docs:visual-test": "npx playwright test",
-    "docs:visual-test:update-screenshot": "npx playwright test -u"
+    "docs:visual-test:update-screenshot": "npx playwright test -u",
+    "docs:code-examples:generate-js": "node scripts/transpile-doc-example.mjs"
   },
   "license": "CC BY 4.0",
   "dependencies": {

--- a/docs/scripts/transpile-doc-example.mjs
+++ b/docs/scripts/transpile-doc-example.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+/**
+ * Emit a sibling `.js` file from a documentation `.ts` example using the
+ * TypeScript compiler API (transpile only -- no typecheck, no path resolution).
+ *
+ * Usage: node scripts/transpile-doc-example.mjs <path-to-example.ts>
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import ts from 'typescript';
+
+const tsPath = process.argv[2];
+
+if (!tsPath || !tsPath.endsWith('.ts')) {
+  console.error('Usage: node scripts/transpile-doc-example.mjs <path-to-example.ts>');
+  process.exit(1);
+}
+
+const absoluteTs = path.resolve(process.cwd(), tsPath);
+
+if (!fs.existsSync(absoluteTs)) {
+  console.error(`File not found: ${absoluteTs}`);
+  process.exit(1);
+}
+
+const sourceText = fs.readFileSync(absoluteTs, 'utf8');
+const jsPath = absoluteTs.replace(/\.ts$/, '.js');
+
+const { outputText } = ts.transpileModule(sourceText, {
+  compilerOptions: {
+    target: ts.ScriptTarget.ES2020,
+    module: ts.ModuleKind.ESNext,
+    removeComments: false,
+    esModuleInterop: true,
+  },
+  fileName: absoluteTs,
+});
+
+fs.writeFileSync(jsPath, `${outputText.replace(/\s*$/, '')}\n`);
+console.log(`Wrote ${path.relative(process.cwd(), jsPath)}`);

--- a/docs/scripts/transpile-doc-example.mjs
+++ b/docs/scripts/transpile-doc-example.mjs
@@ -37,5 +37,5 @@ const { outputText } = ts.transpileModule(sourceText, {
   fileName: absoluteTs,
 });
 
-fs.writeFileSync(jsPath, `${outputText.replace(/\s*$/, '')}\n`);
-console.log(`Wrote ${path.relative(process.cwd(), jsPath)}`);
+fs.writeFileSync(jsPath, outputText);
+console.log(`Wrote ${jsPath}`);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Context
Adds a JavaScript recipe that registers a custom `datepicker` editor based on Flatpickr and uses it in date columns.

ClickUp task: https://app.clickup.com/t/86c9b3bkx

### How has this been tested?
- `cd docs && npm run docs:code-examples:generate-js -- content/recipes/editing-validation/inline-flatpickr-datepicker/javascript/example1.ts`

### Types of changes
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. DEV-1278

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-32280ee0-cf4c-4ab9-b400-9cfe0a94ceb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32280ee0-cf4c-4ab9-b400-9cfe0a94ceb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

