### PR TITLE
DEV-1102: Document height 'auto' value

### DIFF
--- a/docs/content/guides/getting-started/grid-size/grid-size.md
+++ b/docs/content/guides/getting-started/grid-size/grid-size.md
@@ -136,6 +136,80 @@ If container is a block element, then its parent has to have defined `height`. B
 
 Changes called in [`updateSettings()`](@/api/core.md#updatesettings) will re-render the grid with the new properties.
 
+### Use `'auto'` sizing
+
+Set `height: 'auto'` to make the grid grow to match its content height. Handsontable writes `height: auto; overflow: clip;` as inline styles on the root element. No internal vertical scrollbar is created, so the page itself scrolls when the grid is taller than the viewport.
+
+::: only-for javascript
+
+```js
+{
+  height: 'auto',
+}
+```
+
+You can combine it with `width: 'auto'` to let the grid follow its parent container's width:
+
+```js
+{
+  height: 'auto',
+  width: 'auto',
+}
+```
+
+:::
+
+::: only-for react
+
+```jsx
+  <HotTable height="auto" />
+```
+
+You can combine it with `width="auto"` to let the grid follow its parent container's width:
+
+```jsx
+  <HotTable height="auto" width="auto" />
+```
+
+:::
+
+::: only-for angular
+
+```ts
+import { GridSettings } from "@handsontable/angular-wrapper";
+
+gridSettings: GridSettings = {
+  height: "auto",
+};
+```
+
+You can combine it with `width: "auto"` to let the grid follow its parent container's width:
+
+```ts
+import { GridSettings } from "@handsontable/angular-wrapper";
+
+gridSettings: GridSettings = {
+  height: "auto",
+  width: "auto",
+};
+```
+
+:::
+
+`height: 'auto'` is different from leaving `height` unset:
+
+| Setting            | Inline styles on root                                       | Scroll parent                                                                  | Row virtualization          |
+| ------------------ | ----------------------------------------------------------- | ------------------------------------------------------------------------------ | --------------------------- |
+| `height: 'auto'`   | `height: auto; overflow: clip;`                             | The page, outside the grid                                                     | Disabled, all rows render   |
+| `height: <number>` | `height: <n>px; overflow: clip;`                            | The grid itself                                                                | Enabled                     |
+| `height` unset     | None, Handsontable does not touch the root inline styles    | Nearest ancestor with `overflow: auto` or `overflow: hidden`, else the window  | Depends on the scroll parent |
+
+::: tip
+
+With `height: 'auto'`, every row is laid out in the DOM at once. Avoid this value for large datasets. Set a numeric `height` instead so that Handsontable can virtualize off-screen rows.
+
+:::
+
 ### Troubleshooting with 100% height
 
 When the `height` option is set to 100%, there are three ways to define the container’s height. Assuming you're creating an Handsontable instance that has `100% height` and container is element with id `#example`. 

--- a/handsontable/src/__tests__/core/settings.types.ts
+++ b/handsontable/src/__tests__/core/settings.types.ts
@@ -164,7 +164,7 @@ const allSettings: Required<Handsontable.GridSettings> = {
   },
   fragmentSelection: oneOf(true, 'cell'),
   headerClassName: 'htCenter test',
-  height: oneOf(500, () => 500),
+  height: oneOf(500, 'auto', '75vh', () => 500, () => 'auto'),
   hiddenColumns: true,
   hiddenRows: true,
   initialState: {
@@ -354,7 +354,7 @@ const allSettings: Required<Handsontable.GridSettings> = {
   viewportColumnRenderingThreshold: oneOf(100, 'auto'),
   viewportRowRenderingThreshold: oneOf(100, 'auto'),
   visibleRows: 123,
-  width: oneOf(500, () => 500),
+  width: oneOf(500, 'auto', '75vw', () => 500, () => 'auto'),
   wordWrap: true,
 
   // Hooks via settings object

--- a/handsontable/src/dataMap/metaManager/metaSchema.js
+++ b/handsontable/src/dataMap/metaManager/metaSchema.js
@@ -3112,19 +3112,39 @@ export default () => {
     /**
      * The `height` option configures the height of your grid.
      *
-     * You can set `height` option to one of the following:
+     * You can set the `height` option to one of the following:
      *
      * | Setting                                                                    | Example                    |
      * | -------------------------------------------------------------------------- | -------------------------- |
      * | A number of pixels                                                         | `height: 500`              |
      * | A string with a [CSS unit](https://www.w3schools.com/cssref/css_units.asp) | `height: '75vw'`           |
+     * | `'auto'`                                                                   | `height: 'auto'`           |
      * | A function that returns a valid number or string                           | `height() { return 500; }` |
+     *
+     * ### How `'auto'` differs from leaving `height` unset
+     *
+     * When you set `height: 'auto'`, Handsontable writes `height: auto; overflow: clip;`
+     * as inline styles on the root element. The grid then grows to match its content height.
+     * No internal vertical scrollbar is created, so the page itself scrolls when the grid
+     * exceeds the viewport.
+     *
+     * When you leave `height` unset, Handsontable does not touch the root element's inline
+     * styles. Sizing is governed by your CSS, and the nearest ancestor with `overflow: auto`
+     * or `overflow: hidden` becomes the scroll parent. If no such ancestor exists, the window
+     * scrolls. See the [Grid size](@/guides/getting-started/grid-size/grid-size.md) guide for
+     * details.
+     *
+     * ::: tip
+     * With `height: 'auto'`, every row is laid out in the DOM at once. Row-level
+     * virtualization is effectively disabled. Avoid `'auto'` for large datasets and set a
+     * numeric `height` instead, so Handsontable can virtualize off-screen rows.
+     * :::
      *
      * Read more:
      * - [Grid size](@/guides/getting-started/grid-size/grid-size.md)
      *
      * @memberof Options#
-     * @type {number|string|Function}
+     * @type {number|'auto'|string|Function}
      * @default undefined
      * @category Core
      *
@@ -3135,6 +3155,9 @@ export default () => {
      *
      * // set the grid's height to 75vh
      * height: '75vh',
+     *
+     * // let the grid grow to fit all its rows (no internal vertical scroll)
+     * height: 'auto',
      *
      * // set the grid's height to 500px, using a function
      * height() {
@@ -6537,7 +6560,13 @@ export default () => {
      * | -------------------------------------------------------------------------- | ------------------------- |
      * | A number of pixels                                                         | `width: 500`              |
      * | A string with a [CSS unit](https://www.w3schools.com/cssref/css_units.asp) | `width: '75vw'`           |
+     * | `'auto'`                                                                   | `width: 'auto'`           |
      * | A function that returns a valid number or string                           | `width() { return 500; }` |
+     *
+     * With `width: 'auto'`, Handsontable writes `width: auto` as an inline style on the root
+     * element. The grid then follows the width of its parent container. Use this value when
+     * you want the grid to stay flexible horizontally while still setting an explicit
+     * [`height`](#height).
      *
      * ::: tip
      * For horizontal scrolling to work, you must also set the [`height`](#height) option in Handsontable's configuration.
@@ -6549,7 +6578,7 @@ export default () => {
      * - [Grid size](@/guides/getting-started/grid-size/grid-size.md)
      *
      * @memberof Options#
-     * @type {number|string|Function}
+     * @type {number|'auto'|string|Function}
      * @default undefined
      * @category Core
      *
@@ -6560,6 +6589,9 @@ export default () => {
      *
      * // set the grid's width to 75vw
      * width: '75vw',
+     *
+     * // let the grid follow its parent container's width
+     * width: 'auto',
      *
      * // set the grid's width to 500px, using a function
      * width() {

--- a/handsontable/types/settings.d.ts
+++ b/handsontable/types/settings.d.ts
@@ -165,7 +165,7 @@ export interface GridSettings extends Events {
   formulas?: FormulasSettings;
   fragmentSelection?: boolean | 'cell';
   headerClassName?: string;
-  height?: number | string | (() => number | string);
+  height?: number | 'auto' | string | (() => number | 'auto' | string);
   hiddenColumns?: HiddenColumnsSettings;
   hiddenRows?: HiddenRowsSettings;
   initialState?: Partial<GridSettings>;
@@ -253,6 +253,6 @@ export interface GridSettings extends Events {
   viewportColumnRenderingThreshold?: number | 'auto';
   viewportRowRenderingThreshold?: number | 'auto';
   visibleRows?: number;
-  width?: number | string | (() => number | string);
+  width?: number | 'auto' | string | (() => number | 'auto' | string);
   wordWrap?: boolean;
 }


### PR DESCRIPTION
### Context

The `height` and `width` options have long accepted `'auto'` as a valid value (see `handsontable/src/core.js:3037-3072` and Walkontable `table/master.js:76`), but this has never been documented. Users encountered `height: 'auto'` in our examples and had to guess at its semantics, particularly how it differs from leaving `height` unset.

This PR adds `'auto'` as a first-class documented value in three places:

1. JSDoc in `metaSchema.js`, with a side-by-side explanation of how `'auto'` differs from an unset `height`, and a perf caveat on row virtualization.
2. TypeScript types in `settings.d.ts`, narrowed from `string` to `'auto' | string` so IntelliSense surfaces the literal.
3. The Grid size guide, with JS / React / Angular examples and a comparison table covering inline-style output, scroll parent, and virtualization behavior.

Runtime behavior in `handsontable/src/core.js` is unchanged. This is documentation only. Claims were verified empirically with six scenarios (including 1000 rows) using Chrome DevTools to capture `rootElement` inline styles, `overflow`, and rendered row count. The 1000-row run confirmed the virtualization-disabled behavior that is now called out in the perf tip.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1102
Original issue: handsontable/handsontable#2786

[skip changelog]

### How has this been tested?

- `npm run test:types --prefix handsontable` -- passes. Added literal assertions for `height` / `width` accepting `'auto'`, CSS strings, and functions returning them in `src/__tests__/core/settings.types.ts`.
- `npx eslint src/dataMap/metaManager/metaSchema.js` -- clean.
- Manual DOM inspection via Chrome DevTools MCP across six configurations: no size, `height: 'auto'`, `height: 'auto'` + `width: 'auto'`, `height: 300` (control), `height: 'auto'` in a narrow parent, and `height: 'auto'` with 1000 rows. Concrete measurements:
  - `height: 'auto'` writes `height: auto; overflow: clip;` inline; grid height matches content, no internal scroll.
  - `height: 300` writes `height: 300px; overflow: clip;`; internal vertical scroll engaged; virtualization renders 12 of 25 rows.
  - `height: 'auto'` + 1000 rows produces a 29,030-pixel-tall DOM with **all** 1000 `<tr>` elements rendered -- confirms virtualization is disabled.
  - No `height` set leaves `rootElement` inline style untouched.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
2. DEV-1102

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/type-surface change only; main impact is on TypeScript consumers who may see slightly narrower types and new IntelliSense suggestions.
> 
> **Overview**
> Documents `height: 'auto'` and `width: 'auto'` as first-class sizing options, including new guide content with JS/React/Angular examples, a comparison table vs numeric/unset `height`, and a performance caveat that `'auto'` disables row virtualization.
> 
> Updates option JSDoc (`metaSchema.js`) and public TypeScript definitions (`settings.d.ts`) to explicitly include the `'auto'` literal (including function return types), and extends the settings type tests to assert `'auto'`/CSS-unit strings are accepted for `height` and `width`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e55fd6f47e9f562d9fef3798de8480bb74ab8fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->