### PR TITLE
DEV-889: Remove pre-9 docs links from release notes

### DIFF
--- a/docs/content/guides/upgrade-and-migration/changelog-7/changelog-7.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-7/changelog-7.md
@@ -24,7 +24,6 @@ For more information on this release, see:
 <div class="boxes-list gray">
 
 - [Blog post](https://handsontable.com/blog/handsontable-7-4-2-released)
-- [Documentation (7.4.2)](https://handsontable.com/docs/7.4.2/)
 - [GitHub release tag](https://github.com/handsontable/handsontable/releases/tag/7.4.2)
 
 </div>
@@ -57,7 +56,6 @@ For more information on this release, see:
 <div class="boxes-list gray">
 
 - [Blog post](https://handsontable.com/blog/handsontable-7-4-0-released)
-- [Documentation (7.4.0)](https://handsontable.com/docs/7.4.0/)
 - [GitHub release tag](https://github.com/handsontable/handsontable/releases/tag/7.4.0)
 
 </div>

--- a/docs/content/guides/upgrade-and-migration/changelog-8/changelog-8.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-8/changelog-8.md
@@ -24,7 +24,7 @@ For more information on this release, see:
 <div class="boxes-list gray">
 
 - [Blog post](https://handsontable.com/blog/whats-new-in-handsontable-8-4-0)
-- [Documentation (8.4.0)](https://handsontable.com/docs/8.4.0/)
+- [GitHub release tag](https://github.com/handsontable/handsontable/releases/tag/8.4.0)
 
 </div>
 
@@ -109,7 +109,7 @@ For more information on this release, see:
 <div class="boxes-list gray">
 
 - [Blog post](https://handsontable.com/blog/handsontable-8-3-2-introducing-monorepo)
-- [Documentation (8.3.2)](https://handsontable.com/docs/8.3.2/)
+- [GitHub release tag](https://github.com/handsontable/handsontable/releases/tag/8.3.2)
 
 </div>
 
@@ -167,7 +167,7 @@ For more information on this release, see:
 
 <div class="boxes-list gray">
 
-- [Documentation (8.3.1)](https://handsontable.com/docs/8.3.1/)
+- [GitHub release tag](https://github.com/handsontable/handsontable/releases/tag/8.3.1)
 
 </div>
 
@@ -186,7 +186,7 @@ For more information on this release, see:
 <div class="boxes-list gray">
 
 - [Blog post](https://handsontable.com/blog/handsontable-8.3.0-has-been-released)
-- [Documentation (8.3.0)](https://handsontable.com/docs/8.3.0/)
+- [GitHub release tag](https://github.com/handsontable/handsontable/releases/tag/8.3.0)
 
 </div>
 
@@ -243,7 +243,7 @@ For more information on this release, see:
 <div class="boxes-list gray">
 
 - [Blog post](https://handsontable.com/blog/handsontable-8.2.0-has-been-released)
-- [Documentation (8.2.0)](https://handsontable.com/docs/8.2.0/)
+- [GitHub release tag](https://github.com/handsontable/handsontable/releases/tag/8.2.0)
 
 </div>
 
@@ -289,7 +289,7 @@ For more information on this release, see:
 <div class="boxes-list gray">
 
 - [Blog post](https://handsontable.com/blog/handsontable-8.1.0-has-been-released)
-- [Documentation (8.1.0)](https://handsontable.com/docs/8.1.0/)
+- [GitHub release tag](https://github.com/handsontable/handsontable/releases/tag/8.1.0)
 
 </div>
 
@@ -353,7 +353,7 @@ For more information on this release, see:
 <div class="boxes-list gray">
 
 - [Blog post](https://handsontable.com/blog/the-new-handsontable-8-is-now-available)
-- [Documentation (8.0.0)](https://handsontable.com/docs/8.0.0/)
+- [GitHub release tag](https://github.com/handsontable/handsontable/releases/tag/8.0.0)
 - [Migration guide (7.4 → 8.0)](@/guides/upgrade-and-migration/migrating-from-7.4-to-8.0/migrating-from-7.4-to-8.0.md)
 
 </div>


### PR DESCRIPTION
### Context

Older versions of the Handsontable documentation (pre-9.0.0) are no longer hosted. The legacy "Documentation (x.y.z)" links in the release notes now redirect to unrelated pages, which confuses readers.

This PR removes those redirecting links from the 7.x and 8.x changelog pages in the docs site:

- `docs/content/guides/upgrade-and-migration/changelog-7/changelog-7.md` -- removed the "Documentation (7.4.2)" and "Documentation (7.4.0)" links. The existing "GitHub release tag" links remain as the primary reference.
- `docs/content/guides/upgrade-and-migration/changelog-8/changelog-8.md` -- replaced the "Documentation (8.x.x)" links for 8.4.0, 8.3.2, 8.3.1, 8.3.0, 8.2.0, 8.1.0, and 8.0.0 with equivalent "GitHub release tag" links so each entry still has a secondary reference.

Version 9 and above retain their documentation links.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-889

### How has this been tested?

Docs-only change. Verified locally by:

- Reviewing the rendered diff (`git diff`) to confirm only the legacy links are changed and each "boxes-list" block keeps at least one working reference.
- `grep` against `docs/content/guides/upgrade-and-migration` to confirm no `handsontable.com/docs/7.*.*` or `handsontable.com/docs/8.*.*` Documentation links remain in the two files touched by this PR.

No code paths or tests are affected.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. ClickUp: DEV-889
2. Originally migrated from GitHub issue #1909

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

(Docs-only; no library packages affected.)

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change that removes/adjusts outbound links in changelog pages; no runtime code or behavior is affected.
> 
> **Overview**
> Removes legacy `Documentation (x.y.z)` links from the 7.x and 8.x changelog pages because pre-9 docs are no longer hosted and now redirect incorrectly.
> 
> For the affected 8.x entries, keeps each release’s reference section usable by ensuring a `GitHub release tag` link is present (alongside existing blog post links where available).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51a3ccbe50fc65922439986f993bcd00f86242bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->