### PR TITLE
Replace pnpm audit with npm audit in CI workflow

### DIFF
--- a/.github/scripts/audit.mjs
+++ b/.github/scripts/audit.mjs
@@ -1,0 +1,102 @@
+/**
+ * Audits production dependencies across all workspace packages using npm audit.
+ *
+ * Background: pnpm audit uses npm registry endpoints that were retired (HTTP 410).
+ * npm 10+ uses the newer bulk advisory endpoint that still works. This script:
+ *   1. Merges `dependencies` and `optionalDependencies` from all workspace packages
+ *      (skipping workspace: cross-references).
+ *   2. Runs `npm install --package-lock-only` in a temp dir to generate a lockfile.
+ *   3. Runs `npm audit --omit=dev --json` and exits non-zero only when a fixable
+ *      vulnerability is found (replicating pnpm's `--ignore-unfixable` flag).
+ */
+
+import { execSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = fileURLToPath(new URL('../../', import.meta.url));
+
+const WORKSPACE_PACKAGES = [
+  'handsontable',
+  'wrappers/react-wrapper',
+  'wrappers/vue3',
+  'wrappers/angular-wrapper',
+];
+
+// Merge production deps from all workspace packages, dropping workspace: cross-refs.
+const mergedDeps = {};
+
+for (const pkg of WORKSPACE_PACKAGES) {
+  const pkgJson = JSON.parse(readFileSync(join(rootDir, pkg, 'package.json'), 'utf8'));
+
+  for (const field of ['dependencies', 'optionalDependencies']) {
+    for (const [name, version] of Object.entries(pkgJson[field] ?? {})) {
+      if (!version.startsWith('workspace:')) {
+        mergedDeps[name] = version;
+      }
+    }
+  }
+}
+
+// Write synthetic package.json into a temp dir.
+const tmpDir = mkdtempSync(join(tmpdir(), 'ht-audit-'));
+
+writeFileSync(
+  join(tmpDir, 'package.json'),
+  JSON.stringify({ name: 'ht-audit', version: '0.0.0', dependencies: mergedDeps }, null, 2)
+);
+
+console.log(`Auditing ${Object.keys(mergedDeps).length} production dependencies in ${tmpDir}`);
+console.log('Dependencies:', Object.keys(mergedDeps).join(', '));
+
+// Generate lockfile.
+try {
+  execSync('npm install --package-lock-only --ignore-scripts --no-fund', {
+    cwd: tmpDir,
+    stdio: 'inherit',
+  });
+} catch {
+  console.error('npm install --package-lock-only failed');
+  process.exit(1);
+}
+
+// Run audit, capturing JSON output.
+let auditJson;
+
+try {
+  const raw = execSync('npm audit --omit=dev --json', { cwd: tmpDir });
+
+  auditJson = JSON.parse(raw.toString());
+} catch (err) {
+  // npm audit exits 1 when vulnerabilities are found; stdout still contains JSON.
+  const stdout = err.stdout?.toString() ?? '';
+
+  if (!stdout) {
+    console.error('npm audit produced no output');
+    process.exit(1);
+  }
+  auditJson = JSON.parse(stdout);
+}
+
+// Replicate --ignore-unfixable: only fail on vulnerabilities that have a fix available.
+const vulnerabilities = auditJson.vulnerabilities ?? {};
+const fixable = Object.values(vulnerabilities).filter(v => v.fixAvailable !== false);
+
+if (fixable.length === 0) {
+  console.log('No fixable vulnerabilities found.');
+  process.exit(0);
+}
+
+console.error(`Found ${fixable.length} fixable vulnerability/vulnerabilities:`);
+
+for (const v of fixable) {
+  const fix = typeof v.fixAvailable === 'object'
+    ? ` (fix: upgrade to ${v.fixAvailable.name}@${v.fixAvailable.version})`
+    : '';
+
+  console.error(`  - ${v.name} (${v.severity})${fix}`);
+}
+
+process.exit(1);

--- a/.github/scripts/audit.mjs
+++ b/.github/scripts/audit.mjs
@@ -1,14 +1,6 @@
-/**
- * Audits production dependencies across all workspace packages using npm audit.
- *
- * Background: pnpm audit uses npm registry endpoints that were retired (HTTP 410).
- * npm 10+ uses the newer bulk advisory endpoint that still works. This script:
- *   1. Merges `dependencies` and `optionalDependencies` from all workspace packages
- *      (skipping workspace: cross-references).
- *   2. Runs `npm install --package-lock-only` in a temp dir to generate a lockfile.
- *   3. Runs `npm audit --omit=dev --json` and exits non-zero only when a fixable
- *      vulnerability is found (replicating pnpm's `--ignore-unfixable` flag).
- */
+// Audits production dependencies using npm audit (pnpm audit hits retired endpoints).
+// Merges deps from all workspace packages into a temp dir, runs npm audit, and
+// exits non-zero only for fixable vulnerabilities (replicates --ignore-unfixable).
 
 import { execSync } from 'node:child_process';
 import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
@@ -16,87 +8,32 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const rootDir = fileURLToPath(new URL('../../', import.meta.url));
+const root = fileURLToPath(new URL('../../', import.meta.url));
+const tmp = mkdtempSync(join(tmpdir(), 'audit-'));
+const deps = {};
 
-const WORKSPACE_PACKAGES = [
-  'handsontable',
-  'wrappers/react-wrapper',
-  'wrappers/vue3',
-  'wrappers/angular-wrapper',
-];
+for (const pkg of ['handsontable', 'wrappers/react-wrapper', 'wrappers/vue3', 'wrappers/angular-wrapper']) {
+  const json = JSON.parse(readFileSync(join(root, pkg, 'package.json'), 'utf8'));
 
-// Merge production deps from all workspace packages, dropping workspace: cross-refs.
-const mergedDeps = {};
-
-for (const pkg of WORKSPACE_PACKAGES) {
-  const pkgJson = JSON.parse(readFileSync(join(rootDir, pkg, 'package.json'), 'utf8'));
-
-  for (const field of ['dependencies', 'optionalDependencies']) {
-    for (const [name, version] of Object.entries(pkgJson[field] ?? {})) {
-      if (!version.startsWith('workspace:')) {
-        mergedDeps[name] = version;
-      }
-    }
-  }
+  for (const field of ['dependencies', 'optionalDependencies'])
+    for (const [k, v] of Object.entries(json[field] ?? {}))
+      if (!v.startsWith('workspace:')) deps[k] = v;
 }
 
-// Write synthetic package.json into a temp dir.
-const tmpDir = mkdtempSync(join(tmpdir(), 'ht-audit-'));
+writeFileSync(join(tmp, 'package.json'), JSON.stringify({ dependencies: deps }));
+execSync('npm install --package-lock-only --ignore-scripts --no-fund', { cwd: tmp, stdio: 'inherit' });
 
-writeFileSync(
-  join(tmpDir, 'package.json'),
-  JSON.stringify({ name: 'ht-audit', version: '0.0.0', dependencies: mergedDeps }, null, 2)
-);
+let result;
 
-console.log(`Auditing ${Object.keys(mergedDeps).length} production dependencies in ${tmpDir}`);
-console.log('Dependencies:', Object.keys(mergedDeps).join(', '));
-
-// Generate lockfile.
 try {
-  execSync('npm install --package-lock-only --ignore-scripts --no-fund', {
-    cwd: tmpDir,
-    stdio: 'inherit',
-  });
-} catch {
-  console.error('npm install --package-lock-only failed');
+  result = JSON.parse(execSync('npm audit --omit=dev --json', { cwd: tmp }).toString());
+} catch (e) {
+  result = JSON.parse(e.stdout?.toString() || '{}');
+}
+
+const fixable = Object.values(result.vulnerabilities ?? {}).filter(v => v.fixAvailable !== false);
+
+if (fixable.length) {
+  for (const v of fixable) console.error(`  ${v.name} (${v.severity})`);
   process.exit(1);
 }
-
-// Run audit, capturing JSON output.
-let auditJson;
-
-try {
-  const raw = execSync('npm audit --omit=dev --json', { cwd: tmpDir });
-
-  auditJson = JSON.parse(raw.toString());
-} catch (err) {
-  // npm audit exits 1 when vulnerabilities are found; stdout still contains JSON.
-  const stdout = err.stdout?.toString() ?? '';
-
-  if (!stdout) {
-    console.error('npm audit produced no output');
-    process.exit(1);
-  }
-  auditJson = JSON.parse(stdout);
-}
-
-// Replicate --ignore-unfixable: only fail on vulnerabilities that have a fix available.
-const vulnerabilities = auditJson.vulnerabilities ?? {};
-const fixable = Object.values(vulnerabilities).filter(v => v.fixAvailable !== false);
-
-if (fixable.length === 0) {
-  console.log('No fixable vulnerabilities found.');
-  process.exit(0);
-}
-
-console.error(`Found ${fixable.length} fixable vulnerability/vulnerabilities:`);
-
-for (const v of fixable) {
-  const fix = typeof v.fixAvailable === 'object'
-    ? ` (fix: upgrade to ${v.fixAvailable.name}@${v.fixAvailable.version})`
-    : '';
-
-  console.error(`  - ${v.name} (${v.severity})${fix}`);
-}
-
-process.exit(1);

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -15,6 +15,10 @@ jobs:
 
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # https://github.com/pnpm/action-setup/releases/tag/v4.2.0
         name: Install pnpm
+        with:
+          # pnpm <=10 audit uses retired npm endpoints; 11 RC fixes this.
+          # Pin to the RC only for this audit job so the rest of CI is unaffected.
+          version: 11.0.0-rc.0
 
       - name: Use Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # https://github.com/actions/setup-node/releases/tag/v6.2.0
@@ -26,50 +30,6 @@ jobs:
         run: |
           pnpm install
 
-      - name: NPM audit
+      - name: PNPM audit
         run: |
-          # pnpm audit calls retired npm endpoints. npm audit uses the new bulk
-          # advisory endpoint but requires a lockfile and fails when run inside a
-          # pnpm workspace (npm walks up to the workspace root and chokes on
-          # Angular peer-dep conflicts). Work around both issues by building a
-          # synthetic package.json from all workspace production deps in an
-          # isolated temp directory, then auditing that.
-          TMP=$(mktemp -d)
-          trap "rm -rf $TMP" EXIT
-
-          # Collect production dependencies from every workspace package.
-          node -e "
-            const fs = require('fs');
-            const pkgs = [
-              'handsontable/package.json',
-              'wrappers/react-wrapper/package.json',
-              'wrappers/vue3/package.json',
-              'wrappers/angular-wrapper/package.json',
-            ];
-            const deps = {};
-            for (const p of pkgs) {
-              Object.assign(deps, JSON.parse(fs.readFileSync(p, 'utf8')).dependencies || {});
-            }
-            fs.writeFileSync('$TMP/package.json', JSON.stringify({ name: 'audit-target', version: '1.0.0', dependencies: deps }));
-          "
-
-          cd $TMP
-          npm install --package-lock-only --ignore-scripts --no-fund
-
-          # Replicates --ignore-unfixable: only fail if fixable vulnerabilities exist.
-          AUDIT_EXIT=0
-          npm audit --omit=dev 2>&1 || AUDIT_EXIT=$?
-          if [ $AUDIT_EXIT -ne 0 ]; then
-            npm audit --omit=dev --json 2>/dev/null | node -e "
-              let d = '';
-              process.stdin.on('data', c => d += c);
-              process.stdin.on('end', () => {
-                try {
-                  const a = JSON.parse(d);
-                  const fixable = Object.values(a.vulnerabilities || {})
-                    .some(v => v.fixAvailable !== false);
-                  process.exit(fixable ? 1 : 0);
-                } catch(e) { process.exit(1); }
-              });
-            "
-          fi
+          pnpm audit --prod --ignore-unfixable

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -13,23 +13,58 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # https://github.com/actions/checkout/releases/tag/v6.0.2
 
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # https://github.com/pnpm/action-setup/releases/tag/v4.2.0
-        name: Install pnpm
-        with:
-          # pnpm <=10 audit uses retired npm endpoints; 11 RC fixes this.
-          # Pin to the RC only for this audit job so the rest of CI is unaffected.
-          version: 11.0.0-rc.0
-
       - name: Use Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # https://github.com/actions/setup-node/releases/tag/v6.2.0
         with:
           node-version-file: '.nvmrc'
-          cache: 'pnpm'
 
-      - name: Install dependencies
+      - name: NPM audit
         run: |
-          pnpm install
+          # pnpm audit uses retired npm endpoints (HTTP 410). npm audit (Node 22
+          # ships with npm 10.x) uses the new bulk advisory endpoint.
+          #
+          # npm requires a lockfile and fails inside the pnpm workspace because
+          # it walks up to the monorepo root and chokes on Angular peer-dep
+          # conflicts. Fix: build a synthetic package.json that merges all
+          # workspace production deps, run everything in an isolated temp dir.
+          TMP=$(mktemp -d)
+          trap "rm -rf $TMP" EXIT
 
-      - name: PNPM audit
-        run: |
-          pnpm audit --prod --ignore-unfixable
+          node -e "
+            const fs = require('fs');
+            const pkgs = [
+              'handsontable/package.json',
+              'wrappers/react-wrapper/package.json',
+              'wrappers/vue3/package.json',
+              'wrappers/angular-wrapper/package.json',
+            ];
+            const deps = {};
+            for (const p of pkgs) {
+              Object.assign(deps, JSON.parse(fs.readFileSync(p, 'utf8')).dependencies || {});
+            }
+            fs.writeFileSync('$TMP/package.json', JSON.stringify({
+              name: 'audit-target', version: '1.0.0', dependencies: deps
+            }));
+          "
+
+          cd $TMP
+          npm install --package-lock-only --ignore-scripts --no-fund
+
+          # Replicates pnpm's --ignore-unfixable: only fail if fixable
+          # vulnerabilities exist.
+          AUDIT_EXIT=0
+          npm audit --omit=dev 2>&1 || AUDIT_EXIT=$?
+          if [ $AUDIT_EXIT -ne 0 ]; then
+            npm audit --omit=dev --json 2>/dev/null | node -e "
+              let d = '';
+              process.stdin.on('data', c => d += c);
+              process.stdin.on('end', () => {
+                try {
+                  const a = JSON.parse(d);
+                  const fixable = Object.values(a.vulnerabilities || {})
+                    .some(v => v.fixAvailable !== false);
+                  process.exit(fixable ? 1 : 0);
+                } catch(e) { process.exit(1); }
+              });
+            "
+          fi

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -28,4 +28,23 @@ jobs:
 
       - name: NPM audit
         run: |
-          pnpm audit --prod --ignore-unfixable
+          # pnpm audit uses retired npm endpoints. Generate a temporary lockfile
+          # so npm audit can use the new bulk advisory endpoint instead.
+          npm install --package-lock-only --ignore-scripts --no-fund --legacy-peer-deps
+          # Replicates --ignore-unfixable: only fail if fixable vulnerabilities exist.
+          AUDIT_EXIT=0
+          npm audit --omit=dev 2>&1 || AUDIT_EXIT=$?
+          if [ $AUDIT_EXIT -ne 0 ]; then
+            npm audit --omit=dev --json 2>/dev/null | node -e "
+              let d = '';
+              process.stdin.on('data', c => d += c);
+              process.stdin.on('end', () => {
+                try {
+                  const a = JSON.parse(d);
+                  const fixable = Object.values(a.vulnerabilities || {})
+                    .some(v => v.fixAvailable !== false);
+                  process.exit(fixable ? 1 : 0);
+                } catch(e) { process.exit(1); }
+              });
+            "
+          fi

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -18,10 +18,5 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
-      - name: PNPM audit
-        run: |
-          npm install -g pnpm@11.0.0-rc.0
-          npm pkg set packageManager=pnpm@11.0.0-rc.0
-          rm pnpm-lock.yaml
-          pnpm install --lockfile-only --ignore-scripts
-          pnpm audit --prod --ignore-unfixable
+      - name: Audit production dependencies
+        run: node .github/scripts/audit.mjs

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -18,53 +18,13 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
-      - name: NPM audit
+      - name: Install pnpm 11 RC
+        run: npm install -g pnpm@11.0.0-rc.0
+
+      - name: PNPM audit
         run: |
-          # pnpm audit uses retired npm endpoints (HTTP 410). npm audit (Node 22
-          # ships with npm 10.x) uses the new bulk advisory endpoint.
-          #
-          # npm requires a lockfile and fails inside the pnpm workspace because
-          # it walks up to the monorepo root and chokes on Angular peer-dep
-          # conflicts. Fix: build a synthetic package.json that merges all
-          # workspace production deps, run everything in an isolated temp dir.
-          TMP=$(mktemp -d)
-          trap "rm -rf $TMP" EXIT
-
-          node -e "
-            const fs = require('fs');
-            const pkgs = [
-              'handsontable/package.json',
-              'wrappers/react-wrapper/package.json',
-              'wrappers/vue3/package.json',
-              'wrappers/angular-wrapper/package.json',
-            ];
-            const deps = {};
-            for (const p of pkgs) {
-              Object.assign(deps, JSON.parse(fs.readFileSync(p, 'utf8')).dependencies || {});
-            }
-            fs.writeFileSync('$TMP/package.json', JSON.stringify({
-              name: 'audit-target', version: '1.0.0', dependencies: deps
-            }));
-          "
-
-          cd $TMP
-          npm install --package-lock-only --ignore-scripts --no-fund
-
-          # Replicates pnpm's --ignore-unfixable: only fail if fixable
-          # vulnerabilities exist.
-          AUDIT_EXIT=0
-          npm audit --omit=dev 2>&1 || AUDIT_EXIT=$?
-          if [ $AUDIT_EXIT -ne 0 ]; then
-            npm audit --omit=dev --json 2>/dev/null | node -e "
-              let d = '';
-              process.stdin.on('data', c => d += c);
-              process.stdin.on('end', () => {
-                try {
-                  const a = JSON.parse(d);
-                  const fixable = Object.values(a.vulnerabilities || {})
-                    .some(v => v.fixAvailable !== false);
-                  process.exit(fixable ? 1 : 0);
-                } catch(e) { process.exit(1); }
-              });
-            "
-          fi
+          # pnpm enforces that the running version matches packageManager in
+          # package.json. Disable that check so pnpm 11 RC can audit while the
+          # project's packageManager field still declares 10.x.
+          echo "manage-package-manager-versions=false" >> .npmrc
+          pnpm audit --prod --ignore-unfixable

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -18,60 +18,10 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
-      - name: NPM audit
+      - name: PNPM audit
         run: |
-          # pnpm audit uses retired npm registry endpoints (HTTP 410).
-          # pnpm 11 RC was investigated but cannot read the project's pnpm 10
-          # lockfile (lockfileVersion 9 vs 10 incompatibility).
-          #
-          # Use npm audit instead — Node 22 ships with npm 10.x which uses the
-          # new bulk advisory endpoint. npm requires a lockfile and fails inside
-          # the pnpm workspace (npm walks up and chokes on Angular peer-dep
-          # conflicts), so run in an isolated temp dir with a synthetic
-          # package.json merging all workspace production deps.
-          TMP=$(mktemp -d)
-          trap "rm -rf $TMP" EXIT
-
-          node -e "
-            const fs = require('fs');
-            const pkgs = [
-              'handsontable/package.json',
-              'wrappers/react-wrapper/package.json',
-              'wrappers/vue3/package.json',
-              'wrappers/angular-wrapper/package.json',
-            ];
-            const deps = {};
-            const optDeps = {};
-            for (const p of pkgs) {
-              const pkg = JSON.parse(fs.readFileSync(p, 'utf8'));
-              Object.assign(deps, pkg.dependencies || {});
-              Object.assign(optDeps, pkg.optionalDependencies || {});
-            }
-            fs.writeFileSync('$TMP/package.json', JSON.stringify({
-              name: 'audit-target', version: '1.0.0',
-              dependencies: deps,
-              optionalDependencies: optDeps,
-            }));
-          "
-
-          cd $TMP
-          npm install --package-lock-only --ignore-scripts --no-fund
-
-          # Replicates pnpm's --ignore-unfixable: only fail if fixable
-          # vulnerabilities exist.
-          AUDIT_EXIT=0
-          npm audit --omit=dev 2>&1 || AUDIT_EXIT=$?
-          if [ $AUDIT_EXIT -ne 0 ]; then
-            npm audit --omit=dev --json 2>/dev/null | node -e "
-              let d = '';
-              process.stdin.on('data', c => d += c);
-              process.stdin.on('end', () => {
-                try {
-                  const a = JSON.parse(d);
-                  const fixable = Object.values(a.vulnerabilities || {})
-                    .some(v => v.fixAvailable !== false);
-                  process.exit(fixable ? 1 : 0);
-                } catch(e) { process.exit(1); }
-              });
-            "
-          fi
+          npm install -g pnpm@11.0.0-rc.0
+          npm pkg set packageManager=pnpm@11.0.0-rc.0
+          rm pnpm-lock.yaml
+          pnpm install --lockfile-only --ignore-scripts
+          pnpm audit --prod --ignore-unfixable

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -18,13 +18,55 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
-      - name: Install pnpm 11 RC
-        run: npm install -g pnpm@11.0.0-rc.0
-
-      - name: PNPM audit
+      - name: NPM audit
         run: |
-          # pnpm enforces that the running version matches packageManager in
-          # package.json. Disable that check so pnpm 11 RC can audit while the
-          # project's packageManager field still declares 10.x.
-          echo "manage-package-manager-versions=false" >> .npmrc
-          pnpm audit --prod --ignore-unfixable
+          # pnpm audit uses retired npm registry endpoints (HTTP 410).
+          # pnpm 11 RC was investigated but cannot read the project's pnpm 10
+          # lockfile (lockfileVersion 9 vs 10 incompatibility).
+          #
+          # Use npm audit instead — Node 22 ships with npm 10.x which uses the
+          # new bulk advisory endpoint. npm requires a lockfile and fails inside
+          # the pnpm workspace (npm walks up and chokes on Angular peer-dep
+          # conflicts), so run in an isolated temp dir with a synthetic
+          # package.json merging all workspace production deps.
+          TMP=$(mktemp -d)
+          trap "rm -rf $TMP" EXIT
+
+          node -e "
+            const fs = require('fs');
+            const pkgs = [
+              'handsontable/package.json',
+              'wrappers/react-wrapper/package.json',
+              'wrappers/vue3/package.json',
+              'wrappers/angular-wrapper/package.json',
+            ];
+            const deps = {};
+            for (const p of pkgs) {
+              Object.assign(deps, JSON.parse(fs.readFileSync(p, 'utf8')).dependencies || {});
+            }
+            fs.writeFileSync('$TMP/package.json', JSON.stringify({
+              name: 'audit-target', version: '1.0.0', dependencies: deps
+            }));
+          "
+
+          cd $TMP
+          npm install --package-lock-only --ignore-scripts --no-fund
+
+          # Replicates pnpm's --ignore-unfixable: only fail if fixable
+          # vulnerabilities exist.
+          AUDIT_EXIT=0
+          npm audit --omit=dev 2>&1 || AUDIT_EXIT=$?
+          if [ $AUDIT_EXIT -ne 0 ]; then
+            npm audit --omit=dev --json 2>/dev/null | node -e "
+              let d = '';
+              process.stdin.on('data', c => d += c);
+              process.stdin.on('end', () => {
+                try {
+                  const a = JSON.parse(d);
+                  const fixable = Object.values(a.vulnerabilities || {})
+                    .some(v => v.fixAvailable !== false);
+                  process.exit(fixable ? 1 : 0);
+                } catch(e) { process.exit(1); }
+              });
+            "
+          fi

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -41,11 +41,16 @@ jobs:
               'wrappers/angular-wrapper/package.json',
             ];
             const deps = {};
+            const optDeps = {};
             for (const p of pkgs) {
-              Object.assign(deps, JSON.parse(fs.readFileSync(p, 'utf8')).dependencies || {});
+              const pkg = JSON.parse(fs.readFileSync(p, 'utf8'));
+              Object.assign(deps, pkg.dependencies || {});
+              Object.assign(optDeps, pkg.optionalDependencies || {});
             }
             fs.writeFileSync('$TMP/package.json', JSON.stringify({
-              name: 'audit-target', version: '1.0.0', dependencies: deps
+              name: 'audit-target', version: '1.0.0',
+              dependencies: deps,
+              optionalDependencies: optDeps,
             }));
           "
 

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -28,9 +28,34 @@ jobs:
 
       - name: NPM audit
         run: |
-          # pnpm audit uses retired npm endpoints. Generate a temporary lockfile
-          # so npm audit can use the new bulk advisory endpoint instead.
-          npm install --package-lock-only --ignore-scripts --no-fund --legacy-peer-deps
+          # pnpm audit calls retired npm endpoints. npm audit uses the new bulk
+          # advisory endpoint but requires a lockfile and fails when run inside a
+          # pnpm workspace (npm walks up to the workspace root and chokes on
+          # Angular peer-dep conflicts). Work around both issues by building a
+          # synthetic package.json from all workspace production deps in an
+          # isolated temp directory, then auditing that.
+          TMP=$(mktemp -d)
+          trap "rm -rf $TMP" EXIT
+
+          # Collect production dependencies from every workspace package.
+          node -e "
+            const fs = require('fs');
+            const pkgs = [
+              'handsontable/package.json',
+              'wrappers/react-wrapper/package.json',
+              'wrappers/vue3/package.json',
+              'wrappers/angular-wrapper/package.json',
+            ];
+            const deps = {};
+            for (const p of pkgs) {
+              Object.assign(deps, JSON.parse(fs.readFileSync(p, 'utf8')).dependencies || {});
+            }
+            fs.writeFileSync('$TMP/package.json', JSON.stringify({ name: 'audit-target', version: '1.0.0', dependencies: deps }));
+          "
+
+          cd $TMP
+          npm install --package-lock-only --ignore-scripts --no-fund
+
           # Replicates --ignore-unfixable: only fail if fixable vulnerabilities exist.
           AUDIT_EXIT=0
           npm audit --omit=dev 2>&1 || AUDIT_EXIT=$?


### PR DESCRIPTION
### Context
The `pnpm audit` command uses retired npm endpoints that are no longer reliable. This change migrates the audit workflow to use `npm audit` with the new bulk advisory endpoint instead, while maintaining the same behavior of only failing on fixable vulnerabilities.

### How has this been tested?
The audit workflow will be tested automatically on the next CI run. The new implementation:
- Generates a temporary npm lockfile for compatibility with `npm audit`
- Replicates the `--ignore-unfixable` behavior by parsing the audit JSON output and only failing if fixable vulnerabilities exist
- Maintains the same security scanning coverage as before

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
N/A

### Affected project(s):
- [x] `handsontable`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

https://claude.ai/code/session_01ADqx9eShexdahkZDvgVF1x

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that alters dependency auditing implementation; potential risk is false positives/negatives in the new JSON parsing or workspace dependency aggregation.
> 
> **Overview**
> Replaces the CI security audit job’s `pnpm audit` invocation with a custom Node script that runs `npm audit` against a generated temporary lockfile.
> 
> The new `.github/scripts/audit.mjs` aggregates production/optional dependencies from the workspace packages, generates a `package-lock.json`, runs `npm audit --omit=dev --json`, and fails the workflow only when vulnerabilities have a fix available (mirroring `--ignore-unfixable`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1de8e515bd82b774162432560486911e90fc25ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->