### PR TITLE
DEV-1268: Fix VersionsDropdown SSG build resolution failures

### DIFF
--- a/docs/src/components/VersionsDropdown.astro
+++ b/docs/src/components/VersionsDropdown.astro
@@ -12,8 +12,9 @@
  */
 
 import { createRequire } from 'module';
-import { dirname, join } from 'path';
+import { dirname, join, resolve } from 'path';
 import { fileURLToPath } from 'url';
+import { readFileSync } from 'fs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
@@ -26,7 +27,14 @@ try {
   const pkg = require(join(__dirname, '../../..', 'handsontable', 'package.json'));
   rawVersion = pkg.version ?? 'next';
 } catch {
-  // Use 'next' fallback
+  // Vite may transform import.meta.url during SSG build, breaking require().
+  // Fall back to reading from process.cwd() which is the docs/ directory.
+  try {
+    const pkg = JSON.parse(readFileSync(resolve(process.cwd(), '..', 'handsontable', 'package.json'), 'utf-8'));
+    rawVersion = pkg.version ?? 'next';
+  } catch {
+    // Use 'next' fallback
+  }
 }
 
 // Convert patch version (e.g. "17.0.0") to minor version (e.g. "17.0").
@@ -43,11 +51,23 @@ interface DocsData {
 
 let docsData: DocsData | null = null;
 
+// Prefer locally-generated common.json (written by commonJsonIntegration at build
+// start) which merges GitHub release data with the local package version. This
+// ensures pre-release versions not yet on handsontable.com are reflected correctly.
 try {
-  const res = await fetch('https://handsontable.com/docs/data/common.json');
-  if (res.ok) docsData = await res.json();
+  const localJson = readFileSync(resolve(process.cwd(), 'public', 'data', 'common.json'), 'utf-8');
+  docsData = JSON.parse(localJson);
 } catch {
-  // Offline / network unavailable — render with minimal fallback.
+  // Local file not available -- fall back to remote.
+}
+
+if (!docsData) {
+  try {
+    const res = await fetch('https://handsontable.com/docs/data/common.json');
+    if (res.ok) docsData = await res.json();
+  } catch {
+    // Offline / network unavailable — render with minimal fallback.
+  }
 }
 
 const latestVersion = docsData?.latestVersion ?? currentMinor;


### PR DESCRIPTION
## Summary

- Fix `VersionsDropdown.astro` failing to resolve the handsontable package version and docs metadata during Astro's SSG build
- During `astro build`, Vite transforms `import.meta.url` which breaks `createRequire()` path resolution -- the component falls back to `rawVersion = 'next'`, causing the version dropdown to display **"dev"** instead of the actual version
- The component also fetched version metadata exclusively from `https://handsontable.com/docs/data/common.json` (the live production URL), which doesn't include pre-release versions -- this caused the dropdown to show the wrong "latest" version when building docs for a not-yet-released version

### Changes

1. **Package version fallback**: Added `readFileSync` fallback using `process.cwd()` (which reliably points to `docs/`) when `createRequire(import.meta.url)` fails during SSG build
2. **Local common.json priority**: The component now prefers the locally-generated `public/data/common.json` (written by `commonJsonIntegration` at build start, which merges GitHub release data with the local package version) over the remote fetch. This ensures pre-release versions are reflected correctly in the dropdown. Remote fetch is kept as a fallback.

### Before

- Version dropdown showed **"dev latest"** with an empty version list
- No "dev" badge from SiteTitle (BUILD_MODE=production worked), but the dropdown was broken

### After

- Version dropdown shows **"17.1.0 Latest"** with the full version list populated
- 17.1 correctly marked as "Latest" in the dropdown

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1268

[skip changelog]

## Test plan

- [ ] Build docs locally with `BUILD_MODE=production npm run build` in `docs/`
- [ ] Verify the version dropdown button shows the correct version (e.g., `17.0.1 Latest`), not "dev"
- [ ] Verify clicking the dropdown shows the full version list with the correct "Latest" badge
- [ ] Verify the build works offline (disconnect network) -- should fall back to local common.json
- [ ] Verify `npm run dev` in `docs/` still works correctly (dev server)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: docs-only changes that adjust build-time file resolution and data sourcing; potential impact is limited to the version dropdown label/list during `astro build` or offline builds.
> 
> **Overview**
> Fixes `VersionsDropdown.astro` failing during Astro SSG by adding a `process.cwd()` + `readFileSync` fallback to resolve the local `handsontable/package.json` version when `createRequire(import.meta.url)` breaks.
> 
> Changes version metadata loading to **prefer locally-generated** `public/data/common.json` (from `commonJsonIntegration`) and only fetch `https://handsontable.com/docs/data/common.json` as a fallback, improving correctness for pre-release/offline builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a3d435e5f8279fd725e7117da908fc7118b82a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->