### PR TITLE
docs(agents): add coding discipline section with LLM behavioral guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,3 +293,70 @@ To update a task status directly from a commit or PR, append the target status i
 9. After PR is created, use ClickUp MCP to update task status to **"code review"**.
 
 **Authentication**: Use the ClickUp MCP tools for all ClickUp API interactions. Do not call the ClickUp REST API directly.
+
+## Coding discipline
+
+Behavioral guidelines to reduce common LLM coding mistakes. These complement -- not replace -- the [Mandatory checklist for every change](#mandatory-checklist-for-every-change) and [Architecture constraints](#architecture-constraints). They bias toward caution over speed; for small, low-risk tasks, use judgment.
+
+### Think before coding
+
+Do not assume. Do not hide confusion. Surface tradeoffs.
+
+Before implementing:
+
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them -- do not pick silently.
+- If a shorter approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what is confusing. Ask.
+
+### Minimal code
+
+Write the minimum code that solves the problem. Nothing speculative.
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No flexibility or configurability that was not requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: would a senior engineer say this is overcomplicated? If yes, shorten it. This rule aligns with the [Architecture constraints](#architecture-constraints) section: do not add speculative abstractions.
+
+### Surgical changes
+
+Touch only what you must. Clean up only your own mess.
+
+When editing existing code:
+
+- Do not "improve" adjacent code, comments, or formatting.
+- Do not refactor things that are not broken.
+- Match existing style, even if you would do it differently.
+- If you notice unrelated dead code, mention it -- do not delete it.
+
+When your changes create orphans:
+
+- Remove imports, variables, or functions that your changes made unused.
+- Do not remove pre-existing dead code unless asked.
+
+The test: every changed line should trace directly to the user's request.
+
+### Goal-driven execution
+
+Define success criteria. Loop until verified. This extends the [Mandatory checklist for every change](#mandatory-checklist-for-every-change): red-green TDD is the required mechanism; the guidance below is how to frame work around it.
+
+Transform tasks into verifiable goals:
+
+- "Add validation" -> write tests for invalid inputs, then make them pass.
+- "Fix the bug" -> write a test that reproduces it, then make it pass.
+- "Refactor X" -> ensure tests pass before and after.
+
+For multi-step tasks, state a brief plan:
+
+```
+1. [Step] -> verify: [check]
+2. [Step] -> verify: [check]
+3. [Step] -> verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+These guidelines are working if diffs contain fewer unrequested changes, fewer rewrites from overcomplication, and clarifying questions come before implementation rather than after mistakes.


### PR DESCRIPTION
### Context

Adds a new **Coding discipline** section to `AGENTS.md` (symlinked from `CLAUDE.md`) with behavioral guidelines that reduce common LLM coding mistakes: think before coding, write minimal code, make surgical changes, and drive work with verifiable success criteria.

Source: adapted from [forrestchang/andrej-karpathy-skills](https://github.com/forrestchang/andrej-karpathy-skills). The content was integrated under the existing `# AGENTS.md` heading (duplicate H1 removed), aligned with the project's "Writing style" section (ASCII-only arrows/dashes, straight quotes, active voice), and cross-linked to the existing `Mandatory checklist for every change` and `Architecture constraints` sections so it extends rather than duplicates current rules.

No library source code is affected.

[skip changelog]

### How has this been tested?

Not applicable -- documentation/config-only change to `AGENTS.md`. Verified locally:

- File renders correctly (markdown well-formed, anchor links resolve to existing headings).
- No duplicate H1; single top-level title preserved.
- No stylistic violations vs. the `Writing style` section (no unicode arrows, no smart quotes, no en/em dashes).

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

N/A -- internal tooling/agent-guideline update.

### Affected project(s):

- [ ] \`handsontable\`
- [ ] \`@handsontable/angular-wrapper\`
- [ ] \`@handsontable/react-wrapper\`
- [ ] \`@handsontable/vue3\`

None -- only `AGENTS.md` (root).

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change in `AGENTS.md` with no impact on runtime code, builds, or tests.
> 
> **Overview**
> Adds a new **Coding discipline** section to `AGENTS.md` with behavioral guidelines for agents (think before coding, keep changes minimal/surgical, and use goal-driven execution with verifiable success criteria), cross-referencing existing `Mandatory checklist for every change` and `Architecture constraints`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24d0ed72e04ddc4adf7bc51098b7b85ea629b8fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->