### PR TITLE
Fix crash when showing loading indicator from afterChange hook during editor close (#12341)

### DIFF
--- a/.changelogs/12341.json
+++ b/.changelogs/12341.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed an exception when showing the loading indicator from the `afterChange` hook during editor close.",
+  "type": "fixed",
+  "issueOrPR": 12341,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/12341.json
+++ b/.changelogs/12341.json
@@ -2,7 +2,7 @@
   "issuesOrigin": "public",
   "title": "Fixed an exception when showing the loading indicator from the `afterChange` hook during editor close.",
   "type": "fixed",
-  "issueOrPR": 12341,
+  "issueOrPR": 12348,
   "breaking": false,
   "framework": "none"
 }

--- a/handsontable/src/editorManager.js
+++ b/handsontable/src/editorManager.js
@@ -277,6 +277,10 @@ class EditorManager {
    * @param {KeyboardEvent} event The keyboard event object.
    */
   moveSelectionAfterEnter(event) {
+    if (!this.hot.getSelected()) {
+      return;
+    }
+
     const enterMoves = { ...typeof this.tableMeta.enterMoves === 'function' ?
       this.tableMeta.enterMoves(event) : this.tableMeta.enterMoves };
 

--- a/handsontable/src/plugins/loading/__tests__/loading.spec.js
+++ b/handsontable/src/plugins/loading/__tests__/loading.spec.js
@@ -112,4 +112,45 @@ describe('Loading', () => {
     expect(plugin.isVisible()).toBe(false);
     expect(plugin.enabled).toBe(false);
   });
+
+  it('should not throw when showing loading indicator from afterChange hook during editor close (#12341)', async() => {
+    const hot = handsontable({
+      data: createSpreadsheetData(5, 5),
+      loading: true,
+      afterChange(changes, source) {
+        if (source === 'edit') {
+          hot.getPlugin('loading').show();
+        }
+      },
+    });
+
+    await selectCell(0, 0);
+
+    await keyDownUp('enter');
+    document.activeElement.value = 'new value';
+    await keyDownUp('enter');
+
+    expect(getDataAtCell(0, 0)).toBe('new value');
+    expect(hot.getPlugin('loading').isVisible()).toBe(true);
+  });
+
+  it('should not throw when calling deselectCell from afterChange hook during editor close (#12341)', async() => {
+    const hot = handsontable({
+      data: createSpreadsheetData(5, 5),
+      afterChange(changes, source) {
+        if (source === 'edit') {
+          hot.deselectCell();
+        }
+      },
+    });
+
+    await selectCell(0, 0);
+
+    await keyDownUp('enter');
+    document.activeElement.value = 'new value';
+    await keyDownUp('enter');
+
+    expect(getDataAtCell(0, 0)).toBe('new value');
+    expect(hot.getSelected()).toBeUndefined();
+  });
 });

--- a/handsontable/src/selection/selection.js
+++ b/handsontable/src/selection/selection.js
@@ -631,6 +631,10 @@ class Selection {
    * Otherwise, row/column will be created according to `minSpareRows/minSpareCols` settings of Handsontable.
    */
   transformStart(rowDelta, colDelta, createMissingRecords = false) {
+    if (!this.isSelected()) {
+      return;
+    }
+
     const {
       visualCoords
     } = this.#extenderTransformation.transformStart(rowDelta, colDelta, createMissingRecords);
@@ -645,6 +649,10 @@ class Selection {
    * @param {number} colDelta Columns number to move, value can be passed as negative number.
    */
   transformEnd(rowDelta, colDelta) {
+    if (!this.isSelected()) {
+      return;
+    }
+
     const {
       visualCoords,
       selectionLayer,
@@ -660,6 +668,10 @@ class Selection {
    * @param {number} colDelta Columns number to move, value can be passed as negative number.
    */
   transformFocus(rowDelta, colDelta) {
+    if (!this.isSelected()) {
+      return;
+    }
+
     const {
       selectionLayer,
       visualCoords,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Context

Fixes #12341.

When a user calls `loadingPlugin.show()` (or `hot.deselectCell()`) inside the `afterChange` hook with `source === 'edit'`, the application crashes with:

```
TypeError: Cannot read properties of undefined (reading 'highlight')
    at ExtenderTransformation.transformStart
    at Selection.transformStart
    at EditorManager.moveSelectionAfterEnter
```

**Root cause:** The editor close sequence fires `afterChange` synchronously during `applyChanges()` in `core.js`. If the hook clears the selection (e.g. via `Dialog.show()` -> `deselectCell()`), the subsequent `moveSelectionAfterEnter()` call tries to transform a selection that no longer exists.

**Fix:** Added `isSelected()` guards to `Selection.transformStart()`, `Selection.transformEnd()`, and `Selection.transformFocus()`. This follows the existing pattern already used by `Selection.shiftRows()` and `Selection.shiftColumns()`. Additionally, added a guard in `EditorManager.moveSelectionAfterEnter()` for consistency with the existing guard in `closeAndSaveByArrowKeys`.

### How has this been tested?

Added two E2E tests in `loading.spec.js`:
1. Tests that `loadingPlugin.show()` called from `afterChange` during editor close does not throw.
2. Tests that `hot.deselectCell()` called from `afterChange` during editor close does not throw.

```bash
npm run test:e2e --testPathPattern=loading --prefix handsontable
npm run test:e2e --testPathPattern=textEditor --prefix handsontable
npm run test:e2e --testPathPattern=dialog --prefix handsontable
npm run test:e2e --testPathPattern=selection/selection --prefix handsontable
```

All tests pass.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #12341

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a614451-b4b3-4328-a9de-753fdfc80831"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a614451-b4b3-4328-a9de-753fdfc80831"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

