### PR TITLE
docs: Establish documentation standards (Diátaxis)

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,5 +1,7 @@
 # Documentation Standards
 
+These standards apply to both human authors and AI agents contributing to the documentation.
+
 Astro Starlight-based documentation site. **Requires Node 20** (separate from core's Node 22).
 
 For detailed authoring guidance, use skills `writing-docs-pages` and `creating-docs-examples`.

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,47 +1,326 @@
-# Documentation Site
+# Documentation Standards
 
-Astro Starlight-based documentation. **Requires Node 20** (separate from core's Node 22).
+Astro Starlight-based documentation site. **Requires Node 20** (separate from core's Node 22).
 
-## Writing Style
+For detailed authoring guidance, use skills `writing-docs-pages` and `creating-docs-examples`.
 
-- Active voice, American English, short sentences
-- "you" not "we", Oxford comma
-- No evaluative adjectives ("easy", "simple", "obvious")
-- En dashes (-) to separate clauses
-- Bold for UI elements: **Add comment**
-- Inline code for API: `comments`
+---
 
-## Page Frontmatter (required)
+## 2.1 Documentation Architecture (Diátaxis)
+
+Every page belongs to exactly one of four content types from the [Diátaxis framework](https://diataxis.fr/). Mixing types on a single page creates confusion. When content doesn't fit one type, split it into two pages.
+
+### The four content types
+
+| Type | Serves | User's question | Handsontable example |
+|---|---|---|---|
+| **Tutorial** | Learning | "Teach me to do X" | "Build a sortable data grid from scratch" |
+| **How-to guide** | Goals | "How do I accomplish X?" | "How to freeze the first two columns" |
+| **Reference** | Information | "What are the options for X?" | "Column filter configuration options" |
+| **Explanation** | Understanding | "Why does X work this way?" | "Understanding the plugin system" |
+
+### Decision tree
+
+Use this to pick the right type for a new page:
+
+1. Is the reader a beginner who needs guided instruction? → **Tutorial**
+2. Does the reader already know the basics and needs to accomplish a specific task? → **How-to guide**
+3. Is the reader looking up a specific fact, option, or API signature? → **Reference**
+4. Is the page answering "why?" or explaining a concept, design, or trade-off? → **Explanation**
+5. Does the content fit two or more types? → Split into separate pages.
+
+### Folder-to-type mapping
+
+| Folder | Expected type |
+|---|---|
+| `guides/getting-started/` | How-to (task-oriented setup steps) |
+| `guides/*/` (feature guides) | How-to or mixed (lean toward splitting) |
+| `guides/upgrade-and-migration/migrating-from-*/` | How-to |
+| `guides/upgrade-and-migration/changelog-*/` | Reference |
+| `guides/upgrade-and-migration/versioning-policy/` | Explanation |
+| `guides/upgrade-and-migration/deprecation-policy/` | Explanation |
+| `api/` | Reference |
+| `recipes/` | Tutorial |
+
+### Required frontmatter field
+
+Every page **must** declare its Diátaxis type in frontmatter:
 
 ```yaml
----
-id: abc12345              # 8 random alphanumeric chars (NEVER change existing)
-title: Feature Name
-metaTitle: Feature Name - JavaScript Data Grid | Handsontable
-description: Short SEO description
-permalink: /feature-name
-tags: [keyword1, keyword2]
-react:
-  id: def67890            # Different ID per framework
-  metaTitle: Feature Name - React Data Grid | Handsontable
-searchCategory: Guides
-category: Cell features
----
+type: tutorial | how-to | reference | explanation
 ```
 
-## Framework-Specific Content
+This field is in addition to the existing required frontmatter fields (see [Section 2.6](#26-frontmatter-schema)).
+
+---
+
+## 2.2 Voice and Style
+
+### Person, tense, and voice
+
+- **Second person**: "you", not "we" or "the user".
+- **Present tense**: "the plugin renders", not "the plugin will render".
+- **Active voice**: "Click **Save**", not "The Save button should be clicked".
+- **Direct imperative for instructions**: "Click **Save**" not "You should click **Save**".
+
+### Words to avoid
+
+| Avoid | Use instead |
+|---|---|
+| simply, just, easy, straightforward | (omit — state the fact directly) |
+| note that, please | (omit — restructure as a callout or sentence) |
+| allows you to | "lets you" or rephrase actively |
+| in order to | "to" |
+| utilize | "use" |
+
+### Sentence length
+
+- Instructions: max ~25 words per sentence.
+- One idea per sentence.
+- Separate compound sentences at conjunctions.
+
+### Technical terms
+
+- Define on first use in the page: "The `ColumnSorting` plugin -- which sorts rows by column values -- is disabled by default."
+- On subsequent uses, link to the reference page once per page section.
+- Use code formatting for all API names, option keys, file paths, and code values.
+
+### Formatting conventions
+
+- Hyphens (`-`) or double hyphens (`--`) to separate clauses. No en dashes or em dashes.
+- Straight quotes (`"` and `'`) only. No curly/smart quotes.
+- Bold for UI elements: **Save**, **Add column**.
+- Inline code for API names: `columnSorting`, `readOnly`.
+- Oxford comma in lists of three or more items.
+- American English spelling.
+
+---
+
+## 2.3 Page Structure Templates
+
+Use the appropriate template for each Diátaxis type. Do not omit required sections.
+
+### Tutorial template
 
 ```markdown
-::: only-for javascript
-Content for JS only
-:::
+---
+type: tutorial
+id: <8-char alphanum>
+title: <Verb phrase — Build/Create/Set up X>
+metaTitle: <title> - JavaScript Data Grid | Handsontable
+description: <1-2 sentences summarizing outcome and who benefits>
+permalink: /<slug>
+tags: [keyword1, keyword2]
+searchCategory: Guides
+category: <nav category>
+---
 
-::: only-for react
-Content for React only
-:::
+In this tutorial, you will [concrete outcome]. You will learn [skill or concept].
+
+## Before you begin
+
+- [prerequisite 1]
+- [prerequisite 2]
+
+## Step 1 — [Action phrase]
+
+[Instruction text. Keep to ~3-5 sentences. Show one code block.]
+
+## Step 2 — [Action phrase]
+
+...
+
+## What you learned
+
+- [learning point 1]
+- [learning point 2]
+
+## Next steps
+
+- [link to related how-to or reference]
+- [link to deeper topic]
 ```
 
-## Example Embedding
+### How-to guide template
+
+```markdown
+---
+type: how-to
+id: <8-char alphanum>
+title: How to [specific goal]
+metaTitle: How to [specific goal] - JavaScript Data Grid | Handsontable
+description: <1-2 sentences: what this achieves and when to use it>
+permalink: /<slug>
+tags: [keyword1, keyword2]
+searchCategory: Guides
+category: <nav category>
+---
+
+[One sentence: what this accomplishes and when to use it.]
+
+## Prerequisites
+
+- [prerequisite 1]
+
+## Steps
+
+1. [First action]
+
+   [Explanation and code block]
+
+2. [Second action]
+
+   [Explanation and code block]
+
+## Result
+
+[Describe what the reader now has. One or two sentences.]
+
+## Related
+
+- [link to related reference]
+- [link to related how-to]
+```
+
+### Reference template
+
+```markdown
+---
+type: reference
+id: <8-char alphanum>
+title: [Component/API/option name]
+metaTitle: [Component/API name] - JavaScript Data Grid | Handsontable
+description: <1-2 sentences describing what this is>
+permalink: /<slug>
+tags: [keyword1, keyword2]
+searchCategory: Guides
+category: <nav category>
+---
+
+[One sentence describing what this is and what it does.]
+
+## Syntax / Signature
+
+```javascript
+// function/option signature
+```
+
+## Parameters / Options
+
+| Name | Type | Default | Description |
+|---|---|---|---|
+| `name` | `string` | `'value'` | What this controls. |
+
+## Returns
+
+[Return type and description, if applicable.]
+
+## Examples
+
+[Minimal, runnable code example with language tag.]
+
+## Related
+
+- [link to how-to for this feature]
+- [link to related reference]
+```
+
+### Explanation template
+
+```markdown
+---
+type: explanation
+id: <8-char alphanum>
+title: Understanding [concept]
+metaTitle: Understanding [concept] - JavaScript Data Grid | Handsontable
+description: <1-2 sentences: why this concept matters and who should read this>
+permalink: /<slug>
+tags: [keyword1, keyword2]
+searchCategory: Guides
+category: <nav category>
+---
+
+[Why this concept matters and when it is relevant. 2-3 sentences.]
+
+## Background
+
+[Historical or architectural context.]
+
+## How it works
+
+[Mechanism, flow, or design explanation.]
+
+## Trade-offs
+
+[What you gain and what you give up. When to choose differently.]
+
+## Related
+
+- [link to how-to that applies this concept]
+- [link to reference for this feature]
+```
+
+---
+
+## 2.4 Example Data Standards
+
+### Never use
+
+The following placeholder values are banned from all published documentation:
+
+`A1`, `A2`, `A3`, `foo`, `bar`, `baz`, `test`, `Column1`, `Column2`, `Item1`, `value1`, `xxx`, `sample`, `dummy`, `placeholder`, `name1`, `name2`, `data1`, `data2`
+
+### Always use domain-realistic data
+
+Each example must use data from a coherent, plausible real-world domain. Pick one domain per example and stay consistent throughout.
+
+**Approved example domains:**
+
+| Domain | Example data |
+|---|---|
+| **Financial** | Company names (Acme Corp, Vertex Industries), revenue ($4.2M, $18.7M), fiscal quarters (Q1 2025), currencies (USD, EUR) |
+| **HR / workforce** | Employee names (diverse: Ana García, James Okafor, Li Wei), job titles (Senior Engineer, Product Manager), departments (Engineering, Marketing), hire dates (2022-03-14) |
+| **Inventory** | Product SKUs (SKU-4821, SKU-0093), supplier names (Harbor Goods, Alpine Supply Co.), stock quantities (142, 0, 67), categories (Electronics, Apparel) |
+| **Analytics** | Campaign names (Spring Sale 2025, Brand Awareness Q3), conversion rates (3.4%, 8.1%), channels (Email, Paid Search, Organic) |
+| **Project management** | Task names (Update API docs, Deploy hotfix), assignees, due dates (2025-06-30), statuses (In progress, Blocked) |
+
+### Data coherence rules
+
+- All rows in an example use the same domain.
+- Values must be plausible: no negative ages, no revenue of $1, no dates in 1900.
+- The dataset should make the demonstrated feature meaningful. A sorting example must use data where sorting is useful. A filtering example must use data where filtering makes sense.
+- Use at least five rows in table examples so the feature behavior is visible.
+
+---
+
+## 2.5 Code Example Standards
+
+### Language tags
+
+All code blocks **must** include a language tag:
+
+````markdown
+```javascript
+```typescript
+```html
+```css
+```shell
+```json
+```yaml
+````
+
+Untagged code blocks (```` ``` ````) are not allowed.
+
+### Example quality rules
+
+- Examples must be self-contained and runnable (or clearly labeled as a snippet).
+- Use `const` and `let`. Never use `var`.
+- Always include `licenseKey: 'non-commercial-and-evaluation'` in `new Handsontable(...)` calls.
+- No inline `// TODO` or `// ...` comments in published examples.
+- Keep examples between 25 and 60 lines. If longer, link to the live sandbox instead.
+- TypeScript is the primary language for new examples. Generate the JavaScript variant: `npm run docs:code-examples:generate-js <path>`.
+
+### Example embedding
 
 ```markdown
 ::: example #example1 --js 1 --ts 2
@@ -50,22 +329,104 @@ Content for React only
 :::
 ```
 
-## Links
+### Framework-specific content
 
-`[text](@/path/to/file.md#anchor)` - always use `@` prefix with `.md` extension.
+```markdown
+::: only-for javascript
+Content for vanilla JS only.
+:::
 
-## Code Examples
+::: only-for react
+Content for React only.
+:::
+```
 
-- TypeScript is primary. Generate JS: `npm run docs:code-examples:generate-js <path>`
-- Always include `licenseKey: 'non-commercial-and-evaluation'`
-- One concept per example, 25-60 lines
+---
 
-## Trademark
+## 2.6 Frontmatter Schema
 
-Pages mentioning "Excel" must include Microsoft trademark disclaimer. Pages also mentioning "Google Sheets" use expanded disclaimer.
+Required fields for all pages:
 
-## Sidebar
+```yaml
+---
+type: tutorial | how-to | reference | explanation   # Diátaxis type (required)
+id: abc12345              # 8 random alphanumeric chars — NEVER change existing IDs
+title: Feature Name       # Matches H1; do NOT add H1 in body (Starlight renders title once)
+metaTitle: Feature Name - JavaScript Data Grid | Handsontable
+description: Short SEO description (1-2 sentences)
+permalink: /feature-name
+tags: [keyword1, keyword2]  # Optional; kebab-case
+react:
+  id: def67890            # Different ID per framework variant
+  metaTitle: Feature Name - React Data Grid | Handsontable
+searchCategory: Guides
+category: Cell features
+---
+```
 
-Register new pages in `content/guides/sidebar.js`.
+**Rules:**
+- Never change an existing `id` value. IDs are permanent.
+- `title` is the only H1. Do not add `# Title` in the Markdown body.
+- `description` is used in SEO meta and link previews -- make it specific and accurate.
+- `tags` must be lowercase kebab-case.
 
-For detailed guidance: use skills `writing-docs-pages`, `creating-docs-examples`
+---
+
+## 2.7 Links and Paths
+
+Use the `@` prefix with `.md` extension for all internal links:
+
+```markdown
+[text](@/path/to/file.md#anchor)
+```
+
+Do not use relative paths (`../`) for internal links.
+
+---
+
+## 2.8 Trademark Notices
+
+- Pages mentioning "Excel" must include the Microsoft trademark disclaimer.
+- Pages also mentioning "Google Sheets" use the expanded disclaimer.
+- Add the disclaimer in a callout or footnote at the bottom of the page.
+
+---
+
+## 2.9 Sidebar Registration
+
+Register new pages in `content/guides/sidebar.js`. A page not registered there will not appear in navigation.
+
+---
+
+## 2.10 Checklist Before Submitting a Docs PR
+
+Copy and complete this checklist in your PR description:
+
+```markdown
+## Docs PR checklist
+
+- [ ] `type:` field added to frontmatter (tutorial | how-to | reference | explanation)
+- [ ] Page uses the correct Diátaxis template for its type
+- [ ] Title matches Diátaxis naming convention for its type
+  - Tutorial: verb phrase ("Build X", "Create X")
+  - How-to: starts with "How to ..."
+  - Reference: component or API name
+  - Explanation: starts with "Understanding ..."
+- [ ] Intro paragraph states: what, for whom, and what outcome the reader gains
+- [ ] No banned placeholder data (foo, bar, A1, Column1, etc.)
+- [ ] All example data is domain-realistic and internally consistent
+- [ ] All code blocks have language tags (```javascript, ```typescript, etc.)
+- [ ] No `var` in code examples; uses `const` / `let`
+- [ ] All examples include `licenseKey: 'non-commercial-and-evaluation'`
+- [ ] Heading hierarchy is correct (no skipped levels, e.g., H2 → H4)
+- [ ] Active voice and second person ("you") used throughout
+- [ ] No banned words: simply, just, easy, straightforward, note that, please
+- [ ] Tutorials and how-tos have a Prerequisites section
+- [ ] Tutorials have "What you learned" and "Next steps" sections
+- [ ] How-tos have a "Result" section
+- [ ] New page registered in `content/guides/sidebar.js`
+- [ ] `id` field uses 8 random alphanumeric chars (existing IDs are unchanged)
+- [ ] Microsoft trademark disclaimer added where "Excel" is mentioned
+- [ ] TypeScript example exists; JS generated via `npm run docs:code-examples:generate-js`
+- [ ] `[skip changelog]` in PR body (docs changes don't need changelog entries)
+```

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,6 +1,6 @@
 # Documentation Standards
 
-These standards apply to both human authors and AI agents contributing to the documentation.
+This document is written for both human authors and AI agents. All rules are stated explicitly so both roles can apply them without ambiguity.
 
 Astro Starlight-based documentation site. **Requires Node 20** (separate from core's Node 22).
 


### PR DESCRIPTION
## Summary

- Rewrites `docs/CLAUDE.md` from a brief cheat sheet into a comprehensive **Documentation Standards** guide
- Introduces the [Diátaxis framework](https://diataxis.fr/) as the organizing principle for all documentation pages
- Defines four content types (Tutorial, How-to, Reference, Explanation) with Handsontable-specific examples, a decision tree, and folder-to-type mapping
- Adds page structure templates for each Diátaxis type, so authors have a concrete starting point
- Codifies example data standards -- banning generic placeholders (foo, bar, A1, Column1) and requiring domain-realistic, coherent datasets
- Adds a mandatory pre-submission checklist authors must complete in their PR description
- Preserves all existing conventions (frontmatter schema, framework-specific blocks, link format, trademark rules, sidebar registration)

## Why Diátaxis

The current guide describes formatting rules but gives no guidance on *what kind of page to write*. As a result, most guide pages mix reference tables, conceptual explanation, and procedural steps on a single page -- making them harder to navigate and maintain. Diátaxis solves this by giving every page a clear purpose, structure, and intended reader state.

## What authors should do next

1. Read the new `docs/CLAUDE.md` in full before opening a docs PR.
2. Add `type: <tutorial|how-to|reference|explanation>` to the frontmatter of any page you touch.
3. Use the appropriate page template from Section 2.3 when writing new pages.
4. Complete the checklist in Section 2.10 before requesting review.

Existing pages will be updated incrementally -- ClickUp tasks have been created for each page that needs classification and content fixes.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes that adjust authoring guidelines and templates with no product/runtime impact; risk is limited to teams needing to align existing docs with the new required `type` frontmatter.
> 
> **Overview**
> Updates `docs/CLAUDE.md` from a short style cheat sheet into a full **Documentation Standards** spec, introducing mandatory Diátaxis page types (`tutorial`/`how-to`/`reference`/`explanation`) and adding templates, frontmatter requirements, and a pre-submission checklist.
> 
> Codifies stricter rules for writing voice/style, internal links, trademark notices, and especially code/example expectations (language-tagged code blocks, TypeScript-first examples, and domain-realistic sample data with banned placeholder values). Adds `docs/AGENTS.md` to point agents at `CLAUDE.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32db61832209143359d4207d70b5535edae3d2a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->