### PR TITLE
DEV-1268: Add production-mode docs staging for RC release branches

### DIFF
--- a/.github/workflows/docs-staging.yml
+++ b/.github/workflows/docs-staging.yml
@@ -7,8 +7,11 @@ on:
     branches-ignore:
       - 'prod-docs/**'
       - 'master'
+    # Trigger on docs changes (all branches) and on handsontable/package.json
+    # changes (so RC version bumps on release/* branches trigger a rebuild).
     paths:
       - 'docs/**'
+      - 'handsontable/package.json'
   workflow_dispatch:
 
 concurrency:
@@ -36,6 +39,26 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
+
+      - name: Detect release branch
+        id: release-info
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # https://github.com/actions/github-script/releases/tag/v8.0.0
+        with:
+          script: |
+            const ref = context.ref || '';
+            // Match release/x.y.z branches (RC builds)
+            const releaseMatch = ref.match(/^refs\/heads\/release\/(\d+\.\d+\.\d+)$/);
+            const isReleaseBranch = !!releaseMatch;
+            const targetVersion = releaseMatch ? releaseMatch[1] : '';
+
+            core.setOutput('is_release', String(isReleaseBranch));
+            core.setOutput('target_version', targetVersion);
+
+            if (isReleaseBranch) {
+              console.log(`Release branch detected: ${ref}`);
+              console.log(`Target version: ${targetVersion}`);
+              console.log('Will build docs in production mode to mimic the final release.');
+            }
 
       - name: Find PR
         uses: jwalton/gh-find-current-pr@89ee5799558265a1e0e31fab792ebb4ee91c016b # https://github.com/jwalton/gh-find-current-pr/tree/v1.3.3
@@ -80,8 +103,8 @@ jobs:
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_PREVIEW_AUTH_TOKEN }}
           NETLIFY_ACCOUNT_SLUG: ${{ secrets.NETLIFY_ACCOUNT_SLUG }}
-          BRANCH_NAME_PREFIX: dev-handsontable-
-          BRANCH_NAME: ${{ steps.get-pr.outputs.source_branch || github.ref_name }}
+          BRANCH_NAME_PREFIX: ${{ steps.release-info.outputs.is_release == 'true' && 'rc-handsontable-' || 'dev-handsontable-' }}
+          BRANCH_NAME: ${{ steps.release-info.outputs.is_release == 'true' && steps.release-info.outputs.target_version || steps.get-pr.outputs.source_branch || github.ref_name }}
 
       - name: Publish sticky comment in PR. Docs are being built
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # https://github.com/marocchino/sticky-pull-request-comment/tree/v2.9.4
@@ -102,9 +125,38 @@ jobs:
           pnpm install
           npm run all build -- --e examples visual-tests
 
+      # RC release branches: patch handsontable/package.json to the clean target
+      # version (e.g., 17.1.0-rc1 -> 17.1.0) so the docs build uses the correct
+      # version in CodeSandbox URLs, the version dropdown, and common.json.
+      - name: Patch version for RC release branch
+        if: ${{ steps.release-info.outputs.is_release == 'true' }}
+        working-directory: .
+        run: |
+          TARGET_VERSION="${{ steps.release-info.outputs.target_version }}"
+          echo "Patching handsontable/package.json version to ${TARGET_VERSION}"
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('handsontable/package.json', 'utf-8'));
+            pkg.version = '${TARGET_VERSION}';
+            fs.writeFileSync('handsontable/package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+          echo "Version patched: $(node -p "require('./handsontable/package.json').version")"
+
+      # RC release branches: measure module sizes (same as production workflow).
+      - name: Update module size measurements
+        if: ${{ steps.release-info.outputs.is_release == 'true' }}
+        working-directory: .
+        run: |
+          npm run measure:module-sizes --prefix handsontable
+
       - name: Build docs (for staging preview)
         run: |
           npm run build
+        env:
+          # RC release branches build in production mode to mimic the final
+          # production deployment (GTM/HotJar injected, dev badge hidden,
+          # correct version in the version dropdown).
+          BUILD_MODE: ${{ steps.release-info.outputs.is_release == 'true' && 'production' || '' }}
 
       - name: Build and deploy the preview to Netlify
         run: |
@@ -141,3 +193,15 @@ jobs:
           message: |
             ✅ Preview documentation is is available now
             Current staging version of documentation is available at: [${{ env.NETLIFY_SITE_URL }}/docs](${{ env.NETLIFY_SITE_URL }}/docs)
+
+      - name: Post RC staging summary
+        if: ${{ steps.release-info.outputs.is_release == 'true' }}
+        run: |
+          echo "## 🧪 RC Docs Staging Deployment" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Target version:** ${{ steps.release-info.outputs.target_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Build mode:** production" >> $GITHUB_STEP_SUMMARY
+          echo "**Preview URL:** ${{ env.NETLIFY_SITE_URL }}/docs" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "This staging build mimics the production docs deployment for version ${{ steps.release-info.outputs.target_version }}." >> $GITHUB_STEP_SUMMARY
+          echo "Use it to verify the docs before the final release." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

- Add production-mode docs staging builds for RC release branches (`release/x.y.z`)
- When the staging workflow detects a `release/*` branch, it mimics the production docs deployment so QA can verify the documentation before the final release

### What changes for RC branches

| Aspect | Regular staging | RC staging (new) |
|--------|----------------|-----------------|
| `BUILD_MODE` | not set (dev) | `production` |
| Version in docs | `0.0.0-next-SHA-DATE` | target version (e.g., `17.1.0`) |
| Module sizes | not measured | measured |
| GTM/HotJar | not injected | injected |
| Dev badge | visible | hidden |
| Netlify site name | `dev-handsontable-BRANCH` | `rc-handsontable-VERSION` |

### How it works

1. **Detection**: A new `Detect release branch` step checks if the ref matches `release/x.y.z`
2. **Version patching**: On RC branches, `handsontable/package.json` is patched from the RC version (e.g., `17.1.0-rc1`) to the clean target version (`17.1.0`) before building docs -- this ensures CodeSandbox URLs, the version dropdown, and `common.json` all show the correct release version
3. **Production build**: `BUILD_MODE=production` is set so GTM/HotJar are injected and the dev badge is hidden
4. **Module sizes**: `npm run measure:module-sizes` runs (same as the production workflow)
5. **Netlify site**: Deploys to `rc-handsontable-{version}.netlify.app` (e.g., `rc-handsontable-17-1-0.netlify.app`)
6. **Summary**: Posts an RC staging summary to the GitHub Actions step summary

### Trigger

The `push` trigger now also watches `handsontable/package.json`, so RC version bumps from the publish workflow automatically trigger a docs staging rebuild on `release/*` branches.

### Flow

```
release/17.1.0 branch push (version bump to 17.1.0-rc1)
  -> docs-staging.yml triggers (handsontable/package.json changed)
  -> detects release/17.1.0 branch
  -> patches version to 17.1.0
  -> BUILD_MODE=production npm run build
  -> deploys to rc-handsontable-17-1-0.netlify.app
```

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1268

[skip changelog]

## Test plan

- [ ] Verify the workflow YAML is valid (no syntax errors)
- [ ] Manually trigger `workflow_dispatch` on a `release/*` branch and confirm:
  - [ ] Release branch detected in logs
  - [ ] Version patched to clean target (no `-rcX` suffix)
  - [ ] `BUILD_MODE=production` set during docs build
  - [ ] Module sizes measured
  - [ ] Deployed to `rc-handsontable-{version}.netlify.app`
  - [ ] Step summary shows RC staging info
- [ ] Verify regular staging (non-release branch) still works as before
- [ ] Verify push to a release branch with `handsontable/package.json` change triggers the workflow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the docs staging GitHub Actions workflow to behave differently on `release/x.y.z` branches (including patching `handsontable/package.json` and deploying under a new Netlify naming scheme), which could affect CI deployments and preview URLs if the branch detection or version patching is wrong.
> 
> **Overview**
> Adds RC-aware behavior to `docs-staging.yml` so pushes to `release/x.y.z` can produce a staging preview that mimics production.
> 
> The workflow now (1) triggers on changes to `handsontable/package.json`, (2) detects release branches and deploys to `rc-handsontable-<version>` instead of `dev-handsontable-<branch>`, (3) patches `handsontable/package.json` to the clean target version and runs module-size measurement, and (4) builds docs with `BUILD_MODE=production` plus posts an RC deployment summary to the GitHub Actions step summary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0544812f26ed1e25eb87807452cfc9a8a121e8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->