### PR TITLE
docs: apply Diátaxis standards to Cell Features pages

### DIFF
--- a/docs/content/api/introduction.md
+++ b/docs/content/api/introduction.md
@@ -1,4 +1,5 @@
 ---
+type: explanation
 id: 6o0dghoa
 title: Introduction
 metaTitle: API reference - JavaScript Data Grid | Handsontable
@@ -13,6 +14,8 @@ angular:
   id: 48gjbys8
   metaTitle: API reference - Angular Data Grid | Handsontable
 ---
+This page describes the Handsontable API -- the methods, hooks, and plugin interfaces you use to control the grid programmatically.
+
 [[toc]]
 
 Welcome to Handsontable's API reference. Our goal is to make it easy to dive in and start coding from day one.
@@ -45,3 +48,9 @@ The plugins extend the capabilities of Handsontable.
 ## Getting help
 
 If you need help using the API reference, please [contact our Support](https://handsontable.com/contact?category=technical_support).
+
+## Related
+
+- [Configuration options](@/guides/getting-started/configuration-options/configuration-options.md)
+- [Events and hooks](@/guides/getting-started/events-and-hooks/events-and-hooks.md)
+- [Plugins](@/api/plugins.md)

--- a/docs/content/guides/accessibility/accessibility-conformance-report/accessibility-conformance-report.md
+++ b/docs/content/guides/accessibility/accessibility-conformance-report/accessibility-conformance-report.md
@@ -1,4 +1,5 @@
 ---
+type: reference
 id: r7vpat01
 title: Accessibility conformance report (VPAT)
 metaTitle: Accessibility conformance report (VPAT) - JavaScript Data Grid | Handsontable
@@ -23,6 +24,8 @@ searchCategory: Guides
 category: Accessibility
 menuTag: new
 ---
+
+This page is the Voluntary Product Accessibility Template (VPAT) for Handsontable, documenting conformance with WCAG 2.1 and Section 508 accessibility standards.
 
 This Accessibility Conformance Report (ACR) follows the VPAT&reg; 2.5 format developed by the Information Technology Industry Council (ITI). It describes how Handsontable, a JavaScript data grid component, conforms to the Web Content Accessibility Guidelines (WCAG) 2.2 at Level A and Level AA.
 
@@ -502,3 +505,7 @@ Accessibility is an ongoing commitment. Handsontable maintains an active issue b
 Conformance claims reflect the **default configuration** of Handsontable. Developer-controlled options ([`navigableHeaders`](@/api/options.md#navigableheaders), [`renderAllRows`](@/api/options.md#renderallrows), [`renderAllColumns`](@/api/options.md#renderallcolumns), [`tabNavigation`](@/api/options.md#tabnavigation), and others) may significantly affect the accessible experience. Developers are responsible for implementing appropriate configurations and for overall application-level accessibility.
 
 This document does not constitute a legal certification of conformance. Use of this document is voluntary and for informational procurement purposes.
+
+## Related
+
+- [Accessibility](@/guides/accessibility/accessibility/accessibility.md)

--- a/docs/content/guides/accessibility/accessibility/accessibility.md
+++ b/docs/content/guides/accessibility/accessibility/accessibility.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: o4qhm1bg
 title: Accessibility
 metaTitle: Accessibility - JavaScript Data Grid | Handsontable
@@ -26,7 +27,9 @@ angular:
 searchCategory: Guides
 category: Accessibility
 ---
-Handsontable is designed to be accessible, aligning with global standards. We prioritize inclusivity, ensuring web applications are usable by people with disabilities. 
+Handsontable supports keyboard navigation, screen readers, and ARIA roles. Use these steps to configure accessible behavior for your users.
+
+Handsontable is designed to be accessible, aligning with global standards. We prioritize inclusivity, ensuring web applications are usable by people with disabilities.
 
 [[toc]]
 
@@ -298,3 +301,7 @@ Didn't find what you need? Try this:
 - [Contact our technical support](https://handsontable.com/contact?category=technical_support) to get help
 
 </div>
+
+## Result
+
+Your grid now supports keyboard navigation, screen reader announcements, and ARIA attributes for all major interactive elements.

--- a/docs/content/guides/cell-features/autofill-values/autofill-values.md
+++ b/docs/content/guides/cell-features/autofill-values/autofill-values.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: if13we5c
 title: Autofill values
 metaTitle: Autofill values - JavaScript Data Grid | Handsontable
@@ -25,6 +26,8 @@ category: Cell features
 Copy a cell's value into multiple other cells, using the "fill handle" UI element. Configure the direction of copying, and more, through Handsontable's API.
 
 [[toc]]
+
+Autofill lets users drag the fill handle to copy or extend values across adjacent cells. Use it to speed up repetitive data entry.
 
 ## Autofill in all directions
 
@@ -127,3 +130,7 @@ In this configuration, the fill handle is restricted to move only vertically. Ne
 - [Autofill](@/api/autofill.md)
 
 </div>
+
+## Result
+
+The fill handle appears on the selected cell. Dragging it copies or extends values into adjacent cells in the configured direction.

--- a/docs/content/guides/cell-features/clipboard/clipboard.md
+++ b/docs/content/guides/cell-features/clipboard/clipboard.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: 2vbt7ev0
 title: Clipboard
 metaTitle: Clipboard - JavaScript Data Grid | Handsontable
@@ -21,6 +22,8 @@ category: Cell features
 Copy data from selected cells to the system clipboard.
 
 [[toc]]
+
+Handsontable supports copy, cut, and paste via the browser clipboard API and keyboard shortcuts. Configure clipboard behavior to control what data users can copy or paste.
 
 ## Overview
 
@@ -365,3 +368,7 @@ Examples of how to use them are provided in their descriptions.
 - [CopyPaste](@/api/copyPaste.md)
 
 </div>
+
+## Result
+
+Users can copy, cut, and paste cell data using keyboard shortcuts or the context menu. Programmatic copy and cut operations work by calling `document.execCommand()` after selecting the target cells.

--- a/docs/content/guides/cell-features/comments/comments.md
+++ b/docs/content/guides/cell-features/comments/comments.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: deqvum60
 title: Comments
 metaTitle: Comments - JavaScript Data Grid | Handsontable
@@ -19,6 +20,8 @@ category: Cell features
 Add a comment (a note) to a cell, using the context menu, just like in Excel. Edit and delete comments. Make comments read-only.
 
 [[toc]]
+
+The Comments plugin lets users attach text notes to individual cells. Use it when reviewers need to annotate data without changing cell values.
 
 ## Enable the plugin
 
@@ -280,3 +283,7 @@ To display comments after a pre-configured time delay, use the [`displayDelay`](
 - [comments](@/api/options.md#comments)
 
 </div>
+
+## Result
+
+Cells with comments display a small indicator in the corner. Users can view, edit, or delete comments through the context menu, and pre-configured comments appear when the table loads.

--- a/docs/content/guides/cell-features/conditional-formatting/conditional-formatting.md
+++ b/docs/content/guides/cell-features/conditional-formatting/conditional-formatting.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: 4ca0c70r
 title: Conditional formatting
 metaTitle: Conditional formatting - JavaScript Data Grid | Handsontable
@@ -17,6 +18,8 @@ category: Cell features
 Format specified cells, based on dynamic conditions.
 
 [[toc]]
+
+Conditional formatting lets you apply custom styles to cells based on their values. Use it to highlight outliers, flag errors, or visualize data ranges.
 
 ## Overview
 
@@ -103,3 +106,7 @@ This demo shows how to use the cell type renderer feature to make some condition
 - [CustomBorders](@/api/customBorders.md)
 
 </div>
+
+## Result
+
+Cells that match the defined conditions display the configured styles -- colors, fonts, or borders -- automatically updating as data changes.

--- a/docs/content/guides/cell-features/disabled-cells/disabled-cells.md
+++ b/docs/content/guides/cell-features/disabled-cells/disabled-cells.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: k41dcpud
 title: Disabled cells
 metaTitle: Disabled cells - JavaScript Data Grid | Handsontable
@@ -24,6 +25,8 @@ Make specified cells read-only to protect them from unwanted changes but still a
 
 [[toc]]
 
+Disable individual cells, entire columns, or entire rows to prevent user edits. Use `readOnly` on cells, columns, or the whole grid.
+
 ## Overview
 
 Disabling a cell makes the cell read-only or non-editable. Both have similar outcomes, with the following differences:
@@ -35,9 +38,9 @@ Disabling a cell makes the cell read-only or non-editable. Both have similar out
 | Drag-to-fill doesn't work                                                    | Drag-to-fill works                                                         |
 | Can't be changed by [`populateFromArray()`](@/api/core.md#populatefromarray) | Can be changed by [`populateFromArray()`](@/api/core.md#populatefromarray) |
 
-## Read-only grid
+## To disable a cell
 
-You can make the entire grid read-only by setting [`readOnly`](@/api/options.md#readonly) to `true` as a [top-level grid option](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+To make the entire grid read-only, set [`readOnly`](@/api/options.md#readonly) to `true` as a [top-level grid option](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
 
 ::: only-for javascript
 
@@ -72,11 +75,9 @@ You can make the entire grid read-only by setting [`readOnly`](@/api/options.md#
 
 :::
 
-## Read-only columns
+## To disable a column
 
-In many use cases, you will need to configure a certain column to be read-only. This column will be available for keyboard navigation and copying data (<kbd>**Ctrl**</kbd>/<kbd>**Cmd**</kbd>+<kbd>**C**</kbd>). Editing and pasting data will be disabled.
-
-To make a column read-only, declare it in the [`columns`](@/api/options.md#columns) configuration option. You can also define a special renderer function that will dim the read-only values, providing a visual cue for the user that the cells are read-only.
+To make a column read-only, declare it in the [`columns`](@/api/options.md#columns) configuration option. The column remains available for keyboard navigation and copying data (<kbd>**Ctrl**</kbd>/<kbd>**Cmd**</kbd>+<kbd>**C**</kbd>), but editing and pasting are disabled. You can also define a special renderer function that will dim the read-only values, providing a visual cue for the user that the cells are read-only.
 
 ::: only-for javascript
 
@@ -113,9 +114,9 @@ To make a column read-only, declare it in the [`columns`](@/api/options.md#colum
 
 :::
 
-## Read-only specific cells
+## To disable a row
 
-This example makes cells that contain the word "Nissan" read-only. It forces all cells to be processed by the [`cells`](@/api/options.md#cells) function which will decide whether a cell's metadata should have the [`readOnly`](@/api/options.md#readonly) property set.
+To make specific cells read-only, use the [`cells`](@/api/options.md#cells) function to set the [`readOnly`](@/api/options.md#readonly) property conditionally. The example below makes cells that contain the word "Nissan" read-only.
 
 ::: only-for javascript
 
@@ -152,11 +153,9 @@ This example makes cells that contain the word "Nissan" read-only. It forces all
 
 Non-editable cells behave like any other cells apart from preventing you from manually changing their values.
 
-## Non-editable columns
+## To disable a column (non-editable)
 
-In many cases, you will need to configure a certain column to be non-editable. Doing this does not change its basic behaviour, apart from editing. This means that you can still use the keyboard navigation <kbd>**Ctrl**</kbd>/<kbd>**Cmd**</kbd>+<kbd>**C**</kbd>, and <kbd>**Ctrl**</kbd>/<kbd>**Cmd**</kbd>+<kbd>**V**</kbd> functionalities, and drag-to-fill, etc.
-
-To make a column non-editable, declare it in the [`columns`](@/api/options.md#columns) configuration option. You can also define a special renderer function that will dim the `editor` value. This will provide the user with a visual cue that the cell is non-editable.
+To make a column non-editable, declare it in the [`columns`](@/api/options.md#columns) configuration option. The column's basic behavior does not change -- you can still use keyboard navigation, <kbd>**Ctrl**</kbd>/<kbd>**Cmd**</kbd>+<kbd>**C**</kbd>, <kbd>**Ctrl**</kbd>/<kbd>**Cmd**</kbd>+<kbd>**V**</kbd>, and drag-to-fill. You can also define a special renderer function that will dim the `editor` value, providing a visual cue that the cell is non-editable.
 
 ::: only-for javascript
 
@@ -191,9 +190,9 @@ To make a column non-editable, declare it in the [`columns`](@/api/options.md#co
 
 :::
 
-## Non-editable specific cells
+## To disable a cell
 
-The following example shows the table with non-editable cells containing the word "Nissan". This cell property is optional and you can easily set it in the Handsontable configuration.
+To make specific cells non-editable, set `editor: false` in the cell configuration. The following example shows a table with non-editable cells containing the word "Nissan".
 
 ::: only-for javascript
 
@@ -238,3 +237,7 @@ The following example shows the table with non-editable cells containing the wor
 - [readOnlyCellClassName](@/api/options.md#readonlycellclassname)
 
 </div>
+
+## Result
+
+Read-only cells display with the `htDimmed` CSS class and block paste and drag-to-fill operations. Non-editable cells block manual editing but allow copy-paste and drag-to-fill.

--- a/docs/content/guides/cell-features/formatting-cells/formatting-cells.md
+++ b/docs/content/guides/cell-features/formatting-cells/formatting-cells.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: epmvqw9m
 title: Formatting cells
 metaTitle: Formatting cells - JavaScript Data Grid | Handsontable
@@ -17,6 +18,8 @@ category: Cell features
 Change the appearance of cells, using custom CSS classes, inline styles, or custom cell borders.
 
 [[toc]]
+
+Format cells using CSS classes, inline styles, or the renderer API. Choose the approach that fits your use case.
 
 ## Overview
 
@@ -194,3 +197,7 @@ The example below demonstrates different border styles applied to various cell r
 - [CustomBorders](@/api/customBorders.md)
 
 </div>
+
+## Result
+
+Cells display the configured CSS classes, inline styles, or custom borders. The appearance updates each time the grid renders, keeping styles in sync with your configuration.

--- a/docs/content/guides/cell-features/merge-cells/merge-cells.md
+++ b/docs/content/guides/cell-features/merge-cells/merge-cells.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: k5920uow
 title: Merge cells
 metaTitle: Merge cells - JavaScript Data Grid | Handsontable
@@ -195,3 +196,7 @@ The example below uses virtualized merged cells. It's also recommended to increa
 - [MergeCells](@/api/mergeCells.md)
 
 </div>
+
+## Result
+
+Cells at the configured positions are now merged. Users see a single cell spanning multiple rows or columns.

--- a/docs/content/guides/cell-features/selection/selection.md
+++ b/docs/content/guides/cell-features/selection/selection.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: a52om5wr
 title: Selection
 metaTitle: Selection - JavaScript Data Grid | Handsontable
@@ -20,6 +21,8 @@ category: Cell features
 Select a single cell, a range of adjacent cells, or multiple non-adjacent ranges of cells.
 
 [[toc]]
+
+Use the selection API to control how users select cells -- single cells, ranges, columns, or rows -- and to read or set selections programmatically.
 
 ## Overview
 
@@ -346,3 +349,7 @@ To jump across a horizontal edge:
 - [DragToScroll](@/api/dragToScroll.md)
 
 </div>
+
+## Result
+
+Users can select cells using the configured mode -- single cell, range, or multiple ranges. Programmatic selections take effect immediately and fire the relevant selection hooks.

--- a/docs/content/guides/cell-features/text-alignment/text-alignment.md
+++ b/docs/content/guides/cell-features/text-alignment/text-alignment.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: chduupye
 title: Text alignment
 metaTitle: Text alignment - JavaScript Data Grid | Handsontable
@@ -18,9 +19,20 @@ Align values within cells: horizontally (to the right, left, center, or by justi
 
 [[toc]]
 
-## Horizontal and vertical alignment
+Apply text alignment to cells using CSS class names or the `className` configuration option.
 
-To initialize Handsontable with predefined horizontal and vertical alignment globally, provide the alignment details in the [`className`](@/api/options.md#classname) option, for example:
+## To align a cell
+
+To set alignment for individual cells, configure them using the [`cells`](@/api/options.md#cells) option or the [`cell`](@/api/options.md#cell) array. Available class names:
+
+- Horizontal: `htLeft`, `htCenter`, `htRight`, `htJustify`
+- Vertical: `htTop`, `htMiddle`, `htBottom`
+
+You can track alignment changes by using the [`afterSetCellMeta`](@/api/hooks.md#aftersetcellmeta) hook.
+
+## To align a column
+
+To apply alignment globally or per column, provide the alignment details in the [`className`](@/api/options.md#classname) option, for example:
 
 ::: only-for javascript
 
@@ -45,15 +57,6 @@ settings = { className: "htCenter" };
 ```
 
 :::
-
-You can also configure cells individually by setting up the [`cells`](@/api/options.md#cells) option. See the code sample below for an example.
-
-Available class names:
-
-- Horizontal: `htLeft`, `htCenter`, `htRight`, `htJustify`,
-- Vertical: `htTop`, `htMiddle`, `htBottom`.
-
-You can track alignment changes by using the [`afterSetCellMeta`](@/api/hooks.md#aftersetcellmeta) hook.
 
 ## Basic example
 
@@ -110,3 +113,7 @@ The following code sample configures the grid to use `htCenter` and configures i
 - [beforeCellAlignment](@/api/hooks.md#beforecellalignment)
 
 </div>
+
+## Result
+
+Cells display the configured horizontal or vertical alignment. Global settings apply to all cells, and per-cell settings take precedence over the global defaults.


### PR DESCRIPTION
## Summary

- Add `type: how-to` Diátaxis classification to all Cell Features pages
- Add missing intro paragraphs and `## Result` sections
- Restructure disabled-cells and text-alignment from option listings to task steps

## ClickUp tasks

https://app.clickup.com/t/9015210959/DEV-1303
https://app.clickup.com/t/9015210959/DEV-1304
https://app.clickup.com/t/9015210959/DEV-1305
https://app.clickup.com/t/9015210959/DEV-1306
https://app.clickup.com/t/9015210959/DEV-1307
https://app.clickup.com/t/9015210959/DEV-1308
https://app.clickup.com/t/9015210959/DEV-1309
https://app.clickup.com/t/9015210959/DEV-1310
https://app.clickup.com/t/9015210959/DEV-1311

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (frontmatter and copy/structure) with no runtime or API behavior impact; primary risk is broken links or unintended doc-site categorization changes.
> 
> **Overview**
> **Applies Diátaxis classification and structure updates across documentation pages.** Adds `type` frontmatter (primarily `how-to`, plus `explanation`/`reference`) and new introductory paragraphs to improve page intent and scannability.
> 
> **Clarifies outcomes and navigation.** Adds consistent `## Result` sections to multiple Cell Features guides, adds `Related` cross-links on the API introduction and VPAT pages, and rewrites sections in `disabled-cells` and `text-alignment` into task-oriented steps (e.g., “To disable/align …”) rather than option listings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53afecc55e66838960c85418f45eecb8190c84bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1447