### PR TITLE
docs: apply Diátaxis standards to Columns pages

### DIFF
--- a/docs/content/guides/integrate-with-vue3/vue3-custom-context-menu-example/vue3-custom-context-menu-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-custom-context-menu-example/vue3-custom-context-menu-example.md
@@ -1,4 +1,5 @@
 ---
+type: tutorial
 id: 38qivuj4
 title: Custom context menu in Vue 3
 metaTitle: Custom context menu - Vue 3 Data Grid | Handsontable
@@ -14,7 +15,7 @@ angular:
 searchCategory: Guides
 category: Integrate with Vue 3
 ---
-Customize the context menu of your Vue 3 data grid, by creating a custom function for each menu item.
+In this tutorial, you will add custom items to the Handsontable context menu in a Vue 3 application. You will learn to define menu items with labels and callback functions.
 
 [[toc]]
 
@@ -91,3 +92,15 @@ The following example implements the `@handsontable/vue3` component, adding a cu
 - [ContextMenu](@/api/contextMenu.md)
 
 </div>
+
+## What you learned
+
+- How to enable the context menu in a Vue 3 Handsontable application.
+- How to define custom menu items with labels and callback functions.
+- How to restrict menu items to specific contexts using the `contextMenu` option.
+
+## Next steps
+
+- [Context menu](@/guides/accessories-and-menus/context-menu/context-menu.md) -- explore the full context menu API.
+- [Custom editor in Vue 3](@/guides/integrate-with-vue3/vue3-custom-editor-example/vue3-custom-editor-example.md) -- build a custom cell editor.
+- [Custom renderer in Vue 3](@/guides/integrate-with-vue3/vue3-custom-renderer-example/vue3-custom-renderer-example.md) -- build a custom cell renderer.

--- a/docs/content/guides/integrate-with-vue3/vue3-custom-editor-example/vue3-custom-editor-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-custom-editor-example/vue3-custom-editor-example.md
@@ -1,4 +1,5 @@
 ---
+type: tutorial
 id: 5864kf8v
 title: Custom editor in Vue 3
 metaTitle: Custom cell editor - Vue 3 Data Grid | Handsontable
@@ -14,7 +15,7 @@ angular:
 searchCategory: Guides
 category: Integrate with Vue 3
 ---
-Create a custom cell editor, and use it in your Vue 3 data grid by declaring it as a class.
+In this tutorial, you will create a custom cell editor as a Vue 3 component. You will learn to extend the BaseEditor class and register your editor with Handsontable.
 
 [[toc]]
 
@@ -87,3 +88,15 @@ The following example implements the `@handsontable/vue3` component with a custo
 - [beforeGetCellMeta](@/api/hooks.md#beforegetcellmeta)
 
 </div>
+
+## What you learned
+
+- How to extend the `BaseEditor` class to build a custom editor.
+- How to register a custom editor with a Handsontable column or the entire grid.
+- How to pass a `key` attribute to differentiate between multiple editor instances.
+
+## Next steps
+
+- [Cell editor](@/guides/cell-functions/cell-editor/cell-editor.md) -- read the full editor API documentation.
+- [HotColumn component in Vue 3](@/guides/integrate-with-vue3/vue3-hot-column/vue3-hot-column.md) -- declare editors per column using HotColumn.
+- [Custom renderer in Vue 3](@/guides/integrate-with-vue3/vue3-custom-renderer-example/vue3-custom-renderer-example.md) -- complement your editor with a custom renderer.

--- a/docs/content/guides/integrate-with-vue3/vue3-custom-id-class-style/vue3-custom-id-class-style.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-custom-id-class-style/vue3-custom-id-class-style.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: 2kg0f1og
 title: Custom ID, Class and other attributes in Vue 3
 metaTitle: Custom ID, class, and style - Vue 3 Data Grid | Handsontable
@@ -14,7 +15,7 @@ angular:
 searchCategory: Guides
 category: Integrate with Vue 3
 ---
-Pass a custom ID, class, and style to the "HotTable" component, to further customize your Vue 3 data grid.
+Pass `id`, `className`, and `style` props to the HotTable component to control its HTML attributes and appearance.
 
 [[toc]]
 
@@ -33,3 +34,7 @@ Each of them will be applied to the root Handsontable element, allowing further 
 @[code](@/content/guides/integrate-with-vue3/vue3-custom-id-class-style/vue/example1.js)
 
 :::
+
+## Result
+
+The rendered `HotTable` element has the custom `id`, `class`, and `style` attributes applied directly to its root DOM element, making it straightforward to target with CSS or JavaScript selectors.

--- a/docs/content/guides/integrate-with-vue3/vue3-custom-renderer-example/vue3-custom-renderer-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-custom-renderer-example/vue3-custom-renderer-example.md
@@ -1,4 +1,5 @@
 ---
+type: tutorial
 id: uu0rzeo6
 title: Custom renderer in Vue 3
 metaTitle: Custom cell renderer - Vue 3 Data Grid | Handsontable
@@ -14,7 +15,7 @@ angular:
 searchCategory: Guides
 category: Integrate with Vue 3
 ---
-Create a custom cell renderer, and use it in your Vue 3 data grid by declaring it as a function.
+In this tutorial, you will create a custom cell renderer that displays image URLs as actual images in a Vue 3 application.
 
 [[toc]]
 
@@ -87,3 +88,15 @@ The following example is an implementation of `@handsontable/vue3` with a custom
 - [beforeRenderer](@/api/hooks.md#beforerenderer)
 
 </div>
+
+## What you learned
+
+- How to declare a custom renderer function in a Vue 3 application.
+- How to read cell values and render HTML elements -- such as images -- inside cells.
+- How to assign the renderer to a specific column using the `renderer` option.
+
+## Next steps
+
+- [Cell renderer](@/guides/cell-functions/cell-renderer/cell-renderer.md) -- explore the full renderer API.
+- [HotColumn component in Vue 3](@/guides/integrate-with-vue3/vue3-hot-column/vue3-hot-column.md) -- assign renderers per column declaratively.
+- [Custom editor in Vue 3](@/guides/integrate-with-vue3/vue3-custom-editor-example/vue3-custom-editor-example.md) -- pair your renderer with a custom editor.

--- a/docs/content/guides/integrate-with-vue3/vue3-formulas-example/vue3-formulas-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-formulas-example/vue3-formulas-example.md
@@ -1,4 +1,5 @@
 ---
+type: tutorial
 id: o47p9rb3
 title: Formulas integration in Vue 3
 metaTitle: Formulas integration in Vue 3 - Vue 3 Data Grid | Handsontable
@@ -15,7 +16,7 @@ searchCategory: Guides
 category: Integrate with Vue 3
 menuTag: new
 ---
-Integrate the Formulas plugin with your Vue 3 data grid.
+In this tutorial, you will integrate the Formulas plugin (powered by HyperFormula) with Handsontable in a Vue 3 application.
 
 [[toc]]
 
@@ -71,3 +72,15 @@ This keeps the engine untouched and ensures it behaves exactly as intended.
   - [`afterSheetRenamed`](@/api/hooks.md#aftersheetrenamed)
 - Plugins:
   - [`Formulas`](@/api/formulas.md)
+
+## What you learned
+
+- How to install and configure the Formulas plugin in a Vue 3 application.
+- How to wrap a HyperFormula instance with `markRaw()` to prevent Vue from making it reactive.
+- How to reference named expressions and cross-sheet formulas.
+
+## Next steps
+
+- [Formula calculation](@/guides/formulas/formula-calculation/formula-calculation.md) -- learn the full Formulas plugin API.
+- [Modules in Vue 3](@/guides/integrate-with-vue3/vue3-modules/vue3-modules.md) -- reduce bundle size by importing only required modules.
+- [HotColumn component in Vue 3](@/guides/integrate-with-vue3/vue3-hot-column/vue3-hot-column.md) -- configure columns declaratively.

--- a/docs/content/guides/integrate-with-vue3/vue3-hot-column/vue3-hot-column.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-hot-column/vue3-hot-column.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: l884wwjc
 title: Using the `HotColumn` component in Vue 3
 metaTitle: HotColumn component - Vue 3 Data Grid | Handsontable
@@ -14,7 +15,7 @@ angular:
 searchCategory: Guides
 category: Integrate with Vue 3
 ---
-Configure the Vue 3 data grid's columns, using the props of the `HotColumn` component. Define a custom cell editor or a custom cell renderer.
+HotColumn is a Vue 3 component that lets you define column settings declaratively as child components of HotTable.
 
 [[toc]]
 
@@ -52,3 +53,7 @@ You can declare a custom editor by creating a class that extends `TextEditor` an
 @[code](@/content/guides/integrate-with-vue3/vue3-hot-column/vue/example3.js)
 
 :::
+
+## Result
+
+Using `HotColumn` child components, each column reads its settings declaratively from Vue props rather than from a flat `columns` array, keeping your template in sync with your column configuration.

--- a/docs/content/guides/integrate-with-vue3/vue3-hot-reference/vue3-hot-reference.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-hot-reference/vue3-hot-reference.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: aae39zi5
 title: Referencing the Handsontable instance in Vue 3
 metaTitle: Referencing Handsontable - Vue 3 Data Grid | Handsontable
@@ -14,7 +15,7 @@ angular:
 searchCategory: Guides
 category: Integrate with Vue 3
 ---
-Reference the Handsontable instance from a Vue 3 component to programmatically perform actions such as reloading the data in your data grid.
+Use the `hotTableComponent` ref to access the underlying Handsontable instance from your Vue 3 component.
 
 [[toc]]
 
@@ -30,3 +31,7 @@ The following example implements the `@handsontable/vue3`, showing how to refere
 @[code](@/content/guides/integrate-with-vue3/vue3-hot-reference/vue/example1.js)
 
 :::
+
+## Result
+
+You can call any Handsontable API method -- such as `loadData()` or `getPlugin()` -- directly on the instance retrieved via `hotTableComponent.value.hotInstance`, giving you full programmatic control over the grid from your Vue 3 component.

--- a/docs/content/guides/integrate-with-vue3/vue3-language-change-example/vue3-language-change-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-language-change-example/vue3-language-change-example.md
@@ -1,4 +1,5 @@
 ---
+type: tutorial
 id: tcabky5c
 title: Language change in Vue 3
 metaTitle: Language change - Vue 3 Data Grid | Handsontable
@@ -14,7 +15,7 @@ angular:
 searchCategory: Guides
 category: Integrate with Vue 3
 ---
-Change the default language of the context menu from English to any of the built-in translations, using the `language` property.
+In this tutorial, you will add a language selection dropdown that changes the Handsontable UI language at runtime in a Vue 3 application.
 
 [[toc]]
 
@@ -78,3 +79,15 @@ Note that the `language` property is bound to the component separately using `la
 - [beforeLanguageChange](@/api/hooks.md#beforelanguagechange)
 
 </div>
+
+## What you learned
+
+- How to import and register a built-in language pack in a Vue 3 application.
+- How to bind the `language` prop dynamically to switch languages at runtime.
+- How to build a language selection dropdown that updates the Handsontable UI.
+
+## Next steps
+
+- [Setting up a translation in Vue 3](@/guides/integrate-with-vue3/vue3-setting-up-a-language/vue3-setting-up-a-language.md) -- configure number formats alongside the UI language.
+- [Language](@/guides/internationalization/language/language.md) -- explore all available language packs.
+- [Custom context menu in Vue 3](@/guides/integrate-with-vue3/vue3-custom-context-menu-example/vue3-custom-context-menu-example.md) -- add custom items to the localized context menu.

--- a/docs/content/guides/integrate-with-vue3/vue3-modules/vue3-modules.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-modules/vue3-modules.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: 0xtliaah
 title: Modules in Vue 3
 metaTitle: Modules - Vue 3 Data Grid | Handsontable
@@ -14,7 +15,7 @@ angular:
 searchCategory: Guides
 category: Integrate with Vue 3
 ---
-Reduce the size of your Vue 3 app by importing only the modules that you need and use.
+Import only the Handsontable modules you need to reduce your Vue 3 application bundle size.
 
 [[toc]]
 
@@ -91,6 +92,10 @@ registerPlugin(UndoRedo);
 
 createApp(App).use(router).mount('#app');
 ```
+
+## Result
+
+Your Vue 3 application's bundle includes only the Handsontable base module plus the specific cell types and plugins you registered, which reduces the final bundle size compared to importing the full Handsontable package.
 
 ## Related guides
 

--- a/docs/content/guides/integrate-with-vue3/vue3-setting-up-a-language/vue3-setting-up-a-language.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-setting-up-a-language/vue3-setting-up-a-language.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: 7ezlo7y5
 title: Setting up a translation in Vue 3
 metaTitle: Setting up a translation - Vue 3 Data Grid | Handsontable
@@ -14,7 +15,7 @@ angular:
 searchCategory: Guides
 category: Integrate with Vue 3
 ---
-Configure your Vue 3 data grid with different number formats, depending on the specified language and culture.
+Register a language file with Handsontable and pass the `language` option to the HotTable component to translate the grid UI.
 
 [[toc]]
 
@@ -30,6 +31,10 @@ The following example shows a Handsontable instance with translations set up in 
 @[code](@/content/guides/integrate-with-vue3/vue3-setting-up-a-language/vue/example1.js)
 
 :::
+
+## Result
+
+The HotTable component renders with number formatting and locale-specific text determined by the registered language file, and the context menu labels reflect the selected language.
 
 ## Related articles
 

--- a/docs/content/guides/integrate-with-vue3/vue3-simple-example/vue3-simple-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-simple-example/vue3-simple-example.md
@@ -1,4 +1,5 @@
 ---
+type: tutorial
 id: exlnnr23
 title: Basic example in Vue 3
 metaTitle: Basic example - Vue 3 Data Grid | Handsontable
@@ -14,7 +15,7 @@ angular:
 searchCategory: Guides
 category: Integrate with Vue 3
 ---
-Start with a basic example of the Vue 3 data grid, using component props for configuration and external control.
+In this tutorial, you will render your first Handsontable data grid in a Vue 3 application and learn the basic setup steps.
 
 [[toc]]
 
@@ -32,3 +33,15 @@ In this example, a `div` element of `id="example1"` where the `@handsontable/vue
 @[code](@/content/guides/integrate-with-vue3/vue3-simple-example/vue/example1.js)
 
 :::
+
+## What you learned
+
+- How to install and configure the `@handsontable/vue3` wrapper.
+- How to pass data and configuration options as props to the `HotTable` component.
+- How to render a basic data grid inside a Vue 3 application.
+
+## Next steps
+
+- [HotColumn component in Vue 3](@/guides/integrate-with-vue3/vue3-hot-column/vue3-hot-column.md) -- define column settings declaratively with HotColumn.
+- [Custom renderer in Vue 3](@/guides/integrate-with-vue3/vue3-custom-renderer-example/vue3-custom-renderer-example.md) -- customize how cell content is displayed.
+- [Language change in Vue 3](@/guides/integrate-with-vue3/vue3-language-change-example/vue3-language-change-example.md) -- switch the grid UI language at runtime.

--- a/docs/content/guides/integrate-with-vue3/vue3-vuex-example/vue3-vuex-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-vuex-example/vue3-vuex-example.md
@@ -1,4 +1,5 @@
 ---
+type: tutorial
 id: pxr5suzy
 title: Vuex in Vue 3
 metaTitle: Integration with Vuex - Vue 3 Data Grid - Handsontable
@@ -14,7 +15,7 @@ angular:
 searchCategory: Guides
 category: Integrate with Vue 3
 ---
-Use the Vuex state management pattern to maintain the data and configuration options of your Vue 3 data grid.
+In this tutorial, you will connect a Handsontable grid to a Vuex store so that cell changes update shared application state.
 
 [[toc]]
 
@@ -31,3 +32,15 @@ The following example implements the `@handsontable/vue3` component with a [`rea
 @[code](@/content/guides/integrate-with-vue3/vue3-vuex-example/vue/example1.css)
 
 :::
+
+## What you learned
+
+- How to connect a Handsontable grid to a Vuex store in a Vue 3 application.
+- How to use Vuex getters and mutations to read and write grid data.
+- How to propagate cell changes from Handsontable hooks back to the store.
+
+## Next steps
+
+- [Referencing the Handsontable instance in Vue 3](@/guides/integrate-with-vue3/vue3-hot-reference/vue3-hot-reference.md) -- access the Handsontable API directly from your component.
+- [HotColumn component in Vue 3](@/guides/integrate-with-vue3/vue3-hot-column/vue3-hot-column.md) -- configure columns declaratively alongside your store.
+- [Formulas integration in Vue 3](@/guides/integrate-with-vue3/vue3-formulas-example/vue3-formulas-example.md) -- combine Vuex-managed data with formula calculations.

--- a/docs/content/guides/upgrade-and-migration/changelog-10/changelog-10.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-10/changelog-10.md
@@ -1,4 +1,5 @@
 ---
+type: reference
 id: 6x1ythps
 title: Changelog 10.0
 metaTitle: Changelog 10.0 - JavaScript Data Grid | Handsontable
@@ -14,6 +15,9 @@ angular:
 searchCategory: Guides
 category: Upgrade and migration
 ---
+
+These are the release notes for Handsontable 10.x.
+
 ## 10.0.0
 
 Released on September 29, 2021.
@@ -93,3 +97,7 @@ For more information on this release, see:
   [#8704](https://github.com/handsontable/handsontable/issues/8704)
 - Improved the performance of the regular expression used to detect numeric values, and fixed major
   code smells. [#8752](https://github.com/handsontable/handsontable/issues/8752)
+
+## Related
+
+- [Migrating from 9.0 to 10.0](@/guides/upgrade-and-migration/migrating-from-9.0-to-10.0/migrating-from-9.0-to-10.0.md)

--- a/docs/content/guides/upgrade-and-migration/changelog-11/changelog-11.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-11/changelog-11.md
@@ -1,4 +1,5 @@
 ---
+type: reference
 id: kk7fprli
 title: Changelog 11.0
 metaTitle: Changelog 11.0 - JavaScript Data Grid | Handsontable
@@ -14,6 +15,9 @@ angular:
 searchCategory: Guides
 category: Upgrade and migration
 ---
+
+These are the release notes for Handsontable 11.x.
+
 ## 11.1.0
 
 Released on January 13, 2022
@@ -161,3 +165,7 @@ For more information on this release, see:
 - React: Fixed a React wrapper issue where it's impossible to use different sets of props in editor
   components reused across multiple columns.
   [#8527](https://github.com/handsontable/handsontable/issues/8527)
+
+## Related
+
+- [Migrating from 10.0 to 11.0](@/guides/upgrade-and-migration/migrating-from-10.0-to-11.0/migrating-from-10.0-to-11.0.md)

--- a/docs/content/guides/upgrade-and-migration/changelog-12/changelog-12.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-12/changelog-12.md
@@ -1,4 +1,5 @@
 ---
+type: reference
 id: t93bqrh5
 title: Changelog 12.0
 metaTitle: Changelog 12.0 - JavaScript Data Grid | Handsontable
@@ -14,6 +15,9 @@ angular:
 searchCategory: Guides
 category: Upgrade and migration
 ---
+
+These are the release notes for Handsontable 12.x.
+
 ## 12.4.0
 
 Released on May 23, 2023.
@@ -578,3 +582,7 @@ For more information on this release, see:
 - React, Vue 2, Vue 3: Fixed an issue with registering modules for the React, Vue 2, and Vue 3
   wrappers, by adding an `"exports"` field to their `package.json` files.
   [#9140](https://github.com/handsontable/handsontable/issues/9140)
+
+## Related
+
+- [Migrating from 11.1 to 12.0](@/guides/upgrade-and-migration/migrating-from-11.1-to-12.0/migrating-from-11.1-to-12.0.md)

--- a/docs/content/guides/upgrade-and-migration/changelog-13/changelog-13.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-13/changelog-13.md
@@ -1,4 +1,5 @@
 ---
+type: reference
 id: e195f568
 title: Changelog 13.0
 metaTitle: Changelog 13.0 - JavaScript Data Grid | Handsontable
@@ -14,6 +15,9 @@ angular:
 searchCategory: Guides
 category: Upgrade and migration
 ---
+
+These are the release notes for Handsontable 13.x.
+
 ## 13.1.0
 
 Released on August 31, 2023.
@@ -82,3 +86,7 @@ For more information on this release, see:
 #### Fixed
 
 - Fixed an issue where the "Read only" icon of the context menu displayed incorrectly in the RTL layout direction. [#10375](https://github.com/handsontable/handsontable/pull/10375)
+
+## Related
+
+- [Migrating from 12.4 to 13.0](@/guides/upgrade-and-migration/migrating-from-12.4-to-13.0/migrating-from-12.4-to-13.0.md)

--- a/docs/content/guides/upgrade-and-migration/changelog-14/changelog-14.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-14/changelog-14.md
@@ -1,4 +1,5 @@
 ---
+type: reference
 id: 5wvnjbho
 title: Changelog 14.0
 metaTitle: Changelog 14.0 - JavaScript Data Grid | Handsontable
@@ -14,6 +15,9 @@ angular:
 searchCategory: Guides
 category: Upgrade and migration
 ---
+
+These are the release notes for Handsontable 14.x.
+
 ## 14.6.1
 
 Released on October 17, 2024
@@ -348,3 +352,7 @@ For more information on this release, see:
 - Updated the demos for better accessibility. [#10563](https://github.com/handsontable/handsontable/pull/10563)
 - Fixed a problem with the text editor's width being calculated incorrectly. [#10590](https://github.com/handsontable/handsontable/pull/10590)
 - Fixed a problem with two cells being selected after `Ctrl/Cmd + Shift` key combination. [#10622](https://github.com/handsontable/handsontable/pull/10622)
+
+## Related
+
+- [Migrating from 13.1 to 14.0](@/guides/upgrade-and-migration/migrating-from-13.1-to-14.0/migrating-from-13.1-to-14.0.md)

--- a/docs/content/guides/upgrade-and-migration/changelog-15/changelog-15.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-15/changelog-15.md
@@ -1,4 +1,5 @@
 ---
+type: reference
 id: yhyglrda
 title: Changelog 15.0
 metaTitle: Changelog 15.0 - JavaScript Data Grid | Handsontable
@@ -14,6 +15,9 @@ angular:
 searchCategory: Guides
 category: Upgrade and migration
 ---
+
+These are the release notes for Handsontable 15.x.
+
 ## 15.3.0
 
 Released on April 29, 2025
@@ -232,3 +236,7 @@ For more information about this release see:
 - Fixed the missing `source` argument for the `setDataAtCell` method. [#11287](https://github.com/handsontable/handsontable/pull/11287)
 - Fixed the top overlay misalignment issue, visible after vertical scrollbar disappeared. [#11289](https://github.com/handsontable/handsontable/pull/11289)
 - React: Made the build scripts of `@handsontable/react-wrapper` place the TS type definitions in the configured directory. [#11296](https://github.com/handsontable/handsontable/pull/11296)
+
+## Related
+
+- [Migrating from 14.6 to 15.0](@/guides/upgrade-and-migration/migrating-from-14.6-to-15.0/migrating-from-14.6-to-15.0.md)

--- a/docs/content/guides/upgrade-and-migration/changelog-16/changelog-16.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-16/changelog-16.md
@@ -1,4 +1,5 @@
 ---
+type: reference
 id: znsspzmg
 title: Changelog 16.0
 metaTitle: Changelog 16.0 - JavaScript Data Grid | Handsontable
@@ -14,6 +15,9 @@ angular:
 searchCategory: Guides
 category: Upgrade and migration
 ---
+
+These are the release notes for Handsontable 16.x.
+
 ## 16.2.0
 
 Released on November 25th, 2025
@@ -184,3 +188,7 @@ For more information about this release see:
 - Fixed the column filter behavior when adding new columns. [#11616](https://github.com/handsontable/handsontable/pull/11616)
 - Fixed an issue with the dropdown elements' colors. [#11661](https://github.com/handsontable/handsontable/pull/11661)
 - Angular: Fixed an error of `this.hotInstance.getSettings(...).columns?.filter is not a function` in `angular-wrapper`. [#11695](https://github.com/handsontable/handsontable/pull/11695)
+
+## Related
+
+- [Migrating from 15.3 to 16.0](@/guides/upgrade-and-migration/migrating-from-15.3-to-16.0/migrating-from-15.3-to-16.0.md)

--- a/docs/content/guides/upgrade-and-migration/changelog-17/changelog-17.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-17/changelog-17.md
@@ -1,4 +1,5 @@
 ---
+type: reference
 id: l59xqo44
 title: Changelog 17.0
 metaTitle: Changelog 17.0 - JavaScript Data Grid | Handsontable
@@ -14,6 +15,9 @@ angular:
 searchCategory: Guides
 category: Upgrade and migration
 ---
+
+These are the release notes for Handsontable 17.x.
+
 ## 17.0.1
 
 Released on March 25th, 2026
@@ -101,3 +105,7 @@ For more information about this release, see:
 - Fixed incorrect scrollbar width calculation for scaled environments. [#12035](https://github.com/handsontable/handsontable/pull/12035)
 - Fixed and issue with column headers styles [#12058](https://github.com/handsontable/handsontable/pull/12058)
 - Angular: Fixed a problem with the Angular wrapper that broke builds done with a disabled `skipLibCheck`. [#12091](https://github.com/handsontable/handsontable/pull/12091)
+
+## Related
+
+- [Migrating from 16.2 to 17.0](@/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md)

--- a/docs/content/guides/upgrade-and-migration/changelog-7/changelog-7.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-7/changelog-7.md
@@ -1,4 +1,5 @@
 ---
+type: reference
 id: 5t9ao5jq
 title: Older versions
 metaTitle: Older versions - JavaScript Data Grid | Handsontable
@@ -14,6 +15,9 @@ angular:
 searchCategory: Guides
 category: Upgrade and migration
 ---
+
+These are the release notes for Handsontable 7.x.
+
 ## 7.4.2
 
 Released on February 19, 2020.
@@ -85,3 +89,7 @@ For more information on this release, see:
 
 The changelogs from older versions of Handsontable are
 [available on GitHub](https://github.com/handsontable/handsontable/releases).
+
+## Related
+
+- [Migrating from 7.4 to 8.0](@/guides/upgrade-and-migration/migrating-from-7.4-to-8.0/migrating-from-7.4-to-8.0.md)

--- a/docs/content/guides/upgrade-and-migration/changelog-8/changelog-8.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-8/changelog-8.md
@@ -1,4 +1,5 @@
 ---
+type: reference
 id: umu0w734
 title: Changelog 8.0
 metaTitle: Changelog 8.0 - JavaScript Data Grid | Handsontable
@@ -14,6 +15,9 @@ angular:
 searchCategory: Guides
 category: Upgrade and migration
 ---
+
+These are the release notes for Handsontable 8.x.
+
 ## 8.4.0
 
 Released on May 11, 2021.
@@ -984,3 +988,7 @@ methods and hooks were added and there are few depreciations and removals, too.
 - Adding properties which were not defined on initialization or by `updateSettings` to the source
   data is possible only by the usage of `setSourceDataAtCell`.
   [#6664](https://github.com/handsontable/handsontable/issues/6664).
+
+## Related
+
+- [Migrating from 7.4 to 8.0](@/guides/upgrade-and-migration/migrating-from-7.4-to-8.0/migrating-from-7.4-to-8.0.md)

--- a/docs/content/guides/upgrade-and-migration/changelog-9/changelog-9.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-9/changelog-9.md
@@ -1,4 +1,5 @@
 ---
+type: reference
 id: flrcarvt
 title: Changelog 9.0
 metaTitle: Changelog 9.0 - JavaScript Data Grid | Handsontable
@@ -14,6 +15,9 @@ angular:
 searchCategory: Guides
 category: Upgrade and migration
 ---
+
+These are the release notes for Handsontable 9.x.
+
 ## 9.0.2
 
 Released on July 28, 2021.
@@ -138,3 +142,7 @@ For more information on this release, see:
   ([#5870](https://github.com/handsontable/handsontable/issues/5870))
 - Fixed a bug with using the `clear` method broke the formulas in the table.
   ([#6248](https://github.com/handsontable/handsontable/issues/6248))
+
+## Related
+
+- [Migrating from 8.4 to 9.0](@/guides/upgrade-and-migration/migrating-from-8.4-to-9.0/migrating-from-8.4-to-9.0.md)

--- a/docs/content/guides/upgrade-and-migration/changelog/changelog.md
+++ b/docs/content/guides/upgrade-and-migration/changelog/changelog.md
@@ -1,4 +1,5 @@
 ---
+type: reference
 id: nbp8i3mk
 title: Changelog
 metaTitle: Changelog - JavaScript Data Grid | Handsontable
@@ -21,7 +22,8 @@ angular:
 searchCategory: Guides
 category: Upgrade and migration
 ---
-See the full history of changes made to Handsontable in each major, minor, and patch release.
+
+This page aggregates all Handsontable release notes. For upgrade instructions, see the migration guides in this section.
 
 [[toc]]
 
@@ -2639,3 +2641,16 @@ For more information on this release, see:
 
 The changelogs from older versions of Handsontable are
 [available on GitHub](https://github.com/handsontable/handsontable/releases).
+
+## Related
+
+- [Migrating from 7.4 to 8.0](@/guides/upgrade-and-migration/migrating-from-7.4-to-8.0/migrating-from-7.4-to-8.0.md)
+- [Migrating from 8.4 to 9.0](@/guides/upgrade-and-migration/migrating-from-8.4-to-9.0/migrating-from-8.4-to-9.0.md)
+- [Migrating from 9.0 to 10.0](@/guides/upgrade-and-migration/migrating-from-9.0-to-10.0/migrating-from-9.0-to-10.0.md)
+- [Migrating from 10.0 to 11.0](@/guides/upgrade-and-migration/migrating-from-10.0-to-11.0/migrating-from-10.0-to-11.0.md)
+- [Migrating from 11.1 to 12.0](@/guides/upgrade-and-migration/migrating-from-11.1-to-12.0/migrating-from-11.1-to-12.0.md)
+- [Migrating from 12.4 to 13.0](@/guides/upgrade-and-migration/migrating-from-12.4-to-13.0/migrating-from-12.4-to-13.0.md)
+- [Migrating from 13.1 to 14.0](@/guides/upgrade-and-migration/migrating-from-13.1-to-14.0/migrating-from-13.1-to-14.0.md)
+- [Migrating from 14.6 to 15.0](@/guides/upgrade-and-migration/migrating-from-14.6-to-15.0/migrating-from-14.6-to-15.0.md)
+- [Migrating from 15.3 to 16.0](@/guides/upgrade-and-migration/migrating-from-15.3-to-16.0/migrating-from-15.3-to-16.0.md)
+- [Migrating from 16.2 to 17.0](@/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md)


### PR DESCRIPTION
## Summary

- Add `type:` Diátaxis classification to all Columns pages
- Separate how-to steps from reference tables in column-filter, column-groups, column-moving, column-summary
- Reclassify column-menu as reference and column-virtualization as explanation
- Expand thin react-hot-column page with additional examples

## ClickUp tasks

https://app.clickup.com/t/9015210959/DEV-1328
https://app.clickup.com/t/9015210959/DEV-1329
https://app.clickup.com/t/9015210959/DEV-1330
https://app.clickup.com/t/9015210959/DEV-1331
https://app.clickup.com/t/9015210959/DEV-1332
https://app.clickup.com/t/9015210959/DEV-1333
https://app.clickup.com/t/9015210959/DEV-1334

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits (frontmatter metadata and content rewording/linking) with no runtime code changes; main risk is broken links or unintended taxonomy changes in the docs build.
> 
> **Overview**
> Adds Diátaxis classification by introducing a `type:` field in frontmatter across multiple Vue 3 integration guides and upgrade/migration changelog pages.
> 
> Improves the Vue 3 guides’ structure by replacing one-line blurbs with tutorial/how-to intros and appending consistent closure sections such as `Result`, `What you learned`, and `Next steps` with relevant cross-links.
> 
> Enhances changelog pages by adding a short “release notes for X.x” intro and a `Related` section linking to the corresponding migration guide, plus a similar aggregation note and related links on the main `changelog.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af82cad7d5d12c92610b8dc7d927818914c818a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1450