### PR TITLE
docs: apply Diátaxis standards to Vue 3 integration pages

### DIFF
--- a/docs/content/guides/integrate-with-vue3/vue3-custom-context-menu-example/vue3-custom-context-menu-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-custom-context-menu-example/vue3-custom-context-menu-example.md
@@ -1,4 +1,5 @@
 ---
+type: tutorial
 id: 38qivuj4
 title: Custom context menu in Vue 3
 metaTitle: Custom context menu - Vue 3 Data Grid | Handsontable
@@ -14,7 +15,7 @@ angular:
 searchCategory: Guides
 category: Integrate with Vue 3
 ---
-Customize the context menu of your Vue 3 data grid, by creating a custom function for each menu item.
+In this tutorial, you will add custom items to the Handsontable context menu in a Vue 3 application. You will learn to define menu items with labels and callback functions.
 
 [[toc]]
 
@@ -91,3 +92,15 @@ The following example implements the `@handsontable/vue3` component, adding a cu
 - [ContextMenu](@/api/contextMenu.md)
 
 </div>
+
+## What you learned
+
+- How to enable the context menu in a Vue 3 Handsontable application.
+- How to define custom menu items with labels and callback functions.
+- How to restrict menu items to specific contexts using the `contextMenu` option.
+
+## Next steps
+
+- [Context menu](@/guides/accessories-and-menus/context-menu/context-menu.md) -- explore the full context menu API.
+- [Custom editor in Vue 3](@/guides/integrate-with-vue3/vue3-custom-editor-example/vue3-custom-editor-example.md) -- build a custom cell editor.
+- [Custom renderer in Vue 3](@/guides/integrate-with-vue3/vue3-custom-renderer-example/vue3-custom-renderer-example.md) -- build a custom cell renderer.

--- a/docs/content/guides/integrate-with-vue3/vue3-custom-editor-example/vue3-custom-editor-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-custom-editor-example/vue3-custom-editor-example.md
@@ -1,4 +1,5 @@
 ---
+type: tutorial
 id: 5864kf8v
 title: Custom editor in Vue 3
 metaTitle: Custom cell editor - Vue 3 Data Grid | Handsontable
@@ -14,7 +15,7 @@ angular:
 searchCategory: Guides
 category: Integrate with Vue 3
 ---
-Create a custom cell editor, and use it in your Vue 3 data grid by declaring it as a class.
+In this tutorial, you will create a custom cell editor as a Vue 3 component. You will learn to extend the BaseEditor class and register your editor with Handsontable.
 
 [[toc]]
 
@@ -87,3 +88,15 @@ The following example implements the `@handsontable/vue3` component with a custo
 - [beforeGetCellMeta](@/api/hooks.md#beforegetcellmeta)
 
 </div>
+
+## What you learned
+
+- How to extend the `BaseEditor` class to build a custom editor.
+- How to register a custom editor with a Handsontable column or the entire grid.
+- How to pass a `key` attribute to differentiate between multiple editor instances.
+
+## Next steps
+
+- [Cell editor](@/guides/cell-functions/cell-editor/cell-editor.md) -- read the full editor API documentation.
+- [HotColumn component in Vue 3](@/guides/integrate-with-vue3/vue3-hot-column/vue3-hot-column.md) -- declare editors per column using HotColumn.
+- [Custom renderer in Vue 3](@/guides/integrate-with-vue3/vue3-custom-renderer-example/vue3-custom-renderer-example.md) -- complement your editor with a custom renderer.

--- a/docs/content/guides/integrate-with-vue3/vue3-custom-id-class-style/vue3-custom-id-class-style.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-custom-id-class-style/vue3-custom-id-class-style.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: 2kg0f1og
 title: Custom ID, Class and other attributes in Vue 3
 metaTitle: Custom ID, class, and style - Vue 3 Data Grid | Handsontable
@@ -14,7 +15,7 @@ angular:
 searchCategory: Guides
 category: Integrate with Vue 3
 ---
-Pass a custom ID, class, and style to the "HotTable" component, to further customize your Vue 3 data grid.
+Pass `id`, `className`, and `style` props to the HotTable component to control its HTML attributes and appearance.
 
 [[toc]]
 
@@ -33,3 +34,7 @@ Each of them will be applied to the root Handsontable element, allowing further 
 @[code](@/content/guides/integrate-with-vue3/vue3-custom-id-class-style/vue/example1.js)
 
 :::
+
+## Result
+
+The rendered `HotTable` element has the custom `id`, `class`, and `style` attributes applied directly to its root DOM element, making it straightforward to target with CSS or JavaScript selectors.

--- a/docs/content/guides/integrate-with-vue3/vue3-custom-renderer-example/vue3-custom-renderer-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-custom-renderer-example/vue3-custom-renderer-example.md
@@ -1,4 +1,5 @@
 ---
+type: tutorial
 id: uu0rzeo6
 title: Custom renderer in Vue 3
 metaTitle: Custom cell renderer - Vue 3 Data Grid | Handsontable
@@ -14,7 +15,7 @@ angular:
 searchCategory: Guides
 category: Integrate with Vue 3
 ---
-Create a custom cell renderer, and use it in your Vue 3 data grid by declaring it as a function.
+In this tutorial, you will create a custom cell renderer that displays image URLs as actual images in a Vue 3 application.
 
 [[toc]]
 
@@ -87,3 +88,15 @@ The following example is an implementation of `@handsontable/vue3` with a custom
 - [beforeRenderer](@/api/hooks.md#beforerenderer)
 
 </div>
+
+## What you learned
+
+- How to declare a custom renderer function in a Vue 3 application.
+- How to read cell values and render HTML elements -- such as images -- inside cells.
+- How to assign the renderer to a specific column using the `renderer` option.
+
+## Next steps
+
+- [Cell renderer](@/guides/cell-functions/cell-renderer/cell-renderer.md) -- explore the full renderer API.
+- [HotColumn component in Vue 3](@/guides/integrate-with-vue3/vue3-hot-column/vue3-hot-column.md) -- assign renderers per column declaratively.
+- [Custom editor in Vue 3](@/guides/integrate-with-vue3/vue3-custom-editor-example/vue3-custom-editor-example.md) -- pair your renderer with a custom editor.

--- a/docs/content/guides/integrate-with-vue3/vue3-formulas-example/vue3-formulas-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-formulas-example/vue3-formulas-example.md
@@ -1,4 +1,5 @@
 ---
+type: tutorial
 id: o47p9rb3
 title: Formulas integration in Vue 3
 metaTitle: Formulas integration in Vue 3 - Vue 3 Data Grid | Handsontable
@@ -15,7 +16,7 @@ searchCategory: Guides
 category: Integrate with Vue 3
 menuTag: new
 ---
-Integrate the Formulas plugin with your Vue 3 data grid.
+In this tutorial, you will integrate the Formulas plugin (powered by HyperFormula) with Handsontable in a Vue 3 application.
 
 [[toc]]
 
@@ -71,3 +72,15 @@ This keeps the engine untouched and ensures it behaves exactly as intended.
   - [`afterSheetRenamed`](@/api/hooks.md#aftersheetrenamed)
 - Plugins:
   - [`Formulas`](@/api/formulas.md)
+
+## What you learned
+
+- How to install and configure the Formulas plugin in a Vue 3 application.
+- How to wrap a HyperFormula instance with `markRaw()` to prevent Vue from making it reactive.
+- How to reference named expressions and cross-sheet formulas.
+
+## Next steps
+
+- [Formula calculation](@/guides/formulas/formula-calculation/formula-calculation.md) -- learn the full Formulas plugin API.
+- [Modules in Vue 3](@/guides/integrate-with-vue3/vue3-modules/vue3-modules.md) -- reduce bundle size by importing only required modules.
+- [HotColumn component in Vue 3](@/guides/integrate-with-vue3/vue3-hot-column/vue3-hot-column.md) -- configure columns declaratively.

--- a/docs/content/guides/integrate-with-vue3/vue3-hot-column/vue3-hot-column.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-hot-column/vue3-hot-column.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: l884wwjc
 title: Using the `HotColumn` component in Vue 3
 metaTitle: HotColumn component - Vue 3 Data Grid | Handsontable
@@ -14,7 +15,7 @@ angular:
 searchCategory: Guides
 category: Integrate with Vue 3
 ---
-Configure the Vue 3 data grid's columns, using the props of the `HotColumn` component. Define a custom cell editor or a custom cell renderer.
+HotColumn is a Vue 3 component that lets you define column settings declaratively as child components of HotTable.
 
 [[toc]]
 
@@ -52,3 +53,7 @@ You can declare a custom editor by creating a class that extends `TextEditor` an
 @[code](@/content/guides/integrate-with-vue3/vue3-hot-column/vue/example3.js)
 
 :::
+
+## Result
+
+Using `HotColumn` child components, each column reads its settings declaratively from Vue props rather than from a flat `columns` array, keeping your template in sync with your column configuration.

--- a/docs/content/guides/integrate-with-vue3/vue3-hot-reference/vue3-hot-reference.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-hot-reference/vue3-hot-reference.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: aae39zi5
 title: Referencing the Handsontable instance in Vue 3
 metaTitle: Referencing Handsontable - Vue 3 Data Grid | Handsontable
@@ -14,7 +15,7 @@ angular:
 searchCategory: Guides
 category: Integrate with Vue 3
 ---
-Reference the Handsontable instance from a Vue 3 component to programmatically perform actions such as reloading the data in your data grid.
+Use the `hotTableComponent` ref to access the underlying Handsontable instance from your Vue 3 component.
 
 [[toc]]
 
@@ -30,3 +31,7 @@ The following example implements the `@handsontable/vue3`, showing how to refere
 @[code](@/content/guides/integrate-with-vue3/vue3-hot-reference/vue/example1.js)
 
 :::
+
+## Result
+
+You can call any Handsontable API method -- such as `loadData()` or `getPlugin()` -- directly on the instance retrieved via `hotTableComponent.value.hotInstance`, giving you full programmatic control over the grid from your Vue 3 component.

--- a/docs/content/guides/integrate-with-vue3/vue3-language-change-example/vue3-language-change-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-language-change-example/vue3-language-change-example.md
@@ -1,4 +1,5 @@
 ---
+type: tutorial
 id: tcabky5c
 title: Language change in Vue 3
 metaTitle: Language change - Vue 3 Data Grid | Handsontable
@@ -14,7 +15,7 @@ angular:
 searchCategory: Guides
 category: Integrate with Vue 3
 ---
-Change the default language of the context menu from English to any of the built-in translations, using the `language` property.
+In this tutorial, you will add a language selection dropdown that changes the Handsontable UI language at runtime in a Vue 3 application.
 
 [[toc]]
 
@@ -78,3 +79,15 @@ Note that the `language` property is bound to the component separately using `la
 - [beforeLanguageChange](@/api/hooks.md#beforelanguagechange)
 
 </div>
+
+## What you learned
+
+- How to import and register a built-in language pack in a Vue 3 application.
+- How to bind the `language` prop dynamically to switch languages at runtime.
+- How to build a language selection dropdown that updates the Handsontable UI.
+
+## Next steps
+
+- [Setting up a translation in Vue 3](@/guides/integrate-with-vue3/vue3-setting-up-a-language/vue3-setting-up-a-language.md) -- configure number formats alongside the UI language.
+- [Language](@/guides/internationalization/language/language.md) -- explore all available language packs.
+- [Custom context menu in Vue 3](@/guides/integrate-with-vue3/vue3-custom-context-menu-example/vue3-custom-context-menu-example.md) -- add custom items to the localized context menu.

--- a/docs/content/guides/integrate-with-vue3/vue3-modules/vue3-modules.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-modules/vue3-modules.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: 0xtliaah
 title: Modules in Vue 3
 metaTitle: Modules - Vue 3 Data Grid | Handsontable
@@ -14,7 +15,7 @@ angular:
 searchCategory: Guides
 category: Integrate with Vue 3
 ---
-Reduce the size of your Vue 3 app by importing only the modules that you need and use.
+Import only the Handsontable modules you need to reduce your Vue 3 application bundle size.
 
 [[toc]]
 
@@ -91,6 +92,10 @@ registerPlugin(UndoRedo);
 
 createApp(App).use(router).mount('#app');
 ```
+
+## Result
+
+Your Vue 3 application's bundle includes only the Handsontable base module plus the specific cell types and plugins you registered, which reduces the final bundle size compared to importing the full Handsontable package.
 
 ## Related guides
 

--- a/docs/content/guides/integrate-with-vue3/vue3-setting-up-a-language/vue3-setting-up-a-language.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-setting-up-a-language/vue3-setting-up-a-language.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: 7ezlo7y5
 title: Setting up a translation in Vue 3
 metaTitle: Setting up a translation - Vue 3 Data Grid | Handsontable
@@ -14,7 +15,7 @@ angular:
 searchCategory: Guides
 category: Integrate with Vue 3
 ---
-Configure your Vue 3 data grid with different number formats, depending on the specified language and culture.
+Register a language file with Handsontable and pass the `language` option to the HotTable component to translate the grid UI.
 
 [[toc]]
 
@@ -30,6 +31,10 @@ The following example shows a Handsontable instance with translations set up in 
 @[code](@/content/guides/integrate-with-vue3/vue3-setting-up-a-language/vue/example1.js)
 
 :::
+
+## Result
+
+The HotTable component renders with number formatting and locale-specific text determined by the registered language file, and the context menu labels reflect the selected language.
 
 ## Related articles
 

--- a/docs/content/guides/integrate-with-vue3/vue3-simple-example/vue3-simple-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-simple-example/vue3-simple-example.md
@@ -1,4 +1,5 @@
 ---
+type: tutorial
 id: exlnnr23
 title: Basic example in Vue 3
 metaTitle: Basic example - Vue 3 Data Grid | Handsontable
@@ -14,7 +15,7 @@ angular:
 searchCategory: Guides
 category: Integrate with Vue 3
 ---
-Start with a basic example of the Vue 3 data grid, using component props for configuration and external control.
+In this tutorial, you will render your first Handsontable data grid in a Vue 3 application and learn the basic setup steps.
 
 [[toc]]
 
@@ -32,3 +33,15 @@ In this example, a `div` element of `id="example1"` where the `@handsontable/vue
 @[code](@/content/guides/integrate-with-vue3/vue3-simple-example/vue/example1.js)
 
 :::
+
+## What you learned
+
+- How to install and configure the `@handsontable/vue3` wrapper.
+- How to pass data and configuration options as props to the `HotTable` component.
+- How to render a basic data grid inside a Vue 3 application.
+
+## Next steps
+
+- [HotColumn component in Vue 3](@/guides/integrate-with-vue3/vue3-hot-column/vue3-hot-column.md) -- define column settings declaratively with HotColumn.
+- [Custom renderer in Vue 3](@/guides/integrate-with-vue3/vue3-custom-renderer-example/vue3-custom-renderer-example.md) -- customize how cell content is displayed.
+- [Language change in Vue 3](@/guides/integrate-with-vue3/vue3-language-change-example/vue3-language-change-example.md) -- switch the grid UI language at runtime.

--- a/docs/content/guides/integrate-with-vue3/vue3-vuex-example/vue3-vuex-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-vuex-example/vue3-vuex-example.md
@@ -1,4 +1,5 @@
 ---
+type: tutorial
 id: pxr5suzy
 title: Vuex in Vue 3
 metaTitle: Integration with Vuex - Vue 3 Data Grid - Handsontable
@@ -14,7 +15,7 @@ angular:
 searchCategory: Guides
 category: Integrate with Vue 3
 ---
-Use the Vuex state management pattern to maintain the data and configuration options of your Vue 3 data grid.
+In this tutorial, you will connect a Handsontable grid to a Vuex store so that cell changes update shared application state.
 
 [[toc]]
 
@@ -31,3 +32,15 @@ The following example implements the `@handsontable/vue3` component with a [`rea
 @[code](@/content/guides/integrate-with-vue3/vue3-vuex-example/vue/example1.css)
 
 :::
+
+## What you learned
+
+- How to connect a Handsontable grid to a Vuex store in a Vue 3 application.
+- How to use Vuex getters and mutations to read and write grid data.
+- How to propagate cell changes from Handsontable hooks back to the store.
+
+## Next steps
+
+- [Referencing the Handsontable instance in Vue 3](@/guides/integrate-with-vue3/vue3-hot-reference/vue3-hot-reference.md) -- access the Handsontable API directly from your component.
+- [HotColumn component in Vue 3](@/guides/integrate-with-vue3/vue3-hot-column/vue3-hot-column.md) -- configure columns declaratively alongside your store.
+- [Formulas integration in Vue 3](@/guides/integrate-with-vue3/vue3-formulas-example/vue3-formulas-example.md) -- combine Vuex-managed data with formula calculations.


### PR DESCRIPTION
## Summary

- Add `type:` Diátaxis classification to all Vue 3 integration pages
- Add missing intro paragraphs
- Add `## What you learned` / `## Next steps` to tutorial pages
- Add `## Result` to how-to pages

## ClickUp tasks

https://app.clickup.com/t/9015210959/DEV-1359
https://app.clickup.com/t/9015210959/DEV-1360
https://app.clickup.com/t/9015210959/DEV-1361
https://app.clickup.com/t/9015210959/DEV-1362
https://app.clickup.com/t/9015210959/DEV-1363
https://app.clickup.com/t/9015210959/DEV-1364
https://app.clickup.com/t/9015210959/DEV-1365
https://app.clickup.com/t/9015210959/DEV-1366
https://app.clickup.com/t/9015210959/DEV-1367
https://app.clickup.com/t/9015210959/DEV-1368
https://app.clickup.com/t/9015210959/DEV-1369
https://app.clickup.com/t/9015210959/DEV-1370

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (frontmatter and copy/structure) with no runtime or API impact; main risk is minor site rendering or navigation inconsistencies if the new `type` metadata is misinterpreted.
> 
> **Overview**
> Vue 3 integration guides are updated to follow Diátaxis conventions by adding frontmatter `type:` classification (`tutorial` vs `how-to`) and replacing one-line blurbs with fuller introductory sentences.
> 
> Tutorial pages now include new closing sections (`## What you learned` and `## Next steps`) to summarize outcomes and link to follow-on guides, while how-to pages add a `## Result` section describing expected output/behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62ee706e90d2cfd5053fc4f7a5d4c56599425b99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1454