### PR TITLE
docs: apply Diátaxis standards to Cell Functions pages

### DIFF
--- a/docs/content/guides/cell-functions/cell-editor/cell-editor.md
+++ b/docs/content/guides/cell-functions/cell-editor/cell-editor.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: u00oul7m
 title: Cell editor
 metaTitle: Cell editor - JavaScript Data Grid | Handsontable
@@ -155,7 +156,7 @@ Handsontable separates rendering (displaying cell values) from editing (changing
 
 **Overriding keyboard behavior:** Register a [`beforeKeyDown`](@/api/hooks.md#beforekeydown) hook listener and call `event.stopImmediatePropagation()` to prevent `EditorManager` from processing a specific key. Register the listener in `open()` and remove it in `close()` so it only intercepts events while your editor is active.
 
-**Editor singleton:** Each editor class has exactly one instance per table. The constructor and `init()` run once per table; `prepare()` runs every time the user selects a cell that uses that editor.
+**Editor singleton:** Each editor class has exactly one instance per table. The constructor and `init()` run once per table; `prepare()` runs every time you select a cell that uses that editor.
 
 ## BaseEditor API
 
@@ -487,3 +488,7 @@ class ExtendedSelectEditor extends MySelectEditor {
 - [beforeGetCellMeta](@/api/hooks.md#beforegetcellmeta)
 
 </div>
+
+## Result
+
+You now have a custom cell editor that controls how values are entered in your data grid. You can extend a built-in editor for small changes, or build from `BaseEditor` for a completely custom editing experience.

--- a/docs/content/guides/cell-functions/cell-function/cell-function.md
+++ b/docs/content/guides/cell-functions/cell-function/cell-function.md
@@ -1,4 +1,5 @@
 ---
+type: explanation
 id: neoo8dhv
 title: Cell functions
 metaTitle: Cell functions - JavaScript Data Grid | Handsontable
@@ -16,9 +17,7 @@ category: Cell functions
 menuTag: updated
 ---
 
-# Cell functions
-
-Render, edit, and validate cell contents using Handsontable's three independent cell functions.
+A cell function is one of three components -- renderer, editor, or validator -- that controls how a cell displays, accepts, and validates data.
 
 [[toc]]
 
@@ -375,3 +374,9 @@ export class AppComponent implements AfterViewInit {
   - [`beforeGetCellMeta`](@/api/hooks.md#beforegetcellmeta)
   - [`beforeRenderer`](@/api/hooks.md#beforerenderer)
   - [`beforeValidate`](@/api/hooks.md#beforevalidate)
+
+## Related
+
+- [Cell renderer](@/guides/cell-functions/cell-renderer/cell-renderer.md) -- how to control cell display using renderer functions
+- [Cell editor](@/guides/cell-functions/cell-editor/cell-editor.md) -- how to control cell editing using editor classes
+- [Cell validator](@/guides/cell-functions/cell-validator/cell-validator.md) -- how to enforce data rules using validator functions

--- a/docs/content/guides/cell-functions/cell-renderer/cell-renderer.md
+++ b/docs/content/guides/cell-functions/cell-renderer/cell-renderer.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: ohjf69hj
 title: Cell renderer
 metaTitle: Cell renderer - JavaScript Data Grid | Handsontable
@@ -15,211 +16,10 @@ searchCategory: Guides
 category: Cell functions
 menuTag: updated
 ---
-Create a custom cell renderer function, to have full control over how a cell looks.
+
+A cell renderer is a function that controls how cell content is displayed in the DOM. Override a built-in renderer or write your own to customize the visual output.
 
 [[toc]]
-
-## Overview
-
-A renderer is a function that determines how a cell looks. It's responsible for the complete cell rendering process, including DOM structure creation, content insertion, applying CSS classes, setting accessibility attributes, and managing all visual aspects of the cell.
-
-::: tip
-
-If you only need to format the displayed value (e.g., add units, format dates, or apply text transformations), consider using the [`valueFormatter`](@/api/options.md#valueformatter) option instead. It's more performant and simpler for value-only transformations. Use a renderer when you need to modify the DOM structure, add custom HTML elements, or handle complex visual layouts. See the [`renderer` vs `valueFormatter`](#renderer-vs-valueformatter) section for a detailed comparison.
-
-:::
-
-### Built-in renderers
-
-Handsontable provides 10 built-in renderers that you can use by their alias names. Each renderer is designed for a specific use case:
-
-| Alias | What the renderer does |
-|-------|------------------------|
-| `autocomplete` | Renders autocomplete cells with suggestions |
-| `checkbox` | Renders checkbox cells for boolean values or values defined by [`checkedTemplate`](@/api/options.md#checkedtemplate) and [`uncheckedTemplate`](@/api/options.md#uncheckedtemplate) options |
-| `date` | Renders date values with date formatting |
-| `dropdown` | Renders dropdown cells with select options |
-| `html` | Renders HTML content in cells (allows raw HTML) |
-| `numeric` | Renders numeric values with number formatting |
-| `password` | Renders password fields (masks the displayed value) |
-| `text` | Renders plain text (default renderer) |
-| `time` | Renders time values with time formatting |
-
-Using aliases provides a convenient way to specify which renderer should be used without needing to reference the full renderer function. You can change the renderer function associated with an alias without modifying the code that uses it.
-
-## `renderer` vs `valueFormatter`
-
-As mentioned in the [Overview](#overview), Handsontable provides two distinct options for controlling how cell values are displayed: [`valueFormatter`](@/api/options.md#valueformatter) and [`renderer`](@/api/options.md#renderer). This section provides a detailed comparison to help you choose the right tool for your use case.
-
-### What is `renderer`?
-
-The `renderer` option is a function responsible for the complete cell rendering process. It handles DOM structure creation, content insertion (via `innerText` or `innerHTML`), applying CSS classes, setting accessibility attributes, and managing all visual aspects of the cell.
-
-**Function signature:**
-```js
-renderer(hotInstance, td, row, col, prop, value, cellProperties)
-```
-
-**When to use `renderer`:**
-- Modify DOM structure (add icons, custom HTML elements, complex layouts)
-- Apply custom styling or CSS classes dynamically
-- Handle accessibility attributes
-- Create interactive elements within cells
-- When you need full control over the cell's HTML structure
-
-**Example:**
-
-```js
-function customRenderer(hotInstance, td, row, col, prop, value, cellProperties) {
-  // Create custom DOM structure
-  td.innerHTML = `
-    <div class="custom-wrapper">
-      <span class="icon">📊</span>
-      <span class="value">${value}</span>
-    </div>
-  `;
-}
-```
-
-### What is `valueFormatter`?
-
-The `valueFormatter` option (available since v17.0.0) is a function that transforms cell values before they are displayed. It focuses solely on value transformation and is called by the rendering engine right before the renderer function executes.
-
-**Function signature:**
-```js
-valueFormatter(value, cellProperties) => formattedValue
-```
-
-**When to use `valueFormatter`:**
-- Transform displayed values (add prefix, suffix, units)
-- Format dates, numbers, or text in a custom way
-- Apply simple text transformations
-- When you only need to change what is displayed, not how it's rendered
-
-**Example:**
-
-::: only-for javascript
-
-```js
-columns: [
-  {
-    data: 'price',
-    valueFormatter(value) {
-      return value ? `$${value.toFixed(2)}` : '';
-    }
-  },
-  {
-    data: 'weight',
-    valueFormatter(value) {
-      return value ? `${value} kg` : '';
-    }
-  }
-]
-```
-
-:::
-
-::: only-for react
-
-```jsx
-columns={[{
-  data: 'price',
-  valueFormatter(value) {
-    return value ? `$${value.toFixed(2)}` : '';
-  }
-}]}
-```
-
-:::
-
-::: only-for angular
-
-```ts
-settings = {
-  columns: [
-    {
-      data: 'price',
-      valueFormatter(value) {
-        return value ? `$${value.toFixed(2)}` : '';
-      }
-    }
-  ]
-};
-```
-
-:::
-
-### Key differences
-
-| Aspect | `valueFormatter` | `renderer` |
-|--------|------------------|------------|
-| **Purpose** | Transform the value | Complete cell rendering |
-| **Scope** | Value transformation only | DOM structure, styling, accessibility |
-| **Performance** | Faster (called before renderer) | More overhead (full DOM manipulation) |
-| **Use case** | Simple formatting (units, prefixes) | Complex layouts, custom HTML |
-| **Returns** | Formatted value | Nothing (modifies DOM directly) |
-
-### Using `renderer` and `valueFormatter` together
-
-Using both `renderer` and `valueFormatter` together is recommended when you need both value formatting and custom DOM structure. This approach separates concerns: `valueFormatter` handles value transformation, while `renderer` focuses on DOM manipulation. This separation improves maintainability and code clarity. The `valueFormatter` executes first, transforming the value, and then the `renderer` receives the formatted value:
-
-::: only-for javascript
-
-```js
-columns: [
-  {
-    data: 'amount',
-    // First, format the value
-    valueFormatter(value) {
-      return `$${value.toFixed(2)}`;
-    },
-    // Then, render it with custom DOM structure
-    renderer(hotInstance, td, row, col, prop, value, cellProperties) {
-      TD.innerHTML = `<div class="amount-cell"><span class="currency">${value}</span></div>`;
-    }
-  }
-]
-```
-
-:::
-
-::: only-for react
-
-```jsx
-columns={[{
-  data: 'amount',
-  valueFormatter(value) {
-    return `$${value.toFixed(2)}`;
-  },
-  renderer(hotInstance, TD, row, col, prop, value, cellProperties) {
-    TD.innerHTML = `<div class="amount-cell"><span class="currency">${value}</span></div>`;
-  }
-}]}
-```
-
-:::
-
-::: only-for angular
-
-```ts
-settings = {
-  columns: [
-    {
-      data: 'amount',
-      valueFormatter(value) {
-        return `$${value.toFixed(2)}`;
-      },
-      renderer(hotInstance, td, row, col, prop, value, cellProperties) {
-        TD.innerHTML = `<div class="amount-cell"><span class="currency">${value}</span></div>`;
-      }
-    }
-  ]
-};
-```
-
-:::
-
-In this example, `valueFormatter` adds the currency symbol and formatting, while `renderer` wraps it in a custom DOM structure with additional styling.
 
 ## Use a cell renderer
 
@@ -609,7 +409,211 @@ Cell renderers are called separately for every displayed cell, during every tabl
 
 If you only need to format the displayed value (e.g., add units, format dates, or apply text transformations), consider using the [`valueFormatter`](@/api/options.md#valueformatter) option instead of a custom renderer. The `valueFormatter` is called before the renderer and focuses solely on value transformation, making it more performant for simple formatting tasks. Use a renderer when you need to modify the DOM structure, add custom HTML elements, or handle complex visual layouts.
 
-## Related articles
+## Related API
+
+### Overview
+
+A renderer is a function that determines how a cell looks. It's responsible for the complete cell rendering process, including DOM structure creation, content insertion, applying CSS classes, setting accessibility attributes, and managing all visual aspects of the cell.
+
+::: tip
+
+If you only need to format the displayed value (e.g., add units, format dates, or apply text transformations), consider using the [`valueFormatter`](@/api/options.md#valueformatter) option instead. It's more performant and simpler for value-only transformations. Use a renderer when you need to modify the DOM structure, add custom HTML elements, or handle complex visual layouts. See the [`renderer` vs `valueFormatter`](#renderer-vs-valueformatter) section for a detailed comparison.
+
+:::
+
+### Built-in renderers
+
+Handsontable provides 10 built-in renderers that you can use by their alias names. Each renderer is designed for a specific use case:
+
+| Alias | What the renderer does |
+|-------|------------------------|
+| `autocomplete` | Renders autocomplete cells with suggestions |
+| `checkbox` | Renders checkbox cells for boolean values or values defined by [`checkedTemplate`](@/api/options.md#checkedtemplate) and [`uncheckedTemplate`](@/api/options.md#uncheckedtemplate) options |
+| `date` | Renders date values with date formatting |
+| `dropdown` | Renders dropdown cells with select options |
+| `html` | Renders HTML content in cells (allows raw HTML) |
+| `numeric` | Renders numeric values with number formatting |
+| `password` | Renders password fields (masks the displayed value) |
+| `text` | Renders plain text (default renderer) |
+| `time` | Renders time values with time formatting |
+
+Using aliases provides a convenient way to specify which renderer should be used without needing to reference the full renderer function. You can change the renderer function associated with an alias without modifying the code that uses it.
+
+### `renderer` vs `valueFormatter`
+
+Handsontable provides two distinct options for controlling how cell values are displayed: [`valueFormatter`](@/api/options.md#valueformatter) and [`renderer`](@/api/options.md#renderer). This section provides a detailed comparison to help you choose the right tool for your use case.
+
+#### What is `renderer`?
+
+The `renderer` option is a function responsible for the complete cell rendering process. It handles DOM structure creation, content insertion (via `innerText` or `innerHTML`), applying CSS classes, setting accessibility attributes, and managing all visual aspects of the cell.
+
+**Function signature:**
+```js
+renderer(hotInstance, td, row, col, prop, value, cellProperties)
+```
+
+**When to use `renderer`:**
+- Modify DOM structure (add icons, custom HTML elements, complex layouts)
+- Apply custom styling or CSS classes dynamically
+- Handle accessibility attributes
+- Create interactive elements within cells
+- When you need full control over the cell's HTML structure
+
+**Example:**
+
+```js
+function customRenderer(hotInstance, td, row, col, prop, value, cellProperties) {
+  // Create custom DOM structure
+  td.innerHTML = `
+    <div class="custom-wrapper">
+      <span class="icon">📊</span>
+      <span class="value">${value}</span>
+    </div>
+  `;
+}
+```
+
+#### What is `valueFormatter`?
+
+The `valueFormatter` option (available since v17.0.0) is a function that transforms cell values before they are displayed. It focuses solely on value transformation and is called by the rendering engine right before the renderer function executes.
+
+**Function signature:**
+```js
+valueFormatter(value, cellProperties) => formattedValue
+```
+
+**When to use `valueFormatter`:**
+- Transform displayed values (add prefix, suffix, units)
+- Format dates, numbers, or text in a custom way
+- Apply simple text transformations
+- When you only need to change what is displayed, not how it's rendered
+
+**Example:**
+
+::: only-for javascript
+
+```js
+columns: [
+  {
+    data: 'price',
+    valueFormatter(value) {
+      return value ? `$${value.toFixed(2)}` : '';
+    }
+  },
+  {
+    data: 'weight',
+    valueFormatter(value) {
+      return value ? `${value} kg` : '';
+    }
+  }
+]
+```
+
+:::
+
+::: only-for react
+
+```jsx
+columns={[{
+  data: 'price',
+  valueFormatter(value) {
+    return value ? `$${value.toFixed(2)}` : '';
+  }
+}]}
+```
+
+:::
+
+::: only-for angular
+
+```ts
+settings = {
+  columns: [
+    {
+      data: 'price',
+      valueFormatter(value) {
+        return value ? `$${value.toFixed(2)}` : '';
+      }
+    }
+  ]
+};
+```
+
+:::
+
+#### Key differences
+
+| Aspect | `valueFormatter` | `renderer` |
+|--------|------------------|------------|
+| **Purpose** | Transform the value | Complete cell rendering |
+| **Scope** | Value transformation only | DOM structure, styling, accessibility |
+| **Performance** | Faster (called before renderer) | More overhead (full DOM manipulation) |
+| **Use case** | Simple formatting (units, prefixes) | Complex layouts, custom HTML |
+| **Returns** | Formatted value | Nothing (modifies DOM directly) |
+
+#### Using `renderer` and `valueFormatter` together
+
+Using both `renderer` and `valueFormatter` together is recommended when you need both value formatting and custom DOM structure. This approach separates concerns: `valueFormatter` handles value transformation, while `renderer` focuses on DOM manipulation. This separation improves maintainability and code clarity. The `valueFormatter` executes first, transforming the value, and then the `renderer` receives the formatted value:
+
+::: only-for javascript
+
+```js
+columns: [
+  {
+    data: 'amount',
+    // First, format the value
+    valueFormatter(value) {
+      return `$${value.toFixed(2)}`;
+    },
+    // Then, render it with custom DOM structure
+    renderer(hotInstance, td, row, col, prop, value, cellProperties) {
+      TD.innerHTML = `<div class="amount-cell"><span class="currency">${value}</span></div>`;
+    }
+  }
+]
+```
+
+:::
+
+::: only-for react
+
+```jsx
+columns={[{
+  data: 'amount',
+  valueFormatter(value) {
+    return `$${value.toFixed(2)}`;
+  },
+  renderer(hotInstance, TD, row, col, prop, value, cellProperties) {
+    TD.innerHTML = `<div class="amount-cell"><span class="currency">${value}</span></div>`;
+  }
+}]}
+```
+
+:::
+
+::: only-for angular
+
+```ts
+settings = {
+  columns: [
+    {
+      data: 'amount',
+      valueFormatter(value) {
+        return `$${value.toFixed(2)}`;
+      },
+      renderer(hotInstance, td, row, col, prop, value, cellProperties) {
+        TD.innerHTML = `<div class="amount-cell"><span class="currency">${value}</span></div>`;
+      }
+    }
+  ]
+};
+```
+
+:::
+
+In this example, `valueFormatter` adds the currency symbol and formatting, while `renderer` wraps it in a custom DOM structure with additional styling.
+
+### Configuration options and API
 
 ::: only-for javascript
 
@@ -670,3 +674,7 @@ If you only need to format the displayed value (e.g., add units, format dates, o
 - [beforeRenderer](@/api/hooks.md#beforerenderer)
 
 </div>
+
+## Result
+
+You now have a custom cell renderer that controls how cell content appears in the DOM. You can use a built-in renderer by alias, register and reuse your own with `registerRenderer()`, or write inline renderer functions for full control over the cell's HTML structure.

--- a/docs/content/guides/cell-functions/cell-validator/cell-validator.md
+++ b/docs/content/guides/cell-functions/cell-validator/cell-validator.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: h840od8r
 title: Cell validator
 metaTitle: Cell validator - JavaScript Data Grid | Handsontable
@@ -14,13 +15,14 @@ angular:
 searchCategory: Guides
 category: Cell functions
 ---
-Validate data added or changed by the user, with predefined or custom rules. Validation helps you make sure that the data matches the expected format.
+
+Cell validators run when a user finishes editing a cell. Use them to enforce data rules such as required fields, numeric ranges, or pattern matching.
 
 [[toc]]
 
 ## Overview
 
-When you create a validator, a good idea is to assign it as an alias that will refer to this particular validator function. Handsontable defines 5 aliases by default:
+When you create a validator, assign it an alias so you can reference it by name in column configuration. Handsontable defines 5 aliases by default:
 
 - `autocomplete` for `Handsontable.validators.AutocompleteValidator`
 - `date` for `Handsontable.validators.DateValidator`
@@ -28,7 +30,7 @@ When you create a validator, a good idea is to assign it as an alias that will r
 - `numeric` for `Handsontable.validators.NumericValidator`
 - `time` for `Handsontable.validators.TimeValidator`
 
-It gives users a convenient way for defining which validator should be used when table validation was triggered. User doesn't need to know which validator function is responsible for checking the cell value, he does not even need to know that there is any function at all. What is more, you can change the validator function associated with an alias without a need to change code that defines a table.
+Aliases give you a convenient way to specify which validator runs when table validation triggers. You don't need to reference the validator function directly, and you can swap the function behind an alias without changing your column configuration.
 
 ## Register custom cell validator
 
@@ -67,7 +69,7 @@ That's better.
 
 ## Using an alias
 
-The final touch is to use the registered aliases, so that users can easily refer to it without the need to now the actual validator function is.
+The final touch is to use the registered aliases, so that you can easily refer to them without knowing the actual validator function.
 
 To sum up, a well prepared validator function should look like this:
 
@@ -286,3 +288,7 @@ Mind that changes in table are applied after running all validators (both synchr
 - [beforeValidate](@/api/hooks.md#beforevalidate)
 
 </div>
+
+## Result
+
+You now have a cell validator that enforces data rules when a user finishes editing. Register it under an alias to reference it by name across your column configuration, and use `allowInvalid: false` to keep the editor open until the user enters a valid value.

--- a/docs/content/guides/cell-functions/custom-cells/custom-cells.md
+++ b/docs/content/guides/cell-functions/custom-cells/custom-cells.md
@@ -1,4 +1,5 @@
 ---
+type: tutorial
 id: c2670b72
 title: Custom Cells
 metaTitle: Simplified Custom Cell Definitions - JavaScript Data Grid | Handsontable
@@ -15,6 +16,7 @@ searchCategory: Guides
 category: Cell functions
 menuTag: new
 ---
+
 [[toc]]
 
 ## Overview
@@ -1007,7 +1009,7 @@ editorFactory<CustomProperties, CustomMethods = {}>({
 
 ## Lifecycle Methods
 
-Understanding when each method is called:
+Each method runs at a specific point in the editor lifecycle:
 
 1. **`init(editor)`** - Called once when the editor is created (singleton pattern)
    - Create your input element (assign to `editor.input`)
@@ -1048,7 +1050,7 @@ Understanding when each method is called:
    - In case of special `focus` management, add your logic in this hook
 
 9. **`render(editor)`** - Custom render function
-   - Optional - can be used for custom rendering logic
+   - Optional - use for custom rendering logic
    - Receives the editor instance as parameter
 
 10. **`value`** - Initial value property
@@ -1266,7 +1268,7 @@ editor: editorFactory<{input: HTMLDivElement, value: string, config: string[]}>(
 ```
 
 **How it works:**
-- Keyboard shortcut `callback` is called for every key press when the editor is active (open)
+- Handsontable calls the keyboard shortcut `callback` for every key press when the editor is active (open)
 - Return `false` to prevent Handsontable's default behavior for that key
 - Return `true` (or nothing) to allow the default behavior
 - This gives you full control over keyboard interactions within your editor
@@ -1403,7 +1405,7 @@ new Handsontable(container, {
 
 ### 2. Positioning
 
-Positioning is handled automatically by `editorFactory`. You don't need to position the editor manually. The container is automatically positioned over the cell when `open()` is called.
+`editorFactory` handles positioning automatically. You don't need to position the editor manually. The container positions itself over the cell when `open()` runs.
 
 ### 3. Cleanup
 
@@ -1493,7 +1495,7 @@ const editor = editorFactory<{input: HTMLInputElement}>({
 
 - Container positioning is handled automatically
 - Check that `init()` creates `editor.input` element
-- Verify `afterOpen()` is called if you need to trigger UI elements
+- Verify `afterOpen()` runs if you need to trigger UI elements
 
 ### Value Not Saving
 
@@ -1517,3 +1519,16 @@ Have you created a useful custom cell? Consider contributing it as an example!
 ---
 
 *This approach aims to make Handsontable custom cells as accessible as possible, enabling teams to create custom cells in minutes rather than hours.*
+
+## What you learned
+
+- How `rendererFactory` and `editorFactory` simplify custom cell creation compared to the class-based approach.
+- How to use lifecycle hooks (`init`, `beforeOpen`, `afterOpen`, `afterClose`) to control editor behavior.
+- How to add per-cell configuration, keyboard shortcuts, and custom positioning strategies.
+- How `registerCellType` bundles a renderer, editor, and validator under a reusable alias.
+
+## Next steps
+
+- Browse the [recipes](@/recipes/introduction.md) for complete working examples such as color pickers, star ratings, and multi-select dropdowns.
+- Learn how the traditional class-based approach works in the [Cell editor](@/guides/cell-functions/cell-editor/cell-editor.md) guide.
+- Explore [Cell renderer](@/guides/cell-functions/cell-renderer/cell-renderer.md) and [Cell validator](@/guides/cell-functions/cell-validator/cell-validator.md) for standalone function-based customization.


### PR DESCRIPTION
## Summary

- Add `type:` Diátaxis classification to all Cell Functions pages
- Add missing intro paragraphs and closing sections
- Fix heading hierarchy, passive voice, and inconsistent person

## ClickUp tasks

https://app.clickup.com/t/9015210959/DEV-1312
https://app.clickup.com/t/9015210959/DEV-1313
https://app.clickup.com/t/9015210959/DEV-1314
https://app.clickup.com/t/9015210959/DEV-1315
https://app.clickup.com/t/9015210959/DEV-1316

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes (frontmatter and content restructuring) with no runtime or API behavior impact; main risk is broken links/anchors due to moved sections.
> 
> **Overview**
> Updates the Cell Functions documentation set to align with Diátaxis by adding `type:` classifications and tightening page framing (new/rewritten lead paragraphs plus new closing sections like **Result**, **Related**, and **What you learned/Next steps**).
> 
> Restructures the `Cell renderer` guide by significantly trimming and moving the long conceptual/API material into a dedicated **Related API** section, and makes smaller clarity/voice edits across `Cell editor`, `Cell validator`, and `Custom Cells` (including a few wording fixes and consistent second-person phrasing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be77e6d696984803dfc86fe1a9e2d8c82ad67db9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1448