### PR TITLE
docs: apply Diátaxis standards to Navigation, Accessories, i18n and Formulas pages

### DIFF
--- a/docs/content/guides/accessories-and-menus/context-menu/context-menu.md
+++ b/docs/content/guides/accessories-and-menus/context-menu/context-menu.md
@@ -1,4 +1,5 @@
 ---
+type: reference
 id: 3hrrxxln
 title: Context menu
 metaTitle: Context menu - JavaScript Data Grid | Handsontable
@@ -19,7 +20,7 @@ angular:
 searchCategory: Guides
 category: Accessories and menus
 ---
-Quickly access contextual actions such as removing rows, inserting columns or copying data, by opening the context menu.
+The context menu provides cell-level actions accessible by right-clicking. This page lists all available menu items and their configuration keys.
 
 [[toc]]
 
@@ -329,5 +330,15 @@ To see the context menu, right-click on a cell:
 <div class="boxes-list">
 
 - [ContextMenu](@/api/contextMenu.md)
+
+</div>
+
+## Related
+
+<div class="boxes-list">
+
+- [Custom shortcuts](@/guides/navigation/custom-shortcuts/custom-shortcuts.md)
+- [Adding comments via the context menu](@/guides/cell-features/comments/comments.md#add-comments-via-the-context-menu)
+- [Clipboard: Context menu](@/guides/cell-features/clipboard/clipboard.md#context-menu)
 
 </div>

--- a/docs/content/guides/accessories-and-menus/empty-data-state/empty-data-state.md
+++ b/docs/content/guides/accessories-and-menus/empty-data-state/empty-data-state.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: 7b3d9f2e
 title: Empty Data State
 metaTitle: Empty Data State - JavaScript Data Grid | Handsontable
@@ -21,15 +22,28 @@ angular:
 searchCategory: Guides
 category: Accessories and Menus
 ---
-Display empty data state overlays and provide user feedback when your data grid has no data to display using the Empty Data State plugin.
+Use the `EmptyDataState` plugin to display a contextual overlay when the grid has no data or all rows are hidden by active filters.
 
 [[toc]]
 
+## Prerequisites
+
+To use the Empty Data State plugin, import it from Handsontable:
+
+::: only-for javascript
+
+```js
+import Handsontable from 'handsontable';
+import 'handsontable/dist/handsontable.full.min.css';
+```
+
+:::
+
+To use the filter-aware empty state (which automatically detects when all rows are hidden by filters), also enable the [`Filters`](@/api/filters.md) plugin alongside `emptyDataState`.
+
 ## Overview
 
-The Empty Data State plugin provides a user-friendly overlay system for Handsontable when there's no data to display. It automatically detects when your table is empty or when all data is hidden by filters, and displays an appropriate message with optional action buttons.
-
-With simplicity and effectiveness in mind, the empty data state plugin was designed to provide a consistent user experience with customizable appearance and behavior. It automatically integrates with the [Filters](@/api/filters.md) plugin to provide context-aware messages and actions.
+The Empty Data State plugin provides a user-friendly overlay system for Handsontable when there's no data to display. It automatically detects when your table is empty or when all data is hidden by filters, and displays an appropriate message with optional action buttons. It automatically integrates with the [Filters](@/api/filters.md) plugin to provide context-aware messages and actions.
 
 ## Basic configuration
 
@@ -155,6 +169,10 @@ Translate default empty data state labels using the global translations mechanis
 | `EMPTY_DATA_STATE_BUTTONS_FILTERS_RESET` | `'Reset filters'`                                              |
 
 To learn more about the translation mechanism, see the [Languages guide](@/guides/internationalization/language/language.md).
+
+## Result
+
+After enabling the plugin, the grid displays a centered overlay message whenever there is no data to show. When the [`Filters`](@/api/filters.md) plugin is also enabled, the overlay automatically switches to a filter-specific message and shows a "Reset filters" button when all rows are hidden by active filter conditions.
 
 ## Related API reference
 

--- a/docs/content/guides/accessories-and-menus/icon-pack/icon-pack.md
+++ b/docs/content/guides/accessories-and-menus/icon-pack/icon-pack.md
@@ -1,4 +1,5 @@
 ---
+type: reference
 id: zu0ja2qo
 title: Icon pack
 metaTitle: Icon pack - JavaScript Data Grid | Handsontable
@@ -17,7 +18,7 @@ angular:
 searchCategory: Guides
 category: Accessories and menus
 ---
-Create toolbars, menu bars, and context menus with our set of icons, designed specifically for tables, spreadsheets, and data-rich components.
+The Handsontable icon pack contains SVG icons used throughout the grid UI. Download and use these icons to maintain visual consistency in custom components.
 
 [[toc]]
 
@@ -216,5 +217,14 @@ npm install @handsontable/spreadsheet-icons
 <div class="boxes-list">
 
 - [Introducing the new Handsontable spreadsheet icons](https://handsontable.com/blog/handsontable-spreadsheet-icons)
+
+</div>
+
+## Related
+
+<div class="boxes-list">
+
+- [Context menu](@/guides/accessories-and-menus/context-menu/context-menu.md)
+- [Column menu](@/guides/columns/column-menu/column-menu.md)
 
 </div>

--- a/docs/content/guides/formulas/formula-calculation/formula-calculation.md
+++ b/docs/content/guides/formulas/formula-calculation/formula-calculation.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: g7i1xok4
 title: Formula calculation
 metaTitle: Formula calculation - JavaScript Data Grid | Handsontable
@@ -24,34 +25,9 @@ angular:
 searchCategory: Guides
 category: Formulas
 ---
-Perform calculations on cells' values, using a powerful calculation engine that handles nearly 400
-functions, custom functions, named expressions, and more.
+The `Formulas` plugin adds spreadsheet-style calculation to Handsontable, powered by [HyperFormula](https://hyperformula.handsontable.com/). It supports ~400 built-in functions, cross-sheet references, named expressions, and custom function implementations.
 
 [[toc]]
-
-## Overview
-
-The _Formulas_ plugin adds spreadsheet-style calculation to Handsontable. It is powered by
-[HyperFormula](https://hyperformula.handsontable.com/), an open-source formula engine built by the
-Handsontable team.
-
-Key capabilities:
-
-- **~400 built-in functions** - Math, Engineering, Statistical, Financial, Logical, and more.
-- **Cross-sheet references** - formulas can reference cells in other Handsontable instances that
-  share the same HyperFormula engine.
-- **Named expressions** - assign a label to a value or formula and reuse it across the workbook.
-- **Custom functions** - extend HyperFormula with your own function implementations.
-
-Below are some ideas on what you can do with it:
-
-- Fully-featured spreadsheet apps
-- Smart documents
-- Educational apps
-- Business logic builders
-- Forms and form builders
-- Online calculators
-- Low connectivity apps
 
 ## Basic multi-sheet example
 
@@ -831,3 +807,7 @@ details, [contact our Sales Team](https://handsontable.com/get-a-quote).
 - [Formulas](@/api/formulas.md)
 
 </div>
+
+## Result
+
+After setting up the `Formulas` plugin with a HyperFormula engine, cells that contain a formula (starting with `=`) are evaluated automatically. Editing a cell updates all dependent formula cells in real time, and cross-sheet references stay in sync across linked Handsontable instances.

--- a/docs/content/guides/internationalization/ime-support/ime-support.md
+++ b/docs/content/guides/internationalization/ime-support/ime-support.md
@@ -1,4 +1,5 @@
 ---
+type: explanation
 id: bhst4cl4
 title: IME support
 metaTitle: IME support - JavaScript Data Grid | Handsontable
@@ -76,5 +77,14 @@ To test the IME support, you will need to change your language preferences for y
 - [Core: `isRtl()`](@/api/core.md#isrtl)
 - [Hooks: `afterLanguageChange`](@/api/hooks.md#afterlanguagechange)
 - [Hooks: `beforeLanguageChange`](@/api/hooks.md#beforelanguagechange)
+
+</div>
+
+## Related
+
+<div class="boxes-list">
+
+- [Locale](@/guides/internationalization/locale/locale.md)
+- [Language](@/guides/internationalization/language/language.md)
 
 </div>

--- a/docs/content/guides/internationalization/locale/locale.md
+++ b/docs/content/guides/internationalization/locale/locale.md
@@ -1,4 +1,5 @@
 ---
+type: reference
 id: 97k6p9p7
 title: Locale
 metaTitle: Locale - JavaScript Data Grid | Handsontable
@@ -19,7 +20,7 @@ angular:
 searchCategory: Guides
 category: Internationalization
 ---
-Configure Handsontable's locale settings, to properly handle locale-related data and actions such as filtering, searching, or sorting.
+The `locale` option configures number and date formatting using a BCP 47 language tag (for example `'en-US'` or `'de-DE'`).
 
 [[toc]]
 
@@ -198,5 +199,14 @@ settings = {
 
 - [afterLanguageChange](@/api/hooks.md#afterlanguagechange)
 - [beforeLanguageChange](@/api/hooks.md#beforelanguagechange)
+
+</div>
+
+## Related
+
+<div class="boxes-list">
+
+- [Language](@/guides/internationalization/language/language.md)
+- [Layout direction](@/guides/internationalization/layout-direction/layout-direction.md)
 
 </div>

--- a/docs/content/guides/navigation/custom-shortcuts/custom-shortcuts.md
+++ b/docs/content/guides/navigation/custom-shortcuts/custom-shortcuts.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: g7139vli
 title: Custom shortcuts
 metaTitle: Custom shortcuts - JavaScript Data Grid | Handsontable
@@ -26,13 +27,9 @@ searchCategory: Guides
 category: Navigation
 menuTag: updated
 ---
-Customize Handsontable's keyboard shortcuts.
+Use the [`ShortcutManager`](@/api/shortcutManager.md) API to add, remove, replace, or block keyboard shortcuts in Handsontable.
 
 [[toc]]
-
-## Overview
-
-You can completely customize your keyboard shortcuts, using the [`ShortcutManager`](@/api/shortcutManager.md) API:
 
 ::: only-for react
 
@@ -70,7 +67,7 @@ hot.getShortcutManager();
 </li>
 <li>
 
-**Select a keyboard shortcut [context](#keyboard-shortcut-contexts), for example:**
+**Select a keyboard shortcut context, for example:**
 
 ```js
 const gridContext = hot.getShortcutManager().getContext('grid');
@@ -94,32 +91,6 @@ gridContext.addShortcut({
 
 </li>
 </ol>
-
-## Keyboard shortcut contexts
-
-Every keyboard action is registered in a particular context:
-
-| Context  | Description                                                       | Type     |
-| -------- | ----------------------------------------------------------------- | -------- |
-| `grid`   | Activates when the user navigates the data grid (initial context) | Built-in |
-| `editor` | Activates when the user opens a cell editor                       | Built-in |
-| `menu`   | Activates when the user opens a cell's context menu               | Built-in |
-| Custom   | Your [custom context](#manage-keyboard-shortcut-contexts)         | Custom   |
-
-When the user interacts with the keyboard, only actions registered for the currently-active context are executed.
-
-Only one context is active at a time.
-
-### Manage keyboard shortcut contexts
-
-Using the [`ShortcutManager`](@/api/shortcutManager.md) API methods, you can:
-
-- Get the name of the currently-active context: [`getActiveContextName()`](@/api/shortcutManager.md#getactivecontextname)
-- Switch to a different context: [`setActiveContextName()`](@/api/shortcutManager.md#setactivecontextname)
-- Get an already-registered context: [`getContext()`](@/api/shortcutManager.md#getcontext)
-- Create and register a new context: [`addContext()`](@/api/shortcutManager.md#addcontext)
-
-For example: if you're using a complex [custom editor](@/guides/cell-functions/cell-editor/cell-editor.md#how-to-create-a-custom-editor), you can create a new shortcut context to navigate your editor's UI with the arrow keys (normally, the arrow keys would navigate the grid instead).
 
 ## Add a custom keyboard shortcut
 
@@ -152,13 +123,6 @@ gridContext.addShortcut({
 
 </li>
 </ol>
-
-   The [`keys`](@/api/shortcutContext.md#addshortcut) parameter:
-
-   - Accepts all the [`KeyboardEvent.key`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values) key names.
-   - Accepts key names in both lowercase and uppercase (e.g., both `Enter` and `enter` work)
-   - Handles key-name discrepancies between browsers (e.g., both `'Spacebar'` and `' '` work)
-   - Accepts key names in any order (e.g., both `[['control', 'a']]` and `[['a', 'control']]`) work)
 
 ### Add a conditional keyboard action
 
@@ -343,6 +307,41 @@ settings = {
 
 :::
 
+## Reference
+
+### Keyboard shortcut contexts
+
+Every keyboard action is registered in a particular context:
+
+| Context  | Description                                                       | Type     |
+| -------- | ----------------------------------------------------------------- | -------- |
+| `grid`   | Activates when the user navigates the data grid (initial context) | Built-in |
+| `editor` | Activates when the user opens a cell editor                       | Built-in |
+| `menu`   | Activates when the user opens a cell's context menu               | Built-in |
+| Custom   | Your custom context                                               | Custom   |
+
+When the user interacts with the keyboard, only actions registered for the currently-active context are executed. Only one context is active at a time.
+
+### Manage keyboard shortcut contexts
+
+Using the [`ShortcutManager`](@/api/shortcutManager.md) API methods, you can:
+
+- Get the name of the currently-active context: [`getActiveContextName()`](@/api/shortcutManager.md#getactivecontextname)
+- Switch to a different context: [`setActiveContextName()`](@/api/shortcutManager.md#setactivecontextname)
+- Get an already-registered context: [`getContext()`](@/api/shortcutManager.md#getcontext)
+- Create and register a new context: [`addContext()`](@/api/shortcutManager.md#addcontext)
+
+For example: if you're using a complex [custom editor](@/guides/cell-functions/cell-editor/cell-editor.md#how-to-create-a-custom-editor), you can create a new shortcut context to navigate your editor's UI with the arrow keys (normally, the arrow keys would navigate the grid instead).
+
+### `addShortcut()` parameters
+
+The [`keys`](@/api/shortcutContext.md#addshortcut) parameter:
+
+- Accepts all the [`KeyboardEvent.key`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values) key names.
+- Accepts key names in both lowercase and uppercase (e.g., both `Enter` and `enter` work)
+- Handles key-name discrepancies between browsers (e.g., both `'Spacebar'` and `' '` work)
+- Accepts key names in any order (e.g., both `[['control', 'a']]` and `[['a', 'control']]`) work)
+
 ## API reference
 
 For the list of [options](@/guides/getting-started/configuration-options/configuration-options.md), methods, and [Handsontable hooks](@/guides/getting-started/events-and-hooks/events-and-hooks.md) related to keyboard navigation, see the following API reference pages:
@@ -385,6 +384,10 @@ For the list of [options](@/guides/getting-started/configuration-options/configu
 - [beforeKeyDown](@/api/hooks.md#beforekeydown)
 
 </div>
+
+## Result
+
+After completing these steps, you have custom keyboard shortcuts registered in the target context. The shortcuts trigger your callbacks when the user presses the configured key combination, and only when the specified context is active.
 
 ## Troubleshooting
 

--- a/docs/content/guides/navigation/focus-scopes/focus-scopes.md
+++ b/docs/content/guides/navigation/focus-scopes/focus-scopes.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: cdahp04c
 title: Focus scopes
 metaTitle: Focus scopes - JavaScript Data Grid | Handsontable
@@ -23,13 +24,9 @@ searchCategory: Guides
 category: Navigation
 menuTag: updated
 ---
-Manage focus boundaries and keyboard shortcuts contexts with focus scopes.
+Use focus scopes to create isolated focus boundaries within a Handsontable instance and control which keyboard shortcuts are active for each part of the UI. Focus scopes come in two types: `inline` (default) allows natural DOM tab order, and `modal` blocks focus outside the scope -- useful for dialogs and overlays.
 
 [[toc]]
-
-## Overview
-
-Focus scopes allow you to create isolated focus boundaries within your Handsontable instance, enabling seamless focus switching between the grid and your custom UI elements. They automatically manage keyboard shortcuts contexts and provide fine-grained control over which elements can receive focus and which shortcuts are active.
 
 ::: only-for react
 ::: tip
@@ -80,16 +77,7 @@ focusScopeManager.registerScope('customScope', containerElement, {
 </li>
 </ol>
 
-## Focus scope types
-
-Focus scopes come in two types, each with different behavior:
-
-| Type     | Description                                                                                                 |
-| -------- | ----------------------------------------------------------------------------------------------------------- |
-| `inline` (default) | The scope is inline and allows the rest of the component to receive focus in the order of the rendered elements in the DOM. |
-| `modal`  | The scope is modal and blocks the rest of the component from receiving focus. Only elements within the scope can be focused. |
-
-### Inline scopes
+## Inline scopes
 
 Inline scopes allow natural tab navigation through the DOM. Users can  navigate to other parts of the grid using the <kbd>Tab</kbd> or <kbd>Shift</kbd>+<kbd>Tab</kbd> keys.
 
@@ -385,6 +373,10 @@ For the complete API reference, see the following pages:
 - [beforeKeyDown](@/api/hooks.md#beforekeydown)
 
 </div>
+
+## Result
+
+After registering a focus scope, Handsontable automatically activates it when the user clicks inside the container or tabs to it. The associated shortcuts context switches accordingly, and tab navigation flows through your registered scopes in the correct order.
 
 ## Troubleshooting
 

--- a/docs/content/guides/navigation/searching-values/searching-values.md
+++ b/docs/content/guides/navigation/searching-values/searching-values.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: ct5f32ig
 title: Searching values
 metaTitle: Searching values - JavaScript Data Grid | Handsontable
@@ -18,14 +19,9 @@ angular:
 searchCategory: Guides
 category: Navigation
 ---
-
-# Searching values
-
-Search data across Handsontable using the built-in API methods of the [`Search`](@/api/search.md) plugin, and implement your own search UI.
+Enable the [`Search`](@/api/search.md) plugin and call [`query()`](@/api/search.md#query) on each keystroke to highlight matching cells across the grid.
 
 [[toc]]
-
-## Overview
 
 ::: only-for react
 
@@ -54,140 +50,6 @@ For more information, see the [Instance access](@/guides/getting-started/angular
 The [`Search`](@/api/search.md) plugin lets you scan all cells in the grid and get back a list of matches. Enable it by setting the [`search`](@/api/options.md#search) option to `true` or to a configuration object.
 
 Once enabled, the plugin exposes the [`query(queryStr)`](@/api/search.md#query) method. Call it with a search string whenever the user types. By default, the search is case-insensitive and matches partial cell values.
-
-## How `query()` works
-
-Calling [`query(queryStr, [callback], [queryMethod])`](@/api/search.md#query) does two things:
-
-1. Iterates over every cell in the grid and tests each one using the `queryMethod`.
-2. After each test, calls the `callback` to update cell metadata (`isSearchResult`).
-
-It returns an array of result objects - one for each matching cell:
-
-| Property | Type | Description |
-| --- | --- | --- |
-| `row` | `number` | Visual row index of the matching cell |
-| `col` | `number` | Visual column index of the matching cell |
-| `data` | `string\|number\|null` | Value of the matching cell |
-
-After calling `query()`, call `hot.render()` to refresh visual highlighting.
-
-## Search result class
-
-After `query()` runs, every cell where `isSearchResult === true` automatically receives the CSS class `htSearchResult`. You can replace this class in two ways:
-
-- At initialization: set `search: { searchResultClass: 'my-class' }`
-- Programmatically: call `hot.getPlugin('search').setSearchResultClass('my-class')`
-
-## Custom `queryMethod`
-
-The `queryMethod` function determines whether the query string matches a cell value. It is called once per cell during every `query()` call.
-
-**Signature:**
-
-```js
-function queryMethod(query, value, cellProperties) {
-  // return true for a match, false otherwise
-}
-```
-
-| Parameter | Type | Description |
-| --- | --- | --- |
-| `query` | `string` | The search string passed to `query()` |
-| `value` | `string\|number\|null` | The cell value (from `getDataAtCell()`) |
-| `cellProperties` | `object` | The cell's metadata object (includes `locale`, `type`, and other cell options) |
-
-The built-in default performs a **case-insensitive, locale-aware substring match**:
-
-```js
-function defaultQueryMethod(query, value, cellProperties) {
-  if (query === undefined || query === null || query.length === 0) {
-    return false;
-  }
-  if (value === undefined || value === null) {
-    return false;
-  }
-
-  return value.toString().toLocaleLowerCase(cellProperties.locale)
-    .indexOf(query.toLocaleLowerCase(cellProperties.locale)) !== -1;
-}
-```
-
-You can set a custom query method in three ways:
-
-- At initialization: `search: { queryMethod: myQueryMethod }`
-- Programmatically: `hot.getPlugin('search').setQueryMethod(myQueryMethod)`
-- Per `query()` call: `searchPlugin.query(queryStr, callback, myQueryMethod)` (applies to that call only)
-
-## Custom result callback
-
-The `callback` function is called for **every cell** during a `query()` run, whether or not the cell matches. It is responsible for updating cell metadata so the renderer knows which cells to highlight.
-
-**Signature:**
-
-```js
-function callback(instance, row, col, data, testResult) {
-  // update cell metadata based on testResult
-}
-```
-
-| Parameter | Type | Description |
-| --- | --- | --- |
-| `instance` | `Handsontable` | The Handsontable instance |
-| `row` | `number` | Visual row index |
-| `col` | `number` | Visual column index |
-| `data` | `string\|number\|null` | The cell value |
-| `testResult` | `boolean` | `true` if the cell matches the query, `false` otherwise |
-
-The built-in default sets the `isSearchResult` flag on each cell's metadata:
-
-```js
-function defaultCallback(instance, row, col, data, testResult) {
-  instance.getCellMeta(row, col).isSearchResult = testResult;
-}
-```
-
-If you override the callback to add custom logic (for example, to count results), call the default behavior manually so that cell highlighting still works.
-
-You can set a custom callback in three ways:
-
-- At initialization: `search: { callback: myCallback }`
-- Programmatically: `hot.getPlugin('search').setCallback(myCallback)`
-- Per `query()` call: `searchPlugin.query(queryStr, myCallback)` (applies to that call only)
-
-## Per-cell `queryMethod` and `callback`
-
-Both `queryMethod` and `callback` can be overridden for individual cells, columns, or rows using Handsontable's [cascading configuration](@/guides/getting-started/configuration-options/configuration-options.md) model. Set a `search` object directly in a `cell`, `columns`, or `rows` entry:
-
-```js
-handsontable({
-  data: myData,
-  search: true,
-  columns: [
-    {},
-    // Column 1: exact match only, everything else uses the global queryMethod
-    {
-      search: {
-        queryMethod(queryStr, value) {
-          return queryStr.toString() === value.toString();
-        }
-      }
-    }
-  ]
-});
-```
-
-You can also set it programmatically on a specific cell using [`setCellMeta()`](@/api/core.md#setcellmeta):
-
-```js
-hot.setCellMeta(row, col, 'search', {
-  queryMethod(queryStr, value) {
-    return queryStr.toString() === value.toString();
-  }
-});
-```
-
-Per-cell settings take precedence over the plugin-level `queryMethod` and `callback`. Only `queryMethod` and `callback` support per-cell overrides - `searchResultClass` does not.
 
 ## Simplest use case
 
@@ -371,7 +233,143 @@ The example below displays the number of matching search results. To do this, it
 
 :::
 
-## Related API reference
+## Result
+
+After following these steps, typing in your search input highlights matching cells with the `htSearchResult` CSS class. The `query()` call returns an array of matching `{ row, col, data }` objects that you can use to build a results counter or navigate between matches.
+
+## Related API
+
+### How `query()` works
+
+Calling [`query(queryStr, [callback], [queryMethod])`](@/api/search.md#query) does two things:
+
+1. Iterates over every cell in the grid and tests each one using the `queryMethod`.
+2. After each test, calls the `callback` to update cell metadata (`isSearchResult`).
+
+It returns an array of result objects - one for each matching cell:
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `row` | `number` | Visual row index of the matching cell |
+| `col` | `number` | Visual column index of the matching cell |
+| `data` | `string\|number\|null` | Value of the matching cell |
+
+After calling `query()`, call `hot.render()` to refresh visual highlighting.
+
+### Search result class
+
+After `query()` runs, every cell where `isSearchResult === true` automatically receives the CSS class `htSearchResult`. You can replace this class in two ways:
+
+- At initialization: set `search: { searchResultClass: 'my-class' }`
+- Programmatically: call `hot.getPlugin('search').setSearchResultClass('my-class')`
+
+### `queryMethod` signature
+
+The `queryMethod` function determines whether the query string matches a cell value. It is called once per cell during every `query()` call.
+
+```js
+function queryMethod(query, value, cellProperties) {
+  // return true for a match, false otherwise
+}
+```
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `query` | `string` | The search string passed to `query()` |
+| `value` | `string\|number\|null` | The cell value (from `getDataAtCell()`) |
+| `cellProperties` | `object` | The cell's metadata object (includes `locale`, `type`, and other cell options) |
+
+The built-in default performs a **case-insensitive, locale-aware substring match**:
+
+```js
+function defaultQueryMethod(query, value, cellProperties) {
+  if (query === undefined || query === null || query.length === 0) {
+    return false;
+  }
+  if (value === undefined || value === null) {
+    return false;
+  }
+
+  return value.toString().toLocaleLowerCase(cellProperties.locale)
+    .indexOf(query.toLocaleLowerCase(cellProperties.locale)) !== -1;
+}
+```
+
+You can set a custom query method in three ways:
+
+- At initialization: `search: { queryMethod: myQueryMethod }`
+- Programmatically: `hot.getPlugin('search').setQueryMethod(myQueryMethod)`
+- Per `query()` call: `searchPlugin.query(queryStr, callback, myQueryMethod)` (applies to that call only)
+
+### `callback` signature
+
+The `callback` function is called for **every cell** during a `query()` run, whether or not the cell matches. It is responsible for updating cell metadata so the renderer knows which cells to highlight.
+
+```js
+function callback(instance, row, col, data, testResult) {
+  // update cell metadata based on testResult
+}
+```
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `instance` | `Handsontable` | The Handsontable instance |
+| `row` | `number` | Visual row index |
+| `col` | `number` | Visual column index |
+| `data` | `string\|number\|null` | The cell value |
+| `testResult` | `boolean` | `true` if the cell matches the query, `false` otherwise |
+
+The built-in default sets the `isSearchResult` flag on each cell's metadata:
+
+```js
+function defaultCallback(instance, row, col, data, testResult) {
+  instance.getCellMeta(row, col).isSearchResult = testResult;
+}
+```
+
+If you override the callback to add custom logic (for example, to count results), call the default behavior manually so that cell highlighting still works.
+
+You can set a custom callback in three ways:
+
+- At initialization: `search: { callback: myCallback }`
+- Programmatically: `hot.getPlugin('search').setCallback(myCallback)`
+- Per `query()` call: `searchPlugin.query(queryStr, myCallback)` (applies to that call only)
+
+### Per-cell `queryMethod` and `callback`
+
+Both `queryMethod` and `callback` can be overridden for individual cells, columns, or rows using Handsontable's [cascading configuration](@/guides/getting-started/configuration-options/configuration-options.md) model. Set a `search` object directly in a `cell`, `columns`, or `rows` entry:
+
+```js
+handsontable({
+  data: myData,
+  search: true,
+  columns: [
+    {},
+    // Column 1: exact match only, everything else uses the global queryMethod
+    {
+      search: {
+        queryMethod(queryStr, value) {
+          return queryStr.toString() === value.toString();
+        }
+      }
+    }
+  ]
+});
+```
+
+You can also set it programmatically on a specific cell using [`setCellMeta()`](@/api/core.md#setcellmeta):
+
+```js
+hot.setCellMeta(row, col, 'search', {
+  queryMethod(queryStr, value) {
+    return queryStr.toString() === value.toString();
+  }
+});
+```
+
+Per-cell settings take precedence over the plugin-level `queryMethod` and `callback`. Only `queryMethod` and `callback` support per-cell overrides - `searchResultClass` does not.
+
+### Plugin configuration options
 
 **Configuration options**
 


### PR DESCRIPTION
## Summary

- Add `type:` Diátaxis classification to all pages in this group
- Separate how-to steps from reference content in custom-shortcuts and searching-values
- Reclassify context-menu and icon-pack as reference; locale as reference; ime-support as explanation
- Add missing intro paragraphs, `## Result`, `## Related`, and `## Prerequisites` sections

## ClickUp tasks

https://app.clickup.com/t/9015210959/DEV-1342
https://app.clickup.com/t/9015210959/DEV-1343
https://app.clickup.com/t/9015210959/DEV-1344
https://app.clickup.com/t/9015210959/DEV-1345
https://app.clickup.com/t/9015210959/DEV-1346
https://app.clickup.com/t/9015210959/DEV-1347
https://app.clickup.com/t/9015210959/DEV-1348
https://app.clickup.com/t/9015210959/DEV-1349
https://app.clickup.com/t/9015210959/DEV-1350

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (frontmatter/structure/cross-links) with no runtime or API behavior impact; main risk is broken links or rendering regressions in the docs site.
> 
> **Overview**
> Applies Diátaxis classification by adding frontmatter `type:` across multiple guide pages, and updates several pages’ positioning (for example `context-menu`/`icon-pack` as *reference*, `locale` as *reference*, and `ime-support` as *explanation*).
> 
> Reworks guide structure and clarity by adding/rewriting lead-in summaries and introducing consistent sections such as `## Prerequisites`, `## Result`, and `## Related`, plus splitting previously mixed content into clearer how-to vs reference sections (notably `custom-shortcuts` and `searching-values`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f3b611ae75eb650d9fa5bce4726d736ecfbe628. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1452