### PR TITLE
docs: apply Diátaxis standards to Styling, Technical Spec and Tools pages

### DIFF
--- a/docs/content/guides/styling/design-system/design-system.md
+++ b/docs/content/guides/styling/design-system/design-system.md
@@ -1,4 +1,5 @@
 ---
+type: explanation
 id: xfus5qpz
 title: Design System
 metaTitle: Design System / UI Kit - JavaScript Data Grid | Handsontable
@@ -26,7 +27,7 @@ searchCategory: Guides
 category: Styling
 menuTag: updated
 ---
-Design, prototype, and customize your data grid with the Design System for Figma.
+The Handsontable design system defines the tokens, themes, and components that control the grid visual appearance. Read this to understand how themes and CSS variables relate.
 
 [[toc]]
 
@@ -79,5 +80,14 @@ Didn't find what you need? Try this:
 - [Report an issue](https://github.com/handsontable/handsontable/issues/new/choose) on GitHub
 - [Start a discussion](https://forum.handsontable.com/c/getting-help/questions) on Handsontable's forum
 - [Contact our technical support](https://handsontable.com/contact?category=technical_support) to get help
+
+</div>
+
+## Related
+
+<div class="boxes-list">
+
+- [Themes](@/guides/styling/themes/themes.md)
+- [Legacy Style](@/guides/styling/legacy-style/legacy-style.md)
 
 </div>

--- a/docs/content/guides/styling/legacy-style/legacy-style.md
+++ b/docs/content/guides/styling/legacy-style/legacy-style.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: yfus6qpz
 title: Legacy Style
 metaTitle: Legacy Style - JavaScript Data Grid | Handsontable
@@ -162,3 +163,7 @@ The Classic theme provides the same visual appearance as the legacy style, but w
 - [Themes](@/guides/styling/themes/themes.md)
 
 </div>
+
+## Result
+
+Your grid now uses the legacy stylesheet. The visual style matches pre-14.0 Handsontable.

--- a/docs/content/guides/styling/themes/themes.md
+++ b/docs/content/guides/styling/themes/themes.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: jn1po47i
 title: Themes
 metaTitle: Themes - JavaScript Data Grid | Handsontable
@@ -100,125 +101,6 @@ When using the Theme API, you can configure the color scheme using `setColorSche
 
 When using CSS files, color scheme switching is controlled through CSS class names. Use `ht-theme-{name}` for light mode, `ht-theme-{name}-dark` for dark mode, or `ht-theme-{name}-dark-auto` for automatic switching based on system preferences (e.g., `ht-theme-main`, `ht-theme-main-dark`, `ht-theme-main-dark-auto`).
 
-## Available Theme API parameters
-
-When registering a theme with `registerTheme()` or updating it using the `params()` method, you can configure the following keys:
-
-| Key           | Description                                                                                    |
-| ------------- | ---------------------------------------------------------------------------------------------- |
-| `name`        | Theme name string (can only be set during `registerTheme()`, cannot be updated via `params()`) |
-| `sizing`      | Size scale values (`size_0` through `size_10`)                                                 |
-| `density`     | Density type (`'default'`, `'compact'`, `'comfortable'`) or density configuration object       |
-| `icons`       | SVG icon definitions                                                                           |
-| `colors`      | Color palette with nested color values                                                         |
-| `tokens`      | Design tokens for visual properties                                                            |
-| `colorScheme` | Color scheme (`'light'`, `'dark'`, or `'auto'`)                                                |
-
-### Token value references
-
-Token values support a powerful reference system using dot notation. Instead of hardcoding values, you can reference values from other configuration namespaces:
-
-| Reference pattern | Example                    | Description                        |
-| ----------------- | -------------------------- | ---------------------------------- |
-| Direct value      | `'14px'`                   | Use a literal CSS value            |
-| `tokens.*`        | `'tokens.foregroundColor'` | Reference another token value      |
-| `sizing.*`        | `'sizing.size_4'`          | Reference a sizing scale value     |
-| `colors.*`        | `'colors.primary.500'`     | Reference a color from the palette |
-| `density.*`       | `'density.gap'`            | Reference a density-specific value |
-
-#### Sizing references
-
-The sizing scale provides consistent spacing values:
-
-```js
-myTheme.params({
-  tokens: {
-    iconSize: 'sizing.size_5',             // References e.g. 20px
-    wrapperBorderRadius: 'sizing.size_2',  // References e.g. 8px
-  },
-});
-```
-
-#### Color references
-
-Colors use a hierarchical structure with dot notation for nested values:
-
-```js
-myTheme.params({
-  tokens: {
-    accentColor: 'colors.primary.500',      // References primary color
-    borderColor: 'colors.palette.200',      // References palette color
-    backgroundColor: 'colors.white',        // References base white color
-  },
-});
-```
-
-#### Density references
-
-Density values adjust spacing based on the selected density type:
-
-```js
-myTheme.params({
-  tokens: {
-    cellHorizontalPadding: 'density.cellHorizontal',
-    buttonVerticalPadding: 'density.buttonVertical',
-    gapSize: 'density.gap',
-  },
-});
-```
-
-#### Token cross-references
-
-Tokens can reference other tokens for consistent styling:
-
-```js
-myTheme.params({
-  tokens: {
-    barForegroundColor: 'tokens.foregroundColor',
-    cellEditorBackgroundColor: 'tokens.backgroundColor',
-  },
-});
-```
-
-### Light and dark mode values
-
-For tokens that should have different values in light and dark modes, use an array with two values where the first value is for light mode and the second is for dark mode:
-
-```js
-myTheme.params({
-  tokens: {
-    // [lightModeValue, darkModeValue]
-    borderColor: ['colors.palette.100', 'colors.palette.700'],
-    foregroundColor: ['colors.palette.800', 'colors.palette.200'],
-    backgroundColor: ['colors.white', 'colors.palette.950'],
-  },
-});
-```
-
-## Available CSS files
-
-Handsontable provides CSS files needed to style your data grid. Here's an overview of what's available:
-
-### Base CSS file
-
-- **`handsontable.css`** / **`handsontable.min.css`** - The base stylesheet containing all structural styles, layout rules, and core functionality. This file is auto-injected by default. You can inject it manually instead, but you must set [`injectCoreCss`](@/api/options.md#injectcorecss) to `false` first. It includes border styles, cell rendering rules, and other fundamental grid components.
-
-### Theme files
-
-All themes are available in two variants:
-
-- **`ht-theme-{name}.css`** / **`ht-theme-{name}.min.css`** - Complete theme with icons included (where `{name}` is `main`, `horizon`, or `classic`).
-- **`ht-theme-{name}-no-icons.css`** / **`ht-theme-{name}-no-icons.min.css`** - Theme without icon styles.
-
-### Icon files
-
-If you're using a theme without icons (`*-no-icons.css`), you can optionally load separate icon files:
-
-- **`ht-icons-{name}.css`** / **`ht-icons-{name}.min.css`** - Icon styles for the theme (where `{name}` is `main` or `horizon`).
-
-### Recommended usage
-
-For production, use the minified versions (`.min.css`) to reduce file size and improve load times. For development, you may prefer the unminified versions (`.css`) for easier debugging.
 
 ## Use a theme
 
@@ -513,6 +395,128 @@ This hierarchy ensures that you can define a consistent default theme for your e
 
 :::
 
+## Theme reference
+
+### Theme API parameters
+
+When registering a theme with `registerTheme()` or updating it using the `params()` method, you can configure the following keys:
+
+| Key           | Description                                                                                    |
+| ------------- | ---------------------------------------------------------------------------------------------- |
+| `name`        | Theme name string (can only be set during `registerTheme()`, cannot be updated via `params()`) |
+| `sizing`      | Size scale values (`size_0` through `size_10`)                                                 |
+| `density`     | Density type (`'default'`, `'compact'`, `'comfortable'`) or density configuration object       |
+| `icons`       | SVG icon definitions                                                                           |
+| `colors`      | Color palette with nested color values                                                         |
+| `tokens`      | Design tokens for visual properties                                                            |
+| `colorScheme` | Color scheme (`'light'`, `'dark'`, or `'auto'`)                                                |
+
+#### Token value references
+
+Token values support a powerful reference system using dot notation. Instead of hardcoding values, you can reference values from other configuration namespaces:
+
+| Reference pattern | Example                    | Description                        |
+| ----------------- | -------------------------- | ---------------------------------- |
+| Direct value      | `'14px'`                   | Use a literal CSS value            |
+| `tokens.*`        | `'tokens.foregroundColor'` | Reference another token value      |
+| `sizing.*`        | `'sizing.size_4'`          | Reference a sizing scale value     |
+| `colors.*`        | `'colors.primary.500'`     | Reference a color from the palette |
+| `density.*`       | `'density.gap'`            | Reference a density-specific value |
+
+##### Sizing references
+
+The sizing scale provides consistent spacing values:
+
+```js
+myTheme.params({
+  tokens: {
+    iconSize: 'sizing.size_5',             // References e.g. 20px
+    wrapperBorderRadius: 'sizing.size_2',  // References e.g. 8px
+  },
+});
+```
+
+##### Color references
+
+Colors use a hierarchical structure with dot notation for nested values:
+
+```js
+myTheme.params({
+  tokens: {
+    accentColor: 'colors.primary.500',      // References primary color
+    borderColor: 'colors.palette.200',      // References palette color
+    backgroundColor: 'colors.white',        // References base white color
+  },
+});
+```
+
+##### Density references
+
+Density values adjust spacing based on the selected density type:
+
+```js
+myTheme.params({
+  tokens: {
+    cellHorizontalPadding: 'density.cellHorizontal',
+    buttonVerticalPadding: 'density.buttonVertical',
+    gapSize: 'density.gap',
+  },
+});
+```
+
+##### Token cross-references
+
+Tokens can reference other tokens for consistent styling:
+
+```js
+myTheme.params({
+  tokens: {
+    barForegroundColor: 'tokens.foregroundColor',
+    cellEditorBackgroundColor: 'tokens.backgroundColor',
+  },
+});
+```
+
+#### Light and dark mode values
+
+For tokens that should have different values in light and dark modes, use an array with two values where the first value is for light mode and the second is for dark mode:
+
+```js
+myTheme.params({
+  tokens: {
+    // [lightModeValue, darkModeValue]
+    borderColor: ['colors.palette.100', 'colors.palette.700'],
+    foregroundColor: ['colors.palette.800', 'colors.palette.200'],
+    backgroundColor: ['colors.white', 'colors.palette.950'],
+  },
+});
+```
+
+### CSS files
+
+Handsontable provides CSS files needed to style your data grid. Here's an overview of what's available:
+
+#### Base CSS file
+
+- **`handsontable.css`** / **`handsontable.min.css`** - The base stylesheet containing all structural styles, layout rules, and core functionality. This file is auto-injected by default. You can inject it manually instead, but you must set [`injectCoreCss`](@/api/options.md#injectcorecss) to `false` first. It includes border styles, cell rendering rules, and other fundamental grid components.
+
+#### Theme files
+
+All themes are available in two variants:
+
+- **`ht-theme-{name}.css`** / **`ht-theme-{name}.min.css`** - Complete theme with icons included (where `{name}` is `main`, `horizon`, or `classic`).
+- **`ht-theme-{name}-no-icons.css`** / **`ht-theme-{name}-no-icons.min.css`** - Theme without icon styles.
+
+#### Icon files
+
+If you're using a theme without icons (`*-no-icons.css`), you can optionally load separate icon files:
+
+- **`ht-icons-{name}.css`** / **`ht-icons-{name}.min.css`** - Icon styles for the theme (where `{name}` is `main` or `horizon`).
+
+#### Recommended usage
+
+For production, use the minified versions (`.min.css`) to reduce file size and improve load times. For development, you may prefer the unminified versions (`.css`) for easier debugging.
+
 ## The legacy theme
 
 The legacy CSS file ([`handsontable.full.min.css`](https://github.com/handsontable/handsontable/blob/master/handsontable/dist/handsontable.full.min.css)) was the default styles up until `version 15` (released in December 2024). These styles are legacy and are removed in version 17.0.0.
@@ -545,3 +549,7 @@ Didn't find what you need? Try this:
 - [Contact our technical support](https://handsontable.com/contact?category=technical_support) to get help
 
 </div>
+
+## Result
+
+Your grid now renders with the theme you configured. You can switch color schemes and density modes at runtime using the Theme API.

--- a/docs/content/guides/technical-specification/software-license/software-license.md
+++ b/docs/content/guides/technical-specification/software-license/software-license.md
@@ -1,4 +1,5 @@
 ---
+type: reference
 id: jgk5hkn4
 title: Software license
 metaTitle: Software license - JavaScript Data Grid | Handsontable
@@ -100,3 +101,7 @@ For many years Handsontable was available as an open-source software, and releas
 - [`licenseKey`](@/api/options.md#licensekey)
 
 </div>
+
+## Next steps
+
+To purchase a commercial license or talk to the sales team, visit the [pricing page](https://handsontable.com/pricing) or contact [sales@handsontable.com](mailto:sales@handsontable.com).

--- a/docs/content/guides/tools-and-building/custom-builds/custom-builds.md
+++ b/docs/content/guides/tools-and-building/custom-builds/custom-builds.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: 7a5vawwl
 title: Custom builds
 metaTitle: Custom builds - JavaScript Data Grid | Handsontable
@@ -36,7 +37,7 @@ The Handsontable repository is a monorepo that contains the following projects:
 | `@handsontable/angular-wrapper` | `/wrappers/angular-wrapper`       | [Angular (v16+) wrapper](@/angular/guides/getting-started/introduction/introduction.md)              |
 | `@handsontable/vue3`    | `/wrappers/vue3`          | [Vue wrapper](@/javascript/guides/integrate-with-vue3/vue3-installation/vue3-installation.md)      |
 
-All the projects are released together, under the same version number.
+Handsontable releases all projects together, under the same version number.
 But each project has its own [building](#build-processes) and [testing](@/guides/tools-and-building/testing/testing.md) processes.
 
 ### Build processes
@@ -89,8 +90,8 @@ To run your first build:
 2. Install [npm](https://www.npmjs.com/) (needed for the `examples` and `docs` packages).
 3. Install [pnpm](https://pnpm.io/) (needed for the monorepo dependency management). <br>The version should correspond to the one defined in the `packageManager` field of the root's `package.json`.
 4. Clone the [Handsontable repository](https://github.com/handsontable/handsontable).
-5. From the root directory, run `pnpm install`.<br>All the required dependencies get installed.
-6. From the root directory, run `pnpm run build`.<br>All the Handsontable packages get built.
+5. From the root directory, run `pnpm install`.<br>pnpm installs all required dependencies.
+6. From the root directory, run `pnpm run build`.<br>The script builds all Handsontable packages.
 
 ## Build the packages
 
@@ -309,3 +310,7 @@ From the `/wrappers/vue3` directory, you can also run individual Vue `build` tas
 - [Testing](@/guides/tools-and-building/testing/testing.md)
 
 </div>
+
+## Result
+
+You now have a local build of Handsontable. The output files in `handsontable/dist/` and `handsontable/tmp/` reflect your source changes.

--- a/docs/content/guides/tools-and-building/modules/modules.md
+++ b/docs/content/guides/tools-and-building/modules/modules.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: ffimaicc
 title: Modules
 metaTitle: Modules - JavaScript Data Grid | Handsontable
@@ -1290,3 +1291,7 @@ You can also use modules with Handsontable's framework wrappers:
 - [Handsontable 11.0.0: modularization for React, Angular, and Vue](https://handsontable.com/blog/handsontable-11.0.0-modularization-for-react-angular-and-vue)
 
 </div>
+
+## Result
+
+Your bundle now includes only the modules you imported, reducing its size compared to the full Handsontable package.

--- a/docs/content/guides/tools-and-building/packages/packages.md
+++ b/docs/content/guides/tools-and-building/packages/packages.md
@@ -1,4 +1,5 @@
 ---
+type: reference
 id: xt5zuczu
 title: Packages
 metaTitle: Packages - JavaScript Data Grid | Handsontable
@@ -9,7 +10,7 @@ searchCategory: Guides
 category: Tools and building
 menuTag: updated
 ---
-Instantly add Handsontable to your web app, using pre-built UMD packages of JavaScript and CSS.
+Handsontable is distributed as multiple packages targeting different use cases. This page describes each option and when to use it.
 
 [[toc]]
 
@@ -121,5 +122,14 @@ If you want to build your own custom Handsontable package distribution check out
 
 - [Building](@/guides/tools-and-building/custom-builds/custom-builds.md)
 - [Testing](@/guides/tools-and-building/testing/testing.md)
+
+</div>
+
+## Related
+
+<div class="boxes-list">
+
+- [Modules](@/guides/tools-and-building/modules/modules.md)
+- [Themes](@/guides/styling/themes/themes.md)
 
 </div>

--- a/docs/content/guides/tools-and-building/testing/testing.md
+++ b/docs/content/guides/tools-and-building/testing/testing.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: 6fv7kuj6
 title: Testing
 metaTitle: Testing - JavaScript Data Grid | Handsontable
@@ -22,7 +23,7 @@ searchCategory: Guides
 category: Tools and building
 menuTag: updated
 ---
-Run one or multiple tests, using Handsontable's ready-made commands for Jasmine and Puppeteer.
+Handsontable has three test pipelines: unit tests (Jest), E2E tests (Puppeteer/Jasmine), and Walkontable tests. Run them when contributing to the core library or verifying a fix.
 
 [[toc]]
 
@@ -98,3 +99,7 @@ Learn more on our [GitHub](https://github.com/handsontable/handsontable/blob/dev
 :::
 
 </div>
+
+## Result
+
+Your tests ran and reported pass or fail results. A green test suite confirms your change does not introduce regressions.


### PR DESCRIPTION
## Summary

- Add `type:` Diátaxis classification to all pages in this group
- Separate how-to steps from reference tables in themes
- Reclassify packages as reference, design-system as explanation
- Fix passive voice in custom-builds
- Add missing intro paragraphs, `## Result`, `## Related`, and `## Next steps` sections

## ClickUp tasks

https://app.clickup.com/t/9015210959/DEV-1351
https://app.clickup.com/t/9015210959/DEV-1352
https://app.clickup.com/t/9015210959/DEV-1353
https://app.clickup.com/t/9015210959/DEV-1354
https://app.clickup.com/t/9015210959/DEV-1355
https://app.clickup.com/t/9015210959/DEV-1356
https://app.clickup.com/t/9015210959/DEV-1357
https://app.clickup.com/t/9015210959/DEV-1358

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (metadata and content restructuring) with no impact on product runtime behavior; main risk is broken internal links or unintended docs rendering/layout changes.
> 
> **Overview**
> Applies Diátaxis classification by adding a `type:` frontmatter field across Styling, Tools & Building, and Technical Specification pages, including reclassifying `design-system` as *explanation* and `packages`/`software-license` as *reference*.
> 
> Restructures docs content for skimmability and navigation: moves the Themes parameter/CSS reference into a new **Theme reference** section, adds new **Result**, **Related**, and **Next steps** sections/links on multiple pages, and makes small copy edits (e.g., active voice in `custom-builds`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1d64552867fe5b86e8af1787930c8c865c6d748. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1453