### PR TITLE
docs: apply Diátaxis standards to changelog pages

### DIFF
--- a/docs/content/guides/upgrade-and-migration/changelog-10/changelog-10.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-10/changelog-10.md
@@ -1,4 +1,5 @@
 ---
+type: reference
 id: 6x1ythps
 title: Changelog 10.0
 metaTitle: Changelog 10.0 - JavaScript Data Grid | Handsontable
@@ -14,6 +15,9 @@ angular:
 searchCategory: Guides
 category: Upgrade and migration
 ---
+
+These are the release notes for Handsontable 10.x.
+
 ## 10.0.0
 
 Released on September 29, 2021.
@@ -93,3 +97,7 @@ For more information on this release, see:
   [#8704](https://github.com/handsontable/handsontable/issues/8704)
 - Improved the performance of the regular expression used to detect numeric values, and fixed major
   code smells. [#8752](https://github.com/handsontable/handsontable/issues/8752)
+
+## Related
+
+- [Migrating from 9.0 to 10.0](@/guides/upgrade-and-migration/migrating-from-9.0-to-10.0/migrating-from-9.0-to-10.0.md)

--- a/docs/content/guides/upgrade-and-migration/changelog-11/changelog-11.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-11/changelog-11.md
@@ -1,4 +1,5 @@
 ---
+type: reference
 id: kk7fprli
 title: Changelog 11.0
 metaTitle: Changelog 11.0 - JavaScript Data Grid | Handsontable
@@ -14,6 +15,9 @@ angular:
 searchCategory: Guides
 category: Upgrade and migration
 ---
+
+These are the release notes for Handsontable 11.x.
+
 ## 11.1.0
 
 Released on January 13, 2022
@@ -161,3 +165,7 @@ For more information on this release, see:
 - React: Fixed a React wrapper issue where it's impossible to use different sets of props in editor
   components reused across multiple columns.
   [#8527](https://github.com/handsontable/handsontable/issues/8527)
+
+## Related
+
+- [Migrating from 10.0 to 11.0](@/guides/upgrade-and-migration/migrating-from-10.0-to-11.0/migrating-from-10.0-to-11.0.md)

--- a/docs/content/guides/upgrade-and-migration/changelog-12/changelog-12.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-12/changelog-12.md
@@ -1,4 +1,5 @@
 ---
+type: reference
 id: t93bqrh5
 title: Changelog 12.0
 metaTitle: Changelog 12.0 - JavaScript Data Grid | Handsontable
@@ -14,6 +15,9 @@ angular:
 searchCategory: Guides
 category: Upgrade and migration
 ---
+
+These are the release notes for Handsontable 12.x.
+
 ## 12.4.0
 
 Released on May 23, 2023.
@@ -578,3 +582,7 @@ For more information on this release, see:
 - React, Vue 2, Vue 3: Fixed an issue with registering modules for the React, Vue 2, and Vue 3
   wrappers, by adding an `"exports"` field to their `package.json` files.
   [#9140](https://github.com/handsontable/handsontable/issues/9140)
+
+## Related
+
+- [Migrating from 11.1 to 12.0](@/guides/upgrade-and-migration/migrating-from-11.1-to-12.0/migrating-from-11.1-to-12.0.md)

--- a/docs/content/guides/upgrade-and-migration/changelog-13/changelog-13.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-13/changelog-13.md
@@ -1,4 +1,5 @@
 ---
+type: reference
 id: e195f568
 title: Changelog 13.0
 metaTitle: Changelog 13.0 - JavaScript Data Grid | Handsontable
@@ -14,6 +15,9 @@ angular:
 searchCategory: Guides
 category: Upgrade and migration
 ---
+
+These are the release notes for Handsontable 13.x.
+
 ## 13.1.0
 
 Released on August 31, 2023.
@@ -82,3 +86,7 @@ For more information on this release, see:
 #### Fixed
 
 - Fixed an issue where the "Read only" icon of the context menu displayed incorrectly in the RTL layout direction. [#10375](https://github.com/handsontable/handsontable/pull/10375)
+
+## Related
+
+- [Migrating from 12.4 to 13.0](@/guides/upgrade-and-migration/migrating-from-12.4-to-13.0/migrating-from-12.4-to-13.0.md)

--- a/docs/content/guides/upgrade-and-migration/changelog-14/changelog-14.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-14/changelog-14.md
@@ -1,4 +1,5 @@
 ---
+type: reference
 id: 5wvnjbho
 title: Changelog 14.0
 metaTitle: Changelog 14.0 - JavaScript Data Grid | Handsontable
@@ -14,6 +15,9 @@ angular:
 searchCategory: Guides
 category: Upgrade and migration
 ---
+
+These are the release notes for Handsontable 14.x.
+
 ## 14.6.1
 
 Released on October 17, 2024
@@ -348,3 +352,7 @@ For more information on this release, see:
 - Updated the demos for better accessibility. [#10563](https://github.com/handsontable/handsontable/pull/10563)
 - Fixed a problem with the text editor's width being calculated incorrectly. [#10590](https://github.com/handsontable/handsontable/pull/10590)
 - Fixed a problem with two cells being selected after `Ctrl/Cmd + Shift` key combination. [#10622](https://github.com/handsontable/handsontable/pull/10622)
+
+## Related
+
+- [Migrating from 13.1 to 14.0](@/guides/upgrade-and-migration/migrating-from-13.1-to-14.0/migrating-from-13.1-to-14.0.md)

--- a/docs/content/guides/upgrade-and-migration/changelog-15/changelog-15.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-15/changelog-15.md
@@ -1,4 +1,5 @@
 ---
+type: reference
 id: yhyglrda
 title: Changelog 15.0
 metaTitle: Changelog 15.0 - JavaScript Data Grid | Handsontable
@@ -14,6 +15,9 @@ angular:
 searchCategory: Guides
 category: Upgrade and migration
 ---
+
+These are the release notes for Handsontable 15.x.
+
 ## 15.3.0
 
 Released on April 29, 2025
@@ -232,3 +236,7 @@ For more information about this release see:
 - Fixed the missing `source` argument for the `setDataAtCell` method. [#11287](https://github.com/handsontable/handsontable/pull/11287)
 - Fixed the top overlay misalignment issue, visible after vertical scrollbar disappeared. [#11289](https://github.com/handsontable/handsontable/pull/11289)
 - React: Made the build scripts of `@handsontable/react-wrapper` place the TS type definitions in the configured directory. [#11296](https://github.com/handsontable/handsontable/pull/11296)
+
+## Related
+
+- [Migrating from 14.6 to 15.0](@/guides/upgrade-and-migration/migrating-from-14.6-to-15.0/migrating-from-14.6-to-15.0.md)

--- a/docs/content/guides/upgrade-and-migration/changelog-16/changelog-16.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-16/changelog-16.md
@@ -1,4 +1,5 @@
 ---
+type: reference
 id: znsspzmg
 title: Changelog 16.0
 metaTitle: Changelog 16.0 - JavaScript Data Grid | Handsontable
@@ -14,6 +15,9 @@ angular:
 searchCategory: Guides
 category: Upgrade and migration
 ---
+
+These are the release notes for Handsontable 16.x.
+
 ## 16.2.0
 
 Released on November 25th, 2025
@@ -184,3 +188,7 @@ For more information about this release see:
 - Fixed the column filter behavior when adding new columns. [#11616](https://github.com/handsontable/handsontable/pull/11616)
 - Fixed an issue with the dropdown elements' colors. [#11661](https://github.com/handsontable/handsontable/pull/11661)
 - Angular: Fixed an error of `this.hotInstance.getSettings(...).columns?.filter is not a function` in `angular-wrapper`. [#11695](https://github.com/handsontable/handsontable/pull/11695)
+
+## Related
+
+- [Migrating from 15.3 to 16.0](@/guides/upgrade-and-migration/migrating-from-15.3-to-16.0/migrating-from-15.3-to-16.0.md)

--- a/docs/content/guides/upgrade-and-migration/changelog-17/changelog-17.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-17/changelog-17.md
@@ -1,4 +1,5 @@
 ---
+type: reference
 id: l59xqo44
 title: Changelog 17.0
 metaTitle: Changelog 17.0 - JavaScript Data Grid | Handsontable
@@ -14,6 +15,9 @@ angular:
 searchCategory: Guides
 category: Upgrade and migration
 ---
+
+These are the release notes for Handsontable 17.x.
+
 ## 17.0.1
 
 Released on March 25th, 2026
@@ -101,3 +105,7 @@ For more information about this release, see:
 - Fixed incorrect scrollbar width calculation for scaled environments. [#12035](https://github.com/handsontable/handsontable/pull/12035)
 - Fixed and issue with column headers styles [#12058](https://github.com/handsontable/handsontable/pull/12058)
 - Angular: Fixed a problem with the Angular wrapper that broke builds done with a disabled `skipLibCheck`. [#12091](https://github.com/handsontable/handsontable/pull/12091)
+
+## Related
+
+- [Migrating from 16.2 to 17.0](@/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md)

--- a/docs/content/guides/upgrade-and-migration/changelog-7/changelog-7.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-7/changelog-7.md
@@ -1,4 +1,5 @@
 ---
+type: reference
 id: 5t9ao5jq
 title: Older versions
 metaTitle: Older versions - JavaScript Data Grid | Handsontable
@@ -14,6 +15,9 @@ angular:
 searchCategory: Guides
 category: Upgrade and migration
 ---
+
+These are the release notes for Handsontable 7.x.
+
 ## 7.4.2
 
 Released on February 19, 2020.
@@ -85,3 +89,7 @@ For more information on this release, see:
 
 The changelogs from older versions of Handsontable are
 [available on GitHub](https://github.com/handsontable/handsontable/releases).
+
+## Related
+
+- [Migrating from 7.4 to 8.0](@/guides/upgrade-and-migration/migrating-from-7.4-to-8.0/migrating-from-7.4-to-8.0.md)

--- a/docs/content/guides/upgrade-and-migration/changelog-8/changelog-8.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-8/changelog-8.md
@@ -1,4 +1,5 @@
 ---
+type: reference
 id: umu0w734
 title: Changelog 8.0
 metaTitle: Changelog 8.0 - JavaScript Data Grid | Handsontable
@@ -14,6 +15,9 @@ angular:
 searchCategory: Guides
 category: Upgrade and migration
 ---
+
+These are the release notes for Handsontable 8.x.
+
 ## 8.4.0
 
 Released on May 11, 2021.
@@ -984,3 +988,7 @@ methods and hooks were added and there are few depreciations and removals, too.
 - Adding properties which were not defined on initialization or by `updateSettings` to the source
   data is possible only by the usage of `setSourceDataAtCell`.
   [#6664](https://github.com/handsontable/handsontable/issues/6664).
+
+## Related
+
+- [Migrating from 7.4 to 8.0](@/guides/upgrade-and-migration/migrating-from-7.4-to-8.0/migrating-from-7.4-to-8.0.md)

--- a/docs/content/guides/upgrade-and-migration/changelog-9/changelog-9.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-9/changelog-9.md
@@ -1,4 +1,5 @@
 ---
+type: reference
 id: flrcarvt
 title: Changelog 9.0
 metaTitle: Changelog 9.0 - JavaScript Data Grid | Handsontable
@@ -14,6 +15,9 @@ angular:
 searchCategory: Guides
 category: Upgrade and migration
 ---
+
+These are the release notes for Handsontable 9.x.
+
 ## 9.0.2
 
 Released on July 28, 2021.
@@ -138,3 +142,7 @@ For more information on this release, see:
   ([#5870](https://github.com/handsontable/handsontable/issues/5870))
 - Fixed a bug with using the `clear` method broke the formulas in the table.
   ([#6248](https://github.com/handsontable/handsontable/issues/6248))
+
+## Related
+
+- [Migrating from 8.4 to 9.0](@/guides/upgrade-and-migration/migrating-from-8.4-to-9.0/migrating-from-8.4-to-9.0.md)

--- a/docs/content/guides/upgrade-and-migration/changelog/changelog.md
+++ b/docs/content/guides/upgrade-and-migration/changelog/changelog.md
@@ -1,4 +1,5 @@
 ---
+type: reference
 id: nbp8i3mk
 title: Changelog
 metaTitle: Changelog - JavaScript Data Grid | Handsontable
@@ -21,7 +22,8 @@ angular:
 searchCategory: Guides
 category: Upgrade and migration
 ---
-See the full history of changes made to Handsontable in each major, minor, and patch release.
+
+This page aggregates all Handsontable release notes. For upgrade instructions, see the migration guides in this section.
 
 [[toc]]
 
@@ -2639,3 +2641,16 @@ For more information on this release, see:
 
 The changelogs from older versions of Handsontable are
 [available on GitHub](https://github.com/handsontable/handsontable/releases).
+
+## Related
+
+- [Migrating from 7.4 to 8.0](@/guides/upgrade-and-migration/migrating-from-7.4-to-8.0/migrating-from-7.4-to-8.0.md)
+- [Migrating from 8.4 to 9.0](@/guides/upgrade-and-migration/migrating-from-8.4-to-9.0/migrating-from-8.4-to-9.0.md)
+- [Migrating from 9.0 to 10.0](@/guides/upgrade-and-migration/migrating-from-9.0-to-10.0/migrating-from-9.0-to-10.0.md)
+- [Migrating from 10.0 to 11.0](@/guides/upgrade-and-migration/migrating-from-10.0-to-11.0/migrating-from-10.0-to-11.0.md)
+- [Migrating from 11.1 to 12.0](@/guides/upgrade-and-migration/migrating-from-11.1-to-12.0/migrating-from-11.1-to-12.0.md)
+- [Migrating from 12.4 to 13.0](@/guides/upgrade-and-migration/migrating-from-12.4-to-13.0/migrating-from-12.4-to-13.0.md)
+- [Migrating from 13.1 to 14.0](@/guides/upgrade-and-migration/migrating-from-13.1-to-14.0/migrating-from-13.1-to-14.0.md)
+- [Migrating from 14.6 to 15.0](@/guides/upgrade-and-migration/migrating-from-14.6-to-15.0/migrating-from-14.6-to-15.0.md)
+- [Migrating from 15.3 to 16.0](@/guides/upgrade-and-migration/migrating-from-15.3-to-16.0/migrating-from-15.3-to-16.0.md)
+- [Migrating from 16.2 to 17.0](@/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md)


### PR DESCRIPTION
## Summary

- Add `type: reference` Diátaxis classification to all changelog pages
- Add intro paragraphs identifying the version series
- Add `## Related` sections linking each changelog to its migration guide

## ClickUp tasks

https://app.clickup.com/t/9015210959/DEV-1371
https://app.clickup.com/t/9015210959/DEV-1372
https://app.clickup.com/t/9015210959/DEV-1373
https://app.clickup.com/t/9015210959/DEV-1374
https://app.clickup.com/t/9015210959/DEV-1375
https://app.clickup.com/t/9015210959/DEV-1376
https://app.clickup.com/t/9015210959/DEV-1377
https://app.clickup.com/t/9015210959/DEV-1378
https://app.clickup.com/t/9015210959/DEV-1379
https://app.clickup.com/t/9015210959/DEV-1380
https://app.clickup.com/t/9015210959/DEV-1381
https://app.clickup.com/t/9015210959/DEV-1382

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (frontmatter and internal links) with no runtime or API impact; main risk is broken/incorrect doc links or categorization affecting site navigation/search.
> 
> **Overview**
> Applies Diátaxis metadata to changelog documentation by adding `type: reference` frontmatter across the main `changelog.md` and versioned changelog pages.
> 
> Adds a short introductory sentence to each versioned changelog (7.x through 17.x) clarifying the release-note series, and appends a new **`## Related`** section that links directly to the corresponding migration guide. The aggregate `changelog.md` page also updates its intro copy and adds a consolidated **Related** list of migration-guide links at the end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96e9ba5f1988293e3138b3ddaa9cde2ce128e170. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1455