### PR TITLE
docs: apply Diátaxis standards to Rows pages

### DIFF
--- a/docs/content/guides/rows/row-moving/row-moving.md
+++ b/docs/content/guides/rows/row-moving/row-moving.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: d2in9k81
 title: Row moving
 metaTitle: Row moving - JavaScript Data Grid | Handsontable
@@ -74,7 +75,9 @@ This renders the rows in the following order:
 
 The array must contain all physical row indexes (its length must equal the total number of rows). After the initial render, users can still drag rows to change the order further.
 
-## Drag and move actions of `manualRowMove` plugin
+## API reference
+
+### dragRows vs moveRows
 
 There are significant differences between the plugin's [`dragRows`](@/api/manualRowMove.md#dragrows) and [`moveRows`](@/api/manualRowMove.md#moverows) API functions. Both of them change the order of rows, but they rely on different kinds of indexes. The differences between them are shown in the diagrams below.
 
@@ -99,7 +102,7 @@ The [`moveRows`](@/api/manualRowMove.md#moverows) method has a `finalIndex` para
 
 The [`moveRows`](@/api/manualRowMove.md#moverows) function cannot perform some actions, e.g., more than one element can't be moved to the last position. In this scenario, the move will be cancelled. The Plugin's [`isMovePossible`](@/api/manualRowMove.md#ismovepossible) API method and the `movePossible` parameters `beforeRowMove` and `afterRowMove` hooks help in determine such situations.
 
-## Related API reference
+### Related API reference
 
 **Configuration options**
 
@@ -133,3 +136,7 @@ The [`moveRows`](@/api/manualRowMove.md#moverows) function cannot perform some a
 - [ManualRowMove](@/api/manualRowMove.md)
 
 </div>
+
+## Result
+
+After completing this guide, you can reorder rows by dragging them with the mouse or by calling `dragRows()` and `moveRows()` programmatically. You can also set a pre-defined row order at initialization.

--- a/docs/content/guides/rows/row-parent-child/row-parent-child.md
+++ b/docs/content/guides/rows/row-parent-child/row-parent-child.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: ivtc0o9b
 title: Row parent-child
 metaTitle: Row parent-child - JavaScript Data Grid | Handsontable
@@ -138,7 +139,13 @@ The context menu has been extended with a few Nested Rows related options, such 
 
 The “Insert row above” and “Insert row below” options were modified to work properly with the nested data structure.
 
-## Known limitations
+## Result
+
+After completing this guide, your grid displays rows in a parent-child hierarchy with collapse and expand toggle buttons in row headers and context menu options for inserting and detaching child rows.
+
+## Notes
+
+### Known limitations
 
 When you use the parent-child row structure, the following Handsontable features are not supported:
 
@@ -146,7 +153,7 @@ When you use the parent-child row structure, the following Handsontable features
 - [Column filter](@/guides/columns/column-filter/column-filter.md)
 - [Rows sorting](@/guides/rows/rows-sorting/rows-sorting.md)
 
-## Related keyboard shortcuts
+### Keyboard shortcuts
 
 | Windows              | macOS                | Action                           |  Excel  | Sheets  |
 | -------------------- | -------------------- | -------------------------------- | :-----: | :-----: |

--- a/docs/content/guides/rows/row-prepopulating/row-prepopulating.md
+++ b/docs/content/guides/rows/row-prepopulating/row-prepopulating.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: 42px61id
 title: Row pre-populating
 metaTitle: Row pre-populating - JavaScript Data Grid | Handsontable
@@ -19,7 +20,7 @@ angular:
 searchCategory: Guides
 category: Rows
 ---
-Populate newly-added rows with predefined template values, using cell renderers.
+Pre-populate new rows with default values when users add rows to the grid. Use the `afterCreateRow` hook to set initial cell values.
 
 [[toc]]
 
@@ -60,12 +61,60 @@ The example below shows how cell renderers can be used to populate the template 
 
 :::
 
+## Pre-populate from an adjacent row
+
+You can copy values from the row above when the user inserts a new row. Use the [`afterCreateRow`](@/api/hooks.md#aftercreaterow) hook to read the source row's data and write it to the newly created row.
+
+```js
+const hot = new Handsontable(container, {
+  data: [
+    ['Product A', 10, 'active'],
+    ['Product B', 20, 'inactive'],
+  ],
+  colHeaders: ['Name', 'Quantity', 'Status'],
+  afterCreateRow(index) {
+    if (index > 0) {
+      const sourceRow = hot.getSourceDataAtRow(index - 1);
+
+      sourceRow.forEach((value, col) => {
+        hot.setDataAtCell(index, col, value);
+      });
+    }
+  },
+  licenseKey: 'non-commercial-and-evaluation',
+});
+```
+
+## Pre-populate from a server-fetched default
+
+You can fetch default row values from a server and apply them when the user adds a new row. Use the [`afterCreateRow`](@/api/hooks.md#aftercreaterow) hook to trigger the request and populate the row once the response arrives.
+
+```js
+const hot = new Handsontable(container, {
+  data: [],
+  colHeaders: ['Name', 'Quantity', 'Status'],
+  afterCreateRow(index) {
+    fetch('/api/row-defaults')
+      .then((response) => response.json())
+      .then((defaults) => {
+        hot.setDataAtRow(index, [defaults.name, defaults.quantity, defaults.status]);
+      });
+  },
+  licenseKey: 'non-commercial-and-evaluation',
+});
+```
+
+## Result
+
+After completing this guide, your grid fills new rows with template values automatically. You can pre-populate rows from static defaults, adjacent row values, or server-fetched data.
+
 ## Related API reference
 
 **Hooks**
 
 <div class="boxes-list">
 
+- [afterCreateRow](@/api/hooks.md#aftercreaterow)
 - [beforeChange](@/api/hooks.md#beforechange)
 
 </div>

--- a/docs/content/guides/rows/row-trimming/row-trimming.md
+++ b/docs/content/guides/rows/row-trimming/row-trimming.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: 4q2wi29j
 title: Row trimming
 metaTitle: Row trimming - JavaScript Data Grid | Handsontable
@@ -130,7 +131,13 @@ Note that the second, third, and sixth rows are missing in the following example
 
 :::
 
-## API examples
+## Result
+
+After completing this guide, rows you specify are excluded from rendering and from `DataMap`. You can trim rows at initialization or dynamically at runtime using the plugin API.
+
+## Related API
+
+### Plugin methods
 
 ::: only-for react
 
@@ -195,7 +202,7 @@ plugin.untrimRows([0, 4, 6]);
 
 To see the changes made, call `hot.render();` to re-render the table.
 
-## Related API reference
+### API reference
 
 **Options**
 

--- a/docs/content/guides/rows/row-virtualization/row-virtualization.md
+++ b/docs/content/guides/rows/row-virtualization/row-virtualization.md
@@ -1,4 +1,5 @@
 ---
+type: explanation
 id: vasj6t6t
 title: Row virtualization
 metaTitle: Row virtualization - JavaScript Data Grid | Handsontable
@@ -101,5 +102,14 @@ Using row virtualization has the following side effects:
 
 - [renderAllRows](@/api/options.md#renderallrows)
 - [viewportRowRenderingOffset](@/api/options.md#viewportrowrenderingoffset)
+
+</div>
+
+## Related
+
+<div class="boxes-list">
+
+- [Performance](@/guides/optimization/performance/performance.md) -- tips for optimizing grid rendering speed with large data sets
+- [Row height](@/guides/rows/row-height/row-height.md) -- configure fixed or dynamic row heights, which affects viewport calculations during virtualization
 
 </div>

--- a/docs/content/guides/rows/rows-pagination/rows-pagination.md
+++ b/docs/content/guides/rows/rows-pagination/rows-pagination.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: 85u4f81b
 title: Rows pagination
 metaTitle: Rows pagination - JavaScript Data Grid | Handsontable
@@ -28,19 +29,9 @@ searchCategory: Guides
 category: Rows
 menuTag: updated
 ---
-The pagination component splits the data into a range of pages, allowing users to easily navigate through large data sets.
+Split large data sets into pages to improve usability and rendering performance. Pagination operates fully on the client side and automatically recomputes the total page count whenever rows are added, removed, filtered, or otherwise modified.
 
 [[toc]]
-
-## Overview
-
-With pagination, large data sets are divided into smaller pages, significantly improving usability and rendering performance. Users can navigate pages using built-in UI controls such as page navigation buttons, a page size selector, and a page counter, or you can manage pages programmatically via Handsontable's API.
-
-Pagination operates fully on the client side, requiring all data to be loaded into Handsontable.
-
-Whenever rows are added, removed, hidden, unhidden, filtered, or otherwise modified, pagination automatically recomputes total pages and adjusts the currently visible slice of data.
-
-By default, the plugin does not override core data access methods (e.g., `getData`, `getData*`, `getSourceData`, `getSourceData*`, `countRows`). Instead, a developer must explicitly call the pagination [`getCurrentPageData`](@/api/pagination.md#getcurrentpagedata) method or [`getPaginationData`](@/api/pagination.md#getpaginationdata) method conjunction with core methods (e.g., `getData`) to interact with paged data.
 
 ## Pagination demo
 
@@ -435,6 +426,10 @@ When pagination is enabled:
 - [MergeCells](@/api/mergeCells.md)
 
 </div>
+
+## Result
+
+After completing this guide, your grid divides rows into pages with built-in navigation controls. You can configure the page size, customize the UI position, control pagination programmatically, and react to page changes using hooks.
 
 ## Troubleshooting
 

--- a/docs/content/guides/rows/rows-sorting/rows-sorting.md
+++ b/docs/content/guides/rows/rows-sorting/rows-sorting.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: 6o0zftmc
 title: Rows sorting
 metaTitle: Rows sorting - JavaScript Data Grid | Handsontable
@@ -33,9 +34,6 @@ angular:
 searchCategory: Guides
 category: Rows
 ---
-
-# Rows sorting
-
 Sort rows alphabetically or numerically, in ascending, descending, or a custom order, by one or multiple columns.
 
 [[toc]]
@@ -44,8 +42,8 @@ Sort rows alphabetically or numerically, in ascending, descending, or a custom o
 
 Handsontable provides two plugins for sorting rows:
 
-- [`ColumnSorting`](@/api/columnSorting.md) — sorts rows by a **single column** at a time. Clicking a column header cycles through ascending, descending, and unsorted states.
-- [`MultiColumnSorting`](@/api/multiColumnSorting.md) — sorts rows by **multiple columns** simultaneously. Hold Ctrl/Cmd and click column headers to add more sort criteria.
+- [`ColumnSorting`](@/api/columnSorting.md) -- sorts rows by a **single column** at a time. Clicking a column header cycles through ascending, descending, and unsorted states.
+- [`MultiColumnSorting`](@/api/multiColumnSorting.md) -- sorts rows by **multiple columns** simultaneously. Hold Ctrl/Cmd and click column headers to add more sort criteria.
 
 Both plugins sort the view only. The source data array is never modified. To persist the sorted order back to the data source, see [Saving data](@/guides/getting-started/saving-data/saving-data.md).
 
@@ -171,15 +169,7 @@ To disable sorting for specific columns, set [`headerAction`](@/api/options.md#c
 
 ## Configure sorting
 
-Set `columnSorting` to an object to configure the plugin. The available options are:
-
-| Option | Type | Default | Description |
-| --- | --- | --- | --- |
-| `headerAction` | `boolean` | `true` | When `true`, clicking a column header sorts by that column. |
-| `sortEmptyCells` | `boolean` | `false` | When `true`, empty cells participate in sorting. When `false`, empty cells are always placed at the end. |
-| `indicator` | `boolean` | `true` | When `true`, a sort-order arrow icon is shown in the column header. |
-| `compareFunctionFactory` | `function` | — | A factory that returns a custom comparator function. See [Add a custom comparator](#add-a-custom-comparator). |
-| `initialConfig` | `object` | — | Sort config applied at initialization. Contains `column` (visual index) and `sortOrder` (`'asc'` or `'desc'`). |
+Set `columnSorting` to an object to configure the plugin. See the [Reference](#reference) section below for all available options.
 
 ::: only-for javascript
 
@@ -1235,6 +1225,32 @@ registerPlugin(ColumnSorting);
 | --- | --- | --- | :---: | :---: |
 | <kbd>**Enter**</kbd> | <kbd>**Enter**</kbd> | Sort by the focused column, cycling through ascending, descending, and original order | &cross; | &cross; |
 | <kbd>**Shift**</kbd>+<kbd>**Enter**</kbd> | <kbd>⇧</kbd>+<kbd>**Enter**</kbd> | Append the focused column to the active sort criteria. Requires the [`MultiColumnSorting`](@/api/multiColumnSorting.md) plugin. | &cross; | &cross; |
+
+## Reference
+
+### Plugin comparison
+
+| Feature | `ColumnSorting` | `MultiColumnSorting` |
+| --- | --- | --- |
+| Sort by single column | Yes | Yes |
+| Sort by multiple columns | No | Yes |
+| Ctrl/Cmd + click to add columns | No | Yes |
+| `initialConfig` type | Object | Array of objects |
+| Mutual exclusivity | Disabled when `MultiColumnSorting` is enabled | Disables `ColumnSorting` |
+
+### Configuration options
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `headerAction` | `boolean` | `true` | When `true`, clicking a column header sorts by that column. |
+| `sortEmptyCells` | `boolean` | `false` | When `true`, empty cells participate in sorting. When `false`, empty cells are always placed at the end. |
+| `indicator` | `boolean` | `true` | When `true`, a sort-order arrow icon is shown in the column header. |
+| `compareFunctionFactory` | `function` | -- | A factory that returns a custom comparator function. See [Add a custom comparator](#add-a-custom-comparator). |
+| `initialConfig` | `object` | -- | Sort config applied at initialization. Contains `column` (visual index) and `sortOrder` (`'asc'` or `'desc'`). |
+
+## Result
+
+After completing this guide, users can sort rows by clicking column headers, and you can control sort order programmatically. You can use `ColumnSorting` for single-column sorting or `MultiColumnSorting` for multi-column sorting with custom priority.
 
 ## API reference
 


### PR DESCRIPTION
## Summary

- Add `type:` Diátaxis classification to all Rows pages
- Separate how-to steps from reference tables in row-moving, row-trimming, rows-sorting
- Expand thin row-prepopulating page with additional examples
- Add missing `## Result` and `## Related` sections

## ClickUp tasks

https://app.clickup.com/t/9015210959/DEV-1335
https://app.clickup.com/t/9015210959/DEV-1336
https://app.clickup.com/t/9015210959/DEV-1337
https://app.clickup.com/t/9015210959/DEV-1338
https://app.clickup.com/t/9015210959/DEV-1339
https://app.clickup.com/t/9015210959/DEV-1340
https://app.clickup.com/t/9015210959/DEV-1341

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime code impact; main risk is broken links/formatting regressions in the docs build.
> 
> **Overview**
> Applies Diátaxis metadata and structure across Rows documentation by adding `type:` frontmatter (mostly `how-to`, with `row-virtualization` as `explanation`) and standardizing section flow.
> 
> Reorganizes several guides to better separate procedural content from reference material (for example, promoting API details into explicit *Reference/API reference* sections) and adds missing wrap-up sections like `## Result` and additional `## Related` links.
> 
> Expands `row-prepopulating` with new `afterCreateRow` examples (copy-from-adjacent-row and server-fetched defaults) and updates brief page intros (notably `rows-pagination`) to be more task/outcome oriented.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ffe61eb7563eccb56e2ee226893b3ae6c7c4ca2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1451