### PR TITLE
docs: apply Diátaxis standards to migration guides and deprecation policy

### DIFF
--- a/docs/content/guides/upgrade-and-migration/deprecation-policy/deprecation-policy.md
+++ b/docs/content/guides/upgrade-and-migration/deprecation-policy/deprecation-policy.md
@@ -1,4 +1,5 @@
 ---
+type: explanation
 id: 4f25a767
 title: Deprecation policy
 metaTitle: Deprecation policy - JavaScript Data Grid | Handsontable
@@ -14,6 +15,8 @@ angular:
 searchCategory: Guides
 category: Upgrade and migration
 ---
+This page explains how Handsontable handles deprecated APIs -- including the grace period before removal and how you will be notified.
+
 Deprecation occurs when better alternatives emerge that offer improved performance, security, or usability compared to existing implementations. It also helps maintain API consistency by removing redundant or inconsistent functions, creating a cleaner overall design. As web standards and the JavaScript ecosystem evolve, certain approaches become obsolete or suboptimal, requiring updates to stay current. Additionally, deprecation reduces maintenance complexity by phasing out rarely-used or problematic features, while addressing potential security vulnerabilities in older implementations. Rather than introducing breaking changes, deprecation provides a gradual migration path that gives developers time to adapt while clearly signaling the library's future direction.
 
 After a Handsontable feature, a framework wrapper or any other part of the API is marked deprecated, we commit to a **grace period** **(at least 3 months)** during which the deprecated feature still works. We will not remove the feature immediately in the next minor or patch release. Instead, removal is deferred until a future **major release**, in accordance with semantic versioning.
@@ -56,3 +59,8 @@ Below is a list of current deprecations that are planned to be removed in the ne
 | **Built-in HyperFormula** | The Formulas plugin engine. Will be removed from package.json in 18.0. Import HyperFormula yourself and pass it to the Formulas plugin with `licenseKey: 'internal-use-in-handsontable'`. | [Formula calculation](@/guides/formulas/formula-calculation/formula-calculation.md) |
 
 
+
+## Related
+
+- [Versioning policy](@/guides/upgrade-and-migration/versioning-policy/versioning-policy.md)
+- [Long-term support](@/guides/upgrade-and-migration/long-term-support/long-term-support.md)

--- a/docs/content/guides/upgrade-and-migration/migrating-from-10.0-to-11.0/migrating-from-10.0-to-11.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-10.0-to-11.0/migrating-from-10.0-to-11.0.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: m946ghwr
 title: Migrating from 10.0 to 11.0
 metaTitle: Migrate from 10.0 to 11.0 - JavaScript Data Grid | Handsontable
@@ -79,7 +80,7 @@ To see how to benefit from using individual Handsontable modules, see the [Modul
 
 ## Step 2: Adapt to the type definition changes
 
-In Handsontable 11.0.0, we reorganized the TypeScript definitions files, and improved the overall consistency of Handsontable's types.
+In Handsontable 11.0.0, Handsontable reorganizes the TypeScript definitions files and improves the overall consistency of the types.
 
 For more details, see [this pull request](https://github.com/handsontable/handsontable/pull/8875).
 
@@ -87,7 +88,7 @@ For more details, see [this pull request](https://github.com/handsontable/handso
 
 #### Before
 
-Before, all of Handsontable's TypeScript definitions were kept in one file, placed in the root directory: `/handsontable.d.ts`.
+Before, all TypeScript definitions were kept in one file in the root directory: `/handsontable.d.ts`.
 
 The only way to import types was to get all of them by importing the `Handsontable` package:
 
@@ -108,7 +109,7 @@ import { registerPlugin, HiddenRows } from 'handsontable/plugins';
 
 ### Editors' interfaces
 
-When improving the consistency of Handsontable's types, we needed to change the editors' interfaces.
+Handsontable 11.0.0 changes the editors' interfaces to improve type consistency.
 
 #### Before
 
@@ -131,8 +132,8 @@ For more details, see [this pull request](https://github.com/handsontable/handso
 #### Before
 
 - [`populateFromArray()`](@/api/core.md#populatefromarray) performed a separate [`spliceRow`](@/api/options.md#splicerow) action for each populated row, and a separate `spliceColumn` action for each populated column.
-- The [`beforeChange`](@/api/hooks.md#beforechange) and [`afterChange`](@/api/hooks.md#afterchange) hooks were triggered multiple times, separately for each populated row and column.
-- The [`beforeChange`](@/api/hooks.md#beforechange) and [`afterChange`](@/api/hooks.md#afterchange) hooks were triggered by each [`spliceRow`](@/api/options.md#splicerow) and `spliceColumn` action, with the `source` argument defined as [`spliceRow`](@/api/options.md#splicerow) or [`spliceCol`](@/api/core.md#splicecol).
+- The [`beforeChange`](@/api/hooks.md#beforechange) and [`afterChange`](@/api/hooks.md#afterchange) hooks trigger multiple times, separately for each populated row and column.
+- The [`beforeChange`](@/api/hooks.md#beforechange) and [`afterChange`](@/api/hooks.md#afterchange) hooks trigger for each [`spliceRow`](@/api/options.md#splicerow) and `spliceColumn` action, with the `source` argument defined as [`spliceRow`](@/api/options.md#splicerow) or [`spliceCol`](@/api/core.md#splicecol).
 
 ::: only-for javascript
 
@@ -195,3 +196,7 @@ new Handsontable(element, {
 ```
 
 :::
+
+## Result
+
+Your application now runs on Handsontable 11.0.

--- a/docs/content/guides/upgrade-and-migration/migrating-from-11.1-to-12.0/migrating-from-11.1-to-12.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-11.1-to-12.0/migrating-from-11.1-to-12.0.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: tpa768pc
 title: Migrating from 11.1 to 12.0
 metaTitle: Migrate from 11.1 to 12.0 - JavaScript Data Grid | Handsontable
@@ -102,7 +103,7 @@ Read more on referencing the Handsontable instance:
 
 Handsontable 12.0.0 changes how the [`updatePlugin()`](@/api/autoColumnSize.md#updateplugin) method reacts to [`updateSettings()`](@/api/core.md#updatesettings) calls.
 
-This change might affect your custom plugins.
+This change may affect your custom plugins.
 
 #### Before
 
@@ -279,7 +280,7 @@ To keep the previous (pre-12.0) behavior of a default keyboard shortcut, use the
 
 Handsontable 12.0.0 makes it clear that Handsontable's rendering engine (`_wt`, internally referred to as "Walkontable") is not a part of Handsontable's public API.
 
-To emphasize this, we changed the following property name:
+To emphasize this, Handsontable 12.0 changes the following property name:
 
 | Before                         | After                           |
 | ------------------------------ | ------------------------------- |
@@ -299,3 +300,7 @@ If your custom editor needs to know the size and position of the edited cell,
 now you can get them without referring to `_wt`. Instead, use the new [`getEditedCellRect()`](@/api/baseEditor.md#geteditedcellrect) method.
 
 :::
+
+## Result
+
+Your application now runs on Handsontable 12.0.

--- a/docs/content/guides/upgrade-and-migration/migrating-from-12.4-to-13.0/migrating-from-12.4-to-13.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-12.4-to-13.0/migrating-from-12.4-to-13.0.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: fgjqkigc
 title: Migrating from 12.4 to 13.0
 metaTitle: Migrate from 12.4 to 13.0 - JavaScript Data Grid | Handsontable
@@ -28,9 +29,9 @@ For a detailed list of changes in this release, see the [Changelog](@/guides/upg
 
 Handsontable 13.0 is not compatible with Angular 11 and lower.
 
-Officially, Handsontable 13.0 supports only Angular 14-16. Handsontable 13.0 was thoroughly tested and, to the best of our knowledge, works correctly with versions down to Angular 12, but this may change with no further notice.
+Officially, Handsontable 13.0 supports only Angular 14-16. Handsontable 13.0 is thoroughly tested and, to the best of our knowledge, works correctly with versions down to Angular 12, but this may change with no further notice.
 
-To use Handsontable 13.0 with Angular, you need to update at least to Angular 12, but we recommend using the latest version of Angular.
+To use Handsontable 13.0 with Angular, you need to update at least to Angular 12, but using the latest version of Angular is recommended.
 
 If you're having any issues with Handsontable's [Angular wrapper](@/angular/guides/getting-started/installation/installation.md), contact our
 [technical support](https://handsontable.com/contact?category=technical_support) for help.
@@ -40,7 +41,7 @@ If you're having any issues with Handsontable's [Angular wrapper](@/angular/guid
 ## Stop using the `beforeAutofillInsidePopulate` hook
 
 Handsontable 13.0 removes the [`beforeAutofillInsidePopulate`](https://handsontable.com/docs/12.4/javascript-data-grid/api/hooks/#beforeautofillinsidepopulate) hook,
-which has been marked as deprecated since Handsontable [9.0.0](@/guides/upgrade-and-migration/changelog/changelog.md#deprecated-3).
+which was deprecated since Handsontable [9.0.0](@/guides/upgrade-and-migration/changelog/changelog.md#deprecated-3).
 
 Make sure you're not using this hook.
 
@@ -53,7 +54,7 @@ don't pass these arguments to [`populateFromArray()`](@/api/core.md#populatefrom
 ## Change from `getFirstNotHiddenIndex()` to `getNearestNotHiddenIndex()`
 
 Handsontable 13.0 removes the [`getFirstNotHiddenIndex()`](https://handsontable.com/docs/12.4/javascript-data-grid/api/index-mapper/#getfirstnothiddenindex) method,
-which has been marked as deprecated since Handsontable [12.1.0](@/guides/upgrade-and-migration/changelog/changelog.md#deprecated-2). Instead , use the new
+which was deprecated since Handsontable [12.1.0](@/guides/upgrade-and-migration/changelog/changelog.md#deprecated-2). Instead , use the new
 [`getNearestNotHiddenIndex()`](@/api/indexMapper.md#getnearestnothiddenindex) method.
 
 For more details, see the API reference:
@@ -75,7 +76,7 @@ handsontableInstance.getNearestNotHiddenIndex(0, 1, true);
 
 ## Replace `'insert_row'` and `'insert_col'` in your `alter()` calls
 
-The [`alter()`](@/api/core.md#alter) method no longer accepts `'insert_row'` and `'insert_col'` arguments, which have been marked as deprecated since
+The [`alter()`](@/api/core.md#alter) method no longer accepts `'insert_row'` and `'insert_col'` arguments, which were deprecated since
 Handsontable [12.2.0](@/guides/upgrade-and-migration/changelog/changelog.md#deprecated).
 
 You can read more about this change on [our blog](https://handsontable.com/blog/handsontable-12.2.0).
@@ -118,7 +119,7 @@ For more details on this change, see this pull request: [#10231](https://github.
 
 #### Before
 
-Up to Handsontable 12.4, the hooks were fired in the following order:
+Up to Handsontable 12.4, the hooks fire in the following order:
 
 1. [`afterSetDataAtCell`](@/api/hooks.md#aftersetdataatcell) or [`afterSetDataAtRowProp`](@/api/hooks.md#aftersetdataatrowprop)
 2. [`beforeChange`](@/api/hooks.md#beforechange)
@@ -129,3 +130,7 @@ Since Handsontable 13.0, the hooks are fired in the following order:
 
 1. [`beforeChange`](@/api/hooks.md#beforechange)
 2. [`afterSetDataAtCell`](@/api/hooks.md#aftersetdataatcell) or [`afterSetDataAtRowProp`](@/api/hooks.md#aftersetdataatrowprop)
+
+## Result
+
+Your application now runs on Handsontable 13.0.

--- a/docs/content/guides/upgrade-and-migration/migrating-from-13.1-to-14.0/migrating-from-13.1-to-14.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-13.1-to-14.0/migrating-from-13.1-to-14.0.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: migrating-13.1-to-14.0
 title: Migrating from 13.1 to 14.0
 metaTitle: Migrating from 13.1 to 14.0 - JavaScript Data Grid | Handsontable
@@ -23,15 +24,15 @@ For a detailed list of changes in this release, see the [Changelog](@/guides/upg
 [[toc]]
 
 ### Changes to IME
-With the release of Handsontable 14.0, we change the way we manage the browser focus. Now the focus will be assigned to the cell/header elements, not an underlying `TEXTAREA` element, as it used to be in versions <=13.1.0. The change was introduced to allow screen readers to recognize the table contents correctly.
+Handsontable 14.0 changes how it manages browser focus. The focus now goes to the cell/header elements, not an underlying `TEXTAREA` element as in versions <=13.1.0. This change allows screen readers to recognize the table contents correctly.
 However, this makes the IME editor not compatible with our "fast edit" functionality (the ability to start editing a cell without opening the editor first).
 
-To maintain the IME functionalities, we introduce the [`imeFastEdit`](@/api/options.md#imefastedit) option that swaps the browser focus to the editor's editable element after a small, configurable delay.
+To maintain the IME functionalities, Handsontable 14.0 introduces the [`imeFastEdit`](@/api/options.md#imefastedit) option that swaps the browser focus to the editor's editable element after a small, configurable delay.
 
 To utilize it in your implementation, set the [`imeFastEdit`](@/api/options.md#imefastedit) option to `true` in your settings object.
 
 ### Adjust your application to the modified keyboard shortcuts
-The new Handsontable version comes with an updated set of keyboard shortcuts. Most of them are new additions, but there have been some changes in the already-existing ones. Make sure to adjust your application to the current specification.
+The new Handsontable version comes with an updated set of keyboard shortcuts. Most of them are new additions, but some existing shortcuts also change. Make sure to adjust your application to the current specification.
 
 ##### <kbd>Ctrl/Cmd</kbd> + <kbd>A</kbd>
 
@@ -57,3 +58,6 @@ To make the table more accessible, this release changes the color of the invalid
 | Autocomplete-typed cells arrow: `#eeeeee`  | Autocomplete-typed cells arrow: `#bbbbbb`   |
 | Invalid autocomplete-typed cells arrow: `#eeeeee`  | Invalid autocomplete-typed cells arrow: `#555555`   |
 | Invalid autocomplete-typed cells arrow on hover: `#777777`   | Invalid autocomplete-typed cells arrow on hover: `#1a1a1a`    |
+## Result
+
+Your application now runs on Handsontable 14.0.

--- a/docs/content/guides/upgrade-and-migration/migrating-from-14.6-to-15.0/migrating-from-14.6-to-15.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-14.6-to-15.0/migrating-from-14.6-to-15.0.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: migrating-14.6-to-15.0
 title: Migrating from 14.6 to 15.0
 metaTitle: Migrating from 14.6 to 15.0 - JavaScript Data Grid | Handsontable
@@ -24,7 +25,7 @@ For a detailed list of changes in this release, see the [Changelog](@/guides/upg
 
 ## Introducing the New React Wrapper
 
-With Handsontable 15.0, we're rolling out a brand-new React wrapper designed for functional programming. It focuses on type safety, idiomatic React usage, and developer experience. Named `react-wrapper`, you can find it in our [GitHub monorepo](https://github.com/handsontable/handsontable/tree/master/wrappers/react-wrapper) or install it directly from [npm](https://www.npmjs.com/package/@handsontable/react-wrapper).
+With Handsontable 15.0, a brand-new React wrapper is available designed for functional programming. It focuses on type safety, idiomatic React usage, and developer experience. Named `react-wrapper`, you can find it in our [GitHub monorepo](https://github.com/handsontable/handsontable/tree/master/wrappers/react-wrapper) or install it directly from [npm](https://www.npmjs.com/package/@handsontable/react-wrapper).
 
 This guide will help you migrate your existing `@handsontable/react` class-based wrapper to `@handsontable/react-wrapper`.
 
@@ -55,7 +56,7 @@ Pass your component using `editor` prop of the `HotTable` or `HotColumn` compone
 
 ### 1. Removal of `settings` property
 
-The `settings` property has been removed. Configuration options must now be passed directly to the `HotTable` component.
+The `settings` property is removed. Pass configuration options directly to the `HotTable` component.
 
 **`@handsontable/react`:**
 ```jsx
@@ -192,3 +193,7 @@ Just like with renderers, custom editors now need to be provided using the `edit
 ::: tip  
 If you’re using the `editor` option for JavaScript class-based editors, you can still use them. Just define them under the `hotEditor` key instead of `editor`.  
 :::
+
+## Result
+
+Your application now runs on Handsontable 15.0.

--- a/docs/content/guides/upgrade-and-migration/migrating-from-15.3-to-16.0/migrating-from-15.3-to-16.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-15.3-to-16.0/migrating-from-15.3-to-16.0.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: 1k7arh9z
 title: Migrating from 15.3 to 16.0
 metaTitle: Migrating from 15.3 to 16.0 - JavaScript Data Grid | Handsontable
@@ -24,7 +25,7 @@ For a detailed list of changes in this release, see the [Changelog](@/guides/upg
 
 ## 1. Introducing the new DOM structure
 
-In Handsontable 16.0, we changed how the table is mounted in the DOM. Previously, the container `<div>` you provided became the root element of the table. Now, that container acts as a mounting point, and Handsontable creates and injects its own root element inside it.
+In Handsontable 16.0, the table mounts to the DOM differently. Previously, the container `<div>` you provided became the root element of the table. Now, that container acts as a mounting point, and Handsontable creates and injects its own root element inside it.
 
 Here's a side-by-side comparison of the old and new DOM structures:
 
@@ -75,16 +76,16 @@ Here's a side-by-side comparison of the old and new DOM structures:
 
 ### Key changes
 - Root Wrapper: User-provided div is now used as a container for the new DOM structure
-- Focus Catcher Relocation: Input elements used as focus catchers have been moved outside of the treegrid element for accessibility compliance
+- Focus Catcher Relocation: Input elements used as focus catchers move outside of the treegrid element for accessibility compliance
 - Portal Element: New div.ht-portal with ht-theme class for absolutely positioned elements
 - Root Element: rootElement is now created internally by Handsontable instead of using the user-provided container directly
 
 ## 2. Updated the CSS variables
 
-In Handsontable 16.0, we've made significant improvements to our CSS variables system to adjust themes colors, variable order and provide better customization options. Here are the key changes:
+In Handsontable 16.0, Handsontable improves the CSS variables system to adjust theme colors, variable order, and customization options. Here are the key changes:
 
 ### New CSS variables
-We've introduced new variables that allow for easier customization:
+These new variables allow for easier customization:
 
  - `--ht-letter-spacing`: Controls letter spacing for improved readability and visual appearance.
  - `--ht-radio-*`: Enables more accurate styling of radio inputs.
@@ -92,7 +93,7 @@ We've introduced new variables that allow for easier customization:
  - `--ht-checkbox-indeterminate`: Lets you style the indeterminate state of checkboxes.
 
 ### Renamed CSS variables
-We've renamed a few variables to ensure more consistent naming:
+A few variables are renamed for more consistent naming:
 
 | Old variable name                                | New variable name                                |
 |--------------------------------------------------|--------------------------------------------------|
@@ -112,10 +113,10 @@ If you were using custom CSS variables in version 15.3, you'll need to:
 
 ## 3. Updated the placement of custom borders
 
-In version 16.0, we've updated how custom borders are positioned to improve accuracy and consistency. This change affects the visual positioning of borders, particularly for cells with custom borders.
+In version 16.0, Handsontable updates how custom borders are positioned to improve accuracy and consistency. This change affects the visual positioning of borders, particularly for cells with custom borders.
 
 #### What changed?
-- Border positions were adjusted to prevent overlapping with adjacent cells and headers.
+- Border positions are adjusted to prevent overlapping with adjacent cells and headers.
 
 #### Why is this a breaking change?
 It's very unlikely, but if your application relies on specific border positioning or you've implemented custom styling based on border positions, you may need to update your styles. 
@@ -435,9 +436,9 @@ This migration guide covers the major changes between the old and new Angular wr
 
 ## 5. Introducing `pnpm` as the repository package manager
 
-Starting on July 1st, 2025, we've switched to `pnpm` as the repository's main package manager.
+Starting on July 1st, 2025, Handsontable switches to `pnpm` as the repository's main package manager.
 
-As the number of packages in the repository grew, so did the number of dependencies. This made it difficult to manage dependencies and install them in a consistent way. To address this, we've switched to `pnpm` as the main package manager.
+As the number of packages in the repository grew, so did the number of dependencies. This made it difficult to manage dependencies and install them in a consistent way. To address this, the project switches to `pnpm` as the main package manager.
 
 ### Will this affect me?
 
@@ -457,3 +458,7 @@ If you are, however, you'll need to utilize `pnpm` to install the main repositor
 4. All the `npm` commands are still available, so you can build the packages as you did before, for example, by running `npm run build`.
 
 You can always find more information on the custom build process in the [Custom builds](https://handsontable.com/docs/custom-builds/) documentation page.
+
+## Result
+
+Your application now runs on Handsontable 16.0.

--- a/docs/content/guides/upgrade-and-migration/migrating-from-16.0-to-16.1/migrating-from-16.0-to-16.1.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-16.0-to-16.1/migrating-from-16.0-to-16.1.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: sf7vrh9z
 title: Migrating from 16.0 to 16.1
 metaTitle: Migrating from 16.0 to 16.1 - JavaScript Data Grid | Handsontable
@@ -24,7 +25,7 @@ For a detailed list of changes in this release, see the [Changelog](@/guides/upg
 
 ## 1. Migrate from Legacy Styles to Classic Theme
 
-Handsontable 16.1 introduces a new **Classic** theme that replaces the legacy theme. The legacy styles will be removed in version 17.0.
+Handsontable 16.1 introduces a new **Classic** theme that replaces the legacy theme. Handsontable 17.0 will remove the legacy styles.
 
 ### What Changed
 
@@ -34,7 +35,7 @@ Handsontable 16.1 introduces a new **Classic** theme that replaces the legacy th
 
 ### Why This Change
 
-The legacy style was built with hardcoded styles that couldn't be customized. The new Classic theme provides the same visual appearance but with the flexibility of CSS variables, making it easier to customize and maintain consistency with your application's design system.
+The legacy style uses hardcoded styles that cannot be customized. The new Classic theme provides the same visual appearance but with the flexibility of CSS variables, making it easier to customize and maintain consistency with your application's design system.
 
 ### How to Migrate
 
@@ -137,6 +138,10 @@ The new theme supports over 180 CSS variables for [customization](@/guides/styli
 ### Timeline
 
 - **Version 16.1**: New Classic theme introduced
-- **Version 17.0**: Legacy style will be removed
+- **Version 17.0**: Handsontable removes the legacy style
 
 We recommend migrating as soon as possible to avoid issues when version 17.0 is released.
+
+## Result
+
+Your application now runs on Handsontable 16.1.

--- a/docs/content/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: 9w5zs3t2
 title: Migrating from 16.2 to 17.0
 metaTitle: Migrating from 16.2 to 17.0 - JavaScript Data Grid | Handsontable
@@ -23,9 +24,9 @@ For a detailed list of changes in this release, see the [Changelog](@/guides/upg
 
 [[toc]]
 
-## 1. Legacy styles have been removed
+## 1. Remove legacy styles
 
-Starting from **version 17.0.0**, the legacy stylesheet (`dist/handsontable.full.min.css`) has been completely removed from Handsontable. If you're upgrading from an earlier version and still using the legacy styles, you must migrate to a theme.
+Starting from **version 17.0.0**, Handsontable 17.0 completely removes the legacy stylesheet (`dist/handsontable.full.min.css`). If you're upgrading from an earlier version and still using the legacy styles, you must migrate to a theme.
 
 ::: tip Using the main theme without modifications
 If you want to use the `main` theme without any modifications, you don't need to configure anything. Handsontable will automatically use the `main` theme with default settings. However, if you want to retain the legacy look and feel, migrate to the **Classic** theme as described below.
@@ -202,7 +203,7 @@ The Classic theme provides the same visual appearance as the legacy style, but w
 
 ## 2. Migrate from CSS-based themes to the Theme API
 
-If you're currently using CSS-based themes (loading theme CSS files and passing theme name as a string), we recommend migrating to the Theme API for better runtime control and customization options.
+If you're currently using CSS-based themes (loading theme CSS files and passing theme name as a string), migrating to the Theme API provides better runtime control and customization options.
 
 ### What Changed
 
@@ -621,7 +622,8 @@ If you need numbro.js-specific formatting features that aren't available in `Int
 - **Version 17.0**: Numbro format deprecated with warnings
 - **Version 18.0**: Numbro format options (including dependencies) will be removed
 
-### Related resources
+
+## Related resources
 
 - [Numeric cell type](@/guides/cell-types/numeric-cell-type/numeric-cell-type.md)
 
@@ -1102,7 +1104,7 @@ sanitizer: (content, source) =>
 
 ## 6. `core-js` dependency removed
 
-Starting in **version 17.0**, Handsontable no longer depends on or bundles [core-js](https://github.com/zloirock/core-js). The library relied on it in the past for polyfills (e.g. ECMAScript 5/6 features, Promises, Symbols, collections). That dependency has been removed to reduce bundle size and to avoid forcing a specific polyfill set on applications that target modern environments only.
+Starting in **version 17.0**, Handsontable no longer depends on or bundles [core-js](https://github.com/zloirock/core-js). The library relied on it in the past for polyfills (e.g. ECMAScript 5/6 features, Promises, Symbols, collections). Handsontable removes that dependency to reduce bundle size and to avoid forcing a specific polyfill set on applications that target modern environments only.
 
 ### What Changed
 
@@ -1169,3 +1171,7 @@ See the [Formula calculation](@/guides/formulas/formula-calculation/formula-calc
 - [Themes](@/guides/styling/themes/themes.md) - Learn about the theming system
 - [Theme Customization](@/guides/styling/theme-customization/theme-customization.md) - Customize themes with CSS variables
 - [Legacy Style](@/guides/styling/legacy-style/legacy-style.md) - Information about the legacy style deprecation
+
+## Result
+
+Your application now runs on Handsontable 17.0.

--- a/docs/content/guides/upgrade-and-migration/migrating-from-7.4-to-8.0/migrating-from-7.4-to-8.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-7.4-to-8.0/migrating-from-7.4-to-8.0.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: g7ligsfi
 title: Migrate from 7.4 to 8.0
 metaTitle: Migrate from 7.4 to 8.0 - JavaScript Data Grid | Handsontable
@@ -133,7 +134,7 @@ npm install handsontable@8 @handsontable/angular@6
 
 ### Index-related Handsontable hooks were removed
 
-As we introduce a new architecture for index management ([`IndexMapper`](@/api/indexMapper.md)), we remove [Handsontable hooks](@/api/hooks.md) related to indexes.
+Handsontable 8.0.0 introduces a new architecture for index management ([`IndexMapper`](@/api/indexMapper.md)) and removes [Handsontable hooks](@/api/hooks.md) related to indexes.
 
 To keep your app's behavior unchanged, recreate affected functionalities, using the [`IndexMapper`](@/api/indexMapper.md)'s API methods.
 
@@ -157,7 +158,7 @@ modifyRow(row) {
 }
 ```
 
-In 8.0.0 it is no longer the case. To achieve the same functionality you need to use [`rowIndexMapper()`](@/api/core.md#rowindexmapper):
+In 8.0.0, this is no longer the case. To achieve the same functionality, use [`rowIndexMapper()`](@/api/core.md#rowindexmapper):
 
 ::: only-for javascript
 
@@ -586,7 +587,7 @@ The following Handsontable hooks have different sets of parameters now:
 - [`beforeColumnMove`](@/api/hooks.md#beforecolumnmove)
 - [`afterColumnMove`](@/api/hooks.md#aftercolumnmove)
 
-Methods [`moveColumn()`](@/api/manualColumnMove.md#movecolumn), [`moveColumns()`](@/api/manualColumnMove.md#movecolumns), [`moveRow()`](@/api/manualRowMove.md#moverow), and [`moveRows()`](@/api/manualRowMove.md#moverows) have different parameters now. Starting with Handsontable 8.0.0, the `target` parameter was changed to `finalIndex`. They work differently now and a new [`dragRow()`](@/api/manualRowMove.md#dragrow), [`dragRows()`](@/api/manualRowMove.md#dragrows), [`dragColumn`](@/api/manualColumnMove.md#dragcolumn) and [`dragColumns()`](@/api/manualColumnMove.md#dragcolumns) methods took over the old methods' functionality.
+Methods [`moveColumn()`](@/api/manualColumnMove.md#movecolumn), [`moveColumns()`](@/api/manualColumnMove.md#movecolumns), [`moveRow()`](@/api/manualRowMove.md#moverow), and [`moveRows()`](@/api/manualRowMove.md#moverows) have different parameters now. Starting with Handsontable 8.0.0, the `target` parameter is renamed to `finalIndex`. They work differently now and a new [`dragRow()`](@/api/manualRowMove.md#dragrow), [`dragRows()`](@/api/manualRowMove.md#dragrows), [`dragColumn`](@/api/manualColumnMove.md#dragcolumn) and [`dragColumns()`](@/api/manualColumnMove.md#dragcolumns) methods took over the old methods' functionality.
 
 To preserve the previous functionality of [`moveRows()`](@/api/manualRowMove.md#moverows) rename it to [`dragRows()`](@/api/manualRowMove.md#dragrows).
 
@@ -819,7 +820,7 @@ const physicalRow = hotInstance.toPhysicalRow(visualRow) ?? visualRow;
 
 ### `RecordTranslator` in plugins
 
-The `RecordTranslator` object was removed, as a consequence, `t` property is no longer available in the plugins. This alias could be used to translate between visual and physical indexes with four methods: `t.toVisualRow`, `t.toPhysicalRow`, `t.toVisualColumn`, `t.toPhysicalColumn`. It is advised to call the following methods directly on the instance: `hotInstance.toVisualRow`, `hotInstance.toPhysicalRow`, `hotInstance.toVisualColumn`, `hotInstance.toPhysicalColumn`. The mappers can be accessed using `hotInstance.rowIndexMapper` and `hotInstance.columnIndexMapper` properties.
+Handsontable 8.0.0 removes the `RecordTranslator` object; as a consequence, the `t` property is no longer available in the plugins. This alias was used to translate between visual and physical indexes with four methods: `t.toVisualRow`, `t.toPhysicalRow`, `t.toVisualColumn`, `t.toPhysicalColumn`. Call the following methods directly on the instance instead: `hotInstance.toVisualRow`, `hotInstance.toPhysicalRow`, `hotInstance.toVisualColumn`, `hotInstance.toPhysicalColumn`. The mappers can be accessed using `hotInstance.rowIndexMapper` and `hotInstance.columnIndexMapper` properties.
 
 This example shows how to migrate plugins from using `t` property to calling the method directly on the instance:
 
@@ -976,10 +977,14 @@ hotTableComponentRef.current.hotInstance.getSelectedRangeLast().from.clone().nor
 
 ### Removals
 
-Handsontable's `skipLengthCache` hook was removed, as [`IndexMapper`](@/api/indexMapper.md) is now responsible for the cache and length.
+Handsontable 8.0.0 removes the `skipLengthCache` hook, as [`IndexMapper`](@/api/indexMapper.md) is now responsible for the cache and length.
 
-Public methods `colOffset()` and `rowOffset()` were removed and their functionality is now for internal use only.
+Public methods `colOffset()` and `rowOffset()` are removed and their functionality is now for internal use only.
 
-Also, an experimental feature called `ganttChart` was removed and is no longer supported.
+Handsontable 8.0.0 also removes the experimental `ganttChart` feature, which is no longer supported.
 
 If you use these features in your project and need backward compatibility, contact our [Technical Support Team](https://handsontable.com/contact?category=technical_support).
+
+## Result
+
+Your application now runs on Handsontable 8.0.

--- a/docs/content/guides/upgrade-and-migration/migrating-from-8.4-to-9.0/migrating-from-8.4-to-9.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-8.4-to-9.0/migrating-from-8.4-to-9.0.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: 3cqz2dy9
 title: Migrating from 8.4 to 9.0
 metaTitle: Migrate from 8.4 to 9.0 - JavaScript Data Grid | Handsontable
@@ -24,7 +25,7 @@ For a detailed list of changes in this release, see the [Changelog](@/guides/upg
 
 ## Overview
 
-The purpose of this guide is to make it easier to migrate from v8.4.0 to v9.0.0. In the version 9.0 we have introduced a new formula engine with has completely replaced the previous one. There is a breaking change in the formula API - even in the way the plugin itself is initialized.
+The purpose of this guide is to make it easier to migrate from v8.4.0 to v9.0.0. Handsontable 9.0 introduces a new formula engine that completely replaces the previous one. There is a breaking change in the formula API - even in the way the plugin itself is initialized.
 
 ## Plugin initialization
 
@@ -56,13 +57,13 @@ See other available initialization methods [here](@/guides/formulas/formula-calc
 | [`disablePlugin`](https://handsontable.com/docs/8.4.0/Formulas.html#disablePlugin)               | `hot.getPlugin('formulas').disablePlugin()`                   | Unchanged.                                                                                                                                                                            |
 | [`enablePlugin`](https://handsontable.com/docs/8.4.0/Formulas.html#enablePlugin)                 | `hot.getPlugin('formulas').enablePlugin()`                    | Unchanged, but do keep in mind that if you didn't pass in the plugin's config through either `updateSettings` or during Handsontable initialization this method will not do anything. |
 | [`getCellValue`](https://handsontable.com/docs/8.4.0/Formulas.html#getCellValue)                 | `hot.getPlugin('formulas').getCellValue(row, column)`         | Use base Handsontable API instead, for example `hot.getDataAtCell(row, column)`.                                                                                                      |
-| [`getVariable`](https://handsontable.com/docs/8.4.0/Formulas.html#getVariable)                   | `hot.getPlugin('formulas').getVariable(variableName)`         | "Variables" in the plugin have been replaced by a more powerful alternative, [named expressions](@/guides/formulas/formula-calculation/formula-calculation.md#named-expressions).                         |
+| [`getVariable`](https://handsontable.com/docs/8.4.0/Formulas.html#getVariable)                   | `hot.getPlugin('formulas').getVariable(variableName)`         | "Variables" in the plugin are replaced by a more powerful alternative, [named expressions](@/guides/formulas/formula-calculation/formula-calculation.md#named-expressions).                         |
 | [`hasComputedCellValue`](https://handsontable.com/docs/8.4.0/Formulas.html#hasComputedCellValue) | `hot.getPlugin('formulas').hasComputedCellValue(row, column)` | `hot.getPlugin('formulas').getCellType(row, column) === 'FORMULA'`                                                                                                                    |
 | [`isEnabled`](https://handsontable.com/docs/8.4.0/Formulas.html#isEnabled)                       | `hot.getPlugin('formulas').isEnabled()`                       | Unchanged.                                                                                                                                                                            |
 | [`recalculate`](https://handsontable.com/docs/8.4.0/Formulas.html#recalculate)                   | `hot.getPlugin('formulas').recalculate()`                     | `hot.getPlguin('formulas').engine.rebuildAndRecalculate()`                                                                                                                            |
 | [`recalculateFull`](https://handsontable.com/docs/8.4.0/Formulas.html#recalculateFull)           | `hot.getPlugin('formulas').recalculateFull()`                 | `hot.getPlguin('formulas').engine.rebuildAndRecalculate()`                                                                                                                            |
 | [`recalculateOptimized`](https://handsontable.com/docs/8.4.0/Formulas.html#recalculateOptimized) | `hot.getPlugin('formulas').recalculateOptimized()`            | `hot.getPlguin('formulas').engine.rebuildAndRecalculate()`                                                                                                                            |
-| [`setVariable`](https://handsontable.com/docs/8.4.0/Formulas.html#setVariable)                   | `hot.getPlugin('formulas').setVariable(variableName, value)`  | "Variables" in the plugin have been replaced by a more powerful alternative, named expressions.                                                                                       |
+| [`setVariable`](https://handsontable.com/docs/8.4.0/Formulas.html#setVariable)                   | `hot.getPlugin('formulas').setVariable(variableName, value)`  | "Variables" in the plugin are replaced by a more powerful alternative, named expressions.                                                                                       |
 
 ## Available functions
 
@@ -70,7 +71,7 @@ See other available initialization methods [here](@/guides/formulas/formula-calc
 
 ## Autofill hooks
 
-To make autofill hooks more consistent and more powerful, [`beforeAutofill`](@/api/hooks.md#beforeautofill) and [`afterAutofill`](@/api/hooks.md#afterautofill) hooks have had their signatures changed.
+To make autofill hooks more consistent and more powerful, [`beforeAutofill`](@/api/hooks.md#beforeautofill) and [`afterAutofill`](@/api/hooks.md#afterautofill) hooks have new signatures.
 
 Before 9.0.0:
 
@@ -144,7 +145,7 @@ In [`beforeAutofill`](@/api/hooks.md#beforeautofill) instead of mutating [`data`
 
 ## Removed plugins
 
-In Handsontable `9.0.0` we removed the following, previously-deprecated plugins:
+Handsontable 9.0.0 removes the following previously deprecated plugins:
 
 - Header Tooltips
 - Observe Changes
@@ -208,3 +209,7 @@ const onAfterGetHeader = function(index, TH) {
 ### Observe Changes
 
 The plugin fired the [`afterChangesObserved`](@/api/hooks.md#afterchangesobserved) hook. Be sure to stop listening to it after updating to version `>=9.0.0`.
+
+## Result
+
+Your application now runs on Handsontable 9.0.

--- a/docs/content/guides/upgrade-and-migration/migrating-from-9.0-to-10.0/migrating-from-9.0-to-10.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-9.0-to-10.0/migrating-from-9.0-to-10.0.md
@@ -1,4 +1,5 @@
 ---
+type: how-to
 id: 5l7bspro
 title: Migrating from 9.0 to 10.0
 metaTitle: Migrate from 9.0 to 10.0 - JavaScript Data Grid | Handsontable
@@ -39,13 +40,13 @@ There are still Handsontable hooks that are named [`beforeRender`](@/api/hooks.m
 
 ## Step 2: Adapt to the HyperFormula dependency update
 
-In Handsontable 10.0.0, we updated the optional HyperFormula dependency from `0.6.2` to `^1.1.0` ([#8669](https://github.com/handsontable/handsontable/pull/8669)).
+In Handsontable 10.0.0, Handsontable updates the optional HyperFormula dependency from `0.6.2` to `^1.1.0` ([#8669](https://github.com/handsontable/handsontable/pull/8669)).
 
 For more details on the breaking changes between HyperFormula 0.6.x and HyperFormula 1.0.x, see the [migration guide](https://handsontable.github.io/hyperformula/guide/migration-from-0.6-to-1.0.html).
 
 ## Step 3: Adapt to the configuration options' new default values
 
-In Handsontable 10.0.0, we changed the default values of the [`autoWrapCol`](@/api/options.md#autowrapcol) and [`autoWrapRow`](@/api/options.md#autowraprow) [configuration options](@/guides/getting-started/configuration-options/configuration-options.md), from `true` to `false` ([#8662](https://github.com/handsontable/handsontable/pull/8662)):
+In Handsontable 10.0.0, Handsontable changes the default values of the [`autoWrapCol`](@/api/options.md#autowrapcol) and [`autoWrapRow`](@/api/options.md#autowraprow) [configuration options](@/guides/getting-started/configuration-options/configuration-options.md), from `true` to `false` ([#8662](https://github.com/handsontable/handsontable/pull/8662)):
 
 ::: only-for javascript
 
@@ -87,7 +88,7 @@ We also changed the default values for the [`rowsLimit`](@/api/copyPaste.md#rows
 
 ## Step 4: Adapt to the Handsontable hooks changes
 
-In Handsontable 10.0, we unified the naming of an argument used by the [`beforeOnCellMouseDown`](@/api/hooks.md#beforeoncellmousedown) and [`beforeOnCellMouseOver`](@/api/hooks.md#beforeoncellmouseover) Handsontable hooks ([#8591](https://github.com/handsontable/handsontable/pull/8591)):
+In Handsontable 10.0, Handsontable unifies the naming of an argument used by the [`beforeOnCellMouseDown`](@/api/hooks.md#beforeoncellmousedown) and [`beforeOnCellMouseOver`](@/api/hooks.md#beforeoncellmouseover) Handsontable hooks ([#8591](https://github.com/handsontable/handsontable/pull/8591)):
 
 | Handsontable hook                                               | Before              | After        |
 | --------------------------------------------------------------- | ------------------- | ------------ |
@@ -111,4 +112,8 @@ For more details, see [this PR](https://github.com/handsontable/handsontable/pul
 
 ## Step 5: Adapt to the font changes
 
-To make Handsontable look good right out of the box, we added default `font-family`, `font size`, `font weight`, and `color` properties for all elements within the `.handsontable` CSS class ([#8681](https://github.com/handsontable/handsontable/pull/8681)). If you're not overwriting these properties in your app, this change will affect your grid's font.
+To make Handsontable look good right out of the box, Handsontable 10.0 adds default `font-family`, `font size`, `font weight`, and `color` properties for all elements within the `.handsontable` CSS class ([#8681](https://github.com/handsontable/handsontable/pull/8681)). If you do not overwrite these properties in your app, this change will affect your grid's font.
+
+## Result
+
+Your application now runs on Handsontable 10.0.


### PR DESCRIPTION
## Summary

Applies Diátaxis documentation framework standards across 12 files in the upgrade-and-migration section:

- Adds `type: how-to` as first frontmatter key to all 11 migration guide pages
- Adds `type: explanation` as first frontmatter key to the deprecation policy page
- Converts passive-voice constructions to active/second-person voice throughout
- Adds a `## Result` section at the end of each migration guide
- Adds an intro paragraph and `## Related` section to the deprecation policy page

## ClickUp tasks

- https://app.clickup.com/t/9015210959/DEV-1383
- https://app.clickup.com/t/9015210959/DEV-1384
- https://app.clickup.com/t/9015210959/DEV-1385
- https://app.clickup.com/t/9015210959/DEV-1386
- https://app.clickup.com/t/9015210959/DEV-1387
- https://app.clickup.com/t/9015210959/DEV-1388
- https://app.clickup.com/t/9015210959/DEV-1389
- https://app.clickup.com/t/9015210959/DEV-1390
- https://app.clickup.com/t/9015210959/DEV-1391
- https://app.clickup.com/t/9015210959/DEV-1392
- https://app.clickup.com/t/9015210959/DEV-1393
- https://app.clickup.com/t/9015210959/DEV-1394


[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (frontmatter + copy edits) with no runtime behavior impact; primary risk is minor doc build/frontmatter parsing issues.
> 
> **Overview**
> Applies Diátaxis metadata and structure across upgrade-and-migration docs by adding a `type` frontmatter key (`how-to` for migration guides, `explanation` for deprecation policy).
> 
> Updates the migration guides’ prose toward more direct/active wording and appends a consistent `## Result` section stating the upgrade outcome.
> 
> Expands `deprecation-policy.md` with a short intro and a `## Related` section linking to versioning and LTS guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22a124b6e6fbca7c6bd2b30038801e5b5e64677f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1456