### PR TITLE
DEV-1415: Fix missing GitHub links on the demo page

### DIFF
--- a/docs/content/guides/getting-started/demo/demo.md
+++ b/docs/content/guides/getting-started/demo/demo.md
@@ -52,11 +52,11 @@ Play around with a demo of Handsontable, in your favorite framework.
 
 <div class="boxes-list gray">
 
-- <Link :href="`https://github.com/handsontable/handsontable/tree/prod-docs/${$page.currentVersion}/examples/next/docs/js/demo/`">JavaScript demo app</Link>
-- <Link :href="`https://github.com/handsontable/handsontable/tree/prod-docs/${$page.currentVersion}/examples/next/docs/ts/demo/`">TypeScript demo app</Link>
-- <Link :href="`https://github.com/handsontable/handsontable/tree/prod-docs/${$page.currentVersion}/examples/next/docs/angular-wrapper/demo/`">Angular demo app</Link>
-- <Link :href="`https://github.com/handsontable/handsontable/tree/prod-docs/${$page.currentVersion}/examples/next/docs/react-wrapper/demo/`">React demo app</Link>
-- <Link :href="`https://github.com/handsontable/handsontable/tree/prod-docs/${$page.currentVersion}/examples/next/docs/vue3/demo/`">Vue demo app</Link>
+- [JavaScript demo app](https://github.com/handsontable/handsontable/tree/prod-docs/{{$currentVersion}}/examples/next/docs/js/demo/)
+- [TypeScript demo app](https://github.com/handsontable/handsontable/tree/prod-docs/{{$currentVersion}}/examples/next/docs/ts/demo/)
+- [Angular demo app](https://github.com/handsontable/handsontable/tree/prod-docs/{{$currentVersion}}/examples/next/docs/angular-wrapper/demo/)
+- [React demo app](https://github.com/handsontable/handsontable/tree/prod-docs/{{$currentVersion}}/examples/next/docs/react-wrapper/demo/)
+- [Vue demo app](https://github.com/handsontable/handsontable/tree/prod-docs/{{$currentVersion}}/examples/next/docs/vue3/demo/)
 
 </div>
 


### PR DESCRIPTION
## Summary

- Replaced VuePress-specific `<Link :href="...${$page.currentVersion}...">` syntax with standard markdown links using `{{$currentVersion}}` placeholder in the "Find the code on GitHub" section of the demo page.
- The Astro preprocessor's `convertBoxesListToCardGrid` function only handles `[text](url)` markdown link format. The old VuePress `<Link>` component syntax was not recognized, causing the entire card grid to render empty (no links shown).

## Root cause

`demo.md` still used the legacy VuePress `<Link :href="...${$page.currentVersion}...">` template-binding syntax. In the Astro-based docs system, `$page.currentVersion` is not a known template variable (only `{{$currentVersion}}` is replaced by the preprocessor), and the `<Link>` Vue component is not available. The `convertBoxesListToCardGrid` regex could not parse these items, returning an empty card grid.

## Test plan

- [ ] Visit the demo page (`/demo`) in a local docs build
- [ ] Verify the "Find the code on GitHub" section shows 5 clickable link cards: JavaScript, TypeScript, Angular, React, Vue
- [ ] Confirm each link URL contains the correct version string (e.g. `prod-docs/17.0/...`)

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1415

[skip changelog]

https://claude.ai/code/session_01Abwzo1hp1Pi8qrCShCN9cB

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change limited to link markup/templating; no runtime code, security, or data-handling logic is affected.
> 
> **Overview**
> Fixes the demo page’s **missing “Find the code on GitHub” link cards** by replacing legacy VuePress `<Link :href="...${$page.currentVersion}...">` entries with standard markdown list links using the `{{$currentVersion}}` placeholder.
> 
> This makes the links compatible with the docs preprocessor’s `convertBoxesListToCardGrid` parsing, so the card grid renders and versioned GitHub URLs resolve correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76fcfb38832ad30254f2edfcd2b6bc228d8e4346. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

After fix
<img width="1895" height="960" alt="image" src="https://github.com/user-attachments/assets/33c8eaa0-4e75-43ef-a968-e33c22c5cd28" />
