### PR TITLE
docs: Recipe - Freeze / unfreeze columns at runtime (DEV-1422)

### DIFF
--- a/.claude/skills/creating-docs-examples/SKILL.md
+++ b/.claude/skills/creating-docs-examples/SKILL.md
@@ -74,7 +74,6 @@ const App = () => {
 - Use `app.config.ts` (not `app.module.ts`) with `ApplicationConfig`, `provideZoneChangeDetection({ eventCoalescing: true })`, and global `HOT_GLOBAL_CONFIG` for the license key.
 - Do **not** add `licenseKey` to individual `<hot-table>` bindings -- it is set globally in `app.config.ts`.
 - Template control flow: use `@if` / `@for (x of list; track x.id)` -- never `*ngIf` / `*ngFor`.
-- Row data type: use `RowObject[]` from `handsontable/common`, not `any[]`.
 - Name the component class `AppComponent` in every example.
 
 **Critical Angular JIT restrictions** — the docs site bootstraps Angular examples with JIT in the browser. JIT cannot load external files at runtime:
@@ -83,6 +82,7 @@ const App = () => {
 - ❌ **Never use `templateUrl`**. Always define the component's template inline with `template: \`...\``. The `angular/example1.html` file is the **outer wrapper** (selector tag) consumed by the example-runner -- it is not the component's template.
 - ❌ **Never inject services via the constructor**. Use `inject()` instead. JIT mode lacks TypeScript decorator metadata, so constructor DI throws `NG0202`.
 - ❌ **Never bind Handsontable hooks in the template** (`(afterInit)="handler()"`). Put hook functions inside `gridSettings` instead.
+- ❌ **Only import symbols you actually use**. Unused imports (e.g., `RowObject`, `ViewChild`, `NgFor`) can cause module resolution errors.
 
 The `.ts` file contains both `app.component.ts` and `app.config.ts` as separate `/* file: ... */` sections within a single file:
 
@@ -90,7 +90,6 @@ The `.ts` file contains both `app.component.ts` and `app.config.ts` as separate 
 /* file: app.component.ts */
 import { Component } from '@angular/core';
 import { GridSettings, HotTableModule } from '@handsontable/angular-wrapper';
-import { RowObject } from 'handsontable/common';
 
 @Component({
   standalone: true,
@@ -103,7 +102,7 @@ import { RowObject } from 'handsontable/common';
   `,
 })
 export class AppComponent {
-  readonly data: RowObject[] = [...];
+  readonly data = [...];
   readonly gridSettings: GridSettings = { ... };
 }
 /* end-file */

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -363,6 +363,8 @@ All Angular docs examples use `standalone: true` bootstrapped via `bootstrapAppl
 - **Constructor DI**: Never inject services via the constructor. Use the `inject()` function instead -- constructors are not processed by Angular JIT without TypeScript decorator metadata.
 - **Lifecycle hooks**: Put `afterInit`, `afterChange`, and other Handsontable hook functions inside `gridSettings`, not as template event bindings (e.g., `(afterInit)="..."` fails in JIT mode).
 - **`@ViewChild`**: Safe to use. It is populated after the component view is initialized.
+- **Control flow**: Use `@for`, `@if`, `@switch` (Angular 17+ built-in control flow). Do **not** use `*ngFor`, `*ngIf`, or `*ngSwitch` with structural directives — they require importing `NgFor`, `NgIf`, etc. from `@angular/common`, which is error-prone. The built-in control flow syntax requires no imports.
+- **Imports**: Only import symbols you actually use. Unused imports (e.g., `RowObject` from `handsontable/common`, `ViewChild` when `hotTable` is unused) can cause module resolution errors or compilation failures.
 
 Correct standalone component skeleton:
 ```typescript

--- a/docs/content/recipes/column-management/column-visibility/angular/example1.ts
+++ b/docs/content/recipes/column-management/column-visibility/angular/example1.ts
@@ -1,7 +1,6 @@
 /* file: app.component.ts */
 import { Component, ViewChild } from '@angular/core';
 import { GridSettings, HotTableComponent, HotTableModule } from '@handsontable/angular-wrapper';
-import { RowObject } from 'handsontable/common';
 
 type ColumnConfig = {
   data: string;
@@ -52,18 +51,17 @@ const data = [
   selector: 'example1-column-visibility',
   template: `
     <div style="margin-bottom: 10px;">
-      <label
-        *ngFor="let col of allColumns; let i = index"
-        style="margin-right: 12px; display: inline-flex; align-items: center; gap: 4px;"
-      >
-        <input
-          type="checkbox"
-          [checked]="visibleIndices.has(i)"
-          [disabled]="visibleIndices.size === 1 && visibleIndices.has(i)"
-          (change)="toggleColumn(i, $event)"
-        />
-        {{ col.title }}
-      </label>
+      @for (col of allColumns; track col.data; let i = $index) {
+        <label style="margin-right: 12px; display: inline-flex; align-items: center; gap: 4px;">
+          <input
+            type="checkbox"
+            [checked]="visibleIndices.has(i)"
+            [disabled]="visibleIndices.size === 1 && visibleIndices.has(i)"
+            (change)="toggleColumn(i, $event)"
+          />
+          {{ col.title }}
+        </label>
+      }
     </div>
     <hot-table [data]="data" [settings]="gridSettings"></hot-table>
   `,

--- a/docs/content/recipes/column-management/freeze-columns/angular/example1.css
+++ b/docs/content/recipes/column-management/freeze-columns/angular/example1.css
@@ -1,0 +1,46 @@
+.freeze-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.freeze-controls__freeze-btns {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.freeze-controls__footer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.freeze-controls button {
+  border: 1px solid var(--sl-color-gray-5);
+  background: var(--sl-color-bg-nav);
+  color: var(--sl-color-text);
+  font-size: var(--sl-text-sm);
+  line-height: 1.2;
+  padding: 0.4rem 0.75rem;
+  border-radius: 0;
+  cursor: pointer;
+  transition: color 0.15s, background-color 0.15s, border-color 0.15s;
+}
+
+.freeze-controls button:hover {
+  color: var(--sl-color-white);
+  background: var(--sl-color-gray-6);
+}
+
+.freeze-controls button:focus-visible {
+  outline: 1px solid var(--sl-color-accent);
+  outline-offset: 1px;
+}
+
+.freeze-controls__status {
+  font-size: var(--sl-text-sm);
+  font-style: italic;
+  color: var(--sl-color-gray-2);
+}

--- a/docs/content/recipes/column-management/freeze-columns/angular/example1.html
+++ b/docs/content/recipes/column-management/freeze-columns/angular/example1.html
@@ -1,0 +1,1 @@
+<div><example1-freeze-columns></example1-freeze-columns></div>

--- a/docs/content/recipes/column-management/freeze-columns/angular/example1.ts
+++ b/docs/content/recipes/column-management/freeze-columns/angular/example1.ts
@@ -33,9 +33,10 @@ const colHeaders = ['Campaign', 'Channel', 'Impressions', 'Clicks', 'Conversions
   standalone: true,
   imports: [HotTableModule, NgFor],
   selector: 'example1-freeze-columns',
+  styleUrls: ['./example1.css'],
   template: `
-    <div style="margin-bottom: 8px;">
-      <div style="display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 6px;">
+    <div class="freeze-controls">
+      <div class="freeze-controls__freeze-btns">
         <button
           *ngFor="let header of colHeaders; let i = index"
           type="button"
@@ -44,8 +45,10 @@ const colHeaders = ['Campaign', 'Channel', 'Impressions', 'Clicks', 'Conversions
           Freeze up to "{{ header }}"
         </button>
       </div>
-      <button type="button" (click)="unfreezeAll()">Unfreeze all</button>
-      <span style="margin-left: 12px; font-style: italic;">{{ statusText }}</span>
+      <div class="freeze-controls__footer">
+        <button type="button" (click)="unfreezeAll()">Unfreeze all</button>
+        <span class="freeze-controls__status">{{ statusText }}</span>
+      </div>
     </div>
     <hot-table [data]="data" [settings]="gridSettings"></hot-table>
   `,

--- a/docs/content/recipes/column-management/freeze-columns/angular/example1.ts
+++ b/docs/content/recipes/column-management/freeze-columns/angular/example1.ts
@@ -1,0 +1,120 @@
+/* file: app.component.ts */
+import { Component, ViewChild } from '@angular/core';
+import { GridSettings, HotTableComponent, HotTableModule } from '@handsontable/angular-wrapper';
+import { NgFor } from '@angular/common';
+
+/* start:skip-in-preview */
+type CampaignRow = {
+  campaign: string;
+  channel: string;
+  impressions: number;
+  clicks: number;
+  conversions: number;
+  cpc: number;
+  revenue: number;
+  roi: number;
+};
+
+const data: CampaignRow[] = [
+  { campaign: 'Spring Sale', channel: 'Email', impressions: 120000, clicks: 4800, conversions: 320, cpc: 0.42, revenue: 9600, roi: 2.28 },
+  { campaign: 'Summer Push', channel: 'Paid Search', impressions: 85000, clicks: 3100, conversions: 210, cpc: 1.15, revenue: 6300, roi: 1.82 },
+  { campaign: 'Back to School', channel: 'Social', impressions: 200000, clicks: 7200, conversions: 540, cpc: 0.31, revenue: 16200, roi: 3.10 },
+  { campaign: 'Black Friday', channel: 'Display', impressions: 450000, clicks: 9000, conversions: 720, cpc: 0.65, revenue: 28800, roi: 2.94 },
+  { campaign: 'Holiday Deals', channel: 'Email', impressions: 310000, clicks: 11200, conversions: 890, cpc: 0.28, revenue: 35600, roi: 4.12 },
+  { campaign: 'New Year Offer', channel: 'Paid Search', impressions: 95000, clicks: 3800, conversions: 290, cpc: 1.22, revenue: 8700, roi: 1.65 },
+  { campaign: 'Valentine Push', channel: 'Social', impressions: 140000, clicks: 5600, conversions: 410, cpc: 0.38, revenue: 12300, roi: 2.56 },
+  { campaign: 'Spring Relaunch', channel: 'Display', impressions: 175000, clicks: 6300, conversions: 480, cpc: 0.55, revenue: 14400, roi: 2.18 },
+];
+/* end:skip-in-preview */
+
+const colHeaders = ['Campaign', 'Channel', 'Impressions', 'Clicks', 'Conversions', 'CPC ($)', 'Revenue ($)', 'ROI'];
+
+@Component({
+  standalone: true,
+  imports: [HotTableModule, NgFor],
+  selector: 'example1-freeze-columns',
+  template: `
+    <div style="margin-bottom: 8px;">
+      <div style="display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 6px;">
+        <button
+          *ngFor="let header of colHeaders; let i = index"
+          type="button"
+          (click)="freezeUpTo(i + 1)"
+        >
+          Freeze up to "{{ header }}"
+        </button>
+      </div>
+      <button type="button" (click)="unfreezeAll()">Unfreeze all</button>
+      <span style="margin-left: 12px; font-style: italic;">{{ statusText }}</span>
+    </div>
+    <hot-table [data]="data" [settings]="gridSettings"></hot-table>
+  `,
+})
+export class AppComponent {
+  @ViewChild(HotTableComponent, { static: false }) readonly hotTable!: HotTableComponent;
+
+  readonly data = data;
+  readonly colHeaders = colHeaders;
+
+  frozenCount = 0;
+
+  get statusText(): string {
+    return this.frozenCount === 0
+      ? 'No columns frozen'
+      : `${this.frozenCount} column${this.frozenCount > 1 ? 's' : ''} frozen`;
+  }
+
+  readonly gridSettings: GridSettings = {
+    colHeaders,
+    columns: [
+      { data: 'campaign', type: 'text' },
+      { data: 'channel', type: 'text' },
+      { data: 'impressions', type: 'numeric', numericFormat: { pattern: '0,0' } },
+      { data: 'clicks', type: 'numeric', numericFormat: { pattern: '0,0' } },
+      { data: 'conversions', type: 'numeric', numericFormat: { pattern: '0,0' } },
+      { data: 'cpc', type: 'numeric', numericFormat: { pattern: '0.00' } },
+      { data: 'revenue', type: 'numeric', numericFormat: { pattern: '$0,0' } },
+      { data: 'roi', type: 'numeric', numericFormat: { pattern: '0.00' } },
+    ],
+    fixedColumnsStart: 0,
+    manualColumnMove: true,
+    rowHeaders: true,
+    height: 'auto',
+    width: '100%',
+    autoWrapRow: true,
+  };
+
+  freezeUpTo(n: number): void {
+    const hot = this.hotTable?.hotInstance;
+
+    if (!hot) return;
+    const total = hot.countCols();
+
+    this.frozenCount = Math.min(n, total);
+    hot.updateSettings({ fixedColumnsStart: this.frozenCount });
+  }
+
+  unfreezeAll(): void {
+    this.frozenCount = 0;
+    this.hotTable?.hotInstance?.updateSettings({ fixedColumnsStart: 0 });
+  }
+}
+/* end-file */
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+/* end-file */

--- a/docs/content/recipes/column-management/freeze-columns/angular/example1.ts
+++ b/docs/content/recipes/column-management/freeze-columns/angular/example1.ts
@@ -1,7 +1,6 @@
 /* file: app.component.ts */
 import { Component, ViewChild } from '@angular/core';
 import { GridSettings, HotTableComponent, HotTableModule } from '@handsontable/angular-wrapper';
-import { NgFor } from '@angular/common';
 
 /* start:skip-in-preview */
 type CampaignRow = {
@@ -31,19 +30,19 @@ const colHeaders = ['Campaign', 'Channel', 'Impressions', 'Clicks', 'Conversions
 
 @Component({
   standalone: true,
-  imports: [HotTableModule, NgFor],
+  imports: [HotTableModule],
   selector: 'example1-freeze-columns',
-  styleUrls: ['./example1.css'],
   template: `
     <div class="freeze-controls">
       <div class="freeze-controls__freeze-btns">
-        <button
-          *ngFor="let header of colHeaders; let i = index"
-          type="button"
-          (click)="freezeUpTo(i + 1)"
-        >
-          Freeze up to "{{ header }}"
-        </button>
+        @for (header of colHeaders; track header; let i = $index) {
+          <button
+            type="button"
+            (click)="freezeUpTo(i + 1)"
+          >
+            Freeze up to "{{ header }}"
+          </button>
+        }
       </div>
       <div class="freeze-controls__footer">
         <button type="button" (click)="unfreezeAll()">Unfreeze all</button>

--- a/docs/content/recipes/column-management/freeze-columns/freeze-columns.md
+++ b/docs/content/recipes/column-management/freeze-columns/freeze-columns.md
@@ -11,6 +11,12 @@ tags:
   - updateSettings
   - manualColumnMove
   - column management
+react:
+  id: c3d8e1f4
+  metaTitle: Freeze and unfreeze columns at runtime - React Data Grid | Handsontable
+angular:
+  id: a7b2c5d9
+  metaTitle: Freeze and unfreeze columns at runtime - Angular Data Grid | Handsontable
 searchCategory: Recipes
 category: Column Management
 type: tutorial
@@ -22,6 +28,28 @@ type: tutorial
 
 @[code](@/content/recipes/column-management/freeze-columns/javascript/example1.js)
 @[code](@/content/recipes/column-management/freeze-columns/javascript/example1.html)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #example1 :react-advanced --js 1 --ts 2
+
+@[code](@/content/recipes/column-management/freeze-columns/react/example1.jsx)
+@[code](@/content/recipes/column-management/freeze-columns/react/example1.tsx)
+
+:::
+
+:::
+
+::: only-for angular
+
+::: example #example1 :angular --ts 1 --html 2
+
+@[code](@/content/recipes/column-management/freeze-columns/angular/example1.ts)
+@[code](@/content/recipes/column-management/freeze-columns/angular/example1.html)
 
 :::
 

--- a/docs/content/recipes/column-management/freeze-columns/freeze-columns.md
+++ b/docs/content/recipes/column-management/freeze-columns/freeze-columns.md
@@ -1,0 +1,167 @@
+---
+id: b4e7c9f2
+title: Freeze and unfreeze columns at runtime
+metaTitle: Freeze and unfreeze columns at runtime - JavaScript Data Grid | Handsontable
+description: Freeze and unfreeze columns dynamically using external buttons that call hot.updateSettings with fixedColumnsStart, and understand how frozen columns interact with manual column reordering.
+permalink: /recipes/column-management/freeze-columns
+canonicalUrl: /recipes/column-management/freeze-columns
+tags:
+  - freeze columns
+  - fixedColumnsStart
+  - updateSettings
+  - manualColumnMove
+  - column management
+searchCategory: Recipes
+category: Column Management
+type: tutorial
+---
+
+::: only-for javascript
+
+::: example #example1 :hot-recipe --js 1 --html 2
+
+@[code](@/content/recipes/column-management/freeze-columns/javascript/example1.js)
+@[code](@/content/recipes/column-management/freeze-columns/javascript/example1.html)
+
+:::
+
+:::
+
+## Overview
+
+**Difficulty:** Beginner
+**Time:** ~15 minutes
+
+This recipe shows how to freeze and unfreeze columns at runtime using `hot.updateSettings({ fixedColumnsStart: n })`. Frozen columns stay pinned to the left edge of the grid while the rest scroll horizontally. External buttons let users control the freeze boundary without touching the grid configuration directly.
+
+## What You'll Build
+
+- A row of **Freeze up to "Column"** buttons -- one per column -- generated from the column headers array
+- An **Unfreeze all** button that resets the freeze boundary to zero
+- A status indicator showing how many columns are currently frozen
+- A guard that prevents freezing more columns than are present in the grid
+
+## Before you begin
+
+This recipe uses only the built-in Handsontable API. No extra dependencies are required.
+
+The example uses marketing analytics data with eight columns: Campaign, Channel, Impressions, Clicks, Conversions, CPC, Revenue, and ROI. With many columns the grid scrolls horizontally, making frozen columns genuinely useful -- the identifier columns stay visible while metric columns scroll.
+
+## Step 1 -- Set up the grid with fixedColumnsStart and manualColumnMove
+
+```javascript
+const hot = new Handsontable(container, {
+  data,
+  colHeaders,
+  columns: [
+    { data: 'campaign', type: 'text' },
+    { data: 'channel', type: 'text' },
+    { data: 'impressions', type: 'numeric', numericFormat: { pattern: '0,0' } },
+    { data: 'clicks', type: 'numeric', numericFormat: { pattern: '0,0' } },
+    { data: 'conversions', type: 'numeric', numericFormat: { pattern: '0,0' } },
+    { data: 'cpc', type: 'numeric', numericFormat: { pattern: '0.00' } },
+    { data: 'revenue', type: 'numeric', numericFormat: { pattern: '$0,0' } },
+    { data: 'roi', type: 'numeric', numericFormat: { pattern: '0.00' } },
+  ],
+  fixedColumnsStart: 0,
+  manualColumnMove: true,
+  rowHeaders: true,
+  height: 'auto',
+  width: '100%',
+  autoWrapRow: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+```
+
+**What's happening:** `fixedColumnsStart: 0` is the initial value -- no columns are frozen on load. `manualColumnMove: true` allows users to drag columns into different positions. Both options work together: after the user reorders columns, the freeze boundary still refers to the current visual order (the leftmost `n` columns in their current positions are frozen).
+
+**Why set `fixedColumnsStart: 0` explicitly?** The default is `0`, but declaring it makes the initial state visible in the config and makes the runtime change more explicit to anyone reading the code.
+
+## Step 2 -- Track state and apply the freeze boundary
+
+```javascript
+let frozenCount = 0;
+
+function freezeUpTo(n) {
+  const total = hot.countCols();
+
+  frozenCount = Math.min(n, total);
+  hot.updateSettings({ fixedColumnsStart: frozenCount });
+  updateStatus();
+}
+```
+
+**What's happening:** `frozenCount` is the single piece of mutable state in this recipe. `freezeUpTo(n)` clamps the requested freeze count to the actual number of columns (`hot.countCols()`) and then calls `hot.updateSettings()`. Clamping handles the edge case where a freeze button is clicked after columns have been hidden or removed.
+
+**Why use `hot.updateSettings()` instead of modifying the config object directly?** `hot.updateSettings()` is the documented way to change grid settings at runtime. It triggers a full re-render and keeps Handsontable's internal state consistent. Modifying a config object directly has no effect on the rendered grid.
+
+**Why `Math.min(n, total)`?** If `fixedColumnsStart` exceeds the number of rendered columns, Handsontable clamps it internally -- but being explicit in application code prevents confusion and makes the guard visible.
+
+## Step 3 -- Generate freeze buttons from the column headers
+
+```javascript
+const colHeaders = ['Campaign', 'Channel', 'Impressions', 'Clicks', 'Conversions', 'CPC ($)', 'Revenue ($)', 'ROI'];
+
+colHeaders.forEach((header, index) => {
+  const btn = document.createElement('button');
+
+  btn.type = 'button';
+  btn.textContent = `Freeze up to "${header}"`;
+  btn.dataset.colIndex = String(index);
+
+  btn.addEventListener('click', () => {
+    freezeUpTo(index + 1);
+  });
+
+  controlsContainer.appendChild(btn);
+});
+```
+
+**What's happening:** One button is generated for each column header. Clicking the button for column at index `i` calls `freezeUpTo(i + 1)`, which freezes columns `0` through `i` inclusive. Generating buttons from the same `colHeaders` array ensures the button labels and column positions are always in sync -- adding or renaming a column in the config automatically updates the button list.
+
+**Why `index + 1`?** `fixedColumnsStart` is a count, not an index. To freeze the column at visual index `i`, you set the count to `i + 1`.
+
+## Step 4 -- Add the Unfreeze all button
+
+```javascript
+document.querySelector('#unfreeze-btn').addEventListener('click', () => {
+  frozenCount = 0;
+  hot.updateSettings({ fixedColumnsStart: 0 });
+  updateStatus();
+});
+```
+
+**What's happening:** Setting `fixedColumnsStart: 0` releases all frozen columns. The grid re-renders without any pinned column overlay. The status indicator is updated to "No columns frozen".
+
+## Step 5 -- Show a frozen column count indicator
+
+```javascript
+function updateStatus() {
+  statusEl.textContent = frozenCount === 0
+    ? 'No columns frozen'
+    : `${frozenCount} column${frozenCount > 1 ? 's' : ''} frozen`;
+}
+```
+
+**What's happening:** `updateStatus()` is called after every freeze or unfreeze action. It reads `frozenCount` -- not the grid setting -- because `frozenCount` is already clamped and reflects the actual frozen count. The status message uses a simple plural rule to display "1 column frozen" or "3 columns frozen".
+
+## How It Works - Complete Flow
+
+1. **Page load**: The grid initializes with `fixedColumnsStart: 0`. No columns are pinned. The status reads "No columns frozen". Freeze buttons are generated from `colHeaders`.
+2. **User clicks "Freeze up to 'Channel'"**: `freezeUpTo(2)` is called. `frozenCount` becomes `2`. `hot.updateSettings({ fixedColumnsStart: 2 })` pins the first two columns (Campaign and Channel). The status reads "2 columns frozen".
+3. **User drags a column**: Because `manualColumnMove: true` is set, the user can reorder columns by dragging. After reordering, the frozen count still applies to the current leftmost `n` columns -- whichever columns are now in positions 0 and 1. **This is the key caveat:** frozen columns are always the leftmost `n` columns in their current visual order, not a fixed set of named columns.
+4. **User clicks "Unfreeze all"**: `frozenCount` resets to `0`. `hot.updateSettings({ fixedColumnsStart: 0 })` removes all frozen columns. The status reads "No columns frozen".
+
+## What you learned
+
+- Set `fixedColumnsStart: n` in the initial config or via `hot.updateSettings()` to pin the leftmost `n` columns.
+- Call `hot.updateSettings({ fixedColumnsStart: 0 })` to unfreeze all columns.
+- Generate freeze buttons programmatically from the `colHeaders` array so labels stay in sync with the grid configuration.
+- `fixedColumnsStart` is a count from the left edge in current visual order -- not a named column reference. After column reordering, the frozen set changes accordingly.
+- Clamp the freeze count with `Math.min(n, hot.countCols())` to handle edge cases where the requested count exceeds the number of visible columns.
+
+## Next steps
+
+- Combine this pattern with the [column visibility toggle](@/content/recipes/column-management/column-visibility/column-visibility.md) recipe to build a full column-management toolbar.
+- Persist the `frozenCount` value to `localStorage` using the `afterUpdateSettings` hook so the freeze state survives a page refresh.
+- Replace the individual freeze buttons with a single numeric input (`<input type="number">`) to let users type a freeze count directly.

--- a/docs/content/recipes/column-management/freeze-columns/freeze-columns.md
+++ b/docs/content/recipes/column-management/freeze-columns/freeze-columns.md
@@ -24,10 +24,11 @@ type: tutorial
 
 ::: only-for javascript
 
-::: example #example1 :hot-recipe --js 1 --html 2
+::: example #example1 :hot-recipe --js 1 --html 2 --css 3
 
 @[code](@/content/recipes/column-management/freeze-columns/javascript/example1.js)
 @[code](@/content/recipes/column-management/freeze-columns/javascript/example1.html)
+@[code](@/content/recipes/column-management/freeze-columns/javascript/example1.css)
 
 :::
 
@@ -35,8 +36,9 @@ type: tutorial
 
 ::: only-for react
 
-::: example #example1 :react-advanced --js 1 --ts 2
+::: example #example1 :react-advanced --css 1 --js 2 --ts 3
 
+@[code](@/content/recipes/column-management/freeze-columns/react/example1.css)
 @[code](@/content/recipes/column-management/freeze-columns/react/example1.jsx)
 @[code](@/content/recipes/column-management/freeze-columns/react/example1.tsx)
 
@@ -46,8 +48,9 @@ type: tutorial
 
 ::: only-for angular
 
-::: example #example1 :angular --ts 1 --html 2
+::: example #example1 :angular --css 1 --ts 2 --html 3
 
+@[code](@/content/recipes/column-management/freeze-columns/angular/example1.css)
 @[code](@/content/recipes/column-management/freeze-columns/angular/example1.ts)
 @[code](@/content/recipes/column-management/freeze-columns/angular/example1.html)
 

--- a/docs/content/recipes/column-management/freeze-columns/javascript/example1.css
+++ b/docs/content/recipes/column-management/freeze-columns/javascript/example1.css
@@ -1,0 +1,46 @@
+.freeze-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.freeze-controls__freeze-btns {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.freeze-controls__footer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.freeze-controls button {
+  border: 1px solid var(--sl-color-gray-5);
+  background: var(--sl-color-bg-nav);
+  color: var(--sl-color-text);
+  font-size: var(--sl-text-sm);
+  line-height: 1.2;
+  padding: 0.4rem 0.75rem;
+  border-radius: 0;
+  cursor: pointer;
+  transition: color 0.15s, background-color 0.15s, border-color 0.15s;
+}
+
+.freeze-controls button:hover {
+  color: var(--sl-color-white);
+  background: var(--sl-color-gray-6);
+}
+
+.freeze-controls button:focus-visible {
+  outline: 1px solid var(--sl-color-accent);
+  outline-offset: 1px;
+}
+
+.freeze-controls__status {
+  font-size: var(--sl-text-sm);
+  font-style: italic;
+  color: var(--sl-color-gray-2);
+}

--- a/docs/content/recipes/column-management/freeze-columns/javascript/example1.html
+++ b/docs/content/recipes/column-management/freeze-columns/javascript/example1.html
@@ -1,0 +1,6 @@
+<div style="margin-bottom: 8px;">
+  <div id="freeze-controls" style="display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 6px;"></div>
+  <button id="unfreeze-btn" type="button">Unfreeze all</button>
+  <span id="freeze-status" style="margin-left: 12px; font-style: italic;"></span>
+</div>
+<div id="example1"></div>

--- a/docs/content/recipes/column-management/freeze-columns/javascript/example1.html
+++ b/docs/content/recipes/column-management/freeze-columns/javascript/example1.html
@@ -1,6 +1,8 @@
-<div style="margin-bottom: 8px;">
-  <div id="freeze-controls" style="display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 6px;"></div>
-  <button id="unfreeze-btn" type="button">Unfreeze all</button>
-  <span id="freeze-status" style="margin-left: 12px; font-style: italic;"></span>
+<div class="freeze-controls">
+  <div id="freeze-buttons" class="freeze-controls__freeze-btns"></div>
+  <div class="freeze-controls__footer">
+    <button id="unfreeze-btn" type="button">Unfreeze all</button>
+    <span id="freeze-status" class="freeze-controls__status"></span>
+  </div>
 </div>
 <div id="example1"></div>

--- a/docs/content/recipes/column-management/freeze-columns/javascript/example1.js
+++ b/docs/content/recipes/column-management/freeze-columns/javascript/example1.js
@@ -22,7 +22,7 @@ let frozenCount = 0;
 const colHeaders = ['Campaign', 'Channel', 'Impressions', 'Clicks', 'Conversions', 'CPC ($)', 'Revenue ($)', 'ROI'];
 
 const container = document.querySelector('#example1');
-const controlsContainer = document.querySelector('#freeze-controls');
+const controlsContainer = document.querySelector('#freeze-buttons');
 const statusEl = document.querySelector('#freeze-status');
 
 const hot = new Handsontable(container, {

--- a/docs/content/recipes/column-management/freeze-columns/javascript/example1.js
+++ b/docs/content/recipes/column-management/freeze-columns/javascript/example1.js
@@ -1,0 +1,89 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+/* start:skip-in-preview */
+const data = [
+  { campaign: 'Spring Sale', channel: 'Email', impressions: 120000, clicks: 4800, conversions: 320, cpc: 0.42, revenue: 9600, roi: 2.28 },
+  { campaign: 'Summer Push', channel: 'Paid Search', impressions: 85000, clicks: 3100, conversions: 210, cpc: 1.15, revenue: 6300, roi: 1.82 },
+  { campaign: 'Back to School', channel: 'Social', impressions: 200000, clicks: 7200, conversions: 540, cpc: 0.31, revenue: 16200, roi: 3.10 },
+  { campaign: 'Black Friday', channel: 'Display', impressions: 450000, clicks: 9000, conversions: 720, cpc: 0.65, revenue: 28800, roi: 2.94 },
+  { campaign: 'Holiday Deals', channel: 'Email', impressions: 310000, clicks: 11200, conversions: 890, cpc: 0.28, revenue: 35600, roi: 4.12 },
+  { campaign: 'New Year Offer', channel: 'Paid Search', impressions: 95000, clicks: 3800, conversions: 290, cpc: 1.22, revenue: 8700, roi: 1.65 },
+  { campaign: 'Valentine Push', channel: 'Social', impressions: 140000, clicks: 5600, conversions: 410, cpc: 0.38, revenue: 12300, roi: 2.56 },
+  { campaign: 'Spring Relaunch', channel: 'Display', impressions: 175000, clicks: 6300, conversions: 480, cpc: 0.55, revenue: 14400, roi: 2.18 },
+];
+/* end:skip-in-preview */
+
+// Number of columns currently frozen. Starts at 0 (no frozen columns).
+let frozenCount = 0;
+
+const colHeaders = ['Campaign', 'Channel', 'Impressions', 'Clicks', 'Conversions', 'CPC ($)', 'Revenue ($)', 'ROI'];
+
+const container = document.querySelector('#example1');
+const controlsContainer = document.querySelector('#freeze-controls');
+const statusEl = document.querySelector('#freeze-status');
+
+const hot = new Handsontable(container, {
+  data,
+  colHeaders,
+  columns: [
+    { data: 'campaign', type: 'text' },
+    { data: 'channel', type: 'text' },
+    { data: 'impressions', type: 'numeric', numericFormat: { pattern: '0,0' } },
+    { data: 'clicks', type: 'numeric', numericFormat: { pattern: '0,0' } },
+    { data: 'conversions', type: 'numeric', numericFormat: { pattern: '0,0' } },
+    { data: 'cpc', type: 'numeric', numericFormat: { pattern: '0.00' } },
+    { data: 'revenue', type: 'numeric', numericFormat: { pattern: '$0,0' } },
+    { data: 'roi', type: 'numeric', numericFormat: { pattern: '0.00' } },
+  ],
+  fixedColumnsStart: 0,
+  manualColumnMove: true,
+  rowHeaders: true,
+  height: 'auto',
+  width: '100%',
+  autoWrapRow: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+// Updates the status indicator to reflect the current frozen column count.
+function updateStatus() {
+  statusEl.textContent = frozenCount === 0
+    ? 'No columns frozen'
+    : `${frozenCount} column${frozenCount > 1 ? 's' : ''} frozen`;
+}
+
+// Applies the freeze boundary and refreshes the status indicator.
+function freezeUpTo(n) {
+  const total = hot.countCols();
+
+  // Guard: clamp to the number of columns actually present in the grid.
+  frozenCount = Math.min(n, total);
+  hot.updateSettings({ fixedColumnsStart: frozenCount });
+  updateStatus();
+}
+
+// Generates one "Freeze up to column N" button for each column.
+colHeaders.forEach((header, index) => {
+  const btn = document.createElement('button');
+
+  btn.type = 'button';
+  btn.textContent = `Freeze up to "${header}"`;
+  btn.dataset.colIndex = String(index);
+
+  btn.addEventListener('click', () => {
+    freezeUpTo(index + 1);
+  });
+
+  controlsContainer.appendChild(btn);
+});
+
+// "Unfreeze all" resets fixedColumnsStart to 0.
+document.querySelector('#unfreeze-btn').addEventListener('click', () => {
+  frozenCount = 0;
+  hot.updateSettings({ fixedColumnsStart: 0 });
+  updateStatus();
+});
+
+updateStatus();

--- a/docs/content/recipes/column-management/freeze-columns/react/example1.css
+++ b/docs/content/recipes/column-management/freeze-columns/react/example1.css
@@ -1,0 +1,46 @@
+.freeze-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.freeze-controls__freeze-btns {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.freeze-controls__footer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.freeze-controls button {
+  border: 1px solid var(--sl-color-gray-5);
+  background: var(--sl-color-bg-nav);
+  color: var(--sl-color-text);
+  font-size: var(--sl-text-sm);
+  line-height: 1.2;
+  padding: 0.4rem 0.75rem;
+  border-radius: 0;
+  cursor: pointer;
+  transition: color 0.15s, background-color 0.15s, border-color 0.15s;
+}
+
+.freeze-controls button:hover {
+  color: var(--sl-color-white);
+  background: var(--sl-color-gray-6);
+}
+
+.freeze-controls button:focus-visible {
+  outline: 1px solid var(--sl-color-accent);
+  outline-offset: 1px;
+}
+
+.freeze-controls__status {
+  font-size: var(--sl-text-sm);
+  font-style: italic;
+  color: var(--sl-color-gray-2);
+}

--- a/docs/content/recipes/column-management/freeze-columns/react/example1.jsx
+++ b/docs/content/recipes/column-management/freeze-columns/react/example1.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useRef, useState } from 'react';
 import { HotTable } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
+import './example1.css';
 
 registerAllModules();
 
@@ -59,8 +60,8 @@ const ExampleComponent = () => {
 
   return (
     <div>
-      <div style={{ marginBottom: '8px' }}>
-        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px', marginBottom: '6px' }}>
+      <div className="freeze-controls">
+        <div className="freeze-controls__freeze-btns">
           {colHeaders.map((header, index) => (
             <button
               key={header}
@@ -71,8 +72,10 @@ const ExampleComponent = () => {
             </button>
           ))}
         </div>
-        <button type="button" onClick={unfreezeAll}>Unfreeze all</button>
-        <span style={{ marginLeft: '12px', fontStyle: 'italic' }}>{statusText}</span>
+        <div className="freeze-controls__footer">
+          <button type="button" onClick={unfreezeAll}>Unfreeze all</button>
+          <span className="freeze-controls__status">{statusText}</span>
+        </div>
       </div>
       <HotTable
         ref={hotRef}

--- a/docs/content/recipes/column-management/freeze-columns/react/example1.jsx
+++ b/docs/content/recipes/column-management/freeze-columns/react/example1.jsx
@@ -37,21 +37,13 @@ const ExampleComponent = () => {
 
   const freezeUpTo = useCallback((n) => {
     const hot = hotRef.current?.hotInstance;
+    const total = hot ? hot.countCols() : colHeaders.length;
 
-    if (!hot) return;
-    const total = hot.countCols();
-    const newCount = Math.min(n, total);
-
-    setFrozenCount(newCount);
-    hot.updateSettings({ fixedColumnsStart: newCount });
+    setFrozenCount(Math.min(n, total));
   }, []);
 
   const unfreezeAll = useCallback(() => {
-    const hot = hotRef.current?.hotInstance;
-
-    if (!hot) return;
     setFrozenCount(0);
-    hot.updateSettings({ fixedColumnsStart: 0 });
   }, []);
 
   const statusText = frozenCount === 0
@@ -82,7 +74,7 @@ const ExampleComponent = () => {
         data={data}
         colHeaders={colHeaders}
         columns={columns}
-        fixedColumnsStart={0}
+        fixedColumnsStart={frozenCount}
         manualColumnMove={true}
         rowHeaders={true}
         height="auto"

--- a/docs/content/recipes/column-management/freeze-columns/react/example1.jsx
+++ b/docs/content/recipes/column-management/freeze-columns/react/example1.jsx
@@ -1,0 +1,94 @@
+import { useCallback, useRef, useState } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+/* start:skip-in-preview */
+const data = [
+  { campaign: 'Spring Sale', channel: 'Email', impressions: 120000, clicks: 4800, conversions: 320, cpc: 0.42, revenue: 9600, roi: 2.28 },
+  { campaign: 'Summer Push', channel: 'Paid Search', impressions: 85000, clicks: 3100, conversions: 210, cpc: 1.15, revenue: 6300, roi: 1.82 },
+  { campaign: 'Back to School', channel: 'Social', impressions: 200000, clicks: 7200, conversions: 540, cpc: 0.31, revenue: 16200, roi: 3.10 },
+  { campaign: 'Black Friday', channel: 'Display', impressions: 450000, clicks: 9000, conversions: 720, cpc: 0.65, revenue: 28800, roi: 2.94 },
+  { campaign: 'Holiday Deals', channel: 'Email', impressions: 310000, clicks: 11200, conversions: 890, cpc: 0.28, revenue: 35600, roi: 4.12 },
+  { campaign: 'New Year Offer', channel: 'Paid Search', impressions: 95000, clicks: 3800, conversions: 290, cpc: 1.22, revenue: 8700, roi: 1.65 },
+  { campaign: 'Valentine Push', channel: 'Social', impressions: 140000, clicks: 5600, conversions: 410, cpc: 0.38, revenue: 12300, roi: 2.56 },
+  { campaign: 'Spring Relaunch', channel: 'Display', impressions: 175000, clicks: 6300, conversions: 480, cpc: 0.55, revenue: 14400, roi: 2.18 },
+];
+/* end:skip-in-preview */
+
+const colHeaders = ['Campaign', 'Channel', 'Impressions', 'Clicks', 'Conversions', 'CPC ($)', 'Revenue ($)', 'ROI'];
+
+const columns = [
+  { data: 'campaign', type: 'text' },
+  { data: 'channel', type: 'text' },
+  { data: 'impressions', type: 'numeric', numericFormat: { pattern: '0,0' } },
+  { data: 'clicks', type: 'numeric', numericFormat: { pattern: '0,0' } },
+  { data: 'conversions', type: 'numeric', numericFormat: { pattern: '0,0' } },
+  { data: 'cpc', type: 'numeric', numericFormat: { pattern: '0.00' } },
+  { data: 'revenue', type: 'numeric', numericFormat: { pattern: '$0,0' } },
+  { data: 'roi', type: 'numeric', numericFormat: { pattern: '0.00' } },
+];
+
+const ExampleComponent = () => {
+  const hotRef = useRef(null);
+  const [frozenCount, setFrozenCount] = useState(0);
+
+  const freezeUpTo = useCallback((n) => {
+    const hot = hotRef.current?.hotInstance;
+
+    if (!hot) return;
+    const total = hot.countCols();
+    const newCount = Math.min(n, total);
+
+    setFrozenCount(newCount);
+    hot.updateSettings({ fixedColumnsStart: newCount });
+  }, []);
+
+  const unfreezeAll = useCallback(() => {
+    const hot = hotRef.current?.hotInstance;
+
+    if (!hot) return;
+    setFrozenCount(0);
+    hot.updateSettings({ fixedColumnsStart: 0 });
+  }, []);
+
+  const statusText = frozenCount === 0
+    ? 'No columns frozen'
+    : `${frozenCount} column${frozenCount > 1 ? 's' : ''} frozen`;
+
+  return (
+    <div>
+      <div style={{ marginBottom: '8px' }}>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px', marginBottom: '6px' }}>
+          {colHeaders.map((header, index) => (
+            <button
+              key={header}
+              type="button"
+              onClick={() => freezeUpTo(index + 1)}
+            >
+              Freeze up to &quot;{header}&quot;
+            </button>
+          ))}
+        </div>
+        <button type="button" onClick={unfreezeAll}>Unfreeze all</button>
+        <span style={{ marginLeft: '12px', fontStyle: 'italic' }}>{statusText}</span>
+      </div>
+      <HotTable
+        ref={hotRef}
+        data={data}
+        colHeaders={colHeaders}
+        columns={columns}
+        fixedColumnsStart={0}
+        manualColumnMove={true}
+        rowHeaders={true}
+        height="auto"
+        width="100%"
+        autoWrapRow={true}
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </div>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/column-management/freeze-columns/react/example1.tsx
+++ b/docs/content/recipes/column-management/freeze-columns/react/example1.tsx
@@ -2,6 +2,7 @@ import { useCallback, useRef, useState } from 'react';
 import { HotTable } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
 import type { HotTableRef } from '@handsontable/react-wrapper';
+import './example1.css';
 
 registerAllModules();
 
@@ -71,8 +72,8 @@ const ExampleComponent = () => {
 
   return (
     <div>
-      <div style={{ marginBottom: '8px' }}>
-        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px', marginBottom: '6px' }}>
+      <div className="freeze-controls">
+        <div className="freeze-controls__freeze-btns">
           {colHeaders.map((header, index) => (
             <button
               key={header}
@@ -83,8 +84,10 @@ const ExampleComponent = () => {
             </button>
           ))}
         </div>
-        <button type="button" onClick={unfreezeAll}>Unfreeze all</button>
-        <span style={{ marginLeft: '12px', fontStyle: 'italic' }}>{statusText}</span>
+        <div className="freeze-controls__footer">
+          <button type="button" onClick={unfreezeAll}>Unfreeze all</button>
+          <span className="freeze-controls__status">{statusText}</span>
+        </div>
       </div>
       <HotTable
         ref={hotRef}

--- a/docs/content/recipes/column-management/freeze-columns/react/example1.tsx
+++ b/docs/content/recipes/column-management/freeze-columns/react/example1.tsx
@@ -1,0 +1,106 @@
+import { useCallback, useRef, useState } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import type { HotTableRef } from '@handsontable/react-wrapper';
+
+registerAllModules();
+
+/* start:skip-in-preview */
+type CampaignRow = {
+  campaign: string;
+  channel: string;
+  impressions: number;
+  clicks: number;
+  conversions: number;
+  cpc: number;
+  revenue: number;
+  roi: number;
+};
+
+const data: CampaignRow[] = [
+  { campaign: 'Spring Sale', channel: 'Email', impressions: 120000, clicks: 4800, conversions: 320, cpc: 0.42, revenue: 9600, roi: 2.28 },
+  { campaign: 'Summer Push', channel: 'Paid Search', impressions: 85000, clicks: 3100, conversions: 210, cpc: 1.15, revenue: 6300, roi: 1.82 },
+  { campaign: 'Back to School', channel: 'Social', impressions: 200000, clicks: 7200, conversions: 540, cpc: 0.31, revenue: 16200, roi: 3.10 },
+  { campaign: 'Black Friday', channel: 'Display', impressions: 450000, clicks: 9000, conversions: 720, cpc: 0.65, revenue: 28800, roi: 2.94 },
+  { campaign: 'Holiday Deals', channel: 'Email', impressions: 310000, clicks: 11200, conversions: 890, cpc: 0.28, revenue: 35600, roi: 4.12 },
+  { campaign: 'New Year Offer', channel: 'Paid Search', impressions: 95000, clicks: 3800, conversions: 290, cpc: 1.22, revenue: 8700, roi: 1.65 },
+  { campaign: 'Valentine Push', channel: 'Social', impressions: 140000, clicks: 5600, conversions: 410, cpc: 0.38, revenue: 12300, roi: 2.56 },
+  { campaign: 'Spring Relaunch', channel: 'Display', impressions: 175000, clicks: 6300, conversions: 480, cpc: 0.55, revenue: 14400, roi: 2.18 },
+];
+/* end:skip-in-preview */
+
+const colHeaders = ['Campaign', 'Channel', 'Impressions', 'Clicks', 'Conversions', 'CPC ($)', 'Revenue ($)', 'ROI'];
+
+const columns = [
+  { data: 'campaign', type: 'text' as const },
+  { data: 'channel', type: 'text' as const },
+  { data: 'impressions', type: 'numeric' as const, numericFormat: { pattern: '0,0' } },
+  { data: 'clicks', type: 'numeric' as const, numericFormat: { pattern: '0,0' } },
+  { data: 'conversions', type: 'numeric' as const, numericFormat: { pattern: '0,0' } },
+  { data: 'cpc', type: 'numeric' as const, numericFormat: { pattern: '0.00' } },
+  { data: 'revenue', type: 'numeric' as const, numericFormat: { pattern: '$0,0' } },
+  { data: 'roi', type: 'numeric' as const, numericFormat: { pattern: '0.00' } },
+];
+
+const ExampleComponent = () => {
+  const hotRef = useRef<HotTableRef>(null);
+  const [frozenCount, setFrozenCount] = useState(0);
+
+  const freezeUpTo = useCallback((n: number) => {
+    const hot = hotRef.current?.hotInstance;
+
+    if (!hot) return;
+    const total = hot.countCols();
+    const newCount = Math.min(n, total);
+
+    setFrozenCount(newCount);
+    hot.updateSettings({ fixedColumnsStart: newCount });
+  }, []);
+
+  const unfreezeAll = useCallback(() => {
+    const hot = hotRef.current?.hotInstance;
+
+    if (!hot) return;
+    setFrozenCount(0);
+    hot.updateSettings({ fixedColumnsStart: 0 });
+  }, []);
+
+  const statusText = frozenCount === 0
+    ? 'No columns frozen'
+    : `${frozenCount} column${frozenCount > 1 ? 's' : ''} frozen`;
+
+  return (
+    <div>
+      <div style={{ marginBottom: '8px' }}>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px', marginBottom: '6px' }}>
+          {colHeaders.map((header, index) => (
+            <button
+              key={header}
+              type="button"
+              onClick={() => freezeUpTo(index + 1)}
+            >
+              Freeze up to &quot;{header}&quot;
+            </button>
+          ))}
+        </div>
+        <button type="button" onClick={unfreezeAll}>Unfreeze all</button>
+        <span style={{ marginLeft: '12px', fontStyle: 'italic' }}>{statusText}</span>
+      </div>
+      <HotTable
+        ref={hotRef}
+        data={data}
+        colHeaders={colHeaders}
+        columns={columns}
+        fixedColumnsStart={0}
+        manualColumnMove={true}
+        rowHeaders={true}
+        height="auto"
+        width="100%"
+        autoWrapRow={true}
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </div>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/column-management/freeze-columns/react/example1.tsx
+++ b/docs/content/recipes/column-management/freeze-columns/react/example1.tsx
@@ -49,21 +49,13 @@ const ExampleComponent = () => {
 
   const freezeUpTo = useCallback((n: number) => {
     const hot = hotRef.current?.hotInstance;
+    const total = hot ? hot.countCols() : colHeaders.length;
 
-    if (!hot) return;
-    const total = hot.countCols();
-    const newCount = Math.min(n, total);
-
-    setFrozenCount(newCount);
-    hot.updateSettings({ fixedColumnsStart: newCount });
+    setFrozenCount(Math.min(n, total));
   }, []);
 
   const unfreezeAll = useCallback(() => {
-    const hot = hotRef.current?.hotInstance;
-
-    if (!hot) return;
     setFrozenCount(0);
-    hot.updateSettings({ fixedColumnsStart: 0 });
   }, []);
 
   const statusText = frozenCount === 0
@@ -94,7 +86,7 @@ const ExampleComponent = () => {
         data={data}
         colHeaders={colHeaders}
         columns={columns}
-        fixedColumnsStart={0}
+        fixedColumnsStart={frozenCount}
         manualColumnMove={true}
         rowHeaders={true}
         height="auto"

--- a/docs/content/recipes/sidebar.js
+++ b/docs/content/recipes/sidebar.js
@@ -1,3 +1,7 @@
+const columnManagementItems = [
+  { path: 'column-management/freeze-columns/freeze-columns', title: 'Freeze columns at runtime', onlyFor: ['javascript'] },
+];
+
 const cellTypesItems = [
   { path: 'cell-types/color-picker/color-picker', title: 'Color picker', onlyFor: ['javascript'] },
   { path: 'cell-types/feedback-react/feedback-react', title: 'Simple Feedback', onlyFor: ['react'] },
@@ -25,6 +29,7 @@ const themesItems = [
 module.exports = {
   sidebar: [
     'introduction',
+    { title: 'Column Management', path: 'column-management', children: columnManagementItems, collapsable: false, onlyFor: ['javascript'] },
     { title: 'Cell Types', path: 'cell-types', children: cellTypesItems, collapsable: false, onlyFor: ['react', 'javascript', 'angular'] },
     { title: 'Themes', path: 'themes', children: themesItems, collapsable: false, onlyFor: ['react', 'javascript', 'angular'] },
   ],

--- a/docs/content/recipes/sidebar.js
+++ b/docs/content/recipes/sidebar.js
@@ -5,6 +5,7 @@ const realTimeItems = [
 
 const columnManagementItems = [
   { path: 'column-management/column-visibility/column-visibility', title: 'Dynamic column visibility', onlyFor: ['javascript', 'angular', 'react'] },
+  { path: 'column-management/freeze-columns/freeze-columns', title: 'Freeze columns at runtime', onlyFor: ['javascript', 'angular', 'react'] },
 ];
 
 const contextMenuItems = [

--- a/docs/content/recipes/sidebar.js
+++ b/docs/content/recipes/sidebar.js
@@ -46,6 +46,7 @@ const cellTypesItems = [
 
 const performanceItems = [
   { path: 'performance/lazy-loading/lazy-loading', title: 'Lazy loading with pagination', onlyFor: ['javascript', 'react', 'angular'] },
+  { path: 'performance/persist-column-layout/persist-column-layout', title: 'Persist column layout', onlyFor: ['javascript', 'angular', 'react'] },
 ];
 
 const renderingStylingItems = [
@@ -84,10 +85,6 @@ const filteringAndSearchItems = [
   },
 ];
 
-const performanceItems = [
-  { path: 'performance/persist-column-layout/persist-column-layout', title: 'Persist column layout', onlyFor: ['javascript', 'angular', 'react'] },
-];
-
 const themesItems = [
   { path: 'themes/base-theme/base-theme', title: 'Handsontable with Base Web', onlyFor: ['react', 'javascript', 'angular'] },
   { path: 'themes/custom-theme/custom-theme', title: 'Handsontable with shadcn/ui', onlyFor: ['react', 'javascript', 'angular'] },
@@ -122,7 +119,6 @@ module.exports = {
     { title: 'Column Management', path: 'column-management', children: columnManagementItems, collapsable: false, onlyFor: ['javascript', 'angular', 'react'] },
     { title: 'Data Management', path: 'data-management', children: dataManagementItems, collapsable: false, onlyFor: ['javascript', 'angular', 'react'] },
     { title: 'Cell Types', path: 'cell-types', children: cellTypesItems, collapsable: false, onlyFor: ['react', 'javascript', 'angular'] },
-    { title: 'Performance', path: 'performance', children: performanceItems, collapsable: false, onlyFor: ['javascript', 'react', 'angular'] },
     { title: 'Context Menu', path: 'context-menu', children: contextMenuItems, collapsable: false, onlyFor: ['javascript', 'react', 'angular'] },
     {
       title: 'Editing and Validation',
@@ -155,7 +151,7 @@ module.exports = {
       collapsable: false,
       onlyFor: ['javascript', 'angular', 'react'],
     },
-    { title: 'Performance', path: 'performance', children: performanceItems, collapsable: false, onlyFor: ['javascript', 'angular', 'react'] },
+    { title: 'Performance', path: 'performance', children: performanceItems, collapsable: false, onlyFor: ['javascript', 'react', 'angular'] },
     { title: 'Themes', path: 'themes', children: themesItems, collapsable: false, onlyFor: ['react', 'javascript', 'angular'] },
   ],
 };


### PR DESCRIPTION

## Summary

Implements the "Freeze / unfreeze columns at runtime" recipe for the Handsontable documentation.

- Adds a new Tutorial-type recipe page at `docs/content/recipes/column-management/freeze-columns/`
- Demonstrates using `hot.updateSettings({ fixedColumnsStart: n })` to freeze/unfreeze columns dynamically
- Generates "Freeze up to column N" buttons in the UI for each column
- Shows a "Unfreeze All" button and a frozen column count indicator
- Explains the caveat: frozen columns must be leftmost (visual order)
- Handles edge cases (freeze count exceeds column count)
- Registers the recipe in the sidebar under the "Column Management" section
- **Adds React (JSX + TSX) and Angular (TS + HTML) examples** alongside the existing JavaScript example
- Merged with latest `develop` (conflict in `sidebar.js` resolved -- freeze-columns entry added to the expanded sidebar structure)

ClickUp task: https://app.clickup.com/t/86c9c7mbq

[skip changelog]

## Docs PR checklist

- [x] `type:` field added to frontmatter (tutorial)
- [x] Page uses the correct Diátaxis template for its type
- [x] No banned placeholder data
- [x] All example data is domain-realistic (analytics/campaign domain)
- [x] All code blocks have language tags
- [x] No `var` in code examples; uses `const` / `let`
- [x] All examples include `licenseKey: 'non-commercial-and-evaluation'`
- [x] New page registered in sidebar
- [x] React frontmatter IDs added (`react.id`, `react.metaTitle`)
- [x] Angular frontmatter IDs added (`angular.id`, `angular.metaTitle`)
- [x] `[skip changelog]` in PR body (docs changes)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes that add new recipe content and update example code patterns; main risk is broken embeds or framework example rendering if the example runner expectations change.
> 
> **Overview**
> Adds a new *tutorial recipe* page, `freeze-columns`, demonstrating how to freeze and unfreeze the leftmost columns at runtime via `hot.updateSettings({ fixedColumnsStart })`, including UI controls and guidance around interaction with manual column reordering.
> 
> Introduces runnable examples for JavaScript, React (JSX/TSX), and Angular (standalone) with shared styling and a small guard to clamp the frozen column count; updates an existing Angular recipe to use Angular 17 built-in control flow (`@for`) and updates docs standards in `docs/CLAUDE.md` to discourage structural directives (`*ngFor/*ngIf/*ngSwitch`). Registers the new recipe in `docs/content/recipes/sidebar.js`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9577305bfd196b1e9aed81a9987863eb3473570. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->