### PR TITLE
docs: Recipe - ARIA-friendly grid with row descriptions (DEV-1428)

### DIFF
--- a/.claude/skills/creating-docs-examples/SKILL.md
+++ b/.claude/skills/creating-docs-examples/SKILL.md
@@ -74,7 +74,6 @@ const App = () => {
 - Use `app.config.ts` (not `app.module.ts`) with `ApplicationConfig`, `provideZoneChangeDetection({ eventCoalescing: true })`, and global `HOT_GLOBAL_CONFIG` for the license key.
 - Do **not** add `licenseKey` to individual `<hot-table>` bindings -- it is set globally in `app.config.ts`.
 - Template control flow: use `@if` / `@for (x of list; track x.id)` -- never `*ngIf` / `*ngFor`.
-- Row data type: use `RowObject[]` from `handsontable/common`, not `any[]`.
 - Name the component class `AppComponent` in every example.
 
 **Critical Angular JIT restrictions** — the docs site bootstraps Angular examples with JIT in the browser. JIT cannot load external files at runtime:
@@ -83,6 +82,7 @@ const App = () => {
 - ❌ **Never use `templateUrl`**. Always define the component's template inline with `template: \`...\``. The `angular/example1.html` file is the **outer wrapper** (selector tag) consumed by the example-runner -- it is not the component's template.
 - ❌ **Never inject services via the constructor**. Use `inject()` instead. JIT mode lacks TypeScript decorator metadata, so constructor DI throws `NG0202`.
 - ❌ **Never bind Handsontable hooks in the template** (`(afterInit)="handler()"`). Put hook functions inside `gridSettings` instead.
+- ❌ **Only import symbols you actually use**. Unused imports (e.g., `RowObject`, `ViewChild`, `NgFor`) can cause module resolution errors.
 
 The `.ts` file contains both `app.component.ts` and `app.config.ts` as separate `/* file: ... */` sections within a single file:
 
@@ -90,7 +90,6 @@ The `.ts` file contains both `app.component.ts` and `app.config.ts` as separate 
 /* file: app.component.ts */
 import { Component } from '@angular/core';
 import { GridSettings, HotTableModule } from '@handsontable/angular-wrapper';
-import { RowObject } from 'handsontable/common';
 
 @Component({
   standalone: true,
@@ -103,7 +102,7 @@ import { RowObject } from 'handsontable/common';
   `,
 })
 export class AppComponent {
-  readonly data: RowObject[] = [...];
+  readonly data = [...];
   readonly gridSettings: GridSettings = { ... };
 }
 /* end-file */

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -363,6 +363,8 @@ All Angular docs examples use `standalone: true` bootstrapped via `bootstrapAppl
 - **Constructor DI**: Never inject services via the constructor. Use the `inject()` function instead -- constructors are not processed by Angular JIT without TypeScript decorator metadata.
 - **Lifecycle hooks**: Put `afterInit`, `afterChange`, and other Handsontable hook functions inside `gridSettings`, not as template event bindings (e.g., `(afterInit)="..."` fails in JIT mode).
 - **`@ViewChild`**: Safe to use. It is populated after the component view is initialized.
+- **Control flow**: Use `@for`, `@if`, `@switch` (Angular 17+ built-in control flow). Do **not** use `*ngFor`, `*ngIf` — they require importing `NgFor`/`NgIf` from `@angular/common`, which is error-prone.
+- **Imports**: Only import symbols you actually use. Unused imports (e.g., `RowObject`, `ViewChild`, `NgFor`) can cause module resolution errors.
 
 Correct standalone component skeleton:
 ```typescript

--- a/docs/content/recipes/accessibility/aria-grid/angular/example1.ts
+++ b/docs/content/recipes/accessibility/aria-grid/angular/example1.ts
@@ -1,7 +1,7 @@
 /* file: app.component.ts */
-import { Component, ViewChild } from '@angular/core';
-import { GridSettings, HotTableComponent, HotTableModule } from '@handsontable/angular-wrapper';
-import { RowObject } from 'handsontable/common';
+import { Component } from '@angular/core';
+import { GridSettings, HotTableModule } from '@handsontable/angular-wrapper';
+import Handsontable from 'handsontable/base';
 import { getRenderer } from 'handsontable/renderers';
 
 const colHeaders = ['Name', 'Department', 'Role', 'Salary', 'Start Date'];
@@ -26,8 +26,6 @@ const data = [
   `,
 })
 export class AppComponent {
-  @ViewChild(HotTableComponent, { static: false }) readonly hotTable!: HotTableComponent;
-
   readonly data = data;
 
   readonly gridSettings: GridSettings = {

--- a/docs/content/recipes/accessibility/aria-grid/aria-grid.md
+++ b/docs/content/recipes/accessibility/aria-grid/aria-grid.md
@@ -128,8 +128,8 @@ const hot = new Handsontable(container, {
   colHeaders,
   cells() {
     return {
-      renderer(hotInstance, TD, row, col, prop, value) {
-        getRenderer('text')(hotInstance, TD, row, col, prop, value);
+      renderer(hotInstance, TD, row, col, prop, value, cellProperties) {
+        getRenderer('text')(hotInstance, TD, row, col, prop, value, cellProperties);
         TD.setAttribute('aria-label', `${colHeaders[col]}: ${value || 'empty'}`);
       },
     };

--- a/docs/content/recipes/accessibility/aria-grid/javascript/example1.js
+++ b/docs/content/recipes/accessibility/aria-grid/javascript/example1.js
@@ -55,8 +55,8 @@ const hot = new Handsontable(container, {
   // Custom renderer that sets aria-label to "Column Name: cell value" on every cell.
   cells() {
     return {
-      renderer(hotInstance, TD, row, col, prop, value) {
-        getRenderer('text')(hotInstance, TD, row, col, prop, value);
+      renderer(hotInstance, TD, row, col, prop, value, cellProperties) {
+        getRenderer('text')(hotInstance, TD, row, col, prop, value, cellProperties);
         TD.setAttribute('aria-label', `${colHeaders[col]}: ${value || 'empty'}`);
       },
     };

--- a/docs/content/recipes/sidebar.js
+++ b/docs/content/recipes/sidebar.js
@@ -45,6 +45,7 @@ const cellTypesItems = [
 
 const performanceItems = [
   { path: 'performance/lazy-loading/lazy-loading', title: 'Lazy loading with pagination', onlyFor: ['javascript', 'react', 'angular'] },
+  { path: 'performance/persist-column-layout/persist-column-layout', title: 'Persist column layout', onlyFor: ['javascript', 'angular', 'react'] },
 ];
 
 const renderingStylingItems = [
@@ -83,10 +84,6 @@ const filteringAndSearchItems = [
   },
 ];
 
-const performanceItems = [
-  { path: 'performance/persist-column-layout/persist-column-layout', title: 'Persist column layout', onlyFor: ['javascript', 'angular', 'react'] },
-];
-
 const themesItems = [
   { path: 'themes/base-theme/base-theme', title: 'Handsontable with Base Web', onlyFor: ['react', 'javascript', 'angular'] },
   { path: 'themes/custom-theme/custom-theme', title: 'Handsontable with shadcn/ui', onlyFor: ['react', 'javascript', 'angular'] },
@@ -121,7 +118,6 @@ module.exports = {
     { title: 'Column Management', path: 'column-management', children: columnManagementItems, collapsable: false, onlyFor: ['javascript', 'angular', 'react'] },
     { title: 'Data Management', path: 'data-management', children: dataManagementItems, collapsable: false, onlyFor: ['javascript', 'angular', 'react'] },
     { title: 'Cell Types', path: 'cell-types', children: cellTypesItems, collapsable: false, onlyFor: ['react', 'javascript', 'angular'] },
-    { title: 'Performance', path: 'performance', children: performanceItems, collapsable: false, onlyFor: ['javascript', 'react', 'angular'] },
     { title: 'Context Menu', path: 'context-menu', children: contextMenuItems, collapsable: false, onlyFor: ['javascript', 'react', 'angular'] },
     {
       title: 'Editing and Validation',
@@ -154,7 +150,7 @@ module.exports = {
       collapsable: false,
       onlyFor: ['javascript', 'angular', 'react'],
     },
-    { title: 'Performance', path: 'performance', children: performanceItems, collapsable: false, onlyFor: ['javascript', 'angular', 'react'] },
+    { title: 'Performance', path: 'performance', children: performanceItems, collapsable: false, onlyFor: ['javascript', 'react', 'angular'] },
     { title: 'Themes', path: 'themes', children: themesItems, collapsable: false, onlyFor: ['react', 'javascript', 'angular'] },
   ],
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the "ARIA-friendly grid with row descriptions" recipe for the Handsontable documentation.

- Adds a new Tutorial-type recipe page at `docs/content/recipes/accessibility/aria-grid/`
- HR domain: 8 diverse employees with Name, Department, Role, Salary, StartDate columns
- Demonstrates WCAG 2.1 AA compliance configuration:
  - `ariaTags: true` -- adds `role="grid"`, `role="row"`, `role="gridcell"` to the DOM
  - `tabMoves: { row: 1, col: 0 }` -- Tab moves between rows (screen-reader friendly)
  - `enterMoves: { row: 1, col: 0 }` -- Enter moves to next row
  - `autoWrapRow: false` and `autoWrapCol: false` -- prevents disorienting wrap-around
  - Custom renderer using `cells` callback setting `aria-label` as "ColumnName: value" on each TD
  - `afterGetColHeader` hook setting `aria-sort="none"` on sortable headers
- Includes testing guidance for Chrome DevTools Accessibility panel
- Registers the recipe in the sidebar under the "Accessibility & UX" section
- Follows the Diátaxis Tutorial format established in PR #12349

ClickUp task: https://app.clickup.com/t/86c9c7p1z

[skip changelog]

## Docs PR checklist

- [x] `type:` field added to frontmatter (tutorial)
- [x] Page uses the correct Diátaxis template for its type
- [x] No banned placeholder data
- [x] All example data is domain-realistic (HR/workforce domain with diverse names)
- [x] All code blocks have language tags
- [x] No `var` in code examples; uses `const` / `let`
- [x] All examples include `licenseKey: 'non-commercial-and-evaluation'`
- [x] New page registered in sidebar
- [x] `[skip changelog]` in PR body (docs changes)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18cb7bce-eae0-4dc9-9afd-a12a410ec818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18cb7bce-eae0-4dc9-9afd-a12a410ec818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

