### PR TITLE
docs: Recipe - Programmatic row operations (DEV-1426)

### DIFF
--- a/docs/content/recipes/context-menu/row-operations/angular/example1.css
+++ b/docs/content/recipes/context-menu/row-operations/angular/example1.css
@@ -1,0 +1,32 @@
+.row-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.row-toolbar button {
+  padding: 6px 14px;
+  font-size: 13px;
+  border: 1px solid var(--sl-color-gray-5);
+  border-radius: 4px;
+  background: var(--sl-color-bg-nav);
+  color: var(--sl-color-text);
+  cursor: pointer;
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.row-toolbar button:hover:not(:disabled) {
+  background: var(--sl-color-gray-6);
+  color: var(--sl-color-white);
+}
+
+.row-toolbar button:focus-visible {
+  outline: 1px solid var(--sl-color-accent);
+  outline-offset: 1px;
+}
+
+.row-toolbar button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/docs/content/recipes/context-menu/row-operations/angular/example1.ts
+++ b/docs/content/recipes/context-menu/row-operations/angular/example1.ts
@@ -20,7 +20,7 @@ const INITIAL_DATA: string[][] = [
   imports: [HotTableModule],
   selector: 'example1-row-operations',
   template: `
-    <div class="row-toolbar">
+    <div class="row-toolbar" (mousedown)="preventDeselect($event)">
       <button type="button" (click)="addRow()">Add Row</button>
       <button type="button" (click)="deleteRow()" [disabled]="selectedRow === null">Delete Row</button>
       <button type="button" (click)="moveUp()" [disabled]="selectedRow === null || selectedRow === 0">Move Up</button>
@@ -55,6 +55,15 @@ export class AppComponent {
       this.selectedRow = null;
     },
   };
+
+  // Prevent toolbar button clicks from stealing focus away from the grid.
+  // Without this, clicking a button triggers afterDeselect, which clears
+  // selectedRow before the button's click handler runs.
+  preventDeselect(event: MouseEvent): void {
+    if ((event.target as HTMLElement).tagName === 'BUTTON') {
+      event.preventDefault();
+    }
+  }
 
   addRow(): void {
     const hot = this.hotTable?.hotInstance;

--- a/docs/content/recipes/context-menu/row-operations/angular/example1.ts
+++ b/docs/content/recipes/context-menu/row-operations/angular/example1.ts
@@ -19,32 +19,6 @@ const INITIAL_DATA: string[][] = [
   standalone: true,
   imports: [HotTableModule],
   selector: 'example1-row-operations',
-  styles: [`
-    .row-toolbar {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 8px;
-      margin-bottom: 12px;
-    }
-
-    .row-toolbar button {
-      padding: 6px 14px;
-      font-size: 13px;
-      border: 1px solid #ccc;
-      border-radius: 4px;
-      background: #fff;
-      cursor: pointer;
-    }
-
-    .row-toolbar button:hover:not(:disabled) {
-      background: #f0f0f0;
-    }
-
-    .row-toolbar button:disabled {
-      opacity: 0.5;
-      cursor: not-allowed;
-    }
-  `],
   template: `
     <div class="row-toolbar">
       <button type="button" (click)="addRow()">Add Row</button>

--- a/docs/content/recipes/context-menu/row-operations/angular/example1.ts
+++ b/docs/content/recipes/context-menu/row-operations/angular/example1.ts
@@ -1,5 +1,5 @@
 /* file: app.component.ts */
-import { Component, ViewChild } from '@angular/core';
+import { Component, ElementRef, ViewChild } from '@angular/core';
 import { GridSettings, HotTableComponent, HotTableModule } from '@handsontable/angular-wrapper';
 
 /* start:skip-in-preview */
@@ -20,7 +20,7 @@ const INITIAL_DATA: string[][] = [
   imports: [HotTableModule],
   selector: 'example1-row-operations',
   template: `
-    <div class="row-toolbar" (mousedown)="preventDeselect($event)">
+    <div class="row-toolbar" #toolbar>
       <button type="button" (click)="addRow()">Add Row</button>
       <button type="button" (click)="deleteRow()" [disabled]="selectedRow === null">Delete Row</button>
       <button type="button" (click)="moveUp()" [disabled]="selectedRow === null || selectedRow === 0">Move Up</button>
@@ -31,6 +31,7 @@ const INITIAL_DATA: string[][] = [
 })
 export class AppComponent {
   @ViewChild(HotTableComponent, { static: false }) readonly hotTable!: HotTableComponent;
+  @ViewChild('toolbar', { static: true }) readonly toolbarRef!: ElementRef<HTMLElement>;
 
   readonly hotData: string[][] = [...INITIAL_DATA];
 
@@ -48,6 +49,12 @@ export class AppComponent {
     height: 'auto',
     width: '100%',
     manualRowMove: true,
+    // Keep the grid selected when clicking toolbar buttons. Without this,
+    // Handsontable treats toolbar clicks as outside clicks and deselects,
+    // which clears selectedRow before the button's click handler runs.
+    outsideClickDeselects: (target: HTMLElement) => {
+      return !this.toolbarRef?.nativeElement?.contains(target);
+    },
     afterSelectionEnd: (row: number, _col: number, row2: number) => {
       this.selectedRow = row === row2 ? Math.min(row, row2) : null;
     },
@@ -55,15 +62,6 @@ export class AppComponent {
       this.selectedRow = null;
     },
   };
-
-  // Prevent toolbar button clicks from stealing focus away from the grid.
-  // Without this, clicking a button triggers afterDeselect, which clears
-  // selectedRow before the button's click handler runs.
-  preventDeselect(event: MouseEvent): void {
-    if ((event.target as HTMLElement).tagName === 'BUTTON') {
-      event.preventDefault();
-    }
-  }
 
   addRow(): void {
     const hot = this.hotTable?.hotInstance;

--- a/docs/content/recipes/context-menu/row-operations/javascript/example1.js
+++ b/docs/content/recipes/context-menu/row-operations/javascript/example1.js
@@ -29,15 +29,6 @@ toolbar.innerHTML = `
 `;
 container.before(toolbar);
 
-// Prevent toolbar button clicks from stealing focus away from the grid.
-// Without this, clicking a button triggers afterDeselect, which clears
-// selectedRow before the button's click handler runs.
-toolbar.addEventListener('mousedown', (event) => {
-  if (event.target.tagName === 'BUTTON') {
-    event.preventDefault();
-  }
-});
-
 const hot = new Handsontable(container, {
   data,
   colHeaders: ['Task', 'Assignee', 'Priority', 'Status'],
@@ -45,6 +36,12 @@ const hot = new Handsontable(container, {
   height: 'auto',
   width: '100%',
   manualRowMove: true,
+  // Keep the grid selected when clicking toolbar buttons. Without this,
+  // Handsontable treats toolbar clicks as outside clicks and deselects,
+  // which clears selectedRow before the button's click handler runs.
+  outsideClickDeselects(target) {
+    return !toolbar.contains(target);
+  },
   licenseKey: 'non-commercial-and-evaluation',
 });
 

--- a/docs/content/recipes/context-menu/row-operations/javascript/example1.js
+++ b/docs/content/recipes/context-menu/row-operations/javascript/example1.js
@@ -29,6 +29,15 @@ toolbar.innerHTML = `
 `;
 container.before(toolbar);
 
+// Prevent toolbar button clicks from stealing focus away from the grid.
+// Without this, clicking a button triggers afterDeselect, which clears
+// selectedRow before the button's click handler runs.
+toolbar.addEventListener('mousedown', (event) => {
+  if (event.target.tagName === 'BUTTON') {
+    event.preventDefault();
+  }
+});
+
 const hot = new Handsontable(container, {
   data,
   colHeaders: ['Task', 'Assignee', 'Priority', 'Status'],

--- a/docs/content/recipes/context-menu/row-operations/javascript/example1.ts
+++ b/docs/content/recipes/context-menu/row-operations/javascript/example1.ts
@@ -16,7 +16,7 @@ const data = [
 ];
 /* end:skip-in-preview */
 
-const container = document.querySelector('#example1');
+const container = document.querySelector('#example1')!;
 
 const toolbar = document.createElement('div');
 
@@ -39,14 +39,14 @@ const hot = new Handsontable(container, {
   licenseKey: 'non-commercial-and-evaluation',
 });
 
-const btnAddRow = toolbar.querySelector('#btn-add-row');
-const btnDeleteRow = toolbar.querySelector('#btn-delete-row');
-const btnMoveUp = toolbar.querySelector('#btn-move-up');
-const btnMoveDown = toolbar.querySelector('#btn-move-down');
+const btnAddRow = toolbar.querySelector('#btn-add-row') as HTMLButtonElement;
+const btnDeleteRow = toolbar.querySelector('#btn-delete-row') as HTMLButtonElement;
+const btnMoveUp = toolbar.querySelector('#btn-move-up') as HTMLButtonElement;
+const btnMoveDown = toolbar.querySelector('#btn-move-down') as HTMLButtonElement;
 
-let selectedRow = null;
+let selectedRow: number | null = null;
 
-function updateButtonStates() {
+function updateButtonStates(): void {
   const hasSelection = selectedRow !== null;
   const isFirst = selectedRow === 0;
   const isLast = selectedRow === hot.countRows() - 1;
@@ -56,7 +56,7 @@ function updateButtonStates() {
   btnMoveDown.disabled = !hasSelection || isLast;
 }
 
-hot.addHook('afterSelectionEnd', (row, col, row2) => {
+hot.addHook('afterSelectionEnd', (row: number, _col: number, row2: number) => {
   selectedRow = row === row2 ? Math.min(row, row2) : null;
   updateButtonStates();
 });
@@ -77,7 +77,7 @@ btnDeleteRow.addEventListener('click', () => {
     return;
   }
 
-  const rowSet = new Set();
+  const rowSet = new Set<number>();
 
   selected.forEach(([r1, , r2]) => {
     const from = Math.min(r1, r2);

--- a/docs/content/recipes/context-menu/row-operations/javascript/example1.ts
+++ b/docs/content/recipes/context-menu/row-operations/javascript/example1.ts
@@ -29,6 +29,15 @@ toolbar.innerHTML = `
 `;
 container.before(toolbar);
 
+// Prevent toolbar button clicks from stealing focus away from the grid.
+// Without this, clicking a button triggers afterDeselect, which clears
+// selectedRow before the button's click handler runs.
+toolbar.addEventListener('mousedown', (event) => {
+  if ((event.target as HTMLElement).tagName === 'BUTTON') {
+    event.preventDefault();
+  }
+});
+
 const hot = new Handsontable(container, {
   data,
   colHeaders: ['Task', 'Assignee', 'Priority', 'Status'],

--- a/docs/content/recipes/context-menu/row-operations/javascript/example1.ts
+++ b/docs/content/recipes/context-menu/row-operations/javascript/example1.ts
@@ -29,15 +29,6 @@ toolbar.innerHTML = `
 `;
 container.before(toolbar);
 
-// Prevent toolbar button clicks from stealing focus away from the grid.
-// Without this, clicking a button triggers afterDeselect, which clears
-// selectedRow before the button's click handler runs.
-toolbar.addEventListener('mousedown', (event) => {
-  if ((event.target as HTMLElement).tagName === 'BUTTON') {
-    event.preventDefault();
-  }
-});
-
 const hot = new Handsontable(container, {
   data,
   colHeaders: ['Task', 'Assignee', 'Priority', 'Status'],
@@ -45,6 +36,9 @@ const hot = new Handsontable(container, {
   height: 'auto',
   width: '100%',
   manualRowMove: true,
+  outsideClickDeselects(target: HTMLElement) {
+    return !toolbar.contains(target);
+  },
   licenseKey: 'non-commercial-and-evaluation',
 });
 

--- a/docs/content/recipes/context-menu/row-operations/react/example1.jsx
+++ b/docs/content/recipes/context-menu/row-operations/react/example1.jsx
@@ -93,19 +93,8 @@ const ExampleComponent = () => {
     setSelectedRow(newRow);
   };
 
-  const handleSelectionEnd = (_row, _col, row2) => {
-    const hot = getHot();
-    const selected = hot?.getSelected();
-
-    if (!selected || selected.length === 0) {
-      setSelectedRow(null);
-
-      return;
-    }
-
-    const [[r1, , r2_val]] = selected;
-
-    setSelectedRow(r1 === r2_val ? Math.min(r1, row2) : null);
+  const handleSelectionEnd = (row, _col, row2) => {
+    setSelectedRow(row === row2 ? row : null);
   };
 
   const handleDeselect = () => {

--- a/docs/content/recipes/context-menu/row-operations/react/example1.jsx
+++ b/docs/content/recipes/context-menu/row-operations/react/example1.jsx
@@ -103,7 +103,17 @@ const ExampleComponent = () => {
 
   return (
     <>
-      <div className="row-toolbar">
+      {/* Prevent toolbar mousedown from stealing focus away from the grid.
+          Without this, clicking a button triggers afterDeselect, which clears
+          selectedRow before the button's onClick handler runs. */}
+      <div
+        className="row-toolbar"
+        onMouseDown={(e) => {
+          if (e.target.tagName === 'BUTTON') {
+            e.preventDefault();
+          }
+        }}
+      >
         <button type="button" onClick={handleAddRow}>
           Add Row
         </button>

--- a/docs/content/recipes/context-menu/row-operations/react/example1.jsx
+++ b/docs/content/recipes/context-menu/row-operations/react/example1.jsx
@@ -101,19 +101,15 @@ const ExampleComponent = () => {
     setSelectedRow(null);
   };
 
+  const toolbarRef = useRef(null);
+
+  const outsideClickDeselects = (target) => {
+    return !toolbarRef.current?.contains(target);
+  };
+
   return (
     <>
-      {/* Prevent toolbar mousedown from stealing focus away from the grid.
-          Without this, clicking a button triggers afterDeselect, which clears
-          selectedRow before the button's onClick handler runs. */}
-      <div
-        className="row-toolbar"
-        onMouseDown={(e) => {
-          if (e.target.tagName === 'BUTTON') {
-            e.preventDefault();
-          }
-        }}
-      >
+      <div className="row-toolbar" ref={toolbarRef}>
         <button type="button" onClick={handleAddRow}>
           Add Row
         </button>
@@ -139,6 +135,7 @@ const ExampleComponent = () => {
         height="auto"
         width="100%"
         manualRowMove={true}
+        outsideClickDeselects={outsideClickDeselects}
         afterSelectionEnd={handleSelectionEnd}
         afterDeselect={handleDeselect}
         licenseKey="non-commercial-and-evaluation"

--- a/docs/content/recipes/context-menu/row-operations/react/example1.tsx
+++ b/docs/content/recipes/context-menu/row-operations/react/example1.tsx
@@ -94,19 +94,8 @@ const ExampleComponent = () => {
     setSelectedRow(newRow);
   };
 
-  const handleSelectionEnd = (_row: number, _col: number, row2: number): void => {
-    const hot = getHot();
-    const selected = hot?.getSelected();
-
-    if (!selected || selected.length === 0) {
-      setSelectedRow(null);
-
-      return;
-    }
-
-    const [[r1, , r2_val]] = selected;
-
-    setSelectedRow(r1 === r2_val ? Math.min(r1, row2) : null);
+  const handleSelectionEnd = (row: number, _col: number, row2: number): void => {
+    setSelectedRow(row === row2 ? row : null);
   };
 
   const handleDeselect = (): void => {

--- a/docs/content/recipes/context-menu/row-operations/react/example1.tsx
+++ b/docs/content/recipes/context-menu/row-operations/react/example1.tsx
@@ -102,19 +102,18 @@ const ExampleComponent = () => {
     setSelectedRow(null);
   };
 
+  const toolbarRef = useRef<HTMLDivElement>(null);
+
+  // Keep the grid selected when clicking toolbar buttons. Without this,
+  // Handsontable treats toolbar clicks as outside clicks and deselects,
+  // which clears selectedRow before the button's onClick handler runs.
+  const outsideClickDeselects = (target: HTMLElement): boolean => {
+    return !toolbarRef.current?.contains(target);
+  };
+
   return (
     <>
-      {/* Prevent toolbar mousedown from stealing focus away from the grid.
-          Without this, clicking a button triggers afterDeselect, which clears
-          selectedRow before the button's onClick handler runs. */}
-      <div
-        className="row-toolbar"
-        onMouseDown={(e) => {
-          if ((e.target as HTMLElement).tagName === 'BUTTON') {
-            e.preventDefault();
-          }
-        }}
-      >
+      <div className="row-toolbar" ref={toolbarRef}>
         <button type="button" onClick={handleAddRow}>
           Add Row
         </button>
@@ -140,6 +139,7 @@ const ExampleComponent = () => {
         height="auto"
         width="100%"
         manualRowMove={true}
+        outsideClickDeselects={outsideClickDeselects}
         afterSelectionEnd={handleSelectionEnd}
         afterDeselect={handleDeselect}
         licenseKey="non-commercial-and-evaluation"

--- a/docs/content/recipes/context-menu/row-operations/react/example1.tsx
+++ b/docs/content/recipes/context-menu/row-operations/react/example1.tsx
@@ -104,7 +104,17 @@ const ExampleComponent = () => {
 
   return (
     <>
-      <div className="row-toolbar">
+      {/* Prevent toolbar mousedown from stealing focus away from the grid.
+          Without this, clicking a button triggers afterDeselect, which clears
+          selectedRow before the button's onClick handler runs. */}
+      <div
+        className="row-toolbar"
+        onMouseDown={(e) => {
+          if ((e.target as HTMLElement).tagName === 'BUTTON') {
+            e.preventDefault();
+          }
+        }}
+      >
         <button type="button" onClick={handleAddRow}>
           Add Row
         </button>

--- a/docs/content/recipes/context-menu/row-operations/row-operations.md
+++ b/docs/content/recipes/context-menu/row-operations/row-operations.md
@@ -22,9 +22,10 @@ type: tutorial
 
 ::: only-for javascript vue
 
-::: example #example1 :hot-recipe --js 1 --css 2
+::: example #example1 :hot-recipe --js 1 --ts 2 --css 3
 
 @[code](@/content/recipes/context-menu/row-operations/javascript/example1.js)
+@[code](@/content/recipes/context-menu/row-operations/javascript/example1.ts)
 @[code](@/content/recipes/context-menu/row-operations/javascript/example1.css)
 
 :::
@@ -45,10 +46,11 @@ type: tutorial
 
 ::: only-for angular
 
-::: example #example1 :angular --ts 1 --html 2
+::: example #example1 :angular --ts 1 --html 2 --css 3
 
 @[code](@/content/recipes/context-menu/row-operations/angular/example1.ts)
 @[code](@/content/recipes/context-menu/row-operations/angular/example1.html)
+@[code](@/content/recipes/context-menu/row-operations/angular/example1.css)
 
 :::
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the "Programmatic row operations (add, remove, move)" recipe for the Handsontable documentation.

- Adds a new Tutorial-type recipe page at `docs/content/recipes/context-menu/row-operations/`
- Project management domain: 8 tasks with Task, Assignee, Priority, Status columns
- Implements four external toolbar buttons:
  - **Add Row**: `hot.alter('insert_row_below', hot.countRows() - 1)` to append at the bottom
  - **Delete Row**: collects selected ranges via `hot.getSelected()`, deduplicates, deletes bottom-to-top to avoid index shifting
  - **Move Up**: `hot.getPlugin('manualRowMove').moveRow(row, row - 1)` + `hot.render()`
  - **Move Down**: `hot.getPlugin('manualRowMove').moveRow(row, row + 2)` + `hot.render()`
- Disables Move Up when first row is selected, Move Down when last row is selected
- Keeps button states in sync via `afterSelectionEnd` and `afterDeselect` hooks
- Includes CSS for flexbox toolbar with disabled-button styling
- Registers the recipe in the sidebar under the "Context Menu and Interaction" section
- Follows the Diátaxis Tutorial format established in PR #12349

ClickUp task: https://app.clickup.com/t/86c9c7na4

[skip changelog]

## Docs PR checklist

- [x] `type:` field added to frontmatter (tutorial)
- [x] Page uses the correct Diátaxis template for its type
- [x] No banned placeholder data
- [x] All example data is domain-realistic (project management domain)
- [x] All code blocks have language tags
- [x] No `var` in code examples; uses `const` / `let`
- [x] All examples include `licenseKey: 'non-commercial-and-evaluation'`
- [x] New page registered in sidebar
- [x] `[skip changelog]` in PR body (docs changes)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18cb7bce-eae0-4dc9-9afd-a12a410ec818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18cb7bce-eae0-4dc9-9afd-a12a410ec818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

