### PR TITLE
docs: add recipe category overview pages for Data Management and Filtering and Search

### DIFF
--- a/docs/content/recipes/data-management/data-management.md
+++ b/docs/content/recipes/data-management/data-management.md
@@ -1,0 +1,36 @@
+---
+title: Data Management Recipes
+metaTitle: Data Management Recipes - JavaScript Data Grid | Handsontable
+permalink: /recipes/data-management
+canonicalUrl: /recipes/data-management
+searchCategory: Recipes
+hotPlugin: false
+editLink: false
+id: c4b7e2f1
+description: Practical recipes for loading, syncing, and managing data in Handsontable.
+react:
+  id: 9d2f6a4b
+  metaTitle: Data Management Recipes - React Data Grid | Handsontable
+angular:
+  id: 6e1c8b3d
+  metaTitle: Data Management Recipes - Angular Data Grid | Handsontable
+---
+[[toc]]
+
+## Overview
+
+This section provides practical recipes for loading, syncing, and managing data in Handsontable. Each recipe includes a working example you can copy into your app.
+
+## Available Recipes
+
+Our recipes cover common use cases and implementation patterns for:
+
+- **Remote data loading** -- Fetching JSON data and rendering it in the grid.
+- **Data synchronization** -- Keeping multiple grid instances in sync.
+- **Undo and redo UX** -- Connecting built-in data history to custom controls.
+
+Current recipes:
+
+<div class="boxes-list">
+
+</div>

--- a/docs/content/recipes/filtering-search/filtering-search.md
+++ b/docs/content/recipes/filtering-search/filtering-search.md
@@ -1,0 +1,34 @@
+---
+title: Filtering and Search Recipes
+metaTitle: Filtering and Search Recipes - JavaScript Data Grid | Handsontable
+permalink: /recipes/filtering-search
+canonicalUrl: /recipes/filtering-search
+searchCategory: Recipes
+hotPlugin: false
+editLink: false
+id: b9f32a7c
+description: Practical recipes for building external filtering and search interfaces with Handsontable.
+react:
+  id: 24e7c1a8
+  metaTitle: Filtering and Search Recipes - React Data Grid | Handsontable
+angular:
+  id: d8a41e6f
+  metaTitle: Filtering and Search Recipes - Angular Data Grid | Handsontable
+---
+[[toc]]
+
+## Overview
+
+This section provides practical recipes for building external filtering and search workflows with Handsontable. Each recipe includes a working example with step-by-step implementation details.
+
+## Getting Started
+
+Before exploring these recipes, read the [Column filter guide](@/guides/columns/column-filter/column-filter.md) to understand the Filters plugin API and available filter conditions.
+
+## Available Recipes
+
+Use these recipes to build custom filter and search controls outside of the grid.
+
+<div class="boxes-list">
+
+</div>

--- a/docs/content/recipes/sidebar.js
+++ b/docs/content/recipes/sidebar.js
@@ -22,10 +22,18 @@ const themesItems = [
   { path: 'themes/mui-theme/mui-theme', title: 'Handsontable with MUI', onlyFor: ['react', 'javascript', 'angular'] },
 ];
 
+const dataManagementItems = [
+];
+
+const filteringSearchItems = [
+];
+
 module.exports = {
   sidebar: [
     'introduction',
     { title: 'Cell Types', path: 'cell-types', children: cellTypesItems, collapsable: false, onlyFor: ['react', 'javascript', 'angular'] },
+    { title: 'Data Management', path: 'data-management', children: dataManagementItems, collapsable: false, onlyFor: ['javascript'] },
+    { title: 'Filtering and Search', path: 'filtering-search', children: filteringSearchItems, collapsable: false, onlyFor: ['javascript'] },
     { title: 'Themes', path: 'themes', children: themesItems, collapsable: false, onlyFor: ['react', 'javascript', 'angular'] },
   ],
 };


### PR DESCRIPTION
## Summary

- Create shared overview pages (`data-management.md`, `filtering-search.md`) and sidebar entries for two new recipe categories.
- Sidebar entries and overview `boxes-list` sections are intentionally empty -- each recipe PR adds its own entry after rebasing onto this.
- Categories are scoped to `onlyFor: ['javascript']` until React/Angular examples are added.

## Why this is needed

PRs #12323, #12325, #12326, #12327, and #12328 each independently create their own category overview page with different frontmatter IDs, descriptions, and content. Whichever merges second would conflict or silently overwrite the first. This PR provides the single source of truth for both categories.

## What each recipe PR must do after this merges

1. Rebase onto `develop` (which will include this PR).
2. Delete its own `data-management.md` or `filtering-search.md` / `filtering-and-search.md` overview page.
3. Add its sidebar entry to the appropriate array in `sidebar.js`.
4. Add its `boxes-list` link to the shared overview page.
5. Remove its own sidebar category definition (the arrays and `module.exports` changes).

### Affected recipe PRs

| PR | Category | Recipe |
|---|---|---|
| #12323 | Data Management | Load data from a REST API |
| #12325 | Filtering and Search | Multi-column filter panel |
| #12326 | Filtering and Search | External search box |
| #12327 | Data Management | Undo / redo with a custom UI |
| #12328 | Data Management | Sync two grids |

## Test plan

- [ ] `npm run docs:lint --prefix docs` passes
- [ ] `sidebar.js` parses without errors
- [ ] Overview pages render at `/recipes/data-management/` and `/recipes/filtering-search/`
- [ ] No broken links (boxes-list sections are empty until recipe PRs land)

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only additions and sidebar wiring; low risk aside from potential navigation/permalink issues if paths or frontmatter IDs are incorrect.
> 
> **Overview**
> Adds new Recipes category overview pages for `Data Management` and `Filtering and Search`, each with standardized frontmatter (including React/Angular meta placeholders), introductory copy, and an empty `boxes-list` section for future recipe links.
> 
> Updates `docs/content/recipes/sidebar.js` to include the two new categories (scoped to `onlyFor: ['javascript']`) with empty child arrays to be populated by subsequent recipe PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02fbb6e15a9a48c14e7c5cc039ada75adf46fca5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->