### PR TITLE
Disable Cursor/Claude PR and commit attribution

### DIFF
--- a/.cursor/settings.json
+++ b/.cursor/settings.json
@@ -1,0 +1,6 @@
+{
+  "attribution": {
+    "attributeCommitsToAgent": false,
+    "attributePRsToAgent": false
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@
 .idea
 .vscode
 .cache
-.cursor
+.cursor/*
+!.cursor/settings.json
 .claude/*
 !.claude/skills/
 !.claude/agents/


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `.cursor/settings.json` to disable the "Made with Cursor" trailers on agent commits and PR footers.

Also updates `.gitignore` to allow `.cursor/settings.json` to be tracked (mirroring the existing `.claude/settings.json` exception).

[skip changelog]
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c87584d-1714-4b1c-98c5-8ef2646db372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c87584d-1714-4b1c-98c5-8ef2646db372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

