### PR TITLE
docs: style AI assistant panel, header entry point, ToC integration

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -28,7 +28,7 @@
         "react": "^18.3.1",
         "react-colorful": "^5.6.1",
         "react-dom": "^18.3.1",
-        "react-markdown": "^9.0.1",
+        "react-markdown": "^9.1.0",
         "react-redux": "^9.2.0",
         "react-star-rating-component": "^1.4.1",
         "redux": "^5.0.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,8 +16,7 @@
     "docs:lint": "eslint --ext .js,.mjs,.ts,.astro src content",
     "docs:lint:fix": "eslint --ext .js,.mjs,.ts,.astro src content --fix",
     "docs:visual-test": "npx playwright test",
-    "docs:visual-test:update-screenshot": "npx playwright test -u",
-    "docs:code-examples:generate-js": "node scripts/transpile-doc-example.mjs"
+    "docs:visual-test:update-screenshot": "npx playwright test -u"
   },
   "license": "CC BY 4.0",
   "dependencies": {
@@ -40,7 +39,7 @@
     "react": "^18.3.1",
     "react-colorful": "^5.6.1",
     "react-dom": "^18.3.1",
-    "react-markdown": "^9.0.1",
+    "react-markdown": "^9.1.0",
     "react-redux": "^9.2.0",
     "react-star-rating-component": "^1.4.1",
     "redux": "^5.0.1",

--- a/docs/src/components/DocsAssistant/DocsAssistant.css
+++ b/docs/src/components/DocsAssistant/DocsAssistant.css
@@ -6,40 +6,6 @@
   color: var(--sl-color-white);
 }
 
-/* ── Floating action button ─────────────────────────────────────────── */
-
-.da-fab {
-  position: fixed;
-  right: 1.5rem;
-  bottom: 1.5rem;
-  width: 56px;
-  height: 56px;
-  border-radius: 50%;
-  border: none;
-  background: #185ccc;
-  color: #fff;
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.2);
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 50;
-  transition: transform 0.15s ease, background-color 0.15s ease, opacity 0.15s ease;
-}
-.da-fab:hover {
-  background: #1652b8;
-  transform: translateY(-1px);
-}
-.da-fab:focus-visible {
-  outline: 2px solid #fff;
-  outline-offset: 2px;
-}
-.da-fab[data-open='true'] {
-  opacity: 0;
-  pointer-events: none;
-  transform: scale(0.8);
-}
-
 /* ── Panel ──────────────────────────────────────────────────────────── */
 
 .da-panel {
@@ -48,11 +14,12 @@
   right: 0;
   height: calc(100vh - var(--sl-nav-height, 3.25rem));
   max-width: 100vw;
-  background: var(--sl-color-bg, #fff);
-  color: var(--sl-color-text, #1f2328);
-  border-left: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5, rgba(0, 0, 0, 0.1)));
+  background: var(--sl-color-bg);
+  color: var(--sl-color-text);
+  border-left: 1px solid var(--sl-color-gray-5);
   display: flex;
   flex-direction: column;
+  box-sizing: border-box;
   box-shadow: -8px 0 24px rgba(0, 0, 0, 0.08);
   z-index: 49;
   transform: translateX(100%);
@@ -60,6 +27,19 @@
 }
 .da-panel[data-open='true'] {
   transform: translateX(0);
+  top: 0;
+  bottom: 0;
+  height: 100%;
+  z-index: 10100;
+}
+@media (max-width: 50rem) {
+  .da-panel {
+    top: 0;
+    height: 100vh;
+    width: 100vw !important;
+    z-index: 100;
+    border-left: none;
+  }
 }
 
 .da-resize {
@@ -74,7 +54,7 @@
   transition: background-color 0.15s;
 }
 .da-resize:hover {
-  background: rgba(24, 92, 204, 0.25);
+  background: var(--sl-color-accent-low);
 }
 
 /* ── Header ─────────────────────────────────────────────────────────── */
@@ -83,9 +63,9 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.75rem 1rem;
-  border-bottom: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5, rgba(0, 0, 0, 0.1)));
-  background: var(--sl-color-bg, #fff);
+  padding: 0.75rem 1.5rem;
+  border-bottom: 1px solid var(--sl-color-gray-5);
+  background: var(--sl-color-bg);
 }
 .da-title {
   display: flex;
@@ -93,7 +73,7 @@
   gap: 0.5rem;
   font-weight: 600;
   font-size: 0.95rem;
-  color: var(--sl-color-text, inherit);
+  color: var(--sl-color-text);
 }
 .da-logo {
   display: none;
@@ -112,18 +92,18 @@
   padding: 0.375rem;
   border-radius: 4px;
   cursor: pointer;
-  color: var(--sl-color-gray-3, #6b7280);
+  color: var(--sl-color-gray-3);
   display: inline-flex;
   align-items: center;
   justify-content: center;
   transition: background-color 0.15s, color 0.15s;
 }
 .da-header-btn:hover {
-  background: var(--sl-color-gray-6, rgba(0, 0, 0, 0.05));
-  color: var(--sl-color-text, #1f2328);
+  background: var(--sl-color-gray-6);
+  color: var(--sl-color-text);
 }
 .da-header-btn:focus-visible {
-  outline: 2px solid #185ccc;
+  outline: 2px solid var(--sl-color-accent);
   outline-offset: 1px;
 }
 
@@ -138,7 +118,7 @@
 .da-scroll {
   flex: 1;
   overflow-y: auto;
-  padding: 1rem;
+  padding: 1.5rem;
 }
 .da-messages {
   display: flex;
@@ -150,41 +130,83 @@
 .da-welcome {
   padding: 1.5rem 0.5rem;
 }
+.da-welcome-hero {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+@media (max-width: 50rem) {
+  .da-welcome-hero {
+    flex-direction: column-reverse;
+    align-items: center;
+  }
+  .da-welcome-illustration {
+    width: 160px;
+    height: 160px;
+    margin: 0 auto;
+  }
+}
+.da-welcome-text {
+  flex: 1;
+  min-width: 0;
+}
+.da-welcome-illustration {
+  width: 200px;
+  height: 200px;
+  flex-shrink: 0;
+}
 .da-welcome h3 {
   margin: 0 0 0.5rem;
   font-size: 1.1rem;
-  color: var(--sl-color-text, inherit);
+  font-weight: 500;
+  color: var(--sl-color-white);
 }
 .da-welcome p {
-  margin: 0 0 1.25rem;
+  margin: 0;
   font-size: 0.875rem;
-  color: var(--sl-color-gray-2, #4b5563);
+  color: var(--sl-color-gray-2);
   line-height: 1.5;
 }
 .da-suggestions {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0;
+  border-top: 1px solid var(--sl-color-gray-5);
+  border-left: 1px solid var(--sl-color-gray-5);
 }
 .da-suggestion {
-  background: var(--sl-color-bg, #fff);
-  border: 1px solid var(--sl-color-hairline, rgba(0, 0, 0, 0.1));
-  border-radius: 8px;
-  padding: 0.625rem 0.875rem;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 0.5rem;
+  background: none;
+  border: 0;
+  border-right: 1px solid var(--sl-color-gray-5);
+  border-bottom: 1px solid var(--sl-color-gray-5);
+  border-radius: 0;
+  padding: 0.75rem 1rem;
   font-size: 0.875rem;
   text-align: left;
   cursor: pointer;
-  color: var(--sl-color-text, inherit);
+  color: var(--sl-color-white);
   font-family: inherit;
-  transition: border-color 0.15s, background-color 0.15s;
+  transition: background-color 0.15s;
 }
 .da-suggestion:hover:not(:disabled) {
-  border-color: #185ccc;
-  background: rgba(24, 92, 204, 0.04);
+  background: var(--sl-color-hover-bg, var(--sl-color-gray-6));
+}
+.da-suggestion:hover:not(:disabled) .da-suggestion-arrow {
+  color: var(--sl-color-white);
 }
 .da-suggestion:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+.da-suggestion-arrow {
+  color: var(--sl-color-gray-3);
+  font-size: 1.1rem;
+  transition: color 0.15s;
 }
 
 /* Messages */
@@ -196,38 +218,83 @@
   align-items: flex-end;
 }
 .da-msg-user .da-bubble {
-  background: #185ccc;
+  background: var(--sl-color-accent);
   color: #fff;
   padding: 0.625rem 0.875rem;
-  border-radius: 14px 14px 2px 14px;
+  border-radius: 0;
   max-width: 85%;
   line-height: 1.5;
   word-wrap: break-word;
   white-space: pre-wrap;
   font-size: 0.9375rem;
+  position: relative;
+  margin-bottom: 6px;
+}
+.da-msg-user .da-bubble::after {
+  content: '';
+  position: absolute;
+  bottom: -6px;
+  right: 0;
+  width: 0;
+  height: 0;
+  border-left: 6px solid transparent;
+  border-top: 6px solid var(--sl-color-accent);
 }
 .da-msg-assistant {
   align-items: flex-start;
 }
+/* ── Assistant body — mirrors .sl-markdown-content typography ─────── */
 .da-assistant-body {
   max-width: 100%;
   font-size: 0.9375rem;
   line-height: 1.6;
-  color: var(--sl-color-text, inherit);
+  color: var(--sl-color-text);
 }
+
+/* Headings */
+.da-assistant-body :is(h1, h2, h3, h4, h5, h6) {
+  font-weight: 500;
+  line-height: 1.3;
+  color: var(--sl-color-white);
+}
+.da-assistant-body h1 {
+  font-size: 1.5rem;
+  letter-spacing: -0.02em;
+  margin: 1rem 0 0.5rem;
+}
+.da-assistant-body h2 {
+  font-size: 1.25rem;
+  letter-spacing: -0.01em;
+  margin: 1.5rem 0 0.5rem;
+}
+.da-assistant-body h3 {
+  font-size: 1.1rem;
+  letter-spacing: -0.005em;
+  margin: 1.25rem 0 0.5rem;
+}
+.da-assistant-body h4 {
+  font-size: 1rem;
+  margin: 1rem 0 0.5rem;
+}
+.da-assistant-body :not(h1, h2, h3, h4, h5, h6) + :is(h1, h2, h3, h4, h5, h6) {
+  margin-top: 1.5rem;
+}
+
+/* Strong */
+.da-assistant-body strong {
+  font-weight: 500;
+  color: var(--sl-color-white);
+}
+
+/* Paragraphs */
 .da-assistant-body p {
   margin: 0 0 0.75rem;
 }
 .da-assistant-body p:last-child {
   margin-bottom: 0;
 }
-.da-assistant-body h1,
-.da-assistant-body h2,
-.da-assistant-body h3,
-.da-assistant-body h4 {
-  margin: 1rem 0 0.5rem;
-  line-height: 1.3;
-}
+
+/* Lists */
 .da-assistant-body ul,
 .da-assistant-body ol {
   margin: 0 0 0.75rem;
@@ -236,93 +303,157 @@
 .da-assistant-body li {
   margin: 0.25rem 0;
 }
+
+/* Links — match .sl-markdown-content link style */
 .da-assistant-body a {
-  color: #185ccc;
-  text-decoration: underline;
+  color: var(--sl-color-white);
+  text-decoration: none;
+  text-underline-offset: 0.2em;
 }
+.da-assistant-body a:hover {
+  text-decoration: underline;
+  text-decoration-color: var(--sl-color-gray-3);
+}
+
+/* Blockquote */
 .da-assistant-body blockquote {
-  border-left: 3px solid var(--sl-color-hairline, rgba(0, 0, 0, 0.15));
+  border-left: 3px solid var(--sl-color-gray-5);
   margin: 0 0 0.75rem;
   padding: 0 0 0 0.75rem;
-  color: var(--sl-color-gray-2, #4b5563);
+  color: var(--sl-color-gray-2);
 }
+
+/* Inline code — match .sl-markdown-content code style */
 .da-assistant-body code:not(.da-code *) {
-  background: var(--sl-color-gray-6, rgba(0, 0, 0, 0.06));
+  color: var(--sl-color-white);
+  background: var(--sl-color-gray-6);
+  border: 1px solid var(--sl-color-gray-5);
   padding: 0.125rem 0.3rem;
   border-radius: 4px;
   font-size: 0.85em;
+  font-weight: 400;
 }
+
+/* Tables — match .sl-markdown-content table style */
 .da-assistant-body table {
   width: 100%;
   border-collapse: collapse;
   margin: 0 0 0.75rem;
-  font-size: 0.875rem;
+  font-size: var(--sl-text-sm, 0.875rem);
+  background-color: var(--sl-color-block-bg);
+  border: 1px solid var(--sl-color-gray-5);
 }
-.da-assistant-body th,
-.da-assistant-body td {
-  border: 1px solid var(--sl-color-hairline, rgba(0, 0, 0, 0.1));
-  padding: 0.375rem 0.5rem;
+.da-assistant-body th {
+  font-size: var(--sl-text-sm, 0.875rem);
+  font-weight: 600;
+  background-color: var(--sl-color-bg);
+  border-bottom: 1px solid var(--sl-color-gray-5);
+  padding: 0.75rem 1.25rem;
   text-align: left;
+  color: var(--sl-color-white);
 }
+.da-assistant-body td {
+  font-size: var(--sl-text-sm, 0.875rem);
+  border-bottom: 1px solid var(--sl-color-gray-5);
+  padding: 0.75rem 1.25rem;
+}
+.da-assistant-body tr:last-child td {
+  border-bottom: none;
+}
+
+/* Horizontal rule */
 .da-assistant-body hr {
   border: none;
-  border-top: 1px solid var(--sl-color-hairline, rgba(0, 0, 0, 0.1));
+  border-top: 1px solid var(--sl-color-gray-5);
   margin: 0.75rem 0;
 }
 
-/* Code block */
+/* ── Code block — matches Expressive Code visual style ───────────── */
 .da-code {
   margin: 0 0 0.75rem;
-  border: 1px solid var(--sl-color-hairline, rgba(0, 0, 0, 0.1));
-  border-radius: 8px;
+  border: 1px solid var(--sl-color-gray-5);
+  border-radius: 0;
   overflow: hidden;
-  background: var(--sl-color-bg, #fff);
+  background: var(--sl-color-block-bg);
+  position: relative;
 }
 .da-code-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0.3rem 0.6rem;
-  background: var(--sl-color-gray-6, rgba(0, 0, 0, 0.04));
-  border-bottom: 1px solid var(--sl-color-hairline, rgba(0, 0, 0, 0.08));
-  font-size: 0.75rem;
-  color: var(--sl-color-gray-2, #6b7280);
+  display: none;
 }
-.da-code-lang {
-  font-family: var(--sl-font-mono, ui-monospace, monospace);
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
-}
+/* Copy button — absolute top-right, hidden until hover */
 .da-code-copy {
-  background: none;
-  border: none;
-  padding: 0.25rem 0.5rem;
-  border-radius: 4px;
-  font-size: 0.75rem;
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 0;
+  padding: 0.25rem;
   cursor: pointer;
-  color: var(--sl-color-gray-2, #6b7280);
+  color: var(--sl-color-gray-3);
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
+  justify-content: center;
   font-family: inherit;
+  font-size: 0.75rem;
+  opacity: 0;
+  transition: opacity 0.15s, border-color 0.15s, color 0.15s;
+  z-index: 1;
+}
+.da-code-copy span {
+  display: none;
+}
+.da-code:hover .da-code-copy {
+  opacity: 1;
 }
 .da-code-copy:hover {
-  color: var(--sl-color-text, #1f2328);
-  background: var(--sl-color-gray-5, rgba(0, 0, 0, 0.06));
+  border-color: var(--sl-color-gray-5);
+  color: var(--sl-color-white);
+}
+.da-code-copy.is-copied {
+  opacity: 1;
+  color: var(--sl-color-accent);
 }
 .da-code-body {
   overflow-x: auto;
-  font-size: 0.8125rem;
-  line-height: 1.5;
+  font-size: var(--sl-text-xs, 0.8125rem);
+  line-height: 1.45;
 }
 .da-code-body pre {
   margin: 0;
-  padding: 0.75rem;
+  padding: 0.75rem 1rem;
   background: transparent !important;
+  counter-reset: da-line;
 }
 .da-code-body pre,
 .da-code-body code {
   font-family: var(--sl-font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+}
+.da-code-body code {
+  display: flex;
+  flex-direction: column;
+}
+/* Line numbers via CSS counter on .ec-line spans */
+.da-code-body .ec-line {
+  display: block;
+  counter-increment: da-line;
+  padding-left: 56px;
+  position: relative;
+  line-height: 22px;
+}
+.da-code-body .ec-line::before {
+  content: counter(da-line);
+  position: absolute;
+  left: 0;
+  width: 42px;
+  padding-right: 14px;
+  text-align: right;
+  color: var(--sl-color-gray-3);
+  font-size: inherit;
+  line-height: inherit;
+  border-right: 1.5px solid var(--sl-color-gray-5);
+  box-sizing: border-box;
+  user-select: none;
 }
 
 /* Message action row */
@@ -334,7 +465,7 @@
 .da-action {
   background: none;
   border: 1px solid transparent;
-  color: var(--sl-color-gray-3, #9ca3af);
+  color: var(--sl-color-gray-3);
   padding: 0.25rem;
   border-radius: 4px;
   cursor: pointer;
@@ -344,13 +475,13 @@
   transition: background-color 0.15s, color 0.15s, border-color 0.15s;
 }
 .da-action:hover {
-  color: var(--sl-color-text, #1f2328);
-  background: var(--sl-color-gray-6, rgba(0, 0, 0, 0.05));
+  color: var(--sl-color-text);
+  background: var(--sl-color-gray-6);
 }
 .da-action.is-active {
-  color: #185ccc;
-  border-color: rgba(24, 92, 204, 0.3);
-  background: rgba(24, 92, 204, 0.08);
+  color: var(--sl-color-accent);
+  border-color: var(--sl-color-accent-low);
+  background: var(--sl-color-accent-low);
 }
 
 /* Error */
@@ -386,56 +517,80 @@
 /* ── Composer ───────────────────────────────────────────────────────── */
 
 .da-composer {
+  padding: 0;
+  border-top: 1px solid var(--sl-color-gray-5);
+  background: var(--sl-color-bg);
+}
+.da-input-wrap {
+  position: relative;
   display: flex;
-  align-items: flex-end;
-  gap: 0.5rem;
-  padding: 0.75rem;
-  border-top: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5, rgba(0, 0, 0, 0.1)));
-  background: var(--sl-color-bg, #fff);
+  border: 0;
+  border-radius: 0;
+  background: var(--sl-color-bg);
+  width: 100%;
+  box-sizing: border-box;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+.da-input-wrap:focus-within {
+  border-color: transparent;
 }
 .da-input {
   flex: 1;
   resize: none;
-  border: 1px solid var(--sl-color-hairline, rgba(0, 0, 0, 0.12));
-  border-radius: 8px;
-  padding: 0.5rem 0.625rem;
+  border: none;
+  border-radius: 0;
+  padding: 0.75rem 0.75rem;
+  padding-left: 1.5rem;
+  padding-right: 3rem;
   font: inherit;
+  font-size: 0.9375rem;
   color: inherit;
-  background: var(--sl-color-bg, #fff);
+  background: transparent;
   min-height: 2.5rem;
   max-height: 8rem;
+  transition: background-color 0.15s, box-shadow 0.15s;
+}
+.da-input:hover {
+  background: var(--sl-color-hover-bg, var(--sl-color-gray-6));
 }
 .da-input:focus {
   outline: none;
-  border-color: #185ccc;
-  box-shadow: 0 0 0 2px rgba(24, 92, 204, 0.15);
+  box-shadow: inset 0 0 0 1px var(--sl-color-accent);
+}
+.da-input::placeholder {
+  color: var(--sl-color-gray-3);
 }
 .da-send {
-  background: #185ccc;
-  color: #fff;
+  position: absolute;
+  right: 0.5rem;
+  bottom: 0.5rem;
+  background: var(--sl-color-white);
+  color: var(--sl-color-bg);
   border: none;
-  width: 36px;
-  height: 36px;
+  width: 30px;
+  height: 30px;
   border-radius: 8px;
   cursor: pointer;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  transition: background-color 0.15s;
+  transition: opacity 0.15s, background-color 0.15s;
 }
 .da-send:hover:not(:disabled) {
-  background: #1652b8;
+  opacity: 0.85;
 }
 .da-send:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
+  opacity: 0;
+  pointer-events: none;
 }
 .da-send.is-stop {
-  background: var(--sl-color-gray-3, #6b7280);
+  opacity: 1;
+  background: var(--sl-color-gray-3);
+  color: var(--sl-color-bg);
 }
 .da-send.is-stop:hover {
-  background: var(--sl-color-gray-2, #4b5563);
+  background: var(--sl-color-gray-2);
 }
 
 /* ── Typing / thinking indicator ────────────────────────────────────── */
@@ -443,24 +598,6 @@
 .da-typing {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
   padding: 0.5rem 0;
-}
-.da-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: #185ccc;
-  opacity: 0.35;
-  animation: da-pulse 1.2s ease-in-out infinite;
-}
-.da-dot:nth-child(2) {
-  animation-delay: 0.15s;
-}
-.da-dot:nth-child(3) {
-  animation-delay: 0.3s;
-}
-@keyframes da-pulse {
-  0%, 60%, 100% { opacity: 0.35; transform: scale(1); }
-  30% { opacity: 1; transform: scale(1.15); }
+  color: var(--sl-color-accent);
 }

--- a/docs/src/components/DocsAssistant/DocsAssistantWidget.tsx
+++ b/docs/src/components/DocsAssistant/DocsAssistantWidget.tsx
@@ -1,11 +1,11 @@
 /**
  * Docs assistant widget root.
  *
- * Renders a floating action button (FAB) and a right-side panel. The panel
- * is *non-modal* (`aria-modal="false"`) on purpose: readers can keep
- * interacting with the docs while the assistant is open. ESC and the close
- * button both return focus to the FAB; opening the panel moves focus to
- * the composer so keyboard users can start typing immediately.
+ * The panel is triggered by header buttons (`#header-assistant-btn` and
+ * `#mobile-assistant-btn`) rendered in Header.astro. The panel is
+ * *non-modal* (`aria-modal="false"`) so readers can keep interacting
+ * with the docs while the assistant is open. ESC and the close button
+ * both dismiss the panel; opening moves focus to the composer.
  *
  * Open state, thread, and panel width are persisted to localStorage
  * (see `STORAGE_KEYS`) so navigation between docs pages does not reset
@@ -13,7 +13,7 @@
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { STORAGE_KEYS, WIDTH } from './constants';
-import { IconChat, IconClose, IconNew } from './icons';
+import { IconChatbot, IconClose, IconTrash } from './icons';
 import { Thread } from './Thread';
 import { useAssistant } from './useAssistant';
 import './DocsAssistant.css';
@@ -38,10 +38,13 @@ function readInitialWidth(): number {
   }
 }
 
+/** IDs of the header buttons rendered by Header.astro */
+const HEADER_BTN_IDS = ['header-assistant-btn', 'mobile-assistant-btn'];
+
 export function DocsAssistantWidget() {
   const [open, setOpen] = useState<boolean>(() => readInitialOpen());
   const [width, setWidth] = useState<number>(() => readInitialWidth());
-  const fabRef = useRef<HTMLButtonElement>(null);
+  const [pendingDraft, setPendingDraft] = useState<string | null>(null);
   const composerRef = useRef<HTMLTextAreaElement>(null);
   const resizingRef = useRef(false);
   const { state, send, stop, retry, clear, setFeedback } = useAssistant();
@@ -62,13 +65,36 @@ export function DocsAssistantWidget() {
     }
   }, [width]);
 
+  // Listen for clicks on the header buttons (outside React tree)
+  useEffect(() => {
+    const toggle = () => setOpen((v) => !v);
+    const btns = HEADER_BTN_IDS.map((id) => document.getElementById(id)).filter(Boolean);
+    btns.forEach((btn) => btn!.addEventListener('click', toggle));
+    return () => {
+      btns.forEach((btn) => btn!.removeEventListener('click', toggle));
+    };
+  }, []);
+
+  // "Ask AI about this page" button in ToC — clears chat and pre-fills draft
+  useEffect(() => {
+    const tocBtn = document.getElementById('toc-assistant-btn');
+    if (!tocBtn) return;
+    const handleAskAboutPage = () => {
+      const pageTitle = tocBtn.getAttribute('data-page-title') || document.title;
+      clear();
+      setPendingDraft(`I have a question about the "${pageTitle}" page.\n`);
+      setOpen(true);
+    };
+    tocBtn.addEventListener('click', handleAskAboutPage);
+    return () => tocBtn.removeEventListener('click', handleAskAboutPage);
+  }, [clear]);
+
   useEffect(() => {
     if (!open) return;
     const t = setTimeout(() => composerRef.current?.focus(), 50);
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         setOpen(false);
-        fabRef.current?.focus();
       }
     };
     window.addEventListener('keydown', onKey);
@@ -96,80 +122,63 @@ export function DocsAssistantWidget() {
     window.addEventListener('pointerup', onUp);
   }, []);
 
-  const toggleOpen = () => setOpen((v) => !v);
-
   return (
-    <>
-      <button
-        ref={fabRef}
-        type="button"
-        className="da-fab"
-        aria-label="Open docs assistant"
-        aria-hidden={open}
-        tabIndex={open ? -1 : 0}
-        onClick={toggleOpen}
-        data-open={open ? 'true' : 'false'}
-      >
-        <IconChat />
-      </button>
-
-      <aside
-        className="da-panel"
-        role="dialog"
-        aria-modal="false"
-        aria-label="Docs assistant"
-        data-open={open ? 'true' : 'false'}
-        style={{ width: `${width}px` }}
-      >
-        <div
-          className="da-resize"
-          role="separator"
-          aria-orientation="vertical"
-          aria-label="Resize assistant panel"
-          onPointerDown={startResize}
-        />
-        <header className="da-header">
-          <div className="da-title">
-            <img className="da-logo da-logo-light" src="/docs/img/favicon.png" alt="" width="28" height="28" />
-            <img className="da-logo da-logo-dark" src="/docs/img/favicon-dark.png" alt="" width="28" height="28" />
-            <span>Docs assistant</span>
-          </div>
-          <div className="da-header-actions">
+    <aside
+      className="da-panel"
+      role="dialog"
+      aria-modal="false"
+      aria-label="Docs assistant"
+      data-open={open ? 'true' : 'false'}
+      style={{ width: `${width}px` }}
+    >
+      <div
+        className="da-resize"
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize assistant panel"
+        onPointerDown={startResize}
+      />
+      <header className="da-header">
+        <div className="da-title">
+          <IconChatbot />
+          <span>Docs assistant</span>
+        </div>
+        <div className="da-header-actions">
+          {state.messages.length > 0 && (
             <button
               type="button"
               className="da-header-btn"
               onClick={clear}
-              aria-label="New conversation"
-              title="New conversation"
+              aria-label="Clear chat"
+              title="Clear chat"
             >
-              <IconNew />
+              <IconTrash />
             </button>
-            <button
-              type="button"
-              className="da-header-btn"
-              onClick={() => {
-                setOpen(false);
-                fabRef.current?.focus();
-              }}
-              aria-label="Close assistant"
-              title="Close"
-            >
-              <IconClose />
-            </button>
-          </div>
-        </header>
+          )}
+          <button
+            type="button"
+            className="da-header-btn"
+            onClick={() => setOpen(false)}
+            aria-label="Close assistant"
+            title="Close"
+          >
+            <IconClose />
+          </button>
+        </div>
+      </header>
 
-        <Thread
-          messages={state.messages}
-          streaming={state.streaming}
-          error={state.error}
-          composerRef={composerRef}
-          onSend={send}
-          onStop={stop}
-          onRetry={retry}
-          onFeedback={setFeedback}
-        />
-      </aside>
-    </>
+      <Thread
+        messages={state.messages}
+        streaming={state.streaming}
+        error={state.error}
+        composerRef={composerRef}
+        pendingDraft={pendingDraft}
+        onPendingDraftConsumed={() => setPendingDraft(null)}
+        onSend={send}
+        onStop={stop}
+        onRetry={retry}
+        onFeedback={setFeedback}
+      />
+    </aside>
   );
 }

--- a/docs/src/components/DocsAssistant/MarkdownRenderer.tsx
+++ b/docs/src/components/DocsAssistant/MarkdownRenderer.tsx
@@ -19,7 +19,11 @@ function CodeBlock({ lang, source }: CodeBlockProps) {
     const render = async () => {
       const theme = getCurrentTheme();
       if (lang === 'text') {
-        if (!cancelled) setHtml(`<pre><code>${escapeHtml(source)}</code></pre>`);
+        const lines = escapeHtml(source)
+          .split('\n')
+          .map((l) => `<span class="ec-line">${l}</span>`)
+          .join('\n');
+        if (!cancelled) setHtml(`<pre><code>${lines}</code></pre>`);
         return;
       }
       try {
@@ -27,6 +31,11 @@ function CodeBlock({ lang, source }: CodeBlockProps) {
         const out = hl.codeToHtml(source, {
           lang,
           theme: theme === 'dark' ? 'github-dark' : 'github-light',
+          transformers: [{
+            line(node) {
+              node.properties.class = 'ec-line';
+            },
+          }],
         });
         if (!cancelled) setHtml(out);
       } catch {
@@ -57,18 +66,15 @@ function CodeBlock({ lang, source }: CodeBlockProps) {
 
   return (
     <div className="da-code">
-      <div className="da-code-header">
-        <span className="da-code-lang">{lang === 'text' ? '' : lang}</span>
-        <button
-          type="button"
-          className="da-code-copy"
-          onClick={copy}
-          aria-label="Copy code to clipboard"
-        >
-          {copied ? <IconCheck /> : <IconCopy />}
-          <span>{copied ? 'Copied' : 'Copy'}</span>
-        </button>
-      </div>
+      <button
+        type="button"
+        className={`da-code-copy${copied ? ' is-copied' : ''}`}
+        onClick={copy}
+        aria-label="Copy code to clipboard"
+      >
+        {copied ? <IconCheck /> : <IconCopy />}
+        <span>{copied ? 'Copied' : 'Copy'}</span>
+      </button>
       {/* Shiki output is HTML-escaped token spans. The fallback path (render
           failure) also escapes via escapeHtml above, so no user-controlled
           HTML ever reaches this node. */}

--- a/docs/src/components/DocsAssistant/Message.tsx
+++ b/docs/src/components/DocsAssistant/Message.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import type { ChatMessage } from './useAssistant';
 import { MarkdownRenderer } from './MarkdownRenderer';
-import { IconCheck, IconCopy, IconRetry, IconThumbDown, IconThumbUp } from './icons';
+import { IconCheck, IconCopy, IconRetry, IconThumbDown, IconThumbUp, LoaderBoxes } from './icons';
 
 interface Props {
   message: ChatMessage;
@@ -42,9 +42,7 @@ export function Message({ message, isLastAssistant, streaming, onRetry, onFeedba
       >
         {showTyping ? (
           <div className="da-typing" aria-label="Assistant is thinking">
-            <span className="da-dot" />
-            <span className="da-dot" />
-            <span className="da-dot" />
+            <LoaderBoxes />
           </div>
         ) : (
           <MarkdownRenderer content={message.content} />

--- a/docs/src/components/DocsAssistant/Thread.tsx
+++ b/docs/src/components/DocsAssistant/Thread.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Message } from './Message';
 import { STARTER_SUGGESTIONS, WELCOME } from './constants';
-import { IconRetry, IconSend, IconStop } from './icons';
+import { IconRetry, IconSend, IconStop, IllustrationWelcome } from './icons';
 import type { ChatMessage } from './useAssistant';
 
 interface Props {
@@ -9,6 +9,8 @@ interface Props {
   streaming: boolean;
   error: string | null;
   composerRef: React.RefObject<HTMLTextAreaElement>;
+  pendingDraft?: string | null;
+  onPendingDraftConsumed?: () => void;
   onSend: (text: string) => void;
   onStop: () => void;
   onRetry: () => void;
@@ -20,12 +22,22 @@ export function Thread({
   streaming,
   error,
   composerRef,
+  pendingDraft,
+  onPendingDraftConsumed,
   onSend,
   onStop,
   onRetry,
   onFeedback,
 }: Props) {
   const [draft, setDraft] = useState('');
+
+  useEffect(() => {
+    if (pendingDraft) {
+      setDraft(pendingDraft);
+      onPendingDraftConsumed?.();
+      setTimeout(() => composerRef.current?.focus(), 100);
+    }
+  }, [pendingDraft]);
   const scrollRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -56,8 +68,13 @@ export function Thread({
       <div className="da-scroll" ref={scrollRef}>
         {empty ? (
           <div className="da-welcome">
-            <h3>{WELCOME.headline}</h3>
-            <p>{WELCOME.sub}</p>
+            <div className="da-welcome-hero">
+              <div className="da-welcome-text">
+                <h3>{WELCOME.headline}</h3>
+                <p>{WELCOME.sub}</p>
+              </div>
+              <IllustrationWelcome className="da-welcome-illustration" />
+            </div>
             <div className="da-suggestions">
               {STARTER_SUGGESTIONS.map((s) => (
                 <button
@@ -67,7 +84,8 @@ export function Thread({
                   onClick={() => onSend(s)}
                   disabled={streaming}
                 >
-                  {s}
+                  <span>{s}</span>
+                  <span className="da-suggestion-arrow">→</span>
                 </button>
               ))}
             </div>
@@ -103,35 +121,37 @@ export function Thread({
           submit();
         }}
       >
-        <textarea
-          ref={composerRef}
-          className="da-input"
-          placeholder="Ask a question…"
-          rows={2}
-          value={draft}
-          onChange={(e) => setDraft(e.target.value)}
-          onKeyDown={onKeyDown}
-          aria-label="Ask a question"
-        />
-        {streaming ? (
-          <button
-            type="button"
-            className="da-send is-stop"
-            aria-label="Stop generating"
-            onClick={onStop}
-          >
-            <IconStop />
-          </button>
-        ) : (
-          <button
-            type="submit"
-            className="da-send"
-            aria-label="Send message"
-            disabled={!draft.trim()}
-          >
-            <IconSend />
-          </button>
-        )}
+        <div className="da-input-wrap">
+          <textarea
+            ref={composerRef}
+            className="da-input"
+            placeholder="Ask a question..."
+            rows={2}
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={onKeyDown}
+            aria-label="Ask a question"
+          />
+          {streaming ? (
+            <button
+              type="button"
+              className="da-send is-stop"
+              aria-label="Stop generating"
+              onClick={onStop}
+            >
+              <IconStop />
+            </button>
+          ) : (
+            <button
+              type="submit"
+              className="da-send"
+              aria-label="Send message"
+              disabled={!draft.trim()}
+            >
+              <IconSend />
+            </button>
+          )}
+        </div>
       </form>
     </div>
   );

--- a/docs/src/components/DocsAssistant/constants.ts
+++ b/docs/src/components/DocsAssistant/constants.ts
@@ -17,7 +17,7 @@ export const STARTER_SUGGESTIONS = [
 ];
 
 export const WELCOME = {
-  headline: 'Ask me anything about Handsontable',
+  headline: 'How can I help?',
   sub: 'I search the docs to answer questions about APIs, configuration, and usage. I say "I don\'t know" when the docs don\'t cover it.',
 };
 

--- a/docs/src/components/DocsAssistant/icons.tsx
+++ b/docs/src/components/DocsAssistant/icons.tsx
@@ -1,5 +1,42 @@
 import type { SVGProps } from 'react';
 
+export const LoaderBoxes = (props: SVGProps<SVGSVGElement>) => (
+  <svg width="24" height="24" viewBox="0 0 36 36" aria-hidden="true" {...props}>
+    <style>{`
+      .lb{fill:currentColor;transform-origin:50% 50%}
+      @keyframes lb1{9.09%{transform:translate(-12px,0)}18.18%{transform:translate(0,0)}27.27%{transform:translate(0,0)}36.36%{transform:translate(12px,0)}45.45%{transform:translate(12px,12px)}54.55%{transform:translate(12px,12px)}63.64%{transform:translate(12px,12px)}72.73%{transform:translate(12px,0)}81.82%{transform:translate(0,0)}90.91%{transform:translate(-12px,0)}100%{transform:translate(0,0)}}
+      @keyframes lb2{9.09%{transform:translate(0,0)}18.18%{transform:translate(12px,0)}27.27%{transform:translate(0,0)}36.36%{transform:translate(12px,0)}45.45%{transform:translate(12px,12px)}54.55%{transform:translate(12px,12px)}63.64%{transform:translate(12px,12px)}72.73%{transform:translate(12px,12px)}81.82%{transform:translate(0,12px)}90.91%{transform:translate(0,12px)}100%{transform:translate(0,0)}}
+      @keyframes lb3{9.09%{transform:translate(-12px,0)}18.18%{transform:translate(-12px,0)}27.27%{transform:translate(0,0)}36.36%{transform:translate(-12px,0)}45.45%{transform:translate(-12px,0)}54.55%{transform:translate(-12px,0)}63.64%{transform:translate(-12px,0)}72.73%{transform:translate(-12px,0)}81.82%{transform:translate(-12px,-12px)}90.91%{transform:translate(0,-12px)}100%{transform:translate(0,0)}}
+      @keyframes lb4{9.09%{transform:translate(-12px,0)}18.18%{transform:translate(-12px,0)}27.27%{transform:translate(-12px,-12px)}36.36%{transform:translate(0,-12px)}45.45%{transform:translate(0,0)}54.55%{transform:translate(0,-12px)}63.64%{transform:translate(0,-12px)}72.73%{transform:translate(0,-12px)}81.82%{transform:translate(-12px,-12px)}90.91%{transform:translate(-12px,0)}100%{transform:translate(0,0)}}
+      @keyframes lb5{9.09%{transform:translate(0,0)}18.18%{transform:translate(0,0)}27.27%{transform:translate(0,0)}36.36%{transform:translate(12px,0)}45.45%{transform:translate(12px,0)}54.55%{transform:translate(12px,0)}63.64%{transform:translate(12px,0)}72.73%{transform:translate(12px,0)}81.82%{transform:translate(12px,-12px)}90.91%{transform:translate(0,-12px)}100%{transform:translate(0,0)}}
+      @keyframes lb6{9.09%{transform:translate(0,0)}18.18%{transform:translate(-12px,0)}27.27%{transform:translate(-12px,0)}36.36%{transform:translate(0,0)}45.45%{transform:translate(0,0)}54.55%{transform:translate(0,0)}63.64%{transform:translate(0,0)}72.73%{transform:translate(0,12px)}81.82%{transform:translate(-12px,12px)}90.91%{transform:translate(-12px,0)}100%{transform:translate(0,0)}}
+      @keyframes lb7{9.09%{transform:translate(12px,0)}18.18%{transform:translate(12px,0)}27.27%{transform:translate(12px,0)}36.36%{transform:translate(0,0)}45.45%{transform:translate(0,-12px)}54.55%{transform:translate(12px,-12px)}63.64%{transform:translate(0,-12px)}72.73%{transform:translate(0,-12px)}81.82%{transform:translate(0,0)}90.91%{transform:translate(12px,0)}100%{transform:translate(0,0)}}
+      @keyframes lb8{9.09%{transform:translate(0,0)}18.18%{transform:translate(-12px,0)}27.27%{transform:translate(-12px,-12px)}36.36%{transform:translate(0,-12px)}45.45%{transform:translate(0,-12px)}54.55%{transform:translate(0,-12px)}63.64%{transform:translate(0,-12px)}72.73%{transform:translate(0,-12px)}81.82%{transform:translate(12px,-12px)}90.91%{transform:translate(12px,0)}100%{transform:translate(0,0)}}
+      @keyframes lb9{9.09%{transform:translate(-12px,0)}18.18%{transform:translate(-12px,0)}27.27%{transform:translate(0,0)}36.36%{transform:translate(-12px,0)}45.45%{transform:translate(0,0)}54.55%{transform:translate(0,0)}63.64%{transform:translate(-12px,0)}72.73%{transform:translate(-12px,0)}81.82%{transform:translate(-24px,0)}90.91%{transform:translate(-12px,0)}100%{transform:translate(0,0)}}
+      .lb:nth-child(1){animation:lb1 4s infinite}
+      .lb:nth-child(2){animation:lb2 4s infinite}
+      .lb:nth-child(3){animation:lb3 4s infinite}
+      .lb:nth-child(4){animation:lb4 4s infinite}
+      .lb:nth-child(5){animation:lb5 4s infinite}
+      .lb:nth-child(6){animation:lb6 4s infinite}
+      .lb:nth-child(7){animation:lb7 4s infinite}
+      .lb:nth-child(8){animation:lb8 4s infinite}
+      .lb:nth-child(9){animation:lb9 4s infinite}
+    `}</style>
+    <g>
+      <rect className="lb" x="13" y="1" rx="1" width="10" height="10" />
+      <rect className="lb" x="13" y="1" rx="1" width="10" height="10" />
+      <rect className="lb" x="25" y="25" rx="1" width="10" height="10" />
+      <rect className="lb" x="13" y="13" rx="1" width="10" height="10" />
+      <rect className="lb" x="13" y="13" rx="1" width="10" height="10" />
+      <rect className="lb" x="25" y="13" rx="1" width="10" height="10" />
+      <rect className="lb" x="1" y="25" rx="1" width="10" height="10" />
+      <rect className="lb" x="13" y="25" rx="1" width="10" height="10" />
+      <rect className="lb" x="25" y="25" rx="1" width="10" height="10" />
+    </g>
+  </svg>
+);
+
 export const LogoMark = (props: SVGProps<SVGSVGElement>) => (
   <svg width="28" height="28" viewBox="0 0 100 100" fill="none" aria-hidden="true" {...props}>
     <rect width="100" height="100" rx="12" fill="#185CCC" />
@@ -13,6 +50,15 @@ export const LogoMark = (props: SVGProps<SVGSVGElement>) => (
 export const IconChat = (props: SVGProps<SVGSVGElement>) => (
   <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" {...props}>
     <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+  </svg>
+);
+
+export const IconChatbot = (props: SVGProps<SVGSVGElement>) => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" {...props}>
+    <path d="M18 4a3 3 0 0 1 3 3v8a3 3 0 0 1 -3 3h-5l-5 3v-3h-2a3 3 0 0 1 -3 -3v-8a3 3 0 0 1 3 -3h12" />
+    <path d="M9.5 9h.01" />
+    <path d="M14.5 9h.01" />
+    <path d="M9.5 13a3.5 3.5 0 0 0 5 0" />
   </svg>
 );
 
@@ -30,9 +76,21 @@ export const IconNew = (props: SVGProps<SVGSVGElement>) => (
   </svg>
 );
 
+export const IconTrash = (props: SVGProps<SVGSVGElement>) => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" {...props}>
+    <path d="M4 7l16 0" />
+    <path d="M10 11l0 6" />
+    <path d="M14 11l0 6" />
+    <path d="M5 7l1 12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2l1-12" />
+    <path d="M9 7v-3a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v3" />
+  </svg>
+);
+
 export const IconSend = (props: SVGProps<SVGSVGElement>) => (
-  <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" {...props}>
-    <path d="M3.4 20.4l17.45-7.48a1 1 0 0 0 0-1.84L3.4 3.6a1 1 0 0 0-1.39 1.13L4 11l9 1-9 1-1.99 6.27a1 1 0 0 0 1.39 1.13z" />
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" {...props}>
+    <path d="M12 5l0 14" />
+    <path d="M18 11l-6-6" />
+    <path d="M6 11l6-6" />
   </svg>
 );
 
@@ -73,5 +131,23 @@ export const IconRetry = (props: SVGProps<SVGSVGElement>) => (
   <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" {...props}>
     <polyline points="1 4 1 10 7 10" />
     <path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10" />
+  </svg>
+);
+
+export const IllustrationWelcome = (props: SVGProps<SVGSVGElement>) => (
+  <svg width="75" height="86" viewBox="0 0 75 86" fill="none" aria-hidden="true" {...props}>
+    <path opacity="0.5" fillRule="evenodd" clipRule="evenodd" d="M32.1668 78.3137L51.9024 72.2744L69.4126 79.7387L50.0318 85.7779L32.1668 78.3137Z" fill="black"/>
+    <path fillRule="evenodd" clipRule="evenodd" d="M74.8301 55.6135L69.4129 79.6377L49.6448 83.4109L32.1669 71.6729L37.5843 47.4871L57.3199 43.6816L74.8301 55.6135Z" fill="#D0D0D0"/>
+    <path fillRule="evenodd" clipRule="evenodd" d="M49.6443 83.4111L32.1664 71.673L37.5838 47.4873L55.4487 59.4191L49.6443 83.4111Z" fill="white"/>
+    <path d="M41.3826 57.5358C43.2315 58.5923 42.7032 62.8182 42.3731 63.9738C41.9235 63.0343 40.4357 61.1248 38.0811 61.0024C38.3012 59.9569 39.5338 56.4794 41.3826 57.5358Z" stroke="black" strokeWidth="0.893522" strokeLinecap="round"/>
+    <path d="M42.4014 59.529C43.1935 60.1598 42.7309 63.131 42.5895 63.8209C42.3969 63.26 41.4293 62.2433 40.4205 62.1702C40.5148 61.546 41.6092 58.8982 42.4014 59.529Z" fill="black"/>
+    <path d="M47.3538 61.7072C49.2027 62.7637 48.6744 66.9896 48.3443 68.1452C47.8947 67.2057 46.4069 65.2962 44.0523 65.1738C44.2724 64.1283 45.505 60.6507 47.3538 61.7072Z" stroke="black" strokeWidth="0.893522" strokeLinecap="round"/>
+    <path d="M48.3721 63.7004C49.1642 64.3312 48.7016 67.3024 48.5602 67.9923C48.3676 67.4314 47.4 66.4147 46.3912 66.3416C46.4855 65.7173 47.5799 63.0696 48.3721 63.7004Z" fill="black"/>
+    <path d="M40.3784 71.3053C39.1681 70.3767 38.9587 69.1286 39.1748 68.1129L44.0524 71.4504C43.9083 72.3694 41.5886 72.234 40.3784 71.3053Z" fill="black" stroke="black" strokeWidth="0.893522" strokeLinecap="round"/>
+    <path fillRule="evenodd" clipRule="evenodd" d="M37.5843 47.4871L57.3199 43.6816L74.8301 55.6135L55.4493 59.4189L37.5843 47.4871Z" fill="#E7E7E7"/>
+    <path d="M5.43567 0L46.4631 24.3345L41.0243 27.3531L0 3.01943L5.43567 0Z" fill="#59595C"/>
+    <path d="M46.4628 53.0241L41.0239 56.0412V27.3531L46.4628 24.3345V53.0241Z" fill="black"/>
+    <path d="M0 3.01953L41.0243 27.3532V56.0413L35.7523 52.9147V62.9936L26.2299 47.2685L0 31.7076V3.01953Z" fill="#2C2C2C"/>
+    <path d="M3.77123 17.9305L2.73534 17.309L4.35353 12.9902L5.32199 13.5713L6.93406 19.8282L5.87978 19.1956L5.56105 17.8893L4.09609 17.0103L3.77123 17.9305ZM4.70904 15.2765L4.38418 16.211L5.27909 16.748L4.95422 15.4236C4.92971 15.3184 4.90519 15.2107 4.88067 15.1007C4.85615 14.9907 4.83981 14.9023 4.83163 14.8354C4.82346 14.8925 4.80712 14.9613 4.7826 15.0419C4.76217 15.1202 4.73765 15.1984 4.70904 15.2765ZM7.21065 16.2414C7.21065 15.9221 7.28216 15.6838 7.42518 15.5266C7.5682 15.3646 7.76435 15.2893 8.01362 15.3007C8.26697 15.3097 8.55506 15.4111 8.87788 15.6048C9.20478 15.8009 9.48674 16.0368 9.72375 16.3124C9.96076 16.5881 10.1426 16.8854 10.2693 17.2045C10.4 17.526 10.4654 17.8535 10.4654 18.1871L9.47857 17.595C9.47857 17.4091 9.4234 17.2307 9.31307 17.0596C9.20274 16.8838 9.05359 16.7395 8.86562 16.6268C8.66539 16.5066 8.50398 16.4598 8.38139 16.4863C8.26288 16.5153 8.20363 16.6179 8.20363 16.7943C8.20363 16.9563 8.24041 17.1023 8.31396 17.2322C8.38752 17.3621 8.50398 17.4939 8.66334 17.6277L9.34372 18.2003C9.74827 18.5383 10.0486 18.8853 10.2448 19.2413C10.4409 19.5925 10.539 19.9778 10.539 20.3971C10.539 20.7355 10.4675 20.9904 10.3244 21.1619C10.1814 21.3287 9.97915 21.4027 9.71762 21.384C9.46018 21.3677 9.15779 21.2554 8.81045 21.047C8.47537 20.8459 8.18116 20.6027 7.9278 20.3172C7.67854 20.0342 7.48443 19.7295 7.3455 19.4031C7.21065 19.0744 7.14323 18.7457 7.14323 18.4169L8.13008 19.009C8.13008 19.1996 8.18933 19.3829 8.30783 19.5588C8.42634 19.7347 8.59592 19.8889 8.81658 20.0213C9.04133 20.1562 9.21909 20.2152 9.34985 20.1983C9.48061 20.1767 9.54599 20.0825 9.54599 19.9157C9.54599 19.768 9.5133 19.634 9.44792 19.5137C9.38663 19.396 9.28038 19.275 9.12919 19.1509L8.43655 18.571C8.032 18.2329 7.72553 17.8679 7.51713 17.476C7.31281 17.0866 7.21065 16.675 7.21065 16.2414ZM14.9974 19.3766L11.9388 22.202V20.4579L13.8267 18.6741L14.9974 19.3766ZM12.1901 17.6922V22.9818L11.1971 22.3861V17.0964L12.1901 17.6922ZM12.8337 21.2593L13.465 20.6231L15.0097 24.6736L13.8635 23.9859L12.8337 21.2593ZM18.1274 26.5442L17.165 25.9668V20.6771L18.1274 21.2545L19.4758 26.0094L20.8305 22.8764L21.8051 23.4612V28.7508L20.8427 28.1734V27.0654C20.8427 26.7795 20.8427 26.5436 20.8427 26.3578C20.8427 26.1719 20.8448 26.0183 20.8489 25.8968C20.8529 25.7754 20.857 25.6706 20.8611 25.5825C20.8693 25.4921 20.8795 25.4005 20.8918 25.3078L19.9294 27.6254L19.0223 27.0811L18.0661 23.6124C18.0947 23.8249 18.111 24.0468 18.1151 24.278C18.1233 24.5117 18.1274 24.7738 18.1274 25.0645V26.5442ZM25.6307 31.0462L22.7498 29.3177V24.028L25.6307 25.7565V26.8288L23.467 25.5305L23.7428 25.3958V26.7325L25.4162 27.7365V28.7516L23.7428 27.7476V29.1415L23.467 28.6757L25.6307 29.974V31.0462ZM3.77123 26.9305L2.73534 26.309L4.35353 21.9902L5.32199 22.5713L6.93406 28.8282L5.87978 28.1956L5.56105 26.8893L4.09609 26.0103L3.77123 26.9305ZM4.70904 24.2765L4.38418 25.211L5.27909 25.748L4.95422 24.4236C4.92971 24.3184 4.90519 24.2107 4.88067 24.1007C4.85615 23.9907 4.83981 23.9023 4.83163 23.8354C4.82346 23.8925 4.80712 23.9613 4.7826 24.0419C4.76217 24.1202 4.73765 24.1984 4.70904 24.2765ZM8.44268 29.7334L7.46196 29.1449V23.8553L8.44268 24.4437L10.6616 29.678L10.3551 29.4941V25.5912L11.3358 26.1796V31.4693L10.3551 30.8808L8.13621 25.6537L8.44268 25.8376V29.7334ZM13.4023 30.7005L11.8699 26.5001L12.9793 27.1657L13.7394 29.3373C13.7762 29.4404 13.8068 29.535 13.8313 29.6212C13.8599 29.7051 13.8865 29.7878 13.911 29.8692C13.9315 29.8386 13.9498 29.8067 13.9662 29.7736C13.9825 29.7358 14.0009 29.6992 14.0213 29.6638C14.0418 29.6236 14.0643 29.5823 14.0888 29.5398L14.8488 28.2874L15.9276 28.9347L14.3952 31.2963V33.3049L13.4023 32.7091V30.7005ZM18.4493 31.0053V35.7374L17.4564 35.1416V30.4095L18.4493 31.0053ZM16.1692 30.1519V29.0796L19.7365 31.2201V32.2923L16.1692 30.1519ZM21.3245 37.4625L20.3315 36.8667V31.577L21.3245 32.1728V34.2601L23.0776 35.3119V33.2247L24.0705 33.8204V39.1101L23.0776 38.5143V36.3842L21.3245 35.3323V37.4625ZM26.0055 34.9814V40.271L25.0125 39.6753V34.3856L26.0055 34.9814ZM27.9326 41.4273L26.9519 40.8389V35.5493L27.9326 36.1377L30.1515 41.3719L29.845 41.188V37.2851L30.8257 37.8736V43.1632L29.845 42.5748L27.6261 37.3477L27.9326 37.5316V41.4273ZM33.8116 40.6658C33.5378 40.5016 33.309 40.4358 33.1251 40.4684C32.9412 40.4963 32.8023 40.6083 32.7083 40.8044C32.6143 41.0006 32.5673 41.2703 32.5673 41.6134C32.5673 41.966 32.6205 42.2934 32.7267 42.5954C32.8329 42.8974 32.978 43.1631 33.1619 43.3926C33.3499 43.6198 33.5644 43.8057 33.8055 43.9503C34.0098 44.0729 34.1835 44.1461 34.3265 44.17C34.4695 44.1939 34.5839 44.1767 34.6698 44.1186C34.7597 44.063 34.825 43.9783 34.8659 43.8646C34.9108 43.7534 34.9333 43.6239 34.9333 43.4762V43.0544L35.4053 43.888L33.7258 42.8803V41.8653L35.8589 43.1451V46.1831L35.0069 45.6719L34.9272 44.9021L35.0375 45.0755C34.9721 45.1745 34.87 45.2347 34.731 45.2562C34.5962 45.2801 34.4368 45.2655 34.2529 45.2124C34.0731 45.1617 33.8811 45.0751 33.6768 44.9525C33.2559 44.6999 32.882 44.3636 32.5551 43.9435C32.2323 43.521 31.9789 43.0521 31.795 42.5367C31.6111 42.0213 31.5192 41.492 31.5192 40.9488C31.5192 40.415 31.6152 40.0009 31.8073 39.7063C31.9993 39.4069 32.269 39.2447 32.6164 39.2196C32.9637 39.1897 33.3703 39.3145 33.8361 39.594C34.1998 39.8122 34.5267 40.087 34.8169 40.4184C35.1111 40.7474 35.3501 41.11 35.534 41.5063C35.7179 41.8978 35.8262 42.2939 35.8589 42.6948L34.8169 42.0696C34.7597 41.7541 34.6371 41.478 34.4491 41.2413C34.2611 40.9999 34.0486 40.808 33.8116 40.6658Z" fill="white"/>
   </svg>
 );

--- a/docs/src/components/Header.astro
+++ b/docs/src/components/Header.astro
@@ -65,6 +65,17 @@ const frameworks = [
       {shouldRenderSearch && <Search />}
     </div>
     <div class="sl-hidden md:sl-flex print:hidden right-group">
+      <!-- Docs assistant toggle -->
+      <button
+        type="button"
+        class="header-assistant-btn"
+        id="header-assistant-btn"
+        aria-label="Open docs assistant"
+        title="Docs assistant"
+      >
+        <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M18 4a3 3 0 0 1 3 3v8a3 3 0 0 1 -3 3h-5l-5 3v-3h-2a3 3 0 0 1 -3 -3v-8a3 3 0 0 1 3 -3h12" /><path d="M9.5 9h.01" /><path d="M14.5 9h.01" /><path d="M9.5 13a3.5 3.5 0 0 0 5 0" /></svg>
+        <span>Ask AI</span>
+      </button>
       <!-- GitHub stars badge -->
       <a
         href="https://github.com/handsontable/handsontable"
@@ -90,6 +101,15 @@ const frameworks = [
       <div class="mobile-theme-toggle">
         <ThemeSelect />
       </div>
+      <button
+        type="button"
+        class="header-assistant-btn mobile-assistant-btn"
+        id="mobile-assistant-btn"
+        aria-label="Open docs assistant"
+        title="Docs assistant"
+      >
+        <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"><path d="M18 4a3 3 0 0 1 3 3v8a3 3 0 0 1 -3 3h-5l-5 3v-3h-2a3 3 0 0 1 -3 -3v-8a3 3 0 0 1 3 -3h12" /><path d="M9.5 9h.01" /><path d="M14.5 9h.01" /><path d="M9.5 13a3.5 3.5 0 0 0 5 0" /></svg>
+      </button>
       <button class="mobile-menu-btn" aria-label="Open navigation menu" aria-expanded="false" aria-controls="mobile-nav-overlay">
         <svg class="mobile-menu-icon-open" aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6h16"/><path d="M4 12h16"/><path d="M4 18h16"/></svg>
         <svg class="mobile-menu-icon-close" aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6L6 18"/><path d="M6 6l12 12"/></svg>
@@ -604,6 +624,31 @@ const frameworks = [
     border-color: var(--sl-color-accent);
     z-index: 1;
     background: var(--sl-color-gray-7, var(--sl-color-gray-6));
+  }
+
+  /* Docs assistant header button — matches ht-link-card visual style */
+  .header-assistant-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    background: none;
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 0;
+    padding: 0.15rem 0.6rem;
+    color: var(--sl-color-gray-1);
+    font-family: inherit;
+    font-size: var(--sl-text-sm);
+    font-weight: 600;
+    cursor: pointer;
+    transition: color 0.15s, background-color 0.15s;
+    white-space: nowrap;
+  }
+  .header-assistant-btn:hover {
+    color: var(--sl-color-white);
+    background: var(--sl-color-hover-bg, var(--sl-color-gray-6));
+  }
+  .mobile-assistant-btn span {
+    display: none;
   }
 
   /* GitHub stars badge */

--- a/docs/src/components/PageSidebar.astro
+++ b/docs/src/components/PageSidebar.astro
@@ -32,6 +32,7 @@ interface ActionLink {
   icon: string;
   isButton?: boolean;
   hasStates?: boolean;
+  customIcon?: boolean;
 }
 
 const actionLinks: ActionLink[] = [];
@@ -43,6 +44,15 @@ actionLinks.push({
   icon: 'mdx',
   isButton: true,
   hasStates: true,
+});
+
+// Ask AI about this page — opens the docs assistant panel
+actionLinks.push({
+  label: 'Ask AI about this page',
+  id: 'toc-assistant-btn',
+  icon: 'chatbot',
+  isButton: true,
+  customIcon: true,
 });
 
 // Print this page — browser-native print dialog
@@ -89,8 +99,13 @@ if (actions?.claude) {
                   class="toc-action-link"
                   id={action.id}
                   data-path={mdPath}
+                  data-page-title={action.id === 'toc-assistant-btn' ? pageTitle : undefined}
                 >
-                  <Icon name={action.icon} size="0.875rem" class={action.hasStates ? 'icon-default' : undefined} />
+                  {action.customIcon ? (
+                    <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 4a3 3 0 0 1 3 3v8a3 3 0 0 1 -3 3h-5l-5 3v-3h-2a3 3 0 0 1 -3 -3v-8a3 3 0 0 1 3 -3h12" /><path d="M9.5 9h.01" /><path d="M14.5 9h.01" /><path d="M9.5 13a3.5 3.5 0 0 0 5 0" /></svg>
+                  ) : (
+                    <Icon name={action.icon} size="0.875rem" class={action.hasStates ? 'icon-default' : undefined} />
+                  )}
                   {action.hasStates && <Icon name="approve-check" size="0.875rem" class="icon-success" />}
                   {action.hasStates && <Icon name="error" size="0.875rem" class="icon-error" />}
                   <span>{action.label}</span>

--- a/docs/src/styles/base/variables.css
+++ b/docs/src/styles/base/variables.css
@@ -64,7 +64,7 @@
 /* Light mode accent colours + pure neutral gray palette */
 :root[data-theme='light'] {
   --sl-color-accent-low:  #e6f3ff;
-  --sl-color-accent:      #1565c0;
+  --sl-color-accent:      #1A42E8;
   --sl-color-accent-high: #0d47a1;
 
   /* Pure gray palette for light mode */


### PR DESCRIPTION
- Match assistant typography to .sl-markdown-content styles
- Replace all hardcoded colors with Starlight CSS tokens
- Redesign composer (no border-radius, inset focus ring)
- Suggestion boxes match ht-link-card style (stacked, arrows, hover)
- Add message-chatbot icon in header (Ask AI) and ToC sidebar
- Replace FAB with header button entry point (desktop + mobile)
- Add "Ask AI about this page" in ToC (clears chat, pre-fills draft)
- Animated boxes loader replaces bouncing dots during thinking
- Welcome screen with illustration, speech bubble on user messages
- Light mode accent color updated to #1A42E8
- Full-height panel with proper z-index stacking

### Context
<!--- Why is this change required? What problem does it solve? -->

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: adds new DOM event wiring between Astro-rendered buttons and the React widget (open/close + prefilled drafts), which could affect accessibility/focus behavior and panel state across navigation; otherwise changes are mostly visual styling in docs.
> 
> **Overview**
> Moves the Docs Assistant entry point from a floating FAB to **new header buttons** (desktop + mobile) and adds a **ToC action** (`Ask AI about this page`) that clears the thread, opens the panel, and pre-fills a draft prompt.
> 
> Refreshes the assistant UI to better match Starlight/rapide styling: tokenized colors, full-height/z-index adjustments, redesigned composer, updated welcome screen (illustration + suggestion list styling), new loader animation, user bubble tail, and code block tweaks (copy button positioning + CSS-based line numbering). Also bumps `react-markdown` to `^9.1.0` and updates the light-mode accent color.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d2b5a19b45646523a08ea055a41801761eacf7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[skip changelog]