### PR TITLE
DEV-1465: Add React examples for recipe documentation

### DIFF
--- a/docs/content/recipes/accessibility/aria-grid/aria-grid.md
+++ b/docs/content/recipes/accessibility/aria-grid/aria-grid.md
@@ -25,6 +25,17 @@ category: Accessibility & UX
 
 :::
 
+::: only-for react
+
+::: example #example1 :react-advanced --js 1 --ts 2
+
+@[code](@/content/recipes/accessibility/aria-grid/react/example1.jsx)
+@[code](@/content/recipes/accessibility/aria-grid/react/example1.tsx)
+
+:::
+
+:::
+
 ## Overview
 
 This recipe shows how to configure Handsontable so screen readers can navigate the grid meaningfully. You will enable ARIA roles on grid elements, add descriptive `aria-label` attributes to every cell, expose sort state on column headers, and configure keyboard navigation to match screen reader conventions.

--- a/docs/content/recipes/accessibility/aria-grid/react/example1.jsx
+++ b/docs/content/recipes/accessibility/aria-grid/react/example1.jsx
@@ -44,7 +44,7 @@ const ExampleComponent = () => {
         return {
           renderer(hotInstance, TD, row, col, prop, value, cellProperties) {
             getRenderer('text')(hotInstance, TD, row, col, prop, value, cellProperties);
-            TD.setAttribute('aria-label', `${colHeaders[col]}: ${value || 'empty'}`);
+            TD.setAttribute('aria-label', `${colHeaders[col]}: ${value ?? 'empty'}`);
           },
         };
       }}

--- a/docs/content/recipes/accessibility/aria-grid/react/example1.jsx
+++ b/docs/content/recipes/accessibility/aria-grid/react/example1.jsx
@@ -1,0 +1,61 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import { getRenderer } from 'handsontable/renderers';
+
+registerAllModules();
+
+/* start:skip-in-preview */
+const data = [
+  { name: 'Ana García',    department: 'Engineering',  role: 'Senior Engineer',    salary: 95000,  startDate: '2019-03-12' },
+  { name: 'James Okafor',  department: 'Product',      role: 'Product Manager',    salary: 105000, startDate: '2020-07-01' },
+  { name: 'Li Wei',        department: 'Design',       role: 'UX Designer',        salary: 88000,  startDate: '2021-01-15' },
+  { name: 'Priya Sharma',  department: 'Engineering',  role: 'Tech Lead',          salary: 120000, startDate: '2018-09-05' },
+  { name: 'Carlos Mendez', department: 'HR',           role: 'HR Specialist',      salary: 72000,  startDate: '2022-02-20' },
+  { name: 'Sarah Chen',    department: 'Finance',      role: 'Financial Analyst',  salary: 91000,  startDate: '2020-11-30' },
+  { name: 'Omar Hassan',   department: 'Engineering',  role: 'Backend Engineer',   salary: 98000,  startDate: '2021-06-14' },
+  { name: 'Emma Wilson',   department: 'Marketing',    role: 'Marketing Lead',     salary: 85000,  startDate: '2019-08-22' },
+];
+/* end:skip-in-preview */
+
+const colHeaders = ['Name', 'Department', 'Role', 'Salary', 'Start Date'];
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={data}
+      colHeaders={colHeaders}
+      rowHeaders={true}
+      height="auto"
+      width="100%"
+      ariaTags={true}
+      tabMoves={{ row: 1, col: 0 }}
+      enterMoves={{ row: 1, col: 0 }}
+      autoWrapRow={false}
+      autoWrapCol={false}
+      columnSorting={true}
+      columns={[
+        { data: 'name' },
+        { data: 'department' },
+        { data: 'role' },
+        { data: 'salary' },
+        { data: 'startDate' },
+      ]}
+      cells={function() {
+        return {
+          renderer(hotInstance, TD, row, col, prop, value) {
+            getRenderer('text')(hotInstance, TD, row, col, prop, value);
+            TD.setAttribute('aria-label', `${colHeaders[col]}: ${value || 'empty'}`);
+          },
+        };
+      }}
+      afterGetColHeader={function(col, TH) {
+        if (!TH.hasAttribute('aria-sort')) {
+          TH.setAttribute('aria-sort', 'none');
+        }
+      }}
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/accessibility/aria-grid/react/example1.jsx
+++ b/docs/content/recipes/accessibility/aria-grid/react/example1.jsx
@@ -42,8 +42,8 @@ const ExampleComponent = () => {
       ]}
       cells={function() {
         return {
-          renderer(hotInstance, TD, row, col, prop, value) {
-            getRenderer('text')(hotInstance, TD, row, col, prop, value);
+          renderer(hotInstance, TD, row, col, prop, value, cellProperties) {
+            getRenderer('text')(hotInstance, TD, row, col, prop, value, cellProperties);
             TD.setAttribute('aria-label', `${colHeaders[col]}: ${value || 'empty'}`);
           },
         };

--- a/docs/content/recipes/accessibility/aria-grid/react/example1.tsx
+++ b/docs/content/recipes/accessibility/aria-grid/react/example1.tsx
@@ -1,0 +1,77 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import { getRenderer } from 'handsontable/renderers';
+import type Handsontable from 'handsontable/base';
+
+registerAllModules();
+
+/* start:skip-in-preview */
+type EmployeeRow = {
+  name: string;
+  department: string;
+  role: string;
+  salary: number;
+  startDate: string;
+};
+
+const data: EmployeeRow[] = [
+  { name: 'Ana García',    department: 'Engineering',  role: 'Senior Engineer',    salary: 95000,  startDate: '2019-03-12' },
+  { name: 'James Okafor',  department: 'Product',      role: 'Product Manager',    salary: 105000, startDate: '2020-07-01' },
+  { name: 'Li Wei',        department: 'Design',       role: 'UX Designer',        salary: 88000,  startDate: '2021-01-15' },
+  { name: 'Priya Sharma',  department: 'Engineering',  role: 'Tech Lead',          salary: 120000, startDate: '2018-09-05' },
+  { name: 'Carlos Mendez', department: 'HR',           role: 'HR Specialist',      salary: 72000,  startDate: '2022-02-20' },
+  { name: 'Sarah Chen',    department: 'Finance',      role: 'Financial Analyst',  salary: 91000,  startDate: '2020-11-30' },
+  { name: 'Omar Hassan',   department: 'Engineering',  role: 'Backend Engineer',   salary: 98000,  startDate: '2021-06-14' },
+  { name: 'Emma Wilson',   department: 'Marketing',    role: 'Marketing Lead',     salary: 85000,  startDate: '2019-08-22' },
+];
+/* end:skip-in-preview */
+
+const colHeaders: string[] = ['Name', 'Department', 'Role', 'Salary', 'Start Date'];
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={data}
+      colHeaders={colHeaders}
+      rowHeaders={true}
+      height="auto"
+      width="100%"
+      ariaTags={true}
+      tabMoves={{ row: 1, col: 0 }}
+      enterMoves={{ row: 1, col: 0 }}
+      autoWrapRow={false}
+      autoWrapCol={false}
+      columnSorting={true}
+      columns={[
+        { data: 'name' },
+        { data: 'department' },
+        { data: 'role' },
+        { data: 'salary' },
+        { data: 'startDate' },
+      ]}
+      cells={function(): Handsontable.CellMeta {
+        return {
+          renderer(
+            hotInstance: Handsontable,
+            TD: HTMLTableCellElement,
+            row: number,
+            col: number,
+            prop: string | number,
+            value: Handsontable.CellValue,
+          ): void {
+            getRenderer('text')(hotInstance, TD, row, col, prop, value);
+            TD.setAttribute('aria-label', `${colHeaders[col]}: ${value || 'empty'}`);
+          },
+        };
+      }}
+      afterGetColHeader={function(col: number, TH: HTMLTableCellElement): void {
+        if (!TH.hasAttribute('aria-sort')) {
+          TH.setAttribute('aria-sort', 'none');
+        }
+      }}
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/accessibility/aria-grid/react/example1.tsx
+++ b/docs/content/recipes/accessibility/aria-grid/react/example1.tsx
@@ -61,7 +61,7 @@ const ExampleComponent = () => {
             cellProperties: Handsontable.CellProperties,
           ): void {
             getRenderer('text')(hotInstance, TD, row, col, prop, value, cellProperties);
-            TD.setAttribute('aria-label', `${colHeaders[col]}: ${value || 'empty'}`);
+            TD.setAttribute('aria-label', `${colHeaders[col]}: ${value ?? 'empty'}`);
           },
         };
       }}

--- a/docs/content/recipes/accessibility/aria-grid/react/example1.tsx
+++ b/docs/content/recipes/accessibility/aria-grid/react/example1.tsx
@@ -58,8 +58,9 @@ const ExampleComponent = () => {
             col: number,
             prop: string | number,
             value: Handsontable.CellValue,
+            cellProperties: Handsontable.CellProperties,
           ): void {
-            getRenderer('text')(hotInstance, TD, row, col, prop, value);
+            getRenderer('text')(hotInstance, TD, row, col, prop, value, cellProperties);
             TD.setAttribute('aria-label', `${colHeaders[col]}: ${value || 'empty'}`);
           },
         };

--- a/docs/content/recipes/cell-types/color-picker/color-picker.md
+++ b/docs/content/recipes/cell-types/color-picker/color-picker.md
@@ -34,6 +34,18 @@ This tutorial shows you how to integrate the Pickr color picker library as a cus
 
 :::
 
+::: only-for react
+
+::: example #example1 :react-advanced --css 1 --js 2 --ts 3 --deps @simonwep/pickr
+
+@[code](@/content/recipes/cell-types/color-picker/react/example1.css)
+@[code](@/content/recipes/cell-types/color-picker/react/example1.jsx)
+@[code](@/content/recipes/cell-types/color-picker/react/example1.tsx)
+
+:::
+
+:::
+
 ## Overview
 
 This guide shows how to create a custom color picker cell using the [Pickr](https://github.com/Simonwep/pickr) library. Users can click a cell to open a color picker, select a color, and see it rendered with a colored background.

--- a/docs/content/recipes/cell-types/color-picker/react/example1.css
+++ b/docs/content/recipes/cell-types/color-picker/react/example1.css
@@ -1,0 +1,36 @@
+.color-picker-cell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.color-picker-swatch {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+}
+
+.color-picker-editor {
+  width: 100%;
+  height: 100%;
+  border: none;
+  outline: none;
+  box-sizing: border-box !important;
+  cursor: pointer;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.pickr {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+
+html[data-theme="dark"] .pcr-app {
+  background-color: #1a1a1a;
+}

--- a/docs/content/recipes/cell-types/color-picker/react/example1.jsx
+++ b/docs/content/recipes/cell-types/color-picker/react/example1.jsx
@@ -13,7 +13,7 @@ const colorPickerRenderer = rendererFactory(({ td, value }) => {
 });
 
 const colorPickerValidator = (value, callback) => {
-  callback(value.length === 7 && value[0] == '#');
+  callback(value.length === 7 && value[0] === '#');
 };
 
 const colorPickerEditor = editorFactory({

--- a/docs/content/recipes/cell-types/color-picker/react/example1.jsx
+++ b/docs/content/recipes/cell-types/color-picker/react/example1.jsx
@@ -1,0 +1,311 @@
+import { HotTable, HotColumn } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import { editorFactory } from 'handsontable/editors';
+import { rendererFactory } from 'handsontable/renderers';
+import Pickr from '@simonwep/pickr';
+import '@simonwep/pickr/dist/themes/nano.min.css';
+import './example1.css';
+
+registerAllModules();
+
+const colorPickerRenderer = rendererFactory(({ td, value }) => {
+  td.innerHTML = `<span class="color-picker-cell"><span class="color-picker-swatch" style="background:${value}"></span></span>`;
+});
+
+const colorPickerValidator = (value, callback) => {
+  callback(value.length === 7 && value[0] == '#');
+};
+
+const colorPickerEditor = editorFactory({
+  init(editor) {
+    editor.input = editor.hot.rootDocument.createElement('INPUT');
+    editor.input.setAttribute('aria-label', 'Open color picker');
+    editor.input.classList.add('color-picker-editor');
+  },
+  afterInit(editor) {
+    const button = editor.hot.rootDocument.createElement('button');
+    button.textContent = 'Open color picker';
+    button.classList.add('color-picker-button');
+    editor.input.after(button);
+
+    editor.pickr = Pickr.create({
+      el: button,
+      theme: 'nano',
+      default: editor.input.value || '#000000',
+      autoReposition: false,
+      padding: 0,
+      components: {
+        preview: true,
+        hue: true,
+      },
+    });
+
+    editor.pickr._root.root.style.height = '0';
+    editor.pickr._root.root.style.overflow = 'hidden';
+
+    editor.preventCloseElement = editor.pickr._root.app;
+
+    editor.pickr.on('change', (color) => {
+      if (color) {
+        const hex = color.toHEXA().toString();
+        editor.input.value = hex;
+      }
+    });
+
+    editor.pickr.on('hide', () => {
+      if (Date.now() - editor._openedAt < 400) {
+        editor.pickr.show();
+
+        return;
+      }
+      editor.finishEditing();
+    });
+  },
+  afterOpen(editor) {
+    editor._openedAt = Date.now();
+    editor.pickr.setColor(editor.input.value || '#000000');
+    editor.pickr.show();
+
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        const cellRect = editor.TD.getBoundingClientRect();
+
+        editor.pickr._root.app.style.top = `${cellRect.bottom}px`;
+      });
+    });
+  },
+  afterClose(editor) {
+    editor.pickr._root.app.classList.remove('visible');
+    editor.pickr.hide();
+  },
+  getValue(editor) {
+    return editor.input.value;
+  },
+  setValue(editor, value) {
+    editor.input.value = value;
+  },
+  shortcuts: [
+    {
+      keys: [['Tab']],
+      callback: (editor) => {
+        editor.pickr.hide();
+      },
+    },
+  ],
+});
+
+/* start:skip-in-preview */
+const inputData = [
+  {
+    id: 640329,
+    itemName: 'Lunar Core',
+    itemNo: 'XJ-12',
+    leadEngineer: 'Ellen Ripley',
+    cost: 350000,
+    inStock: true,
+    category: 'Lander',
+    itemQuality: 87,
+    origin: '🇺🇸 USA',
+    quantity: 2,
+    valueStock: 700000,
+    repairable: false,
+    supplierName: 'TechNova',
+    restockDate: '2025-08-01',
+    operationalStatus: 'Awaiting Parts',
+  },
+  {
+    id: 863104,
+    itemName: 'Zero Thrusters',
+    itemNo: 'QL-54',
+    leadEngineer: 'Sam Bell',
+    cost: 450000,
+    inStock: false,
+    category: 'Propulsion',
+    itemQuality: 0,
+    origin: '🇩🇪 Germany',
+    quantity: 0,
+    valueStock: 0,
+    repairable: true,
+    supplierName: 'PropelMax',
+    restockDate: '2025-09-15',
+    operationalStatus: 'In Maintenance',
+  },
+  {
+    id: 395603,
+    itemName: 'EVA Suits',
+    itemNo: 'PM-67',
+    leadEngineer: 'Alex Rogan',
+    cost: 150000,
+    inStock: true,
+    category: 'Equipment',
+    itemQuality: 79,
+    origin: '🇮🇹 Italy',
+    quantity: 50,
+    valueStock: 7500000,
+    repairable: true,
+    supplierName: 'SuitCraft',
+    restockDate: '2025-10-05',
+    operationalStatus: 'Ready for Testing',
+  },
+  {
+    id: 679083,
+    itemName: 'Solar Panels',
+    itemNo: 'BW-09',
+    leadEngineer: 'Dave Bowman',
+    cost: 75000,
+    inStock: true,
+    category: 'Energy',
+    itemQuality: 95,
+    origin: '🇺🇸 USA',
+    quantity: 10,
+    valueStock: 750000,
+    repairable: false,
+    supplierName: 'SolarStream',
+    restockDate: '2025-11-10',
+    operationalStatus: 'Operational',
+  },
+  {
+    id: 912663,
+    itemName: 'Comm Array',
+    itemNo: 'ZR-56',
+    leadEngineer: 'Louise Banks',
+    cost: 125000,
+    inStock: false,
+    category: 'Communication',
+    itemQuality: 0,
+    origin: '🇯🇵 Japan',
+    quantity: 0,
+    valueStock: 0,
+    repairable: true,
+    supplierName: 'CommTech',
+    restockDate: '2025-12-20',
+    operationalStatus: 'Decommissioned',
+  },
+  {
+    id: 315806,
+    itemName: 'Habitat Dome',
+    itemNo: 'UJ-23',
+    leadEngineer: 'Dr. Ryan Stone',
+    cost: 1000000,
+    inStock: true,
+    category: 'Shelter',
+    itemQuality: 93,
+    origin: '🇨🇦 Canada',
+    quantity: 3,
+    valueStock: 3000000,
+    repairable: false,
+    supplierName: 'DomeInnovate',
+    restockDate: '2026-01-25',
+    operationalStatus: 'Operational',
+  },
+  {
+    id: 954632,
+    itemName: 'Oxygen Unit',
+    itemNo: 'FK-87',
+    leadEngineer: 'Dr. Grace Augustine',
+    cost: 600000,
+    inStock: true,
+    category: 'Life Support',
+    itemQuality: 85,
+    origin: '🇺🇸 USA',
+    quantity: 15,
+    valueStock: 9000000,
+    repairable: true,
+    supplierName: 'OxyGenius',
+    restockDate: '2026-03-02',
+    operationalStatus: 'Awaiting Parts',
+  },
+  {
+    id: 734944,
+    itemName: 'Processing Rig',
+    itemNo: 'LK-13',
+    leadEngineer: 'Jake Sully',
+    cost: 350000,
+    inStock: true,
+    category: 'Mining',
+    itemQuality: 81,
+    origin: '🇦🇺 Australia',
+    quantity: 25,
+    valueStock: 8750000,
+    repairable: true,
+    supplierName: 'RigTech',
+    restockDate: '2026-04-15',
+    operationalStatus: 'Ready for Testing',
+  },
+  {
+    id: 834662,
+    itemName: 'Navigation Module',
+    itemNo: 'XP-24',
+    leadEngineer: 'Dr. Ellie Arroway',
+    cost: 450000,
+    inStock: true,
+    category: 'Navigation',
+    itemQuality: 89,
+    origin: '🇫🇷 France',
+    quantity: 8,
+    valueStock: 3600000,
+    repairable: false,
+    supplierName: 'NavSolutions',
+    restockDate: '2026-05-30',
+    operationalStatus: 'In Maintenance',
+  },
+  {
+    id: 714329,
+    itemName: 'Surveyor Arm',
+    itemNo: 'QA-86',
+    leadEngineer: 'Mark Watney',
+    cost: 100000,
+    inStock: true,
+    category: 'Exploration',
+    itemQuality: 78,
+    origin: '🇺🇸 USA',
+    quantity: 40,
+    valueStock: 4000000,
+    repairable: true,
+    supplierName: 'ExploreTech',
+    restockDate: '2026-07-12',
+    operationalStatus: 'Decommissioned',
+  },
+];
+
+const data = inputData.map((el) => ({
+  ...el,
+  // eslint-disable-next-line no-mixed-operators
+  color: `#${
+    // eslint-disable-next-line no-mixed-operators
+    Math.round(0x1000000 + 0xffffff * Math.random())
+      .toString(16)
+      .slice(1)
+      .toUpperCase()
+    }`,
+}));
+/* end:skip-in-preview */
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={data}
+      colHeaders={['ID', 'Item Name', 'Item Color', 'Item No.', 'Cost', 'Value in Stock']}
+      autoRowSize={true}
+      rowHeaders={true}
+      height="auto"
+      width="100%"
+      licenseKey="non-commercial-and-evaluation"
+    >
+      <HotColumn data="id" type="numeric" width={80} headerClassName="htLeft" />
+      <HotColumn data="itemName" type="text" width={200} headerClassName="htLeft" />
+      <HotColumn
+        data="color"
+        headerClassName="htLeft"
+        hotRenderer={colorPickerRenderer}
+        hotEditor={colorPickerEditor}
+        validator={colorPickerValidator}
+      />
+      <HotColumn data="itemNo" type="text" width={100} headerClassName="htLeft" />
+      <HotColumn data="cost" type="numeric" width={70} headerClassName="htLeft" />
+      <HotColumn data="valueStock" type="numeric" width={130} headerClassName="htRight" />
+    </HotTable>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/cell-types/color-picker/react/example1.tsx
+++ b/docs/content/recipes/cell-types/color-picker/react/example1.tsx
@@ -1,0 +1,339 @@
+import { HotTable, HotColumn } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import { editorFactory } from 'handsontable/editors';
+import { rendererFactory } from 'handsontable/renderers';
+import Pickr from '@simonwep/pickr';
+import '@simonwep/pickr/dist/themes/nano.min.css';
+import './example1.css';
+
+registerAllModules();
+
+interface ColorPickerEditorInstance {
+  input: HTMLInputElement;
+  pickr: Pickr;
+  _openedAt: number;
+  preventCloseElement: HTMLElement;
+}
+
+const colorPickerRenderer = rendererFactory(({ td, value }) => {
+  td.innerHTML = `<span class="color-picker-cell"><span class="color-picker-swatch" style="background:${value as string}"></span></span>`;
+});
+
+const colorPickerValidator = (value: string, callback: (valid: boolean) => void) => {
+  callback(value.length === 7 && value[0] === '#');
+};
+
+const colorPickerEditor = editorFactory<ColorPickerEditorInstance>({
+  init(editor) {
+    editor.input = editor.hot.rootDocument.createElement('INPUT') as HTMLInputElement;
+    editor.input.setAttribute('aria-label', 'Open color picker');
+    editor.input.classList.add('color-picker-editor');
+  },
+  afterInit(editor) {
+    const button = editor.hot.rootDocument.createElement('button') as HTMLButtonElement;
+
+    button.textContent = 'Open color picker';
+    button.classList.add('color-picker-button');
+    editor.input.after(button);
+
+    editor.pickr = Pickr.create({
+      el: button,
+      theme: 'nano',
+      default: editor.input.value || '#000000',
+      autoReposition: false,
+      padding: 0,
+      components: {
+        preview: true,
+        hue: true,
+      },
+    });
+
+    (editor.pickr as any)._root.root.style.height = '0';
+    (editor.pickr as any)._root.root.style.overflow = 'hidden';
+
+    editor.preventCloseElement = (editor.pickr as any)._root.app;
+
+    editor.pickr.on('change', (color: Pickr.HSVaColor | null) => {
+      if (color) {
+        const hex = color.toHEXA().toString();
+
+        editor.input.value = hex;
+      }
+    });
+
+    editor.pickr.on('hide', () => {
+      if (Date.now() - editor._openedAt < 400) {
+        editor.pickr.show();
+
+        return;
+      }
+      editor.finishEditing();
+    });
+  },
+  afterOpen(editor) {
+    editor._openedAt = Date.now();
+    editor.pickr.setColor(editor.input.value || '#000000');
+    editor.pickr.show();
+
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        const cellRect = editor.TD.getBoundingClientRect();
+
+        (editor.pickr as any)._root.app.style.top = `${cellRect.bottom}px`;
+      });
+    });
+  },
+  afterClose(editor) {
+    (editor.pickr as any)._root.app.classList.remove('visible');
+    editor.pickr.hide();
+  },
+  getValue(editor) {
+    return editor.input.value;
+  },
+  setValue(editor, value) {
+    editor.input.value = value;
+  },
+  shortcuts: [
+    {
+      keys: [['Tab']],
+      callback: (editor) => {
+        editor.pickr.hide();
+      },
+    },
+  ],
+});
+
+/* start:skip-in-preview */
+interface InventoryItem {
+  id: number;
+  itemName: string;
+  itemNo: string;
+  leadEngineer: string;
+  cost: number;
+  inStock: boolean;
+  category: string;
+  itemQuality: number;
+  origin: string;
+  quantity: number;
+  valueStock: number;
+  repairable: boolean;
+  supplierName: string;
+  restockDate: string;
+  operationalStatus: string;
+  color?: string;
+}
+
+const inputData: InventoryItem[] = [
+  {
+    id: 640329,
+    itemName: 'Lunar Core',
+    itemNo: 'XJ-12',
+    leadEngineer: 'Ellen Ripley',
+    cost: 350000,
+    inStock: true,
+    category: 'Lander',
+    itemQuality: 87,
+    origin: '🇺🇸 USA',
+    quantity: 2,
+    valueStock: 700000,
+    repairable: false,
+    supplierName: 'TechNova',
+    restockDate: '2025-08-01',
+    operationalStatus: 'Awaiting Parts',
+  },
+  {
+    id: 863104,
+    itemName: 'Zero Thrusters',
+    itemNo: 'QL-54',
+    leadEngineer: 'Sam Bell',
+    cost: 450000,
+    inStock: false,
+    category: 'Propulsion',
+    itemQuality: 0,
+    origin: '🇩🇪 Germany',
+    quantity: 0,
+    valueStock: 0,
+    repairable: true,
+    supplierName: 'PropelMax',
+    restockDate: '2025-09-15',
+    operationalStatus: 'In Maintenance',
+  },
+  {
+    id: 395603,
+    itemName: 'EVA Suits',
+    itemNo: 'PM-67',
+    leadEngineer: 'Alex Rogan',
+    cost: 150000,
+    inStock: true,
+    category: 'Equipment',
+    itemQuality: 79,
+    origin: '🇮🇹 Italy',
+    quantity: 50,
+    valueStock: 7500000,
+    repairable: true,
+    supplierName: 'SuitCraft',
+    restockDate: '2025-10-05',
+    operationalStatus: 'Ready for Testing',
+  },
+  {
+    id: 679083,
+    itemName: 'Solar Panels',
+    itemNo: 'BW-09',
+    leadEngineer: 'Dave Bowman',
+    cost: 75000,
+    inStock: true,
+    category: 'Energy',
+    itemQuality: 95,
+    origin: '🇺🇸 USA',
+    quantity: 10,
+    valueStock: 750000,
+    repairable: false,
+    supplierName: 'SolarStream',
+    restockDate: '2025-11-10',
+    operationalStatus: 'Operational',
+  },
+  {
+    id: 912663,
+    itemName: 'Comm Array',
+    itemNo: 'ZR-56',
+    leadEngineer: 'Louise Banks',
+    cost: 125000,
+    inStock: false,
+    category: 'Communication',
+    itemQuality: 0,
+    origin: '🇯🇵 Japan',
+    quantity: 0,
+    valueStock: 0,
+    repairable: true,
+    supplierName: 'CommTech',
+    restockDate: '2025-12-20',
+    operationalStatus: 'Decommissioned',
+  },
+  {
+    id: 315806,
+    itemName: 'Habitat Dome',
+    itemNo: 'UJ-23',
+    leadEngineer: 'Dr. Ryan Stone',
+    cost: 1000000,
+    inStock: true,
+    category: 'Shelter',
+    itemQuality: 93,
+    origin: '🇨🇦 Canada',
+    quantity: 3,
+    valueStock: 3000000,
+    repairable: false,
+    supplierName: 'DomeInnovate',
+    restockDate: '2026-01-25',
+    operationalStatus: 'Operational',
+  },
+  {
+    id: 954632,
+    itemName: 'Oxygen Unit',
+    itemNo: 'FK-87',
+    leadEngineer: 'Dr. Grace Augustine',
+    cost: 600000,
+    inStock: true,
+    category: 'Life Support',
+    itemQuality: 85,
+    origin: '🇺🇸 USA',
+    quantity: 15,
+    valueStock: 9000000,
+    repairable: true,
+    supplierName: 'OxyGenius',
+    restockDate: '2026-03-02',
+    operationalStatus: 'Awaiting Parts',
+  },
+  {
+    id: 734944,
+    itemName: 'Processing Rig',
+    itemNo: 'LK-13',
+    leadEngineer: 'Jake Sully',
+    cost: 350000,
+    inStock: true,
+    category: 'Mining',
+    itemQuality: 81,
+    origin: '🇦🇺 Australia',
+    quantity: 25,
+    valueStock: 8750000,
+    repairable: true,
+    supplierName: 'RigTech',
+    restockDate: '2026-04-15',
+    operationalStatus: 'Ready for Testing',
+  },
+  {
+    id: 834662,
+    itemName: 'Navigation Module',
+    itemNo: 'XP-24',
+    leadEngineer: 'Dr. Ellie Arroway',
+    cost: 450000,
+    inStock: true,
+    category: 'Navigation',
+    itemQuality: 89,
+    origin: '🇫🇷 France',
+    quantity: 8,
+    valueStock: 3600000,
+    repairable: false,
+    supplierName: 'NavSolutions',
+    restockDate: '2026-05-30',
+    operationalStatus: 'In Maintenance',
+  },
+  {
+    id: 714329,
+    itemName: 'Surveyor Arm',
+    itemNo: 'QA-86',
+    leadEngineer: 'Mark Watney',
+    cost: 100000,
+    inStock: true,
+    category: 'Exploration',
+    itemQuality: 78,
+    origin: '🇺🇸 USA',
+    quantity: 40,
+    valueStock: 4000000,
+    repairable: true,
+    supplierName: 'ExploreTech',
+    restockDate: '2026-07-12',
+    operationalStatus: 'Decommissioned',
+  },
+];
+
+const data = inputData.map((el) => ({
+  ...el,
+  // eslint-disable-next-line no-mixed-operators
+  color: `#${
+    // eslint-disable-next-line no-mixed-operators
+    Math.round(0x1000000 + 0xffffff * Math.random())
+      .toString(16)
+      .slice(1)
+      .toUpperCase()
+    }`,
+}));
+/* end:skip-in-preview */
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={data}
+      colHeaders={['ID', 'Item Name', 'Item Color', 'Item No.', 'Cost', 'Value in Stock']}
+      autoRowSize={true}
+      rowHeaders={true}
+      height="auto"
+      width="100%"
+      licenseKey="non-commercial-and-evaluation"
+    >
+      <HotColumn data="id" type="numeric" width={80} headerClassName="htLeft" />
+      <HotColumn data="itemName" type="text" width={200} headerClassName="htLeft" />
+      <HotColumn
+        data="color"
+        headerClassName="htLeft"
+        hotRenderer={colorPickerRenderer}
+        hotEditor={colorPickerEditor}
+        validator={colorPickerValidator}
+      />
+      <HotColumn data="itemNo" type="text" width={100} headerClassName="htLeft" />
+      <HotColumn data="cost" type="numeric" width={70} headerClassName="htLeft" />
+      <HotColumn data="valueStock" type="numeric" width={130} headerClassName="htRight" />
+    </HotTable>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/cell-types/colorful-picker/react/example1.jsx
+++ b/docs/content/recipes/cell-types/colorful-picker/react/example1.jsx
@@ -2,6 +2,7 @@ import { HotTable, HotColumn, EditorComponent } from '@handsontable/react-wrappe
 import { registerAllModules } from 'handsontable/registry';
 import { rendererFactory } from 'handsontable/renderers';
 import { HexColorPicker } from 'react-colorful';
+import './example1.css';
 
 registerAllModules();
 

--- a/docs/content/recipes/cell-types/colorful-picker/react/example1.tsx
+++ b/docs/content/recipes/cell-types/colorful-picker/react/example1.tsx
@@ -2,6 +2,7 @@ import { HotTable, HotColumn, EditorComponent } from '@handsontable/react-wrappe
 import { registerAllModules } from 'handsontable/registry';
 import { rendererFactory } from 'handsontable/renderers';
 import { HexColorPicker } from 'react-colorful';
+import './example1.css';
 
 registerAllModules();
 

--- a/docs/content/recipes/cell-types/feedback-react/react/example1.jsx
+++ b/docs/content/recipes/cell-types/feedback-react/react/example1.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { HotTable, HotColumn, EditorComponent } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
+import './example1.css';
 
 // register Handsontable's modules
 registerAllModules();

--- a/docs/content/recipes/cell-types/feedback-react/react/example1.tsx
+++ b/docs/content/recipes/cell-types/feedback-react/react/example1.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, ComponentProps, useCallback } from 'react';
 import { HotTable, HotColumn, EditorComponent } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
+import './example1.css';
 
 // register Handsontable's modules
 registerAllModules();

--- a/docs/content/recipes/cell-types/feedback/feedback.md
+++ b/docs/content/recipes/cell-types/feedback/feedback.md
@@ -34,6 +34,18 @@ This tutorial shows you how to build an emoji feedback cell using Handsontable's
 
 :::
 
+::: only-for react
+
+::: example #example1 :react-advanced --css 1 --js 2 --ts 3
+
+@[code](@/content/recipes/cell-types/feedback/react/example1.css)
+@[code](@/content/recipes/cell-types/feedback/react/example1.jsx)
+@[code](@/content/recipes/cell-types/feedback/react/example1.tsx)
+
+:::
+
+:::
+
 ## Overview
 
 This guide shows how to create a simple feedback editor cell using emoji buttons. Perfect for quick feedback selection, status indicators, or any scenario where users need to choose from a small set of visual options.

--- a/docs/content/recipes/cell-types/feedback/react/example1.css
+++ b/docs/content/recipes/cell-types/feedback/react/example1.css
@@ -1,0 +1,41 @@
+.feedback-editor {
+  display: flex;
+  gap: var(--ht-gap, 4px);
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box !important;
+  padding: var(--ht-cell-vertical-padding, 4px) var(--ht-cell-horizontal-padding, 8px);
+  background-color: var(--ht-cell-editor-background-color, #ffffff);
+  box-shadow: inset 0 0 0 var(--ht-cell-editor-border-width, 2px)
+    var(--ht-cell-editor-border-color, #1a42e8),
+    0 0 var(--ht-cell-editor-shadow-blur-radius, 0) 0
+    var(--ht-cell-editor-shadow-color, transparent);
+  border: none;
+  border-radius: 0;
+}
+
+.feedback-editor button {
+  display: block;
+  background: var(--ht-background-color, #ffffff);
+  color: var(--ht-foreground-color, #000000);
+  border: 1px solid var(--ht-border-color, #e0e0e0);
+  border-radius: var(--ht-border-radius, 4px);
+  padding: 0;
+  margin: 0;
+  height: 100%;
+  width: 33%;
+  font-size: var(--ht-font-size, 14px);
+  text-align: center;
+  cursor: pointer;
+}
+
+.feedback-editor button:hover {
+  background: var(--ht-border-color, #e0e0e0);
+}
+
+.feedback-editor button.active,
+.feedback-editor button.active:hover {
+  background: var(--ht-accent-color, #1a42e8);
+  color: #ffffff;
+  border-color: var(--ht-accent-color, #1a42e8);
+}

--- a/docs/content/recipes/cell-types/feedback/react/example1.jsx
+++ b/docs/content/recipes/cell-types/feedback/react/example1.jsx
@@ -1,0 +1,98 @@
+import { HotTable, HotColumn } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import { editorFactory } from 'handsontable/editors';
+import { registerCellType } from 'handsontable/cellTypes';
+import './example1.css';
+
+registerAllModules();
+
+/* start:skip-in-preview */
+const data = [
+  { feature: 'Dark Mode', category: 'UI', priority: 'High', feedback: '👍', votes: 124, status: 'Planned' },
+  { feature: 'Bulk Edit', category: 'Core', priority: 'High', feedback: '👍', votes: 98, status: 'In Progress' },
+  { feature: 'AI Suggestions', category: 'Beta', priority: 'Medium', feedback: '🤷', votes: 45, status: 'Research' },
+  { feature: 'Offline Mode', category: 'Infra', priority: 'Low', feedback: '👎', votes: 12, status: 'Backlog' },
+];
+/* end:skip-in-preview */
+
+const feedbackCellDefinition = {
+  editor: editorFactory({
+    config: ['👍', '👎', '🤷'],
+    value: '👍',
+    shortcuts: [
+      {
+        keys: [['ArrowRight'], ['Tab']],
+        callback: (editor, _event) => {
+          let index = editor.config.indexOf(editor.value);
+
+          index = index === editor.config.length - 1 ? 0 : index + 1;
+          editor.setValue(editor.config[index]);
+
+          return false;
+        },
+      },
+      {
+        keys: [['ArrowLeft']],
+        callback: (editor, _event) => {
+          let index = editor.config.indexOf(editor.value);
+
+          index = index === 0 ? editor.config.length - 1 : index - 1;
+          editor.setValue(editor.config[index]);
+        },
+      },
+    ],
+    render: (editor) => {
+      editor.input.innerHTML = editor.config
+        .map((option) => `<button class="${editor.value === option ? 'active' : ''}">${option}</button>`)
+        .join('');
+    },
+    init: (editor) => {
+      editor.input = document.createElement('DIV');
+      editor.input.classList.add('feedback-editor');
+      editor._openedAt = 0;
+      editor.input.addEventListener('click', (event) => {
+        if (Date.now() - editor._openedAt < 300) {
+          return;
+        }
+        if (event.target instanceof HTMLButtonElement) {
+          editor.setValue(event.target.innerText);
+          editor.finishEditing();
+        }
+      });
+      editor.render(editor);
+    },
+    afterOpen: (editor) => {
+      editor._openedAt = Date.now();
+    },
+    beforeOpen: (editor, { originalValue }) => {
+      editor.setValue(originalValue);
+    },
+  }),
+};
+
+registerCellType('feedback', feedbackCellDefinition);
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={data}
+      colHeaders={['Feature', 'Category', 'Priority', 'Feedback', 'Votes', 'Status']}
+      autoRowSize={true}
+      rowHeaders={true}
+      autoWrapRow={true}
+      height="auto"
+      width="100%"
+      headerClassName="htLeft"
+      licenseKey="non-commercial-and-evaluation"
+    >
+      <HotColumn data="feature" type="text" width={200} />
+      <HotColumn data="category" type="text" width={90} />
+      <HotColumn data="priority" type="text" width={100} />
+      <HotColumn data="feedback" type="feedback" width={100} />
+      <HotColumn data="votes" type="numeric" width={60} />
+      <HotColumn data="status" type="text" width={120} />
+    </HotTable>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/cell-types/feedback/react/example1.tsx
+++ b/docs/content/recipes/cell-types/feedback/react/example1.tsx
@@ -1,0 +1,110 @@
+import { HotTable, HotColumn } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import { CellProperties } from 'handsontable/settings';
+import { BaseEditor } from 'handsontable/editors/baseEditor';
+import { editorFactory } from 'handsontable/editors';
+import { registerCellType } from 'handsontable/cellTypes';
+import './example1.css';
+
+registerAllModules();
+
+/* start:skip-in-preview */
+const data = [
+  { feature: 'Dark Mode', category: 'UI', priority: 'High', feedback: '👍', votes: 124, status: 'Planned' },
+  { feature: 'Bulk Edit', category: 'Core', priority: 'High', feedback: '👍', votes: 98, status: 'In Progress' },
+  { feature: 'AI Suggestions', category: 'Beta', priority: 'Medium', feedback: '🤷', votes: 45, status: 'Research' },
+  { feature: 'Offline Mode', category: 'Infra', priority: 'Low', feedback: '👎', votes: 12, status: 'Backlog' },
+];
+/* end:skip-in-preview */
+
+interface FeedbackEditorInstance {
+  input: HTMLDivElement;
+  value: string;
+  config: string[];
+  _openedAt: number;
+}
+
+const feedbackCellDefinition: Pick<CellProperties, 'renderer' | 'validator' | 'editor'> = {
+  editor: editorFactory<FeedbackEditorInstance>({
+    config: ['👍', '👎', '🤷'],
+    value: '👍',
+    shortcuts: [
+      {
+        keys: [['ArrowRight'], ['Tab']],
+        callback: (editor, _event) => {
+          let index = editor.config.indexOf(editor.value);
+
+          index = index === editor.config.length - 1 ? 0 : index + 1;
+          editor.setValue(editor.config[index]);
+
+          return false;
+        },
+      },
+      {
+        keys: [['ArrowLeft']],
+        callback: (editor, _event) => {
+          let index = editor.config.indexOf(editor.value);
+
+          index = index === 0 ? editor.config.length - 1 : index - 1;
+          editor.setValue(editor.config[index]);
+        },
+      },
+    ],
+    render: (editor) => {
+      editor.input.innerHTML = editor.config
+        .map(
+          (option) =>
+            `<button class="${editor.value === option ? 'active' : ''}">${option}</button>`,
+        )
+        .join('');
+    },
+    init: (editor) => {
+      editor.input = document.createElement('DIV') as HTMLDivElement;
+      editor.input.classList.add('feedback-editor');
+      editor._openedAt = 0;
+      editor.input.addEventListener('click', (event) => {
+        if (Date.now() - editor._openedAt < 300) {
+          return;
+        }
+        if (event.target instanceof HTMLButtonElement) {
+          editor.setValue(event.target.innerText);
+          editor.finishEditing();
+        }
+      });
+      editor.render(editor);
+    },
+    afterOpen: (editor) => {
+      editor._openedAt = Date.now();
+    },
+    beforeOpen: (editor, { originalValue }) => {
+      editor.setValue(originalValue);
+    },
+  }),
+};
+
+registerCellType('feedback', feedbackCellDefinition as BaseEditor);
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={data}
+      colHeaders={['Feature', 'Category', 'Priority', 'Feedback', 'Votes', 'Status']}
+      autoRowSize={true}
+      rowHeaders={true}
+      autoWrapRow={true}
+      height="auto"
+      width="100%"
+      headerClassName="htLeft"
+      licenseKey="non-commercial-and-evaluation"
+    >
+      <HotColumn data="feature" type="text" width={200} />
+      <HotColumn data="category" type="text" width={90} />
+      <HotColumn data="priority" type="text" width={100} />
+      <HotColumn data="feedback" type="feedback" width={100} />
+      <HotColumn data="votes" type="numeric" width={60} />
+      <HotColumn data="status" type="text" width={120} />
+    </HotTable>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/cell-types/flatpickr/flatpickr.md
+++ b/docs/content/recipes/cell-types/flatpickr/flatpickr.md
@@ -34,6 +34,18 @@ This tutorial shows you how to integrate the Flatpickr date picker as a custom H
 
 :::
 
+::: only-for react
+
+::: example #example1 :react-advanced --css 1 --js 2 --ts 3 --deps date-fns flatpickr
+
+@[code](@/content/recipes/cell-types/flatpickr/react/example1.css)
+@[code](@/content/recipes/cell-types/flatpickr/react/example1.jsx)
+@[code](@/content/recipes/cell-types/flatpickr/react/example1.tsx)
+
+:::
+
+:::
+
 ## Overview
 
 This guide shows how to create a custom date picker cell using [Flatpickr](https://flatpickr.js.org/), a powerful and flexible date picker library. This is more advanced than using native HTML5 date inputs, offering better cross-browser consistency and extensive customization options.

--- a/docs/content/recipes/cell-types/flatpickr/react/example1.css
+++ b/docs/content/recipes/cell-types/flatpickr/react/example1.css
@@ -1,0 +1,29 @@
+.flatpickr-editor {
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box !important;
+  border: none;
+  border-radius: 0;
+  outline: none;
+  box-shadow: inset 0 0 0 var(--ht-cell-editor-border-width, 2px)
+    var(--ht-cell-editor-border-color, #1a42e8),
+    0 0 var(--ht-cell-editor-shadow-blur-radius, 0) 0
+    var(--ht-cell-editor-shadow-color, transparent) !important;
+  background-color: var(--ht-cell-editor-background-color, #ffffff) !important;
+  padding: var(--ht-cell-vertical-padding, 4px)
+    var(--ht-cell-horizontal-padding, 8px) !important;
+  border: none !important;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+}
+.flatpickr-editor:focus-visible {
+  border: none !important;
+}
+
+.flatpickr-editor.active {
+  box-shadow: none;
+  background-color: transparent;
+  border-radius: 0 !important;
+  border-radius: none;
+}

--- a/docs/content/recipes/cell-types/flatpickr/react/example1.jsx
+++ b/docs/content/recipes/cell-types/flatpickr/react/example1.jsx
@@ -1,0 +1,180 @@
+import { HotTable, HotColumn } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import { format, isDate } from 'date-fns';
+import flatpickr from 'flatpickr';
+import 'flatpickr/dist/flatpickr.css';
+import { editorFactory } from 'handsontable/editors';
+import { rendererFactory } from 'handsontable/renderers';
+import './example1.css';
+
+registerAllModules();
+
+const DATE_FORMAT_US = 'MM/dd/yyyy';
+const DATE_FORMAT_EU = 'dd/MM/yyyy';
+
+/* start:skip-in-preview */
+const data = [
+  {
+    product: 'Dashboard Pro',
+    category: 'Analytics',
+    version: '3.2.0',
+    releaseDate: '2025-03-15',
+    status: 'Released',
+    downloads: 12450,
+  },
+  {
+    product: 'Form Builder',
+    category: 'Tools',
+    version: '2.1.0',
+    releaseDate: '2025-04-22',
+    status: 'Released',
+    downloads: 8320,
+  },
+  {
+    product: 'Chart Engine',
+    category: 'Analytics',
+    version: '4.0.0',
+    releaseDate: '2025-06-10',
+    status: 'Beta',
+    downloads: 3100,
+  },
+  {
+    product: 'Auth Module',
+    category: 'Security',
+    version: '1.5.2',
+    releaseDate: '2025-07-01',
+    status: 'Released',
+    downloads: 15600,
+  },
+  {
+    product: 'File Manager',
+    category: 'Storage',
+    version: '2.0.0',
+    releaseDate: '2025-08-18',
+    status: 'Planned',
+    downloads: 0,
+  },
+  {
+    product: 'Email Service',
+    category: 'Communication',
+    version: '3.1.0',
+    releaseDate: '2025-09-05',
+    status: 'Released',
+    downloads: 9870,
+  },
+  {
+    product: 'Search Index',
+    category: 'Tools',
+    version: '1.2.0',
+    releaseDate: '2025-10-12',
+    status: 'Beta',
+    downloads: 2450,
+  },
+  {
+    product: 'Cache Layer',
+    category: 'Infra',
+    version: '2.3.1',
+    releaseDate: '2025-11-28',
+    status: 'Planned',
+    downloads: 0,
+  },
+];
+/* end:skip-in-preview */
+
+const flatpickrValidator = (value, callback) => {
+  callback(isDate(new Date(value)));
+};
+
+const flatpickrRenderer = rendererFactory(({ td, value, cellProperties }) => {
+  td.innerText = value ? format(new Date(value), cellProperties.renderFormat) : '';
+});
+
+const flatpickrEditor = editorFactory({
+  init(editor) {
+    editor.input = editor.hot.rootDocument.createElement('INPUT');
+    editor.input.classList.add('flatpickr-editor');
+
+    editor.flatpickr = flatpickr(editor.input, {
+      dateFormat: 'Y-m-d',
+      disableMobile: true,
+      onClose: () => {
+        editor.finishEditing();
+      },
+    });
+
+    editor.preventCloseElement = editor.flatpickr.calendarContainer;
+
+    editor._darkThemeLink = editor.hot.rootDocument.createElement('LINK');
+    editor._darkThemeLink.rel = 'stylesheet';
+    editor._darkThemeLink.href = 'https://cdn.jsdelivr.net/npm/flatpickr/dist/themes/dark.css';
+  },
+  afterClose(editor) {
+    editor.flatpickr.close();
+  },
+  afterOpen(editor) {
+    const isDark = editor.hot.rootDocument.documentElement.getAttribute('data-theme') === 'dark';
+    const head = editor.hot.rootDocument.head;
+
+    if (isDark && !editor._darkThemeLink.parentNode) {
+      head.appendChild(editor._darkThemeLink);
+    } else if (!isDark && editor._darkThemeLink.parentNode) {
+      head.removeChild(editor._darkThemeLink);
+    }
+
+    editor.flatpickr.open();
+  },
+  beforeOpen(editor, { cellProperties }) {
+    for (const key in cellProperties.flatpickrSettings) {
+      editor.flatpickr.set(key, cellProperties.flatpickrSettings[key]);
+    }
+  },
+  getValue(editor) {
+    return editor.input.value;
+  },
+  setValue(editor, value) {
+    editor.input.value = value;
+    editor.flatpickr.setDate(value ? new Date(value) : new Date());
+  },
+});
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={data}
+      colHeaders={['Product', 'Version', 'Release (EU)', 'Release (US)', 'Status']}
+      autoRowSize={true}
+      rowHeaders={true}
+      height="auto"
+      width="100%"
+      autoWrapRow={true}
+      headerClassName="htLeft"
+      licenseKey="non-commercial-and-evaluation"
+    >
+      <HotColumn data="product" type="text" width={200} />
+      <HotColumn data="version" type="text" width={80} />
+      <HotColumn
+        data="releaseDate"
+        width={130}
+        allowInvalid={false}
+        hotRenderer={flatpickrRenderer}
+        hotEditor={flatpickrEditor}
+        validator={flatpickrValidator}
+        renderFormat={DATE_FORMAT_EU}
+        flatpickrSettings={{ locale: { firstDayOfWeek: 1 } }}
+      />
+      <HotColumn
+        data="releaseDate"
+        width={130}
+        allowInvalid={false}
+        hotRenderer={flatpickrRenderer}
+        hotEditor={flatpickrEditor}
+        validator={flatpickrValidator}
+        renderFormat={DATE_FORMAT_US}
+        flatpickrSettings={{ locale: { firstDayOfWeek: 0 } }}
+      />
+      <HotColumn data="status" type="text" width={130} />
+    </HotTable>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/cell-types/flatpickr/react/example1.tsx
+++ b/docs/content/recipes/cell-types/flatpickr/react/example1.tsx
@@ -1,0 +1,188 @@
+import { HotTable, HotColumn } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import { format, isDate } from 'date-fns';
+import flatpickr from 'flatpickr';
+import 'flatpickr/dist/flatpickr.css';
+import { CellProperties } from 'handsontable/settings';
+import { editorFactory } from 'handsontable/editors';
+import { rendererFactory } from 'handsontable/renderers';
+import './example1.css';
+
+registerAllModules();
+
+const DATE_FORMAT_US = 'MM/dd/yyyy';
+const DATE_FORMAT_EU = 'dd/MM/yyyy';
+
+/* start:skip-in-preview */
+const data = [
+  {
+    product: 'Dashboard Pro',
+    category: 'Analytics',
+    version: '3.2.0',
+    releaseDate: '2025-03-15',
+    status: 'Released',
+    downloads: 12450,
+  },
+  {
+    product: 'Form Builder',
+    category: 'Tools',
+    version: '2.1.0',
+    releaseDate: '2025-04-22',
+    status: 'Released',
+    downloads: 8320,
+  },
+  {
+    product: 'Chart Engine',
+    category: 'Analytics',
+    version: '4.0.0',
+    releaseDate: '2025-06-10',
+    status: 'Beta',
+    downloads: 3100,
+  },
+  {
+    product: 'Auth Module',
+    category: 'Security',
+    version: '1.5.2',
+    releaseDate: '2025-07-01',
+    status: 'Released',
+    downloads: 15600,
+  },
+  {
+    product: 'File Manager',
+    category: 'Storage',
+    version: '2.0.0',
+    releaseDate: '2025-08-18',
+    status: 'Planned',
+    downloads: 0,
+  },
+  {
+    product: 'Email Service',
+    category: 'Communication',
+    version: '3.1.0',
+    releaseDate: '2025-09-05',
+    status: 'Released',
+    downloads: 9870,
+  },
+  {
+    product: 'Search Index',
+    category: 'Tools',
+    version: '1.2.0',
+    releaseDate: '2025-10-12',
+    status: 'Beta',
+    downloads: 2450,
+  },
+  {
+    product: 'Cache Layer',
+    category: 'Infra',
+    version: '2.3.1',
+    releaseDate: '2025-11-28',
+    status: 'Planned',
+    downloads: 0,
+  },
+];
+/* end:skip-in-preview */
+
+interface FlatpickrEditorInstance {
+  input: HTMLInputElement;
+  flatpickr: flatpickr.Instance;
+  preventCloseElement: HTMLElement;
+  _darkThemeLink: HTMLLinkElement;
+}
+
+const flatpickrValidator = (value: string, callback: (valid: boolean) => void) => {
+  callback(isDate(new Date(value)));
+};
+
+const flatpickrRenderer = rendererFactory(({ td, value, cellProperties }) => {
+  td.innerText = value ? format(new Date(value), cellProperties.renderFormat) : '';
+});
+
+const flatpickrEditor = editorFactory<FlatpickrEditorInstance>({
+  init(editor) {
+    editor.input = editor.hot.rootDocument.createElement('INPUT') as HTMLInputElement;
+    editor.input.classList.add('flatpickr-editor');
+
+    editor.flatpickr = flatpickr(editor.input, {
+      dateFormat: 'Y-m-d',
+      disableMobile: true,
+      onClose: () => {
+        editor.finishEditing();
+      },
+    });
+
+    editor.preventCloseElement = editor.flatpickr.calendarContainer;
+
+    editor._darkThemeLink = editor.hot.rootDocument.createElement('LINK') as HTMLLinkElement;
+    editor._darkThemeLink.rel = 'stylesheet';
+    editor._darkThemeLink.href = 'https://cdn.jsdelivr.net/npm/flatpickr/dist/themes/dark.css';
+  },
+  afterClose(editor) {
+    editor.flatpickr.close();
+  },
+  afterOpen(editor) {
+    const isDark = editor.hot.rootDocument.documentElement.getAttribute('data-theme') === 'dark';
+    const head = editor.hot.rootDocument.head;
+
+    if (isDark && !editor._darkThemeLink.parentNode) {
+      head.appendChild(editor._darkThemeLink);
+    } else if (!isDark && editor._darkThemeLink.parentNode) {
+      head.removeChild(editor._darkThemeLink);
+    }
+
+    editor.flatpickr.open();
+  },
+  beforeOpen(editor, { cellProperties }) {
+    for (const key in cellProperties.flatpickrSettings) {
+      editor.flatpickr.set(key as keyof flatpickr.Options.Options, cellProperties.flatpickrSettings[key]);
+    }
+  },
+  getValue(editor) {
+    return editor.input.value;
+  },
+  setValue(editor, value) {
+    editor.input.value = value;
+    editor.flatpickr.setDate(value ? new Date(value) : new Date());
+  },
+});
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={data}
+      colHeaders={['Product', 'Version', 'Release (EU)', 'Release (US)', 'Status']}
+      autoRowSize={true}
+      rowHeaders={true}
+      height="auto"
+      width="100%"
+      autoWrapRow={true}
+      headerClassName="htLeft"
+      licenseKey="non-commercial-and-evaluation"
+    >
+      <HotColumn data="product" type="text" width={200} />
+      <HotColumn data="version" type="text" width={80} />
+      <HotColumn
+        data="releaseDate"
+        width={130}
+        allowInvalid={false}
+        hotRenderer={flatpickrRenderer}
+        hotEditor={flatpickrEditor}
+        validator={flatpickrValidator}
+        renderFormat={DATE_FORMAT_EU}
+        flatpickrSettings={{ locale: { firstDayOfWeek: 1 } }}
+      />
+      <HotColumn
+        data="releaseDate"
+        width={130}
+        allowInvalid={false}
+        hotRenderer={flatpickrRenderer}
+        hotEditor={flatpickrEditor}
+        validator={flatpickrValidator}
+        renderFormat={DATE_FORMAT_US}
+        flatpickrSettings={{ locale: { firstDayOfWeek: 0 } }}
+      />
+      <HotColumn data="status" type="text" width={130} />
+    </HotTable>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/cell-types/moment-date/moment-date.md
+++ b/docs/content/recipes/cell-types/moment-date/moment-date.md
@@ -24,7 +24,7 @@ category: Cell Types
 
 This tutorial shows you how to create a custom date cell type using Moment.js and the Pikaday calendar picker, with format auto-correction and per-column configuration.
 
-::: only-for javascript vue
+::: only-for javascript vue angular
 
 ::: example #example1 :hot-recipe --js 1 --ts 2 --css 3 --deps moment @handsontable/pikaday
 

--- a/docs/content/recipes/cell-types/moment-date/moment-date.md
+++ b/docs/content/recipes/cell-types/moment-date/moment-date.md
@@ -24,11 +24,27 @@ category: Cell Types
 
 This tutorial shows you how to create a custom date cell type using Moment.js and the Pikaday calendar picker, with format auto-correction and per-column configuration.
 
+::: only-for javascript vue
+
 ::: example #example1 :hot-recipe --js 1 --ts 2 --css 3 --deps moment @handsontable/pikaday
 
 @[code](@/content/recipes/cell-types/moment-date/javascript/example1.js)
 @[code](@/content/recipes/cell-types/moment-date/javascript/example1.ts)
 @[code](@/content/recipes/cell-types/moment-date/javascript/example1.css)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #example1 :react-advanced --css 1 --js 2 --ts 3 --deps moment @handsontable/pikaday
+
+@[code](@/content/recipes/cell-types/moment-date/react/example1.css)
+@[code](@/content/recipes/cell-types/moment-date/react/example1.jsx)
+@[code](@/content/recipes/cell-types/moment-date/react/example1.tsx)
+
+:::
 
 :::
 

--- a/docs/content/recipes/cell-types/moment-date/react/example1.css
+++ b/docs/content/recipes/cell-types/moment-date/react/example1.css
@@ -1,0 +1,25 @@
+.ht_editor_visible > input {
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box !important;
+  border: none;
+  border-radius: 0;
+  outline: none;
+  margin-top: -1px;
+  margin-left: -1px;
+  box-shadow: inset 0 0 0 var(--ht-cell-editor-border-width, 2px)
+    var(--ht-cell-editor-border-color, #1a42e8),
+    0 0 var(--ht-cell-editor-shadow-blur-radius, 0) 0
+    var(--ht-cell-editor-shadow-color, transparent) !important;
+  background-color: var(--ht-cell-editor-background-color, #ffffff) !important;
+  padding: var(--ht-cell-vertical-padding, 4px)
+    var(--ht-cell-horizontal-padding, 8px) !important;
+  border: none !important;
+  font-family: inherit;
+  font-size: var(--ht-font-size);
+  line-height: var(--ht-line-height);
+}
+.ht_editor_visible > input:focus-visible {
+  border: none !important;
+  outline: none !important;
+}

--- a/docs/content/recipes/cell-types/moment-date/react/example1.jsx
+++ b/docs/content/recipes/cell-types/moment-date/react/example1.jsx
@@ -1,0 +1,388 @@
+import { HotTable, HotColumn } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import { getRenderer } from 'handsontable/renderers';
+import { editorFactory } from 'handsontable/editors';
+import { registerCellType } from 'handsontable/cellTypes';
+import moment from 'moment';
+import Pikaday from '@handsontable/pikaday';
+import Handsontable from 'handsontable/base';
+import './example1.css';
+
+registerAllModules();
+
+const correctFormat = (value, dateFormat) => {
+  const dateFromDate = moment(value);
+  const dateFromMoment = moment(value, dateFormat);
+  const isAlphanumeric = value.search(/[A-Za-z]/g) > -1;
+  let date;
+
+  if (
+    (dateFromDate.isValid() && dateFromDate.format('x') === dateFromMoment.format('x')) ||
+    !dateFromMoment.isValid() ||
+    isAlphanumeric
+  ) {
+    date = dateFromDate;
+  } else {
+    date = dateFromMoment;
+  }
+
+  return date.format(dateFormat);
+};
+
+const cellDateTypeDefinition = {
+  renderer: getRenderer('autocomplete'),
+  validator(value, callback) {
+    let valid = true;
+
+    if (value === null || value === undefined) {
+      value = '';
+    }
+
+    let isValidFormat = moment(value, this.dateFormat, true).isValid();
+    let isValidDate = moment(new Date(value)).isValid() || isValidFormat;
+
+    if (this.allowEmpty && value === '') {
+      isValidDate = true;
+      isValidFormat = true;
+    }
+
+    if (!isValidDate) {
+      valid = false;
+    }
+
+    if (!isValidDate && isValidFormat) {
+      valid = true;
+    }
+
+    if (isValidDate && !isValidFormat) {
+      if (this.correctFormat === true) {
+        const correctedValue = correctFormat(value, this.dateFormat);
+
+        this.instance.setDataAtCell(this.visualRow, this.visualCol, correctedValue, 'dateValidator');
+        valid = true;
+      } else {
+        valid = false;
+      }
+    }
+
+    callback(valid);
+  },
+  editor: editorFactory({
+    position: 'portal',
+    shortcuts: [
+      {
+        keys: [['ArrowLeft']],
+        callback: (editor, _event) => {
+          // @ts-ignore
+          editor.pikaday.adjustDate('subtract', 1);
+          _event.preventDefault();
+        },
+      },
+      {
+        keys: [['ArrowRight']],
+        callback: (editor, _event) => {
+          // @ts-ignore
+          editor.pikaday.adjustDate('add', 1);
+          _event.preventDefault();
+        },
+      },
+      {
+        keys: [['ArrowUp']],
+        callback: (editor, _event) => {
+          // @ts-ignore
+          editor.pikaday.adjustDate('subtract', 7);
+          _event.preventDefault();
+        },
+      },
+      {
+        keys: [['ArrowDown']],
+        callback: (editor, _event) => {
+          // @ts-ignore
+          editor.pikaday.adjustDate('add', 7);
+          _event.preventDefault();
+        },
+      },
+    ],
+    init(editor) {
+      editor.parentDestroyed = false;
+      editor.input = editor.hot.rootDocument.createElement('input');
+      editor.datePicker = editor.container;
+      editor.hot.rootDocument.addEventListener('mousedown', (event) => {
+        if (event.target && event.target.classList.contains('pika-day')) {
+          editor.hideDatepicker(editor);
+        }
+      });
+    },
+    getDatePickerConfig(editor) {
+      const htInput = editor.input;
+      const options = {};
+
+      if (editor.cellProperties && editor.cellProperties.datePickerConfig) {
+        Object.assign(options, editor.cellProperties.datePickerConfig);
+      }
+
+      const origOnSelect = options.onSelect;
+      const origOnClose = options.onClose;
+
+      options.field = htInput;
+      options.trigger = htInput;
+      options.container = editor.datePicker;
+      options.bound = false;
+      options.keyboardInput = false;
+      options.format = options.format ?? editor.getDateFormat(editor);
+      options.reposition = options.reposition || false;
+      options.isRTL = false;
+      options.onSelect = function (date) {
+        let dateStr;
+
+        if (!isNaN(date.getTime())) {
+          dateStr = moment(date).format(editor.getDateFormat(editor));
+        }
+
+        editor.setValue(dateStr);
+
+        if (origOnSelect) {
+          origOnSelect.call(editor.pikaday, date);
+        }
+
+        if (Handsontable.helper.isMobileBrowser()) {
+          editor.hideDatepicker(editor);
+        }
+      };
+      options.onClose = () => {
+        if (!editor.parentDestroyed) {
+          editor.finishEditing(false);
+        }
+
+        if (origOnClose) {
+          origOnClose();
+        }
+      };
+
+      return options;
+    },
+    hideDatepicker(editor) {
+      editor.pikaday.hide();
+    },
+    showDatepicker(editor, event) {
+      const dateFormat = editor.getDateFormat(editor);
+      // @ts-ignore
+      const isMouseDown = editor.hot.view.isMouseDown();
+      const isMeta = event && 'keyCode' in event ? Handsontable.helper.isFunctionKey(event.keyCode) : false;
+      let dateStr;
+
+      editor.datePicker.style.display = 'block';
+      editor.pikaday = new Pikaday(editor.getDatePickerConfig(editor));
+
+      // @ts-ignore
+      if (typeof editor.pikaday.useMoment === 'function') {
+        // @ts-ignore
+        editor.pikaday.useMoment(moment);
+      }
+
+      // @ts-ignore
+      editor.pikaday._onInputFocus = function () {};
+
+      if (editor.originalValue) {
+        dateStr = editor.originalValue;
+
+        if (moment(dateStr, dateFormat, true).isValid()) {
+          editor.pikaday.setMoment(moment(dateStr, dateFormat), true);
+        }
+
+        if (editor.getValue() !== editor.originalValue) {
+          editor.setValue(editor.originalValue);
+        }
+
+        if (!isMeta && !isMouseDown) {
+          editor.setValue('');
+        }
+      } else if (editor.cellProperties.defaultDate) {
+        dateStr = editor.cellProperties.defaultDate;
+
+        if (moment(dateStr, dateFormat, true).isValid()) {
+          editor.pikaday.setMoment(moment(dateStr, dateFormat), true);
+        }
+
+        if (!isMeta && !isMouseDown) {
+          editor.setValue('');
+        }
+      } else {
+        editor.pikaday.gotoToday();
+      }
+    },
+    afterClose(editor) {
+      if (editor.pikaday.destroy) {
+        editor.pikaday.destroy();
+      }
+    },
+    afterOpen(editor, event) {
+      const cellRect = editor.TD.getBoundingClientRect();
+
+      editor.input.style.width = `${cellRect.width}px`;
+      editor.input.style.height = `${cellRect.height}px`;
+      editor.showDatepicker(editor, event);
+    },
+    getValue(editor) {
+      return editor.input.value;
+    },
+    setValue(editor, value) {
+      editor.input.value = value;
+    },
+    getDateFormat(editor) {
+      return editor.cellProperties.dateFormat ?? 'DD/MM/YYYY';
+    },
+  }),
+};
+
+registerCellType('moment-date', cellDateTypeDefinition);
+
+/* start:skip-in-preview */
+const data = [
+  {
+    id: 640329,
+    itemName: 'Lunar Core',
+    itemNo: 'XJ-12',
+    leadEngineer: 'Ellen Ripley',
+    cost: 350000,
+    inStock: true,
+    category: 'Lander',
+    itemQuality: 87,
+    origin: '🇺🇸 USA',
+    quantity: 2,
+    valueStock: 700000,
+    repairable: false,
+    supplierName: 'TechNova',
+    restockDate: '2025-08-01',
+    operationalStatus: 'Awaiting Parts',
+  },
+  {
+    id: 863104,
+    itemName: 'Zero Thrusters',
+    itemNo: 'QL-54',
+    leadEngineer: 'Sam Bell',
+    cost: 450000,
+    inStock: false,
+    category: 'Propulsion',
+    itemQuality: 0,
+    origin: '🇩🇪 Germany',
+    quantity: 0,
+    valueStock: 0,
+    repairable: true,
+    supplierName: 'PropelMax',
+    restockDate: '2025-09-15',
+    operationalStatus: 'In Maintenance',
+  },
+  {
+    id: 395603,
+    itemName: 'EVA Suits',
+    itemNo: 'PM-67',
+    leadEngineer: 'Alex Rogan',
+    cost: 150000,
+    inStock: true,
+    category: 'Equipment',
+    itemQuality: 79,
+    origin: '🇮🇹 Italy',
+    quantity: 50,
+    valueStock: 7500000,
+    repairable: true,
+    supplierName: 'SuitCraft',
+    restockDate: '2025-10-05',
+    operationalStatus: 'Ready for Testing',
+  },
+  {
+    id: 679083,
+    itemName: 'Solar Panels',
+    itemNo: 'BW-09',
+    leadEngineer: 'Dave Bowman',
+    cost: 75000,
+    inStock: true,
+    category: 'Energy',
+    itemQuality: 95,
+    origin: '🇺🇸 USA',
+    quantity: 10,
+    valueStock: 750000,
+    repairable: false,
+    supplierName: 'SolarStream',
+    restockDate: '2025-11-10',
+    operationalStatus: 'Operational',
+  },
+  {
+    id: 912663,
+    itemName: 'Comm Array',
+    itemNo: 'ZR-56',
+    leadEngineer: 'Louise Banks',
+    cost: 125000,
+    inStock: false,
+    category: 'Communication',
+    itemQuality: 0,
+    origin: '🇯🇵 Japan',
+    quantity: 0,
+    valueStock: 0,
+    repairable: true,
+    supplierName: 'CommTech',
+    restockDate: '2025-12-20',
+    operationalStatus: 'Decommissioned',
+  },
+  {
+    id: 315806,
+    itemName: 'Habitat Dome',
+    itemNo: 'UJ-23',
+    leadEngineer: 'Dr. Ryan Stone',
+    cost: 1000000,
+    inStock: true,
+    category: 'Shelter',
+    itemQuality: 93,
+    origin: '🇨🇦 Canada',
+    quantity: 3,
+    valueStock: 3000000,
+    repairable: false,
+    supplierName: 'DomeInnovate',
+    restockDate: '2026-01-25',
+    operationalStatus: 'Operational',
+  },
+];
+/* end:skip-in-preview */
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={data}
+      colHeaders={['Item Name', 'Category', 'Lead Engineer', 'Restock Date', 'Cost']}
+      autoRowSize={true}
+      rowHeaders={true}
+      height="auto"
+      width="100%"
+      autoWrapRow={true}
+      headerClassName="htLeft"
+      licenseKey="non-commercial-and-evaluation"
+    >
+      <HotColumn data="itemName" type="text" width={130} />
+      <HotColumn data="category" type="text" width={120} />
+      <HotColumn data="leadEngineer" type="text" width={150} />
+      <HotColumn
+        data="restockDate"
+        type="moment-date"
+        width={150}
+        dateFormat="YYYY-MM-DD"
+        correctFormat={true}
+        datePickerConfig={{
+          firstDay: 0,
+          showWeekNumber: true,
+          disableDayFn(date) {
+            return date.getDay() === 0 || date.getDay() === 6;
+          },
+        }}
+      />
+      <HotColumn
+        data="cost"
+        type="numeric"
+        width={120}
+        className="htRight"
+        numericFormat={{ pattern: '$0,0.00', culture: 'en-US' }}
+      />
+    </HotTable>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/cell-types/moment-date/react/example1.tsx
+++ b/docs/content/recipes/cell-types/moment-date/react/example1.tsx
@@ -1,0 +1,416 @@
+import { HotTable, HotColumn } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import { getRenderer } from 'handsontable/renderers';
+import { editorFactory } from 'handsontable/editors';
+import { registerCellType } from 'handsontable/cellTypes';
+import moment from 'moment';
+import Pikaday from '@handsontable/pikaday';
+import Handsontable from 'handsontable/base';
+import './example1.css';
+
+registerAllModules();
+
+interface MomentDateEditorInstance {
+  parentDestroyed: boolean;
+  input: HTMLInputElement;
+  datePicker: HTMLElement;
+  pikaday: Pikaday;
+}
+
+const correctFormat = (value: string, dateFormat: string): string => {
+  const dateFromDate = moment(value);
+  const dateFromMoment = moment(value, dateFormat);
+  const isAlphanumeric = value.search(/[A-Za-z]/g) > -1;
+  let date;
+
+  if (
+    (dateFromDate.isValid() && dateFromDate.format('x') === dateFromMoment.format('x')) ||
+    !dateFromMoment.isValid() ||
+    isAlphanumeric
+  ) {
+    date = dateFromDate;
+  } else {
+    date = dateFromMoment;
+  }
+
+  return date.format(dateFormat);
+};
+
+const cellDateTypeDefinition = {
+  renderer: getRenderer('autocomplete'),
+  validator(this: any, value: string, callback: (valid: boolean) => void) {
+    let valid = true;
+
+    if (value === null || value === undefined) {
+      value = '';
+    }
+
+    let isValidFormat = moment(value, this.dateFormat, true).isValid();
+    let isValidDate = moment(new Date(value)).isValid() || isValidFormat;
+
+    if (this.allowEmpty && value === '') {
+      isValidDate = true;
+      isValidFormat = true;
+    }
+
+    if (!isValidDate) {
+      valid = false;
+    }
+
+    if (!isValidDate && isValidFormat) {
+      valid = true;
+    }
+
+    if (isValidDate && !isValidFormat) {
+      if (this.correctFormat === true) {
+        const correctedValue = correctFormat(value, this.dateFormat);
+
+        this.instance.setDataAtCell(this.visualRow, this.visualCol, correctedValue, 'dateValidator');
+        valid = true;
+      } else {
+        valid = false;
+      }
+    }
+
+    callback(valid);
+  },
+  editor: editorFactory<MomentDateEditorInstance>({
+    position: 'portal',
+    shortcuts: [
+      {
+        keys: [['ArrowLeft']],
+        callback: (editor, _event) => {
+          // @ts-ignore
+          editor.pikaday.adjustDate('subtract', 1);
+          _event.preventDefault();
+        },
+      },
+      {
+        keys: [['ArrowRight']],
+        callback: (editor, _event) => {
+          // @ts-ignore
+          editor.pikaday.adjustDate('add', 1);
+          _event.preventDefault();
+        },
+      },
+      {
+        keys: [['ArrowUp']],
+        callback: (editor, _event) => {
+          // @ts-ignore
+          editor.pikaday.adjustDate('subtract', 7);
+          _event.preventDefault();
+        },
+      },
+      {
+        keys: [['ArrowDown']],
+        callback: (editor, _event) => {
+          // @ts-ignore
+          editor.pikaday.adjustDate('add', 7);
+          _event.preventDefault();
+        },
+      },
+    ],
+    init(editor) {
+      editor.parentDestroyed = false;
+      editor.input = editor.hot.rootDocument.createElement('input') as HTMLInputElement;
+      editor.datePicker = editor.container;
+      editor.hot.rootDocument.addEventListener('mousedown', (event: MouseEvent) => {
+        const target = event.target as Element;
+
+        if (target && target.classList.contains('pika-day')) {
+          editor.hideDatepicker(editor);
+        }
+      });
+    },
+    getDatePickerConfig(editor: any) {
+      const htInput = editor.input;
+      const options: Record<string, any> = {};
+
+      if (editor.cellProperties && editor.cellProperties.datePickerConfig) {
+        Object.assign(options, editor.cellProperties.datePickerConfig);
+      }
+
+      const origOnSelect = options.onSelect;
+      const origOnClose = options.onClose;
+
+      options.field = htInput;
+      options.trigger = htInput;
+      options.container = editor.datePicker;
+      options.bound = false;
+      options.keyboardInput = false;
+      options.format = options.format ?? editor.getDateFormat(editor);
+      options.reposition = options.reposition || false;
+      options.isRTL = false;
+      options.onSelect = function (date: Date) {
+        let dateStr: string | undefined;
+
+        if (!isNaN(date.getTime())) {
+          dateStr = moment(date).format(editor.getDateFormat(editor));
+        }
+
+        editor.setValue(dateStr);
+
+        if (origOnSelect) {
+          origOnSelect.call(editor.pikaday, date);
+        }
+
+        if (Handsontable.helper.isMobileBrowser()) {
+          editor.hideDatepicker(editor);
+        }
+      };
+      options.onClose = () => {
+        if (!editor.parentDestroyed) {
+          editor.finishEditing(false);
+        }
+
+        if (origOnClose) {
+          origOnClose();
+        }
+      };
+
+      return options;
+    },
+    hideDatepicker(editor: any) {
+      editor.pikaday.hide();
+    },
+    showDatepicker(editor: any, event: Event) {
+      const dateFormat = editor.getDateFormat(editor);
+      // @ts-ignore
+      const isMouseDown = editor.hot.view.isMouseDown();
+      const isMeta =
+        event && 'keyCode' in event ? Handsontable.helper.isFunctionKey((event as KeyboardEvent).keyCode) : false;
+      let dateStr: string;
+
+      editor.datePicker.style.display = 'block';
+      editor.pikaday = new Pikaday(editor.getDatePickerConfig(editor));
+
+      // @ts-ignore
+      if (typeof editor.pikaday.useMoment === 'function') {
+        // @ts-ignore
+        editor.pikaday.useMoment(moment);
+      }
+
+      // @ts-ignore
+      editor.pikaday._onInputFocus = function () {};
+
+      if (editor.originalValue) {
+        dateStr = editor.originalValue;
+
+        if (moment(dateStr, dateFormat, true).isValid()) {
+          editor.pikaday.setMoment(moment(dateStr, dateFormat), true);
+        }
+
+        if (editor.getValue() !== editor.originalValue) {
+          editor.setValue(editor.originalValue);
+        }
+
+        if (!isMeta && !isMouseDown) {
+          editor.setValue('');
+        }
+      } else if (editor.cellProperties.defaultDate) {
+        dateStr = editor.cellProperties.defaultDate;
+
+        if (moment(dateStr, dateFormat, true).isValid()) {
+          editor.pikaday.setMoment(moment(dateStr, dateFormat), true);
+        }
+
+        if (!isMeta && !isMouseDown) {
+          editor.setValue('');
+        }
+      } else {
+        editor.pikaday.gotoToday();
+      }
+    },
+    afterClose(editor: any) {
+      if (editor.pikaday.destroy) {
+        editor.pikaday.destroy();
+      }
+    },
+    afterOpen(editor: any, event: Event) {
+      const cellRect = editor.TD.getBoundingClientRect();
+
+      editor.input.style.width = `${cellRect.width}px`;
+      editor.input.style.height = `${cellRect.height}px`;
+      editor.showDatepicker(editor, event);
+    },
+    getValue(editor) {
+      return editor.input.value;
+    },
+    setValue(editor, value) {
+      editor.input.value = value;
+    },
+    getDateFormat(editor: any): string {
+      return editor.cellProperties.dateFormat ?? 'DD/MM/YYYY';
+    },
+  }),
+};
+
+registerCellType('moment-date', cellDateTypeDefinition);
+
+/* start:skip-in-preview */
+interface InventoryItem {
+  id: number;
+  itemName: string;
+  itemNo: string;
+  leadEngineer: string;
+  cost: number;
+  inStock: boolean;
+  category: string;
+  itemQuality: number;
+  origin: string;
+  quantity: number;
+  valueStock: number;
+  repairable: boolean;
+  supplierName: string;
+  restockDate: string;
+  operationalStatus: string;
+}
+
+const data: InventoryItem[] = [
+  {
+    id: 640329,
+    itemName: 'Lunar Core',
+    itemNo: 'XJ-12',
+    leadEngineer: 'Ellen Ripley',
+    cost: 350000,
+    inStock: true,
+    category: 'Lander',
+    itemQuality: 87,
+    origin: '🇺🇸 USA',
+    quantity: 2,
+    valueStock: 700000,
+    repairable: false,
+    supplierName: 'TechNova',
+    restockDate: '2025-08-01',
+    operationalStatus: 'Awaiting Parts',
+  },
+  {
+    id: 863104,
+    itemName: 'Zero Thrusters',
+    itemNo: 'QL-54',
+    leadEngineer: 'Sam Bell',
+    cost: 450000,
+    inStock: false,
+    category: 'Propulsion',
+    itemQuality: 0,
+    origin: '🇩🇪 Germany',
+    quantity: 0,
+    valueStock: 0,
+    repairable: true,
+    supplierName: 'PropelMax',
+    restockDate: '2025-09-15',
+    operationalStatus: 'In Maintenance',
+  },
+  {
+    id: 395603,
+    itemName: 'EVA Suits',
+    itemNo: 'PM-67',
+    leadEngineer: 'Alex Rogan',
+    cost: 150000,
+    inStock: true,
+    category: 'Equipment',
+    itemQuality: 79,
+    origin: '🇮🇹 Italy',
+    quantity: 50,
+    valueStock: 7500000,
+    repairable: true,
+    supplierName: 'SuitCraft',
+    restockDate: '2025-10-05',
+    operationalStatus: 'Ready for Testing',
+  },
+  {
+    id: 679083,
+    itemName: 'Solar Panels',
+    itemNo: 'BW-09',
+    leadEngineer: 'Dave Bowman',
+    cost: 75000,
+    inStock: true,
+    category: 'Energy',
+    itemQuality: 95,
+    origin: '🇺🇸 USA',
+    quantity: 10,
+    valueStock: 750000,
+    repairable: false,
+    supplierName: 'SolarStream',
+    restockDate: '2025-11-10',
+    operationalStatus: 'Operational',
+  },
+  {
+    id: 912663,
+    itemName: 'Comm Array',
+    itemNo: 'ZR-56',
+    leadEngineer: 'Louise Banks',
+    cost: 125000,
+    inStock: false,
+    category: 'Communication',
+    itemQuality: 0,
+    origin: '🇯🇵 Japan',
+    quantity: 0,
+    valueStock: 0,
+    repairable: true,
+    supplierName: 'CommTech',
+    restockDate: '2025-12-20',
+    operationalStatus: 'Decommissioned',
+  },
+  {
+    id: 315806,
+    itemName: 'Habitat Dome',
+    itemNo: 'UJ-23',
+    leadEngineer: 'Dr. Ryan Stone',
+    cost: 1000000,
+    inStock: true,
+    category: 'Shelter',
+    itemQuality: 93,
+    origin: '🇨🇦 Canada',
+    quantity: 3,
+    valueStock: 3000000,
+    repairable: false,
+    supplierName: 'DomeInnovate',
+    restockDate: '2026-01-25',
+    operationalStatus: 'Operational',
+  },
+];
+/* end:skip-in-preview */
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={data}
+      colHeaders={['Item Name', 'Category', 'Lead Engineer', 'Restock Date', 'Cost']}
+      autoRowSize={true}
+      rowHeaders={true}
+      height="auto"
+      width="100%"
+      autoWrapRow={true}
+      headerClassName="htLeft"
+      licenseKey="non-commercial-and-evaluation"
+    >
+      <HotColumn data="itemName" type="text" width={130} />
+      <HotColumn data="category" type="text" width={120} />
+      <HotColumn data="leadEngineer" type="text" width={150} />
+      <HotColumn
+        data="restockDate"
+        type="moment-date"
+        width={150}
+        dateFormat="YYYY-MM-DD"
+        correctFormat={true}
+        datePickerConfig={{
+          firstDay: 0,
+          showWeekNumber: true,
+          disableDayFn(date: Date) {
+            return date.getDay() === 0 || date.getDay() === 6;
+          },
+        }}
+      />
+      <HotColumn
+        data="cost"
+        type="numeric"
+        width={120}
+        className="htRight"
+        numericFormat={{ pattern: '$0,0.00', culture: 'en-US' }}
+      />
+    </HotTable>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/cell-types/moment-time/moment-time.md
+++ b/docs/content/recipes/cell-types/moment-time/moment-time.md
@@ -24,7 +24,7 @@ category: Cell Types
 
 This tutorial shows you how to create a custom time cell type using Moment.js for validation and format auto-correction.
 
-::: only-for javascript vue
+::: only-for javascript vue angular
 
 ::: example #example1 :hot-recipe --js 1 --ts 2 --deps moment @handsontable/pikaday
 

--- a/docs/content/recipes/cell-types/moment-time/moment-time.md
+++ b/docs/content/recipes/cell-types/moment-time/moment-time.md
@@ -24,10 +24,25 @@ category: Cell Types
 
 This tutorial shows you how to create a custom time cell type using Moment.js for validation and format auto-correction.
 
+::: only-for javascript vue
+
 ::: example #example1 :hot-recipe --js 1 --ts 2 --deps moment @handsontable/pikaday
 
 @[code](@/content/recipes/cell-types/moment-time/javascript/example1.js)
 @[code](@/content/recipes/cell-types/moment-time/javascript/example1.ts)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #example1 :react-advanced --js 1 --ts 2 --deps moment
+
+@[code](@/content/recipes/cell-types/moment-time/react/example1.jsx)
+@[code](@/content/recipes/cell-types/moment-time/react/example1.tsx)
+
+:::
 
 :::
 

--- a/docs/content/recipes/cell-types/moment-time/react/example1.jsx
+++ b/docs/content/recipes/cell-types/moment-time/react/example1.jsx
@@ -1,0 +1,215 @@
+import { HotTable, HotColumn } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import { getRenderer } from 'handsontable/renderers';
+import { getEditor } from 'handsontable/editors';
+import { registerCellType } from 'handsontable/cellTypes';
+import moment from 'moment';
+
+registerAllModules();
+
+const cellTimeTypeDefinition = {
+  renderer: getRenderer('text'),
+  validator(value, callback) {
+    const timeFormat = this.timeFormat ?? 'h:mm:ss a';
+    let valid = true;
+
+    if (value === null) {
+      value = '';
+    }
+
+    value = /^\d{3,}$/.test(value) ? parseInt(value, 10) : value;
+
+    const twoDigitValue = /^\d{1,2}$/.test(value);
+
+    if (twoDigitValue) {
+      value += ':00';
+    }
+
+    const date = moment(
+      value,
+      [
+        'YYYY-MM-DDTHH:mm:ss.SSSZ',
+        'X',
+        'x',
+      ],
+      true
+    ).isValid()
+      ? moment(value)
+      : moment(value, timeFormat);
+
+    let isValidTime = date.isValid();
+    let isValidFormat = moment(value, timeFormat, true).isValid() && !twoDigitValue;
+
+    if (this.allowEmpty && value === '') {
+      isValidTime = true;
+      isValidFormat = true;
+    }
+
+    if (!isValidTime) {
+      valid = false;
+    }
+
+    if (!isValidTime && isValidFormat) {
+      valid = true;
+    }
+
+    if (isValidTime && !isValidFormat) {
+      if (this.correctFormat === true) {
+        const correctedValue = date.format(timeFormat);
+
+        this.instance.setDataAtCell(this.visualRow, this.visualCol, correctedValue, 'timeValidator');
+        valid = true;
+      } else {
+        valid = false;
+      }
+    }
+
+    callback(valid);
+  },
+  editor: getEditor('text'),
+};
+
+registerCellType('moment-time', cellTimeTypeDefinition);
+
+/* start:skip-in-preview */
+const data = [
+  {
+    id: 640329,
+    itemName: 'Lunar Core',
+    itemNo: 'XJ-12',
+    leadEngineer: 'Ellen Ripley',
+    cost: 350000,
+    inStock: true,
+    category: 'Lander',
+    itemQuality: 87,
+    origin: '🇺🇸 USA',
+    quantity: 2,
+    valueStock: 700000,
+    repairable: false,
+    supplierName: 'TechNova',
+    time: '09:30',
+    operationalStatus: 'Awaiting Parts',
+  },
+  {
+    id: 863104,
+    itemName: 'Zero Thrusters',
+    itemNo: 'QL-54',
+    leadEngineer: 'Sam Bell',
+    cost: 450000,
+    inStock: false,
+    category: 'Propulsion',
+    itemQuality: 0,
+    origin: '🇩🇪 Germany',
+    quantity: 0,
+    valueStock: 0,
+    repairable: true,
+    supplierName: 'PropelMax',
+    time: '14:15',
+    operationalStatus: 'In Maintenance',
+  },
+  {
+    id: 395603,
+    itemName: 'EVA Suits',
+    itemNo: 'PM-67',
+    leadEngineer: 'Alex Rogan',
+    cost: 150000,
+    inStock: true,
+    category: 'Equipment',
+    itemQuality: 79,
+    origin: '🇮🇹 Italy',
+    quantity: 50,
+    valueStock: 7500000,
+    repairable: true,
+    supplierName: 'SuitCraft',
+    time: '08:00',
+    operationalStatus: 'Ready for Testing',
+  },
+  {
+    id: 679083,
+    itemName: 'Solar Panels',
+    itemNo: 'BW-09',
+    leadEngineer: 'Dave Bowman',
+    cost: 75000,
+    inStock: true,
+    category: 'Energy',
+    itemQuality: 95,
+    origin: '🇺🇸 USA',
+    quantity: 10,
+    valueStock: 750000,
+    repairable: false,
+    supplierName: 'SolarStream',
+    time: '16:45',
+    operationalStatus: 'Operational',
+  },
+  {
+    id: 912663,
+    itemName: 'Comm Array',
+    itemNo: 'ZR-56',
+    leadEngineer: 'Louise Banks',
+    cost: 125000,
+    inStock: false,
+    category: 'Communication',
+    itemQuality: 0,
+    origin: '🇯🇵 Japan',
+    quantity: 0,
+    valueStock: 0,
+    repairable: true,
+    supplierName: 'CommTech',
+    time: '11:20',
+    operationalStatus: 'Decommissioned',
+  },
+  {
+    id: 315806,
+    itemName: 'Habitat Dome',
+    itemNo: 'UJ-23',
+    leadEngineer: 'Dr. Ryan Stone',
+    cost: 1000000,
+    inStock: true,
+    category: 'Shelter',
+    itemQuality: 93,
+    origin: '🇨🇦 Canada',
+    quantity: 3,
+    valueStock: 3000000,
+    repairable: false,
+    supplierName: 'DomeInnovate',
+    time: '23:00',
+    operationalStatus: 'Operational',
+  },
+];
+/* end:skip-in-preview */
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={data}
+      colHeaders={['Item Name', 'Category', 'Lead Engineer', 'Arrival Time', 'Cost']}
+      autoRowSize={true}
+      rowHeaders={true}
+      height="auto"
+      width="100%"
+      autoWrapRow={true}
+      headerClassName="htLeft"
+      licenseKey="non-commercial-and-evaluation"
+    >
+      <HotColumn data="itemName" type="text" width={130} />
+      <HotColumn data="category" type="text" width={120} />
+      <HotColumn data="leadEngineer" type="text" width={150} />
+      <HotColumn
+        data="time"
+        type="moment-time"
+        width={150}
+        timeFormat="HH:mm"
+        correctFormat={true}
+      />
+      <HotColumn
+        data="cost"
+        type="numeric"
+        width={120}
+        className="htRight"
+        numericFormat={{ pattern: '$0,0.00', culture: 'en-US' }}
+      />
+    </HotTable>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/cell-types/moment-time/react/example1.tsx
+++ b/docs/content/recipes/cell-types/moment-time/react/example1.tsx
@@ -1,0 +1,233 @@
+import { HotTable, HotColumn } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import { getRenderer } from 'handsontable/renderers';
+import { getEditor } from 'handsontable/editors';
+import { registerCellType } from 'handsontable/cellTypes';
+import moment from 'moment';
+
+registerAllModules();
+
+const cellTimeTypeDefinition = {
+  renderer: getRenderer('text'),
+  validator(this: any, value: string | number, callback: (valid: boolean) => void) {
+    const timeFormat: string = this.timeFormat ?? 'h:mm:ss a';
+    let valid = true;
+
+    if (value === null) {
+      value = '';
+    }
+
+    value = /^\d{3,}$/.test(String(value)) ? parseInt(String(value), 10) : value;
+
+    const twoDigitValue = /^\d{1,2}$/.test(String(value));
+
+    if (twoDigitValue) {
+      value = `${value}:00`;
+    }
+
+    const date = moment(
+      value,
+      [
+        'YYYY-MM-DDTHH:mm:ss.SSSZ',
+        'X',
+        'x',
+      ],
+      true
+    ).isValid()
+      ? moment(value)
+      : moment(value, timeFormat);
+
+    let isValidTime = date.isValid();
+    let isValidFormat = moment(value, timeFormat, true).isValid() && !twoDigitValue;
+
+    if (this.allowEmpty && value === '') {
+      isValidTime = true;
+      isValidFormat = true;
+    }
+
+    if (!isValidTime) {
+      valid = false;
+    }
+
+    if (!isValidTime && isValidFormat) {
+      valid = true;
+    }
+
+    if (isValidTime && !isValidFormat) {
+      if (this.correctFormat === true) {
+        const correctedValue = date.format(timeFormat);
+
+        this.instance.setDataAtCell(this.visualRow, this.visualCol, correctedValue, 'timeValidator');
+        valid = true;
+      } else {
+        valid = false;
+      }
+    }
+
+    callback(valid);
+  },
+  editor: getEditor('text'),
+};
+
+registerCellType('moment-time', cellTimeTypeDefinition);
+
+/* start:skip-in-preview */
+interface InventoryItem {
+  id: number;
+  itemName: string;
+  itemNo: string;
+  leadEngineer: string;
+  cost: number;
+  inStock: boolean;
+  category: string;
+  itemQuality: number;
+  origin: string;
+  quantity: number;
+  valueStock: number;
+  repairable: boolean;
+  supplierName: string;
+  time: string;
+  operationalStatus: string;
+}
+
+const data: InventoryItem[] = [
+  {
+    id: 640329,
+    itemName: 'Lunar Core',
+    itemNo: 'XJ-12',
+    leadEngineer: 'Ellen Ripley',
+    cost: 350000,
+    inStock: true,
+    category: 'Lander',
+    itemQuality: 87,
+    origin: '🇺🇸 USA',
+    quantity: 2,
+    valueStock: 700000,
+    repairable: false,
+    supplierName: 'TechNova',
+    time: '09:30',
+    operationalStatus: 'Awaiting Parts',
+  },
+  {
+    id: 863104,
+    itemName: 'Zero Thrusters',
+    itemNo: 'QL-54',
+    leadEngineer: 'Sam Bell',
+    cost: 450000,
+    inStock: false,
+    category: 'Propulsion',
+    itemQuality: 0,
+    origin: '🇩🇪 Germany',
+    quantity: 0,
+    valueStock: 0,
+    repairable: true,
+    supplierName: 'PropelMax',
+    time: '14:15',
+    operationalStatus: 'In Maintenance',
+  },
+  {
+    id: 395603,
+    itemName: 'EVA Suits',
+    itemNo: 'PM-67',
+    leadEngineer: 'Alex Rogan',
+    cost: 150000,
+    inStock: true,
+    category: 'Equipment',
+    itemQuality: 79,
+    origin: '🇮🇹 Italy',
+    quantity: 50,
+    valueStock: 7500000,
+    repairable: true,
+    supplierName: 'SuitCraft',
+    time: '08:00',
+    operationalStatus: 'Ready for Testing',
+  },
+  {
+    id: 679083,
+    itemName: 'Solar Panels',
+    itemNo: 'BW-09',
+    leadEngineer: 'Dave Bowman',
+    cost: 75000,
+    inStock: true,
+    category: 'Energy',
+    itemQuality: 95,
+    origin: '🇺🇸 USA',
+    quantity: 10,
+    valueStock: 750000,
+    repairable: false,
+    supplierName: 'SolarStream',
+    time: '16:45',
+    operationalStatus: 'Operational',
+  },
+  {
+    id: 912663,
+    itemName: 'Comm Array',
+    itemNo: 'ZR-56',
+    leadEngineer: 'Louise Banks',
+    cost: 125000,
+    inStock: false,
+    category: 'Communication',
+    itemQuality: 0,
+    origin: '🇯🇵 Japan',
+    quantity: 0,
+    valueStock: 0,
+    repairable: true,
+    supplierName: 'CommTech',
+    time: '11:20',
+    operationalStatus: 'Decommissioned',
+  },
+  {
+    id: 315806,
+    itemName: 'Habitat Dome',
+    itemNo: 'UJ-23',
+    leadEngineer: 'Dr. Ryan Stone',
+    cost: 1000000,
+    inStock: true,
+    category: 'Shelter',
+    itemQuality: 93,
+    origin: '🇨🇦 Canada',
+    quantity: 3,
+    valueStock: 3000000,
+    repairable: false,
+    supplierName: 'DomeInnovate',
+    time: '23:00',
+    operationalStatus: 'Operational',
+  },
+];
+/* end:skip-in-preview */
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={data}
+      colHeaders={['Item Name', 'Category', 'Lead Engineer', 'Arrival Time', 'Cost']}
+      autoRowSize={true}
+      rowHeaders={true}
+      height="auto"
+      width="100%"
+      autoWrapRow={true}
+      headerClassName="htLeft"
+      licenseKey="non-commercial-and-evaluation"
+    >
+      <HotColumn data="itemName" type="text" width={130} />
+      <HotColumn data="category" type="text" width={120} />
+      <HotColumn data="leadEngineer" type="text" width={150} />
+      <HotColumn
+        data="time"
+        type="moment-time"
+        width={150}
+        timeFormat="HH:mm"
+        correctFormat={true}
+      />
+      <HotColumn
+        data="cost"
+        type="numeric"
+        width={120}
+        className="htRight"
+        numericFormat={{ pattern: '$0,0.00', culture: 'en-US' }}
+      />
+    </HotTable>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/cell-types/numbro/numbro.md
+++ b/docs/content/recipes/cell-types/numbro/numbro.md
@@ -23,10 +23,25 @@ category: Cell Types
 
 This tutorial shows you how to create a custom numeric cell type using the Numbro library for locale-aware number formatting.
 
+::: only-for javascript vue
+
 ::: example #example1 :hot-recipe --js 1 --ts 2 --deps numbro
 
 @[code](@/content/recipes/cell-types/numbro/javascript/example1.js)
 @[code](@/content/recipes/cell-types/numbro/javascript/example1.ts)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #example1 :react-advanced --js 1 --ts 2 --deps numbro
+
+@[code](@/content/recipes/cell-types/numbro/react/example1.jsx)
+@[code](@/content/recipes/cell-types/numbro/react/example1.tsx)
+
+:::
 
 :::
 

--- a/docs/content/recipes/cell-types/numbro/numbro.md
+++ b/docs/content/recipes/cell-types/numbro/numbro.md
@@ -23,7 +23,7 @@ category: Cell Types
 
 This tutorial shows you how to create a custom numeric cell type using the Numbro library for locale-aware number formatting.
 
-::: only-for javascript vue
+::: only-for javascript vue angular
 
 ::: example #example1 :hot-recipe --js 1 --ts 2 --deps numbro
 

--- a/docs/content/recipes/cell-types/numbro/react/example1.jsx
+++ b/docs/content/recipes/cell-types/numbro/react/example1.jsx
@@ -1,0 +1,236 @@
+import { HotTable, HotColumn } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import { rendererFactory, getRenderer } from 'handsontable/renderers';
+import { getEditor } from 'handsontable/editors';
+import { getValidator } from 'handsontable/validators';
+import { registerCellType } from 'handsontable/cellTypes';
+import numbro from 'numbro';
+import languages from 'numbro/dist/languages.min.js';
+
+registerAllModules();
+Object.values(languages).forEach((language) => numbro.registerLanguage(language));
+
+function isNumeric(value) {
+  const type = typeof value;
+
+  if (type === 'number') {
+    return !isNaN(value) && isFinite(value);
+  } else if (type === 'string') {
+    if (value.length === 0) {
+      return false;
+    } else if (value.length === 1) {
+      return /\d/.test(value);
+    }
+
+    const delimiter = Array.from(new Set(['.']))
+      .map((d) => `\\${d}`)
+      .join('|');
+
+    return new RegExp(`^[+-]?(((${delimiter})?\\d+((${delimiter})\\d+)?(e[+-]?\\d+)?)|(0x[a-f\\d]+))$`, 'i').test(
+      value.trim()
+    );
+  } else if (type === 'object') {
+    return !!value && typeof value.valueOf() === 'number' && !(value instanceof Date);
+  }
+
+  return false;
+}
+
+const cellTypeDefinition = {
+  renderer: rendererFactory(({ hotInstance, td, row, col, prop, value, cellProperties }) => {
+    if (isNumeric(value)) {
+      let classArr = [];
+
+      if (Array.isArray(cellProperties.className)) {
+        classArr = cellProperties.className;
+      } else {
+        const className = cellProperties.className ?? '';
+
+        if (className.length) {
+          classArr = className.split(' ');
+        }
+      }
+
+      const numericFormat = cellProperties.numericFormat;
+      const cellCulture = (numericFormat && numericFormat.culture) || 'en-US';
+      const cellFormatPattern = numericFormat && numericFormat.pattern;
+
+      if (cellCulture && !numbro.languages()[cellCulture]) {
+        const shortTag = cellCulture.replace('-', '');
+        const langData = numbro.allLanguages ? numbro.allLanguages[cellCulture] : numbro[shortTag];
+
+        if (langData) {
+          numbro.registerLanguage(langData);
+        }
+      }
+
+      numbro.setLanguage(cellCulture);
+      value = numbro(value).format(cellFormatPattern ?? '0');
+
+      if (
+        classArr.indexOf('htLeft') < 0 &&
+        classArr.indexOf('htCenter') < 0 &&
+        classArr.indexOf('htRight') < 0 &&
+        classArr.indexOf('htJustify') < 0
+      ) {
+        classArr.push('htRight');
+      }
+
+      if (classArr.indexOf('htNumeric') < 0) {
+        classArr.push('htNumeric');
+      }
+
+      cellProperties.className = classArr.join(' ');
+      td.dir = 'ltr';
+    }
+
+    getRenderer('text')(hotInstance, td, row, col, prop, value, cellProperties);
+  }),
+  validator: getValidator('numeric'),
+  editor: getEditor('numeric'),
+};
+
+registerCellType('numbro', cellTypeDefinition);
+
+/* start:skip-in-preview */
+const data = [
+  {
+    id: 640329,
+    itemName: 'Lunar Core',
+    itemNo: 'XJ-12',
+    leadEngineer: 'Ellen Ripley',
+    cost: 350000,
+    inStock: true,
+    category: 'Lander',
+    itemQuality: 87,
+    origin: '🇺🇸 USA',
+    quantity: 2,
+    valueStock: 700000,
+    repairable: false,
+    supplierName: 'TechNova',
+    restockDate: '2025-08-01',
+    operationalStatus: 'Awaiting Parts',
+  },
+  {
+    id: 863104,
+    itemName: 'Zero Thrusters',
+    itemNo: 'QL-54',
+    leadEngineer: 'Sam Bell',
+    cost: 450000,
+    inStock: false,
+    category: 'Propulsion',
+    itemQuality: 0,
+    origin: '🇩🇪 Germany',
+    quantity: 0,
+    valueStock: 0,
+    repairable: true,
+    supplierName: 'PropelMax',
+    restockDate: '2025-09-15',
+    operationalStatus: 'In Maintenance',
+  },
+  {
+    id: 395603,
+    itemName: 'EVA Suits',
+    itemNo: 'PM-67',
+    leadEngineer: 'Alex Rogan',
+    cost: 150000,
+    inStock: true,
+    category: 'Equipment',
+    itemQuality: 79,
+    origin: '🇮🇹 Italy',
+    quantity: 50,
+    valueStock: 7500000,
+    repairable: true,
+    supplierName: 'SuitCraft',
+    restockDate: '2025-10-05',
+    operationalStatus: 'Ready for Testing',
+  },
+  {
+    id: 679083,
+    itemName: 'Solar Panels',
+    itemNo: 'BW-09',
+    leadEngineer: 'Dave Bowman',
+    cost: 75000,
+    inStock: true,
+    category: 'Energy',
+    itemQuality: 95,
+    origin: '🇺🇸 USA',
+    quantity: 10,
+    valueStock: 750000,
+    repairable: false,
+    supplierName: 'SolarStream',
+    restockDate: '2025-11-10',
+    operationalStatus: 'Operational',
+  },
+  {
+    id: 912663,
+    itemName: 'Comm Array',
+    itemNo: 'ZR-56',
+    leadEngineer: 'Louise Banks',
+    cost: 125000,
+    inStock: false,
+    category: 'Communication',
+    itemQuality: 0,
+    origin: '🇯🇵 Japan',
+    quantity: 0,
+    valueStock: 0,
+    repairable: true,
+    supplierName: 'CommTech',
+    restockDate: '2025-12-20',
+    operationalStatus: 'Decommissioned',
+  },
+  {
+    id: 315806,
+    itemName: 'Habitat Dome',
+    itemNo: 'UJ-23',
+    leadEngineer: 'Dr. Ryan Stone',
+    cost: 1000000,
+    inStock: true,
+    category: 'Shelter',
+    itemQuality: 93,
+    origin: '🇨🇦 Canada',
+    quantity: 3,
+    valueStock: 3000000,
+    repairable: false,
+    supplierName: 'DomeInnovate',
+    restockDate: '2026-01-25',
+    operationalStatus: 'Operational',
+  },
+];
+/* end:skip-in-preview */
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={data}
+      colHeaders={['Item Name', 'Category', 'Lead Engineer', 'Quantity', 'Cost']}
+      autoRowSize={true}
+      rowHeaders={true}
+      height="auto"
+      width="100%"
+      autoWrapRow={true}
+      headerClassName="htLeft"
+      licenseKey="non-commercial-and-evaluation"
+    >
+      <HotColumn data="itemName" type="text" width={130} />
+      <HotColumn data="category" type="text" width={120} />
+      <HotColumn data="leadEngineer" type="text" width={150} />
+      <HotColumn
+        data="quantity"
+        type="numbro"
+        width={150}
+        className="htRight"
+        numericFormat={{ pattern: '0,0', culture: 'en-US' }}
+      />
+      <HotColumn
+        data="cost"
+        type="numbro"
+        width={120}
+        className="htRight"
+        numericFormat={{ pattern: '$0,0.00', culture: 'en-US' }}
+      />
+    </HotTable>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/cell-types/numbro/react/example1.tsx
+++ b/docs/content/recipes/cell-types/numbro/react/example1.tsx
@@ -1,0 +1,256 @@
+import { HotTable, HotColumn } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import { rendererFactory, getRenderer } from 'handsontable/renderers';
+import { getEditor } from 'handsontable/editors';
+import { getValidator } from 'handsontable/validators';
+import { registerCellType } from 'handsontable/cellTypes';
+import numbro from 'numbro';
+import languages from 'numbro/dist/languages.min.js';
+
+registerAllModules();
+Object.values(languages).forEach((language) => numbro.registerLanguage(language as numbro.NumbroLanguage));
+
+function isNumeric(value: unknown): boolean {
+  const type = typeof value;
+
+  if (type === 'number') {
+    return !isNaN(value as number) && isFinite(value as number);
+  } else if (type === 'string') {
+    const str = value as string;
+
+    if (str.length === 0) {
+      return false;
+    } else if (str.length === 1) {
+      return /\d/.test(str);
+    }
+
+    const delimiter = Array.from(new Set(['.']))
+      .map((d) => `\\${d}`)
+      .join('|');
+
+    return new RegExp(`^[+-]?(((${delimiter})?\\d+((${delimiter})\\d+)?(e[+-]?\\d+)?)|(0x[a-f\\d]+))$`, 'i').test(
+      str.trim()
+    );
+  } else if (type === 'object') {
+    return !!value && typeof (value as object).valueOf() === 'number' && !(value instanceof Date);
+  }
+
+  return false;
+}
+
+const cellTypeDefinition = {
+  renderer: rendererFactory(({ hotInstance, td, row, col, prop, value, cellProperties }) => {
+    if (isNumeric(value)) {
+      let classArr: string[] = [];
+
+      if (Array.isArray(cellProperties.className)) {
+        classArr = cellProperties.className as string[];
+      } else {
+        const className = (cellProperties.className as string) ?? '';
+
+        if (className.length) {
+          classArr = className.split(' ');
+        }
+      }
+
+      const numericFormat = cellProperties.numericFormat as { culture?: string; pattern?: string } | undefined;
+      const cellCulture = (numericFormat && numericFormat.culture) || 'en-US';
+      const cellFormatPattern = numericFormat && numericFormat.pattern;
+
+      if (cellCulture && !numbro.languages()[cellCulture]) {
+        const shortTag = cellCulture.replace('-', '');
+        const langData = (numbro as any).allLanguages ? (numbro as any).allLanguages[cellCulture] : (numbro as any)[shortTag];
+
+        if (langData) {
+          numbro.registerLanguage(langData);
+        }
+      }
+
+      numbro.setLanguage(cellCulture);
+      value = numbro(value as number).format(cellFormatPattern ?? '0');
+
+      if (
+        classArr.indexOf('htLeft') < 0 &&
+        classArr.indexOf('htCenter') < 0 &&
+        classArr.indexOf('htRight') < 0 &&
+        classArr.indexOf('htJustify') < 0
+      ) {
+        classArr.push('htRight');
+      }
+
+      if (classArr.indexOf('htNumeric') < 0) {
+        classArr.push('htNumeric');
+      }
+
+      cellProperties.className = classArr.join(' ');
+      td.dir = 'ltr';
+    }
+
+    getRenderer('text')(hotInstance, td, row, col, prop, value, cellProperties);
+  }),
+  validator: getValidator('numeric'),
+  editor: getEditor('numeric'),
+};
+
+registerCellType('numbro', cellTypeDefinition);
+
+/* start:skip-in-preview */
+interface InventoryItem {
+  id: number;
+  itemName: string;
+  itemNo: string;
+  leadEngineer: string;
+  cost: number;
+  inStock: boolean;
+  category: string;
+  itemQuality: number;
+  origin: string;
+  quantity: number;
+  valueStock: number;
+  repairable: boolean;
+  supplierName: string;
+  restockDate: string;
+  operationalStatus: string;
+}
+
+const data: InventoryItem[] = [
+  {
+    id: 640329,
+    itemName: 'Lunar Core',
+    itemNo: 'XJ-12',
+    leadEngineer: 'Ellen Ripley',
+    cost: 350000,
+    inStock: true,
+    category: 'Lander',
+    itemQuality: 87,
+    origin: '🇺🇸 USA',
+    quantity: 2,
+    valueStock: 700000,
+    repairable: false,
+    supplierName: 'TechNova',
+    restockDate: '2025-08-01',
+    operationalStatus: 'Awaiting Parts',
+  },
+  {
+    id: 863104,
+    itemName: 'Zero Thrusters',
+    itemNo: 'QL-54',
+    leadEngineer: 'Sam Bell',
+    cost: 450000,
+    inStock: false,
+    category: 'Propulsion',
+    itemQuality: 0,
+    origin: '🇩🇪 Germany',
+    quantity: 0,
+    valueStock: 0,
+    repairable: true,
+    supplierName: 'PropelMax',
+    restockDate: '2025-09-15',
+    operationalStatus: 'In Maintenance',
+  },
+  {
+    id: 395603,
+    itemName: 'EVA Suits',
+    itemNo: 'PM-67',
+    leadEngineer: 'Alex Rogan',
+    cost: 150000,
+    inStock: true,
+    category: 'Equipment',
+    itemQuality: 79,
+    origin: '🇮🇹 Italy',
+    quantity: 50,
+    valueStock: 7500000,
+    repairable: true,
+    supplierName: 'SuitCraft',
+    restockDate: '2025-10-05',
+    operationalStatus: 'Ready for Testing',
+  },
+  {
+    id: 679083,
+    itemName: 'Solar Panels',
+    itemNo: 'BW-09',
+    leadEngineer: 'Dave Bowman',
+    cost: 75000,
+    inStock: true,
+    category: 'Energy',
+    itemQuality: 95,
+    origin: '🇺🇸 USA',
+    quantity: 10,
+    valueStock: 750000,
+    repairable: false,
+    supplierName: 'SolarStream',
+    restockDate: '2025-11-10',
+    operationalStatus: 'Operational',
+  },
+  {
+    id: 912663,
+    itemName: 'Comm Array',
+    itemNo: 'ZR-56',
+    leadEngineer: 'Louise Banks',
+    cost: 125000,
+    inStock: false,
+    category: 'Communication',
+    itemQuality: 0,
+    origin: '🇯🇵 Japan',
+    quantity: 0,
+    valueStock: 0,
+    repairable: true,
+    supplierName: 'CommTech',
+    restockDate: '2025-12-20',
+    operationalStatus: 'Decommissioned',
+  },
+  {
+    id: 315806,
+    itemName: 'Habitat Dome',
+    itemNo: 'UJ-23',
+    leadEngineer: 'Dr. Ryan Stone',
+    cost: 1000000,
+    inStock: true,
+    category: 'Shelter',
+    itemQuality: 93,
+    origin: '🇨🇦 Canada',
+    quantity: 3,
+    valueStock: 3000000,
+    repairable: false,
+    supplierName: 'DomeInnovate',
+    restockDate: '2026-01-25',
+    operationalStatus: 'Operational',
+  },
+];
+/* end:skip-in-preview */
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={data}
+      colHeaders={['Item Name', 'Category', 'Lead Engineer', 'Quantity', 'Cost']}
+      autoRowSize={true}
+      rowHeaders={true}
+      height="auto"
+      width="100%"
+      autoWrapRow={true}
+      headerClassName="htLeft"
+      licenseKey="non-commercial-and-evaluation"
+    >
+      <HotColumn data="itemName" type="text" width={130} />
+      <HotColumn data="category" type="text" width={120} />
+      <HotColumn data="leadEngineer" type="text" width={150} />
+      <HotColumn
+        data="quantity"
+        type="numbro"
+        width={150}
+        className="htRight"
+        numericFormat={{ pattern: '0,0', culture: 'en-US' }}
+      />
+      <HotColumn
+        data="cost"
+        type="numbro"
+        width={120}
+        className="htRight"
+        numericFormat={{ pattern: '$0,0.00', culture: 'en-US' }}
+      />
+    </HotTable>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/cell-types/pikaday/pikaday.md
+++ b/docs/content/recipes/cell-types/pikaday/pikaday.md
@@ -34,6 +34,18 @@ This tutorial shows you how to integrate the Pikaday date picker as a custom Han
 
 :::
 
+::: only-for react
+
+::: example #example1 :react-advanced --css 1 --js 2 --ts 3 --deps moment @handsontable/pikaday
+
+@[code](@/content/recipes/cell-types/pikaday/react/example1.css)
+@[code](@/content/recipes/cell-types/pikaday/react/example1.jsx)
+@[code](@/content/recipes/cell-types/pikaday/react/example1.tsx)
+
+:::
+
+:::
+
 ## Overview
 
 This guide shows how to create a custom date picker cell using [Pikaday](https://github.com/Pikaday/Pikaday), a lightweight, no-dependencies date picker library. **This guide is essential for migration** - the built-in `date` cell type with Pikaday will be removed in the next Handsontable release. Use this recipe to maintain Pikaday functionality in your application.

--- a/docs/content/recipes/cell-types/pikaday/react/example1.css
+++ b/docs/content/recipes/cell-types/pikaday/react/example1.css
@@ -1,0 +1,25 @@
+.ht_editor_visible > input {
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box !important;
+  border: none;
+  border-radius: 0;
+  outline: none;
+  margin-top: -1px;
+  margin-left: -1px;
+  box-shadow: inset 0 0 0 var(--ht-cell-editor-border-width, 2px)
+    var(--ht-cell-editor-border-color, #1a42e8),
+    0 0 var(--ht-cell-editor-shadow-blur-radius, 0) 0
+    var(--ht-cell-editor-shadow-color, transparent) !important;
+  background-color: var(--ht-cell-editor-background-color, #ffffff) !important;
+  padding: var(--ht-cell-vertical-padding, 4px)
+    var(--ht-cell-horizontal-padding, 8px) !important;
+  border: none !important;
+  font-family: inherit;
+  font-size: var(--ht-font-size);
+  line-height: var(--ht-line-height);
+}
+.ht_editor_visible > input:focus-visible {
+  border: none !important;
+  outline: none !important;
+}

--- a/docs/content/recipes/cell-types/pikaday/react/example1.jsx
+++ b/docs/content/recipes/cell-types/pikaday/react/example1.jsx
@@ -1,0 +1,412 @@
+import { HotTable, HotColumn } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import moment from 'moment';
+import Pikaday from '@handsontable/pikaday';
+import { editorFactory } from 'handsontable/editors';
+import { rendererFactory } from 'handsontable/renderers';
+import Handsontable from 'handsontable/base';
+import './example1.css';
+
+registerAllModules();
+
+const DATE_FORMAT_US = 'MM/DD/YYYY';
+const DEFAULT_DATE_FORMAT = DATE_FORMAT_US;
+
+const pikadayRenderer = rendererFactory(({ td, value, cellProperties }) => {
+  td.innerText = moment(new Date(value), cellProperties.renderFormat).format(cellProperties.renderFormat);
+});
+
+const pikadayEditor = editorFactory({
+  position: 'portal',
+  shortcuts: [
+    {
+      keys: [['ArrowLeft']],
+      callback: (editor, _event) => {
+        // @ts-ignore
+        editor.pickaday.adjustDate('subtract', 1);
+        _event.preventDefault();
+      },
+    },
+    {
+      keys: [['ArrowRight']],
+      callback: (editor, _event) => {
+        // @ts-ignore
+        editor.pickaday.adjustDate('add', 1);
+        _event.preventDefault();
+      },
+    },
+    {
+      keys: [['ArrowUp']],
+      callback: (editor, _event) => {
+        // @ts-ignore
+        editor.pickaday.adjustDate('subtract', 7);
+        _event.preventDefault();
+      },
+    },
+    {
+      keys: [['ArrowDown']],
+      callback: (editor, _event) => {
+        // @ts-ignore
+        editor.pickaday.adjustDate('add', 7);
+        _event.preventDefault();
+      },
+    },
+  ],
+  init(editor) {
+    editor.parentDestroyed = false;
+    editor.input = editor.hot.rootDocument.createElement('INPUT');
+    editor.datePicker = editor.container;
+    editor.hot.rootDocument.addEventListener('mousedown', (event) => {
+      if (event.target && event.target.classList.contains('pika-day')) {
+        editor.hideDatepicker(editor);
+      }
+    });
+  },
+  getDatePickerConfig(editor) {
+    const htInput = editor.input;
+    const options = {};
+
+    if (editor.cellProperties && editor.cellProperties.datePickerConfig) {
+      Object.assign(options, editor.cellProperties.datePickerConfig);
+    }
+
+    const origOnSelect = options.onSelect;
+    const origOnClose = options.onClose;
+
+    options.field = htInput;
+    options.trigger = htInput;
+    options.container = editor.datePicker;
+    options.bound = false;
+    options.keyboardInput = false;
+    options.format = options.format ?? editor.getDateFormat(editor);
+    options.reposition = options.reposition || false;
+    options.isRTL = false;
+    options.onSelect = function (date) {
+      let dateStr;
+
+      if (!isNaN(date.getTime())) {
+        dateStr = moment(date).format(editor.getDateFormat(editor));
+      }
+
+      editor.setValue(dateStr);
+
+      if (origOnSelect) {
+        origOnSelect.call(editor.pickaday, date);
+      }
+
+      if (Handsontable.helper.isMobileBrowser()) {
+        editor.hideDatepicker(editor);
+      }
+    };
+    options.onClose = () => {
+      if (!editor.parentDestroyed) {
+        editor.finishEditing(false);
+      }
+
+      if (origOnClose) {
+        origOnClose();
+      }
+    };
+
+    return options;
+  },
+  hideDatepicker(editor) {
+    editor.pickaday.hide();
+  },
+  showDatepicker(editor, event) {
+    const dateFormat = editor.getDateFormat(editor);
+    // @ts-ignore
+    const isMouseDown = editor.hot.view.isMouseDown();
+    const isMeta = event && 'keyCode' in event ? Handsontable.helper.isFunctionKey(event.keyCode) : false;
+
+    let dateStr;
+
+    editor.datePicker.style.display = 'block';
+    editor.pickaday = new Pikaday(editor.getDatePickerConfig(editor));
+
+    // @ts-ignore
+    if (typeof editor.pickaday.useMoment === 'function') {
+      // @ts-ignore
+      editor.pickaday.useMoment(moment);
+    }
+
+    // @ts-ignore
+    editor.pickaday._onInputFocus = function () {};
+
+    if (editor.originalValue) {
+      dateStr = editor.originalValue;
+
+      if (moment(dateStr, dateFormat, true).isValid()) {
+        editor.pickaday.setMoment(moment(dateStr, dateFormat), true);
+      }
+
+      if (editor.getValue() !== editor.originalValue) {
+        editor.setValue(editor.originalValue);
+      }
+
+      if (!isMeta && !isMouseDown) {
+        editor.setValue('');
+      }
+    } else if (editor.cellProperties.defaultDate) {
+      dateStr = editor.cellProperties.defaultDate;
+
+      if (moment(dateStr, dateFormat, true).isValid()) {
+        editor.pickaday.setMoment(moment(dateStr, dateFormat), true);
+      }
+
+      if (!isMeta && !isMouseDown) {
+        editor.setValue('');
+      }
+    } else {
+      editor.pickaday.gotoToday();
+    }
+  },
+  afterClose(editor) {
+    if (editor.pickaday.destroy) {
+      editor.pickaday.destroy();
+    }
+  },
+  afterOpen(editor, event) {
+    const cellRect = editor.TD.getBoundingClientRect();
+
+    editor.input.style.width = `${cellRect.width}px`;
+    editor.input.style.height = `${cellRect.height}px`;
+    editor.showDatepicker(editor, event);
+  },
+  getValue(editor) {
+    return editor.input.value;
+  },
+  setValue(editor, value) {
+    editor.input.value = value;
+  },
+  getDateFormat(editor) {
+    return editor.cellProperties.dateFormat ?? DEFAULT_DATE_FORMAT;
+  },
+});
+
+/* start:skip-in-preview */
+const inputData = [
+  {
+    id: 640329,
+    itemName: 'Lunar Core',
+    itemNo: 'XJ-12',
+    leadEngineer: 'Ellen Ripley',
+    cost: 350000,
+    inStock: true,
+    category: 'Lander',
+    itemQuality: 87,
+    origin: '🇺🇸 USA',
+    quantity: 2,
+    valueStock: 700000,
+    repairable: false,
+    supplierName: 'TechNova',
+    restockDate: '2025-08-01',
+    operationalStatus: 'Awaiting Parts',
+  },
+  {
+    id: 863104,
+    itemName: 'Zero Thrusters',
+    itemNo: 'QL-54',
+    leadEngineer: 'Sam Bell',
+    cost: 450000,
+    inStock: false,
+    category: 'Propulsion',
+    itemQuality: 0,
+    origin: '🇩🇪 Germany',
+    quantity: 0,
+    valueStock: 0,
+    repairable: true,
+    supplierName: 'PropelMax',
+    restockDate: '2025-09-15',
+    operationalStatus: 'In Maintenance',
+  },
+  {
+    id: 395603,
+    itemName: 'EVA Suits',
+    itemNo: 'PM-67',
+    leadEngineer: 'Alex Rogan',
+    cost: 150000,
+    inStock: true,
+    category: 'Equipment',
+    itemQuality: 79,
+    origin: '🇮🇹 Italy',
+    quantity: 50,
+    valueStock: 7500000,
+    repairable: true,
+    supplierName: 'SuitCraft',
+    restockDate: '2025-10-05',
+    operationalStatus: 'Ready for Testing',
+  },
+  {
+    id: 679083,
+    itemName: 'Solar Panels',
+    itemNo: 'BW-09',
+    leadEngineer: 'Dave Bowman',
+    cost: 75000,
+    inStock: true,
+    category: 'Energy',
+    itemQuality: 95,
+    origin: '🇺🇸 USA',
+    quantity: 10,
+    valueStock: 750000,
+    repairable: false,
+    supplierName: 'SolarStream',
+    restockDate: '2025-11-10',
+    operationalStatus: 'Operational',
+  },
+  {
+    id: 912663,
+    itemName: 'Comm Array',
+    itemNo: 'ZR-56',
+    leadEngineer: 'Louise Banks',
+    cost: 125000,
+    inStock: false,
+    category: 'Communication',
+    itemQuality: 0,
+    origin: '🇯🇵 Japan',
+    quantity: 0,
+    valueStock: 0,
+    repairable: true,
+    supplierName: 'CommTech',
+    restockDate: '2025-12-20',
+    operationalStatus: 'Decommissioned',
+  },
+  {
+    id: 315806,
+    itemName: 'Habitat Dome',
+    itemNo: 'UJ-23',
+    leadEngineer: 'Dr. Ryan Stone',
+    cost: 1000000,
+    inStock: true,
+    category: 'Shelter',
+    itemQuality: 93,
+    origin: '🇨🇦 Canada',
+    quantity: 3,
+    valueStock: 3000000,
+    repairable: false,
+    supplierName: 'DomeInnovate',
+    restockDate: '2026-01-25',
+    operationalStatus: 'Operational',
+  },
+  {
+    id: 954632,
+    itemName: 'Oxygen Unit',
+    itemNo: 'FK-87',
+    leadEngineer: 'Dr. Grace Augustine',
+    cost: 600000,
+    inStock: true,
+    category: 'Life Support',
+    itemQuality: 85,
+    origin: '🇺🇸 USA',
+    quantity: 15,
+    valueStock: 9000000,
+    repairable: true,
+    supplierName: 'OxyGenius',
+    restockDate: '2026-03-02',
+    operationalStatus: 'Awaiting Parts',
+  },
+  {
+    id: 734944,
+    itemName: 'Processing Rig',
+    itemNo: 'LK-13',
+    leadEngineer: 'Jake Sully',
+    cost: 350000,
+    inStock: true,
+    category: 'Mining',
+    itemQuality: 81,
+    origin: '🇦🇺 Australia',
+    quantity: 25,
+    valueStock: 8750000,
+    repairable: true,
+    supplierName: 'RigTech',
+    restockDate: '2026-04-15',
+    operationalStatus: 'Ready for Testing',
+  },
+  {
+    id: 834662,
+    itemName: 'Navigation',
+    itemNo: 'XP-24',
+    leadEngineer: 'Dr. Ellie Arroway',
+    cost: 450000,
+    inStock: true,
+    category: 'Navigation',
+    itemQuality: 89,
+    origin: '🇫🇷 France',
+    quantity: 8,
+    valueStock: 3600000,
+    repairable: false,
+    supplierName: 'NavSolutions',
+    restockDate: '2026-05-30',
+    operationalStatus: 'In Maintenance',
+  },
+  {
+    id: 714329,
+    itemName: 'Surveyor Arm',
+    itemNo: 'QA-86',
+    leadEngineer: 'Mark Watney',
+    cost: 100000,
+    inStock: true,
+    category: 'Exploration',
+    itemQuality: 78,
+    origin: '🇺🇸 USA',
+    quantity: 40,
+    valueStock: 4000000,
+    repairable: true,
+    supplierName: 'ExploreTech',
+    restockDate: '2026-07-12',
+    operationalStatus: 'Decommissioned',
+  },
+];
+
+const data = inputData.map((item) => ({
+  ...item,
+  restockDate: moment(new Date(item.restockDate)).format(DATE_FORMAT_US),
+}));
+/* end:skip-in-preview */
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={data}
+      height="auto"
+      colHeaders={['Item Name', 'Category', 'Lead Engineer', 'Restock Date', 'Cost']}
+      autoRowSize={true}
+      rowHeaders={true}
+      width="100%"
+      autoWrapRow={true}
+      headerClassName="htLeft"
+      licenseKey="non-commercial-and-evaluation"
+    >
+      <HotColumn data="itemName" type="text" width={130} />
+      <HotColumn data="category" type="text" width={120} />
+      <HotColumn data="leadEngineer" type="text" width={150} />
+      <HotColumn
+        data="restockDate"
+        width={150}
+        allowInvalid={false}
+        hotRenderer={pikadayRenderer}
+        hotEditor={pikadayEditor}
+        renderFormat={DATE_FORMAT_US}
+        dateFormat={DATE_FORMAT_US}
+        correctFormat={true}
+        defaultDate="01/01/2020"
+        datePickerConfig={{
+          firstDay: 0,
+          showWeekNumber: true,
+          disableDayFn(date) {
+            return date.getDay() === 0 || date.getDay() === 6;
+          },
+        }}
+      />
+      <HotColumn
+        data="cost"
+        type="numeric"
+        width={120}
+        className="htRight"
+        numericFormat={{ pattern: '$0,0.00', culture: 'en-US' }}
+      />
+    </HotTable>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/cell-types/pikaday/react/example1.tsx
+++ b/docs/content/recipes/cell-types/pikaday/react/example1.tsx
@@ -1,0 +1,440 @@
+import { HotTable, HotColumn } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import moment from 'moment';
+import Pikaday from '@handsontable/pikaday';
+import { editorFactory } from 'handsontable/editors';
+import { rendererFactory } from 'handsontable/renderers';
+import Handsontable from 'handsontable/base';
+import './example1.css';
+
+registerAllModules();
+
+const DATE_FORMAT_US = 'MM/DD/YYYY';
+const DEFAULT_DATE_FORMAT = DATE_FORMAT_US;
+
+interface PikadayEditorInstance {
+  parentDestroyed: boolean;
+  input: HTMLInputElement;
+  datePicker: HTMLElement;
+  pickaday: Pikaday;
+}
+
+const pikadayRenderer = rendererFactory(({ td, value, cellProperties }) => {
+  td.innerText = moment(new Date(value as string), cellProperties.renderFormat).format(cellProperties.renderFormat);
+});
+
+const pikadayEditor = editorFactory<PikadayEditorInstance>({
+  position: 'portal',
+  shortcuts: [
+    {
+      keys: [['ArrowLeft']],
+      callback: (editor, _event) => {
+        // @ts-ignore
+        editor.pickaday.adjustDate('subtract', 1);
+        _event.preventDefault();
+      },
+    },
+    {
+      keys: [['ArrowRight']],
+      callback: (editor, _event) => {
+        // @ts-ignore
+        editor.pickaday.adjustDate('add', 1);
+        _event.preventDefault();
+      },
+    },
+    {
+      keys: [['ArrowUp']],
+      callback: (editor, _event) => {
+        // @ts-ignore
+        editor.pickaday.adjustDate('subtract', 7);
+        _event.preventDefault();
+      },
+    },
+    {
+      keys: [['ArrowDown']],
+      callback: (editor, _event) => {
+        // @ts-ignore
+        editor.pickaday.adjustDate('add', 7);
+        _event.preventDefault();
+      },
+    },
+  ],
+  init(editor) {
+    editor.parentDestroyed = false;
+    editor.input = editor.hot.rootDocument.createElement('INPUT') as HTMLInputElement;
+    editor.datePicker = editor.container;
+    editor.hot.rootDocument.addEventListener('mousedown', (event: MouseEvent) => {
+      const target = event.target as Element;
+
+      if (target && target.classList.contains('pika-day')) {
+        editor.hideDatepicker(editor);
+      }
+    });
+  },
+  getDatePickerConfig(editor: any) {
+    const htInput = editor.input;
+    const options: Record<string, any> = {};
+
+    if (editor.cellProperties && editor.cellProperties.datePickerConfig) {
+      Object.assign(options, editor.cellProperties.datePickerConfig);
+    }
+
+    const origOnSelect = options.onSelect;
+    const origOnClose = options.onClose;
+
+    options.field = htInput;
+    options.trigger = htInput;
+    options.container = editor.datePicker;
+    options.bound = false;
+    options.keyboardInput = false;
+    options.format = options.format ?? editor.getDateFormat(editor);
+    options.reposition = options.reposition || false;
+    options.isRTL = false;
+    options.onSelect = function (date: Date) {
+      let dateStr: string | undefined;
+
+      if (!isNaN(date.getTime())) {
+        dateStr = moment(date).format(editor.getDateFormat(editor));
+      }
+
+      editor.setValue(dateStr);
+
+      if (origOnSelect) {
+        origOnSelect.call(editor.pickaday, date);
+      }
+
+      if (Handsontable.helper.isMobileBrowser()) {
+        editor.hideDatepicker(editor);
+      }
+    };
+    options.onClose = () => {
+      if (!editor.parentDestroyed) {
+        editor.finishEditing(false);
+      }
+
+      if (origOnClose) {
+        origOnClose();
+      }
+    };
+
+    return options;
+  },
+  hideDatepicker(editor: any) {
+    editor.pickaday.hide();
+  },
+  showDatepicker(editor: any, event: Event) {
+    const dateFormat = editor.getDateFormat(editor);
+    // @ts-ignore
+    const isMouseDown = editor.hot.view.isMouseDown();
+    const isMeta =
+      event && 'keyCode' in event ? Handsontable.helper.isFunctionKey((event as KeyboardEvent).keyCode) : false;
+
+    let dateStr: string;
+
+    editor.datePicker.style.display = 'block';
+    editor.pickaday = new Pikaday(editor.getDatePickerConfig(editor));
+
+    // @ts-ignore
+    if (typeof editor.pickaday.useMoment === 'function') {
+      // @ts-ignore
+      editor.pickaday.useMoment(moment);
+    }
+
+    // @ts-ignore
+    editor.pickaday._onInputFocus = function () {};
+
+    if (editor.originalValue) {
+      dateStr = editor.originalValue;
+
+      if (moment(dateStr, dateFormat, true).isValid()) {
+        editor.pickaday.setMoment(moment(dateStr, dateFormat), true);
+      }
+
+      if (editor.getValue() !== editor.originalValue) {
+        editor.setValue(editor.originalValue);
+      }
+
+      if (!isMeta && !isMouseDown) {
+        editor.setValue('');
+      }
+    } else if (editor.cellProperties.defaultDate) {
+      dateStr = editor.cellProperties.defaultDate;
+
+      if (moment(dateStr, dateFormat, true).isValid()) {
+        editor.pickaday.setMoment(moment(dateStr, dateFormat), true);
+      }
+
+      if (!isMeta && !isMouseDown) {
+        editor.setValue('');
+      }
+    } else {
+      editor.pickaday.gotoToday();
+    }
+  },
+  afterClose(editor: any) {
+    if (editor.pickaday.destroy) {
+      editor.pickaday.destroy();
+    }
+  },
+  afterOpen(editor: any, event: Event) {
+    const cellRect = editor.TD.getBoundingClientRect();
+
+    editor.input.style.width = `${cellRect.width}px`;
+    editor.input.style.height = `${cellRect.height}px`;
+    editor.showDatepicker(editor, event);
+  },
+  getValue(editor) {
+    return editor.input.value;
+  },
+  setValue(editor, value) {
+    editor.input.value = value;
+  },
+  getDateFormat(editor: any): string {
+    return editor.cellProperties.dateFormat ?? DEFAULT_DATE_FORMAT;
+  },
+});
+
+/* start:skip-in-preview */
+interface InventoryItem {
+  id: number;
+  itemName: string;
+  itemNo: string;
+  leadEngineer: string;
+  cost: number;
+  inStock: boolean;
+  category: string;
+  itemQuality: number;
+  origin: string;
+  quantity: number;
+  valueStock: number;
+  repairable: boolean;
+  supplierName: string;
+  restockDate: string;
+  operationalStatus: string;
+}
+
+const inputData: InventoryItem[] = [
+  {
+    id: 640329,
+    itemName: 'Lunar Core',
+    itemNo: 'XJ-12',
+    leadEngineer: 'Ellen Ripley',
+    cost: 350000,
+    inStock: true,
+    category: 'Lander',
+    itemQuality: 87,
+    origin: '🇺🇸 USA',
+    quantity: 2,
+    valueStock: 700000,
+    repairable: false,
+    supplierName: 'TechNova',
+    restockDate: '2025-08-01',
+    operationalStatus: 'Awaiting Parts',
+  },
+  {
+    id: 863104,
+    itemName: 'Zero Thrusters',
+    itemNo: 'QL-54',
+    leadEngineer: 'Sam Bell',
+    cost: 450000,
+    inStock: false,
+    category: 'Propulsion',
+    itemQuality: 0,
+    origin: '🇩🇪 Germany',
+    quantity: 0,
+    valueStock: 0,
+    repairable: true,
+    supplierName: 'PropelMax',
+    restockDate: '2025-09-15',
+    operationalStatus: 'In Maintenance',
+  },
+  {
+    id: 395603,
+    itemName: 'EVA Suits',
+    itemNo: 'PM-67',
+    leadEngineer: 'Alex Rogan',
+    cost: 150000,
+    inStock: true,
+    category: 'Equipment',
+    itemQuality: 79,
+    origin: '🇮🇹 Italy',
+    quantity: 50,
+    valueStock: 7500000,
+    repairable: true,
+    supplierName: 'SuitCraft',
+    restockDate: '2025-10-05',
+    operationalStatus: 'Ready for Testing',
+  },
+  {
+    id: 679083,
+    itemName: 'Solar Panels',
+    itemNo: 'BW-09',
+    leadEngineer: 'Dave Bowman',
+    cost: 75000,
+    inStock: true,
+    category: 'Energy',
+    itemQuality: 95,
+    origin: '🇺🇸 USA',
+    quantity: 10,
+    valueStock: 750000,
+    repairable: false,
+    supplierName: 'SolarStream',
+    restockDate: '2025-11-10',
+    operationalStatus: 'Operational',
+  },
+  {
+    id: 912663,
+    itemName: 'Comm Array',
+    itemNo: 'ZR-56',
+    leadEngineer: 'Louise Banks',
+    cost: 125000,
+    inStock: false,
+    category: 'Communication',
+    itemQuality: 0,
+    origin: '🇯🇵 Japan',
+    quantity: 0,
+    valueStock: 0,
+    repairable: true,
+    supplierName: 'CommTech',
+    restockDate: '2025-12-20',
+    operationalStatus: 'Decommissioned',
+  },
+  {
+    id: 315806,
+    itemName: 'Habitat Dome',
+    itemNo: 'UJ-23',
+    leadEngineer: 'Dr. Ryan Stone',
+    cost: 1000000,
+    inStock: true,
+    category: 'Shelter',
+    itemQuality: 93,
+    origin: '🇨🇦 Canada',
+    quantity: 3,
+    valueStock: 3000000,
+    repairable: false,
+    supplierName: 'DomeInnovate',
+    restockDate: '2026-01-25',
+    operationalStatus: 'Operational',
+  },
+  {
+    id: 954632,
+    itemName: 'Oxygen Unit',
+    itemNo: 'FK-87',
+    leadEngineer: 'Dr. Grace Augustine',
+    cost: 600000,
+    inStock: true,
+    category: 'Life Support',
+    itemQuality: 85,
+    origin: '🇺🇸 USA',
+    quantity: 15,
+    valueStock: 9000000,
+    repairable: true,
+    supplierName: 'OxyGenius',
+    restockDate: '2026-03-02',
+    operationalStatus: 'Awaiting Parts',
+  },
+  {
+    id: 734944,
+    itemName: 'Processing Rig',
+    itemNo: 'LK-13',
+    leadEngineer: 'Jake Sully',
+    cost: 350000,
+    inStock: true,
+    category: 'Mining',
+    itemQuality: 81,
+    origin: '🇦🇺 Australia',
+    quantity: 25,
+    valueStock: 8750000,
+    repairable: true,
+    supplierName: 'RigTech',
+    restockDate: '2026-04-15',
+    operationalStatus: 'Ready for Testing',
+  },
+  {
+    id: 834662,
+    itemName: 'Navigation',
+    itemNo: 'XP-24',
+    leadEngineer: 'Dr. Ellie Arroway',
+    cost: 450000,
+    inStock: true,
+    category: 'Navigation',
+    itemQuality: 89,
+    origin: '🇫🇷 France',
+    quantity: 8,
+    valueStock: 3600000,
+    repairable: false,
+    supplierName: 'NavSolutions',
+    restockDate: '2026-05-30',
+    operationalStatus: 'In Maintenance',
+  },
+  {
+    id: 714329,
+    itemName: 'Surveyor Arm',
+    itemNo: 'QA-86',
+    leadEngineer: 'Mark Watney',
+    cost: 100000,
+    inStock: true,
+    category: 'Exploration',
+    itemQuality: 78,
+    origin: '🇺🇸 USA',
+    quantity: 40,
+    valueStock: 4000000,
+    repairable: true,
+    supplierName: 'ExploreTech',
+    restockDate: '2026-07-12',
+    operationalStatus: 'Decommissioned',
+  },
+];
+
+const data = inputData.map((item) => ({
+  ...item,
+  restockDate: moment(new Date(item.restockDate)).format(DATE_FORMAT_US),
+}));
+/* end:skip-in-preview */
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={data}
+      height="auto"
+      colHeaders={['Item Name', 'Category', 'Lead Engineer', 'Restock Date', 'Cost']}
+      autoRowSize={true}
+      rowHeaders={true}
+      width="100%"
+      autoWrapRow={true}
+      headerClassName="htLeft"
+      licenseKey="non-commercial-and-evaluation"
+    >
+      <HotColumn data="itemName" type="text" width={130} />
+      <HotColumn data="category" type="text" width={120} />
+      <HotColumn data="leadEngineer" type="text" width={150} />
+      <HotColumn
+        data="restockDate"
+        width={150}
+        allowInvalid={false}
+        hotRenderer={pikadayRenderer}
+        hotEditor={pikadayEditor}
+        renderFormat={DATE_FORMAT_US}
+        dateFormat={DATE_FORMAT_US}
+        correctFormat={true}
+        defaultDate="01/01/2020"
+        datePickerConfig={{
+          firstDay: 0,
+          showWeekNumber: true,
+          disableDayFn(date: Date) {
+            return date.getDay() === 0 || date.getDay() === 6;
+          },
+        }}
+      />
+      <HotColumn
+        data="cost"
+        type="numeric"
+        width={120}
+        className="htRight"
+        numericFormat={{ pattern: '$0,0.00', culture: 'en-US' }}
+      />
+    </HotTable>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/cell-types/rating/rating.md
+++ b/docs/content/recipes/cell-types/rating/rating.md
@@ -34,6 +34,18 @@ This tutorial shows you how to build an interactive SVG star rating cell using `
 
 :::
 
+::: only-for react
+
+::: example #example1 :react-advanced --css 1 --js 2 --ts 3
+
+@[code](@/content/recipes/cell-types/rating/react/example1.css)
+@[code](@/content/recipes/cell-types/rating/react/example1.jsx)
+@[code](@/content/recipes/cell-types/rating/react/example1.tsx)
+
+:::
+
+:::
+
 ## Overview
 
 This guide shows how to create an interactive star rating cell using inline SVG stars. Perfect for product ratings, review scores, or any scenario where users need to provide a 1-5 star rating.

--- a/docs/content/recipes/cell-types/rating/react/example1.css
+++ b/docs/content/recipes/cell-types/rating/react/example1.css
@@ -1,0 +1,45 @@
+.rating-cell {
+  display: flex;
+  align-items: center;
+  margin: 3px 0 0 -1px;
+}
+
+.rating-star {
+  color: var(--ht-background-secondary-color, #e0e0e0 );
+  cursor: default;
+  display: inline-flex;
+  align-items: center;
+}
+
+.rating-star.active {
+  color: #facc15;
+}
+
+.rating-editor {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box !important;
+  border: none;
+  border-radius: 0;
+  box-shadow: inset 0 0 0 var(--ht-cell-editor-border-width, 2px)
+    var(--ht-cell-editor-border-color, #1a42e8),
+    0 0 var(--ht-cell-editor-shadow-blur-radius, 0) 0
+    var(--ht-cell-editor-shadow-color, transparent);
+  background-color: var(--ht-cell-editor-background-color, #ffffff);
+  padding: var(--ht-cell-vertical-padding, 4px)
+    var(--ht-cell-horizontal-padding, 8px);
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  cursor: pointer;
+}
+
+.rating-editor .rating-star {
+  cursor: pointer;
+}
+
+.rating-editor .rating-star.current {
+  color: var(--ht-accent-color, #1a42e8);
+}

--- a/docs/content/recipes/cell-types/rating/react/example1.jsx
+++ b/docs/content/recipes/cell-types/rating/react/example1.jsx
@@ -1,0 +1,117 @@
+import { HotTable, HotColumn } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import { editorFactory } from 'handsontable/editors';
+import { rendererFactory } from 'handsontable/renderers';
+import './example1.css';
+
+registerAllModules();
+
+const starSvg =
+  '<svg width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>';
+
+const ratingRenderer = rendererFactory(({ td, value }) => {
+  td.innerHTML = `<div class="rating-cell">${Array.from(
+    { length: 5 },
+    (_, index) => `<span class="rating-star ${index < value ? 'active' : ''}">${starSvg}</span>`
+  ).join('')}</div>`;
+});
+
+const ratingValidator = (value, callback) => {
+  value = parseInt(value);
+  callback(value >= 0 && value <= 100);
+};
+
+const ratingEditor = editorFactory({
+  shortcuts: [
+    {
+      keys: [['1'], ['2'], ['3'], ['4'], ['5']],
+      callback: (editor, _event) => {
+        editor.setValue(_event.key);
+      },
+    },
+    {
+      keys: [['ArrowRight']],
+      callback: (editor, _event) => {
+        if (parseInt(editor.value) < 5) {
+          editor.setValue(parseInt(editor.value) + 1);
+        }
+      },
+    },
+    {
+      keys: [['ArrowLeft']],
+      callback: (editor, _event) => {
+        if (parseInt(editor.value) > 1) {
+          editor.setValue(parseInt(editor.value) - 1);
+        }
+      },
+    },
+  ],
+  init(editor) {
+    editor.input = editor.hot.rootDocument.createElement('DIV');
+    editor.input.classList.add('rating-editor');
+  },
+  afterInit(editor) {
+    editor.input.addEventListener('mouseover', (event) => {
+      const star = event.target.closest('.rating-star');
+
+      if (star?.dataset.value && parseInt(editor.value) !== parseInt(star.dataset.value)) {
+        editor.setValue(star.dataset.value);
+      }
+    });
+    editor.input.addEventListener('mousedown', () => {
+      editor.finishEditing();
+    });
+  },
+  render(editor) {
+    editor.input.innerHTML = Array.from(
+      { length: 5 },
+      (_, index) =>
+        `<span data-value="${index + 1}" class="rating-star ${index < editor.value ? 'active' : ''}${
+          index + 1 === parseInt(editor.value) ? ' current' : ''
+        }">${starSvg}</span>`
+    ).join('');
+  },
+});
+
+/* start:skip-in-preview */
+const data = [
+  { product: 'Dashboard Pro', category: 'Analytics', rating: 5, reviews: 342, price: 49 },
+  { product: 'Form Builder', category: 'Tools', rating: 4, reviews: 218, price: 29 },
+  { product: 'Chart Engine', category: 'Analytics', rating: 3, reviews: 156, price: 39 },
+  { product: 'Auth Module', category: 'Security', rating: 5, reviews: 89, price: 19 },
+  { product: 'File Manager', category: 'Storage', rating: 2, reviews: 64, price: 15 },
+  { product: 'Email Service', category: 'Communication', rating: 4, reviews: 275, price: 25 },
+  { product: 'Search Index', category: 'Tools', rating: 1, reviews: 31, price: 35 },
+  { product: 'Cache Layer', category: 'Infra', rating: 4, reviews: 112, price: 20 },
+];
+/* end:skip-in-preview */
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={data}
+      colHeaders={['Product', 'Category', 'Rating', 'Reviews', 'Price']}
+      autoRowSize={true}
+      rowHeaders={true}
+      height="auto"
+      width="100%"
+      autoWrapRow={true}
+      headerClassName="htLeft"
+      licenseKey="non-commercial-and-evaluation"
+    >
+      <HotColumn data="product" type="text" width={240} />
+      <HotColumn data="category" type="text" width={120} />
+      <HotColumn
+        data="rating"
+        width={150}
+        hotRenderer={ratingRenderer}
+        hotEditor={ratingEditor}
+        validator={ratingValidator}
+      />
+      <HotColumn data="reviews" type="numeric" width={80} />
+      <HotColumn data="price" type="numeric" width={80} />
+    </HotTable>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/cell-types/rating/react/example1.tsx
+++ b/docs/content/recipes/cell-types/rating/react/example1.tsx
@@ -1,0 +1,131 @@
+import { HotTable, HotColumn } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import { editorFactory } from 'handsontable/editors';
+import { rendererFactory } from 'handsontable/renderers';
+import './example1.css';
+
+registerAllModules();
+
+const starSvg =
+  '<svg width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>';
+
+interface RatingEditorInstance {
+  input: HTMLDivElement;
+  value: number | string;
+}
+
+const ratingRenderer = rendererFactory(({ td, value }) => {
+  td.innerHTML = `<div class="rating-cell">${Array.from(
+    { length: 5 },
+    (_, index) => `<span class="rating-star ${index < (value as number) ? 'active' : ''}">${starSvg}</span>`
+  ).join('')}</div>`;
+});
+
+const ratingValidator = (value: unknown, callback: (valid: boolean) => void) => {
+  const num = parseInt(String(value));
+
+  callback(num >= 0 && num <= 100);
+};
+
+const ratingEditor = editorFactory<RatingEditorInstance>({
+  shortcuts: [
+    {
+      keys: [['1'], ['2'], ['3'], ['4'], ['5']],
+      callback: (editor, _event) => {
+        editor.setValue((_event as KeyboardEvent).key);
+      },
+    },
+    {
+      keys: [['ArrowRight']],
+      callback: (editor, _event) => {
+        if (parseInt(String(editor.value)) < 5) {
+          editor.setValue(parseInt(String(editor.value)) + 1);
+        }
+      },
+    },
+    {
+      keys: [['ArrowLeft']],
+      callback: (editor, _event) => {
+        if (parseInt(String(editor.value)) > 1) {
+          editor.setValue(parseInt(String(editor.value)) - 1);
+        }
+      },
+    },
+  ],
+  init(editor) {
+    editor.input = editor.hot.rootDocument.createElement('DIV') as HTMLDivElement;
+    editor.input.classList.add('rating-editor');
+  },
+  afterInit(editor) {
+    editor.input.addEventListener('mouseover', (event: MouseEvent) => {
+      const star = (event.target as Element).closest('.rating-star') as HTMLElement | null;
+
+      if (star?.dataset.value && parseInt(String(editor.value)) !== parseInt(star.dataset.value)) {
+        editor.setValue(star.dataset.value);
+      }
+    });
+    editor.input.addEventListener('mousedown', () => {
+      editor.finishEditing();
+    });
+  },
+  render(editor) {
+    editor.input.innerHTML = Array.from(
+      { length: 5 },
+      (_, index) =>
+        `<span data-value="${index + 1}" class="rating-star ${index < (editor.value as number) ? 'active' : ''}${
+          index + 1 === parseInt(String(editor.value)) ? ' current' : ''
+        }">${starSvg}</span>`
+    ).join('');
+  },
+});
+
+/* start:skip-in-preview */
+interface ProductRow {
+  product: string;
+  category: string;
+  rating: number;
+  reviews: number;
+  price: number;
+}
+
+const data: ProductRow[] = [
+  { product: 'Dashboard Pro', category: 'Analytics', rating: 5, reviews: 342, price: 49 },
+  { product: 'Form Builder', category: 'Tools', rating: 4, reviews: 218, price: 29 },
+  { product: 'Chart Engine', category: 'Analytics', rating: 3, reviews: 156, price: 39 },
+  { product: 'Auth Module', category: 'Security', rating: 5, reviews: 89, price: 19 },
+  { product: 'File Manager', category: 'Storage', rating: 2, reviews: 64, price: 15 },
+  { product: 'Email Service', category: 'Communication', rating: 4, reviews: 275, price: 25 },
+  { product: 'Search Index', category: 'Tools', rating: 1, reviews: 31, price: 35 },
+  { product: 'Cache Layer', category: 'Infra', rating: 4, reviews: 112, price: 20 },
+];
+/* end:skip-in-preview */
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={data}
+      colHeaders={['Product', 'Category', 'Rating', 'Reviews', 'Price']}
+      autoRowSize={true}
+      rowHeaders={true}
+      height="auto"
+      width="100%"
+      autoWrapRow={true}
+      headerClassName="htLeft"
+      licenseKey="non-commercial-and-evaluation"
+    >
+      <HotColumn data="product" type="text" width={240} />
+      <HotColumn data="category" type="text" width={120} />
+      <HotColumn
+        data="rating"
+        width={150}
+        hotRenderer={ratingRenderer}
+        hotEditor={ratingEditor}
+        validator={ratingValidator}
+      />
+      <HotColumn data="reviews" type="numeric" width={80} />
+      <HotColumn data="price" type="numeric" width={80} />
+    </HotTable>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/cell-types/react-rating/react/example1.jsx
+++ b/docs/content/recipes/cell-types/react-rating/react/example1.jsx
@@ -1,6 +1,7 @@
 import { HotTable, HotColumn, EditorComponent } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
 import StarRatingComponent from 'react-star-rating-component';
+import './example1.css';
 
 registerAllModules();
 

--- a/docs/content/recipes/cell-types/react-rating/react/example1.tsx
+++ b/docs/content/recipes/cell-types/react-rating/react/example1.tsx
@@ -1,6 +1,7 @@
 import { HotTable, HotColumn, EditorComponent } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
 import StarRatingComponent from 'react-star-rating-component';
+import './example1.css';
 
 registerAllModules();
 

--- a/docs/content/recipes/column-management/column-visibility/column-visibility.md
+++ b/docs/content/recipes/column-management/column-visibility/column-visibility.md
@@ -25,6 +25,17 @@ category: Column Management
 
 :::
 
+::: only-for react
+
+::: example #example1 :react-advanced --js 1 --ts 2
+
+@[code](@/content/recipes/column-management/column-visibility/react/example1.jsx)
+@[code](@/content/recipes/column-management/column-visibility/react/example1.tsx)
+
+:::
+
+:::
+
 ## Overview
 
 **Difficulty:** Beginner

--- a/docs/content/recipes/column-management/column-visibility/react/example1.jsx
+++ b/docs/content/recipes/column-management/column-visibility/react/example1.jsx
@@ -1,0 +1,136 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+/* start:skip-in-preview */
+const data = [
+  { name: 'Alice Johnson', department: 'Engineering', role: 'Senior Engineer', salary: 95000, startDate: '2019-03-12', location: 'New York', status: 'Active' },
+  { name: 'Bob Martinez', department: 'Marketing', role: 'Marketing Manager', salary: 78000, startDate: '2020-07-01', location: 'Chicago', status: 'Active' },
+  { name: 'Carol Lee', department: 'Engineering', role: 'Tech Lead', salary: 115000, startDate: '2017-11-15', location: 'San Francisco', status: 'Active' },
+  { name: 'David Kim', department: 'HR', role: 'HR Specialist', salary: 65000, startDate: '2021-02-28', location: 'Austin', status: 'On Leave' },
+  { name: 'Eva Novak', department: 'Finance', role: 'Financial Analyst', salary: 82000, startDate: '2018-09-03', location: 'New York', status: 'Active' },
+  { name: 'Frank Chen', department: 'Engineering', role: 'Junior Engineer', salary: 72000, startDate: '2022-05-16', location: 'Seattle', status: 'Active' },
+  { name: 'Grace Okafor', department: 'Sales', role: 'Sales Executive', salary: 70000, startDate: '2020-01-20', location: 'Dallas', status: 'Active' },
+  { name: 'Henry Walsh', department: 'Finance', role: 'Finance Director', salary: 130000, startDate: '2015-06-10', location: 'Chicago', status: 'Active' },
+];
+/* end:skip-in-preview */
+
+// The full columns config is the immutable source of truth.
+// Never mutate this array -- always derive a visible subset from it.
+const allColumns = [
+  { data: 'name', title: 'Name', type: 'text', width: 140 },
+  { data: 'department', title: 'Department', type: 'text', width: 120 },
+  { data: 'role', title: 'Role', type: 'text', width: 150 },
+  {
+    data: 'salary',
+    title: 'Salary',
+    type: 'numeric',
+    numericFormat: { pattern: '$0,0', culture: 'en-US' },
+    width: 110,
+  },
+  { data: 'startDate', title: 'Start Date', type: 'date', dateFormat: 'YYYY-MM-DD', width: 110 },
+  { data: 'location', title: 'Location', type: 'text', width: 110 },
+  {
+    data: 'status',
+    title: 'Status',
+    type: 'dropdown',
+    source: ['Active', 'On Leave', 'Inactive'],
+    width: 100,
+  },
+];
+
+const ExampleComponent = () => {
+  const hotRef = useRef(null);
+  // Track which column indices (into allColumns) are currently visible.
+  // Start with all columns visible.
+  const [visibleIndices, setVisibleIndices] = useState(
+    () => new Set(allColumns.map((_, i) => i))
+  );
+
+  const getVisibleColumns = useCallback(
+    (indices) => allColumns.filter((_, i) => indices.has(i)),
+    []
+  );
+
+  const getVisibleHeaders = useCallback(
+    (indices) => allColumns.filter((_, i) => indices.has(i)).map((col) => col.title),
+    []
+  );
+
+  const handleToggle = useCallback(
+    (index) => {
+      setVisibleIndices((prev) => {
+        if (prev.has(index)) {
+          // Prevent hiding the last visible column.
+          if (prev.size === 1) {
+            return prev;
+          }
+
+          const next = new Set(prev);
+
+          next.delete(index);
+          // Apply the new visible subset. updateSettings() re-renders the grid
+          // with only the provided columns config -- no DOM manipulation needed.
+          hotRef.current?.hotInstance?.updateSettings({
+            columns: getVisibleColumns(next),
+            colHeaders: getVisibleHeaders(next),
+          });
+
+          return next;
+        }
+
+        const next = new Set(prev);
+
+        next.add(index);
+        hotRef.current?.hotInstance?.updateSettings({
+          columns: getVisibleColumns(next),
+          colHeaders: getVisibleHeaders(next),
+        });
+
+        return next;
+      });
+    },
+    [getVisibleColumns, getVisibleHeaders]
+  );
+
+  const columns = useMemo(() => getVisibleColumns(visibleIndices), [visibleIndices, getVisibleColumns]);
+  const colHeaders = useMemo(() => getVisibleHeaders(visibleIndices), [visibleIndices, getVisibleHeaders]);
+
+  return (
+    <div>
+      <div id="column-toggles" style={{ marginBottom: '10px' }}>
+        {allColumns.map((col, index) => (
+          <label
+            key={col.data}
+            style={{ marginRight: '12px', display: 'inline-flex', alignItems: 'center', gap: '4px' }}
+          >
+            <input
+              type="checkbox"
+              checked={visibleIndices.has(index)}
+              // When only one column remains visible, disable its checkbox so the user
+              // cannot produce an empty grid.
+              disabled={visibleIndices.size === 1 && visibleIndices.has(index)}
+              onChange={() => handleToggle(index)}
+            />
+            {col.title}
+          </label>
+        ))}
+      </div>
+      <HotTable
+        ref={hotRef}
+        data={data}
+        columns={columns}
+        colHeaders={colHeaders}
+        rowHeaders={true}
+        height="auto"
+        width="100%"
+        autoWrapRow={true}
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </div>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/column-management/column-visibility/react/example1.jsx
+++ b/docs/content/recipes/column-management/column-visibility/react/example1.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { HotTable } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
 
@@ -42,61 +42,39 @@ const allColumns = [
 ];
 
 const ExampleComponent = () => {
-  const hotRef = useRef(null);
   // Track which column indices (into allColumns) are currently visible.
   // Start with all columns visible.
   const [visibleIndices, setVisibleIndices] = useState(
     () => new Set(allColumns.map((_, i) => i))
   );
 
-  const getVisibleColumns = useCallback(
-    (indices) => allColumns.filter((_, i) => indices.has(i)),
-    []
-  );
+  const handleToggle = useCallback((index) => {
+    setVisibleIndices((prev) => {
+      // Prevent hiding the last visible column.
+      if (prev.has(index) && prev.size === 1) {
+        return prev;
+      }
 
-  const getVisibleHeaders = useCallback(
-    (indices) => allColumns.filter((_, i) => indices.has(i)).map((col) => col.title),
-    []
-  );
+      const next = new Set(prev);
 
-  const handleToggle = useCallback(
-    (index) => {
-      setVisibleIndices((prev) => {
-        if (prev.has(index)) {
-          // Prevent hiding the last visible column.
-          if (prev.size === 1) {
-            return prev;
-          }
-
-          const next = new Set(prev);
-
-          next.delete(index);
-          // Apply the new visible subset. updateSettings() re-renders the grid
-          // with only the provided columns config -- no DOM manipulation needed.
-          hotRef.current?.hotInstance?.updateSettings({
-            columns: getVisibleColumns(next),
-            colHeaders: getVisibleHeaders(next),
-          });
-
-          return next;
-        }
-
-        const next = new Set(prev);
-
+      if (prev.has(index)) {
+        next.delete(index);
+      } else {
         next.add(index);
-        hotRef.current?.hotInstance?.updateSettings({
-          columns: getVisibleColumns(next),
-          colHeaders: getVisibleHeaders(next),
-        });
+      }
 
-        return next;
-      });
-    },
-    [getVisibleColumns, getVisibleHeaders]
+      return next;
+    });
+  }, []);
+
+  const columns = useMemo(
+    () => allColumns.filter((_, i) => visibleIndices.has(i)),
+    [visibleIndices]
   );
-
-  const columns = useMemo(() => getVisibleColumns(visibleIndices), [visibleIndices, getVisibleColumns]);
-  const colHeaders = useMemo(() => getVisibleHeaders(visibleIndices), [visibleIndices, getVisibleHeaders]);
+  const colHeaders = useMemo(
+    () => allColumns.filter((_, i) => visibleIndices.has(i)).map((col) => col.title),
+    [visibleIndices]
+  );
 
   return (
     <div>
@@ -119,7 +97,6 @@ const ExampleComponent = () => {
         ))}
       </div>
       <HotTable
-        ref={hotRef}
         data={data}
         columns={columns}
         colHeaders={colHeaders}

--- a/docs/content/recipes/column-management/column-visibility/react/example1.tsx
+++ b/docs/content/recipes/column-management/column-visibility/react/example1.tsx
@@ -108,7 +108,6 @@ const ExampleComponent = () => {
         ))}
       </div>
       <HotTable
-        ref={hotRef}
         data={data}
         columns={columns}
         colHeaders={colHeaders}

--- a/docs/content/recipes/column-management/column-visibility/react/example1.tsx
+++ b/docs/content/recipes/column-management/column-visibility/react/example1.tsx
@@ -1,0 +1,154 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { HotTable, type HotTableRef } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import type { ColumnSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+/* start:skip-in-preview */
+type EmployeeRow = {
+  name: string;
+  department: string;
+  role: string;
+  salary: number;
+  startDate: string;
+  location: string;
+  status: string;
+};
+
+const data: EmployeeRow[] = [
+  { name: 'Alice Johnson', department: 'Engineering', role: 'Senior Engineer', salary: 95000, startDate: '2019-03-12', location: 'New York', status: 'Active' },
+  { name: 'Bob Martinez', department: 'Marketing', role: 'Marketing Manager', salary: 78000, startDate: '2020-07-01', location: 'Chicago', status: 'Active' },
+  { name: 'Carol Lee', department: 'Engineering', role: 'Tech Lead', salary: 115000, startDate: '2017-11-15', location: 'San Francisco', status: 'Active' },
+  { name: 'David Kim', department: 'HR', role: 'HR Specialist', salary: 65000, startDate: '2021-02-28', location: 'Austin', status: 'On Leave' },
+  { name: 'Eva Novak', department: 'Finance', role: 'Financial Analyst', salary: 82000, startDate: '2018-09-03', location: 'New York', status: 'Active' },
+  { name: 'Frank Chen', department: 'Engineering', role: 'Junior Engineer', salary: 72000, startDate: '2022-05-16', location: 'Seattle', status: 'Active' },
+  { name: 'Grace Okafor', department: 'Sales', role: 'Sales Executive', salary: 70000, startDate: '2020-01-20', location: 'Dallas', status: 'Active' },
+  { name: 'Henry Walsh', department: 'Finance', role: 'Finance Director', salary: 130000, startDate: '2015-06-10', location: 'Chicago', status: 'Active' },
+];
+/* end:skip-in-preview */
+
+// The full columns config is the immutable source of truth.
+// Never mutate this array -- always derive a visible subset from it.
+const allColumns: (ColumnSettings & { title: string })[] = [
+  { data: 'name', title: 'Name', type: 'text', width: 140 },
+  { data: 'department', title: 'Department', type: 'text', width: 120 },
+  { data: 'role', title: 'Role', type: 'text', width: 150 },
+  {
+    data: 'salary',
+    title: 'Salary',
+    type: 'numeric',
+    numericFormat: { pattern: '$0,0', culture: 'en-US' },
+    width: 110,
+  },
+  { data: 'startDate', title: 'Start Date', type: 'date', dateFormat: 'YYYY-MM-DD', width: 110 },
+  { data: 'location', title: 'Location', type: 'text', width: 110 },
+  {
+    data: 'status',
+    title: 'Status',
+    type: 'dropdown',
+    source: ['Active', 'On Leave', 'Inactive'],
+    width: 100,
+  },
+];
+
+const ExampleComponent = () => {
+  const hotRef = useRef<HotTableRef>(null);
+  // Track which column indices (into allColumns) are currently visible.
+  // Start with all columns visible.
+  const [visibleIndices, setVisibleIndices] = useState<Set<number>>(
+    () => new Set(allColumns.map((_, i) => i))
+  );
+
+  const getVisibleColumns = useCallback(
+    (indices: Set<number>): ColumnSettings[] => allColumns.filter((_, i) => indices.has(i)),
+    []
+  );
+
+  const getVisibleHeaders = useCallback(
+    (indices: Set<number>): string[] =>
+      allColumns.filter((_, i) => indices.has(i)).map((col) => col.title),
+    []
+  );
+
+  const handleToggle = useCallback(
+    (index: number) => {
+      setVisibleIndices((prev) => {
+        if (prev.has(index)) {
+          // Prevent hiding the last visible column.
+          if (prev.size === 1) {
+            return prev;
+          }
+
+          const next = new Set(prev);
+
+          next.delete(index);
+          // Apply the new visible subset. updateSettings() re-renders the grid
+          // with only the provided columns config -- no DOM manipulation needed.
+          hotRef.current?.hotInstance?.updateSettings({
+            columns: getVisibleColumns(next),
+            colHeaders: getVisibleHeaders(next),
+          });
+
+          return next;
+        }
+
+        const next = new Set(prev);
+
+        next.add(index);
+        hotRef.current?.hotInstance?.updateSettings({
+          columns: getVisibleColumns(next),
+          colHeaders: getVisibleHeaders(next),
+        });
+
+        return next;
+      });
+    },
+    [getVisibleColumns, getVisibleHeaders]
+  );
+
+  const columns = useMemo(
+    () => getVisibleColumns(visibleIndices),
+    [visibleIndices, getVisibleColumns]
+  );
+  const colHeaders = useMemo(
+    () => getVisibleHeaders(visibleIndices),
+    [visibleIndices, getVisibleHeaders]
+  );
+
+  return (
+    <div>
+      <div id="column-toggles" style={{ marginBottom: '10px' }}>
+        {allColumns.map((col, index) => (
+          <label
+            key={col.data as string}
+            style={{ marginRight: '12px', display: 'inline-flex', alignItems: 'center', gap: '4px' }}
+          >
+            <input
+              type="checkbox"
+              checked={visibleIndices.has(index)}
+              // When only one column remains visible, disable its checkbox so the user
+              // cannot produce an empty grid.
+              disabled={visibleIndices.size === 1 && visibleIndices.has(index)}
+              onChange={() => handleToggle(index)}
+            />
+            {col.title}
+          </label>
+        ))}
+      </div>
+      <HotTable
+        ref={hotRef}
+        data={data}
+        columns={columns}
+        colHeaders={colHeaders}
+        rowHeaders={true}
+        height="auto"
+        width="100%"
+        autoWrapRow={true}
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </div>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/column-management/column-visibility/react/example1.tsx
+++ b/docs/content/recipes/column-management/column-visibility/react/example1.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
-import { HotTable, type HotTableRef } from '@handsontable/react-wrapper';
+import { useCallback, useMemo, useState } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
 import type { ColumnSettings } from 'handsontable/settings';
 
@@ -53,67 +53,38 @@ const allColumns: (ColumnSettings & { title: string })[] = [
 ];
 
 const ExampleComponent = () => {
-  const hotRef = useRef<HotTableRef>(null);
   // Track which column indices (into allColumns) are currently visible.
   // Start with all columns visible.
   const [visibleIndices, setVisibleIndices] = useState<Set<number>>(
     () => new Set(allColumns.map((_, i) => i))
   );
 
-  const getVisibleColumns = useCallback(
-    (indices: Set<number>): ColumnSettings[] => allColumns.filter((_, i) => indices.has(i)),
-    []
-  );
+  const handleToggle = useCallback((index: number) => {
+    setVisibleIndices((prev) => {
+      // Prevent hiding the last visible column.
+      if (prev.has(index) && prev.size === 1) {
+        return prev;
+      }
 
-  const getVisibleHeaders = useCallback(
-    (indices: Set<number>): string[] =>
-      allColumns.filter((_, i) => indices.has(i)).map((col) => col.title),
-    []
-  );
+      const next = new Set(prev);
 
-  const handleToggle = useCallback(
-    (index: number) => {
-      setVisibleIndices((prev) => {
-        if (prev.has(index)) {
-          // Prevent hiding the last visible column.
-          if (prev.size === 1) {
-            return prev;
-          }
-
-          const next = new Set(prev);
-
-          next.delete(index);
-          // Apply the new visible subset. updateSettings() re-renders the grid
-          // with only the provided columns config -- no DOM manipulation needed.
-          hotRef.current?.hotInstance?.updateSettings({
-            columns: getVisibleColumns(next),
-            colHeaders: getVisibleHeaders(next),
-          });
-
-          return next;
-        }
-
-        const next = new Set(prev);
-
+      if (prev.has(index)) {
+        next.delete(index);
+      } else {
         next.add(index);
-        hotRef.current?.hotInstance?.updateSettings({
-          columns: getVisibleColumns(next),
-          colHeaders: getVisibleHeaders(next),
-        });
+      }
 
-        return next;
-      });
-    },
-    [getVisibleColumns, getVisibleHeaders]
-  );
+      return next;
+    });
+  }, []);
 
   const columns = useMemo(
-    () => getVisibleColumns(visibleIndices),
-    [visibleIndices, getVisibleColumns]
+    (): ColumnSettings[] => allColumns.filter((_, i) => visibleIndices.has(i)),
+    [visibleIndices]
   );
   const colHeaders = useMemo(
-    () => getVisibleHeaders(visibleIndices),
-    [visibleIndices, getVisibleHeaders]
+    (): string[] => allColumns.filter((_, i) => visibleIndices.has(i)).map((col) => col.title),
+    [visibleIndices]
   );
 
   return (

--- a/docs/content/recipes/data-management/auto-save-backend/auto-save-backend.md
+++ b/docs/content/recipes/data-management/auto-save-backend/auto-save-backend.md
@@ -31,6 +31,17 @@ category: Data Management
 
 :::
 
+::: only-for react
+
+::: example #example1 :react-advanced --js 1 --ts 2
+
+@[code](@/content/recipes/data-management/auto-save-backend/react/example1.jsx)
+@[code](@/content/recipes/data-management/auto-save-backend/react/example1.tsx)
+
+:::
+
+:::
+
 ## Overview
 
 This recipe shows how to auto-save edited rows to a backend with `afterChange`, an 800 ms debounce, and row-level dirty tracking. It sends only modified rows, ignores `loadData` changes, and reports save status in the UI.

--- a/docs/content/recipes/data-management/auto-save-backend/react/example1.jsx
+++ b/docs/content/recipes/data-management/auto-save-backend/react/example1.jsx
@@ -1,0 +1,134 @@
+import { useRef, useState } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const data = [
+  { id: 1, product: 'Keyboard', stock: 14, price: 89, status: 'active' },
+  { id: 2, product: 'Monitor', stock: 5, price: 249, status: 'active' },
+  { id: 3, product: 'Dock', stock: 22, price: 139, status: 'draft' },
+  { id: 4, product: 'Webcam', stock: 9, price: 119, status: 'active' },
+  { id: 5, product: 'Headset', stock: 16, price: 99, status: 'paused' },
+];
+
+const statusLabels = {
+  idle: 'No pending changes',
+  saving: 'Saving...',
+  saved: 'Saved \u2713',
+  error: 'Error',
+};
+
+const statusColors = {
+  idle: '#616161',
+  saving: '#1a42e8',
+  saved: '#117a1f',
+  error: '#c62828',
+};
+
+const saveRowsToBackend = async (rows) => {
+  await new Promise((resolve) => setTimeout(resolve, 450));
+
+  // Replace this with fetch('/api/products', { method: 'PATCH', body: ... }) in production.
+  // eslint-disable-next-line no-console
+  console.log('PATCH /api/products', rows);
+};
+
+const ExampleComponent = () => {
+  const hotRef = useRef(null);
+  const [saveStatus, setSaveStatus] = useState('idle');
+  const dirtyRowsRef = useRef(new Set());
+  const saveTimeoutRef = useRef(null);
+  const saveRequestCounterRef = useRef(0);
+
+  const handleAfterChange = (changes, source) => {
+    if (!changes || source === 'loadData') {
+      return;
+    }
+
+    const hot = hotRef.current?.hotInstance;
+
+    if (!hot) {
+      return;
+    }
+
+    changes.forEach(([visualRow, _prop, oldValue, newValue]) => {
+      if (oldValue !== newValue) {
+        const physicalRow = hot.toPhysicalRow(visualRow);
+
+        if (physicalRow !== null && physicalRow >= 0) {
+          dirtyRowsRef.current.add(physicalRow);
+        }
+      }
+    });
+
+    if (saveTimeoutRef.current) {
+      clearTimeout(saveTimeoutRef.current);
+    }
+
+    saveTimeoutRef.current = setTimeout(async () => {
+      const physicalRows = Array.from(dirtyRowsRef.current);
+
+      if (physicalRows.length === 0) {
+        return;
+      }
+
+      const requestId = ++saveRequestCounterRef.current;
+      const rowsToSave = physicalRows
+        .map((physicalRow) => hot.getSourceDataAtRow(physicalRow))
+        .filter((row) => row !== undefined && row !== null);
+
+      dirtyRowsRef.current.clear();
+      setSaveStatus('saving');
+
+      try {
+        await saveRowsToBackend(rowsToSave);
+
+        if (requestId === saveRequestCounterRef.current) {
+          setSaveStatus('saved');
+        }
+      } catch (_error) {
+        physicalRows.forEach((physicalRow) => dirtyRowsRef.current.add(physicalRow));
+
+        if (requestId === saveRequestCounterRef.current) {
+          setSaveStatus('error');
+        }
+      }
+    }, 800);
+  };
+
+  return (
+    <>
+      <div
+        style={{
+          marginBottom: '8px',
+          fontFamily: 'Arial, sans-serif',
+          fontSize: '13px',
+          fontWeight: '600',
+          color: statusColors[saveStatus],
+        }}
+      >
+        {statusLabels[saveStatus]}
+      </div>
+      <HotTable
+        ref={hotRef}
+        data={data}
+        rowHeaders={true}
+        colHeaders={['ID', 'Product', 'Stock', 'Price', 'Status']}
+        columns={[
+          { data: 'id', type: 'numeric', readOnly: true, width: 70 },
+          { data: 'product', type: 'text', width: 180 },
+          { data: 'stock', type: 'numeric', width: 90 },
+          { data: 'price', type: 'numeric', numericFormat: { pattern: '$0,0.00' }, width: 110 },
+          { data: 'status', type: 'text', width: 120 },
+        ]}
+        stretchH="all"
+        height="auto"
+        afterChange={handleAfterChange}
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/data-management/auto-save-backend/react/example1.tsx
+++ b/docs/content/recipes/data-management/auto-save-backend/react/example1.tsx
@@ -1,0 +1,139 @@
+import { useRef, useState } from 'react';
+import { HotTable, HotTableRef } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const data = [
+  { id: 1, product: 'Keyboard', stock: 14, price: 89, status: 'active' },
+  { id: 2, product: 'Monitor', stock: 5, price: 249, status: 'active' },
+  { id: 3, product: 'Dock', stock: 22, price: 139, status: 'draft' },
+  { id: 4, product: 'Webcam', stock: 9, price: 119, status: 'active' },
+  { id: 5, product: 'Headset', stock: 16, price: 99, status: 'paused' },
+];
+
+type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
+
+const statusLabels: Record<SaveStatus, string> = {
+  idle: 'No pending changes',
+  saving: 'Saving...',
+  saved: 'Saved \u2713',
+  error: 'Error',
+};
+
+const statusColors: Record<SaveStatus, string> = {
+  idle: '#616161',
+  saving: '#1a42e8',
+  saved: '#117a1f',
+  error: '#c62828',
+};
+
+const saveRowsToBackend = async (rows: unknown[]): Promise<void> => {
+  await new Promise<void>((resolve) => setTimeout(resolve, 450));
+
+  // Replace this with fetch('/api/products', { method: 'PATCH', body: ... }) in production.
+  // eslint-disable-next-line no-console
+  console.log('PATCH /api/products', rows);
+};
+
+const ExampleComponent = () => {
+  const hotRef = useRef<HotTableRef>(null);
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
+  const dirtyRowsRef = useRef(new Set<number>());
+  const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const saveRequestCounterRef = useRef(0);
+
+  const handleAfterChange = (
+    changes: [number, string | number, unknown, unknown][] | null,
+    source: string
+  ): void => {
+    if (!changes || source === 'loadData') {
+      return;
+    }
+
+    const hot = hotRef.current?.hotInstance;
+
+    if (!hot) {
+      return;
+    }
+
+    changes.forEach(([visualRow, _prop, oldValue, newValue]) => {
+      if (oldValue !== newValue) {
+        const physicalRow = hot.toPhysicalRow(visualRow);
+
+        if (physicalRow !== null && physicalRow >= 0) {
+          dirtyRowsRef.current.add(physicalRow);
+        }
+      }
+    });
+
+    if (saveTimeoutRef.current) {
+      clearTimeout(saveTimeoutRef.current);
+    }
+
+    saveTimeoutRef.current = setTimeout(async () => {
+      const physicalRows = Array.from(dirtyRowsRef.current);
+
+      if (physicalRows.length === 0) {
+        return;
+      }
+
+      const requestId = ++saveRequestCounterRef.current;
+      const rowsToSave = physicalRows
+        .map((physicalRow) => hot.getSourceDataAtRow(physicalRow))
+        .filter((row) => row !== undefined && row !== null);
+
+      dirtyRowsRef.current.clear();
+      setSaveStatus('saving');
+
+      try {
+        await saveRowsToBackend(rowsToSave);
+
+        if (requestId === saveRequestCounterRef.current) {
+          setSaveStatus('saved');
+        }
+      } catch (_error) {
+        physicalRows.forEach((physicalRow) => dirtyRowsRef.current.add(physicalRow));
+
+        if (requestId === saveRequestCounterRef.current) {
+          setSaveStatus('error');
+        }
+      }
+    }, 800);
+  };
+
+  return (
+    <>
+      <div
+        style={{
+          marginBottom: '8px',
+          fontFamily: 'Arial, sans-serif',
+          fontSize: '13px',
+          fontWeight: '600',
+          color: statusColors[saveStatus],
+        }}
+      >
+        {statusLabels[saveStatus]}
+      </div>
+      <HotTable
+        ref={hotRef}
+        data={data}
+        rowHeaders={true}
+        colHeaders={['ID', 'Product', 'Stock', 'Price', 'Status']}
+        columns={[
+          { data: 'id', type: 'numeric', readOnly: true, width: 70 },
+          { data: 'product', type: 'text', width: 180 },
+          { data: 'stock', type: 'numeric', width: 90 },
+          { data: 'price', type: 'numeric', numericFormat: { pattern: '$0,0.00' }, width: 110 },
+          { data: 'status', type: 'text', width: 120 },
+        ]}
+        stretchH="all"
+        height="auto"
+        afterChange={handleAfterChange}
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/data-management/server-side-django/react/example1.jsx
+++ b/docs/content/recipes/data-management/server-side-django/react/example1.jsx
@@ -1,0 +1,193 @@
+import { useCallback, useMemo } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+// ---------------------------------------------------------------------------
+// Step 1: Read Django's CSRF token from the cookie.
+//
+// Django sets a `csrftoken` cookie on every response. You must read it and
+// include it in the X-CSRFToken request header for every mutating request
+// (POST, PATCH, DELETE). Without it Django returns 403 Forbidden.
+// ---------------------------------------------------------------------------
+function getCsrfToken() {
+  return document.cookie
+    .split('; ')
+    .find((row) => row.startsWith('csrftoken='))
+    ?.split('=')[1];
+}
+
+// ---------------------------------------------------------------------------
+// Step 2: Build the request URL for fetchRows.
+//
+// Handsontable's dataProvider calls fetchRows with { page, pageSize, sort,
+// filters }. This helper converts those into query string parameters that
+// Django REST Framework understands.
+//
+// - `page` and `pageSize` map directly (DRF uses page_size_query_param =
+//   'pageSize', so the parameter name matches without any translation).
+// - `sort` becomes sort[prop] + sort[order] -- the Django view reads these
+//   and converts them to DRF's `ordering` param internally.
+// - Each filter condition in the `filters` array becomes a filters[N][...]
+//   triplet (prop, value, condition).
+// ---------------------------------------------------------------------------
+function buildUrl(base, { page, pageSize, sort, filters }) {
+  const params = new URLSearchParams();
+
+  params.set('page', page);
+  params.set('pageSize', pageSize);
+
+  if (sort?.prop) {
+    params.set('sort[prop]', sort.prop);
+    params.set('sort[order]', sort.order ?? 'asc');
+  }
+
+  if (filters?.length) {
+    filters.forEach(({ prop, value, condition }, i) => {
+      params.set(`filters[${i}][prop]`, prop);
+      params.set(`filters[${i}][value]`, value);
+      params.set(`filters[${i}][condition]`, condition);
+    });
+  }
+
+  return `${base}?${params.toString()}`;
+}
+
+// ---------------------------------------------------------------------------
+// Step 3: React component with the dataProvider plugin.
+//
+// `rowId: 'id'` tells dataProvider which field uniquely identifies each row.
+// Django's auto-increment primary key is used here.
+//
+// Each callback receives the signal from the AbortController so that
+// in-flight requests are cancelled when the user sorts or filters before
+// the previous request completes.
+// ---------------------------------------------------------------------------
+
+const ExampleComponent = () => {
+  // fetchRows is called on mount and whenever page, sort, or filters change.
+  const fetchRows = useCallback(async ({ page, pageSize, sort, filters }, { signal }) => {
+    const url = buildUrl('http://localhost:8000/api/employees/', {
+      page,
+      pageSize,
+      sort,
+      filters,
+    });
+
+    const res = await fetch(url, { signal });
+
+    if (!res.ok) {
+      throw new Error(`Fetch failed: ${res.status}`);
+    }
+
+    // Django pagination.py already maps DRF's { count, results } to
+    // { rows, totalRows }, so we can return the JSON directly.
+    return res.json();
+  }, []);
+
+  // onRowsCreate is called when the user adds new rows via the context menu.
+  // It receives an array of row objects without ids.
+  const onRowsCreate = useCallback(async (rows) => {
+    const res = await fetch('http://localhost:8000/api/employees/create-rows/', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRFToken': getCsrfToken(),
+      },
+      body: JSON.stringify(rows),
+    });
+
+    if (!res.ok) {
+      throw new Error(`Create failed: ${res.status}`);
+    }
+
+    // Return the created rows so dataProvider can update its row map
+    // with the server-assigned ids.
+    return res.json();
+  }, []);
+
+  // onRowsUpdate is called when the user edits cells.
+  // It receives an array of partial row objects that each contain the row
+  // id plus only the changed fields.
+  const onRowsUpdate = useCallback(async (rows) => {
+    const res = await fetch('http://localhost:8000/api/employees/update-rows/', {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRFToken': getCsrfToken(),
+      },
+      body: JSON.stringify(rows),
+    });
+
+    if (!res.ok) {
+      throw new Error(`Update failed: ${res.status}`);
+    }
+  }, []);
+
+  // onRowsRemove is called when the user deletes rows.
+  // It receives an array of row ids.
+  const onRowsRemove = useCallback(async (rowIds) => {
+    const res = await fetch('http://localhost:8000/api/employees/remove-rows/', {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRFToken': getCsrfToken(),
+      },
+      body: JSON.stringify(rowIds),
+    });
+
+    if (!res.ok) {
+      throw new Error(`Delete failed: ${res.status}`);
+    }
+  }, []);
+
+  const dataProvider = useMemo(
+    () => ({
+      rowId: 'id',
+      fetchRows,
+      onRowsCreate,
+      onRowsUpdate,
+      onRowsRemove,
+    }),
+    [fetchRows, onRowsCreate, onRowsUpdate, onRowsRemove]
+  );
+
+  return (
+    <div>
+      <HotTable
+        dataProvider={dataProvider}
+        // Show 10 rows per page; users can change this via the pagination UI.
+        pagination={{ pageSize: 10 }}
+        // Enable server-side column sorting. dataProvider passes the sort state
+        // to fetchRows automatically.
+        columnSorting={true}
+        // Enable the column filter UI. dataProvider passes active conditions
+        // to fetchRows automatically.
+        filters={true}
+        dropdownMenu={['filter_by_condition', 'filter_action_bar']}
+        // Show a friendly illustration when the server returns zero rows
+        // (for example, when a filter matches nothing).
+        emptyDataState={true}
+        // Show automatic error toasts when fetchRows or a mutation callback throws.
+        // This uses the Notification plugin internally.
+        notification={true}
+        colHeaders={['First Name', 'Last Name', 'Department', 'Role', 'Salary']}
+        columns={[
+          { data: 'first_name', type: 'text' },
+          { data: 'last_name', type: 'text' },
+          { data: 'department', type: 'text' },
+          { data: 'role', type: 'text' },
+          { data: 'salary', type: 'numeric', numericFormat: { pattern: '$0,0' } },
+        ]}
+        rowHeaders={true}
+        height={400}
+        width="100%"
+        autoWrapRow={true}
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </div>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/data-management/server-side-django/react/example1.tsx
+++ b/docs/content/recipes/data-management/server-side-django/react/example1.tsx
@@ -1,0 +1,198 @@
+import { useCallback, useMemo } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import type {
+  DataProviderQueryParameters,
+  DataProviderFetchOptions,
+  DataProviderFetchResult,
+} from 'handsontable/plugins/dataProvider';
+
+registerAllModules();
+
+// ---------------------------------------------------------------------------
+// Step 1: Read Django's CSRF token from the cookie.
+//
+// Django sets a `csrftoken` cookie on every response. You must read it and
+// include it in the X-CSRFToken request header for every mutating request
+// (POST, PATCH, DELETE). Without it Django returns 403 Forbidden.
+// ---------------------------------------------------------------------------
+function getCsrfToken(): string | undefined {
+  return document.cookie
+    .split('; ')
+    .find((row) => row.startsWith('csrftoken='))
+    ?.split('=')[1];
+}
+
+// ---------------------------------------------------------------------------
+// Step 2: Build the request URL for fetchRows.
+//
+// Handsontable's dataProvider calls fetchRows with { page, pageSize, sort,
+// filters }. This helper converts those into query string parameters that
+// Django REST Framework understands.
+//
+// - `page` and `pageSize` map directly (DRF uses page_size_query_param =
+//   'pageSize', so the parameter name matches without any translation).
+// - `sort` becomes sort[prop] + sort[order] -- the Django view reads these
+//   and converts them to DRF's `ordering` param internally.
+// - Each filter condition in the `filters` array becomes a filters[N][...]
+//   triplet (prop, value, condition).
+// ---------------------------------------------------------------------------
+function buildUrl(base: string, { page, pageSize, sort, filters }: DataProviderQueryParameters): string {
+  const params = new URLSearchParams();
+
+  params.set('page', String(page));
+  params.set('pageSize', String(pageSize));
+
+  if (sort?.prop) {
+    params.set('sort[prop]', sort.prop);
+    params.set('sort[order]', sort.order ?? 'asc');
+  }
+
+  if (filters?.length) {
+    filters.forEach(({ prop, value, condition }, i) => {
+      params.set(`filters[${i}][prop]`, prop);
+      params.set(`filters[${i}][value]`, String(value));
+      params.set(`filters[${i}][condition]`, condition);
+    });
+  }
+
+  return `${base}?${params.toString()}`;
+}
+
+// ---------------------------------------------------------------------------
+// Step 3: React component with the dataProvider plugin.
+//
+// `rowId: 'id'` tells dataProvider which field uniquely identifies each row.
+// Django's auto-increment primary key is used here.
+//
+// Each callback receives the signal from the AbortController so that
+// in-flight requests are cancelled when the user sorts or filters before
+// the previous request completes.
+// ---------------------------------------------------------------------------
+
+const ExampleComponent = () => {
+  // fetchRows is called on mount and whenever page, sort, or filters change.
+  const fetchRows = useCallback(
+    async (
+      params: DataProviderQueryParameters,
+      { signal }: DataProviderFetchOptions
+    ): Promise<DataProviderFetchResult> => {
+      const url = buildUrl('http://localhost:8000/api/employees/', params);
+      const res = await fetch(url, { signal });
+
+      if (!res.ok) {
+        throw new Error(`Fetch failed: ${res.status}`);
+      }
+
+      // Django pagination.py already maps DRF's { count, results } to
+      // { rows, totalRows }, so we can return the JSON directly.
+      return res.json() as Promise<DataProviderFetchResult>;
+    },
+    []
+  );
+
+  // onRowsCreate is called when the user adds new rows via the context menu.
+  // It receives an array of row objects without ids.
+  const onRowsCreate = useCallback(async (rows: unknown): Promise<unknown> => {
+    const res = await fetch('http://localhost:8000/api/employees/create-rows/', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRFToken': getCsrfToken() ?? '',
+      },
+      body: JSON.stringify(rows),
+    });
+
+    if (!res.ok) {
+      throw new Error(`Create failed: ${res.status}`);
+    }
+
+    // Return the created rows so dataProvider can update its row map
+    // with the server-assigned ids.
+    return res.json();
+  }, []);
+
+  // onRowsUpdate is called when the user edits cells.
+  // It receives an array of partial row objects that each contain the row
+  // id plus only the changed fields.
+  const onRowsUpdate = useCallback(async (rows: unknown): Promise<void> => {
+    const res = await fetch('http://localhost:8000/api/employees/update-rows/', {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRFToken': getCsrfToken() ?? '',
+      },
+      body: JSON.stringify(rows),
+    });
+
+    if (!res.ok) {
+      throw new Error(`Update failed: ${res.status}`);
+    }
+  }, []);
+
+  // onRowsRemove is called when the user deletes rows.
+  // It receives an array of row ids.
+  const onRowsRemove = useCallback(async (rowIds: unknown[]): Promise<void> => {
+    const res = await fetch('http://localhost:8000/api/employees/remove-rows/', {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRFToken': getCsrfToken() ?? '',
+      },
+      body: JSON.stringify(rowIds),
+    });
+
+    if (!res.ok) {
+      throw new Error(`Delete failed: ${res.status}`);
+    }
+  }, []);
+
+  const dataProvider = useMemo(
+    () => ({
+      rowId: 'id',
+      fetchRows,
+      onRowsCreate,
+      onRowsUpdate,
+      onRowsRemove,
+    }),
+    [fetchRows, onRowsCreate, onRowsUpdate, onRowsRemove]
+  );
+
+  return (
+    <div>
+      <HotTable
+        dataProvider={dataProvider}
+        // Show 10 rows per page; users can change this via the pagination UI.
+        pagination={{ pageSize: 10 }}
+        // Enable server-side column sorting. dataProvider passes the sort state
+        // to fetchRows automatically.
+        columnSorting={true}
+        // Enable the column filter UI. dataProvider passes active conditions
+        // to fetchRows automatically.
+        filters={true}
+        dropdownMenu={['filter_by_condition', 'filter_action_bar']}
+        // Show a friendly illustration when the server returns zero rows
+        // (for example, when a filter matches nothing).
+        emptyDataState={true}
+        // Show automatic error toasts when fetchRows or a mutation callback throws.
+        // This uses the Notification plugin internally.
+        notification={true}
+        colHeaders={['First Name', 'Last Name', 'Department', 'Role', 'Salary']}
+        columns={[
+          { data: 'first_name', type: 'text' },
+          { data: 'last_name', type: 'text' },
+          { data: 'department', type: 'text' },
+          { data: 'role', type: 'text' },
+          { data: 'salary', type: 'numeric', numericFormat: { pattern: '$0,0' } },
+        ]}
+        rowHeaders={true}
+        height={400}
+        width="100%"
+        autoWrapRow={true}
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </div>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/data-management/server-side-django/server-side-django.md
+++ b/docs/content/recipes/data-management/server-side-django/server-side-django.md
@@ -462,6 +462,12 @@ const hot = new Handsontable(container, {
 });
 ```
 
+::: only-for react
+
+@[code jsx](@/content/recipes/data-management/server-side-django/react/example1.jsx)
+
+:::
+
 **Key options explained:**
 
 | Option | What it does |

--- a/docs/content/recipes/data-management/server-side-django/server-side-django.md
+++ b/docs/content/recipes/data-management/server-side-django/server-side-django.md
@@ -467,6 +467,12 @@ const hot = new Handsontable(container, {
 });
 ```
 
+::: only-for react
+
+@[code jsx](@/content/recipes/data-management/server-side-django/react/example1.jsx)
+
+:::
+
 **Key options explained:**
 
 | Option | What it does |

--- a/docs/content/recipes/data-management/server-side-laravel/react/example1.jsx
+++ b/docs/content/recipes/data-management/server-side-laravel/react/example1.jsx
@@ -1,0 +1,166 @@
+import { useCallback, useMemo } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+// Serializes fetchRows query parameters into a URL query string that Laravel
+// reads via request()->input().
+//
+// Handsontable sends:
+//   sort:    { prop: 'name', order: 'asc' }  or  null
+//   filters: [{ prop: 'price', condition: { name: 'gt', args: [100] } }]  or  null
+//
+// Laravel reads:
+//   sort[prop], sort[order]
+//   filters[0][prop], filters[0][condition], filters[0][value], filters[0][value2]
+function buildUrl(base, { page, pageSize, sort, filters }) {
+  const params = new URLSearchParams({
+    page: String(page),
+    pageSize: String(pageSize),
+  });
+
+  if (sort) {
+    params.set('sort[prop]', sort.prop);
+    params.set('sort[order]', sort.order);
+  }
+
+  if (filters) {
+    filters.forEach((filter, i) => {
+      params.set(`filters[${i}][prop]`, filter.prop);
+      params.set(`filters[${i}][condition]`, filter.condition.name);
+      const args = filter.condition.args ?? [];
+      // Single-value conditions: contains, gt, eq, begins_with …
+      if (args[0] != null) params.set(`filters[${i}][value]`, String(args[0]));
+      // Range conditions: between, not_between
+      if (args[1] != null) params.set(`filters[${i}][value2]`, String(args[1]));
+    });
+  }
+
+  return `${base}?${params}`;
+}
+
+// Reads the CSRF token injected by Blade into <meta name="csrf-token">.
+// For SPA routes protected by Sanctum, use cookie-based auth instead
+// (see Step 9 in the recipe).
+function csrfToken() {
+  return document.querySelector('meta[name="csrf-token"]')?.content ?? '';
+}
+
+const ExampleComponent = () => {
+  // fetchRows is called on every page change, sort, and filter.
+  // queryParameters: { page, pageSize, sort, filters }
+  // signal: AbortSignal — pass it to fetch() so stale requests cancel
+  // when the user sorts, filters, or changes pages quickly.
+  const fetchRows = useCallback(async ({ page, pageSize, sort, filters }, { signal }) => {
+    const url = buildUrl('/api/products', { page, pageSize, sort, filters });
+    const res = await fetch(url, { signal });
+
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+    // Laravel returns: { data: [...], total: n }
+    const json = await res.json();
+
+    return { rows: json.data, totalRows: json.total };
+  }, []);
+
+  // onRowsCreate fires when the user inserts rows from the context menu.
+  // payload: { position: 'above'|'below', referenceRowId, rowsAmount }
+  const onRowsCreate = useCallback(async (payload) => {
+    await fetch('/api/products', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': csrfToken() },
+      body: JSON.stringify(payload),
+    });
+  }, []);
+
+  // onRowsUpdate fires after a cell edit, paste, or autofill batch.
+  // rows is an array of { id, changes, rowData } objects.
+  // Changes appear in the grid immediately (optimistic update) and roll back
+  // if this callback throws or rejects.
+  const onRowsUpdate = useCallback(async (rows) => {
+    await fetch('/api/products', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': csrfToken() },
+      body: JSON.stringify(rows),
+    });
+  }, []);
+
+  // onRowsRemove fires after the user confirms deletion.
+  // rowIds is an array of stable row IDs (values of the rowId field).
+  const onRowsRemove = useCallback(async (rowIds) => {
+    await fetch('/api/products', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': csrfToken() },
+      body: JSON.stringify(rowIds),
+    });
+  }, []);
+
+  const dataProvider = useMemo(
+    () => ({
+      // rowId must match the primary key field in your Laravel model.
+      // Handsontable uses this value in every update and remove callback.
+      rowId: 'id',
+      fetchRows,
+      onRowsCreate,
+      onRowsUpdate,
+      onRowsRemove,
+    }),
+    [fetchRows, onRowsCreate, onRowsUpdate, onRowsRemove]
+  );
+
+  // beforeRowsMutation fires before any create, update, or remove operation.
+  // Return false to cancel. Here it adds a confirm dialog before deletes.
+  const beforeRowsMutation = useCallback((operation, payload) => {
+    if (operation === 'remove') {
+      const count = payload.rowsRemove.length;
+      // eslint-disable-next-line no-alert
+      return window.confirm(`Delete ${count} row${count !== 1 ? 's' : ''}? This cannot be undone.`);
+    }
+  }, []);
+
+  return (
+    <div>
+      <HotTable
+        dataProvider={dataProvider}
+        // beforeRowsMutation fires before any create, update, or remove operation.
+        beforeRowsMutation={beforeRowsMutation}
+        // pagination: pageSize controls how many rows fetchRows requests per call.
+        pagination={{ pageSize: 10 }}
+        // columnSorting sends { prop, order } in queryParameters.sort.
+        // Keep multiColumnSorting off -- it conflicts with dataProvider.
+        columnSorting={true}
+        // filters sends condition objects in queryParameters.filters.
+        // The grid resets to page 1 automatically on each filter change.
+        filters={true}
+        // dropdownMenu shows the column header filter button.
+        dropdownMenu={true}
+        // contextMenu exposes "Insert row above / below" and "Remove row".
+        contextMenu={true}
+        // emptyDataState shows a loading overlay while fetchRows is in flight
+        // and an empty-state overlay when the result set is empty.
+        emptyDataState={true}
+        // notification shows an error toast when fetchRows or any CRUD callback
+        // rejects. Fetch failures include a Refetch button.
+        notification={true}
+        rowHeaders={true}
+        colHeaders={['Name', 'SKU', 'Category', 'Price', 'Stock']}
+        columns={[
+          { data: 'name', type: 'text' },
+          // SKU is generated server-side, so it is read-only in the grid.
+          { data: 'sku', type: 'text', readOnly: true },
+          {
+            data: 'category',
+            type: 'dropdown',
+            source: ['Electronics', 'Accessories', 'Storage', 'Networking', 'Peripherals'],
+          },
+          { data: 'price', type: 'numeric', numericFormat: { pattern: '$0,0.00' } },
+          { data: 'stock', type: 'numeric' },
+        ]}
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </div>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/data-management/server-side-laravel/react/example1.tsx
+++ b/docs/content/recipes/data-management/server-side-laravel/react/example1.tsx
@@ -33,14 +33,12 @@ function buildUrl(base: string, { page, pageSize, sort, filters }: DataProviderQ
   if (filters) {
     filters.forEach((filter, i) => {
       params.set(`filters[${i}][prop]`, filter.prop);
-      params.set(`filters[${i}][condition]`, filter.condition);
-      const value = filter.value;
-      if (Array.isArray(value)) {
-        // Single-value conditions: contains, gt, eq, begins_with …
-        if (value[0] != null) params.set(`filters[${i}][value]`, String(value[0]));
-        // Range conditions: between, not_between
-        if (value[1] != null) params.set(`filters[${i}][value2]`, String(value[1]));
-      }
+      params.set(`filters[${i}][condition]`, filter.condition.name);
+      const args = filter.condition.args ?? [];
+      // Single-value conditions: contains, gt, eq, begins_with …
+      if (args[0] != null) params.set(`filters[${i}][value]`, String(args[0]));
+      // Range conditions: between, not_between
+      if (args[1] != null) params.set(`filters[${i}][value2]`, String(args[1]));
     });
   }
 

--- a/docs/content/recipes/data-management/server-side-laravel/react/example1.tsx
+++ b/docs/content/recipes/data-management/server-side-laravel/react/example1.tsx
@@ -1,0 +1,179 @@
+import { useCallback, useMemo } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import type {
+  DataProviderQueryParameters,
+  DataProviderFetchOptions,
+  DataProviderFetchResult,
+} from 'handsontable/plugins/dataProvider';
+
+registerAllModules();
+
+// Serializes fetchRows query parameters into a URL query string that Laravel
+// reads via request()->input().
+//
+// Handsontable sends:
+//   sort:    { prop: 'name', order: 'asc' }  or  null
+//   filters: [{ prop: 'price', condition: { name: 'gt', args: [100] } }]  or  null
+//
+// Laravel reads:
+//   sort[prop], sort[order]
+//   filters[0][prop], filters[0][condition], filters[0][value], filters[0][value2]
+function buildUrl(base: string, { page, pageSize, sort, filters }: DataProviderQueryParameters): string {
+  const params = new URLSearchParams({
+    page: String(page),
+    pageSize: String(pageSize),
+  });
+
+  if (sort) {
+    params.set('sort[prop]', sort.prop);
+    params.set('sort[order]', sort.order);
+  }
+
+  if (filters) {
+    filters.forEach((filter, i) => {
+      params.set(`filters[${i}][prop]`, filter.prop);
+      params.set(`filters[${i}][condition]`, filter.condition);
+      const value = filter.value;
+      if (Array.isArray(value)) {
+        // Single-value conditions: contains, gt, eq, begins_with …
+        if (value[0] != null) params.set(`filters[${i}][value]`, String(value[0]));
+        // Range conditions: between, not_between
+        if (value[1] != null) params.set(`filters[${i}][value2]`, String(value[1]));
+      }
+    });
+  }
+
+  return `${base}?${params}`;
+}
+
+// Reads the CSRF token injected by Blade into <meta name="csrf-token">.
+// For SPA routes protected by Sanctum, use cookie-based auth instead
+// (see Step 9 in the recipe).
+function csrfToken(): string {
+  return (document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement)?.content ?? '';
+}
+
+const ExampleComponent = () => {
+  // fetchRows is called on every page change, sort, and filter.
+  // queryParameters: { page, pageSize, sort, filters }
+  // signal: AbortSignal — pass it to fetch() so stale requests cancel
+  // when the user sorts, filters, or changes pages quickly.
+  const fetchRows = useCallback(
+    async (
+      params: DataProviderQueryParameters,
+      { signal }: DataProviderFetchOptions
+    ): Promise<DataProviderFetchResult> => {
+      const url = buildUrl('/api/products', params);
+      const res = await fetch(url, { signal });
+
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+      // Laravel returns: { data: [...], total: n }
+      const json = await res.json() as { data: unknown[]; total: number };
+
+      return { rows: json.data, totalRows: json.total };
+    },
+    []
+  );
+
+  // onRowsCreate fires when the user inserts rows from the context menu.
+  // payload: { position: 'above'|'below', referenceRowId, rowsAmount }
+  const onRowsCreate = useCallback(async (payload: unknown): Promise<void> => {
+    await fetch('/api/products', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': csrfToken() },
+      body: JSON.stringify(payload),
+    });
+  }, []);
+
+  // onRowsUpdate fires after a cell edit, paste, or autofill batch.
+  // rows is an array of { id, changes, rowData } objects.
+  // Changes appear in the grid immediately (optimistic update) and roll back
+  // if this callback throws or rejects.
+  const onRowsUpdate = useCallback(async (rows: unknown): Promise<void> => {
+    await fetch('/api/products', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': csrfToken() },
+      body: JSON.stringify(rows),
+    });
+  }, []);
+
+  // onRowsRemove fires after the user confirms deletion.
+  // rowIds is an array of stable row IDs (values of the rowId field).
+  const onRowsRemove = useCallback(async (rowIds: unknown[]): Promise<void> => {
+    await fetch('/api/products', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': csrfToken() },
+      body: JSON.stringify(rowIds),
+    });
+  }, []);
+
+  const dataProvider = useMemo(
+    () => ({
+      // rowId must match the primary key field in your Laravel model.
+      // Handsontable uses this value in every update and remove callback.
+      rowId: 'id',
+      fetchRows,
+      onRowsCreate,
+      onRowsUpdate,
+      onRowsRemove,
+    }),
+    [fetchRows, onRowsCreate, onRowsUpdate, onRowsRemove]
+  );
+
+  // beforeRowsMutation fires before any create, update, or remove operation.
+  // Return false to cancel. Here it adds a confirm dialog before deletes.
+  const beforeRowsMutation = useCallback((operation: string, payload: { rowsRemove: unknown[] }) => {
+    if (operation === 'remove') {
+      const count = payload.rowsRemove.length;
+      // eslint-disable-next-line no-alert
+      return window.confirm(`Delete ${count} row${count !== 1 ? 's' : ''}? This cannot be undone.`);
+    }
+  }, []);
+
+  return (
+    <div>
+      <HotTable
+        dataProvider={dataProvider}
+        // beforeRowsMutation fires before any create, update, or remove operation.
+        beforeRowsMutation={beforeRowsMutation}
+        // pagination: pageSize controls how many rows fetchRows requests per call.
+        pagination={{ pageSize: 10 }}
+        // columnSorting sends { prop, order } in queryParameters.sort.
+        // Keep multiColumnSorting off -- it conflicts with dataProvider.
+        columnSorting={true}
+        // filters sends condition objects in queryParameters.filters.
+        // The grid resets to page 1 automatically on each filter change.
+        filters={true}
+        // dropdownMenu shows the column header filter button.
+        dropdownMenu={true}
+        // contextMenu exposes "Insert row above / below" and "Remove row".
+        contextMenu={true}
+        // emptyDataState shows a loading overlay while fetchRows is in flight
+        // and an empty-state overlay when the result set is empty.
+        emptyDataState={true}
+        // notification shows an error toast when fetchRows or any CRUD callback
+        // rejects. Fetch failures include a Refetch button.
+        notification={true}
+        rowHeaders={true}
+        colHeaders={['Name', 'SKU', 'Category', 'Price', 'Stock']}
+        columns={[
+          { data: 'name', type: 'text' },
+          // SKU is generated server-side, so it is read-only in the grid.
+          { data: 'sku', type: 'text', readOnly: true },
+          {
+            data: 'category',
+            type: 'dropdown',
+            source: ['Electronics', 'Accessories', 'Storage', 'Networking', 'Peripherals'],
+          },
+          { data: 'price', type: 'numeric', numericFormat: { pattern: '$0,0.00' } },
+          { data: 'stock', type: 'numeric' },
+        ]}
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </div>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/data-management/server-side-laravel/server-side-laravel.md
+++ b/docs/content/recipes/data-management/server-side-laravel/server-side-laravel.md
@@ -215,6 +215,12 @@ With the server running (`php artisan serve`), configure Handsontable to use the
 
 :::
 
+::: only-for react
+
+@[code jsx](@/content/recipes/data-management/server-side-laravel/react/example1.jsx)
+
+:::
+
 **What's happening:**
 
 ### `buildUrl` helper

--- a/docs/content/recipes/data-management/server-side-laravel/server-side-laravel.md
+++ b/docs/content/recipes/data-management/server-side-laravel/server-side-laravel.md
@@ -210,6 +210,12 @@ With the server running (`php artisan serve`), configure Handsontable to use the
 
 :::
 
+::: only-for react
+
+@[code jsx](@/content/recipes/data-management/server-side-laravel/react/example1.jsx)
+
+:::
+
 **What's happening:**
 
 ### `buildUrl` helper

--- a/docs/content/recipes/data-management/server-side-nestjs/react/example1.jsx
+++ b/docs/content/recipes/data-management/server-side-nestjs/react/example1.jsx
@@ -1,0 +1,164 @@
+import { useCallback, useMemo, useState } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+// ---------------------------------------------------------------------------
+// URL builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Converts Handsontable's DataProviderQueryParameters into a URL query string
+ * that the NestJS backend can parse with @Query() and class-transformer.
+ *
+ * Handsontable passes `params` to fetchRows every time the page, sort, or
+ * filters change. The shape is:
+ *
+ *   {
+ *     page: 1,
+ *     pageSize: 10,
+ *     sort: { column: 'status', order: 'asc' } | undefined,
+ *     filters: [{ prop: 'status', condition: 'eq', value: ['open'] }] | undefined,
+ *   }
+ *
+ * NestJS expects nested objects as bracket notation in the query string:
+ *   sort[column]=status&sort[order]=asc
+ *   filters[0][prop]=status&filters[0][condition]=eq&filters[0][value][]=open
+ */
+function buildUrl(base, params) {
+  const query = new URLSearchParams();
+
+  query.set('page', String(params.page));
+  query.set('pageSize', String(params.pageSize));
+
+  if (params.sort) {
+    query.set('sort[column]', params.sort.column);
+    query.set('sort[order]', params.sort.order);
+  }
+
+  if (params.filters && params.filters.length > 0) {
+    params.filters.forEach((filter, i) => {
+      query.set(`filters[${i}][prop]`, filter.prop);
+      query.set(`filters[${i}][condition]`, filter.condition);
+
+      filter.value.forEach((v, j) => {
+        query.set(`filters[${i}][value][${j}]`, String(v));
+      });
+    });
+  }
+
+  return `${base}?${query.toString()}`;
+}
+
+// ---------------------------------------------------------------------------
+// React component
+// ---------------------------------------------------------------------------
+
+const ExampleComponent = () => {
+  const [status, setStatus] = useState('');
+
+  const fetchRows = useCallback(async (params, { signal }) => {
+    const url = buildUrl('http://localhost:3000/tickets', params);
+    const res = await fetch(url, { signal });
+
+    if (!res.ok) {
+      throw new Error(`Server error ${res.status}`);
+    }
+
+    return res.json();
+  }, []);
+
+  const onRowsCreate = useCallback(async (payload) => {
+    const res = await fetch('http://localhost:3000/tickets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+
+    if (!res.ok) {
+      throw new Error(`Create failed: ${res.status}`);
+    }
+
+    return res.json();
+  }, []);
+
+  const onRowsUpdate = useCallback(async (rows) => {
+    const res = await fetch('http://localhost:3000/tickets', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(rows),
+    });
+
+    if (!res.ok) {
+      throw new Error(`Update failed: ${res.status}`);
+    }
+  }, []);
+
+  const onRowsRemove = useCallback(async (rowIds) => {
+    const res = await fetch('http://localhost:3000/tickets', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(rowIds),
+    });
+
+    if (!res.ok) {
+      throw new Error(`Delete failed: ${res.status}`);
+    }
+  }, []);
+
+  const dataProvider = useMemo(
+    () => ({
+      rowId: 'id',
+      fetchRows,
+      onRowsCreate,
+      onRowsUpdate,
+      onRowsRemove,
+    }),
+    [fetchRows, onRowsCreate, onRowsUpdate, onRowsRemove]
+  );
+
+  return (
+    <div>
+      {status && <div id="status-label">{status}</div>}
+      <HotTable
+        dataProvider={dataProvider}
+        pagination={{ pageSize: 5 }}
+        columnSorting={true}
+        filters={true}
+        dropdownMenu={true}
+        emptyDataState={true}
+        notification={true}
+        colHeaders={['ID', 'Subject', 'Status', 'Priority', 'Assignee', 'Created']}
+        columns={[
+          { data: 'id', type: 'text', readOnly: true, width: 50 },
+          { data: 'subject', type: 'text', width: 280 },
+          {
+            data: 'status',
+            type: 'dropdown',
+            source: ['open', 'in-progress', 'resolved', 'closed'],
+            width: 110,
+          },
+          {
+            data: 'priority',
+            type: 'dropdown',
+            source: ['low', 'medium', 'high', 'critical'],
+            width: 90,
+          },
+          { data: 'assignee', type: 'text', width: 140 },
+          { data: 'createdAt', type: 'date', dateFormat: 'YYYY-MM-DD', width: 110 },
+        ]}
+        rowHeaders={true}
+        height="auto"
+        width="100%"
+        autoWrapRow={true}
+        licenseKey="non-commercial-and-evaluation"
+        afterDataProviderFetch={(result) => {
+          setStatus(`${result.totalRows} tickets total`);
+        }}
+      />
+    </div>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/data-management/server-side-nestjs/react/example1.jsx
+++ b/docs/content/recipes/data-management/server-side-nestjs/react/example1.jsx
@@ -18,7 +18,7 @@ registerAllModules();
  *   {
  *     page: 1,
  *     pageSize: 10,
- *     sort: { column: 'status', order: 'asc' } | undefined,
+ *     sort: { prop: 'status', order: 'asc' } | undefined,
  *     filters: [{ prop: 'status', condition: 'eq', value: ['open'] }] | undefined,
  *   }
  *
@@ -33,7 +33,7 @@ function buildUrl(base, params) {
   query.set('pageSize', String(params.pageSize));
 
   if (params.sort) {
-    query.set('sort[column]', params.sort.column);
+    query.set('sort[column]', params.sort.prop);
     query.set('sort[order]', params.sort.order);
   }
 

--- a/docs/content/recipes/data-management/server-side-nestjs/react/example1.tsx
+++ b/docs/content/recipes/data-management/server-side-nestjs/react/example1.tsx
@@ -23,7 +23,7 @@ registerAllModules();
  *   {
  *     page: 1,
  *     pageSize: 10,
- *     sort: { column: 'status', order: 'asc' } | undefined,
+ *     sort: { prop: 'status', order: 'asc' } | undefined,
  *     filters: [{ prop: 'status', condition: 'eq', value: ['open'] }] | undefined,
  *   }
  *

--- a/docs/content/recipes/data-management/server-side-nestjs/react/example1.tsx
+++ b/docs/content/recipes/data-management/server-side-nestjs/react/example1.tsx
@@ -1,0 +1,167 @@
+import { useCallback, useMemo, useState } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import type {
+  DataProviderQueryParameters,
+  DataProviderFetchOptions,
+  DataProviderFetchResult,
+} from 'handsontable/plugins/dataProvider';
+
+registerAllModules();
+
+// ---------------------------------------------------------------------------
+// URL builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Converts Handsontable's DataProviderQueryParameters into a URL query string
+ * that the NestJS backend can parse with @Query() and class-transformer.
+ *
+ * Handsontable passes `params` to fetchRows every time the page, sort, or
+ * filters change. The shape is:
+ *
+ *   {
+ *     page: 1,
+ *     pageSize: 10,
+ *     sort: { column: 'status', order: 'asc' } | undefined,
+ *     filters: [{ prop: 'status', condition: 'eq', value: ['open'] }] | undefined,
+ *   }
+ *
+ * NestJS expects nested objects as bracket notation in the query string:
+ *   sort[column]=status&sort[order]=asc
+ *   filters[0][prop]=status&filters[0][condition]=eq&filters[0][value][]=open
+ */
+function buildUrl(base: string, params: DataProviderQueryParameters): string {
+  const query = new URLSearchParams();
+
+  query.set('page', String(params.page));
+  query.set('pageSize', String(params.pageSize));
+
+  if (params.sort) {
+    query.set('sort[column]', params.sort.prop);
+    query.set('sort[order]', params.sort.order);
+  }
+
+  if (params.filters && params.filters.length > 0) {
+    params.filters.forEach((filter, i) => {
+      query.set(`filters[${i}][prop]`, filter.prop);
+    });
+  }
+
+  return `${base}?${query.toString()}`;
+}
+
+// ---------------------------------------------------------------------------
+// React component
+// ---------------------------------------------------------------------------
+
+const ExampleComponent = () => {
+  const [status, setStatus] = useState('');
+
+  const fetchRows = useCallback(
+    async (params: DataProviderQueryParameters, { signal }: DataProviderFetchOptions): Promise<DataProviderFetchResult> => {
+      const url = buildUrl('http://localhost:3000/tickets', params);
+      const res = await fetch(url, { signal });
+
+      if (!res.ok) {
+        throw new Error(`Server error ${res.status}`);
+      }
+
+      return res.json() as Promise<DataProviderFetchResult>;
+    },
+    []
+  );
+
+  const onRowsCreate = useCallback(async (payload: unknown): Promise<unknown> => {
+    const res = await fetch('http://localhost:3000/tickets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+
+    if (!res.ok) {
+      throw new Error(`Create failed: ${res.status}`);
+    }
+
+    return res.json();
+  }, []);
+
+  const onRowsUpdate = useCallback(async (rows: unknown): Promise<void> => {
+    const res = await fetch('http://localhost:3000/tickets', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(rows),
+    });
+
+    if (!res.ok) {
+      throw new Error(`Update failed: ${res.status}`);
+    }
+  }, []);
+
+  const onRowsRemove = useCallback(async (rowIds: unknown[]): Promise<void> => {
+    const res = await fetch('http://localhost:3000/tickets', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(rowIds),
+    });
+
+    if (!res.ok) {
+      throw new Error(`Delete failed: ${res.status}`);
+    }
+  }, []);
+
+  const dataProvider = useMemo(
+    () => ({
+      rowId: 'id',
+      fetchRows,
+      onRowsCreate,
+      onRowsUpdate,
+      onRowsRemove,
+    }),
+    [fetchRows, onRowsCreate, onRowsUpdate, onRowsRemove]
+  );
+
+  return (
+    <div>
+      {status && <div id="status-label">{status}</div>}
+      <HotTable
+        dataProvider={dataProvider}
+        pagination={{ pageSize: 5 }}
+        columnSorting={true}
+        filters={true}
+        dropdownMenu={true}
+        emptyDataState={true}
+        notification={true}
+        colHeaders={['ID', 'Subject', 'Status', 'Priority', 'Assignee', 'Created']}
+        columns={[
+          { data: 'id', type: 'text', readOnly: true, width: 50 },
+          { data: 'subject', type: 'text', width: 280 },
+          {
+            data: 'status',
+            type: 'dropdown',
+            source: ['open', 'in-progress', 'resolved', 'closed'],
+            width: 110,
+          },
+          {
+            data: 'priority',
+            type: 'dropdown',
+            source: ['low', 'medium', 'high', 'critical'],
+            width: 90,
+          },
+          { data: 'assignee', type: 'text', width: 140 },
+          { data: 'createdAt', type: 'date', dateFormat: 'YYYY-MM-DD', width: 110 },
+        ]}
+        rowHeaders={true}
+        height="auto"
+        width="100%"
+        autoWrapRow={true}
+        licenseKey="non-commercial-and-evaluation"
+        afterDataProviderFetch={(result) => {
+          setStatus(`${result.totalRows} tickets total`);
+        }}
+      />
+    </div>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/data-management/server-side-nestjs/react/example1.tsx
+++ b/docs/content/recipes/data-management/server-side-nestjs/react/example1.tsx
@@ -45,6 +45,11 @@ function buildUrl(base: string, params: DataProviderQueryParameters): string {
   if (params.filters && params.filters.length > 0) {
     params.filters.forEach((filter, i) => {
       query.set(`filters[${i}][prop]`, filter.prop);
+      query.set(`filters[${i}][condition]`, filter.condition);
+
+      filter.value.forEach((v: string | number, j: number) => {
+        query.set(`filters[${i}][value][${j}]`, String(v));
+      });
     });
   }
 

--- a/docs/content/recipes/data-management/server-side-nestjs/server-side-nestjs.md
+++ b/docs/content/recipes/data-management/server-side-nestjs/server-side-nestjs.md
@@ -218,6 +218,12 @@ With the server running on `http://localhost:3000`, configure Handsontable to us
 
 :::
 
+::: only-for react
+
+@[code jsx](@/content/recipes/data-management/server-side-nestjs/react/example1.jsx)
+
+:::
+
 **What's happening:**
 
 ### `buildUrl` helper

--- a/docs/content/recipes/data-management/server-side-nestjs/server-side-nestjs.md
+++ b/docs/content/recipes/data-management/server-side-nestjs/server-side-nestjs.md
@@ -227,6 +227,12 @@ With the server running on `http://localhost:3000`, configure Handsontable to us
 
 :::
 
+::: only-for react
+
+@[code jsx](@/content/recipes/data-management/server-side-nestjs/react/example1.jsx)
+
+:::
+
 **What's happening:**
 
 ### `buildUrl` helper

--- a/docs/content/recipes/data-management/server-side-spring/react/example1.jsx
+++ b/docs/content/recipes/data-management/server-side-spring/react/example1.jsx
@@ -1,0 +1,146 @@
+import { useCallback, useMemo } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+/**
+ * Builds a URL with query parameters, skipping undefined and null values.
+ *
+ * @param {string} base - The base path (e.g. '/api/products').
+ * @param {Object} params - Key/value pairs to append as query parameters.
+ * @returns {string} The assembled URL string.
+ */
+function buildUrl(base, params) {
+  const url = new URL(base, window.location.origin);
+
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== null) {
+      url.searchParams.set(key, String(value));
+    }
+  }
+
+  return url.toString();
+}
+
+const ExampleComponent = () => {
+  /**
+   * Fetches a page of products from the Spring Boot REST API.
+   *
+   * Handsontable passes the current page, pageSize, sort state, and active
+   * filters. The function maps them to Spring Boot query parameters and
+   * returns { rows, totalRows } so the grid can render pagination controls.
+   *
+   * The AbortSignal in the second argument lets the browser cancel
+   * in-flight requests when the user quickly changes pages or filters.
+   */
+  const fetchRows = useCallback(async ({ page, pageSize, sort, filters }, { signal }) => {
+    const url = buildUrl('/api/products', {
+      page,
+      pageSize,
+      sortProp: sort?.prop,
+      sortOrder: sort?.order,
+      // Handsontable passes filters as an array of objects; serialize to JSON
+      // so it can travel as a single query parameter.
+      filters: filters ? JSON.stringify(filters) : undefined,
+    });
+
+    const res = await fetch(url, { signal });
+    const json = await res.json();
+
+    // The Spring Boot controller returns { rows, totalRows }.
+    return { rows: json.rows, totalRows: json.totalRows };
+  }, []);
+
+  /**
+   * Sends a request to create one or more empty rows on the server.
+   *
+   * The payload shape is { position, referenceRowId, rowsAmount }, which
+   * matches the CreateRowsPayload DTO in ProductController.
+   */
+  const onRowsCreate = useCallback(async (payload) => {
+    await fetch('/api/products/create-rows', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+  }, []);
+
+  /**
+   * Sends changed cell values to the server.
+   *
+   * Each element in the array is { id, changes } where changes is a map
+   * of column name to new value -- matching UpdateRowPayload on the server.
+   */
+  const onRowsUpdate = useCallback(async (rows) => {
+    await fetch('/api/products/update-rows', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(rows),
+    });
+  }, []);
+
+  /**
+   * Sends an array of row IDs to delete on the server.
+   */
+  const onRowsRemove = useCallback(async (rowIds) => {
+    await fetch('/api/products/remove-rows', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(rowIds),
+    });
+  }, []);
+
+  const dataProvider = useMemo(
+    () => ({
+      // 'id' is the primary key returned by the Spring Boot API.
+      rowId: 'id',
+      fetchRows,
+      onRowsCreate,
+      onRowsUpdate,
+      onRowsRemove,
+    }),
+    [fetchRows, onRowsCreate, onRowsUpdate, onRowsRemove]
+  );
+
+  return (
+    <div>
+      <HotTable
+        dataProvider={dataProvider}
+        // Column definitions map to the fields returned by the Spring Boot API.
+        columns={[
+          { data: 'id', title: 'ID', readOnly: true, width: 60 },
+          { data: 'name', title: 'Name', width: 200 },
+          { data: 'sku', title: 'SKU', width: 120 },
+          { data: 'category', title: 'Category', width: 130 },
+          {
+            data: 'price',
+            title: 'Price',
+            type: 'numeric',
+            numericFormat: { pattern: '0,0.00', culture: 'en-US' },
+            width: 100,
+          },
+          { data: 'stock', title: 'Stock', type: 'numeric', width: 80 },
+        ]}
+        colHeaders={true}
+        rowHeaders={true}
+        height={450}
+        width="100%"
+        // Enable server-side column sorting.
+        columnSorting={true}
+        // Enable column filter dropdowns.
+        filters={true}
+        dropdownMenu={true}
+        // Show 10 rows per page; the server returns the matching slice.
+        pagination={{ pageSize: 10 }}
+        // Show a placeholder message when no rows match the active filters.
+        emptyDataState={true}
+        // Show an error toast when a fetch or mutation request fails.
+        notification={true}
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </div>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/data-management/server-side-spring/react/example1.tsx
+++ b/docs/content/recipes/data-management/server-side-spring/react/example1.tsx
@@ -1,0 +1,157 @@
+import { useCallback, useMemo } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import type {
+  DataProviderQueryParameters,
+  DataProviderFetchOptions,
+  DataProviderFetchResult,
+} from 'handsontable/plugins/dataProvider';
+
+registerAllModules();
+
+/**
+ * Builds a URL with query parameters, skipping undefined and null values.
+ *
+ * @param base - The base path (e.g. '/api/products').
+ * @param params - Key/value pairs to append as query parameters.
+ * @returns The assembled URL string.
+ */
+function buildUrl(base: string, params: Record<string, string | number | undefined>): string {
+  const url = new URL(base, window.location.origin);
+
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== null) {
+      url.searchParams.set(key, String(value));
+    }
+  }
+
+  return url.toString();
+}
+
+const ExampleComponent = () => {
+  /**
+   * Fetches a page of products from the Spring Boot REST API.
+   *
+   * Handsontable passes the current page, pageSize, sort state, and active
+   * filters. The function maps them to Spring Boot query parameters and
+   * returns { rows, totalRows } so the grid can render pagination controls.
+   *
+   * The AbortSignal in the second argument lets the browser cancel
+   * in-flight requests when the user quickly changes pages or filters.
+   */
+  const fetchRows = useCallback(
+    async (
+      { page, pageSize, sort, filters }: DataProviderQueryParameters,
+      { signal }: DataProviderFetchOptions
+    ): Promise<DataProviderFetchResult> => {
+      const url = buildUrl('/api/products', {
+        page,
+        pageSize,
+        sortProp: sort?.prop,
+        sortOrder: sort?.order,
+        // Handsontable passes filters as an array of objects; serialize to JSON
+        // so it can travel as a single query parameter.
+        filters: filters ? JSON.stringify(filters) : undefined,
+      });
+
+      const res = await fetch(url, { signal });
+      const json = await res.json() as { rows: unknown[]; totalRows: number };
+
+      // The Spring Boot controller returns { rows, totalRows }.
+      return { rows: json.rows, totalRows: json.totalRows };
+    },
+    []
+  );
+
+  /**
+   * Sends a request to create one or more empty rows on the server.
+   *
+   * The payload shape is { position, referenceRowId, rowsAmount }, which
+   * matches the CreateRowsPayload DTO in ProductController.
+   */
+  const onRowsCreate = useCallback(async (payload: unknown): Promise<void> => {
+    await fetch('/api/products/create-rows', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+  }, []);
+
+  /**
+   * Sends changed cell values to the server.
+   *
+   * Each element in the array is { id, changes } where changes is a map
+   * of column name to new value -- matching UpdateRowPayload on the server.
+   */
+  const onRowsUpdate = useCallback(async (rows: unknown): Promise<void> => {
+    await fetch('/api/products/update-rows', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(rows),
+    });
+  }, []);
+
+  /**
+   * Sends an array of row IDs to delete on the server.
+   */
+  const onRowsRemove = useCallback(async (rowIds: unknown[]): Promise<void> => {
+    await fetch('/api/products/remove-rows', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(rowIds),
+    });
+  }, []);
+
+  const dataProvider = useMemo(
+    () => ({
+      // 'id' is the primary key returned by the Spring Boot API.
+      rowId: 'id',
+      fetchRows,
+      onRowsCreate,
+      onRowsUpdate,
+      onRowsRemove,
+    }),
+    [fetchRows, onRowsCreate, onRowsUpdate, onRowsRemove]
+  );
+
+  return (
+    <div>
+      <HotTable
+        dataProvider={dataProvider}
+        // Column definitions map to the fields returned by the Spring Boot API.
+        columns={[
+          { data: 'id', title: 'ID', readOnly: true, width: 60 },
+          { data: 'name', title: 'Name', width: 200 },
+          { data: 'sku', title: 'SKU', width: 120 },
+          { data: 'category', title: 'Category', width: 130 },
+          {
+            data: 'price',
+            title: 'Price',
+            type: 'numeric',
+            numericFormat: { pattern: '0,0.00', culture: 'en-US' },
+            width: 100,
+          },
+          { data: 'stock', title: 'Stock', type: 'numeric', width: 80 },
+        ]}
+        colHeaders={true}
+        rowHeaders={true}
+        height={450}
+        width="100%"
+        // Enable server-side column sorting.
+        columnSorting={true}
+        // Enable column filter dropdowns.
+        filters={true}
+        dropdownMenu={true}
+        // Show 10 rows per page; the server returns the matching slice.
+        pagination={{ pageSize: 10 }}
+        // Show a placeholder message when no rows match the active filters.
+        emptyDataState={true}
+        // Show an error toast when a fetch or mutation request fails.
+        notification={true}
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </div>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/data-management/server-side-spring/server-side-spring.md
+++ b/docs/content/recipes/data-management/server-side-spring/server-side-spring.md
@@ -239,6 +239,12 @@ With the server running on `http://localhost:8080`, configure Handsontable to us
 
 :::
 
+::: only-for react
+
+@[code jsx](@/content/recipes/data-management/server-side-spring/react/example1.jsx)
+
+:::
+
 **What's happening:**
 
 ### `buildUrl` helper

--- a/docs/content/recipes/data-management/server-side-spring/server-side-spring.md
+++ b/docs/content/recipes/data-management/server-side-spring/server-side-spring.md
@@ -234,6 +234,12 @@ With the server running on `http://localhost:8080`, configure Handsontable to us
 
 :::
 
+::: only-for react
+
+@[code jsx](@/content/recipes/data-management/server-side-spring/react/example1.jsx)
+
+:::
+
 **What's happening:**
 
 ### `buildUrl` helper

--- a/docs/content/recipes/data-management/sync-two-grids/react/example1.css
+++ b/docs/content/recipes/data-management/sync-two-grids/react/example1.css
@@ -1,0 +1,24 @@
+.sync-grids-layout {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.sync-grids-card {
+  border: 1px solid var(--ht-border-color, #e0e0e0);
+  border-radius: var(--ht-border-radius, 8px);
+  padding: 8px;
+  background: var(--ht-background-color, #ffffff);
+}
+
+.sync-grids-card h4 {
+  margin: 0 0 8px;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+@media (max-width: 960px) {
+  .sync-grids-layout {
+    grid-template-columns: 1fr;
+  }
+}

--- a/docs/content/recipes/data-management/sync-two-grids/react/example1.jsx
+++ b/docs/content/recipes/data-management/sync-two-grids/react/example1.jsx
@@ -1,0 +1,143 @@
+import { useRef } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const SOURCE_SYNC_FROM_MASTER = 'sync-from-master';
+
+/* start:skip-in-preview */
+const masterData = [
+  { firstName: 'Mia', lastName: 'Johnson', plan: 'Starter', seats: 5, pricePerSeat: 29, lastActive: '2026-03-09' },
+  { firstName: 'Noah', lastName: 'Chen', plan: 'Team', seats: 12, pricePerSeat: 24, lastActive: '2026-03-10' },
+  { firstName: 'Ava', lastName: 'Miller', plan: 'Business', seats: 18, pricePerSeat: 21, lastActive: '2026-03-08' },
+  { firstName: 'Liam', lastName: 'Davis', plan: 'Enterprise', seats: 35, pricePerSeat: 19, lastActive: '2026-03-11' },
+  { firstName: 'Emma', lastName: 'Wilson', plan: 'Team', seats: 9, pricePerSeat: 24, lastActive: '2026-03-06' },
+  { firstName: 'Oliver', lastName: 'Khan', plan: 'Starter', seats: 4, pricePerSeat: 29, lastActive: '2026-03-07' },
+  { firstName: 'Sophia', lastName: 'Lee', plan: 'Business', seats: 22, pricePerSeat: 21, lastActive: '2026-03-05' },
+  { firstName: 'James', lastName: 'Patel', plan: 'Team', seats: 14, pricePerSeat: 24, lastActive: '2026-03-12' },
+  { firstName: 'Isabella', lastName: 'Rossi', plan: 'Starter', seats: 6, pricePerSeat: 29, lastActive: '2026-03-04' },
+  { firstName: 'Benjamin', lastName: 'Garcia', plan: 'Enterprise', seats: 41, pricePerSeat: 19, lastActive: '2026-03-03' },
+  { firstName: 'Charlotte', lastName: 'Nguyen', plan: 'Business', seats: 19, pricePerSeat: 21, lastActive: '2026-03-02' },
+  { firstName: 'Elijah', lastName: 'Brown', plan: 'Team', seats: 11, pricePerSeat: 24, lastActive: '2026-03-01' },
+];
+/* end:skip-in-preview */
+
+const toDetailRow = (row) => ({
+  customer: `${row.firstName} ${row.lastName}`,
+  plan: String(row.plan ?? '').toUpperCase(),
+  seats: row.seats,
+  monthlyRevenue: `$${(row.seats * row.pricePerSeat).toFixed(2)}`,
+  lastActive: row.lastActive,
+});
+
+const detailColumnMap = {
+  customer: 0,
+  plan: 1,
+  seats: 2,
+  monthlyRevenue: 3,
+  lastActive: 4,
+};
+
+const ExampleComponent = () => {
+  const masterHotRef = useRef(null);
+  const detailHotRef = useRef(null);
+
+  const syncDetailRow = (rowIndex, rowData) => {
+    const detailHot = detailHotRef.current?.hotInstance;
+
+    if (!detailHot) {
+      return;
+    }
+
+    const detailRow = toDetailRow(rowData);
+    const detailChanges = Object.entries(detailColumnMap).map(([prop, columnIndex]) => [
+      rowIndex,
+      columnIndex,
+      detailRow[prop],
+    ]);
+
+    detailHot.setDataAtCell(detailChanges, SOURCE_SYNC_FROM_MASTER);
+  };
+
+  const handleMasterAfterChange = (changes, source) => {
+    // Ignore init/sync writes to prevent re-entrant updates.
+    if (!changes || source === SOURCE_SYNC_FROM_MASTER || source === 'loadData') {
+      return;
+    }
+
+    const masterHot = masterHotRef.current?.hotInstance;
+
+    if (!masterHot) {
+      return;
+    }
+
+    const changedRows = new Set();
+
+    changes.forEach(([row]) => {
+      if (typeof row === 'number') {
+        changedRows.add(row);
+      }
+    });
+
+    changedRows.forEach((rowIndex) => {
+      const rowData = masterHot.getSourceDataAtRow(rowIndex);
+
+      syncDetailRow(rowIndex, rowData);
+    });
+  };
+
+  return (
+    <div className="sync-grids-layout">
+      <section className="sync-grids-card">
+        <h4>Master grid (editable)</h4>
+        <HotTable
+          ref={masterHotRef}
+          data={masterData}
+          colHeaders={['First name', 'Last name', 'Plan', 'Seats', 'Price / seat', 'Last active']}
+          columns={[
+            { data: 'firstName', type: 'text', width: 120 },
+            { data: 'lastName', type: 'text', width: 120 },
+            { data: 'plan', type: 'dropdown', source: ['Starter', 'Team', 'Business', 'Enterprise'], width: 110 },
+            { data: 'seats', type: 'numeric', width: 70 },
+            { data: 'pricePerSeat', type: 'numeric', numericFormat: { pattern: '$0,0.00' }, width: 105 },
+            { data: 'lastActive', type: 'date', dateFormat: 'YYYY-MM-DD', correctFormat: true, width: 110 },
+          ]}
+          rowHeaders={true}
+          height={260}
+          width="100%"
+          autoWrapRow={true}
+          manualColumnResize={true}
+          dropdownMenu={true}
+          stretchH="all"
+          afterChange={handleMasterAfterChange}
+          licenseKey="non-commercial-and-evaluation"
+        />
+      </section>
+      <section className="sync-grids-card">
+        <h4>Detail grid (synced)</h4>
+        <HotTable
+          ref={detailHotRef}
+          data={masterData.map(toDetailRow)}
+          colHeaders={['Customer', 'Plan', 'Seats', 'Monthly revenue', 'Last active']}
+          columns={[
+            { data: 'customer', readOnly: true, width: 170 },
+            { data: 'plan', readOnly: true, width: 110 },
+            { data: 'seats', readOnly: true, type: 'numeric', width: 70 },
+            { data: 'monthlyRevenue', readOnly: true, width: 130 },
+            { data: 'lastActive', readOnly: true, width: 110 },
+          ]}
+          rowHeaders={true}
+          height={260}
+          width="100%"
+          autoWrapRow={true}
+          manualColumnResize={true}
+          stretchH="all"
+          licenseKey="non-commercial-and-evaluation"
+        />
+      </section>
+    </div>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/data-management/sync-two-grids/react/example1.jsx
+++ b/docs/content/recipes/data-management/sync-two-grids/react/example1.jsx
@@ -1,6 +1,7 @@
 import { useRef } from 'react';
 import { HotTable } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
+import './example1.css';
 
 registerAllModules();
 

--- a/docs/content/recipes/data-management/sync-two-grids/react/example1.tsx
+++ b/docs/content/recipes/data-management/sync-two-grids/react/example1.tsx
@@ -1,0 +1,158 @@
+import { useRef } from 'react';
+import { HotTable, HotTableRef } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const SOURCE_SYNC_FROM_MASTER = 'sync-from-master';
+
+/* start:skip-in-preview */
+const masterData = [
+  { firstName: 'Mia', lastName: 'Johnson', plan: 'Starter', seats: 5, pricePerSeat: 29, lastActive: '2026-03-09' },
+  { firstName: 'Noah', lastName: 'Chen', plan: 'Team', seats: 12, pricePerSeat: 24, lastActive: '2026-03-10' },
+  { firstName: 'Ava', lastName: 'Miller', plan: 'Business', seats: 18, pricePerSeat: 21, lastActive: '2026-03-08' },
+  { firstName: 'Liam', lastName: 'Davis', plan: 'Enterprise', seats: 35, pricePerSeat: 19, lastActive: '2026-03-11' },
+  { firstName: 'Emma', lastName: 'Wilson', plan: 'Team', seats: 9, pricePerSeat: 24, lastActive: '2026-03-06' },
+  { firstName: 'Oliver', lastName: 'Khan', plan: 'Starter', seats: 4, pricePerSeat: 29, lastActive: '2026-03-07' },
+  { firstName: 'Sophia', lastName: 'Lee', plan: 'Business', seats: 22, pricePerSeat: 21, lastActive: '2026-03-05' },
+  { firstName: 'James', lastName: 'Patel', plan: 'Team', seats: 14, pricePerSeat: 24, lastActive: '2026-03-12' },
+  { firstName: 'Isabella', lastName: 'Rossi', plan: 'Starter', seats: 6, pricePerSeat: 29, lastActive: '2026-03-04' },
+  { firstName: 'Benjamin', lastName: 'Garcia', plan: 'Enterprise', seats: 41, pricePerSeat: 19, lastActive: '2026-03-03' },
+  { firstName: 'Charlotte', lastName: 'Nguyen', plan: 'Business', seats: 19, pricePerSeat: 21, lastActive: '2026-03-02' },
+  { firstName: 'Elijah', lastName: 'Brown', plan: 'Team', seats: 11, pricePerSeat: 24, lastActive: '2026-03-01' },
+];
+/* end:skip-in-preview */
+
+type MasterRow = {
+  firstName: string;
+  lastName: string;
+  plan: string;
+  seats: number;
+  pricePerSeat: number;
+  lastActive: string;
+};
+
+type DetailRow = {
+  customer: string;
+  plan: string;
+  seats: number;
+  monthlyRevenue: string;
+  lastActive: string;
+};
+
+const toDetailRow = (row: MasterRow): DetailRow => ({
+  customer: `${row.firstName} ${row.lastName}`,
+  plan: String(row.plan ?? '').toUpperCase(),
+  seats: row.seats,
+  monthlyRevenue: `$${(row.seats * row.pricePerSeat).toFixed(2)}`,
+  lastActive: row.lastActive,
+});
+
+const detailColumnMap: Record<keyof DetailRow, number> = {
+  customer: 0,
+  plan: 1,
+  seats: 2,
+  monthlyRevenue: 3,
+  lastActive: 4,
+};
+
+const ExampleComponent = () => {
+  const masterHotRef = useRef<HotTableRef>(null);
+  const detailHotRef = useRef<HotTableRef>(null);
+
+  const syncDetailRow = (rowIndex: number, rowData: MasterRow): void => {
+    const detailHot = detailHotRef.current?.hotInstance;
+
+    if (!detailHot) {
+      return;
+    }
+
+    const detailRow = toDetailRow(rowData);
+    const detailChanges = (Object.entries(detailColumnMap) as [keyof DetailRow, number][]).map(
+      ([prop, columnIndex]) => [rowIndex, columnIndex, detailRow[prop]] as [number, number, unknown]
+    );
+
+    detailHot.setDataAtCell(detailChanges, SOURCE_SYNC_FROM_MASTER);
+  };
+
+  const handleMasterAfterChange = (changes: [number, string | number, unknown, unknown][] | null, source: string): void => {
+    // Ignore init/sync writes to prevent re-entrant updates.
+    if (!changes || source === SOURCE_SYNC_FROM_MASTER || source === 'loadData') {
+      return;
+    }
+
+    const masterHot = masterHotRef.current?.hotInstance;
+
+    if (!masterHot) {
+      return;
+    }
+
+    const changedRows = new Set<number>();
+
+    changes.forEach(([row]) => {
+      if (typeof row === 'number') {
+        changedRows.add(row);
+      }
+    });
+
+    changedRows.forEach((rowIndex) => {
+      const rowData = masterHot.getSourceDataAtRow(rowIndex) as MasterRow;
+
+      syncDetailRow(rowIndex, rowData);
+    });
+  };
+
+  return (
+    <div className="sync-grids-layout">
+      <section className="sync-grids-card">
+        <h4>Master grid (editable)</h4>
+        <HotTable
+          ref={masterHotRef}
+          data={masterData}
+          colHeaders={['First name', 'Last name', 'Plan', 'Seats', 'Price / seat', 'Last active']}
+          columns={[
+            { data: 'firstName', type: 'text', width: 120 },
+            { data: 'lastName', type: 'text', width: 120 },
+            { data: 'plan', type: 'dropdown', source: ['Starter', 'Team', 'Business', 'Enterprise'], width: 110 },
+            { data: 'seats', type: 'numeric', width: 70 },
+            { data: 'pricePerSeat', type: 'numeric', numericFormat: { pattern: '$0,0.00' }, width: 105 },
+            { data: 'lastActive', type: 'date', dateFormat: 'YYYY-MM-DD', correctFormat: true, width: 110 },
+          ]}
+          rowHeaders={true}
+          height={260}
+          width="100%"
+          autoWrapRow={true}
+          manualColumnResize={true}
+          dropdownMenu={true}
+          stretchH="all"
+          afterChange={handleMasterAfterChange}
+          licenseKey="non-commercial-and-evaluation"
+        />
+      </section>
+      <section className="sync-grids-card">
+        <h4>Detail grid (synced)</h4>
+        <HotTable
+          ref={detailHotRef}
+          data={masterData.map(toDetailRow)}
+          colHeaders={['Customer', 'Plan', 'Seats', 'Monthly revenue', 'Last active']}
+          columns={[
+            { data: 'customer', readOnly: true, width: 170 },
+            { data: 'plan', readOnly: true, width: 110 },
+            { data: 'seats', readOnly: true, type: 'numeric', width: 70 },
+            { data: 'monthlyRevenue', readOnly: true, width: 130 },
+            { data: 'lastActive', readOnly: true, width: 110 },
+          ]}
+          rowHeaders={true}
+          height={260}
+          width="100%"
+          autoWrapRow={true}
+          manualColumnResize={true}
+          stretchH="all"
+          licenseKey="non-commercial-and-evaluation"
+        />
+      </section>
+    </div>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/data-management/sync-two-grids/react/example1.tsx
+++ b/docs/content/recipes/data-management/sync-two-grids/react/example1.tsx
@@ -1,6 +1,7 @@
 import { useRef } from 'react';
 import { HotTable, HotTableRef } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
+import './example1.css';
 
 registerAllModules();
 

--- a/docs/content/recipes/data-management/sync-two-grids/sync-two-grids.md
+++ b/docs/content/recipes/data-management/sync-two-grids/sync-two-grids.md
@@ -32,6 +32,18 @@ category: Data Management
 
 :::
 
+::: only-for react
+
+::: example #example1 :react-advanced --css 1 --js 2 --ts 3
+
+@[code](@/content/recipes/data-management/sync-two-grids/react/example1.css)
+@[code](@/content/recipes/data-management/sync-two-grids/react/example1.jsx)
+@[code](@/content/recipes/data-management/sync-two-grids/react/example1.tsx)
+
+:::
+
+:::
+
 ## Overview
 
 This recipe shows how to keep two Handsontable instances in sync on the same page. You edit data in the master grid, and the detail grid updates immediately.

--- a/docs/content/recipes/data-management/undo-redo-custom-ui/react/example1.css
+++ b/docs/content/recipes/data-management/undo-redo-custom-ui/react/example1.css
@@ -1,0 +1,36 @@
+.undo-redo-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.undo-redo-controls button {
+  border: 1px solid var(--sl-color-gray-5);
+  background: var(--sl-color-bg-nav);
+  color: var(--sl-color-text);
+  font-size: var(--sl-text-sm);
+  line-height: 1.2;
+  padding: 0.4rem 0.75rem;
+  border-radius: 0;
+  cursor: pointer;
+  transition: color 0.15s, background-color 0.15s, border-color 0.15s;
+}
+
+.undo-redo-controls button:not(:disabled):hover {
+  color: var(--sl-color-white);
+  background: var(--sl-color-gray-6);
+}
+
+.undo-redo-controls button:focus-visible {
+  outline: 1px solid var(--sl-color-accent);
+  outline-offset: 1px;
+}
+
+.undo-redo-controls button:disabled {
+  color: var(--sl-color-gray-3);
+  border-color: var(--sl-color-gray-5);
+  background: var(--sl-color-gray-7);
+  opacity: 0.8;
+  cursor: not-allowed;
+}

--- a/docs/content/recipes/data-management/undo-redo-custom-ui/react/example1.jsx
+++ b/docs/content/recipes/data-management/undo-redo-custom-ui/react/example1.jsx
@@ -1,0 +1,83 @@
+import { useRef, useState } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+/* start:skip-in-preview */
+const data = [
+  { id: 1, task: 'Write release notes', status: 'Done', owner: 'Mia' },
+  { id: 2, task: 'Update API docs', status: 'In progress', owner: 'Owen' },
+  { id: 3, task: 'Review recipes', status: 'Blocked', owner: 'Lena' },
+  { id: 4, task: 'Ship hotfix', status: 'Done', owner: 'Kai' },
+];
+/* end:skip-in-preview */
+
+const ExampleComponent = () => {
+  const hotRef = useRef(null);
+  const [undoDisabled, setUndoDisabled] = useState(true);
+  const [redoDisabled, setRedoDisabled] = useState(true);
+
+  const updateButtonsState = () => {
+    const hot = hotRef.current?.hotInstance;
+
+    if (!hot) {
+      return;
+    }
+
+    const undoRedoPlugin = hot.getPlugin('undoRedo');
+
+    setUndoDisabled(!undoRedoPlugin.isUndoAvailable());
+    setRedoDisabled(!undoRedoPlugin.isRedoAvailable());
+  };
+
+  const handleUndo = () => {
+    hotRef.current?.hotInstance?.getPlugin('undoRedo').undo();
+    updateButtonsState();
+  };
+
+  const handleRedo = () => {
+    hotRef.current?.hotInstance?.getPlugin('undoRedo').redo();
+    updateButtonsState();
+  };
+
+  return (
+    <>
+      <div className="undo-redo-controls">
+        <button type="button" onClick={handleUndo} disabled={undoDisabled}>
+          Undo
+        </button>
+        <button type="button" onClick={handleRedo} disabled={redoDisabled}>
+          Redo
+        </button>
+      </div>
+      <HotTable
+        ref={hotRef}
+        data={data}
+        colHeaders={['ID', 'Task', 'Status', 'Owner']}
+        rowHeaders={true}
+        width="100%"
+        height="auto"
+        autoWrapRow={true}
+        autoWrapCol={true}
+        undoRedo={true}
+        columns={[
+          { data: 'id', type: 'numeric', width: 60, readOnly: true },
+          { data: 'task', type: 'text', width: 220 },
+          { data: 'status', type: 'text', width: 130 },
+          { data: 'owner', type: 'text', width: 120 },
+        ]}
+        afterChange={(_changes, source) => {
+          if (source !== 'loadData') {
+            updateButtonsState();
+          }
+        }}
+        afterUndo={updateButtonsState}
+        afterRedo={updateButtonsState}
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/data-management/undo-redo-custom-ui/react/example1.jsx
+++ b/docs/content/recipes/data-management/undo-redo-custom-ui/react/example1.jsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from 'react';
 import { HotTable } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
+import './example1.css';
 
 registerAllModules();
 

--- a/docs/content/recipes/data-management/undo-redo-custom-ui/react/example1.tsx
+++ b/docs/content/recipes/data-management/undo-redo-custom-ui/react/example1.tsx
@@ -1,0 +1,83 @@
+import { useRef, useState } from 'react';
+import { HotTable, HotTableRef } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+/* start:skip-in-preview */
+const data = [
+  { id: 1, task: 'Write release notes', status: 'Done', owner: 'Mia' },
+  { id: 2, task: 'Update API docs', status: 'In progress', owner: 'Owen' },
+  { id: 3, task: 'Review recipes', status: 'Blocked', owner: 'Lena' },
+  { id: 4, task: 'Ship hotfix', status: 'Done', owner: 'Kai' },
+];
+/* end:skip-in-preview */
+
+const ExampleComponent = () => {
+  const hotRef = useRef<HotTableRef>(null);
+  const [undoDisabled, setUndoDisabled] = useState(true);
+  const [redoDisabled, setRedoDisabled] = useState(true);
+
+  const updateButtonsState = (): void => {
+    const hot = hotRef.current?.hotInstance;
+
+    if (!hot) {
+      return;
+    }
+
+    const undoRedoPlugin = hot.getPlugin('undoRedo');
+
+    setUndoDisabled(!undoRedoPlugin.isUndoAvailable());
+    setRedoDisabled(!undoRedoPlugin.isRedoAvailable());
+  };
+
+  const handleUndo = (): void => {
+    hotRef.current?.hotInstance?.getPlugin('undoRedo').undo();
+    updateButtonsState();
+  };
+
+  const handleRedo = (): void => {
+    hotRef.current?.hotInstance?.getPlugin('undoRedo').redo();
+    updateButtonsState();
+  };
+
+  return (
+    <>
+      <div className="undo-redo-controls">
+        <button type="button" onClick={handleUndo} disabled={undoDisabled}>
+          Undo
+        </button>
+        <button type="button" onClick={handleRedo} disabled={redoDisabled}>
+          Redo
+        </button>
+      </div>
+      <HotTable
+        ref={hotRef}
+        data={data}
+        colHeaders={['ID', 'Task', 'Status', 'Owner']}
+        rowHeaders={true}
+        width="100%"
+        height="auto"
+        autoWrapRow={true}
+        autoWrapCol={true}
+        undoRedo={true}
+        columns={[
+          { data: 'id', type: 'numeric', width: 60, readOnly: true },
+          { data: 'task', type: 'text', width: 220 },
+          { data: 'status', type: 'text', width: 130 },
+          { data: 'owner', type: 'text', width: 120 },
+        ]}
+        afterChange={(_changes, source) => {
+          if (source !== 'loadData') {
+            updateButtonsState();
+          }
+        }}
+        afterUndo={updateButtonsState}
+        afterRedo={updateButtonsState}
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/data-management/undo-redo-custom-ui/react/example1.tsx
+++ b/docs/content/recipes/data-management/undo-redo-custom-ui/react/example1.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from 'react';
 import { HotTable, HotTableRef } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
+import './example1.css';
 
 registerAllModules();
 

--- a/docs/content/recipes/data-management/undo-redo-custom-ui/undo-redo-custom-ui.md
+++ b/docs/content/recipes/data-management/undo-redo-custom-ui/undo-redo-custom-ui.md
@@ -32,6 +32,18 @@ category: Data Management
 
 :::
 
+::: only-for react
+
+::: example #example1 :react-advanced --css 1 --js 2 --ts 3
+
+@[code](@/content/recipes/data-management/undo-redo-custom-ui/react/example1.css)
+@[code](@/content/recipes/data-management/undo-redo-custom-ui/react/example1.jsx)
+@[code](@/content/recipes/data-management/undo-redo-custom-ui/react/example1.tsx)
+
+:::
+
+:::
+
 ## Overview
 
 This recipe shows how to connect external **Undo** and **Redo** buttons to Handsontable's built-in undo/redo stack. The buttons stay disabled until an action is available, and they update after every change, undo, and redo.

--- a/docs/content/recipes/editing-validation/dependent-dropdowns/dependent-dropdowns.md
+++ b/docs/content/recipes/editing-validation/dependent-dropdowns/dependent-dropdowns.md
@@ -32,6 +32,17 @@ category: Editing and Validation
 
 :::
 
+::: only-for react
+
+::: example #example1 :react-advanced --js 1 --ts 2
+
+@[code](@/content/recipes/editing-validation/dependent-dropdowns/react/example1.jsx)
+@[code](@/content/recipes/editing-validation/dependent-dropdowns/react/example1.tsx)
+
+:::
+
+:::
+
 ## Overview
 
 Use a **parent** `dropdown` column and a **child** `dropdown` whose `source` list depends on the parent value (for example, Category and Subcategory). When the parent changes, you refresh the child's `source` with `setCellMeta`, clear the child's value, and call `render()` so the editor picks up the new options.

--- a/docs/content/recipes/editing-validation/dependent-dropdowns/react/example1.jsx
+++ b/docs/content/recipes/editing-validation/dependent-dropdowns/react/example1.jsx
@@ -1,0 +1,92 @@
+import { useRef } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const CATEGORY_COL = 0;
+const SUBCATEGORY_COL = 1;
+
+/** Parent value -> allowed child dropdown labels */
+const dependencyMap = {
+  Fruit: ['Apple', 'Banana', 'Orange'],
+  Vegetable: ['Carrot', 'Pea', 'Broccoli'],
+  Grain: ['Rice', 'Wheat', 'Oats'],
+};
+
+function optionsForCategory(category) {
+  return dependencyMap[category] ?? [];
+}
+
+/* start:skip-in-preview */
+const data = [
+  ['Fruit', 'Apple'],
+  ['Vegetable', 'Carrot'],
+  ['Grain', ''],
+];
+/* end:skip-in-preview */
+
+const ExampleComponent = () => {
+  const hotRef = useRef(null);
+
+  function afterInit() {
+    const hot = hotRef.current?.hotInstance;
+
+    if (!hot) {
+      return;
+    }
+
+    for (let row = 0; row < hot.countRows(); row++) {
+      const category = String(hot.getDataAtCell(row, CATEGORY_COL) ?? '');
+
+      hot.setCellMeta(row, SUBCATEGORY_COL, 'source', optionsForCategory(category));
+    }
+
+    hot.render();
+  }
+
+  function afterChange(changes, source) {
+    const hot = hotRef.current?.hotInstance;
+
+    if (!hot || source === 'loadData' || !changes) {
+      return;
+    }
+
+    for (const change of changes) {
+      const [row, prop, oldVal, newVal] = change;
+
+      if (prop !== CATEGORY_COL || oldVal === newVal) {
+        continue;
+      }
+
+      const next = optionsForCategory(String(newVal));
+
+      hot.setCellMeta(row, SUBCATEGORY_COL, 'source', next);
+      hot.setDataAtCell(row, SUBCATEGORY_COL, next[0] ?? '');
+    }
+
+    hot.render();
+  }
+
+  return (
+    <div>
+      <HotTable
+        ref={hotRef}
+        data={data}
+        colHeaders={['Category', 'Subcategory']}
+        columns={[
+          { type: 'dropdown', source: Object.keys(dependencyMap) },
+          { type: 'dropdown', source: optionsForCategory(String(data[0][CATEGORY_COL])) },
+        ]}
+        rowHeaders={true}
+        height={200}
+        width="100%"
+        afterInit={afterInit}
+        afterChange={afterChange}
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </div>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/editing-validation/dependent-dropdowns/react/example1.tsx
+++ b/docs/content/recipes/editing-validation/dependent-dropdowns/react/example1.tsx
@@ -1,0 +1,96 @@
+import { useRef } from 'react';
+import { HotTable, HotTableRef } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import Handsontable from 'handsontable/base';
+
+registerAllModules();
+
+const CATEGORY_COL = 0;
+const SUBCATEGORY_COL = 1;
+
+/** Parent value -> allowed child dropdown labels */
+const dependencyMap: Record<string, string[]> = {
+  Fruit: ['Apple', 'Banana', 'Orange'],
+  Vegetable: ['Carrot', 'Pea', 'Broccoli'],
+  Grain: ['Rice', 'Wheat', 'Oats'],
+};
+
+function optionsForCategory(category: string): string[] {
+  return dependencyMap[category] ?? [];
+}
+
+/* start:skip-in-preview */
+const data: string[][] = [
+  ['Fruit', 'Apple'],
+  ['Vegetable', 'Carrot'],
+  ['Grain', ''],
+];
+/* end:skip-in-preview */
+
+const ExampleComponent = () => {
+  const hotRef = useRef<HotTableRef>(null);
+
+  function afterInit(this: Handsontable): void {
+    const hot = hotRef.current?.hotInstance;
+
+    if (!hot) {
+      return;
+    }
+
+    for (let row = 0; row < hot.countRows(); row++) {
+      const category = String(hot.getDataAtCell(row, CATEGORY_COL) ?? '');
+
+      hot.setCellMeta(row, SUBCATEGORY_COL, 'source', optionsForCategory(category));
+    }
+
+    hot.render();
+  }
+
+  function afterChange(
+    changes: Handsontable.CellChange[] | null,
+    source: Handsontable.ChangeSource
+  ): void {
+    const hot = hotRef.current?.hotInstance;
+
+    if (!hot || source === 'loadData' || !changes) {
+      return;
+    }
+
+    for (const change of changes) {
+      const [row, prop, oldVal, newVal] = change;
+
+      if (prop !== CATEGORY_COL || oldVal === newVal) {
+        continue;
+      }
+
+      const next = optionsForCategory(String(newVal));
+
+      hot.setCellMeta(row, SUBCATEGORY_COL, 'source', next);
+      hot.setDataAtCell(row, SUBCATEGORY_COL, next[0] ?? '');
+    }
+
+    hot.render();
+  }
+
+  return (
+    <div>
+      <HotTable
+        ref={hotRef}
+        data={data}
+        colHeaders={['Category', 'Subcategory']}
+        columns={[
+          { type: 'dropdown', source: Object.keys(dependencyMap) },
+          { type: 'dropdown', source: optionsForCategory(String(data[0][CATEGORY_COL])) },
+        ]}
+        rowHeaders={true}
+        height={200}
+        width="100%"
+        afterInit={afterInit}
+        afterChange={afterChange}
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </div>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/editing-validation/row-validation-error-summary/react/example1.css
+++ b/docs/content/recipes/editing-validation/row-validation-error-summary/react/example1.css
@@ -1,0 +1,52 @@
+.row-validation-demo {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ht-gap, 12px);
+  width: 100%;
+}
+
+.row-validation-demo__toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ht-gap, 8px);
+  align-items: center;
+}
+
+.row-validation-demo__submit {
+  padding: 6px 14px;
+  font-size: var(--ht-font-size, 14px);
+  border-radius: var(--ht-border-radius, 4px);
+  border: 1px solid var(--ht-border-color, #ccc);
+  background: var(--ht-accent-color, #1a42e8);
+  color: #fff;
+  cursor: pointer;
+}
+
+.row-validation-demo__submit:hover {
+  filter: brightness(1.05);
+}
+
+.row-validation-demo__summary-title {
+  margin: 0 0 8px;
+  font-size: var(--ht-font-size, 14px);
+  font-weight: 600;
+}
+
+.row-validation-demo__summary-list {
+  margin: 0;
+  padding-left: 1.25rem;
+  font-size: var(--ht-font-size, 14px);
+  color: var(--ht-foreground-color, currentColor);
+}
+
+.row-validation-demo__summary-list:empty::before {
+  content: 'No issues. Click Submit orders to validate.';
+  display: block;
+  margin-left: -1.25rem;
+  color: currentColor;
+  opacity: 0.8;
+}
+
+.row-validation-demo .handsontable td.htInvalid {
+  background-color: var(--ht-cell-error-background-color, #ffe4e4) !important;
+}

--- a/docs/content/recipes/editing-validation/row-validation-error-summary/react/example1.jsx
+++ b/docs/content/recipes/editing-validation/row-validation-error-summary/react/example1.jsx
@@ -1,0 +1,181 @@
+import { useRef, useState } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import './example1.css';
+
+registerAllModules();
+
+const COLUMN_LABELS = ['Item', 'Quantity', 'Unit price'];
+
+/** Column index -> returns `null` when valid, otherwise an error message. */
+const validationRules = {
+  0: (value) => {
+    const text = String(value ?? '').trim();
+
+    return text.length > 0 ? null : 'Item name is required';
+  },
+  1: (value) => {
+    if (value === null || value === '') {
+      return 'Quantity is required';
+    }
+
+    const n = Number(value);
+
+    return !Number.isNaN(n) && n > 0 && Number.isInteger(n)
+      ? null
+      : 'Quantity must be a positive whole number';
+  },
+  2: (value) => {
+    if (value === null || value === '') {
+      return 'Unit price is required';
+    }
+
+    const n = Number(value);
+
+    return !Number.isNaN(n) && n > 0 ? null : 'Unit price must be greater than 0';
+  },
+};
+
+function cellKey(row, col) {
+  return `${row}:${col}`;
+}
+
+const initialData = [
+  { item: 'Widget A', qty: 2, price: 19.99 },
+  { item: '', qty: 1, price: 5 },
+  { item: 'Gadget', qty: -1, price: 12 },
+  { item: 'Cable', qty: 3, price: 0 },
+];
+
+const ExampleComponent = () => {
+  const hotRef = useRef(null);
+  const invalidCellsRef = useRef(new Set());
+  const [issues, setIssues] = useState([]);
+
+  function afterRenderer(TD, row, col) {
+    TD.style.backgroundColor = invalidCellsRef.current.has(cellKey(row, col))
+      ? 'var(--ht-cell-error-background-color, #ffe4e4)'
+      : '';
+  }
+
+  function afterChange(changes, source) {
+    const hot = hotRef.current?.hotInstance;
+
+    if (!hot || source === 'loadData' || !changes) {
+      return;
+    }
+
+    let touched = false;
+
+    for (const change of changes) {
+      const [row, prop] = change;
+      const col = typeof prop === 'string' ? hot.propToCol(prop) : prop;
+      const key = cellKey(row, col);
+
+      if (!invalidCellsRef.current.has(key)) {
+        continue;
+      }
+
+      hot.removeCellMeta(row, col, 'className');
+      hot.removeCellMeta(row, col, 'title');
+      invalidCellsRef.current.delete(key);
+      touched = true;
+    }
+
+    if (touched) {
+      setIssues((prev) =>
+        prev.filter((i) => invalidCellsRef.current.has(cellKey(i.row, i.col)))
+      );
+      hot.render();
+    }
+  }
+
+  function handleSubmit() {
+    const hot = hotRef.current?.hotInstance;
+
+    if (!hot) {
+      return;
+    }
+
+    // Clear existing highlights
+    invalidCellsRef.current.forEach((key) => {
+      const [r, c] = key.split(':').map(Number);
+
+      hot.removeCellMeta(r, c, 'className');
+      hot.removeCellMeta(r, c, 'title');
+    });
+    invalidCellsRef.current.clear();
+
+    // Collect new issues
+    const newIssues = [];
+
+    for (let row = 0; row < hot.countRows(); row++) {
+      for (let col = 0; col < hot.countCols(); col++) {
+        const rule = validationRules[col];
+
+        if (!rule) {
+          continue;
+        }
+
+        const value = hot.getDataAtCell(row, col);
+        const message = rule(value);
+
+        if (message !== null) {
+          newIssues.push({ row, col, message });
+        }
+      }
+    }
+
+    // Apply highlights
+    newIssues.forEach((issue) => {
+      hot.setCellMeta(issue.row, issue.col, 'className', 'htInvalid');
+      hot.setCellMeta(issue.row, issue.col, 'title', issue.message);
+      invalidCellsRef.current.add(cellKey(issue.row, issue.col));
+    });
+
+    hot.render();
+    setIssues(newIssues);
+  }
+
+  return (
+    <div className="row-validation-demo">
+      <div className="row-validation-demo__toolbar">
+        <button
+          type="button"
+          className="row-validation-demo__submit"
+          onClick={handleSubmit}
+        >
+          Submit orders
+        </button>
+      </div>
+      <HotTable
+        ref={hotRef}
+        data={initialData}
+        colHeaders={COLUMN_LABELS}
+        columns={[
+          { data: 'item', type: 'text', width: 180 },
+          { data: 'qty', type: 'numeric', width: 100 },
+          { data: 'price', type: 'numeric', numericFormat: { pattern: '0.00' }, width: 110 },
+        ]}
+        rowHeaders={true}
+        height="auto"
+        width="100%"
+        afterRenderer={afterRenderer}
+        afterChange={afterChange}
+        licenseKey="non-commercial-and-evaluation"
+      />
+      <div>
+        <p className="row-validation-demo__summary-title">Validation summary</p>
+        <ul className="row-validation-demo__summary-list">
+          {issues.map((issue) => (
+            <li key={cellKey(issue.row, issue.col)}>
+              Row {issue.row + 1}, {COLUMN_LABELS[issue.col]}: {issue.message}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/editing-validation/row-validation-error-summary/react/example1.tsx
+++ b/docs/content/recipes/editing-validation/row-validation-error-summary/react/example1.tsx
@@ -1,0 +1,191 @@
+import { useRef, useState } from 'react';
+import { HotTable, HotTableRef } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import Handsontable from 'handsontable/base';
+import './example1.css';
+
+registerAllModules();
+
+const COLUMN_LABELS = ['Item', 'Quantity', 'Unit price'];
+
+/** Column index -> returns `null` when valid, otherwise an error message. */
+const validationRules: Record<number, (value: unknown) => string | null> = {
+  0: (value) => {
+    const text = String(value ?? '').trim();
+
+    return text.length > 0 ? null : 'Item name is required';
+  },
+  1: (value) => {
+    if (value === null || value === '') {
+      return 'Quantity is required';
+    }
+
+    const n = Number(value);
+
+    return !Number.isNaN(n) && n > 0 && Number.isInteger(n)
+      ? null
+      : 'Quantity must be a positive whole number';
+  },
+  2: (value) => {
+    if (value === null || value === '') {
+      return 'Unit price is required';
+    }
+
+    const n = Number(value);
+
+    return !Number.isNaN(n) && n > 0 ? null : 'Unit price must be greater than 0';
+  },
+};
+
+interface Issue {
+  row: number;
+  col: number;
+  message: string;
+}
+
+function cellKey(row: number, col: number): string {
+  return `${row}:${col}`;
+}
+
+const initialData = [
+  { item: 'Widget A', qty: 2, price: 19.99 },
+  { item: '', qty: 1, price: 5 },
+  { item: 'Gadget', qty: -1, price: 12 },
+  { item: 'Cable', qty: 3, price: 0 },
+];
+
+const ExampleComponent = () => {
+  const hotRef = useRef<HotTableRef>(null);
+  const invalidCellsRef = useRef<Set<string>>(new Set());
+  const [issues, setIssues] = useState<Issue[]>([]);
+
+  function afterRenderer(TD: HTMLTableCellElement, row: number, col: number): void {
+    TD.style.backgroundColor = invalidCellsRef.current.has(cellKey(row, col))
+      ? 'var(--ht-cell-error-background-color, #ffe4e4)'
+      : '';
+  }
+
+  function afterChange(
+    changes: Handsontable.CellChange[] | null,
+    source: Handsontable.ChangeSource
+  ): void {
+    const hot = hotRef.current?.hotInstance;
+
+    if (!hot || source === 'loadData' || !changes) {
+      return;
+    }
+
+    let touched = false;
+
+    for (const change of changes) {
+      const [row, prop] = change;
+      const col = typeof prop === 'string' ? hot.propToCol(prop) : (prop as number);
+      const key = cellKey(row, col);
+
+      if (!invalidCellsRef.current.has(key)) {
+        continue;
+      }
+
+      hot.removeCellMeta(row, col, 'className');
+      hot.removeCellMeta(row, col, 'title');
+      invalidCellsRef.current.delete(key);
+      touched = true;
+    }
+
+    if (touched) {
+      setIssues((prev) =>
+        prev.filter((i) => invalidCellsRef.current.has(cellKey(i.row, i.col)))
+      );
+      hot.render();
+    }
+  }
+
+  function handleSubmit(): void {
+    const hot = hotRef.current?.hotInstance;
+
+    if (!hot) {
+      return;
+    }
+
+    // Clear existing highlights
+    invalidCellsRef.current.forEach((key) => {
+      const [r, c] = key.split(':').map(Number);
+
+      hot.removeCellMeta(r, c, 'className');
+      hot.removeCellMeta(r, c, 'title');
+    });
+    invalidCellsRef.current.clear();
+
+    // Collect new issues
+    const newIssues: Issue[] = [];
+
+    for (let row = 0; row < hot.countRows(); row++) {
+      for (let col = 0; col < hot.countCols(); col++) {
+        const rule = validationRules[col];
+
+        if (!rule) {
+          continue;
+        }
+
+        const value = hot.getDataAtCell(row, col);
+        const message = rule(value);
+
+        if (message !== null) {
+          newIssues.push({ row, col, message });
+        }
+      }
+    }
+
+    // Apply highlights
+    newIssues.forEach((issue) => {
+      hot.setCellMeta(issue.row, issue.col, 'className', 'htInvalid');
+      hot.setCellMeta(issue.row, issue.col, 'title', issue.message);
+      invalidCellsRef.current.add(cellKey(issue.row, issue.col));
+    });
+
+    hot.render();
+    setIssues(newIssues);
+  }
+
+  return (
+    <div className="row-validation-demo">
+      <div className="row-validation-demo__toolbar">
+        <button
+          type="button"
+          className="row-validation-demo__submit"
+          onClick={handleSubmit}
+        >
+          Submit orders
+        </button>
+      </div>
+      <HotTable
+        ref={hotRef}
+        data={initialData}
+        colHeaders={COLUMN_LABELS}
+        columns={[
+          { data: 'item', type: 'text', width: 180 },
+          { data: 'qty', type: 'numeric', width: 100 },
+          { data: 'price', type: 'numeric', numericFormat: { pattern: '0.00' }, width: 110 },
+        ]}
+        rowHeaders={true}
+        height="auto"
+        width="100%"
+        afterRenderer={afterRenderer}
+        afterChange={afterChange}
+        licenseKey="non-commercial-and-evaluation"
+      />
+      <div>
+        <p className="row-validation-demo__summary-title">Validation summary</p>
+        <ul className="row-validation-demo__summary-list">
+          {issues.map((issue) => (
+            <li key={cellKey(issue.row, issue.col)}>
+              Row {issue.row + 1}, {COLUMN_LABELS[issue.col]}: {issue.message}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/editing-validation/row-validation-error-summary/row-validation-error-summary.md
+++ b/docs/content/recipes/editing-validation/row-validation-error-summary/row-validation-error-summary.md
@@ -33,6 +33,18 @@ category: Editing and Validation
 
 :::
 
+::: only-for react
+
+::: example #example1 :react-advanced --css 1 --js 2 --ts 3
+
+@[code](@/content/recipes/editing-validation/row-validation-error-summary/react/example1.css)
+@[code](@/content/recipes/editing-validation/row-validation-error-summary/react/example1.jsx)
+@[code](@/content/recipes/editing-validation/row-validation-error-summary/react/example1.tsx)
+
+:::
+
+:::
+
 ## Overview
 
 Run validation for **all rows** when the user clicks **Submit orders**. Keep rules in a map from **column index** to a small function that returns `null` when the value is valid, or a string message when it is not. Collect every failure, show them in a list under the grid, and mark bad cells with `htInvalid` using `setCellMeta` plus `render()`. When the user edits a cell that was marked invalid, clear that cell's highlight and update the summary.

--- a/docs/content/recipes/filtering-and-search/external-search-box/external-search-box.md
+++ b/docs/content/recipes/filtering-and-search/external-search-box/external-search-box.md
@@ -32,6 +32,17 @@ category: Filtering and Search
 
 :::
 
+::: only-for react
+
+::: example #example1 :react-advanced --js 1 --ts 2
+
+@[code](@/content/recipes/filtering-and-search/external-search-box/react/example1.jsx)
+@[code](@/content/recipes/filtering-and-search/external-search-box/react/example1.tsx)
+
+:::
+
+:::
+
 ## Overview
 
 This recipe shows how to place a search input outside Handsontable and use the built-in `Search` plugin to highlight matching cells in real time.

--- a/docs/content/recipes/filtering-and-search/external-search-box/react/example1.jsx
+++ b/docs/content/recipes/filtering-and-search/external-search-box/react/example1.jsx
@@ -1,0 +1,81 @@
+import { useRef, useCallback } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+/* start:skip-in-preview */
+const data = [
+  ['Alice Johnson', 'Engineering', 'Berlin', 'alice.johnson@example.com'],
+  ['Noah Smith', 'Design', 'Warsaw', 'noah.smith@example.com'],
+  ['Mia Garcia', 'Marketing', 'New York', 'mia.garcia@example.com'],
+  ['Liam Brown', 'Engineering', 'Toronto', 'liam.brown@example.com'],
+  ['Emma Davis', 'Sales', 'London', 'emma.davis@example.com'],
+  ['Oliver Miller', 'Support', 'Madrid', 'oliver.miller@example.com'],
+];
+/* end:skip-in-preview */
+
+const debounce = (callback, delay = 120) => {
+  let timeoutId;
+
+  return (...args) => {
+    window.clearTimeout(timeoutId);
+    timeoutId = window.setTimeout(() => callback(...args), delay);
+  };
+};
+
+const ExampleComponent = () => {
+  const hotRef = useRef(null);
+
+  const runSearch = useCallback(
+    debounce((value) => {
+      const hot = hotRef.current?.hotInstance;
+
+      if (!hot) {
+        return;
+      }
+
+      hot.getPlugin('search').query(value);
+      hot.render();
+    }),
+    []
+  );
+
+  function handleSearchInput(e) {
+    runSearch(e.target.value);
+  }
+
+  return (
+    <div>
+      <div style={{ marginBottom: '12px' }}>
+        <label
+          htmlFor="external-search-input"
+          style={{ display: 'block', marginBottom: '4px' }}
+        >
+          Search rows
+        </label>
+        <input
+          id="external-search-input"
+          type="text"
+          placeholder="Type to highlight matching cells..."
+          style={{ width: '100%', boxSizing: 'border-box', padding: '8px' }}
+          onInput={handleSearchInput}
+        />
+      </div>
+      <HotTable
+        ref={hotRef}
+        data={data}
+        rowHeaders={true}
+        colHeaders={['Name', 'Team', 'Location', 'Email']}
+        height="auto"
+        width="100%"
+        autoWrapRow={true}
+        autoWrapCol={true}
+        search={true}
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </div>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/filtering-and-search/external-search-box/react/example1.tsx
+++ b/docs/content/recipes/filtering-and-search/external-search-box/react/example1.tsx
@@ -1,0 +1,81 @@
+import { useRef, useCallback } from 'react';
+import { HotTable, HotTableRef } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+/* start:skip-in-preview */
+const data = [
+  ['Alice Johnson', 'Engineering', 'Berlin', 'alice.johnson@example.com'],
+  ['Noah Smith', 'Design', 'Warsaw', 'noah.smith@example.com'],
+  ['Mia Garcia', 'Marketing', 'New York', 'mia.garcia@example.com'],
+  ['Liam Brown', 'Engineering', 'Toronto', 'liam.brown@example.com'],
+  ['Emma Davis', 'Sales', 'London', 'emma.davis@example.com'],
+  ['Oliver Miller', 'Support', 'Madrid', 'oliver.miller@example.com'],
+];
+/* end:skip-in-preview */
+
+const debounce = (callback: (...args: unknown[]) => void, delay = 120) => {
+  let timeoutId: ReturnType<typeof setTimeout>;
+
+  return (...args: unknown[]) => {
+    window.clearTimeout(timeoutId);
+    timeoutId = window.setTimeout(() => callback(...args), delay);
+  };
+};
+
+const ExampleComponent = () => {
+  const hotRef = useRef<HotTableRef>(null);
+
+  const runSearch = useCallback(
+    debounce((value: unknown) => {
+      const hot = hotRef.current?.hotInstance;
+
+      if (!hot) {
+        return;
+      }
+
+      hot.getPlugin('search').query(String(value));
+      hot.render();
+    }),
+    []
+  );
+
+  function handleSearchInput(e: React.FormEvent<HTMLInputElement>) {
+    runSearch(e.currentTarget.value);
+  }
+
+  return (
+    <div>
+      <div style={{ marginBottom: '12px' }}>
+        <label
+          htmlFor="external-search-input"
+          style={{ display: 'block', marginBottom: '4px' }}
+        >
+          Search rows
+        </label>
+        <input
+          id="external-search-input"
+          type="text"
+          placeholder="Type to highlight matching cells..."
+          style={{ width: '100%', boxSizing: 'border-box', padding: '8px' }}
+          onInput={handleSearchInput}
+        />
+      </div>
+      <HotTable
+        ref={hotRef}
+        data={data}
+        rowHeaders={true}
+        colHeaders={['Name', 'Team', 'Location', 'Email']}
+        height="auto"
+        width="100%"
+        autoWrapRow={true}
+        autoWrapCol={true}
+        search={true}
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </div>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/filtering-and-search/highlight-search-matches/highlight-search-matches.md
+++ b/docs/content/recipes/filtering-and-search/highlight-search-matches/highlight-search-matches.md
@@ -33,6 +33,17 @@ category: Filtering and Search
 
 :::
 
+::: only-for react
+
+::: example #example1 :react-advanced --js 1 --ts 2
+
+@[code](@/content/recipes/filtering-and-search/highlight-search-matches/react/example1.jsx)
+@[code](@/content/recipes/filtering-and-search/highlight-search-matches/react/example1.tsx)
+
+:::
+
+:::
+
 ## Overview
 
 This recipe shows how to highlight matched text fragments with a custom renderer that wraps matches in a `<mark>` element. You can use this approach when you want richer highlighting than the default Search plugin class.

--- a/docs/content/recipes/filtering-and-search/highlight-search-matches/react/example1.jsx
+++ b/docs/content/recipes/filtering-and-search/highlight-search-matches/react/example1.jsx
@@ -1,0 +1,97 @@
+import { useRef } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import { rendererFactory } from 'handsontable/renderers';
+
+registerAllModules();
+
+const data = [
+  { id: 101, title: 'Search API docs', owner: 'Alex', status: 'In progress' },
+  { id: 102, title: 'Renderer refactor', owner: 'Mia', status: 'Review' },
+  { id: 103, title: 'Fix keyboard shortcut', owner: 'Noah', status: 'Done' },
+  { id: 104, title: 'Search UX tests', owner: 'Ava', status: 'In progress' },
+];
+
+let currentSearchTerm = '';
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function escapeHtml(value) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+const highlightRenderer = rendererFactory(({ td, value, cellProperties }) => {
+  const cellText = value === null || value === undefined ? '' : String(value);
+  const query = currentSearchTerm.trim();
+
+  if (!query || !cellProperties.isSearchResult) {
+    td.textContent = cellText;
+    return;
+  }
+
+  const splitter = new RegExp(`(${escapeRegExp(query)})`, 'gi');
+  const highlighted = cellText
+    .split(splitter)
+    .map((fragment) =>
+      fragment.toLocaleLowerCase() === query.toLocaleLowerCase()
+        ? `<mark>${escapeHtml(fragment)}</mark>`
+        : escapeHtml(fragment)
+    )
+    .join('');
+
+  td.innerHTML = highlighted;
+});
+
+const ExampleComponent = () => {
+  const hotRef = useRef(null);
+
+  function handleSearchInput(e) {
+    const hot = hotRef.current?.hotInstance;
+
+    if (!hot) {
+      return;
+    }
+
+    currentSearchTerm = e.target.value;
+    hot.getPlugin('search').query(currentSearchTerm);
+    hot.render();
+  }
+
+  return (
+    <div>
+      <div className="example-controls-container">
+        <div className="controls">
+          <input
+            type="search"
+            placeholder="Search tasks"
+            onInput={handleSearchInput}
+          />
+        </div>
+      </div>
+      <HotTable
+        ref={hotRef}
+        data={data}
+        colHeaders={['ID', 'Title', 'Owner', 'Status']}
+        rowHeaders={true}
+        height="auto"
+        search={true}
+        columns={[
+          { data: 'id', type: 'numeric' },
+          { data: 'title', renderer: highlightRenderer },
+          { data: 'owner', renderer: highlightRenderer },
+          { data: 'status', renderer: highlightRenderer },
+        ]}
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </div>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/filtering-and-search/highlight-search-matches/react/example1.tsx
+++ b/docs/content/recipes/filtering-and-search/highlight-search-matches/react/example1.tsx
@@ -1,0 +1,97 @@
+import { useRef } from 'react';
+import { HotTable, HotTableRef } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import { rendererFactory } from 'handsontable/renderers';
+
+registerAllModules();
+
+const data = [
+  { id: 101, title: 'Search API docs', owner: 'Alex', status: 'In progress' },
+  { id: 102, title: 'Renderer refactor', owner: 'Mia', status: 'Review' },
+  { id: 103, title: 'Fix keyboard shortcut', owner: 'Noah', status: 'Done' },
+  { id: 104, title: 'Search UX tests', owner: 'Ava', status: 'In progress' },
+];
+
+let currentSearchTerm = '';
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+const highlightRenderer = rendererFactory(({ td, value, cellProperties }) => {
+  const cellText = value === null || value === undefined ? '' : String(value);
+  const query = currentSearchTerm.trim();
+
+  if (!query || !cellProperties.isSearchResult) {
+    td.textContent = cellText;
+    return;
+  }
+
+  const splitter = new RegExp(`(${escapeRegExp(query)})`, 'gi');
+  const highlighted = cellText
+    .split(splitter)
+    .map((fragment) =>
+      fragment.toLocaleLowerCase() === query.toLocaleLowerCase()
+        ? `<mark>${escapeHtml(fragment)}</mark>`
+        : escapeHtml(fragment)
+    )
+    .join('');
+
+  td.innerHTML = highlighted;
+});
+
+const ExampleComponent = () => {
+  const hotRef = useRef<HotTableRef>(null);
+
+  function handleSearchInput(e: React.FormEvent<HTMLInputElement>) {
+    const hot = hotRef.current?.hotInstance;
+
+    if (!hot) {
+      return;
+    }
+
+    currentSearchTerm = e.currentTarget.value;
+    hot.getPlugin('search').query(currentSearchTerm);
+    hot.render();
+  }
+
+  return (
+    <div>
+      <div className="example-controls-container">
+        <div className="controls">
+          <input
+            type="search"
+            placeholder="Search tasks"
+            onInput={handleSearchInput}
+          />
+        </div>
+      </div>
+      <HotTable
+        ref={hotRef}
+        data={data}
+        colHeaders={['ID', 'Title', 'Owner', 'Status']}
+        rowHeaders={true}
+        height="auto"
+        search={true}
+        columns={[
+          { data: 'id', type: 'numeric' },
+          { data: 'title', renderer: highlightRenderer },
+          { data: 'owner', renderer: highlightRenderer },
+          { data: 'status', renderer: highlightRenderer },
+        ]}
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </div>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/filtering-search/multi-column-filter-panel/multi-column-filter-panel.md
+++ b/docs/content/recipes/filtering-search/multi-column-filter-panel/multi-column-filter-panel.md
@@ -32,6 +32,18 @@ category: Filtering and Search
 
 :::
 
+::: only-for react
+
+::: example #example1 :react-advanced --css 1 --js 2 --ts 3
+
+@[code](@/content/recipes/filtering-search/multi-column-filter-panel/react/example1.css)
+@[code](@/content/recipes/filtering-search/multi-column-filter-panel/react/example1.jsx)
+@[code](@/content/recipes/filtering-search/multi-column-filter-panel/react/example1.tsx)
+
+:::
+
+:::
+
 ## Overview
 
 This recipe shows how to control the Filters plugin from a filter panel outside of the grid. The panel includes controls aligned with the grid columns, and it applies all active filters together with AND logic.

--- a/docs/content/recipes/filtering-search/multi-column-filter-panel/react/example1.css
+++ b/docs/content/recipes/filtering-search/multi-column-filter-panel/react/example1.css
@@ -1,0 +1,20 @@
+.filter-panel {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  align-items: flex-end;
+}
+
+/* Stack label text above the control (overrides the inline-flex horizontal
+   layout from interactive-example.css) */
+.example-controls-container .filter-label {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.25rem;
+  min-width: 120px;
+}
+
+.example-controls-container .filter-label--wide {
+  min-width: 160px;
+}

--- a/docs/content/recipes/filtering-search/multi-column-filter-panel/react/example1.jsx
+++ b/docs/content/recipes/filtering-search/multi-column-filter-panel/react/example1.jsx
@@ -1,0 +1,193 @@
+import { useRef, useState } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import './example1.css';
+
+registerAllModules();
+
+/* start:skip-in-preview */
+const sourceData = [
+  { name: 'Trail Bike', category: 'Bikes', price: 1499, stock: 12 },
+  { name: 'Road Helmet', category: 'Safety', price: 89, stock: 42 },
+  { name: 'Flat Pedals', category: 'Components', price: 59, stock: 80 },
+  { name: 'Hydration Pack', category: 'Accessories', price: 129, stock: 23 },
+  { name: 'Brake Pads', category: 'Components', price: 25, stock: 150 },
+  { name: 'Cycling Glasses', category: 'Accessories', price: 79, stock: 33 },
+  { name: 'Chain Lube', category: 'Maintenance', price: 16, stock: 99 },
+  { name: 'Torque Wrench', category: 'Maintenance', price: 139, stock: 14 },
+  { name: 'Kids Helmet', category: 'Safety', price: 54, stock: 20 },
+  { name: 'Gravel Bike', category: 'Bikes', price: 2199, stock: 7 },
+];
+/* end:skip-in-preview */
+
+const ExampleComponent = () => {
+  const hotRef = useRef(null);
+  const [nameFilter, setNameFilter] = useState('');
+  const [categoryFilter, setCategoryFilter] = useState('');
+  const [minPrice, setMinPrice] = useState('');
+  const [maxPrice, setMaxPrice] = useState('');
+
+  function applyFilters(name, category, min, max) {
+    const hot = hotRef.current?.hotInstance;
+
+    if (!hot) {
+      return;
+    }
+
+    const filtersPlugin = hot.getPlugin('filters');
+
+    filtersPlugin.clearConditions();
+
+    if (category) {
+      filtersPlugin.addCondition(1, 'eq', [category]);
+    }
+
+    if (name.trim()) {
+      filtersPlugin.addCondition(0, 'contains', [name.trim()]);
+    }
+
+    if (min && max) {
+      const lowerBound = Number(min);
+      const upperBound = Number(max);
+
+      if (Number.isFinite(lowerBound) && Number.isFinite(upperBound)) {
+        filtersPlugin.addCondition(2, 'between', [lowerBound, upperBound]);
+      }
+    } else if (min) {
+      const lowerBound = Number(min);
+
+      if (Number.isFinite(lowerBound)) {
+        filtersPlugin.addCondition(2, 'gte', [lowerBound]);
+      }
+    } else if (max) {
+      const upperBound = Number(max);
+
+      if (Number.isFinite(upperBound)) {
+        filtersPlugin.addCondition(2, 'lte', [upperBound]);
+      }
+    }
+
+    filtersPlugin.filter();
+    hot.render();
+  }
+
+  function handleNameChange(e) {
+    const value = e.target.value;
+
+    setNameFilter(value);
+    applyFilters(value, categoryFilter, minPrice, maxPrice);
+  }
+
+  function handleCategoryChange(e) {
+    const value = e.target.value;
+
+    setCategoryFilter(value);
+    applyFilters(nameFilter, value, minPrice, maxPrice);
+  }
+
+  function handleMinPriceChange(e) {
+    const value = e.target.value;
+
+    setMinPrice(value);
+    applyFilters(nameFilter, categoryFilter, value, maxPrice);
+  }
+
+  function handleMaxPriceChange(e) {
+    const value = e.target.value;
+
+    setMaxPrice(value);
+    applyFilters(nameFilter, categoryFilter, minPrice, value);
+  }
+
+  function clearFilters() {
+    setNameFilter('');
+    setCategoryFilter('');
+    setMinPrice('');
+    setMaxPrice('');
+
+    const hot = hotRef.current?.hotInstance;
+
+    if (!hot) {
+      return;
+    }
+
+    const filtersPlugin = hot.getPlugin('filters');
+
+    filtersPlugin.clearConditions();
+    filtersPlugin.filter();
+    hot.render();
+  }
+
+  return (
+    <div>
+      <div className="example-controls-container">
+        <div className="filter-panel">
+          <label className="filter-label filter-label--wide">
+            Product name
+            <input
+              type="text"
+              placeholder="Contains..."
+              value={nameFilter}
+              onChange={handleNameChange}
+            />
+          </label>
+          <label className="filter-label filter-label--wide">
+            Category
+            <select value={categoryFilter} onChange={handleCategoryChange}>
+              <option value="">All categories</option>
+              <option value="Bikes">Bikes</option>
+              <option value="Safety">Safety</option>
+              <option value="Components">Components</option>
+              <option value="Accessories">Accessories</option>
+              <option value="Maintenance">Maintenance</option>
+            </select>
+          </label>
+          <label className="filter-label">
+            Min price
+            <input
+              type="number"
+              min="0"
+              placeholder="0"
+              value={minPrice}
+              onChange={handleMinPriceChange}
+            />
+          </label>
+          <label className="filter-label">
+            Max price
+            <input
+              type="number"
+              min="0"
+              placeholder="2500"
+              value={maxPrice}
+              onChange={handleMaxPriceChange}
+            />
+          </label>
+          <button type="button" onClick={clearFilters}>
+            Clear all filters
+          </button>
+        </div>
+      </div>
+      <HotTable
+        ref={hotRef}
+        data={sourceData}
+        columns={[
+          { data: 'name', type: 'text', title: 'Product' },
+          { data: 'category', type: 'text', title: 'Category' },
+          { data: 'price', type: 'numeric', title: 'Price' },
+          { data: 'stock', type: 'numeric', title: 'Stock' },
+        ]}
+        colHeaders={['Product', 'Category', 'Price', 'Stock']}
+        rowHeaders={true}
+        filters={true}
+        dropdownMenu={false}
+        width="100%"
+        height={320}
+        autoWrapRow={true}
+        autoWrapCol={true}
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </div>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/filtering-search/multi-column-filter-panel/react/example1.tsx
+++ b/docs/content/recipes/filtering-search/multi-column-filter-panel/react/example1.tsx
@@ -1,0 +1,193 @@
+import { useRef, useState } from 'react';
+import { HotTable, HotTableRef } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import './example1.css';
+
+registerAllModules();
+
+/* start:skip-in-preview */
+const sourceData = [
+  { name: 'Trail Bike', category: 'Bikes', price: 1499, stock: 12 },
+  { name: 'Road Helmet', category: 'Safety', price: 89, stock: 42 },
+  { name: 'Flat Pedals', category: 'Components', price: 59, stock: 80 },
+  { name: 'Hydration Pack', category: 'Accessories', price: 129, stock: 23 },
+  { name: 'Brake Pads', category: 'Components', price: 25, stock: 150 },
+  { name: 'Cycling Glasses', category: 'Accessories', price: 79, stock: 33 },
+  { name: 'Chain Lube', category: 'Maintenance', price: 16, stock: 99 },
+  { name: 'Torque Wrench', category: 'Maintenance', price: 139, stock: 14 },
+  { name: 'Kids Helmet', category: 'Safety', price: 54, stock: 20 },
+  { name: 'Gravel Bike', category: 'Bikes', price: 2199, stock: 7 },
+];
+/* end:skip-in-preview */
+
+const ExampleComponent = () => {
+  const hotRef = useRef<HotTableRef>(null);
+  const [nameFilter, setNameFilter] = useState('');
+  const [categoryFilter, setCategoryFilter] = useState('');
+  const [minPrice, setMinPrice] = useState('');
+  const [maxPrice, setMaxPrice] = useState('');
+
+  function applyFilters(name: string, category: string, min: string, max: string) {
+    const hot = hotRef.current?.hotInstance;
+
+    if (!hot) {
+      return;
+    }
+
+    const filtersPlugin = hot.getPlugin('filters');
+
+    filtersPlugin.clearConditions();
+
+    if (category) {
+      filtersPlugin.addCondition(1, 'eq', [category]);
+    }
+
+    if (name.trim()) {
+      filtersPlugin.addCondition(0, 'contains', [name.trim()]);
+    }
+
+    if (min && max) {
+      const lowerBound = Number(min);
+      const upperBound = Number(max);
+
+      if (Number.isFinite(lowerBound) && Number.isFinite(upperBound)) {
+        filtersPlugin.addCondition(2, 'between', [lowerBound, upperBound]);
+      }
+    } else if (min) {
+      const lowerBound = Number(min);
+
+      if (Number.isFinite(lowerBound)) {
+        filtersPlugin.addCondition(2, 'gte', [lowerBound]);
+      }
+    } else if (max) {
+      const upperBound = Number(max);
+
+      if (Number.isFinite(upperBound)) {
+        filtersPlugin.addCondition(2, 'lte', [upperBound]);
+      }
+    }
+
+    filtersPlugin.filter();
+    hot.render();
+  }
+
+  function handleNameChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const value = e.target.value;
+
+    setNameFilter(value);
+    applyFilters(value, categoryFilter, minPrice, maxPrice);
+  }
+
+  function handleCategoryChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    const value = e.target.value;
+
+    setCategoryFilter(value);
+    applyFilters(nameFilter, value, minPrice, maxPrice);
+  }
+
+  function handleMinPriceChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const value = e.target.value;
+
+    setMinPrice(value);
+    applyFilters(nameFilter, categoryFilter, value, maxPrice);
+  }
+
+  function handleMaxPriceChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const value = e.target.value;
+
+    setMaxPrice(value);
+    applyFilters(nameFilter, categoryFilter, minPrice, value);
+  }
+
+  function clearFilters() {
+    setNameFilter('');
+    setCategoryFilter('');
+    setMinPrice('');
+    setMaxPrice('');
+
+    const hot = hotRef.current?.hotInstance;
+
+    if (!hot) {
+      return;
+    }
+
+    const filtersPlugin = hot.getPlugin('filters');
+
+    filtersPlugin.clearConditions();
+    filtersPlugin.filter();
+    hot.render();
+  }
+
+  return (
+    <div>
+      <div className="example-controls-container">
+        <div className="filter-panel">
+          <label className="filter-label filter-label--wide">
+            Product name
+            <input
+              type="text"
+              placeholder="Contains..."
+              value={nameFilter}
+              onChange={handleNameChange}
+            />
+          </label>
+          <label className="filter-label filter-label--wide">
+            Category
+            <select value={categoryFilter} onChange={handleCategoryChange}>
+              <option value="">All categories</option>
+              <option value="Bikes">Bikes</option>
+              <option value="Safety">Safety</option>
+              <option value="Components">Components</option>
+              <option value="Accessories">Accessories</option>
+              <option value="Maintenance">Maintenance</option>
+            </select>
+          </label>
+          <label className="filter-label">
+            Min price
+            <input
+              type="number"
+              min="0"
+              placeholder="0"
+              value={minPrice}
+              onChange={handleMinPriceChange}
+            />
+          </label>
+          <label className="filter-label">
+            Max price
+            <input
+              type="number"
+              min="0"
+              placeholder="2500"
+              value={maxPrice}
+              onChange={handleMaxPriceChange}
+            />
+          </label>
+          <button type="button" onClick={clearFilters}>
+            Clear all filters
+          </button>
+        </div>
+      </div>
+      <HotTable
+        ref={hotRef}
+        data={sourceData}
+        columns={[
+          { data: 'name', type: 'text', title: 'Product' },
+          { data: 'category', type: 'text', title: 'Category' },
+          { data: 'price', type: 'numeric', title: 'Price' },
+          { data: 'stock', type: 'numeric', title: 'Stock' },
+        ]}
+        colHeaders={['Product', 'Category', 'Price', 'Stock']}
+        rowHeaders={true}
+        filters={true}
+        dropdownMenu={false}
+        width="100%"
+        height={320}
+        autoWrapRow={true}
+        autoWrapCol={true}
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </div>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/import-export/export-to-pdf/export-to-pdf.md
+++ b/docs/content/recipes/import-export/export-to-pdf/export-to-pdf.md
@@ -32,6 +32,17 @@ category: Import and Export
 
 :::
 
+::: only-for react
+
+::: example #example1 :react-advanced --js 1 --ts 2 --deps jspdf jspdf-autotable
+
+@[code](@/content/recipes/import-export/export-to-pdf/react/example1.jsx)
+@[code](@/content/recipes/import-export/export-to-pdf/react/example1.tsx)
+
+:::
+
+:::
+
 [[toc]]
 
 ## Overview

--- a/docs/content/recipes/import-export/export-to-pdf/react/example1.jsx
+++ b/docs/content/recipes/import-export/export-to-pdf/react/example1.jsx
@@ -1,0 +1,77 @@
+import { useRef } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import { jsPDF } from 'jspdf';
+import { autoTable } from 'jspdf-autotable';
+
+registerAllModules();
+
+/* start:skip-in-preview */
+// Enough rows to span multiple A4 pages when exported (jspdf-autotable paginates automatically).
+const ROWS = 85;
+const data = Array.from({ length: ROWS }, (_, row) => [
+  `SKU-${1000 + row}`,
+  `Product ${row + 1}`,
+  row % 12 + 1,
+  (9.99 + row * 0.25).toFixed(2),
+  ((row % 12 + 1) * (9.99 + row * 0.25)).toFixed(2),
+]);
+/* end:skip-in-preview */
+
+const ExampleComponent = () => {
+  const hotRef = useRef(null);
+
+  const exportGridToPdf = () => {
+    const hot = hotRef.current?.hotInstance;
+
+    if (!hot) {
+      return;
+    }
+
+    const body = hot.getData();
+    const colCount = hot.countCols();
+    const head = [
+      Array.from({ length: colCount }, (_, col) => String(hot.getColHeader(col))),
+    ];
+
+    const doc = new jsPDF({ orientation: 'portrait', unit: 'mm', format: 'a4' });
+
+    autoTable(doc, {
+      head,
+      body,
+      styles: { fontSize: 8, cellPadding: 1.5, overflow: 'linebreak' },
+      headStyles: {
+        fillColor: [26, 66, 232],
+        textColor: 255,
+        fontStyle: 'bold',
+      },
+      alternateRowStyles: { fillColor: [245, 247, 250] },
+      margin: { top: 14, left: 12, right: 12, bottom: 14 },
+      showHead: 'everyPage',
+    });
+
+    doc.save('export.pdf');
+  };
+
+  return (
+    <>
+      <div className="export-pdf-toolbar">
+        <button type="button" className="export-pdf-btn" onClick={exportGridToPdf}>
+          Export to PDF
+        </button>
+      </div>
+      <HotTable
+        ref={hotRef}
+        data={data}
+        colHeaders={['SKU', 'Product', 'Qty', 'Unit price', 'Line total']}
+        columnSorting={true}
+        rowHeaders={true}
+        height={320}
+        width="100%"
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/import-export/export-to-pdf/react/example1.tsx
+++ b/docs/content/recipes/import-export/export-to-pdf/react/example1.tsx
@@ -1,0 +1,77 @@
+import { useRef } from 'react';
+import { HotTable, HotTableRef } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import { jsPDF } from 'jspdf';
+import { autoTable } from 'jspdf-autotable';
+
+registerAllModules();
+
+/* start:skip-in-preview */
+// Enough rows to span multiple A4 pages when exported (jspdf-autotable paginates automatically).
+const ROWS = 85;
+const data: (string | number)[][] = Array.from({ length: ROWS }, (_, row) => [
+  `SKU-${1000 + row}`,
+  `Product ${row + 1}`,
+  row % 12 + 1,
+  (9.99 + row * 0.25).toFixed(2),
+  ((row % 12 + 1) * (9.99 + row * 0.25)).toFixed(2),
+]);
+/* end:skip-in-preview */
+
+const ExampleComponent = () => {
+  const hotRef = useRef<HotTableRef>(null);
+
+  const exportGridToPdf = (): void => {
+    const hot = hotRef.current?.hotInstance;
+
+    if (!hot) {
+      return;
+    }
+
+    const body = hot.getData() as (string | number)[][];
+    const colCount = hot.countCols();
+    const head: string[][] = [
+      Array.from({ length: colCount }, (_, col) => String(hot.getColHeader(col))),
+    ];
+
+    const doc = new jsPDF({ orientation: 'portrait', unit: 'mm', format: 'a4' });
+
+    autoTable(doc, {
+      head,
+      body,
+      styles: { fontSize: 8, cellPadding: 1.5, overflow: 'linebreak' },
+      headStyles: {
+        fillColor: [26, 66, 232],
+        textColor: 255,
+        fontStyle: 'bold',
+      },
+      alternateRowStyles: { fillColor: [245, 247, 250] },
+      margin: { top: 14, left: 12, right: 12, bottom: 14 },
+      showHead: 'everyPage',
+    });
+
+    doc.save('export.pdf');
+  };
+
+  return (
+    <>
+      <div className="export-pdf-toolbar">
+        <button type="button" className="export-pdf-btn" onClick={exportGridToPdf}>
+          Export to PDF
+        </button>
+      </div>
+      <HotTable
+        ref={hotRef}
+        data={data}
+        colHeaders={['SKU', 'Product', 'Qty', 'Unit price', 'Line total']}
+        columnSorting={true}
+        rowHeaders={true}
+        height={320}
+        width="100%"
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/import-export/import-csv-excel/import-csv-excel.md
+++ b/docs/content/recipes/import-export/import-csv-excel/import-csv-excel.md
@@ -52,6 +52,18 @@ This recipe shows a small UI with:
 
 :::
 
+::: only-for react
+
+::: example #example1 :react-advanced --css 1 --js 2 --ts 3
+
+@[code](@/content/recipes/import-export/import-csv-excel/react/example1.css)
+@[code](@/content/recipes/import-export/import-csv-excel/react/example1.jsx)
+@[code](@/content/recipes/import-export/import-csv-excel/react/example1.tsx)
+
+:::
+
+:::
+
 ## CDN scripts (no bundler)
 
 For a plain HTML page, load Handsontable plus the parsers from a CDN (pin versions to match what you test):

--- a/docs/content/recipes/import-export/import-csv-excel/react/example1.css
+++ b/docs/content/recipes/import-export/import-csv-excel/react/example1.css
@@ -1,0 +1,111 @@
+.import-csv-excel-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.import-dropzone {
+  border: 2px dashed var(--sl-color-gray-4, #ccc);
+  border-radius: 8px;
+  padding: 16px;
+  text-align: center;
+  background: var(--sl-color-bg-inline-code, rgba(0, 0, 0, 0.04));
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.import-dropzone.import-dropzone--active {
+  border-color: var(--sl-color-accent, #3b82f6);
+  background: var(--sl-color-accent-low, rgba(59, 130, 246, 0.08));
+}
+
+.import-file-label {
+  display: inline-block;
+  margin-top: 8px;
+  cursor: pointer;
+}
+
+.import-file-label span {
+  display: inline-block;
+  padding: 6px 14px;
+  border-radius: 6px;
+  background: var(--sl-color-accent, #3b82f6);
+  color: var(--sl-color-black, #fff);
+  font-size: 0.875rem;
+}
+
+.import-file-label input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.import-sample-block label {
+  display: block;
+  font-size: 0.875rem;
+  margin-bottom: 6px;
+}
+
+.import-sample-block textarea {
+  width: 100%;
+  box-sizing: border-box;
+  font-family: ui-monospace, monospace;
+  font-size: 0.8rem;
+  padding: 8px;
+  border-radius: 6px;
+  border: 1px solid var(--sl-color-gray-4, #ccc);
+  resize: vertical;
+}
+
+.import-sample-actions {
+  margin-top: 8px;
+}
+
+.import-sample-actions button,
+.import-apply-btn {
+  padding: 6px 14px;
+  border-radius: 6px;
+  border: 1px solid var(--sl-color-gray-4, #ccc);
+  background: var(--sl-color-bg, #fff);
+  cursor: pointer;
+  font-size: 0.875rem;
+}
+
+.import-apply-btn {
+  margin-top: 8px;
+  border-color: var(--sl-color-accent, #3b82f6);
+  color: var(--sl-color-accent, #3b82f6);
+}
+
+.import-msg {
+  padding: 10px 12px;
+  border-radius: 6px;
+  font-size: 0.875rem;
+}
+
+.import-msg--error {
+  background: var(--sl-color-red-low, rgba(239, 68, 68, 0.12));
+  border: 1px solid var(--sl-color-red, #ef4444);
+  color: var(--sl-color-red-high, #b91c1c);
+}
+
+.import-preview {
+  padding: 12px;
+  border-radius: 8px;
+  border: 1px solid var(--sl-color-gray-4, #ccc);
+  background: var(--sl-color-bg-inline-code, rgba(0, 0, 0, 0.03));
+}
+
+.import-preview-title {
+  margin: 0 0 8px;
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+.import-header-list {
+  margin: 0;
+  padding-left: 1.25rem;
+  font-size: 0.875rem;
+}

--- a/docs/content/recipes/import-export/import-csv-excel/react/example1.jsx
+++ b/docs/content/recipes/import-export/import-csv-excel/react/example1.jsx
@@ -1,0 +1,459 @@
+import { useRef, useState } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import './example1.css';
+
+registerAllModules();
+
+const CDN_PAPAPARSE = 'https://cdn.jsdelivr.net/npm/papaparse@5.5.3/papaparse.min.js';
+const CDN_XLSX = 'https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js';
+
+const scriptPromises = new Map();
+
+function loadScript(src) {
+  const cached = scriptPromises.get(src);
+
+  if (cached) {
+    return cached;
+  }
+
+  const p = new Promise((resolve, reject) => {
+    const existing = document.querySelector(`script[data-cdn="${src}"]`);
+
+    if (existing) {
+      existing.addEventListener('load', () => resolve(), { once: true });
+      existing.addEventListener('error', () => reject(new Error(`Failed to load ${src}`)), { once: true });
+      if (existing.getAttribute('data-loaded') === '1') {
+        resolve();
+      }
+
+      return;
+    }
+
+    const s = document.createElement('script');
+
+    s.src = src;
+    s.async = true;
+    s.dataset.cdn = src;
+    s.onload = () => {
+      s.setAttribute('data-loaded', '1');
+      resolve();
+    };
+    s.onerror = () => reject(new Error(`Failed to load ${src}`));
+    document.head.appendChild(s);
+  });
+
+  scriptPromises.set(src, p);
+
+  return p;
+}
+
+async function ensurePapa() {
+  if (typeof window.Papa !== 'undefined') {
+    return window.Papa;
+  }
+
+  await loadScript(CDN_PAPAPARSE);
+
+  if (typeof window.Papa === 'undefined') {
+    throw new Error('PapaParse did not register on window.');
+  }
+
+  return window.Papa;
+}
+
+async function ensureXlsx() {
+  if (typeof window.XLSX !== 'undefined') {
+    return window.XLSX;
+  }
+
+  await loadScript(CDN_XLSX);
+
+  if (typeof window.XLSX === 'undefined') {
+    throw new Error('SheetJS did not register on window.');
+  }
+
+  return window.XLSX;
+}
+
+function extensionOf(name) {
+  const i = name.lastIndexOf('.');
+
+  return i >= 0 ? name.slice(i + 1).toLowerCase() : '';
+}
+
+function normalizeCellValue(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+
+  const text = String(value).trim();
+
+  return text === '' ? null : text;
+}
+
+function mapRowByHeaders(row, headers) {
+  const out = {};
+
+  for (const key of headers) {
+    out[key] = normalizeCellValue(row[key]);
+  }
+
+  return out;
+}
+
+function processPapaResults(results) {
+  if (results.errors.length > 0) {
+    throw new Error(results.errors[0].message || 'CSV parse error.');
+  }
+
+  const fields = results.meta.fields?.filter((f) => f !== undefined && f !== '') ?? [];
+
+  if (fields.length === 0) {
+    throw new Error('No header row found in the CSV.');
+  }
+
+  const rows = results.data.map((row) => mapRowByHeaders(row, fields));
+
+  if (rows.length === 0) {
+    throw new Error('No data rows after the header.');
+  }
+
+  return { headers: fields, rows };
+}
+
+function parseCsvText(text, PapaRef) {
+  const trimmed = text.trim();
+
+  if (!trimmed) {
+    throw new Error('The file is empty.');
+  }
+
+  const parsed = PapaRef.parse(trimmed, {
+    header: true,
+    dynamicTyping: true,
+    skipEmptyLines: 'greedy',
+    transformHeader: (h) => h.trim(),
+  });
+
+  return processPapaResults(parsed);
+}
+
+async function parseCsvFile(file, PapaRef) {
+  return new Promise((resolve, reject) => {
+    PapaRef.parse(file, {
+      header: true,
+      dynamicTyping: true,
+      skipEmptyLines: 'greedy',
+      transformHeader: (h) => h.trim(),
+      complete: (results) => {
+        try {
+          resolve(processPapaResults(results));
+        } catch (e) {
+          reject(e instanceof Error ? e : new Error(String(e)));
+        }
+      },
+      error: (err) => reject(err instanceof Error ? err : new Error(String(err))),
+    });
+  });
+}
+
+function parseXlsxArrayBuffer(buf, XLSXRef) {
+  let workbook;
+
+  try {
+    workbook = XLSXRef.read(buf, { type: 'array' });
+  } catch {
+    throw new Error('Could not read the Excel workbook. The file may be corrupted.');
+  }
+
+  const sheetName = workbook.SheetNames[0];
+
+  if (!sheetName) {
+    throw new Error('The workbook has no sheets.');
+  }
+
+  const sheet = workbook.Sheets[sheetName];
+  const matrix = XLSXRef.utils.sheet_to_json(sheet, {
+    header: 1,
+    defval: null,
+    raw: true,
+  });
+
+  if (!matrix.length) {
+    throw new Error('The sheet is empty.');
+  }
+
+  const rawHeader = matrix[0].map((cell) => String(cell ?? '').trim());
+
+  if (rawHeader.length === 0 || rawHeader.every((h) => h === '')) {
+    throw new Error('No header row found in the Excel sheet.');
+  }
+
+  const keys = rawHeader.map((h, i) => (h === '' ? `Column ${i + 1}` : h));
+  const rows = [];
+
+  for (let r = 1; r < matrix.length; r++) {
+    const line = matrix[r];
+    const allEmpty = !line || line.every((c) => normalizeCellValue(c) === null);
+
+    if (allEmpty) {
+      continue;
+    }
+
+    const obj = {};
+
+    for (let c = 0; c < keys.length; c++) {
+      const key = keys[c];
+      const raw = line[c];
+
+      obj[key] = normalizeCellValue(raw);
+    }
+
+    rows.push(obj);
+  }
+
+  if (rows.length === 0) {
+    throw new Error('No data rows after the header.');
+  }
+
+  return { headers: keys, rows };
+}
+
+async function parseFile(file) {
+  const ext = extensionOf(file.name);
+
+  if (ext === 'csv') {
+    const PapaRef = await ensurePapa();
+
+    return parseCsvFile(file, PapaRef);
+  }
+
+  if (ext === 'xlsx') {
+    const XLSXRef = await ensureXlsx();
+    const buf = await file.arrayBuffer();
+
+    return parseXlsxArrayBuffer(buf, XLSXRef);
+  }
+
+  throw new Error('Unsupported file type. Use a .csv or .xlsx file.');
+}
+
+function columnsFromHeaders(headers, pendingRows) {
+  if (!pendingRows) {
+    return headers.map((data) => ({ data, type: 'text' }));
+  }
+
+  return headers.map((data) => {
+    const values = pendingRows
+      .map((row) => row[data])
+      .filter((v) => v !== null);
+
+    if (values.length > 0 && values.every((v) => typeof v === 'number')) {
+      return { data, type: 'numeric' };
+    }
+
+    if (values.length > 0 && values.every((v) => typeof v === 'boolean')) {
+      return { data, type: 'checkbox' };
+    }
+
+    return { data, type: 'text' };
+  });
+}
+
+/* start:skip-in-preview */
+const SAMPLE_CSV = `Product,Category,In stock,Price
+Widget A,Hardware,true,19.99
+Widget B,Hardware,false,24.5
+Service Pack,Services,true,0
+`;
+/* end:skip-in-preview */
+
+const ExampleComponent = () => {
+  const hotRef = useRef(null);
+  const [pending, setPendingState] = useState(null);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [showPreview, setShowPreview] = useState(false);
+  const [sampleCsv, setSampleCsv] = useState(SAMPLE_CSV);
+  const [dropzoneActive, setDropzoneActive] = useState(false);
+
+  const clearPendingPreview = () => {
+    setPendingState(null);
+    setShowPreview(false);
+  };
+
+  const handleParsed = (payload) => {
+    setErrorMessage('');
+    setPendingState(payload);
+    setShowPreview(true);
+  };
+
+  const handleError = (e) => {
+    clearPendingPreview();
+    setErrorMessage(e instanceof Error ? e.message : String(e));
+  };
+
+  const handleFile = async (file) => {
+    setErrorMessage('');
+
+    if (!file) {
+      return;
+    }
+
+    if (file.size === 0) {
+      setErrorMessage('The file is empty.');
+
+      return;
+    }
+
+    try {
+      const payload = await parseFile(file);
+
+      handleParsed(payload);
+    } catch (e) {
+      handleError(e);
+    }
+  };
+
+  const handleFileInputChange = (ev) => {
+    const f = ev.target.files?.[0];
+
+    handleFile(f);
+    ev.target.value = '';
+  };
+
+  const handleDragOver = (ev) => {
+    ev.preventDefault();
+    setDropzoneActive(true);
+  };
+
+  const handleDragLeave = () => {
+    setDropzoneActive(false);
+  };
+
+  const handleDrop = (ev) => {
+    ev.preventDefault();
+    setDropzoneActive(false);
+    const f = ev.dataTransfer?.files?.[0];
+
+    handleFile(f);
+  };
+
+  const handleParseSample = async () => {
+    setErrorMessage('');
+
+    try {
+      const PapaRef = await ensurePapa();
+      const payload = parseCsvText(sampleCsv, PapaRef);
+
+      handleParsed(payload);
+    } catch (e) {
+      handleError(e);
+    }
+  };
+
+  const handleApply = () => {
+    setErrorMessage('');
+
+    if (!pending) {
+      setErrorMessage('Nothing to load. Import a file first.');
+
+      return;
+    }
+
+    const hot = hotRef.current?.hotInstance;
+
+    if (!hot) {
+      return;
+    }
+
+    const { headers, rows } = pending;
+
+    hot.updateSettings({
+      colHeaders: headers,
+      columns: columnsFromHeaders(headers, rows),
+    });
+    hot.loadData(rows);
+    setPendingState(null);
+    setShowPreview(false);
+  };
+
+  return (
+    <div className="import-csv-excel-wrap">
+      <div
+        className={`import-dropzone${dropzoneActive ? ' import-dropzone--active' : ''}`}
+        tabIndex={0}
+        role="button"
+        aria-label="Drop a CSV or Excel file here"
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+      >
+        <p>
+          Drop a <code>.csv</code> or <code>.xlsx</code> file here, or use the file picker.
+        </p>
+        <label className="import-file-label">
+          <span>Choose file</span>
+          <input
+            type="file"
+            accept=".csv,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,text/csv"
+            onChange={handleFileInputChange}
+          />
+        </label>
+      </div>
+
+      <div className="import-sample-block">
+        <label htmlFor="import-sample-csv">
+          Sample CSV (copy into a file or click <strong>Parse sample CSV</strong>):
+        </label>
+        <textarea
+          id="import-sample-csv"
+          rows={5}
+          spellCheck={false}
+          value={sampleCsv}
+          onChange={(ev) => setSampleCsv(ev.target.value)}
+        />
+        <div className="import-sample-actions">
+          <button type="button" onClick={handleParseSample}>
+            Parse sample CSV
+          </button>
+        </div>
+      </div>
+
+      {errorMessage && (
+        <div className="import-msg import-msg--error">{errorMessage}</div>
+      )}
+
+      {showPreview && pending && (
+        <div className="import-preview">
+          <p className="import-preview-title">Detected column headers (not loaded yet):</p>
+          <ul className="import-header-list">
+            {pending.headers.map((h) => (
+              <li key={h}>{h}</li>
+            ))}
+          </ul>
+          <button type="button" className="import-apply-btn" onClick={handleApply}>
+            Load into grid
+          </button>
+        </div>
+      )}
+
+      <HotTable
+        ref={hotRef}
+        data={[]}
+        columns={[]}
+        colHeaders={[]}
+        rowHeaders={true}
+        height="auto"
+        width="100%"
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </div>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/import-export/import-csv-excel/react/example1.tsx
+++ b/docs/content/recipes/import-export/import-csv-excel/react/example1.tsx
@@ -1,0 +1,491 @@
+import { useRef, useState } from 'react';
+import { HotTable, HotTableRef } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import './example1.css';
+
+registerAllModules();
+
+declare global {
+  interface Window {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Papa?: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    XLSX?: any;
+  }
+}
+
+const CDN_PAPAPARSE = 'https://cdn.jsdelivr.net/npm/papaparse@5.5.3/papaparse.min.js';
+const CDN_XLSX = 'https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js';
+
+const scriptPromises = new Map<string, Promise<void>>();
+
+function loadScript(src: string): Promise<void> {
+  const cached = scriptPromises.get(src);
+
+  if (cached) {
+    return cached;
+  }
+
+  const p = new Promise<void>((resolve, reject) => {
+    const existing = document.querySelector(`script[data-cdn="${src}"]`) as HTMLScriptElement | null;
+
+    if (existing) {
+      existing.addEventListener('load', () => resolve(), { once: true });
+      existing.addEventListener('error', () => reject(new Error(`Failed to load ${src}`)), { once: true });
+      if (existing.getAttribute('data-loaded') === '1') {
+        resolve();
+      }
+
+      return;
+    }
+
+    const s = document.createElement('script');
+
+    s.src = src;
+    s.async = true;
+    s.dataset.cdn = src;
+    s.onload = () => {
+      s.setAttribute('data-loaded', '1');
+      resolve();
+    };
+    s.onerror = () => reject(new Error(`Failed to load ${src}`));
+    document.head.appendChild(s);
+  });
+
+  scriptPromises.set(src, p);
+
+  return p;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function ensurePapa(): Promise<any> {
+  if (typeof window.Papa !== 'undefined') {
+    return window.Papa;
+  }
+
+  await loadScript(CDN_PAPAPARSE);
+
+  if (typeof window.Papa === 'undefined') {
+    throw new Error('PapaParse did not register on window.');
+  }
+
+  return window.Papa;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function ensureXlsx(): Promise<any> {
+  if (typeof window.XLSX !== 'undefined') {
+    return window.XLSX;
+  }
+
+  await loadScript(CDN_XLSX);
+
+  if (typeof window.XLSX === 'undefined') {
+    throw new Error('SheetJS did not register on window.');
+  }
+
+  return window.XLSX;
+}
+
+function extensionOf(name: string): string {
+  const i = name.lastIndexOf('.');
+
+  return i >= 0 ? name.slice(i + 1).toLowerCase() : '';
+}
+
+type CellValue = string | number | boolean | null;
+
+type ParsedPayload = {
+  headers: string[];
+  rows: Record<string, CellValue>[];
+};
+
+type ColumnDef = {
+  data: string;
+  type: 'text' | 'numeric' | 'checkbox';
+};
+
+function normalizeCellValue(value: unknown): CellValue {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+
+  const text = String(value).trim();
+
+  return text === '' ? null : text;
+}
+
+function mapRowByHeaders(row: Record<string, unknown>, headers: string[]): Record<string, CellValue> {
+  const out: Record<string, CellValue> = {};
+
+  for (const key of headers) {
+    out[key] = normalizeCellValue(row[key]);
+  }
+
+  return out;
+}
+
+type PapaParseResults = {
+  data: Record<string, unknown>[];
+  errors: { message?: string }[];
+  meta: { fields?: string[] };
+};
+
+function processPapaResults(results: PapaParseResults): ParsedPayload {
+  if (results.errors.length > 0) {
+    throw new Error(results.errors[0].message || 'CSV parse error.');
+  }
+
+  const fields = results.meta.fields?.filter((f) => f !== undefined && f !== '') ?? [];
+
+  if (fields.length === 0) {
+    throw new Error('No header row found in the CSV.');
+  }
+
+  const rows = results.data.map((row) => mapRowByHeaders(row, fields));
+
+  if (rows.length === 0) {
+    throw new Error('No data rows after the header.');
+  }
+
+  return { headers: fields, rows };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function parseCsvText(text: string, PapaRef: any): ParsedPayload {
+  const trimmed = text.trim();
+
+  if (!trimmed) {
+    throw new Error('The file is empty.');
+  }
+
+  const parsed = PapaRef.parse(trimmed, {
+    header: true,
+    dynamicTyping: true,
+    skipEmptyLines: 'greedy',
+    transformHeader: (h: string) => h.trim(),
+  }) as PapaParseResults;
+
+  return processPapaResults(parsed);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function parseCsvFile(file: File, PapaRef: any): Promise<ParsedPayload> {
+  return new Promise((resolve, reject) => {
+    PapaRef.parse(file, {
+      header: true,
+      dynamicTyping: true,
+      skipEmptyLines: 'greedy',
+      transformHeader: (h: string) => h.trim(),
+      complete: (results: PapaParseResults) => {
+        try {
+          resolve(processPapaResults(results));
+        } catch (e) {
+          reject(e instanceof Error ? e : new Error(String(e)));
+        }
+      },
+      error: (err: unknown) => reject(err instanceof Error ? err : new Error(String(err))),
+    });
+  });
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function parseXlsxArrayBuffer(buf: ArrayBuffer, XLSXRef: any): ParsedPayload {
+  let workbook: { SheetNames: string[]; Sheets: Record<string, unknown> };
+
+  try {
+    workbook = XLSXRef.read(buf, { type: 'array' });
+  } catch {
+    throw new Error('Could not read the Excel workbook. The file may be corrupted.');
+  }
+
+  const sheetName = workbook.SheetNames[0];
+
+  if (!sheetName) {
+    throw new Error('The workbook has no sheets.');
+  }
+
+  const sheet = workbook.Sheets[sheetName];
+  const matrix = XLSXRef.utils.sheet_to_json(sheet, {
+    header: 1,
+    defval: null,
+    raw: true,
+  }) as unknown[][];
+
+  if (!matrix.length) {
+    throw new Error('The sheet is empty.');
+  }
+
+  const rawHeader = (matrix[0] as unknown[]).map((cell) => String(cell ?? '').trim());
+
+  if (rawHeader.length === 0 || rawHeader.every((h) => h === '')) {
+    throw new Error('No header row found in the Excel sheet.');
+  }
+
+  const keys = rawHeader.map((h, i) => (h === '' ? `Column ${i + 1}` : h));
+  const rows: Record<string, CellValue>[] = [];
+
+  for (let r = 1; r < matrix.length; r++) {
+    const line = matrix[r] as unknown[];
+    const allEmpty = !line || line.every((c) => normalizeCellValue(c) === null);
+
+    if (allEmpty) {
+      continue;
+    }
+
+    const obj: Record<string, CellValue> = {};
+
+    for (let c = 0; c < keys.length; c++) {
+      const key = keys[c];
+      const raw = line[c];
+
+      obj[key] = normalizeCellValue(raw);
+    }
+
+    rows.push(obj);
+  }
+
+  if (rows.length === 0) {
+    throw new Error('No data rows after the header.');
+  }
+
+  return { headers: keys, rows };
+}
+
+async function parseFile(file: File): Promise<ParsedPayload> {
+  const ext = extensionOf(file.name);
+
+  if (ext === 'csv') {
+    const PapaRef = await ensurePapa();
+
+    return parseCsvFile(file, PapaRef);
+  }
+
+  if (ext === 'xlsx') {
+    const XLSXRef = await ensureXlsx();
+    const buf = await file.arrayBuffer();
+
+    return parseXlsxArrayBuffer(buf, XLSXRef);
+  }
+
+  throw new Error('Unsupported file type. Use a .csv or .xlsx file.');
+}
+
+function columnsFromHeaders(headers: string[], pendingRows: Record<string, CellValue>[] | null): ColumnDef[] {
+  if (!pendingRows) {
+    return headers.map((data) => ({ data, type: 'text' }));
+  }
+
+  return headers.map((data) => {
+    const values = pendingRows
+      .map((row) => row[data])
+      .filter((v) => v !== null);
+
+    if (values.length > 0 && values.every((v) => typeof v === 'number')) {
+      return { data, type: 'numeric' as const };
+    }
+
+    if (values.length > 0 && values.every((v) => typeof v === 'boolean')) {
+      return { data, type: 'checkbox' as const };
+    }
+
+    return { data, type: 'text' as const };
+  });
+}
+
+/* start:skip-in-preview */
+const SAMPLE_CSV = `Product,Category,In stock,Price
+Widget A,Hardware,true,19.99
+Widget B,Hardware,false,24.5
+Service Pack,Services,true,0
+`;
+/* end:skip-in-preview */
+
+const ExampleComponent = () => {
+  const hotRef = useRef<HotTableRef>(null);
+  const [pending, setPendingState] = useState<ParsedPayload | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string>('');
+  const [showPreview, setShowPreview] = useState<boolean>(false);
+  const [sampleCsv, setSampleCsv] = useState<string>(SAMPLE_CSV);
+  const [dropzoneActive, setDropzoneActive] = useState<boolean>(false);
+
+  const clearPendingPreview = (): void => {
+    setPendingState(null);
+    setShowPreview(false);
+  };
+
+  const handleParsed = (payload: ParsedPayload): void => {
+    setErrorMessage('');
+    setPendingState(payload);
+    setShowPreview(true);
+  };
+
+  const handleError = (e: unknown): void => {
+    clearPendingPreview();
+    setErrorMessage(e instanceof Error ? e.message : String(e));
+  };
+
+  const handleFile = async (file: File | undefined): Promise<void> => {
+    setErrorMessage('');
+
+    if (!file) {
+      return;
+    }
+
+    if (file.size === 0) {
+      setErrorMessage('The file is empty.');
+
+      return;
+    }
+
+    try {
+      const payload = await parseFile(file);
+
+      handleParsed(payload);
+    } catch (e) {
+      handleError(e);
+    }
+  };
+
+  const handleFileInputChange = (ev: React.ChangeEvent<HTMLInputElement>): void => {
+    const f = ev.target.files?.[0];
+
+    handleFile(f);
+    ev.target.value = '';
+  };
+
+  const handleDragOver = (ev: React.DragEvent<HTMLDivElement>): void => {
+    ev.preventDefault();
+    setDropzoneActive(true);
+  };
+
+  const handleDragLeave = (): void => {
+    setDropzoneActive(false);
+  };
+
+  const handleDrop = (ev: React.DragEvent<HTMLDivElement>): void => {
+    ev.preventDefault();
+    setDropzoneActive(false);
+    const f = ev.dataTransfer?.files?.[0];
+
+    handleFile(f);
+  };
+
+  const handleParseSample = async (): Promise<void> => {
+    setErrorMessage('');
+
+    try {
+      const PapaRef = await ensurePapa();
+      const payload = parseCsvText(sampleCsv, PapaRef);
+
+      handleParsed(payload);
+    } catch (e) {
+      handleError(e);
+    }
+  };
+
+  const handleApply = (): void => {
+    setErrorMessage('');
+
+    if (!pending) {
+      setErrorMessage('Nothing to load. Import a file first.');
+
+      return;
+    }
+
+    const hot = hotRef.current?.hotInstance;
+
+    if (!hot) {
+      return;
+    }
+
+    const { headers, rows } = pending;
+
+    hot.updateSettings({
+      colHeaders: headers,
+      columns: columnsFromHeaders(headers, rows),
+    });
+    hot.loadData(rows);
+    setPendingState(null);
+    setShowPreview(false);
+  };
+
+  return (
+    <div className="import-csv-excel-wrap">
+      <div
+        className={`import-dropzone${dropzoneActive ? ' import-dropzone--active' : ''}`}
+        tabIndex={0}
+        role="button"
+        aria-label="Drop a CSV or Excel file here"
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+      >
+        <p>
+          Drop a <code>.csv</code> or <code>.xlsx</code> file here, or use the file picker.
+        </p>
+        <label className="import-file-label">
+          <span>Choose file</span>
+          <input
+            type="file"
+            accept=".csv,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,text/csv"
+            onChange={handleFileInputChange}
+          />
+        </label>
+      </div>
+
+      <div className="import-sample-block">
+        <label htmlFor="import-sample-csv">
+          Sample CSV (copy into a file or click <strong>Parse sample CSV</strong>):
+        </label>
+        <textarea
+          id="import-sample-csv"
+          rows={5}
+          spellCheck={false}
+          value={sampleCsv}
+          onChange={(ev) => setSampleCsv(ev.target.value)}
+        />
+        <div className="import-sample-actions">
+          <button type="button" onClick={handleParseSample}>
+            Parse sample CSV
+          </button>
+        </div>
+      </div>
+
+      {errorMessage && (
+        <div className="import-msg import-msg--error">{errorMessage}</div>
+      )}
+
+      {showPreview && pending && (
+        <div className="import-preview">
+          <p className="import-preview-title">Detected column headers (not loaded yet):</p>
+          <ul className="import-header-list">
+            {pending.headers.map((h) => (
+              <li key={h}>{h}</li>
+            ))}
+          </ul>
+          <button type="button" className="import-apply-btn" onClick={handleApply}>
+            Load into grid
+          </button>
+        </div>
+      )}
+
+      <HotTable
+        ref={hotRef}
+        data={[]}
+        columns={[]}
+        colHeaders={[]}
+        rowHeaders={true}
+        height="auto"
+        width="100%"
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </div>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/rendering-styling/conditional-row-coloring/conditional-row-coloring.md
+++ b/docs/content/recipes/rendering-styling/conditional-row-coloring/conditional-row-coloring.md
@@ -32,6 +32,18 @@ category: Rendering and styling
 
 :::
 
+::: only-for react
+
+::: example #example1 :react-advanced --css 1 --js 2 --ts 3
+
+@[code](@/content/recipes/rendering-styling/conditional-row-coloring/react/example1.css)
+@[code](@/content/recipes/rendering-styling/conditional-row-coloring/react/example1.jsx)
+@[code](@/content/recipes/rendering-styling/conditional-row-coloring/react/example1.tsx)
+
+:::
+
+:::
+
 [[toc]]
 
 ## Overview

--- a/docs/content/recipes/rendering-styling/conditional-row-coloring/react/example1.css
+++ b/docs/content/recipes/rendering-styling/conditional-row-coloring/react/example1.css
@@ -1,0 +1,21 @@
+/* Scoped to the recipe preview container */
+#example1 td.ht-demo-row-status-active {
+  background-color: rgba(26, 66, 232, 0.12);
+  background-color: color-mix(in srgb, var(--ht-accent-color, #1a42e8) 12%, var(--ht-background-color, #ffffff));
+}
+
+#example1 td.ht-demo-row-status-pending {
+  background-color: rgba(202, 138, 4, 0.14);
+  background-color: color-mix(in srgb, var(--ht-warn-color, #ca8a04) 14%, var(--ht-background-color, #ffffff));
+}
+
+#example1 td.ht-demo-row-status-inactive {
+  background-color: var(--ht-background-secondary-color, #f3f4f6);
+  color: var(--ht-foreground-secondary-color, #6b7280);
+}
+
+/* Flash feedback for rejected edits (allowInvalid: false) */
+#example1 td.ht-demo-invalid-flash {
+  background-color: var(--ht-cell-error-background-color, rgba(250, 77, 50, 0.2)) !important;
+  color: inherit;
+}

--- a/docs/content/recipes/rendering-styling/conditional-row-coloring/react/example1.jsx
+++ b/docs/content/recipes/rendering-styling/conditional-row-coloring/react/example1.jsx
@@ -1,0 +1,89 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import './example1.css';
+
+registerAllModules();
+
+const STATUS_ROW_CLASSES = {
+  active: 'ht-demo-row-status-active',
+  pending: 'ht-demo-row-status-pending',
+  inactive: 'ht-demo-row-status-inactive',
+};
+
+function statusToRowClass(status) {
+  if (typeof status !== 'string') {
+    return undefined;
+  }
+
+  return STATUS_ROW_CLASSES[status];
+}
+
+/* start:skip-in-preview */
+const data = [
+  { task: 'Invoice export', owner: 'A. Lee', status: 'active' },
+  { task: 'SSO rollout', owner: 'M. Costa', status: 'pending' },
+  { task: 'Legacy reports', owner: 'J. Park', status: 'inactive' },
+  { task: 'API docs', owner: 'R. Singh', status: 'active' },
+  { task: 'Mobile parity', owner: 'T. Nguyen', status: 'pending' },
+];
+/* end:skip-in-preview */
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      id="example1"
+      data={data}
+      licenseKey="non-commercial-and-evaluation"
+      rowHeaders={true}
+      colHeaders={['Task', 'Owner', 'Status']}
+      height="auto"
+      width="100%"
+      columns={[
+        { data: 'task', type: 'text', width: 220 },
+        { data: 'owner', type: 'text', width: 120 },
+        {
+          data: 'status',
+          type: 'dropdown',
+          width: 120,
+          source: ['active', 'pending', 'inactive'],
+          strict: true,
+          allowInvalid: false,
+        },
+      ]}
+      cells={function (row, _column, _prop) {
+        const hot = this.instance;
+        const visualRow = hot.toVisualRow(row);
+
+        if (visualRow === null || visualRow < 0) {
+          return {};
+        }
+
+        const status = hot.getDataAtRowProp(visualRow, 'status');
+        const rowClass = statusToRowClass(status);
+
+        if (!rowClass) {
+          return {};
+        }
+
+        return { className: rowClass };
+      }}
+      afterValidate={function (isValid, _value, row, prop) {
+        if (isValid) {
+          return;
+        }
+
+        const col = this.propToCol(prop);
+        const td = this.getCell(row, col);
+
+        if (!td) {
+          return;
+        }
+
+        td.classList.add('ht-demo-invalid-flash');
+        setTimeout(() => td.classList.remove('ht-demo-invalid-flash'), 800);
+      }}
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/rendering-styling/conditional-row-coloring/react/example1.tsx
+++ b/docs/content/recipes/rendering-styling/conditional-row-coloring/react/example1.tsx
@@ -1,0 +1,102 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import type { CellMeta, CellProperties } from 'handsontable/settings';
+import type Handsontable from 'handsontable/base';
+import './example1.css';
+
+registerAllModules();
+
+const STATUS_ROW_CLASSES: Record<string, string> = {
+  active: 'ht-demo-row-status-active',
+  pending: 'ht-demo-row-status-pending',
+  inactive: 'ht-demo-row-status-inactive',
+};
+
+function statusToRowClass(status: unknown): string | undefined {
+  if (typeof status !== 'string') {
+    return undefined;
+  }
+
+  return STATUS_ROW_CLASSES[status];
+}
+
+/* start:skip-in-preview */
+const data = [
+  { task: 'Invoice export', owner: 'A. Lee', status: 'active' },
+  { task: 'SSO rollout', owner: 'M. Costa', status: 'pending' },
+  { task: 'Legacy reports', owner: 'J. Park', status: 'inactive' },
+  { task: 'API docs', owner: 'R. Singh', status: 'active' },
+  { task: 'Mobile parity', owner: 'T. Nguyen', status: 'pending' },
+];
+/* end:skip-in-preview */
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      id="example1"
+      data={data}
+      licenseKey="non-commercial-and-evaluation"
+      rowHeaders={true}
+      colHeaders={['Task', 'Owner', 'Status']}
+      height="auto"
+      width="100%"
+      columns={[
+        { data: 'task', type: 'text', width: 220 },
+        { data: 'owner', type: 'text', width: 120 },
+        {
+          data: 'status',
+          type: 'dropdown',
+          width: 120,
+          source: ['active', 'pending', 'inactive'],
+          strict: true,
+          allowInvalid: false,
+        },
+      ]}
+      cells={function (
+        this: CellProperties,
+        row: number,
+        _column: number,
+        _prop: string | number,
+      ): CellMeta {
+        const hot = this.instance;
+        const visualRow = hot.toVisualRow(row);
+
+        if (visualRow === null || visualRow < 0) {
+          return {};
+        }
+
+        const status = hot.getDataAtRowProp(visualRow, 'status');
+        const rowClass = statusToRowClass(status);
+
+        if (!rowClass) {
+          return {};
+        }
+
+        return { className: rowClass };
+      }}
+      afterValidate={function (
+        this: Handsontable,
+        isValid: boolean,
+        _value: Handsontable.CellValue,
+        row: number,
+        prop: string | number,
+      ): void {
+        if (isValid) {
+          return;
+        }
+
+        const col = this.propToCol(prop);
+        const td = this.getCell(row, col);
+
+        if (!td) {
+          return;
+        }
+
+        td.classList.add('ht-demo-invalid-flash');
+        setTimeout(() => td.classList.remove('ht-demo-invalid-flash'), 800);
+      }}
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/rendering-styling/frozen-summary-row/frozen-summary-row.md
+++ b/docs/content/recipes/rendering-styling/frozen-summary-row/frozen-summary-row.md
@@ -33,6 +33,18 @@ category: Rendering and styling
 
 :::
 
+::: only-for react
+
+::: example #example1 :react-advanced --css 1 --js 2 --ts 3
+
+@[code](@/content/recipes/rendering-styling/frozen-summary-row/react/example1.css)
+@[code](@/content/recipes/rendering-styling/frozen-summary-row/react/example1.jsx)
+@[code](@/content/recipes/rendering-styling/frozen-summary-row/react/example1.tsx)
+
+:::
+
+:::
+
 ## Overview
 
 This recipe pins a single **summary** row to the bottom of the grid so it stays visible while you scroll. The row shows **sum**, **average**, and **count** for each numeric column, skips non-numeric values, stays **read-only**, and updates whenever data changes.

--- a/docs/content/recipes/rendering-styling/frozen-summary-row/react/example1.css
+++ b/docs/content/recipes/rendering-styling/frozen-summary-row/react/example1.css
@@ -1,0 +1,4 @@
+.htSummaryRow {
+  font-weight: 600;
+  background-color: var(--ht-background-color-extra-light, #f2f3f5);
+}

--- a/docs/content/recipes/rendering-styling/frozen-summary-row/react/example1.jsx
+++ b/docs/content/recipes/rendering-styling/frozen-summary-row/react/example1.jsx
@@ -1,0 +1,124 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import './example1.css';
+
+registerAllModules();
+
+const SUMMARY_SOURCE = 'updateSummary';
+
+function parseNumeric(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string' && value.trim() !== '') {
+    const n = Number(value);
+
+    if (Number.isFinite(n)) {
+      return n;
+    }
+  }
+
+  return null;
+}
+
+const data = [
+  { item: 'Module A', units: 12, price: 49.5, tax: 5.2 },
+  { item: 'Module B', units: 8, price: 120, tax: 8 },
+  { item: 'Module C', units: 3, price: 200, tax: '\u2014' },
+  { item: 'Module D', units: 15, price: 35, tax: 4.1 },
+  { item: 'Module E', units: 0, price: 75, tax: 6 },
+  { item: '', units: '', price: '', tax: '' },
+];
+
+const numericProps = ['units', 'price', 'tax'];
+const summaryRowIndex = data.length - 1;
+
+function formatSummary(prop) {
+  const numbers = [];
+
+  for (let row = 0; row < summaryRowIndex; row += 1) {
+    const n = parseNumeric(data[row][prop]);
+
+    if (n !== null) {
+      numbers.push(n);
+    }
+  }
+
+  if (numbers.length === 0) {
+    return '\u2014';
+  }
+
+  const sum = numbers.reduce((acc, n) => acc + n, 0);
+  const avg = sum / numbers.length;
+
+  return `Sum: ${sum.toFixed(2)} · Avg: ${avg.toFixed(2)} · Count: ${numbers.length}`;
+}
+
+function refreshSummary(hot) {
+  hot.batch(() => {
+    hot.setDataAtRowProp(summaryRowIndex, 'item', 'Totals', SUMMARY_SOURCE);
+
+    numericProps.forEach((prop) => {
+      hot.setDataAtRowProp(summaryRowIndex, prop, formatSummary(prop), SUMMARY_SOURCE);
+    });
+  });
+}
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={data}
+      licenseKey="non-commercial-and-evaluation"
+      rowHeaders={true}
+      colHeaders={['Item', 'Units', 'Price', 'Tax']}
+      fixedRowsBottom={1}
+      height="auto"
+      width="100%"
+      columns={[
+        { data: 'item', type: 'text', readOnly: false },
+        { data: 'units', type: 'numeric', numericFormat: { pattern: '0' } },
+        { data: 'price', type: 'numeric', numericFormat: { pattern: '0.00' } },
+        { data: 'tax', type: 'numeric', numericFormat: { pattern: '0.00' } },
+      ]}
+      cells={function (row, _col, prop) {
+        if (row !== summaryRowIndex) {
+          return {};
+        }
+
+        const meta = {
+          readOnly: true,
+          className: 'htSummaryRow',
+        };
+
+        if (prop !== 'item') {
+          meta.type = 'text';
+          meta.className = 'htSummaryRow htRight';
+        }
+
+        return meta;
+      }}
+      afterInit={function () {
+        refreshSummary(this);
+      }}
+      afterChange={function (changes, source) {
+        if (!changes || source === SUMMARY_SOURCE) {
+          return;
+        }
+
+        if (changes.every(([row]) => row === summaryRowIndex)) {
+          return;
+        }
+
+        refreshSummary(this);
+      }}
+      beforeUndoStackChange={function (_doneActions, source) {
+        if (source === SUMMARY_SOURCE) {
+          return false;
+        }
+      }}
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/rendering-styling/frozen-summary-row/react/example1.tsx
+++ b/docs/content/recipes/rendering-styling/frozen-summary-row/react/example1.tsx
@@ -1,0 +1,144 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import type Handsontable from 'handsontable/base';
+import './example1.css';
+
+registerAllModules();
+
+type Row = {
+  item: string;
+  units: number | string;
+  price: number | string;
+  tax: number | string;
+};
+
+const SUMMARY_SOURCE = 'updateSummary';
+
+function parseNumeric(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string' && value.trim() !== '') {
+    const n = Number(value);
+
+    if (Number.isFinite(n)) {
+      return n;
+    }
+  }
+
+  return null;
+}
+
+const data: Row[] = [
+  { item: 'Module A', units: 12, price: 49.5, tax: 5.2 },
+  { item: 'Module B', units: 8, price: 120, tax: 8 },
+  { item: 'Module C', units: 3, price: 200, tax: '\u2014' },
+  { item: 'Module D', units: 15, price: 35, tax: 4.1 },
+  { item: 'Module E', units: 0, price: 75, tax: 6 },
+  { item: '', units: '', price: '', tax: '' },
+];
+
+const numericProps: (keyof Row)[] = ['units', 'price', 'tax'];
+const summaryRowIndex = data.length - 1;
+
+function formatSummary(prop: keyof Row): string {
+  const numbers: number[] = [];
+
+  for (let row = 0; row < summaryRowIndex; row += 1) {
+    const n = parseNumeric(data[row][prop]);
+
+    if (n !== null) {
+      numbers.push(n);
+    }
+  }
+
+  if (numbers.length === 0) {
+    return '\u2014';
+  }
+
+  const sum = numbers.reduce((acc, n) => acc + n, 0);
+  const avg = sum / numbers.length;
+
+  return `Sum: ${sum.toFixed(2)} · Avg: ${avg.toFixed(2)} · Count: ${numbers.length}`;
+}
+
+function refreshSummary(hot: Handsontable): void {
+  hot.batch(() => {
+    hot.setDataAtRowProp(summaryRowIndex, 'item', 'Totals', SUMMARY_SOURCE);
+
+    numericProps.forEach((prop) => {
+      hot.setDataAtRowProp(summaryRowIndex, prop, formatSummary(prop), SUMMARY_SOURCE);
+    });
+  });
+}
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={data}
+      licenseKey="non-commercial-and-evaluation"
+      rowHeaders={true}
+      colHeaders={['Item', 'Units', 'Price', 'Tax']}
+      fixedRowsBottom={1}
+      height="auto"
+      width="100%"
+      columns={[
+        { data: 'item', type: 'text', readOnly: false },
+        { data: 'units', type: 'numeric', numericFormat: { pattern: '0' } },
+        { data: 'price', type: 'numeric', numericFormat: { pattern: '0.00' } },
+        { data: 'tax', type: 'numeric', numericFormat: { pattern: '0.00' } },
+      ]}
+      cells={function (
+        this: Handsontable.CellProperties,
+        row: number,
+        _col: number,
+        prop: string | number,
+      ): Handsontable.CellMeta {
+        if (row !== summaryRowIndex) {
+          return {};
+        }
+
+        const meta: Handsontable.CellProperties = {
+          readOnly: true,
+          className: 'htSummaryRow',
+        };
+
+        if (prop !== 'item') {
+          meta.type = 'text';
+          meta.className = 'htSummaryRow htRight';
+        }
+
+        return meta;
+      }}
+      afterInit={function (this: Handsontable): void {
+        refreshSummary(this);
+      }}
+      afterChange={function (
+        this: Handsontable,
+        changes: Handsontable.CellChange[] | null,
+        source: Handsontable.ChangeSource,
+      ): void {
+        if (!changes || source === SUMMARY_SOURCE) {
+          return;
+        }
+
+        if (changes.every(([row]) => row === summaryRowIndex)) {
+          return;
+        }
+
+        refreshSummary(this);
+      }}
+      beforeUndoStackChange={function (
+        _doneActions: Handsontable.UndoRedoAction[],
+        source: string | undefined,
+      ): boolean | void {
+        if (source === SUMMARY_SOURCE) {
+          return false;
+        }
+      }}
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/rendering-styling/sparkline-cell-renderer/react/example1.css
+++ b/docs/content/recipes/rendering-styling/sparkline-cell-renderer/react/example1.css
@@ -1,0 +1,4 @@
+/* Keep sparkline cells vertically centered and tall enough for the SVG */
+#example1 .handsontable td.sparkline-cell {
+  vertical-align: middle;
+}

--- a/docs/content/recipes/rendering-styling/sparkline-cell-renderer/react/example1.jsx
+++ b/docs/content/recipes/rendering-styling/sparkline-cell-renderer/react/example1.jsx
@@ -1,0 +1,95 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import { registerRenderer, baseRenderer } from 'handsontable/renderers';
+import './example1.css';
+
+registerAllModules();
+
+const SLOT = 10;
+const GAP = 2;
+const VIEW_HEIGHT = 100;
+const WEEK_KEYS = ['w1', 'w2', 'w3', 'w4', 'w5'];
+
+function toNumbers(rowData) {
+  return WEEK_KEYS.map((key) => rowData?.[key])
+    .map((value) => (typeof value === 'number' ? value : Number(value)))
+    .filter((n) => Number.isFinite(n));
+}
+
+// Inline SVG bars generated from the row values in w1-w5.
+const sparklineRenderer = (instance, td, row, col, prop, value, cellProperties) => {
+  baseRenderer(instance, td, row, col, prop, value, cellProperties);
+
+  const sourceRow = instance.getSourceDataAtRow(row);
+  const numbers = toNumbers(sourceRow);
+  const max = numbers.reduce((m, n) => Math.max(m, Math.abs(n)), 0);
+
+  if (numbers.length === 0 || max === 0) {
+    td.textContent = '\u2014';
+    td.title = numbers.length === 0 ? 'No data' : 'All values are zero';
+
+    return;
+  }
+
+  const average = numbers.reduce((sum, n) => sum + n, 0) / numbers.length;
+  const viewWidth = numbers.length * SLOT - GAP;
+  const rects = numbers
+    .map((n, i) => {
+      const barHeight = (Math.abs(n) / max) * VIEW_HEIGHT;
+      const x = i * SLOT;
+      const y = VIEW_HEIGHT - barHeight;
+      const w = SLOT - GAP;
+      const fill = n >= average ? '#16a34a' : '#dc2626';
+
+      return `<rect x="${x}" y="${y}" width="${w}" height="${barHeight}" fill="${fill}"/>`;
+    })
+    .join('');
+
+  td.innerHTML = `<svg width="100%" height="100%" viewBox="0 0 ${viewWidth} ${VIEW_HEIGHT}" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">${rects}</svg>`;
+  td.removeAttribute('title');
+};
+
+registerRenderer('sparklineBar', sparklineRenderer);
+
+/* start:skip-in-preview */
+const data = [
+  { product: 'Desk lamp', w1: 4, w2: 8, w3: 2, w4: 9, w5: 5 },
+  { product: 'Monitor arm', w1: 1, w2: 1, w3: 0, w4: 0, w5: 0 },
+  { product: 'USB hub', w1: null, w2: null, w3: null, w4: null, w5: null },
+  { product: 'Mouse', w1: undefined, w2: undefined, w3: 3, w4: 5, w5: 2 },
+  { product: 'Keyboard', w1: 3, w2: 6, w3: 7, w4: 4, w5: 8 },
+  { product: 'Webcam', w1: 0, w2: 0, w3: 0, w4: 0, w5: 0 },
+];
+/* end:skip-in-preview */
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      id="example1"
+      data={data}
+      rowHeaders={true}
+      rowHeights={44}
+      colHeaders={['Product', 'W1', 'W2', 'W3', 'W4', 'W5', 'Sparkline']}
+      licenseKey="non-commercial-and-evaluation"
+      height="auto"
+      width="100%"
+      columns={[
+        { data: 'product', type: 'text', width: 140, readOnly: true },
+        { data: 'w1', type: 'numeric', width: 65 },
+        { data: 'w2', type: 'numeric', width: 65 },
+        { data: 'w3', type: 'numeric', width: 65 },
+        { data: 'w4', type: 'numeric', width: 65 },
+        { data: 'w5', type: 'numeric', width: 65 },
+        {
+          data: null,
+          width: 220,
+          renderer: 'sparklineBar',
+          className: 'htMiddle sparkline-cell',
+          readOnly: true,
+        },
+      ]}
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/rendering-styling/sparkline-cell-renderer/react/example1.tsx
+++ b/docs/content/recipes/rendering-styling/sparkline-cell-renderer/react/example1.tsx
@@ -1,0 +1,95 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import { BaseRenderer, registerRenderer, baseRenderer } from 'handsontable/renderers';
+import './example1.css';
+
+registerAllModules();
+
+const SLOT = 10;
+const GAP = 2;
+const VIEW_HEIGHT = 100;
+const WEEK_KEYS = ['w1', 'w2', 'w3', 'w4', 'w5'] as const;
+
+function toNumbers(rowData: Record<string, unknown> | null): number[] {
+  return WEEK_KEYS.map((key) => rowData?.[key])
+    .map((value) => (typeof value === 'number' ? value : Number(value)))
+    .filter((n) => Number.isFinite(n));
+}
+
+// Inline SVG bars generated from the row values in w1-w5.
+const sparklineRenderer: BaseRenderer = (instance, td, row, col, prop, value, cellProperties) => {
+  baseRenderer(instance, td, row, col, prop, value, cellProperties);
+
+  const sourceRow = instance.getSourceDataAtRow(row) as Record<string, unknown> | null;
+  const numbers = toNumbers(sourceRow);
+  const max = numbers.reduce((m, n) => Math.max(m, Math.abs(n)), 0);
+
+  if (numbers.length === 0 || max === 0) {
+    td.textContent = '\u2014';
+    td.title = numbers.length === 0 ? 'No data' : 'All values are zero';
+
+    return;
+  }
+
+  const average = numbers.reduce((sum, n) => sum + n, 0) / numbers.length;
+  const viewWidth = numbers.length * SLOT - GAP;
+  const rects = numbers
+    .map((n, i) => {
+      const barHeight = (Math.abs(n) / max) * VIEW_HEIGHT;
+      const x = i * SLOT;
+      const y = VIEW_HEIGHT - barHeight;
+      const w = SLOT - GAP;
+      const fill = n >= average ? '#16a34a' : '#dc2626';
+
+      return `<rect x="${x}" y="${y}" width="${w}" height="${barHeight}" fill="${fill}"/>`;
+    })
+    .join('');
+
+  td.innerHTML = `<svg width="100%" height="100%" viewBox="0 0 ${viewWidth} ${VIEW_HEIGHT}" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">${rects}</svg>`;
+  td.removeAttribute('title');
+};
+
+registerRenderer('sparklineBar', sparklineRenderer);
+
+/* start:skip-in-preview */
+const data = [
+  { product: 'Desk lamp', w1: 4, w2: 8, w3: 2, w4: 9, w5: 5 },
+  { product: 'Monitor arm', w1: 1, w2: 1, w3: 0, w4: 0, w5: 0 },
+  { product: 'USB hub', w1: null, w2: null, w3: null, w4: null, w5: null },
+  { product: 'Mouse', w1: undefined, w2: undefined, w3: 3, w4: 5, w5: 2 },
+  { product: 'Keyboard', w1: 3, w2: 6, w3: 7, w4: 4, w5: 8 },
+  { product: 'Webcam', w1: 0, w2: 0, w3: 0, w4: 0, w5: 0 },
+];
+/* end:skip-in-preview */
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      id="example1"
+      data={data}
+      rowHeaders={true}
+      rowHeights={44}
+      colHeaders={['Product', 'W1', 'W2', 'W3', 'W4', 'W5', 'Sparkline']}
+      licenseKey="non-commercial-and-evaluation"
+      height="auto"
+      width="100%"
+      columns={[
+        { data: 'product', type: 'text', width: 140, readOnly: true },
+        { data: 'w1', type: 'numeric', width: 65 },
+        { data: 'w2', type: 'numeric', width: 65 },
+        { data: 'w3', type: 'numeric', width: 65 },
+        { data: 'w4', type: 'numeric', width: 65 },
+        { data: 'w5', type: 'numeric', width: 65 },
+        {
+          data: null,
+          width: 220,
+          renderer: 'sparklineBar',
+          className: 'htMiddle sparkline-cell',
+          readOnly: true,
+        },
+      ]}
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/rendering-styling/sparkline-cell-renderer/sparkline-cell-renderer.md
+++ b/docs/content/recipes/rendering-styling/sparkline-cell-renderer/sparkline-cell-renderer.md
@@ -32,6 +32,18 @@ category: Rendering and styling
 
 :::
 
+::: only-for react
+
+::: example #example1 :react-advanced --css 1 --js 2 --ts 3
+
+@[code](@/content/recipes/rendering-styling/sparkline-cell-renderer/react/example1.css)
+@[code](@/content/recipes/rendering-styling/sparkline-cell-renderer/react/example1.jsx)
+@[code](@/content/recipes/rendering-styling/sparkline-cell-renderer/react/example1.tsx)
+
+:::
+
+:::
+
 ## Overview
 
 This recipe shows how to edit weekly values in table cells and render a mini bar chart with inline SVG in a separate sparkline column. No charting library is required.

--- a/docs/content/recipes/sidebar.js
+++ b/docs/content/recipes/sidebar.js
@@ -1,31 +1,30 @@
 const columnManagementItems = [
-  { path: 'column-management/column-visibility/column-visibility', title: 'Dynamic column visibility', onlyFor: ['javascript'] },
+  { path: 'column-management/column-visibility/column-visibility', title: 'Dynamic column visibility', onlyFor: ['javascript', 'react'] },
 ];
 
-const dataManagementItems = [
-  { path: 'data-management/load-data-graphql/load-data-graphql', title: 'Load data from a GraphQL API', onlyFor: ['javascript', 'react', 'angular'] },
-  { path: 'data-management/sync-two-grids/sync-two-grids', title: 'Sync two grids', onlyFor: ['javascript'] },
-  { path: 'data-management/undo-redo-custom-ui/undo-redo-custom-ui', title: 'Undo / redo with a custom UI', onlyFor: ['javascript'] },
-  { path: 'data-management/auto-save-backend/auto-save-backend', title: 'Auto-save changes to a backend', onlyFor: ['javascript'] },
-  { path: 'data-management/server-side-django/server-side-django', title: 'Server-side data with Django', onlyFor: ['javascript'] },
-  { path: 'data-management/server-side-laravel/server-side-laravel', title: 'Server-side data with Laravel', onlyFor: ['javascript'] },
-  { path: 'data-management/server-side-nestjs/server-side-nestjs', title: 'Server-side data with NestJS', onlyFor: ['javascript'] },
+const recipeDataManagementItems = [
+  { path: 'data-management/server-side-laravel/server-side-laravel', title: 'Server-side data with Laravel', onlyFor: ['javascript', 'react'] },
+  { path: 'data-management/sync-two-grids/sync-two-grids', title: 'Sync two grids', onlyFor: ['javascript', 'react'] },
+  { path: 'data-management/undo-redo-custom-ui/undo-redo-custom-ui', title: 'Undo / redo with a custom UI', onlyFor: ['javascript', 'react'] },
+  { path: 'data-management/auto-save-backend/auto-save-backend', title: 'Auto-save changes to a backend', onlyFor: ['javascript', 'react'] },
+  { path: 'data-management/server-side-django/server-side-django', title: 'Server-side data with Django', onlyFor: ['javascript', 'react'] },
   { path: 'data-management/server-side-rails/server-side-rails', title: 'Server-side data with Ruby on Rails', onlyFor: ['javascript'] },
-  { path: 'data-management/server-side-spring/server-side-spring', title: 'Server-side data with Spring Boot', onlyFor: ['javascript'] },
+  { path: 'data-management/server-side-spring/server-side-spring', title: 'Server-side data with Spring Boot', onlyFor: ['javascript', 'react'] },
+  { path: 'data-management/server-side-nestjs/server-side-nestjs', title: 'Server-side data with NestJS', onlyFor: ['javascript', 'react'] },
 ];
 
 const cellTypesItems = [
-  { path: 'cell-types/color-picker/color-picker', title: 'Color picker', onlyFor: ['javascript'] },
+  { path: 'cell-types/color-picker/color-picker', title: 'Color picker', onlyFor: ['javascript', 'react'] },
   { path: 'cell-types/feedback-react/feedback-react', title: 'Simple Feedback', onlyFor: ['react'] },
   { path: 'cell-types/colorful-picker/colorful-picker', title: 'Colorful Picker', onlyFor: ['react'] },
   { path: 'cell-types/react-rating/react-rating', title: 'Star Rating', onlyFor: ['react'] },
-  { path: 'cell-types/feedback/feedback', title: 'Simple Feedback', onlyFor: ['javascript'] },
-  { path: 'cell-types/flatpickr/flatpickr', title: 'Datetime `flatpickr` picker', onlyFor: ['javascript'] },
-  { path: 'cell-types/moment-date/moment-date', title: 'Moment.js-based date', onlyFor: ['javascript'] },
-  { path: 'cell-types/moment-time/moment-time', title: 'Moment.js-based time', onlyFor: ['javascript'] },
-  { path: 'cell-types/numbro/numbro', title: 'Numbro', onlyFor: ['javascript'] },
-  { path: 'cell-types/pikaday/pikaday', title: 'Date picker pikaday', onlyFor: ['javascript'] },
-  { path: 'cell-types/rating/rating', title: 'Stars Rating', onlyFor: ['javascript'] },
+  { path: 'cell-types/feedback/feedback', title: 'Simple Feedback', onlyFor: ['javascript', 'react'] },
+  { path: 'cell-types/flatpickr/flatpickr', title: 'Datetime `flatpickr` picker', onlyFor: ['javascript', 'react'] },
+  { path: 'cell-types/moment-date/moment-date', title: 'Moment.js-based date', onlyFor: ['javascript', 'react'] },
+  { path: 'cell-types/moment-time/moment-time', title: 'Moment.js-based time', onlyFor: ['javascript', 'react'] },
+  { path: 'cell-types/numbro/numbro', title: 'Numbro', onlyFor: ['javascript', 'react'] },
+  { path: 'cell-types/pikaday/pikaday', title: 'Date picker pikaday', onlyFor: ['javascript', 'react'] },
+  { path: 'cell-types/rating/rating', title: 'Stars Rating', onlyFor: ['javascript', 'react'] },
   { path: 'cell-types/guide-feedback-angular/guide-feedback', title: 'Simple Feedback', onlyFor: ['angular'] },
   { path: 'cell-types/guide-rating-angular/guide-rating', title: 'Stars Rating', onlyFor: ['angular'] },
   { path: 'cell-types/guide-color-picker-angular/guide-color-picker', title: 'Color picker', onlyFor: ['angular'] },
@@ -36,17 +35,17 @@ const renderingStylingItems = [
   {
     path: 'rendering-styling/frozen-summary-row/frozen-summary-row',
     title: 'Frozen summary row',
-    onlyFor: ['javascript'],
+    onlyFor: ['javascript', 'react'],
   },
   {
     path: 'rendering-styling/sparkline-cell-renderer/sparkline-cell-renderer',
     title: 'Sparkline cell renderer',
-    onlyFor: ['javascript'],
+    onlyFor: ['javascript', 'react'],
   },
   {
     path: 'rendering-styling/conditional-row-coloring/conditional-row-coloring',
     title: 'Conditional row coloring',
-    onlyFor: ['javascript'],
+    onlyFor: ['javascript', 'react'],
   },
 ];
 
@@ -54,17 +53,17 @@ const importExportItems = [
   {
     path: 'import-export/export-to-pdf/export-to-pdf',
     title: 'Export to PDF',
-    onlyFor: ['javascript'],
+    onlyFor: ['javascript', 'react'],
   },
-  { path: 'import-export/import-csv-excel/import-csv-excel', title: 'Import from CSV or Excel', onlyFor: ['javascript'] },
+  { path: 'import-export/import-csv-excel/import-csv-excel', title: 'Import from CSV or Excel', onlyFor: ['javascript', 'react'] },
 ];
 
 const filteringAndSearchItems = [
-  { path: 'filtering-and-search/external-search-box/external-search-box', title: 'Global Search', onlyFor: ['javascript'] },
+  { path: 'filtering-and-search/external-search-box/external-search-box', title: 'Global Search', onlyFor: ['javascript', 'react'] },
   {
     path: 'filtering-and-search/highlight-search-matches/highlight-search-matches',
     title: 'Highlight search matches',
-    onlyFor: ['javascript'],
+    onlyFor: ['javascript', 'react'],
   },
 ];
 
@@ -80,51 +79,56 @@ const editingValidationItems = [
   {
     path: 'editing-validation/dependent-dropdowns/dependent-dropdowns',
     title: 'Dependent dropdowns',
-    onlyFor: ['javascript'],
+    onlyFor: ['javascript', 'react'],
   },
   {
     path: 'editing-validation/row-validation-error-summary/row-validation-error-summary',
     title: 'Row validation with error summary',
-    onlyFor: ['javascript'],
+    onlyFor: ['javascript', 'react'],
   },
+];
+
+const accessibilityItems = [
+  { path: 'accessibility/aria-grid/aria-grid', title: 'ARIA grid', onlyFor: ['javascript', 'react'] },
 ];
 
 module.exports = {
   sidebar: [
     'introduction',
-    { title: 'Column Management', path: 'column-management', children: columnManagementItems, collapsable: false, onlyFor: ['javascript'] },
-    { title: 'Data Management', path: 'data-management', children: dataManagementItems, collapsable: false, onlyFor: ['javascript', 'react', 'angular'] },
+    { title: 'Accessibility', path: 'accessibility', children: accessibilityItems, collapsable: false, onlyFor: ['javascript', 'react'] },
+    { title: 'Column Management', path: 'column-management', children: columnManagementItems, collapsable: false, onlyFor: ['javascript', 'react'] },
+    { title: 'Data Management', path: 'data-management', children: recipeDataManagementItems, collapsable: false, onlyFor: ['javascript', 'react'] },
     { title: 'Cell Types', path: 'cell-types', children: cellTypesItems, collapsable: false, onlyFor: ['react', 'javascript', 'angular'] },
     {
       title: 'Editing and Validation',
       path: 'editing-validation',
       children: editingValidationItems,
       collapsable: false,
-      onlyFor: ['javascript'],
+      onlyFor: ['javascript', 'react'],
     },
     {
       title: 'Import and Export',
       path: 'import-export',
       children: importExportItems,
       collapsable: false,
-      onlyFor: ['javascript'],
+      onlyFor: ['javascript', 'react'],
     },
     {
       title: 'Filtering and Search',
       path: 'filtering-and-search',
       children: [
         ...filteringAndSearchItems,
-        { path: 'filtering-search/multi-column-filter-panel/multi-column-filter-panel', title: 'Multi-column filter panel', onlyFor: ['javascript'] },
+        { path: 'filtering-search/multi-column-filter-panel/multi-column-filter-panel', title: 'Multi-column filter panel', onlyFor: ['javascript', 'react'] },
       ],
       collapsable: false,
-      onlyFor: ['javascript'],
+      onlyFor: ['javascript', 'react'],
     },
     {
       title: 'Rendering and styling',
       path: 'rendering-styling',
       children: renderingStylingItems,
       collapsable: false,
-      onlyFor: ['javascript'],
+      onlyFor: ['javascript', 'react'],
     },
     { title: 'Themes', path: 'themes', children: themesItems, collapsable: false, onlyFor: ['react', 'javascript', 'angular'] },
   ],

--- a/docs/content/recipes/sidebar.js
+++ b/docs/content/recipes/sidebar.js
@@ -3,14 +3,14 @@ const columnManagementItems = [
 ];
 
 const recipeDataManagementItems = [
-  { path: 'data-management/server-side-laravel/server-side-laravel', title: 'Server-side data with Laravel', onlyFor: ['javascript', 'react'] },
   { path: 'data-management/sync-two-grids/sync-two-grids', title: 'Sync two grids', onlyFor: ['javascript', 'react'] },
   { path: 'data-management/undo-redo-custom-ui/undo-redo-custom-ui', title: 'Undo / redo with a custom UI', onlyFor: ['javascript', 'react'] },
   { path: 'data-management/auto-save-backend/auto-save-backend', title: 'Auto-save changes to a backend', onlyFor: ['javascript', 'react'] },
   { path: 'data-management/server-side-django/server-side-django', title: 'Server-side data with Django', onlyFor: ['javascript', 'react'] },
+  { path: 'data-management/server-side-laravel/server-side-laravel', title: 'Server-side data with Laravel', onlyFor: ['javascript', 'react'] },
+  { path: 'data-management/server-side-nestjs/server-side-nestjs', title: 'Server-side data with NestJS', onlyFor: ['javascript', 'react'] },
   { path: 'data-management/server-side-rails/server-side-rails', title: 'Server-side data with Ruby on Rails', onlyFor: ['javascript'] },
   { path: 'data-management/server-side-spring/server-side-spring', title: 'Server-side data with Spring Boot', onlyFor: ['javascript', 'react'] },
-  { path: 'data-management/server-side-nestjs/server-side-nestjs', title: 'Server-side data with NestJS', onlyFor: ['javascript', 'react'] },
 ];
 
 const cellTypesItems = [

--- a/docs/content/recipes/sidebar.js
+++ b/docs/content/recipes/sidebar.js
@@ -2,7 +2,8 @@ const columnManagementItems = [
   { path: 'column-management/column-visibility/column-visibility', title: 'Dynamic column visibility', onlyFor: ['javascript', 'angular', 'react'] },
 ];
 
-const recipeDataManagementItems = [
+const dataManagementItems = [
+  { path: 'data-management/load-data-graphql/load-data-graphql', title: 'Load data from a GraphQL API', onlyFor: ['javascript', 'react', 'angular'] },
   { path: 'data-management/sync-two-grids/sync-two-grids', title: 'Sync two grids', onlyFor: ['javascript', 'angular', 'react'] },
   { path: 'data-management/undo-redo-custom-ui/undo-redo-custom-ui', title: 'Undo / redo with a custom UI', onlyFor: ['javascript', 'angular', 'react'] },
   { path: 'data-management/auto-save-backend/auto-save-backend', title: 'Auto-save changes to a backend', onlyFor: ['javascript', 'angular', 'react'] },
@@ -97,7 +98,7 @@ module.exports = {
     'introduction',
     { title: 'Accessibility', path: 'accessibility', children: accessibilityItems, collapsable: false, onlyFor: ['javascript', 'angular', 'react'] },
     { title: 'Column Management', path: 'column-management', children: columnManagementItems, collapsable: false, onlyFor: ['javascript', 'angular', 'react'] },
-    { title: 'Data Management', path: 'data-management', children: recipeDataManagementItems, collapsable: false, onlyFor: ['javascript', 'angular', 'react'] },
+    { title: 'Data Management', path: 'data-management', children: dataManagementItems, collapsable: false, onlyFor: ['javascript', 'angular', 'react'] },
     { title: 'Cell Types', path: 'cell-types', children: cellTypesItems, collapsable: false, onlyFor: ['react', 'javascript', 'angular'] },
     {
       title: 'Editing and Validation',

--- a/docs/content/recipes/sidebar.js
+++ b/docs/content/recipes/sidebar.js
@@ -1,30 +1,30 @@
 const columnManagementItems = [
-  { path: 'column-management/column-visibility/column-visibility', title: 'Dynamic column visibility', onlyFor: ['javascript', 'react'] },
+  { path: 'column-management/column-visibility/column-visibility', title: 'Dynamic column visibility', onlyFor: ['javascript', 'angular', 'react'] },
 ];
 
 const recipeDataManagementItems = [
-  { path: 'data-management/sync-two-grids/sync-two-grids', title: 'Sync two grids', onlyFor: ['javascript', 'react'] },
-  { path: 'data-management/undo-redo-custom-ui/undo-redo-custom-ui', title: 'Undo / redo with a custom UI', onlyFor: ['javascript', 'react'] },
-  { path: 'data-management/auto-save-backend/auto-save-backend', title: 'Auto-save changes to a backend', onlyFor: ['javascript', 'react'] },
-  { path: 'data-management/server-side-django/server-side-django', title: 'Server-side data with Django', onlyFor: ['javascript', 'react'] },
-  { path: 'data-management/server-side-laravel/server-side-laravel', title: 'Server-side data with Laravel', onlyFor: ['javascript', 'react'] },
-  { path: 'data-management/server-side-nestjs/server-side-nestjs', title: 'Server-side data with NestJS', onlyFor: ['javascript', 'react'] },
+  { path: 'data-management/sync-two-grids/sync-two-grids', title: 'Sync two grids', onlyFor: ['javascript', 'angular', 'react'] },
+  { path: 'data-management/undo-redo-custom-ui/undo-redo-custom-ui', title: 'Undo / redo with a custom UI', onlyFor: ['javascript', 'angular', 'react'] },
+  { path: 'data-management/auto-save-backend/auto-save-backend', title: 'Auto-save changes to a backend', onlyFor: ['javascript', 'angular', 'react'] },
+  { path: 'data-management/server-side-django/server-side-django', title: 'Server-side data with Django', onlyFor: ['javascript', 'angular', 'react'] },
+  { path: 'data-management/server-side-laravel/server-side-laravel', title: 'Server-side data with Laravel', onlyFor: ['javascript', 'angular', 'react'] },
+  { path: 'data-management/server-side-nestjs/server-side-nestjs', title: 'Server-side data with NestJS', onlyFor: ['javascript', 'angular', 'react'] },
   { path: 'data-management/server-side-rails/server-side-rails', title: 'Server-side data with Ruby on Rails', onlyFor: ['javascript'] },
-  { path: 'data-management/server-side-spring/server-side-spring', title: 'Server-side data with Spring Boot', onlyFor: ['javascript', 'react'] },
+  { path: 'data-management/server-side-spring/server-side-spring', title: 'Server-side data with Spring Boot', onlyFor: ['javascript', 'angular', 'react'] },
 ];
 
 const cellTypesItems = [
-  { path: 'cell-types/color-picker/color-picker', title: 'Color picker', onlyFor: ['javascript', 'react'] },
+  { path: 'cell-types/color-picker/color-picker', title: 'Color picker', onlyFor: ['javascript', 'angular', 'react'] },
   { path: 'cell-types/feedback-react/feedback-react', title: 'Simple Feedback', onlyFor: ['react'] },
   { path: 'cell-types/colorful-picker/colorful-picker', title: 'Colorful Picker', onlyFor: ['react'] },
   { path: 'cell-types/react-rating/react-rating', title: 'Star Rating', onlyFor: ['react'] },
-  { path: 'cell-types/feedback/feedback', title: 'Simple Feedback', onlyFor: ['javascript', 'react'] },
-  { path: 'cell-types/flatpickr/flatpickr', title: 'Datetime `flatpickr` picker', onlyFor: ['javascript', 'react'] },
-  { path: 'cell-types/moment-date/moment-date', title: 'Moment.js-based date', onlyFor: ['javascript', 'react'] },
-  { path: 'cell-types/moment-time/moment-time', title: 'Moment.js-based time', onlyFor: ['javascript', 'react'] },
-  { path: 'cell-types/numbro/numbro', title: 'Numbro', onlyFor: ['javascript', 'react'] },
-  { path: 'cell-types/pikaday/pikaday', title: 'Date picker pikaday', onlyFor: ['javascript', 'react'] },
-  { path: 'cell-types/rating/rating', title: 'Stars Rating', onlyFor: ['javascript', 'react'] },
+  { path: 'cell-types/feedback/feedback', title: 'Simple Feedback', onlyFor: ['javascript', 'angular', 'react'] },
+  { path: 'cell-types/flatpickr/flatpickr', title: 'Datetime `flatpickr` picker', onlyFor: ['javascript', 'angular', 'react'] },
+  { path: 'cell-types/moment-date/moment-date', title: 'Moment.js-based date', onlyFor: ['javascript', 'angular', 'react'] },
+  { path: 'cell-types/moment-time/moment-time', title: 'Moment.js-based time', onlyFor: ['javascript', 'angular', 'react'] },
+  { path: 'cell-types/numbro/numbro', title: 'Numbro', onlyFor: ['javascript', 'angular', 'react'] },
+  { path: 'cell-types/pikaday/pikaday', title: 'Date picker pikaday', onlyFor: ['javascript', 'angular', 'react'] },
+  { path: 'cell-types/rating/rating', title: 'Stars Rating', onlyFor: ['javascript', 'angular', 'react'] },
   { path: 'cell-types/guide-feedback-angular/guide-feedback', title: 'Simple Feedback', onlyFor: ['angular'] },
   { path: 'cell-types/guide-rating-angular/guide-rating', title: 'Stars Rating', onlyFor: ['angular'] },
   { path: 'cell-types/guide-color-picker-angular/guide-color-picker', title: 'Color picker', onlyFor: ['angular'] },
@@ -35,17 +35,17 @@ const renderingStylingItems = [
   {
     path: 'rendering-styling/frozen-summary-row/frozen-summary-row',
     title: 'Frozen summary row',
-    onlyFor: ['javascript', 'react'],
+    onlyFor: ['javascript', 'angular', 'react'],
   },
   {
     path: 'rendering-styling/sparkline-cell-renderer/sparkline-cell-renderer',
     title: 'Sparkline cell renderer',
-    onlyFor: ['javascript', 'react'],
+    onlyFor: ['javascript', 'angular', 'react'],
   },
   {
     path: 'rendering-styling/conditional-row-coloring/conditional-row-coloring',
     title: 'Conditional row coloring',
-    onlyFor: ['javascript', 'react'],
+    onlyFor: ['javascript', 'angular', 'react'],
   },
 ];
 
@@ -53,17 +53,17 @@ const importExportItems = [
   {
     path: 'import-export/export-to-pdf/export-to-pdf',
     title: 'Export to PDF',
-    onlyFor: ['javascript', 'react'],
+    onlyFor: ['javascript', 'angular', 'react'],
   },
-  { path: 'import-export/import-csv-excel/import-csv-excel', title: 'Import from CSV or Excel', onlyFor: ['javascript', 'react'] },
+  { path: 'import-export/import-csv-excel/import-csv-excel', title: 'Import from CSV or Excel', onlyFor: ['javascript', 'angular', 'react'] },
 ];
 
 const filteringAndSearchItems = [
-  { path: 'filtering-and-search/external-search-box/external-search-box', title: 'Global Search', onlyFor: ['javascript', 'react'] },
+  { path: 'filtering-and-search/external-search-box/external-search-box', title: 'Global Search', onlyFor: ['javascript', 'angular', 'react'] },
   {
     path: 'filtering-and-search/highlight-search-matches/highlight-search-matches',
     title: 'Highlight search matches',
-    onlyFor: ['javascript', 'react'],
+    onlyFor: ['javascript', 'angular', 'react'],
   },
 ];
 
@@ -79,56 +79,56 @@ const editingValidationItems = [
   {
     path: 'editing-validation/dependent-dropdowns/dependent-dropdowns',
     title: 'Dependent dropdowns',
-    onlyFor: ['javascript', 'react'],
+    onlyFor: ['javascript', 'angular', 'react'],
   },
   {
     path: 'editing-validation/row-validation-error-summary/row-validation-error-summary',
     title: 'Row validation with error summary',
-    onlyFor: ['javascript', 'react'],
+    onlyFor: ['javascript', 'angular', 'react'],
   },
 ];
 
 const accessibilityItems = [
-  { path: 'accessibility/aria-grid/aria-grid', title: 'ARIA grid', onlyFor: ['javascript', 'react'] },
+  { path: 'accessibility/aria-grid/aria-grid', title: 'ARIA grid', onlyFor: ['javascript', 'angular', 'react'] },
 ];
 
 module.exports = {
   sidebar: [
     'introduction',
-    { title: 'Accessibility', path: 'accessibility', children: accessibilityItems, collapsable: false, onlyFor: ['javascript', 'react'] },
-    { title: 'Column Management', path: 'column-management', children: columnManagementItems, collapsable: false, onlyFor: ['javascript', 'react'] },
-    { title: 'Data Management', path: 'data-management', children: recipeDataManagementItems, collapsable: false, onlyFor: ['javascript', 'react'] },
+    { title: 'Accessibility', path: 'accessibility', children: accessibilityItems, collapsable: false, onlyFor: ['javascript', 'angular', 'react'] },
+    { title: 'Column Management', path: 'column-management', children: columnManagementItems, collapsable: false, onlyFor: ['javascript', 'angular', 'react'] },
+    { title: 'Data Management', path: 'data-management', children: recipeDataManagementItems, collapsable: false, onlyFor: ['javascript', 'angular', 'react'] },
     { title: 'Cell Types', path: 'cell-types', children: cellTypesItems, collapsable: false, onlyFor: ['react', 'javascript', 'angular'] },
     {
       title: 'Editing and Validation',
       path: 'editing-validation',
       children: editingValidationItems,
       collapsable: false,
-      onlyFor: ['javascript', 'react'],
+      onlyFor: ['javascript', 'angular', 'react'],
     },
     {
       title: 'Import and Export',
       path: 'import-export',
       children: importExportItems,
       collapsable: false,
-      onlyFor: ['javascript', 'react'],
+      onlyFor: ['javascript', 'angular', 'react'],
     },
     {
       title: 'Filtering and Search',
       path: 'filtering-and-search',
       children: [
         ...filteringAndSearchItems,
-        { path: 'filtering-search/multi-column-filter-panel/multi-column-filter-panel', title: 'Multi-column filter panel', onlyFor: ['javascript', 'react'] },
+        { path: 'filtering-search/multi-column-filter-panel/multi-column-filter-panel', title: 'Multi-column filter panel', onlyFor: ['javascript', 'angular', 'react'] },
       ],
       collapsable: false,
-      onlyFor: ['javascript', 'react'],
+      onlyFor: ['javascript', 'angular', 'react'],
     },
     {
       title: 'Rendering and styling',
       path: 'rendering-styling',
       children: renderingStylingItems,
       collapsable: false,
-      onlyFor: ['javascript', 'react'],
+      onlyFor: ['javascript', 'angular', 'react'],
     },
     { title: 'Themes', path: 'themes', children: themesItems, collapsable: false, onlyFor: ['react', 'javascript', 'angular'] },
   ],


### PR DESCRIPTION
### Context
This PR adds comprehensive React examples for the Handsontable recipe documentation. The recipes cover various use cases including cell types (date pickers, color pickers, ratings), data management (server-side integration, auto-save, syncing), filtering, validation, and rendering/styling features.

Each recipe includes both TypeScript (`.tsx`) and JavaScript (`.jsx`) implementations, along with associated CSS files for styling. The examples demonstrate best practices for integrating Handsontable with React and third-party libraries like Pikaday, Flatpickr, Pickr, Moment.js, and Numbro.

### How has this been tested?
The examples follow the established patterns from existing recipe implementations and are structured to work with the documentation build system. Each example includes proper imports, type definitions (for TypeScript), and integration with Handsontable's React wrapper.

### Types of changes
- [x] New feature or improvement (non-breaking change which adds functionality)

### Related issue(s):
Documentation enhancement for React framework support in recipes.

ClickUp task: https://app.clickup.com/t/86c9dkbqx

### Affected project(s):
- [x] `@handsontable/react-wrapper`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] My change requires a change to the documentation.

[skip changelog]

https://claude.ai/code/session_01ET61Z7JaFdTbudBahKiQnH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only additions that primarily introduce new example files and wiring; risk is limited to docs build/rendering and example correctness, not production runtime behavior.
> 
> **Overview**
> Adds **React-specific example sections** (using `::: only-for react` and `:react-advanced`) to multiple recipe pages so the documentation can render framework-appropriate snippets alongside existing JavaScript examples.
> 
> Introduces new React example implementations (JSX + TSX, plus CSS where needed) for recipes covering ARIA-friendly grids, custom cell types (color picker, feedback, flatpickr, moment-date/time, numbro, pikaday, rating), column visibility toggling, and data-management patterns (auto-save debounce + dirty tracking, plus server-side `dataProvider` integrations for Django/Laravel/NestJS/Spring). Also updates a few existing React examples to explicitly import their local `example1.css`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d39e35f71282c1f4eedf8a3e30f12a33b0000565. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->