### PR TITLE
fix(docs): built-in themes demo respects selected color scheme [DEV-1460]

### DIFF
--- a/docs/src/plugins/framework-loader.mjs
+++ b/docs/src/plugins/framework-loader.mjs
@@ -114,9 +114,10 @@ function escapeHtml(str) {
  * @param {string[]} fileRefs - Paths relative to contentDir (after stripping '@/content/')
  * @param {string} contentDir - Absolute path to docs/content/
  * @param {Object<string, string>} [fileMeta] - Optional EC meta attributes keyed by file path
+ * @param {string} [extraClasses] - Space-separated CSS classes to add to the container div
  * @returns {string} HTML + markdown fences string
  */
-function buildExampleHtml(id, directive, fileRefs, contentDir, fileMeta = {}) {
+function buildExampleHtml(id, directive, fileRefs, contentDir, fileMeta = {}, extraClasses = '') {
   const hideTabs = directive === 'example-without-tabs';
 
   // Detect framework from the directory path first. JS examples also ship a
@@ -285,7 +286,7 @@ function buildExampleHtml(id, directive, fileRefs, contentDir, fileMeta = {}) {
     <div class="hot-example-loader__row"></div>
     <div class="hot-example-loader__row"></div>
   </div>
-  ${htmlPreviewContent || `<div id="${escapeHtml(id)}"></div>`}
+  ${htmlPreviewContent || `<div id="${escapeHtml(id)}"${extraClasses ? ` class="${escapeHtml(extraClasses)}"` : ''}></div>`}
 </div>
 <div class="hot-example-toolbar">
   <button class="hot-example-source-btn" type="button" aria-expanded="false" aria-controls="hot-code-${escapeHtml(id)}">
@@ -337,6 +338,10 @@ function processExampleBlocks(content, contentDir) {
       const idMatch = header.match(/#(\S+)/);
       const id = idMatch ? idMatch[1] : 'unknown';
 
+      // Extract CSS classes from the header (e.g. '.disable-auto-theme')
+      const classMatches = [...header.matchAll(/\.([a-zA-Z][a-zA-Z0-9_-]*)/g)];
+      const extraClasses = classMatches.map(m => m[1]).join(' ');
+
       // Collect all lines inside this block until the matching closing :::
       const blockLines = [];
       let depth = 1;
@@ -377,7 +382,7 @@ function processExampleBlocks(content, contentDir) {
         }
       }
 
-      result.push(buildExampleHtml(id, directive, fileRefs, contentDir, fileMeta));
+      result.push(buildExampleHtml(id, directive, fileRefs, contentDir, fileMeta, extraClasses));
       // i is already incremented past the closing ::: by the inner loop
     } else {
       result.push(line);

--- a/docs/src/styles/overrides/example-specific.css
+++ b/docs/src/styles/overrides/example-specific.css
@@ -1,8 +1,9 @@
-/* Sync Handsontable theme with docs theme toggle (override browser default) */
-[data-theme="dark"] .ht-theme-main {
+/* Sync Handsontable theme with docs theme toggle (override browser default).
+   Exclude .disable-auto-theme containers that manage their own color scheme. */
+[data-theme="dark"] .ht-theme-main:not(.disable-auto-theme *) {
   color-scheme: dark;
 }
-[data-theme="light"] .ht-theme-main {
+[data-theme="light"] .ht-theme-main:not(.disable-auto-theme *) {
   color-scheme: light;
 }
 


### PR DESCRIPTION
## Summary

- The Built-in themes demo on the Styling/Themes docs page was ignoring the user's theme selection (e.g. selecting "Main Dark" while the page was in Light mode had no effect).
- Root cause: `example-specific.css` had CSS rules that forced `color-scheme: light/dark` on all `.ht-theme-main` elements based on the page's `data-theme` attribute. These rules had higher specificity than Handsontable's own injected `:where(.ht-theme-main)` style (which uses `:where()` for zero specificity), so the page-level CSS always won.
- Fix has two parts:
  1. **`example-specific.css`**: Added `:not(.disable-auto-theme *)` to both selectors so the page-sync only applies to demos that don't manage their own color scheme.
  2. **`framework-loader.mjs`**: The loader was silently dropping CSS classes declared in `:::example` directive headers (e.g. `.disable-auto-theme`). For React/Angular/Vue examples it always generated a bare `<div id="..."></div>`. Now CSS classes from the header are extracted and applied to the generated container div, so `:::: example #exampleTheme .disable-auto-theme :react` correctly produces `<div id="exampleTheme" class="disable-auto-theme"></div>`.

## Test plan

- [ ] Open the Styling/Themes docs page with the page theme set to **Light**
- [ ] In the Built-in themes demo, select **Main Dark** -- the grid should switch to dark mode
- [ ] Select **Main Light** -- the grid should switch to light mode
- [ ] Repeat with the page theme set to **Dark**: selecting Main Light should show light mode, Main Dark should show dark mode
- [ ] Verify other demos on the site (without `.disable-auto-theme`) still sync correctly with the page theme toggle
- [ ] Verify that example directives using classes like `.docs-height-small` now correctly pass those classes to the container div for React/Angular/Vue examples

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1460

[skip changelog]

https://claude.ai/code/session_01Em4mgmJQuoZU82MmdYoMcq

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the markdown-to-HTML loader used for all docs examples and changes global theme CSS selectors, so regressions could affect rendering/styling across multiple pages if the new parsing or selector logic misfires.
> 
> **Overview**
> Fixes the docs “Built-in themes” demo so its internal light/dark switching isn’t overridden by the page theme by excluding `.disable-auto-theme` containers from the global `color-scheme` sync rules.
> 
> Extends the markdown `::: example` processing so class tokens in the directive header (e.g. `.disable-auto-theme`) are parsed and applied to the generated preview mount element, enabling per-example styling/behavior flags without custom HTML.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cc53326256de3aec3b0620908bbd55f24ede1ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->