### PR TITLE
DEV-1461: Update TypeScript type for dateFormat to support Intl.DateTimeFormatOptions

### DIFF
--- a/.changelogs/12395.json
+++ b/.changelogs/12395.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed TypeScript type for the `dateFormat` option to accept `Intl.DateTimeFormatOptions` objects required by the `intl-date` cell type.",
+  "type": "fixed",
+  "issueOrPR": 12395,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.claude/skills/changelog-creation/SKILL.md
+++ b/.claude/skills/changelog-creation/SKILL.md
@@ -15,9 +15,21 @@ Any PR that changes source code needs a changelog entry. This includes bug fixes
 
 Add `[skip changelog]` in the PR description to explicitly skip.
 
+## Workflow: Create the PR First, Then the Changelog
+
+The changelog file is named after the GitHub PR number, so the PR must exist before the entry is written. Guessing the next available number by reading `.changelogs/` or the GitHub API is unreliable — another PR can be opened between the check and the push, and the filename will no longer match.
+
+Correct order:
+
+1. Commit the source code change on the feature branch.
+2. Push the branch and run `gh pr create` (see the `pr-creation` skill).
+3. Read the PR number from the URL `gh pr create` prints (e.g. `https://github.com/handsontable/handsontable/pull/12395` → `12395`).
+4. Create `.changelogs/<PR-number>.json` using that number, set `"issueOrPR"` to the same number.
+5. Commit the new file with a message like `DEV-xxx: Add changelog entry for PR #<number>` and push — the PR picks it up.
+
 ## JSON Format
 
-Create a file at `.changelogs/{issue-or-pr-number}.json`:
+Create a file at `.changelogs/{PR-number}.json` (using the PR number returned by `gh pr create`):
 
 ```json
 {
@@ -75,8 +87,10 @@ Create **one changelog entry per PR**, even if the PR fixes multiple issues. The
 
 ## Checklist
 
-1. Pick the correct `type` from the table above.
-2. Write a clear, user-facing `title` ending with a period.
-3. Set `breaking` to `true` only if the change breaks existing behavior.
-4. Set `framework` to match the affected package, or `"none"` for core.
-5. Name the file after the GitHub PR number (ask the user, never infer).
+1. Confirm the PR already exists (open or draft). Capture its number from the `gh pr create` output or the PR URL.
+2. Pick the correct `type` from the table above.
+3. Write a clear, user-facing `title` ending with a period.
+4. Set `breaking` to `true` only if the change breaks existing behavior.
+5. Set `framework` to match the affected package, or `"none"` for core.
+6. Name the file `<PR-number>.json` and set `"issueOrPR"` to the same number. Do not guess or infer the number — read it from the created PR.
+7. Commit and push the new changelog file to the same feature branch so the open PR picks it up.

--- a/.claude/skills/pr-creation/SKILL.md
+++ b/.claude/skills/pr-creation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-creation
-description: Use when creating, updating, or editing a pull request for the Handsontable monorepo, or when asked to commit and push changes, update PR description, or edit PR body. Also trigger when the user says "update the PR", "fix PR description", "update PR body", or references a PR URL and wants changes to its content. Covers branch naming conventions, pre-flight checks (lint and tests), changelog entry, and filling the PR template with context, test plan, and affected projects.
+description: Use this skill whenever you are about to create, update, or edit a pull request in the Handsontable monorepo. **This skill must be loaded BEFORE running `gh pr create` or pushing a feature branch to GitHub**, not just when the user says the word "PR". Trigger it on any of these phrases, even indirect ones: "create a PR / pull request", "open a PR", "submit a PR", "push the branch", "push changes", "commit and push", "fix the issue" (when a branch has been created from a task), "ship it", "ready to review", "update the PR", "edit PR body", "fix PR description", "update PR description", or any mention of a PR URL. Also trigger when finishing work on a `feature/*`, `docs/*`, or `fix/*` branch, or when a ClickUp/DEV task has been implemented and needs to be submitted. Covers branch naming conventions, pre-flight checks (lint and tests), the PR-first / changelog-second workflow, authentication fallback (`gh auth setup-git` when SSH is unavailable), and filling the GitHub PR template with context, test plan, affected projects, and ClickUp task link.
 ---
 
 ## 1. Branch Naming
@@ -40,11 +40,7 @@ npm run test --prefix wrappers/vue3
 npm run test --prefix wrappers/angular-wrapper
 ```
 
-## 3. Changelog Entry
-
-Every PR that changes source code needs a changelog entry in `.changelogs/`. See the `changelog-creation` skill for the full process. Use `[skip changelog]` in the PR description only for test-only or docs-only changes.
-
-## 4. Fill the PR Template
+## 3. Fill the PR Template
 
 The repository has a PR template at `.github/PULL_REQUEST_TEMPLATE.md`. Fill in each section:
 
@@ -55,22 +51,93 @@ The repository has a PR template at `.github/PULL_REQUEST_TEMPLATE.md`. Fill in 
 - **Affected project(s)** -- Check every package your change touches: `handsontable`, `@handsontable/react-wrapper`, `@handsontable/angular-wrapper`, `@handsontable/vue3`.
 - **Checklist** -- Confirm code style, CLA signature, and whether documentation needs updating.
 
-## 5. Target Branch
+## 4. Target Branch
 
 All PRs target the **develop** branch. Cherry-picks to `release/*` or `lts/*` branches are handled separately by maintainers.
 
-## 6. Create the PR
+## 5. Create the PR First (before the changelog)
+
+The PR is created **before** the changelog entry. The changelog file is named after the PR number, so you need the number the GitHub API returns from `gh pr create` before you can write the file correctly. Creating the changelog first and guessing the next PR number is unreliable — other PRs can be opened between your check and your push.
+
+Workflow:
+
+1. Commit the code change on the feature branch.
+2. Push the branch (use `gh auth setup-git` once if git is configured for SSH and the SSH key is unavailable in the session; then push over HTTPS).
+3. Run `gh pr create` and capture the returned PR URL / number.
+4. Use that PR number when creating the changelog entry (next step).
 
 Use the GitHub CLI to create the PR. **Always create PRs as drafts** -- the author marks it ready for review when appropriate.
 
+**Authentication fallback:** If `git push` fails with `Permission denied (publickey)` because the session has no SSH key, switch the remote to HTTPS and let `gh` provide credentials, then push:
+
 ```bash
-gh pr create --draft --base develop --title "DEV-xxx: Short description" --body "..."
+git remote set-url origin https://github.com/handsontable/handsontable.git
+gh auth setup-git
+git push -u origin <branch-name>
+```
+
+**Fill the full PR template in `--body`.** Do not submit a bare "Summary / Test plan" body — the repo's template at `.github/PULL_REQUEST_TEMPLATE.md` has **Context**, **How has this been tested?**, **Types of changes**, **Related issue(s)**, **Affected project(s)**, and **Checklist** sections, and every section must be filled in. Always include the ClickUp task URL on its own line so ClickUp auto-links the PR.
+
+```bash
+gh pr create --draft --base develop \
+  --title "DEV-xxx: Short description" \
+  --body "$(cat <<'EOF'
+### Context
+
+<why this change is needed; link the task and explain the problem>
+
+### How has this been tested?
+
+- <tests you added or ran, with commands>
+
+### Types of changes
+
+- [x] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature or improvement (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Additional language file or change to the existing one (translations)
+
+### Related issue(s):
+
+1. DEV-xxx
+
+### Affected project(s):
+
+- [x] `handsontable`
+- [ ] `@handsontable/angular-wrapper`
+- [ ] `@handsontable/react-wrapper`
+- [ ] `@handsontable/vue3`
+
+### Checklist:
+
+- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
+- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
+- [ ] My change requires a change to the documentation.
+
+ClickUp task: https://app.clickup.com/t/9015210959/DEV-xxx
+EOF
+)"
 ```
 
 - **Commit messages:** Descriptive, max 80 characters. Include task ID (e.g. `DEV-627: Fix filter column index`).
 - Include the ClickUp task ID in the PR title when applicable.
-- Start the description with "The PR fixes/adds/changes/..." -- be direct, no filler.
+- Start the **Context** section with "The PR fixes/adds/changes/..." -- be direct, no filler.
 - If the PR introduces a breaking change, require the `Breaking change` label and include a migration section with before/after examples. Update migration guides in `docs/content/guides/upgrade-and-migration/`.
+
+## 5a. Updating an Existing PR's Body
+
+When asked to update, fix, or re-fill a PR description, use `gh pr edit <number> --body "$(cat <<'EOF' ... EOF)"`. Keep the full template structure — do not replace it with a shorter summary. The heredoc approach preserves newlines and checkboxes reliably.
+
+## 6. Changelog Entry (after PR is created)
+
+Every PR that changes source code needs a changelog entry in `.changelogs/`. The filename **must** be `{PR-number}.json`, using the PR number returned by `gh pr create` in the previous step. See the `changelog-creation` skill for the JSON schema and title-writing rules.
+
+After writing the file:
+
+1. Commit it on the same branch (`DEV-xxx: Add changelog entry for PR #<number>`).
+2. Push so the PR picks up the new commit.
+
+Use `[skip changelog]` in the PR body only for test-only, docs-only, or CI/tooling changes. When skipping, you do **not** create a PR-first round-trip — just open the PR and be done.
 
 ## 7. After PR Creation
 

--- a/handsontable/src/__tests__/core/settings.types.ts
+++ b/handsontable/src/__tests__/core/settings.types.ts
@@ -126,7 +126,7 @@ const allSettings: Required<Handsontable.GridSettings> = {
     onRowsRemove: async () => {},
   },
   dataSchema: oneOf({}, [[]], (index: number) => oneOf([index], { index })),
-  dateFormat: 'foo',
+  dateFormat: oneOf('foo', { year: 'numeric', month: '2-digit', day: '2-digit' } as Intl.DateTimeFormatOptions),
   datePickerConfig: {
     firstDay: 0,
     showWeekNumber: true,

--- a/handsontable/types/settings.d.ts
+++ b/handsontable/types/settings.d.ts
@@ -143,7 +143,7 @@ export interface GridSettings extends Events {
   dataDotNotation?: boolean;
   dataProvider?: DataProviderSettings;
   dataSchema?: RowObject | CellValue[] | ((row: number) => RowObject | CellValue[]);
-  dateFormat?: string;
+  dateFormat?: string | Intl.DateTimeFormatOptions;
   datePickerConfig?: PikadayOptions;
   defaultDate?: string;
   tabNavigation?: boolean;


### PR DESCRIPTION
### Context

The `dateFormat` TypeScript option in `handsontable/types/settings.d.ts` was typed as `string`, but Handsontable now also accepts an `Intl.DateTimeFormatOptions` object for the new `intl-date` cell type. The renderer (`intlDateRenderer.valueFormatter`) passes the value straight into `new Intl.DateTimeFormat(locale, dateFormat)`, and the JSDoc in `metaSchema.js` already documents both forms. TypeScript users configuring an `intl-date` column were getting a type error on a fully supported configuration.

### How has this been tested?

- Added the object form to the TypeScript regression test `handsontable/src/__tests__/core/settings.types.ts` so both the legacy string and the new `Intl.DateTimeFormatOptions` object are type-checked.
- `npm run test:types --prefix handsontable` passes.
- `npm run type-lint --prefix handsontable` passes.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1461

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1461

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a TypeScript type widening plus a regression test update, with no runtime behavior changes.
> 
> **Overview**
> Fixes the `handsontable` TypeScript definitions by widening `GridSettings.dateFormat` from `string` to `string | Intl.DateTimeFormatOptions`, matching the supported `intl-date` configuration.
> 
> Updates the TS settings type test to exercise both the legacy string and the `Intl.DateTimeFormatOptions` object form, and adds a changelog entry for the fix. Separately, the internal `.claude` workflow docs are updated to enforce a **PR-first, changelog-second** process and expand guidance for creating/editing PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74c770ec4185dabba1daca20bdbe3ba3d15ab241. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->