### PR TITLE
docs: add GitHub example CTA buttons to server-side data recipes

### DIFF
--- a/docs/content/recipes/data-management/data-management.md
+++ b/docs/content/recipes/data-management/data-management.md
@@ -30,5 +30,8 @@ Current recipes:
 - [Auto-save changes to a backend](@/content/recipes/data-management/auto-save-backend/auto-save-backend.md)
 - [Undo / redo with a custom UI](@/content/recipes/data-management/undo-redo-custom-ui/undo-redo-custom-ui.md)
 - [Server-side data with Django](@/content/recipes/data-management/server-side-django/server-side-django.md)
+- [Server-side data with Laravel](@/content/recipes/data-management/server-side-laravel/server-side-laravel.md)
+- [Server-side data with NestJS](@/content/recipes/data-management/server-side-nestjs/server-side-nestjs.md)
+- [Server-side data with Ruby on Rails](@/content/recipes/data-management/server-side-rails/server-side-rails.md)
 - [Server-side data with Spring Boot](@/content/recipes/data-management/server-side-spring/server-side-spring.md)
 </div>

--- a/docs/content/recipes/data-management/server-side-django/server-side-django.md
+++ b/docs/content/recipes/data-management/server-side-django/server-side-django.md
@@ -20,6 +20,11 @@ type: tutorial
 
 This recipe shows how to wire Handsontable's `dataProvider` plugin to a [Django REST Framework](https://www.django-rest-framework.org/) (DRF) backend. The backend handles pagination, sorting, and filtering on the server. The frontend displays results and sends all edits back to the API.
 
+<a class="github-example-cta" href="https://github.com/handsontable/examples/tree/master/server-examples/django" target="_blank" rel="noopener noreferrer">
+  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+  View full example on GitHub
+</a>
+
 **Difficulty:** Intermediate  
 **Time:** ~30 minutes  
 **Backend:** Python 3.11+, Django 4+, Django REST Framework 3.14+

--- a/docs/content/recipes/data-management/server-side-laravel/server-side-laravel.md
+++ b/docs/content/recipes/data-management/server-side-laravel/server-side-laravel.md
@@ -20,6 +20,11 @@ category: Data Management
 
 This recipe shows how to connect Handsontable's `dataProvider` plugin to a Laravel backend. You will build a product inventory grid that loads data from a REST API with server-side pagination, sorting, and filtering, and that persists row create, update, and delete operations to a Laravel database.
 
+<a class="github-example-cta" href="https://github.com/handsontable/examples/tree/master/server-examples/laravel" target="_blank" rel="noopener noreferrer">
+  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+  View full example on GitHub
+</a>
+
 **Difficulty:** Intermediate  
 **Time:** ~30 minutes  
 **Stack:** Laravel 11 (PHP 8.2+), Eloquent ORM, Handsontable `dataProvider`

--- a/docs/content/recipes/data-management/server-side-nestjs/server-side-nestjs.md
+++ b/docs/content/recipes/data-management/server-side-nestjs/server-side-nestjs.md
@@ -20,6 +20,11 @@ category: Data Management
 
 This recipe shows how to connect Handsontable's `dataProvider` plugin to a NestJS 10 backend. You will build a support-tickets grid that loads data from a REST API with server-side pagination, sorting, and filtering, and that persists row create, update, and delete operations to an in-memory store.
 
+<a class="github-example-cta" href="https://github.com/handsontable/examples/tree/master/server-examples/nestjs" target="_blank" rel="noopener noreferrer">
+  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+  View full example on GitHub
+</a>
+
 **Difficulty:** Intermediate
 **Time:** ~40 minutes
 **Stack:** NestJS 10, TypeScript, `class-validator`, `class-transformer`, Handsontable `dataProvider`

--- a/docs/content/recipes/data-management/server-side-rails/server-side-rails.md
+++ b/docs/content/recipes/data-management/server-side-rails/server-side-rails.md
@@ -20,6 +20,11 @@ type: tutorial
 
 This recipe shows how to wire Handsontable's `dataProvider` plugin to a [Ruby on Rails](https://rubyonrails.org/) API-only backend. The backend handles pagination, sorting, and filtering on the server. The frontend displays results and sends every edit back to the API.
 
+<a class="github-example-cta" href="https://github.com/handsontable/examples/tree/master/server-examples/rails" target="_blank" rel="noopener noreferrer">
+  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+  View full example on GitHub
+</a>
+
 **Difficulty:** Intermediate  
 **Time:** ~30 minutes  
 **Backend:** Ruby 3.2+, Rails 7.1+, `kaminari` for pagination, `rack-cors` for CORS

--- a/docs/content/recipes/data-management/server-side-spring/server-side-spring.md
+++ b/docs/content/recipes/data-management/server-side-spring/server-side-spring.md
@@ -20,6 +20,11 @@ category: Data Management
 
 This recipe shows how to connect Handsontable's `dataProvider` plugin to a Spring Boot 3 backend. You will build a product catalog grid that loads data from a REST API with server-side pagination, sorting, and filtering, and that persists row create, update, and delete operations to a JPA-managed H2 database.
 
+<a class="github-example-cta" href="https://github.com/handsontable/examples/tree/master/server-examples/spring" target="_blank" rel="noopener noreferrer">
+  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+  View full example on GitHub
+</a>
+
 **Difficulty:** Intermediate
 **Time:** ~45 minutes
 **Stack:** Spring Boot 3, Spring Data JPA, H2 (in-memory), Handsontable `dataProvider`

--- a/docs/content/recipes/sidebar.js
+++ b/docs/content/recipes/sidebar.js
@@ -3,14 +3,14 @@ const columnManagementItems = [
 ];
 
 const recipeDataManagementItems = [
-  { path: 'data-management/server-side-laravel/server-side-laravel', title: 'Server-side data with Laravel', onlyFor: ['javascript'] },
   { path: 'data-management/sync-two-grids/sync-two-grids', title: 'Sync two grids', onlyFor: ['javascript'] },
   { path: 'data-management/undo-redo-custom-ui/undo-redo-custom-ui', title: 'Undo / redo with a custom UI', onlyFor: ['javascript'] },
   { path: 'data-management/auto-save-backend/auto-save-backend', title: 'Auto-save changes to a backend', onlyFor: ['javascript'] },
   { path: 'data-management/server-side-django/server-side-django', title: 'Server-side data with Django', onlyFor: ['javascript'] },
+  { path: 'data-management/server-side-laravel/server-side-laravel', title: 'Server-side data with Laravel', onlyFor: ['javascript'] },
+  { path: 'data-management/server-side-nestjs/server-side-nestjs', title: 'Server-side data with NestJS', onlyFor: ['javascript'] },
   { path: 'data-management/server-side-rails/server-side-rails', title: 'Server-side data with Ruby on Rails', onlyFor: ['javascript'] },
   { path: 'data-management/server-side-spring/server-side-spring', title: 'Server-side data with Spring Boot', onlyFor: ['javascript'] },
-  { path: 'data-management/server-side-nestjs/server-side-nestjs', title: 'Server-side data with NestJS', onlyFor: ['javascript'] },
 ];
 
 const cellTypesItems = [

--- a/docs/src/styles/utilities.css
+++ b/docs/src/styles/utilities.css
@@ -84,6 +84,34 @@ html {
 }
 
 /* -------------------------------------------------------------------------
+ * GitHub example CTA button — used in recipe pages to link to the full
+ * runnable example in the handsontable/examples repository.
+ * ------------------------------------------------------------------------- */
+.github-example-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-block: 1rem;
+  padding: 0.5rem 1rem;
+  background-color: var(--sl-color-accent);
+  color: #fff !important;
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-decoration: none !important;
+  border-radius: 4px;
+  transition: background-color 0.15s, opacity 0.15s;
+}
+
+.github-example-cta:hover {
+  background-color: var(--sl-color-accent-high, #1237c8);
+  opacity: 0.9;
+}
+
+.github-example-cta svg {
+  flex-shrink: 0;
+}
+
+/* -------------------------------------------------------------------------
  * Screen-reader-only utility — visually hidden but accessible to AT
  * ------------------------------------------------------------------------- */
 .sr-only {

--- a/docs/src/styles/utilities.css
+++ b/docs/src/styles/utilities.css
@@ -99,12 +99,11 @@ html {
   font-weight: 600;
   text-decoration: none !important;
   border-radius: 4px;
-  transition: background-color 0.15s, opacity 0.15s;
+  transition: filter 0.15s;
 }
 
 .github-example-cta:hover {
-  background-color: var(--sl-color-accent-high, #1237c8);
-  opacity: 0.9;
+  filter: brightness(0.85);
 }
 
 .github-example-cta svg {


### PR DESCRIPTION
### Context

The PR adds a visible "View full example on GitHub" CTA button to the Overview section of each server-side data recipe page. Each button links directly to the corresponding runnable example in the `handsontable/examples` repository (`server-examples/` directory). This makes it immediately obvious that a full working example exists, without requiring readers to scroll through the entire recipe first.

Recipes updated:
- Server-side data with Django → `server-examples/django`
- Server-side data with Laravel → `server-examples/laravel`
- Server-side data with NestJS → `server-examples/nestjs`
- Server-side data with Ruby on Rails → `server-examples/rails`
- Server-side data with Spring Boot → `server-examples/spring`

Also adds the missing Laravel, NestJS, and Rails entries to the `data-management.md` index page, and introduces a reusable `.github-example-cta` CSS class in `docs/src/styles/utilities.css`.

### How has this been tested?

- Verified all five recipe `.md` files render the HTML button block correctly in the Overview section.
- Verified the `data-management.md` index now lists all eight data management recipes.
- CSS class reviewed against existing Starlight CSS custom properties (`--sl-color-accent`, `--sl-color-accent-high`).

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. N/A

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes (Markdown content, sidebar list, and CSS) with no runtime product logic; main risk is minor styling/regression in docs rendering.
> 
> **Overview**
> Adds a prominent **“View full example on GitHub”** CTA button (with GitHub icon) to the Overview section of each server-side data recipe (`Django`, `Laravel`, `NestJS`, `Rails`, `Spring`), linking directly to the runnable `handsontable/examples` implementation.
> 
> Updates the Data Management recipes index and sidebar ordering to ensure the `Laravel`, `NestJS`, and `Rails` server-side recipes are listed, and introduces a reusable `.github-example-cta` style in `utilities.css` for consistent button styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da937ae2317c82c585800249435576902ff73056. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->