### PR TITLE
fix(docs): use inject() for ChangeDetectorRef in row-validation Angular example

### DIFF
--- a/docs/content/recipes/editing-validation/row-validation-error-summary/angular/example1.ts
+++ b/docs/content/recipes/editing-validation/row-validation-error-summary/angular/example1.ts
@@ -1,5 +1,5 @@
 /* file: app.component.ts */
-import { Component, ViewChild, ChangeDetectorRef } from '@angular/core';
+import { Component, ViewChild, ChangeDetectorRef, inject } from '@angular/core';
 import { GridSettings, HotTableComponent } from '@handsontable/angular-wrapper';
 
 const COLUMN_LABELS = ['Item', 'Quantity', 'Unit price'];
@@ -59,6 +59,8 @@ export class Example1RowValidationErrorSummaryComponent {
 
   readonly columnLabels = COLUMN_LABELS;
 
+  private readonly cdr = inject(ChangeDetectorRef);
+
   invalidCells = new Set<string>();
   issues: { row: number; col: number; message: string }[] = [];
 
@@ -68,8 +70,6 @@ export class Example1RowValidationErrorSummaryComponent {
     { item: 'Gadget', qty: -1, price: 12 },
     { item: 'Cable', qty: 3, price: 0 },
   ];
-
-  constructor(private readonly cdr: ChangeDetectorRef) {}
 
   readonly gridSettings: GridSettings = {
     colHeaders: COLUMN_LABELS,


### PR DESCRIPTION
## Problem

The `row-validation-error-summary` Angular recipe example crashes at runtime with:

```
NG0202: This constructor is not compatible with Angular Dependency Injection
because its dependency at index 0 of the parameter list is invalid.
```

The component used constructor-based injection for `ChangeDetectorRef`:

```ts
constructor(private readonly cdr: ChangeDetectorRef) {}
```

The docs preview environment compiles TypeScript through Vite, which strips `emitDecoratorMetadata`. Without that metadata, Angular's DI system cannot determine the injection token from the constructor parameter type — causing `NG0202` and a blank example iframe.

## Fix

Replace constructor injection with the `inject()` function, which resolves the token directly and does not rely on decorator metadata:

```ts
private readonly cdr = inject(ChangeDetectorRef);
```

This is the recommended modern pattern (Angular 14+) and works reliably regardless of `emitDecoratorMetadata`.

## Test plan

- [x] Navigate to `/docs/angular-data-grid/recipes/editing-validation/row-validation-error-summary/` — example renders the grid and "Submit orders" button
- [x] Click "Submit orders" — invalid cells (empty item, negative qty, zero price) are highlighted in red and listed in the Validation issues panel
- [x] Edit a highlighted cell — its error is cleared from the list on change
- [x] No `NG0202` errors in the browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk doc/example-only change that swaps Angular DI style; behavior should be unchanged aside from avoiding runtime DI failure in the docs build.
> 
> **Overview**
> Fixes the `row-validation-error-summary` Angular recipe example to avoid `NG0202` in the docs preview by replacing constructor-based `ChangeDetectorRef` injection with `inject(ChangeDetectorRef)`.
> 
> No functional logic changes beyond the DI wiring; the example should now render reliably in the Vite/metadata-stripped build environment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a93314180961c014f56120608974be48e98bd60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->