### PR TITLE
fix(docs): resolve Astro 404 route collision with Starlight built-in

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -741,6 +741,7 @@ export default defineConfig({
         Header: './src/components/Header.astro',
         Footer: './src/components/Footer.astro',
         MarkdownContent: './src/components/MarkdownContent.astro',
+        NotFound: './src/components/NotFound.astro',
         PageTitle: './src/components/PageTitle.astro',
         Sidebar: './src/components/Sidebar.astro',
         PageSidebar: './src/components/PageSidebar.astro',

--- a/docs/src/components/NotFound.astro
+++ b/docs/src/components/NotFound.astro
@@ -1,40 +1,28 @@
 ---
 /**
- * Custom 404 page.
+ * Custom 404 page content.
  *
- * Renders the full site layout (header, footer) via StarlightPage so that
- * users landing on a missing URL see the same styled shell as every other
- * docs page -- rather than Netlify's bare default 404 screen.
- * sidebar={[]} passes an empty sidebar array so Starlight computes
- * hasSidebar=false and omits the sidebar panel entirely.
- *
- * Netlify serves the built 404.html for all unmatched routes when the publish
- * directory contains that file. Astro generates it automatically from this
- * src/pages/404.astro source.
+ * This component is rendered inside Starlight's built-in 404 route
+ * (node_modules/@astrojs/starlight/routes/static/404.astro), which
+ * already provides the StarlightPage shell (header, footer, no sidebar).
+ * Placing custom content here avoids the duplicate-route collision that
+ * occurs when src/pages/404.astro shadows Starlight's own static route.
  */
-import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 ---
 
-<StarlightPage
-  frontmatter={{
-    title: 'Page not found',
-  }}
-  sidebar={[]}
->
-  <div class="not-found">
-    <div class="not-found__grid">
-      <div class="not-found__code">404</div>
-      <div class="not-found__message">
-        <p class="not-found__text">
-          The page you are looking for does not exist or has been moved.
-        </p>
-        <a href="/docs/javascript-data-grid/" class="not-found__link">
-          Go to documentation home
-        </a>
-      </div>
+<div class="not-found">
+  <div class="not-found__grid">
+    <div class="not-found__code">404</div>
+    <div class="not-found__message">
+      <p class="not-found__text">
+        The page you are looking for does not exist or has been moved.
+      </p>
+      <a href="/docs/javascript-data-grid/" class="not-found__link">
+        Go to documentation home
+      </a>
     </div>
   </div>
-</StarlightPage>
+</div>
 
 <style>
   .not-found {


### PR DESCRIPTION
### Context

The PR fixes a route collision warning in the Astro docs site:

```
[WARN] [router] The route "/404" is defined in both "src/pages/404.astro"
and "node_modules/@astrojs/starlight/routes/static/404.astro".
A static route cannot be defined more than once.
[WARN] [router] A collision will result in a hard error in following versions of Astro.
```

Starlight already provides its own `/404` route. The custom `src/pages/404.astro` shadowed it, causing a duplicate-route warning that will become a hard error in a future Astro version.

The fix switches to Starlight's `NotFound` component override mechanism: the styled 404 content moves to `src/components/NotFound.astro` and is registered via the `components` option in `astro.config.mjs`. The `src/pages/404.astro` file is removed, eliminating the collision entirely. Starlight's built-in 404 route continues to render the full page shell (header, footer, no sidebar) while the custom `NotFound` component provides the inner content.

### How has this been tested?

This is a docs-only change to the Astro configuration and component structure. The fix eliminates the Astro router warning at startup. Manual verification: start the docs dev server and confirm the warning no longer appears and the `/404` page renders with the custom styled layout.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. Astro duplicate route collision warning for `/404`

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only configuration/component change; main risk is an incorrectly rendered 404 page or broken link back to the docs home.
> 
> **Overview**
> Switches the docs site’s custom 404 from a user-defined `/404` page route to Starlight’s supported `NotFound` component override to eliminate the duplicate static route collision.
> 
> Updates `docs/astro.config.mjs` to register `NotFound`, and refactors `NotFound.astro` to provide only the inner 404 content (removing the extra `StarlightPage` wrapper) so Starlight’s built-in 404 route supplies the page shell.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22d1932570c5542c5c1a014ab040055805f7a6fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->