### PR TITLE
Fix docs build warnings: duplicate class member and circular chunk imports

### DIFF
--- a/docs/content/guides/accessories-and-menus/export-to-csv/angular/example4.ts
+++ b/docs/content/guides/accessories-and-menus/export-to-csv/angular/example4.ts
@@ -71,7 +71,7 @@ export class AppComponent {
     });
   }
 
-  downloadCSVWithNoSanitization() {
+  downloadCSVWithRegexpSanitization() {
     const exportPlugin = this.hotTable.hotInstance!.getPlugin('exportFile');
 
     exportPlugin.downloadFile('csv', {

--- a/handsontable/src/plugins/multiColumnSorting/multiColumnSorting.js
+++ b/handsontable/src/plugins/multiColumnSorting/multiColumnSorting.js
@@ -2,7 +2,7 @@ import {
   APPEND_COLUMN_CONFIG_STRATEGY,
   ColumnSorting
 } from '../columnSorting';
-import { registerRootComparator } from '../columnSorting/sortService';
+import { registerRootComparator } from '../columnSorting/sortService/registry';
 import { wasHeaderClickedProperly } from '../columnSorting/utils';
 import { addClass, removeClass } from '../../helpers/dom/element';
 import { rootComparator } from './rootComparator';

--- a/handsontable/src/plugins/multiColumnSorting/rootComparator.js
+++ b/handsontable/src/plugins/multiColumnSorting/rootComparator.js
@@ -1,4 +1,5 @@
-import { getCompareFunctionFactory, DO_NOT_SWAP } from '../columnSorting/sortService';
+import { getCompareFunctionFactory } from '../columnSorting/sortService/registry';
+import { DO_NOT_SWAP } from '../columnSorting/sortService/engine';
 
 /**
  * Sort comparator handled by conventional sort algorithm.


### PR DESCRIPTION
### Context

The PR fixes two categories of `[WARN]` messages emitted during the Astro docs build:

1. **Duplicate class member** -- `example4.ts` (export-to-csv Angular example) had two methods both named `downloadCSVWithNoSanitization`. The second one uses `sanitizeValues: /WEBSERVICE/` (a regexp), so it was renamed to `downloadCSVWithRegexpSanitization` to match the button label in the template.

2. **Circular chunk dependency** -- Vite/Rollup warned that `getCompareFunctionFactory` and `registerRootComparator` were re-exported through `columnSorting/sortService/index.mjs` while both `index.mjs` and `registry.mjs` ended up in different chunks. The fix is to import directly from the specific sub-modules (`sortService/registry` and `sortService/engine`) instead of going through the barrel `sortService/index`.

### How has this been tested?

- Verified the renamed method matches the `(click)` binding in the Angular template (`downloadCSVWithRegexpSanitization()`).
- Verified that `getCompareFunctionFactory` is exported from `sortService/registry.js` and `DO_NOT_SWAP` is exported from `sortService/engine.js`.
- Verified that `registerRootComparator` is exported from `sortService/registry.js`.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. N/A

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

https://claude.ai/code/session_017UHowW3LSkGENPFigqFF23

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes import paths in the `multiColumnSorting` plugin, which could impact bundling/runtime if module paths or exports differ, though behavior should remain the same.
> 
> **Overview**
> Resolves an Astro docs build warning by renaming the Angular CSV export example’s duplicate `downloadCSVWithNoSanitization` method to `downloadCSVWithRegexpSanitization` (matching the template button and the regexp-based `sanitizeValues` behavior).
> 
> Fixes Vite/Rollup circular-chunk warnings by changing `multiColumnSorting` to import `registerRootComparator`/`getCompareFunctionFactory` from `sortService/registry` and `DO_NOT_SWAP` from `sortService/engine` instead of the `sortService` barrel export.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ae68bb5c24f77f1259273bfa980afde92cfb6e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->