### PR TITLE
docs(DEV-870): enhance kbd element styling for light and dark mode

### DIFF
--- a/docs/src/styles/base/typography.css
+++ b/docs/src/styles/base/typography.css
@@ -45,20 +45,25 @@
 kbd:not(.handsontable kbd, .example-controls-container kbd, .hot-example-preview kbd) {
   display: inline-block;
   margin: 0 0.375rem;
-  padding: 0.075rem 0.375rem;
+  padding: 0.1rem 0.45rem;
   font-family: var(--sl-font);
   font-size: var(--sl-text-xs);
   font-weight: 600;
   line-height: 1.4;
   color: var(--sl-color-white);
   background: var(--sl-color-gray-6);
-  border: 1px solid var(--sl-color-gray-5);
+  border: 1px solid var(--sl-color-gray-4);
   border-radius: 4px;
-  box-shadow: 0 2px 0 var(--sl-color-gray-5);
+  box-shadow: 0 2px 0 var(--sl-color-gray-4);
   white-space: nowrap;
   vertical-align: middle;
   box-decoration-break: clone;
   -webkit-box-decoration-break: clone;
+}
+
+[data-theme='light'] kbd:not(.handsontable kbd, .example-controls-container kbd, .hot-example-preview kbd) {
+  border-color: oklch(72% 0 0);
+  box-shadow: 0 2px 0 oklch(65% 0 0);
 }
 
 kbd:first-child:not(.handsontable kbd, .example-controls-container kbd, .hot-example-preview kbd) {


### PR DESCRIPTION
### Context

The PR improves the visual appearance of `<kbd>` elements in the docs site, following a review comment on the original DEV-870 PR (#12266) requesting enhanced keyboard button styling.

The previous implementation used `--sl-color-gray-5` (29% lightness) for borders and shadows in dark mode -- barely distinguishable from the `--sl-color-gray-6` (23% lightness) background. In light mode, the same variables resolve to 92%/94% lightness, making keyboard keys nearly invisible against the near-white page background (98%).

Changes:
- Dark mode: border/shadow upgraded from `--sl-color-gray-5` (29%) to `--sl-color-gray-4` (48%) for clearly visible key edges
- Light mode: `[data-theme='light']` override with `oklch(72% 0 0)` border and `oklch(65% 0 0)` shadow so keys are clearly visible against the near-white background
- Padding slightly increased from `0.075rem 0.375rem` to `0.1rem 0.45rem` for better breathing room

### How has this been tested?

- Manually verified the color variable values for dark mode (`--sl-color-gray-4` = `oklch(48% 0 0)`) against the dark background (`--sl-color-gray-6` = `oklch(23% 0 0)`) -- 25% lightness contrast vs previous 6%
- Verified light mode override values (`oklch(72%)` border, `oklch(65%)` shadow) against light background (`oklch(94%)`) -- 22% lightness contrast, clearly visible
- No JS or library changes; CSS-only, docs-scoped

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. DEV-870

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-870