### PR TITLE
docs: add Handsontable sponsorship note to NestJS recipe

### DIFF
--- a/docs/content/recipes/data-management/server-side-nestjs/server-side-nestjs.md
+++ b/docs/content/recipes/data-management/server-side-nestjs/server-side-nestjs.md
@@ -16,6 +16,10 @@ searchCategory: Recipes
 category: Data Management
 ---
 
+::: tip Handsontable sponsors NestJS
+Handsontable is a proud sponsor of NestJS. You can support the project on [Open Collective](https://opencollective.com/handsontable-javascript-data-grid).
+:::
+
 ## Overview
 
 This recipe shows how to connect Handsontable's `dataProvider` plugin to a NestJS 10 backend. You will build a support-tickets grid that loads data from a REST API with server-side pagination, sorting, and filtering, and that persists row create, update, and delete operations to an in-memory store.


### PR DESCRIPTION
### Context

The PR adds a tip callout to the NestJS recipe page noting that Handsontable is a proud sponsor of NestJS, with a link to the Open Collective page.

### How has this been tested?

- Docs-only change, no code tests required.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

N/A

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that adds a callout and link; no product code or behavior is affected.
> 
> **Overview**
> Adds a `::: tip` callout at the top of the NestJS server-side data recipe noting Handsontable’s sponsorship of NestJS, including a link to the NestJS Open Collective page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 882afd5f8ba46eb76e34176757e721c982a7da46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->