### PR TITLE
DEV-1475: Add "Ask AI" button next to source code link on API reference pages

### DIFF
--- a/docs/scripts/jsdoc-convert/integrations/jsdoc-to-markdown/dmd/partials/all-docs/docs/hot-docs.hbs
+++ b/docs/scripts/jsdoc-convert/integrations/jsdoc-to-markdown/dmd/partials/all-docs/docs/hot-docs.hbs
@@ -1,10 +1,10 @@
 {{>hot-header~}}
 {{#unless (isConstructor)}}
 
-::: source-code-link {{{sourceLink}}}
+::: ask-about-api {{{name}}}|{{{memberof}}}
 
 :::
-::: ask-about-api {{{name}}}|{{{memberof}}}
+::: source-code-link {{{sourceLink}}}
 
 :::
 {{>hot-sig-name}}

--- a/docs/scripts/jsdoc-convert/integrations/jsdoc-to-markdown/dmd/partials/all-docs/docs/hot-docs.hbs
+++ b/docs/scripts/jsdoc-convert/integrations/jsdoc-to-markdown/dmd/partials/all-docs/docs/hot-docs.hbs
@@ -1,7 +1,10 @@
 {{>hot-header~}}
 {{#unless (isConstructor)}}
-  
+
 ::: source-code-link {{{sourceLink}}}
+
+:::
+::: ask-about-api {{{name}}}|{{{memberof}}}
 
 :::
 {{>hot-sig-name}}

--- a/docs/scripts/jsdoc-convert/integrations/jsdoc-to-markdown/dmd/partials/all-docs/docs/hot-docs.hbs
+++ b/docs/scripts/jsdoc-convert/integrations/jsdoc-to-markdown/dmd/partials/all-docs/docs/hot-docs.hbs
@@ -4,6 +4,7 @@
 ::: ask-about-api {{{name}}}|{{{memberof}}}
 
 :::
+
 ::: source-code-link {{{sourceLink}}}
 
 :::

--- a/docs/src/components/DocsAssistant/DocsAssistantWidget.tsx
+++ b/docs/src/components/DocsAssistant/DocsAssistantWidget.tsx
@@ -47,7 +47,7 @@ export function DocsAssistantWidget() {
   const [pendingDraft, setPendingDraft] = useState<string | null>(null);
   const composerRef = useRef<HTMLTextAreaElement>(null);
   const resizingRef = useRef(false);
-  const { state, send, stop, retry, clear, setFeedback } = useAssistant();
+  const { state, send, stop, retry, clear, clearAndSend, setFeedback } = useAssistant();
 
   useEffect(() => {
     try {
@@ -88,6 +88,18 @@ export function DocsAssistantWidget() {
     tocBtn.addEventListener('click', handleAskAboutPage);
     return () => tocBtn.removeEventListener('click', handleAskAboutPage);
   }, [clear]);
+
+  // "Ask AI about this API" buttons on API reference pages — opens assistant
+  // and auto-submits the prefilled question without user interaction.
+  useEffect(() => {
+    const handleAskAboutApi = (e: Event) => {
+      const { question } = (e as CustomEvent<{ question: string }>).detail;
+      setOpen(true);
+      clearAndSend(question);
+    };
+    window.addEventListener('docs-assistant:ask', handleAskAboutApi);
+    return () => window.removeEventListener('docs-assistant:ask', handleAskAboutApi);
+  }, [clearAndSend]);
 
   useEffect(() => {
     if (!open) return;

--- a/docs/src/components/DocsAssistant/useAssistant.ts
+++ b/docs/src/components/DocsAssistant/useAssistant.ts
@@ -198,12 +198,20 @@ export function useAssistant() {
         dispatch({ type: 'END' });
       } catch (err) {
         if ((err as Error).name === 'AbortError') {
-          dispatch({ type: 'END' });
+          // Only dispatch END if no newer request has replaced this controller.
+          // clearAndSend sets abortRef.current to null/new before aborting the
+          // old one, so this guard prevents the old abort from killing the new
+          // request's streaming state.
+          if (abortRef.current === controller) {
+            dispatch({ type: 'END' });
+          }
           return;
         }
         dispatch({ type: 'ERROR', error: (err as Error).message || 'Request failed' });
       } finally {
-        abortRef.current = null;
+        if (abortRef.current === controller) {
+          abortRef.current = null;
+        }
       }
     },
     []

--- a/docs/src/components/DocsAssistant/useAssistant.ts
+++ b/docs/src/components/DocsAssistant/useAssistant.ts
@@ -243,9 +243,28 @@ export function useAssistant() {
     dispatch({ type: 'CLEAR' });
   }, []);
 
+  const clearAndSend = useCallback(
+    async (text: string) => {
+      abortRef.current?.abort();
+      abortRef.current = null;
+      dispatch({ type: 'CLEAR' });
+      const trimmed = text.trim();
+      if (!trimmed) return;
+      const userMessage: ChatMessage = {
+        id: uid(),
+        role: 'user',
+        content: trimmed,
+        ts: Date.now(),
+      };
+      dispatch({ type: 'ADD_USER', message: userMessage });
+      await sendInternal(trimmed, []);
+    },
+    [sendInternal]
+  );
+
   const setFeedback = useCallback((id: string, feedback: 'up' | 'down') => {
     dispatch({ type: 'SET_FEEDBACK', id, feedback });
   }, []);
 
-  return { state, send, stop, retry, clear, setFeedback };
+  return { state, send, stop, retry, clear, clearAndSend, setFeedback };
 }

--- a/docs/src/components/DocsAssistant/useAssistant.ts
+++ b/docs/src/components/DocsAssistant/useAssistant.ts
@@ -160,7 +160,19 @@ export function useAssistant() {
 
   const sendInternal = useCallback(
     async (userMessageText: string, historyForApi: ChatMessage[]) => {
+      // Register the controller before any await so clearAndSend can abort
+      // even while buildContextualMessage is still fetching page context.
+      const controller = new AbortController();
+      abortRef.current = controller;
+
       const contextualised = await buildContextualMessage(userMessageText);
+
+      // Bail out if aborted during page-context fetch (no UI state committed yet).
+      if (controller.signal.aborted) {
+        if (abortRef.current === controller) abortRef.current = null;
+        return;
+      }
+
       const apiMessages = [
         ...historyForApi.map(({ role, content }) => ({ role, content })),
         { role: 'user' as const, content: contextualised },
@@ -171,9 +183,6 @@ export function useAssistant() {
         type: 'BEGIN_ASSISTANT',
         message: { id: assistantId, role: 'assistant', content: '', ts: Date.now() },
       });
-
-      const controller = new AbortController();
-      abortRef.current = controller;
 
       try {
         const res = await fetch(CHAT_ENDPOINT, {

--- a/docs/src/components/Head.astro
+++ b/docs/src/components/Head.astro
@@ -45,16 +45,40 @@ import Default from '@astrojs/starlight/components/Head.astro';
 </script>
 
 <script>
-  // Move source-code-link elements inside their preceding heading for
-  // absolute positioning. The preprocessor emits them as standalone <a> tags
-  // (wrapped in <p> by Astro), but CSS absolute positioning requires a
-  // parent–child relationship.
-  document.querySelectorAll<HTMLAnchorElement>('.source-code-link').forEach((link) => {
-    const p = link.parentElement;
-    if (!p || p.tagName !== 'P') return;
-    const heading = p.previousElementSibling;
-    if (!heading || !/^H[2-4]$/.test(heading.tagName)) return;
-    heading.appendChild(link);
-    p.remove();
+  // Group .source-code-link and .ask-about-api-btn elements into an
+  // .api-member-actions container inside their preceding heading.
+  // The preprocessor emits them as standalone elements (wrapped in <p> by Astro),
+  // so we scan each heading for consecutive action-element paragraphs and
+  // move them into a flex container for side-by-side layout.
+  document.querySelectorAll<HTMLElement>('.sl-markdown-content :is(h2, h3, h4)').forEach((heading) => {
+    const actions: HTMLElement[] = [];
+    const parasToRemove: HTMLElement[] = [];
+
+    let next = heading.nextElementSibling as HTMLElement | null;
+    while (next && next.tagName === 'P') {
+      const actionEl = next.querySelector<HTMLElement>('.source-code-link, .ask-about-api-btn');
+      if (!actionEl) break;
+      actions.push(actionEl);
+      parasToRemove.push(next);
+      next = next.nextElementSibling as HTMLElement | null;
+    }
+
+    if (actions.length === 0) return;
+
+    const container = document.createElement('div');
+    container.className = 'api-member-actions';
+    actions.forEach((el) => container.appendChild(el));
+    heading.appendChild(container);
+    parasToRemove.forEach((p) => p.remove());
+  });
+
+  // Wire up ask-about-api buttons to dispatch the docs-assistant:ask event.
+  document.addEventListener('click', (e) => {
+    const btn = (e.target as HTMLElement).closest<HTMLElement>('.ask-about-api-btn');
+    if (!btn) return;
+    const option = btn.dataset.option ?? '';
+    const plugin = btn.dataset.plugin ?? 'Handsontable';
+    const question = `Tell me what ${option} in ${plugin} is responsible for and give me an example use case.`;
+    window.dispatchEvent(new CustomEvent('docs-assistant:ask', { detail: { question } }));
   });
 </script>

--- a/docs/src/plugins/framework-loader.mjs
+++ b/docs/src/plugins/framework-loader.mjs
@@ -582,6 +582,52 @@ function convertDetailsContainers(content) {
 }
 
 /**
+ * Converts ::: ask-about-api name|memberof ::: blocks to Ask AI button elements.
+ *
+ * @param {string} content
+ * @returns {string}
+ */
+function convertAskAboutApiButtons(content) {
+  const lines = content.split('\n');
+  const result = [];
+  let inBlock = false;
+  let optionData = '';
+
+  for (const line of lines) {
+    const openMatch = line.match(/^:::\s+ask-about-api\s+(\S+)\s*$/);
+
+    if (openMatch) {
+      inBlock = true;
+      optionData = openMatch[1];
+      continue;
+    }
+
+    if (inBlock && /^:::\s*$/.test(line)) {
+      inBlock = false;
+      const pipeIdx = optionData.indexOf('|');
+      const optionName = pipeIdx >= 0 ? optionData.slice(0, pipeIdx) : optionData;
+      // Strip namespace prefix (e.g. "module:Core" -> "Core")
+      const rawPlugin = pipeIdx >= 0 ? optionData.slice(pipeIdx + 1) : '';
+      const pluginName = rawPlugin.split(':').pop()?.split('~')[0]?.split('#')[0] || 'Handsontable';
+
+      if (optionName) {
+        result.push(
+          `<button type="button" class="ask-about-api-btn" data-option="${optionName}" data-plugin="${pluginName}" aria-label="Ask AI about ${optionName}">Ask AI</button>`
+        );
+      }
+      optionData = '';
+      continue;
+    }
+
+    if (!inBlock) {
+      result.push(line);
+    }
+  }
+
+  return result.join('\n');
+}
+
+/**
  * Converts ::: source-code-link URL ::: blocks to plain HTML anchor tags.
  *
  * @param {string} content
@@ -1057,6 +1103,9 @@ function applyVuepressPreprocessing(content, prefix, contentDir) {
 
   // Strip :::example / :::example-without-tabs container markers
   result = stripExampleContainers(result);
+
+  // Convert ::: ask-about-api name|memberof to a button element
+  result = convertAskAboutApiButtons(result);
 
   // Convert ::: source-code-link URL to an HTML anchor
   result = convertSourceCodeLinks(result);

--- a/docs/src/plugins/vuepress-preprocessor.mjs
+++ b/docs/src/plugins/vuepress-preprocessor.mjs
@@ -69,7 +69,10 @@ function preprocessMarkdown(content, framework) {
   //    Keep the code blocks inside so they render as plain fenced code.
   result = stripExampleContainers(result);
 
-  // 5. Convert ::: source-code-link URL to an HTML anchor
+  // 5. Convert ::: ask-about-api name|memberof to a button element
+  result = convertAskAboutApiButtons(result);
+
+  // 5b. Convert ::: source-code-link URL to an HTML anchor
   result = convertSourceCodeLinks(result);
 
   // 6. Fix $withBase('/path') → /path in image srcs and link hrefs
@@ -357,6 +360,52 @@ function convertInlineCodeInAsides(content) {
     }
 
     result.push(line);
+  }
+
+  return result.join('\n');
+}
+
+/**
+ * Converts ::: ask-about-api name|memberof ::: blocks to Ask AI button elements.
+ *
+ * @param {string} content
+ * @returns {string}
+ */
+function convertAskAboutApiButtons(content) {
+  const lines = content.split('\n');
+  const result = [];
+  let inBlock = false;
+  let optionData = '';
+
+  for (const line of lines) {
+    const openMatch = line.match(/^:::\s+ask-about-api\s+(\S+)\s*$/);
+
+    if (openMatch) {
+      inBlock = true;
+      optionData = openMatch[1];
+      continue;
+    }
+
+    if (inBlock && /^:::\s*$/.test(line)) {
+      inBlock = false;
+      const pipeIdx = optionData.indexOf('|');
+      const optionName = pipeIdx >= 0 ? optionData.slice(0, pipeIdx) : optionData;
+      // Strip namespace prefix (e.g. "module:Core" -> "Core")
+      const rawPlugin = pipeIdx >= 0 ? optionData.slice(pipeIdx + 1) : '';
+      const pluginName = rawPlugin.split(':').pop()?.split('~')[0]?.split('#')[0] || 'Handsontable';
+
+      if (optionName) {
+        result.push(
+          `<button type="button" class="ask-about-api-btn" data-option="${optionName}" data-plugin="${pluginName}" aria-label="Ask AI about ${optionName}">Ask AI</button>`
+        );
+      }
+      optionData = '';
+      continue;
+    }
+
+    if (!inBlock) {
+      result.push(line);
+    }
   }
 
   return result.join('\n');

--- a/docs/src/styles/components/tables.css
+++ b/docs/src/styles/components/tables.css
@@ -9,33 +9,52 @@
 }
 
 /* -------------------------------------------------------------------------
- * API method header — heading + source code link in a visual row.
- * A client-side script moves the <a class="source-code-link"> inside the
+ * API method header — heading + action buttons (source code + Ask AI) in a
+ * visual row. A client-side script groups .source-code-link and
+ * .ask-about-api-btn into an .api-member-actions container inside the
  * preceding heading, enabling absolute positioning within it.
  * ------------------------------------------------------------------------- */
-/* Before JS moves the link: hide the standalone <p> wrapper to prevent FOUC */
-.sl-markdown-content :is(h2, h3, h4):has(+ p > .source-code-link) {
+
+/* Before JS moves elements: apply heading border/padding early to prevent FOUC */
+.sl-markdown-content :is(h2, h3, h4):has(+ p > .source-code-link),
+.sl-markdown-content :is(h2, h3, h4):has(+ p > .ask-about-api-btn) {
   border-top: 1px solid var(--sl-color-gray-5);
   padding-top: 1rem;
   margin-bottom: 0;
 }
 
-.sl-markdown-content p:has(> .source-code-link:only-child) {
+/* Before JS: hide standalone <p> wrappers to prevent flash */
+.sl-markdown-content p:has(> .source-code-link:only-child),
+.sl-markdown-content p:has(> .ask-about-api-btn:only-child) {
   display: none;
 }
 
-/* After JS moves the link inside the heading */
-.sl-markdown-content :is(h2, h3, h4):has(> .source-code-link) {
+/* After JS: heading with the actions container */
+.sl-markdown-content :is(h2, h3, h4):has(> .api-member-actions) {
   position: relative;
   border-top: 1px solid var(--sl-color-gray-5);
   padding-top: 1rem;
   margin-bottom: 0;
 }
 
-.source-code-link {
+/* Actions container — positioned at the top-right of the heading */
+.api-member-actions {
   position: absolute;
   top: 0;
   right: 0;
+  display: inline-flex;
+  flex-direction: row;
+  align-items: stretch;
+}
+
+/* Source code link inside the container — position is handled by the container */
+.api-member-actions .source-code-link {
+  position: static;
+}
+
+/* Shared visual styles for both action buttons */
+.source-code-link,
+.ask-about-api-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -52,6 +71,26 @@
   transition: color 0.15s, background-color 0.15s;
 }
 
+/* Source code link: standalone absolute position (no container) */
+.source-code-link {
+  position: absolute;
+  top: 0;
+  right: 0;
+}
+
+/* Ask AI button: reset default button styles */
+.ask-about-api-btn {
+  cursor: pointer;
+  background: none;
+  font-family: inherit;
+  border-right: none;
+}
+
+/* Source code link: rightmost in the group — no left border overlap */
+.api-member-actions .source-code-link {
+  border-left: none;
+}
+
 .source-code-link::before {
   content: '';
   display: inline-block;
@@ -64,7 +103,21 @@
   flex-shrink: 0;
 }
 
-.source-code-link:hover {
+/* Ask AI button icon — chat bubble */
+.ask-about-api-btn::before {
+  content: '';
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  background: currentColor;
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z'/%3E%3C/svg%3E");
+  mask-size: contain;
+  mask-repeat: no-repeat;
+  flex-shrink: 0;
+}
+
+.source-code-link:hover,
+.ask-about-api-btn:hover {
   color: var(--sl-color-white);
   background-color: var(--sl-color-gray-6);
 }

--- a/docs/src/styles/components/tables.css
+++ b/docs/src/styles/components/tables.css
@@ -47,11 +47,6 @@
   align-items: stretch;
 }
 
-/* Source code link inside the container — position is handled by the container */
-.api-member-actions .source-code-link {
-  position: static;
-}
-
 /* Shared visual styles for both action buttons */
 .source-code-link,
 .ask-about-api-btn {

--- a/docs/src/styles/components/tables.css
+++ b/docs/src/styles/components/tables.css
@@ -86,8 +86,9 @@
   border-right: none;
 }
 
-/* Source code link: rightmost in the group — no left border overlap */
+/* Source code link inside the container: flow as a flex item, no left border overlap */
 .api-member-actions .source-code-link {
+  position: static;
   border-left: none;
 }
 


### PR DESCRIPTION
### Context

The PR adds an "Ask AI" button next to the existing "Source code" button for every API option, method, and hook on the docs API reference pages. Clicking the button opens the Docs Assistant panel and auto-submits the question "Tell me what {option} in {plugin} is responsible for and give me an example use case." — no user typing required.

This lowers the friction from "I'm reading an API entry" to "I understand what it does" by driving Docs Assistant engagement directly from the highest-intent surface in the docs.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1475

### How has this been tested?

The docs site requires Node 20 and is separate from the core test pipeline. Functional correctness was verified by code review of the changed files:

- `hot-docs.hbs` — new `::: ask-about-api name|memberof :::` directive emitted for every non-constructor member
- `framework-loader.mjs` / `vuepress-preprocessor.mjs` — `convertAskAboutApiButtons()` parses the directive and produces `<button class="ask-about-api-btn" data-option="..." data-plugin="...">Ask AI</button>`
- `Head.astro` — JS groups `.source-code-link` and `.ask-about-api-btn` into a `.api-member-actions` flex container inside the heading, then wires click → `docs-assistant:ask` CustomEvent
- `useAssistant.ts` — new `clearAndSend(text)` clears thread history and sends the question atomically
- `DocsAssistantWidget.tsx` — listens for `docs-assistant:ask`, opens the panel, calls `clearAndSend`
- `tables.css` — `.api-member-actions` flex container handles absolute positioning; `.ask-about-api-btn` matches source-code-link visual style

Manual testing of the docs site is needed to confirm rendering before marking ready for review.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. DEV-1475

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches docs build/preprocessing and client-side assistant request/abort behavior; mistakes could break API page rendering or cause assistant streaming state/race issues, but changes are scoped to the docs UI.
> 
> **Overview**
> Adds an **“Ask AI”** action next to the existing **“Source code”** link for each API member in the generated reference docs.
> 
> The JSDoc→Markdown template now emits a `::: ask-about-api name|memberof :::` marker, both markdown preprocessors (`framework-loader.mjs` and `vuepress-preprocessor.mjs`) convert it into an `.ask-about-api-btn`, and `Head.astro` groups these actions into a single `.api-member-actions` container and dispatches a `docs-assistant:ask` event on click.
> 
> The Docs Assistant gains an event listener to open the panel and auto-submit the generated question, backed by a new `clearAndSend()` API plus improved abort handling in `useAssistant` to avoid races when clearing/sending during contextual fetch. Styling in `tables.css` is updated to lay out and theme the new button alongside the source link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b983e284ca1a2e2c19b61596012ce88ff4ff3de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->