### PR TITLE
docs: update agent docs for modern Angular patterns (standalone, app.config.ts, @if/@for)

### DIFF
--- a/.ai/INTEGRATIONS.md
+++ b/.ai/INTEGRATIONS.md
@@ -112,6 +112,7 @@ These are the only external libraries bundled or referenced at runtime:
 - Core component: `wrappers/angular-wrapper/projects/hot-table/src/lib/`
 - Runtime deps: `rxjs` ^7.8.1, `tslib` ^2.3.0, `zone.js` ~0.13.0
 - Tests require `NODE_OPTIONS=--openssl-legacy-provider`
+- **Modern pattern (required for all examples):** Components use `standalone: true` with `imports: [HotTableModule]`. Use `app.config.ts` (`ApplicationConfig` + `provideZoneChangeDetection`) instead of `AppModule`. License is set globally via `HOT_GLOBAL_CONFIG` -- no per-table `licenseKey`. Templates use `@if`/`@for` control flow, not `*ngIf`/`*ngFor`. Row data typed as `RowObject[]` from `handsontable/common`.
 
 **Vue 3 (`wrappers/vue3/`):**
 - Peer dependency: `handsontable` ^17.0.0, `vue` ^3.2.22

--- a/.claude/skills/angular-wrapper-dev/SKILL.md
+++ b/.claude/skills/angular-wrapper-dev/SKILL.md
@@ -32,7 +32,7 @@ The main `HotTableComponent` uses Angular `@Component` with individual `@Input()
 
 ## Module system
 
-`HotTableModule` is the Angular module that declares and exports the component. Consumers add it to their `imports` array.
+`HotTableModule` is the Angular module that declares and exports the component. Consumers add it to their `imports` array in standalone components.
 
 ## Build and test
 
@@ -50,7 +50,95 @@ The main `HotTableComponent` uses Angular `@Component` with individual `@Input()
 | `projects/hot-table/src/lib/services/` | Settings resolver and global config services |
 | `projects/hot-table/src/lib/hot-table.module.ts` | Angular module declaration |
 
+## Modern Angular patterns (required for all new and updated examples)
+
+### Standalone components
+
+All Angular example components must use `standalone: true` with `HotTableModule` in the `imports` array. Do **not** use `standalone: false` or `NgModule`-based declarations.
+
+```typescript
+import { Component } from '@angular/core';
+import { HotTableModule } from '@handsontable/angular-wrapper';
+
+@Component({
+  selector: 'app-example1',
+  standalone: true,
+  imports: [HotTableModule],
+  template: `<hot-table [settings]="hotSettings"></hot-table>`,
+})
+export class AppComponent { ... }
+```
+
+### app.config.ts instead of app.module.ts
+
+Replace `AppModule` (`@NgModule`) with an `ApplicationConfig` in `app.config.ts`. Register Handsontable modules and provide the global license key here:
+
+```typescript
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+```
+
+- `provideZoneChangeDetection({ eventCoalescing: true })` is required in every `app.config.ts`.
+- The global `HOT_GLOBAL_CONFIG` license replaces per-table `licenseKey` on every `<hot-table>`. Do **not** add `licenseKey` to individual component settings.
+- `CommonModule` and `BrowserModule` are no longer needed in standalone components.
+
+### Template control flow
+
+Use Angular 17+ built-in control flow syntax instead of structural directives:
+
+| Old (do not use) | New (required) |
+|---|---|
+| `*ngIf="condition"` | `@if (condition) { ... }` |
+| `*ngFor="let x of list"` | `@for (x of list; track x.id) { ... }` |
+
+Example:
+```html
+@if (isOpen) {
+  <ul role="listbox">
+    @for (opt of options; track opt.value) {
+      <li (click)="select(opt.value)">{{ opt.label }}</li>
+    }
+  </ul>
+}
+```
+
+### Type safety
+
+- Use `RowObject` from `handsontable/common` instead of `any[]` for row data arrays.
+- Use typed `querySelector`: `document.querySelector<HTMLInputElement>('#my-input')`.
+- Use non-null assertion on `hotInstance` where the instance is guaranteed to exist: `this.hotTable.hotInstance!.updateSettings(...)`.
+- Use `hotInstance!.updateSettings()` to change settings at runtime -- never destroy and recreate the Handsontable instance.
+
+```typescript
+import { RowObject } from 'handsontable/common';
+
+export class AppComponent {
+  hotData: RowObject[] = [];
+}
+```
+
+### Component naming
+
+Name all example components `AppComponent`, not `ExampleNComponent` or feature-specific names.
+
 ## Rules
 
 - No business logic in wrappers. All data transformation and validation belongs in `handsontable/src/`.
 - Cross-platform npm scripts: use Node.js `.mjs` helpers instead of bash-only constructs. Never use bash-specific syntax (`if [ ]`, `mv`, `&&` with `||`) directly in `package.json` script entries.
+- Never add `licenseKey` to individual `<hot-table>` settings in examples -- set it globally via `HOT_GLOBAL_CONFIG` in `app.config.ts`.
+- Never use `standalone: false` in new or updated example components.
+- Never use `*ngIf` or `*ngFor` in new or updated templates -- use `@if` / `@for` control flow.

--- a/.claude/skills/angular-wrapper-dev/SKILL.md
+++ b/.claude/skills/angular-wrapper-dev/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: angular-wrapper-dev
+path: wrappers/angular-wrapper/**
 description: Use when developing or modifying the @handsontable/angular-wrapper package - Angular components with decorators, NgZone performance optimization, and ng-packagr build system
 ---
 

--- a/.claude/skills/creating-docs-examples/SKILL.md
+++ b/.claude/skills/creating-docs-examples/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: creating-docs-examples
+path: docs/**
 description: Use when creating code examples for documentation pages - JavaScript, TypeScript, React, Angular, and Vue variants with proper imports, registration, and license key
 ---
 

--- a/.claude/skills/creating-docs-examples/SKILL.md
+++ b/.claude/skills/creating-docs-examples/SKILL.md
@@ -69,8 +69,48 @@ const App = () => {
 ```
 
 **Angular:**
-- Component logic goes in the `.ts` file.
-- Template markup goes in the `.html` file using `<hot-table>`.
+- Component logic goes in the `.ts` file; template markup goes in the `.html` file using `<hot-table>`.
+- All components must be **standalone** (`standalone: true`, `imports: [HotTableModule]`).
+- Use `app.config.ts` (not `app.module.ts`) with `ApplicationConfig`, `provideZoneChangeDetection({ eventCoalescing: true })`, and global `HOT_GLOBAL_CONFIG` for the license key.
+- Do **not** add `licenseKey` to individual `<hot-table>` bindings -- it is set globally in `app.config.ts`.
+- Template control flow: use `@if` / `@for (x of list; track x.id)` -- never `*ngIf` / `*ngFor`.
+- Row data type: use `RowObject[]` from `handsontable/common`, not `any[]`.
+- Name the component class `AppComponent` in every example.
+
+`app.config.ts` template:
+```typescript
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    { provide: HOT_GLOBAL_CONFIG, useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig },
+  ],
+};
+```
+
+Component template:
+```typescript
+import { Component } from '@angular/core';
+import { HotTableModule } from '@handsontable/angular-wrapper';
+import { RowObject } from 'handsontable/common';
+
+@Component({
+  selector: 'app-example1',
+  standalone: true,
+  imports: [HotTableModule],
+  templateUrl: './example1.html',
+})
+export class AppComponent {
+  hotData: RowObject[] = [];
+}
+```
+
+See skill `angular-wrapper-dev` for the full reference.
 
 **Vue 3:**
 - Component logic goes in the `.js` file.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,10 @@ These are the most frequent mistakes. Read this section first.
 | Using `.bind(this)` for hook/event callbacks | Use arrow-function class fields (`#onAfterX = () => { ... }`) instead. |
 | Direct cross-plugin imports | Use hooks for inter-plugin communication or `hot.getPlugin('{Name}')` if API access is required. |
 | Confusing the context menu with the column (dropdown) menu | These are two separate plugins. See [Context menu vs column menu](#context-menu-vs-column-menu). |
+| Using `standalone: false` or `AppModule` in Angular examples | All Angular docs examples use `standalone: true` with `imports: [HotTableModule]` and `app.config.ts`. See skill `angular-wrapper-dev`. |
+| Adding `licenseKey` to individual `<hot-table>` in Angular examples | Set it globally via `HOT_GLOBAL_CONFIG` in `app.config.ts`. Never put it on each component. |
+| Using `*ngIf` / `*ngFor` in Angular templates | Use Angular 17+ built-in control flow: `@if (cond) { }` and `@for (x of list; track x.id) { }`. |
+| Typing Angular row data as `any[]` | Use `RowObject[]` imported from `handsontable/common`. |
 | Expecting built-in DataProvider error UI from `dialog: true` alone | Enable `notification: true` (or a `notification` config object). DataProvider uses the Notification plugin for fetch/CRUD failures. Dialog stays for blocking modals (for example Loading plugin, ExportFile binary export overlay, custom `show` content). |
 
 ---


### PR DESCRIPTION
## Summary

- Updates `CLAUDE.md` (AGENTS.md) with 4 new Angular-specific gotchas covering standalone components, global license key, `@if`/`@for` control flow, and `RowObject[]` typing
- Rewrites `.claude/skills/angular-wrapper-dev/SKILL.md` with a full "Modern Angular patterns" section covering standalone components, `app.config.ts`, template control flow, type safety rules, and component naming conventions
- Updates `.claude/skills/creating-docs-examples/SKILL.md` Angular section with concrete templates and the `app.config.ts` boilerplate
- Updates `.ai/INTEGRATIONS.md` Angular wrapper entry with a one-line modern-pattern summary
- Runs `sync-skills-to-cursor.mjs` to keep Cursor rules in sync

Based on patterns introduced in PR #12408 (DEV-1215 - Modernize Angular examples).

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs/agent-guidance changes only; no runtime code paths or builds are modified, so impact is limited to developer workflows and example consistency.
> 
> **Overview**
> Aligns agent and skill documentation around a **single required “modern Angular” approach** for Handsontable examples.
> 
> Updates `angular-wrapper-dev` and `creating-docs-examples` skills (plus a one-line note in `.ai/INTEGRATIONS.md`) to require **standalone components**, `app.config.ts` (`ApplicationConfig` + `provideZoneChangeDetection`) instead of `AppModule`, **global licensing via `HOT_GLOBAL_CONFIG`** (no per-table `licenseKey`), Angular 17 **`@if`/`@for` control flow** instead of `*ngIf`/`*ngFor`, and **`RowObject[]` typing**.
> 
> Adds the same Angular gotchas to `AGENTS.md` to reduce repeated review feedback on docs examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8a898d4e43f7391c8cde77c091c27b09d549d9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->