### PR TITLE
DEV-860: Fix capitalization in beforeSelectColumns hook description

### DIFF
--- a/handsontable/src/core/hooks/constants.js
+++ b/handsontable/src/core/hooks/constants.js
@@ -1028,7 +1028,7 @@ export const REGISTERED_HOOKS = [
   'afterSelectionFocusSet',
 
   /**
-   * Fired before one or more columns are selected (e.g. During mouse header click or {@link Core#selectColumns} API call).
+   * Fired before one or more columns are selected (e.g. during mouse header click or {@link Core#selectColumns} API call).
    *
    * @since 14.0.0
    * @event Hooks#beforeSelectColumns


### PR DESCRIPTION
### Context

The PR fixes a capitalization error in the `beforeSelectColumns` hook JSDoc description. The text read "(e.g. During mouse header click...)" but should read "(e.g. during mouse header click...)" to match the lowercase convention used in all other similar hook descriptions (`afterSelectColumns`, `afterSelectRows`, `beforeSelectRows`).

This was identified during QA verification of DEV-860 formatting changes.

### How has this been tested?

- Reviewed the JSDoc comment in `handsontable/src/core/hooks/constants.js` and verified the fix is consistent with surrounding hooks.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-860

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-860

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change (comment text) with no runtime or API behavior impact.
> 
> **Overview**
> Fixes a minor JSDoc typo in `handsontable/src/core/hooks/constants.js` by lowercasing “During” to “during” in the `beforeSelectColumns` hook description to match surrounding hook docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fae7d78d6d0cc8761707b421fc9f8d0b693b3e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->