### PR TITLE
DEV-1268: Fix 9 broken internal links in docs

### DIFF
--- a/docs/content/guides/cell-functions/custom-cells/custom-cells.md
+++ b/docs/content/guides/cell-functions/custom-cells/custom-cells.md
@@ -1439,7 +1439,6 @@ We provide complete working examples for common use cases. All examples use the 
 3. **[Flatpickr Date Picker](@/recipes/cell-types/flatpickr/flatpickr.md)** - Advanced date picker with options using `factoryEditor`
 4. **[Pikaday Date Picker](@/recipes/cell-types/pikaday/pikaday.md)** - Integrate Pikaday date picker using `factoryEditor`
 5. **[Star Rating](@/recipes/cell-types/rating/rating.md)** - Interactive star rating using `factoryEditor`
-6. **[Multiple Select](@/recipes/cell-types/select-multiple/select-multiple.md)** - Multi-select dropdown using `factoryEditor`
 
 ## Migration from Traditional Approach
 

--- a/docs/content/recipes/themes/themes.md
+++ b/docs/content/recipes/themes/themes.md
@@ -36,8 +36,8 @@ Current recipes:
 
 <div class="boxes-list">
 
-- [Handsontable with shadcn/ui](@/content/recipes/themes/custom-theme/custom-theme.md)
-- [Handsontable with MUI](@/content/recipes/themes/mui-theme/mui-theme.md)
+- [Handsontable with shadcn/ui](@/recipes/themes/custom-theme/custom-theme.md)
+- [Handsontable with MUI](@/recipes/themes/mui-theme/mui-theme.md)
 
 </div>
 


### PR DESCRIPTION
## Summary

Fixes 9 broken internal links (404s) found during the 17.1.0 docs production build QA pass (DEV-1268).

### Bug 1: Theme recipe links use wrong path prefix (6 broken links)

**File:** `docs/content/recipes/themes/themes.md` (lines 39-40)

**Root cause:** Links to custom-theme and mui-theme used `@/content/recipes/...` instead of `@/recipes/...`. The extra `content/` directory prefix leaked the source file structure into the built URL, producing paths like `/docs/javascript-data-grid/content/recipes/themes/custom-theme/` which don't exist.

**Fix:** `@/content/recipes/` -> `@/recipes/`

**Affected URLs (all 404):**
- `/docs/javascript-data-grid/content/recipes/themes/custom-theme/`
- `/docs/javascript-data-grid/content/recipes/themes/mui-theme/`
- `/docs/react-data-grid/content/recipes/themes/custom-theme/`
- `/docs/react-data-grid/content/recipes/themes/mui-theme/`
- `/docs/angular-data-grid/content/recipes/themes/custom-theme/`
- `/docs/angular-data-grid/content/recipes/themes/mui-theme/`

### Bug 2: Link to non-existent recipe page (3 broken links)

**File:** `docs/content/guides/cell-functions/custom-cells/custom-cells.md` (line 1442)

**Root cause:** The custom-cells guide linked to a "Multiple Select" recipe (`@/recipes/cell-types/select-multiple/select-multiple.md`) that hasn't been created yet. The directory doesn't exist.

**Fix:** Removed the broken link. The recipe can be added to the list when the page is created.

**Affected URLs (all 404):**
- `/docs/javascript-data-grid/recipes/cell-types/select-multiple/`
- `/docs/react-data-grid/recipes/cell-types/select-multiple/`
- `/docs/angular-data-grid/recipes/cell-types/select-multiple/`

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1268

[skip changelog]

## Test plan

- [ ] Build docs (`npm run build` in `docs/`)
- [ ] Verify themes overview page links to custom-theme and mui-theme resolve correctly
- [ ] Verify custom-cells guide no longer links to non-existent select-multiple recipe
- [ ] Run link checker against built output -- 0 broken internal links expected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that corrects internal link targets and removes a link to a non-existent page; no runtime code paths are affected.
> 
> **Overview**
> Fixes broken internal docs navigation by updating the theme recipe overview links to use the correct `@/recipes/...` paths (removing the erroneous `@/content/recipes/...` prefix).
> 
> Also removes the `Multiple Select` recipe link from the custom cells guide since the referenced recipe page doesn’t exist yet, preventing 404s during docs builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d9d061aeac1e6b079324322ca530e0d97b8ac78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->