### PR TITLE
docs: Update Data management recipes

### DIFF
--- a/docs/content/recipes/data-management/auto-save-backend/javascript/example1.js
+++ b/docs/content/recipes/data-management/auto-save-backend/javascript/example1.js
@@ -56,7 +56,6 @@ if (container instanceof HTMLElement) {
 
   const hot = new Handsontable(container, {
     data,
-    rowHeaders: true,
     colHeaders: ['ID', 'Product', 'Stock', 'Price', 'Status'],
     columns: [
       { data: 'id', type: 'numeric', readOnly: true, width: 70 },

--- a/docs/content/recipes/data-management/auto-save-backend/javascript/example1.ts
+++ b/docs/content/recipes/data-management/auto-save-backend/javascript/example1.ts
@@ -64,7 +64,6 @@ if (container instanceof HTMLElement) {
 
   const hot = new Handsontable(container, {
     data,
-    rowHeaders: true,
     colHeaders: ['ID', 'Product', 'Stock', 'Price', 'Status'],
     columns: [
       { data: 'id', type: 'numeric', readOnly: true, width: 70 },

--- a/docs/content/recipes/data-management/auto-save-backend/react/example1.jsx
+++ b/docs/content/recipes/data-management/auto-save-backend/react/example1.jsx
@@ -113,7 +113,6 @@ const ExampleComponent = () => {
       <HotTable
         ref={hotRef}
         data={data}
-        rowHeaders={true}
         colHeaders={['ID', 'Product', 'Stock', 'Price', 'Status']}
         columns={[
           { data: 'id', type: 'numeric', readOnly: true, width: 70 },

--- a/docs/content/recipes/data-management/auto-save-backend/react/example1.tsx
+++ b/docs/content/recipes/data-management/auto-save-backend/react/example1.tsx
@@ -118,7 +118,6 @@ const ExampleComponent = () => {
       <HotTable
         ref={hotRef}
         data={data}
-        rowHeaders={true}
         colHeaders={['ID', 'Product', 'Stock', 'Price', 'Status']}
         columns={[
           { data: 'id', type: 'numeric', readOnly: true, width: 70 },

--- a/docs/content/recipes/data-management/server-side-laravel/javascript/example1.js
+++ b/docs/content/recipes/data-management/server-side-laravel/javascript/example1.js
@@ -48,6 +48,8 @@ function csrfToken() {
 
 const container = document.querySelector('#example1');
 
+let removeConfirmed = false;
+
 // eslint-disable-next-line no-unused-vars
 const hot = new Handsontable(container, {
   dataProvider: {
@@ -74,11 +76,12 @@ const hot = new Handsontable(container, {
     // onRowsCreate fires when the user inserts rows from the context menu.
     // payload: { position: 'above'|'below', referenceRowId, rowsAmount }
     onRowsCreate: async (payload) => {
-      await fetch('/api/products', {
+      const res = await fetch('/api/products', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': csrfToken() },
         body: JSON.stringify(payload),
       });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
     },
 
     // onRowsUpdate fires after a cell edit, paste, or autofill batch.
@@ -86,31 +89,60 @@ const hot = new Handsontable(container, {
     // Changes appear in the grid immediately (optimistic update) and roll back
     // if this callback throws or rejects.
     onRowsUpdate: async (rows) => {
-      await fetch('/api/products', {
+      const res = await fetch('/api/products', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': csrfToken() },
         body: JSON.stringify(rows),
       });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
     },
 
     // onRowsRemove fires after the user confirms deletion.
     // rowIds is an array of stable row IDs (values of the rowId field).
     onRowsRemove: async (rowIds) => {
-      await fetch('/api/products', {
+      const res = await fetch('/api/products', {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': csrfToken() },
         body: JSON.stringify(rowIds),
       });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
     },
   },
 
-  // beforeRowsMutation fires before any create, update, or remove operation.
-  // Return false to cancel. Here it adds a confirm dialog before deletes.
+  // beforeRowsMutation is sync (checks for a strict `=== false` return), so
+  // we cannot await an async prompt inline. Instead: cancel the original
+  // attempt, show a notification with Delete/Cancel actions, and on Delete
+  // re-issue the remove via the DataProvider API. The flag lets the second
+  // pass through without re-prompting.
   beforeRowsMutation(operation, payload) {
-    if (operation === 'remove') {
+    if (operation === 'remove' && !removeConfirmed) {
       const count = payload.rowsRemove.length;
-      // eslint-disable-next-line no-alert
-      return window.confirm(`Delete ${count} row${count !== 1 ? 's' : ''}? This cannot be undone.`);
+      const notification = hot.getPlugin('notification');
+      const id = notification.showMessage({
+        variant: 'warning',
+        title: 'Delete rows',
+        message: `Delete ${count} row${count !== 1 ? 's' : ''}? This cannot be undone.`,
+        duration: 0,
+        actions: [
+          {
+            label: 'Delete',
+            type: 'primary',
+            callback: () => {
+              notification.hide(id);
+              removeConfirmed = true;
+              hot.getPlugin('dataProvider').removeRows(payload.rowsRemove).finally(() => {
+                removeConfirmed = false;
+              });
+            },
+          },
+          {
+            label: 'Cancel',
+            type: 'secondary',
+            callback: () => notification.hide(id),
+          },
+        ],
+      });
+      return false;
     }
   },
 

--- a/docs/content/recipes/data-management/server-side-laravel/javascript/example1.ts
+++ b/docs/content/recipes/data-management/server-side-laravel/javascript/example1.ts
@@ -59,6 +59,8 @@ interface LaravelResponse {
 
 const container = document.querySelector('#example1')!;
 
+let removeConfirmed = false;
+
 // eslint-disable-next-line no-unused-vars
 const hot = new Handsontable(container, {
   dataProvider: {
@@ -85,11 +87,12 @@ const hot = new Handsontable(container, {
     // onRowsCreate fires when the user inserts rows from the context menu.
     // payload: { position: 'above'|'below', referenceRowId, rowsAmount }
     onRowsCreate: async (payload) => {
-      await fetch('/api/products', {
+      const res = await fetch('/api/products', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': csrfToken() },
         body: JSON.stringify(payload),
       });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
     },
 
     // onRowsUpdate fires after a cell edit, paste, or autofill batch.
@@ -97,32 +100,61 @@ const hot = new Handsontable(container, {
     // Changes appear in the grid immediately (optimistic update) and roll back
     // if this callback throws or rejects.
     onRowsUpdate: async (rows) => {
-      await fetch('/api/products', {
+      const res = await fetch('/api/products', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': csrfToken() },
         body: JSON.stringify(rows),
       });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
     },
 
     // onRowsRemove fires after the user confirms deletion.
     // rowIds is an array of stable row IDs (values of the rowId field).
     onRowsRemove: async (rowIds) => {
-      await fetch('/api/products', {
+      const res = await fetch('/api/products', {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': csrfToken() },
         body: JSON.stringify(rowIds),
       });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
     },
   },
 
-  // beforeRowsMutation fires before any create, update, or remove operation.
-  // Return false to cancel. Here it adds a confirm dialog before deletes.
+  // beforeRowsMutation is sync (checks for a strict `=== false` return), so
+  // we cannot await an async prompt inline. Instead: cancel the original
+  // attempt, show a notification with Delete/Cancel actions, and on Delete
+  // re-issue the remove via the DataProvider API. The flag lets the second
+  // pass through without re-prompting.
   beforeRowsMutation(operation, payload) {
-    if (operation === 'remove') {
+    if (operation === 'remove' && !removeConfirmed) {
       const rowsRemove = (payload as { rowsRemove: unknown[] }).rowsRemove;
       const count = rowsRemove.length;
-      // eslint-disable-next-line no-alert
-      return window.confirm(`Delete ${count} row${count !== 1 ? 's' : ''}? This cannot be undone.`);
+      const notification = hot.getPlugin('notification');
+      const id = notification.showMessage({
+        variant: 'warning',
+        title: 'Delete rows',
+        message: `Delete ${count} row${count !== 1 ? 's' : ''}? This cannot be undone.`,
+        duration: 0,
+        actions: [
+          {
+            label: 'Delete',
+            type: 'primary',
+            callback: () => {
+              notification.hide(id);
+              removeConfirmed = true;
+              hot.getPlugin('dataProvider').removeRows(rowsRemove).finally(() => {
+                removeConfirmed = false;
+              });
+            },
+          },
+          {
+            label: 'Cancel',
+            type: 'secondary',
+            callback: () => notification.hide(id),
+          },
+        ],
+      });
+      return false;
     }
   },
 

--- a/docs/content/recipes/data-management/server-side-laravel/react/example1.jsx
+++ b/docs/content/recipes/data-management/server-side-laravel/react/example1.jsx
@@ -48,6 +48,13 @@ function csrfToken() {
 }
 
 const ExampleComponent = () => {
+  const hotTableRef = useCallback((hotInstance) => {
+    if (hotInstance) {
+      // Store reference to the instance
+      ExampleComponent._hotInstance = hotInstance;
+    }
+  }, []);
+
   // fetchRows is called on every page change, sort, and filter.
   // queryParameters: { page, pageSize, sort, filters }
   // signal: AbortSignal — pass it to fetch() so stale requests cancel
@@ -67,11 +74,12 @@ const ExampleComponent = () => {
   // onRowsCreate fires when the user inserts rows from the context menu.
   // payload: { position: 'above'|'below', referenceRowId, rowsAmount }
   const onRowsCreate = useCallback(async (payload) => {
-    await fetch('/api/products', {
+    const res = await fetch('/api/products', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': csrfToken() },
       body: JSON.stringify(payload),
     });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
   }, []);
 
   // onRowsUpdate fires after a cell edit, paste, or autofill batch.
@@ -79,21 +87,23 @@ const ExampleComponent = () => {
   // Changes appear in the grid immediately (optimistic update) and roll back
   // if this callback throws or rejects.
   const onRowsUpdate = useCallback(async (rows) => {
-    await fetch('/api/products', {
+    const res = await fetch('/api/products', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': csrfToken() },
       body: JSON.stringify(rows),
     });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
   }, []);
 
   // onRowsRemove fires after the user confirms deletion.
   // rowIds is an array of stable row IDs (values of the rowId field).
   const onRowsRemove = useCallback(async (rowIds) => {
-    await fetch('/api/products', {
+    const res = await fetch('/api/products', {
       method: 'DELETE',
       headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': csrfToken() },
       body: JSON.stringify(rowIds),
     });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
   }, []);
 
   const dataProvider = useMemo(
@@ -109,19 +119,50 @@ const ExampleComponent = () => {
     [fetchRows, onRowsCreate, onRowsUpdate, onRowsRemove]
   );
 
-  // beforeRowsMutation fires before any create, update, or remove operation.
-  // Return false to cancel. Here it adds a confirm dialog before deletes.
+  // beforeRowsMutation is sync (checks for a strict `=== false` return), so
+  // we cannot await an async prompt inline. Instead: cancel the original
+  // attempt, show a notification with Delete/Cancel actions, and on Delete
+  // re-issue the remove via the DataProvider API. A ref tracks confirmation.
+  const removeConfirmedRef = { current: false };
   const beforeRowsMutation = useCallback((operation, payload) => {
-    if (operation === 'remove') {
+    if (operation === 'remove' && !removeConfirmedRef.current) {
       const count = payload.rowsRemove.length;
-      // eslint-disable-next-line no-alert
-      return window.confirm(`Delete ${count} row${count !== 1 ? 's' : ''}? This cannot be undone.`);
+      const hot = ExampleComponent._hotInstance;
+      if (!hot) return false;
+
+      const notification = hot.getPlugin('notification');
+      const id = notification.showMessage({
+        variant: 'warning',
+        title: 'Delete rows',
+        message: `Delete ${count} row${count !== 1 ? 's' : ''}? This cannot be undone.`,
+        duration: 0,
+        actions: [
+          {
+            label: 'Delete',
+            type: 'primary',
+            callback: () => {
+              notification.hide(id);
+              removeConfirmedRef.current = true;
+              hot.getPlugin('dataProvider').removeRows(payload.rowsRemove).finally(() => {
+                removeConfirmedRef.current = false;
+              });
+            },
+          },
+          {
+            label: 'Cancel',
+            type: 'secondary',
+            callback: () => notification.hide(id),
+          },
+        ],
+      });
+      return false;
     }
   }, []);
 
   return (
     <div>
       <HotTable
+        ref={hotTableRef}
         dataProvider={dataProvider}
         // beforeRowsMutation fires before any create, update, or remove operation.
         beforeRowsMutation={beforeRowsMutation}

--- a/docs/content/recipes/data-management/server-side-laravel/server-side-laravel.md
+++ b/docs/content/recipes/data-management/server-side-laravel/server-side-laravel.md
@@ -315,15 +315,46 @@ Cell edits appear in the grid immediately (optimistic update). If the server ret
 ### `beforeRowsMutation`
 
 ```javascript
+let removeConfirmed = false;
+
+// ...
+
 beforeRowsMutation(operation, payload) {
-  if (operation === 'remove') {
+  if (operation === 'remove' && !removeConfirmed) {
     const count = payload.rowsRemove.length;
-    return window.confirm(`Delete ${count} row${count !== 1 ? 's' : ''}? This cannot be undone.`);
+    const notification = hot.getPlugin('notification');
+    const id = notification.showMessage({
+      variant: 'warning',
+      title: 'Delete rows',
+      message: `Delete ${count} row${count !== 1 ? 's' : ''}? This cannot be undone.`,
+      duration: 0,
+      actions: [
+        {
+          label: 'Delete',
+          type: 'primary',
+          callback: () => {
+            notification.hide(id);
+            removeConfirmed = true;
+            hot.getPlugin('dataProvider').removeRows(payload.rowsRemove).finally(() => {
+              removeConfirmed = false;
+            });
+          },
+        },
+        {
+          label: 'Cancel',
+          type: 'secondary',
+          callback: () => notification.hide(id),
+        },
+      ],
+    });
+    return false;
   }
 },
 ```
 
 `beforeRowsMutation` fires before any create, update, or remove operation. Returning `false` cancels the operation -- `onRowsRemove` is not called and no rows are deleted on the server.
+
+Because `beforeRowsMutation` is synchronous and checks for a strict `=== false` return, you cannot use `window.confirm()` or other async dialogs. Instead, cancel the first attempt by returning `false`, show a notification with **Delete** and **Cancel** actions, and on **Delete** re-issue the remove via the DataProvider API. The `removeConfirmed` flag lets the second pass through without re-prompting.
 
 ### `notification: true` and `emptyDataState: true`
 


### PR DESCRIPTION
### Context

The PR fixes issues reported in review on the **Recipes → Data management** documentation. Those include a **duplicate identifier** problem in the examples, **`window.confirm`** usage inside **`beforeRowsMutation`** on the Server-side Laravel recipe (which clashes with embedded docs and with the grid’s **`notification`** option), and redundant **`rowHeaders`** on the Auto-save backend examples that added an unnecessary row-index column.

### How has this been tested?

- Manual: opened the affected recipe pages in the docs app and confirmed the examples render and behave as intended.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. [DEV-1477](https://app.clickup.com/t/9015210959/DEV-1477)

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/example-only changes; main risk is minor behavior differences in the embedded demos (delete confirmation flow and error handling).
> 
> **Overview**
> Updates the data-management recipe examples to improve correctness and UX in embedded demos.
> 
> In the Server-side Laravel recipe examples (JS/TS/React), mutation callbacks now **throw on non-2xx responses** (`res.ok` checks) so optimistic updates correctly roll back and `notification: true` surfaces failures. Row deletion confirmation in `beforeRowsMutation` is reworked to avoid `window.confirm()` by **showing an in-grid notification with Delete/Cancel actions** and re-issuing `dataProvider.removeRows()` on confirmation (guarded by a `removeConfirmed` flag/ref); the markdown recipe text is updated to explain this synchronous constraint.
> 
> In Auto-save backend examples (JS/TS/React), `rowHeaders` is removed to avoid an unnecessary index column in the demo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af99d35bec0bd5871aa753cc9bb4a49980799788. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->