### PR TITLE
fix(ci): reliably resolve PR number for Netlify preview comments

### DIFF
--- a/.github/workflows/docs-staging.yml
+++ b/.github/workflows/docs-staging.yml
@@ -64,19 +64,30 @@ jobs:
         uses: jwalton/gh-find-current-pr@89ee5799558265a1e0e31fab792ebb4ee91c016b # https://github.com/jwalton/gh-find-current-pr/tree/v1.3.3
         id: pr-finder
 
+      - name: Resolve PR number
+        id: resolve-pr
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # https://github.com/actions/github-script/releases/tag/v8.0.0
+        with:
+          script: |
+            // For pull_request events the number is in the event payload directly.
+            // gh-find-current-pr searches by commit SHA and can miss brand-new PRs
+            // due to GitHub API eventual consistency, causing comment steps to skip.
+            const prNumber = context.payload.pull_request?.number || '${{ steps.pr-finder.outputs.pr }}' || '';
+            core.setOutput('number', String(prNumber));
+
       - name: Get PR details
         id: get-pr
-        if: ${{ steps.pr-finder.outputs.pr }}
+        if: ${{ steps.resolve-pr.outputs.number }}
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # https://github.com/actions/github-script/releases/tag/v8.0.0
         with:
           script: |
             const { data: pullRequest } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: context.issue.number ||  ${{ steps.pr-finder.outputs.pr }}
+              pull_number: Number('${{ steps.resolve-pr.outputs.number }}')
             });
 
-            console.log(`PR #${context.issue.number} details fetched`);
+            console.log(`PR #${{ steps.resolve-pr.outputs.number }} details fetched`);
             console.log(`Source branch: ${pullRequest.head.ref}`);
             console.log(`Target branch: ${pullRequest.base.ref}`);
 
@@ -104,13 +115,13 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_PREVIEW_AUTH_TOKEN }}
           NETLIFY_ACCOUNT_SLUG: ${{ secrets.NETLIFY_ACCOUNT_SLUG }}
           BRANCH_NAME_PREFIX: ${{ steps.release-info.outputs.is_release == 'true' && 'rc-handsontable-' || 'dev-handsontable-' }}
-          BRANCH_NAME: ${{ steps.release-info.outputs.is_release == 'true' && steps.release-info.outputs.target_version || steps.get-pr.outputs.source_branch || github.ref_name }}
+          BRANCH_NAME: ${{ steps.release-info.outputs.is_release == 'true' && steps.release-info.outputs.target_version || github.head_ref || steps.get-pr.outputs.source_branch || github.ref_name }}
 
       - name: Publish sticky comment in PR. Docs are being built
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # https://github.com/marocchino/sticky-pull-request-comment/tree/v2.9.4
-        if: ${{ steps.pr-finder.outputs.pr }}
+        if: ${{ steps.resolve-pr.outputs.number }}
         with:
-          number: ${{ steps.pr-finder.outputs.pr }}
+          number: ${{ steps.resolve-pr.outputs.number }}
           message: |
             🏗️ Preview documentation is being built/rebuilt.
             Current staging version of documentation will be available at: [${{ env.NETLIFY_SITE_URL }}/docs](${{ env.NETLIFY_SITE_URL }}/docs)
@@ -187,9 +198,9 @@ jobs:
 
       - name: Publish sticky comment in PR
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # https://github.com/marocchino/sticky-pull-request-comment/tree/v2.9.4
-        if: ${{ steps.pr-finder.outputs.pr }}
+        if: ${{ steps.resolve-pr.outputs.number }}
         with:
-          number: ${{ steps.pr-finder.outputs.pr }}
+          number: ${{ steps.resolve-pr.outputs.number }}
           message: |
             ✅ Preview documentation is is available now
             Current staging version of documentation is available at: [${{ env.NETLIFY_SITE_URL }}/docs](${{ env.NETLIFY_SITE_URL }}/docs)

--- a/docs/content/guides/getting-started/introduction/introduction.md
+++ b/docs/content/guides/getting-started/introduction/introduction.md
@@ -17,6 +17,7 @@ category: Getting started
 ---
 Handsontable is a JavaScript data grid component. This page explains what it does, who uses it, and when it is the right tool for your project.
 
+
 [[toc]]
 
 ## Getting started 🚀

--- a/docs/content/guides/getting-started/introduction/introduction.md
+++ b/docs/content/guides/getting-started/introduction/introduction.md
@@ -17,7 +17,6 @@ category: Getting started
 ---
 Handsontable is a JavaScript data grid component. This page explains what it does, who uses it, and when it is the right tool for your project.
 
-
 [[toc]]
 
 ## Getting started 🚀


### PR DESCRIPTION
### Context

The PR fixes a race condition in the `docs-staging.yml` workflow where the Netlify preview URL comment was silently skipped on new PR creation.

`jwalton/gh-find-current-pr` finds a PR by searching the GitHub API for the current commit SHA. When the `ci:docs-deploy` label is applied at PR creation time, this search can return empty due to GitHub API eventual consistency -- the PR is brand new and hasn't been indexed yet. Both sticky comment steps are gated on `if: ${{ steps.pr-finder.outputs.pr }}`, so when `pr-finder` returns nothing the deployment succeeds but no URL is ever posted to the PR.

For `pull_request` events (`labeled`, `synchronize`), `github.event.pull_request.number` is always present in the event payload -- no search needed. The fix adds a "Resolve PR number" step that uses the event payload directly for PR events and falls back to `pr-finder` for `push`/`workflow_dispatch` events.

Also fixes `BRANCH_NAME` to use `github.head_ref` (the actual PR branch name) for PR events before falling through to `github.ref_name`, which for `pull_request` events is the merge ref (`N/merge`) rather than the branch name.

### How has this been tested?

- Code review of the workflow logic -- the change is additive: one extra step that resolves the PR number from the event payload, replacing the unreliable `pr-finder` output as the gating condition.
- No automated tests exist for GitHub Actions workflows; the fix is verifiable by triggering the workflow on a new PR with the `ci:docs-deploy` label and confirming the comment appears.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. N/A (CI fix)

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow logic changes; risk is limited to potentially skipping/misposting PR comments or using an incorrect branch name for Netlify previews.
> 
> **Overview**
> Improves the `docs-staging.yml` workflow so Netlify preview comments are reliably posted on newly created PRs by resolving the PR number from the `pull_request` event payload (with a fallback to `gh-find-current-pr`) and gating comment/PR-fetch steps on that resolved value.
> 
> Adjusts Netlify preview `BRANCH_NAME` selection to prefer `github.head_ref` for PR events (before falling back to PR details or `github.ref_name`), avoiding use of the `N/merge` ref for preview deployments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a080b93c99f5333d5a3f0331eb3262fbd9209ea2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->