### PR TITLE
SU-545: Add AI accuracy disclaimer below docs assistant composer

### DIFF
--- a/docs/src/components/DocsAssistant/DocsAssistant.css
+++ b/docs/src/components/DocsAssistant/DocsAssistant.css
@@ -593,6 +593,18 @@
   background: var(--sl-color-gray-2);
 }
 
+/* ── Disclaimer ─────────────────────────────────────────────────────── */
+
+.da-disclaimer {
+  margin: 0;
+  padding: 0.5rem 1rem 0.75rem;
+  font-size: 0.75rem;
+  line-height: 1.3;
+  color: var(--sl-color-gray-3);
+  text-align: center;
+  background: var(--sl-color-bg);
+}
+
 /* ── Typing / thinking indicator ────────────────────────────────────── */
 
 .da-typing {

--- a/docs/src/components/DocsAssistant/Thread.tsx
+++ b/docs/src/components/DocsAssistant/Thread.tsx
@@ -153,6 +153,9 @@ export function Thread({
           )}
         </div>
       </form>
+      <p className="da-disclaimer" role="note">
+        AI-generated responses may be inaccurate. Verify critical information before use.
+      </p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Adds a small, always-visible disclaimer below the composer in the Docs Assistant panel.
- Text: *"AI-generated responses may be inaccurate. Verify critical information before use."*
- Implemented as a new `<p class="da-disclaimer">` inside `.da-thread` (below the composer `<form>`), styled with existing `--sl-*` design tokens for light/dark parity.

## Test plan

- [ ] Open the docs site, click the assistant FAB, and verify the disclaimer is visible under the composer.
- [ ] Toggle light/dark theme — verify text color stays legible via `--sl-color-gray-3`.
- [ ] Resize the panel to min (360 px) and max (800 px) — verify the disclaimer wraps cleanly.
- [ ] Verify the disclaimer remains visible regardless of thread scroll position.

ClickUp task: https://app.clickup.com/t/9015210959/SU-545

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds static text and styling; no business logic, data handling, or security-sensitive behavior is modified.
> 
> **Overview**
> Adds an always-visible AI accuracy disclaimer below the Docs Assistant composer in `Thread.tsx` (marked with `role="note"`).
> 
> Introduces `da-disclaimer` styles in `DocsAssistant.css` to keep the message small, centered, and theme-consistent using existing `--sl-*` tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43edcc0a27c1357d2d1ab210d3a3842cf6feeed0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->