### PR TITLE
SU-546: Thread docs assistant conversations via X-Thread-Id header

### DIFF
--- a/docs/src/components/DocsAssistant/constants.ts
+++ b/docs/src/components/DocsAssistant/constants.ts
@@ -2,6 +2,7 @@ export const STORAGE_KEYS = {
   thread: 'hot-docs-chat-thread',
   open: 'hot-docs-chat-open',
   width: 'hot-docs-chat-width',
+  slackThread: 'hot-docs-chat-slack-thread',
 } as const;
 
 export const WIDTH = {

--- a/docs/src/components/DocsAssistant/constants.ts
+++ b/docs/src/components/DocsAssistant/constants.ts
@@ -2,7 +2,7 @@ export const STORAGE_KEYS = {
   thread: 'hot-docs-chat-thread',
   open: 'hot-docs-chat-open',
   width: 'hot-docs-chat-width',
-  slackThread: 'hot-docs-chat-slack-thread',
+  threadId: 'hot-docs-chat-thread-id',
 } as const;
 
 export const WIDTH = {

--- a/docs/src/components/DocsAssistant/useAssistant.ts
+++ b/docs/src/components/DocsAssistant/useAssistant.ts
@@ -91,6 +91,30 @@ function persistThread(messages: ChatMessage[]) {
   }
 }
 
+function readSlackThread(): string | null {
+  try {
+    return localStorage.getItem(STORAGE_KEYS.slackThread);
+  } catch {
+    return null;
+  }
+}
+
+function writeSlackThread(ts: string) {
+  try {
+    localStorage.setItem(STORAGE_KEYS.slackThread, ts);
+  } catch {
+    // Quota or privacy-mode — drop silently.
+  }
+}
+
+function clearSlackThreadStorage() {
+  try {
+    localStorage.removeItem(STORAGE_KEYS.slackThread);
+  } catch {
+    // Quota or privacy-mode — drop silently.
+  }
+}
+
 function uid() {
   return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 }
@@ -139,6 +163,11 @@ export function useAssistant() {
   });
   const abortRef = useRef<AbortController | null>(null);
   const hydratedRef = useRef(false);
+  // Slack thread timestamp for the current conversation. Persisted in
+  // localStorage under STORAGE_KEYS.slackThread so the thread id survives
+  // page reloads and cross-page navigation, matching the lifecycle of the
+  // visible conversation. Reset in `clear` / `clearAndSend`.
+  const slackThreadRef = useRef<string | null>(readSlackThread());
 
   useEffect(() => {
     if (hydratedRef.current) return;
@@ -185,16 +214,35 @@ export function useAssistant() {
       });
 
       try {
+        const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+        if (slackThreadRef.current) {
+          headers['X-Slack-Thread'] = slackThreadRef.current;
+        }
+
         const res = await fetch(CHAT_ENDPOINT, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ messages: apiMessages }),
+          headers,
+          body: JSON.stringify({
+            messages: apiMessages,
+            pageTitle: document.title,
+            pageUrl: window.location.href,
+          }),
           signal: controller.signal,
         });
         if (!res.ok) {
           throw new Error(`${res.status} ${res.statusText || 'Request failed'}`);
         }
         if (!res.body) throw new Error('No response body');
+
+        // Capture the Slack thread id returned by the first successful turn so
+        // subsequent turns thread under the same Slack post. The server returns
+        // the same value on every turn of a conversation; the `!current` guard
+        // avoids redundant writes.
+        const returnedTs = res.headers.get('X-Slack-Thread');
+        if (returnedTs && !slackThreadRef.current) {
+          slackThreadRef.current = returnedTs;
+          writeSlackThread(returnedTs);
+        }
 
         for await (const event of readSSE(res.body, controller.signal)) {
           if (event.type === 'content_chunk') {
@@ -257,6 +305,8 @@ export function useAssistant() {
   const clear = useCallback(() => {
     abortRef.current?.abort();
     abortRef.current = null;
+    slackThreadRef.current = null;
+    clearSlackThreadStorage();
     dispatch({ type: 'CLEAR' });
   }, []);
 
@@ -264,6 +314,8 @@ export function useAssistant() {
     async (text: string) => {
       abortRef.current?.abort();
       abortRef.current = null;
+      slackThreadRef.current = null;
+      clearSlackThreadStorage();
       dispatch({ type: 'CLEAR' });
       const trimmed = text.trim();
       if (!trimmed) return;

--- a/docs/src/components/DocsAssistant/useAssistant.ts
+++ b/docs/src/components/DocsAssistant/useAssistant.ts
@@ -91,25 +91,25 @@ function persistThread(messages: ChatMessage[]) {
   }
 }
 
-function readSlackThread(): string | null {
+function readThreadId(): string | null {
   try {
-    return localStorage.getItem(STORAGE_KEYS.slackThread);
+    return localStorage.getItem(STORAGE_KEYS.threadId);
   } catch {
     return null;
   }
 }
 
-function writeSlackThread(ts: string) {
+function writeThreadId(ts: string) {
   try {
-    localStorage.setItem(STORAGE_KEYS.slackThread, ts);
+    localStorage.setItem(STORAGE_KEYS.threadId, ts);
   } catch {
     // Quota or privacy-mode — drop silently.
   }
 }
 
-function clearSlackThreadStorage() {
+function clearThreadIdStorage() {
   try {
-    localStorage.removeItem(STORAGE_KEYS.slackThread);
+    localStorage.removeItem(STORAGE_KEYS.threadId);
   } catch {
     // Quota or privacy-mode — drop silently.
   }
@@ -163,11 +163,11 @@ export function useAssistant() {
   });
   const abortRef = useRef<AbortController | null>(null);
   const hydratedRef = useRef(false);
-  // Slack thread timestamp for the current conversation. Persisted in
-  // localStorage under STORAGE_KEYS.slackThread so the thread id survives
-  // page reloads and cross-page navigation, matching the lifecycle of the
-  // visible conversation. Reset in `clear` / `clearAndSend`.
-  const slackThreadRef = useRef<string | null>(readSlackThread());
+  // Conversation thread id returned by the backend. Persisted in localStorage
+  // under STORAGE_KEYS.threadId so the id survives page reloads and cross-page
+  // navigation, matching the lifecycle of the visible conversation. Reset in
+  // `clear` / `clearAndSend`.
+  const threadIdRef = useRef<string | null>(readThreadId());
 
   useEffect(() => {
     if (hydratedRef.current) return;
@@ -215,8 +215,8 @@ export function useAssistant() {
 
       try {
         const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-        if (slackThreadRef.current) {
-          headers['X-Slack-Thread'] = slackThreadRef.current;
+        if (threadIdRef.current) {
+          headers['X-Thread-Id'] = threadIdRef.current;
         }
 
         const res = await fetch(CHAT_ENDPOINT, {
@@ -234,14 +234,14 @@ export function useAssistant() {
         }
         if (!res.body) throw new Error('No response body');
 
-        // Capture the Slack thread id returned by the first successful turn so
-        // subsequent turns thread under the same Slack post. The server returns
-        // the same value on every turn of a conversation; the `!current` guard
-        // avoids redundant writes.
-        const returnedTs = res.headers.get('X-Slack-Thread');
-        if (returnedTs && !slackThreadRef.current) {
-          slackThreadRef.current = returnedTs;
-          writeSlackThread(returnedTs);
+        // Capture the thread id returned by the first successful turn so the
+        // backend can correlate subsequent turns to the same conversation. The
+        // server returns the same value on every turn of a conversation; the
+        // `!current` guard avoids redundant writes.
+        const returnedId = res.headers.get('X-Thread-Id');
+        if (returnedId && !threadIdRef.current) {
+          threadIdRef.current = returnedId;
+          writeThreadId(returnedId);
         }
 
         for await (const event of readSSE(res.body, controller.signal)) {
@@ -305,8 +305,8 @@ export function useAssistant() {
   const clear = useCallback(() => {
     abortRef.current?.abort();
     abortRef.current = null;
-    slackThreadRef.current = null;
-    clearSlackThreadStorage();
+    threadIdRef.current = null;
+    clearThreadIdStorage();
     dispatch({ type: 'CLEAR' });
   }, []);
 
@@ -314,8 +314,8 @@ export function useAssistant() {
     async (text: string) => {
       abortRef.current?.abort();
       abortRef.current = null;
-      slackThreadRef.current = null;
-      clearSlackThreadStorage();
+      threadIdRef.current = null;
+      clearThreadIdStorage();
       dispatch({ type: 'CLEAR' });
       const trimmed = text.trim();
       if (!trimmed) return;


### PR DESCRIPTION
## Summary

Updates the docs assistant widget to match a new backend contract that correlates conversation turns via a stable `X-Thread-Id` header, so the backend can link all turns of one conversation together. Invisible to readers — no UI, no new dependencies, SSE stream format unchanged.

- **Request body** now includes top-level `pageTitle` (`document.title`) and `pageUrl` (`window.location.href`) — backend uses these to record which docs page a conversation was started from.
- **Request header** `X-Thread-Id: <id>` is sent on turns 2..N once the id is known.
- **Response header** `X-Thread-Id: <id>` is captured on the first successful turn and persisted.
- Thread id lifecycle matches the visible conversation: stored in `localStorage` under `hot-docs-chat-thread-id`, cleared by both `clear` and `clearAndSend` (the two "new conversation" entry points). Survives page reloads and cross-page navigation.

## Verification against the live backend (done via curl)

- Preflight: `Access-Control-Allow-Headers: Content-Type, X-Thread-Id`, `Access-Control-Expose-Headers: X-Thread-Id` — OK
- First turn (`pageTitle`/`pageUrl` body, no thread header) returned `x-thread-id: 1776710139.410949` — OK
- Follow-up turn (`X-Thread-Id: 1776710139.410949` request header) echoed the same id back — OK
- SSE event stream unchanged — OK

## Test plan

- [ ] On the Netlify preview, open the widget and ask a question. DevTools → Network: response carries `X-Thread-Id`.
- [ ] Application → Local Storage → `hot-docs-chat-thread-id` is set.
- [ ] Ask a follow-up. Request carries `X-Thread-Id: <same id>`.
- [ ] Click "New conversation", send another question. No `X-Thread-Id` on this request; response sets a fresh one.
- [ ] Reload the docs page mid-conversation. Next follow-up still carries the pre-reload `X-Thread-Id`.
- [ ] Trigger "Ask AI about this page" from the ToC — starts a new thread (goes through `clearAndSend`).

(Backend-side verification that threading correlates correctly is tracked in the private backend repo.)

ClickUp task: https://app.clickup.com/t/9015210959/SU-546

[skip changelog]