### PR TITLE
Add code-review-graph MCP server with accurate usage guidance

### DIFF
--- a/.ai/MCP.md
+++ b/.ai/MCP.md
@@ -93,10 +93,12 @@ Run `/mcp` in Claude Code and confirm `code-review-graph` appears with status `c
 The graph is built against a specific git commit. After switching branches, rebuild so tools like `detect_changes` don't report function names from unrelated files:
 
 ```bash
-code-review-graph build
+pipx run code-review-graph==2.3.2 build
 ```
 
-The `PostToolUse` hook in `.claude/settings.json` runs `pipx run code-review-graph==2.3.2 update --skip-flows` after each file edit, keeping the graph in sync during a session. A full rebuild is only needed after `git checkout`, `git pull`, or large merges.
+The `PostToolUse` hook in `.claude/settings.json` runs `pipx run code-review-graph==2.3.2 update --skip-flows` after each `Edit` or `Write` to keep the graph in sync during a session. The `--skip-flows` flag skips execution-flow re-analysis for speed -- flows are only re-indexed on a full `build`. A rebuild is only needed after `git checkout`, `git pull`, or large merges.
+
+The hooks are guarded with `command -v pipx >/dev/null 2>&1 && ... || true` so machines without `pipx` installed (or air-gapped sessions where PyPI is unreachable) do not error on every session start or file edit.
 
 ### Troubleshooting
 
@@ -104,7 +106,7 @@ The `PostToolUse` hook in `.claude/settings.json` runs `pipx run code-review-gra
 |---|---|
 | `code-review-graph` not listed in `/mcp` | Check `pipx --version` is installed; run `pipx run code-review-graph==2.3.2 --version` manually to confirm |
 | First session is slow (~10s hang at start) | Expected -- pipx is downloading the package. Subsequent sessions use the cached venv |
-| `detect_changes` reports wrong function names | Graph is stale on the wrong branch. Run `code-review-graph build` |
+| `detect_changes` reports wrong function names | Graph is stale on the wrong branch. Run `pipx run code-review-graph==2.3.2 build` |
 | `tests_for` returns 0 for files with known tests | Known limitation -- use grep for `.spec.js` / `.unit.js` files instead |
 | `get_architecture_overview` fails with token-limit error | Do not call this tool -- it produces 3.9M characters. Use `list_communities` + `get_community` for specific areas |
 

--- a/.ai/MCP.md
+++ b/.ai/MCP.md
@@ -72,6 +72,48 @@ Once connected, the following tools are available to AI assistants:
 
 ---
 
+## code-review-graph MCP
+
+A Tree-sitter knowledge graph over the full codebase (28k+ nodes, 419k+ edges). Used by AI agents for cross-file structural queries -- finding all callers of a function, tracing imports, and getting blast-radius counts without reading individual files. See the `MCP Tools: code-review-graph` section in `AGENTS.md` for when to use it vs. plain grep.
+
+### Prerequisites
+
+- `pipx` (Python equivalent of `npx`). Standard on most Python developer machines. Install:
+  - macOS: `brew install pipx && pipx ensurepath`
+  - Linux: `python3 -m pip install --user pipx && pipx ensurepath`
+
+No manual `code-review-graph` install is required. The `.mcp.json` configuration invokes it via `pipx run code-review-graph==2.3.2 serve`, which fetches and caches the package on first use (~10s one-time download, instant on subsequent starts).
+
+### Verifying the setup
+
+Run `/mcp` in Claude Code and confirm `code-review-graph` appears with status `connected`. On first session the startup is slower while pipx downloads the package.
+
+### Rebuild after switching branches
+
+The graph is built against a specific git commit. After switching branches, rebuild so tools like `detect_changes` don't report function names from unrelated files:
+
+```bash
+code-review-graph build
+```
+
+The `PostToolUse` hook in `.claude/settings.json` runs `pipx run code-review-graph==2.3.2 update --skip-flows` after each file edit, keeping the graph in sync during a session. A full rebuild is only needed after `git checkout`, `git pull`, or large merges.
+
+### Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `code-review-graph` not listed in `/mcp` | Check `pipx --version` is installed; run `pipx run code-review-graph==2.3.2 --version` manually to confirm |
+| First session is slow (~10s hang at start) | Expected -- pipx is downloading the package. Subsequent sessions use the cached venv |
+| `detect_changes` reports wrong function names | Graph is stale on the wrong branch. Run `code-review-graph build` |
+| `tests_for` returns 0 for files with known tests | Known limitation -- use grep for `.spec.js` / `.unit.js` files instead |
+| `get_architecture_overview` fails with token-limit error | Do not call this tool -- it produces 3.9M characters. Use `list_communities` + `get_community` for specific areas |
+
+### Do not re-run `code-review-graph install`
+
+The `install` subcommand would re-append boilerplate instructions to `CLAUDE.md` / `AGENTS.md` that have been hand-corrected for accuracy, and may overwrite fixes in `.claude/skills/` and `.claude/settings.json`. The MCP server is already configured in `.mcp.json`; nothing else needs to run.
+
+---
+
 ## Other MCP servers in this repo
 
 The `.cursor/mcp.json` and `.mcp.json` files also configure:
@@ -81,3 +123,4 @@ The `.cursor/mcp.json` and `.mcp.json` files also configure:
 | `github` | Read/write GitHub issues, PRs, and checks via `GITHUB_TOKEN` |
 | `filesystem_workspace` | Read/write access to the full repo workspace |
 | `filesystem_docs` | Read/write access to `./docs/content` only |
+| `code-review-graph` | Knowledge graph over the codebase (see above) |

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,11 +6,11 @@
   "hooks": {
     "PostToolUse": [
       {
-        "matcher": "Edit|Write|Bash",
+        "matcher": "Edit|Write",
         "hooks": [
           {
             "type": "command",
-            "command": "pipx run code-review-graph==2.3.2 update --skip-flows",
+            "command": "command -v pipx >/dev/null 2>&1 && pipx run code-review-graph==2.3.2 update --skip-flows || true",
             "timeout": 30
           }
         ]
@@ -22,7 +22,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "pipx run code-review-graph==2.3.2 status",
+            "command": "command -v pipx >/dev/null 2>&1 && pipx run code-review-graph==2.3.2 status || true",
             "timeout": 30
           }
         ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,5 +2,31 @@
   "attribution": {
     "commit": "",
     "pr": ""
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pipx run code-review-graph==2.3.2 update --skip-flows",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pipx run code-review-graph==2.3.2 status",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.claude/skills/debug-issue.md
+++ b/.claude/skills/debug-issue.md
@@ -12,7 +12,7 @@ Use the knowledge graph to systematically trace and debug issues.
 1. Use `semantic_search_nodes` (detail_level="minimal") to find code related to the issue by name or keyword.
 2. Use `query_graph` with `callers_of` and `callees_of` (detail_level="minimal") to trace call chains.
 3. Use `get_flow` to see full execution paths through suspected areas.
-4. To check if recent changes caused the issue, first verify the graph is on the correct branch (`code-review-graph status`). A stale graph makes `detect_changes` report unrelated function names. Rebuild if needed: `code-review-graph build`.
+4. To check if recent changes caused the issue, first verify the graph is on the correct branch (`pipx run code-review-graph==2.3.2 status`). A stale graph makes `detect_changes` report unrelated function names. Rebuild if needed: `pipx run code-review-graph==2.3.2 build`.
 5. Use `get_impact_radius` (detail_level="minimal") on suspected files to see what else is affected.
 
 ### Tips
@@ -21,7 +21,4 @@ Use the knowledge graph to systematically trace and debug issues.
 - Look at affected flows to find the entry point that triggers the bug.
 - Recent changes are the most common source of new issues.
 
-## Token Efficiency Rules
-- ALWAYS start with `get_minimal_context(task="<your task>")` before any other graph tool.
-- Use `detail_level="minimal"` on all calls. Only escalate to "standard" when minimal is insufficient.
-- Target: complete any review/debug/refactor task in ≤5 tool calls and ≤800 total output tokens.
+See `AGENTS.md` "MCP Tools: code-review-graph" for the full set of rules (detail_level, qualified names, when to use grep instead). Target: complete any debug task in ≤5 tool calls.

--- a/.claude/skills/debug-issue.md
+++ b/.claude/skills/debug-issue.md
@@ -1,0 +1,27 @@
+---
+name: Debug Issue
+description: Systematically debug issues using graph-powered code navigation
+---
+
+## Debug Issue
+
+Use the knowledge graph to systematically trace and debug issues.
+
+### Steps
+
+1. Use `semantic_search_nodes` (detail_level="minimal") to find code related to the issue by name or keyword.
+2. Use `query_graph` with `callers_of` and `callees_of` (detail_level="minimal") to trace call chains.
+3. Use `get_flow` to see full execution paths through suspected areas.
+4. To check if recent changes caused the issue, first verify the graph is on the correct branch (`code-review-graph status`). A stale graph makes `detect_changes` report unrelated function names. Rebuild if needed: `code-review-graph build`.
+5. Use `get_impact_radius` (detail_level="minimal") on suspected files to see what else is affected.
+
+### Tips
+
+- Check both callers and callees to understand the full context.
+- Look at affected flows to find the entry point that triggers the bug.
+- Recent changes are the most common source of new issues.
+
+## Token Efficiency Rules
+- ALWAYS start with `get_minimal_context(task="<your task>")` before any other graph tool.
+- Use `detail_level="minimal"` on all calls. Only escalate to "standard" when minimal is insufficient.
+- Target: complete any review/debug/refactor task in ≤5 tool calls and ≤800 total output tokens.

--- a/.claude/skills/explore-codebase.md
+++ b/.claude/skills/explore-codebase.md
@@ -1,0 +1,29 @@
+---
+name: Explore Codebase
+description: Navigate and understand codebase structure using the knowledge graph
+---
+
+## Explore Codebase
+
+Use the code-review-graph MCP tools to explore and understand the codebase.
+
+### Steps
+
+1. Run `list_graph_stats` to see overall codebase metrics.
+2. Use `list_communities` to find major modules, then `get_community` for a specific area.
+3. Use `semantic_search_nodes` to find specific functions or classes by name (keyword matching, not natural language).
+4. Use `query_graph` with patterns like `callers_of`, `callees_of`, `importers_of` to trace relationships.
+5. Use `query_graph` with `children_of` on a class to list its methods.
+6. Use `list_flows` and `get_flow` to understand execution paths.
+
+### Tips
+
+- Do NOT call `get_architecture_overview` -- it returns 3.9M characters and will overflow context.
+- Use `children_of` on a fully-qualified class name (e.g. `path/to/file.js::ClassName`), not bare names.
+- Always pass `detail_level: "minimal"` -- standard mode repeats the full path per node and inflates output 6x.
+- For single-file structure, grep is faster and cheaper than `children_of`.
+
+## Token Efficiency Rules
+- ALWAYS start with `get_minimal_context(task="<your task>")` before any other graph tool.
+- Use `detail_level="minimal"` on all calls. Only escalate to "standard" when minimal is insufficient.
+- Target: complete any review/debug/refactor task in ≤5 tool calls and ≤800 total output tokens.

--- a/.claude/skills/explore-codebase.md
+++ b/.claude/skills/explore-codebase.md
@@ -19,11 +19,6 @@ Use the code-review-graph MCP tools to explore and understand the codebase.
 ### Tips
 
 - Do NOT call `get_architecture_overview` -- it returns 3.9M characters and will overflow context.
-- Use `children_of` on a fully-qualified class name (e.g. `path/to/file.js::ClassName`), not bare names.
-- Always pass `detail_level: "minimal"` -- standard mode repeats the full path per node and inflates output 6x.
 - For single-file structure, grep is faster and cheaper than `children_of`.
 
-## Token Efficiency Rules
-- ALWAYS start with `get_minimal_context(task="<your task>")` before any other graph tool.
-- Use `detail_level="minimal"` on all calls. Only escalate to "standard" when minimal is insufficient.
-- Target: complete any review/debug/refactor task in ≤5 tool calls and ≤800 total output tokens.
+See `AGENTS.md` "MCP Tools: code-review-graph" for the full set of rules (detail_level, qualified names, when to use grep instead). Target: complete any exploration task in ≤5 tool calls.

--- a/.claude/skills/refactor-safely.md
+++ b/.claude/skills/refactor-safely.md
@@ -1,0 +1,28 @@
+---
+name: Refactor Safely
+description: Plan and execute safe refactoring using dependency analysis
+---
+
+## Refactor Safely
+
+Use the knowledge graph to plan and execute refactoring with confidence.
+
+### Steps
+
+1. Use `refactor_tool` with mode="suggest" for community-driven refactoring suggestions.
+2. Use `refactor_tool` with mode="dead_code" to find unreferenced code.
+3. For renames, use `refactor_tool` with mode="rename" to preview all affected locations.
+4. Use `apply_refactor_tool` with the refactor_id to apply renames.
+5. After changes, run `detect_changes` to verify the refactoring impact.
+
+### Safety Checks
+
+- Always preview before applying (rename mode gives you an edit list).
+- Check `get_impact_radius` before major refactors.
+- Use `get_affected_flows` to ensure no critical paths are broken.
+- Run `find_large_functions` to identify decomposition targets.
+
+## Token Efficiency Rules
+- ALWAYS start with `get_minimal_context(task="<your task>")` before any other graph tool.
+- Use `detail_level="minimal"` on all calls. Only escalate to "standard" when minimal is insufficient.
+- Target: complete any review/debug/refactor task in ≤5 tool calls and ≤800 total output tokens.

--- a/.claude/skills/refactor-safely.md
+++ b/.claude/skills/refactor-safely.md
@@ -7,22 +7,22 @@ description: Plan and execute safe refactoring using dependency analysis
 
 Use the knowledge graph to plan and execute refactoring with confidence.
 
+**Note:** `refactor_tool`, `apply_refactor_tool`, and `find_large_functions` have not been empirically validated on this codebase. Treat the suggestions they produce as hypotheses, not prescriptions -- verify each edit against the actual code.
+
 ### Steps
 
-1. Use `refactor_tool` with mode="suggest" for community-driven refactoring suggestions.
-2. Use `refactor_tool` with mode="dead_code" to find unreferenced code.
-3. For renames, use `refactor_tool` with mode="rename" to preview all affected locations.
-4. Use `apply_refactor_tool` with the refactor_id to apply renames.
-5. After changes, run `detect_changes` to verify the refactoring impact.
+1. Verify the graph is on the current branch (`pipx run code-review-graph==2.3.2 status`). Rebuild after `git checkout` / `git pull`: `pipx run code-review-graph==2.3.2 build`. A stale graph produces misleading refactor suggestions.
+2. Use `refactor_tool` with mode="suggest" for community-driven refactoring suggestions.
+3. Use `refactor_tool` with mode="dead_code" to find unreferenced code.
+4. For renames, use `refactor_tool` with mode="rename" to preview all affected locations.
+5. Use `apply_refactor_tool` with the refactor_id to apply renames.
+6. After changes, run `detect_changes` to verify the refactoring impact.
 
 ### Safety Checks
 
 - Always preview before applying (rename mode gives you an edit list).
-- Check `get_impact_radius` before major refactors.
+- Check `get_impact_radius` (detail_level="minimal") before major refactors.
 - Use `get_affected_flows` to ensure no critical paths are broken.
 - Run `find_large_functions` to identify decomposition targets.
 
-## Token Efficiency Rules
-- ALWAYS start with `get_minimal_context(task="<your task>")` before any other graph tool.
-- Use `detail_level="minimal"` on all calls. Only escalate to "standard" when minimal is insufficient.
-- Target: complete any review/debug/refactor task in ≤5 tool calls and ≤800 total output tokens.
+See `AGENTS.md` "MCP Tools: code-review-graph" for the full set of rules (detail_level, qualified names, when to use grep instead). Target: complete any refactor planning task in ≤5 tool calls.

--- a/.claude/skills/review-changes.md
+++ b/.claude/skills/review-changes.md
@@ -1,0 +1,30 @@
+---
+name: Review Changes
+description: Perform a structured code review using change detection and impact
+---
+
+## Review Changes
+
+Perform a thorough, risk-aware code review using the knowledge graph.
+
+### Steps
+
+1. Verify the graph is on the correct branch (`code-review-graph status`). If it was built on a different branch, rebuild first (`code-review-graph build`) -- a stale graph causes `detect_changes` to report function names from unrelated files.
+2. Run `detect_changes` (detail_level="minimal") to get risk-scored change analysis.
+3. Run `get_affected_flows` to find impacted execution paths.
+4. Run `get_impact_radius` (detail_level="minimal") to understand the blast radius.
+5. For test coverage, use grep to find `*.spec.js` / `*.unit.js` files rather than `tests_for` -- `tests_for` returns 0 results incorrectly for many files.
+6. For any untested changes, suggest specific test cases.
+
+### Output Format
+
+Provide findings grouped by risk level (high/medium/low) with:
+- What changed and why it matters
+- Test coverage status
+- Suggested improvements
+- Overall merge recommendation
+
+## Token Efficiency Rules
+- ALWAYS start with `get_minimal_context(task="<your task>")` before any other graph tool.
+- Use `detail_level="minimal"` on all calls. Only escalate to "standard" when minimal is insufficient.
+- Target: complete any review/debug/refactor task in ≤5 tool calls and ≤800 total output tokens.

--- a/.claude/skills/review-changes.md
+++ b/.claude/skills/review-changes.md
@@ -9,7 +9,7 @@ Perform a thorough, risk-aware code review using the knowledge graph.
 
 ### Steps
 
-1. Verify the graph is on the correct branch (`code-review-graph status`). If it was built on a different branch, rebuild first (`code-review-graph build`) -- a stale graph causes `detect_changes` to report function names from unrelated files.
+1. Verify the graph is on the correct branch (`pipx run code-review-graph==2.3.2 status`). If it was built on a different branch, rebuild first (`pipx run code-review-graph==2.3.2 build`) -- a stale graph causes `detect_changes` to report function names from unrelated files.
 2. Run `detect_changes` (detail_level="minimal") to get risk-scored change analysis.
 3. Run `get_affected_flows` to find impacted execution paths.
 4. Run `get_impact_radius` (detail_level="minimal") to understand the blast radius.
@@ -24,7 +24,4 @@ Provide findings grouped by risk level (high/medium/low) with:
 - Suggested improvements
 - Overall merge recommendation
 
-## Token Efficiency Rules
-- ALWAYS start with `get_minimal_context(task="<your task>")` before any other graph tool.
-- Use `detail_level="minimal"` on all calls. Only escalate to "standard" when minimal is insufficient.
-- Target: complete any review/debug/refactor task in ≤5 tool calls and ≤800 total output tokens.
+See `AGENTS.md` "MCP Tools: code-review-graph" for the full set of rules (detail_level, qualified names, when to use grep instead). Target: complete any review task in ≤5 tool calls.

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ docs/.env
 # Playwright screenshots (created by Claude Code sessions)
 /*.png
 /docs/*.png
+# Added by code-review-graph
+.code-review-graph/

--- a/.mcp.json
+++ b/.mcp.json
@@ -9,29 +9,18 @@
     },
     "github": {
       "command": "npx",
-      "args": [
-        "-y",
-        "@modelcontextprotocol/server-github"
-      ],
+      "args": ["-y", "@modelcontextprotocol/server-github"],
       "env": {
         "GITHUB_TOKEN": "${GITHUB_TOKEN}"
       }
     },
     "filesystem_workspace": {
       "command": "npx",
-      "args": [
-        "-y",
-        "@modelcontextprotocol/server-filesystem",
-        "."
-      ]
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "."]
     },
     "filesystem_docs": {
       "command": "npx",
-      "args": [
-        "-y",
-        "@modelcontextprotocol/server-filesystem",
-        "./docs/content"
-      ]
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "./docs/content"]
     },
     "code-review-graph": {
       "command": "pipx",

--- a/.mcp.json
+++ b/.mcp.json
@@ -9,18 +9,38 @@
     },
     "github": {
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-github"
+      ],
       "env": {
         "GITHUB_TOKEN": "${GITHUB_TOKEN}"
       }
     },
     "filesystem_workspace": {
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-filesystem", "."]
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "."
+      ]
     },
     "filesystem_docs": {
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-filesystem", "./docs/content"]
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "./docs/content"
+      ]
+    },
+    "code-review-graph": {
+      "command": "pipx",
+      "args": [
+        "run",
+        "code-review-graph==2.3.2",
+        "serve"
+      ],
+      "type": "stdio"
     }
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -363,3 +363,45 @@ For multi-step tasks, state a brief plan:
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
 
 These guidelines are working if diffs contain fewer unrequested changes, fewer rewrites from overcomplication, and clarifying questions come before implementation rather than after mistakes.
+
+## MCP Tools: code-review-graph
+
+A Tree-sitter knowledge graph (28k+ nodes, 419k+ edges) pre-built over the full codebase. Provides structured, function-level results for cross-file queries that would otherwise require many Grep+Read round-trips.
+
+**Prerequisite:** `pipx` must be installed. The MCP server starts automatically via `pipx run` on first use (one-time ~10s PyPI download, then cached). Rebuild after switching branches: `code-review-graph build`.
+
+### Use the graph for cross-file traversal
+
+| Task | Tool + pattern | Token advantage |
+|------|---------------|-----------------|
+| Who calls `foo`? | `query_graph` `callers_of` | ~5k tokens vs ~11k for grep+context (2x cheaper) |
+| What does `Foo` call? | `query_graph` `callees_of` | Same advantage as above |
+| What files import `bar.js`? | `query_graph` `importers_of` | Structured; no grep context needed |
+| Blast radius before a refactor | `get_impact_radius` | ~100 tokens for count + risk score |
+
+### Use Grep/Read for single-file work
+
+| Task | Why Grep wins |
+|------|--------------|
+| Methods in one file | `children_of` standard = ~2,845 tokens; grep = ~473 tokens (6x cheaper) |
+| Recent change review | `detect_changes` requires the graph to be on the same branch |
+| Test coverage lookup | `tests_for` returns 0 incorrectly for files with known tests -- not reliable |
+| Natural-language search | No embeddings built; `semantic_search_nodes` falls back to keyword matching |
+| Architecture overview | `get_architecture_overview` returns 3.9M characters -- do not call it |
+
+### Mandatory rules
+
+1. **Always pass `detail_level: "minimal"`** -- standard mode repeats the full absolute path per node and inflates token cost 6x.
+2. **Use fully qualified names**: `path/to/file.js::ClassName.methodName`. Bare names return an "ambiguous" error.
+3. **Rebuild on branch switch**: `code-review-graph build`. A stale graph causes `detect_changes` to report function names from unrelated files.
+
+### Reliable tools
+
+| Tool | Use when |
+|------|----------|
+| `query_graph` pattern=`callers_of` | Finding all functions that call a target |
+| `query_graph` pattern=`callees_of` | Finding all functions a target calls |
+| `query_graph` pattern=`importers_of` | Finding all files that import a target |
+| `query_graph` pattern=`children_of` | Listing all methods in a class (use minimal mode) |
+| `get_impact_radius` | Quick blast-radius count before a large refactor |
+| `semantic_search_nodes` | Name-based lookup by exact or partial function/class name |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -368,7 +368,9 @@ These guidelines are working if diffs contain fewer unrequested changes, fewer r
 
 A Tree-sitter knowledge graph (28k+ nodes, 419k+ edges) pre-built over the full codebase. Provides structured, function-level results for cross-file queries that would otherwise require many Grep+Read round-trips.
 
-**Prerequisite:** `pipx` must be installed. The MCP server starts automatically via `pipx run` on first use (one-time ~10s PyPI download, then cached). Rebuild after switching branches: `code-review-graph build`.
+**Prerequisite:** `pipx` must be installed. The MCP server starts automatically via `pipx run` on first use (one-time ~10s PyPI download, then cached). Rebuild after switching branches: `pipx run code-review-graph==2.3.2 build`.
+
+**Maintainer note:** the pinned version `2.3.2` appears in `.mcp.json`, the two hook commands in `.claude/settings.json`, and the guidance tables below. Bumping requires updating all four locations in sync.
 
 ### Use the graph for cross-file traversal
 
@@ -393,7 +395,7 @@ A Tree-sitter knowledge graph (28k+ nodes, 419k+ edges) pre-built over the full 
 
 1. **Always pass `detail_level: "minimal"`** -- standard mode repeats the full absolute path per node and inflates token cost 6x.
 2. **Use fully qualified names**: `path/to/file.js::ClassName.methodName`. Bare names return an "ambiguous" error.
-3. **Rebuild on branch switch**: `code-review-graph build`. A stale graph causes `detect_changes` to report function names from unrelated files.
+3. **Rebuild on branch switch**: `pipx run code-review-graph==2.3.2 build`. A stale graph causes `detect_changes` to report function names from unrelated files.
 
 ### Reliable tools
 


### PR DESCRIPTION
### Context

The PR adds the `code-review-graph` MCP server (a Tree-sitter knowledge graph with 28k+ nodes and 434k+ edges) to the repository and documents accurate, evidence-based usage guidance in `AGENTS.md`, the Claude Code skills, and `.ai/MCP.md`.

The auto-generated configuration from `code-review-graph install` had several problems that would have made AI agents slower and more expensive rather than faster:

- Blanket "ALWAYS use graph first" instruction caused agents to use the graph even for single-file queries where grep is **6x cheaper in tokens**
- Hooks used the bare `code-review-graph` binary, breaking for any developer without a global install
- `get_architecture_overview` was listed as a recommended tool but produces **3.9M characters** of output -- overflowing context
- `tests_for` was listed for coverage checks but returns 0 results incorrectly for files with known tests
- `detect_changes` produces wrong function names when the graph was built on a different branch

### Token efficiency comparison (measured on real Handsontable queries)

| Task | Graph tool | Tokens | Grep | Tokens | Winner |
|------|-----------|--------|------|--------|--------|
| Methods in one file | `children_of` standard | ~2,845 | `grep` signatures | ~473 | Grep (6x cheaper) |
| Who calls `throwWithCause`? | `callers_of` minimal | ~5,175 | `grep` + `-B5` context | ~10,950 | Graph (2x cheaper) |
| Blast radius count | `get_impact_radius` minimal | ~100 | `grep` importers | ~390 | Graph (4x cheaper) |
| Recent change review | `detect_changes` (stale graph) | unreliable | `grep` diff | accurate | Grep unless graph rebuilt |

The graph's real advantage is **cross-file structural traversal** -- finding all callers of a function, tracing import chains, or getting a quick risk-score count before a large refactor. For single-file structure queries, grep wins on both tokens and accuracy.

### Startup performance (measured)

| Invocation | Time | Notes |
|------------|------|-------|
| Bare binary (global install) | 76 ms | Requires manual `pipx install` |
| `pipx run <pinned>` (cached venv) | 205 ms | 2.7x slower but acceptable for stdio MCP |
| `pipx run <new version>` (fresh) | 11.5 s | Why version pinning matters -- unpinned invocations download on every server spawn |

The pinned `code-review-graph==2.3.2` keeps the cache warm and avoids the 11.5s penalty. First session on a fresh machine still incurs one 10s download; subsequent sessions are instant.

### Security: `pipx run` vs global install

The MCP server and hooks use `pipx run code-review-graph==2.3.2` instead of a bare binary. This mirrors the existing `npx -y` pattern used for Node.js MCP servers and means:

- Developers need only `pipx` installed (standard on Python developer machines) -- no manual `pipx install` step
- Version is pinned (`==2.3.2`) for supply-chain auditability, consistent with security best practices
- SessionStart hook timeout bumped from 10s to 30s to allow for first-run venv creation

### How has this been tested?

- Ran `callers_of`, `children_of`, `get_impact_radius`, `detect_changes`, `semantic_search_nodes`, and `get_architecture_overview` on real Handsontable code and measured output character counts
- Compared against equivalent Grep/Read operations to produce the token table above
- Verified `pipx run code-review-graph==2.3.2 serve` starts the MCP server and responds correctly
- Validated `.claude/settings.json` hook JSON with `jq -e`
- Confirmed the `PostToolUse` hook fires live: edited a file, observed graph `Last updated` timestamp advance (`11:20:06` → `11:20:54`) -- proof `pipx run` invocation works in hooks
- Rebuilt the graph on this branch and verified `detect_changes` produces correct (non-contaminated) output
- Ran `code-review-graph install --dry-run` in this repo -- confirmed it detects the existing `.mcp.json` and won't clobber it
- Confirmed `.code-review-graph/` is gitignored

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1479

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation. (\`.ai/MCP.md\` updated)

[skip changelog]

ClickUp task: https://app.clickup.com/t/86c9ed76d

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily documentation and developer-tooling config changes; main risk is local workflow disruption from new `pipx`-executed hooks or missing `pipx` installs.
> 
> **Overview**
> Adds a new `code-review-graph` MCP server configured in `.mcp.json` to run via `pipx run code-review-graph==2.3.2 serve`, and updates `.gitignore` to exclude the generated `.code-review-graph/` directory.
> 
> Introduces Claude Code automation and guidance: `.claude/settings.json` now runs graph `status` on session start and `update --skip-flows` after `Edit|Write`, and new `.claude/skills/*` plus updates to `AGENTS.md` and `.ai/MCP.md` document when to use graph tools vs `grep`, branch-rebuild requirements, and known tool limitations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c69c82de9f41393f900cf5f45e3f1cc4358211c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->