### PR TITLE
DEV-882: Add related blog articles to 13 documentation pages

### DIFF
--- a/docs/content/guides/accessibility/accessibility/accessibility.md
+++ b/docs/content/guides/accessibility/accessibility/accessibility.md
@@ -285,6 +285,7 @@ For the list of [options](@/guides/getting-started/configuration-options/configu
 
 <div class="boxes-list gray">
 
+- [Handsontable 15.3.0: CSV sanitization, accessibility updates, and 30+ fixes](https://handsontable.com/blog/handsontable-15.3.0-csv-sanitization-accessibility-updates-and-30-fixes)
 - [What's new in Handsontable 14: Improvements to accessibility](https://handsontable.com/blog/whats-new-in-handsontable-14-improvements-to-accessibility)
 
 </div>

--- a/docs/content/guides/accessories-and-menus/export-to-csv/export-to-csv.md
+++ b/docs/content/guides/accessories-and-menus/export-to-csv/export-to-csv.md
@@ -194,6 +194,14 @@ Each method takes two parameters. The first, `format`, is required. The second, 
 | `rowHeaders`           | `Boolean`, default `false`              | Include row headers. |
 | `sanitizeValues`       | `Boolean` \| `RegExp` \| `Function`, default `false` | Value sanitization. `true` = [OWASP CSV injection](https://owasp.org/www-community/attacks/CSV_Injection) rules; `RegExp` = escape matching values; `Function` = replace with return value. |
 
+## Related blog articles
+
+<div class="boxes-list gray">
+
+- [Handsontable 15.3.0: CSV sanitization, accessibility updates, and 30+ fixes](https://handsontable.com/blog/handsontable-15.3.0-csv-sanitization-accessibility-updates-and-30-fixes)
+
+</div>
+
 ## Related API reference
 
 **Plugins**

--- a/docs/content/guides/columns/column-header/column-header.md
+++ b/docs/content/guides/columns/column-header/column-header.md
@@ -223,6 +223,14 @@ More complex data structures can be displayed with multiple headers, each repres
 
 </div>
 
+**Related blog articles**
+
+<div class="boxes-list">
+
+- [Handsontable 14.5.0: Improved performance and flexible column header class](https://handsontable.com/blog/handsontable-14.5.0-improved-performance-and-flexible-column-header-class)
+
+</div>
+
 **Configuration options**
 
 <div class="boxes-list">

--- a/docs/content/guides/dialog/loading/loading.md
+++ b/docs/content/guides/dialog/loading/loading.md
@@ -195,6 +195,7 @@ To learn more about the translation mechanism, see the [Languages guide](@/guide
 
 <div class="boxes-list gray">
 
+- [Handsontable 16.2.0: Simplified theming and advanced user notifications](https://handsontable.com/blog/handsontable-16.2.0-simplified-theming-and-advanced-user-notifications)
 - [Handsontable 16.1: Row Pagination, Loading Plugin, and Long-Term Support Policy](https://handsontable.com/blog/handsontable-16.1-row-pagination-loading-plugin-and-long-term-support-policy)
 
 </div>

--- a/docs/content/guides/dialog/notification/notification.md
+++ b/docs/content/guides/dialog/notification/notification.md
@@ -116,6 +116,14 @@ Use separate buttons for save, error recovery, and warnings. Primary and seconda
 
 Hooks: `beforeNotificationShow`, `afterNotificationShow`, `beforeNotificationHide`, and `afterNotificationHide`. Returning `false` from `beforeNotificationShow` cancels `showMessage` (no id, nothing enqueued). That hook runs once per call to `showMessage`, including when the toast is queued because `stackLimit` is full; it does not run again when a queued toast mounts. Returning `false` from `beforeNotificationHide` keeps the toast visible and stops automatic dismissal for that toast.
 
+## Related blog articles
+
+<div class="boxes-list gray">
+
+- [Handsontable 16.2.0: Simplified theming and advanced user notifications](https://handsontable.com/blog/handsontable-16.2.0-simplified-theming-and-advanced-user-notifications)
+
+</div>
+
 ## Read more
 
 - [`Notification`](@/api/notification.md) plugin reference.

--- a/docs/content/guides/formulas/formula-calculation/formula-calculation.md
+++ b/docs/content/guides/formulas/formula-calculation/formula-calculation.md
@@ -774,6 +774,11 @@ details, [contact our Sales Team](https://handsontable.com/get-a-quote).
 
 <div class="boxes-list">
 
+- [HyperFormula 3.2.0: Expanding Excel parity and removing scalability limits](https://handsontable.com/blog/hyperformula-3.2.0-expanding-excel-parity-and-removing-scalability-limits)
+- [HyperFormula 3.1.1: Improved lazy computations and easier sheet dependency handling](https://handsontable.com/blog/hyperformula-3.1.1-improved-lazy-computations-and-easier-sheet-dependency-handling)
+- [HyperFormula 3.1.0: Improved cross-sheet operations, easier APIs, and clearer docs](https://handsontable.com/blog/hyperformula-3.1.0-improved-cross-sheet-operations-easier-apis-and-clearer-docs)
+- [HyperFormula 3.0.1: Community fixes, improved docs, and roadmap insights](https://handsontable.com/blog/hyperformula-3.0.1-community-fixes-improved-docs-and-roadmap-insights)
+- [HyperFormula 3.0: Introducing the XLOOKUP function](https://handsontable.com/blog/hyperformula-3-0-introducing-the-xlookup-function)
 - [Handsontable 9.0.0: New formula plugin](https://handsontable.com/blog/handsontable-9.0.0-new-formula-plugin)
 - [8 examples of useful Excel functions in HyperFormula](https://handsontable.com/blog/8-examples-of-useful-excel-functions-in-hyperformula)
 

--- a/docs/content/guides/navigation/focus-scopes/focus-scopes.md
+++ b/docs/content/guides/navigation/focus-scopes/focus-scopes.md
@@ -378,6 +378,14 @@ For the complete API reference, see the following pages:
 
 After registering a focus scope, Handsontable automatically activates it when the user clicks inside the container or tabs to it. The associated shortcuts context switches accordingly, and tab navigation flows through your registered scopes in the correct order.
 
+## Related blog articles
+
+<div class="boxes-list gray">
+
+- [Handsontable 14.3.0: Enhanced navigation and bug fixes](https://handsontable.com/blog/handsontable-14.3.0-enhanced-navigation-and-bug-fixes)
+
+</div>
+
 ## Troubleshooting
 
 Didn't find what you need? Try this:

--- a/docs/content/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md
+++ b/docs/content/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md
@@ -280,6 +280,7 @@ For the list of [options](@/guides/getting-started/configuration-options/configu
 
 <div class="boxes-list gray">
 
+- [Handsontable 14.3.0: Enhanced navigation and bug fixes](https://handsontable.com/blog/handsontable-14.3.0-enhanced-navigation-and-bug-fixes)
 - [Handsontable 12.0.0: RTL support, and a new keyboard shortcuts API](https://handsontable.com/blog/handsontable-12.0.0-data-grid-rtl-support-and-a-new-keyboard-shortcuts-api)
 
 </div>

--- a/docs/content/guides/optimization/performance/performance.md
+++ b/docs/content/guides/optimization/performance/performance.md
@@ -174,7 +174,13 @@ For more information, see our [Pagination guide](@/guides/rows/rows-pagination/r
 
 ### Related blog articles
 
+<div class="boxes-list">
+
+- [Handsontable 15.1.0: Performance and stability improvements](https://handsontable.com/blog/handsontable-15.1.0-performance-and-stability-improvements)
+- [Handsontable 14.5.0: Improved performance and flexible column header class](https://handsontable.com/blog/handsontable-14.5.0-improved-performance-and-flexible-column-header-class)
 - [Handsontable 10.0.0: Improved performance and consistency](https://handsontable.com/blog/handsontable-10.0.0-improved-performance-and-consistency)
+
+</div>
 
 ### Related API reference
 

--- a/docs/content/guides/security/security/security.md
+++ b/docs/content/guides/security/security/security.md
@@ -130,3 +130,11 @@ Security of our software and its application in our customers' system is our top
 ## Bug bounty
 
 We don't offer a bug bounty program, but we sincerely appreciate the work done by security researchers and independent developers.
+
+## Related blog articles
+
+<div class="boxes-list gray">
+
+- [Handsontable 15.3.0: CSV sanitization, accessibility updates, and 30+ fixes](https://handsontable.com/blog/handsontable-15.3.0-csv-sanitization-accessibility-updates-and-30-fixes)
+
+</div>

--- a/docs/content/guides/styling/design-system/design-system.md
+++ b/docs/content/guides/styling/design-system/design-system.md
@@ -70,6 +70,14 @@ The design system is our primary reference when planning new features or redesig
 
 - The legacy style is not part of the design system. Starting from version 17.0.0, legacy styles are no longer supported and you need to migrate to the Classic theme.
 
+## Related blog articles
+
+<div class="boxes-list gray">
+
+- [From components to tables: Designing a data table component in your design system](https://handsontable.com/blog/from-components-to-tables-designing-a-data-table-component-in-your-design-system)
+
+</div>
+
 ## Troubleshooting
 
 Didn't find what you need? Try this:

--- a/docs/content/guides/styling/theme-customization/theme-customization.md
+++ b/docs/content/guides/styling/theme-customization/theme-customization.md
@@ -767,3 +767,12 @@ These variables style the [Notification](@/guides/dialog/notification/notificati
 | <div class="variables-table__item"><span>CSS:</span> `--ht-pagination-button-disabled-foreground-color` </div><div class="variables-table__item"><span>JS:</span> `paginationButtonDisabledForegroundColor` </div>   | Icon color of pagination navigation button when disabled |
 
 </div>
+
+## Related blog articles
+
+<div class="boxes-list gray">
+
+- [From components to tables: Designing a data table component in your design system](https://handsontable.com/blog/from-components-to-tables-designing-a-data-table-component-in-your-design-system)
+- [Handsontable 14.6.0: Easier styling and enhanced undo-redo](https://handsontable.com/blog/handsontable-14-6-0-easier-styling-and-enhanced-undo-redo)
+
+</div>

--- a/docs/content/guides/styling/themes/themes.md
+++ b/docs/content/guides/styling/themes/themes.md
@@ -532,6 +532,7 @@ In some cases, global styles enforced by the browser or operating system can imp
 
 <div class="boxes-list gray">
 
+- [From components to tables: Designing a data table component in your design system](https://handsontable.com/blog/from-components-to-tables-designing-a-data-table-component-in-your-design-system)
 - [Handsontable 15.0.0: Introducing Themes and Functional React Wrapper](https://handsontable.com/blog/handsontable-15.0.0-introducing-themes-and-functional-react-wrapper)
 - [Handsontable 16.2.0: Simplified Theming and Advanced User Notifications](https://handsontable.com/blog/handsontable-16.2.0-simplified-theming-and-advanced-user-notifications)
 


### PR DESCRIPTION
### Context

The PR adds missing "Related blog articles" links to 13 documentation guide pages. Each page was cross-referenced with the blog to surface relevant release announcements and in-depth articles that readers may find useful.

Pages updated:
- **Styling → Themes**: add "From components to tables: Designing a data table component in your design system"
- **Styling → Theme Customization**: add new "Related blog articles" section with the design-system article and "Handsontable 14.6.0: Easier styling and enhanced undo-redo"
- **Styling → Design System**: add new "Related blog articles" section with the design-system article
- **Columns → Column headers**: add "Handsontable 14.5.0: Improved performance and flexible column header class"
- **Formulas → Formula calculation**: add 5 HyperFormula 3.x release articles
- **Navigation → Keyboard shortcuts**: add "Handsontable 14.3.0: Enhanced navigation and bug fixes"
- **Navigation → Focus scopes**: add new "Related blog articles" section with the 14.3.0 navigation article
- **Accessibility**: add "Handsontable 15.3.0: CSV sanitization, accessibility updates, and 30+ fixes"
- **Data management → Export to CSV**: add new "Related blog articles" section with the 15.3.0 article
- **Dialog → Loading**: add "Handsontable 16.2.0: Simplified theming and advanced user notifications"
- **Dialog → Notification**: add new "Related blog articles" section with the 16.2.0 article
- **Performance**: add "Handsontable 15.1.0: Performance and stability improvements" and "Handsontable 14.5.0: Improved performance and flexible column header class"; fix missing `<div class="boxes-list">` wrapper on existing 10.0.0 link
- **Security**: add new "Related blog articles" section with "Handsontable 15.3.0: CSV sanitization, accessibility updates, and 30+ fixes"

### How has this been tested?

Docs-only change -- no code paths affected. Verified that each added URL matches the correct blog post slug and that the HTML structure (`<div class="boxes-list gray">`) matches the existing pattern used throughout the docs.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-882

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-882

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only content/markup updates (additional outbound links and small layout wrapper tweaks) with no impact on runtime code paths.
> 
> **Overview**
> Adds **"Related blog articles"** link blocks to multiple guide pages (e.g. Accessibility, Export to CSV, Column headers, Focus scopes, Notification, Security, Design System, Theme customization, and Performance), and expands some existing sections with additional release/post links.
> 
> Also standardizes the markup around these link blocks (e.g. ensuring the expected `boxes-list` wrapper is present where it was missing) to match the docs’ existing styling patterns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ee27bb16fc5c208bc35b8ee4627e9bb2c6bb41c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->