### PR TITLE
Fix #12093: refresh dimensions after browser zoom changes

### DIFF
--- a/.changelogs/12426.json
+++ b/.changelogs/12426.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed missing dimensions refresh after browser zoom changes by reacting to `visualViewport` resize events.",
+  "type": "fixed",
+  "issueOrPR": 12426,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/src/overlays.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlays.js
@@ -410,8 +410,7 @@ class Overlays {
     });
 
     let resizeTimeout;
-
-    this.eventManager.addEventListener(rootWindow, 'resize', () => {
+    const onViewportResize = () => {
       requestAnimationFrame(() => {
         clearTimeout(resizeTimeout);
         this.wtSettings.getSetting('onWindowResize');
@@ -421,7 +420,13 @@ class Overlays {
           this.#containerDomResizeCount = 0;
         }, 200);
       });
-    });
+    };
+
+    this.eventManager.addEventListener(rootWindow, 'resize', onViewportResize);
+
+    if (rootWindow.visualViewport) {
+      this.eventManager.addEventListener(rootWindow.visualViewport, 'resize', onViewportResize);
+    }
 
     if (!isScrollOnWindow) {
       this.resizeObserver.observe(this.wtTable.wtRootElement.parentElement);

--- a/handsontable/src/3rdparty/walkontable/src/overlays.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlays.js
@@ -410,10 +410,44 @@ class Overlays {
     });
 
     let resizeTimeout;
-
-    this.eventManager.addEventListener(rootWindow, 'resize', () => {
+    let resizeRafPending = false;
+    // Full-page browser zoom and window resize both fire `window.resize` and
+    // `visualViewport.resize`. Listening to `visualViewport.resize` covers
+    // cases where `window.resize` does not fire reliably (seen on browser
+    // zoom with percentage-sized tables -- see #12093). The shared
+    // `resizeRafPending` flag coalesces both events into a single refresh
+    // per animation frame so hooks don't fire twice.
+    const scheduleRefresh = () => {
+      if (resizeRafPending) {
+        return;
+      }
+      resizeRafPending = true;
       requestAnimationFrame(() => {
+        resizeRafPending = false;
         clearTimeout(resizeTimeout);
+
+        // Break out of horizontal intrinsic-sizing feedback loops where a
+        // CSS Grid or Flex container latches onto HOT's own explicit
+        // holder width and keeps the root element from ever measuring
+        // smaller after viewport shrink (classic symptom of #12093:
+        // columns stuck at their zoomed-out stretched widths after zoom
+        // restore). Clearing the inline width and forcing a layout lets
+        // the container reflow to its real available width before
+        // `refreshDimensions` re-measures. Height is intentionally left
+        // alone: in the common `height: auto` CSS Grid track case the
+        // track legitimately sizes to HOT's natural content height, and
+        // clearing the holder height there would just let the content
+        // expand further.
+        const { holder, hider } = this.wtTable;
+
+        if (holder) {
+          holder.style.width = '';
+        }
+        if (hider) {
+          hider.style.width = '';
+        }
+        void this.wtTable.wtRootElement.offsetWidth;
+
         this.wtSettings.getSetting('onWindowResize');
 
         resizeTimeout = setTimeout(() => {
@@ -421,7 +455,34 @@ class Overlays {
           this.#containerDomResizeCount = 0;
         }, 200);
       });
-    });
+    };
+
+    this.eventManager.addEventListener(rootWindow, 'resize', scheduleRefresh);
+
+    const { visualViewport } = rootWindow;
+
+    if (visualViewport) {
+      // `visualViewport` also fires `resize` when scrollbars appear or
+      // disappear or when mobile chrome (address bar, on-screen keyboard)
+      // shifts. Guard those out by requiring a real width/height/scale
+      // change -- otherwise stacking with the ResizeObserver produces extra
+      // refresh cycles for element-size changes that don't affect zoom.
+      let lastVvWidth = visualViewport.width;
+      let lastVvHeight = visualViewport.height;
+      let lastVvScale = visualViewport.scale;
+
+      this.eventManager.addEventListener(visualViewport, 'resize', () => {
+        if (visualViewport.width === lastVvWidth
+            && visualViewport.height === lastVvHeight
+            && visualViewport.scale === lastVvScale) {
+          return;
+        }
+        lastVvWidth = visualViewport.width;
+        lastVvHeight = visualViewport.height;
+        lastVvScale = visualViewport.scale;
+        scheduleRefresh();
+      });
+    }
 
     if (!isScrollOnWindow) {
       this.resizeObserver.observe(this.wtTable.wtRootElement.parentElement);

--- a/handsontable/src/3rdparty/walkontable/src/overlays.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlays.js
@@ -410,7 +410,8 @@ class Overlays {
     });
 
     let resizeTimeout;
-    const onViewportResize = () => {
+
+    this.eventManager.addEventListener(rootWindow, 'resize', () => {
       requestAnimationFrame(() => {
         clearTimeout(resizeTimeout);
         this.wtSettings.getSetting('onWindowResize');
@@ -420,13 +421,7 @@ class Overlays {
           this.#containerDomResizeCount = 0;
         }, 200);
       });
-    };
-
-    this.eventManager.addEventListener(rootWindow, 'resize', onViewportResize);
-
-    if (rootWindow.visualViewport) {
-      this.eventManager.addEventListener(rootWindow.visualViewport, 'resize', onViewportResize);
-    }
+    });
 
     if (!isScrollOnWindow) {
       this.resizeObserver.observe(this.wtTable.wtRootElement.parentElement);

--- a/handsontable/src/tableView.js
+++ b/handsontable/src/tableView.js
@@ -513,7 +513,11 @@ class TableView {
 
         lastVisualViewportState = currentVisualViewportState;
 
-        if (this.hot && !this.hot.isDestroyed && isVisible(this.hot.rootElement)) {
+        const { left, right, top, bottom } = this.hot.rootElement.getBoundingClientRect();
+        const isOutsideViewport = right <= 0 || left >= visualViewport.width ||
+          bottom <= 0 || top >= visualViewport.height;
+
+        if (this.hot && !this.hot.isDestroyed && this.isVisible() && !isOutsideViewport) {
           this.hot.refreshDimensions();
         }
       });

--- a/handsontable/src/tableView.js
+++ b/handsontable/src/tableView.js
@@ -488,41 +488,6 @@ class TableView {
       parentWindow = getParentWindow(parentWindow);
     }
 
-    const visualViewport = rootWindow.visualViewport;
-
-    if (visualViewport && rootWindow.top === rootWindow) {
-      let lastVisualViewportState = {
-        width: visualViewport.width,
-        height: visualViewport.height,
-        scale: visualViewport.scale,
-      };
-
-      this.eventManager.addEventListener(visualViewport, 'resize', () => {
-        const currentVisualViewportState = {
-          width: visualViewport.width,
-          height: visualViewport.height,
-          scale: visualViewport.scale,
-        };
-        const isVisualViewportChanged = currentVisualViewportState.width !== lastVisualViewportState.width ||
-          currentVisualViewportState.height !== lastVisualViewportState.height ||
-          currentVisualViewportState.scale !== lastVisualViewportState.scale;
-
-        if (!isVisualViewportChanged) {
-          return;
-        }
-
-        lastVisualViewportState = currentVisualViewportState;
-
-        const { left, right, top, bottom } = this.hot.rootElement.getBoundingClientRect();
-        const isOutsideViewport = right <= 0 || left >= visualViewport.width ||
-          bottom <= 0 || top >= visualViewport.height;
-
-        if (this.hot && !this.hot.isDestroyed && this.isVisible() && !isOutsideViewport) {
-          this.hot.refreshDimensions();
-        }
-      });
-    }
-
     this.eventManager.addEventListener(this.#table, 'selectstart', (event) => {
       if (this.settings.fragmentSelection || isInput(event.target)) {
         return;
@@ -974,9 +939,31 @@ class TableView {
       selections: this.hot.selection.highlight,
       hideBorderOnMouseDownOver: () => this.settings.fragmentSelection,
       onWindowResize: () => {
-        if (this.hot && !this.hot.isDestroyed) {
-          this.hot.refreshDimensions();
+        if (!this.hot || this.hot.isDestroyed || !isVisible(this.hot.rootElement)) {
+          return;
         }
+
+        // Skip the refresh when the table is entirely outside the visual
+        // viewport (for example a window-controlled instance that is below
+        // or above the scrolled-into-view area). Without this guard, any
+        // `visualViewport.resize` that fires due to scroll-related
+        // scrollbar changes would trigger a full re-render even though the
+        // table is not on screen -- see #12093 and
+        // `Core_render.spec.js` "fast render when scrolling out of
+        // viewport" regressions.
+        const rootWindow = this.hot.rootWindow;
+        const visualViewport = rootWindow.visualViewport;
+        const viewportWidth = visualViewport ? visualViewport.width : rootWindow.innerWidth;
+        const viewportHeight = visualViewport ? visualViewport.height : rootWindow.innerHeight;
+        const { left, right, top, bottom } = this.hot.rootElement.getBoundingClientRect();
+        const isOutsideViewport = right <= 0 || left >= viewportWidth
+          || bottom <= 0 || top >= viewportHeight;
+
+        if (isOutsideViewport) {
+          return;
+        }
+
+        this.hot.refreshDimensions();
       },
       onContainerElementResize: () => {
         if (this.hot && !this.hot.isDestroyed && isVisible(this.hot.rootElement)) {

--- a/handsontable/src/tableView.js
+++ b/handsontable/src/tableView.js
@@ -488,6 +488,37 @@ class TableView {
       parentWindow = getParentWindow(parentWindow);
     }
 
+    const visualViewport = rootWindow.visualViewport;
+
+    if (visualViewport && rootWindow.top === rootWindow) {
+      let lastVisualViewportState = {
+        width: visualViewport.width,
+        height: visualViewport.height,
+        scale: visualViewport.scale,
+      };
+
+      this.eventManager.addEventListener(visualViewport, 'resize', () => {
+        const currentVisualViewportState = {
+          width: visualViewport.width,
+          height: visualViewport.height,
+          scale: visualViewport.scale,
+        };
+        const isVisualViewportChanged = currentVisualViewportState.width !== lastVisualViewportState.width ||
+          currentVisualViewportState.height !== lastVisualViewportState.height ||
+          currentVisualViewportState.scale !== lastVisualViewportState.scale;
+
+        if (!isVisualViewportChanged) {
+          return;
+        }
+
+        lastVisualViewportState = currentVisualViewportState;
+
+        if (this.hot && !this.hot.isDestroyed && isVisible(this.hot.rootElement)) {
+          this.hot.refreshDimensions();
+        }
+      });
+    }
+
     this.eventManager.addEventListener(this.#table, 'selectstart', (event) => {
       if (this.settings.fragmentSelection || isInput(event.target)) {
         return;

--- a/handsontable/test/e2e/core/refreshDimensions.spec.js
+++ b/handsontable/test/e2e/core/refreshDimensions.spec.js
@@ -124,4 +124,52 @@ describe('Core.await refreshDimensions()', () => {
 
     expect(beforeRefreshDimensions.calls.count()).toBe(callsBeforeResize + 1);
   });
+
+  it('should refresh dimensions after `visualViewport` resize when running inside an iframe', async() => {
+    const iframe = $('<iframe/>').appendTo(spec().$container);
+    const iframeWindow = iframe[0].contentWindow;
+    const iframeDoc = iframe[0].contentDocument;
+
+    if (!iframeWindow.visualViewport) {
+      return;
+    }
+
+    iframeDoc.open('text/html', 'replace');
+    iframeDoc.write(`
+      <!doctype html>
+      <head>
+        <link type="text/css" rel="stylesheet" href="../styles/ht-theme-classic.css">
+        <link type="text/css" rel="stylesheet" href="../styles/ht-theme-main.css">
+        <link type="text/css" rel="stylesheet" href="../styles/ht-theme-horizon.css">
+      </head>
+      <body><div id="hot-in-iframe"></div></body>`);
+    iframeDoc.close();
+
+    let visualViewportScale = iframeWindow.visualViewport.scale;
+
+    spyOnProperty(iframeWindow.visualViewport, 'scale', 'get').and.callFake(() => visualViewportScale);
+
+    const beforeRefreshDimensions = jasmine.createSpy('beforeRefreshDimensions');
+    const container = iframeDoc.getElementById('hot-in-iframe');
+    const hot = new Handsontable(container, {
+      data: createSpreadsheetData(50, 5),
+      width: 320,
+      height: 200,
+      beforeRefreshDimensions,
+    });
+
+    await sleep(50);
+
+    expect(iframeWindow.top).not.toBe(iframeWindow);
+
+    const callsBeforeResize = beforeRefreshDimensions.calls.count();
+
+    visualViewportScale += 0.1;
+    iframeWindow.visualViewport.dispatchEvent(new Event('resize'));
+    await sleep(50);
+
+    expect(beforeRefreshDimensions.calls.count()).toBe(callsBeforeResize + 1);
+
+    hot.destroy();
+  });
 });

--- a/handsontable/test/e2e/core/refreshDimensions.spec.js
+++ b/handsontable/test/e2e/core/refreshDimensions.spec.js
@@ -101,6 +101,10 @@ describe('Core.await refreshDimensions()', () => {
       return;
     }
 
+    let visualViewportScale = window.visualViewport.scale;
+
+    spyOnProperty(window.visualViewport, 'scale', 'get').and.callFake(() => visualViewportScale);
+
     const beforeRefreshDimensions = jasmine.createSpy('beforeRefreshDimensions');
 
     handsontable({
@@ -114,6 +118,7 @@ describe('Core.await refreshDimensions()', () => {
 
     const callsBeforeResize = beforeRefreshDimensions.calls.count();
 
+    visualViewportScale += 0.1;
     window.visualViewport.dispatchEvent(new Event('resize'));
     await sleep(50);
 

--- a/handsontable/test/e2e/core/refreshDimensions.spec.js
+++ b/handsontable/test/e2e/core/refreshDimensions.spec.js
@@ -95,4 +95,28 @@ describe('Core.await refreshDimensions()', () => {
     expect(hot.view.adjustElementsSize).toHaveBeenCalledBefore(hot.render);
     expect(hot.view.adjustElementsSize).toHaveBeenCalledTimes(1);
   });
+
+  it('should refresh dimensions after `visualViewport` resize', async() => {
+    if (!window.visualViewport) {
+      return;
+    }
+
+    const beforeRefreshDimensions = jasmine.createSpy('beforeRefreshDimensions');
+
+    handsontable({
+      data: createSpreadsheetData(50, 5),
+      width: 320,
+      height: 200,
+      beforeRefreshDimensions,
+    });
+
+    await sleep(50);
+
+    const callsBeforeResize = beforeRefreshDimensions.calls.count();
+
+    window.visualViewport.dispatchEvent(new Event('resize'));
+    await sleep(50);
+
+    expect(beforeRefreshDimensions.calls.count()).toBe(callsBeforeResize + 1);
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Context
The PR fixes issue #12093 where zooming out and back in could leave the table with stale dimensions and a missing vertical scrollbar.

It also avoids a rendering regression in `Core_render` by skipping `visualViewport`-driven refreshes when the table is outside the viewport.

### How has this been tested?
- Added an E2E regression test in `test/e2e/core/refreshDimensions.spec.js` that simulates a `visualViewport` scale change and verifies a dimensions refresh hook is fired.
- Ran `npm run test:e2e --testPathPattern=refreshDimensions --prefix handsontable` before the fix to confirm the new regression test fails.
- Ran `npm run test:e2e --testPathPattern=refreshDimensions --theme=main --prefix handsontable` after the fix.
- Ran `npm run test:e2e --testPathPattern=Core_render --theme=main --prefix handsontable` after the CI-related fix.
- Ran `npm run test:e2e --testPathPattern=Core_render --theme=classic --prefix handsontable` after the CI-related fix.
- Ran `npm run test:e2e --testPathPattern=Core_render --theme=horizon --prefix handsontable` after the CI-related fix.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #12093
2.
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79947666-5538-46d3-9b8c-63159667789a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79947666-5538-46d3-9b8c-63159667789a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

