### PR TITLE
DEV-869: Add missing kbd elements to VPAT guide and recipe pages

### DIFF
--- a/docs/content/guides/accessibility/accessibility-conformance-report/accessibility-conformance-report.md
+++ b/docs/content/guides/accessibility/accessibility-conformance-report/accessibility-conformance-report.md
@@ -62,7 +62,7 @@ WCAG 2.2, published October 2023, supersedes WCAG 2.1. It removes Success Criter
 
 Handsontable supports two primary keyboard navigation paradigms configurable by the developer:
 
-- **Spreadsheet Mode** (default) - Tab/Shift+Tab as primary navigation, emulating Microsoft Excel and Google Sheets behavior.
+- **Spreadsheet Mode** (default) - <kbd>Tab</kbd>/<kbd>Shift+Tab</kbd> as primary navigation, emulating Microsoft Excel and Google Sheets behavior.
 - **Data Grid Mode** - Arrow-key navigation with a single tab stop; navigable headers via [`navigableHeaders: true`](@/api/options.md#navigableheaders); Tab navigation disabled via [`tabNavigation: false`](@/api/options.md#tabnavigation).
 
 Row and column virtualization is enabled by default. For complete assistive technology support, [`renderAllRows: true`](@/api/options.md#renderallrows) and [`renderAllColumns: true`](@/api/options.md#renderallcolumns) are recommended, which ensures a complete accessibility tree is available to screen readers.

--- a/docs/content/recipes/cell-types/color-picker/color-picker.md
+++ b/docs/content/recipes/cell-types/color-picker/color-picker.md
@@ -492,7 +492,7 @@ const hot = new Handsontable(container, hotOptions);
 ## How It Works - Complete Flow
 
 1. **Initial Render**: Cell displays a colored circle swatch
-2. **User Double-Clicks or F2**: Editor opens with a styled input and an "Open color picker" button
+2. **User Double-Clicks or <kbd>F2</kbd>**: Editor opens with a styled input and an "Open color picker" button
 3. **Color Picker Opens**: `afterOpen` sets the current color and calls `pickr.show()`
 4. **User Selects Color**: Pickr updates the preview; the `change` event updates `editor.input.value` with the hex from `color.toHEXA().toString()`
 5. **User Closes Picker (or presses Tab)**: The `hide` event fires (or Tab triggers `pickr.hide()`), we call `editor.finishEditing()`

--- a/docs/content/recipes/cell-types/feedback/feedback.md
+++ b/docs/content/recipes/cell-types/feedback/feedback.md
@@ -71,7 +71,7 @@ A cell that:
 - Displays emoji feedback buttons (rounded) when editing
 - Shows the selected emoji when viewing
 - Uses Handsontable CSS tokens for theme-aware styling
-- Supports keyboard navigation (arrow keys, Tab)
+- Supports keyboard navigation (arrow keys, <kbd>Tab</kbd>)
 - Provides click-to-select functionality
 - Works without any external libraries
 
@@ -234,8 +234,8 @@ shortcuts: [
 ```
 
 **What's happening:**
-- **ArrowRight**: Move to next option (wraps to first if at end)
-- **ArrowLeft**: Move to previous option (wraps to last if at start)
+- <kbd>ArrowRight</kbd>: Move to next option (wraps to first if at end)
+- <kbd>ArrowLeft</kbd>: Move to previous option (wraps to last if at start)
 - Finds current index in config array
 - Updates value and triggers render automatically
 
@@ -354,7 +354,7 @@ const cellDefinition = {
 **What's happening:**
 - **config**: Array of emoji options (`👍`, `👎`, `🤷`)
 - **value**: Default/initial value
-- **shortcuts**: Keyboard navigation (ArrowLeft/Right cycle options, Tab cycles and prevents default)
+- **shortcuts**: Keyboard navigation (<kbd>ArrowLeft</kbd>/<kbd>ArrowRight</kbd> cycle options, <kbd>Tab</kbd> cycles and prevents default)
 - **render**: Creates button HTML with `active` CSS class for the selected option
 - **init**: Sets up the container with `feedback-editor` class and click handler
 - **beforeOpen**: Initializes editor with the current cell value
@@ -406,13 +406,13 @@ const hot = new Handsontable(container, hotOptions);
 ## How It Works - Complete Flow
 
 1. **Initial Render**: Cell displays the emoji value (👍, 👎, or 🤷)
-2. **User Double-Clicks or Enter**: Editor opens over cell showing three rounded buttons with the Handsontable blue border
+2. **User Double-Clicks or <kbd>Enter</kbd>**: Editor opens over cell showing three rounded buttons with the Handsontable blue border
 3. **Button Display**: All options visible, current value highlighted using `--ht-accent-color`
 4. **User Interaction**:
    - Click a button: Selects value and closes editor
-   - Press ArrowLeft/Right: Cycles through options
-   - Press Tab: Cycles through options (stays in editor)
-   - Enter key saves value and closes editor
+   - Press <kbd>ArrowLeft</kbd>/<kbd>ArrowRight</kbd>: Cycles through options
+   - Press <kbd>Tab</kbd>: Cycles through options (stays in editor)
+   - <kbd>Enter</kbd> key saves value and closes editor
 5. **Visual Feedback**: Selected button highlighted with accent color
 6. **Save**: Value saved to cell
 7. **Editor Closes**: Cell shows selected emoji
@@ -475,10 +475,10 @@ config: ['Positive', 'Negative', 'Neutral'],
 ## Accessibility
 
 **Keyboard navigation:**
-- **Tab**: Cycles through feedback options (stays in editor)
-- **Arrow Left/Right**: Cycles through options
-- **Enter**: Saves value and closes editor
-- **Escape**: Cancels editing
+- <kbd>Tab</kbd>: Cycles through feedback options (stays in editor)
+- <kbd>ArrowLeft</kbd> / <kbd>ArrowRight</kbd>: Cycles through options
+- <kbd>Enter</kbd>: Saves value and closes editor
+- <kbd>Escape</kbd>: Cancels editing
 - **Click**: Direct selection
 
 ---

--- a/docs/content/recipes/cell-types/rating/rating.md
+++ b/docs/content/recipes/cell-types/rating/rating.md
@@ -363,8 +363,8 @@ shortcuts: [
 - Gets key value from keyboard event
 
 ### Arrow Keys:
-- **ArrowRight**: Increase rating (max 5)
-- **ArrowLeft**: Decrease rating (min 1)
+- <kbd>ArrowRight</kbd>: Increase rating (max 5)
+- <kbd>ArrowLeft</kbd>: Decrease rating (min 1)
 - Bounded within valid range
 - Smooth incremental adjustment
 
@@ -503,7 +503,7 @@ const hot = new Handsontable(container, hotOptions);
 4. **Mouse Hover**: User hovers over stars → preview rating updates in real-time (detected via `closest()`)
 5. **Click Selection**: User clicks → rating selected and editor closes
 6. **Keyboard Input**: User presses 1-5 keys → rating set directly
-7. **Arrow Navigation**: User presses ArrowLeft/Right → rating increments/decrements
+7. **Arrow Navigation**: User presses <kbd>ArrowLeft</kbd>/<kbd>ArrowRight</kbd> → rating increments/decrements
 8. **Validation**: Validator checks the value is valid
 9. **Save**: Valid value saved to cell
 10. **Editor Closes**: Cell shows updated star rating
@@ -591,10 +591,10 @@ Change colors by overriding CSS for specific columns:
 
 **Keyboard navigation:**
 - **Number keys (1-5)**: Direct rating selection
-- **Arrow Right**: Increase rating (max 5)
-- **Arrow Left**: Decrease rating (min 1)
-- **Enter**: Confirm selection and finish editing
-- **Escape**: Cancel editing
+- <kbd>ArrowRight</kbd>: Increase rating (max 5)
+- <kbd>ArrowLeft</kbd>: Decrease rating (min 1)
+- <kbd>Enter</kbd>: Confirm selection and finish editing
+- <kbd>Escape</kbd>: Cancel editing
 
 ---
 


### PR DESCRIPTION
### Context

The PR fixes missing `<kbd>` elements in several documentation pages where keyboard key names appeared as plain text or bold text instead of using the semantic `<kbd>` HTML element. The keyboard shortcuts guide already uses `<kbd>` correctly; this change brings the VPAT guide and three recipe pages into alignment.

Pages fixed:
- **Accessibility conformance report (VPAT)** - Notes section, Spreadsheet Mode: `Tab`/`Shift+Tab`
- **Simple feedback recipe** - "What you'll build", "What's happening", and "Keyboard navigation (Accessibility)" sections: `Tab`, `ArrowRight`, `ArrowLeft`, `Enter`, `Escape`
- **Star rating recipe** - "What's happening" (Step 9) and "Keyboard navigation (Accessibility)" sections: `ArrowRight`, `ArrowLeft`, `Enter`, `Escape`
- **Color picker recipe** - "How It Works" section: `F2`

### How has this been tested?

- Docs-only change. No code logic changed.
- Verified each modified line visually via diff.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-869

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-870

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only semantic markup updates; low risk aside from potential minor formatting/rendering differences in the docs site.
> 
> **Overview**
> Updates several documentation pages to use semantic `<kbd>` markup for keyboard keys/shortcuts instead of plain/bold text.
> 
> This standardizes key references in the VPAT accessibility conformance report and the `color-picker`, `feedback`, and `rating` recipes (e.g., Tab/Shift+Tab, F2, Enter/Escape, Arrow keys) to improve accessibility and consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fbdd0bbbf1262470bb13082e90bcdae53dd880b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->