### PR TITLE
docs: fix 404 on Angular (and JS/React) performance recipes overview page

### DIFF
--- a/docs/content/recipes/performance/performance.md
+++ b/docs/content/recipes/performance/performance.md
@@ -1,0 +1,33 @@
+---
+title: Performance Recipes
+metaTitle: Performance Recipes - JavaScript Data Grid | Handsontable
+description: Practical recipes for optimizing Handsontable performance -- lazy loading large datasets, persisting user layout preferences, and more.
+permalink: /recipes/performance
+canonicalUrl: /recipes/performance
+searchCategory: Recipes
+hotPlugin: false
+editLink: false
+id: e7c3b1a9
+react:
+  id: f8d4c2ba
+  metaTitle: Performance Recipes - React Data Grid | Handsontable
+angular:
+  id: a9e5d3cb
+  metaTitle: Performance Recipes - Angular Data Grid | Handsontable
+---
+[[toc]]
+
+## Overview
+
+This section provides practical recipes for keeping Handsontable fast and responsive, even with large datasets or complex user interactions. Each recipe includes a working example you can copy into your app.
+
+## Available Recipes
+
+Current recipes:
+
+<div class="boxes-list">
+
+- [Lazy loading with pagination](@/content/recipes/performance/lazy-loading/lazy-loading.md)
+- [Persist and restore column widths and order](@/content/recipes/performance/persist-column-layout/persist-column-layout.md)
+
+</div>


### PR DESCRIPTION
### Context

The PR fixes a 404 error on `/angular-data-grid/recipes/performance/` (and the equivalent JS and React URLs). The sidebar config in `docs/content/recipes/sidebar.js` registered a `path: 'performance'` entry for the Performance section -- which tells the sidebar builder to generate an "Overview" link pointing to `recipes/performance/performance.md` -- but that file did not exist. All other recipe categories with a `path` property (data-management, cell-types, editing-validation, etc.) have a corresponding index file; performance was the only exception.

The child recipe pages (`lazy-loading` and `persist-column-layout`) already had Angular examples, so they were fully implemented but unreachable via navigation.

Fix: create the missing `docs/content/recipes/performance/performance.md` overview page.

### How has this been tested?

- Verified the file renders correctly by checking it matches the structure of sibling overview files (data-management.md, themes.md).
- Confirmed the sidebar config references `path: 'performance'` for `javascript`, `react`, and `angular` frameworks -- all three URLs are now served by the new file.
- No source code was changed; docs-only change.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

None (reported as a 404 bug).

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1y/viewform)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that adds a missing index page to resolve broken navigation/404s; no runtime code or APIs are affected.
> 
> **Overview**
> Adds a new `docs/content/recipes/performance/performance.md` overview page for the Performance recipes section, aligning with the sidebar’s `path: 'performance'` entry.
> 
> The page provides a brief overview and links to the existing performance recipes (lazy loading and persisting column layout), fixing the broken “Overview” navigation for JS/React/Angular recipe docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f09cab8b80712d80b0a0c67a585823ff4589334. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->