### PR TITLE
Fix comment editor position when cell is inside a merged range (#11901)

### DIFF
--- a/.changelogs/12433.json
+++ b/.changelogs/12433.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed comment editor positioning for cells inside a merged range. The editor now aligns with the merged cell's border instead of appearing over the hidden inner cell.",
+  "type": "fixed",
+  "issueOrPR": 12433,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/comments/__tests__/comments.spec.js
+++ b/handsontable/src/plugins/comments/__tests__/comments.spec.js
@@ -1219,6 +1219,47 @@ describe('Comments', () => {
       expect($editor.offset().top).toBeCloseTo($mergedCell.offset().top, 0);
       expect($editor.offset().left).toBeCloseTo($mergedCell.offset().left + $mergedCell.outerWidth() - 1, 0);
     });
+
+    it('should display the comment editor at the merged cell border when the merge spans multiple rows and columns (#11901)', async() => {
+      handsontable({
+        data: createSpreadsheetData(6, 6),
+        comments: true,
+        mergeCells: [
+          { row: 1, col: 1, rowspan: 3, colspan: 3 },
+        ],
+      });
+
+      const plugin = getPlugin('comments');
+      const $editor = $(plugin.getEditorInputElement().parentNode);
+      const $mergedCell = $(getCell(1, 1));
+
+      plugin.showAtCell(1, 1);
+
+      expect($editor.offset().top).toBeCloseTo($mergedCell.offset().top, 0);
+      expect($editor.offset().left).toBeCloseTo($mergedCell.offset().left + $mergedCell.outerWidth() - 1, 0);
+    });
+
+    it('should display the comment editor at the merged cell border when opened for a cell nested inside the merge (#11901)', async() => {
+      handsontable({
+        data: createSpreadsheetData(6, 6),
+        comments: true,
+        mergeCells: [
+          { row: 1, col: 1, rowspan: 3, colspan: 3 },
+        ],
+        cell: [
+          { row: 2, col: 2, comment: { value: 'More comments' } },
+        ],
+      });
+
+      const plugin = getPlugin('comments');
+      const $editor = $(plugin.getEditorInputElement().parentNode);
+      const $mergedCell = $(getCell(1, 1));
+
+      plugin.showAtCell(2, 2);
+
+      expect($editor.offset().top).toBeCloseTo($mergedCell.offset().top, 0);
+      expect($editor.offset().left).toBeCloseTo($mergedCell.offset().left + $mergedCell.outerWidth() - 1, 0);
+    });
   });
 
   describe('hidden row an column integration', () => {

--- a/handsontable/src/plugins/comments/__tests__/rtl/comments.spec.js
+++ b/handsontable/src/plugins/comments/__tests__/rtl/comments.spec.js
@@ -254,6 +254,31 @@ describe('Comments (RTL mode)', () => {
         expect(editorOffset.top).toBeCloseTo(cellOffset.top - editorHeight + cellHeight - 1, 0);
         expect(editorOffset.left).toBeCloseTo(cellOffset.left - editorWidth - 1, 0);
       });
+
+      it('should display the comment editor at the merged cell border when opened for a cell nested inside the merge (#11901)', async() => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(6, 6),
+          comments: true,
+          mergeCells: [
+            { row: 1, col: 1, rowspan: 3, colspan: 3 },
+          ],
+          cell: [
+            { row: 2, col: 2, comment: { value: 'More comments' } },
+          ],
+        });
+
+        const plugin = getPlugin('comments');
+        const $editor = $(plugin.getEditorInputElement());
+        const $mergedCell = $(getCell(1, 1));
+
+        plugin.showAtCell(2, 2);
+
+        // The extra `-2` accounts for the merged-cell border compensation (-1) and the
+        // textarea's negative `margin-left` (-1) relative to its container.
+        expect($editor.offset().top).toBeCloseTo($mergedCell.offset().top, 0);
+        expect($editor.offset().left).toBeCloseTo($mergedCell.offset().left - $editor.outerWidth() - 2, 0);
+      });
     });
 
     describe('Displaying comment after `mouseover` event', () => {

--- a/handsontable/src/plugins/comments/comments.js
+++ b/handsontable/src/plugins/comments/comments.js
@@ -601,9 +601,14 @@ export class Comments extends BasePlugin {
 
     const { rowIndexMapper, columnIndexMapper } = this.hot;
     const { row: visualRow, col: visualColumn } = this.#getRangeCoords();
+    // When the cell is part of a merged range, anchor the editor at the merge parent so the
+    // popup aligns with the merged cell's border instead of the hidden inner cell's position.
+    const mergeParent = this.#getMergeParent(visualRow, visualColumn);
+    const anchorRow = mergeParent ? mergeParent.row : visualRow;
+    const anchorColumn = mergeParent ? mergeParent.col : visualColumn;
 
-    let renderableRow = rowIndexMapper.getRenderableFromVisualIndex(visualRow);
-    let renderableColumn = columnIndexMapper.getRenderableFromVisualIndex(visualColumn);
+    let renderableRow = rowIndexMapper.getRenderableFromVisualIndex(anchorRow);
+    let renderableColumn = columnIndexMapper.getRenderableFromVisualIndex(anchorColumn);
     // Used when the requested row is hidden, and the editor needs to be positioned on the previous row's coords.
     const targetingPreviousRow = renderableRow === null;
 
@@ -613,12 +618,12 @@ export class Comments extends BasePlugin {
 
     if (renderableRow === null) {
       renderableRow = rowIndexMapper
-        .getRenderableFromVisualIndex(rowIndexMapper.getNearestNotHiddenIndex(visualRow, -1));
+        .getRenderableFromVisualIndex(rowIndexMapper.getNearestNotHiddenIndex(anchorRow, -1));
     }
 
     if (renderableColumn === null) {
       renderableColumn = columnIndexMapper
-        .getRenderableFromVisualIndex(columnIndexMapper.getNearestNotHiddenIndex(visualColumn, -1));
+        .getRenderableFromVisualIndex(columnIndexMapper.getNearestNotHiddenIndex(anchorColumn, -1));
     }
 
     const isBeforeRenderedRows = renderableRow === null;
@@ -632,7 +637,7 @@ export class Comments extends BasePlugin {
     // TODO: Probably using `hot.getCell` would be the best. However, case for showing comment editor for hidden cell
     // potentially should be removed with that change (currently a test for it is passing).
     const TD = wt.getCell({ row: renderableRow, col: renderableColumn }, true);
-    const cellMeta = this.hot.getCellMeta(visualRow, visualColumn);
+    const cellMeta = this.hot.getCellMeta(anchorRow, anchorColumn);
     const metaColspan = cellMeta.colspan ?? 1;
     const commentStyle = this.getCommentMeta(visualRow, visualColumn, META_STYLE);
 
@@ -927,6 +932,25 @@ export class Comments extends BasePlugin {
     }
 
     return this.hot._createCellCoords(this.range.from.row, this.range.from.col);
+  }
+
+  /**
+   * Returns the merge parent descriptor for a cell, or `null` when the cell is not part
+   * of a merged range or when the MergeCells plugin is disabled.
+   *
+   * @param {number} visualRow Visual row index.
+   * @param {number} visualColumn Visual column index.
+   * @returns {MergedCellCoords | null}
+   */
+  #getMergeParent(visualRow, visualColumn) {
+    const mergeCellsPlugin = this.hot.getPlugin('mergeCells');
+
+    if (!mergeCellsPlugin?.enabled) {
+      return null;
+    }
+
+    // `mergedCellsCollection.get()` returns `false` on miss, so coerce to `null`.
+    return mergeCellsPlugin.mergedCellsCollection.get(visualRow, visualColumn) || null;
   }
 
   /**


### PR DESCRIPTION
### Context

The PR fixes a comment-editor positioning bug reported in #11901. When a cell belongs to a merged range but is **not** the merge anchor, opening its comment placed the popup over the hidden inner cell's coordinates (often inside the merged area or at an unexpected location) instead of aligning it with the merged cell's border.

**Root cause:** `Comments.refreshEditor()` resolved the anchoring TD via the cell's own `(visualRow, visualColumn)`. For a cell inside a merged region, that TD is rendered with `display: none` and its `getBoundingClientRect()` reports zero-sized coordinates. In addition, MergeCells' `afterGetCellMeta` decorates only the **anchor** cell with `colspan` / `rowspan`, so `metaColspan` defaulted to `1` for inner cells and broke `getEditorAnchorWidth()` as well as the `mergedBorderCompensation` adjustment.

**Fix:** In `refreshEditor()`, resolve an anchor `(anchorRow, anchorColumn)` via `hot.getPlugin('mergeCells').mergedCellsCollection.get(row, col)`. When the target cell is inside a merged range, the anchor's coordinates are used for:
- `rowIndexMapper` / `columnIndexMapper` renderable lookups,
- `wt.getCell(...)` (so `TD.getBoundingClientRect()` reports the merged geometry),
- `hot.getCellMeta(...)` (so `metaColspan` reflects the merged span).

`commentStyle` and `readOnly` still read from the user-supplied `(visualRow, visualColumn)` - the comment value and custom size remain per-cell meta, only the popup anchor changes.

### How has this been tested?

New tests were added and existing suites re-run clean:

- `handsontable/src/plugins/comments/__tests__/comments.spec.js` - two new LTR specs:
  - Editor aligns with the merged cell border for a `rowspan: 3, colspan: 3` merge (anchor case).
  - Editor aligns with the merged cell border when opened for a hidden inner cell of the same merge (regression case).
- `handsontable/src/plugins/comments/__tests__/rtl/comments.spec.js` - RTL counterpart of the inner-cell case, runs for both `{ htmlDir: 'rtl', layoutDirection: 'inherit' }` and `{ htmlDir: 'ltr', layoutDirection: 'rtl' }`.

Commands to reproduce:

```bash
npm run lint --prefix handsontable
npm run test:e2e --prefix handsontable --testPathPattern="comments/__tests__"
npm run test:e2e --prefix handsontable --testPathPattern="mergeCells/__tests__"
```

Results on this branch:
- Comments (LTR + RTL): 137/137 passing.
- MergeCells: 483/483 passing (1 pre-existing pending, unrelated).
- Lint: clean.

Manual test page: `handsontable/dev-generated.html` reproduces the JSFiddle config from the issue (merge B2:D4 with `rowspan: 3, colspan: 3`, comments on B2 and C3) with a Released-vs-PR-Build tab split and buttons that call `showAtCell(1, 1)` and `showAtCell(2, 2)` on demand.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. Fixes #11901

### Affected project(s):

- [x] \`handsontable\`
- [ ] \`@handsontable/angular-wrapper\`
- [ ] \`@handsontable/react-wrapper\`
- [ ] \`@handsontable/vue3\`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches comment editor positioning logic and its integration with the MergeCells plugin; while well-covered by new LTR/RTL tests, subtle layout/scroll/hidden-row edge cases could still regress.
> 
> **Overview**
> Fixes comment editor positioning for merged cells by anchoring `Comments.refreshEditor()` to the merge parent cell (when `mergeCells` is enabled), so the popup aligns to the merged range border even when the comment is opened from a hidden inner cell.
> 
> Adds regression tests for multi-row/column merges in both LTR and RTL suites, and includes a changelog entry describing the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47d7f4d9bb4d4afacb975168ee82f749f98f09cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->