### PR TITLE
DEV-1517: Publish RC packages to NuGet in CI workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -403,6 +403,90 @@ jobs:
           payload-file-path: /tmp/slack-payload.json
 
   # ============================================================
+  # Scenario B.1 — First RC NuGet build and publish
+  # ============================================================
+  first-rc-build-nuget:
+    name: Build NuGet package (first RC)
+    runs-on: ubuntu-latest
+    needs: [first-rc-build]
+    if: ${{ !cancelled() && needs.first-rc-build.result == 'success' }}
+    outputs:
+      rc-version: ${{ needs.first-rc-build.outputs.rc-version }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # https://github.com/actions/checkout/releases/tag/v6.0.2
+        with:
+          ref: ${{ needs.first-rc-build.outputs.release-branch }}
+
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # https://github.com/pnpm/action-setup/releases/tag/v4.2.0
+        name: Install pnpm
+
+      - name: Use Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # https://github.com/actions/setup-node/releases/tag/v6.2.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download npm build artifacts
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # https://github.com/actions/download-artifact/releases/tag/v8.0.0
+        with:
+          name: npm_packs_${{ needs.first-rc-build.outputs.rc-version }}
+          path: _tmp_packs/
+
+      - name: Unpack handsontable tarball
+        run: |
+          mkdir -p handsontable/tmp
+          tar -xzf _tmp_packs/handsontable-${{ needs.first-rc-build.outputs.rc-version }}.tgz \
+            -C handsontable/tmp --strip-components=1
+
+      - name: Install nuget
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mono-complete
+          curl -o /tmp/nuget.exe https://dist.nuget.org/win-x86-commandline/v7.3.0/nuget.exe
+          sudo bash -c 'echo "#!/bin/bash" > /usr/local/bin/nuget && echo "exec mono /tmp/nuget.exe \"\$@\"" >> /usr/local/bin/nuget && chmod +x /usr/local/bin/nuget'
+
+      - name: Generate NuGet package
+        run: node .github/scripts/generate-nuget-package.mjs
+
+      - name: Upload NuGet package artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # https://github.com/actions/upload-artifact/releases/tag/v7.0.0
+        with:
+          name: nuget_pack_${{ needs.first-rc-build.outputs.rc-version }}
+          path: Handsontable.*.nupkg
+
+      - name: Clean up NuGet package
+        run: rm -f Handsontable.*.nupkg
+
+  first-rc-publish-nuget:
+    name: Publish NuGet package (first RC)
+    runs-on: ubuntu-latest
+    if: ${{ !cancelled() && needs.first-rc-build.result == 'success' && needs.first-rc-test.result == 'success' && needs.first-rc-build-nuget.result == 'success' }}
+    needs: [first-rc-build, first-rc-test, first-rc-build-nuget]
+    environment: approvers
+    steps:
+      - name: Download NuGet package artifact
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # https://github.com/actions/download-artifact/releases/tag/v8.0.0
+        with:
+          name: nuget_pack_${{ needs.first-rc-build.outputs.rc-version }}
+
+      - name: NuGet login (OIDC trusted publishing)
+        uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544 # https://github.com/NuGet/login/releases/tag/v1.0.0
+        id: nuget-login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
+      - name: Publish NuGet package
+        run: |
+          NUPKG=$(ls *.nupkg)
+          echo "Publishing: $NUPKG"
+          dotnet nuget push "$NUPKG" \
+            --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" \
+            --source https://api.nuget.org/v3/index.json
+
+  # ============================================================
   # Scenario C — Subsequent RC (push to release/**)
   # ============================================================
   rc-check:
@@ -803,6 +887,90 @@ jobs:
           webhook: ${{ secrets.SLACK_RELEASE_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload-file-path: /tmp/slack-payload.json
+
+  # ============================================================
+  # Scenario C.1 — Subsequent RC NuGet build and publish
+  # ============================================================
+  rc-build-nuget:
+    name: Build NuGet package (RC)
+    runs-on: ubuntu-latest
+    needs: [rc-build]
+    if: ${{ !cancelled() && needs.rc-build.result == 'success' }}
+    outputs:
+      rc-version: ${{ needs.rc-build.outputs.rc-version }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # https://github.com/actions/checkout/releases/tag/v6.0.2
+        with:
+          ref: ${{ github.ref_name }}
+
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # https://github.com/pnpm/action-setup/releases/tag/v4.2.0
+        name: Install pnpm
+
+      - name: Use Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # https://github.com/actions/setup-node/releases/tag/v6.2.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download npm build artifacts
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # https://github.com/actions/download-artifact/releases/tag/v8.0.0
+        with:
+          name: npm_packs_${{ needs.rc-build.outputs.rc-version }}
+          path: _tmp_packs/
+
+      - name: Unpack handsontable tarball
+        run: |
+          mkdir -p handsontable/tmp
+          tar -xzf _tmp_packs/handsontable-${{ needs.rc-build.outputs.rc-version }}.tgz \
+            -C handsontable/tmp --strip-components=1
+
+      - name: Install nuget
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mono-complete
+          curl -o /tmp/nuget.exe https://dist.nuget.org/win-x86-commandline/v7.3.0/nuget.exe
+          sudo bash -c 'echo "#!/bin/bash" > /usr/local/bin/nuget && echo "exec mono /tmp/nuget.exe \"\$@\"" >> /usr/local/bin/nuget && chmod +x /usr/local/bin/nuget'
+
+      - name: Generate NuGet package
+        run: node .github/scripts/generate-nuget-package.mjs
+
+      - name: Upload NuGet package artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # https://github.com/actions/upload-artifact/releases/tag/v7.0.0
+        with:
+          name: nuget_pack_${{ needs.rc-build.outputs.rc-version }}
+          path: Handsontable.*.nupkg
+
+      - name: Clean up NuGet package
+        run: rm -f Handsontable.*.nupkg
+
+  rc-publish-nuget:
+    name: Publish NuGet package (RC)
+    runs-on: ubuntu-latest
+    if: ${{ !cancelled() && needs.rc-build.result == 'success' && needs.rc-test.result == 'success' && needs.rc-build-nuget.result == 'success' }}
+    needs: [rc-build, rc-test, rc-build-nuget]
+    environment: approvers
+    steps:
+      - name: Download NuGet package artifact
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # https://github.com/actions/download-artifact/releases/tag/v8.0.0
+        with:
+          name: nuget_pack_${{ needs.rc-build.outputs.rc-version }}
+
+      - name: NuGet login (OIDC trusted publishing)
+        uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544 # https://github.com/NuGet/login/releases/tag/v1.0.0
+        id: nuget-login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
+      - name: Publish NuGet package
+        run: |
+          NUPKG=$(ls *.nupkg)
+          echo "Publishing: $NUPKG"
+          dotnet nuget push "$NUPKG" \
+            --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" \
+            --source https://api.nuget.org/v3/index.json
 
   # ============================================================
   # Scenario D — Stable release (release event, not prerelease)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -323,85 +323,6 @@ jobs:
           done
           echo "All packages published successfully."
 
-      - name: Prepare Slack message
-        if: always()
-        env:
-          JOB_STATUS: ${{ job.status }}
-          RC_VERSION: ${{ needs.first-rc-build.outputs.rc-version }}
-          RELEASE_BRANCH: ${{ needs.first-rc-build.outputs.release-branch }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
-        run: |
-          if [ "$JOB_STATUS" = "success" ]; then
-            STATUS=":white_check_mark: Success"; NPM_STATUS=":white_check_mark: :npm: *npm*"; NPM_OK="true"
-          else
-            STATUS=":x: Failed"; NPM_STATUS=":x: :npm: *npm*"; NPM_OK="false"
-          fi
-          CHANGELOG_URL="${REPO_URL}/blob/${RELEASE_BRANCH}/CHANGELOG.md"
-
-          jq -n \
-            --arg version       "${RC_VERSION}" \
-            --arg branch        "${RELEASE_BRANCH}" \
-            --arg status        "$STATUS" \
-            --arg npm_status    "$NPM_STATUS" \
-            --arg npm_ok        "$NPM_OK" \
-            --arg changelog_url "$CHANGELOG_URL" \
-            --arg repo_url      "${REPO_URL}" \
-            --arg run_url       "${RUN_URL}" \
-          '{
-            text: (if $npm_ok == "true" then "🚀 Version " + $version + " released!" else "❌ Release of version " + $version + " failed." end),
-            blocks: [
-              (if $npm_ok == "true" then
-                { type: "header", text: { type: "plain_text", text: ("🚀 Version " + $version + " released!"), emoji: true } }
-              else
-                { type: "section", text: { type: "mrkdwn", text: (":x: *Release of version " + $version + " failed.* Check the <" + $run_url + "|GitHub Actions run> for details.") } }
-              end),
-              {
-                type: "section",
-                text: { type: "mrkdwn", text: "⚠️ *This is a pre-release.* Not intended for production use." }
-              },
-              {
-                type: "section",
-                fields: [
-                  { type: "mrkdwn", text: ("*Status*\n" + $status) },
-                  { type: "mrkdwn", text: "*Type*\n🔖 Pre-release" },
-                  { type: "mrkdwn", text: ("*Version*\n<https://www.npmjs.com/package/handsontable/v/" + $version + "|" + $version + ">") },
-                  { type: "mrkdwn", text: ("*Branch*\n<" + $repo_url + "/tree/" + $branch + "|" + $branch + ">") }
-                ]
-              },
-              { type: "divider" },
-              {
-                type: "section",
-                fields: [
-                  { type: "mrkdwn", text: ":white_check_mark: :github: *GitHub*" },
-                  { type: "mrkdwn", text: $npm_status }
-                ]
-              },
-              { type: "divider" },
-              {
-                type: "section",
-                text: {
-                  type: "mrkdwn",
-                  text: ("*📋 Changelog*\n<" + $changelog_url + "|View CHANGELOG.md>" + if $npm_ok == "true" then "\n\n*🎮 Demos*\n• :javascript: <https://handsontable.com/codesandbox-browser?example-dir=javascript&handsontable-version=" + $version + "|JS>\n• :react: <https://handsontable.com/codesandbox-browser?example-dir=react&handsontable-version=" + $version + "|React>\n• :angular: <https://handsontable.com/codesandbox-vm?example-dir=angular&handsontable-version=" + $version + "|Angular>\n• :vue: <https://handsontable.com/codesandbox-vm?example-dir=vue&handsontable-version=" + $version + "|Vue>\n• :typescript: <https://handsontable.com/codesandbox-browser?example-dir=typescript&handsontable-version=" + $version + "|TypeScript>" else "" end)
-                }
-              },
-              {
-                type: "context",
-                elements: [{ type: "mrkdwn", text: ("<" + $run_url + "|🔗 View GitHub Actions run>") }]
-              }
-            ]
-          }' > /tmp/slack-payload.json
-          echo "Slack payload:"
-          cat /tmp/slack-payload.json
-
-      - name: Notify Slack
-        if: always()
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
-        with:
-          webhook: ${{ secrets.SLACK_RELEASE_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload-file-path: /tmp/slack-payload.json
-
   # ============================================================
   # Scenario B.1 — First RC NuGet build and publish
   # ============================================================
@@ -485,6 +406,93 @@ jobs:
           dotnet nuget push "$NUPKG" \
             --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" \
             --source https://api.nuget.org/v3/index.json
+
+  first-rc-notify:
+    name: Notify Slack (first RC)
+    runs-on: ubuntu-latest
+    if: ${{ !cancelled() && needs.first-rc-publish.result != 'skipped' }}
+    needs: [first-rc-build, first-rc-publish, first-rc-publish-nuget]
+    steps:
+      - name: Prepare and send Slack message
+        env:
+          RC_VERSION: ${{ needs.first-rc-build.outputs.rc-version }}
+          RELEASE_BRANCH: ${{ needs.first-rc-build.outputs.release-branch }}
+          NPM_RESULT: ${{ needs.first-rc-publish.result }}
+          NUGET_RESULT: ${{ needs.first-rc-publish-nuget.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+        run: |
+          if [ "$NPM_RESULT" = "success" ]; then
+            STATUS=":white_check_mark: Success"; NPM_STATUS=":white_check_mark: :npm: *npm*"; NPM_OK="true"
+          else
+            STATUS=":x: Failed"; NPM_STATUS=":x: :npm: *npm*"; NPM_OK="false"
+          fi
+          if [ "$NUGET_RESULT" = "success" ]; then NUGET_STATUS=":white_check_mark: :nuget: *NuGet*"; else NUGET_STATUS=":x: :nuget: *NuGet*"; fi
+          CHANGELOG_URL="${REPO_URL}/blob/${RELEASE_BRANCH}/CHANGELOG.md"
+
+          jq -n \
+            --arg version       "${RC_VERSION}" \
+            --arg branch        "${RELEASE_BRANCH}" \
+            --arg status        "$STATUS" \
+            --arg npm_status    "$NPM_STATUS" \
+            --arg npm_ok        "$NPM_OK" \
+            --arg nuget_status  "$NUGET_STATUS" \
+            --arg changelog_url "$CHANGELOG_URL" \
+            --arg repo_url      "${REPO_URL}" \
+            --arg run_url       "${RUN_URL}" \
+          '{
+            text: (if $npm_ok == "true" then "🚀 Version " + $version + " released!" else "❌ Release of version " + $version + " failed." end),
+            blocks: [
+              (if $npm_ok == "true" then
+                { type: "header", text: { type: "plain_text", text: ("🚀 Version " + $version + " released!"), emoji: true } }
+              else
+                { type: "section", text: { type: "mrkdwn", text: (":x: *Release of version " + $version + " failed.* Check the <" + $run_url + "|GitHub Actions run> for details.") } }
+              end),
+              {
+                type: "section",
+                text: { type: "mrkdwn", text: "⚠️ *This is a pre-release.* Not intended for production use." }
+              },
+              {
+                type: "section",
+                fields: [
+                  { type: "mrkdwn", text: ("*Status*\n" + $status) },
+                  { type: "mrkdwn", text: "*Type*\n🔖 Pre-release" },
+                  { type: "mrkdwn", text: ("*Version*\n<https://www.npmjs.com/package/handsontable/v/" + $version + "|" + $version + ">") },
+                  { type: "mrkdwn", text: ("*Branch*\n<" + $repo_url + "/tree/" + $branch + "|" + $branch + ">") }
+                ]
+              },
+              { type: "divider" },
+              {
+                type: "section",
+                fields: [
+                  { type: "mrkdwn", text: ":white_check_mark: :github: *GitHub*" },
+                  { type: "mrkdwn", text: $npm_status },
+                  { type: "mrkdwn", text: $nuget_status }
+                ]
+              },
+              { type: "divider" },
+              {
+                type: "section",
+                text: {
+                  type: "mrkdwn",
+                  text: ("*📋 Changelog*\n<" + $changelog_url + "|View CHANGELOG.md>" + if $npm_ok == "true" then "\n\n*🎮 Demos*\n• :javascript: <https://handsontable.com/codesandbox-browser?example-dir=javascript&handsontable-version=" + $version + "|JS>\n• :react: <https://handsontable.com/codesandbox-browser?example-dir=react&handsontable-version=" + $version + "|React>\n• :angular: <https://handsontable.com/codesandbox-vm?example-dir=angular&handsontable-version=" + $version + "|Angular>\n• :vue: <https://handsontable.com/codesandbox-vm?example-dir=vue&handsontable-version=" + $version + "|Vue>\n• :typescript: <https://handsontable.com/codesandbox-browser?example-dir=typescript&handsontable-version=" + $version + "|TypeScript>" else "" end)
+                }
+              },
+              {
+                type: "context",
+                elements: [{ type: "mrkdwn", text: ("<" + $run_url + "|🔗 View GitHub Actions run>") }]
+              }
+            ]
+          }' > /tmp/slack-payload.json
+          echo "Slack payload:"
+          cat /tmp/slack-payload.json
+
+      - name: Notify Slack
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_RELEASE_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload-file-path: /tmp/slack-payload.json
 
   # ============================================================
   # Scenario C — Subsequent RC (push to release/**)
@@ -767,127 +775,6 @@ jobs:
           done
           echo "All packages published successfully."
 
-      - name: Prepare Slack message
-        if: always()
-        env:
-          JOB_STATUS: ${{ job.status }}
-          RC_VERSION: ${{ needs.rc-build.outputs.rc-version }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
-        run: |
-          if [ "$JOB_STATUS" = "success" ]; then
-            STATUS=":white_check_mark: Success"; NPM_STATUS=":white_check_mark: :npm: *npm*"; NPM_OK="true"
-          else
-            STATUS=":x: Failed"; NPM_STATUS=":x: :npm: *npm*"; NPM_OK="false"
-          fi
-
-          # Build commit list since previous RC tag
-          BASE_VERSION=$(echo "$RC_VERSION" | sed 's/-rc[0-9]*//')
-          RC_NUMBER=$(echo "$RC_VERSION" | sed -n 's/.*-rc\([0-9]*\)/\1/p')
-          PREV_TAG="${BASE_VERSION}-rc$((RC_NUMBER - 1))"
-          RELEASE_BRANCH="${{ github.ref_name }}"
-          CHANGELOG_URL="${REPO_URL}/blob/${RELEASE_BRANCH}/CHANGELOG.md"
-
-          git fetch --unshallow 2>/dev/null || true
-          git fetch --tags --quiet
-
-          COMMITS_TEXT=""
-
-          if git rev-parse "$PREV_TAG" >/dev/null 2>&1; then
-            COMMITS=$(git log "${PREV_TAG}..HEAD" --pretty=format:"%H %s" --no-merges)
-
-            if [ -n "$COMMITS" ]; then
-              while IFS= read -r line; do
-                SHA=$(echo "$line" | cut -d' ' -f1)
-                MSG=$(echo "$line" | cut -d' ' -f2-)
-                COMMITS_TEXT="${COMMITS_TEXT}• <${REPO_URL}/commit/${SHA}|${MSG}>"$'\n'
-              done <<< "$COMMITS"
-            fi
-          fi
-
-          if [ -z "$COMMITS_TEXT" ]; then
-            COMMITS_TEXT="No commits found since \`${PREV_TAG}\`."
-          fi
-
-          CHANGELOG_SYNCED='${{ needs.rc-build.outputs.changelog-synced }}'
-
-          jq -n \
-            --arg version          "${RC_VERSION}" \
-            --arg branch           "${RELEASE_BRANCH}" \
-            --arg status           "$STATUS" \
-            --arg npm_status       "$NPM_STATUS" \
-            --arg npm_ok           "$NPM_OK" \
-            --arg prev_tag         "${PREV_TAG}" \
-            --arg commits          "$COMMITS_TEXT" \
-            --arg changelog_synced "${CHANGELOG_SYNCED}" \
-            --arg changelog_url    "$CHANGELOG_URL" \
-            --arg run_url          "${RUN_URL}" \
-            --arg repo_url         "${REPO_URL}" \
-          '{
-            text: (if $npm_ok == "true" then "🚀 Version " + $version + " released!" else "❌ Release of version " + $version + " failed." end),
-            blocks: [
-              (if $npm_ok == "true" then
-                { type: "header", text: { type: "plain_text", text: ("🚀 Version " + $version + " released!"), emoji: true } }
-              else
-                { type: "section", text: { type: "mrkdwn", text: (":x: *Release of version " + $version + " failed.* Check the <" + $run_url + "|GitHub Actions run> for details.") } }
-              end),
-              {
-                type: "section",
-                text: { type: "mrkdwn", text: "⚠️ *This is a pre-release.* Not intended for production use." }
-              },
-              {
-                type: "section",
-                fields: [
-                  { type: "mrkdwn", text: ("*Status*\n" + $status) },
-                  { type: "mrkdwn", text: "*Type*\n🔖 Pre-release" },
-                  { type: "mrkdwn", text: ("*Version*\n<https://www.npmjs.com/package/handsontable/v/" + $version + "|" + $version + ">") },
-                  { type: "mrkdwn", text: ("*Branch*\n<" + $repo_url + "/tree/" + $branch + "|" + $branch + ">") }
-                ]
-              },
-              { type: "divider" },
-              {
-                type: "section",
-                fields: [
-                  { type: "mrkdwn", text: ":white_check_mark: :github: *GitHub*" },
-                  { type: "mrkdwn", text: $npm_status }
-                ]
-              },
-              { type: "divider" },
-              {
-                type: "section",
-                text: { type: "mrkdwn", text: ("*Commits since `" + $prev_tag + "`*\n" + $commits) }
-              },
-              if $changelog_synced == "true" then
-                {
-                  type: "context",
-                  elements: [{ type: "mrkdwn", text: "❗ *Changelog extended with new entries!*" }]
-                }
-              else empty end,
-              { type: "divider" },
-              {
-                type: "section",
-                text: {
-                  type: "mrkdwn",
-                  text: ("*📋 Changelog*\n<" + $changelog_url + "|View CHANGELOG.md>" + if $npm_ok == "true" then "\n\n*🎮 Demos*\n• :javascript: <https://handsontable.com/codesandbox-browser?example-dir=javascript&handsontable-version=" + $version + "|JS>\n• :react: <https://handsontable.com/codesandbox-browser?example-dir=react&handsontable-version=" + $version + "|React>\n• :angular: <https://handsontable.com/codesandbox-vm?example-dir=angular&handsontable-version=" + $version + "|Angular>\n• :vue: <https://handsontable.com/codesandbox-vm?example-dir=vue&handsontable-version=" + $version + "|Vue>\n• :typescript: <https://handsontable.com/codesandbox-browser?example-dir=typescript&handsontable-version=" + $version + "|TypeScript>" else "" end)
-                }
-              },
-              {
-                type: "context",
-                elements: [{ type: "mrkdwn", text: ("<" + $run_url + "|🔗 View GitHub Actions run>") }]
-              }
-            ]
-          }' > /tmp/slack-payload.json
-          echo "Slack payload:"
-          cat /tmp/slack-payload.json
-
-      - name: Notify Slack
-        if: always()
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
-        with:
-          webhook: ${{ secrets.SLACK_RELEASE_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload-file-path: /tmp/slack-payload.json
-
   # ============================================================
   # Scenario C.1 — Subsequent RC NuGet build and publish
   # ============================================================
@@ -971,6 +858,138 @@ jobs:
           dotnet nuget push "$NUPKG" \
             --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" \
             --source https://api.nuget.org/v3/index.json
+
+  rc-notify:
+    name: Notify Slack (RC)
+    runs-on: ubuntu-latest
+    if: ${{ !cancelled() && needs.rc-publish.result != 'skipped' }}
+    needs: [rc-build, rc-publish, rc-publish-nuget]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # https://github.com/actions/checkout/releases/tag/v6.0.2
+        with:
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0
+
+      - name: Prepare and send Slack message
+        env:
+          RC_VERSION: ${{ needs.rc-build.outputs.rc-version }}
+          CHANGELOG_SYNCED: ${{ needs.rc-build.outputs.changelog-synced }}
+          NPM_RESULT: ${{ needs.rc-publish.result }}
+          NUGET_RESULT: ${{ needs.rc-publish-nuget.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+        run: |
+          if [ "$NPM_RESULT" = "success" ]; then
+            STATUS=":white_check_mark: Success"; NPM_STATUS=":white_check_mark: :npm: *npm*"; NPM_OK="true"
+          else
+            STATUS=":x: Failed"; NPM_STATUS=":x: :npm: *npm*"; NPM_OK="false"
+          fi
+          if [ "$NUGET_RESULT" = "success" ]; then NUGET_STATUS=":white_check_mark: :nuget: *NuGet*"; else NUGET_STATUS=":x: :nuget: *NuGet*"; fi
+
+          BASE_VERSION=$(echo "$RC_VERSION" | sed 's/-rc[0-9]*//')
+          RC_NUMBER=$(echo "$RC_VERSION" | sed -n 's/.*-rc\([0-9]*\)/\1/p')
+          PREV_TAG="${BASE_VERSION}-rc$((RC_NUMBER - 1))"
+          RELEASE_BRANCH="${{ github.ref_name }}"
+          CHANGELOG_URL="${REPO_URL}/blob/${RELEASE_BRANCH}/CHANGELOG.md"
+
+          git fetch --unshallow 2>/dev/null || true
+          git fetch --tags --quiet
+
+          COMMITS_TEXT=""
+
+          if git rev-parse "$PREV_TAG" >/dev/null 2>&1; then
+            COMMITS=$(git log "${PREV_TAG}..HEAD" --pretty=format:"%H %s" --no-merges)
+
+            if [ -n "$COMMITS" ]; then
+              while IFS= read -r line; do
+                SHA=$(echo "$line" | cut -d' ' -f1)
+                MSG=$(echo "$line" | cut -d' ' -f2-)
+                COMMITS_TEXT="${COMMITS_TEXT}• <${REPO_URL}/commit/${SHA}|${MSG}>"$'\n'
+              done <<< "$COMMITS"
+            fi
+          fi
+
+          if [ -z "$COMMITS_TEXT" ]; then
+            COMMITS_TEXT="No commits found since \`${PREV_TAG}\`."
+          fi
+
+          jq -n \
+            --arg version          "${RC_VERSION}" \
+            --arg branch           "${RELEASE_BRANCH}" \
+            --arg status           "$STATUS" \
+            --arg npm_status       "$NPM_STATUS" \
+            --arg npm_ok           "$NPM_OK" \
+            --arg nuget_status     "$NUGET_STATUS" \
+            --arg prev_tag         "${PREV_TAG}" \
+            --arg commits          "$COMMITS_TEXT" \
+            --arg changelog_synced "${CHANGELOG_SYNCED}" \
+            --arg changelog_url    "$CHANGELOG_URL" \
+            --arg run_url          "${RUN_URL}" \
+            --arg repo_url         "${REPO_URL}" \
+          '{
+            text: (if $npm_ok == "true" then "🚀 Version " + $version + " released!" else "❌ Release of version " + $version + " failed." end),
+            blocks: [
+              (if $npm_ok == "true" then
+                { type: "header", text: { type: "plain_text", text: ("🚀 Version " + $version + " released!"), emoji: true } }
+              else
+                { type: "section", text: { type: "mrkdwn", text: (":x: *Release of version " + $version + " failed.* Check the <" + $run_url + "|GitHub Actions run> for details.") } }
+              end),
+              {
+                type: "section",
+                text: { type: "mrkdwn", text: "⚠️ *This is a pre-release.* Not intended for production use." }
+              },
+              {
+                type: "section",
+                fields: [
+                  { type: "mrkdwn", text: ("*Status*\n" + $status) },
+                  { type: "mrkdwn", text: "*Type*\n🔖 Pre-release" },
+                  { type: "mrkdwn", text: ("*Version*\n<https://www.npmjs.com/package/handsontable/v/" + $version + "|" + $version + ">") },
+                  { type: "mrkdwn", text: ("*Branch*\n<" + $repo_url + "/tree/" + $branch + "|" + $branch + ">") }
+                ]
+              },
+              { type: "divider" },
+              {
+                type: "section",
+                fields: [
+                  { type: "mrkdwn", text: ":white_check_mark: :github: *GitHub*" },
+                  { type: "mrkdwn", text: $npm_status },
+                  { type: "mrkdwn", text: $nuget_status }
+                ]
+              },
+              { type: "divider" },
+              {
+                type: "section",
+                text: { type: "mrkdwn", text: ("*Commits since `" + $prev_tag + "`*\n" + $commits) }
+              },
+              if $changelog_synced == "true" then
+                {
+                  type: "context",
+                  elements: [{ type: "mrkdwn", text: "❗ *Changelog extended with new entries!*" }]
+                }
+              else empty end,
+              { type: "divider" },
+              {
+                type: "section",
+                text: {
+                  type: "mrkdwn",
+                  text: ("*📋 Changelog*\n<" + $changelog_url + "|View CHANGELOG.md>" + if $npm_ok == "true" then "\n\n*🎮 Demos*\n• :javascript: <https://handsontable.com/codesandbox-browser?example-dir=javascript&handsontable-version=" + $version + "|JS>\n• :react: <https://handsontable.com/codesandbox-browser?example-dir=react&handsontable-version=" + $version + "|React>\n• :angular: <https://handsontable.com/codesandbox-vm?example-dir=angular&handsontable-version=" + $version + "|Angular>\n• :vue: <https://handsontable.com/codesandbox-vm?example-dir=vue&handsontable-version=" + $version + "|Vue>\n• :typescript: <https://handsontable.com/codesandbox-browser?example-dir=typescript&handsontable-version=" + $version + "|TypeScript>" else "" end)
+                }
+              },
+              {
+                type: "context",
+                elements: [{ type: "mrkdwn", text: ("<" + $run_url + "|🔗 View GitHub Actions run>") }]
+              }
+            ]
+          }' > /tmp/slack-payload.json
+          echo "Slack payload:"
+          cat /tmp/slack-payload.json
+
+      - name: Notify Slack
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_RELEASE_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload-file-path: /tmp/slack-payload.json
 
   # ============================================================
   # Scenario D — Stable release (release event, not prerelease)


### PR DESCRIPTION
### Context

The PR extends the `publish.yml` CI workflow to publish RC (release candidate) packages to NuGet in addition to npm. Previously, NuGet publishing only ran during stable releases (Scenario D). This means RC testers using NuGet could not install pre-release builds without a separate manual process.

Four new jobs are added, mirroring the existing `stable-build-nuget` / `stable-publish-nuget` pattern:

- **`first-rc-build-nuget`** (Scenario B.1) - builds the NuGet package after the first RC build, downloading the npm tarballs artifact, unpacking the handsontable tarball, and generating the `.nupkg` via `generate-nuget-package.mjs`.
- **`first-rc-publish-nuget`** - gated by the `approvers` environment; requires both `first-rc-test` and `first-rc-build-nuget` to succeed.
- **`rc-build-nuget`** (Scenario C.1) - same pattern for subsequent RCs, triggered on push to `release/**`.
- **`rc-publish-nuget`** - gated by `approvers`; requires `rc-test` and `rc-build-nuget` to succeed.

NuGet supports SemVer 2.0 pre-release identifiers (e.g. `15.0.0-rc1`), so no changes to `generate-nuget-package.mjs` were needed - it reads the version from the unpacked tarball's `package.json` without transformation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1517

### How has this been tested?

- Reviewed the `generate-nuget-package.mjs` script - it passes the version string directly to `nuget pack -Version`, with no filtering, so `X.Y.Z-rcN` versions work without modification.
- Verified NuGet SemVer 2.0 support for pre-release identifiers like `-rc1`.
- The new jobs are structurally identical to the existing `stable-build-nuget` / `stable-publish-nuget` jobs, which are proven to work.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1517

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release pipeline by adding new NuGet publishing steps and approval gates; mistakes could block RC releases or publish incorrect packages, but production code is unaffected.
> 
> **Overview**
> RC releases now publish to NuGet as well as npm.
> 
> For both the *first RC* (release prerelease) and *subsequent RCs* (push to `release/**`), the workflow adds gated NuGet build+publish jobs that generate a `.nupkg` from the packed `handsontable` tarball and push it to nuget.org via OIDC trusted publishing. Slack notifications for RC releases are updated to report npm vs NuGet publish results separately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ca2fe1a3ebcf83933e98ae3446580436195f9c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->