### PR TITLE
Add SessionStart hook to persist git author identity

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,6 +24,11 @@
             "type": "command",
             "command": "command -v pipx >/dev/null 2>&1 && pipx run code-review-graph==2.3.2 status || true",
             "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "git config --global user.name 'Mateusz Wojczal' && git config --global user.email 'mateusz.wojczal@handsontable.com'",
+            "timeout": 10
           }
         ]
       }


### PR DESCRIPTION
Adds a `SessionStart` hook to `.claude/settings.json` that re-applies the correct git `user.name` and `user.email` at the start of every Claude Code session, ensuring commits are always attributed to the repo owner rather than Claude.

[skip changelog]

https://claude.ai/code/session_015UoRMF7LAGhH4K8xMbnz4i

---
_Generated by [Claude Code](https://claude.ai/code/session_015UoRMF7LAGhH4K8xMbnz4i)_