### PR TITLE
Update CHANGELOG and documentation for release 14.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -374,6 +374,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixed the top overlay misalignment issue, visible after vertical scrollbar disappeared. [#11289](https://github.com/handsontable/handsontable/pull/11289)
 - React: Made the build scripts of `@handsontable/react-wrapper` place the TS type definitions in the configured directory. [#11296](https://github.com/handsontable/handsontable/pull/11296)
 
+## [14.6.2] - 2025-02-10
+
+#### Fixed
+- Fixed the copy/paste feature not working correctly in Chrome 133. [#11428](https://github.com/handsontable/handsontable/pull/11428)
+
 ## [14.6.1] - 2024-10-17
 
 ### Removed

--- a/docs/content/guides/upgrade-and-migration/changelog-14/changelog-14.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-14/changelog-14.md
@@ -18,6 +18,21 @@ category: Upgrade and migration
 
 These are the release notes for Handsontable 14.x.
 
+## 14.6.2
+
+Released on February 10, 2025
+
+For more information about this release see:
+
+<div class="boxes-list gray">
+
+- [Documentation (14.6)](https://handsontable.com/docs/14.6)
+
+</div>
+
+#### Fixed
+- Fixed the copy/paste feature not working correctly in Chrome 133. [#11428](https://github.com/handsontable/handsontable/pull/11428)
+
 ## 14.6.1
 
 Released on October 17, 2024


### PR DESCRIPTION
### Context

The PR adds the missing **14.6.2** (2025-02-10) release notes to the root `CHANGELOG.md` and to the v14 upgrade guide (`changelog-14.md`), so they match what was shipped in that patch. The entry documents the Chrome 133 copy/paste fix ([#11428](https://github.com/handsontable/handsontable/pull/11428)).

### How has this been tested?

- Verified the new sections render as valid Markdown and follow the same structure as adjacent releases (14.6.1 / 14.6.x).
- No runtime or build changes; documentation and changelog only.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)
- [x] Documentation and changelog alignment (no product code changes)

### Related issue(s)

1. DEV-1097 — https://app.clickup.com/t/9015210959/DEV-1097

### Affected project(s)

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`
- [x] Repository documentation / published changelog only

### Checklist

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation. *(This PR is the documentation/changelog update.)*

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates Markdown content without touching runtime code or build logic.
> 
> **Overview**
> Adds the missing **`14.6.2` (2025-02-10)** entry to `CHANGELOG.md` and the v14 upgrade guide changelog (`changelog-14.md`).
> 
> The new notes document a single fix: copy/paste not working correctly in **Chrome 133** (PR `#11428`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8732059425a6ddf06ddbfde99f7774cc1e48b74b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->