### PR TITLE
DEV-1522: Fix incorrect claude secrets set command and migrate code-graph skills to correct folder structure

### DIFF
--- a/.ai/MCP.md
+++ b/.ai/MCP.md
@@ -19,14 +19,14 @@ To get a personal API token: ClickUp Settings > Apps > API Token > Generate.
 
 Project-level MCP servers are configured in `.mcp.json` at the repo root. This file is committed and shared with the team.
 
-The bearer token is **not** stored in `.mcp.json`. Store it as a secret:
+The bearer token is **not** stored in `.mcp.json`. Set it as a shell environment variable before starting Claude Code:
 
 ```bash
-# Store the token once (saved in Claude Code's local secrets store)
-claude secrets set CLICKUP_API_TOKEN pk_your_token_here
+# Add to your shell profile (~/.zshrc, ~/.bashrc, etc.) so it persists
+export CLICKUP_API_TOKEN=pk_your_token_here
 ```
 
-The `.mcp.json` file references the secret via `${CLICKUP_API_TOKEN}`. Claude Code expands secrets at startup.
+The `.mcp.json` file references the variable via `${CLICKUP_API_TOKEN}`. Claude Code expands environment variables at startup.
 
 If you prefer OAuth instead of a bearer token, remove the `headers` block from `.mcp.json`. Claude Code will prompt for OAuth on first use.
 
@@ -66,7 +66,7 @@ Once connected, the following tools are available to AI assistants:
 | Symptom | Fix |
 |---|---|
 | `clickup` server not listed in `/mcp` | Run `claude mcp list` to check config; verify `.mcp.json` exists at repo root |
-| `401 Unauthorized` errors | Token is wrong or expired; re-run `claude secrets set CLICKUP_API_TOKEN` |
+| `401 Unauthorized` errors | Token is wrong or expired; update `CLICKUP_API_TOKEN` in your shell profile and restart Claude Code |
 | OAuth prompt keeps appearing | Switch to bearer token auth (set `CLICKUP_API_TOKEN` and add `headers` block) |
 | Cursor shows server as disconnected | Check that `CLICKUP_API_TOKEN` is set in Cursor secrets or shell env |
 

--- a/.ai/MCP.md
+++ b/.ai/MCP.md
@@ -122,7 +122,7 @@ The `.cursor/mcp.json` and `.mcp.json` files also configure:
 
 | Server | Purpose |
 |---|---|
-| `github` | Read/write GitHub issues, PRs, and checks via `GITHUB_TOKEN` |
+| `github` | Read/write GitHub issues, PRs, and checks via `GITHUB_PERSONAL_ACCESS_TOKEN` (the package reads this env var — `GITHUB_TOKEN` is silently ignored) |
 | `filesystem_workspace` | Read/write access to the full repo workspace |
 | `filesystem_docs` | Read/write access to `./docs/content` only |
 | `code-review-graph` | Knowledge graph over the codebase (see above) |

--- a/.claude/skills/code-graph-debug-issue/SKILL.md
+++ b/.claude/skills/code-graph-debug-issue/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Debug Issue
+name: code-graph-debug-issue
 description: Systematically debug issues using graph-powered code navigation
 ---
 

--- a/.claude/skills/code-graph-explore-codebase/SKILL.md
+++ b/.claude/skills/code-graph-explore-codebase/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Explore Codebase
+name: code-graph-explore-codebase
 description: Navigate and understand codebase structure using the knowledge graph
 ---
 

--- a/.claude/skills/code-graph-refactor-safely/SKILL.md
+++ b/.claude/skills/code-graph-refactor-safely/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: Refactor Safely
-description: Plan and execute safe refactoring using dependency analysis
+name: code-graph-refactor-safely
+description: Plan and execute safe refactoring using dependency analysis from the knowledge graph
 ---
 
 ## Refactor Safely

--- a/.claude/skills/code-graph-review-changes/SKILL.md
+++ b/.claude/skills/code-graph-review-changes/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: Review Changes
-description: Perform a structured code review using change detection and impact
+name: code-graph-review-changes
+description: Perform a structured code review using change detection and impact analysis from the knowledge graph
 ---
 
 ## Review Changes

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -10,7 +10,7 @@
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-github"],
       "env": {
-        "GITHUB_TOKEN": "${GITHUB_TOKEN}"
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
       }
     },
     "filesystem_workspace": {

--- a/.mcp.json
+++ b/.mcp.json
@@ -11,7 +11,7 @@
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-github"],
       "env": {
-        "GITHUB_TOKEN": "${GITHUB_TOKEN}"
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
       }
     },
     "filesystem_workspace": {


### PR DESCRIPTION
### Context

The PR fixes three issues in the AI agent tooling configuration:

1. **Incorrect CLI command in `.ai/MCP.md`:** The file instructed users to run `claude secrets set CLICKUP_API_TOKEN pk_your_token_here` to store the ClickUp bearer token. This command does not exist - the Claude Code CLI has no `secrets` subcommand. The correct approach is to export `CLICKUP_API_TOKEN` as a shell environment variable (e.g., in `~/.zshrc`), which Claude Code picks up at startup via the `${CLICKUP_API_TOKEN}` reference in `.mcp.json`.

2. **Wrong env var name for the GitHub MCP server:** Both `.mcp.json` and `.cursor/mcp.json` passed `GITHUB_TOKEN` to `@modelcontextprotocol/server-github`. The package ignores that variable entirely - it reads `GITHUB_PERSONAL_ACCESS_TOKEN` (verified in `dist/common/utils.js`). With the wrong name the server runs unauthenticated: 60 req/hour rate limit, no access to private repos.

3. **Wrong skill file structure for 4 code-graph skills:** The skills `debug-issue`, `explore-codebase`, `refactor-safely`, and `review-changes` were created as flat `.md` files directly in `.claude/skills/`. Every other skill in the repo follows the correct spec: a folder named after the skill containing a single `SKILL.md` file (e.g., `.claude/skills/skill-name/SKILL.md`). Flat files are not loaded by Claude Code's skill system. The skills were also renamed with the `code-graph-` prefix to make their purpose (knowledge graph navigation) clear and avoid naming conflicts with existing skills (`refactoring`, `architecture-review`, etc.).

### How has this been tested?

- Verified `claude secrets --help` and `claude --help | grep secret` return no `secrets` subcommand
- Verified `GITHUB_PERSONAL_ACCESS_TOKEN` is the correct env var by reading `dist/common/utils.js` in the installed `@modelcontextprotocol/server-github@2025.4.8` package
- Confirmed all 4 skills appear in the live skill list immediately after moving to the correct folder structure (`code-graph-debug-issue`, `code-graph-explore-codebase`, `code-graph-refactor-safely`, `code-graph-review-changes`)

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1522

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWFA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1522