### PR TITLE
DEV-1519: Fix duplicate cell type recipes in React/Angular sidebar

### DIFF
--- a/docs/content/recipes/sidebar.js
+++ b/docs/content/recipes/sidebar.js
@@ -27,21 +27,24 @@ const dataManagementItems = [
 ];
 
 const cellTypesItems = [
-  { path: 'cell-types/color-picker/color-picker', title: 'Color picker', onlyFor: ['javascript', 'angular', 'react'] },
-  { path: 'cell-types/feedback-react/feedback-react', title: 'Simple Feedback', onlyFor: ['react'] },
+  // JavaScript
+  { path: 'cell-types/color-picker/color-picker', title: 'Color picker', onlyFor: ['javascript'] },
+  { path: 'cell-types/feedback/feedback', title: 'Feedback', onlyFor: ['javascript'] },
+  { path: 'cell-types/flatpickr/flatpickr', title: 'Flatpickr', onlyFor: ['javascript'] },
+  { path: 'cell-types/moment-date/moment-date', title: 'Moment.js-based date', onlyFor: ['javascript'] },
+  { path: 'cell-types/moment-time/moment-time', title: 'Moment.js-based time', onlyFor: ['javascript'] },
+  { path: 'cell-types/numbro/numbro', title: 'Numbro', onlyFor: ['javascript'] },
+  { path: 'cell-types/pikaday/pikaday', title: 'Pikaday', onlyFor: ['javascript'] },
+  { path: 'cell-types/rating/rating', title: 'Star Rating', onlyFor: ['javascript'] },
+  // React
+  { path: 'cell-types/feedback-react/feedback-react', title: 'Feedback', onlyFor: ['react'] },
   { path: 'cell-types/colorful-picker/colorful-picker', title: 'Colorful Picker', onlyFor: ['react'] },
   { path: 'cell-types/react-rating/react-rating', title: 'Star Rating', onlyFor: ['react'] },
-  { path: 'cell-types/feedback/feedback', title: 'Simple Feedback', onlyFor: ['javascript', 'angular', 'react'] },
-  { path: 'cell-types/flatpickr/flatpickr', title: 'Datetime `flatpickr` picker', onlyFor: ['javascript', 'angular', 'react'] },
-  { path: 'cell-types/moment-date/moment-date', title: 'Moment.js-based date', onlyFor: ['javascript', 'angular', 'react'] },
-  { path: 'cell-types/moment-time/moment-time', title: 'Moment.js-based time', onlyFor: ['javascript', 'angular', 'react'] },
-  { path: 'cell-types/numbro/numbro', title: 'Numbro', onlyFor: ['javascript', 'angular', 'react'] },
-  { path: 'cell-types/pikaday/pikaday', title: 'Date picker pikaday', onlyFor: ['javascript', 'angular', 'react'] },
-  { path: 'cell-types/rating/rating', title: 'Stars Rating', onlyFor: ['javascript', 'angular', 'react'] },
-  { path: 'cell-types/guide-feedback-angular/guide-feedback', title: 'Simple Feedback', onlyFor: ['angular'] },
-  { path: 'cell-types/guide-rating-angular/guide-rating', title: 'Stars Rating', onlyFor: ['angular'] },
+  // Angular
+  { path: 'cell-types/guide-feedback-angular/guide-feedback', title: 'Feedback Editor', onlyFor: ['angular'] },
+  { path: 'cell-types/guide-rating-angular/guide-rating', title: 'Star Rating Editor', onlyFor: ['angular'] },
   { path: 'cell-types/guide-color-picker-angular/guide-color-picker', title: 'Color picker', onlyFor: ['angular'] },
-  { path: 'cell-types/guide-datepicker-angular/guide-datepicker', title: 'Datetime picker', onlyFor: ['angular'] },
+  { path: 'cell-types/guide-datepicker-angular/guide-datepicker', title: 'Date picker', onlyFor: ['angular'] },
 ];
 
 const performanceItems = [


### PR DESCRIPTION
### Context

The PR fixes duplicate entries in the Cell Types section of the recipes sidebar (`docs/content/recipes/sidebar.js`). The dev site was showing the same recipe concept multiple times on the React and Angular pages because framework-specific entries (`onlyFor: ['react']` / `onlyFor: ['angular']`) coexisted with matching all-frameworks entries (`onlyFor: ['javascript', 'angular', 'react']`).

Before this fix, the React page showed "Simple Feedback" twice and "Star Rating"/"Stars Rating" twice. The Angular page showed "Simple Feedback", "Stars Rating", and "Color picker" each twice.

The fix reorganizes `cellTypesItems` to match the production site (handsontable.com):

**JavaScript** (8 entries): Color picker, Feedback, Flatpickr, Moment.js-based date, Moment.js-based time, Numbro, Pikaday, Star Rating

**React** (3 entries): Feedback, Colorful Picker, Star Rating

**Angular** (4 entries): Feedback Editor, Star Rating Editor, Color picker, Date picker

Nav titles are also corrected to match production: "Simple Feedback" → "Feedback", "Datetime \`flatpickr\` picker" → "Flatpickr", "Date picker pikaday" → "Pikaday", "Stars Rating" → "Star Rating", "Datetime picker" → "Date picker".

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1519

### How has this been tested?

- Manually reviewed `sidebar.js` diff against the production site entries
- No code logic changed - only sidebar navigation configuration

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1519

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

---
_Generated by [Claude Code](https://claude.ai/code/session_01KymLU2Ymv4GBiALeu8cFHm)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only documentation sidebar navigation config by adjusting `onlyFor` filters and link titles; no runtime or data-handling logic is modified.
> 
> **Overview**
> **Fixes duplicate “Cell Types” recipe entries** in the docs recipes sidebar by splitting the list into framework-specific sections (JavaScript/React/Angular) and removing the previous mixed all-framework entries that caused duplicates.
> 
> Also **normalizes several nav titles** (e.g., “Simple Feedback” → “Feedback”, “Datetime picker” → “Date picker”, “Stars Rating” → “Star Rating”) to match the intended naming across frameworks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0e39738aaadb6efbb28df76e07039587ec954e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->