### PR TITLE
fix(docs): make checkbox tick always white in both themes

### DIFF
--- a/docs/src/styles/utilities.css
+++ b/docs/src/styles/utilities.css
@@ -78,7 +78,7 @@ html {
   top: 1px;
   width: 4px;
   height: 8px;
-  border: solid var(--sl-color-white);
+  border: solid #ffffff;
   border-width: 0 1px 1px 0;
   transform: rotate(45deg);
 }


### PR DESCRIPTION
### Context

The PR fixes the checkbox tick/checkmark color in the documentation site. The custom-drawn checkbox `::after` pseudo-element used `var(--sl-color-white)` for the border (tick) color. In light mode, `--sl-color-white` resolves to `oklch(30% 0 0)` (near-black), making the checkmark nearly invisible against the blue accent background (`--sl-color-accent`). The fix hard-codes `#ffffff` so the tick is always white regardless of theme.

Affected areas: all pages using `.sl-markdown-content input[type="checkbox"]` or `.hot-example input[type="checkbox"]` - this covers guide pages, recipe pages, and example pages across both dark and light themes.

File changed: `docs/src/styles/utilities.css` (1 line)

### How has this been tested?

- Manually inspected the rendered checkbox in both light and dark theme on the documentation site
- Confirmed `#ffffff` always appears as white against the `--sl-color-accent` blue background in both themes

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. Checkbox tick color broken in light theme on documentation pages (e.g. https://dev.handsontable.com/docs/react-data-grid/events-and-hooks/)

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcXe7zLym3UAEwqZpBPWTJ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only change that affects only the visual color of the custom checkbox tick in docs; no functional or data-handling logic is impacted.
> 
> **Overview**
> Fixes docs checkbox contrast in light mode by changing the custom checkbox `::after` checkmark border color from theme variable `var(--sl-color-white)` to hard-coded `#ffffff`, ensuring the tick stays white across themes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1193a546d1145213b80239a8a0704263bbe6876a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->