### PR TITLE
Fix hidden table when height: 100% is used in React/Vue wrappers (#11848)

### DIFF
--- a/.changelogs/12445.json
+++ b/.changelogs/12445.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed the React and Vue 3 wrappers hiding the table when `height: '100%'` was set inside a fixed-height parent.",
+  "type": "fixed",
+  "issueOrPR": 12445,
+  "breaking": false,
+  "framework": "none"
+}

--- a/wrappers/react-wrapper/src/hotTableInner.tsx
+++ b/wrappers/react-wrapper/src/hotTableInner.tsx
@@ -252,7 +252,11 @@ const HotTableInner = forwardRef<
 
   return (
     <Fragment>
-      <div ref={hotElementRef} {...containerProps}>
+      <div
+        ref={hotElementRef}
+        {...containerProps}
+        style={{ height: '100%', ...containerProps.style }}
+      >
         {hotColumnWrapped}
       </div>
       <RenderersPortalManager ref={context.setRenderersPortalManagerRef} />

--- a/wrappers/vue3/src/HotTable.vue
+++ b/wrappers/vue3/src/HotTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :id="id">
+  <div :id="id" style="height: 100%">
     <slot></slot>
   </div>
 </template>


### PR DESCRIPTION
### Context

The PR fixes [issue #11848](https://github.com/handsontable/handsontable/issues/11848). When users set `height: '100%'` on `<HotTable>` in the React or Vue 3 wrapper and place it inside a parent with a fixed height, the table collapses to 0 and only headers/scrollbar remain visible.

The root cause is the height cascade: the core CSS sets `.ht-root-wrapper { height: 100% }` (fixed in #11769), but `.ht-root-wrapper` is mounted inside the wrapper component's container `<div>`. That container had no inherent height, so `height: 100%` on the root wrapper resolved against a zero-height parent and collapsed.

The fix defaults the wrapper-mounted `<div>` in both React and Vue 3 wrappers to `height: 100%`. User-supplied `style` still overrides via merge order, so existing setups that pass an explicit height keep working.

### How has this been tested?

- Manual test pages comparing CDN v17.0.1 (bug) vs PR build (fixed) for both React and Vue 3 wrappers — table fills the 450px parent on the PR build, collapses on the released build.
- Existing wrapper Jest suites:
  - `npm run test --prefix wrappers/react-wrapper`
  - `npm run test --prefix wrappers/vue3`
- Builds:
  - `npm run build:umd --prefix wrappers/react-wrapper`
  - `npm run build:umd --prefix wrappers/vue3`

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. https://github.com/handsontable/handsontable/issues/11848

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [x] `@handsontable/react-wrapper`
- [x] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS/prop-merging change limited to wrapper container elements; primary impact is layout behavior for consumers relying on the previous zero-height default.
> 
> **Overview**
> Fixes a wrapper layout bug where `height: '100%'` on `<HotTable>` could resolve against a zero-height wrapper container and hide the table inside fixed-height parents.
> 
> The React wrapper now merges a default `style={{ height: '100%', ...props.style }}` onto the mount `<div>`, and the Vue 3 wrapper sets `style="height: 100%"` on its root element. Adds a changelog entry for the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 522aea89a5831b294c2e4e1c0f18fff9d06f0e5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->