### PR TITLE
DEV-1526: Fix button styling in React and Angular docs examples

### DIFF
--- a/docs/content/guides/accessories-and-menus/export-to-csv/react/example2.jsx
+++ b/docs/content/guides/accessories-and-menus/export-to-csv/react/example2.jsx
@@ -26,10 +26,12 @@ const ExampleComponent = () => {
 
   return (
     <>
-      <div className="controls">
-        <button id="export-blob" onClick={() => buttonClickCallback()}>
-          Export as a Blob
-        </button>
+      <div className="example-controls-container">
+        <div className="controls">
+          <button id="export-blob" onClick={() => buttonClickCallback()}>
+            Export as a Blob
+          </button>
+        </div>
       </div>
       <HotTable
         ref={hotRef}

--- a/docs/content/guides/accessories-and-menus/export-to-csv/react/example2.tsx
+++ b/docs/content/guides/accessories-and-menus/export-to-csv/react/example2.tsx
@@ -27,10 +27,12 @@ const ExampleComponent = () => {
 
   return (
     <>
-      <div className="controls">
-        <button id="export-blob" onClick={() => buttonClickCallback()}>
-          Export as a Blob
-        </button>
+      <div className="example-controls-container">
+        <div className="controls">
+          <button id="export-blob" onClick={() => buttonClickCallback()}>
+            Export as a Blob
+          </button>
+        </div>
       </div>
       <HotTable
         ref={hotRef}

--- a/docs/content/guides/accessories-and-menus/export-to-csv/react/example3.jsx
+++ b/docs/content/guides/accessories-and-menus/export-to-csv/react/example3.jsx
@@ -25,10 +25,12 @@ const ExampleComponent = () => {
 
   return (
     <>
-      <div className="controls">
-        <button id="export-string" onClick={() => buttonClickCallback()}>
-          Export as a string
-        </button>
+      <div className="example-controls-container">
+        <div className="controls">
+          <button id="export-string" onClick={() => buttonClickCallback()}>
+            Export as a string
+          </button>
+        </div>
       </div>
       <HotTable
         ref={hotRef}

--- a/docs/content/guides/accessories-and-menus/export-to-csv/react/example3.tsx
+++ b/docs/content/guides/accessories-and-menus/export-to-csv/react/example3.tsx
@@ -26,10 +26,12 @@ const ExampleComponent = () => {
 
   return (
     <>
-      <div className="controls">
-        <button id="export-string" onClick={() => buttonClickCallback()}>
-          Export as a string
-        </button>
+      <div className="example-controls-container">
+        <div className="controls">
+          <button id="export-string" onClick={() => buttonClickCallback()}>
+            Export as a string
+          </button>
+        </div>
       </div>
       <HotTable
         ref={hotRef}

--- a/docs/content/guides/cell-features/clipboard/react/example3.jsx
+++ b/docs/content/guides/cell-features/clipboard/react/example3.jsx
@@ -29,13 +29,15 @@ const ExampleComponent = () => {
 
   return (
     <>
-      <div className="controls">
-        <button id="copy" onMouseDown={() => copyBtnMousedownCallback()} onClick={() => copyBtnClickCallback()}>
-          Select and copy cell B2
-        </button>
-        <button id="cut" onMouseDown={() => cutBtnMousedownCallback()} onClick={() => cutBtnClickCallback()}>
-          Select and cut cell B2
-        </button>
+      <div className="example-controls-container">
+        <div className="controls">
+          <button id="copy" onMouseDown={() => copyBtnMousedownCallback()} onClick={() => copyBtnClickCallback()}>
+            Select and copy cell B2
+          </button>
+          <button id="cut" onMouseDown={() => cutBtnMousedownCallback()} onClick={() => cutBtnClickCallback()}>
+            Select and cut cell B2
+          </button>
+        </div>
       </div>
       <HotTable
         ref={hotRef}

--- a/docs/content/guides/cell-features/clipboard/react/example3.tsx
+++ b/docs/content/guides/cell-features/clipboard/react/example3.tsx
@@ -30,13 +30,15 @@ const ExampleComponent = () => {
 
   return (
     <>
-      <div className="controls">
-        <button id="copy" onMouseDown={() => copyBtnMousedownCallback()} onClick={() => copyBtnClickCallback()}>
-          Select and copy cell B2
-        </button>
-        <button id="cut" onMouseDown={() => cutBtnMousedownCallback()} onClick={() => cutBtnClickCallback()}>
-          Select and cut cell B2
-        </button>
+      <div className="example-controls-container">
+        <div className="controls">
+          <button id="copy" onMouseDown={() => copyBtnMousedownCallback()} onClick={() => copyBtnClickCallback()}>
+            Select and copy cell B2
+          </button>
+          <button id="cut" onMouseDown={() => cutBtnMousedownCallback()} onClick={() => cutBtnClickCallback()}>
+            Select and cut cell B2
+          </button>
+        </div>
       </div>
       <HotTable
         ref={hotRef}

--- a/docs/content/guides/cell-features/selection/angular/example1.ts
+++ b/docs/content/guides/cell-features/selection/angular/example1.ts
@@ -6,31 +6,33 @@ import { GridSettings, HotTableComponent, HotTableModule } from '@handsontable/a
   selector: 'example1-selection',
   standalone: true,
   imports: [HotTableModule],
-  template: ` <div class="controls">
-      <div class="theme-dropdown" #dropdownRef>
-        <button
-          class="theme-dropdown-trigger"
-          type="button"
-          aria-haspopup="listbox"
-          [attr.aria-expanded]="isOpen"
-          (click)="toggleDropdown()"
-        >
-          <span>{{ selectedLabel }}</span>
-          <svg class="theme-dropdown-chevron" aria-hidden="true" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6l6 -6"/></svg>
-        </button>
-        @if (isOpen) {
-          <ul class="theme-dropdown-menu" role="listbox">
-            @for (opt of options; track opt.value) {
-              <li
-                role="option"
-                [attr.aria-selected]="selected === opt.value"
-                (click)="selectOption(opt.value)"
-              >
-                {{ opt.label }}
-              </li>
-            }
-          </ul>
-        }
+  template: ` <div class="example-controls-container">
+      <div class="controls">
+        <div class="theme-dropdown" #dropdownRef>
+          <button
+            class="theme-dropdown-trigger"
+            type="button"
+            aria-haspopup="listbox"
+            [attr.aria-expanded]="isOpen"
+            (click)="toggleDropdown()"
+          >
+            <span>{{ selectedLabel }}</span>
+            <svg class="theme-dropdown-chevron" aria-hidden="true" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6l6 -6"/></svg>
+          </button>
+          @if (isOpen) {
+            <ul class="theme-dropdown-menu" role="listbox">
+              @for (opt of options; track opt.value) {
+                <li
+                  role="option"
+                  [attr.aria-selected]="selected === opt.value"
+                  (click)="selectOption(opt.value)"
+                >
+                  {{ opt.label }}
+                </li>
+              }
+            </ul>
+          }
+        </div>
       </div>
     </div>
     <div>

--- a/docs/content/guides/cell-features/selection/angular/example3.ts
+++ b/docs/content/guides/cell-features/selection/angular/example3.ts
@@ -6,10 +6,12 @@ import { GridSettings, HotTableComponent, HotTableModule } from '@handsontable/a
   selector: 'example3-selection',
   standalone: true,
   imports: [HotTableModule],
-  template: ` <div class="controls">
-      <button id="set-data-action" (click)="buttonClick()">
-        Click to modify the selected cells
-      </button>
+  template: ` <div class="example-controls-container">
+      <div class="controls">
+        <button id="set-data-action" (click)="buttonClick()">
+          Click to modify the selected cells
+        </button>
+      </div>
     </div>
     <div>
       <hot-table [data]="data" [settings]="gridSettings"></hot-table>

--- a/docs/content/guides/cell-features/selection/react/example1.jsx
+++ b/docs/content/guides/cell-features/selection/react/example1.jsx
@@ -48,32 +48,34 @@ const ExampleComponent = () => {
 
   return (
     <>
-      <div className="controls">
-        <div className="theme-dropdown" ref={dropdownRef}>
-          <button
-            className="theme-dropdown-trigger"
-            type="button"
-            aria-haspopup="listbox"
-            aria-expanded={isOpen}
-            onClick={() => setIsOpen(!isOpen)}
-          >
-            <span>{selectedLabel}</span>
-            <svg className="theme-dropdown-chevron" aria-hidden="true" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M6 9l6 6l6 -6"/></svg>
-          </button>
-          {isOpen && (
-            <ul className="theme-dropdown-menu" role="listbox">
-              {options.map((opt) => (
-                <li
-                  key={opt.value}
-                  role="option"
-                  aria-selected={selected === opt.value}
-                  onClick={() => handleSelect(opt.value)}
-                >
-                  {opt.label}
-                </li>
-              ))}
-            </ul>
-          )}
+      <div className="example-controls-container">
+        <div className="controls">
+          <div className="theme-dropdown" ref={dropdownRef}>
+            <button
+              className="theme-dropdown-trigger"
+              type="button"
+              aria-haspopup="listbox"
+              aria-expanded={isOpen}
+              onClick={() => setIsOpen(!isOpen)}
+            >
+              <span>{selectedLabel}</span>
+              <svg className="theme-dropdown-chevron" aria-hidden="true" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M6 9l6 6l6 -6"/></svg>
+            </button>
+            {isOpen && (
+              <ul className="theme-dropdown-menu" role="listbox">
+                {options.map((opt) => (
+                  <li
+                    key={opt.value}
+                    role="option"
+                    aria-selected={selected === opt.value}
+                    onClick={() => handleSelect(opt.value)}
+                  >
+                    {opt.label}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
         </div>
       </div>
       <HotTable

--- a/docs/content/guides/cell-features/selection/react/example1.tsx
+++ b/docs/content/guides/cell-features/selection/react/example1.tsx
@@ -49,32 +49,34 @@ const ExampleComponent = () => {
 
   return (
     <>
-      <div className="controls">
-        <div className="theme-dropdown" ref={dropdownRef}>
-          <button
-            className="theme-dropdown-trigger"
-            type="button"
-            aria-haspopup="listbox"
-            aria-expanded={isOpen}
-            onClick={() => setIsOpen(!isOpen)}
-          >
-            <span>{selectedLabel}</span>
-            <svg className="theme-dropdown-chevron" aria-hidden="true" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M6 9l6 6l6 -6"/></svg>
-          </button>
-          {isOpen && (
-            <ul className="theme-dropdown-menu" role="listbox">
-              {options.map((opt) => (
-                <li
-                  key={opt.value}
-                  role="option"
-                  aria-selected={selected === opt.value}
-                  onClick={() => handleSelect(opt.value)}
-                >
-                  {opt.label}
-                </li>
-              ))}
-            </ul>
-          )}
+      <div className="example-controls-container">
+        <div className="controls">
+          <div className="theme-dropdown" ref={dropdownRef}>
+            <button
+              className="theme-dropdown-trigger"
+              type="button"
+              aria-haspopup="listbox"
+              aria-expanded={isOpen}
+              onClick={() => setIsOpen(!isOpen)}
+            >
+              <span>{selectedLabel}</span>
+              <svg className="theme-dropdown-chevron" aria-hidden="true" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M6 9l6 6l6 -6"/></svg>
+            </button>
+            {isOpen && (
+              <ul className="theme-dropdown-menu" role="listbox">
+                {options.map((opt) => (
+                  <li
+                    key={opt.value}
+                    role="option"
+                    aria-selected={selected === opt.value}
+                    onClick={() => handleSelect(opt.value)}
+                  >
+                    {opt.label}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
         </div>
       </div>
       <HotTable

--- a/docs/content/guides/cell-features/selection/react/example3.jsx
+++ b/docs/content/guides/cell-features/selection/react/example3.jsx
@@ -34,10 +34,12 @@ const ExampleComponent = () => {
 
   return (
     <>
-      <div className="controls">
-        <button id="set-data-action" onClick={() => buttonClickCallback()}>
-          Click to modify the selected cells
-        </button>
+      <div className="example-controls-container">
+        <div className="controls">
+          <button id="set-data-action" onClick={() => buttonClickCallback()}>
+            Click to modify the selected cells
+          </button>
+        </div>
       </div>
       <HotTable
         ref={hotRef}

--- a/docs/content/guides/cell-features/selection/react/example3.tsx
+++ b/docs/content/guides/cell-features/selection/react/example3.tsx
@@ -35,10 +35,12 @@ const ExampleComponent = () => {
 
   return (
     <>
-      <div className="controls">
-        <button id="set-data-action" onClick={() => buttonClickCallback()}>
-          Click to modify the selected cells
-        </button>
+      <div className="example-controls-container">
+        <div className="controls">
+          <button id="set-data-action" onClick={() => buttonClickCallback()}>
+            Click to modify the selected cells
+          </button>
+        </div>
       </div>
       <HotTable
         ref={hotRef}

--- a/docs/content/guides/cell-functions/cell-renderer/react/example2.jsx
+++ b/docs/content/guides/cell-functions/cell-renderer/react/example2.jsx
@@ -31,10 +31,12 @@ const ExampleComponent = () => {
 
   return (
     <HighlightContext.Provider value={darkMode}>
-      <div className="controls">
-        <label>
-          <input type="checkbox" onClick={toggleDarkMode} /> Dark mode
-        </label>
+      <div className="example-controls-container">
+        <div className="controls">
+          <label>
+            <input type="checkbox" onClick={toggleDarkMode} /> Dark mode
+          </label>
+        </div>
       </div>
       <HotTable
         data={[['A1'], ['A2'], ['A3'], ['A4'], ['A5'], ['A6'], ['A7'], ['A8'], ['A9'], ['A10']]}

--- a/docs/content/guides/cell-functions/cell-renderer/react/example2.tsx
+++ b/docs/content/guides/cell-functions/cell-renderer/react/example2.tsx
@@ -41,10 +41,12 @@ const ExampleComponent = () => {
 
   return (
     <HighlightContext.Provider value={darkMode}>
-      <div className="controls">
-        <label>
-          <input type="checkbox" onClick={toggleDarkMode} /> Dark mode
-        </label>
+      <div className="example-controls-container">
+        <div className="controls">
+          <label>
+            <input type="checkbox" onClick={toggleDarkMode} /> Dark mode
+          </label>
+        </div>
       </div>
       <HotTable
         data={[['A1'], ['A2'], ['A3'], ['A4'], ['A5'], ['A6'], ['A7'], ['A8'], ['A9'], ['A10']]}

--- a/docs/content/guides/columns/column-filter/react/exampleFilterThroughAPI1.jsx
+++ b/docs/content/guides/columns/column-filter/react/exampleFilterThroughAPI1.jsx
@@ -40,10 +40,12 @@ const ExampleComponent = () => {
 
   return (
     <>
-      <div className="controls">
-        <button onClick={filterBelow200}>Show items &lt; $200</button>
-        <button onClick={filterAbove200}>Show items &gt; $200</button>
-        <button onClick={clearAllFilters}>Clear filters</button>
+      <div className="example-controls-container">
+        <div className="controls">
+          <button onClick={filterBelow200}>Show items &lt; $200</button>
+          <button onClick={filterAbove200}>Show items &gt; $200</button>
+          <button onClick={clearAllFilters}>Clear filters</button>
+        </div>
       </div>
       <HotTable
         ref={hotTableComponentRef}

--- a/docs/content/guides/columns/column-filter/react/exampleFilterThroughAPI1.tsx
+++ b/docs/content/guides/columns/column-filter/react/exampleFilterThroughAPI1.tsx
@@ -40,10 +40,12 @@ const ExampleComponent = () => {
 
   return (
     <>
-      <div className="controls">
-        <button onClick={filterBelow200}>Show items &lt; $200</button>
-        <button onClick={filterAbove200}>Show items &gt; $200</button>
-        <button onClick={clearAllFilters}>Clear filters</button>
+      <div className="example-controls-container">
+        <div className="controls">
+          <button onClick={filterBelow200}>Show items &lt; $200</button>
+          <button onClick={filterAbove200}>Show items &gt; $200</button>
+          <button onClick={clearAllFilters}>Clear filters</button>
+        </div>
       </div>
       <HotTable
         ref={hotTableComponentRef}

--- a/docs/content/guides/formulas/formula-calculation/react/example-named-expressions1.jsx
+++ b/docs/content/guides/formulas/formula-calculation/react/example-named-expressions1.jsx
@@ -49,16 +49,18 @@ const ExampleComponent = () => {
         autoWrapCol={true}
         licenseKey="non-commercial-and-evaluation"
       />
-      <div className="controls">
-        <input
-          id="named-expressions-input"
-          type="text"
-          defaultValue={namedExpressionValue}
-          onChange={(...args) => inputChangeCallback(...args)}
-        />
-        <button id="named-expressions-button" onClick={() => buttonClickCallback()}>
-          Calculate the price
-        </button>
+      <div className="example-controls-container">
+        <div className="controls">
+          <input
+            id="named-expressions-input"
+            type="text"
+            defaultValue={namedExpressionValue}
+            onChange={(...args) => inputChangeCallback(...args)}
+          />
+          <button id="named-expressions-button" onClick={() => buttonClickCallback()}>
+            Calculate the price
+          </button>
+        </div>
       </div>
     </>
   );

--- a/docs/content/guides/formulas/formula-calculation/react/example-named-expressions1.tsx
+++ b/docs/content/guides/formulas/formula-calculation/react/example-named-expressions1.tsx
@@ -54,16 +54,18 @@ const ExampleComponent = () => {
         autoWrapCol={true}
         licenseKey="non-commercial-and-evaluation"
       />
-      <div className="controls">
-        <input
-          id="named-expressions-input"
-          type="text"
-          defaultValue={namedExpressionValue}
-          onChange={(...args) => inputChangeCallback(...args)}
-        />
-        <button id="named-expressions-button" onClick={() => buttonClickCallback()}>
-          Calculate the price
-        </button>
+      <div className="example-controls-container">
+        <div className="controls">
+          <input
+            id="named-expressions-input"
+            type="text"
+            defaultValue={namedExpressionValue}
+            onChange={(...args) => inputChangeCallback(...args)}
+          />
+          <button id="named-expressions-button" onClick={() => buttonClickCallback()}>
+            Calculate the price
+          </button>
+        </div>
       </div>
     </>
   );

--- a/docs/content/guides/getting-started/angular-hot-instance/angular/example1.ts
+++ b/docs/content/guides/getting-started/angular-hot-instance/angular/example1.ts
@@ -6,8 +6,10 @@ import { GridSettings, HotTableComponent, HotTableModule} from '@handsontable/an
   selector: 'example1-instance-access',
   standalone: true,
   imports: [HotTableModule],
-  template: ` <div class="controls">
-      <button (click)="selectCell()">Select cell B2</button>
+  template: ` <div class="example-controls-container">
+      <div class="controls">
+        <button (click)="selectCell()">Select cell B2</button>
+      </div>
     </div>
     <div>
       <hot-table [data]="data" [settings]="gridSettings"></hot-table>

--- a/docs/content/guides/getting-started/events-and-hooks/angular/example3.ts
+++ b/docs/content/guides/getting-started/events-and-hooks/angular/example3.ts
@@ -6,42 +6,44 @@ import { HotTableComponent, HotTableModule} from '@handsontable/angular-wrapper'
   selector: 'example3-events-hooks',
   standalone: true,
   imports: [HotTableModule],
-  template: ` <div class="controls">
-      <label>
-        <input
-          (change)="handleChange('fixedRowsTop', [0, 2], $event)"
-          type="checkbox"
-        />
-        Add fixed rows
-      </label>
-      <br />
+  template: ` <div class="example-controls-container">
+      <div class="controls">
+        <label>
+          <input
+            (change)="handleChange('fixedRowsTop', [0, 2], $event)"
+            type="checkbox"
+          />
+          Add fixed rows
+        </label>
+        <br />
 
-      <label>
-        <input
-          (change)="handleChange('fixedColumnsStart', [0, 2], $event)"
-          type="checkbox"
-        />
-        Add fixed columns
-      </label>
-      <br />
+        <label>
+          <input
+            (change)="handleChange('fixedColumnsStart', [0, 2], $event)"
+            type="checkbox"
+          />
+          Add fixed columns
+        </label>
+        <br />
 
-      <label>
-        <input
-          (change)="handleChange('rowHeaders', [false, true], $event)"
-          type="checkbox"
-        />
-        Enable row headers
-      </label>
-      <br />
+        <label>
+          <input
+            (change)="handleChange('rowHeaders', [false, true], $event)"
+            type="checkbox"
+          />
+          Enable row headers
+        </label>
+        <br />
 
-      <label>
-        <input
-          (change)="handleChange('colHeaders', [false, true], $event)"
-          type="checkbox"
-        />
-        Enable column headers
-      </label>
-      <br />
+        <label>
+          <input
+            (change)="handleChange('colHeaders', [false, true], $event)"
+            type="checkbox"
+          />
+          Enable column headers
+        </label>
+        <br />
+      </div>
     </div>
     <div style="max-width: 440px">
       <hot-table [data]="data" [settings]="initialState"></hot-table>

--- a/docs/content/guides/getting-started/events-and-hooks/react/example3.jsx
+++ b/docs/content/guides/getting-started/events-and-hooks/react/example3.jsx
@@ -40,30 +40,32 @@ const ExampleComponent = () => {
 
   return (
     <div>
-      <div className="controls">
-        <label>
-          <input onChange={handleChange('fixedRowsTop', [0, 2])} type="checkbox" />
-          Add fixed rows
-        </label>
-        <br />
+      <div className="example-controls-container">
+        <div className="controls">
+          <label>
+            <input onChange={handleChange('fixedRowsTop', [0, 2])} type="checkbox" />
+            Add fixed rows
+          </label>
+          <br />
 
-        <label>
-          <input onChange={handleChange('fixedColumnsStart', [0, 2])} type="checkbox" />
-          Add fixed columns
-        </label>
-        <br />
+          <label>
+            <input onChange={handleChange('fixedColumnsStart', [0, 2])} type="checkbox" />
+            Add fixed columns
+          </label>
+          <br />
 
-        <label>
-          <input onChange={handleChange('rowHeaders', [false, true])} type="checkbox" />
-          Enable row headers
-        </label>
-        <br />
+          <label>
+            <input onChange={handleChange('rowHeaders', [false, true])} type="checkbox" />
+            Enable row headers
+          </label>
+          <br />
 
-        <label>
-          <input onChange={handleChange('colHeaders', [false, true])} type="checkbox" />
-          Enable column headers
-        </label>
-        <br />
+          <label>
+            <input onChange={handleChange('colHeaders', [false, true])} type="checkbox" />
+            Enable column headers
+          </label>
+          <br />
+        </div>
       </div>
 
       <HotTable id="hot" {...settings} />

--- a/docs/content/guides/getting-started/events-and-hooks/react/example3.tsx
+++ b/docs/content/guides/getting-started/events-and-hooks/react/example3.tsx
@@ -40,30 +40,32 @@ const ExampleComponent = () => {
 
   return (
     <div>
-      <div className="controls">
-        <label>
-          <input onChange={handleChange('fixedRowsTop', [0, 2])} type="checkbox" />
-          Add fixed rows
-        </label>
-        <br />
+      <div className="example-controls-container">
+        <div className="controls">
+          <label>
+            <input onChange={handleChange('fixedRowsTop', [0, 2])} type="checkbox" />
+            Add fixed rows
+          </label>
+          <br />
 
-        <label>
-          <input onChange={handleChange('fixedColumnsStart', [0, 2])} type="checkbox" />
-          Add fixed columns
-        </label>
-        <br />
+          <label>
+            <input onChange={handleChange('fixedColumnsStart', [0, 2])} type="checkbox" />
+            Add fixed columns
+          </label>
+          <br />
 
-        <label>
-          <input onChange={handleChange('rowHeaders', [false, true])} type="checkbox" />
-          Enable row headers
-        </label>
-        <br />
+          <label>
+            <input onChange={handleChange('rowHeaders', [false, true])} type="checkbox" />
+            Enable row headers
+          </label>
+          <br />
 
-        <label>
-          <input onChange={handleChange('colHeaders', [false, true])} type="checkbox" />
-          Enable column headers
-        </label>
-        <br />
+          <label>
+            <input onChange={handleChange('colHeaders', [false, true])} type="checkbox" />
+            Enable column headers
+          </label>
+          <br />
+        </div>
       </div>
 
       <HotTable id="hot" {...settings} />

--- a/docs/content/guides/getting-started/grid-size/angular/example.ts
+++ b/docs/content/guides/getting-started/grid-size/angular/example.ts
@@ -6,14 +6,16 @@ import { GridSettings, HotTableComponent, HotTableModule} from '@handsontable/an
   selector: 'example-grid-size',
   standalone: true,
   imports: [HotTableModule],
-  template: `<div class="controls">
-      <button
-        id="triggerBtn"
-        class="button button--primary"
-        (click)="btnClick()"
-      >
-        {{ isContainerExpanded ? 'Collapse container' : 'Expand container' }}
-      </button>
+  template: `<div class="example-controls-container">
+      <div class="controls">
+        <button
+          id="triggerBtn"
+          class="button button--primary"
+          (click)="btnClick()"
+        >
+          {{ isContainerExpanded ? 'Collapse container' : 'Expand container' }}
+        </button>
+      </div>
     </div>
     <div class="table-container" [style.height.px]="currentHeight">
       <hot-table [data]="data" [settings]="gridSettings"></hot-table>

--- a/docs/content/guides/getting-started/grid-size/react/example.jsx
+++ b/docs/content/guides/getting-started/grid-size/react/example.jsx
@@ -30,10 +30,12 @@ const ExampleComponent = () => {
 
   return (
     <>
-      <div className="controls">
-        <button id="triggerBtn" className="button button--primary" onClick={() => triggerBtnClickCallback()}>
-          {isContainerExpanded ? 'Collapse container' : 'Expand container'}
-        </button>
+      <div className="example-controls-container">
+        <div className="controls">
+          <button id="triggerBtn" className="button button--primary" onClick={() => triggerBtnClickCallback()}>
+            {isContainerExpanded ? 'Collapse container' : 'Expand container'}
+          </button>
+        </div>
       </div>
       <div id="exampleParent" className="exampleParent">
         <HotTable

--- a/docs/content/guides/getting-started/grid-size/react/example.tsx
+++ b/docs/content/guides/getting-started/grid-size/react/example.tsx
@@ -31,10 +31,12 @@ const ExampleComponent = () => {
 
   return (
     <>
-      <div className="controls">
-        <button id="triggerBtn" className="button button--primary" onClick={() => triggerBtnClickCallback()}>
-          {isContainerExpanded ? 'Collapse container' : 'Expand container'}
-        </button>
+      <div className="example-controls-container">
+        <div className="controls">
+          <button id="triggerBtn" className="button button--primary" onClick={() => triggerBtnClickCallback()}>
+            {isContainerExpanded ? 'Collapse container' : 'Expand container'}
+          </button>
+        </div>
       </div>
       <div id="exampleParent" className="exampleParent">
         <HotTable

--- a/docs/content/guides/getting-started/react-methods/react/example1.jsx
+++ b/docs/content/guides/getting-started/react-methods/react/example1.jsx
@@ -21,8 +21,10 @@ const ExampleComponent = () => {
 
   return (
     <>
-      <div className="controls">
-        <button onClick={selectCell}>Select cell B2</button>
+      <div className="example-controls-container">
+        <div className="controls">
+          <button onClick={selectCell}>Select cell B2</button>
+        </div>
       </div>
       <HotTable
         ref={hotTableComponentRef}

--- a/docs/content/guides/getting-started/react-methods/react/example1.tsx
+++ b/docs/content/guides/getting-started/react-methods/react/example1.tsx
@@ -22,8 +22,10 @@ const ExampleComponent = () => {
 
   return (
     <>
-      <div className="controls">
-        <button onClick={selectCell}>Select cell B2</button>
+      <div className="example-controls-container">
+        <div className="controls">
+          <button onClick={selectCell}>Select cell B2</button>
+        </div>
       </div>
       <HotTable
         ref={hotTableComponentRef}

--- a/docs/content/guides/getting-started/react-redux/react/example1.jsx
+++ b/docs/content/guides/getting-started/react-redux/react/example1.jsx
@@ -33,11 +33,13 @@ const ExampleComponentContent = () => {
     <div className="dump-example-container">
       <div id="example-container">
         <div id="example-preview">
-          <div className="controls">
-            <label>
-              <input onClick={toggleReadOnly} type="checkbox" />
-              Toggle <code>readOnly</code> for the entire table
-            </label>
+          <div className="example-controls-container">
+            <div className="controls">
+              <label>
+                <input onClick={toggleReadOnly} type="checkbox" />
+                Toggle <code>readOnly</code> for the entire table
+              </label>
+            </div>
           </div>
 
           <HotTable

--- a/docs/content/guides/getting-started/react-redux/react/example1.tsx
+++ b/docs/content/guides/getting-started/react-redux/react/example1.tsx
@@ -36,11 +36,13 @@ const ExampleComponentContent = () => {
     <div className="dump-example-container">
       <div id="example-container">
         <div id="example-preview">
-          <div className="controls">
-            <label>
-              <input onClick={toggleReadOnly} type="checkbox" />
-              Toggle <code>readOnly</code> for the entire table
-            </label>
+          <div className="example-controls-container">
+            <div className="controls">
+              <label>
+                <input onClick={toggleReadOnly} type="checkbox" />
+                Toggle <code>readOnly</code> for the entire table
+              </label>
+            </div>
           </div>
 
           <HotTable

--- a/docs/content/guides/rows/rows-sorting/react/exampleSortByAPIMultipleColumns.jsx
+++ b/docs/content/guides/rows/rows-sorting/react/exampleSortByAPIMultipleColumns.jsx
@@ -121,8 +121,10 @@ const ExampleComponent = () => {
         autoWrapCol={true}
         licenseKey="non-commercial-and-evaluation"
       />
-      <div className="controls">
-        <button onClick={sort}>Sort</button>
+      <div className="example-controls-container">
+        <div className="controls">
+          <button onClick={sort}>Sort</button>
+        </div>
       </div>
     </>
   );

--- a/docs/content/guides/rows/rows-sorting/react/exampleSortByAPIMultipleColumns.tsx
+++ b/docs/content/guides/rows/rows-sorting/react/exampleSortByAPIMultipleColumns.tsx
@@ -121,8 +121,10 @@ const ExampleComponent = () => {
         autoWrapCol={true}
         licenseKey="non-commercial-and-evaluation"
       />
-      <div className="controls">
-        <button onClick={sort}>Sort</button>
+      <div className="example-controls-container">
+        <div className="controls">
+          <button onClick={sort}>Sort</button>
+        </div>
       </div>
     </>
   );


### PR DESCRIPTION
### Context

The PR fixes missing button styling in 31 React (JSX/TSX) and Angular docs examples. Buttons inside `.controls` divs were not receiving the visual styling defined in `interactive-example.css` because they lacked the required `.example-controls-container` wrapper.

The CSS rule `.example-controls-container button { ... }` provides the consistent button appearance (border, background, font, hover states) seen in JS examples. React and Angular examples were rendering bare unstyled browser-default buttons instead.

The fix wraps every `.controls` div with `<div className="example-controls-container">` (React) or `<div class="example-controls-container">` (Angular), matching the pattern already used correctly in JavaScript HTML examples.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1526

### How has this been tested?

- Verified all 31 affected files now contain `.example-controls-container` wrapping `.controls`
- Confirmed zero remaining files have `.controls` without the wrapper (grep check passed)
- Manual inspection of representative examples: selection, export-to-csv, clipboard, grid-size, events-and-hooks

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1526

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y8BhC9xVt1Kdec7iFrWXJT)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only markup changes that affect presentation, with no runtime/business logic changes beyond DOM structure around existing controls.
> 
> **Overview**
> Fixes inconsistent styling in docs interactive examples by ensuring React and Angular snippets wrap their `.controls` sections in `.example-controls-container`, matching the CSS selectors in `interactive-example.css`.
> 
> This is a markup-only change across multiple guides (export-to-csv, clipboard, selection, formulas, filters, grid sizing, events/hooks, sorting, redux) to make buttons/inputs consistently styled and laid out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e09244e255856a2ada227ed4406650a81b14bfe7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->