### PR TITLE
Wire up docs-assistant feedback buttons to POST /api/feedback

### DIFF
--- a/docs/src/components/DocsAssistant/constants.ts
+++ b/docs/src/components/DocsAssistant/constants.ts
@@ -27,6 +27,7 @@ export const API_URL =
   'https://hot-docs-assistant.netlify.app';
 
 export const CHAT_ENDPOINT = `${API_URL.replace(/\/$/, '')}/api/chat`;
+export const FEEDBACK_ENDPOINT = `${API_URL.replace(/\/$/, '')}/api/feedback`;
 
 export const SHIKI_LANGS = ['js', 'ts', 'html', 'css', 'json', 'bash'] as const;
 export const SHIKI_THEMES = { light: 'github-light', dark: 'github-dark' } as const;

--- a/docs/src/components/DocsAssistant/useAssistant.ts
+++ b/docs/src/components/DocsAssistant/useAssistant.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useReducer, useRef } from 'react';
-import { CHAT_ENDPOINT, STORAGE_KEYS } from './constants';
+import { CHAT_ENDPOINT, FEEDBACK_ENDPOINT, STORAGE_KEYS } from './constants';
 import { buildContextualMessage } from './pageContext';
 
 export interface ChatMessage {
@@ -181,6 +181,14 @@ export function useAssistant() {
     persistThread(state.messages);
   }, [state.messages]);
 
+  // Mirror of state.messages so setFeedback can read the current value without
+  // listing it in deps. Including it would re-create the callback on every
+  // streaming chunk and force every <Message> to re-render its action bar.
+  const messagesRef = useRef(state.messages);
+  useEffect(() => {
+    messagesRef.current = state.messages;
+  }, [state.messages]);
+
   const stop = useCallback(() => {
     abortRef.current?.abort();
     abortRef.current = null;
@@ -332,7 +340,40 @@ export function useAssistant() {
   );
 
   const setFeedback = useCallback((id: string, feedback: 'up' | 'down') => {
+    const messages = messagesRef.current;
+    const target = messages.find((m) => m.id === id);
+    if (!target || target.role !== 'assistant') return;
+    if (target.feedback === feedback) return;
+
+    const threadId = threadIdRef.current;
+    if (!threadId) {
+      // No thread id means no AI message has been received yet, so there is
+      // nothing to rate. Defensive guard; should not happen in practice.
+      return;
+    }
+
+    const assistantMessageIndex = messages
+      .filter((m) => m.role === 'assistant')
+      .findIndex((m) => m.id === id);
+    if (assistantMessageIndex < 0) return;
+
     dispatch({ type: 'SET_FEEDBACK', id, feedback });
+
+    fetch(FEEDBACK_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ threadId, assistantMessageIndex, feedback }),
+    })
+      .then((res) => {
+        if (!res.ok) {
+          // eslint-disable-next-line no-console
+          console.error(`docs-assistant feedback failed: ${res.status} ${res.statusText}`);
+        }
+      })
+      .catch((err) => {
+        // eslint-disable-next-line no-console
+        console.error('docs-assistant feedback failed', err);
+      });
   }, []);
 
   return { state, send, stop, retry, clear, clearAndSend, setFeedback };


### PR DESCRIPTION
### Context

The PR wires the existing thumbs-up / thumbs-down buttons under each AI reply in the docs-assistant chat widget to the new `POST /api/feedback` endpoint. Before this change the buttons only flipped local React state; the click never reached the backend.

The new endpoint accepts:

```json
{ "threadId": "<id>", "assistantMessageIndex": <int>, "feedback": "up" | "down" }
```

`threadId` is reused from the same `localStorage` slot the chat call uses for follow-up turns. `assistantMessageIndex` is the 0-based position of the rated message among `role === "assistant"` messages in the current thread. The POST is fire-and-forget; the optimistic UI flip is unchanged.

### How has this been tested?

- `npm run docs:lint --prefix docs` — passes.
- Manual end-to-end against the deployed `hot-docs-assistant.netlify.app` proxy — verified in `develop` mode by clicking 👍 and 👎 on real AI replies and confirming the backend received both events.
- Local browser preview with stubbed `fetch` — confirmed:
  - POST body shape matches the contract.
  - `assistantMessageIndex` is 0 for the first assistant reply, 1 for the second.
  - `threadId` is in the body, no `X-Thread-Id` header.
  - Mutual exclusivity within a message (clicking 👎 after 👍 swaps the active state cleanly).
  - Clicking the same already-active button is a no-op (no duplicate POST).
  - On non-OK / network failure: `console.error` fires and the optimistic UI persists (intentional - user intent stays captured locally).

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

n/a

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

(Affects only the `docs/` site, which is not in the package list above.)

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: docs-only change that adds a fire-and-forget feedback POST alongside the existing optimistic UI toggle, with defensive guards and error logging.
> 
> **Overview**
> Wires the docs assistant’s 👍/👎 buttons to a new `POST /api/feedback` call, sending `{ threadId, assistantMessageIndex, feedback }` while keeping the existing optimistic local state update.
> 
> Adds `FEEDBACK_ENDPOINT` and updates `setFeedback` to no-op on invalid targets/duplicates, derive the rated message’s index among assistant replies, and avoid extra re-renders during streaming via a `messagesRef` mirror; failures are logged to `console.error`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aaf5d8440cd332bfc3ee2e1c37dcbfdae4e40344. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->