### PR TITLE
Fix mobile scroll re-triggering cell selection (#11659)

### DIFF
--- a/.changelogs/12450.json
+++ b/.changelogs/12450.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed cell selection re-triggering on every scroll gesture on mobile devices.",
+  "type": "fixed",
+  "issueOrPR": 12450,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/src/event.js
+++ b/handsontable/src/3rdparty/walkontable/src/event.js
@@ -385,7 +385,8 @@ class Event {
    * @param {TouchEvent} event The touch event object.
    */
   onTouchEnd(event) {
-    const isTap = !this.#touchWasMoved && !this.#longPressFired && this.#deferredTouchStartEvent !== null;
+    const wasScrolled = this.#touchWasMoved;
+    const isTap = !wasScrolled && !this.#longPressFired && this.#deferredTouchStartEvent !== null;
     const deferredTouchStartEvent = this.#deferredTouchStartEvent;
 
     this.#cancelLongPressTimer();
@@ -425,7 +426,10 @@ class Event {
       }
     }
 
-    if (isTap) {
+    // Fire mouseUp for both tap and long-press (matches pre-fix behavior so plugins
+    // listening to onCellMouseUp / before/after hooks still run). Suppress only for
+    // pure scroll gestures, where onMouseDown was never fired in the first place.
+    if (!wasScrolled) {
       this.onMouseUp(event);
     }
 
@@ -457,6 +461,11 @@ class Event {
       this.#longPressTimeout = null;
       this.#longPressFired = true;
       this.#touchStartCoords = null;
+
+      // Select the long-pressed cell so context-menu commands (e.g. "Insert row above")
+      // operate on it. With the deferred-mousedown flow, touchend skips onMouseDown
+      // when #longPressFired is true, so we fire it here before opening the menu.
+      this.onMouseDown(event);
 
       this.#dblClickOrigin[0] = null;
       this.#dblClickOrigin[1] = null;

--- a/handsontable/src/3rdparty/walkontable/src/event.js
+++ b/handsontable/src/3rdparty/walkontable/src/event.js
@@ -57,11 +57,32 @@ class Event {
    */
   #longPressTimeout = null;
   /**
-   * Starting coordinates of a touch gesture (used to detect movement that cancels long-press).
+   * Marks that the long-press contextmenu gesture has been triggered for the current touch.
+   *
+   * @type {boolean}
+   */
+  #longPressFired = false;
+  /**
+   * Starting coordinates of a touch gesture (used to detect movement that cancels long-press
+   * and to distinguish a tap from a scroll).
    *
    * @type {{ x: number, y: number }|null}
    */
   #touchStartCoords = null;
+  /**
+   * Marks that the current touch gesture has moved beyond the threshold and should be treated
+   * as a scroll rather than a tap.
+   *
+   * @type {boolean}
+   */
+  #touchWasMoved = false;
+  /**
+   * The original `touchstart` event captured so the synthesized mousedown can be deferred to
+   * `touchend` and only fired when the gesture is a tap (not a scroll).
+   *
+   * @type {TouchEvent|null}
+   */
+  #deferredTouchStartEvent = null;
 
   /**
    * @param {FacadeGetter} facadeGetter Gets an instance facade.
@@ -97,7 +118,7 @@ class Event {
     const initTouchEvents = () => {
       this.#eventManager.addEventListener(this.#wtTable.holder, 'touchstart', event => this.onTouchStart(event));
       this.#eventManager.addEventListener(this.#wtTable.holder, 'touchend', event => this.onTouchEnd(event));
-      this.#eventManager.addEventListener(this.#wtTable.holder, 'touchmove', event => this.#onTouchMove(event));
+      this.#eventManager.addEventListener(this.#wtTable.holder, 'touchmove', event => this.onTouchMove(event));
 
       if (!this.momentumScrolling) {
         this.momentumScrolling = {};
@@ -338,7 +359,9 @@ class Event {
   }
 
   /**
-   * OnTouchStart callback. Simulates mousedown event.
+   * OnTouchStart callback. Captures the gesture start so the synthesized mousedown can be
+   * deferred to `touchend`; this lets a touch-drag gesture scroll the grid without
+   * re-triggering the cell selection (see issue #11659).
    *
    * @private
    * @param {TouchEvent} event The touch event object.
@@ -346,19 +369,31 @@ class Event {
   onTouchStart(event) {
     this.#selectedCellBeforeTouchEnd = this.#selectionManager.getFocusSelection().cellRange;
     this.touchApplied = true;
+    this.#touchWasMoved = false;
+    this.#longPressFired = false;
+    this.#deferredTouchStartEvent = event;
 
-    this.onMouseDown(event);
     this.#startLongPressTimer(event);
   }
 
   /**
-   * OnTouchEnd callback. Simulates mouseup event.
+   * OnTouchEnd callback. Fires the deferred mousedown only when the gesture is a tap
+   * (no movement past the threshold and no long-press); for a scroll gesture the
+   * selection stays untouched (see issue #11659).
    *
    * @private
    * @param {TouchEvent} event The touch event object.
    */
   onTouchEnd(event) {
+    const isTap = !this.#touchWasMoved && !this.#longPressFired && this.#deferredTouchStartEvent !== null;
+    const deferredTouchStartEvent = this.#deferredTouchStartEvent;
+
     this.#cancelLongPressTimer();
+    this.#deferredTouchStartEvent = null;
+
+    if (isTap) {
+      this.onMouseDown(deferredTouchStartEvent);
+    }
 
     const target = event.target;
     const parentCellCoords = this.parentCell(target)?.coords;
@@ -390,9 +425,13 @@ class Event {
       }
     }
 
-    this.onMouseUp(event);
+    if (isTap) {
+      this.onMouseUp(event);
+    }
 
     this.touchApplied = false;
+    this.#touchWasMoved = false;
+    this.#longPressFired = false;
   }
 
   /**
@@ -416,6 +455,7 @@ class Event {
 
     this.#longPressTimeout = setTimeout(() => {
       this.#longPressTimeout = null;
+      this.#longPressFired = true;
       this.#touchStartCoords = null;
 
       this.#dblClickOrigin[0] = null;
@@ -451,19 +491,21 @@ class Event {
   }
 
   /**
-   * OnTouchMove callback. Cancels the long-press timer if the finger moves beyond the threshold.
+   * OnTouchMove callback. Once the finger moves beyond the threshold, marks the gesture as a
+   * scroll so `touchend` skips firing the deferred mousedown, and cancels the long-press timer.
    *
    * @private
    * @param {TouchEvent} event The touch event object.
    */
-  #onTouchMove(event) {
-    if (this.#longPressTimeout === null || this.#touchStartCoords === null) {
+  onTouchMove(event) {
+    if (this.#touchStartCoords === null) {
       return;
     }
 
     const touch = event.touches[0];
 
     if (!touch) {
+      this.#touchWasMoved = true;
       this.#cancelLongPressTimer();
 
       return;
@@ -473,6 +515,7 @@ class Event {
     const dy = Math.abs(touch.clientY - this.#touchStartCoords.y);
 
     if (dx > LONG_PRESS_MOVE_THRESHOLD || dy > LONG_PRESS_MOVE_THRESHOLD) {
+      this.#touchWasMoved = true;
       this.#cancelLongPressTimer();
     }
   }

--- a/handsontable/src/3rdparty/walkontable/src/event.js
+++ b/handsontable/src/3rdparty/walkontable/src/event.js
@@ -119,27 +119,7 @@ class Event {
       this.#eventManager.addEventListener(this.#wtTable.holder, 'touchstart', event => this.onTouchStart(event));
       this.#eventManager.addEventListener(this.#wtTable.holder, 'touchend', event => this.onTouchEnd(event));
       this.#eventManager.addEventListener(this.#wtTable.holder, 'touchmove', event => this.onTouchMove(event));
-
-      if (!this.momentumScrolling) {
-        this.momentumScrolling = {};
-      }
-      this.#eventManager.addEventListener(this.#wtTable.holder, 'scroll', () => {
-        this.#cancelLongPressTimer();
-        clearTimeout(this.momentumScrolling._timeout);
-
-        if (!this.momentumScrolling.ongoing) {
-          this.#wtSettings.getSetting('onBeforeTouchScroll');
-        }
-        this.momentumScrolling.ongoing = true;
-
-        this.momentumScrolling._timeout = setTimeout(() => {
-          if (!this.touchApplied) {
-            this.momentumScrolling.ongoing = false;
-
-            this.#wtSettings.getSetting('onAfterMomentumScroll');
-          }
-        }, 200);
-      });
+      this.#eventManager.addEventListener(this.#wtTable.holder, 'scroll', () => this.onHolderScroll());
     };
 
     const initMouseEvents = () => {
@@ -487,6 +467,39 @@ class Event {
   }
 
   /**
+   * Holder `scroll` callback. Cancels the long-press timer and runs the momentum-scroll
+   * bookkeeping. When called during an active touch sequence it also marks the gesture
+   * as a scroll so the deferred mousedown is not fired on `touchend` - native scrolling
+   * can start at ~8px, before the 10px LONG_PRESS_MOVE_THRESHOLD that `onTouchMove`
+   * watches (issue #11659).
+   *
+   * @private
+   */
+  onHolderScroll() {
+    if (!this.momentumScrolling) {
+      this.momentumScrolling = {};
+    }
+    if (this.touchApplied) {
+      this.#touchWasMoved = true;
+    }
+    this.#cancelLongPressTimer();
+    clearTimeout(this.momentumScrolling._timeout);
+
+    if (!this.momentumScrolling.ongoing) {
+      this.#wtSettings.getSetting('onBeforeTouchScroll');
+    }
+    this.momentumScrolling.ongoing = true;
+
+    this.momentumScrolling._timeout = setTimeout(() => {
+      if (!this.touchApplied) {
+        this.momentumScrolling.ongoing = false;
+
+        this.#wtSettings.getSetting('onAfterMomentumScroll');
+      }
+    }, 200);
+  }
+
+  /**
    * Cancels the pending long-press timer.
    *
    * @private
@@ -553,6 +566,10 @@ class Event {
     clearTimeout(this.#dblClickTimeout[0]);
     clearTimeout(this.#dblClickTimeout[1]);
     this.#cancelLongPressTimer();
+
+    if (this.momentumScrolling) {
+      clearTimeout(this.momentumScrolling._timeout);
+    }
 
     this.#eventManager.destroy();
   }

--- a/handsontable/src/3rdparty/walkontable/src/event.js
+++ b/handsontable/src/3rdparty/walkontable/src/event.js
@@ -406,10 +406,13 @@ class Event {
       }
     }
 
-    // Fire mouseUp for both tap and long-press (matches pre-fix behavior so plugins
-    // listening to onCellMouseUp / before/after hooks still run). Suppress only for
-    // pure scroll gestures, where onMouseDown was never fired in the first place.
-    if (!wasScrolled) {
+    // Fire mouseUp whenever the gesture also produced a mouseDown - either a tap
+    // (deferred mousedown above) or a long-press (mousedown fired from the timer
+    // callback). Skipping it for a long-press that ended in a scroll would leave
+    // an unpaired mousedown and break plugins listening to onCellMouseUp /
+    // before/after hooks (e.g. nestedHeaders, ContextMenu close logic).
+    // Suppress only for pure scroll gestures, where onMouseDown was never fired.
+    if (!wasScrolled || this.#longPressFired) {
       this.onMouseUp(event);
     }
 

--- a/handsontable/src/__tests__/tableView.spec.js
+++ b/handsontable/src/__tests__/tableView.spec.js
@@ -793,4 +793,121 @@ describe('TableView', () => {
       expect(getSelected()).toBeUndefined();
     });
   });
+
+  describe('touch gesture vs scroll', () => {
+    // Direct calls to walkontable's Event handlers are used because the headless
+    // Chrome that runs E2E tests does not expose `'ontouchstart' in window`,
+    // so touch listeners are not registered. Calling the handlers directly
+    // exercises the same code path real mobile browsers trigger.
+    const fireTouchStart = async(cell, x, y) => {
+      const evt = await triggerTouchEvent('touchstart', cell, x, y);
+
+      tableView()._wt.wtEvent.onTouchStart(evt);
+    };
+    const fireTouchMove = async(cell, x, y) => {
+      const evt = await triggerTouchEvent('touchmove', cell, x, y);
+
+      tableView()._wt.wtEvent.onTouchMove(evt);
+    };
+    const fireTouchEnd = async(cell, x, y) => {
+      const evt = await triggerTouchEvent('touchend', cell, x, y);
+
+      tableView()._wt.wtEvent.onTouchEnd(evt);
+    };
+
+    it('should select a cell on a tap (touchstart + touchend with no movement)', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      const cell = getCell(2, 2);
+
+      await fireTouchStart(cell);
+      await fireTouchEnd(cell);
+
+      expect(getSelected()).toEqual([[2, 2, 2, 2]]);
+    });
+
+    it('should not change selection when touch moves beyond threshold (scroll gesture)', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      await selectCell(0, 0);
+      expect(getSelected()).toEqual([[0, 0, 0, 0]]);
+
+      const cell = getCell(2, 2);
+      const rect = cell.getBoundingClientRect();
+      const startX = Math.round(rect.left + 5);
+      const startY = Math.round(rect.top + 5);
+
+      await fireTouchStart(cell, startX, startY);
+      await fireTouchMove(cell, startX, startY + 50);
+      await fireTouchEnd(cell, startX, startY + 50);
+
+      expect(getSelected()).toEqual([[0, 0, 0, 0]]);
+    });
+
+    it('should not select a previously unselected cell when the gesture is a scroll', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      expect(getSelected()).toBeUndefined();
+
+      const cell = getCell(2, 2);
+      const rect = cell.getBoundingClientRect();
+      const startX = Math.round(rect.left + 5);
+      const startY = Math.round(rect.top + 5);
+
+      await fireTouchStart(cell, startX, startY);
+      await fireTouchMove(cell, startX + 40, startY);
+      await fireTouchEnd(cell, startX + 40, startY);
+
+      expect(getSelected()).toBeUndefined();
+    });
+
+    it('should still select when the touch moves within the threshold (small jitter)', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      const cell = getCell(1, 1);
+      const rect = cell.getBoundingClientRect();
+      const startX = Math.round(rect.left + 5);
+      const startY = Math.round(rect.top + 5);
+
+      await fireTouchStart(cell, startX, startY);
+      await fireTouchMove(cell, startX + 4, startY + 4);
+      await fireTouchEnd(cell, startX + 4, startY + 4);
+
+      expect(getSelected()).toEqual([[1, 1, 1, 1]]);
+    });
+
+    it('should select a new cell on a tap performed after a scroll gesture', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      await selectCell(0, 0);
+
+      const scrollCell = getCell(2, 2);
+      const scrollRect = scrollCell.getBoundingClientRect();
+      const startX = Math.round(scrollRect.left + 5);
+      const startY = Math.round(scrollRect.top + 5);
+
+      await fireTouchStart(scrollCell, startX, startY);
+      await fireTouchMove(scrollCell, startX, startY + 60);
+      await fireTouchEnd(scrollCell, startX, startY + 60);
+
+      expect(getSelected()).toEqual([[0, 0, 0, 0]]);
+
+      const tapCell = getCell(3, 3);
+
+      await fireTouchStart(tapCell);
+      await fireTouchEnd(tapCell);
+
+      expect(getSelected()).toEqual([[3, 3, 3, 3]]);
+    });
+  });
 });

--- a/handsontable/src/__tests__/tableView.spec.js
+++ b/handsontable/src/__tests__/tableView.spec.js
@@ -884,6 +884,29 @@ describe('TableView', () => {
       expect(getSelected()).toEqual([[1, 1, 1, 1]]);
     });
 
+    it('should select the long-pressed cell before the context menu opens', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      await selectCell(0, 0);
+      expect(getSelected()).toEqual([[0, 0, 0, 0]]);
+
+      const cell = getCell(3, 3);
+
+      await fireTouchStart(cell);
+
+      // Wait past LONG_PRESS_DELAY (500ms) so the timer fires synchronously with
+      // the synthetic contextmenu dispatch. That path must still select the cell.
+      await sleep(600);
+
+      expect(getSelected()).toEqual([[3, 3, 3, 3]]);
+
+      await fireTouchEnd(cell);
+
+      expect(getSelected()).toEqual([[3, 3, 3, 3]]);
+    });
+
     it('should select a new cell on a tap performed after a scroll gesture', async() => {
       handsontable({
         data: createSpreadsheetData(5, 5),

--- a/handsontable/src/__tests__/tableView.spec.js
+++ b/handsontable/src/__tests__/tableView.spec.js
@@ -884,6 +884,29 @@ describe('TableView', () => {
       expect(getSelected()).toEqual([[1, 1, 1, 1]]);
     });
 
+    it('should treat a native scroll during touch as a scroll gesture even if no touchmove crossed the threshold', async() => {
+      handsontable({
+        data: createSpreadsheetData(20, 5),
+        height: 200,
+      });
+
+      await selectCell(0, 0);
+      expect(getSelected()).toEqual([[0, 0, 0, 0]]);
+
+      const cell = getCell(3, 3);
+
+      await fireTouchStart(cell);
+
+      // Browsers start native scrolling at ~8px movement, before the 10px
+      // LONG_PRESS_MOVE_THRESHOLD that onTouchMove watches. Simulate the
+      // resulting holder `scroll` callback firing during an active touch.
+      tableView()._wt.wtEvent.onHolderScroll();
+
+      await fireTouchEnd(cell);
+
+      expect(getSelected()).toEqual([[0, 0, 0, 0]]);
+    });
+
     it('should select the long-pressed cell before the context menu opens', async() => {
       handsontable({
         data: createSpreadsheetData(5, 5),


### PR DESCRIPTION
### Context

The PR fixes [#11659](https://github.com/handsontable/handsontable/issues/11659) — on mobile, every scroll gesture re-triggered the cell selection: a user trying to pan the grid with their finger ended up selecting whichever cell their finger first touched, and the selection moved as the finger moved. The reporter asked for the touch flow to distinguish a tap (touch + release without movement) from a scroll (touch + drag).

The root cause is in `walkontable/src/event.js`: `onTouchStart` synthesised a `mousedown` immediately, so the very first `touchstart` of a scroll gesture already produced a `setRangeStart()` call. Movement was tracked only to cancel the long-press timer, not to suppress the selection.

This change defers the synthesized `mousedown` from `touchstart` to `touchend`, and only fires it when the gesture qualifies as a tap:

- `#touchWasMoved` is set in `onTouchMove` once the finger crosses the existing `LONG_PRESS_MOVE_THRESHOLD` (10px), marking the gesture as a scroll.
- `#longPressFired` is set when the long-press timer expires, so the context-menu path doesn't double up with a deferred selection.
- `onTouchEnd` evaluates `isTap = !#touchWasMoved && !#longPressFired && #deferredTouchStartEvent !== null` and skips both the deferred `onMouseDown` and the matching `onMouseUp` for a scroll. A pure tap still selects, including sub-threshold finger jitter.

The previously private `#onTouchMove` is promoted to public `onTouchMove` for parity with the other touch handlers and so the new tests can drive it directly.

### How has this been tested?

New E2E specs in `handsontable/src/__tests__/tableView.spec.js` (`describe('touch gesture vs scroll')`):

1. Tap (touchstart + touchend, no movement) selects the cell.
2. A scroll gesture (touchmove past threshold) preserves a prior selection.
3. A scroll gesture starting from no selection still selects nothing.
4. Sub-threshold jitter (4px) still counts as a tap.
5. A tap after a scroll selects the new cell.

The specs call `tableView()._wt.wtEvent.onTouchStart/onTouchMove/onTouchEnd` directly because headless Chrome in the E2E runner doesn't expose `'ontouchstart' in window`, so the touch listeners are not registered through the normal event manager. A short comment in the spec explains why.

Commands:

```bash
# new specs + every selection-adjacent suite
npm run test:e2e --testPathPattern='tableView|selection|multipleSelectionHandles|cellMouse|core/_base'
# walkontable unit tests
npm run test:unit --testPathPattern=walkontable
# lint
npm run lint --prefix handsontable
```

Results on this branch:

- E2E sweep: **1280 specs, 0 failures**.
- Unit tests: **393 passed**.
- Lint: clean.

Manual: a self-contained demo (gitignored at `handsontable/dev-generated.html`) was used to reproduce the bug against `v17.0.1` (CDN) and verify the fix against the local build, with Chrome DevTools "Device toolbar" enabled to dispatch real touch events.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. #11659

### Affected project(s):

- [x] \`handsontable\`
- [ ] \`@handsontable/angular-wrapper\`
- [ ] \`@handsontable/react-wrapper\`
- [ ] \`@handsontable/vue3\`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes low-level touch/selection event sequencing on mobile, which can affect selection hooks and context menu behavior across plugins; new E2E tests reduce but don’t eliminate behavioral regression risk on edge devices/browsers.
> 
> **Overview**
> Fixes mobile touch handling so a touch-drag scroll no longer synthesizes an immediate `mousedown` that re-triggers cell selection.
> 
> `walkontable` now defers the synthetic `onMouseDown` from `touchstart` to `touchend` and only fires it for tap-like gestures (no meaningful movement, no long-press). It also treats holder `scroll` during an active touch as movement, ensures long-press selects the target cell before opening the context menu, and avoids leaving unpaired `mousedown`/`mouseup` sequences.
> 
> Adds E2E coverage in `tableView.spec.js` for tap vs scroll vs jitter vs native scroll and long-press selection, plus a changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b46f63a3940e5da5a923adbccff1f042c5245a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->