### PR TITLE
DEV-1528: Fix server-side-data React example constantly reloading

### DIFF
--- a/docs/content/guides/getting-started/server-side-data/react/example1.jsx
+++ b/docs/content/guides/getting-started/server-side-data/react/example1.jsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useMemo, useRef } from 'react';
 import { HotTable } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
 
@@ -444,12 +444,13 @@ const columns = [
 
 const colHeaders = ['Product', 'SKU', 'Category', 'Unit price', 'In stock'];
 /**
- * Renders HotTable in isolation so parent `setState` (status text) does not re-render HotTable.
- * The React wrapper calls `updateSettings` after every HotTable render; with `dataProvider`, each
- * update refetches. Skipping redundant HotTable renders avoids a fetch → setStatus → render loop.
+ * Renders HotTable in isolation to avoid a fetch loop.
+ * The React wrapper calls `updateSettings` after every HotTable render. With `dataProvider`,
+ * each `updateSettings` call re-triggers a fetch. Status is therefore updated via a DOM ref
+ * rather than React state so that status changes never cause HotTable to re-render.
  */
 const InventoryServerTable = memo(function InventoryServerTable({
-  status,
+  statusRef,
   beforeDataProviderFetch,
   afterDataProviderFetch,
   afterDataProviderFetchError,
@@ -496,7 +497,7 @@ const InventoryServerTable = memo(function InventoryServerTable({
             Simulate failed fetch
           </button>
         </div>
-        <output id="example1-status">{status}</output>
+        <output ref={statusRef} id="example1-status">Initializing…</output>
       </div>
       <div id="example1">
         <HotTable
@@ -525,23 +526,30 @@ const InventoryServerTable = memo(function InventoryServerTable({
 });
 
 const ExampleComponent = () => {
-  const [status, setStatus] = useState('Initializing…');
+  const statusRef = useRef(null);
+
   const beforeDataProviderFetch = useCallback((params) => {
-    setStatus(params.skipLoading ? 'Updating after sort or edit…' : 'Loading data…');
+    if (statusRef.current) {
+      statusRef.current.textContent = params.skipLoading ? 'Updating after sort or edit…' : 'Loading data…';
+    }
   }, []);
 
   const afterDataProviderFetch = useCallback(() => {
-    setStatus(`Ready (simulated ${LATENCY_MS}ms request).`);
+    if (statusRef.current) {
+      statusRef.current.textContent = `Ready (simulated ${LATENCY_MS}ms request).`;
+    }
   }, []);
 
   const afterDataProviderFetchError = useCallback((error) => {
-    setStatus(`Could not load data: ${error.message}`);
+    if (statusRef.current) {
+      statusRef.current.textContent = `Could not load data: ${error.message}`;
+    }
   }, []);
 
   return (
     <>
       <InventoryServerTable
-        status={status}
+        statusRef={statusRef}
         beforeDataProviderFetch={beforeDataProviderFetch}
         afterDataProviderFetch={afterDataProviderFetch}
         afterDataProviderFetchError={afterDataProviderFetchError}

--- a/docs/content/guides/getting-started/server-side-data/react/example1.tsx
+++ b/docs/content/guides/getting-started/server-side-data/react/example1.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo, useRef, useState } from 'react';
+import React, { memo, useCallback, useMemo, useRef } from 'react';
 import { HotTable, type HotTableRef } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
 import type {
@@ -486,19 +486,20 @@ const columns = [
 const colHeaders = ['Product', 'SKU', 'Category', 'Unit price', 'In stock'];
 
 type InventoryServerTableProps = {
-  status: string;
+  statusRef: React.RefObject<HTMLOutputElement>;
   beforeDataProviderFetch: (params: DataProviderBeforeFetchParameters) => void;
   afterDataProviderFetch: () => void;
   afterDataProviderFetchError: (error: Error) => void;
 };
 
 /**
- * Renders HotTable in isolation so parent `setState` (status text) does not re-render HotTable.
- * The React wrapper calls `updateSettings` after every HotTable render; with `dataProvider`, each
- * update refetches. Skipping redundant HotTable renders avoids a fetch → setStatus → render loop.
+ * Renders HotTable in isolation to avoid a fetch loop.
+ * The React wrapper calls `updateSettings` after every HotTable render. With `dataProvider`,
+ * each `updateSettings` call re-triggers a fetch. Status is therefore updated via a DOM ref
+ * rather than React state so that status changes never cause HotTable to re-render.
  */
 const InventoryServerTable = memo(function InventoryServerTable({
-  status,
+  statusRef,
   beforeDataProviderFetch,
   afterDataProviderFetch,
   afterDataProviderFetchError,
@@ -551,7 +552,7 @@ const InventoryServerTable = memo(function InventoryServerTable({
             Simulate failed fetch
           </button>
         </div>
-        <output id="example1-status">{status}</output>
+        <output ref={statusRef} id="example1-status">Initializing…</output>
       </div>
       <div id="example1">
         <HotTable
@@ -580,27 +581,33 @@ const InventoryServerTable = memo(function InventoryServerTable({
 });
 
 const ExampleComponent = () => {
-  const [status, setStatus] = useState('Initializing…');
+  const statusRef = useRef<HTMLOutputElement>(null);
 
   const beforeDataProviderFetch = useCallback(
     (params: DataProviderBeforeFetchParameters) => {
-      setStatus(params.skipLoading ? 'Updating after sort or edit…' : 'Loading data…');
+      if (statusRef.current) {
+        statusRef.current.textContent = params.skipLoading ? 'Updating after sort or edit…' : 'Loading data…';
+      }
     },
     []
   );
 
   const afterDataProviderFetch = useCallback(() => {
-    setStatus(`Ready (simulated ${LATENCY_MS}ms request).`);
+    if (statusRef.current) {
+      statusRef.current.textContent = `Ready (simulated ${LATENCY_MS}ms request).`;
+    }
   }, []);
 
   const afterDataProviderFetchError = useCallback((error: Error) => {
-    setStatus(`Could not load data: ${error.message}`);
+    if (statusRef.current) {
+      statusRef.current.textContent = `Could not load data: ${error.message}`;
+    }
   }, []);
 
   return (
     <>
       <InventoryServerTable
-        status={status}
+        statusRef={statusRef}
         beforeDataProviderFetch={beforeDataProviderFetch}
         afterDataProviderFetch={afterDataProviderFetch}
         afterDataProviderFetchError={afterDataProviderFetchError}


### PR DESCRIPTION
### Context

The PR fixes an infinite reload loop in the server-side-data React documentation example (`docs/content/guides/getting-started/server-side-data/react/example1.tsx`).

**Root cause:** The memoized `InventoryServerTable` component accepted `status` as a React prop. The data provider hooks (`beforeDataProviderFetch`, `afterDataProviderFetch`, `afterDataProviderFetchError`) called `setStatus` to update the status text. Each `setStatus` call caused a parent re-render, which changed the `status` prop, which caused `InventoryServerTable` to re-render (memo does not prevent re-renders when a prop actually changes). This re-rendered `HotTable`, which triggered `HotTableInner`'s `useUpdateEffect` to call `updateSettings`. Because the component has a `dataProvider` configured, calling `updateSettings` re-triggers a data fetch. That fetch fires `beforeDataProviderFetch` → `setStatus` → re-render → `updateSettings` → fetch → ... infinitely.

**Fix:** Replace the `useState` / `setStatus` pattern with a DOM `ref` on the `<output>` element. The fetch callbacks now update `statusRef.current.textContent` directly, bypassing React's render cycle entirely. Since `statusRef` is a stable `useRef` object (same reference across renders), it does not cause `InventoryServerTable` to re-render when the displayed text changes.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1528

### How has this been tested?

- Manually verified the pattern: `status` as a prop causes `InventoryServerTable` to re-render on every fetch, which calls `updateSettings`, which re-triggers the fetch.
- After the fix, `InventoryServerTable` never receives a changed prop from the status update path, so `memo` holds and no extra renders occur.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1528

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4gKivCxgKRC6CJM1Nj71P)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only example change that adjusts UI status rendering; low risk aside from potential ref null/SSR edge cases.
> 
> **Overview**
> Fixes an infinite reload loop in the server-side React docs example by decoupling status updates from React renders.
> 
> `example1.jsx`/`example1.tsx` replace the `status` state/prop with a stable `statusRef` wired to the `<output>` element, and the data-provider fetch callbacks now update `textContent` directly so status changes no longer re-render `HotTable` (and thus no longer re-trigger `updateSettings` → fetch).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3606107aa9a7d54d8d23a7b17024e8fafa88a4be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->