### PR TITLE
fix: prevent runaway container height when parent has overflow-y:hidden and no height (#3119)

### DIFF
--- a/.changelogs/12453.json
+++ b/.changelogs/12453.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed a bug where placing Handsontable inside a container with `overflow-y: hidden` and no explicit height caused the container to expand to the browser's CSS height limit (~2²⁵ px).",
+  "type": "fixed",
+  "issueOrPR": 12453,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/AGENTS.md
+++ b/handsontable/src/3rdparty/walkontable/AGENTS.md
@@ -31,7 +31,7 @@ Self-contained rendering engine for viewport calculation, DOM rendering, scroll 
 ## Testing
 
 Separate test runner - do NOT mix with main E2E tests:
-`pnpm --filter handsontable run test:walkontable`
+`npm run test:walkontable --prefix handsontable`
 
 Tests in: `src/3rdparty/walkontable/test/`
 

--- a/handsontable/src/3rdparty/walkontable/src/table/master.js
+++ b/handsontable/src/3rdparty/walkontable/src/table/master.js
@@ -44,9 +44,13 @@ class MasterTable extends Table {
       const { scrollWidth, scrollHeight } = trimmingElement;
       let width = trimmingElement.offsetWidth;
       let height = trimmingElement.offsetHeight;
-      const overflow = ['auto', 'hidden', 'scroll', 'clip'];
+      const overflowValues = ['auto', 'hidden', 'scroll', 'clip'];
+      // getStyle() may return a compound value (e.g. 'auto hidden') when overflow-x and
+      // overflow-y are set independently. Split on whitespace so each token is checked.
+      const hasScrollOverflow = trimmingOverflow.split(' ').some(v => overflowValues.includes(v));
+      let useAutoHeight = (trimmingHeight === 'auto');
 
-      if (trimmingElementParent && overflow.includes(trimmingOverflow)) {
+      if (trimmingElementParent && hasScrollOverflow) {
         const cloneNode = trimmingElement.cloneNode(false);
 
         // Before calculating the height of the trimming element, set overflow: auto to hide scrollbars.
@@ -56,6 +60,12 @@ class MasterTable extends Table {
         // Issue #9545 shows problem with calculating height for HOT on Firefox while placing instance in some
         // flex containers and setting overflow for some `div` section.
         cloneNode.style.position = 'absolute';
+        // Reset border and padding so border-box sizing does not contribute to the measured height.
+        // Without this, a container with a visible border (e.g. border: 1px solid) produces
+        // cloneHeight = 2 even though it has no intrinsic height, preventing the zero-height
+        // detection that guards against the feedback-loop bug. See issue #3119.
+        cloneNode.style.border = '0';
+        cloneNode.style.padding = '0';
 
         if (trimmingElement.nextElementSibling) {
           trimmingElementParent.insertBefore(cloneNode, trimmingElement.nextElementSibling);
@@ -69,11 +79,22 @@ class MasterTable extends Table {
 
         if (cloneHeight === 0) {
           height = 0;
+
+          // The trimming container has no intrinsic height — its size is driven entirely by
+          // its content (HOT instances). For containers with scrollable overflow (auto/scroll),
+          // setting the holder to a fixed pixel value creates a height feedback loop when
+          // multiple HOT instances share the same parent, expanding it to the browser's
+          // CSS height limit (~2^25 px). Using 'auto' lets the holder size to its content
+          // (the hider element) instead. For non-scrollable overflow (hidden/clip), keep
+          // height=0 to signal that the table has no defined size. See issue #3119.
+          if (trimmingOverflow.split(' ').some(v => v === 'auto' || v === 'scroll')) {
+            useAutoHeight = true;
+          }
         }
       }
 
       height = Math.min(height, scrollHeight);
-      holderStyle.height = trimmingHeight === 'auto' ? 'auto' : `${height}px`;
+      holderStyle.height = useAutoHeight ? 'auto' : `${height}px`;
 
       width = Math.min(width, scrollWidth);
       holderStyle.width = `${width}px`;

--- a/handsontable/src/3rdparty/walkontable/src/table/master.js
+++ b/handsontable/src/3rdparty/walkontable/src/table/master.js
@@ -81,13 +81,26 @@ class MasterTable extends Table {
           height = 0;
 
           // The trimming container has no intrinsic height — its size is driven entirely by
-          // its content (HOT instances). For containers with scrollable overflow (auto/scroll),
-          // setting the holder to a fixed pixel value creates a height feedback loop when
-          // multiple HOT instances share the same parent, expanding it to the browser's
+          // its content (HOT instances). When overflow-y is non-scrollable (hidden/clip),
+          // the container cannot be scrolled vertically, so its height grows with content.
+          // Setting the holder to a fixed pixel value in this case creates a feedback loop
+          // when multiple HOT instances share the same parent, expanding it to the browser's
           // CSS height limit (~2^25 px). Using 'auto' lets the holder size to its content
-          // (the hider element) instead. For non-scrollable overflow (hidden/clip), keep
-          // height=0 to signal that the table has no defined size. See issue #3119.
-          if (trimmingOverflow.split(' ').some(v => v === 'auto' || v === 'scroll')) {
+          // (the hider element) and breaks the loop. When overflow-y is scrollable (auto/
+          // scroll), the container IS a vertical scroll viewport and height=0 correctly
+          // signals that it has no defined size. See issue #3119.
+          const computedStyle = rootWindow.getComputedStyle(trimmingElement);
+          const overflowX = computedStyle.overflowX;
+          const overflowY = computedStyle.overflowY;
+
+          // Only switch to auto-height for horizontal-scroll containers where:
+          // - overflow-x is scrollable (auto/scroll) — the container is intentionally wider than its content
+          // - overflow-y is non-scrollable (hidden/clip) — the container height is content-driven
+          // This is the exact pattern that triggers the height feedback loop (issue #3119).
+          // All-axis scroll/auto containers (overflow: scroll/auto) keep height=0 to correctly
+          // signal no defined size. Similarly, overflow: hidden on both axes keeps height=0.
+          if ((overflowX === 'auto' || overflowX === 'scroll') &&
+              (overflowY !== 'auto' && overflowY !== 'scroll')) {
             useAutoHeight = true;
           }
         }

--- a/handsontable/src/3rdparty/walkontable/src/viewport.js
+++ b/handsontable/src/3rdparty/walkontable/src/viewport.js
@@ -103,7 +103,15 @@ class Viewport {
       const elemHeight = outerHeight(trimmingContainer);
 
       // returns height without DIV scrollbar
-      height = (elemHeight > 0 && trimmingContainer.clientHeight > 0) ? trimmingContainer.clientHeight : Infinity;
+      if (elemHeight > 0 && trimmingContainer.clientHeight > 0) {
+        height = trimmingContainer.clientHeight;
+      } else {
+        // Fall back to window height when the trimming container has zero client height
+        // (e.g. a parent with overflow set but no explicit height). Returning Infinity
+        // previously caused an unbounded viewport, expanding the parent to the browser's
+        // ~2^25 px CSS height limit. See issue #3119.
+        height = Math.max(currentDocument.documentElement.clientHeight, 1);
+      }
     }
 
     return height;
@@ -114,10 +122,6 @@ class Viewport {
    */
   getViewportHeight() {
     let containerHeight = this.getWorkspaceHeight();
-
-    if (containerHeight === Infinity) {
-      return containerHeight;
-    }
 
     const columnHeaderHeight = this.getColumnHeaderHeight();
 
@@ -165,10 +169,6 @@ class Viewport {
    */
   getViewportWidth() {
     const containerWidth = this.getWorkspaceWidth();
-
-    if (containerWidth === Infinity) {
-      return containerWidth;
-    }
 
     const rowHeaderWidth = this.getRowHeaderWidth();
 

--- a/handsontable/src/3rdparty/walkontable/test/spec/viewport.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/viewport.spec.js
@@ -123,6 +123,50 @@ describe('WalkontableViewport', () => {
 
       expect(wt.wtViewport.getWorkspaceHeight()).toBe(200);
     });
+
+    it('should return a finite value bounded by window height when the trimming container has overflow set but no explicit height (#3119)', async() => {
+      spec().$wrapper
+        .css('overflow-x', 'auto')
+        .css('overflow-y', 'hidden')
+        .css('width', '350px')
+        .css('height', '');
+
+      createDataArray(10, 10);
+
+      const wt = walkontable({
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
+      });
+
+      wt.draw();
+
+      const workspaceHeight = wt.wtViewport.getWorkspaceHeight();
+
+      expect(isFinite(workspaceHeight)).toBe(true);
+      expect(workspaceHeight).toBeGreaterThan(0);
+      expect(workspaceHeight).toBeLessThanOrEqual(window.innerHeight);
+    });
+
+    it('should not render all rows when the trimming container has overflow set but no explicit height (#3119)', async() => {
+      spec().$wrapper
+        .css('overflow-x', 'auto')
+        .css('overflow-y', 'hidden')
+        .css('width', '350px')
+        .css('height', '');
+
+      createDataArray(1000, 10);
+
+      const wt = walkontable({
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
+      });
+
+      wt.draw();
+
+      expect(wt.wtTable.getRenderedRowsCount()).toBeLessThan(100);
+    });
   });
 
   describe('getViewportWidth()', () => {

--- a/handsontable/test/e2e/Core_view.spec.js
+++ b/handsontable/test/e2e/Core_view.spec.js
@@ -474,6 +474,36 @@ describe('Core_view', () => {
     spec().$container.unwrap();
   });
 
+  it('should not expand the parent container to the browser CSS height limit when parent has overflow-y:hidden and no explicit height (#3119)', async() => {
+    const wrapper = $('<div></div>').css({
+      border: '1px solid red',
+      width: '350px',
+      overflowX: 'auto',
+      overflowY: 'hidden',
+    });
+
+    spec().$container.wrap(wrapper);
+
+    handsontable({
+      data: [
+        { car: 'Mercedes A 160', year: 2011, price: 7000 },
+        { car: 'Citroen C4 Coupe', year: 2012, price: 8330 },
+        { car: 'Audi A4 Avant', year: 2013, price: 33900 },
+        { car: 'Opel Astra', year: 2014, price: 5000 },
+        { car: 'BMW 320i Coupe', year: 2015, price: 30500 },
+      ],
+      colHeaders: true,
+    });
+
+    await waitForNextAnimationFrames(2);
+
+    const outerWrapper = spec().$container.parent()[0];
+
+    expect(outerWrapper.offsetHeight).toBeLessThan(window.innerHeight * 2);
+
+    spec().$container.unwrap();
+  });
+
   it('should fire beforeViewRender event after table has been scrolled', async() => {
     spec().$container[0].style.width = '400px';
     spec().$container[0].style.height = '60px';


### PR DESCRIPTION
### Context

The PR fixes a long-standing bug (first reported in 2015, still present in v17.0.1) where placing one or more Handsontable instances inside a container with `overflow-x: auto; overflow-y: hidden` and no explicit height causes the container to expand to exactly 33,554,432 px — the browser's ~2²⁵ CSS height ceiling.

**Exact reproduction markup from the issue:**
```html
<div style="border: 1px solid red; width:350px; overflow-x:auto; overflow-y:hidden">
  <div id="ht1Anchor"></div>
  <br/><br/>
  <div id="ht2Anchor"></div>
</div>
```
With any data and no `height` option set, the outer `<div>` grew to 33,554,432 px.

---

### Root causes (three compounding bugs)

#### 1. `viewport.js` — Infinity fallback for zero-clientHeight containers

`getWorkspaceHeight()` returned `Infinity` when the trimming container had `clientHeight === 0` (which happens on first render when the parent has overflow set but no explicit height and no content yet). The `Infinity` value passed through to the row calculators, which treated it as an unbounded viewport and attempted to render every row.

**Fix:** Replace `Infinity` with `Math.max(documentElement.clientHeight, 1)`. Also removed two now-unreachable `Infinity` short-circuit guards in `getViewportHeight()` and `getViewportWidth()`.

#### 2. `master.js` — compound overflow value not matched by clone-height guard

`alignOverlaysWithTrimmingContainer()` runs a clone-height test to detect containers with no intrinsic height. The test was gated by `overflow.includes(trimmingOverflow)`, but `getComputedStyle` returns `'auto hidden'` (a compound string) when `overflow-x` and `overflow-y` are set separately via individual properties. The string `'auto hidden'` is not in the single-value array, so the guard was skipped entirely. With the guard skipped, each HOT instance read the shared parent's `offsetHeight` (which already included the other HOT instance's content) and wrote that value back to its own holder — a classic height feedback loop that doubled the outer container height on each render cycle until hitting the browser limit.

**Fix:** Split the overflow string on whitespace before matching (`trimmingOverflow.split(' ').some(v => overflowValues.includes(v))`).

#### 3. `master.js` — clone inherited CSS border, producing `cloneHeight = 2` instead of `0`

Even after fix 2, the clone test produced `cloneHeight = 2` rather than `0` because the cloned element inherited the container's CSS class (`.issue-outer` has `border: 1px solid red`). With `box-sizing: border-box`, the border contributed 2 px to the computed height of an otherwise empty element. The `cloneHeight === 0` guard never fired.

**Fix:** Reset `border: 0; padding: 0` on the clone node before measuring, so the computed height reflects only intrinsic content height.

#### Selecting the correct behaviour when `cloneHeight === 0`

The existing code set `holderStyle.height = '0px'` when `cloneHeight === 0`, which blocked all renders. For containers that are intentionally vertical-scroll viewports (`overflow: scroll`, `overflow: auto`, `overflow: hidden` on both axes), `height = 0` correctly signals "no defined size" and HOT should not render.

For **horizontal-scroll containers** (`overflow-x: auto/scroll` + `overflow-y: hidden/clip`), the container has no intrinsic vertical height — it is content-driven vertically. Setting the holder to `'auto'` lets it size to its content (the hider element) and breaks the feedback loop.

**Fix:** Set `holderStyle.height = 'auto'` only when `overflow-x` is scrollable (`auto`/`scroll`) AND `overflow-y` is non-scrollable (`hidden`/`clip`). All other overflow combinations retain the existing `height = 0` behaviour.

---

### Files changed

| File | Change |
|---|---|
| `src/3rdparty/walkontable/src/viewport.js` | Replace `Infinity` fallback with `Math.max(documentElement.clientHeight, 1)`; remove dead `Infinity` guards |
| `src/3rdparty/walkontable/src/table/master.js` | Fix compound-overflow matching; reset border/padding on clone; use `'auto'` holder height for horizontal-scroll containers |

---

### How has this been tested?

**New tests (all fail before the fix, pass after):**

- **Walkontable unit A** — `getWorkspaceHeight()` returns a finite value ≤ `window.innerHeight` when the trimming container has `overflow-x:auto; overflow-y:hidden` and no explicit height.
- **Walkontable unit B** — for a 1000-row dataset in the same degenerate container, the rendered row count stays below 100 (proves the row calculator received a bounded viewport, not `Infinity`).
- **E2E C** — the exact issue #3119 markup produces an outer `offsetHeight < window.innerHeight * 2`. Prior to the fix it produced 33,554,432 px.

```bash
# Walkontable suite (A + B + all existing)
pnpm --filter handsontable run test:walkontable

# E2E — new test C + existing resize/view tests
npm run test:e2e --prefix handsontable --testPathPattern="Core_resize |Core_view"
```

**Results:** 661 Walkontable specs, 0 failures; 38 Core_resize + Core_view E2E specs, 0 failures.

**Manual verification:** local demo at `handsontable/dev-generated.html` (gitignored) shows:
- Released tab (v17.0.1 CDN): outer container height = 33,554,432 px (bug reproduced)
- PR Build tab (local `dist/`): outer container height = 418 px, both grids render correctly with horizontal scrollbar

---

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. https://github.com/handsontable/handsontable/issues/3119

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Walkontable viewport sizing and holder height behavior, which can affect rendering/layout and virtualization across edge-case container overflow configurations.
> 
> **Overview**
> Fixes a long-standing edge case where Handsontable inside a horizontally scrollable container with `overflow-y: hidden` and no explicit height could trigger an unbounded viewport and a height feedback loop that expands the parent to the browser’s CSS height limit.
> 
> Walkontable now **bounds workspace height** to the window height (instead of `Infinity`) when the trimming container reports zero height, and updates overlay alignment to correctly detect compound overflow values, ignore inherited border/padding when measuring zero-height containers, and selectively use `holder` height `auto` for the `overflow-x: auto/scroll` + non-scrollable `overflow-y` scenario.
> 
> Adds targeted Walkontable unit tests and a core E2E regression test for #3119, plus a changelog entry and a minor test command doc update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa10f7fb8c2affc38b3684591348c9b3d74c949e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->