### PR TITLE
DEV-1531: Fix Angular demo JIT incompatibilities (templateUrl and constructor DI)

### DIFF
--- a/docs/content/guides/cell-features/selection/angular/example1.ts
+++ b/docs/content/guides/cell-features/selection/angular/example1.ts
@@ -1,5 +1,5 @@
 /* file: app.component.ts */
-import {Component, ViewChild, ViewEncapsulation, HostListener, ElementRef} from '@angular/core';
+import {Component, ViewChild, ViewEncapsulation, HostListener, ElementRef, inject} from '@angular/core';
 import { GridSettings, HotTableComponent, HotTableModule } from '@handsontable/angular-wrapper';
 
 @Component({
@@ -79,7 +79,7 @@ export class AppComponent {
     return this.options.find((o) => o.value === this.selected)?.label || '';
   }
 
-  constructor(private elementRef: ElementRef) {}
+  private elementRef = inject(ElementRef);
 
   toggleDropdown(): void {
     this.isOpen = !this.isOpen;

--- a/docs/content/guides/cell-types/date-cell-type/angular/example1.ts
+++ b/docs/content/guides/cell-types/date-cell-type/angular/example1.ts
@@ -1,5 +1,5 @@
 /* file: app.component.ts */
-import { Component, ViewChild, ViewEncapsulation, HostListener, ElementRef } from '@angular/core';
+import { Component, ViewChild, ViewEncapsulation, HostListener, ElementRef, inject } from '@angular/core';
 import { GridSettings, HotTableComponent, HotTableModule} from '@handsontable/angular-wrapper';
 
 interface CarData {
@@ -155,7 +155,7 @@ export class AppComponent {
     return this.localeOptions.find((o) => o.value === this.locale)?.label || '';
   }
 
-  constructor(private elementRef: ElementRef) {}
+  private elementRef = inject(ElementRef);
 
   toggleDropdown(): void {
     this.isOpen = !this.isOpen;

--- a/docs/content/guides/cell-types/numeric-cell-type/angular/example1.ts
+++ b/docs/content/guides/cell-types/numeric-cell-type/angular/example1.ts
@@ -1,5 +1,5 @@
 /* file: app.component.ts */
-import { Component, ViewChild, ViewEncapsulation, HostListener, ElementRef } from '@angular/core';
+import { Component, ViewChild, ViewEncapsulation, HostListener, ElementRef, inject } from '@angular/core';
 import { GridSettings, HotTableComponent, HotTableModule} from '@handsontable/angular-wrapper';
 
 interface CarData {
@@ -214,7 +214,7 @@ export class AppComponent {
     return this.localeOptions.find((o) => o.value === this.locale)?.label || '';
   }
 
-  constructor(private elementRef: ElementRef) {}
+  private elementRef = inject(ElementRef);
 
   toggleDropdown(): void {
     this.isOpen = !this.isOpen;

--- a/docs/content/guides/cell-types/time-cell-type/angular/example1.ts
+++ b/docs/content/guides/cell-types/time-cell-type/angular/example1.ts
@@ -1,5 +1,5 @@
 /* file: app.component.ts */
-import { Component, ViewChild, ViewEncapsulation, HostListener, ElementRef } from '@angular/core';
+import { Component, ViewChild, ViewEncapsulation, HostListener, ElementRef, inject } from '@angular/core';
 import { GridSettings, HotTableComponent, HotTableModule} from '@handsontable/angular-wrapper';
 
 interface ShiftData {
@@ -131,7 +131,7 @@ export class AppComponent {
     return this.localeOptions.find((o) => o.value === this.locale)?.label || '';
   }
 
-  constructor(private elementRef: ElementRef) {}
+  private elementRef = inject(ElementRef);
 
   toggleDropdown(): void {
     this.isOpen = !this.isOpen;

--- a/docs/content/guides/dialog/notification/angular/example1.html
+++ b/docs/content/guides/dialog/notification/angular/example1.html
@@ -1,1 +1,3 @@
-<hot-table #hotTable [settings]="hotSettings"></hot-table>
+<div>
+  <notification-example></notification-example>
+</div>

--- a/docs/content/guides/dialog/notification/angular/example1.ts
+++ b/docs/content/guides/dialog/notification/angular/example1.ts
@@ -1,35 +1,35 @@
 /* file: app.component.ts */
 import { Component, AfterViewInit, ViewChild } from '@angular/core';
-import Handsontable from 'handsontable/base';
-import { HotTableModule, HotTableComponent } from '@handsontable/angular-wrapper';
+import { GridSettings, HotTableModule, HotTableComponent } from '@handsontable/angular-wrapper';
 
 @Component({
   standalone: true,
   imports: [HotTableModule],
   selector: 'notification-example',
-  template: `<hot-table #hotTable [settings]="hotSettings"></hot-table>`,
+  template: `<hot-table #hotTable [data]="hotData" [settings]="hotSettings"></hot-table>`,
 })
 export class AppComponent implements AfterViewInit {
   @ViewChild('hotTable', { static: false }) hotTable: HotTableComponent;
 
-  hotSettings: Handsontable.GridSettings = {
-    data: [
-      ['Review pricing sheet', 'Draft', 'Apr 12', 'Morgan Lee', 'Medium', 'Finance'],
-      ['Ship partner samples', 'In progress', 'Apr 14', 'Jordan Kim', 'High', 'Sales'],
-      ['Q2 revenue forecast', 'Done', 'Apr 8', 'Avery Chen', 'Low', 'Finance'],
-      ['New client onboarding', 'Blocked', 'Apr 18', 'Riley Patel', 'High', 'Success'],
-      ['Update documentation', 'Draft', 'Apr 20', 'Casey Ruiz', 'Low', 'Engineering'],
-      ['Audit vendor contracts', 'In progress', 'Apr 22', 'Morgan Lee', 'Medium', 'Legal'],
-      ['Refresh brand assets', 'Draft', 'Apr 25', 'Sam Okafor', 'Low', 'Marketing'],
-      ['Fix login timeout bug', 'In progress', 'Apr 16', 'Devon Walsh', 'High', 'Engineering'],
-      ['Prep board deck', 'Done', 'Apr 10', 'Jordan Kim', 'Medium', 'Exec'],
-      ['Migrate legacy CRM rows', 'Blocked', 'Apr 28', 'Alex Rivera', 'High', 'Engineering'],
-      ['Schedule user interviews', 'Draft', 'Apr 19', 'Riley Patel', 'Medium', 'Product'],
-      ['Approve expense policy', 'In progress', 'Apr 21', 'Morgan Lee', 'Low', 'Finance'],
-      ['Localize help center', 'Draft', 'May 2', 'Sam Okafor', 'Medium', 'Marketing'],
-      ['Load test checkout API', 'In progress', 'Apr 17', 'Devon Walsh', 'High', 'Engineering'],
-      ['Quarterly OKR check-in', 'Done', 'Apr 9', 'Avery Chen', 'Low', 'Exec'],
-    ],
+  readonly hotData = [
+    ['Review pricing sheet', 'Draft', 'Apr 12', 'Morgan Lee', 'Medium', 'Finance'],
+    ['Ship partner samples', 'In progress', 'Apr 14', 'Jordan Kim', 'High', 'Sales'],
+    ['Q2 revenue forecast', 'Done', 'Apr 8', 'Avery Chen', 'Low', 'Finance'],
+    ['New client onboarding', 'Blocked', 'Apr 18', 'Riley Patel', 'High', 'Success'],
+    ['Update documentation', 'Draft', 'Apr 20', 'Casey Ruiz', 'Low', 'Engineering'],
+    ['Audit vendor contracts', 'In progress', 'Apr 22', 'Morgan Lee', 'Medium', 'Legal'],
+    ['Refresh brand assets', 'Draft', 'Apr 25', 'Sam Okafor', 'Low', 'Marketing'],
+    ['Fix login timeout bug', 'In progress', 'Apr 16', 'Devon Walsh', 'High', 'Engineering'],
+    ['Prep board deck', 'Done', 'Apr 10', 'Jordan Kim', 'Medium', 'Exec'],
+    ['Migrate legacy CRM rows', 'Blocked', 'Apr 28', 'Alex Rivera', 'High', 'Engineering'],
+    ['Schedule user interviews', 'Draft', 'Apr 19', 'Riley Patel', 'Medium', 'Product'],
+    ['Approve expense policy', 'In progress', 'Apr 21', 'Morgan Lee', 'Low', 'Finance'],
+    ['Localize help center', 'Draft', 'May 2', 'Sam Okafor', 'Medium', 'Marketing'],
+    ['Load test checkout API', 'In progress', 'Apr 17', 'Devon Walsh', 'High', 'Engineering'],
+    ['Quarterly OKR check-in', 'Done', 'Apr 9', 'Avery Chen', 'Low', 'Exec'],
+  ];
+
+  readonly hotSettings: GridSettings = {
     colHeaders: ['Task', 'Status', 'Due', 'Owner', 'Priority', 'Team'],
     columns: [
       { data: 0, type: 'text', width: 200 },
@@ -43,7 +43,6 @@ export class AppComponent implements AfterViewInit {
     width: '100%',
     height: 420,
     notification: true,
-    licenseKey: 'non-commercial-and-evaluation',
   };
 
   ngAfterViewInit(): void {

--- a/docs/content/guides/dialog/notification/angular/example1.ts
+++ b/docs/content/guides/dialog/notification/angular/example1.ts
@@ -7,7 +7,7 @@ import { HotTableModule, HotTableComponent } from '@handsontable/angular-wrapper
   standalone: true,
   imports: [HotTableModule],
   selector: 'notification-example',
-  templateUrl: './example1.html',
+  template: `<hot-table #hotTable [settings]="hotSettings"></hot-table>`,
 })
 export class AppComponent implements AfterViewInit {
   @ViewChild('hotTable', { static: false }) hotTable: HotTableComponent;

--- a/docs/content/guides/dialog/notification/angular/example1.ts
+++ b/docs/content/guides/dialog/notification/angular/example1.ts
@@ -9,7 +9,7 @@ import { GridSettings, HotTableModule, HotTableComponent } from '@handsontable/a
   template: `<hot-table #hotTable [data]="hotData" [settings]="hotSettings"></hot-table>`,
 })
 export class AppComponent implements AfterViewInit {
-  @ViewChild('hotTable', { static: false }) hotTable: HotTableComponent;
+  @ViewChild('hotTable', { static: false }) hotTable!: HotTableComponent;
 
   readonly hotData = [
     ['Review pricing sheet', 'Draft', 'Apr 12', 'Morgan Lee', 'Medium', 'Finance'],

--- a/docs/content/guides/dialog/notification/angular/example2.html
+++ b/docs/content/guides/dialog/notification/angular/example2.html
@@ -1,6 +1,3 @@
-<div style="display:flex;gap:8px;margin-bottom:8px;flex-wrap:wrap;">
-  <button type="button" (click)="onSave()">Save</button>
-  <button type="button" (click)="onSyncError()">Sync error</button>
-  <button type="button" (click)="onLowStock()">Low stock</button>
+<div>
+  <notification-example-2></notification-example-2>
 </div>
-<hot-table #hotTable [settings]="hotSettings"></hot-table>

--- a/docs/content/guides/dialog/notification/angular/example2.ts
+++ b/docs/content/guides/dialog/notification/angular/example2.ts
@@ -16,7 +16,7 @@ import { GridSettings, HotTableModule, HotTableComponent } from '@handsontable/a
   `,
 })
 export class AppComponent {
-  @ViewChild('hotTable', { static: false }) hotTable: HotTableComponent;
+  @ViewChild('hotTable', { static: false }) hotTable!: HotTableComponent;
 
   readonly hotData = [
     ['SKU-001', 'Alkaline AA 4pk', 240, 40, 'A-12'],

--- a/docs/content/guides/dialog/notification/angular/example2.ts
+++ b/docs/content/guides/dialog/notification/angular/example2.ts
@@ -7,7 +7,14 @@ import { HotTableModule, HotTableComponent } from '@handsontable/angular-wrapper
   standalone: true,
   imports: [HotTableModule],
   selector: 'notification-example-2',
-  templateUrl: './example2.html',
+  template: `
+    <div style="display:flex;gap:8px;margin-bottom:8px;flex-wrap:wrap;">
+      <button type="button" (click)="onSave()">Save</button>
+      <button type="button" (click)="onSyncError()">Sync error</button>
+      <button type="button" (click)="onLowStock()">Low stock</button>
+    </div>
+    <hot-table #hotTable [settings]="hotSettings"></hot-table>
+  `,
 })
 export class AppComponent {
   @ViewChild('hotTable', { static: false }) hotTable: HotTableComponent;

--- a/docs/content/guides/dialog/notification/angular/example2.ts
+++ b/docs/content/guides/dialog/notification/angular/example2.ts
@@ -1,7 +1,6 @@
 /* file: app.component.ts */
 import { Component, ViewChild } from '@angular/core';
-import Handsontable from 'handsontable/base';
-import { HotTableModule, HotTableComponent } from '@handsontable/angular-wrapper';
+import { GridSettings, HotTableModule, HotTableComponent } from '@handsontable/angular-wrapper';
 
 @Component({
   standalone: true,
@@ -13,23 +12,24 @@ import { HotTableModule, HotTableComponent } from '@handsontable/angular-wrapper
       <button type="button" (click)="onSyncError()">Sync error</button>
       <button type="button" (click)="onLowStock()">Low stock</button>
     </div>
-    <hot-table #hotTable [settings]="hotSettings"></hot-table>
+    <hot-table #hotTable [data]="hotData" [settings]="hotSettings"></hot-table>
   `,
 })
 export class AppComponent {
   @ViewChild('hotTable', { static: false }) hotTable: HotTableComponent;
 
-  hotSettings: Handsontable.GridSettings = {
-    data: [
-      ['SKU-001', 'Alkaline AA 4pk', 240, 40, 'A-12'],
-      ['SKU-002', 'USB-C cable 1m', 18, 24, 'B-03'],
-      ['SKU-003', 'Notebook A5 ruled', 0, 30, 'C-01'],
-      ['SKU-004', 'Wireless mouse', 6, 15, 'B-07'],
-      ['SKU-005', 'HDMI cable 2m', 2, 10, 'A-04'],
-      ['SKU-006', 'Desk lamp LED', 45, 12, 'D-02'],
-      ['SKU-007', 'Laptop stand aluminum', 0, 8, 'C-14'],
-      ['SKU-008', 'Mechanical keycap set', 112, 20, 'B-01'],
-    ],
+  readonly hotData = [
+    ['SKU-001', 'Alkaline AA 4pk', 240, 40, 'A-12'],
+    ['SKU-002', 'USB-C cable 1m', 18, 24, 'B-03'],
+    ['SKU-003', 'Notebook A5 ruled', 0, 30, 'C-01'],
+    ['SKU-004', 'Wireless mouse', 6, 15, 'B-07'],
+    ['SKU-005', 'HDMI cable 2m', 2, 10, 'A-04'],
+    ['SKU-006', 'Desk lamp LED', 45, 12, 'D-02'],
+    ['SKU-007', 'Laptop stand aluminum', 0, 8, 'C-14'],
+    ['SKU-008', 'Mechanical keycap set', 112, 20, 'B-01'],
+  ];
+
+  readonly hotSettings: GridSettings = {
     colHeaders: ['SKU', 'Product', 'Qty on hand', 'Reorder at', 'Bin'],
     columns: [
       { data: 0, type: 'text', width: 90 },
@@ -42,7 +42,6 @@ export class AppComponent {
     width: '100%',
     height: 280,
     notification: true,
-    licenseKey: 'non-commercial-and-evaluation',
   };
 
   onSave(): void {


### PR DESCRIPTION
### Context

The PR fixes six Angular doc examples that silently failed to render due to Angular JIT compiler incompatibilities:

**Rule 1 - `templateUrl` (2 files):** Angular JIT cannot fetch external template files at runtime. `dialog/notification/angular/example1.ts` and `example2.ts` used `templateUrl: './exampleN.html'`. Fixed by inlining the template content directly in `template: \`...\``.

**Rule 2 - Constructor DI (4 files):** Angular JIT does not process TypeScript decorator metadata, so constructor-based service injection fails silently. Four examples used `constructor(private elementRef: ElementRef) {}`. Fixed by replacing with the `inject()` function: `private elementRef = inject(ElementRef);`. Import of `inject` added to each file.

Affected examples:
- `docs/content/guides/dialog/notification/angular/example1.ts`
- `docs/content/guides/dialog/notification/angular/example2.ts`
- `docs/content/guides/cell-features/selection/angular/example1.ts`
- `docs/content/guides/cell-types/date-cell-type/angular/example1.ts`
- `docs/content/guides/cell-types/numeric-cell-type/angular/example1.ts`
- `docs/content/guides/cell-types/time-cell-type/angular/example1.ts`

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1531

### How has this been tested?

Static code analysis confirming the forbidden patterns (`templateUrl`, constructor DI) are no longer present in any Angular example file. These are docs-only changes with no library source code modifications.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1531

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

---
_Generated by [Claude Code](https://claude.ai/code/session_01W78bgZUpCVkXPV4CQGcxcK)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only changes that adjust Angular demo wiring (DI and templates) without touching library/runtime code.
> 
> **Overview**
> Fixes Angular documentation demos that failed under JIT by removing patterns that require build-time processing.
> 
> Updates four examples to use `inject(ElementRef)` instead of constructor DI, and refactors the notification dialog examples to inline templates (and move table `data` to a separate `hotData` binding), eliminating `templateUrl` usage and `Handsontable.GridSettings` typing in favor of `GridSettings`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eeee30d2b4a044c54c3dae4f6f2c25d943f643dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->