### PR TITLE
DEV-1532: Increase code-review-graph usage for cross-file exploration in agent workflows

### DIFF
--- a/.claude/skills/code-graph-debug-issue/SKILL.md
+++ b/.claude/skills/code-graph-debug-issue/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: code-graph-debug-issue
-description: Systematically debug issues using graph-powered code navigation
+description: Use when debugging any bug, regression, or unexpected behavior - trace from symptom to root cause via callers/callees, find the entry point of an execution path, or identify which recent change caused a regression. Reach for this BEFORE manual Grep+Read traversal of call chains. Trigger on phrases like "why does X fail", "trace this bug", "what triggers Y", "follow the call chain", "what changed recently", "where does this error come from", or any symptom that needs cross-file investigation to find the root cause.
 ---
 
 ## Debug Issue
 
 Use the knowledge graph to systematically trace and debug issues.
+
+**Before the first graph call in a session**, load the tool schemas: call `ToolSearch` with `query: "select:mcp__code-review-graph__query_graph_tool"` (comma-separate names to load several at once). Graph MCP tools are deferred at session start, so calling them without this bootstrap fails with `InputValidationError`. This is one cheap call that unblocks every subsequent graph query for the rest of the session.
 
 ### Steps
 

--- a/.claude/skills/code-graph-explore-codebase/SKILL.md
+++ b/.claude/skills/code-graph-explore-codebase/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: code-graph-explore-codebase
-description: Navigate and understand codebase structure using the knowledge graph
+description: Use FIRST for any cross-file code lookup in this monorepo - finding callers of a function, importers of a file, dependency chains, references to a symbol, methods on a class, blast radius, or "who uses X". The pre-built knowledge graph returns structured results 2-6x cheaper than Grep+Read traversal. Trigger on phrases like "who calls", "what imports", "where is X used", "find references", "dependency chain", "methods of class", "callers of", "callees of", or any question that spans multiple files - even when you think Grep would work.
 ---
 
 ## Explore Codebase
 
 Use the code-review-graph MCP tools to explore and understand the codebase.
+
+**Before the first graph call in a session**, load the tool schemas: call `ToolSearch` with `query: "select:mcp__code-review-graph__query_graph_tool"` (comma-separate names to load several at once). Graph MCP tools are deferred at session start, so calling them without this bootstrap fails with `InputValidationError`. This is one cheap call that unblocks every subsequent graph query for the rest of the session.
 
 ### Steps
 

--- a/.claude/skills/code-graph-refactor-safely/SKILL.md
+++ b/.claude/skills/code-graph-refactor-safely/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: code-graph-refactor-safely
-description: Plan and execute safe refactoring using dependency analysis from the knowledge graph
+description: Use when planning a refactor, rename, or API change - preview every affected location before touching code, measure blast radius, find dead code, or rename a symbol safely across the codebase. Required before large renames, moves, or API redesigns. Trigger on phrases like "rename X to Y", "extract this into", "find dead code", "what would break if I change", "blast radius", "safe to remove", "move this function", or any change with non-obvious downstream impact.
 ---
 
 ## Refactor Safely
 
 Use the knowledge graph to plan and execute refactoring with confidence.
+
+**Before the first graph call in a session**, load the tool schemas: call `ToolSearch` with `query: "select:mcp__code-review-graph__query_graph_tool,mcp__code-review-graph__get_impact_radius_tool,mcp__code-review-graph__refactor_tool"` (or whichever tools you plan to call). Graph MCP tools are deferred at session start, so calling them without this bootstrap fails with `InputValidationError`. One cheap call unblocks every subsequent graph query for the rest of the session.
 
 **Note:** `refactor_tool`, `apply_refactor_tool`, and `find_large_functions` have not been empirically validated on this codebase. Treat the suggestions they produce as hypotheses, not prescriptions -- verify each edit against the actual code.
 

--- a/.claude/skills/code-graph-review-changes/SKILL.md
+++ b/.claude/skills/code-graph-review-changes/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: code-graph-review-changes
-description: Perform a structured code review using change detection and impact analysis from the knowledge graph
+description: Use when reviewing a branch, PR, or set of recent changes - get change detection with risk scoring, affected execution flows, and impact radius across files. Prefer over manually walking the diff line-by-line. Trigger on phrases like "review this PR", "review my changes", "what's the risk of this branch", "what does this change affect", "are there regressions in", "review the diff", or any request to assess the safety or quality of pending changes.
 ---
 
 ## Review Changes
 
 Perform a thorough, risk-aware code review using the knowledge graph.
+
+**Before the first graph call in a session**, load the tool schemas: call `ToolSearch` with `query: "select:mcp__code-review-graph__detect_changes_tool,mcp__code-review-graph__get_affected_flows_tool,mcp__code-review-graph__get_impact_radius_tool"` (or whichever tools you plan to call). Graph MCP tools are deferred at session start, so calling them without this bootstrap fails with `InputValidationError`. One cheap call unblocks every subsequent graph query for the rest of the session.
 
 ### Steps
 

--- a/.claude/skills/pr-creation/SKILL.md
+++ b/.claude/skills/pr-creation/SKILL.md
@@ -14,7 +14,15 @@ Choose the prefix that matches your work:
 | Docs | `docs/issue-xxxx` | `docs/issue-9500` |
 | Release | `release/x.y.z` | `release/16.1.0` |
 
-When working from a ClickUp task, the task ID (e.g. `DEV-627`) **must** appear in the branch name so ClickUp links automatically.
+When working from a ClickUp task, the **human-readable custom ID** (e.g. `DEV-627`, `IT-42`) **must** appear in the branch name so ClickUp links automatically. Never use the internal ClickUp hash ID (e.g. `86c9j4fxj`) — it is not a valid task identifier for branch linking.
+
+**Important:** `clickup_create_task` returns `custom_id: null` in its response. Always call `clickup_get_task` immediately after creating a task to retrieve the real custom ID before naming the branch:
+
+```
+1. clickup_create_task → returns task_id (hash, e.g. "86c9j4fxj")
+2. clickup_get_task(task_id) → returns custom_id (e.g. "DEV-1532")
+3. Use custom_id in the branch name: feature/DEV-1532_Short-Description
+```
 
 ## 2. Pre-flight Checks
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -335,6 +335,31 @@ A Tree-sitter knowledge graph (28k+ nodes, 419k+ edges) pre-built over the full 
 
 **Maintainer note:** the pinned version `2.3.2` appears in `.mcp.json`, the two hook commands in `.claude/settings.json`, and the guidance tables below. Bumping requires updating all four locations in sync.
 
+### First-call protocol - load schema before grep
+
+Graph MCP tools are **deferred** at session start; their schemas are not loaded. Calling them directly fails with `InputValidationError`. The sequence is always:
+
+1. `ToolSearch` with `query: "select:mcp__code-review-graph__query_graph_tool"` to load the schema (comma-separate names to load several in one call).
+2. Call `mcp__code-review-graph__query_graph_tool` with `pattern` and `detail_level: "minimal"`.
+
+If you reach for `grep -r "from.*foo"`, `grep -rn` for a symbol, or repeated `Read` calls to answer a cross-file question, **stop and load the graph tool first.** Grep produces 2-6x more tokens, lacks structural context (no callsite framing, no resolved import targets), and misses dynamic dispatch.
+
+### Trigger phrases - these mean "use the graph"
+
+The first tool call should be `ToolSearch` for the graph schema whenever the user asks any of:
+
+- "dependency chain" / "dependencies of X" / "what does X depend on"
+- "who calls X" / "callers of X" / "who uses X"
+- "what does X call" / "callees of X"
+- "where is X used" / "find references to X" / "find usages"
+- "what imports Y" / "importers of Y" / "who imports this file"
+- "blast radius" / "impact of changing X" / "what breaks if I change X"
+- "methods on class Z" / "members of Z" (use `children_of`)
+- "find dead code" / "unreferenced code"
+- "trace this bug through the call chain"
+
+The matching `code-graph-*` skill is helpful but not required - for a single lookup, going straight from `ToolSearch` to `query_graph_tool` is fine.
+
 ### Use the graph for cross-file traversal
 
 | Task | Tool + pattern | Token advantage |

--- a/handsontable/src/3rdparty/walkontable/AGENTS.md
+++ b/handsontable/src/3rdparty/walkontable/AGENTS.md
@@ -36,3 +36,60 @@ Separate test runner - do NOT mix with main E2E tests:
 Tests in: `src/3rdparty/walkontable/test/`
 
 For detailed guidance: use skills `walkontable-dev`, `walkontable-testing`
+
+## MCP Tools: code-review-graph
+
+A Tree-sitter knowledge graph (28k+ nodes, 419k+ edges) pre-built over the full codebase. Provides structured, function-level results for cross-file queries that would otherwise require many Grep+Read round-trips.
+
+**Prerequisite:** `pipx` must be installed. The MCP server starts automatically via `pipx run` on first use (one-time ~10s PyPI download, then cached). Rebuild after switching branches: `pipx run code-review-graph==2.3.2 build`.
+
+**Maintainer note:** the pinned version `2.3.2` appears in `.mcp.json`, the two hook commands in `.claude/settings.json`, and the guidance tables below. Bumping requires updating all four locations in sync.
+
+### First-call protocol - load schema before grep
+
+Graph MCP tools are **deferred** at session start; their schemas are not loaded. Calling them directly fails with `InputValidationError`. The sequence is always:
+
+1. `ToolSearch` with `query: "select:mcp__code-review-graph__query_graph_tool"` to load the schema (comma-separate names to load several in one call).
+2. Call `mcp__code-review-graph__query_graph_tool` with `pattern` and `detail_level: "minimal"`.
+
+If you reach for `grep -r "from.*foo"`, `grep -rn` for a symbol, or repeated `Read` calls to answer a cross-file question, **stop and load the graph tool first.** Grep produces 2-6x more tokens, lacks structural context, and misses dynamic dispatch.
+
+### Trigger phrases - these mean "use the graph"
+
+The first tool call should be `ToolSearch` for the graph schema whenever the user asks any of: "dependency chain", "who calls X", "callers of X", "callees of X", "where is X used", "find references", "what imports Y", "blast radius", "impact of changing X", "methods on class Z", "find dead code", "trace this bug". The matching `code-graph-*` skill is helpful but not required - a single `ToolSearch` -> `query_graph_tool` round trip is fine.
+
+### Use the graph for cross-file traversal
+
+| Task | Tool + pattern | Token advantage |
+|------|---------------|-----------------|
+| Who calls `foo`? | `query_graph` `callers_of` | ~5k tokens vs ~11k for grep+context (2x cheaper) |
+| What does `Foo` call? | `query_graph` `callees_of` | Same advantage as above |
+| What files import `bar.js`? | `query_graph` `importers_of` | Structured; no grep context needed |
+| Blast radius before a refactor | `get_impact_radius` | ~100 tokens for count + risk score |
+
+### Use Grep/Read for single-file work
+
+| Task | Why Grep wins |
+|------|--------------|
+| Methods in one file | `children_of` standard = ~2,845 tokens; grep = ~473 tokens (6x cheaper) |
+| Recent change review | `detect_changes` requires the graph to be on the same branch |
+| Test coverage lookup | `tests_for` returns 0 incorrectly for files with known tests - not reliable |
+| Natural-language search | No embeddings built; `semantic_search_nodes` falls back to keyword matching |
+| Architecture overview | `get_architecture_overview` returns 3.9M characters - do not call it |
+
+### Mandatory rules
+
+1. **Always pass `detail_level: "minimal"`** - standard mode repeats the full absolute path per node and inflates token cost 6x.
+2. **Use fully qualified names**: `path/to/file.js::ClassName.methodName`. Bare names return an "ambiguous" error.
+3. **Rebuild on branch switch**: `pipx run code-review-graph==2.3.2 build`. A stale graph causes `detect_changes` to report function names from unrelated files.
+
+### Reliable tools
+
+| Tool | Use when |
+|------|----------|
+| `query_graph` pattern=`callers_of` | Finding all functions that call a target |
+| `query_graph` pattern=`callees_of` | Finding all functions a target calls |
+| `query_graph` pattern=`importers_of` | Finding all files that import a target |
+| `query_graph` pattern=`children_of` | Listing all methods in a class (use minimal mode) |
+| `get_impact_radius` | Quick blast-radius count before a large refactor |
+| `semantic_search_nodes` | Name-based lookup by exact or partial function/class name |


### PR DESCRIPTION
### Context

The PR improves how AI agents (Claude, Cursor) use the `code-review-graph` MCP tool for cross-file lookups instead of falling back to `grep`/`Read`, which costs 2-6x more tokens and lacks structural context.

Three root causes were fixed:

1. The four `code-graph-*` skill descriptions used narrow framings ("Navigate codebase", "Debug issues") that did not trigger on everyday phrases like "show dependency chain", "who calls X", or "find references to Y".
2. The graph MCP tools are deferred at session start - their schemas are not loaded by default. Calling them directly fails with `InputValidationError`. There was no guidance on the required `ToolSearch` bootstrap step.
3. The `pr-creation` skill did not warn that `clickup_create_task` always returns `custom_id: null`. Without a follow-up `clickup_get_task` call, branches were named with the internal hash ID (e.g. `86c9j4fxj`) instead of the human-readable custom ID (e.g. `DEV-1532`).

Changes:
- **4 skill descriptions broadened** (`.claude/skills/code-graph-*/SKILL.md`): each now lists concrete trigger phrases (callers, importers, dependency chain, blast radius, find usages, etc.) and includes a "Mandatory first step" body note about loading schemas via `ToolSearch` before the first graph call.
- **`AGENTS.md` updated** (root + `handsontable/src/3rdparty/walkontable/`): added "First-call protocol" and "Trigger phrases" subsections to the existing `## MCP Tools: code-review-graph` section so the rule is visible at session start without needing to invoke any skill.
- **`pr-creation` skill updated** (`.claude/skills/pr-creation/SKILL.md`): branch naming section now explicitly prohibits internal hash IDs and documents the required `create_task` → `get_task` → use `custom_id` sequence.

### How has this been tested?

- Manually verified trigger phrases match the updated skill descriptions in the session context.
- Confirmed `ToolSearch` → `query_graph_tool` flow works without `InputValidationError` after the bootstrap step is followed.
- Verified the `code-graph-explore-codebase` skill now triggers on "show dependency chain" and "who imports this file" queries that previously bypassed it.
- Confirmed `clickup_get_task` returns `custom_id: "DEV-1532"` where `clickup_create_task` returned `custom_id: null`.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. DEV-1532

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1532

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates that adjust agent workflow instructions for using `code-review-graph`; no product/runtime code is touched.
> 
> **Overview**
> Updates Claude skill docs to **prefer `code-review-graph` for cross-file questions**, expanding each `code-graph-*` skill description with concrete trigger phrases and adding a **mandatory first step** to run `ToolSearch` to load deferred MCP tool schemas (avoiding `InputValidationError`).
> 
> Adds the same **first-call protocol** and trigger-phrase guidance to `AGENTS.md` (root and Walkontable) so agents see it immediately, and clarifies ClickUp branch naming in `pr-creation` (use the human-readable `custom_id` and fetch it via `clickup_get_task` after task creation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b67158b7c63271f7ce51a2baf5f00fe2831084bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->