### PR TITLE
DEV-1474: Fix broken Available Recipes links in docs

### DIFF
--- a/docs/content/recipes/accessibility/accessibility.md
+++ b/docs/content/recipes/accessibility/accessibility.md
@@ -27,7 +27,7 @@ Current recipes:
 
 <div class="boxes-list">
 
-- [Custom keyboard shortcuts](@/content/recipes/accessibility/keyboard-shortcuts/keyboard-shortcuts.md)
-- [ARIA-friendly grid](@/content/recipes/accessibility/aria-grid/aria-grid.md)
+- [Custom keyboard shortcuts](@/recipes/accessibility/keyboard-shortcuts/keyboard-shortcuts.md)
+- [ARIA-friendly grid](@/recipes/accessibility/aria-grid/aria-grid.md)
 
 </div>

--- a/docs/content/recipes/column-management/column-management.md
+++ b/docs/content/recipes/column-management/column-management.md
@@ -27,7 +27,7 @@ Current recipes:
 
 <div class="boxes-list">
 
-- [Build a dynamic column visibility toggle](@/content/recipes/column-management/column-visibility/column-visibility.md)
-- [Freeze and unfreeze columns at runtime](@/content/recipes/column-management/freeze-columns/freeze-columns.md)
+- [Build a dynamic column visibility toggle](@/recipes/column-management/column-visibility/column-visibility.md)
+- [Freeze and unfreeze columns at runtime](@/recipes/column-management/freeze-columns/freeze-columns.md)
 
 </div>

--- a/docs/content/recipes/column-management/freeze-columns/freeze-columns.md
+++ b/docs/content/recipes/column-management/freeze-columns/freeze-columns.md
@@ -193,6 +193,6 @@ function updateStatus() {
 
 ## Next steps
 
-- Combine this pattern with the [column visibility toggle](@/content/recipes/column-management/column-visibility/column-visibility.md) recipe to build a full column-management toolbar.
+- Combine this pattern with the [column visibility toggle](@/recipes/column-management/column-visibility/column-visibility.md) recipe to build a full column-management toolbar.
 - Persist the `frozenCount` value to `localStorage` using the `afterUpdateSettings` hook so the freeze state survives a page refresh.
 - Replace the individual freeze buttons with a single numeric input (`<input type="number">`) to let users type a freeze count directly.

--- a/docs/content/recipes/context-menu/context-menu.md
+++ b/docs/content/recipes/context-menu/context-menu.md
@@ -27,7 +27,7 @@ Current recipes:
 
 <div class="boxes-list">
 
-- [Custom context menu actions](@/content/recipes/context-menu/custom-context-menu/custom-context-menu.md)
-- [Programmatic row operations](@/content/recipes/context-menu/row-operations/row-operations.md)
+- [Custom context menu actions](@/recipes/context-menu/custom-context-menu/custom-context-menu.md)
+- [Programmatic row operations](@/recipes/context-menu/row-operations/row-operations.md)
 
 </div>

--- a/docs/content/recipes/data-management/data-management.md
+++ b/docs/content/recipes/data-management/data-management.md
@@ -26,14 +26,14 @@ This section provides practical recipes for loading, syncing, and managing data 
 Current recipes:
 
 <div class="boxes-list">
-- [Load data from a REST API](@/content/recipes/data-management/load-data-rest-api/load-data-rest-api.md)
-- [Load data from a GraphQL API](@/content/recipes/data-management/load-data-graphql/load-data-graphql.md)
-- [Sync two grids](@/content/recipes/data-management/sync-two-grids/sync-two-grids.md)
-- [Auto-save changes to a backend](@/content/recipes/data-management/auto-save-backend/auto-save-backend.md)
-- [Undo / redo with a custom UI](@/content/recipes/data-management/undo-redo-custom-ui/undo-redo-custom-ui.md)
-- [Server-side data with Django](@/content/recipes/data-management/server-side-django/server-side-django.md)
-- [Server-side data with Laravel](@/content/recipes/data-management/server-side-laravel/server-side-laravel.md)
-- [Server-side data with NestJS](@/content/recipes/data-management/server-side-nestjs/server-side-nestjs.md)
-- [Server-side data with Ruby on Rails](@/content/recipes/data-management/server-side-rails/server-side-rails.md)
-- [Server-side data with Spring Boot](@/content/recipes/data-management/server-side-spring/server-side-spring.md)
+- [Load data from a REST API](@/recipes/data-management/load-data-rest-api/load-data-rest-api.md)
+- [Load data from a GraphQL API](@/recipes/data-management/load-data-graphql/load-data-graphql.md)
+- [Sync two grids](@/recipes/data-management/sync-two-grids/sync-two-grids.md)
+- [Auto-save changes to a backend](@/recipes/data-management/auto-save-backend/auto-save-backend.md)
+- [Undo / redo with a custom UI](@/recipes/data-management/undo-redo-custom-ui/undo-redo-custom-ui.md)
+- [Server-side data with Django](@/recipes/data-management/server-side-django/server-side-django.md)
+- [Server-side data with Laravel](@/recipes/data-management/server-side-laravel/server-side-laravel.md)
+- [Server-side data with NestJS](@/recipes/data-management/server-side-nestjs/server-side-nestjs.md)
+- [Server-side data with Ruby on Rails](@/recipes/data-management/server-side-rails/server-side-rails.md)
+- [Server-side data with Spring Boot](@/recipes/data-management/server-side-spring/server-side-spring.md)
 </div>

--- a/docs/content/recipes/data-management/server-side-nestjs/server-side-nestjs.md
+++ b/docs/content/recipes/data-management/server-side-nestjs/server-side-nestjs.md
@@ -380,4 +380,4 @@ emptyDataState: true,
 - Replace the in-memory store with TypeORM + SQLite (zero extra config) or PostgreSQL.
 - Add authentication -- pass a `Bearer` token in the `fetchRows` fetch headers and protect mutation endpoints with a NestJS `AuthGuard`.
 - Share the DTO types between the NestJS backend and the Handsontable frontend in a monorepo using a shared `packages/types` workspace package.
-- Compare with the [Spring Boot recipe](@/content/recipes/data-management/server-side-spring/server-side-spring.md) to see the same Handsontable frontend wired to a Java backend using the same endpoint shapes.
+- Compare with the [Spring Boot recipe](@/recipes/data-management/server-side-spring/server-side-spring.md) to see the same Handsontable frontend wired to a Java backend using the same endpoint shapes.

--- a/docs/content/recipes/data-management/server-side-rails/server-side-rails.md
+++ b/docs/content/recipes/data-management/server-side-rails/server-side-rails.md
@@ -482,8 +482,8 @@ const hot = new Handsontable(container, {
 
 ## Next steps
 
-- [Server-side data with Django](@/content/recipes/data-management/server-side-django/server-side-django.md)
-- [Server-side data with Spring Boot](@/content/recipes/data-management/server-side-spring/server-side-spring.md)
+- [Server-side data with Django](@/recipes/data-management/server-side-django/server-side-django.md)
+- [Server-side data with Spring Boot](@/recipes/data-management/server-side-spring/server-side-spring.md)
 - [Rows pagination guide](@/content/guides/rows/rows-pagination/rows-pagination.md)
 - [Column filter guide](@/content/guides/columns/column-filter/column-filter.md)
 - [Rows sorting guide](@/content/guides/rows/rows-sorting/rows-sorting.md)

--- a/docs/content/recipes/data-management/server-side-spring/server-side-spring.md
+++ b/docs/content/recipes/data-management/server-side-spring/server-side-spring.md
@@ -392,4 +392,4 @@ emptyDataState: true,
 - Replace H2 with a persistent database (PostgreSQL, MySQL) by swapping the datasource in `application.properties` and changing `ddl-auto` to `validate`.
 - Add `@Valid` to the controller DTOs and define Bean Validation constraints (e.g. `@NotBlank` on `name`, `@Positive` on `price`) to return structured error responses when the user saves invalid data.
 - Secure the API with Spring Security: require authentication for mutation endpoints while keeping `GET /api/products` public.
-- Compare with the [Laravel recipe](@/content/recipes/data-management/server-side-spring/server-side-spring.md) to see the same Handsontable frontend wired to a PHP backend using the same endpoint shapes.
+- Compare with the [Laravel recipe](@/recipes/data-management/server-side-laravel/server-side-laravel.md) to see the same Handsontable frontend wired to a PHP backend using the same endpoint shapes.

--- a/docs/content/recipes/editing-validation/editing-validation.md
+++ b/docs/content/recipes/editing-validation/editing-validation.md
@@ -23,5 +23,5 @@ This section collects recipes focused on editing behavior, validation, and keepi
 
 ## Available recipes
 
-- **[Dependent dropdowns](@/content/recipes/editing-validation/dependent-dropdowns/dependent-dropdowns.md)** - Update a child column's `dropdown` source when a parent value changes.
-- **[Row validation with error summary](@/content/recipes/editing-validation/row-validation-error-summary/row-validation-error-summary.md)** - Validate all rows on Submit, show an external issue list, and highlight invalid cells with `htInvalid`.
+- **[Dependent dropdowns](@/recipes/editing-validation/dependent-dropdowns/dependent-dropdowns.md)** - Update a child column's `dropdown` source when a parent value changes.
+- **[Row validation with error summary](@/recipes/editing-validation/row-validation-error-summary/row-validation-error-summary.md)** - Validate all rows on Submit, show an external issue list, and highlight invalid cells with `htInvalid`.

--- a/docs/content/recipes/filtering-and-search/filtering-and-search.md
+++ b/docs/content/recipes/filtering-and-search/filtering-and-search.md
@@ -31,8 +31,8 @@ Current recipes:
 
 <div class="boxes-list">
 
-- [External search box](@/content/recipes/filtering-and-search/external-search-box/external-search-box.md)
-- [Highlight search matches](@/content/recipes/filtering-and-search/highlight-search-matches/highlight-search-matches.md)
+- [External search box](@/recipes/filtering-and-search/external-search-box/external-search-box.md)
+- [Highlight search matches](@/recipes/filtering-and-search/highlight-search-matches/highlight-search-matches.md)
 
 </div>
 

--- a/docs/content/recipes/filtering-search/filtering-search.md
+++ b/docs/content/recipes/filtering-search/filtering-search.md
@@ -31,6 +31,6 @@ Use these recipes to build custom filter controls outside of the grid and apply 
 
 <div class="boxes-list">
 
-- [Multi-column filter panel](@/content/recipes/filtering-search/multi-column-filter-panel/multi-column-filter-panel.md)
+- [Multi-column filter panel](@/recipes/filtering-search/multi-column-filter-panel/multi-column-filter-panel.md)
 
 </div>

--- a/docs/content/recipes/import-export/import-export.md
+++ b/docs/content/recipes/import-export/import-export.md
@@ -25,7 +25,7 @@ This section collects recipes for exporting grid data to common formats and for 
 
 <div class="boxes-list">
 
-- [Export to PDF](@/content/recipes/import-export/export-to-pdf/export-to-pdf.md)
-- [Import from CSV or Excel](@/content/recipes/import-export/import-csv-excel/import-csv-excel.md)
+- [Export to PDF](@/recipes/import-export/export-to-pdf/export-to-pdf.md)
+- [Import from CSV or Excel](@/recipes/import-export/import-csv-excel/import-csv-excel.md)
 
 </div>

--- a/docs/content/recipes/introduction.md
+++ b/docs/content/recipes/introduction.md
@@ -29,18 +29,18 @@ This is a collection of practical, production-ready recipes for common Handsonta
 
 Browse recipes by category, difficulty, or use case. Each guide is designed to get you from zero to working implementation in minutes.
 
-Recipe categories include [cell types](@/content/recipes/cell-types/cell-types.md), [themes](@/content/recipes/themes/themes.md), and [rendering and styling](@/content/recipes/rendering-styling/rendering-styling.md).
+Recipe categories include [cell types](@/recipes/cell-types/cell-types.md), [themes](@/recipes/themes/themes.md), and [rendering and styling](@/recipes/rendering-styling/rendering-styling.md).
 
 ### Editing and validation
 
-- [Editing and validation recipes](@/content/recipes/editing-validation/editing-validation.md) - Custom editors, validation patterns, and dynamic cell configuration.
+- [Editing and validation recipes](@/recipes/editing-validation/editing-validation.md) - Custom editors, validation patterns, and dynamic cell configuration.
 ### For AI Agents
 
 This resource is structured for easy indexing and retrieval. Each recipe includes metadata, keywords, problem descriptions, and solution patterns to help AI assistants provide accurate, contextual examples.
 
 ### Import and export
 
-- [Import from CSV or Excel](@/content/recipes/import-export/import-csv-excel/import-csv-excel.md) - Client-side CSV (PapaParse) and `.xlsx` (SheetJS) import with header preview.
+- [Import from CSV or Excel](@/recipes/import-export/import-csv-excel/import-csv-excel.md) - Client-side CSV (PapaParse) and `.xlsx` (SheetJS) import with header preview.
 ## Contributing
 
 Have a useful recipe? We'd love to include it!

--- a/docs/content/recipes/performance/performance.md
+++ b/docs/content/recipes/performance/performance.md
@@ -27,7 +27,7 @@ Current recipes:
 
 <div class="boxes-list">
 
-- [Lazy loading with pagination](@/content/recipes/performance/lazy-loading/lazy-loading.md)
-- [Persist and restore column widths and order](@/content/recipes/performance/persist-column-layout/persist-column-layout.md)
+- [Lazy loading with pagination](@/recipes/performance/lazy-loading/lazy-loading.md)
+- [Persist and restore column widths and order](@/recipes/performance/persist-column-layout/persist-column-layout.md)
 
 </div>

--- a/docs/content/recipes/performance/persist-column-layout/persist-column-layout.md
+++ b/docs/content/recipes/performance/persist-column-layout/persist-column-layout.md
@@ -279,4 +279,4 @@ document.querySelector('#reset-layout-btn').addEventListener('click', () => {
 - Extend the recipe to also persist `colHeaders` label overrides or hidden column state.
 - If your page has multiple grids, give each grid its own storage key (e.g., `ht-column-layout-v1-products`, `ht-column-layout-v1-orders`).
 - Replace `localStorage` with a server-side API call to sync layout preferences across devices and browsers.
-- Combine this recipe with [Build a dynamic column visibility toggle](@/content/recipes/column-management/column-visibility/column-visibility.md) to let users both hide columns and remember their visibility state.
+- Combine this recipe with [Build a dynamic column visibility toggle](@/recipes/column-management/column-visibility/column-visibility.md) to let users both hide columns and remember their visibility state.

--- a/docs/content/recipes/real-time/real-time.md
+++ b/docs/content/recipes/real-time/real-time.md
@@ -27,7 +27,7 @@ Current recipes:
 
 <div class="boxes-list">
 
-- [Real-time cell updates via WebSocket](@/content/recipes/real-time/websocket-updates/websocket-updates.md)
-- [Sync rows to a Chart.js chart](@/content/recipes/real-time/chartjs-sync/chartjs-sync.md)
+- [Real-time cell updates via WebSocket](@/recipes/real-time/websocket-updates/websocket-updates.md)
+- [Sync rows to a Chart.js chart](@/recipes/real-time/chartjs-sync/chartjs-sync.md)
 
 </div>

--- a/docs/content/recipes/rendering-styling/rendering-styling.md
+++ b/docs/content/recipes/rendering-styling/rendering-styling.md
@@ -27,8 +27,8 @@ If you are new to fixed rows, read the [Row freezing](@/guides/rows/row-freezing
 
 ## Available recipes
 
-- [Frozen summary row](@/content/recipes/rendering-styling/frozen-summary-row/frozen-summary-row.md) - pinned bottom row with sum, average, and count that updates on edits
-- [Sparkline cell renderer](@/content/recipes/rendering-styling/sparkline-cell-renderer/sparkline-cell-renderer.md) - mini SVG bar charts from array values in a cell
-- [Conditional row coloring](@/content/recipes/rendering-styling/conditional-row-coloring/conditional-row-coloring.md) - map a status column to row-level CSS classes with the `cells` callback and scoped styles
+- [Frozen summary row](@/recipes/rendering-styling/frozen-summary-row/frozen-summary-row.md) - pinned bottom row with sum, average, and count that updates on edits
+- [Sparkline cell renderer](@/recipes/rendering-styling/sparkline-cell-renderer/sparkline-cell-renderer.md) - mini SVG bar charts from array values in a cell
+- [Conditional row coloring](@/recipes/rendering-styling/conditional-row-coloring/conditional-row-coloring.md) - map a status column to row-level CSS classes with the `cells` callback and scoped styles
 
 Each recipe includes runnable examples you can copy into your project.

--- a/docs/content/recipes/themes/themes.md
+++ b/docs/content/recipes/themes/themes.md
@@ -38,10 +38,10 @@ Current recipes:
 
 - [Handsontable with shadcn/ui](@/recipes/themes/custom-theme/custom-theme.md)
 - [Handsontable with MUI](@/recipes/themes/mui-theme/mui-theme.md)
+- [Handsontable with Base Web](@/recipes/themes/base-theme/base-theme.md)
+- [Handsontable with Ant Design](@/recipes/themes/ant-design/ant-design.md)
+- [Handsontable with Fluent UI](@/recipes/themes/fluent-ui/fluent-ui.md)
 
 </div>
 
 Each recipe includes complete code examples, configuration options, and troubleshooting tips to help you integrate Handsontable with your app's look and feel.
-
-- [Handsontable with shadcn/ui](/recipes/themes/custom-theme)
-- [Handsontable with Base Web](/recipes/themes/base-theme)


### PR DESCRIPTION
### Context

The PR fixes broken "Available Recipes" links across all recipe category pages (JavaScript, React, Angular variants).

All link references in recipe category pages used `@/content/recipes/` as the path prefix. The `resolveAtLink` function in `src/plugins/framework-loader.mjs` resolves `@/` links relative to `docs/content/` (the `contentDir`), so the correct prefix is `@/recipes/` -- not `@/content/recipes/`. With the wrong prefix, `resolveAtLink` looked for files at `docs/content/content/recipes/...`, found nothing, and fell back to a malformed URL, causing 404 errors on all framework variants.

Additional fixes:
- Corrected a self-referential link in `server-side-spring.md` that said "Laravel recipe" but pointed to the Spring Boot page.
- Added missing `base-theme`, `ant-design`, and `fluent-ui` theme recipes to the themes category card grid.
- Removed duplicate raw-URL links in `themes.md` that pointed to `/recipes/themes/...` instead of the correct `/docs/{framework}/recipes/themes/...` URL.

Note: `@[code](@/content/recipes/...)` code-include references were intentionally left unchanged -- the `processExampleBlocks` function in the same plugin hardcodes the `@/content/` prefix for code includes.

### How has this been tested?

This is a docs-only change. Tested by:
- Tracing the `resolveAtLink` function logic in `src/plugins/framework-loader.mjs` to confirm the correct path prefix.
- Grepping all recipe markdown files to confirm no `@/content/recipes/` link references remain.
- Confirming `@[code](@/content/recipes/...)` code includes are untouched.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1474

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1474

[skip changelog]

---
_Generated by [Claude Code](https://claude.ai/code/session_019BR14whqLuegtWAjxRPoQ1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b6f2e54c973cdf17e75a2306af322895390b6fab. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->