### PR TITLE
Fix alter('remove_row') ignoring null index with trimmed rows (#11643)

### DIFF
--- a/.changelogs/12460.json
+++ b/.changelogs/12460.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed `alter('remove_row', null, N)` not removing the last rows when rows were trimmed.",
+  "type": "fixed",
+  "issueOrPR": 12460,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/dataMap/dataMap.js
+++ b/handsontable/src/dataMap/dataMap.js
@@ -511,9 +511,9 @@ class DataMap {
   removeRow(index, amount = 1, source) {
     let rowIndex = Number.isInteger(index) ? index : -amount; // -amount = taking indexes from the end.
     const removedPhysicalIndexes = this.visualRowsToPhysical(rowIndex, amount);
-    const sourceRowsLength = this.hot.countSourceRows();
+    const visualRowsLength = this.hot.countRows();
 
-    rowIndex = (sourceRowsLength + rowIndex) % sourceRowsLength;
+    rowIndex = (visualRowsLength + rowIndex) % visualRowsLength;
 
     // It handle also callback from the `NestedRows` plugin. Removing parent node has effect in removing children nodes.
     const actionWasNotCancelled = this.hot.runHooks(
@@ -884,18 +884,18 @@ class DataMap {
    * @returns {number}
    */
   visualRowsToPhysical(index, amount) {
-    const totalRows = this.hot.countSourceRows();
+    const totalRows = this.hot.countRows();
     const logicRows = [];
-    let physicRow = (totalRows + index) % totalRows;
+    let visualRow = (totalRows + index) % totalRows;
     let rowsToRemove = amount;
     let row;
 
-    while (physicRow < totalRows && rowsToRemove) {
-      row = this.hot.toPhysicalRow(physicRow);
+    while (visualRow < totalRows && rowsToRemove) {
+      row = this.hot.toPhysicalRow(visualRow);
       logicRows.push(row);
 
       rowsToRemove -= 1;
-      physicRow += 1;
+      visualRow += 1;
     }
 
     return logicRows;

--- a/handsontable/src/plugins/pagination/__tests__/pagination.spec.js
+++ b/handsontable/src/plugins/pagination/__tests__/pagination.spec.js
@@ -103,6 +103,20 @@ describe('Pagination', () => {
     expect(countVisibleRows()).toBe(3);
   });
 
+  it('should remove the last rows when `index` is `null` and pagination is enabled (regression #11643)', async() => {
+    handsontable({
+      data: createSpreadsheetData(10, 1),
+      pagination: {
+        pageSize: 3,
+      },
+    });
+
+    await alter('remove_row', null, 2);
+
+    expect(countRows()).toBe(8);
+    expect(getDataAtCol(0)).toEqual(['A1', 'A2', 'A3', 'A4', 'A5', 'A6', 'A7', 'A8']);
+  });
+
   it('should recalculate the internal state correctly after removing rows (complex scenario)', async() => {
     handsontable({
       data: createSpreadsheetData(10, 10),

--- a/handsontable/src/plugins/trimRows/__tests__/trimRows.spec.js
+++ b/handsontable/src/plugins/trimRows/__tests__/trimRows.spec.js
@@ -207,6 +207,18 @@ describe('TrimRows', () => {
     expect(getDataAtCell(2, 0)).toBe(null);
   });
 
+  it('should remove the last rows when `index` is `null` and rows are trimmed (regression #11643)', async() => {
+    handsontable({
+      data: createSpreadsheetData(8, 1),
+      trimRows: [1, 3],
+    });
+
+    await alter('remove_row', null, 2);
+
+    expect(countRows()).toBe(4);
+    expect(getDataAtCol(0)).toEqual(['A1', 'A3', 'A5', 'A6']);
+  });
+
   it('should remove correct rows after inserting new ones', async() => {
     handsontable({
       data: getMultilineData(6, 10),


### PR DESCRIPTION
### Context

The PR fixes the bug reported in #11643: calling `core.alter('remove_row', null, N)` on a table that has trimmed rows fails to remove anything (or silently nulls out cells without removing rows).

Root cause is in `handsontable/src/dataMap/dataMap.js`. Two related places mix the visual and physical row counts:

1. `visualRowsToPhysical()` used `countSourceRows()` (physical) when computing the visual start index from a negative offset; out-of-range visual indexes then resolved to `null` physical indexes, so nothing was removed.
2. `removeRow()` did the same thing one frame later when normalizing `rowIndex`, which made the subsequent `rowIndex < countRows()` guard short-circuit `rowIndexMapper.removeIndexes()`.

Both lines now use `countRows()` (visual count), aligning the row path with the equivalent column path in `removeCol()` (`countCols()`). The misnamed `physicRow` local in `visualRowsToPhysical()` is also renamed to `visualRow` since it has always held a visual index.

A previous community attempt (#11644) patched only the first call site and was closed for missing tests; this PR ships both fixes plus regression coverage.

### How has this been tested?

- New regression test in `handsontable/src/plugins/trimRows/__tests__/trimRows.spec.js` reproducing the issue's call (`alter('remove_row', null, 2)` with `trimRows: [1, 3]` on 8 rows).
- New regression test in `handsontable/src/plugins/pagination/__tests__/pagination.spec.js` covering the same call pattern under pagination, since pagination uses a hiding map and the fix should be transparent there.
- Local runs:
  - `npm run test:e2e --prefix handsontable --testPathPattern=trimRows --theme=main` -- 88/88 green
  - `npm run test:e2e --prefix handsontable --testPathPattern=pagination --theme=main` -- 208/208 green
  - `npm run test:e2e --prefix handsontable --testPathPattern="alter|removeRow|dataMap|nestedRows|hiddenRows|trimRows" --theme=main` -- 773/773 green
  - `npm run lint --prefix handsontable` -- clean
- Manual: side-by-side demo (Released v17.0.1 via CDN vs local PR build) confirms the bug on the released tab and the fix on the PR build tab.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. #11643
2. Supersedes #11644

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1545

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 06a9573c8b8d37bfedc67274d7fac8b5fec89837. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->