### PR TITLE
DEV-1547: Bump third-party GitHub Actions to support Node.js runtime requirements

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -394,7 +394,7 @@ jobs:
           name: nuget_pack_${{ needs.first-rc-build.outputs.rc-version }}
 
       - name: NuGet login (OIDC trusted publishing)
-        uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544 # https://github.com/NuGet/login/releases/tag/v1.0.0
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # https://github.com/NuGet/login/releases/tag/v1.2.0
         id: nuget-login
         with:
           user: ${{ secrets.NUGET_USER }}
@@ -488,7 +488,7 @@ jobs:
           cat /tmp/slack-payload.json
 
       - name: Notify Slack
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        uses: slackapi/slack-github-action@03ea5433c137af7c0495bc0cad1af10403fc800c # https://github.com/slackapi/slack-github-action/releases/tag/v3.0.2
         with:
           webhook: ${{ secrets.SLACK_RELEASE_WEBHOOK_URL }}
           webhook-type: incoming-webhook
@@ -846,7 +846,7 @@ jobs:
           name: nuget_pack_${{ needs.rc-build.outputs.rc-version }}
 
       - name: NuGet login (OIDC trusted publishing)
-        uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544 # https://github.com/NuGet/login/releases/tag/v1.0.0
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # https://github.com/NuGet/login/releases/tag/v1.2.0
         id: nuget-login
         with:
           user: ${{ secrets.NUGET_USER }}
@@ -985,7 +985,7 @@ jobs:
           cat /tmp/slack-payload.json
 
       - name: Notify Slack
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        uses: slackapi/slack-github-action@03ea5433c137af7c0495bc0cad1af10403fc800c # https://github.com/slackapi/slack-github-action/releases/tag/v3.0.2
         with:
           webhook: ${{ secrets.SLACK_RELEASE_WEBHOOK_URL }}
           webhook-type: incoming-webhook
@@ -1658,7 +1658,7 @@ jobs:
           name: nuget_pack_${{ needs.stable-build-nuget.outputs.version }}
 
       - name: NuGet login (OIDC trusted publishing)
-        uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544 # https://github.com/NuGet/login/releases/tag/v1.0.0
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # https://github.com/NuGet/login/releases/tag/v1.2.0
         id: nuget-login
         with:
           user: ${{ secrets.NUGET_USER }}
@@ -1809,7 +1809,7 @@ jobs:
           cat /tmp/slack-payload.json
 
       - name: Notify Slack
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # https://github.com/slackapi/slack-github-action/releases/tag/v2.1.1
+        uses: slackapi/slack-github-action@03ea5433c137af7c0495bc0cad1af10403fc800c # https://github.com/slackapi/slack-github-action/releases/tag/v3.0.2
         with:
           webhook: ${{ secrets.SLACK_RELEASE_WEBHOOK_URL }}
           webhook-type: incoming-webhook


### PR DESCRIPTION
### Context

Updates third-party GitHub Actions in the publish workflow to newer versions that support modern Node.js runtime requirements.

- \`NuGet/login\`: v1.0.0 → v1.2.0
- \`slackapi/slack-github-action\`: v2.1.1 → v3.0.2

These updates are applied consistently across all publish workflow jobs that use these actions.

### How has this been tested?

These are GitHub Actions configuration changes. Testing can be verified by:
- Running the publish workflow on the feature branch to confirm the updated actions execute successfully
- Verifying the updated action versions are compatible with the build environment

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1547

### Affected project(s):

- [ ] \`handsontable\`
- [ ] \`@handsontable/angular-wrapper\`
- [ ] \`@handsontable/react-wrapper\`
- [ ] \`@handsontable/vue3\`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/901522623934/DEV-1547

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI-only change, but it affects release publishing/authentication and Slack notifications, so failures would block or misreport releases if the new action versions behave differently.
> 
> **Overview**
> Updates the `publish.yml` workflow to use newer third-party GitHub Actions across all RC and stable release jobs.
> 
> `NuGet/login` is bumped from `v1.0.0` to `v1.2.0` for OIDC-based NuGet publishing, and `slackapi/slack-github-action` is bumped from `v2.1.1` to `v3.0.2` for release notifications; no workflow logic changes beyond the action version pins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5a7ffd02b899bdd8b30c90b846af58d21e33503. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->