### PR TITLE
DEV-1417 - Recipe: Load data from a GraphQL API

### DIFF
--- a/docs/content/recipes/accessibility/keyboard-shortcuts/angular/example1.ts
+++ b/docs/content/recipes/accessibility/keyboard-shortcuts/angular/example1.ts
@@ -24,6 +24,7 @@ const employees = [
     <span class="shortcut-status" [class.visible]="statusMessage">{{ statusMessage }}</span>
     <div class="submit-log">{{ submitLog }}</div>
   `,
+  styleUrls: ['./example1.css'],
 })
 export class AppComponent implements AfterViewInit, OnDestroy {
   @ViewChild(HotTableComponent, { static: false }) readonly hotTable!: HotTableComponent;

--- a/docs/content/recipes/accessibility/keyboard-shortcuts/angular/example1.ts
+++ b/docs/content/recipes/accessibility/keyboard-shortcuts/angular/example1.ts
@@ -1,6 +1,6 @@
 /* file: app.component.ts */
 import { Component, ViewChild, AfterViewInit, OnDestroy } from '@angular/core';
-import { GridSettings, HotTableComponent } from '@handsontable/angular-wrapper';
+import { GridSettings, HotTableComponent, HotTableModule } from '@handsontable/angular-wrapper';
 
 /* start:skip-in-preview */
 const employees = [
@@ -17,15 +17,15 @@ const employees = [
 
 @Component({
   selector: 'example1-keyboard-shortcuts',
-  standalone: false,
+  standalone: true,
+  imports: [HotTableModule],
   template: `
     <hot-table [data]="data" [settings]="gridSettings"></hot-table>
     <span class="shortcut-status" [class.visible]="statusMessage">{{ statusMessage }}</span>
     <div class="submit-log">{{ submitLog }}</div>
   `,
-  styleUrls: ['./example1.css'],
 })
-export class Example1KeyboardShortcutsComponent implements AfterViewInit, OnDestroy {
+export class AppComponent implements AfterViewInit, OnDestroy {
   @ViewChild(HotTableComponent, { static: false }) readonly hotTable!: HotTableComponent;
 
   data = employees;
@@ -59,12 +59,16 @@ export class Example1KeyboardShortcutsComponent implements AfterViewInit, OnDest
     const shortcutManager = hot.getShortcutManager();
     const gridContext = shortcutManager.getContext('grid');
 
+    if (!gridContext) {
+      return;
+    }
+
     // Ctrl+D: duplicate the currently selected row
     gridContext.addShortcut({
       keys: [['Control', 'd']],
       group: 'customActions',
       runOnlyIf: () => hot.getSelected() !== undefined,
-      callback: (event: KeyboardEvent) => {
+      callback: (event: Event) => {
         event.preventDefault();
 
         const selectedRange = hot.getSelectedRangeLast();
@@ -88,7 +92,7 @@ export class Example1KeyboardShortcutsComponent implements AfterViewInit, OnDest
       keys: [['Control', 'Enter']],
       group: 'customActions',
       runOnlyIf: () => true,
-      callback: (event: KeyboardEvent) => {
+      callback: (event: Event) => {
         event.preventDefault();
 
         const data = hot.getData();
@@ -109,7 +113,7 @@ export class Example1KeyboardShortcutsComponent implements AfterViewInit, OnDest
       return;
     }
 
-    hot.getShortcutManager().getContext('grid').removeShortcutsByGroup('customActions');
+    hot.getShortcutManager().getContext('grid')?.removeShortcutsByGroup('customActions');
   }
 
   private showStatus(message: string): void {
@@ -125,36 +129,20 @@ export class Example1KeyboardShortcutsComponent implements AfterViewInit, OnDest
 }
 /* end-file */
 
-/* file: app.module.ts */
-import { NgModule, ApplicationConfig } from '@angular/core';
-import { BrowserModule } from '@angular/platform-browser';
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { registerAllModules } from 'handsontable/registry';
-import { HOT_GLOBAL_CONFIG, HotGlobalConfig, HotTableModule } from '@handsontable/angular-wrapper';
-import { CommonModule } from '@angular/common';
-import { NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
-/* start:skip-in-compilation */
-import { Example1KeyboardShortcutsComponent } from './app.component';
-/* end:skip-in-compilation */
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
 
-// register Handsontable's modules
 registerAllModules();
 
 export const appConfig: ApplicationConfig = {
   providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
     {
       provide: HOT_GLOBAL_CONFIG,
-      useValue: {
-        license: NON_COMMERCIAL_LICENSE,
-      } as HotGlobalConfig,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
     },
   ],
 };
-
-@NgModule({
-  imports: [BrowserModule, HotTableModule, CommonModule],
-  declarations: [Example1KeyboardShortcutsComponent],
-  providers: [...appConfig.providers],
-  bootstrap: [Example1KeyboardShortcutsComponent],
-})
-export class AppModule {}
 /* end-file */

--- a/docs/content/recipes/data-management/auto-save-backend/angular/example1.ts
+++ b/docs/content/recipes/data-management/auto-save-backend/angular/example1.ts
@@ -1,7 +1,6 @@
 /* file: app.component.ts */
 import { Component, ViewChild } from '@angular/core';
 import { GridSettings, HotTableComponent, HotTableModule } from '@handsontable/angular-wrapper';
-import { RowObject } from 'handsontable/common';
 import Handsontable from 'handsontable/base';
 
 type RowData = {

--- a/docs/content/recipes/data-management/load-data-graphql/angular/example1.ts
+++ b/docs/content/recipes/data-management/load-data-graphql/angular/example1.ts
@@ -1,7 +1,6 @@
 /* file: app.component.ts */
 import { Component, OnInit } from '@angular/core';
 import { GridSettings, HotTableModule } from '@handsontable/angular-wrapper';
-import { RowObject } from 'handsontable/common';
 
 type ApiUser = {
   id: number;

--- a/docs/content/recipes/data-management/load-data-graphql/angular/example2.ts
+++ b/docs/content/recipes/data-management/load-data-graphql/angular/example2.ts
@@ -1,7 +1,6 @@
 /* file: app.component.ts */
 import { Component, ViewChild, AfterViewInit } from '@angular/core';
 import { GridSettings, HotTableComponent, HotTableModule } from '@handsontable/angular-wrapper';
-import { RowObject } from 'handsontable/common';
 
 type ApiUser = {
   id: number;
@@ -72,7 +71,6 @@ export class AppComponent implements AfterViewInit {
   showRefresh = false;
 
   readonly gridSettings: GridSettings = {
-    data: [],
     colHeaders: ['ID', 'Name', 'Username', 'Email', 'City', 'Company'],
     columns: [
       { data: 'id', type: 'numeric', width: 70 },

--- a/docs/content/recipes/data-management/load-data-rest-api/angular/example1.ts
+++ b/docs/content/recipes/data-management/load-data-rest-api/angular/example1.ts
@@ -1,6 +1,6 @@
 /* file: app.component.ts */
 import { Component, NgZone, ViewChild, AfterViewInit, inject } from '@angular/core';
-import { GridSettings, HotTableComponent } from '@handsontable/angular-wrapper';
+import { GridSettings, HotTableComponent, HotTableModule } from '@handsontable/angular-wrapper';
 
 type UserRow = {
   id: number;
@@ -35,21 +35,22 @@ function mapUsersToGridRows(users: Array<{
 
 @Component({
   selector: 'example1-load-data-rest-api',
-  standalone: false,
+  standalone: true,
+  imports: [HotTableModule],
   template: `
     <div style="display: flex; gap: 12px; align-items: center; margin-bottom: 8px;">
       <p style="margin: 0; font-family: Arial, sans-serif; font-size: 14px;"
          [style.color]="hasError ? 'var(--ht-cell-error-foreground-color, #c62828)' : 'var(--ht-foreground-color, #202124)'">
         {{ statusMessage }}
       </p>
-      <button *ngIf="hasError" type="button" [disabled]="loading" (click)="loadUsers()">
-        Retry
-      </button>
+      @if (hasError) {
+        <button type="button" [disabled]="loading" (click)="loadUsers()">Retry</button>
+      }
     </div>
     <hot-table [settings]="gridSettings"></hot-table>
   `,
 })
-export class Example1LoadDataRestApiComponent implements AfterViewInit {
+export class AppComponent implements AfterViewInit {
   @ViewChild(HotTableComponent, { static: false }) readonly hotTable!: HotTableComponent;
 
   private readonly ngZone = inject(NgZone);
@@ -59,7 +60,6 @@ export class Example1LoadDataRestApiComponent implements AfterViewInit {
   loading = false;
 
   readonly gridSettings: GridSettings = {
-    data: [],
     colHeaders: ['ID', 'Name', 'Username', 'Email', 'City', 'Company'],
     columns: [
       { data: 'id', type: 'numeric', width: 70, readOnly: true },
@@ -122,35 +122,20 @@ export class Example1LoadDataRestApiComponent implements AfterViewInit {
 /* end-file */
 
 
-/* file: app.module.ts */
-import { NgModule, ApplicationConfig } from '@angular/core';
-import { BrowserModule } from '@angular/platform-browser';
-import { CommonModule } from '@angular/common';
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { registerAllModules } from 'handsontable/registry';
-import { HOT_GLOBAL_CONFIG, HotGlobalConfig, HotTableModule, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
-/* start:skip-in-compilation */
-import { Example1LoadDataRestApiComponent } from './app.component';
-/* end:skip-in-compilation */
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
 
 registerAllModules();
 
 export const appConfig: ApplicationConfig = {
   providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
     {
       provide: HOT_GLOBAL_CONFIG,
-      useValue: {
-        license: NON_COMMERCIAL_LICENSE,
-      } as HotGlobalConfig,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
     },
   ],
 };
-
-@NgModule({
-  imports: [BrowserModule, HotTableModule, CommonModule],
-  declarations: [Example1LoadDataRestApiComponent],
-  providers: [...appConfig.providers],
-  bootstrap: [Example1LoadDataRestApiComponent],
-})
-
-export class AppModule {}
 /* end-file */

--- a/docs/content/recipes/data-management/load-data-rest-api/angular/example2.ts
+++ b/docs/content/recipes/data-management/load-data-rest-api/angular/example2.ts
@@ -1,6 +1,6 @@
 /* file: app.component.ts */
 import { Component, NgZone, ViewChild, AfterViewInit, inject } from '@angular/core';
-import { GridSettings, HotTableComponent } from '@handsontable/angular-wrapper';
+import { GridSettings, HotTableComponent, HotTableModule } from '@handsontable/angular-wrapper';
 
 type UserRow = {
   id: number;
@@ -40,24 +40,24 @@ function mapUsersToGridRows(users: ApiUser[]): UserRow[] {
 
 @Component({
   selector: 'example2-load-data-rest-api',
-  standalone: false,
+  standalone: true,
+  imports: [HotTableModule],
   template: `
     <div style="display: flex; gap: 12px; align-items: center; margin-bottom: 8px;">
       <p style="margin: 0; font-family: Arial, sans-serif; font-size: 14px;"
          [style.color]="hasError ? 'var(--ht-cell-error-foreground-color, #c62828)' : 'var(--ht-foreground-color, #202124)'">
         {{ statusMessage }}
       </p>
-      <button *ngIf="hasData && !hasError" type="button" [disabled]="loading" (click)="refreshUsers()">
-        Refresh
-      </button>
-      <button *ngIf="hasError" type="button" [disabled]="loading" (click)="initialLoad()">
-        Retry
-      </button>
+      @if (hasData && !hasError) {
+        <button type="button" [disabled]="loading" (click)="refreshUsers()">Refresh</button>
+      } @else if (hasError) {
+        <button type="button" [disabled]="loading" (click)="initialLoad()">Retry</button>
+      }
     </div>
     <hot-table [settings]="gridSettings"></hot-table>
   `,
 })
-export class Example2LoadDataRestApiComponent implements AfterViewInit {
+export class AppComponent implements AfterViewInit {
   @ViewChild(HotTableComponent, { static: false }) readonly hotTable!: HotTableComponent;
 
   private readonly ngZone = inject(NgZone);
@@ -68,7 +68,6 @@ export class Example2LoadDataRestApiComponent implements AfterViewInit {
   loading = false;
 
   readonly gridSettings: GridSettings = {
-    data: [],
     colHeaders: ['ID', 'Name', 'Username', 'Email', 'City', 'Company'],
     columns: [
       { data: 'id', type: 'numeric', width: 70, readOnly: true },
@@ -145,36 +144,20 @@ export class Example2LoadDataRestApiComponent implements AfterViewInit {
 }
 /* end-file */
 
-
-/* file: app.module.ts */
-import { NgModule, ApplicationConfig } from '@angular/core';
-import { BrowserModule } from '@angular/platform-browser';
-import { CommonModule } from '@angular/common';
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { registerAllModules } from 'handsontable/registry';
-import { HOT_GLOBAL_CONFIG, HotGlobalConfig, HotTableModule, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
-/* start:skip-in-compilation */
-import { Example2LoadDataRestApiComponent } from './app.component';
-/* end:skip-in-compilation */
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
 
 registerAllModules();
 
 export const appConfig: ApplicationConfig = {
   providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
     {
       provide: HOT_GLOBAL_CONFIG,
-      useValue: {
-        license: NON_COMMERCIAL_LICENSE,
-      } as HotGlobalConfig,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
     },
   ],
 };
-
-@NgModule({
-  imports: [BrowserModule, HotTableModule, CommonModule],
-  declarations: [Example2LoadDataRestApiComponent],
-  providers: [...appConfig.providers],
-  bootstrap: [Example2LoadDataRestApiComponent],
-})
-
-export class AppModule {}
 /* end-file */

--- a/docs/content/recipes/data-management/load-data-rest-api/angular/example3.ts
+++ b/docs/content/recipes/data-management/load-data-rest-api/angular/example3.ts
@@ -1,6 +1,6 @@
 /* file: app.component.ts */
 import { Component, NgZone, inject } from '@angular/core';
-import { GridSettings } from '@handsontable/angular-wrapper';
+import { GridSettings, HotTableModule } from '@handsontable/angular-wrapper';
 import type {
   DataProviderQueryParameters,
   DataProviderFetchOptions,
@@ -18,7 +18,8 @@ type UserRow = {
 
 @Component({
   selector: 'example3-load-data-rest-api',
-  standalone: false,
+  standalone: true,
+  imports: [HotTableModule],
   template: `
     <p style="margin: 0 0 8px; font-family: Arial, sans-serif; font-size: 14px;"
        [style.color]="statusColor">
@@ -27,7 +28,7 @@ type UserRow = {
     <hot-table [settings]="hotSettings"></hot-table>
   `,
 })
-export class Example3LoadDataRestApiComponent {
+export class AppComponent {
   private readonly ngZone = inject(NgZone);
 
   statusMessage = 'Loading...';
@@ -91,7 +92,7 @@ export class Example3LoadDataRestApiComponent {
       columnSorting: true,
       emptyDataState: true,
       rowHeaders: true,
-      height: '360px',
+      height: 360,
       width: '100%',
       stretchH: 'all',
       autoWrapRow: true,
@@ -147,35 +148,20 @@ export class Example3LoadDataRestApiComponent {
 /* end-file */
 
 
-/* file: app.module.ts */
-import { NgModule, ApplicationConfig } from '@angular/core';
-import { BrowserModule } from '@angular/platform-browser';
-import { CommonModule } from '@angular/common';
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { registerAllModules } from 'handsontable/registry';
-import { HOT_GLOBAL_CONFIG, HotGlobalConfig, HotTableModule, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
-/* start:skip-in-compilation */
-import { Example3LoadDataRestApiComponent } from './app.component';
-/* end:skip-in-compilation */
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
 
 registerAllModules();
 
 export const appConfig: ApplicationConfig = {
   providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
     {
       provide: HOT_GLOBAL_CONFIG,
-      useValue: {
-        license: NON_COMMERCIAL_LICENSE,
-      } as HotGlobalConfig,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
     },
   ],
 };
-
-@NgModule({
-  imports: [BrowserModule, HotTableModule, CommonModule],
-  declarations: [Example3LoadDataRestApiComponent],
-  providers: [...appConfig.providers],
-  bootstrap: [Example3LoadDataRestApiComponent],
-})
-
-export class AppModule {}
 /* end-file */

--- a/docs/content/recipes/data-management/server-side-django/angular/example1.ts
+++ b/docs/content/recipes/data-management/server-side-django/angular/example1.ts
@@ -1,7 +1,6 @@
 /* file: app.component.ts */
 import { Component, ViewChild } from '@angular/core';
 import { GridSettings, HotTableComponent, HotTableModule } from '@handsontable/angular-wrapper';
-import { RowObject } from 'handsontable/common';
 
 function getCsrfToken(): string {
   return (

--- a/docs/content/recipes/data-management/server-side-laravel/angular/example1.ts
+++ b/docs/content/recipes/data-management/server-side-laravel/angular/example1.ts
@@ -1,7 +1,6 @@
 /* file: app.component.ts */
 import { Component, ViewChild } from '@angular/core';
 import { GridSettings, HotTableComponent, HotTableModule } from '@handsontable/angular-wrapper';
-import { RowObject } from 'handsontable/common';
 
 function buildUrl(base: string, params: { page: unknown; pageSize: unknown; sort?: unknown; filters?: unknown }): string {
   const query = new URLSearchParams({

--- a/docs/content/recipes/data-management/server-side-nestjs/angular/example1.ts
+++ b/docs/content/recipes/data-management/server-side-nestjs/angular/example1.ts
@@ -1,7 +1,6 @@
 /* file: app.component.ts */
 import { Component, ViewChild } from '@angular/core';
 import { GridSettings, HotTableComponent, HotTableModule } from '@handsontable/angular-wrapper';
-import { RowObject } from 'handsontable/common';
 
 function buildUrl(base: string, params: Record<string, unknown>): string {
   const query = new URLSearchParams();


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Updated angular-wrapper usage example in the Recipe documentation

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only TypeScript snippet changes; risk is limited to example correctness (standalone bootstrap/imports and minor API/type adjustments).
> 
> **Overview**
> **Updates multiple Angular recipe snippets to the standalone-component bootstrap style.** Examples now import `HotTableModule` directly, replace `AppModule` snippets with `app.config.ts` using `ApplicationConfig` (including `provideZoneChangeDetection({ eventCoalescing: true })`), and standardize component naming to `AppComponent`.
> 
> Also tightens a few examples: guards shortcut-context access and uses optional chaining on cleanup in the keyboard-shortcuts recipe, switches REST/GraphQL templates from `*ngIf` to `@if`, removes unused `RowObject` imports and some redundant initial `data: []` settings, and normalizes a grid height value to a number in one REST API example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9086dbb0cea5e1c373d21e44aaa1f81c0fbd4c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->