### PR TITLE
Fix nestedHeaders overriding colWidths when autoColumnSize is false

### DIFF
--- a/.changelogs/12465.json
+++ b/.changelogs/12465.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed `nestedHeaders` overriding `colWidths` with measured header label widths when `autoColumnSize` is explicitly disabled",
+  "type": "fixed",
+  "issueOrPR": 12465,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/nestedHeaders/__tests__/nestedHeaders.spec.js
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/nestedHeaders.spec.js
@@ -48,6 +48,24 @@ describe('NestedHeaders', () => {
       expect(getColWidth(1)).toBeGreaterThan(50);
       expect(headers[1].offsetWidth).toBeGreaterThan(100);
     });
+
+    it('should respect colWidths and not expand columns to fit nested header labels when autoColumnSize is false', async() => {
+      handsontable({
+        data: createSpreadsheetData(10, 10),
+        colHeaders: true,
+        autoColumnSize: false,
+        colWidths: 50,
+        nestedHeaders: [
+          ['a', { label: 'This is a very long group header label', colspan: 2 }, 'c', 'd'],
+          ['a', 'b', 'c', 'd', 'e']
+        ]
+      });
+
+      expect(getColWidth(0)).toBe(50);
+      expect(getColWidth(1)).toBe(50);
+      expect(getColWidth(2)).toBe(50);
+      expect(getColWidth(3)).toBe(50);
+    });
   });
 
   describe('cooperation with drop-down menu element', () => {

--- a/handsontable/src/plugins/nestedHeaders/nestedHeaders.js
+++ b/handsontable/src/plugins/nestedHeaders/nestedHeaders.js
@@ -1268,11 +1268,19 @@ export class NestedHeaders extends BasePlugin {
   /**
    * `modifyColWidth` hook callback - returns width from cache, when is greater than incoming from hook.
    *
+   * When `autoColumnSize` is explicitly disabled, the user opts out of auto-sizing
+   * columns based on content; the plugin respects user-provided widths and does
+   * not override them with the ghost-table-measured header label width.
+   *
    * @param {number} width Width from hook.
    * @param {number} column Visual index of an column.
    * @returns {number}
    */
   #onModifyColWidth(width, column) {
+    if (this.hot.getSettings().autoColumnSize === false) {
+      return width;
+    }
+
     const cachedWidth = this.ghostTable.getWidth(column);
 
     return width > cachedWidth ? width : cachedWidth;


### PR DESCRIPTION
## Summary

Fixes #12465. Related: #5998, #6589.

When `nestedHeaders` is combined with `autoColumnSize: false` and explicit `colWidths`, the plugin's `modifyColWidth` hook ignores the user-provided width and returns the ghost-table-measured header label width instead. This PR makes the plugin respect `autoColumnSize: false` as an opt-out.

## Change

In `NestedHeaders.#onModifyColWidth`, return the user-provided `width` unchanged when `autoColumnSize === false`. Default behavior (`autoColumnSize` unset or `true`) is unchanged.

## Tests

Added one E2E test in `nestedHeaders.spec.js` covering the new behavior. Verified red-green:

- Without the fix: test fails — columns under the long header are 127px / 123px instead of 50px
- With the fix: all 138 nestedHeaders specs pass

## Back-compatibility

Not a breaking change:
- No default values changed
- Existing behavior (no `autoColumnSize` setting, or `autoColumnSize: true`) unchanged
- The opt-out is purely additive

ClickUp task: N/A — external contribution

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized change to `modifyColWidth` behavior gated behind `autoColumnSize === false`, with a regression test covering the new expectation.
> 
> **Overview**
> Fixes `nestedHeaders` column width calculation so that when `autoColumnSize: false` is explicitly set, the plugin no longer replaces user-provided `colWidths` with ghost-table-measured header label widths.
> 
> Adds an E2E spec asserting fixed widths remain unchanged under long nested header labels, and includes a changelog entry for issue `#12465`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3548f5674bf9e8d3dad95c286abfd03108f3f180. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->