### PR TITLE
DEV-1544: Use "Code" tab label for Angular examples with HTML/CSS tabs

### DIFF
--- a/docs/src/plugins/framework-loader.mjs
+++ b/docs/src/plugins/framework-loader.mjs
@@ -250,10 +250,13 @@ function buildExampleHtml(id, directive, fileRefs, contentDir, fileMeta = {}, ex
   const scriptFiles = files.filter(f => scriptExts.has(f.ext));
   const otherFiles = files.filter(f => !scriptExts.has(f.ext));
 
-  // Build logical tab names: "JavaScript" (once for all script variants) + others
+  // Build logical tab names: "JavaScript" (once for all script variants) + others.
+  // Angular examples with other tabs (HTML/CSS) use "Code" instead of "JavaScript".
   const tabNames = [];
 
-  if (scriptFiles.length > 0) tabNames.push('JavaScript');
+  if (scriptFiles.length > 0) {
+    tabNames.push(isAngularDir && otherFiles.length > 0 ? 'Code' : 'JavaScript');
+  }
 
   for (const f of otherFiles) tabNames.push(f.label);
 
@@ -403,7 +406,7 @@ const PREFIXES = {
 
 // Bump this when the loader logic changes to force Astro's data store to
 // re-process all entries (the store skips entries whose digest hasn't changed).
-const LOADER_VERSION = 'v33';
+const LOADER_VERSION = 'v34';
 
 // ---------------------------------------------------------------------------
 // File listing (recursive, no external glob)


### PR DESCRIPTION
### Context

The PR updates the Angular documentation example tab labels. Previously, the script tab was always labeled "JavaScript" for all frameworks. For Angular examples that have additional tabs (HTML, CSS), the label is now "Code" -- which is more accurate since Angular examples use TypeScript, not JavaScript. For Angular examples that only have a single script tab (no HTML or CSS), no tab is shown at all (this was already the case when `showTabs` evaluates to false for a single tab).

The change is in `docs/src/plugins/framework-loader.mjs` inside `buildExampleHtml()`. The `LOADER_VERSION` is bumped from `v33` to `v34` to force Astro's data store to re-process all entries with the updated logic.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1544

### How has this been tested?

- Manually verified the logic: Angular examples with `.ts` + `.html` files produce `data-tabs="Code,HTML"` instead of `data-tabs="JavaScript,HTML"`.
- Angular-only examples (`.ts` with no HTML/CSS) produce `data-tabs=""` (no tab shown), which was already the behavior before this change.
- Non-Angular frameworks (JavaScript, React, Vue) are unaffected -- they still use `"JavaScript"` as the tab label.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. DEV-1544

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

---
_Generated by [Claude Code](https://claude.ai/code/session_01QrQKYf3nFE66fRcvtQsPsG)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated change to documentation rendering (tab labels) plus a cache-busting version bump; no runtime business logic or data/security impact.
> 
> **Overview**
> Adjusts docs example code tab labeling so Angular examples that include additional non-script files (e.g. HTML/CSS) show the primary script tab as **"Code"** instead of **"JavaScript"**; other frameworks and Angular script-only examples keep existing tab behavior.
> 
> Bumps `LOADER_VERSION` to `v34` to force Astro’s content store to reprocess entries with the updated tab-generation logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdbc562fcac2bb631f54aba6dd3ee81de6b54ca8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->