### PR TITLE
DEV-1560: Fix select editor not repositioning on scroll after reopen (#11365)

### DIFF
--- a/.changelogs/12468.json
+++ b/.changelogs/12468.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed the select cell editor losing its scroll-tracking behavior after being closed and reopened.",
+  "type": "fixed",
+  "issueOrPR": 12468,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/editors/selectEditor/__tests__/selectEditor.spec.js
+++ b/handsontable/src/editors/selectEditor/__tests__/selectEditor.spec.js
@@ -323,6 +323,47 @@ describe('SelectEditor', () => {
     expect(editorWrapper.css('left')).toEqual('-20px');
   });
 
+  it('should not accumulate `beforeDialogShow` hook callbacks across open/close cycles', async() => {
+    const hot = handsontable({
+      columns: [{ editor: 'select' }],
+    });
+
+    await selectCell(0, 0);
+
+    const editor = getActiveEditor();
+    const cancelSpy = spyOn(editor, 'cancelChanges').and.callThrough();
+
+    await keyDownUp('enter');
+    await keyDownUp('escape');
+    await selectCell(0, 0);
+    await keyDownUp('enter');
+    await keyDownUp('escape');
+    await selectCell(0, 0);
+    await keyDownUp('enter');
+
+    cancelSpy.calls.reset();
+
+    hot.runHooks('beforeDialogShow');
+
+    expect(cancelSpy.calls.count()).toBe(1);
+  });
+
+  it('should clear all registered hooks when the Handsontable instance is destroyed', async() => {
+    handsontable({
+      columns: [{ editor: 'select' }],
+    });
+
+    await selectCell(0, 0);
+
+    const editor = getActiveEditor();
+
+    expect(editor._hooksStorage.afterScrollHorizontally.length).toBe(1);
+
+    destroy();
+
+    expect(editor._hooksStorage).toEqual({});
+  });
+
   it('should not highlight the input element by browsers native selection', async() => {
     handsontable({
       editor: 'select',

--- a/handsontable/src/editors/selectEditor/__tests__/selectEditor.spec.js
+++ b/handsontable/src/editors/selectEditor/__tests__/selectEditor.spec.js
@@ -296,6 +296,33 @@ describe('SelectEditor', () => {
     expect(editorWrapper.css('left')).toEqual('-20px');
   });
 
+  it('should keep repositioning the select editor on scroll after it was closed and reopened (#11365)', async() => {
+    handsontable({
+      width: 200,
+      height: 200,
+      data: createSpreadsheetData(100, 100),
+      columns: [
+        { editor: 'select' }, {}, {}, {}, {}, {}, {}, {}, {}, {},
+        {}, {}, {}, {}, {}, {}, {}, {}, {}, { editor: 'select' }
+      ]
+    });
+
+    await selectCell(0, 0);
+    await keyDownUp('enter');
+    await keyDownUp('escape');
+
+    await selectCell(0, 0);
+    await keyDownUp('enter');
+
+    await scrollViewportVertically(10);
+    await scrollViewportHorizontally(20);
+
+    const editorWrapper = $('.htSelectEditor');
+
+    expect(editorWrapper.css('top')).toEqual('-10px');
+    expect(editorWrapper.css('left')).toEqual('-20px');
+  });
+
   it('should not highlight the input element by browsers native selection', async() => {
     handsontable({
       editor: 'select',

--- a/handsontable/src/editors/selectEditor/selectEditor.js
+++ b/handsontable/src/editors/selectEditor/selectEditor.js
@@ -97,7 +97,6 @@ export class SelectEditor extends BaseEditor {
     }
 
     this.unregisterShortcuts();
-    this.clearHooks();
   }
 
   /**

--- a/handsontable/src/editors/selectEditor/selectEditor.js
+++ b/handsontable/src/editors/selectEditor/selectEditor.js
@@ -50,6 +50,8 @@ export class SelectEditor extends BaseEditor {
 
     this.hot.rootElement.appendChild(this.selectWrapper);
     this.registerHooks();
+
+    this.hot.addHookOnce('afterDestroy', () => this.destroy());
   }
 
   /**
@@ -97,6 +99,7 @@ export class SelectEditor extends BaseEditor {
     }
 
     this.unregisterShortcuts();
+    this.removeHooksByKey('beforeDialogShow');
   }
 
   /**
@@ -270,5 +273,14 @@ export class SelectEditor extends BaseEditor {
     const editorContext = shortcutManager.getContext('editor');
 
     editorContext.removeShortcutsByGroup(SHORTCUTS_GROUP);
+  }
+
+  /**
+   * Clears all attached hooks.
+   *
+   * @private
+   */
+  destroy() {
+    this.clearHooks();
   }
 }


### PR DESCRIPTION
### Context

The PR fixes the select editor losing its scroll-reposition behavior after it has been closed and reopened. `SelectEditor#close()` was calling `clearHooks()`, which removed the `afterScrollVertically` / `afterScrollHorizontally` listeners that `refreshDimensions()` relies on. Since `registerHooks()` runs only once in `init()` (per editor-instance lifetime), every subsequent open of the select editor had no scroll hooks and the editor stayed anchored to its original screen position while the cell scrolled away. The reproduction matches the user report on issue #11365 ("the edit box gets scrambled" while scrolling after the editor was used previously).

The fix removes the `clearHooks()` call from `close()`. The hooks are now only torn down on editor destruction, mirroring the pattern used by `TextEditor`. `refreshDimensions()` already short-circuits with `if (this.state !== EDITOR_STATE.EDITING) return;`, so persistent hooks are no-ops while the editor is closed.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1560

### How has this been tested?

- Added regression E2E test `should keep repositioning the select editor on scroll after it was closed and reopened (#11365)` that opens the editor, presses Esc, reopens, scrolls, and asserts the wrapper `top` / `left` reflect the scroll offset.
- Existing test `should display and correctly reposition select editor while scrolling` still passes (single-open + scroll path is unchanged).
- Ran the full select editor E2E suite locally:
  ```
  npm run test:e2e --testPathPattern=selectEditor
  # 118 specs, 0 failures
  ```
- Manual verification via `handsontable/dev-generated.html` (CDN v17.0.1 vs local build), full open → scroll → close → reopen → scroll cycle.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. https://github.com/handsontable/handsontable/issues/11365
2. DEV-1560

### Affected project(s):

- [x] \`handsontable\`
- [ ] \`@handsontable/angular-wrapper\`
- [ ] \`@handsontable/react-wrapper\`
- [ ] \`@handsontable/vue3\`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1560

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, editor-scoped lifecycle change plus tests; primary risk is unintended hook persistence or cleanup timing affecting select editor behavior.
> 
> **Overview**
> Fixes a regression where the `select` cell editor stopped tracking viewport scroll after being closed and reopened by no longer clearing its scroll/resize hooks on `close()`.
> 
> To avoid hook leaks, the editor now removes only the per-edit `beforeDialogShow` hook on close and clears all hooks on Handsontable `afterDestroy` via a new `destroy()` path. Adds E2E coverage for reopen+scroll repositioning, hook-callback non-accumulation across open/close cycles, and hook cleanup on instance destroy, plus a changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b8ffafc4b7f736f463b824ead1414ed385056d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->