### PR TITLE
DEV-1573: Re-export public types as named top-level imports (#11240)

### DIFF
--- a/.changelogs/11240.json
+++ b/.changelogs/11240.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Re-exported `CellMeta`, `CellProperties`, `ColumnSettings`, `GridSettings` and other public types as named top-level imports from `handsontable` and `handsontable/base`.",
+  "type": "added",
+  "issueOrPR": 11240,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/__tests__/core/typeImports.types.ts
+++ b/handsontable/src/__tests__/core/typeImports.types.ts
@@ -34,12 +34,34 @@ import {
 } from 'handsontable';
 
 import {
+  CellChange as BaseCellChange,
   CellMeta as BaseCellMeta,
   CellProperties as BaseCellProperties,
-  ColumnSettings as BaseColumnSettings,
-  GridSettings as BaseGridSettings,
+  CellType as BaseCellType,
   CellValue as BaseCellValue,
+  ChangeSource as BaseChangeSource,
+  ColumnSettings as BaseColumnSettings,
+  EditorType as BaseEditorType,
+  GridSettings as BaseGridSettings,
+  NumericFormatOptions as BaseNumericFormatOptions,
+  RendererType as BaseRendererType,
   RowObject as BaseRowObject,
+  SelectOptionsObject as BaseSelectOptionsObject,
+  SourceRowData as BaseSourceRowData,
+  ValidatorType as BaseValidatorType,
+  BaseTheme as BaseBaseTheme,
+  ThemeBuilder as BaseThemeBuilder,
+  ThemeColorScheme as BaseThemeColorScheme,
+  ThemeColorsConfig as BaseThemeColorsConfig,
+  ThemeConfig as BaseThemeConfig,
+  ThemeDensityConfig as BaseThemeDensityConfig,
+  ThemeDensitySizes as BaseThemeDensitySizes,
+  ThemeIconsConfig as BaseThemeIconsConfig,
+  ThemeLightDarkValue as BaseThemeLightDarkValue,
+  ThemeParams as BaseThemeParams,
+  ThemeSizingConfig as BaseThemeSizingConfig,
+  ThemeTokenValue as BaseThemeTokenValue,
+  ThemeTokensConfig as BaseThemeTokensConfig,
 } from 'handsontable/base';
 
 const cellMeta: CellMeta = {};
@@ -52,13 +74,6 @@ const sourceRow: SourceRowData = [1, 2, 3];
 const changeSource: ChangeSource = 'edit';
 const cellChange: CellChange = [0, 0, null, 'next'];
 const selectOptions: SelectOptionsObject = { key: 'value' };
-
-const baseCellMeta: BaseCellMeta = {};
-const baseCellProps: Partial<BaseCellProperties> = {};
-const baseColumnSettings: BaseColumnSettings = {};
-const baseGridSettings: BaseGridSettings = {};
-const baseRowObject: BaseRowObject = {};
-const baseCellValue: BaseCellValue = null;
 
 let cellType: CellType | null = null;
 let editorType: EditorType | null = null;
@@ -78,3 +93,33 @@ let themeParams: ThemeParams | null = null;
 let themeSizingConfig: ThemeSizingConfig | null = null;
 let themeTokenValue: ThemeTokenValue | null = null;
 let themeTokensConfig: ThemeTokensConfig | null = null;
+
+const baseCellMeta: BaseCellMeta = {};
+const baseCellProps: Partial<BaseCellProperties> = {};
+const baseColumnSettings: BaseColumnSettings = {};
+const baseGridSettings: BaseGridSettings = {};
+const baseRowObject: BaseRowObject = { foo: 'bar' };
+const baseCellValue: BaseCellValue = 'x';
+const baseSourceRow: BaseSourceRowData = [1, 2, 3];
+const baseChangeSource: BaseChangeSource = 'edit';
+const baseCellChange: BaseCellChange = [0, 0, null, 'next'];
+const baseSelectOptions: BaseSelectOptionsObject = { key: 'value' };
+
+let baseCellType: BaseCellType | null = null;
+let baseEditorType: BaseEditorType | null = null;
+let baseRendererType: BaseRendererType | null = null;
+let baseValidatorType: BaseValidatorType | null = null;
+let baseNumericFormat: BaseNumericFormatOptions | null = null;
+let baseBaseTheme: BaseBaseTheme | null = null;
+let baseThemeBuilder: BaseThemeBuilder | null = null;
+let baseThemeColorScheme: BaseThemeColorScheme | null = null;
+let baseThemeColorsConfig: BaseThemeColorsConfig | null = null;
+let baseThemeConfig: BaseThemeConfig | null = null;
+let baseThemeDensityConfig: BaseThemeDensityConfig | null = null;
+let baseThemeDensitySizes: BaseThemeDensitySizes | null = null;
+let baseThemeIconsConfig: BaseThemeIconsConfig | null = null;
+let baseThemeLightDarkValue: BaseThemeLightDarkValue | null = null;
+let baseThemeParams: BaseThemeParams | null = null;
+let baseThemeSizingConfig: BaseThemeSizingConfig | null = null;
+let baseThemeTokenValue: BaseThemeTokenValue | null = null;
+let baseThemeTokensConfig: BaseThemeTokensConfig | null = null;

--- a/handsontable/src/__tests__/core/typeImports.types.ts
+++ b/handsontable/src/__tests__/core/typeImports.types.ts
@@ -1,0 +1,80 @@
+// Verifies that commonly-needed types are importable as named top-level
+// exports from both the main `handsontable` entry and the tree-shakeable
+// `handsontable/base` entry. Regression test for issue #11240.
+
+import {
+  CellChange,
+  CellMeta,
+  CellProperties,
+  CellType,
+  CellValue,
+  ChangeSource,
+  ColumnSettings,
+  EditorType,
+  GridSettings,
+  NumericFormatOptions,
+  RendererType,
+  RowObject,
+  SelectOptionsObject,
+  SourceRowData,
+  ValidatorType,
+  BaseTheme,
+  ThemeBuilder,
+  ThemeColorScheme,
+  ThemeColorsConfig,
+  ThemeConfig,
+  ThemeDensityConfig,
+  ThemeDensitySizes,
+  ThemeIconsConfig,
+  ThemeLightDarkValue,
+  ThemeParams,
+  ThemeSizingConfig,
+  ThemeTokenValue,
+  ThemeTokensConfig,
+} from 'handsontable';
+
+import {
+  CellMeta as BaseCellMeta,
+  CellProperties as BaseCellProperties,
+  ColumnSettings as BaseColumnSettings,
+  GridSettings as BaseGridSettings,
+  CellValue as BaseCellValue,
+  RowObject as BaseRowObject,
+} from 'handsontable/base';
+
+const cellMeta: CellMeta = {};
+const cellProps: Partial<CellProperties> = {};
+const columnSettings: ColumnSettings = {};
+const gridSettings: GridSettings = {};
+const rowObject: RowObject = { foo: 'bar' };
+const cellValue: CellValue = 'x';
+const sourceRow: SourceRowData = [1, 2, 3];
+const changeSource: ChangeSource = 'edit';
+const cellChange: CellChange = [0, 0, null, 'next'];
+const selectOptions: SelectOptionsObject = { key: 'value' };
+
+const baseCellMeta: BaseCellMeta = {};
+const baseCellProps: Partial<BaseCellProperties> = {};
+const baseColumnSettings: BaseColumnSettings = {};
+const baseGridSettings: BaseGridSettings = {};
+const baseRowObject: BaseRowObject = {};
+const baseCellValue: BaseCellValue = null;
+
+let cellType: CellType | null = null;
+let editorType: EditorType | null = null;
+let rendererType: RendererType | null = null;
+let validatorType: ValidatorType | null = null;
+let numericFormat: NumericFormatOptions | null = null;
+let baseTheme: BaseTheme | null = null;
+let themeBuilder: ThemeBuilder | null = null;
+let themeColorScheme: ThemeColorScheme | null = null;
+let themeColorsConfig: ThemeColorsConfig | null = null;
+let themeConfig: ThemeConfig | null = null;
+let themeDensityConfig: ThemeDensityConfig | null = null;
+let themeDensitySizes: ThemeDensitySizes | null = null;
+let themeIconsConfig: ThemeIconsConfig | null = null;
+let themeLightDarkValue: ThemeLightDarkValue | null = null;
+let themeParams: ThemeParams | null = null;
+let themeSizingConfig: ThemeSizingConfig | null = null;
+let themeTokenValue: ThemeTokenValue | null = null;
+let themeTokensConfig: ThemeTokensConfig | null = null;

--- a/handsontable/types/index.d.ts
+++ b/handsontable/types/index.d.ts
@@ -702,5 +702,37 @@ export {
   classicTheme,
   mainTheme,
   horizonTheme,
+  // common
+  CellValue,
+  CellChange,
+  RowObject,
+  SelectOptionsObject,
+  SourceRowData,
+  ChangeSource,
+  NumericFormatOptions,
+  // settings
+  CellMeta,
+  CellProperties,
+  ColumnSettings,
+  GridSettings,
+  // cell types / editors / renderers / validators
+  CellType,
+  EditorType,
+  RendererType,
+  ValidatorType,
+  // themes
+  BaseTheme,
+  ThemeBuilder,
+  ThemeColorScheme,
+  ThemeColorsConfig,
+  ThemeConfig,
+  ThemeDensityConfig,
+  ThemeDensitySizes,
+  ThemeIconsConfig,
+  ThemeLightDarkValue,
+  ThemeParams,
+  ThemeSizingConfig,
+  ThemeTokenValue,
+  ThemeTokensConfig,
 };
 export default Handsontable;


### PR DESCRIPTION
## Summary

- Re-export public types (`CellMeta`, `CellProperties`, `ColumnSettings`, `GridSettings`, `CellValue`, `CellChange`, `RowObject`, `SelectOptionsObject`, `SourceRowData`, `ChangeSource`, `NumericFormatOptions`, `CellType`, `EditorType`, `RendererType`, `ValidatorType`, and theme types) as named top-level exports from `handsontable/types/index.d.ts`.
- Both `handsontable` and `handsontable/base` now resolve named type imports, e.g. `import type { CellMeta, GridSettings } from "handsontable"` and `import type { CellMeta } from "handsontable/base"`.
- Adds a TypeScript regression test (`handsontable/src/__tests__/core/typeImports.types.ts`) verifying both entry points.
- Adds changelog entry.

Previously these types were only accessible via the `Handsontable` namespace, forcing consumers into workarounds like `import type HandsonTypes from "handsontable/base"; type CellMeta = HandsonTypes.CellMeta`.

Closes #11240
ClickUp task: https://app.clickup.com/t/86c9k5626

## Affected projects

- [x] `handsontable` (type definitions only - no runtime impact)

## Test plan

- [x] `npm run test:types --prefix handsontable` passes
- [x] `npm run type-lint --prefix handsontable` passes
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-definition-only change with no runtime impact; risk is limited to unintended TypeScript export surface collisions or packaging/entrypoint resolution issues.
> 
> **Overview**
> Makes commonly used public TypeScript types (settings, cell/editor/renderer/validator, common value/change, and theme types) available as **top-level named exports** from `handsontable`/`handsontable/base`, instead of requiring access via the `Handsontable` namespace.
> 
> Adds a type-only regression test (`typeImports.types.ts`) to assert these named imports resolve from both entrypoints, and includes a changelog entry for the new export surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d26e69ed79704411d2c732b306df4dd85ef78d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->