### PR TITLE
DEV-1578: Fix Vue 3 wrapper crash on cell edit when uiContainer is set (#11220)

### DIFF
--- a/.changelogs/12475.json
+++ b/.changelogs/12475.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed a Vue 3 wrapper crash on cell edit when `contextMenu` or `dropdownMenu` had `uiContainer` set to a DOM element under the Vue mount root.",
+  "type": "fixed",
+  "issueOrPR": 12475,
+  "breaking": false,
+  "framework": "vue"
+}

--- a/wrappers/vue3/src/helpers.ts
+++ b/wrappers/vue3/src/helpers.ts
@@ -143,24 +143,42 @@ export function prepareSettings(props: HotTableProps, currentSettings?: Handsont
  * @returns {boolean} `true` if they're the same, `false` otherwise.
  */
 function simpleEqual(objectA, objectB) {
+  // Shared across both stringify calls so the same Node/function instance maps
+  // to the same identity token in objectA's string and objectB's string.
+  const identityMap = new WeakMap<object, string>();
+  let nextIdentityId = 0;
+
   const stringifyToJSON = (val) => {
-    const circularReplacer = (function() {
-      const seen = new WeakSet();
+    const seen = new WeakSet();
 
-      return function(key, value) {
-        if (typeof value === 'object' && value !== null) {
-          if (seen.has(value)) {
-            return;
-          }
-
-          seen.add(value);
+    return JSON.stringify(val, (key, value) => {
+      if (typeof value === 'object' && value !== null) {
+        if (seen.has(value)) {
+          return undefined;
         }
 
-        return value;
-      };
-    }());
+        seen.add(value);
 
-    return JSON.stringify(val, circularReplacer);
+        // DOM nodes carry framework metadata as enumerable own properties
+        // (e.g., Vue 3 attaches `_vnode` to the mount root). Recursing into them
+        // can reach getters that throw - see GH #11220 - and produces noise that
+        // is irrelevant to settings equality. Replace each Node with an identity
+        // token so reference equality is still detected.
+        if (typeof Node !== 'undefined' && value instanceof Node) {
+          let id = identityMap.get(value);
+
+          if (id === undefined) {
+            nextIdentityId += 1;
+            id = `__hot_node_${nextIdentityId}__`;
+            identityMap.set(value, id);
+          }
+
+          return id;
+        }
+      }
+
+      return value;
+    });
   };
 
   if (typeof objectA === 'function' && typeof objectB === 'function') {
@@ -170,6 +188,12 @@ function simpleEqual(objectA, objectB) {
     return false;
 
   } else {
-    return stringifyToJSON(objectA) === stringifyToJSON(objectB);
+    try {
+      return stringifyToJSON(objectA) === stringifyToJSON(objectB);
+    } catch (e) {
+      // If either side cannot be serialized (e.g., contains a throwing getter),
+      // assume the values are not equal so the wrapper still updates settings.
+      return false;
+    }
   }
 }

--- a/wrappers/vue3/test/hotTableHelpers.spec.ts
+++ b/wrappers/vue3/test/hotTableHelpers.spec.ts
@@ -110,4 +110,58 @@ describe('prepareSettings', () => {
     expect(preparedSettings.renderAllRows).toBe(true);
     expect(preparedSettings.width).toBe(300);
   });
+
+  // Regression: GH #11220 - cell edit threw "Cannot read properties of undefined (reading 'wtTable')"
+  // when contextMenu/dropdownMenu had `uiContainer: <DOM element>` and the comparison via
+  // JSON.stringify walked into an object whose getter threw.
+  it('should not throw when settings contain a DOM element (uiContainer pattern)', () => {
+    const el = document.createElement('div');
+    const settingsObj = {
+      contextMenu: { uiContainer: el, items: ['row_above', 'row_below'] },
+    } as GridSettings;
+
+    expect(() => prepareSettings(settingsObj, settingsObj)).not.toThrow();
+  });
+
+  it('should not throw when comparing settings that contain a value whose getter throws', () => {
+    const obj: { uiContainer?: unknown } = {};
+
+    Object.defineProperty(obj, 'parentTableOffset', {
+      enumerable: true,
+      get() {
+        throw new TypeError('Cannot read properties of undefined (reading \'wtTable\')');
+      },
+    });
+
+    const propsMock = {
+      contextMenu: { uiContainer: obj, items: ['row_above'] },
+    } as GridSettings;
+    const currentSettings = {
+      contextMenu: { uiContainer: obj, items: ['row_above'] },
+    } as GridSettings;
+
+    expect(() => prepareSettings(propsMock, currentSettings)).not.toThrow();
+  });
+
+  it('should treat settings with the same DOM element reference as unchanged', () => {
+    const el = document.createElement('div');
+    const cm = { uiContainer: el, items: ['row_above'] };
+    const propsMock = { contextMenu: cm } as GridSettings;
+    const currentSettings = { contextMenu: cm } as GridSettings;
+
+    const preparedSettings = prepareSettings(propsMock, currentSettings);
+
+    expect(preparedSettings.contextMenu).toBe(undefined);
+  });
+
+  it('should treat settings with different DOM element references as changed', () => {
+    const el1 = document.createElement('div');
+    const el2 = document.createElement('div');
+    const propsMock = { contextMenu: { uiContainer: el1, items: ['row_above'] } } as GridSettings;
+    const currentSettings = { contextMenu: { uiContainer: el2, items: ['row_above'] } } as GridSettings;
+
+    const preparedSettings = prepareSettings(propsMock, currentSettings);
+
+    expect(preparedSettings.contextMenu).toEqual(propsMock.contextMenu);
+  });
 });


### PR DESCRIPTION
### Context

The PR fixes [#11220](https://github.com/handsontable/handsontable/issues/11220).

When a user passes a DOM element as `contextMenu.uiContainer` or `dropdownMenu.uiContainer` and the Vue 3 reactive cycle fires (for example, after editing a cell), `prepareSettings` calls `simpleEqual`, which uses `JSON.stringify` to compare each setting against the current Handsontable settings.

`JSON.stringify` walks own enumerable properties. Vue 3 attaches `_vnode` to the mount-root element, so when the user's `uiContainer` is the same element Vue mounts on (a common pattern: `document.getElementById('app')`), the stringify recurses through the entire Vue component graph and Handsontable prop definitions. It eventually reaches Walkontable's `parentTableOffset` getter, which throws `TypeError: Cannot read properties of undefined (reading 'wtTable')`. The throw kills the wrapper's settings-update on every reactive change.

The fix replaces every `Node` value in the replacer with a stable identity token shared between the two stringify calls, so reference equality is still detected without descending into framework metadata. A `try/catch` around the stringify call also makes any future throwing getter fall back to "treat as changed" rather than crash the wrapper.

Reproduced on `handsontable@14.6.0` and `handsontable@17.0.1` using the original StackBlitz from the bug report ([fclmgn-gnpb7d](https://stackblitz.com/edit/fclmgn-gnpb7d)). Confirmed fixed against the local PR build.

### How has this been tested?

New unit tests in `wrappers/vue3/test/hotTableHelpers.spec.ts`:

- DOM element in `uiContainer` no longer throws
- A value with a throwing getter (regression for #11220) no longer throws
- Same DOM ref is treated as unchanged (no spurious `updateSettings` call)
- Different DOM refs are treated as changed (identity preserved)

```bash
npm run test --prefix wrappers/vue3
# 4 suites, 24 tests, all passing
```

Manual verification via Vue 3 + StackBlitz repro replicated locally — error fires on `v14.6.0` and `v17.0.1`, no error with the PR build.

Lint: `wrappers/vue3/node_modules/.bin/eslint --ext .js,.ts,.vue wrappers/vue3/src wrappers/vue3/test` exit 0.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. https://github.com/handsontable/handsontable/issues/11220
2. DEV-1578

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [x] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1578

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Vue 3 wrapper’s settings-diffing logic used to decide when to call `updateSettings`, which could alter when updates are applied. Logic is guarded with tests but could still affect edge-case equality behavior for complex settings objects.
> 
> **Overview**
> Fixes a Vue 3 wrapper crash during reactive updates when `contextMenu`/`dropdownMenu` `uiContainer` is a DOM element by making `simpleEqual`’s `JSON.stringify` comparison *Node-safe* (replaces DOM nodes with stable identity tokens) and by falling back to “not equal” if serialization throws.
> 
> Adds unit tests covering DOM-element `uiContainer` comparisons, throwing getters, and ensuring same-node refs are treated as unchanged while different-node refs are treated as changed, plus a changelog entry for the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d9fd4c671dd2ba93b9932857b6021f73bb76f88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->