### PR TITLE
DEV-1581: Fix Redux example mutating store data

### DIFF
--- a/docs/content/guides/getting-started/react-redux/react/example1.jsx
+++ b/docs/content/guides/getting-started/react-redux/react/example1.jsx
@@ -108,7 +108,7 @@ const initialReduxStoreState = {
 const updatesReducer = (state = initialReduxStoreState, action) => {
   switch (action.type) {
     case 'updateData':
-      const newData = [...state.data];
+      const newData = state.data.map((row) => [...row]);
 
       action.dataChanges.forEach(([row, column, oldValue, newValue]) => {
         newData[row][column] = newValue;

--- a/docs/content/guides/getting-started/react-redux/react/example1.tsx
+++ b/docs/content/guides/getting-started/react-redux/react/example1.tsx
@@ -127,7 +127,7 @@ const updatesReducer = (
 ) => {
   switch (action.type) {
     case 'updateData':
-      const newData = [...state.data];
+      const newData = state.data.map((row) => [...row]);
 
       action.dataChanges.forEach(([row, column, oldValue, newValue]) => {
         newData[row][column] = newValue;


### PR DESCRIPTION
### Context

The PR fixes a bug in the Redux integration example shown in the React docs (`docs/content/guides/getting-started/react-redux/react-redux.md` -> Simple example). The `updateData` reducer in `example1.jsx` and `example1.tsx` did `const newData = [...state.data]`, which copies only the outer array. The inner row arrays still pointed to the same references as `state.data` and `initialReduxStoreState.data`, so `newData[row][column] = newValue` mutated the shared row.

This violates one of the [core Redux reducer rules](https://redux.js.org/usage/structuring-reducers/prerequisite-concepts#immutable-data-management) and was reported by @xmedeko in https://github.com/handsontable/handsontable/issues/11098.

The fix copies each row as well: `state.data.map((row) => [...row])`. The reducer now returns a fully immutable update.

### How has this been tested?

- Manual review of the diff against the Redux immutable update pattern.
- The change is limited to two docs example files (no library source). Docs example renders unchanged on the page; only the reducer's internal state handling is corrected.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. Closes https://github.com/handsontable/handsontable/issues/11098
2. DEV-1581

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

(docs only)

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1581

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to documentation example reducers and only adjusts array cloning to prevent accidental state mutation.
> 
> **Overview**
> Fixes the React-Redux docs example reducer to perform an immutable update when handling `updateData` by deep-copying the table `data` rows (instead of shallow-copying only the outer array), preventing mutations of the existing Redux state in both `example1.jsx` and `example1.tsx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30f86b0521af7a034bcdb03afd60ff008c228c52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->