### PR TITLE
DEV-1582: Fix core.clear() selecting all cells after table is cleared

### DIFF
--- a/.changelogs/12477.json
+++ b/.changelogs/12477.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed `clear()` selecting all cells after the table data is cleared.",
+  "type": "fixed",
+  "issueOrPR": 12477,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -3134,7 +3134,7 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
   };
 
   /**
-   * Clears the data from the table (the table settings remain intact).
+   * Clears the data from the table (the table settings remain intact) and clears the current selection.
    *
    * @memberof Core#
    * @function clear
@@ -3142,6 +3142,7 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
   this.clear = function() {
     this.selectAll();
     this.emptySelectedCells();
+    this.deselectCell();
   };
 
   /**

--- a/handsontable/test/e2e/core/clear.spec.js
+++ b/handsontable/test/e2e/core/clear.spec.js
@@ -1,0 +1,78 @@
+describe('Core.clear', () => {
+  beforeEach(function() {
+    this.$container = $('<div id="testContainer"></div>').appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should clear all cell data', async() => {
+    handsontable({
+      data: createSpreadsheetData(3, 3),
+    });
+
+    await hot().clear();
+
+    expect(getData()).toEqual([
+      [null, null, null],
+      [null, null, null],
+      [null, null, null],
+    ]);
+  });
+
+  it('should not leave any cells selected after clearing', async() => {
+    handsontable({
+      data: createSpreadsheetData(3, 3),
+    });
+
+    await selectCell(0, 0);
+    await hot().clear();
+
+    expect(getSelected()).toBeUndefined();
+  });
+
+  it('should not select any cells when no selection existed before clearing', async() => {
+    handsontable({
+      data: createSpreadsheetData(3, 3),
+    });
+
+    await hot().clear();
+
+    expect(getSelected()).toBeUndefined();
+  });
+
+  it('should keep table settings intact after clearing', async() => {
+    handsontable({
+      data: createSpreadsheetData(3, 3),
+      colHeaders: true,
+      rowHeaders: true,
+    });
+
+    await hot().clear();
+
+    expect(hot().getSettings().colHeaders).toBe(true);
+    expect(hot().getSettings().rowHeaders).toBe(true);
+    expect(hot().countRows()).toBe(3);
+    expect(hot().countCols()).toBe(3);
+  });
+
+  it('should not clear read-only cells', async() => {
+    handsontable({
+      data: createSpreadsheetData(3, 3),
+      cells(row, col) {
+        if (row === 0 && col === 0) {
+          return { readOnly: true };
+        }
+      },
+    });
+
+    await hot().clear();
+
+    expect(getDataAtCell(0, 0)).toBe('A1');
+    expect(getDataAtCell(0, 1)).toBeNull();
+  });
+});

--- a/handsontable/test/e2e/core/clear.spec.js
+++ b/handsontable/test/e2e/core/clear.spec.js
@@ -15,7 +15,7 @@ describe('Core.clear', () => {
       data: createSpreadsheetData(3, 3),
     });
 
-    await hot().clear();
+    await clear();
 
     expect(getData()).toEqual([
       [null, null, null],
@@ -30,7 +30,7 @@ describe('Core.clear', () => {
     });
 
     await selectCell(0, 0);
-    await hot().clear();
+    await clear();
 
     expect(getSelected()).toBeUndefined();
   });
@@ -40,7 +40,7 @@ describe('Core.clear', () => {
       data: createSpreadsheetData(3, 3),
     });
 
-    await hot().clear();
+    await clear();
 
     expect(getSelected()).toBeUndefined();
   });
@@ -52,7 +52,7 @@ describe('Core.clear', () => {
       rowHeaders: true,
     });
 
-    await hot().clear();
+    await clear();
 
     expect(hot().getSettings().colHeaders).toBe(true);
     expect(hot().getSettings().rowHeaders).toBe(true);
@@ -70,7 +70,7 @@ describe('Core.clear', () => {
       },
     });
 
-    await hot().clear();
+    await clear();
 
     expect(getDataAtCell(0, 0)).toBe('A1');
     expect(getDataAtCell(0, 1)).toBeNull();


### PR DESCRIPTION
### Context

The PR fixes `hot.clear()` unexpectedly selecting all cells after clearing the table data. The method called `selectAll()` internally to gather all cells for emptying, but never restored the previous selection state, leaving all cells selected on return. The fix adds a `deselectCell()` call after `emptySelectedCells()`.

Fixes https://github.com/handsontable/handsontable/issues/9665

### How has this been tested?

New E2E tests added in `handsontable/test/e2e/core/clear.spec.js` covering:
- All cell data is cleared
- No cells are selected after clearing
- No cells selected when no prior selection existed
- Table settings remain intact after clearing
- Read-only cells are not cleared

```bash
npm run test:e2e --testPathPattern=core/clear --prefix handsontable
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1582
2. https://github.com/handsontable/handsontable/issues/9665

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1582

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `clear()` behavior and selection state, which could affect integrations relying on post-clear selection, though the change is small and covered by new E2E tests.
> 
> **Overview**
> Fixes `Core.clear()` so it no longer leaves all cells selected after clearing table data by explicitly calling `deselectCell()` after `emptySelectedCells()`.
> 
> Adds E2E coverage for `clear()` to verify data is cleared, **no selection remains** (including when none existed before), settings/row+col counts stay intact, and read-only cells are preserved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8914084e84009e9c0f9c79a0f3cb5aea34842513. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->