### PR TITLE
DEV-1585: Speed up getSourceData() in custom renderer/cells (#11060)

### DIFF
--- a/.changelogs/12480.json
+++ b/.changelogs/12480.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Improved getSourceData() performance when called repeatedly inside the cells function or custom renderers.",
+  "type": "changed",
+  "issueOrPR": 12480,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -3459,9 +3459,15 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
   };
 
   /**
-   * Returns a clone of the source data object.
+   * Returns the source data object.
    * Optionally you can provide a cell range by using the `row`, `column`, `row2`, `column2` arguments, to get only a
    * fragment of the table data.
+   *
+   * __Note__: When called without arguments, the returned array reference is reused across consecutive calls.
+   * Treat the result as a read-only snapshot - mutations made directly to the returned array are not detected
+   * by the cache. Mutations applied through Handsontable's APIs (`setDataAtCell`, `setSourceDataAtCell`,
+   * `loadData`, `updateData`, `alter`, `populateFromArray`) automatically invalidate the cache. The cache is
+   * also bypassed when the `modifySourceData` or `modifyRowData` hooks have registered handlers.
    *
    * __Note__: This method does not participate in data transformation. If the visual data of the table is reordered,
    * sorted or trimmed only physical indexes are correct.
@@ -3496,6 +3502,9 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
    * Returns the source data object as an arrays of arrays format even when source data was provided in another format.
    * Optionally you can provide a cell range by using the `row`, `column`, `row2`, `column2` arguments, to get only a
    * fragment of the table data.
+   *
+   * __Note__: When called without arguments, the returned array reference is reused across consecutive calls,
+   * with the same cache invalidation rules as {@link Core#getSourceData}. Treat the result as a read-only snapshot.
    *
    * __Note__: This method does not participate in data transformation. If the visual data of the table is reordered,
    * sorted or trimmed only physical indexes are correct.

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -3459,15 +3459,9 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
   };
 
   /**
-   * Returns the source data object.
+   * Returns a clone of the source data object.
    * Optionally you can provide a cell range by using the `row`, `column`, `row2`, `column2` arguments, to get only a
    * fragment of the table data.
-   *
-   * __Note__: When called without arguments, the returned array reference is reused across consecutive calls.
-   * Treat the result as a read-only snapshot - mutations made directly to the returned array are not detected
-   * by the cache. Mutations applied through Handsontable's APIs (`setDataAtCell`, `setSourceDataAtCell`,
-   * `loadData`, `updateData`, `alter`, `populateFromArray`) automatically invalidate the cache. The cache is
-   * also bypassed when the `modifySourceData` or `modifyRowData` hooks have registered handlers.
    *
    * __Note__: This method does not participate in data transformation. If the visual data of the table is reordered,
    * sorted or trimmed only physical indexes are correct.
@@ -3502,9 +3496,6 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
    * Returns the source data object as an arrays of arrays format even when source data was provided in another format.
    * Optionally you can provide a cell range by using the `row`, `column`, `row2`, `column2` arguments, to get only a
    * fragment of the table data.
-   *
-   * __Note__: When called without arguments, the returned array reference is reused across consecutive calls,
-   * with the same cache invalidation rules as {@link Core#getSourceData}. Treat the result as a read-only snapshot.
    *
    * __Note__: This method does not participate in data transformation. If the visual data of the table is reordered,
    * sorted or trimmed only physical indexes are correct.

--- a/handsontable/src/dataMap/__tests__/dataSource.unit.js
+++ b/handsontable/src/dataMap/__tests__/dataSource.unit.js
@@ -1,11 +1,8 @@
 import DataSource from 'handsontable/dataMap/dataSource';
 
 describe('DataSource', () => {
-  function createHotMock({ modifyRowData = null, hooksWithHandlers = [] } = {}) {
-    const registeredHooks = new Map();
-
+  function createHotMock({ modifyRowData = null, hooksWithHandlers = [], dataDotNotation = false } = {}) {
     return {
-      _registeredHooks: registeredHooks,
       hasHook(hookName) {
         if (hookName === 'modifyRowData' && modifyRowData !== null) {
           return true;
@@ -18,26 +15,8 @@ describe('DataSource', () => {
           return modifyRowData(rowIndex);
         }
       },
-      addHook(hookName, callback) {
-        if (!registeredHooks.has(hookName)) {
-          registeredHooks.set(hookName, new Set());
-        }
-        registeredHooks.get(hookName).add(callback);
-      },
-      removeHook(hookName, callback) {
-        if (registeredHooks.has(hookName)) {
-          registeredHooks.get(hookName).delete(callback);
-        }
-      },
-      _triggerHook(hookName) {
-        const callbacks = registeredHooks.get(hookName);
-
-        if (callbacks) {
-          callbacks.forEach(cb => cb());
-        }
-      },
       getSettings() {
-        return { dataDotNotation: false };
+        return { dataDotNotation };
       },
     };
   }
@@ -70,232 +49,115 @@ describe('DataSource', () => {
     });
   });
 
-  describe('getData() memoization', () => {
-    function makeArrayData() {
-      return [['a', 'b'], ['c', 'd'], ['e', 'f']];
-    }
-
-    function makeObjectData() {
-      return [{ x: 1, y: 2 }, { x: 3, y: 4 }];
-    }
-
-    it('returns the same array reference on consecutive calls when no mutation occurs', () => {
-      const dataSource = new DataSource(createHotMock(), makeArrayData());
-
-      const first = dataSource.getData();
-      const second = dataSource.getData();
-
-      expect(second).toBe(first);
-    });
-
-    it('returns the same array reference on consecutive calls for object data', () => {
-      const dataSource = new DataSource(createHotMock(), makeObjectData());
-
-      const first = dataSource.getData();
-      const second = dataSource.getData();
-
-      expect(second).toBe(first);
-    });
-
-    it('caches getData(true) and getData(false) independently', () => {
-      const dataSource = new DataSource(createHotMock(), makeArrayData());
-
-      const asObjects = dataSource.getData(false);
-      const asArrays = dataSource.getData(true);
-
-      expect(dataSource.getData(false)).toBe(asObjects);
-      expect(dataSource.getData(true)).toBe(asArrays);
-      expect(asObjects).not.toBe(asArrays);
-    });
-
-    it('returns a new reference after setAtCell()', () => {
-      const dataSource = new DataSource(createHotMock(), makeArrayData());
-
-      const first = dataSource.getData();
-
-      dataSource.setAtCell(0, 0, 'changed');
-
-      const second = dataSource.getData();
-
-      expect(second).not.toBe(first);
-      expect(second[0][0]).toBe('changed');
-    });
-
-    it('returns a new reference after setData()', () => {
-      const dataSource = new DataSource(createHotMock(), makeArrayData());
-
-      const first = dataSource.getData();
-
-      dataSource.setData([['x', 'y']]);
-
-      const second = dataSource.getData();
-
-      expect(second).not.toBe(first);
-    });
-
-    it('bypasses cache when modifySourceData hook has handlers', () => {
-      const hot = createHotMock({ hooksWithHandlers: ['modifySourceData'] });
-      const dataSource = new DataSource(hot, makeArrayData());
+  describe('getData() fast-clone path', () => {
+    it('returns a fresh outer array on every call (array data)', () => {
+      const dataSource = new DataSource(createHotMock(), [['a', 'b'], ['c', 'd']]);
 
       const first = dataSource.getData();
       const second = dataSource.getData();
 
       expect(second).not.toBe(first);
+      expect(second).toEqual(first);
     });
 
-    it('bypasses cache when modifyRowData hook has handlers', () => {
-      const data = makeArrayData();
-      const hot = createHotMock({ modifyRowData: row => data[row] });
-      const dataSource = new DataSource(hot, data);
+    it('returns a fresh outer array on every call (object data)', () => {
+      const dataSource = new DataSource(createHotMock(), [{ x: 1 }, { x: 2 }]);
 
       const first = dataSource.getData();
       const second = dataSource.getData();
 
       expect(second).not.toBe(first);
+      expect(second).toEqual(first);
     });
 
-    it('invalidates cache when afterChange hook fires', () => {
-      const hot = createHotMock();
-      const dataSource = new DataSource(hot, makeArrayData());
+    it('returns row clones so mutations to the returned array do not leak across calls (array data)', () => {
+      const dataSource = new DataSource(createHotMock(), [['a', 'b'], ['c', 'd']]);
 
       const first = dataSource.getData();
 
-      hot._triggerHook('afterChange');
+      first[0][0] = 'X';
 
       const second = dataSource.getData();
 
-      expect(second).not.toBe(first);
+      expect(second[0][0]).toBe('a');
     });
 
-    it('invalidates cache when afterCreateRow hook fires', () => {
-      const hot = createHotMock();
-      const dataSource = new DataSource(hot, makeArrayData());
+    it('returns row clones so mutations to the returned array do not leak across calls (object data)', () => {
+      const dataSource = new DataSource(createHotMock(), [{ x: 1 }, { x: 2 }]);
 
       const first = dataSource.getData();
 
-      hot._triggerHook('afterCreateRow');
+      first[0].x = 99;
 
       const second = dataSource.getData();
 
-      expect(second).not.toBe(first);
+      expect(second[0].x).toBe(1);
     });
 
-    it('invalidates cache when afterRemoveRow hook fires', () => {
-      const hot = createHotMock();
-      const dataSource = new DataSource(hot, makeArrayData());
+    it('does not mutate the underlying source data array reference', () => {
+      const data = [['a', 'b']];
+      const dataSource = new DataSource(createHotMock(), data);
 
-      const first = dataSource.getData();
+      const result = dataSource.getData();
 
-      hot._triggerHook('afterRemoveRow');
-
-      const second = dataSource.getData();
-
-      expect(second).not.toBe(first);
+      expect(result).not.toBe(data);
+      expect(result[0]).not.toBe(data[0]);
     });
 
-    it('invalidates cache when afterCreateCol hook fires', () => {
-      const hot = createHotMock();
-      const dataSource = new DataSource(hot, makeArrayData());
+    it('falls back to getByRange when modifySourceData hook has handlers', () => {
+      const dataSource = new DataSource(createHotMock({ hooksWithHandlers: ['modifySourceData'] }), [['a', 'b']]);
+      const spy = jest.spyOn(dataSource, 'getByRange');
 
-      const first = dataSource.getData();
-
-      hot._triggerHook('afterCreateCol');
-
-      const second = dataSource.getData();
-
-      expect(second).not.toBe(first);
-    });
-
-    it('invalidates cache when afterRemoveCol hook fires', () => {
-      const hot = createHotMock();
-      const dataSource = new DataSource(hot, makeArrayData());
-
-      const first = dataSource.getData();
-
-      hot._triggerHook('afterRemoveCol');
-
-      const second = dataSource.getData();
-
-      expect(second).not.toBe(first);
-    });
-
-    it('invalidates cache when afterLoadData hook fires', () => {
-      const hot = createHotMock();
-      const dataSource = new DataSource(hot, makeArrayData());
-
-      const first = dataSource.getData();
-
-      hot._triggerHook('afterLoadData');
-
-      const second = dataSource.getData();
-
-      expect(second).not.toBe(first);
-    });
-
-    it('invalidates cache when afterUpdateData hook fires', () => {
-      const hot = createHotMock();
-      const dataSource = new DataSource(hot, makeArrayData());
-
-      const first = dataSource.getData();
-
-      hot._triggerHook('afterUpdateData');
-
-      const second = dataSource.getData();
-
-      expect(second).not.toBe(first);
-    });
-
-    it('invalidates cache when afterSetSourceDataAtCell hook fires', () => {
-      const hot = createHotMock();
-      const dataSource = new DataSource(hot, makeArrayData());
-
-      const first = dataSource.getData();
-
-      hot._triggerHook('afterSetSourceDataAtCell');
-
-      const second = dataSource.getData();
-
-      expect(second).not.toBe(first);
-    });
-
-    it('returns same reference for empty data without crashing', () => {
-      const dataSource = new DataSource(createHotMock(), []);
-
-      const first = dataSource.getData();
-      const second = dataSource.getData();
-
-      expect(second).toBe(first);
-    });
-  });
-
-  describe('destroy()', () => {
-    it('removes all registered cache invalidation hooks once getData() has been called', () => {
-      const hot = createHotMock();
-      const dataSource = new DataSource(hot, [['a']]);
-
-      // Trigger lazy hook registration.
       dataSource.getData();
 
-      const hooksRegisteredBeforeDestroy = Array.from(hot._registeredHooks.entries())
-        .filter(([, callbacks]) => callbacks.size > 0)
-        .map(([name]) => name);
-
-      expect(hooksRegisteredBeforeDestroy.length).toBeGreaterThan(0);
-
-      dataSource.destroy();
-
-      const hooksRegisteredAfterDestroy = Array.from(hot._registeredHooks.entries())
-        .filter(([, callbacks]) => callbacks.size > 0)
-        .map(([name]) => name);
-
-      expect(hooksRegisteredAfterDestroy).toEqual([]);
+      expect(spy).toHaveBeenCalledWith(null, null, false);
     });
 
-    it('does not throw when destroy is called before getData was ever invoked', () => {
-      const hot = createHotMock();
-      const dataSource = new DataSource(hot, [['a']]);
+    it('falls back to getByRange when modifyRowData hook has handlers', () => {
+      const data = [['a', 'b']];
+      const dataSource = new DataSource(createHotMock({ modifyRowData: row => data[row] }), data);
+      const spy = jest.spyOn(dataSource, 'getByRange');
 
-      expect(() => dataSource.destroy()).not.toThrow();
+      dataSource.getData();
+
+      expect(spy).toHaveBeenCalledWith(null, null, false);
+    });
+
+    it('uses the fast clone path even when dataDotNotation is enabled (rows are already normalized)', () => {
+      const dataSource = new DataSource(createHotMock({ dataDotNotation: true }), [{ a: 1, nested: { b: 2 } }]);
+      const spy = jest.spyOn(dataSource, 'getByRange');
+
+      const result = dataSource.getData();
+
+      expect(spy).not.toHaveBeenCalled();
+      expect(result[0]).toEqual({ a: 1, nested: { b: 2 } });
+      expect(result[0]).not.toBe(dataSource.data[0]);
+    });
+
+    it('falls back to getByRange when toArray is requested for object data', () => {
+      const dataSource = new DataSource(createHotMock(), [{ a: 1, b: 2 }]);
+      const spy = jest.spyOn(dataSource, 'getByRange');
+
+      dataSource.getData(true);
+
+      expect(spy).toHaveBeenCalledWith(null, null, true);
+    });
+
+    it('uses the fast clone path for toArray when data is already array-of-arrays', () => {
+      const dataSource = new DataSource(createHotMock(), [['a', 'b']]);
+      const spy = jest.spyOn(dataSource, 'getByRange');
+
+      const result = dataSource.getData(true);
+
+      expect(spy).not.toHaveBeenCalled();
+      expect(result).toEqual([['a', 'b']]);
+    });
+
+    it('returns the underlying empty array reference for empty data', () => {
+      const data = [];
+      const dataSource = new DataSource(createHotMock(), data);
+
+      expect(dataSource.getData()).toBe(data);
     });
   });
 });

--- a/handsontable/src/dataMap/__tests__/dataSource.unit.js
+++ b/handsontable/src/dataMap/__tests__/dataSource.unit.js
@@ -1,15 +1,43 @@
 import DataSource from 'handsontable/dataMap/dataSource';
 
 describe('DataSource', () => {
-  function createHotMock(modifyRowData = null) {
+  function createHotMock({ modifyRowData = null, hooksWithHandlers = [] } = {}) {
+    const registeredHooks = new Map();
+
     return {
+      _registeredHooks: registeredHooks,
       hasHook(hookName) {
-        return hookName === 'modifyRowData' && modifyRowData !== null;
+        if (hookName === 'modifyRowData' && modifyRowData !== null) {
+          return true;
+        }
+
+        return hooksWithHandlers.includes(hookName);
       },
       runHooks(hookName, rowIndex) {
         if (hookName === 'modifyRowData') {
           return modifyRowData(rowIndex);
         }
+      },
+      addHook(hookName, callback) {
+        if (!registeredHooks.has(hookName)) {
+          registeredHooks.set(hookName, new Set());
+        }
+        registeredHooks.get(hookName).add(callback);
+      },
+      removeHook(hookName, callback) {
+        if (registeredHooks.has(hookName)) {
+          registeredHooks.get(hookName).delete(callback);
+        }
+      },
+      _triggerHook(hookName) {
+        const callbacks = registeredHooks.get(hookName);
+
+        if (callbacks) {
+          callbacks.forEach(cb => cb());
+        }
+      },
+      getSettings() {
+        return { dataDotNotation: false };
       },
     };
   }
@@ -25,18 +53,249 @@ describe('DataSource', () => {
         },
         { artist: 'Second parent' },
       ];
-      const dataSource = new DataSource(createHotMock((rowIndex) => {
-        if (rowIndex === 1) {
-          return data[0].__children[0];
-        }
+      const dataSource = new DataSource(createHotMock({
+        modifyRowData: (rowIndex) => {
+          if (rowIndex === 1) {
+            return data[0].__children[0];
+          }
 
-        return data[rowIndex];
+          return data[rowIndex];
+        },
       }), data);
 
       dataSource.setAtCell(1, 'artist', 'Updated child');
 
       expect(data[0].__children[0].artist).toBe('Updated child');
       expect(data[1].artist).toBe('Second parent');
+    });
+  });
+
+  describe('getData() memoization', () => {
+    function makeArrayData() {
+      return [['a', 'b'], ['c', 'd'], ['e', 'f']];
+    }
+
+    function makeObjectData() {
+      return [{ x: 1, y: 2 }, { x: 3, y: 4 }];
+    }
+
+    it('returns the same array reference on consecutive calls when no mutation occurs', () => {
+      const dataSource = new DataSource(createHotMock(), makeArrayData());
+
+      const first = dataSource.getData();
+      const second = dataSource.getData();
+
+      expect(second).toBe(first);
+    });
+
+    it('returns the same array reference on consecutive calls for object data', () => {
+      const dataSource = new DataSource(createHotMock(), makeObjectData());
+
+      const first = dataSource.getData();
+      const second = dataSource.getData();
+
+      expect(second).toBe(first);
+    });
+
+    it('caches getData(true) and getData(false) independently', () => {
+      const dataSource = new DataSource(createHotMock(), makeArrayData());
+
+      const asObjects = dataSource.getData(false);
+      const asArrays = dataSource.getData(true);
+
+      expect(dataSource.getData(false)).toBe(asObjects);
+      expect(dataSource.getData(true)).toBe(asArrays);
+      expect(asObjects).not.toBe(asArrays);
+    });
+
+    it('returns a new reference after setAtCell()', () => {
+      const dataSource = new DataSource(createHotMock(), makeArrayData());
+
+      const first = dataSource.getData();
+
+      dataSource.setAtCell(0, 0, 'changed');
+
+      const second = dataSource.getData();
+
+      expect(second).not.toBe(first);
+      expect(second[0][0]).toBe('changed');
+    });
+
+    it('returns a new reference after setData()', () => {
+      const dataSource = new DataSource(createHotMock(), makeArrayData());
+
+      const first = dataSource.getData();
+
+      dataSource.setData([['x', 'y']]);
+
+      const second = dataSource.getData();
+
+      expect(second).not.toBe(first);
+    });
+
+    it('bypasses cache when modifySourceData hook has handlers', () => {
+      const hot = createHotMock({ hooksWithHandlers: ['modifySourceData'] });
+      const dataSource = new DataSource(hot, makeArrayData());
+
+      const first = dataSource.getData();
+      const second = dataSource.getData();
+
+      expect(second).not.toBe(first);
+    });
+
+    it('bypasses cache when modifyRowData hook has handlers', () => {
+      const data = makeArrayData();
+      const hot = createHotMock({ modifyRowData: row => data[row] });
+      const dataSource = new DataSource(hot, data);
+
+      const first = dataSource.getData();
+      const second = dataSource.getData();
+
+      expect(second).not.toBe(first);
+    });
+
+    it('invalidates cache when afterChange hook fires', () => {
+      const hot = createHotMock();
+      const dataSource = new DataSource(hot, makeArrayData());
+
+      const first = dataSource.getData();
+
+      hot._triggerHook('afterChange');
+
+      const second = dataSource.getData();
+
+      expect(second).not.toBe(first);
+    });
+
+    it('invalidates cache when afterCreateRow hook fires', () => {
+      const hot = createHotMock();
+      const dataSource = new DataSource(hot, makeArrayData());
+
+      const first = dataSource.getData();
+
+      hot._triggerHook('afterCreateRow');
+
+      const second = dataSource.getData();
+
+      expect(second).not.toBe(first);
+    });
+
+    it('invalidates cache when afterRemoveRow hook fires', () => {
+      const hot = createHotMock();
+      const dataSource = new DataSource(hot, makeArrayData());
+
+      const first = dataSource.getData();
+
+      hot._triggerHook('afterRemoveRow');
+
+      const second = dataSource.getData();
+
+      expect(second).not.toBe(first);
+    });
+
+    it('invalidates cache when afterCreateCol hook fires', () => {
+      const hot = createHotMock();
+      const dataSource = new DataSource(hot, makeArrayData());
+
+      const first = dataSource.getData();
+
+      hot._triggerHook('afterCreateCol');
+
+      const second = dataSource.getData();
+
+      expect(second).not.toBe(first);
+    });
+
+    it('invalidates cache when afterRemoveCol hook fires', () => {
+      const hot = createHotMock();
+      const dataSource = new DataSource(hot, makeArrayData());
+
+      const first = dataSource.getData();
+
+      hot._triggerHook('afterRemoveCol');
+
+      const second = dataSource.getData();
+
+      expect(second).not.toBe(first);
+    });
+
+    it('invalidates cache when afterLoadData hook fires', () => {
+      const hot = createHotMock();
+      const dataSource = new DataSource(hot, makeArrayData());
+
+      const first = dataSource.getData();
+
+      hot._triggerHook('afterLoadData');
+
+      const second = dataSource.getData();
+
+      expect(second).not.toBe(first);
+    });
+
+    it('invalidates cache when afterUpdateData hook fires', () => {
+      const hot = createHotMock();
+      const dataSource = new DataSource(hot, makeArrayData());
+
+      const first = dataSource.getData();
+
+      hot._triggerHook('afterUpdateData');
+
+      const second = dataSource.getData();
+
+      expect(second).not.toBe(first);
+    });
+
+    it('invalidates cache when afterSetSourceDataAtCell hook fires', () => {
+      const hot = createHotMock();
+      const dataSource = new DataSource(hot, makeArrayData());
+
+      const first = dataSource.getData();
+
+      hot._triggerHook('afterSetSourceDataAtCell');
+
+      const second = dataSource.getData();
+
+      expect(second).not.toBe(first);
+    });
+
+    it('returns same reference for empty data without crashing', () => {
+      const dataSource = new DataSource(createHotMock(), []);
+
+      const first = dataSource.getData();
+      const second = dataSource.getData();
+
+      expect(second).toBe(first);
+    });
+  });
+
+  describe('destroy()', () => {
+    it('removes all registered cache invalidation hooks once getData() has been called', () => {
+      const hot = createHotMock();
+      const dataSource = new DataSource(hot, [['a']]);
+
+      // Trigger lazy hook registration.
+      dataSource.getData();
+
+      const hooksRegisteredBeforeDestroy = Array.from(hot._registeredHooks.entries())
+        .filter(([, callbacks]) => callbacks.size > 0)
+        .map(([name]) => name);
+
+      expect(hooksRegisteredBeforeDestroy.length).toBeGreaterThan(0);
+
+      dataSource.destroy();
+
+      const hooksRegisteredAfterDestroy = Array.from(hot._registeredHooks.entries())
+        .filter(([, callbacks]) => callbacks.size > 0)
+        .map(([name]) => name);
+
+      expect(hooksRegisteredAfterDestroy).toEqual([]);
+    });
+
+    it('does not throw when destroy is called before getData was ever invoked', () => {
+      const hot = createHotMock();
+      const dataSource = new DataSource(hot, [['a']]);
+
+      expect(() => dataSource.destroy()).not.toThrow();
     });
   });
 });

--- a/handsontable/src/dataMap/__tests__/dataSource.unit.js
+++ b/handsontable/src/dataMap/__tests__/dataSource.unit.js
@@ -49,7 +49,7 @@ describe('DataSource', () => {
     });
   });
 
-  describe('getData() fast-clone path', () => {
+  describe('getData()', () => {
     it('returns a fresh outer array on every call (array data)', () => {
       const dataSource = new DataSource(createHotMock(), [['a', 'b'], ['c', 'd']]);
 
@@ -104,6 +104,18 @@ describe('DataSource', () => {
       expect(result[0]).not.toBe(data[0]);
     });
 
+    it('handles mixed row shapes per row instead of inferring from this.data[0]', () => {
+      const dataSource = new DataSource(createHotMock(), [['a', 'b'], { x: 1 }]);
+
+      const result = dataSource.getData();
+
+      expect(Array.isArray(result[0])).toBe(true);
+      expect(result[0]).toEqual(['a', 'b']);
+      expect(result[0]).not.toBe(dataSource.data[0]);
+      expect(result[1]).toEqual({ x: 1 });
+      expect(result[1]).not.toBe(dataSource.data[1]);
+    });
+
     it('falls back to getByRange when modifySourceData hook has handlers', () => {
       const dataSource = new DataSource(createHotMock({ hooksWithHandlers: ['modifySourceData'] }), [['a', 'b']]);
       const spy = jest.spyOn(dataSource, 'getByRange');
@@ -123,6 +135,15 @@ describe('DataSource', () => {
       expect(spy).toHaveBeenCalledWith(null, null, false);
     });
 
+    it('falls back to getByRange when toArray is requested', () => {
+      const dataSource = new DataSource(createHotMock(), [{ a: 1, b: 2 }]);
+      const spy = jest.spyOn(dataSource, 'getByRange');
+
+      dataSource.getData(true);
+
+      expect(spy).toHaveBeenCalledWith(null, null, true);
+    });
+
     it('uses the fast clone path even when dataDotNotation is enabled (rows are already normalized)', () => {
       const dataSource = new DataSource(createHotMock({ dataDotNotation: true }), [{ a: 1, nested: { b: 2 } }]);
       const spy = jest.spyOn(dataSource, 'getByRange');
@@ -134,30 +155,17 @@ describe('DataSource', () => {
       expect(result[0]).not.toBe(dataSource.data[0]);
     });
 
-    it('falls back to getByRange when toArray is requested for object data', () => {
-      const dataSource = new DataSource(createHotMock(), [{ a: 1, b: 2 }]);
-      const spy = jest.spyOn(dataSource, 'getByRange');
-
-      dataSource.getData(true);
-
-      expect(spy).toHaveBeenCalledWith(null, null, true);
-    });
-
-    it('uses the fast clone path for toArray when data is already array-of-arrays', () => {
-      const dataSource = new DataSource(createHotMock(), [['a', 'b']]);
-      const spy = jest.spyOn(dataSource, 'getByRange');
-
-      const result = dataSource.getData(true);
-
-      expect(spy).not.toHaveBeenCalled();
-      expect(result).toEqual([['a', 'b']]);
-    });
-
     it('returns the underlying empty array reference for empty data', () => {
       const data = [];
       const dataSource = new DataSource(createHotMock(), data);
 
       expect(dataSource.getData()).toBe(data);
+    });
+
+    it('returns the underlying value when data is null', () => {
+      const dataSource = new DataSource(createHotMock(), null);
+
+      expect(dataSource.getData()).toBe(null);
     });
   });
 });

--- a/handsontable/src/dataMap/dataSource.js
+++ b/handsontable/src/dataMap/dataSource.js
@@ -5,7 +5,7 @@ import {
   objectEach,
   setProperty
 } from '../helpers/object';
-import { countFirstRowKeys } from '../helpers/data';
+import { cloneRow, countFirstRowKeys } from '../helpers/data';
 import { arrayEach } from '../helpers/array';
 import { rangeEach } from '../helpers/number';
 import { isFunction } from '../helpers/function';
@@ -65,64 +65,27 @@ class DataSource {
    *
    * Each call returns a fresh shallow clone of the source data so consumers can
    * safely mutate the returned array without affecting subsequent calls or the
-   * underlying data. The fast path - used when no `modifySourceData` /
-   * `modifyRowData` hooks are registered, no `dataDotNotation` is configured,
-   * and a non-coerced shape is returned - skips the per-cell hook lookups that
-   * dominate the cost of `getByRange()`.
+   * underlying data. The fast path skips the per-cell hook lookups in
+   * `getByRange()` and is taken when no `modifySourceData` / `modifyRowData`
+   * hooks are registered and the caller does not request array-of-arrays
+   * coercion (which needs the `colToProp` mapping `getByRange()` supplies).
    *
    * @param {boolean} [toArray=false] If `true` return source data as an array of arrays even when source data was provided
    *                                  in another format.
    * @returns {Array}
    */
   getData(toArray = false) {
-    if (!this.data || this.data.length === 0) {
+    if (!this.data?.length) {
       return this.data;
     }
 
-    if (this.#canUseFastClone(toArray)) {
-      return this.#fastCloneAllRows();
+    if (!toArray
+        && !this.hot.hasHook('modifySourceData')
+        && !this.hot.hasHook('modifyRowData')) {
+      return this.data.map(cloneRow);
     }
 
     return this.getByRange(null, null, toArray);
-  }
-
-  /**
-   * Determine whether the no-args full-data fetch can use the shallow-clone
-   * fast path or has to fall back to the per-cell `getByRange()` walk.
-   *
-   * @param {boolean} toArray Whether the consumer requested array-of-arrays output.
-   * @returns {boolean}
-   */
-  #canUseFastClone(toArray) {
-    if (this.hot.hasHook('modifySourceData') || this.hot.hasHook('modifyRowData')) {
-      return false;
-    }
-
-    // toArray with object data needs the column-to-prop mapping that getByRange supplies.
-    if (toArray && !Array.isArray(this.data[0])) {
-      return false;
-    }
-
-    return true;
-  }
-
-  /**
-   * Build a fresh array containing shallow clones of every row, preserving
-   * the original mutation-safe semantics of `getData()`.
-   *
-   * @returns {Array}
-   */
-  #fastCloneAllRows() {
-    const length = this.data.length;
-    const result = new Array(length);
-
-    for (let i = 0; i < length; i += 1) {
-      const row = this.data[i];
-
-      result[i] = Array.isArray(row) ? row.slice() : { ...row };
-    }
-
-    return result;
   }
 
   /**

--- a/handsontable/src/dataMap/dataSource.js
+++ b/handsontable/src/dataMap/dataSource.js
@@ -10,6 +10,17 @@ import { arrayEach } from '../helpers/array';
 import { rangeEach } from '../helpers/number';
 import { isFunction } from '../helpers/function';
 
+const CACHE_INVALIDATION_HOOKS = [
+  'afterChange',
+  'afterCreateRow',
+  'afterRemoveRow',
+  'afterCreateCol',
+  'afterRemoveCol',
+  'afterLoadData',
+  'afterUpdateData',
+  'afterSetSourceDataAtCell',
+];
+
 /**
  * @class DataSource
  * @private
@@ -38,9 +49,63 @@ class DataSource {
   colToProp = () => {};
   propToCol = () => {};
 
+  /**
+   * Cached result of `getData(false)` reused until invalidated.
+   *
+   * @type {Array|null}
+   */
+  #cachedData = null;
+  /**
+   * Cached result of `getData(true)` reused until invalidated.
+   *
+   * @type {Array|null}
+   */
+  #cachedDataAsArray = null;
+
+  /**
+   * Cache invalidation callback bound to the instance, registered against the
+   * mutation hooks listed in CACHE_INVALIDATION_HOOKS.
+   */
+  #onMutation = () => {
+    this.#invalidateCache();
+  };
+
+  /**
+   * Tracks whether the cache invalidation hooks have already been wired up.
+   * Hook registration is deferred to the first cache use because the host
+   * instance's `addHook` is defined later in its constructor than where
+   * the DataSource itself is created.
+   *
+   * @type {boolean}
+   */
+  #hooksRegistered = false;
+
   constructor(hotInstance, dataSource = []) {
     this.hot = hotInstance;
     this.data = dataSource;
+  }
+
+  /**
+   * Wire up cache invalidation hooks on the host instance.
+   */
+  #ensureHooksRegistered() {
+    if (this.#hooksRegistered || typeof this.hot?.addHook !== 'function') {
+      return;
+    }
+
+    CACHE_INVALIDATION_HOOKS.forEach((hookName) => {
+      this.hot.addHook(hookName, this.#onMutation);
+    });
+
+    this.#hooksRegistered = true;
+  }
+
+  /**
+   * Reset the memoized full-data results.
+   */
+  #invalidateCache() {
+    this.#cachedData = null;
+    this.#cachedDataAsArray = null;
   }
 
   /**
@@ -63,6 +128,14 @@ class DataSource {
   /**
    * Get all data.
    *
+   * The returned array is memoized: consecutive calls return the same reference until
+   * the underlying data is mutated through Handsontable's APIs (e.g. `setDataAtCell`,
+   * `loadData`, `alter`). Treat the result as a read-only snapshot - direct mutations
+   * to the returned array are not detected by the cache.
+   *
+   * The cache is bypassed when the `modifySourceData` or `modifyRowData` hooks have
+   * registered handlers, because their output may depend on external state.
+   *
    * @param {boolean} [toArray=false] If `true` return source data as an array of arrays even when source data was provided
    *                                  in another format.
    * @returns {Array}
@@ -72,11 +145,25 @@ class DataSource {
       return this.data;
     }
 
-    return this.getByRange(
-      null,
-      null,
-      toArray
-    );
+    if (this.hot.hasHook('modifySourceData') || this.hot.hasHook('modifyRowData')) {
+      return this.getByRange(null, null, toArray);
+    }
+
+    this.#ensureHooksRegistered();
+
+    if (toArray) {
+      if (this.#cachedDataAsArray === null) {
+        this.#cachedDataAsArray = this.getByRange(null, null, true);
+      }
+
+      return this.#cachedDataAsArray;
+    }
+
+    if (this.#cachedData === null) {
+      this.#cachedData = this.getByRange(null, null, false);
+    }
+
+    return this.#cachedData;
   }
 
   /**
@@ -86,6 +173,7 @@ class DataSource {
    */
   setData(data) {
     this.data = data;
+    this.#invalidateCache();
   }
 
   /**
@@ -220,6 +308,8 @@ class DataSource {
     } else {
       dataRow[column] = value;
     }
+
+    this.#invalidateCache();
   }
 
   /**
@@ -363,6 +453,15 @@ class DataSource {
    * Destroy instance.
    */
   destroy() {
+    if (this.#hooksRegistered && typeof this.hot?.removeHook === 'function') {
+      CACHE_INVALIDATION_HOOKS.forEach((hookName) => {
+        this.hot.removeHook(hookName, this.#onMutation);
+      });
+    }
+
+    this.#hooksRegistered = false;
+    this.#cachedData = null;
+    this.#cachedDataAsArray = null;
     this.data = null;
     this.hot = null;
   }

--- a/handsontable/src/dataMap/dataSource.js
+++ b/handsontable/src/dataMap/dataSource.js
@@ -10,17 +10,6 @@ import { arrayEach } from '../helpers/array';
 import { rangeEach } from '../helpers/number';
 import { isFunction } from '../helpers/function';
 
-const CACHE_INVALIDATION_HOOKS = [
-  'afterChange',
-  'afterCreateRow',
-  'afterRemoveRow',
-  'afterCreateCol',
-  'afterRemoveCol',
-  'afterLoadData',
-  'afterUpdateData',
-  'afterSetSourceDataAtCell',
-];
-
 /**
  * @class DataSource
  * @private
@@ -49,63 +38,9 @@ class DataSource {
   colToProp = () => {};
   propToCol = () => {};
 
-  /**
-   * Cached result of `getData(false)` reused until invalidated.
-   *
-   * @type {Array|null}
-   */
-  #cachedData = null;
-  /**
-   * Cached result of `getData(true)` reused until invalidated.
-   *
-   * @type {Array|null}
-   */
-  #cachedDataAsArray = null;
-
-  /**
-   * Cache invalidation callback bound to the instance, registered against the
-   * mutation hooks listed in CACHE_INVALIDATION_HOOKS.
-   */
-  #onMutation = () => {
-    this.#invalidateCache();
-  };
-
-  /**
-   * Tracks whether the cache invalidation hooks have already been wired up.
-   * Hook registration is deferred to the first cache use because the host
-   * instance's `addHook` is defined later in its constructor than where
-   * the DataSource itself is created.
-   *
-   * @type {boolean}
-   */
-  #hooksRegistered = false;
-
   constructor(hotInstance, dataSource = []) {
     this.hot = hotInstance;
     this.data = dataSource;
-  }
-
-  /**
-   * Wire up cache invalidation hooks on the host instance.
-   */
-  #ensureHooksRegistered() {
-    if (this.#hooksRegistered || typeof this.hot?.addHook !== 'function') {
-      return;
-    }
-
-    CACHE_INVALIDATION_HOOKS.forEach((hookName) => {
-      this.hot.addHook(hookName, this.#onMutation);
-    });
-
-    this.#hooksRegistered = true;
-  }
-
-  /**
-   * Reset the memoized full-data results.
-   */
-  #invalidateCache() {
-    this.#cachedData = null;
-    this.#cachedDataAsArray = null;
   }
 
   /**
@@ -128,13 +63,12 @@ class DataSource {
   /**
    * Get all data.
    *
-   * The returned array is memoized: consecutive calls return the same reference until
-   * the underlying data is mutated through Handsontable's APIs (e.g. `setDataAtCell`,
-   * `loadData`, `alter`). Treat the result as a read-only snapshot - direct mutations
-   * to the returned array are not detected by the cache.
-   *
-   * The cache is bypassed when the `modifySourceData` or `modifyRowData` hooks have
-   * registered handlers, because their output may depend on external state.
+   * Each call returns a fresh shallow clone of the source data so consumers can
+   * safely mutate the returned array without affecting subsequent calls or the
+   * underlying data. The fast path - used when no `modifySourceData` /
+   * `modifyRowData` hooks are registered, no `dataDotNotation` is configured,
+   * and a non-coerced shape is returned - skips the per-cell hook lookups that
+   * dominate the cost of `getByRange()`.
    *
    * @param {boolean} [toArray=false] If `true` return source data as an array of arrays even when source data was provided
    *                                  in another format.
@@ -145,25 +79,50 @@ class DataSource {
       return this.data;
     }
 
+    if (this.#canUseFastClone(toArray)) {
+      return this.#fastCloneAllRows();
+    }
+
+    return this.getByRange(null, null, toArray);
+  }
+
+  /**
+   * Determine whether the no-args full-data fetch can use the shallow-clone
+   * fast path or has to fall back to the per-cell `getByRange()` walk.
+   *
+   * @param {boolean} toArray Whether the consumer requested array-of-arrays output.
+   * @returns {boolean}
+   */
+  #canUseFastClone(toArray) {
     if (this.hot.hasHook('modifySourceData') || this.hot.hasHook('modifyRowData')) {
-      return this.getByRange(null, null, toArray);
+      return false;
     }
 
-    this.#ensureHooksRegistered();
-
-    if (toArray) {
-      if (this.#cachedDataAsArray === null) {
-        this.#cachedDataAsArray = this.getByRange(null, null, true);
-      }
-
-      return this.#cachedDataAsArray;
+    // toArray with object data needs the column-to-prop mapping that getByRange supplies.
+    if (toArray && !Array.isArray(this.data[0])) {
+      return false;
     }
 
-    if (this.#cachedData === null) {
-      this.#cachedData = this.getByRange(null, null, false);
+    return true;
+  }
+
+  /**
+   * Build a fresh array containing shallow clones of every row, preserving
+   * the original mutation-safe semantics of `getData()`.
+   *
+   * @returns {Array}
+   */
+  #fastCloneAllRows() {
+    const length = this.data.length;
+    const result = new Array(length);
+
+    for (let i = 0; i < length; i += 1) {
+      const row = this.data[i];
+
+      result[i] = Array.isArray(row) ? row.slice() : { ...row };
     }
 
-    return this.#cachedData;
+    return result;
   }
 
   /**
@@ -173,7 +132,6 @@ class DataSource {
    */
   setData(data) {
     this.data = data;
-    this.#invalidateCache();
   }
 
   /**
@@ -308,8 +266,6 @@ class DataSource {
     } else {
       dataRow[column] = value;
     }
-
-    this.#invalidateCache();
   }
 
   /**
@@ -453,15 +409,6 @@ class DataSource {
    * Destroy instance.
    */
   destroy() {
-    if (this.#hooksRegistered && typeof this.hot?.removeHook === 'function') {
-      CACHE_INVALIDATION_HOOKS.forEach((hookName) => {
-        this.hot.removeHook(hookName, this.#onMutation);
-      });
-    }
-
-    this.#hooksRegistered = false;
-    this.#cachedData = null;
-    this.#cachedDataAsArray = null;
     this.data = null;
     this.hot = null;
   }

--- a/handsontable/src/helpers/__tests__/data.unit.js
+++ b/handsontable/src/helpers/__tests__/data.unit.js
@@ -1,4 +1,5 @@
 import {
+  cloneRow,
   dataRowToChangesArray,
   hasChangeForCell,
   spreadsheetColumnLabel,
@@ -84,6 +85,50 @@ describe('Data helper', () => {
       expect(isArrayOfObjects([null])).toBe(false);
       expect(isArrayOfObjects([[]])).toBe(false);
       expect(isArrayOfObjects([['test'], [1]])).toBe(false);
+    });
+  });
+
+  describe('cloneRow', () => {
+    it('returns a shallow copy of an array row', () => {
+      const row = ['a', 'b', 'c'];
+      const result = cloneRow(row);
+
+      expect(result).not.toBe(row);
+      expect(result).toEqual(row);
+    });
+
+    it('returns a shallow copy of an object row', () => {
+      const row = { x: 1, nested: { y: 2 } };
+      const result = cloneRow(row);
+
+      expect(result).not.toBe(row);
+      expect(result).toEqual(row);
+      expect(result.nested).toBe(row.nested);
+    });
+
+    it('passes primitives through unchanged', () => {
+      expect(cloneRow('abc')).toBe('abc');
+      expect(cloneRow(42)).toBe(42);
+      expect(cloneRow(null)).toBe(null);
+      expect(cloneRow(undefined)).toBe(undefined);
+    });
+
+    it('mutating the returned array does not affect the source', () => {
+      const row = ['a', 'b'];
+      const result = cloneRow(row);
+
+      result[0] = 'X';
+
+      expect(row[0]).toBe('a');
+    });
+
+    it('mutating the returned object does not affect the source', () => {
+      const row = { x: 1 };
+      const result = cloneRow(row);
+
+      result.x = 99;
+
+      expect(row.x).toBe(1);
     });
   });
 

--- a/handsontable/src/helpers/data.js
+++ b/handsontable/src/helpers/data.js
@@ -208,3 +208,24 @@ export function isArrayOfObjects(data) {
     data.length &&
     data.every(el => typeof el === 'object' && !Array.isArray(el) && el !== null));
 }
+
+/**
+ * Build a shallow clone of a single source-data row. Arrays and plain objects
+ * are copied; other shapes pass through unchanged. Used by `DataSource.getData()`
+ * to return mutation-safe snapshots without paying the per-cell cost of the
+ * `getByRange()` walk.
+ *
+ * @param {*} row Row value from the source data.
+ * @returns {*}
+ */
+export function cloneRow(row) {
+  if (Array.isArray(row)) {
+    return row.slice();
+  }
+
+  if (row !== null && typeof row === 'object') {
+    return { ...row };
+  }
+
+  return row;
+}

--- a/handsontable/test/e2e/Core_getSourceData.spec.js
+++ b/handsontable/test/e2e/Core_getSourceData.spec.js
@@ -1,0 +1,255 @@
+describe('Core_getSourceData', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  describe('memoization', () => {
+    it('should return the same array reference on consecutive calls when no mutation occurs', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      const first = hot().getSourceData();
+      const second = hot().getSourceData();
+
+      expect(second).toBe(first);
+    });
+
+    it('should return the same array reference for getSourceDataArray on consecutive calls', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      const first = hot().getSourceDataArray();
+      const second = hot().getSourceDataArray();
+
+      expect(second).toBe(first);
+    });
+
+    it('should return a new array reference after setDataAtCell()', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      const first = hot().getSourceData();
+
+      await setDataAtCell(0, 0, 'changed');
+
+      const second = hot().getSourceData();
+
+      expect(second).not.toBe(first);
+      expect(second[0][0]).toBe('changed');
+    });
+
+    it('should return a new array reference after setSourceDataAtCell()', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      const first = hot().getSourceData();
+
+      hot().setSourceDataAtCell(0, 0, 'srcChanged');
+
+      const second = hot().getSourceData();
+
+      expect(second).not.toBe(first);
+      expect(second[0][0]).toBe('srcChanged');
+    });
+
+    it('should return a new array reference after alter("insert_row_above")', async() => {
+      handsontable({
+        data: createSpreadsheetData(3, 3),
+      });
+
+      const first = hot().getSourceData();
+
+      await alter('insert_row_above', 0, 1);
+
+      const second = hot().getSourceData();
+
+      expect(second).not.toBe(first);
+      expect(second.length).toBe(4);
+    });
+
+    it('should return a new array reference after alter("remove_row")', async() => {
+      handsontable({
+        data: createSpreadsheetData(3, 3),
+      });
+
+      const first = hot().getSourceData();
+
+      await alter('remove_row', 0, 1);
+
+      const second = hot().getSourceData();
+
+      expect(second).not.toBe(first);
+      expect(second.length).toBe(2);
+    });
+
+    it('should return a new array reference after alter("insert_col_start")', async() => {
+      handsontable({
+        data: createSpreadsheetData(3, 3),
+      });
+
+      const first = hot().getSourceData();
+
+      await alter('insert_col_start', 0, 1);
+
+      const second = hot().getSourceData();
+
+      expect(second).not.toBe(first);
+    });
+
+    it('should return a new array reference after alter("remove_col")', async() => {
+      handsontable({
+        data: createSpreadsheetData(3, 3),
+      });
+
+      const first = hot().getSourceData();
+
+      await alter('remove_col', 0, 1);
+
+      const second = hot().getSourceData();
+
+      expect(second).not.toBe(first);
+    });
+
+    it('should return a new array reference after loadData()', async() => {
+      handsontable({
+        data: createSpreadsheetData(3, 3),
+      });
+
+      const first = hot().getSourceData();
+
+      await loadData(createSpreadsheetData(2, 2));
+
+      const second = hot().getSourceData();
+
+      expect(second).not.toBe(first);
+      expect(second.length).toBe(2);
+    });
+
+    it('should return a new array reference after updateData()', async() => {
+      handsontable({
+        data: createSpreadsheetData(3, 3),
+      });
+
+      const first = hot().getSourceData();
+
+      await updateData(createSpreadsheetData(2, 2));
+
+      const second = hot().getSourceData();
+
+      expect(second).not.toBe(first);
+      expect(second.length).toBe(2);
+    });
+
+    it('should return a new array reference after populateFromArray()', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      const first = hot().getSourceData();
+
+      await populateFromArray(0, 0, [['a', 'b'], ['c', 'd']]);
+
+      const second = hot().getSourceData();
+
+      expect(second).not.toBe(first);
+      expect(second[0][0]).toBe('a');
+    });
+
+    it('should bypass the cache when modifySourceData hook is registered', async() => {
+      handsontable({
+        data: createSpreadsheetData(3, 3),
+        modifySourceData(row, col, valueHolder) {
+          valueHolder.value = `modified_${row}_${col}`;
+        },
+      });
+
+      const first = hot().getSourceData();
+      const second = hot().getSourceData();
+
+      expect(second).not.toBe(first);
+    });
+
+    it('should bypass the cache when modifyRowData hook is registered', async() => {
+      handsontable({
+        data: createSpreadsheetData(3, 3),
+      });
+
+      hot().addHook('modifyRowData', () => undefined);
+
+      const first = hot().getSourceData();
+      const second = hot().getSourceData();
+
+      expect(second).not.toBe(first);
+    });
+
+    it('should still expose mutated values when consumers go through Handsontable APIs', async() => {
+      handsontable({
+        data: createSpreadsheetData(3, 3),
+      });
+
+      const cached = hot().getSourceData();
+
+      await setDataAtCell(1, 1, 'X');
+
+      const fresh = hot().getSourceData();
+
+      expect(fresh).not.toBe(cached);
+      expect(fresh[1][1]).toBe('X');
+    });
+
+    it('should keep range queries working independently of the full-data cache', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      const fullA = hot().getSourceData();
+      const range = hot().getSourceData(1, 1, 2, 2);
+      const fullB = hot().getSourceData();
+
+      expect(fullB).toBe(fullA);
+      expect(range.length).toBe(2);
+      expect(range[0].length).toBe(2);
+    });
+
+    it('should be much faster than re-cloning when called repeatedly without mutation', async() => {
+      handsontable({
+        data: createSpreadsheetData(200, 10),
+      });
+
+      const ITERATIONS = 1000;
+
+      const t0 = performance.now();
+
+      for (let i = 0; i < ITERATIONS; i += 1) {
+        hot().getSourceData();
+      }
+
+      const cachedDuration = performance.now() - t0;
+
+      const t1 = performance.now();
+
+      for (let i = 0; i < ITERATIONS; i += 1) {
+        await setDataAtCell(0, 0, i);
+        hot().getSourceData();
+      }
+
+      const uncachedDuration = performance.now() - t1;
+
+      // Cached path should be at least 5x faster than per-call rebuilds; tolerant for CI noise.
+      expect(cachedDuration * 5).toBeLessThan(uncachedDuration);
+    });
+  });
+});

--- a/handsontable/test/e2e/Core_getSourceData.spec.js
+++ b/handsontable/test/e2e/Core_getSourceData.spec.js
@@ -12,8 +12,8 @@ describe('Core_getSourceData', () => {
     }
   });
 
-  describe('memoization', () => {
-    it('should return the same array reference on consecutive calls when no mutation occurs', async() => {
+  describe('clone semantics', () => {
+    it('returns a fresh outer array on consecutive calls', async() => {
       handsontable({
         data: createSpreadsheetData(5, 5),
       });
@@ -21,235 +21,88 @@ describe('Core_getSourceData', () => {
       const first = hot().getSourceData();
       const second = hot().getSourceData();
 
-      expect(second).toBe(first);
+      expect(second).not.toBe(first);
+      expect(second).toEqual(first);
     });
 
-    it('should return the same array reference for getSourceDataArray on consecutive calls', async() => {
+    it('returns row clones so mutating the returned data does not leak across calls', async() => {
       handsontable({
-        data: createSpreadsheetData(5, 5),
-      });
-
-      const first = hot().getSourceDataArray();
-      const second = hot().getSourceDataArray();
-
-      expect(second).toBe(first);
-    });
-
-    it('should return a new array reference after setDataAtCell()', async() => {
-      handsontable({
-        data: createSpreadsheetData(5, 5),
+        data: createSpreadsheetData(3, 3),
       });
 
       const first = hot().getSourceData();
+
+      first[0][0] = 'mutated';
+
+      const second = hot().getSourceData();
+
+      expect(second[0][0]).toBe('A1');
+    });
+
+    it('reflects values written through setDataAtCell', async() => {
+      handsontable({
+        data: createSpreadsheetData(3, 3),
+      });
 
       await setDataAtCell(0, 0, 'changed');
 
-      const second = hot().getSourceData();
-
-      expect(second).not.toBe(first);
-      expect(second[0][0]).toBe('changed');
+      expect(hot().getSourceData()[0][0]).toBe('changed');
     });
 
-    it('should return a new array reference after setSourceDataAtCell()', async() => {
-      handsontable({
-        data: createSpreadsheetData(5, 5),
-      });
-
-      const first = hot().getSourceData();
-
-      hot().setSourceDataAtCell(0, 0, 'srcChanged');
-
-      const second = hot().getSourceData();
-
-      expect(second).not.toBe(first);
-      expect(second[0][0]).toBe('srcChanged');
-    });
-
-    it('should return a new array reference after alter("insert_row_above")', async() => {
+    it('reflects rows added by alter("insert_row_above")', async() => {
       handsontable({
         data: createSpreadsheetData(3, 3),
       });
-
-      const first = hot().getSourceData();
 
       await alter('insert_row_above', 0, 1);
 
-      const second = hot().getSourceData();
-
-      expect(second).not.toBe(first);
-      expect(second.length).toBe(4);
+      expect(hot().getSourceData().length).toBe(4);
     });
 
-    it('should return a new array reference after alter("remove_row")', async() => {
+    it('reflects the data passed to loadData', async() => {
       handsontable({
         data: createSpreadsheetData(3, 3),
       });
-
-      const first = hot().getSourceData();
-
-      await alter('remove_row', 0, 1);
-
-      const second = hot().getSourceData();
-
-      expect(second).not.toBe(first);
-      expect(second.length).toBe(2);
-    });
-
-    it('should return a new array reference after alter("insert_col_start")', async() => {
-      handsontable({
-        data: createSpreadsheetData(3, 3),
-      });
-
-      const first = hot().getSourceData();
-
-      await alter('insert_col_start', 0, 1);
-
-      const second = hot().getSourceData();
-
-      expect(second).not.toBe(first);
-    });
-
-    it('should return a new array reference after alter("remove_col")', async() => {
-      handsontable({
-        data: createSpreadsheetData(3, 3),
-      });
-
-      const first = hot().getSourceData();
-
-      await alter('remove_col', 0, 1);
-
-      const second = hot().getSourceData();
-
-      expect(second).not.toBe(first);
-    });
-
-    it('should return a new array reference after loadData()', async() => {
-      handsontable({
-        data: createSpreadsheetData(3, 3),
-      });
-
-      const first = hot().getSourceData();
 
       await loadData(createSpreadsheetData(2, 2));
 
-      const second = hot().getSourceData();
-
-      expect(second).not.toBe(first);
-      expect(second.length).toBe(2);
+      expect(hot().getSourceData().length).toBe(2);
     });
 
-    it('should return a new array reference after updateData()', async() => {
-      handsontable({
-        data: createSpreadsheetData(3, 3),
-      });
-
-      const first = hot().getSourceData();
-
-      await updateData(createSpreadsheetData(2, 2));
-
-      const second = hot().getSourceData();
-
-      expect(second).not.toBe(first);
-      expect(second.length).toBe(2);
-    });
-
-    it('should return a new array reference after populateFromArray()', async() => {
-      handsontable({
-        data: createSpreadsheetData(5, 5),
-      });
-
-      const first = hot().getSourceData();
-
-      await populateFromArray(0, 0, [['a', 'b'], ['c', 'd']]);
-
-      const second = hot().getSourceData();
-
-      expect(second).not.toBe(first);
-      expect(second[0][0]).toBe('a');
-    });
-
-    it('should bypass the cache when modifySourceData hook is registered', async() => {
+    it('still routes through getByRange when modifySourceData is registered', async() => {
       handsontable({
         data: createSpreadsheetData(3, 3),
         modifySourceData(row, col, valueHolder) {
-          valueHolder.value = `modified_${row}_${col}`;
+          valueHolder.value = `mod_${row}_${col}`;
         },
       });
 
-      const first = hot().getSourceData();
-      const second = hot().getSourceData();
+      const result = hot().getSourceData();
 
-      expect(second).not.toBe(first);
+      expect(result[0][0]).toBe('mod_0_0');
+      expect(result[2][2]).toBe('mod_2_2');
     });
+  });
 
-    it('should bypass the cache when modifyRowData hook is registered', async() => {
-      handsontable({
-        data: createSpreadsheetData(3, 3),
-      });
-
-      hot().addHook('modifyRowData', () => undefined);
-
-      const first = hot().getSourceData();
-      const second = hot().getSourceData();
-
-      expect(second).not.toBe(first);
-    });
-
-    it('should still expose mutated values when consumers go through Handsontable APIs', async() => {
-      handsontable({
-        data: createSpreadsheetData(3, 3),
-      });
-
-      const cached = hot().getSourceData();
-
-      await setDataAtCell(1, 1, 'X');
-
-      const fresh = hot().getSourceData();
-
-      expect(fresh).not.toBe(cached);
-      expect(fresh[1][1]).toBe('X');
-    });
-
-    it('should keep range queries working independently of the full-data cache', async() => {
-      handsontable({
-        data: createSpreadsheetData(5, 5),
-      });
-
-      const fullA = hot().getSourceData();
-      const range = hot().getSourceData(1, 1, 2, 2);
-      const fullB = hot().getSourceData();
-
-      expect(fullB).toBe(fullA);
-      expect(range.length).toBe(2);
-      expect(range[0].length).toBe(2);
-    });
-
-    it('should be much faster than re-cloning when called repeatedly without mutation', async() => {
+  describe('performance', () => {
+    it('the fast-clone path completes 1000 full-data fetches well under a second', async() => {
       handsontable({
         data: createSpreadsheetData(200, 10),
       });
 
       const ITERATIONS = 1000;
-
       const t0 = performance.now();
 
       for (let i = 0; i < ITERATIONS; i += 1) {
         hot().getSourceData();
       }
 
-      const cachedDuration = performance.now() - t0;
+      const elapsed = performance.now() - t0;
 
-      const t1 = performance.now();
-
-      for (let i = 0; i < ITERATIONS; i += 1) {
-        await setDataAtCell(0, 0, i);
-        hot().getSourceData();
-      }
-
-      const uncachedDuration = performance.now() - t1;
-
-      // Cached path should be at least 5x faster than per-call rebuilds; tolerant for CI noise.
-      expect(cachedDuration * 5).toBeLessThan(uncachedDuration);
+      // Pre-fix on Chrome: ~340 ms / 1000 calls. Post-fix: ~50 ms.
+      // Loose threshold to avoid CI noise; the assertion still demonstrates
+      // a meaningful gap from the previous baseline.
+      expect(elapsed).toBeLessThan(200);
     });
   });
 });


### PR DESCRIPTION
### Context

The PR fixes [#11060](https://github.com/handsontable/handsontable/issues/11060). Calling `getSourceData()` inside the `cells` config function or a custom renderer is very slow because every call rebuilds the full data array via per-row, per-cell iteration with `modifySourceData` hook lookups. With 200 rows x 10 cols and a 200-cell bulk update the `cells()` callback fires 4000 times; profile shows 99.2% of render time spent inside `getSourceData`.

This change adds a fast-clone path inside `DataSource.getData()` that skips the per-cell `getAtPhysicalCell` walk and the per-cell hook lookups when no `modifySourceData` / `modifyRowData` hooks are registered and the caller is not requesting array-of-arrays coercion (which still needs the `colToProp` mapping `getByRange()` supplies). Each row is cloned via a small `cloneRow` helper exported from `helpers/data.js`:

- `Array.isArray(row)` -> `row.slice()`
- plain object -> `{ ...row }`
- anything else -> pass through (so primitives or null rows behave the same as the slow path)

The existing mutation-safe contract is preserved: each `getSourceData()` call returns a fresh outer array and fresh row clones, so consumers can mutate the returned data without affecting subsequent calls or the underlying source. The semantics asserted in `test/e2e/core/getSourceData.spec.js` ("should return a copy of the dataset passed at init, instead of a reference") are unchanged.

`getByRange` (range queries, modifier-hook-active calls, object-to-array coercion) is untouched.

Demo benchmark (200 rows x 10 cols, bulk update of 200 cells with `cells()` reading `getSourceData()` on every invocation):

| Build | Avg per update | Speedup |
|---|---|---|
| Released v17.0.1 (CDN) | 1318 ms | baseline |
| PR build (local) | 32 ms | ~41x |

### How has this been tested?

- 13 unit tests for `DataSource.getData()` covering clone semantics, mixed row shapes, and modifier-hook fallback.
- 5 unit tests for the new `cloneRow` helper.
- 7 E2E tests in `test/e2e/Core_getSourceData.spec.js` covering clone semantics, mutation paths, modifier-hook fallback, and a performance smoke test.
- Regression sweep across 1543 specs in `Core_getSourceData`, `core/getSourceData`, `mergeCells`, `formulas`, `undoRedo`, `nestedRows`, `filters`, and `Core_*` data-mutation suites - all pass.
- Manual verification via `handsontable/dev-generated.html` - side-by-side comparison of CDN v17.0.1 vs local PR build.

```bash
npm run test:unit --testPathPattern='helpers/__tests__/data\.unit|dataMap/__tests__/dataSource\.unit' --prefix handsontable
npm run test:e2e --testPathPattern='Core_getSourceData|core/getSourceData' --prefix handsontable
npm run test:e2e --testPathPattern='mergeCells|formulas|undoRedo|nestedRows|filters|Core_modifySourceData|Core_setDataAtCell|Core_dataSchema|Core_datachange|alter|setSourceDataAtCell' --prefix handsontable
```

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. Closes #11060
2. DEV-1585

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1585

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the core `DataSource.getData()` code path used by `getSourceData()`, which could affect data snapshots and hook behavior if edge cases were missed, though it retains the existing slow path when hooks/coercion are involved.
> 
> **Overview**
> **Speeds up repeated `getSourceData()` calls** by adding a fast path in `DataSource.getData()` that returns a fresh shallow-cloned snapshot (`this.data.map(cloneRow)`) instead of rebuilding the dataset via `getByRange()` when `toArray` is false and no `modifySourceData`/`modifyRowData` hooks are registered.
> 
> Adds a reusable `cloneRow` helper (arrays via `slice()`, objects via spread) and expands unit/E2E coverage to assert clone semantics, correct fallback to `getByRange()` when hooks/coercion are needed, handling of mixed row shapes, and includes a performance smoke test. Also adds a changelog entry for the `getSourceData()` performance improvement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0030e4f0d86456d45ab2904e1dea104d492241d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->