### PR TITLE
DEV-1283: Fix Angular PDF export preview not rendering

### DIFF
--- a/docs/content/recipes/import-export/export-to-pdf/angular/example1.ts
+++ b/docs/content/recipes/import-export/export-to-pdf/angular/example1.ts
@@ -1,7 +1,6 @@
 /* file: app.component.ts */
 import { Component, ViewChild } from '@angular/core';
 import { GridSettings, HotTableComponent, HotTableModule } from '@handsontable/angular-wrapper';
-import { RowObject } from 'handsontable/common';
 import { jsPDF } from 'jspdf';
 import { autoTable } from 'jspdf-autotable';
 
@@ -20,7 +19,6 @@ const data = Array.from({ length: ROWS }, (_, row) => [
   standalone: true,
   imports: [HotTableModule],
   selector: 'example1-export-to-pdf',
-  styleUrls: ['./example1.css'],
   template: `
     <div class="export-pdf-toolbar">
       <button type="button" class="export-pdf-btn" (click)="exportToPdf()">Export to PDF</button>


### PR DESCRIPTION
### Context

The PR fixes the Angular PDF export example not rendering in the docs preview at https://dev.handsontable.com/docs/angular-data-grid/recipes/import-export/export-to-pdf/

The Angular example component used `styleUrls: ['./example1.css']` in its `@Component` decorator. Angular JIT compilation (used by the docs example runner) cannot fetch external CSS files at runtime, which causes the component to silently fail to render. Additionally, `RowObject` was imported from `handsontable/common` but never used, which can cause module resolution errors under JIT.

The fix removes `styleUrls` (the CSS is already injected by the example runner via the `--css` slot in the doc directive) and removes the unused `RowObject` import.

### How has this been tested?

Reviewed against the documented rule in `docs/CLAUDE.md`:
> "Never do this: `styleUrls: ['./example1.css']` -- JIT cannot fetch files at runtime"

The CSS is already referenced in the example directive with `--css 3`, so the styles are correctly injected by the example runner without `styleUrls`.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1283

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1283

---
_Generated by [Claude Code](https://claude.ai/code/session_01FEHw3JffHvAGCimpLoL2Xc)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs/example-only change that removes an unused import and avoids external `styleUrls` that break Angular JIT rendering in the docs runner.
> 
> **Overview**
> Fixes the Angular “Export to PDF” docs example preview by removing `styleUrls` from the component decorator so the docs runner can inject styles without Angular JIT trying (and failing) to load an external CSS file at runtime.
> 
> Also removes an unused `RowObject` import to avoid potential JIT/module-resolution issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 403e1651b1cf3a4ba8a1667394f4ba628815deb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->