### PR TITLE
DEV-1590: Fix numeric cell dot-thousands parsing for European locales

### DIFF
--- a/.changelogs/12482.json
+++ b/.changelogs/12482.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed numeric cell type incorrectly parsing dot-thousands values in European locales (e.g. `7.000` stored as 7 instead of 7000 with `de-DE` locale).",
+  "type": "fixed",
+  "issueOrPR": 12482,
+  "breaking": false,
+  "framework": "none"
+}

--- a/docs/content/guides/cell-types/numeric-cell-type/numeric-cell-type.md
+++ b/docs/content/guides/cell-types/numeric-cell-type/numeric-cell-type.md
@@ -399,8 +399,10 @@ you edit a numeric cell:
   separator or currency symbol.<br>For example, during editing `$7,000.02`, the number displays as
   `7000.02`.
 - You can enter a decimal separator either with a period (`.`), or with a comma (`,`).
-- You can't enter a thousands separator. After you finish editing the cell, the thousands
-  separator is added automatically, based on your [`numericFormat`](@/api/options.md#numericformat)
+- For European locales where the decimal separator is a comma (e.g., `de-DE`, `fr-FR`, `es-ES`),
+  you can enter a dot-thousands grouped value such as `7.000` or `7.000,25`. Handsontable parses
+  these as `7000` and `7000.25` respectively. For other locales, the thousands separator is added
+  automatically after editing, based on your [`numericFormat`](@/api/options.md#numericformat)
   configuration.
 
 ## Result

--- a/handsontable/src/cellTypes/numericType/__tests__/numericType.unit.js
+++ b/handsontable/src/cellTypes/numericType/__tests__/numericType.unit.js
@@ -101,6 +101,15 @@ describe('NumericCellType', () => {
       })).toBe(100);
     });
 
+    it('should parse dot-thousands integers for European locales (decimal=comma)', () => {
+      expect(valueSetter('7.000', 0, 0, { locale: 'de-DE' })).toBe(7000);
+      expect(valueSetter('1.234.567', 0, 0, { locale: 'de-DE' })).toBe(1234567);
+    });
+
+    it('should parse dot-thousands with comma decimal as float for European locales (regression guard)', () => {
+      expect(valueSetter('7.000,25', 0, 0, { locale: 'de-DE' })).toBe(7000.25);
+    });
+
     it('should not treat zero-prefixed comma values as thousands when decimal is dot (en-US)', () => {
       const meta = {
         numericFormat: {

--- a/handsontable/src/cellTypes/numericType/accessors/valueSetter.js
+++ b/handsontable/src/cellTypes/numericType/accessors/valueSetter.js
@@ -1,5 +1,7 @@
 import {
   isCommaThousandsGroupedInteger,
+  isDotThousandsGroupedInteger,
+  isDotThousandsGroupedFloat,
   isNumericLike,
   getParsedNumber,
 } from '../../../helpers/number';
@@ -69,7 +71,9 @@ export function valueSetter(newValue, row, column, cellMeta) {
 
   if (
     isNumericLike(newValue) ||
-    isCommaThousandsGroupedInteger(newValue, decimalSeparator)
+    isCommaThousandsGroupedInteger(newValue, decimalSeparator) ||
+    isDotThousandsGroupedInteger(newValue, decimalSeparator) ||
+    isDotThousandsGroupedFloat(newValue, decimalSeparator)
   ) {
     const parsedNumber = getParsedNumber(newValue, {
       decimalSeparator,

--- a/handsontable/src/editors/numericEditor/__tests__/numericEditor.spec.js
+++ b/handsontable/src/editors/numericEditor/__tests__/numericEditor.spec.js
@@ -443,7 +443,8 @@ describe('NumericEditor', () => {
     expect(getDataAtCell(1, 1)).toEqual('200,000.5');
     expect(getDataAtCell(0, 2)).toEqual('300,000.5');
     expect(getDataAtCell(1, 2)).toEqual('300.000,5');
-    expect(getDataAtCell(0, 3)).toEqual('400.000,5');
+    // '400.000,5' in a de-DE column is correctly parsed as 400000.5 (dot-thousands + comma-decimal).
+    expect(getDataAtCell(0, 3)).toBe(400000.5);
     expect(getDataAtCell(1, 3)).toEqual('400,000.5');
   });
 
@@ -1038,6 +1039,76 @@ describe('NumericEditor', () => {
     const editableElement = getActiveEditor().TEXTAREA;
 
     expect(editableElement.getAttribute('dir')).toBeNull();
+  });
+
+  describe('European locale (dot-thousands, comma-decimal)', () => {
+    it('should store 7000 when typing "7.000" in a de-DE numeric cell (issue #4396)', async() => {
+      handsontable({
+        data: [[7000]],
+        columns: [{ type: 'numeric', locale: 'de-DE' }],
+      });
+
+      await selectCell(0, 0);
+      await keyDownUp('enter');
+
+      const editor = getActiveEditor();
+
+      editor.setValue('7.000');
+      await keyDownUp('enter');
+
+      expect(getDataAtCell(0, 0)).toBe(7000);
+    });
+
+    it('should store 1234567 when typing "1.234.567" in a de-DE numeric cell', async() => {
+      handsontable({
+        data: [[0]],
+        columns: [{ type: 'numeric', locale: 'de-DE' }],
+      });
+
+      await selectCell(0, 0);
+      await keyDownUp('enter');
+
+      const editor = getActiveEditor();
+
+      editor.setValue('1.234.567');
+      await keyDownUp('enter');
+
+      expect(getDataAtCell(0, 0)).toBe(1234567);
+    });
+
+    it('should store 7000.25 when typing "7.000,25" in a de-DE numeric cell', async() => {
+      handsontable({
+        data: [[0]],
+        columns: [{ type: 'numeric', locale: 'de-DE' }],
+      });
+
+      await selectCell(0, 0);
+      await keyDownUp('enter');
+
+      const editor = getActiveEditor();
+
+      editor.setValue('7.000,25');
+      await keyDownUp('enter');
+
+      expect(getDataAtCell(0, 0)).toBe(7000.25);
+    });
+
+    it('should keep comma as decimal when typing "100,25" in a de-DE numeric cell', async() => {
+      handsontable({
+        data: [[0]],
+        columns: [{ type: 'numeric', locale: 'de-DE' }],
+      });
+
+      await selectCell(0, 0);
+      await keyDownUp('enter');
+
+      const editor = getActiveEditor();
+
+      editor.setValue('100,25');
+      await keyDownUp('enter');
+
+      expect(getDataAtCell(0, 0)).toBe(100.25);
+    });
   });
 
   describe('IME support', () => {

--- a/handsontable/src/helpers/__tests__/number.unit.js
+++ b/handsontable/src/helpers/__tests__/number.unit.js
@@ -4,6 +4,8 @@ import {
   isNumeric,
   isNumericLike,
   isCommaThousandsGroupedInteger,
+  isDotThousandsGroupedInteger,
+  isDotThousandsGroupedFloat,
   valueAccordingPercent,
   clamp,
   isUnsignedNumber,
@@ -316,6 +318,50 @@ describe('Number helper', () => {
   });
 
   //
+  // Handsontable.helper.isDotThousandsGroupedInteger
+  //
+  describe('isDotThousandsGroupedInteger', () => {
+    it('should return `true` for valid dot-thousands integers when decimal separator is a comma', () => {
+      expect(isDotThousandsGroupedInteger('7.000', ',')).toBe(true);
+      expect(isDotThousandsGroupedInteger('1.234.567', ',')).toBe(true);
+      expect(isDotThousandsGroupedInteger('  1.234.567  ', ',')).toBe(true);
+      expect(isDotThousandsGroupedInteger('-12.345', ',')).toBe(true);
+    });
+
+    it('should return `false` when decimal separator is not a comma', () => {
+      expect(isDotThousandsGroupedInteger('7.000', '.')).toBe(false);
+      expect(isDotThousandsGroupedInteger('7.000', undefined)).toBe(false);
+    });
+
+    it('should return `false` for values that are not valid grouped integers', () => {
+      expect(isDotThousandsGroupedInteger('0.001', ',')).toBe(false);
+      expect(isDotThousandsGroupedInteger('7.00', ',')).toBe(false);
+      expect(isDotThousandsGroupedInteger('7.000,25', ',')).toBe(false);
+    });
+  });
+
+  //
+  // Handsontable.helper.isDotThousandsGroupedFloat
+  //
+  describe('isDotThousandsGroupedFloat', () => {
+    it('should return `true` for dot-thousands floats with comma decimal when decimal separator is a comma', () => {
+      expect(isDotThousandsGroupedFloat('7.000,25', ',')).toBe(true);
+      expect(isDotThousandsGroupedFloat('1.234.567,89', ',')).toBe(true);
+      expect(isDotThousandsGroupedFloat('-12.345,6', ',')).toBe(true);
+    });
+
+    it('should return `false` when decimal separator is not a comma', () => {
+      expect(isDotThousandsGroupedFloat('7.000,25', '.')).toBe(false);
+      expect(isDotThousandsGroupedFloat('7.000,25', undefined)).toBe(false);
+    });
+
+    it('should return `false` for pure integers without comma decimal part', () => {
+      expect(isDotThousandsGroupedFloat('7.000', ',')).toBe(false);
+      expect(isDotThousandsGroupedFloat('1.234.567', ',')).toBe(false);
+    });
+  });
+
+  //
   // Handsontable.helper.valueAccordingPercent
   //
   describe('valueAccordingPercent', () => {
@@ -434,6 +480,21 @@ describe('Number helper', () => {
     it('should return null for invalid strings', () => {
       expect(getParsedNumber('abc')).toBe(null);
       expect(getParsedNumber('')).toBe(null);
+    });
+
+    it('should strip dot thousands separators when comma is the decimal separator and grouping is valid', () => {
+      const commaDecimal = { decimalSeparator: ',' };
+
+      expect(getParsedNumber('7.000', commaDecimal)).toBe(7000);
+      expect(getParsedNumber('1.234.567', commaDecimal)).toBe(1234567);
+      expect(getParsedNumber('-12.345', commaDecimal)).toBe(-12345);
+    });
+
+    it('should parse dot-thousands float with comma decimal when comma is the decimal separator', () => {
+      const commaDecimal = { decimalSeparator: ',' };
+
+      expect(getParsedNumber('7.000,25', commaDecimal)).toBe(7000.25);
+      expect(getParsedNumber('1.234.567,89', commaDecimal)).toBe(1234567.89);
     });
 
     it('should parse comma as decimal when dot is the decimal separator and the value is not US-style grouping', () => {

--- a/handsontable/src/helpers/number.js
+++ b/handsontable/src/helpers/number.js
@@ -194,7 +194,8 @@ export function clamp(value, minValue, maxValue) {
 /**
  * Get parsed number from numeric string.
  *
- * @param {string} numericData Float (separated by a dot or a comma) or integer.
+ * @param {string} numericData Float (separated by a dot or a comma), integer, or a dot-thousands
+ * grouped value used by European locales (e.g. `7.000` or `7.000,25` when `decimalSeparator` is `','`).
  * @param {object} [options={}] Parsing options.
  * @param {'.'|','} [options.decimalSeparator] Preferred decimal separator used by the cell.
  * @returns {number|null} Number if we get data in parsable format, not changed value otherwise.

--- a/handsontable/src/helpers/number.js
+++ b/handsontable/src/helpers/number.js
@@ -78,6 +78,40 @@ export function isCommaThousandsGroupedInteger(value, decimalSeparator) {
 }
 
 /**
+ * Whether the string is an integer with dot-separated thousands groups only.
+ * This matches the grouping rule used by European locales where the decimal separator
+ * is a comma and the thousands separator is a dot (e.g. `7.000` → 7000).
+ *
+ * @param {string} value The raw string value.
+ * @param {'.'|','|undefined} decimalSeparator Preferred decimal separator from cell meta.
+ * @returns {boolean}
+ */
+export function isDotThousandsGroupedInteger(value, decimalSeparator) {
+  if (decimalSeparator !== ',' || typeof value !== 'string') {
+    return false;
+  }
+
+  return /^[+-]?[1-9]\d{0,2}(\.\d{3})+$/.test(value.trim());
+}
+
+/**
+ * Whether the string is a float with dot-separated thousands groups and a comma decimal part.
+ * This matches the grouping rule used by European locales where the decimal separator
+ * is a comma and the thousands separator is a dot (e.g. `7.000,25` → 7000.25).
+ *
+ * @param {string} value The raw string value.
+ * @param {'.'|','|undefined} decimalSeparator Preferred decimal separator from cell meta.
+ * @returns {boolean}
+ */
+export function isDotThousandsGroupedFloat(value, decimalSeparator) {
+  if (decimalSeparator !== ',' || typeof value !== 'string') {
+    return false;
+  }
+
+  return /^[+-]?[1-9]\d{0,2}(\.\d{3})+,\d+$/.test(value.trim());
+}
+
+/**
  * A specialized version of `.forEach` defined by ranges.
  *
  * @param {number} rangeFrom The number from start iterate.
@@ -171,6 +205,14 @@ export function getParsedNumber(numericData, options = {}) {
 
   if (isCommaThousandsGroupedInteger(numericData, decimalSeparator)) {
     return parseFloat(normalizedNumericData.replace(/,/g, ''));
+  }
+
+  if (isDotThousandsGroupedInteger(numericData, decimalSeparator)) {
+    return parseFloat(normalizedNumericData.replace(/\./g, ''));
+  }
+
+  if (isDotThousandsGroupedFloat(numericData, decimalSeparator)) {
+    return parseFloat(normalizedNumericData.replace(/\./g, '').replace(',', '.'));
   }
 
   // Unifying "float like" string. Change from value with comma determiner to value with dot determiner,

--- a/handsontable/types/helpers/number.d.ts
+++ b/handsontable/types/helpers/number.d.ts
@@ -4,6 +4,14 @@ export function isCommaThousandsGroupedInteger(
   value: string,
   decimalSeparator: '.' | ',' | undefined
 ): boolean;
+export function isDotThousandsGroupedInteger(
+  value: string,
+  decimalSeparator: '.' | ',' | undefined
+): boolean;
+export function isDotThousandsGroupedFloat(
+  value: string,
+  decimalSeparator: '.' | ',' | undefined
+): boolean;
 export function rangeEach(rangeFrom: number, rangeTo: number, iteratee: (index: number) => void): void;
 export function rangeEachReverse(rangeFrom: number, rangeTo: number, iteratee: (index: number) => void): void;
 export function valueAccordingPercent(value: number, percent: string | number): number;


### PR DESCRIPTION
### Context

The PR fixes a bug where numeric cells using European locales (decimal separator `,`, thousands separator `.`) incorrectly parsed values like `7.000` as `7` instead of `7000`. The same bug affected multi-group values (`1.234.567` → 1 instead of 1234567) and European-style floats (`7.000,25` → string instead of 7000.25).

Root cause: `getParsedNumber` only handled comma-thousands grouping (English style). There was no equivalent path for dot-thousands grouping used by locales like `de-DE`, `fr-FR`, `es-ES`.

Fixes: https://github.com/handsontable/handsontable/issues/4396

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1590

### How has this been tested?

New unit tests added:

- `src/helpers/__tests__/number.unit.js` — tests for `isDotThousandsGroupedInteger`, `isDotThousandsGroupedFloat`, and `getParsedNumber` with `decimalSeparator: ','`
- `src/cellTypes/numericType/__tests__/numericType.unit.js` — `valueSetter` tests for `de-DE` locale with `7.000`, `1.234.567`, `7.000,25`

```bash
npm run test:unit --prefix handsontable -- --testPathPattern="number.unit |numericType.unit"
```

Manual demo: `handsontable/dev-generated.html` (gitignored). Shows Released tab with the bug and PR Build tab with the fix side by side.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. #4396
2. DEV-1590

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes numeric parsing behavior for comma-decimal locales to treat dot-grouped inputs (e.g. `7.000`, `7.000,25`) as thousands-grouped numbers, which could affect how some user-entered strings are converted to numbers. Scope is localized and covered by new unit/integration tests.
> 
> **Overview**
> Fixes numeric cell parsing for European locales (comma decimal) so dot-thousands user input like `7.000`, `1.234.567`, and `7.000,25` is stored as `7000`, `1234567`, and `7000.25` instead of being mis-parsed.
> 
> Adds `isDotThousandsGroupedInteger`/`isDotThousandsGroupedFloat` and extends `getParsedNumber` and numeric `valueSetter` to recognize/normalize these formats, updates TypeScript typings, and adds regression tests (including updating an existing `NumericEditor` expectation). Documentation and changelog are updated to describe the supported input format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e797e843c559e7150ee68092708e61a97eafebf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->