### PR TITLE
DEV-1591: Fix date validator infinite loop with correctFormat and allowInvalid: false

### DIFF
--- a/.changelogs/12483.json
+++ b/.changelogs/12483.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed an infinite loop when pasting a value that cannot be auto-corrected into a date cell with `correctFormat: true` and `allowInvalid: false`.",
+  "type": "fixed",
+  "issueOrPR": 12483,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/validators/dateValidator/__tests__/dateValidator.spec.js
+++ b/handsontable/src/validators/dateValidator/__tests__/dateValidator.spec.js
@@ -368,6 +368,53 @@ describe('dateValidator', () => {
       expect(onAfterValidate).toHaveBeenCalledWith(false, 'test non-date string', 1, 'date');
     });
 
+    it('should not cause an infinite loop when a numeric value is pasted into a date cell with `allowInvalid: false` (#9246)', async() => {
+      const afterChangeSpy = jasmine.createSpy('afterChange');
+      const afterValidateSpy = jasmine.createSpy('afterValidate');
+
+      handsontable({
+        data: [
+          ['03-FEBRUARY-2022', 50000]
+        ],
+        columns: [
+          { type: 'date', dateFormat: 'DD-MMMM-YYYY', correctFormat: true },
+          {}
+        ],
+        allowInvalid: false,
+        afterChange: afterChangeSpy,
+        afterValidate: afterValidateSpy
+      });
+
+      await setDataAtCell(0, 0, '50000');
+
+      await waitForNextAnimationFrames(10);
+
+      // afterChange should fire at most twice: once for the paste, once for the revert
+      expect(afterChangeSpy.calls.count()).toBeLessThan(5);
+      // The cell value should be reverted to the original valid date
+      expect(getDataAtCell(0, 0)).toEqual('03-FEBRUARY-2022');
+      // Validation should mark the numeric value as invalid
+      expect(afterValidateSpy).toHaveBeenCalledWith(false, '50000', 0, 0);
+    });
+
+    it('should mark a numeric value that cannot be auto-corrected to a valid date as invalid when `correctFormat` is enabled (#9246)', async() => {
+      const afterValidateSpy = jasmine.createSpy('afterValidate');
+
+      handsontable({
+        data: [['01/01/2020']],
+        columns: [
+          { type: 'date', dateFormat: 'MM/DD/YYYY', correctFormat: true }
+        ],
+        afterValidate: afterValidateSpy
+      });
+
+      await setDataAtCell(0, 0, '50000');
+
+      await waitForNextAnimationFrames(2);
+
+      expect(afterValidateSpy).toHaveBeenCalledWith(false, '50000', 0, 0);
+    });
+
     it('should populate all pasted values in the table when `correctFormat` is enabled (#dev-793)', async() => {
       handsontable({
         data: arrayOfObjects(),

--- a/handsontable/src/validators/dateValidator/dateValidator.js
+++ b/handsontable/src/validators/dateValidator/dateValidator.js
@@ -38,9 +38,12 @@ export function dateValidator(value, callback) {
   if (isValidDate && !isValidFormat) {
     if (this.correctFormat === true) { // if format correction is enabled
       const correctedValue = correctFormat(valueToValidate, this.dateFormat);
+      const isCorrectedValueValid = moment(correctedValue, this.dateFormat, true).isValid();
 
-      this.instance.setDataAtCell(this.visualRow, this.visualCol, correctedValue, 'dateValidator');
-      valid = true;
+      if (isCorrectedValueValid) {
+        this.instance.setDataAtCell(this.visualRow, this.visualCol, correctedValue, 'dateValidator');
+      }
+      valid = isCorrectedValueValid;
     } else {
       valid = false;
     }


### PR DESCRIPTION
### Context

The PR fixes an infinite loop that occurs when pasting a numeric value (e.g. `50000`) into a `date` cell configured with `correctFormat: true`, a custom `dateFormat`, and `allowInvalid: false`.

**Root cause:** When the pasted value is a valid date in some representation but not in the configured format, the validator calls `correctFormat(value, dateFormat)`. If the value cannot be meaningfully converted (e.g. a pure integer that moment.js cannot reliably reformat), `correctFormat()` returns the string `'Invalid date'`. The validator then calls `setDataAtCell` with that invalid string. This triggers a new `afterChange`, which runs the validator again. The `'Invalid date'` string fails validation, so `allowInvalid: false` reverts the cell to its previous value (the original paste), which triggers another `afterChange` - creating an infinite loop.

**Fix:** Before calling `setDataAtCell`, check that the corrected value actually passes strict format validation (`moment(correctedValue, dateFormat, true).isValid()`). If it does not, skip `setDataAtCell` and mark the cell invalid instead, allowing `allowInvalid: false` to revert cleanly without looping.

Related: https://github.com/handsontable/handsontable/issues/9246

ClickUp task: https://app.clickup.com/t/86c9mygyw

### How has this been tested?

Two new E2E tests added to `dateValidator.spec.js`:

1. **Infinite loop regression test** - sets a numeric value in a date cell with `correctFormat: true` + `allowInvalid: false`, waits 10 animation frames, and asserts `afterChange` fired fewer than 5 times and the cell reverted to the original valid date.
2. **Invalid numeric validation** - asserts that a numeric value that cannot be auto-corrected to a valid date format is marked invalid.

```bash
npm run test:e2e --testPathPattern=dateValidator --prefix handsontable
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1591
2. https://github.com/handsontable/handsontable/issues/9246

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, targeted change to date validation/correction logic plus regression tests; main risk is slightly different validation outcomes for edge-case inputs that previously got auto-rewritten.
> 
> **Overview**
> Fixes an **infinite validation/revert loop** when `correctFormat: true` is used with `allowInvalid: false` and the pasted value can’t be meaningfully reformatted as a date.
> 
> The date validator now only calls `setDataAtCell` after format correction if the corrected value passes strict `moment(..., dateFormat, true)` validation; otherwise it leaves the cell unchanged and returns an invalid result. Adds E2E regression coverage for numeric pastes (`50000`) and records the fix in `.changelogs/12483.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f3a0ac04d1418cc7900d9bca9ca0740cb67f284. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->