### PR TITLE
DEV-1595: Fix SelectEditor not preserving selectOptions array order for numeric keys

### DIFF
--- a/.changelogs/12487.json
+++ b/.changelogs/12487.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed the select cell type not preserving the order of numeric selectOptions values.",
+  "type": "fixed",
+  "issueOrPR": 12487,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/editors/selectEditor/__tests__/selectEditor.spec.js
+++ b/handsontable/src/editors/selectEditor/__tests__/selectEditor.spec.js
@@ -408,6 +408,33 @@ describe('SelectEditor', () => {
     expect($options.eq(2).html()).toMatch(options[2]);
   });
 
+  it('should preserve the order of array selectOptions containing negative numbers', async() => {
+    const options = Array.from({ length: 18 }, (_, i) => -5 + i); // [-5, -4, ..., 12]
+
+    handsontable({
+      columns: [
+        {
+          editor: 'select',
+          selectOptions: options
+        }
+      ]
+    });
+
+    await selectCell(0, 0);
+
+    const editorWrapper = $('.htSelectEditor');
+
+    await keyDownUp('enter');
+
+    const $options = editorWrapper.find('option');
+
+    expect($options.length).toEqual(options.length);
+
+    for (let i = 0; i < options.length; i++) {
+      expect($options.eq(i).val()).toMatch(String(options[i]));
+    }
+  });
+
   it('should populate select with given options (object)', async() => {
     const options = {
       mit: 'Misubishi',

--- a/handsontable/src/editors/selectEditor/__tests__/selectEditor.spec.js
+++ b/handsontable/src/editors/selectEditor/__tests__/selectEditor.spec.js
@@ -431,7 +431,7 @@ describe('SelectEditor', () => {
     expect($options.length).toEqual(options.length);
 
     for (let i = 0; i < options.length; i++) {
-      expect($options.eq(i).val()).toMatch(String(options[i]));
+      expect($options.eq(i).val()).toBe(String(options[i]));
     }
   });
 

--- a/handsontable/src/editors/selectEditor/selectEditor.js
+++ b/handsontable/src/editors/selectEditor/selectEditor.js
@@ -145,36 +145,44 @@ export class SelectEditor extends BaseEditor {
 
     empty(this.select);
 
-    objectEach(options, (optionValue, key) => {
-      const optionElement = this.hot.rootDocument.createElement('OPTION');
+    const { sanitizer } = this.hot.getSettings();
 
-      optionElement.value = key;
+    if (Array.isArray(options)) {
+      for (let i = 0; i < options.length; i++) {
+        const optionElement = this.hot.rootDocument.createElement('OPTION');
 
-      fastInnerHTML(optionElement, optionValue, this.hot.getSettings().sanitizer);
-      this.select.appendChild(optionElement);
-    });
+        optionElement.value = options[i];
+        fastInnerHTML(optionElement, options[i], sanitizer);
+        this.select.appendChild(optionElement);
+      }
+    } else {
+      objectEach(options, (optionValue, key) => {
+        const optionElement = this.hot.rootDocument.createElement('OPTION');
+
+        optionElement.value = key;
+        fastInnerHTML(optionElement, optionValue, sanitizer);
+        this.select.appendChild(optionElement);
+      });
+    }
   }
 
   /**
    * Creates consistent list of available options.
    *
    * @private
-   * @param {Array|object} optionsToPrepare The list of the values to render in the select eleemnt.
-   * @returns {object}
+   * @param {Array|object} optionsToPrepare The list of the values to render in the select element.
+   * @returns {Array|object}
    */
   prepareOptions(optionsToPrepare) {
-    let preparedOptions = {};
-
     if (Array.isArray(optionsToPrepare)) {
-      for (let i = 0, len = optionsToPrepare.length; i < len; i++) {
-        preparedOptions[optionsToPrepare[i]] = optionsToPrepare[i];
-      }
-
-    } else if (typeof optionsToPrepare === 'object') {
-      preparedOptions = optionsToPrepare;
+      return optionsToPrepare;
     }
 
-    return preparedOptions;
+    if (typeof optionsToPrepare === 'object') {
+      return optionsToPrepare;
+    }
+
+    return {};
   }
 
   /**


### PR DESCRIPTION
### Context

The PR fixes a bug where `SelectEditor` does not preserve the insertion order of `selectOptions` when the option values are numeric (especially when the array contains negative numbers). For example, `[-5, -4, ..., 12]` renders as `0, 1, 2, ..., 12, -5, -4, ..., -1` in the dropdown.

Root cause: `prepareOptions()` converted any array to a plain object using the option values as keys. JavaScript V8 sorts non-negative integer string keys numerically before regular string keys, so negative numbers (stored as string keys like `"-5"`) were always appended after `0–12`.

Fix: `prepareOptions()` now returns arrays as-is. The `prepare()` method handles arrays via a direct `for` loop (preserving insertion order) and falls back to `objectEach` for object-based options.

Fixes #9477.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1595

### How has this been tested?

Added a regression E2E test in `selectEditor.spec.js`:
- Creates a select column with `selectOptions: Array.from({ length: 18 }, (_, i) => -5 + i)` (i.e. -5 to 12)
- Opens the editor and asserts each `<option>` appears in the correct position

```bash
npm run test:e2e.dump --testPathPattern=selectEditor
npm run test:e2e.puppeteer --testPathPattern=selectEditor
# Result: 121 specs, 0 failures
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #9477
2. DEV-1595

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk bug fix localized to `SelectEditor` option rendering, with a regression test added to cover numeric/negative array ordering.
> 
> **Overview**
> Fixes `SelectEditor` option rendering so **array-based** `selectOptions` are rendered in insertion order (avoiding JS object key reordering for numeric/negative values) by keeping arrays as arrays and iterating them directly.
> 
> Adds a regression E2E spec covering negative-number `selectOptions` ordering, and includes a changelog entry for the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a0213c9cd43c5a7aeb4b784e928fa37a0483680. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->