### PR TITLE
DEV-1599: Fix paste with smart quotes and bare mid-cell quote chars

### DIFF
--- a/.changelogs/12488.json
+++ b/.changelogs/12488.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed pasting cells from Apple Numbers losing bare mid-cell quote characters and splitting into multiple rows.",
+  "type": "fixed",
+  "issueOrPR": 12488,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/SheetClip/SheetClip.js
+++ b/handsontable/src/3rdparty/SheetClip/SheetClip.js
@@ -16,6 +16,37 @@ const regNextCellNoQuotes = /^[^\t\r\n]+/;
 const regNextEmptyCell = /^\t/;
 
 /**
+ * Locate the structural closing `"` for a quoted cell starting at `str[0]`. A structural close is a
+ * `"` that is followed by a separator (`\t`, `\r`, `\n`) or end-of-string and is not part of an
+ * escaped pair `""`.
+ *
+ * @param {string} str Remaining input where `str[0]` is the first char after the opening `"`.
+ * @returns {number} Index of the structural closing `"` within `str`, or -1 when not found.
+ */
+function findQuoteCloseIndex(str) {
+  let i = 0;
+
+  while (i < str.length) {
+    if (str[i] === '"') {
+      if (str[i + 1] === '"') {
+        i += 2;
+        continue;
+      }
+
+      const next = str[i + 1];
+
+      if (next === undefined || next === '\t' || next === '\r' || next === '\n') {
+        return i;
+      }
+    }
+
+    i += 1;
+  }
+
+  return -1;
+}
+
+/**
  * Decode spreadsheet string into array.
  *
  * @param {string} str The string to parse.
@@ -57,27 +88,51 @@ export function parse(str) {
       let nextCell = '';
 
       if (str.startsWith('"')) {
-        let quoteNo = 0;
-        let isStillCell = true;
+        const closeIndex = findQuoteCloseIndex(str.slice(1));
 
-        while (isStillCell) {
-          const nextChar = str.slice(0, 1);
+        if (closeIndex !== -1) {
+          // Properly terminated quoted cell: read content up to the structural close, decoding
+          // escaped `""` to literal `"` and preserving any bare `"` chars that appear mid-cell.
+          let i = 0;
+          const content = str.slice(1);
 
-          if (nextChar === '"') {
-            quoteNo += 1;
+          while (i < closeIndex) {
+            if (content[i] === '"' && content[i + 1] === '"') {
+              nextCell += '"';
+              i += 2;
+            } else {
+              nextCell += content[i];
+              i += 1;
+            }
           }
 
-          nextCell += nextChar;
+          str = str.slice(closeIndex + 2);
 
-          str = str.slice(1);
+        } else {
+          // Fallback for malformed input without a structural closing quote: keep the legacy
+          // behavior of consuming quotes by parity and halving runs of `"` chars.
+          let quoteNo = 0;
+          let isStillCell = true;
 
-          if (str.length === 0 || (str.match(/^[\t\r\n]/) && quoteNo % 2 === 0)) {
-            isStillCell = false;
+          while (isStillCell) {
+            const nextChar = str.slice(0, 1);
+
+            if (nextChar === '"') {
+              quoteNo += 1;
+            }
+
+            nextCell += nextChar;
+
+            str = str.slice(1);
+
+            if (str.length === 0 || (str.match(/^[\t\r\n]/) && quoteNo % 2 === 0)) {
+              isStillCell = false;
+            }
           }
+
+          nextCell = nextCell.replace(/^"/, '').replace(/"$/, '')
+            .replace(/["]*/g, match => (new Array(Math.floor(match.length / 2))).fill('"').join(''));
         }
-
-        nextCell = nextCell.replace(/^"/, '').replace(/"$/, '')
-          .replace(/["]*/g, match => (new Array(Math.floor(match.length / 2))).fill('"').join(''));
 
       } else {
         const matchedText = str.match(regNextCellNoQuotes);

--- a/handsontable/src/3rdparty/SheetClip/test/SheetClip.unit.js
+++ b/handsontable/src/3rdparty/SheetClip/test/SheetClip.unit.js
@@ -237,5 +237,29 @@ describe('SheetClip', () => {
 
       expect(result).toEqual(expected);
     });
+
+    it('should keep a single quoted cell with bare mid-cell quote chars on one row (issue #11001)', () => {
+      // Apple Numbers exports a single cell that contains both smart quotes and bare ASCII
+      // double-quote characters. The structural closing `"` is followed by end-of-string, so
+      // the entire content (including bare `"`) must be parsed as one cell - never split on
+      // internal `\n`.
+      const entry = '"Test: stage line 2\nClick "check balance" on 42” tile.\nNote: text."';
+      const result = parse(entry);
+      const expected = [
+        ['Test: stage line 2\nClick "check balance" on 42” tile.\nNote: text.'],
+      ];
+
+      expect(result).toEqual(expected);
+    });
+
+    it('should keep a single quoted cell with bare mid-cell quotes when followed by tab-separated cell', () => {
+      const entry = '"Click "OK" now\nthen continue"\tNext';
+      const result = parse(entry);
+      const expected = [
+        ['Click "OK" now\nthen continue', 'Next'],
+      ];
+
+      expect(result).toEqual(expected);
+    });
   });
 });

--- a/handsontable/src/plugins/copyPaste/__tests__/paste.spec.js
+++ b/handsontable/src/plugins/copyPaste/__tests__/paste.spec.js
@@ -454,6 +454,22 @@ describe('CopyPaste', () => {
       expect(getDataAtCell(0, 0)).toEqual('very\r\nlong\r\n\r\ntext');
     });
 
+    it('should keep a single quoted cell with bare mid-cell quote chars on one row (issue #11001)', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 2),
+      });
+
+      await selectCell(0, 0);
+
+      // Apple Numbers wraps a multi-line cell with `"..."` and writes bare ASCII `"` chars
+      // (not `""`-escaped) inside the content. Internal `\n` characters must not split the
+      // cell into multiple rows, and bare `"` chars must be preserved.
+      triggerPaste('"Test: Some stage\nClick "check balance" on 42” tile.\nNote: text."');
+
+      expect(getDataAtCell(0, 0)).toBe('Test: Some stage\nClick "check balance" on 42” tile.\nNote: text.');
+      expect(getDataAtCell(1, 0)).toBe('A2');
+    });
+
     it('should properly paste data with excel-style multiline text', async() => {
       handsontable();
 


### PR DESCRIPTION
### Context

The PR fixes a bug where pasting a single cell copied from Apple Numbers (or any other source containing bare ASCII `"` characters mid-cell) would lose the embedded quote characters. The SheetClip parser counted `"` chars by parity, so an even number of bare mid-cell quotes (e.g. `"check balance"` inside a wrapping `"..."` cell) made the legacy halve-regex strip every internal `"`, and in some inputs split the cell across multiple rows.

The fix adds a `findQuoteCloseIndex` helper that finds the structural closing `"` (followed by `\t`, `\r`, `\n`, or end-of-string, ignoring escaped `""` pairs) and walks the cell content directly when one is found, decoding `""` to `"` and preserving any bare mid-cell `"` chars. When no structural close is found (genuinely malformed input), the parser falls back to the legacy parity-and-halve path so existing behavior is unchanged for those cases.

Fixes https://github.com/handsontable/handsontable/issues/11001

### How has this been tested?

- 2 new unit tests in `handsontable/src/3rdparty/SheetClip/test/SheetClip.unit.js` covering the bug case and a tab-separated variant.
- 1 new E2E test in `handsontable/src/plugins/copyPaste/__tests__/paste.spec.js` confirming the cell stays on one row and the bare `"` chars survive.
- All 2674 unit tests pass: `npm run test:unit --prefix handsontable`.
- All 42 paste E2E specs pass: `npm run test:e2e --prefix handsontable --testpathpattern=copyPaste/__tests__/paste`.
- Lint clean on changed files.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. #11001
2. DEV-1599

### Affected project(s):

- [x] \`handsontable\`
- [ ] \`@handsontable/angular-wrapper\`
- [ ] \`@handsontable/react-wrapper\`
- [ ] \`@handsontable/vue3\`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0 & w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1599

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core clipboard TSV parsing for quoted cells, which could affect how multiline/quoted paste data is split into rows/columns across different spreadsheet sources. Added fallback and tests reduce risk, but behavior changes may surface in edge paste formats.
> 
> **Overview**
> Fixes pasting from Apple Numbers where a quoted, multi-line *single cell* containing bare ASCII `"` characters could lose quotes and/or be split into multiple rows.
> 
> Updates `SheetClip.parse` to detect the *structural* closing quote via `findQuoteCloseIndex`, decode escaped `""` pairs, and preserve bare mid-cell quotes; malformed quoted input still uses the legacy parity-based path. Adds unit coverage for the Numbers-specific cases and an integration test in `copyPaste` paste specs, plus a changelog entry (`.changelogs/12488.json`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3c37c8c01caa4361b24457fa4339ad1893482d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->