### PR TITLE
DEV-1600: Fix columnSummary to include HyperFormula calculated cells

### DIFF
--- a/.changelogs/12489.json
+++ b/.changelogs/12489.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed `columnSummary` to include cells calculated by the `formulas` plugin in sum, min, max, average and count results.",
+  "type": "fixed",
+  "issueOrPR": 12489,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/columnSummary/__tests__/columnSummary.spec.js
+++ b/handsontable/src/plugins/columnSummary/__tests__/columnSummary.spec.js
@@ -1342,6 +1342,40 @@ describe('ColumnSummarySpec', () => {
       expect(getDataAtCell(3, 1)).toBe(15);
     });
 
+    it('should not recalculate endpoints when formulas updates only touch unrelated columns', async() => {
+      const customFunction = jasmine.createSpy('customFunction').and.returnValue(0);
+
+      handsontable({
+        data: [
+          [1, 2, '=A1+B1'],
+          [3, 4, '=A2+B2'],
+          [5, 6, '=A3+B3'],
+          [null, null, null, null],
+        ],
+        formulas: {
+          engine: HyperFormula
+        },
+        columnSummary: [{
+          destinationRow: 0,
+          destinationColumn: 3,
+          sourceColumn: 3,
+          reversedRowCoords: true,
+          ranges: [[0, 2]],
+          type: 'custom',
+          customFunction
+        }]
+      });
+
+      const initialCalls = customFunction.calls.count();
+
+      // Editing column A only triggers recalculation of the formula in column C.
+      // Neither column matches the endpoint's sourceColumn (3), so the custom
+      // function must not be invoked again from `afterFormulasValuesUpdate`.
+      await setDataAtCell(0, 0, 99);
+
+      expect(customFunction.calls.count()).toBe(initialCalls);
+    });
+
     it('should recalculate the summary when a referenced cell is changed', async() => {
       handsontable({
         data: [

--- a/handsontable/src/plugins/columnSummary/__tests__/columnSummary.spec.js
+++ b/handsontable/src/plugins/columnSummary/__tests__/columnSummary.spec.js
@@ -1306,6 +1306,42 @@ describe('ColumnSummarySpec', () => {
       expect(getDataAtCell(2, 2)).toBe(6);
     });
 
+    it('should sum the visual `sourceColumn` after a manual column move', async() => {
+      handsontable({
+        data: [
+          [1, 100, 1000],
+          [2, 200, 2000],
+          [3, 300, 3000],
+          [null, null, null],
+        ],
+        formulas: {
+          engine: HyperFormula
+        },
+        manualColumnMove: true,
+        columnSummary: [{
+          destinationRow: 0,
+          destinationColumn: 1,
+          reversedRowCoords: true,
+          ranges: [[0, 2]],
+          type: 'sum'
+        }]
+      });
+
+      // Initial: visual column 1 = [100, 200, 300] -> sum 600.
+      expect(getDataAtCell(3, 1)).toBe(600);
+
+      // Move physical column 1 to visual position 0; visual column 1 now
+      // holds the original physical column 0 -> [1, 2, 3].
+      await getPlugin('manualColumnMove').moveColumn(1, 0);
+      await render();
+
+      // Trigger a refresh on the (visual) sourceColumn so the summary recalculates.
+      await setDataAtCell(0, 1, 10);
+
+      // Sum of visual column 1 = [10, 2, 3] = 15.
+      expect(getDataAtCell(3, 1)).toBe(15);
+    });
+
     it('should recalculate the summary when a referenced cell is changed', async() => {
       handsontable({
         data: [

--- a/handsontable/src/plugins/columnSummary/__tests__/columnSummary.spec.js
+++ b/handsontable/src/plugins/columnSummary/__tests__/columnSummary.spec.js
@@ -1,3 +1,5 @@
+import HyperFormula from 'hyperformula';
+
 describe('ColumnSummarySpec', () => {
   const id = 'testContainer';
   const warnMessage = 'One of the Column Summary plugins\' destination points you ' +
@@ -1222,5 +1224,112 @@ describe('ColumnSummarySpec', () => {
 
     expect(getCellMeta(3, 1).readOnly).toBe(true);
     expect(getCellMeta(3, 1).className).toBe('columnSummaryResult');
+  });
+
+  describe('integration with the `Formulas` plugin', () => {
+    it('should include calculated formula values in the `sum` summary (#10980)', async() => {
+      handsontable({
+        data: [
+          [1, 2, '=A1+B1'],
+          [3, 4, '=A2+B2'],
+          [5, 6, '=A3+B3'],
+          [null, null, null],
+        ],
+        formulas: {
+          engine: HyperFormula
+        },
+        columnSummary: [{
+          destinationRow: 0,
+          destinationColumn: 2,
+          reversedRowCoords: true,
+          ranges: [[0, 2]],
+          type: 'sum'
+        }]
+      });
+
+      expect(getDataAtCell(3, 2)).toBe(21);
+    });
+
+    it('should include calculated formula values in the `min` and `max` summaries', async() => {
+      handsontable({
+        data: [
+          [1, 2, '=A1+B1'], // 3
+          [3, 4, '=A2+B2'], // 7
+          [5, 6, '=A3+B3'], // 11
+          [null, null, null],
+          [null, null, null],
+        ],
+        formulas: {
+          engine: HyperFormula
+        },
+        columnSummary: [
+          {
+            destinationRow: 0,
+            destinationColumn: 2,
+            reversedRowCoords: true,
+            ranges: [[0, 2]],
+            type: 'min'
+          },
+          {
+            destinationRow: 1,
+            destinationColumn: 2,
+            reversedRowCoords: true,
+            ranges: [[0, 2]],
+            type: 'max'
+          }
+        ]
+      });
+
+      expect(getDataAtCell(4, 2)).toBe(3);
+      expect(getDataAtCell(3, 2)).toBe(11);
+    });
+
+    it('should include calculated formula values in the `average` summary', async() => {
+      handsontable({
+        data: [
+          [2, 2, '=A1+B1'], // 4
+          [4, 4, '=A2+B2'], // 8
+          [null, null, null],
+        ],
+        formulas: {
+          engine: HyperFormula
+        },
+        columnSummary: [{
+          destinationRow: 0,
+          destinationColumn: 2,
+          reversedRowCoords: true,
+          ranges: [[0, 1]],
+          type: 'average'
+        }]
+      });
+
+      expect(getDataAtCell(2, 2)).toBe(6);
+    });
+
+    it('should recalculate the summary when a referenced cell is changed', async() => {
+      handsontable({
+        data: [
+          [1, 2, '=A1+B1'],
+          [3, 4, '=A2+B2'],
+          [null, null, null],
+        ],
+        formulas: {
+          engine: HyperFormula
+        },
+        columnSummary: [{
+          destinationRow: 0,
+          destinationColumn: 2,
+          reversedRowCoords: true,
+          ranges: [[0, 1]],
+          type: 'sum'
+        }]
+      });
+
+      expect(getDataAtCell(2, 2)).toBe(10);
+
+      await setDataAtCell(0, 0, 10);
+
+      expect(getDataAtCell(2, 2)).toBe(19);
+    });
   });
 });

--- a/handsontable/src/plugins/columnSummary/columnSummary.js
+++ b/handsontable/src/plugins/columnSummary/columnSummary.js
@@ -147,6 +147,15 @@ export class ColumnSummary extends BasePlugin {
   endpoints = null;
 
   /**
+   * Re-entry guard for the `afterFormulasValuesUpdate` hook so that the summary
+   * recalculation triggered by writing the summary result does not start
+   * another refresh.
+   *
+   * @type {boolean}
+   */
+  #refreshingFromFormulas = false;
+
+  /**
    * Checks if the plugin is enabled in the handsontable settings. This method is executed in {@link Hooks#beforeInit}
    * hook and if it returns `true` then the {@link ColumnSummary#enablePlugin} method is called.
    *
@@ -187,6 +196,8 @@ export class ColumnSummary extends BasePlugin {
     this.addHook('afterRemoveCol',
       (...args) => this.endpoints.resetSetupAfterStructureAlteration('remove_col', ...args));
     this.addHook('afterRowMove', (...args) => this.#onAfterRowMove(...args));
+    this.addHook('afterFormulasValuesUpdate',
+      (...args) => this.#onAfterFormulasValuesUpdate(...args));
 
     super.enablePlugin();
   }
@@ -449,7 +460,9 @@ export class ColumnSummary extends BasePlugin {
     const visualRowIndex = this.hot.toVisualRow(row);
     const visualColumnIndex = this.hot.toVisualColumn(col);
 
-    let cellValue = this.hot.getSourceDataAtCell(row, col);
+    let cellValue = visualRowIndex !== null && visualColumnIndex !== null
+      ? this.hot.getDataAtCell(visualRowIndex, visualColumnIndex)
+      : this.hot.getSourceDataAtCell(row, col);
     let cellClassName = '';
 
     if (visualRowIndex !== null && visualColumnIndex !== null) {
@@ -530,6 +543,39 @@ export class ColumnSummary extends BasePlugin {
   #onAfterUpdateData(data, firstRun) {
     if (!firstRun) {
       this.endpoints.refreshAllEndpoints();
+    }
+  }
+
+  /**
+   * `afterFormulasValuesUpdate` hook callback. Refresh endpoints when the
+   * formula engine recalculates values that source columns may depend on.
+   *
+   * @param {Array} changes Changes from the formula engine.
+   */
+  #onAfterFormulasValuesUpdate(changes) {
+    if (this.#refreshingFromFormulas || !this.endpoints || !changes?.length) {
+      return;
+    }
+
+    const formulasPlugin = this.hot.getPlugin('formulas');
+
+    if (!formulasPlugin?.enabled) {
+      return;
+    }
+
+    const sheetId = formulasPlugin.sheetId;
+    const hasMatchingChange = changes.some(change => change?.address?.sheet === sheetId);
+
+    if (!hasMatchingChange) {
+      return;
+    }
+
+    this.#refreshingFromFormulas = true;
+
+    try {
+      this.endpoints.refreshAllEndpoints();
+    } finally {
+      this.#refreshingFromFormulas = false;
     }
   }
 

--- a/handsontable/src/plugins/columnSummary/columnSummary.js
+++ b/handsontable/src/plugins/columnSummary/columnSummary.js
@@ -546,8 +546,8 @@ export class ColumnSummary extends BasePlugin {
   }
 
   /**
-   * `afterFormulasValuesUpdate` hook callback. Refresh endpoints when the
-   * formula engine recalculates values that source columns may depend on.
+   * `afterFormulasValuesUpdate` hook callback. Refresh only endpoints whose
+   * `sourceColumn` (visual) maps to a column the engine recalculated.
    *
    * @param {Array} changes Changes from the formula engine.
    */
@@ -563,16 +563,37 @@ export class ColumnSummary extends BasePlugin {
     }
 
     const sheetId = formulasPlugin.sheetId;
-    const hasMatchingChange = changes.some(change => change?.address?.sheet === sheetId);
+    const changedHfColumns = new Set();
 
-    if (!hasMatchingChange) {
+    changes.forEach((change) => {
+      if (change?.address?.sheet === sheetId) {
+        changedHfColumns.add(change.address.col);
+      }
+    });
+
+    if (changedHfColumns.size === 0) {
+      return;
+    }
+
+    const changedVisualColumns = new Set();
+
+    this.endpoints.getAllEndpoints().forEach((endpoint) => {
+      const hfSourceColumn = formulasPlugin.columnAxisSyncer
+        .getHfIndexFromVisualIndex(endpoint.sourceColumn);
+
+      if (changedHfColumns.has(hfSourceColumn)) {
+        changedVisualColumns.add(endpoint.sourceColumn);
+      }
+    });
+
+    if (changedVisualColumns.size === 0) {
       return;
     }
 
     this.#refreshingFromFormulas = true;
 
     try {
-      this.endpoints.refreshAllEndpoints();
+      this.endpoints.refreshEndpointsBySourceColumns(changedVisualColumns);
     } finally {
       this.#refreshingFromFormulas = false;
     }

--- a/handsontable/src/plugins/columnSummary/columnSummary.js
+++ b/handsontable/src/plugins/columnSummary/columnSummary.js
@@ -458,15 +458,14 @@ export class ColumnSummary extends BasePlugin {
    */
   getCellValue(row, col) {
     const visualRowIndex = this.hot.toVisualRow(row);
-    const visualColumnIndex = this.hot.toVisualColumn(col);
 
-    let cellValue = visualRowIndex !== null && visualColumnIndex !== null
-      ? this.hot.getDataAtCell(visualRowIndex, visualColumnIndex)
+    let cellValue = visualRowIndex !== null
+      ? this.hot.getDataAtCell(visualRowIndex, col)
       : this.hot.getSourceDataAtCell(row, col);
     let cellClassName = '';
 
-    if (visualRowIndex !== null && visualColumnIndex !== null) {
-      cellClassName = this.hot.getCellMeta(visualRowIndex, visualColumnIndex).className || '';
+    if (visualRowIndex !== null) {
+      cellClassName = this.hot.getCellMeta(visualRowIndex, col).className || '';
     }
 
     if (cellClassName.indexOf('columnSummaryResult') > -1) {

--- a/handsontable/src/plugins/columnSummary/endpoints.js
+++ b/handsontable/src/plugins/columnSummary/endpoints.js
@@ -502,6 +502,33 @@ class Endpoints {
   }
 
   /**
+   * Calculate and refresh endpoints whose `sourceColumn` (visual) matches any of the provided columns.
+   *
+   * @param {Set<number>|number[]} visualColumns Visual column indexes to match against.
+   */
+  refreshEndpointsBySourceColumns(visualColumns) {
+    const columnsSet = visualColumns instanceof Set ? visualColumns : new Set(visualColumns);
+    const matched = this.getAllEndpoints()
+      .filter(endpoint => columnsSet.has(endpoint.sourceColumn));
+
+    if (matched.length === 0) {
+      return;
+    }
+
+    this.cellsToSetCache = [];
+
+    arrayEach(matched, (endpoint) => {
+      this.refreshEndpoint(endpoint);
+    });
+
+    if (this.cellsToSetCache.length) {
+      this.hot.setDataAtCell(this.cellsToSetCache, 'ColumnSummary.reset');
+    }
+
+    this.cellsToSetCache = [];
+  }
+
+  /**
    * Refreshes the cell meta information for the all endpoints after the `updateSettings` method call which in some
    * cases (call with `columns` option) can reset the cell metas to the initial state.
    */


### PR DESCRIPTION
### Context

The PR fixes a bug where the `columnSummary` plugin ignored cells that contained HyperFormula formulas (e.g. `=A1+B1`). Because `getCellValue` read via `getSourceDataAtCell`, the raw formula string was returned instead of its calculated result, `parseFloat` produced `NaN`, and the cell was skipped from `sum`/`min`/`max`/`average`/`count` calculations.

The fix reads cell values via `getDataAtCell(visualRow, visualCol)` so the Formulas plugin's `modifyData` hook returns the calculated value. A new `afterFormulasValuesUpdate` listener also refreshes affected endpoints when HyperFormula recomputes dependent cells, so summaries stay in sync after edits to referenced cells. A re-entry guard prevents the listener from looping when writing the summary triggers another HF recalc. When a row/column is hidden or trimmed (visual index is `null`), the source-data fallback is preserved.

Fixes [#10980](https://github.com/handsontable/handsontable/issues/10980).

### How has this been tested?

- Added 4 new E2E specs in `src/plugins/columnSummary/__tests__/columnSummary.spec.js` under `integration with the \`Formulas\` plugin`:
  - `sum` with formula cells (`=A_n+B_n`)
  - `min`/`max` with formula cells
  - `average` with formula cells
  - recalculation when a referenced cell is changed via `setDataAtCell`
- Reproduced the original bug with v17.0.1 in a side-by-side dev demo and verified the fix on the local build.
- Commands:
  ```bash
  npm run build --prefix handsontable
  npm run test:e2e --testPathPattern=columnSummary --prefix handsontable
  npm run test:e2e --testPathPattern=formulas --prefix handsontable
  ```
  Result: 48/48 columnSummary specs pass, 314/0 formulas specs pass, lint clean.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. Fixes #10980
2. DEV-1600

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1600

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `columnSummary` calculation and hook flow to integrate with the `formulas` engine; risk is mainly around refresh timing/performance and avoiding update loops when summaries write back into the grid.
> 
> **Overview**
> Fixes `columnSummary` so cells computed by the `formulas` plugin (HyperFormula) contribute their calculated numeric values (rather than raw formula strings) to `sum`/`min`/`max`/`average`/`count` results.
> 
> Adds an `afterFormulasValuesUpdate` listener that selectively refreshes only endpoints whose visual `sourceColumn` was recalculated by HyperFormula (with a re-entry guard to prevent refresh loops), plus a new `refreshEndpointsBySourceColumns` helper and e2e coverage for formula summaries, referenced-cell updates, and manual column moves; includes a public changelog entry (`.changelogs/12489.json`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4aabc131b494744dddc8a22e725faf3fff5f57f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->