### PR TITLE
DEV-1270: Fix auto-save-backend recipe example bugs (Angular zone, font size, validation)

### DIFF
--- a/docs/content/recipes/data-management/auto-save-backend/angular/example1.ts
+++ b/docs/content/recipes/data-management/auto-save-backend/angular/example1.ts
@@ -1,5 +1,5 @@
 /* file: app.component.ts */
-import { Component, ViewChild } from '@angular/core';
+import { Component, NgZone, ViewChild, inject } from '@angular/core';
 import { GridSettings, HotTableComponent, HotTableModule } from '@handsontable/angular-wrapper';
 import Handsontable from 'handsontable/base';
 
@@ -16,7 +16,7 @@ type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
 const STATUS_LABELS: Record<SaveStatus, string> = {
   idle: 'No pending changes',
   saving: 'Saving...',
-  saved: 'Saved \u2713',
+  saved: 'Saved ✓',
   error: 'Error',
 };
 
@@ -33,7 +33,7 @@ const STATUS_COLORS: Record<SaveStatus, string> = {
   selector: 'example1-auto-save-backend',
   template: `
     <div
-      class="auto-save-status"
+      style="margin-bottom: 8px; font-family: Arial, sans-serif; font-size: 13px; font-weight: 600;"
       [style.color]="statusColor"
     >{{ statusLabel }}</div>
     <hot-table [data]="hotData" [settings]="hotSettings"></hot-table>
@@ -41,6 +41,8 @@ const STATUS_COLORS: Record<SaveStatus, string> = {
 })
 export class AppComponent {
   @ViewChild(HotTableComponent, { static: false }) readonly hotTable!: HotTableComponent;
+
+  private readonly ngZone = inject(NgZone);
 
   saveStatus: SaveStatus = 'idle';
 
@@ -64,12 +66,12 @@ export class AppComponent {
   private saveTimeout: ReturnType<typeof setTimeout> | null = null;
   private saveRequestCounter = 0;
 
-  private async saveRowsToBackend(rows: RowData[]): Promise<void> {
-    await new Promise((resolve) => setTimeout(resolve, 450));
-
-    // Replace with fetch('/api/products', { method: 'PATCH', body: ... }) in production.
-    // eslint-disable-next-line no-console
-    console.log('PATCH /api/products', rows);
+  private saveRowsToBackend(rows: RowData[]): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, 450)).then(() => {
+      // Replace with fetch('/api/products', { method: 'PATCH', body: ... }) in production.
+      // eslint-disable-next-line no-console
+      console.log('PATCH /api/products', rows);
+    });
   }
 
   readonly hotSettings: GridSettings = {
@@ -109,7 +111,7 @@ export class AppComponent {
         clearTimeout(this.saveTimeout);
       }
 
-      this.saveTimeout = setTimeout(async () => {
+      this.saveTimeout = setTimeout(() => {
         const physicalRows = Array.from(this.dirtyRows);
 
         if (physicalRows.length === 0) {
@@ -117,26 +119,48 @@ export class AppComponent {
         }
 
         const requestId = ++this.saveRequestCounter;
-        const rowsToSave = physicalRows
-          .map((physicalRow) => hot.getSourceDataAtRow(physicalRow))
-          .filter((row): row is RowData => row !== undefined && row !== null);
+        const visualRows = physicalRows
+          .map((physicalRow) => hot.toVisualRow(physicalRow))
+          .filter((row): row is number => row !== null);
 
-        this.dirtyRows.clear();
-        this.saveStatus = 'saving';
+        hot.validateRows(visualRows, (valid) => {
+          if (!valid) {
+            if (requestId === this.saveRequestCounter) {
+              this.ngZone.run(() => {
+                this.saveStatus = 'error';
+              });
+            }
 
-        try {
-          await this.saveRowsToBackend(rowsToSave);
-
-          if (requestId === this.saveRequestCounter) {
-            this.saveStatus = 'saved';
+            return;
           }
-        } catch (_error) {
-          physicalRows.forEach((physicalRow) => this.dirtyRows.add(physicalRow));
 
-          if (requestId === this.saveRequestCounter) {
-            this.saveStatus = 'error';
-          }
-        }
+          const rowsToSave = physicalRows
+            .map((physicalRow) => hot.getSourceDataAtRow(physicalRow))
+            .filter((row): row is RowData => row !== undefined && row !== null);
+
+          this.dirtyRows.clear();
+          this.ngZone.run(() => {
+            this.saveStatus = 'saving';
+          });
+
+          void this.saveRowsToBackend(rowsToSave)
+            .then(() => {
+              if (requestId === this.saveRequestCounter) {
+                this.ngZone.run(() => {
+                  this.saveStatus = 'saved';
+                });
+              }
+            })
+            .catch(() => {
+              physicalRows.forEach((physicalRow) => this.dirtyRows.add(physicalRow));
+
+              if (requestId === this.saveRequestCounter) {
+                this.ngZone.run(() => {
+                  this.saveStatus = 'error';
+                });
+              }
+            });
+        });
       }, 800);
     },
   };

--- a/docs/content/recipes/data-management/auto-save-backend/javascript/example1.js
+++ b/docs/content/recipes/data-management/auto-save-backend/javascript/example1.js
@@ -46,12 +46,12 @@ if (container instanceof HTMLElement) {
     statusEl.dataset.state = state;
   };
 
-  const saveRowsToBackend = async (rows) => {
-    await new Promise((resolve) => setTimeout(resolve, 450));
-
-    // Replace this with fetch('/api/products', { method: 'PATCH', body: ... }) in production.
-    // eslint-disable-next-line no-console
-    console.log('PATCH /api/products', rows);
+  const saveRowsToBackend = (rows) => {
+    return new Promise((resolve) => setTimeout(resolve, 450)).then(() => {
+      // Replace this with fetch('/api/products', { method: 'PATCH', body: ... }) in production.
+      // eslint-disable-next-line no-console
+      console.log('PATCH /api/products', rows);
+    });
   };
 
   const hot = new Handsontable(container, {
@@ -86,7 +86,7 @@ if (container instanceof HTMLElement) {
         clearTimeout(saveTimeout);
       }
 
-      saveTimeout = setTimeout(async () => {
+      saveTimeout = setTimeout(() => {
         const physicalRows = Array.from(dirtyRows);
 
         if (physicalRows.length === 0) {
@@ -94,26 +94,40 @@ if (container instanceof HTMLElement) {
         }
 
         const requestId = ++saveRequestCounter;
-        const rowsToSave = physicalRows
-          .map((physicalRow) => hot.getSourceDataAtRow(physicalRow))
-          .filter((row) => row !== undefined && row !== null);
+        const visualRows = physicalRows
+          .map((physicalRow) => hot.toVisualRow(physicalRow))
+          .filter((row) => row !== null);
 
-        dirtyRows.clear();
-        setSaveStatus('saving');
+        hot.validateRows(visualRows, (valid) => {
+          if (!valid) {
+            if (requestId === saveRequestCounter) {
+              setSaveStatus('error');
+            }
 
-        try {
-          await saveRowsToBackend(rowsToSave);
-
-          if (requestId === saveRequestCounter) {
-            setSaveStatus('saved');
+            return;
           }
-        } catch (_error) {
-          physicalRows.forEach((physicalRow) => dirtyRows.add(physicalRow));
 
-          if (requestId === saveRequestCounter) {
-            setSaveStatus('error');
-          }
-        }
+          const rowsToSave = physicalRows
+            .map((physicalRow) => hot.getSourceDataAtRow(physicalRow))
+            .filter((row) => row !== undefined && row !== null);
+
+          dirtyRows.clear();
+          setSaveStatus('saving');
+
+          void saveRowsToBackend(rowsToSave)
+            .then(() => {
+              if (requestId === saveRequestCounter) {
+                setSaveStatus('saved');
+              }
+            })
+            .catch(() => {
+              physicalRows.forEach((physicalRow) => dirtyRows.add(physicalRow));
+
+              if (requestId === saveRequestCounter) {
+                setSaveStatus('error');
+              }
+            });
+        });
       }, 800);
     },
   });

--- a/docs/content/recipes/data-management/auto-save-backend/javascript/example1.ts
+++ b/docs/content/recipes/data-management/auto-save-backend/javascript/example1.ts
@@ -54,12 +54,12 @@ if (container instanceof HTMLElement) {
     statusEl.dataset.state = state;
   };
 
-  const saveRowsToBackend = async (rows: RowData[]) => {
-    await new Promise((resolve) => setTimeout(resolve, 450));
-
-    // Replace this with fetch('/api/products', { method: 'PATCH', body: ... }) in production.
-    // eslint-disable-next-line no-console
-    console.log('PATCH /api/products', rows);
+  const saveRowsToBackend = (rows: RowData[]): Promise<void> => {
+    return new Promise((resolve) => setTimeout(resolve, 450)).then(() => {
+      // Replace this with fetch('/api/products', { method: 'PATCH', body: ... }) in production.
+      // eslint-disable-next-line no-console
+      console.log('PATCH /api/products', rows);
+    });
   };
 
   const hot = new Handsontable(container, {
@@ -94,7 +94,7 @@ if (container instanceof HTMLElement) {
         clearTimeout(saveTimeout);
       }
 
-      saveTimeout = setTimeout(async () => {
+      saveTimeout = setTimeout(() => {
         const physicalRows = Array.from(dirtyRows);
 
         if (physicalRows.length === 0) {
@@ -102,26 +102,40 @@ if (container instanceof HTMLElement) {
         }
 
         const requestId = ++saveRequestCounter;
-        const rowsToSave = physicalRows
-          .map((physicalRow) => hot.getSourceDataAtRow(physicalRow))
-          .filter((row): row is RowData => row !== undefined && row !== null);
+        const visualRows = physicalRows
+          .map((physicalRow) => hot.toVisualRow(physicalRow))
+          .filter((row): row is number => row !== null);
 
-        dirtyRows.clear();
-        setSaveStatus('saving');
+        hot.validateRows(visualRows, (valid) => {
+          if (!valid) {
+            if (requestId === saveRequestCounter) {
+              setSaveStatus('error');
+            }
 
-        try {
-          await saveRowsToBackend(rowsToSave);
-
-          if (requestId === saveRequestCounter) {
-            setSaveStatus('saved');
+            return;
           }
-        } catch (_error) {
-          physicalRows.forEach((physicalRow) => dirtyRows.add(physicalRow));
 
-          if (requestId === saveRequestCounter) {
-            setSaveStatus('error');
-          }
-        }
+          const rowsToSave = physicalRows
+            .map((physicalRow) => hot.getSourceDataAtRow(physicalRow))
+            .filter((row): row is RowData => row !== undefined && row !== null);
+
+          dirtyRows.clear();
+          setSaveStatus('saving');
+
+          void saveRowsToBackend(rowsToSave)
+            .then(() => {
+              if (requestId === saveRequestCounter) {
+                setSaveStatus('saved');
+              }
+            })
+            .catch(() => {
+              physicalRows.forEach((physicalRow) => dirtyRows.add(physicalRow));
+
+              if (requestId === saveRequestCounter) {
+                setSaveStatus('error');
+              }
+            });
+        });
       }, 800);
     },
   });

--- a/docs/content/recipes/data-management/auto-save-backend/react/example1.jsx
+++ b/docs/content/recipes/data-management/auto-save-backend/react/example1.jsx
@@ -15,7 +15,7 @@ const data = [
 const statusLabels = {
   idle: 'No pending changes',
   saving: 'Saving...',
-  saved: 'Saved \u2713',
+  saved: 'Saved ✓',
   error: 'Error',
 };
 
@@ -26,12 +26,12 @@ const statusColors = {
   error: '#c62828',
 };
 
-const saveRowsToBackend = async (rows) => {
-  await new Promise((resolve) => setTimeout(resolve, 450));
-
-  // Replace this with fetch('/api/products', { method: 'PATCH', body: ... }) in production.
-  // eslint-disable-next-line no-console
-  console.log('PATCH /api/products', rows);
+const saveRowsToBackend = (rows) => {
+  return new Promise((resolve) => setTimeout(resolve, 450)).then(() => {
+    // Replace this with fetch('/api/products', { method: 'PATCH', body: ... }) in production.
+    // eslint-disable-next-line no-console
+    console.log('PATCH /api/products', rows);
+  });
 };
 
 const ExampleComponent = () => {
@@ -66,7 +66,7 @@ const ExampleComponent = () => {
       clearTimeout(saveTimeoutRef.current);
     }
 
-    saveTimeoutRef.current = setTimeout(async () => {
+    saveTimeoutRef.current = setTimeout(() => {
       const physicalRows = Array.from(dirtyRowsRef.current);
 
       if (physicalRows.length === 0) {
@@ -74,26 +74,40 @@ const ExampleComponent = () => {
       }
 
       const requestId = ++saveRequestCounterRef.current;
-      const rowsToSave = physicalRows
-        .map((physicalRow) => hot.getSourceDataAtRow(physicalRow))
-        .filter((row) => row !== undefined && row !== null);
+      const visualRows = physicalRows
+        .map((physicalRow) => hot.toVisualRow(physicalRow))
+        .filter((row) => row !== null);
 
-      dirtyRowsRef.current.clear();
-      setSaveStatus('saving');
+      hot.validateRows(visualRows, (valid) => {
+        if (!valid) {
+          if (requestId === saveRequestCounterRef.current) {
+            setSaveStatus('error');
+          }
 
-      try {
-        await saveRowsToBackend(rowsToSave);
-
-        if (requestId === saveRequestCounterRef.current) {
-          setSaveStatus('saved');
+          return;
         }
-      } catch (_error) {
-        physicalRows.forEach((physicalRow) => dirtyRowsRef.current.add(physicalRow));
 
-        if (requestId === saveRequestCounterRef.current) {
-          setSaveStatus('error');
-        }
-      }
+        const rowsToSave = physicalRows
+          .map((physicalRow) => hot.getSourceDataAtRow(physicalRow))
+          .filter((row) => row !== undefined && row !== null);
+
+        dirtyRowsRef.current.clear();
+        setSaveStatus('saving');
+
+        void saveRowsToBackend(rowsToSave)
+          .then(() => {
+            if (requestId === saveRequestCounterRef.current) {
+              setSaveStatus('saved');
+            }
+          })
+          .catch(() => {
+            physicalRows.forEach((physicalRow) => dirtyRowsRef.current.add(physicalRow));
+
+            if (requestId === saveRequestCounterRef.current) {
+              setSaveStatus('error');
+            }
+          });
+      });
     }, 800);
   };
 

--- a/docs/content/recipes/data-management/auto-save-backend/react/example1.tsx
+++ b/docs/content/recipes/data-management/auto-save-backend/react/example1.tsx
@@ -17,7 +17,7 @@ type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
 const statusLabels: Record<SaveStatus, string> = {
   idle: 'No pending changes',
   saving: 'Saving...',
-  saved: 'Saved \u2713',
+  saved: 'Saved ✓',
   error: 'Error',
 };
 
@@ -28,12 +28,12 @@ const statusColors: Record<SaveStatus, string> = {
   error: '#c62828',
 };
 
-const saveRowsToBackend = async (rows: unknown[]): Promise<void> => {
-  await new Promise<void>((resolve) => setTimeout(resolve, 450));
-
-  // Replace this with fetch('/api/products', { method: 'PATCH', body: ... }) in production.
-  // eslint-disable-next-line no-console
-  console.log('PATCH /api/products', rows);
+const saveRowsToBackend = (rows: unknown[]): Promise<void> => {
+  return new Promise<void>((resolve) => setTimeout(resolve, 450)).then(() => {
+    // Replace this with fetch('/api/products', { method: 'PATCH', body: ... }) in production.
+    // eslint-disable-next-line no-console
+    console.log('PATCH /api/products', rows);
+  });
 };
 
 const ExampleComponent = () => {
@@ -71,7 +71,7 @@ const ExampleComponent = () => {
       clearTimeout(saveTimeoutRef.current);
     }
 
-    saveTimeoutRef.current = setTimeout(async () => {
+    saveTimeoutRef.current = setTimeout(() => {
       const physicalRows = Array.from(dirtyRowsRef.current);
 
       if (physicalRows.length === 0) {
@@ -79,26 +79,40 @@ const ExampleComponent = () => {
       }
 
       const requestId = ++saveRequestCounterRef.current;
-      const rowsToSave = physicalRows
-        .map((physicalRow) => hot.getSourceDataAtRow(physicalRow))
-        .filter((row) => row !== undefined && row !== null);
+      const visualRows = physicalRows
+        .map((physicalRow) => hot.toVisualRow(physicalRow))
+        .filter((row): row is number => row !== null);
 
-      dirtyRowsRef.current.clear();
-      setSaveStatus('saving');
+      hot.validateRows(visualRows, (valid) => {
+        if (!valid) {
+          if (requestId === saveRequestCounterRef.current) {
+            setSaveStatus('error');
+          }
 
-      try {
-        await saveRowsToBackend(rowsToSave);
-
-        if (requestId === saveRequestCounterRef.current) {
-          setSaveStatus('saved');
+          return;
         }
-      } catch (_error) {
-        physicalRows.forEach((physicalRow) => dirtyRowsRef.current.add(physicalRow));
 
-        if (requestId === saveRequestCounterRef.current) {
-          setSaveStatus('error');
-        }
-      }
+        const rowsToSave = physicalRows
+          .map((physicalRow) => hot.getSourceDataAtRow(physicalRow))
+          .filter((row) => row !== undefined && row !== null);
+
+        dirtyRowsRef.current.clear();
+        setSaveStatus('saving');
+
+        void saveRowsToBackend(rowsToSave)
+          .then(() => {
+            if (requestId === saveRequestCounterRef.current) {
+              setSaveStatus('saved');
+            }
+          })
+          .catch(() => {
+            physicalRows.forEach((physicalRow) => dirtyRowsRef.current.add(physicalRow));
+
+            if (requestId === saveRequestCounterRef.current) {
+              setSaveStatus('error');
+            }
+          });
+      });
     }, 800);
   };
 


### PR DESCRIPTION
### Context

The PR fixes three bugs in the auto-save-backend recipe example (`docs/content/recipes/data-management/auto-save-backend/`):

1. **Angular save status stuck on "Saving..."** - The `afterChange` hook runs outside Angular's zone (the wrapper uses `ngZone.runOutsideAngular()` internally), so `this.saveStatus = 'saving'` / `'saved'` / `'error'` assignments never triggered change detection. Fixed by injecting `NgZone` via `inject(NgZone)` and wrapping every status update with `this.ngZone.run(...)`.

2. **Angular status font too large** - The Angular template used a bare `class="auto-save-status"` with no font-size/family/weight rules, so it inherited the docs site's default body text size instead of the intended 13px. Fixed by adding the same inline `style` attributes as the React and JS examples (`font-size: 13px; font-family: Arial, sans-serif; font-weight: 600; margin-bottom: 8px`).

3. **Entering invalid numeric value triggers save and shows "Saved"** - There was no client-side validation before the debounced save fired. Fixed in all three frameworks (Angular, React, JS) by converting the physical dirty-row indices to visual indices and calling `hot.validateRows(visualRows, callback)` before the save. If validation fails the status shows "Error" and no request is sent.

ClickUp task: https://app.clickup.com/t/86c9b3awm

### How has this been tested?

- Manually verified on https://dev.handsontable.com/docs/angular-data-grid/recipes/data-management/auto-save-backend/ against all three reported scenarios
- Confirmed Angular status label transitions correctly through idle → saving → saved → error
- Confirmed Angular font size matches React and JS examples
- Confirmed entering "abc" in a numeric column shows "Error" and no PATCH log appears in all three frameworks

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1270

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvAYWB4JHYMECWJDgpa2ut)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-example-only changes that adjust UI styling and debounce/validation flow; primary risk is behavior drift in the sample code paths across frameworks.
> 
> **Overview**
> Fixes the `auto-save-backend` recipe examples so save-status UI updates reliably and saves don’t fire when the grid contains invalid data.
> 
> In the Angular example, save status updates are now executed inside `NgZone` and the status header styling is inlined to match the JS/React examples. Across Angular/React/JS, the debounced save now runs `hot.validateRows()` (mapping dirty *physical* rows to *visual* rows) before sending the save, and the mock save helper is refactored to a promise chain; the “Saved” label is also standardized to `Saved ✓`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71e460eb034f120bbe94b7ea97b9ffd578a0adb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->