### PR TITLE
DEV-1603: Fix React renderer flicker / cleared cells after edit (#10800)

### DIFF
--- a/.changelogs/12494.json
+++ b/.changelogs/12494.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed React component renderers being unmounted and visibly cleared on every grid render after a cell edit.",
+  "type": "fixed",
+  "issueOrPR": 12494,
+  "breaking": false,
+  "framework": "react"
+}

--- a/wrappers/react-wrapper/src/helpers.tsx
+++ b/wrappers/react-wrapper/src/helpers.tsx
@@ -173,16 +173,22 @@ export function createPortal(rElement: React.ReactElement, ownerDocument: Docume
     ownerDocument = document;
   }
 
-  if (!bulkComponentContainer) {
-    bulkComponentContainer = ownerDocument.createDocumentFragment();
-  }
+  let portalContainer = cachedContainer;
 
-  const portalContainer = cachedContainer ?? ownerDocument.createElement('DIV');
-  bulkComponentContainer.appendChild(portalContainer);
+  // A new container needs an anchor before React mounts into it. A cached
+  // container is already attached (typically inside its TD) and must be
+  // left in place to avoid wiping the DOM on every grid render.
+  if (!portalContainer) {
+    if (!bulkComponentContainer) {
+      bulkComponentContainer = ownerDocument.createDocumentFragment();
+    }
+    portalContainer = ownerDocument.createElement('DIV');
+    bulkComponentContainer.appendChild(portalContainer);
+  }
 
   return {
     portal: ReactDOM.createPortal(rElement, portalContainer, portalKey),
-    portalContainer
+    portalContainer,
   };
 }
 

--- a/wrappers/react-wrapper/src/hotTableContext.tsx
+++ b/wrappers/react-wrapper/src/hotTableContext.tsx
@@ -88,45 +88,44 @@ const HotTableContextProvider: FC<PropsWithChildren> = ({ children }) => {
       // Handsontable.Core type is missing guid
       const instanceGuid = (instance as unknown as { guid: string }).guid;
 
-      const portalContainerKey = `${instanceGuid}-${key}`
-      const portalKey = `${key}-${instanceGuid}`
-
-      if (renderedCellCache.current.has(key)) {
-        TD.innerHTML = renderedCellCache.current.get(key)!.innerHTML;
-      }
+      const portalContainerKey = `${instanceGuid}-${key}`;
+      const portalKey = `${key}-${instanceGuid}`;
 
       if (TD && !TD.getAttribute('ghost-table')) {
-        const cachedPortal = portalCache.current.get(portalKey);
         const cachedPortalContainer = portalContainerCache.current.get(portalContainerKey);
+        // When the cached portal container is still attached to the same
+        // TD as the previous render, the DOM is already correct and must
+        // not be wiped. Wiping detaches the React-managed children, which
+        // forces a full remount of the renderer component on every grid
+        // render (see issue #10800).
+        const containerInPlace = !!cachedPortalContainer && cachedPortalContainer.parentNode === TD;
 
-        while (TD.firstChild) {
-          TD.removeChild(TD.firstChild);
-        }
+        const rendererElement = (
+          <Renderer instance={instance}
+                    TD={TD}
+                    row={row}
+                    col={col}
+                    prop={prop}
+                    value={value}
+                    cellProperties={cellProperties}/>
+        );
 
-        // if portal already exists, do not recreate
-        if (cachedPortal && cachedPortalContainer) {
-          TD.appendChild(cachedPortalContainer);
-        } else {
-          const rendererElement = (
-            <Renderer instance={instance}
-                      TD={TD}
-                      row={row}
-                      col={col}
-                      prop={prop}
-                      value={value}
-                      cellProperties={cellProperties}/>
-          );
+        const { portal, portalContainer } = createPortal(
+          rendererElement, TD.ownerDocument, portalKey, cachedPortalContainer
+        );
 
-          const {portal, portalContainer} = createPortal(rendererElement, TD.ownerDocument, portalKey, cachedPortalContainer);
-
-          portalContainerCache.current.set(portalContainerKey, portalContainer);
+        if (!containerInPlace) {
+          while (TD.firstChild) {
+            TD.removeChild(TD.firstChild);
+          }
           TD.appendChild(portalContainer);
-
-          portalCache.current.set(portalKey, portal);
         }
+
+        portalContainerCache.current.set(portalContainerKey, portalContainer);
+        portalCache.current.set(portalKey, portal);
       }
 
-      renderedCellCache.current.set(`${row}-${col}`, TD);
+      renderedCellCache.current.set(key, TD);
       return TD;
     };
   }, []);

--- a/wrappers/react-wrapper/test/componentInternals.spec.tsx
+++ b/wrappers/react-wrapper/test/componentInternals.spec.tsx
@@ -150,4 +150,125 @@ describe('Component lifecyle', () => {
 
     console.warn = warnFunc;
   });
+
+  // Regression tests for issue #10800 — custom React renderer components were
+  // unmounted and their portal container DIVs detached from the TD on every
+  // grid render, causing a visible flicker and loss of component-local state.
+  it('should not detach the portal container DIV from any TD when a single cell is edited (#10800)', async () => {
+    function StableCell(props: HotRendererProps) {
+      return (
+        <span data-cell={`${props.row}-${props.col}`}>{String(props.value)}</span>
+      );
+    }
+
+    const hotInstance = mountComponentWithRef<HotTableRef>((
+      <HotTable licenseKey="non-commercial-and-evaluation"
+                id="test-hot"
+                data={createSpreadsheetData(4, 3)}
+                width={300}
+                height={300}
+                rowHeights={23}
+                colWidths={50}
+                autoRowSize={false}
+                autoColumnSize={false}
+                init={function () {
+                  mockElementDimensions(this.rootElement, 300, 300);
+                }}
+                renderer={(props) => <StableCell {...props} />}
+      />
+    ), false).hotInstance!;
+
+    await sleep(100);
+
+    let detachedTdCount = 0;
+    const observer = new MutationObserver((records) => {
+      for (const rec of records) {
+        if (
+          rec.type === 'childList' &&
+          rec.target instanceof HTMLTableCellElement &&
+          rec.removedNodes.length > 0
+        ) {
+          detachedTdCount += rec.removedNodes.length;
+        }
+      }
+    });
+
+    observer.observe(hotInstance.rootElement, { childList: true, subtree: true });
+
+    await act(async () => {
+      hotInstance.setDataAtCell(0, 0, 'edited');
+    });
+
+    await sleep(50);
+
+    // Flush any queued mutation records so they are reflected in the count.
+    observer.takeRecords().forEach((rec) => {
+      if (
+        rec.type === 'childList' &&
+        rec.target instanceof HTMLTableCellElement &&
+        rec.removedNodes.length > 0
+      ) {
+        detachedTdCount += rec.removedNodes.length;
+      }
+    });
+    observer.disconnect();
+
+    expect(detachedTdCount).toEqual(0);
+  });
+
+  it('should preserve renderer component state across grid renders (#10800)', async () => {
+    let nextSeed = 0;
+
+    function SeededCell(props: HotRendererProps) {
+      // useState initialiser runs once per mount. If the wrapper remounts the
+      // component on every render, the seed will change.
+      const [seed] = React.useState(() => {
+        nextSeed += 1;
+        return nextSeed;
+      });
+
+      return (
+        <span data-seed={seed} data-cell={`${props.row}-${props.col}`}>
+          {String(props.value)}
+        </span>
+      );
+    }
+
+    const hotInstance = mountComponentWithRef<HotTableRef>((
+      <HotTable licenseKey="non-commercial-and-evaluation"
+                id="test-hot"
+                data={createSpreadsheetData(4, 3)}
+                width={300}
+                height={300}
+                rowHeights={23}
+                colWidths={50}
+                autoRowSize={false}
+                autoColumnSize={false}
+                init={function () {
+                  mockElementDimensions(this.rootElement, 300, 300);
+                }}
+                renderer={(props) => <SeededCell {...props} />}
+      />
+    ), false).hotInstance!;
+
+    await sleep(100);
+
+    const seedsBefore = Array.from(
+      hotInstance.rootElement.querySelectorAll<HTMLElement>('span[data-seed]')
+    ).map((el) => `${el.dataset.cell}:${el.dataset.seed}`);
+
+    expect(seedsBefore.length).toEqual(4 * 3);
+
+    await act(async () => {
+      hotInstance.setDataAtCell(0, 0, 'edited');
+    });
+
+    await sleep(50);
+
+    const seedsAfter = Array.from(
+      hotInstance.rootElement.querySelectorAll<HTMLElement>('span[data-seed]')
+    ).map((el) => `${el.dataset.cell}:${el.dataset.seed}`);
+
+    expect(seedsAfter).toEqual(seedsBefore);
+  });
 });


### PR DESCRIPTION
### Context

The PR fixes [#10800](https://github.com/handsontable/handsontable/issues/10800). When a `HotTable` from `@handsontable/react-wrapper` uses a component-based cell renderer, every grid render (including the one triggered after a single cell edit) detached and re-attached the React portal container DIV inside every visible TD. Symptoms reported by users:

- The whole grid flashes/flickers after editing one cell.
- At a DevTools breakpoint inside the renderer, all other TDs are momentarily empty.
- Cell-local React state (e.g. `useState` initial values) was reset on grids using the legacy `@handsontable/react` package.

Root cause sat in two places in the wrapper:

- `helpers.createPortal` always moved the portal container into the internal `bulkComponentContainer` `DocumentFragment`, even when the caller passed a cached container that was still attached to its TD. That detached the live DOM and forced React to commit on a moved target.
- `hotTableContext.getRendererWrapper` unconditionally wiped the TD (`while (TD.firstChild) TD.removeChild(...)`) and re-attached the cached container on every render. It also re-read and rewrote `TD.innerHTML` from a cache that always pointed back to the same TD, which reparses the HTML string, replaces the live DOM nodes with clones, and orphans the React portal target.

After the fix:

- A cached container is left in place and reused; the TD is only wiped when the container is not already a child of the TD passed in (e.g. on a Walkontable TD recycle or first render of a cell).
- `createPortal` only anchors freshly created containers in the document fragment.
- The redundant `TD.innerHTML` reparse is removed.
- React reconciles the new portal element against the same key + same `containerInfo`, so the renderer component receives updated props without unmounting.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1603

### How has this been tested?

Added two regression tests in `wrappers/react-wrapper/test/componentInternals.spec.tsx`:

- `should not detach the portal container DIV from any TD when a single cell is edited (#10800)` — uses a `MutationObserver` to count `removedNodes` on TD targets after `setDataAtCell`. On `develop` the count is `12` (a 4×3 grid is fully wiped); with this fix it is `0`.
- `should preserve renderer component state across grid renders (#10800)` — captures per-cell `useState`-seeded `data-seed` attributes before and after an edit and asserts they are unchanged. Acts as a guard against future regressions in the portal/container caching.

```bash
npm run build --prefix handsontable
npm run build --prefix wrappers/react-wrapper
npm run test --prefix wrappers/react-wrapper -- --testPathPattern componentInternals --testTimeout=60000
```

Result with the fix: 5/5 tests pass. Without the fix the new TD-detach test fails as expected.

The pre-existing 8 timeout-related failures in `hotColumn.spec.tsx` / `hotTable.spec.tsx` are present on `develop` as well and are unrelated to this change.

Manual verification: a `dev-generated.html` page comparing `handsontable@14.1.0` + `@handsontable/react@14.1.0` (CDN, original buggy versions) against the local PR build was used to confirm the flicker disappears and that 0 TD detaches occur per edit (vs 40 in v14).

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. https://github.com/handsontable/handsontable/issues/10800
2. DEV-1603

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [x] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the React wrapper’s cell renderer/portal mounting logic; mistakes could cause rendering glitches or memory leaks across rerenders, but scope is limited to portal container reuse behavior and is covered by new regression tests.
> 
> **Overview**
> Fixes React cell renderer flicker/state resets by **stopping unnecessary TD DOM wipes and portal container detaches** during grid rerenders after edits.
> 
> `createPortal` now only anchors *new* portal containers in the internal `DocumentFragment`, while `getRendererWrapper` reuses an existing cached container in-place (only clearing/reattaching when the container isn’t already a child of the current TD). Adds regression tests to ensure no TD child removals occur on single-cell edits and that renderer component state is preserved across rerenders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01f402fcd8dae2009f06226190fa04c2cab4a5a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->