### PR TITLE
DEV-1604: Update ClickUp MCP configuration and documentation

### DIFF
--- a/.ai/MCP.md
+++ b/.ai/MCP.md
@@ -34,13 +34,15 @@ If you prefer OAuth instead of a bearer token, remove the `headers` block from `
 
 Project-level MCP servers for Cursor are configured in `.cursor/mcp.json`. This file is committed.
 
-The bearer token is stored as a Cursor secret:
+ClickUp is configured as an **HTTP** MCP server (`url` + `headers`). Cursor resolves secrets in `headers` using **`${env:VARIABLE_NAME}`** syntax where needed (see [Cursor MCP docs](https://cursor.com/docs/context/mcp) — Config interpolation).
 
-1. Open Cursor Settings > MCP.
-2. Find the `clickup` entry and click the lock icon next to `CLICKUP_API_TOKEN`.
-3. Enter your ClickUp personal API token.
+The committed `.cursor/mcp.json` sets **`x-workspace-id`** to the shared team workspace (numeric ID, fixed in the file). You only need a **`CLICKUP_API_TOKEN`** in your environment for the `Authorization` header.
 
-Alternatively, set the variable in your shell environment (`export CLICKUP_API_TOKEN=pk_...`) and Cursor will pick it up via `${CLICKUP_API_TOKEN}` in `.cursor/mcp.json`.
+Set it in the environment Cursor inherits (shell profile, or your OS user environment), then restart Cursor:
+
+```bash
+export CLICKUP_API_TOKEN=pk_your_token_here
+```
 
 ### Verifying the setup
 
@@ -67,8 +69,9 @@ Once connected, the following tools are available to AI assistants:
 |---|---|
 | `clickup` server not listed in `/mcp` | Run `claude mcp list` to check config; verify `.mcp.json` exists at repo root |
 | `401 Unauthorized` errors | Token is wrong or expired; update `CLICKUP_API_TOKEN` in your shell profile and restart Claude Code |
-| OAuth prompt keeps appearing | Switch to bearer token auth (set `CLICKUP_API_TOKEN` and add `headers` block) |
-| Cursor shows server as disconnected | Check that `CLICKUP_API_TOKEN` is set in Cursor secrets or shell env |
+| OAuth prompt keeps appearing | Switch to bearer token auth: set `CLICKUP_API_TOKEN` and restore the `headers` block in `.cursor/mcp.json` |
+| Cursor shows server as disconnected | Set `CLICKUP_API_TOKEN`; restart Cursor so `${env:CLICKUP_API_TOKEN}` resolves |
+| Wrong space or "not found" from ClickUp tools | Token may be for another workspace, or `x-workspace-id` in `.cursor/mcp.json` does not match the workspace you use. Adjust `x-workspace-id` locally if needed (see Cursor setup above) |
 
 ---
 

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -3,7 +3,8 @@
     "clickup": {
       "url": "https://mcp.clickup.com/mcp",
       "headers": {
-        "Authorization": "Bearer ${CLICKUP_API_TOKEN}"
+        "Authorization": "Bearer ${env:CLICKUP_API_TOKEN}",
+        "x-workspace-id": "9015210959"
       }
     },
     "github": {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->

Cursor was not connecting cleanly to ClickUp’s hosted HTTP MCP (https://mcp.clickup.com/mcp). The committed `.cursor/mcp.json` used `Authorization: Bearer ${CLICKUP_API_TOKEN}`, which does not match Cursor’s documented interpolation form (`${env:CLICKUP_API_TOKEN}`), so the token often failed to resolve and the server stayed disconnected or misconfigured.
ClickUp’s MCP also expects a workspace scope. Without an `x-workspace-id` header, calls can fail or target the wrong context. That header should not depend on each developer guessing an env var when the team uses one primary workspace.
Contributor docs in `.ai/MCP.md` still described setting the token via Cursor MCP secrets UI (lock icon). That flow did not match the committed JSON-first setup and did not explain HTTP transport, `${env:…}`, or workspace scope.

ClickUp task: [DEV-1604](https://app.clickup.com/t/86c9nxq28)

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Manual testing of the MCP connection in Cursor

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/config-only change; main risk is mis-scoping ClickUp requests if the committed `x-workspace-id` is wrong for a developer’s workspace.
> 
> **Overview**
> Fixes Cursor’s ClickUp MCP connection by updating `.cursor/mcp.json` to use Cursor’s `${env:CLICKUP_API_TOKEN}` interpolation and by adding a fixed `x-workspace-id` header for the team workspace.
> 
> Updates `.ai/MCP.md` to match the new Cursor setup (HTTP server config, env var setup/restart steps) and expands troubleshooting for OAuth prompts, disconnected servers, and workspace mismatches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 934269e36e704dbe498c87f51132af2d41875697. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



[skip changelog]