### PR TITLE
DEV-1605: Preserve active cell direction after autofill (#10771)

### DIFF
--- a/.changelogs/12498.json
+++ b/.changelogs/12498.json
@@ -2,7 +2,7 @@
   "issuesOrigin": "public",
   "title": "Fixed an issue where the active cell flipped to the top-start corner after autofill, causing `getSelected` to report incorrect start/end coordinates. The selection direction now matches the drag direction (like Google Sheets and Excel).",
   "type": "fixed",
-  "issueOrPR": 10771,
+  "issueOrPR": 12498,
   "breaking": false,
   "framework": "none"
 }

--- a/.changelogs/12498.json
+++ b/.changelogs/12498.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed an issue where the active cell flipped to the top-start corner after autofill, causing `getSelected` to report incorrect start/end coordinates. The selection direction now matches the drag direction (like Google Sheets and Excel).",
+  "type": "fixed",
+  "issueOrPR": 10771,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/autofill/__tests__/autofill.spec.js
+++ b/handsontable/src/plugins/autofill/__tests__/autofill.spec.js
@@ -1802,5 +1802,33 @@ describe('AutoFill', () => {
 
       expect(getSelected()).toEqual([[1, 1, 4, 2]]);
     });
+
+    it('should still allow double-click fill after a reversed (upward) autofill drag', async() => {
+      handsontable({
+        data: [
+          [null, 'a'],
+          ['X', 'b'],
+          [null, 'c'],
+          [null, 'd'],
+          [null, 'e'],
+        ],
+        fillHandle: true,
+      });
+
+      await selectCell(1, 0);
+
+      simulateFillHandleDrag($(getCell(0, 0, true)));
+
+      expect(getSelectedRange()).toEqualCellRange(['highlight: 1,0 from: 1,0 to: 0,0']);
+      expect(getDataAtCell(0, 0)).toBe('X');
+
+      const fillHandle = spec().$container.find('.wtBorder.current.corner')[0];
+
+      await mouseDoubleClick(fillHandle);
+
+      expect(getDataAtCell(2, 0)).toBe('X');
+      expect(getDataAtCell(3, 0)).toBe('X');
+      expect(getDataAtCell(4, 0)).toBe('X');
+    });
   });
 });

--- a/handsontable/src/plugins/autofill/__tests__/autofill.spec.js
+++ b/handsontable/src/plugins/autofill/__tests__/autofill.spec.js
@@ -1748,9 +1748,7 @@ describe('AutoFill', () => {
 
       simulateFillHandleDrag($(getCell(3, 1, true)));
 
-      expect(getSelected()).toEqual([[1, 1, 3, 1]]);
-      expect(getSelectedRangeLast().highlight.row).toBe(1);
-      expect(getSelectedRangeLast().highlight.col).toBe(1);
+      expect(getSelectedRange()).toEqualCellRange(['highlight: 1,1 from: 1,1 to: 3,1']);
     });
 
     it('should keep the active cell at the original position when dragging the fill handle up', async() => {
@@ -1763,9 +1761,7 @@ describe('AutoFill', () => {
 
       simulateFillHandleDrag($(getCell(1, 1, true)));
 
-      expect(getSelected()).toEqual([[3, 1, 1, 1]]);
-      expect(getSelectedRangeLast().highlight.row).toBe(3);
-      expect(getSelectedRangeLast().highlight.col).toBe(1);
+      expect(getSelectedRange()).toEqualCellRange(['highlight: 3,1 from: 3,1 to: 1,1']);
     });
 
     it('should keep the active cell at the original position when dragging the fill handle right', async() => {
@@ -1778,9 +1774,7 @@ describe('AutoFill', () => {
 
       simulateFillHandleDrag($(getCell(1, 3, true)));
 
-      expect(getSelected()).toEqual([[1, 1, 1, 3]]);
-      expect(getSelectedRangeLast().highlight.row).toBe(1);
-      expect(getSelectedRangeLast().highlight.col).toBe(1);
+      expect(getSelectedRange()).toEqualCellRange(['highlight: 1,1 from: 1,1 to: 1,3']);
     });
 
     it('should keep the active cell at the original position when dragging the fill handle left', async() => {
@@ -1793,9 +1787,7 @@ describe('AutoFill', () => {
 
       simulateFillHandleDrag($(getCell(1, 1, true)));
 
-      expect(getSelected()).toEqual([[1, 3, 1, 1]]);
-      expect(getSelectedRangeLast().highlight.row).toBe(1);
-      expect(getSelectedRangeLast().highlight.col).toBe(3);
+      expect(getSelectedRange()).toEqualCellRange(['highlight: 1,3 from: 1,3 to: 1,1']);
     });
 
     it('should preserve the multi-cell selection direction when extending downward', async() => {

--- a/handsontable/src/plugins/autofill/__tests__/autofill.spec.js
+++ b/handsontable/src/plugins/autofill/__tests__/autofill.spec.js
@@ -1736,4 +1736,79 @@ describe('AutoFill', () => {
 
     style.remove();
   });
+
+  describe('selection direction after autofill (#10771)', () => {
+    it('should keep the active cell at the original position when dragging the fill handle down', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        fillHandle: true,
+      });
+
+      await selectCell(1, 1);
+
+      simulateFillHandleDrag($(getCell(3, 1, true)));
+
+      expect(getSelected()).toEqual([[1, 1, 3, 1]]);
+      expect(getSelectedRangeLast().highlight.row).toBe(1);
+      expect(getSelectedRangeLast().highlight.col).toBe(1);
+    });
+
+    it('should keep the active cell at the original position when dragging the fill handle up', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        fillHandle: true,
+      });
+
+      await selectCell(3, 1);
+
+      simulateFillHandleDrag($(getCell(1, 1, true)));
+
+      expect(getSelected()).toEqual([[3, 1, 1, 1]]);
+      expect(getSelectedRangeLast().highlight.row).toBe(3);
+      expect(getSelectedRangeLast().highlight.col).toBe(1);
+    });
+
+    it('should keep the active cell at the original position when dragging the fill handle right', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        fillHandle: true,
+      });
+
+      await selectCell(1, 1);
+
+      simulateFillHandleDrag($(getCell(1, 3, true)));
+
+      expect(getSelected()).toEqual([[1, 1, 1, 3]]);
+      expect(getSelectedRangeLast().highlight.row).toBe(1);
+      expect(getSelectedRangeLast().highlight.col).toBe(1);
+    });
+
+    it('should keep the active cell at the original position when dragging the fill handle left', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        fillHandle: true,
+      });
+
+      await selectCell(1, 3);
+
+      simulateFillHandleDrag($(getCell(1, 1, true)));
+
+      expect(getSelected()).toEqual([[1, 3, 1, 1]]);
+      expect(getSelectedRangeLast().highlight.row).toBe(1);
+      expect(getSelectedRangeLast().highlight.col).toBe(3);
+    });
+
+    it('should preserve the multi-cell selection direction when extending downward', async() => {
+      handsontable({
+        data: createSpreadsheetData(6, 6),
+        fillHandle: true,
+      });
+
+      await selectCell(1, 1, 2, 2);
+
+      simulateFillHandleDrag($(getCell(4, 2, true)));
+
+      expect(getSelected()).toEqual([[1, 1, 4, 2]]);
+    });
+  });
 });

--- a/handsontable/src/plugins/autofill/autofill.js
+++ b/handsontable/src/plugins/autofill/autofill.js
@@ -409,11 +409,11 @@ export class Autofill extends BasePlugin {
    */
   addNewRowIfNeeded() {
     if (!this.hot.selection.highlight.getFill().isEmpty() && this.addingStarted === false && this.autoInsertRow) {
-      const cornersOfSelectedCells = this.hot.getSelectedLast();
+      const bottomRow = this.hot.getSelectedRangeLast().getBottomEndCorner().row;
       const cornersOfSelectedDragArea = this.hot.selection.highlight.getFill().getVisualCorners();
       const nrOfTableRows = this.hot.countRows();
 
-      if (cornersOfSelectedCells[2] < nrOfTableRows - 1 && cornersOfSelectedDragArea[2] === nrOfTableRows - 1) {
+      if (bottomRow < nrOfTableRows - 1 && cornersOfSelectedDragArea[2] === nrOfTableRows - 1) {
         this.addingStarted = true;
 
         this.addRow();
@@ -523,7 +523,10 @@ export class Autofill extends BasePlugin {
    * @returns {boolean}
    */
   selectAdjacent() {
-    const cornersOfSelectedCells = this.hot.getSelectedLast();
+    const range = this.hot.getSelectedRangeLast();
+    const topStart = range.getTopStartCorner();
+    const bottomEnd = range.getBottomEndCorner();
+    const cornersOfSelectedCells = [topStart.row, topStart.col, bottomEnd.row, bottomEnd.col];
     const lastFilledInRowIndex = this.getIndexOfLastAdjacentFilledInRow(cornersOfSelectedCells);
 
     if (lastFilledInRowIndex === -1 || lastFilledInRowIndex === undefined) {

--- a/handsontable/src/plugins/autofill/autofill.js
+++ b/handsontable/src/plugins/autofill/autofill.js
@@ -490,10 +490,8 @@ export class Autofill extends BasePlugin {
     let toCol = maxCol;
 
     if (sourceRange) {
-      const preMinRow = Math.min(sourceRange.from.row, sourceRange.to.row);
-      const preMaxRow = Math.max(sourceRange.from.row, sourceRange.to.row);
-      const preMinCol = Math.min(sourceRange.from.col, sourceRange.to.col);
-      const preMaxCol = Math.max(sourceRange.from.col, sourceRange.to.col);
+      const { row: preMinRow, col: preMinCol } = sourceRange.getTopStartCorner();
+      const { row: preMaxRow, col: preMaxCol } = sourceRange.getBottomEndCorner();
 
       if (minRow < preMinRow) {
         fromRow = maxRow; // dragged up - anchor stays at the (preserved) bottom

--- a/handsontable/src/plugins/autofill/autofill.js
+++ b/handsontable/src/plugins/autofill/autofill.js
@@ -377,7 +377,7 @@ export class Autofill extends BasePlugin {
         null
       );
 
-      this.setSelection(cornersOfSelectionAndDragAreas);
+      this.setSelection(cornersOfSelectionAndDragAreas, sourceRange);
       this.hot.runHooks('afterAutofill', fillData, sourceRange, targetRange, directionOfDrag);
       this.hot.render();
 
@@ -472,11 +472,50 @@ export class Autofill extends BasePlugin {
   /**
    * Sets selection based on passed corners.
    *
+   * When `sourceRange` is provided, the active cell (`from`) is anchored to the corner
+   * of the merged selection that wasn't extended by the autofill drag. This keeps the
+   * highlight at its pre-fill position instead of flipping to the top-start corner,
+   * matching Google Sheets and Excel behavior.
+   *
    * @private
    * @param {Array} cornersOfArea An array witch defines selection.
+   * @param {CellRange} [sourceRange] Pre-fill selection range used to preserve the
+   *                                  original `from` corner orientation.
    */
-  setSelection(cornersOfArea) {
-    this.hot.selectCell(...arrayMap(cornersOfArea, index => Math.max(index, 0)), false, false);
+  setSelection(cornersOfArea, sourceRange) {
+    const [minRow, minCol, maxRow, maxCol] = arrayMap(cornersOfArea, index => Math.max(index, 0));
+    let fromRow = minRow;
+    let fromCol = minCol;
+    let toRow = maxRow;
+    let toCol = maxCol;
+
+    if (sourceRange) {
+      const preMinRow = Math.min(sourceRange.from.row, sourceRange.to.row);
+      const preMaxRow = Math.max(sourceRange.from.row, sourceRange.to.row);
+      const preMinCol = Math.min(sourceRange.from.col, sourceRange.to.col);
+      const preMaxCol = Math.max(sourceRange.from.col, sourceRange.to.col);
+
+      if (minRow < preMinRow) {
+        fromRow = maxRow; // dragged up - anchor stays at the (preserved) bottom
+      } else if (maxRow > preMaxRow) {
+        fromRow = minRow; // dragged down - anchor stays at the (preserved) top
+      } else {
+        fromRow = sourceRange.from.row === preMinRow ? minRow : maxRow;
+      }
+
+      if (minCol < preMinCol) {
+        fromCol = maxCol; // dragged left - anchor stays at the (preserved) right
+      } else if (maxCol > preMaxCol) {
+        fromCol = minCol; // dragged right - anchor stays at the (preserved) left
+      } else {
+        fromCol = sourceRange.from.col === preMinCol ? minCol : maxCol;
+      }
+
+      toRow = fromRow === minRow ? maxRow : minRow;
+      toCol = fromCol === minCol ? maxCol : minCol;
+    }
+
+    this.hot.selectCell(fromRow, fromCol, toRow, toCol, false, false);
   }
 
   /**


### PR DESCRIPTION
### Context

The PR fixes [#10771](https://github.com/handsontable/handsontable/issues/10771) - after dragging the fill handle, `getSelected()` always returned the top-left corner as the start, regardless of the drag direction. The active cell flipped to the top-start corner of the merged range, which made `getSelected()` inconsistent with Google Sheets and Excel.

The selection's `from` corner is now anchored to the side of the merged range that wasn't extended by the autofill drag, preserving the original active cell direction. For multi-cell pre-fill selections where the row or column dimension is unchanged, the original `from`/`to` orientation is kept.

### How has this been tested?

- Added a `selection direction after autofill (#10771)` describe block in `handsontable/src/plugins/autofill/__tests__/autofill.spec.js` covering down, up, right, left drags from a single cell, plus a multi-cell drag.
- Verified the existing autofill suite still passes:
  ```
  npm run test:e2e --testPathPattern=autofill --prefix handsontable
  # 166 specs, 0 failures, 2 pending
  ```
- Lint clean:
  ```
  npm run lint --prefix handsontable
  ```
- Manual verification via `handsontable/dev-generated.html` (CDN v14.6.1 vs local PR build) - dragging B4 → B2 (up) returns `[[3, 1, 1, 1]]` on the fix vs `[[1, 1, 3, 1]]` on the released version.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. Fixes #10771
2. DEV-1605

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1605

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the autofill plugin re-applies selection after filling, which can affect downstream selection-dependent behavior (e.g., `getSelected()` results and follow-up autofill actions). Covered by new directional tests, but still touches core selection logic.
> 
> **Overview**
> Fixes autofill so the *active cell/selection `from` corner* no longer flips to the top-left after a fill-handle drag; the resulting selection direction now matches the drag direction (Sheets/Excel-style), improving `getSelected()`/`getSelectedRange()` consistency.
> 
> Updates `Autofill#setSelection` to accept the pre-fill `sourceRange` and compute `from`/`to` based on which side was extended, and adjusts selection-corner calculations to rely on `getSelectedRangeLast()` APIs. Adds an autofill test suite covering up/down/left/right drags, multi-cell extension, and ensuring double-click fill still works after a reversed drag, plus a changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1c6b8e51949d7aa8d03949299f10589dd1e67be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->