### PR TITLE
DEV-1208: Fix React selection example always using multiple range mode

### DIFF
--- a/docs/content/guides/cell-features/selection/react/example1.jsx
+++ b/docs/content/guides/cell-features/selection/react/example1.jsx
@@ -12,7 +12,6 @@ const options = [
 ];
 
 const ExampleComponent = () => {
-  const hotRef = useRef(null);
   const dropdownRef = useRef(null);
   const [isOpen, setIsOpen] = useState(false);
   const [selected, setSelected] = useState('multiple');
@@ -41,7 +40,6 @@ const ExampleComponent = () => {
   const handleSelect = (value) => {
     setSelected(value);
     setIsOpen(false);
-    hotRef.current?.hotInstance?.updateSettings({ selectionMode: value });
   };
 
   const selectedLabel = options.find((o) => o.value === selected)?.label;
@@ -79,7 +77,6 @@ const ExampleComponent = () => {
         </div>
       </div>
       <HotTable
-        ref={hotRef}
         data={[
           ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1'],
           ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2', 'H2', 'I2'],
@@ -96,7 +93,7 @@ const ExampleComponent = () => {
         colWidths={100}
         rowHeaders={true}
         colHeaders={true}
-        selectionMode="multiple"
+        selectionMode={selected}
         autoWrapRow={true}
         autoWrapCol={true}
         licenseKey="non-commercial-and-evaluation"

--- a/docs/content/guides/cell-features/selection/react/example1.tsx
+++ b/docs/content/guides/cell-features/selection/react/example1.tsx
@@ -1,6 +1,5 @@
-import { useRef, useState, useEffect, RefObject } from 'react';
-import Handsontable from 'handsontable/base';
-import { HotTable, HotTableRef } from '@handsontable/react-wrapper';
+import { useRef, useState, useEffect } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
 
 // register Handsontable's modules
@@ -13,7 +12,6 @@ const options: { value: string; label: string }[] = [
 ];
 
 const ExampleComponent = () => {
-  const hotRef = useRef<HotTableRef>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const [isOpen, setIsOpen] = useState(false);
   const [selected, setSelected] = useState('multiple');
@@ -42,7 +40,6 @@ const ExampleComponent = () => {
   const handleSelect = (value: string) => {
     setSelected(value);
     setIsOpen(false);
-    hotRef.current?.hotInstance?.updateSettings({ selectionMode: value } as Handsontable.GridSettings);
   };
 
   const selectedLabel = options.find((o) => o.value === selected)?.label;
@@ -80,7 +77,6 @@ const ExampleComponent = () => {
         </div>
       </div>
       <HotTable
-        ref={hotRef}
         data={[
           ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1'],
           ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2', 'H2', 'I2'],
@@ -97,7 +93,7 @@ const ExampleComponent = () => {
         colWidths={100}
         rowHeaders={true}
         colHeaders={true}
-        selectionMode="multiple"
+        selectionMode={selected as 'single' | 'range' | 'multiple'}
         autoWrapRow={true}
         autoWrapCol={true}
         licenseKey="non-commercial-and-evaluation"


### PR DESCRIPTION
### Context

The PR fixes the React selection example on the docs selection guide page. The example provides a dropdown to switch between single, range, and multiple selection modes, but it always behaved as if multiple range selection was active regardless of the chosen option.

The root cause: `selectionMode="multiple"` was hardcoded as a static prop on `<HotTable>`. When the user picked a new mode from the dropdown, `handleSelect` called `updateSettings` to apply the change -- but it also called `setSelected` and `setIsOpen`, both of which trigger a React re-render. On re-render, the hardcoded `selectionMode="multiple"` prop was passed back to the wrapper, overriding the `updateSettings` call immediately.

The fix is idiomatic React: drive `selectionMode` from the `selected` state variable as a prop (`selectionMode={selected}`). The wrapper internally calls `updateSettings` when the prop value changes, so no manual `updateSettings` call is needed. The `hotRef` and the `Handsontable` import (used only for the type cast) are also removed as they became unused.

This matches how the Angular and JS vanilla examples already work.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1208

### How has this been tested?

- Manual verification: open the React selection example, switch between all three modes, confirm each mode restricts selection correctly (single cell, contiguous range, multiple non-adjacent ranges with Ctrl/Cmd).
- The Angular and JS examples serve as the reference implementation - both already use the correct pattern.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1208

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ho7dQbPEBkQHoXDGcvSd4G)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that adjusts a React example’s state/props wiring; the only impact is on displayed example behavior.
> 
> **Overview**
> Fixes the React selection-mode docs example so the dropdown actually changes Handsontable’s selection behavior.
> 
> The example now drives `HotTable`’s `selectionMode` from React state (`selectionMode={selected}`) instead of hardcoding `"multiple"` and imperatively calling `updateSettings`, removing the unused `hotRef` and related TS-only imports/casts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3cc398ba6e97912af1bd34175cfa8909b89ad8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->