### PR TITLE
DEV-1608: Fix Angular docs redirects for versions 12.1-15.3

### DIFF
--- a/docs/netlify/_redirects
+++ b/docs/netlify/_redirects
@@ -3,24 +3,25 @@
 /docs/:version/redirect pageId=:pageId /docs/:version
 /docs/redirect pageId=:pageId /docs 301
 
-# Angular docs are available from 16.0+ only.
-/docs/15.3/angular-data-grid/* /docs/javascript-data-grid/ 301
-/docs/15.2/angular-data-grid/* /docs/javascript-data-grid/ 301
-/docs/15.1/angular-data-grid/* /docs/javascript-data-grid/ 301
-/docs/15.0/angular-data-grid/* /docs/javascript-data-grid/ 301
-/docs/14.6/angular-data-grid/* /docs/javascript-data-grid/ 301
-/docs/14.5/angular-data-grid/* /docs/javascript-data-grid/ 301
-/docs/14.4/angular-data-grid/* /docs/javascript-data-grid/ 301
-/docs/14.3/angular-data-grid/* /docs/javascript-data-grid/ 301
-/docs/14.2/angular-data-grid/* /docs/javascript-data-grid/ 301
-/docs/14.1/angular-data-grid/* /docs/javascript-data-grid/ 301
-/docs/14.0/angular-data-grid/* /docs/javascript-data-grid/ 301
-/docs/13.1/angular-data-grid/* /docs/javascript-data-grid/ 301
-/docs/13.0/angular-data-grid/* /docs/javascript-data-grid/ 301
-/docs/12.4/angular-data-grid/* /docs/javascript-data-grid/ 301
-/docs/12.3/angular-data-grid/* /docs/javascript-data-grid/ 301
-/docs/12.2/angular-data-grid/* /docs/javascript-data-grid/ 301
-/docs/12.1/angular-data-grid/* /docs/javascript-data-grid/ 301
+# Angular dedicated docs are available from 16.0+ only.
+# Versions 12.1-15.3 had the Angular package but no dedicated docs pages - redirect to latest Angular docs.
+/docs/15.3/angular-data-grid/* /docs/angular-data-grid/ 301
+/docs/15.2/angular-data-grid/* /docs/angular-data-grid/ 301
+/docs/15.1/angular-data-grid/* /docs/angular-data-grid/ 301
+/docs/15.0/angular-data-grid/* /docs/angular-data-grid/ 301
+/docs/14.6/angular-data-grid/* /docs/angular-data-grid/ 301
+/docs/14.5/angular-data-grid/* /docs/angular-data-grid/ 301
+/docs/14.4/angular-data-grid/* /docs/angular-data-grid/ 301
+/docs/14.3/angular-data-grid/* /docs/angular-data-grid/ 301
+/docs/14.2/angular-data-grid/* /docs/angular-data-grid/ 301
+/docs/14.1/angular-data-grid/* /docs/angular-data-grid/ 301
+/docs/14.0/angular-data-grid/* /docs/angular-data-grid/ 301
+/docs/13.1/angular-data-grid/* /docs/angular-data-grid/ 301
+/docs/13.0/angular-data-grid/* /docs/angular-data-grid/ 301
+/docs/12.4/angular-data-grid/* /docs/angular-data-grid/ 301
+/docs/12.3/angular-data-grid/* /docs/angular-data-grid/ 301
+/docs/12.2/angular-data-grid/* /docs/angular-data-grid/ 301
+/docs/12.1/angular-data-grid/* /docs/angular-data-grid/ 301
 /docs/12.0/angular-data-grid/* /docs/javascript-data-grid/ 301
 /docs/11.1/angular-data-grid/* /docs/javascript-data-grid/ 301
 /docs/11.0/angular-data-grid/* /docs/javascript-data-grid/ 301


### PR DESCRIPTION
### Context

The PR fixes broken Netlify redirects for Angular documentation on versions 12.1-15.3. Visiting any URL under `/docs/{12.1-15.3}/angular-data-grid/` was either showing a 404 or redirecting to the wrong destination (`/docs/javascript-data-grid/`). The Angular wrapper package existed from version 12.1, but dedicated Angular documentation pages were only introduced in version 16.0. Users visiting old versioned Angular docs URLs should be redirected to the latest Angular docs (`/docs/angular-data-grid/`), not the JavaScript docs.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1608

### How has this been tested?

This is a Netlify `_redirects` file change. The rules can be verified by checking that URLs like `/docs/15.3/angular-data-grid/installation` now redirect to `/docs/angular-data-grid/` (HTTP 301) instead of `/docs/javascript-data-grid/`.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1608

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

---
_Generated by [Claude Code](https://claude.ai/code/session_016DihyMdn8M6znUEEgeW2pC)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates Netlify redirect rules and comments, with no runtime code changes. Potential impact is limited to documentation URL routing/SEO for those versions.
> 
> **Overview**
> Fixes broken redirects for `/docs/{12.1-15.3}/angular-data-grid/*` by changing their 301 targets from `/docs/javascript-data-grid/` to the latest Angular docs at `/docs/angular-data-grid/`.
> 
> Adds clarifying comments that dedicated Angular docs start at 16.0, while older versions should forward to the current Angular documentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8cab837c3244feb7d7161d9b442cf2200d71ada. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->