### PR TITLE
DEV-1625: Fix dropdown cut-off on right side when trimDropdown is false

### DIFF
--- a/.changelogs/12506.json
+++ b/.changelogs/12506.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed the dropdown/autocomplete editor overflowing the table's right boundary when `trimDropdown` is set to `false`.",
+  "type": "fixed",
+  "issueOrPR": 12506,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
+++ b/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
@@ -1234,6 +1234,115 @@ describe('AutocompleteEditor', () => {
       }
     });
 
+    it('should display the dropdown to the left of the edited cell, when there is not enough space on the right side (table has defined size)', async() => {
+      spec().$container.css('overflow', '');
+
+      const longChoices = [
+        'Short',
+        'A very long dropdown option that far exceeds the column width',
+        'AnotherVeryLongOptionWithoutAnySpaces',
+      ];
+
+      handsontable({
+        data: createEmptySpreadsheetData(5, 3),
+        editor: 'autocomplete',
+        source: longChoices,
+        trimDropdown: false,
+        width: 400,
+        height: 200,
+        stretchH: 'all',
+      });
+
+      await mouseDoubleClick($(getCell(0, 2)));
+      await waitForNextAnimationFrames(2);
+
+      const tableRight = hot().rootElement.getBoundingClientRect().right;
+      const { dd, td } = getDropdownVsEditedCell();
+
+      expect(dd.right).toBeLessThanOrEqual(tableRight + E2E_DOM_RECT_EPSILON_PX); // stays within table
+      expect(dd.left).toBeLessThan(td.left); // flipped to the left of the cell
+    });
+
+    it('should display the dropdown to the left of the edited cell, when there is not enough space on the right side (table has not defined size)', async() => {
+      spec().$container
+        .css('overflow', '')
+        .css('width', '')
+        .css('height', '');
+
+      const longChoices = [
+        'Short',
+        'A very long dropdown option that far exceeds the column width',
+        'AnotherVeryLongOptionWithoutAnySpaces',
+      ];
+
+      handsontable({
+        data: createEmptySpreadsheetData(5, 30),
+        editor: 'autocomplete',
+        source: longChoices,
+        trimDropdown: false,
+        colWidths: 100,
+      });
+
+      await scrollWindowTo(10000, 0); // scroll to the right edge
+
+      const cell = document.elementsFromPoint(
+        document.documentElement.clientWidth - 10, getDefaultRowHeight() + 10)[0];
+
+      await mouseDoubleClick($(cell));
+      await waitForNextAnimationFrames(2);
+
+      const { dd } = getDropdownVsEditedCell();
+
+      // dropdown must not overflow the viewport
+      expect(dd.right).toBeLessThanOrEqual(document.documentElement.clientWidth + E2E_DOM_RECT_EPSILON_PX);
+    });
+
+    it('should maintain the dropdown flipped to the left of the edited cell, after the choices list is changed (table has defined size)', async() => {
+      spec().$container.css('overflow', '');
+
+      const longChoices = [
+        'Short',
+        'A very long dropdown option that far exceeds the column width',
+      ];
+
+      handsontable({
+        data: createEmptySpreadsheetData(5, 3),
+        editor: 'autocomplete',
+        source: longChoices,
+        trimDropdown: false,
+        width: 400,
+        height: 200,
+        stretchH: 'all',
+      });
+
+      // Open shows all choices (including long one) — should flip left
+      await mouseDoubleClick($(getCell(0, 2)));
+      await waitForNextAnimationFrames(2);
+
+      {
+        const tableRight = hot().rootElement.getBoundingClientRect().right;
+        const { dd, td } = getDropdownVsEditedCell();
+
+        expect(dd.right).toBeLessThanOrEqual(tableRight + E2E_DOM_RECT_EPSILON_PX); // flipped left
+        expect(dd.left).toBeLessThan(td.left);
+      }
+
+      // Type 'a' — filters to only the long option ('Short' has no 'a') — dropdown stays wide and flipped
+      const editor = getActiveEditor();
+
+      editor.TEXTAREA.value = 'a';
+      await keyDownUp('a');
+      await waitForNextAnimationFrames(2);
+
+      {
+        const tableRight = hot().rootElement.getBoundingClientRect().right;
+        const { dd, td } = getDropdownVsEditedCell();
+
+        expect(dd.right).toBeLessThanOrEqual(tableRight + E2E_DOM_RECT_EPSILON_PX); // still flipped left
+        expect(dd.left).toBeLessThan(td.left);
+      }
+    });
+
     it('should not sort the choices list, when the `sortByRelevance` option is set to `true`', async() => {
       handsontable({
         editor: 'autocomplete',

--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.js
@@ -345,6 +345,7 @@ export class AutocompleteEditor extends HandsontableEditor {
     if (choices.length > 0) {
       this.updateDropdownDimensions();
       this.flipDropdownVerticallyIfNeeded();
+      this.flipDropdownHorizontallyIfNeeded();
 
       if (this.cellProperties.strict === true) {
         this.highlightBestMatchingChoice(highlightIndex);

--- a/handsontable/src/editors/handsontableEditor/handsontableEditor.js
+++ b/handsontable/src/editors/handsontableEditor/handsontableEditor.js
@@ -264,15 +264,19 @@ export class HandsontableEditor extends TextEditor {
     const { view } = this.hot;
     const cellRect = this.getEditedCellRect();
     let spaceInlineStart = cellRect.start + cellRect.width;
+    let workspaceWidth = view.getWorkspaceWidth();
 
     if (view.isHorizontallyScrollableByWindow()) {
       const inlineStartOffset = view.getTableOffset().left - this.hot.rootWindow.scrollX;
 
       spaceInlineStart = Math.max(spaceInlineStart + inlineStartOffset, 0);
+      // For window-scrollable tables, spaceInlineStart is viewport-relative so the right
+      // boundary must also be viewport width, not the holder's offsetWidth.
+      workspaceWidth = this.hot.rootDocument.documentElement.clientWidth;
     }
 
     const dropdownTargetWidth = this.getDropdownWidth();
-    const spaceInlineEnd = view.getWorkspaceWidth() - spaceInlineStart + cellRect.width;
+    const spaceInlineEnd = workspaceWidth - spaceInlineStart + cellRect.width;
     const flipNeeded = dropdownTargetWidth > spaceInlineEnd && spaceInlineStart > spaceInlineEnd;
 
     if (flipNeeded) {


### PR DESCRIPTION
### Context

The PR fixes the dropdown/autocomplete editor being cut off on the right side of the table when `trimDropdown: false` is used and options are wider than the column. The dropdown should flip to the left when there is not enough space on the right (or flip to the right in RTL mode).

**Root cause:** `flipDropdownHorizontallyIfNeeded()` is called in `handsontableEditor.open()` before the internal dropdown table has any data — at that point `getDropdownWidth()` returns `2` (empty table borders only). After data loads in `autocompleteEditor.updateChoicesList()`, only `flipDropdownVerticallyIfNeeded()` is re-evaluated. The horizontal flip is never called with the real dropdown width.

**Fix:** Add one `this.flipDropdownHorizontallyIfNeeded()` call after `this.flipDropdownVerticallyIfNeeded()` in `updateChoicesList()`. The base method in `handsontableEditor.js` already handles both the defined-width (trimming container) and window-scrollable cases correctly — it just needed to be called at the right time.

GitHub issue: https://github.com/handsontable/handsontable/issues/4851

### How has this been tested?

Three new E2E tests added to `autocompleteEditor.spec.js`:

```bash
npm run test:e2e --testPathPattern=autocompleteEditor --prefix handsontable
npm run test:e2e --testPathPattern=dropdownEditor --prefix handsontable
```

- **Defined-size table:** `width: 400, stretchH: 'all'` — asserts `dd.right <= tableRight + 2px`
- **Window-scrollable table:** no fixed width, scrolled right — asserts `dd.right <= viewportWidth + 2px`
- **Re-evaluation after filtering:** types a character, asserts flip is maintained on subsequent `queryChoices` calls

All 133 autocomplete specs and 44 dropdown specs pass.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. https://github.com/handsontable/handsontable/issues/4851
2. DEV-1625

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1625

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> UI positioning logic changes for the autocomplete dropdown, including window-scrollable edge cases; risk is moderate due to layout/viewport calculations but scoped to editor rendering.
> 
> **Overview**
> Fixes the autocomplete/dropdown editor overflowing the right boundary when `trimDropdown: false` by re-running `flipDropdownHorizontallyIfNeeded()` after the choices table is populated (in `AutocompleteEditor.updateChoicesList()`).
> 
> Adjusts horizontal flip calculations for window-scrollable tables to use the viewport width as the right boundary, and adds E2E coverage to ensure the dropdown flips left (and stays flipped after filtering) for both fixed-size and window-scrollable tables. Also adds a changelog entry for the public fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ee2d5c8df4240c0bdcd4adca359b3c05ee89bde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->