### PR TITLE
DEV-1626: Fix Windows runner label windows-2025 to windows-2025-vs2026

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -50,8 +50,8 @@ jobs:
         run: npm run all build
 
   build-on-windows:
-    name: Build all packages in windows-latest
-    runs-on: windows-latest
+    name: Build all packages in windows-2025-vs2026
+    runs-on: windows-2025-vs2026
     timeout-minutes: 60
     env:
       # Force npm operations to use the D drive (much faster)


### PR DESCRIPTION
### Context

The PR fixes the GitHub Actions workflow to use the updated Windows runner label. GitHub Actions is retiring `windows-2025` and redirecting all requests to `windows-2025-vs2026` by May 12, 2026. This updates `.github/workflows/build-all.yml` to use the new label explicitly before the deadline.

### How has this been tested?

- CI will validate the runner label on the next workflow run.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1626

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1626

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that updates the GitHub Actions Windows runner label; main impact is CI environment selection for Windows builds.
> 
> **Overview**
> Updates the `build-on-windows` GitHub Actions job in `.github/workflows/build-all.yml` to run on the new `windows-2025-vs2026` runner label (and updates the job display name accordingly) to avoid relying on the deprecated/redirected `windows-2025` label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc997b7f023f2d193c036b91c7dff2ae82531111. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->