### PR TITLE
DEV-1627: Fix cell editor docs to use Handsontable.dom.stopImmediatePropagation

### DIFF
--- a/docs/content/guides/cell-functions/cell-editor/cell-editor.md
+++ b/docs/content/guides/cell-functions/cell-editor/cell-editor.md
@@ -153,7 +153,7 @@ Handsontable separates rendering (displaying cell values) from editing (changing
 
 :::
 
-**Overriding keyboard behavior:** Register a [`beforeKeyDown`](@/api/hooks.md#beforekeydown) hook listener and call `Handsontable.dom.stopImmediatePropagation(event)` to prevent `EditorManager` from processing a specific key. The native `event.stopImmediatePropagation()` does not stop Handsontable's internal key pipeline -- you must use the `Handsontable.dom` helper (or import `stopImmediatePropagation` from `handsontable/helpers/dom/event`). Register the listener in `open()` and remove it in `close()` so it only intercepts events while your editor is active.
+**Overriding keyboard behavior:** Register a [`beforeKeyDown`](@/api/hooks.md#beforekeydown) hook listener and call `Handsontable.dom.stopImmediatePropagation(event)` to prevent `EditorManager` from processing a specific key. The native `event.stopImmediatePropagation()` does not stop Handsontable's internal key pipeline - you must use the `Handsontable.dom` helper (or import `stopImmediatePropagation` from `handsontable/helpers/dom/event`). Register the listener in `open()` and remove it in `close()` so it only intercepts events while your editor is active.
 
 **Editor singleton:** Each editor class has exactly one instance per table. The constructor and `init()` run once per table; `prepare()` runs every time you select a cell that uses that editor.
 

--- a/docs/content/guides/cell-functions/cell-editor/cell-editor.md
+++ b/docs/content/guides/cell-functions/cell-editor/cell-editor.md
@@ -153,7 +153,7 @@ Handsontable separates rendering (displaying cell values) from editing (changing
 
 :::
 
-**Overriding keyboard behavior:** Register a [`beforeKeyDown`](@/api/hooks.md#beforekeydown) hook listener and call `event.stopImmediatePropagation()` to prevent `EditorManager` from processing a specific key. Register the listener in `open()` and remove it in `close()` so it only intercepts events while your editor is active.
+**Overriding keyboard behavior:** Register a [`beforeKeyDown`](@/api/hooks.md#beforekeydown) hook listener and call `Handsontable.dom.stopImmediatePropagation(event)` to prevent `EditorManager` from processing a specific key. The native `event.stopImmediatePropagation()` does not stop Handsontable's internal key pipeline -- you must use the `Handsontable.dom` helper (or import `stopImmediatePropagation` from `handsontable/helpers/dom/event`). Register the listener in `open()` and remove it in `close()` so it only intercepts events while your editor is active.
 
 **Editor singleton:** Each editor class has exactly one instance per table. The constructor and `init()` run once per table; `prepare()` runs every time you select a cell that uses that editor.
 

--- a/docs/content/guides/cell-functions/cell-editor/javascript/example2.js
+++ b/docs/content/guides/cell-functions/cell-editor/javascript/example2.js
@@ -1,131 +1,121 @@
 import Handsontable from 'handsontable/base';
 import { registerAllModules } from 'handsontable/registry';
 import { BaseEditor } from 'handsontable/editors/baseEditor';
-
+import { stopImmediatePropagation } from 'handsontable/helpers/dom/event';
 registerAllModules();
-
 class SelectEditor extends BaseEditor {
-  init() {
-    this.select = this.hot.rootDocument.createElement('SELECT');
-    this.select.setAttribute('data-hot-input', 'true');
-    this.select.classList.add('htSelectEditor');
-    this.select.style.display = 'none';
-    this.hot.rootElement.appendChild(this.select);
-  }
-  prepare(row, col, prop, td, originalValue, cellProperties) {
-    super.prepare(row, col, prop, td, originalValue, cellProperties);
-
-    const rawOptions = this.cellProperties.selectOptions ?? [];
-    const options = Array.isArray(rawOptions) ? Object.fromEntries(rawOptions.map((v) => [v, v])) : rawOptions;
-
-    this.select.innerText = '';
-    Object.keys(options).forEach((key) => {
-      const option = this.hot.rootDocument.createElement('OPTION');
-
-      option.value = key;
-      option.innerText = options[key];
-      this.select.appendChild(option);
-    });
-  }
-  getValue() {
-    return this.select.value;
-  }
-  setValue(value) {
-    this.select.value = value;
-  }
-  open() {
-    const { top, start, width, height } = this.getEditedCellRect();
-    const s = this.select.style;
-
-    s.height = `${height}px`;
-    s.minWidth = `${width}px`;
-    s.top = `${top}px`;
-    s[this.hot.isRtl() ? 'right' : 'left'] = `${start}px`;
-    s.margin = '0px';
-    s.display = '';
-    this.addHook('beforeKeyDown', (event) => {
-      const { selectedIndex, length } = this.select;
-
-      if (event.keyCode === 38 && selectedIndex > 0) {
-        this.select[selectedIndex - 1].selected = true;
-        event.stopImmediatePropagation();
-        event.preventDefault();
-      } else if (event.keyCode === 40 && selectedIndex < length - 1) {
-        this.select[selectedIndex + 1].selected = true;
-        event.stopImmediatePropagation();
-        event.preventDefault();
-      }
-    });
-  }
-  close() {
-    this.select.style.display = 'none';
-    this.clearHooks();
-  }
-  focus() {
-    this.select.focus();
-  }
+    init() {
+        this.select = this.hot.rootDocument.createElement('SELECT');
+        this.select.setAttribute('data-hot-input', 'true');
+        this.select.classList.add('htSelectEditor');
+        this.select.style.display = 'none';
+        this.hot.rootElement.appendChild(this.select);
+    }
+    prepare(row, col, prop, td, originalValue, cellProperties) {
+        super.prepare(row, col, prop, td, originalValue, cellProperties);
+        const rawOptions = this.cellProperties.selectOptions ?? [];
+        const options = Array.isArray(rawOptions)
+            ? Object.fromEntries(rawOptions.map((v) => [v, v]))
+            : rawOptions;
+        this.select.innerText = '';
+        Object.keys(options).forEach((key) => {
+            const option = this.hot.rootDocument.createElement('OPTION');
+            option.value = key;
+            option.innerText = options[key];
+            this.select.appendChild(option);
+        });
+    }
+    getValue() {
+        return this.select.value;
+    }
+    setValue(value) {
+        this.select.value = value;
+    }
+    open() {
+        const { top, start, width, height } = this.getEditedCellRect();
+        const s = this.select.style;
+        s.height = `${height}px`;
+        s.minWidth = `${width}px`;
+        s.top = `${top}px`;
+        s[this.hot.isRtl() ? 'right' : 'left'] = `${start}px`;
+        s.margin = '0px';
+        s.display = '';
+        this.addHook('beforeKeyDown', (event) => {
+            const { selectedIndex, length } = this.select;
+            if (event.keyCode === 38 && selectedIndex > 0) {
+                this.select[selectedIndex - 1].selected = true;
+                stopImmediatePropagation(event);
+                event.preventDefault();
+            }
+            else if (event.keyCode === 40 && selectedIndex < length - 1) {
+                this.select[selectedIndex + 1].selected = true;
+                stopImmediatePropagation(event);
+                event.preventDefault();
+            }
+        });
+    }
+    close() {
+        this.select.style.display = 'none';
+        this.clearHooks();
+    }
+    focus() {
+        this.select.focus();
+    }
 }
 const PRIORITY_COLORS = {
-  Low: '#22c55e',
-  Medium: '#f59e0b',
-  High: '#ef4444',
-  Critical: '#7c3aed',
+    Low: '#22c55e',
+    Medium: '#f59e0b',
+    High: '#ef4444',
+    Critical: '#7c3aed',
 };
-
 const STATUS_COLORS = {
-  'To Do': '#6b7280',
-  'In Progress': '#3b82f6',
-  Review: '#f59e0b',
-  Done: '#22c55e',
+    'To Do': '#6b7280',
+    'In Progress': '#3b82f6',
+    Review: '#f59e0b',
+    Done: '#22c55e',
 };
-
 function badgeRenderer(colorMap) {
-  return (hotInstance, td, row, col, prop, value) => {
-    td.innerText = '';
-
-    if (value) {
-      const badge = hotInstance.rootDocument.createElement('span');
-
-      badge.className = 'htSelectBadge';
-      badge.style.background = colorMap[value] ?? '#6b7280';
-      badge.innerText = value;
-      td.appendChild(badge);
-    }
-
-    return td;
-  };
+    return (hotInstance, td, row, col, prop, value) => {
+        td.innerText = '';
+        if (value) {
+            const badge = hotInstance.rootDocument.createElement('span');
+            badge.className = 'htSelectBadge';
+            badge.style.background = colorMap[value] ?? '#6b7280';
+            badge.innerText = value;
+            td.appendChild(badge);
+        }
+        return td;
+    };
 }
-
 const container = document.querySelector('#example2');
-
 new Handsontable(container, {
-  data: [
-    ['Migrate database schema', 'High', 'In Progress'],
-    ['Update API documentation', 'Medium', 'To Do'],
-    ['Fix authentication bug', 'Critical', 'Review'],
-    ['Add dark mode support', 'Low', 'Done'],
-    ['Improve test coverage', 'Medium', 'In Progress'],
-    ['Deploy to staging server', 'High', 'To Do'],
-    ['Refactor billing module', 'Medium', 'Done'],
-  ],
-  colHeaders: ['Task', 'Priority', 'Status'],
-  columns: [
-    { type: 'text' },
-    {
-      editor: SelectEditor,
-      renderer: badgeRenderer(PRIORITY_COLORS),
-      selectOptions: ['Low', 'Medium', 'High', 'Critical'],
-    },
-    {
-      editor: SelectEditor,
-      renderer: badgeRenderer(STATUS_COLORS),
-      selectOptions: ['To Do', 'In Progress', 'Review', 'Done'],
-    },
-  ],
-  colWidths: [220, 110, 130],
-  rowHeaders: true,
-  height: 'auto',
-  autoWrapRow: true,
-  autoWrapCol: true,
-  licenseKey: 'non-commercial-and-evaluation',
+    data: [
+        ['Migrate database schema', 'High', 'In Progress'],
+        ['Update API documentation', 'Medium', 'To Do'],
+        ['Fix authentication bug', 'Critical', 'Review'],
+        ['Add dark mode support', 'Low', 'Done'],
+        ['Improve test coverage', 'Medium', 'In Progress'],
+        ['Deploy to staging server', 'High', 'To Do'],
+        ['Refactor billing module', 'Medium', 'Done'],
+    ],
+    colHeaders: ['Task', 'Priority', 'Status'],
+    columns: [
+        { type: 'text' },
+        {
+            editor: SelectEditor,
+            renderer: badgeRenderer(PRIORITY_COLORS),
+            selectOptions: ['Low', 'Medium', 'High', 'Critical'],
+        },
+        {
+            editor: SelectEditor,
+            renderer: badgeRenderer(STATUS_COLORS),
+            selectOptions: ['To Do', 'In Progress', 'Review', 'Done'],
+        },
+    ],
+    colWidths: [220, 110, 130],
+    rowHeaders: true,
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true,
+    licenseKey: 'non-commercial-and-evaluation',
 });

--- a/docs/content/guides/cell-functions/cell-editor/javascript/example2.js
+++ b/docs/content/guides/cell-functions/cell-editor/javascript/example2.js
@@ -4,118 +4,118 @@ import { BaseEditor } from 'handsontable/editors/baseEditor';
 import { stopImmediatePropagation } from 'handsontable/helpers/dom/event';
 registerAllModules();
 class SelectEditor extends BaseEditor {
-    init() {
-        this.select = this.hot.rootDocument.createElement('SELECT');
-        this.select.setAttribute('data-hot-input', 'true');
-        this.select.classList.add('htSelectEditor');
-        this.select.style.display = 'none';
-        this.hot.rootElement.appendChild(this.select);
-    }
-    prepare(row, col, prop, td, originalValue, cellProperties) {
-        super.prepare(row, col, prop, td, originalValue, cellProperties);
-        const rawOptions = this.cellProperties.selectOptions ?? [];
-        const options = Array.isArray(rawOptions)
-            ? Object.fromEntries(rawOptions.map((v) => [v, v]))
-            : rawOptions;
-        this.select.innerText = '';
-        Object.keys(options).forEach((key) => {
-            const option = this.hot.rootDocument.createElement('OPTION');
-            option.value = key;
-            option.innerText = options[key];
-            this.select.appendChild(option);
-        });
-    }
-    getValue() {
-        return this.select.value;
-    }
-    setValue(value) {
-        this.select.value = value;
-    }
-    open() {
-        const { top, start, width, height } = this.getEditedCellRect();
-        const s = this.select.style;
-        s.height = `${height}px`;
-        s.minWidth = `${width}px`;
-        s.top = `${top}px`;
-        s[this.hot.isRtl() ? 'right' : 'left'] = `${start}px`;
-        s.margin = '0px';
-        s.display = '';
-        this.addHook('beforeKeyDown', (event) => {
-            const { selectedIndex, length } = this.select;
-            if (event.keyCode === 38 && selectedIndex > 0) {
-                this.select[selectedIndex - 1].selected = true;
-                stopImmediatePropagation(event);
-                event.preventDefault();
-            }
-            else if (event.keyCode === 40 && selectedIndex < length - 1) {
-                this.select[selectedIndex + 1].selected = true;
-                stopImmediatePropagation(event);
-                event.preventDefault();
-            }
-        });
-    }
-    close() {
-        this.select.style.display = 'none';
-        this.clearHooks();
-    }
-    focus() {
-        this.select.focus();
-    }
+  init() {
+    this.select = this.hot.rootDocument.createElement('SELECT');
+    this.select.setAttribute('data-hot-input', 'true');
+    this.select.classList.add('htSelectEditor');
+    this.select.style.display = 'none';
+    this.hot.rootElement.appendChild(this.select);
+  }
+  prepare(row, col, prop, td, originalValue, cellProperties) {
+    super.prepare(row, col, prop, td, originalValue, cellProperties);
+    const rawOptions = this.cellProperties.selectOptions ?? [];
+    const options = Array.isArray(rawOptions)
+      ? Object.fromEntries(rawOptions.map((v) => [v, v]))
+      : rawOptions;
+    this.select.innerText = '';
+    Object.keys(options).forEach((key) => {
+      const option = this.hot.rootDocument.createElement('OPTION');
+      option.value = key;
+      option.innerText = options[key];
+      this.select.appendChild(option);
+    });
+  }
+  getValue() {
+    return this.select.value;
+  }
+  setValue(value) {
+    this.select.value = value;
+  }
+  open() {
+    const { top, start, width, height } = this.getEditedCellRect();
+    const s = this.select.style;
+    s.height = `${height}px`;
+    s.minWidth = `${width}px`;
+    s.top = `${top}px`;
+    s[this.hot.isRtl() ? 'right' : 'left'] = `${start}px`;
+    s.margin = '0px';
+    s.display = '';
+    this.addHook('beforeKeyDown', (event) => {
+      const { selectedIndex, length } = this.select;
+      if (event.keyCode === 38 && selectedIndex > 0) {
+        this.select[selectedIndex - 1].selected = true;
+        stopImmediatePropagation(event);
+        event.preventDefault();
+      }
+      else if (event.keyCode === 40 && selectedIndex < length - 1) {
+        this.select[selectedIndex + 1].selected = true;
+        stopImmediatePropagation(event);
+        event.preventDefault();
+      }
+    });
+  }
+  close() {
+    this.select.style.display = 'none';
+    this.clearHooks();
+  }
+  focus() {
+    this.select.focus();
+  }
 }
 const PRIORITY_COLORS = {
-    Low: '#22c55e',
-    Medium: '#f59e0b',
-    High: '#ef4444',
-    Critical: '#7c3aed',
+  Low: '#22c55e',
+  Medium: '#f59e0b',
+  High: '#ef4444',
+  Critical: '#7c3aed',
 };
 const STATUS_COLORS = {
-    'To Do': '#6b7280',
-    'In Progress': '#3b82f6',
-    Review: '#f59e0b',
-    Done: '#22c55e',
+  'To Do': '#6b7280',
+  'In Progress': '#3b82f6',
+  Review: '#f59e0b',
+  Done: '#22c55e',
 };
 function badgeRenderer(colorMap) {
-    return (hotInstance, td, row, col, prop, value) => {
-        td.innerText = '';
-        if (value) {
-            const badge = hotInstance.rootDocument.createElement('span');
-            badge.className = 'htSelectBadge';
-            badge.style.background = colorMap[value] ?? '#6b7280';
-            badge.innerText = value;
-            td.appendChild(badge);
-        }
-        return td;
-    };
+  return (hotInstance, td, row, col, prop, value) => {
+    td.innerText = '';
+    if (value) {
+      const badge = hotInstance.rootDocument.createElement('span');
+      badge.className = 'htSelectBadge';
+      badge.style.background = colorMap[value] ?? '#6b7280';
+      badge.innerText = value;
+      td.appendChild(badge);
+    }
+    return td;
+  };
 }
 const container = document.querySelector('#example2');
 new Handsontable(container, {
-    data: [
-        ['Migrate database schema', 'High', 'In Progress'],
-        ['Update API documentation', 'Medium', 'To Do'],
-        ['Fix authentication bug', 'Critical', 'Review'],
-        ['Add dark mode support', 'Low', 'Done'],
-        ['Improve test coverage', 'Medium', 'In Progress'],
-        ['Deploy to staging server', 'High', 'To Do'],
-        ['Refactor billing module', 'Medium', 'Done'],
-    ],
-    colHeaders: ['Task', 'Priority', 'Status'],
-    columns: [
-        { type: 'text' },
-        {
-            editor: SelectEditor,
-            renderer: badgeRenderer(PRIORITY_COLORS),
-            selectOptions: ['Low', 'Medium', 'High', 'Critical'],
-        },
-        {
-            editor: SelectEditor,
-            renderer: badgeRenderer(STATUS_COLORS),
-            selectOptions: ['To Do', 'In Progress', 'Review', 'Done'],
-        },
-    ],
-    colWidths: [220, 110, 130],
-    rowHeaders: true,
-    height: 'auto',
-    autoWrapRow: true,
-    autoWrapCol: true,
-    licenseKey: 'non-commercial-and-evaluation',
+  data: [
+    ['Migrate database schema', 'High', 'In Progress'],
+    ['Update API documentation', 'Medium', 'To Do'],
+    ['Fix authentication bug', 'Critical', 'Review'],
+    ['Add dark mode support', 'Low', 'Done'],
+    ['Improve test coverage', 'Medium', 'In Progress'],
+    ['Deploy to staging server', 'High', 'To Do'],
+    ['Refactor billing module', 'Medium', 'Done'],
+  ],
+  colHeaders: ['Task', 'Priority', 'Status'],
+  columns: [
+    { type: 'text' },
+    {
+      editor: SelectEditor,
+      renderer: badgeRenderer(PRIORITY_COLORS),
+      selectOptions: ['Low', 'Medium', 'High', 'Critical'],
+    },
+    {
+      editor: SelectEditor,
+      renderer: badgeRenderer(STATUS_COLORS),
+      selectOptions: ['To Do', 'In Progress', 'Review', 'Done'],
+    },
+  ],
+  colWidths: [220, 110, 130],
+  rowHeaders: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
 });

--- a/docs/content/guides/cell-functions/cell-editor/javascript/example2.ts
+++ b/docs/content/guides/cell-functions/cell-editor/javascript/example2.ts
@@ -1,6 +1,7 @@
 import Handsontable from 'handsontable/base';
 import { registerAllModules } from 'handsontable/registry';
 import { BaseEditor } from 'handsontable/editors/baseEditor';
+import { stopImmediatePropagation } from 'handsontable/helpers/dom/event';
 
 registerAllModules();
 
@@ -64,11 +65,11 @@ class SelectEditor extends BaseEditor {
 
       if (event.keyCode === 38 && selectedIndex > 0) {
         (this.select[selectedIndex - 1] as HTMLOptionElement).selected = true;
-        event.stopImmediatePropagation();
+        stopImmediatePropagation(event);
         event.preventDefault();
       } else if (event.keyCode === 40 && selectedIndex < length - 1) {
         (this.select[selectedIndex + 1] as HTMLOptionElement).selected = true;
-        event.stopImmediatePropagation();
+        stopImmediatePropagation(event);
         event.preventDefault();
       }
     });

--- a/docs/content/guides/getting-started/events-and-hooks/angular/example2.ts
+++ b/docs/content/guides/getting-started/events-and-hooks/angular/example2.ts
@@ -1,6 +1,7 @@
 /* file: app.component.ts */
 import { AfterViewInit, Component, ViewChild } from '@angular/core';
 import { GridSettings, HotTableComponent, HotTableModule} from '@handsontable/angular-wrapper';
+import { stopImmediatePropagation } from 'handsontable/helpers/dom/event';
 
 @Component({
   selector: 'example2-events-hooks',
@@ -50,7 +51,7 @@ export class AppComponent implements AfterViewInit {
 
         // BACKSPACE or DELETE
         if (e.keyCode === 8 || e.keyCode === 46) {
-          e.stopImmediatePropagation();
+          stopImmediatePropagation(e);
           // remove data at cell, shift up
           hot.spliceCol(selection[1], selection[0], 1);
           e.preventDefault();
@@ -63,7 +64,7 @@ export class AppComponent implements AfterViewInit {
             this.lastChange.length === 1 &&
             this.lastChange[0][2] == this.lastChange[0][3]
           ) {
-            e.stopImmediatePropagation();
+            stopImmediatePropagation(e);
             hot.spliceCol(selection[1], selection[0], 0, '');
             // add new cell
             hot.selectCell(selection[0], selection[1]);

--- a/docs/content/guides/getting-started/events-and-hooks/javascript/example2.js
+++ b/docs/content/guides/getting-started/events-and-hooks/javascript/example2.js
@@ -1,60 +1,56 @@
 import Handsontable from 'handsontable/base';
 import { registerAllModules } from 'handsontable/registry';
-
+import { stopImmediatePropagation } from 'handsontable/helpers/dom/event';
 // Register all Handsontable's modules.
 registerAllModules();
-
 let lastChange = null;
 const container = document.querySelector('#example2');
 const hot = new Handsontable(container, {
-  data: [
-    ['Tesla', 2017, 'black', 'black'],
-    ['Nissan', 2018, 'blue', 'blue'],
-    ['Chrysler', 2019, 'yellow', 'black'],
-    ['Volvo', 2020, 'yellow', 'gray'],
-  ],
-  colHeaders: true,
-  rowHeaders: true,
-  height: 'auto',
-  minSpareRows: 1,
-  beforeChange(changes) {
-    lastChange = changes;
-  },
-  autoWrapRow: true,
-  autoWrapCol: true,
-  licenseKey: 'non-commercial-and-evaluation',
+    data: [
+        ['Tesla', 2017, 'black', 'black'],
+        ['Nissan', 2018, 'blue', 'blue'],
+        ['Chrysler', 2019, 'yellow', 'black'],
+        ['Volvo', 2020, 'yellow', 'gray'],
+    ],
+    colHeaders: true,
+    rowHeaders: true,
+    height: 'auto',
+    minSpareRows: 1,
+    beforeChange(changes) {
+        lastChange = changes;
+    },
+    autoWrapRow: true,
+    autoWrapCol: true,
+    licenseKey: 'non-commercial-and-evaluation',
 });
-
 hot.updateSettings({
-  beforeKeyDown(e) {
-    const selected = hot.getSelected();
-
-    if (!selected) return;
-    const selection = selected[0];
-
-    // Ignore header and corner selections (row or column index < 0)
-    if (selection[0] < 0 || selection[1] < 0) return;
-    console.log(selection);
-
-    // BACKSPACE or DELETE
-    if (e.keyCode === 8 || e.keyCode === 46) {
-      e.stopImmediatePropagation();
-      // remove data at cell, shift up
-      hot.spliceCol(selection[1], selection[0], 1);
-      e.preventDefault();
-    }
-    // ENTER
-    else if (e.keyCode === 13) {
-      // if last change affected a single cell and did not change it's values
-      if (lastChange && lastChange.length === 1 && lastChange[0][2] == lastChange[0][3]) {
-        e.stopImmediatePropagation();
-        hot.spliceCol(selection[1], selection[0], 0, '');
-        // add new cell
-        hot.selectCell(selection[0], selection[1]);
-        // select new cell
-      }
-    }
-
-    lastChange = null;
-  },
+    beforeKeyDown(e) {
+        const selected = hot.getSelected();
+        if (!selected)
+            return;
+        const selection = selected[0];
+        // Ignore header and corner selections (row or column index < 0)
+        if (selection[0] < 0 || selection[1] < 0)
+            return;
+        console.log(selection);
+        // BACKSPACE or DELETE
+        if (e.keyCode === 8 || e.keyCode === 46) {
+            stopImmediatePropagation(e);
+            // remove data at cell, shift up
+            hot.spliceCol(selection[1], selection[0], 1);
+            e.preventDefault();
+        }
+        // ENTER
+        else if (e.keyCode === 13) {
+            // if last change affected a single cell and did not change it's values
+            if (lastChange && lastChange.length === 1 && lastChange[0][2] == lastChange[0][3]) {
+                stopImmediatePropagation(e);
+                hot.spliceCol(selection[1], selection[0], 0, '');
+                // add new cell
+                hot.selectCell(selection[0], selection[1]);
+                // select new cell
+            }
+        }
+        lastChange = null;
+    },
 });

--- a/docs/content/guides/getting-started/events-and-hooks/javascript/example2.js
+++ b/docs/content/guides/getting-started/events-and-hooks/javascript/example2.js
@@ -6,51 +6,51 @@ registerAllModules();
 let lastChange = null;
 const container = document.querySelector('#example2');
 const hot = new Handsontable(container, {
-    data: [
-        ['Tesla', 2017, 'black', 'black'],
-        ['Nissan', 2018, 'blue', 'blue'],
-        ['Chrysler', 2019, 'yellow', 'black'],
-        ['Volvo', 2020, 'yellow', 'gray'],
-    ],
-    colHeaders: true,
-    rowHeaders: true,
-    height: 'auto',
-    minSpareRows: 1,
-    beforeChange(changes) {
-        lastChange = changes;
-    },
-    autoWrapRow: true,
-    autoWrapCol: true,
-    licenseKey: 'non-commercial-and-evaluation',
+  data: [
+    ['Tesla', 2017, 'black', 'black'],
+    ['Nissan', 2018, 'blue', 'blue'],
+    ['Chrysler', 2019, 'yellow', 'black'],
+    ['Volvo', 2020, 'yellow', 'gray'],
+  ],
+  colHeaders: true,
+  rowHeaders: true,
+  height: 'auto',
+  minSpareRows: 1,
+  beforeChange(changes) {
+    lastChange = changes;
+  },
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
 });
 hot.updateSettings({
-    beforeKeyDown(e) {
-        const selected = hot.getSelected();
-        if (!selected)
-            return;
-        const selection = selected[0];
-        // Ignore header and corner selections (row or column index < 0)
-        if (selection[0] < 0 || selection[1] < 0)
-            return;
-        console.log(selection);
-        // BACKSPACE or DELETE
-        if (e.keyCode === 8 || e.keyCode === 46) {
-            stopImmediatePropagation(e);
-            // remove data at cell, shift up
-            hot.spliceCol(selection[1], selection[0], 1);
-            e.preventDefault();
-        }
-        // ENTER
-        else if (e.keyCode === 13) {
-            // if last change affected a single cell and did not change it's values
-            if (lastChange && lastChange.length === 1 && lastChange[0][2] == lastChange[0][3]) {
-                stopImmediatePropagation(e);
-                hot.spliceCol(selection[1], selection[0], 0, '');
-                // add new cell
-                hot.selectCell(selection[0], selection[1]);
-                // select new cell
-            }
-        }
-        lastChange = null;
-    },
+  beforeKeyDown(e) {
+    const selected = hot.getSelected();
+    if (!selected)
+      return;
+    const selection = selected[0];
+    // Ignore header and corner selections (row or column index < 0)
+    if (selection[0] < 0 || selection[1] < 0)
+      return;
+    console.log(selection);
+    // BACKSPACE or DELETE
+    if (e.keyCode === 8 || e.keyCode === 46) {
+      stopImmediatePropagation(e);
+      // remove data at cell, shift up
+      hot.spliceCol(selection[1], selection[0], 1);
+      e.preventDefault();
+    }
+    // ENTER
+    else if (e.keyCode === 13) {
+      // if last change affected a single cell and did not change it's values
+      if (lastChange && lastChange.length === 1 && lastChange[0][2] == lastChange[0][3]) {
+        stopImmediatePropagation(e);
+        hot.spliceCol(selection[1], selection[0], 0, '');
+        // add new cell
+        hot.selectCell(selection[0], selection[1]);
+        // select new cell
+      }
+    }
+    lastChange = null;
+  },
 });

--- a/docs/content/guides/getting-started/events-and-hooks/javascript/example2.ts
+++ b/docs/content/guides/getting-started/events-and-hooks/javascript/example2.ts
@@ -1,5 +1,6 @@
 import Handsontable from 'handsontable/base';
 import { registerAllModules } from 'handsontable/registry';
+import { stopImmediatePropagation } from 'handsontable/helpers/dom/event';
 
 // Register all Handsontable's modules.
 registerAllModules();
@@ -40,7 +41,7 @@ hot.updateSettings({
 
     // BACKSPACE or DELETE
     if (e.keyCode === 8 || e.keyCode === 46) {
-      e.stopImmediatePropagation();
+      stopImmediatePropagation(e);
       // remove data at cell, shift up
       hot.spliceCol(selection[1], selection[0], 1);
       e.preventDefault();
@@ -49,7 +50,7 @@ hot.updateSettings({
     else if (e.keyCode === 13) {
       // if last change affected a single cell and did not change it's values
       if (lastChange && lastChange.length === 1 && lastChange[0]![2] == lastChange[0]![3]) {
-        e.stopImmediatePropagation();
+        stopImmediatePropagation(e);
         hot.spliceCol(selection[1], selection[0], 0, '');
         // add new cell
         hot.selectCell(selection[0], selection[1]);

--- a/docs/content/guides/getting-started/events-and-hooks/react/example2.jsx
+++ b/docs/content/guides/getting-started/events-and-hooks/react/example2.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { HotTable } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
+import { stopImmediatePropagation } from 'handsontable/helpers/dom/event';
 
 // register Handsontable's modules
 registerAllModules();
@@ -23,7 +24,7 @@ const ExampleComponent = () => {
 
         // BACKSPACE or DELETE
         if (e.keyCode === 8 || e.keyCode === 46) {
-          e.stopImmediatePropagation();
+          stopImmediatePropagation(e);
           // remove data at cell, shift up
           hot.spliceCol(selection[1], selection[0], 1);
           e.preventDefault();
@@ -32,7 +33,7 @@ const ExampleComponent = () => {
         else if (e.keyCode === 13) {
           // if last change affected a single cell and did not change it's values
           if (lastChange && lastChange.length === 1 && lastChange[0][2] == lastChange[0][3]) {
-            e.stopImmediatePropagation();
+            stopImmediatePropagation(e);
             hot.spliceCol(selection[1], selection[0], 0, '');
             // add new cell
             hot.selectCell(selection[0], selection[1]);

--- a/docs/content/guides/getting-started/events-and-hooks/react/example2.tsx
+++ b/docs/content/guides/getting-started/events-and-hooks/react/example2.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { HotTable, HotTableRef } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
+import { stopImmediatePropagation } from 'handsontable/helpers/dom/event';
 
 // register Handsontable's modules
 registerAllModules();
@@ -25,7 +26,7 @@ const ExampleComponent = () => {
 
         // BACKSPACE or DELETE
         if (e.keyCode === 8 || e.keyCode === 46) {
-          e.stopImmediatePropagation();
+          stopImmediatePropagation(e);
           // remove data at cell, shift up
           hot.spliceCol(selection[1], selection[0], 1);
           e.preventDefault();
@@ -34,7 +35,7 @@ const ExampleComponent = () => {
         else if (e.keyCode === 13) {
           // if last change affected a single cell and did not change it's values
           if (lastChange && lastChange.length === 1 && lastChange[0][2] == lastChange[0][3]) {
-            e.stopImmediatePropagation();
+            stopImmediatePropagation(e);
             hot.spliceCol(selection[1], selection[0], 0, '');
             // add new cell
             hot.selectCell(selection[0], selection[1]);


### PR DESCRIPTION
### Context

The PR fixes inaccurate guidance in the **Cell editor** and **Events and hooks** docs. The native `event.stopImmediatePropagation()` does not stop Handsontable's internal key pipeline (`isImmediatePropagationStopped` checks `event.isImmediatePropagationEnabled === false`, which is set only by Handsontable's own helper). Examples and prose previously mixed the two forms across versions, causing confusion (see issue #10423). All examples now use the Handsontable helper, and the prose explicitly calls out the difference.

[skip changelog]

### How has this been tested?

- Manually verified the regenerated JS variants match the TS sources.
- Grep confirms no remaining native `event.stopImmediatePropagation()` calls in `docs/content/guides/cell-functions/cell-editor/` or `docs/content/guides/getting-started/events-and-hooks/`.
- Migration guide (`migrating-from-7.4-to-8.0.md:868`) intentionally left as historical reference.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. Closes #10423
2. DEV-1627

### Affected project(s):

- [ ] \`handsontable\`
- [ ] \`@handsontable/angular-wrapper\`
- [ ] \`@handsontable/react-wrapper\`
- [ ] \`@handsontable/vue3\`

(Docs only.)

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation. (this PR is the docs change)

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1627

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that updates guidance and sample code for keyboard-event interception; no runtime/library code is modified.
> 
> **Overview**
> Updates the **Cell editor** guide to explicitly instruct using `Handsontable.dom.stopImmediatePropagation(event)` (or `stopImmediatePropagation` from `handsontable/helpers/dom/event`) instead of the native `event.stopImmediatePropagation()`, clarifying why the native call doesn’t stop Handsontable’s internal key pipeline.
> 
> Regenerates related Angular/React/JS/TS code samples to import and call `stopImmediatePropagation` in `beforeKeyDown` handlers (including the custom `SelectEditor` example), ensuring the examples consistently reflect the correct pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4be644be1ebbe3b3b652101a612c62690797e68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->