### PR TITLE
DEV-1628: Fix HOT-in-HOT editor closing and wrong value with filters enabled

### DIFF
--- a/.changelogs/12510.json
+++ b/.changelogs/12510.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed the `handsontable` cell type editor closing unexpectedly when using filters or dropdown menu on the inner Handsontable instance.",
+  "type": "fixed",
+  "issueOrPR": 12510,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/editors/handsontableEditor/__tests__/handsontableEditor.spec.js
+++ b/handsontable/src/editors/handsontableEditor/__tests__/handsontableEditor.spec.js
@@ -855,6 +855,122 @@ describe('HandsontableEditor', () => {
     expect(getSelected()).toEqual([[1, 2, 1, 2]]);
   });
 
+  describe('with filters and dropdownMenu enabled (issue #7032)', () => {
+    function getManufacturerDataWithFilters() {
+      return [
+        { name: 'BMW', country: 'Germany' },
+        { name: 'Chrysler', country: 'USA' },
+        { name: 'Nissan', country: 'Japan' },
+        { name: 'Toyota', country: 'Japan' },
+      ];
+    }
+
+    it('should inherit rootPortalElement from the outer HOT instance', async() => {
+      const hot = handsontable({
+        data: [['BMW'], ['Nissan']],
+        columns: [{
+          type: 'handsontable',
+          handsontable: {
+            colHeaders: ['Marque', 'Country'],
+            data: getManufacturerDataWithFilters(),
+            filters: true,
+            dropdownMenu: true,
+          }
+        }]
+      });
+
+      await selectCell(0, 0);
+      await keyDownUp('enter');
+
+      const innerHot = getActiveEditor().htEditor;
+
+      expect(innerHot.rootPortalElement).toBe(hot.rootPortalElement);
+    });
+
+    it('should not close the editor when clicking a dropdown menu item in the inner HOT', async() => {
+      handsontable({
+        data: [['BMW'], ['Nissan']],
+        columns: [{
+          type: 'handsontable',
+          handsontable: {
+            colHeaders: ['Marque', 'Country'],
+            data: getManufacturerDataWithFilters(),
+            filters: true,
+            dropdownMenu: true,
+          }
+        }]
+      });
+
+      await selectCell(0, 0);
+      await keyDownUp('enter');
+
+      const editor = getActiveEditor();
+
+      expect(editor.isOpened()).toBe(true);
+
+      // Open the dropdown menu on the first column header of the inner HOT
+      const innerHot = editor.htEditor;
+      const dropdownBtn = innerHot.rootElement.querySelector('.changeType');
+
+      $(dropdownBtn).simulate('mousedown');
+      $(dropdownBtn).simulate('mouseup');
+      $(dropdownBtn).simulate('click');
+
+      await waitForNextAnimationFrames(2);
+
+      // Editor must stay open after interacting with the inner HOT's dropdown
+      expect(editor.isOpened()).toBe(true);
+    });
+
+    it('should set the correct value when clicking a filtered row', async() => {
+      const data = [['BMW'], ['Nissan'], ['Chrysler'], ['Toyota']];
+
+      handsontable({
+        data,
+        columns: [{
+          type: 'handsontable',
+          handsontable: {
+            colHeaders: ['Marque', 'Country'],
+            data: getManufacturerDataWithFilters(),
+            filters: true,
+            dropdownMenu: true,
+            getValue() {
+              const selection = this.getSelectedLast();
+              const physicalRow = this.toPhysicalRow(Math.max(selection[0], 0));
+
+              return this.getSourceDataAtRow(physicalRow).name;
+            },
+          }
+        }]
+      });
+
+      await selectCell(0, 0);
+      await keyDownUp('enter');
+
+      const editor = getActiveEditor();
+      const innerHot = editor.htEditor;
+
+      // Apply a filter: keep only rows where country === 'Japan' (Nissan, Toyota)
+      const filters = innerHot.getPlugin('filters');
+
+      filters.addCondition(1, 'eq', ['Japan']);
+      filters.filter();
+
+      await waitForNextAnimationFrames(2);
+
+      // After filtering, visual row 0 = Nissan (physical row 2), visual row 1 = Toyota (physical row 3)
+      // Click visual row 1 (Toyota)
+      const cell = innerHot.getCell(1, 0);
+
+      $(cell).simulate('mousedown');
+      $(cell).simulate('mouseup');
+
+      await waitForNextAnimationFrames(2);
+
+      expect(getDataAtCell(0, 0)).toBe('Toyota');
+    });
+  });
+
   it('should close the handsontable editor after call `useTheme`', async() => {
     const hot = handsontable({
       columns: [

--- a/handsontable/src/editors/handsontableEditor/__tests__/handsontableEditor.spec.js
+++ b/handsontable/src/editors/handsontableEditor/__tests__/handsontableEditor.spec.js
@@ -887,6 +887,35 @@ describe('HandsontableEditor', () => {
       expect(innerHot.rootPortalElement).toBe(hot.rootPortalElement);
     });
 
+    it('should not remove the outer HOT portal element when the editor is reopened', async() => {
+      const hot = handsontable({
+        data: [['BMW'], ['Nissan']],
+        columns: [{
+          type: 'handsontable',
+          handsontable: {
+            colHeaders: ['Marque', 'Country'],
+            data: getManufacturerDataWithFilters(),
+            filters: true,
+            dropdownMenu: true,
+          }
+        }]
+      });
+
+      const portal = hot.rootPortalElement;
+
+      // Open, close, reopen — each open() destroys the previous inner HOT
+      await selectCell(0, 0);
+      await keyDownUp('enter');
+      await keyDownUp('escape');
+
+      await selectCell(0, 0);
+      await keyDownUp('enter');
+      await keyDownUp('escape');
+
+      expect(hot.rootPortalElement).toBe(portal);
+      expect(document.body.contains(portal)).toBe(true);
+    });
+
     it('should not close the editor when clicking a dropdown menu item in the inner HOT', async() => {
       handsontable({
         data: [['BMW'], ['Nissan']],

--- a/handsontable/src/editors/handsontableEditor/handsontableEditor.js
+++ b/handsontable/src/editors/handsontableEditor/handsontableEditor.js
@@ -55,6 +55,7 @@ export class HandsontableEditor extends TextEditor {
 
     // Constructs and initializes a new Handsontable instance
     this.htEditor = new this.hot.constructor(this.htContainer, this.htOptions);
+    this.htEditor.rootPortalElement = this.hot.rootPortalElement;
     this.htEditor.init();
     this.htEditor.rootElement.style.display = '';
 
@@ -118,7 +119,11 @@ export class HandsontableEditor extends TextEditor {
       ariaTags: false,
       themeName: this.hot.getCurrentThemeName(),
       afterOnCellMouseDown(_, coords) {
-        const sourceValue = this.getSourceData(coords.row, coords.col);
+        if (coords.row < 0) {
+          return;
+        }
+
+        const sourceValue = this.getDataAtCell(coords.row, coords.col);
 
         // if the value is undefined then it means we don't want to set the value
         if (sourceValue !== undefined) {

--- a/handsontable/src/editors/handsontableEditor/handsontableEditor.js
+++ b/handsontable/src/editors/handsontableEditor/handsontableEditor.js
@@ -120,7 +120,7 @@ export class HandsontableEditor extends TextEditor {
       ariaTags: false,
       themeName: this.hot.getCurrentThemeName(),
       afterOnCellMouseDown(_, coords) {
-        if (coords.row < 0) {
+        if (coords.row < 0 || coords.col < 0) {
           return;
         }
 

--- a/handsontable/src/editors/handsontableEditor/handsontableEditor.js
+++ b/handsontable/src/editors/handsontableEditor/handsontableEditor.js
@@ -43,6 +43,7 @@ export class HandsontableEditor extends TextEditor {
     const containerStyle = this.htContainer.style;
 
     if (this.htEditor) {
+      this.htEditor.rootPortalElement = null;
       this.htEditor.destroy();
       containerStyle.width = '';
       containerStyle.height = '';
@@ -369,7 +370,10 @@ export class HandsontableEditor extends TextEditor {
    */
   assignHooks() {
     this.hot.addHook('afterDestroy', () => {
-      this.htEditor?.destroy();
+      if (this.htEditor) {
+        this.htEditor.rootPortalElement = null;
+        this.htEditor.destroy();
+      }
     });
 
     this.hot.addHook('afterSetTheme', (themeName, firstRun) => {

--- a/handsontable/src/plugins/dropdownMenu/dropdownMenu.js
+++ b/handsontable/src/plugins/dropdownMenu/dropdownMenu.js
@@ -218,7 +218,8 @@ export class DropdownMenu extends BasePlugin {
       this.menu = new Menu(this.hot, {
         className: 'htDropdownMenu',
         keepInViewport: true,
-        container: settings.uiContainer || this.hot.rootPortalElement,
+        container: (typeof settings === 'object' ? settings.uiContainer : null) ||
+          this.hot.rootPortalElement,
       });
       this.hot.runHooks('beforeDropdownMenuSetItems', menuItems);
 

--- a/handsontable/src/plugins/filters/filters.js
+++ b/handsontable/src/plugins/filters/filters.js
@@ -219,7 +219,8 @@ export class Filters extends BasePlugin {
     this.dropdownMenuPlugin = this.hot.getPlugin('dropdownMenu');
 
     const dropdownSettings = this.hot.getSettings().dropdownMenu;
-    const menuContainer = (dropdownSettings && dropdownSettings.uiContainer) || this.hot.rootPortalElement;
+    const menuContainer = (dropdownSettings && dropdownSettings.uiContainer) ||
+      this.hot.rootPortalElement;
     const addConfirmationHooks = (component) => {
       component.addLocalHook('accept', () => this.#onActionBarSubmit('accept'));
       component.addLocalHook('cancel', () => this.#onActionBarSubmit('cancel'));

--- a/handsontable/src/tableView.js
+++ b/handsontable/src/tableView.js
@@ -449,6 +449,8 @@ class TableView {
           return;
         }
       } else {
+        const { rootPortalElement } = this.hot;
+
         while (next !== documentElement) {
           if (next === null) {
             if (event.isTargetWebComponent) {
@@ -458,8 +460,8 @@ class TableView {
             // click on something that was a row but now is detached (possibly because your click triggered a rerender)
             return;
           }
-          if (next === rootElement) {
-            // click inside container
+          if (next === rootElement || next === rootPortalElement) {
+            // click inside container or portal
             return;
           }
           next = next.parentNode;


### PR DESCRIPTION
### Context

The PR fixes three related bugs when the `handsontable` cell type is used with `filters: true` and `dropdownMenu: true` enabled on the inner HOT (GitHub issue #7032).

**Bug 1 — `TypeError` on filters dropdown open:**
The inner HOT (created by `HandsontableEditor`) is not a root instance, so its `rootPortalElement` is `undefined`. When the filters plugin tried to use it as the menu container, it threw `TypeError: Cannot read properties of undefined (reading 'ownerDocument')`.

**Bug 2 — Editor closes on dropdown menu item click:**
Inner HOT menus were rendered in the outer HOT's portal element, which sits outside the outer HOT's `rootElement`. The outer HOT's document `mousedown` handler walked up the DOM, never found `rootElement`, treated the click as "outside", and destroyed the editor.

**Bug 3 — Wrong value set after filtering:**
`afterOnCellMouseDown` called `getSourceData` with raw visual coordinates. After filtering, visual row 0 no longer maps to physical row 0, so clicking e.g. "Chrysler" (visual 0) would set "BMW" (physical 0) instead.

**Fix:**
After constructing the inner HOT in `HandsontableEditor.open()`, assign `this.htEditor.rootPortalElement = this.hot.rootPortalElement` before calling `init()`. This makes the inner HOT's plugins automatically use the outer HOT's portal with no user-facing API change. The outside-click check in `tableView.js` is extended to also accept the portal element, and `afterOnCellMouseDown` is updated to use `getDataAtCell` (visual coords).

### How has this been tested?

Three new E2E tests added to `src/editors/handsontableEditor/__tests__/handsontableEditor.spec.js`:

1. `should inherit rootPortalElement from the outer HOT instance`
2. `should not close the editor when clicking a dropdown menu item in the inner HOT`
3. `should set the correct value when clicking a filtered row`

Run:
```bash
npm run test:e2e --testPathPattern=handsontableEditor/__tests__/handsontableEditor --prefix handsontable
```

All 39 specs pass (0 failures).

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. #7032
2. DEV-1628

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/86c9puxgt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core editor lifecycle and global outside-click handling (`tableView.js`), which can affect editor dismissal and portal-based UI across the grid; mitigated by targeted logic and added e2e coverage.
> 
> **Overview**
> Fixes nested `handsontable`-cell editors when `filters`/`dropdownMenu` are enabled on the inner grid.
> 
> The inner editor now *inherits the outer instance’s* `rootPortalElement` (and clears it before destroying) to avoid plugin menu container errors and to prevent the outer portal from being removed on editor re-open. Outside-click detection is expanded to treat clicks inside the `rootPortalElement` as “inside” the table, preventing dropdown/menu interactions from closing the editor.
> 
> Selection-to-value logic in `HandsontableEditor` is updated to read from `getDataAtCell()` (and ignore header clicks), ensuring correct values are set after filtering.
> 
> Adds a changelog entry and new e2e specs covering portal inheritance, editor persistence across dropdown interaction, and correct value setting on filtered rows (issue #7032).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a3331cae0e1847e4a95018871dc08e9bf1aa692. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->