### PR TITLE
DEV-1638: Add docs URL to release Slack notifications

### DIFF
--- a/.github/workflows/docs-staging-delete.yml
+++ b/.github/workflows/docs-staging-delete.yml
@@ -1,4 +1,4 @@
-name: Docs Staging Deployment. Documentation Review Delete (if exist).
+name: Docs delete Staging Deployment
 
 on:
   pull_request:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -428,6 +428,8 @@ jobs:
             STATUS=":x: Failed"; NPM_STATUS=":x: :npm: *npm*"; NPM_OK="false"
           fi
           if [ "$NUGET_RESULT" = "success" ]; then NUGET_STATUS=":white_check_mark: :nuget: *NuGet*"; else NUGET_STATUS=":x: :nuget: *NuGet*"; fi
+          BASE_VERSION_DASHES=$(echo "$RC_VERSION" | sed 's/-rc[0-9]*//' | tr '.' '-')
+          DOCS_URL="https://rc-handsontable-${BASE_VERSION_DASHES}.netlify.app/docs/javascript-data-grid/"
           CHANGELOG_URL="${REPO_URL}/blob/${RELEASE_BRANCH}/CHANGELOG.md"
 
           jq -n \
@@ -437,6 +439,7 @@ jobs:
             --arg npm_status    "$NPM_STATUS" \
             --arg npm_ok        "$NPM_OK" \
             --arg nuget_status  "$NUGET_STATUS" \
+            --arg docs_url      "$DOCS_URL" \
             --arg changelog_url "$CHANGELOG_URL" \
             --arg repo_url      "${REPO_URL}" \
             --arg run_url       "${RUN_URL}" \
@@ -475,7 +478,7 @@ jobs:
                 type: "section",
                 text: {
                   type: "mrkdwn",
-                  text: ("*📋 Changelog*\n<" + $changelog_url + "|View CHANGELOG.md>" + if $npm_ok == "true" then "\n\n*🎮 Demos*\n• :javascript: <https://handsontable.com/codesandbox-browser?example-dir=javascript&handsontable-version=" + $version + "|JS>\n• :react: <https://handsontable.com/codesandbox-browser?example-dir=react&handsontable-version=" + $version + "|React>\n• :angular: <https://handsontable.com/codesandbox-vm?example-dir=angular&handsontable-version=" + $version + "|Angular>\n• :vue: <https://handsontable.com/codesandbox-vm?example-dir=vue&handsontable-version=" + $version + "|Vue>\n• :typescript: <https://handsontable.com/codesandbox-browser?example-dir=typescript&handsontable-version=" + $version + "|TypeScript>" else "" end)
+                  text: ("*📋 Changelog*\n<" + $changelog_url + "|View CHANGELOG.md>" + if $npm_ok == "true" then "\n\n*🎮 Demos*\n• :javascript: <https://handsontable.com/codesandbox-browser?example-dir=javascript&handsontable-version=" + $version + "|JS>\n• :react: <https://handsontable.com/codesandbox-browser?example-dir=react&handsontable-version=" + $version + "|React>\n• :angular: <https://handsontable.com/codesandbox-vm?example-dir=angular&handsontable-version=" + $version + "|Angular>\n• :vue: <https://handsontable.com/codesandbox-vm?example-dir=vue&handsontable-version=" + $version + "|Vue>\n• :typescript: <https://handsontable.com/codesandbox-browser?example-dir=typescript&handsontable-version=" + $version + "|TypeScript>\n\n*📖 RC Docs*\n• :chrome: <" + $docs_url + "|View RC Docs Preview>" else "" end)
                 }
               },
               {
@@ -889,6 +892,8 @@ jobs:
           BASE_VERSION=$(echo "$RC_VERSION" | sed 's/-rc[0-9]*//')
           RC_NUMBER=$(echo "$RC_VERSION" | sed -n 's/.*-rc\([0-9]*\)/\1/p')
           PREV_TAG="${BASE_VERSION}-rc$((RC_NUMBER - 1))"
+          BASE_VERSION_DASHES=$(echo "$BASE_VERSION" | tr '.' '-')
+          DOCS_URL="https://rc-handsontable-${BASE_VERSION_DASHES}.netlify.app/docs/javascript-data-grid/"
           RELEASE_BRANCH="${{ github.ref_name }}"
           CHANGELOG_URL="${REPO_URL}/blob/${RELEASE_BRANCH}/CHANGELOG.md"
 
@@ -920,6 +925,7 @@ jobs:
             --arg npm_status       "$NPM_STATUS" \
             --arg npm_ok           "$NPM_OK" \
             --arg nuget_status     "$NUGET_STATUS" \
+            --arg docs_url         "$DOCS_URL" \
             --arg prev_tag         "${PREV_TAG}" \
             --arg commits          "$COMMITS_TEXT" \
             --arg changelog_synced "${CHANGELOG_SYNCED}" \
@@ -972,7 +978,7 @@ jobs:
                 type: "section",
                 text: {
                   type: "mrkdwn",
-                  text: ("*📋 Changelog*\n<" + $changelog_url + "|View CHANGELOG.md>" + if $npm_ok == "true" then "\n\n*🎮 Demos*\n• :javascript: <https://handsontable.com/codesandbox-browser?example-dir=javascript&handsontable-version=" + $version + "|JS>\n• :react: <https://handsontable.com/codesandbox-browser?example-dir=react&handsontable-version=" + $version + "|React>\n• :angular: <https://handsontable.com/codesandbox-vm?example-dir=angular&handsontable-version=" + $version + "|Angular>\n• :vue: <https://handsontable.com/codesandbox-vm?example-dir=vue&handsontable-version=" + $version + "|Vue>\n• :typescript: <https://handsontable.com/codesandbox-browser?example-dir=typescript&handsontable-version=" + $version + "|TypeScript>" else "" end)
+                  text: ("*📋 Changelog*\n<" + $changelog_url + "|View CHANGELOG.md>" + if $npm_ok == "true" then "\n\n*🎮 Demos*\n• :javascript: <https://handsontable.com/codesandbox-browser?example-dir=javascript&handsontable-version=" + $version + "|JS>\n• :react: <https://handsontable.com/codesandbox-browser?example-dir=react&handsontable-version=" + $version + "|React>\n• :angular: <https://handsontable.com/codesandbox-vm?example-dir=angular&handsontable-version=" + $version + "|Angular>\n• :vue: <https://handsontable.com/codesandbox-vm?example-dir=vue&handsontable-version=" + $version + "|Vue>\n• :typescript: <https://handsontable.com/codesandbox-browser?example-dir=typescript&handsontable-version=" + $version + "|TypeScript>\n\n*📖 RC Docs*\n• :chrome: <" + $docs_url + "|View RC Docs Preview>" else "" end)
                 }
               },
               {
@@ -1789,7 +1795,7 @@ jobs:
                 type: "section",
                 text: {
                   type: "mrkdwn",
-                  text: ("*📋 Changelog*\n<" + $changelog_url + "|View CHANGELOG.md>" + if $npm_ok == "true" then "\n\n*🎮 Demos*\n• :javascript: <https://handsontable.com/codesandbox-browser?example-dir=javascript&handsontable-version=" + $version + "|JS>\n• :react: <https://handsontable.com/codesandbox-browser?example-dir=react&handsontable-version=" + $version + "|React>\n• :angular: <https://handsontable.com/codesandbox-vm?example-dir=angular&handsontable-version=" + $version + "|Angular>\n• :vue: <https://handsontable.com/codesandbox-vm?example-dir=vue&handsontable-version=" + $version + "|Vue>\n• :typescript: <https://handsontable.com/codesandbox-browser?example-dir=typescript&handsontable-version=" + $version + "|TypeScript>" else "" end)
+                  text: ("*📋 Changelog*\n<" + $changelog_url + "|View CHANGELOG.md>" + if $npm_ok == "true" then "\n\n*🎮 Demos*\n• :javascript: <https://handsontable.com/codesandbox-browser?example-dir=javascript&handsontable-version=" + $version + "|JS>\n• :react: <https://handsontable.com/codesandbox-browser?example-dir=react&handsontable-version=" + $version + "|React>\n• :angular: <https://handsontable.com/codesandbox-vm?example-dir=angular&handsontable-version=" + $version + "|Angular>\n• :vue: <https://handsontable.com/codesandbox-vm?example-dir=vue&handsontable-version=" + $version + "|Vue>\n• :typescript: <https://handsontable.com/codesandbox-browser?example-dir=typescript&handsontable-version=" + $version + "|TypeScript>\n\n*📖 Docs*\n• :chrome: <https://handsontable.com/docs/javascript-data-grid/|View Docs>" else "" end)
                 }
               },
               {


### PR DESCRIPTION
### Context

The PR adds documentation preview links to the Slack release notifications in the publish.yml workflow. Previously, after an RC or stable release, the Slack message had no link to the published docs - engineers had to manually navigate to the Netlify preview URL.

- For RC releases: the Netlify preview URL is computed from the RC version string (e.g. `17.1.0-rc1` → `https://rc-handsontable-17-1-0.netlify.app/docs/javascript-data-grid/`) and appended to both `first-rc-notify` and `rc-notify` Slack payloads. The link is shown only when npm publishing succeeded (`npm_ok == "true"`).
- For stable releases: a static link to the production docs (`https://handsontable.com/docs/javascript-data-grid/`) is appended to the `stable-notify` Slack payload under the same condition.

The `docs-staging.yml` workflow already auto-deploys RC docs to Netlify when the publish workflow pushes to a `release/*` branch — this PR only adds the notification link.

### How has this been tested?

- Reviewed the jq payload construction manually against the existing Slack message format.
- URL pattern verified against the live RC Netlify deployment: `https://rc-handsontable-17-1-0.netlify.app/docs/javascript-data-grid/`.
- No functional code changes — CI/workflow-only change.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1638

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1638

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only changes that adjust Slack message payloads and a workflow display name; main risk is incorrect URL/version formatting causing broken links in notifications.
> 
> **Overview**
> Adds **documentation links** to the Slack release notifications generated by `publish.yml`.
> 
> For RC releases, the workflow now derives a Netlify preview URL from the RC/stable base version and includes an *RC Docs preview* link in the Slack payload (only when npm publish succeeds). For stable releases, the Slack payload now includes a link to the production docs under the same success condition.
> 
> Also renames the `docs-staging-delete.yml` workflow title for clarity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5103ff7ebf585bb5f93ffc2b6c4217481151e59e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->