### PR TITLE
DEV-1263: Fix row headers not rendering on initial example load

### DIFF
--- a/docs/src/scripts/example-runner.ts
+++ b/docs/src/scripts/example-runner.ts
@@ -62,6 +62,29 @@ function markLoaded(el: Element): void {
   el.querySelector('.hot-example-preview')?.classList.remove('hot-example-preview--loading');
 }
 
+/**
+ * Calls render() on every Handsontable instance inside an example element.
+ *
+ * The delay is intentional: autoRowSize sampling runs over several RAF cycles
+ * immediately after mount. Calling render() mid-sampling produces 0 rows because
+ * the plugin temporarily resets holder dimensions. 100ms lets sampling complete
+ * before the forced re-render.
+ */
+function renderInstances(el: Element): void {
+  setTimeout(() => {
+    try {
+      el.querySelectorAll<HTMLElement>('.ht-root-wrapper').forEach((wrapper) => {
+        const hot = (wrapper as any).__hotInstance;
+
+        if (!hot || hot.isDestroyed) return;
+        hot.render();
+      });
+    } catch (err) {
+      console.warn('[hot-example] renderInstances failed:', err);
+    }
+  }, 100);
+}
+
 // ── Main runner ───────────────────────────────────────────────────────────
 
 async function runExamples(): Promise<void> {
@@ -97,6 +120,7 @@ async function runExamples(): Promise<void> {
     try {
       await loader();
       markLoaded(el);
+      renderInstances(el);
     } catch (err) {
       console.error('[hot-example] JS failed:', src, err);
       markLoaded(el);
@@ -138,6 +162,7 @@ async function runExamples(): Promise<void> {
         const root = createRoot(container);
         root.render(createElement(Component));
         markLoaded(el);
+        renderInstances(el);
       } catch (err) {
         console.error('[hot-example] JSX failed:', src, err);
         markLoaded(el);
@@ -185,6 +210,7 @@ async function runExamples(): Promise<void> {
 
         app.mount(container);
         markLoaded(el);
+        renderInstances(el);
       } catch (err) {
         console.error('[hot-example] Vue failed:', src, err);
         markLoaded(el);
@@ -235,12 +261,14 @@ async function runExamples(): Promise<void> {
         const mod = await loader() as Record<string, unknown>;
         await bootstrapAngular(mod);
         markLoaded(el);
+        renderInstances(el);
       } catch (err) {
         console.error('[hot-example] Angular failed:', src, err);
         markLoaded(el);
       }
     }
   }
+
 }
 
 if (document.readyState === 'loading') {

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -263,6 +263,7 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
     this.rootGridElement.appendChild(this.rootElement);
     this.rootWrapperElement.appendChild(this.rootGridElement);
     this.rootContainer.appendChild(this.rootWrapperElement);
+    this.rootWrapperElement.__hotInstance = this;
 
     addClass(this.rootPortalElement, 'ht-portal');
 


### PR DESCRIPTION
## Summary

- Store `__hotInstance` on `rootWrapperElement` in `core.js` so the docs example runner can locate the Handsontable instance via a DOM query.
- Replace `requestAnimationFrame` with `setTimeout(fn, 100)` in `renderInstances()` in `example-runner.ts`. The RAF fired mid-`autoRowSize` sampling (which runs over several RAF cycles), causing `wtHolder` to be 0×0 and Walkontable to render 0 rows. A 100ms delay lets sampling complete before the forced re-render.

## Test plan

- [ ] Open http://localhost:4321/docs/javascript-data-grid/demo/ — row headers and inline-start clone should render correctly on initial load without any user interaction
- [ ] Open any other JS/JSX/Vue/Angular example page — verify examples load and render correctly
- [ ] Confirm no console errors on example pages

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1263

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Handsontable core DOM initialization by attaching the live instance to `rootWrapperElement`, which could have unintended side effects if external code relies on DOM purity or if multiple instances exist. Docs runner now forces delayed `render()` calls, which may mask other timing issues or affect initial paint timing on example pages.
> 
> **Overview**
> Fixes initial docs example rendering issues (e.g., missing row headers) by **forcing a post-mount re-render** of any Handsontable grids inside an example.
> 
> Handsontable now stores a reference to itself on the root wrapper DOM node (`__hotInstance`), allowing the docs `example-runner` to locate instances via `.ht-root-wrapper` and call `render()` after loading JS/JSX/Vue/Angular examples with a **100ms delay** to avoid conflicting with `autoRowSize` sampling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0256a3d15e892f817850496f7ff7bf1e1c1cc0fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->