### PR TITLE
DEV-1629: Fix column/row resize handle drift after scroll with preventOverflow

### DIFF
--- a/.changelogs/12515.json
+++ b/.changelogs/12515.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed manual column and row resize handle position after scrolling when `preventOverflow` is set.",
+  "type": "fixed",
+  "issueOrPR": 12515,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/src/overlay/_base.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/_base.js
@@ -202,11 +202,19 @@ export class Overlay {
    */
   getRelativeCellPositionWithinWindow(onFixedRowTop, onFixedColumn, elementOffset, spreaderOffset) {
     const absoluteRootElementPosition = this.wot.wtTable.wtRootElement.getBoundingClientRect(); // todo refactoring: DEMETER
+    // `preventOverflow` can force this overlay onto the window (see `makeClone()`) while the
+    // master still scrolls its holder. `wtRootElement` does not move with that scroll, so
+    // subtract the master scroll from spreader-based offsets to align with the visible cell (#10403).
+    const masterScrollsHolder = this.wot.wtOverlays.scrollableElement !== this.domBindings.rootWindow;
+    const tableScrollPosition = {
+      horizontal: masterScrollsHolder ? this.wot.wtOverlays.inlineStartOverlay.getScrollPosition() : 0,
+      vertical: masterScrollsHolder ? this.wot.wtOverlays.topOverlay.getScrollPosition() : 0,
+    };
     let horizontalOffset = 0;
     let verticalOffset = 0;
 
     if (!onFixedColumn) {
-      horizontalOffset = spreaderOffset.start;
+      horizontalOffset = spreaderOffset.start - tableScrollPosition.horizontal;
 
     } else {
       let absoluteRootElementStartPosition = absoluteRootElementPosition.left;
@@ -225,7 +233,7 @@ export class Overlay {
       verticalOffset = absoluteOverlayPosition.top - absoluteRootElementPosition.top;
 
     } else {
-      verticalOffset = spreaderOffset.top;
+      verticalOffset = spreaderOffset.top - tableScrollPosition.vertical;
     }
 
     return {

--- a/handsontable/src/plugins/manualColumnResize/__tests__/manualColumnResize.spec.js
+++ b/handsontable/src/plugins/manualColumnResize/__tests__/manualColumnResize.spec.js
@@ -1400,4 +1400,57 @@ describe('manualColumnResize', () => {
       expect(getTopClone().find('table').width()).toBe(getMaster().find('table').width());
     });
   });
+
+  describe('with `preventOverflow: \'horizontal\'`', () => {
+    it('should position the resize handle at the visible column header right edge after horizontal scroll (#10403)', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 20),
+        colHeaders: true,
+        manualColumnResize: true,
+        preventOverflow: 'horizontal',
+        width: 400,
+        height: 200,
+      });
+
+      await scrollViewportHorizontally(300);
+      await waitForNextAnimationFrames(2);
+
+      const $headerTH = getTopClone().find('thead tr:eq(0) th:eq(8)');
+
+      $headerTH.simulate('mouseover');
+
+      const $handle = $('.manualColumnResizer');
+
+      expect($handle.offset().left)
+        .toEqual($headerTH.offset().left + $headerTH.outerWidth() - ($handle.outerWidth() / 2) - 1);
+    });
+
+    it('should resize a column by dragging the handle after horizontal scroll (#10403)', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 20),
+        colHeaders: true,
+        manualColumnResize: true,
+        preventOverflow: 'horizontal',
+        width: 400,
+        height: 200,
+      });
+
+      await scrollViewportHorizontally(300);
+      await waitForNextAnimationFrames(2);
+
+      const $headerTH = getTopClone().find('thead tr:eq(0) th:eq(8)');
+      const initialWidth = $headerTH.outerWidth();
+
+      $headerTH.simulate('mouseover');
+
+      const $handle = $('.manualColumnResizer');
+      const handleOffset = $handle.offset();
+
+      $handle.simulate('mousedown', { clientX: handleOffset.left });
+      $handle.simulate('mousemove', { clientX: handleOffset.left + 30 });
+      $handle.simulate('mouseup');
+
+      expect(colWidth(spec().$container, 8)).toBe(initialWidth + 30);
+    });
+  });
 });

--- a/handsontable/src/plugins/manualColumnResize/__tests__/rtl/manualColumnResize.spec.js
+++ b/handsontable/src/plugins/manualColumnResize/__tests__/rtl/manualColumnResize.spec.js
@@ -150,6 +150,30 @@ describe('manualColumnResize (RTL)', () => {
 
         expect($handle.css('z-index')).toBeGreaterThan(getTopClone().css('z-index'));
       });
+
+      it('should position the resize handle at the visible column header start edge after horizontal scroll with `preventOverflow: \'horizontal\'` (#10403)', async() => {
+        handsontable({
+          layoutDirection,
+          data: createSpreadsheetData(5, 20),
+          colHeaders: true,
+          manualColumnResize: true,
+          preventOverflow: 'horizontal',
+          width: 400,
+          height: 200,
+        });
+
+        await scrollViewportHorizontally(300);
+        await waitForNextAnimationFrames(2);
+
+        const $headerTH = getTopClone().find('thead tr:eq(0) th:eq(8)');
+
+        $headerTH.simulate('mouseover');
+
+        const $handle = $('.manualColumnResizer');
+
+        expect($handle.offset().left)
+          .toEqual($headerTH.offset().left - ($handle.outerWidth() / 2) + 1);
+      });
     });
   });
 });

--- a/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
+++ b/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
@@ -1273,4 +1273,59 @@ describe('manualRowResize', () => {
       expect(getInlineStartClone().find('table').height()).toBe(getMaster().find('table').height());
     });
   });
+
+  describe('with `preventOverflow: \'vertical\'`', () => {
+    it('should position the resize handle at the visible row header bottom edge after vertical scroll (#10403)', async() => {
+      handsontable({
+        data: createSpreadsheetData(50, 5),
+        rowHeaders: true,
+        manualRowResize: true,
+        preventOverflow: 'vertical',
+        width: 200,
+        height: 300,
+      });
+
+      await scrollViewportVertically(150);
+      await waitForNextAnimationFrames(2);
+
+      const $headerTH = getInlineStartClone().find('tbody tr:eq(8) th:eq(0)');
+
+      $headerTH.simulate('mouseover');
+
+      const $handle = spec().$container.find('.manualRowResizer');
+
+      expect($headerTH.offset().top + $headerTH.height() - 5).toBeCloseTo($handle.offset().top, 0);
+      expect($headerTH.offset().left).toBeCloseTo($handle.offset().left, 0);
+    });
+
+    it('should resize a row by dragging the handle after vertical scroll (#10403)', async() => {
+      handsontable({
+        data: createSpreadsheetData(50, 5),
+        rowHeaders: true,
+        manualRowResize: true,
+        preventOverflow: 'vertical',
+        width: 200,
+        height: 300,
+      });
+
+      await scrollViewportVertically(150);
+      await waitForNextAnimationFrames(2);
+
+      const $headerTH = getInlineStartClone().find('tbody tr:eq(8) th:eq(0)');
+      const initialHeight = $headerTH.outerHeight();
+
+      $headerTH.simulate('mouseover');
+
+      const $handle = spec().$container.find('.manualRowResizer');
+      const handleOffset = $handle.offset();
+
+      $handle.simulate('mousedown', { clientY: handleOffset.top });
+      $handle.simulate('mousemove', { clientY: handleOffset.top + 20 });
+      $handle.simulate('mouseup');
+
+      const cellCoords = hot().view._wt.wtTable.getCoords($headerTH[0]);
+
+      expect(hot().getRowHeight(cellCoords.row)).toBe(initialHeight + 20);
+    });
+  });
 });


### PR DESCRIPTION
### Context

The PR fixes a positioning bug in the manual column/row resize handle that occurs when `preventOverflow` is set and the master table scrolls internally (constrained container width or height).

`getRelativeCellPositionWithinWindow` in `walkontable/src/overlay/_base.js` did not compensate for the master holder's internal scroll. When `preventOverflow` forces an overlay onto the window (top overlay for `preventOverflow: 'horizontal'`, inline-start overlay for `preventOverflow: 'vertical'`) while the master keeps scrolling its holder, the resize handle was placed at `spreaderOffset + columnOffset` with no scroll compensation - landing offset by the scroll amount and making the column/row impossible to resize.

The fix subtracts `inlineStartOverlay.getScrollPosition()` / `topOverlay.getScrollPosition()` from the spreader-based offsets only when the master scrolls a holder (`wtOverlays.scrollableElement !== rootWindow`). When the master itself scrolls the window, no compensation is applied - preserving the existing behavior covered by the pre-existing `transform` + window-scroll handle position tests.

### How has this been tested?

New tests (all initially failed on `develop`, pass with the fix):

- `handsontable/src/plugins/manualColumnResize/__tests__/manualColumnResize.spec.js` - handle position + drag-resize after horizontal scroll with `preventOverflow: 'horizontal'`
- `handsontable/src/plugins/manualColumnResize/__tests__/rtl/manualColumnResize.spec.js` - handle position after horizontal scroll under RTL with `preventOverflow: 'horizontal'`
- `handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js` - handle position + drag-resize after vertical scroll with `preventOverflow: 'vertical'`

Regression coverage executed locally:

```
npm run test:e2e --testPathPattern=manualColumnResize --prefix handsontable    # 72 specs, 0 failures
npm run test:e2e --testPathPattern=manualRowResize --prefix handsontable       # 70 specs, 0 failures
npm run test:e2e --testPathPattern=preventOverflow --prefix handsontable       # 7 specs, 0 failures
npm run test:e2e --testPathPattern=autofill --prefix handsontable              # 167 specs, 0 failures
npm run test:e2e --testPathPattern=mergeCells --prefix handsontable            # 464 specs, 0 failures
npm run test:walkontable --prefix handsontable                                 # 666 specs, 0 failures
```

A demo page (`handsontable/dev-generated.html`) with side-by-side Released v17.0.1 vs PR Build comparison was used for manual verification of both `preventOverflow: 'horizontal'` and `'vertical'` scenarios.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. Closes #10403
2. DEV-1629

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1629

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Walkontable overlay coordinate calculations; while the change is small and gated to holder-scrolling scenarios, it can affect positioning of other overlay-driven UI elements if the scroll-detection logic is wrong.
> 
> **Overview**
> Fixes manual column/row resize handle drift when `preventOverflow` forces an overlay to scroll with the window while the master table continues scrolling inside its holder.
> 
> `getRelativeCellPositionWithinWindow()` now compensates for the master table’s internal scroll by subtracting overlay scroll positions from spreader-based offsets when the master scrollable element is *not* the window, restoring correct handle alignment and enabling drag-resize after scrolling.
> 
> Adds E2E regression coverage for `preventOverflow: 'horizontal'` and `'vertical'` (including RTL) to assert handle placement and successful drag-resize after scrolling, and includes a changelog entry for the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00c8a40fe9fd52f842911e5e252d390f98965e0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->