### PR TITLE
DEV-1549: Fix Angular grid-size demo - row header too wide due to broken height cascade

### DIFF
--- a/docs/content/guides/getting-started/grid-size/angular/example.html
+++ b/docs/content/guides/getting-started/grid-size/angular/example.html
@@ -1,9 +1,12 @@
 <div>
   <style>
-    .table-container hot-table > div {
+    .table-container {
+      height: 157px;
+    }
+    .table-container hot-table {
       height: 100%;
     }
-    .table-container hot-table > div > div {
+    .table-container hot-table > div {
       height: 100%;
     }
   </style>

--- a/docs/content/guides/getting-started/grid-size/angular/example.html
+++ b/docs/content/guides/getting-started/grid-size/angular/example.html
@@ -1,14 +1,3 @@
 <div>
-  <style>
-    .table-container {
-      height: 157px;
-    }
-    .table-container hot-table {
-      height: 100%;
-    }
-    .table-container hot-table > div {
-      height: 100%;
-    }
-  </style>
   <example-grid-size></example-grid-size>
 </div>

--- a/docs/content/guides/getting-started/grid-size/angular/example.ts
+++ b/docs/content/guides/getting-started/grid-size/angular/example.ts
@@ -1,6 +1,6 @@
 /* file: app.component.ts */
-import { Component, ElementRef, ViewChild } from '@angular/core';
-import { GridSettings, HotTableComponent, HotTableModule} from '@handsontable/angular-wrapper';
+import { Component } from '@angular/core';
+import { GridSettings, HotTableModule } from '@handsontable/angular-wrapper';
 
 @Component({
   selector: 'example-grid-size',
@@ -17,14 +17,9 @@ import { GridSettings, HotTableComponent, HotTableModule} from '@handsontable/an
         </button>
       </div>
     </div>
-    <div class="table-container" #tableContainer>
-      <hot-table [data]="data" [settings]="gridSettings"></hot-table>
-    </div>`,
+    <hot-table [data]="data" [settings]="gridSettings"></hot-table>`,
 })
 export class AppComponent {
-  @ViewChild(HotTableComponent, { static: false }) readonly hotTable!: HotTableComponent;
-  @ViewChild('tableContainer', { static: false }) readonly tableContainer!: ElementRef<HTMLDivElement>;
-
   // generate an array of arrays with dummy data
   readonly data = new Array(100) // number of rows
     .fill(null)
@@ -36,22 +31,22 @@ export class AppComponent {
 
   isContainerExpanded = false;
 
-  readonly gridSettings: GridSettings = {
+  gridSettings: GridSettings = {
     rowHeaders: true,
     colHeaders: true,
     width: '100%',
-    height: '100%',
+    height: 157,
     colWidths: 100,
     autoWrapRow: true,
-    autoWrapCol: true
+    autoWrapCol: true,
   };
 
   btnClick(): void {
     this.isContainerExpanded = !this.isContainerExpanded;
-    const newHeight = this.isContainerExpanded ? 410 : 157;
-
-    this.tableContainer.nativeElement.style.height = `${newHeight}px`;
-    this.hotTable?.hotInstance?.refreshDimensions();
+    this.gridSettings = {
+      ...this.gridSettings,
+      height: this.isContainerExpanded ? 410 : 157,
+    };
   }
 }
 /* end-file */

--- a/docs/content/guides/getting-started/grid-size/angular/example.ts
+++ b/docs/content/guides/getting-started/grid-size/angular/example.ts
@@ -1,5 +1,5 @@
 /* file: app.component.ts */
-import { Component, ViewChild } from '@angular/core';
+import { Component, ElementRef, ViewChild } from '@angular/core';
 import { GridSettings, HotTableComponent, HotTableModule} from '@handsontable/angular-wrapper';
 
 @Component({
@@ -17,12 +17,13 @@ import { GridSettings, HotTableComponent, HotTableModule} from '@handsontable/an
         </button>
       </div>
     </div>
-    <div class="table-container" [style.height.px]="currentHeight">
+    <div class="table-container" #tableContainer>
       <hot-table [data]="data" [settings]="gridSettings"></hot-table>
     </div>`,
 })
 export class AppComponent {
   @ViewChild(HotTableComponent, { static: false }) readonly hotTable!: HotTableComponent;
+  @ViewChild('tableContainer', { static: false }) readonly tableContainer!: ElementRef<HTMLDivElement>;
 
   // generate an array of arrays with dummy data
   readonly data = new Array(100) // number of rows
@@ -34,9 +35,8 @@ export class AppComponent {
     );
 
   isContainerExpanded = false;
-  currentHeight = 157;
 
-  readonly gridSettings: GridSettings ={
+  readonly gridSettings: GridSettings = {
     rowHeaders: true,
     colHeaders: true,
     width: '100%',
@@ -48,8 +48,9 @@ export class AppComponent {
 
   btnClick(): void {
     this.isContainerExpanded = !this.isContainerExpanded;
-    this.currentHeight = this.isContainerExpanded ? 410 : 157;
+    const newHeight = this.isContainerExpanded ? 410 : 157;
 
+    this.tableContainer.nativeElement.style.height = `${newHeight}px`;
     this.hotTable?.hotInstance?.refreshDimensions();
   }
 }


### PR DESCRIPTION
### Context

The PR fixes a broken layout in the Angular grid-size documentation demo (`/docs/angular-data-grid/grid-size/#manual-resizing`). The row header column appeared far too wide compared to the equivalent JS and React demos, pushing data columns out of view.

Two root causes:

**1. Broken CSS height cascade.**
The CSS in `example.html` was setting `height: 100%` on `#container` (the `<div>` inside `<hot-table>`) but not on `hot-table` itself. Because `hot-table` had no explicit height, `height: 100%` on `#container` resolved to `auto` (the browser treats percentage heights as `auto` when the parent has no explicit height). Handsontable then rendered all 100 rows in auto-height mode, computing grid dimensions incorrectly and producing the oversized row header.

Fix: added `.table-container { height: 157px; }` and `.table-container hot-table { height: 100%; }` to complete the cascade: `.table-container` (157 px) → `hot-table` (100% = 157 px) → `#container` (100% = 157 px) → Handsontable (height: 100% = 157 px).

**2. `refreshDimensions()` called before Angular applies the binding change.**
The original `btnClick()` updated `this.currentHeight` (an Angular binding) and immediately called `refreshDimensions()`. Angular change detection had not yet written the new height to the DOM at that point, so `refreshDimensions()` measured the old size.

Fix: replaced the Angular binding with a `@ViewChild('tableContainer')` `ElementRef` and set `nativeElement.style.height` directly before calling `refreshDimensions()` - the same synchronous DOM-first approach used by the JS and React examples.

ClickUp task: https://app.clickup.com/t/86c9jjht1

### How has this been tested?

- Manual visual inspection of the fixed example in the docs dev server
- Compared rendered output against the JS and React grid-size demos - row headers now match

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1549

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tvg8qpChpG4JCA5PTaQPzz)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: docs-only Angular example change that adjusts how the demo sets Handsontable height; no production logic or APIs affected.
> 
> **Overview**
> Fixes the Angular grid-size docs demo by removing the wrapper `.table-container`/inline CSS height cascade and managing grid height directly via Handsontable `settings.height`.
> 
> The toggle button now updates `gridSettings` (creating a new settings object) to switch between `157` and `410` height, eliminating the prior `ViewChild`/`refreshDimensions()` approach and simplifying the template to a single `<hot-table>`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6a88b1acbadb98a1d48a533f54d5d2ff799a093. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->