### PR TITLE
DEV-1641: Fix GitHub MCP env variable format in .cursor/mcp.json

### DIFF
--- a/.ai/MCP.md
+++ b/.ai/MCP.md
@@ -129,3 +129,7 @@ The `.cursor/mcp.json` and `.mcp.json` files also configure:
 | `filesystem_workspace` | Read/write access to the full repo workspace |
 | `filesystem_docs` | Read/write access to `./docs/content` only |
 | `code-review-graph` | Knowledge graph over the codebase (see above) |
+
+### Cursor secret interpolation
+
+All secrets in `.cursor/mcp.json` must use `${env:VARIABLE_NAME}` syntax — not shell-style `${VARIABLE_NAME}`. This applies to both HTTP server `headers` (e.g., ClickUp's `Authorization` header) and `command`-type server `env` blocks (e.g., the GitHub token). Without the `env:` prefix, Cursor treats the value as a literal string and the secret is never resolved.

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -11,7 +11,7 @@
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-github"],
       "env": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${env:GITHUB_PERSONAL_ACCESS_TOKEN}"
       }
     },
     "filesystem_workspace": {


### PR DESCRIPTION
### Context

The PR fixes an incorrect environment variable reference in `.cursor/mcp.json`. The `github` MCP server's `env` block used `${GITHUB_PERSONAL_ACCESS_TOKEN}` (shell-style syntax), but Cursor requires `${env:VARIABLE_NAME}` for all secret interpolation. Without the `env:` prefix, the placeholder is treated as a literal string and the GitHub MCP server fails to authenticate. The `clickup` server in the same file already used the correct syntax.

Also adds a note to `.ai/MCP.md` clarifying that the `${env:VAR}` prefix is required for all Cursor secret references - both in HTTP `headers` blocks and `command`-type `env` blocks.

### How has this been tested?

Config-only and docs change - no automated tests apply. Verified by restarting Cursor with `GITHUB_PERSONAL_ACCESS_TOKEN` set and confirming the GitHub MCP server connects successfully.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1641

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1641

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config/docs-only change; it only adjusts how Cursor interpolates the GitHub token and doesn’t affect application/runtime code paths.
> 
> **Overview**
> Fixes Cursor’s GitHub MCP configuration by switching the `GITHUB_PERSONAL_ACCESS_TOKEN` value in `.cursor/mcp.json` to Cursor’s required `${env:...}` secret interpolation format so the server can authenticate correctly.
> 
> Adds a short note to `.ai/MCP.md` clarifying that Cursor requires `${env:VARIABLE_NAME}` (not `${VARIABLE_NAME}`) for secrets in both HTTP `headers` and command server `env` blocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53d9f42d023cd417eef13c5e19ac342f16056fcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->