### PR TITLE
DEV-413 - `minSpareRows` creates a conflict when we ask …

### DIFF
--- a/.changelogs/12519.json
+++ b/.changelogs/12519.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed the `@handsontable/angular-wrapper` ERROR RuntimeError: NG0100: ExpressionChangedAfterItHasBeenCheckedError",
+  "type": "fixed",
+  "issueOrPR": 12519,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/12519.json
+++ b/.changelogs/12519.json
@@ -4,5 +4,5 @@
   "type": "fixed",
   "issueOrPR": 12519,
   "breaking": false,
-  "framework": "none"
+  "framework": "angular"
 }

--- a/wrappers/angular-wrapper/projects/hot-table/jest.config.js
+++ b/wrappers/angular-wrapper/projects/hot-table/jest.config.js
@@ -1,14 +1,11 @@
 module.exports = {
   preset: 'jest-preset-angular',
   setupFilesAfterEnv: ['<rootDir>/setup-jest.ts'],
-  globals: {
-    'jest-preset-angular': {
+  transform: {
+    '^.+\\.(ts|js|html)$': ['jest-preset-angular', {
       tsconfig: '<rootDir>/tsconfig.spec.json',
       stringifyContentPathRegex: '\\.html$'
-    }
-  },
-  transform: {
-    '^.+\\.(ts|js|html)$': 'jest-preset-angular'
+    }]
   },
   testEnvironment: 'jsdom',
   moduleNameMapper: {

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.spec.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.spec.ts
@@ -25,35 +25,38 @@ describe('HotTableComponent', () => {
 
   });
 
-  it(`should render 'hot-table'`, () => {
+  it(`should render 'hot-table'`, async () => {
     fixture = TestBed.createComponent(HotTableComponent);
     fixture.componentInstance.settings = { ...settings };
     fixture.detectChanges();
+    await fixture.whenStable();
 
     const elem = fixture.nativeElement;
     expect(elem.querySelectorAll('.handsontable').length).toBeGreaterThan(0);
     expect(fixture.componentInstance.hotInstance).toBeDefined();
   });
 
-  it(`should render 'hot-table' even when settings are not provided`, () => {
+  it(`should render 'hot-table' even when settings are not provided`, async () => {
     fixture = TestBed.createComponent(HotTableComponent);
     fixture.detectChanges();
+    await fixture.whenStable();
 
     const elem = fixture.nativeElement;
     expect(elem.querySelectorAll('.handsontable').length).toBeGreaterThan(0);
     expect(fixture.componentInstance.hotInstance).toBeDefined();
   });
 
-  it(`should set data`, () => {
+  it(`should set data`, async () => {
     fixture = TestBed.createComponent(HotTableComponent);
     fixture.componentInstance.settings = {};
     fixture.componentInstance.data = createSpreadsheetData(5, 5);
     fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(fixture.componentInstance.hotInstance.getDataAtCell(0, 0)).toBe('A1');
   });
 
-  it(`should be possible to set some option and pass it to Handsontable`, () => {
+  it(`should be possible to set some option and pass it to Handsontable`, async () => {
     fixture = TestBed.createComponent(HotTableComponent);
     fixture.componentInstance.settings = {
       ...settings,
@@ -64,6 +67,7 @@ describe('HotTableComponent', () => {
     };
 
     fixture.detectChanges();
+    await fixture.whenStable();
 
     const handsontableSettings = fixture.componentInstance.hotInstance.getSettings();
     expect(handsontableSettings.rowHeaders).toBe(true);
@@ -73,11 +77,12 @@ describe('HotTableComponent', () => {
   });
 
   describe('ngOnChanges', () => {
-    it('should update Handsontable settings if settings change and it is not the first change', () => {
+    it('should update Handsontable settings if settings change and it is not the first change', async () => {
       const newSettings = { readOnly: true };
       fixture = TestBed.createComponent(HotTableComponent);
       fixture.componentInstance.settings = {};
       fixture.detectChanges();
+      await fixture.whenStable();
       const hotSettingsResolver = fixture.componentRef.injector.get(HotSettingsResolver);
       const component = fixture.componentInstance;
       const applyCustomSettingsSpy = jest.spyOn(hotSettingsResolver, 'applyCustomSettings');
@@ -93,11 +98,12 @@ describe('HotTableComponent', () => {
       expect(updateHotTableSpy).toHaveBeenCalledWith(newSettings, false);
     });
 
-    it('should not update Handsontable settings if it is the first change', () => {
+    it('should not update Handsontable settings if it is the first change', async () => {
       const newSettings = { data: [[1, 2, 3]] };
       fixture = TestBed.createComponent(HotTableComponent);
       fixture.componentInstance.settings = {};
       fixture.detectChanges();
+      await fixture.whenStable();
       const hotSettingsResolver = fixture.componentRef.injector.get(HotSettingsResolver);
       const applyCustomSettingsSpy = jest.spyOn(hotSettingsResolver, 'applyCustomSettings');
       const component = fixture.componentInstance;
@@ -113,11 +119,12 @@ describe('HotTableComponent', () => {
       expect(updateHotTableSpy).not.toHaveBeenCalled();
     });
 
-    it('should update Handsontable data if data change and it is not the first change', () => {
+    it('should update Handsontable data if data change and it is not the first change', async () => {
       const newData = [[1, 2, 3]];
       fixture = TestBed.createComponent(HotTableComponent);
       fixture.componentInstance.settings = {};
       fixture.detectChanges();
+      await fixture.whenStable();
       const component = fixture.componentInstance;
 
       const updateDataSpy = jest.spyOn(component.hotInstance, 'updateData');
@@ -130,11 +137,12 @@ describe('HotTableComponent', () => {
       expect(updateDataSpy).toHaveBeenCalledWith(newData);
     });
 
-    it('should not update Handsontable data if data change and it is the first change', () => {
+    it('should not update Handsontable data if data change and it is the first change', async () => {
       const newData = [[1, 2, 3]];
       fixture = TestBed.createComponent(HotTableComponent);
       fixture.componentInstance.settings = {};
       fixture.detectChanges();
+      await fixture.whenStable();
       const component = fixture.componentInstance;
 
       const updateDataSpy = jest.spyOn(component.hotInstance, 'updateData');
@@ -147,13 +155,14 @@ describe('HotTableComponent', () => {
       expect(updateDataSpy).not.toHaveBeenCalledWith(newData);
     });
 
-    it('should not pass init-only settings to updateSettings after initialization', () => {
+    it('should not pass init-only settings to updateSettings after initialization', async () => {
       fixture = TestBed.createComponent(HotTableComponent);
       fixture.componentInstance.settings = {
         renderAllRows: false,
         width: 300,
       };
       fixture.detectChanges();
+      await fixture.whenStable();
       const component = fixture.componentInstance;
       const updateSettingsSpy = jest.spyOn(component.hotInstance, 'updateSettings');
 
@@ -175,7 +184,7 @@ describe('HotTableComponent', () => {
   });
 
   describe('ngOnDestroy', () => {
-    it('should destroy Handsontable instance and editor component references, when columns property is an array', () => {
+    it('should destroy Handsontable instance and editor component references, when columns property is an array', async () => {
       fixture = TestBed.createComponent(HotTableComponent);
       const editorRefMock = {
         destroy: jest.fn(),
@@ -189,6 +198,7 @@ describe('HotTableComponent', () => {
         ],
       };
       fixture.detectChanges();
+      await fixture.whenStable();
       const hotInstance = fixture.componentInstance.hotInstance;
       const destroySpy = jest.spyOn(hotInstance, 'destroy');
 
@@ -198,7 +208,7 @@ describe('HotTableComponent', () => {
       expect(destroySpy).toHaveBeenCalled();
     });
 
-    it('should destroy Handsontable instance, when columns property is a function', () => {
+    it('should destroy Handsontable instance, when columns property is a function', async () => {
       fixture = TestBed.createComponent(HotTableComponent);
 
       fixture.componentInstance.settings = {
@@ -207,6 +217,7 @@ describe('HotTableComponent', () => {
       };
 
       fixture.detectChanges();
+      await fixture.whenStable();
       const hotInstance = fixture.componentInstance.hotInstance;
       const destroySpy = jest.spyOn(hotInstance, 'destroy');
 
@@ -214,7 +225,7 @@ describe('HotTableComponent', () => {
       expect(destroySpy).toHaveBeenCalled();
     });
 
-    it('should destroy Handsontable instance, when columns property is undefined', () => {
+    it('should destroy Handsontable instance, when columns property is undefined', async () => {
       fixture = TestBed.createComponent(HotTableComponent);
 
       fixture.componentInstance.settings = {
@@ -222,16 +233,29 @@ describe('HotTableComponent', () => {
       };
 
       fixture.detectChanges();
+      await fixture.whenStable();
       const hotInstance = fixture.componentInstance.hotInstance;
       const destroySpy = jest.spyOn(hotInstance, 'destroy');
 
       fixture.componentInstance.ngOnDestroy();
       expect(destroySpy).toHaveBeenCalled();
     });
+
+    it('should not create Handsontable instance if component is destroyed before microtask resolves', async () => {
+      fixture = TestBed.createComponent(HotTableComponent);
+      fixture.componentInstance.settings = { ...settings };
+      fixture.detectChanges();
+
+      // Destroy before the pending Promise resolves
+      fixture.componentInstance.ngOnDestroy();
+      await fixture.whenStable();
+
+      expect(fixture.componentInstance.hotInstance).toBeNull();
+    });
   });
 
   describe('hooks', () => {
-    it(`should use Handsontable as a hook's context, if is defined as a component's method`, () => {
+    it(`should use Handsontable as a hook's context, if is defined as a component's method`, async () => {
       fixture = TestBed.createComponent(HotTableComponent);
       fixture.componentInstance.settings = {
         ...settings,
@@ -240,6 +264,7 @@ describe('HotTableComponent', () => {
         },
       };
       fixture.detectChanges();
+      await fixture.whenStable();
 
       const instance: Handsontable = fixture.componentInstance.hotInstance;
       instance.runHooks('afterInit');
@@ -257,6 +282,7 @@ describe('HotTableComponent', () => {
         },
       };
       fixture.detectChanges();
+      await fixture.whenStable();
 
       const instance: Handsontable = fixture.componentInstance.hotInstance.runHooks('afterInit');
 
@@ -264,7 +290,7 @@ describe('HotTableComponent', () => {
       expect(instance.getPlugin('copyPaste')).toBeTruthy();
     });
 
-    it(`should allow to block 'before*' hooks`, () => {
+    it(`should allow to block 'before*' hooks`, async () => {
       fixture = TestBed.createComponent(HotTableComponent);
       const component = fixture.componentInstance;
       component.settings = {
@@ -281,6 +307,7 @@ describe('HotTableComponent', () => {
       };
       let afterChangeResult = false;
       fixture.detectChanges();
+      await fixture.whenStable();
 
       component.hotInstance.setDataAtCell(0, 0, 'test');
 

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.ts
@@ -48,6 +48,7 @@ export class HotTableComponent implements AfterViewInit, OnChanges, OnDestroy {
 
   /** The Handsontable instance. */
   private __hotInstance: Handsontable | null = null;
+  private _pendingDestroy = false;
 
   constructor(
     private readonly _hotSettingsResolver: HotSettingsResolver,
@@ -84,23 +85,32 @@ export class HotTableComponent implements AfterViewInit, OnChanges, OnDestroy {
    */
   ngAfterViewInit(): void {
     let options: Handsontable.GridSettings = this._hotSettingsResolver.applyCustomSettings(this.settings);
-
     const negotiatedSettings = this.getNegotiatedSettings(options);
-    options = { ...options, ...negotiatedSettings, data: this.data };
+    options = { ...options, ...negotiatedSettings, ...(this.data != null ? { data: this.data } : {}) };
 
-    this.ngZone.runOutsideAngular(() => {
-      this.hotInstance = new Handsontable.Core(this.container.nativeElement, options);
-
-      (this.hotInstance as any)._angularEnvironmentInjector = this.environmentInjector;
-
-      this.hotInstance.init();
-    });
-
-    this._hotConfig.config$.pipe(skip(1), takeUntilDestroyed(this.destroyRef)).subscribe(() => {
-      if (this.hotInstance) {
-        const negotiatedSettings = this.getNegotiatedSettings(this.settings);
-        this.updateHotTable(negotiatedSettings);
+    // Defer initialization to the next microtask to prevent NG0100
+    // (ExpressionChangedAfterItHasBeenCheckedError). HOT mutates the input
+    // data array during init (e.g. minSpareRows), which Angular's dev-mode
+    // double-check detects as an illegal mid-cycle change.
+    Promise.resolve().then(() => {
+      if (this._pendingDestroy) {
+        return;
       }
+
+      this.ngZone.runOutsideAngular(() => {
+        this.hotInstance = new Handsontable.Core(this.container.nativeElement, options);
+
+        (this.hotInstance as any)._angularEnvironmentInjector = this.environmentInjector;
+
+        this.hotInstance.init();
+      });
+
+      this._hotConfig.config$.pipe(skip(1), takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+        if (this.hotInstance) {
+          const negotiatedSettings = this.getNegotiatedSettings(this.settings);
+          this.updateHotTable(negotiatedSettings);
+        }
+      });
     });
   }
 
@@ -131,6 +141,8 @@ export class HotTableComponent implements AfterViewInit, OnChanges, OnDestroy {
    * Destroys the Handsontable instance and clears the columns from custom editors.
    */
   ngOnDestroy(): void {
+    this._pendingDestroy = true;
+
     if (!this.hotInstance) {
       return;
     }


### PR DESCRIPTION
### Context
The PR fixes ERROR RuntimeError: NG0100: ExpressionChangedAfterItHasBeenCheckedError

### Fix
 Adding Promise.resolve().then() — defers Handsontable initialization to the next microtask to prevent NG0100 (ExpressionChangedAfterItHasBeenCheckedError).
  During initialization, HOT mutates the input data array (e.g. when minSpareRows is set), which Angular's dev-mode double-check detects as an illegal mid-cycle change.


### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/dev-handsontable/issues/711

### Affected project(s):
- [ ] `handsontable`
- [x] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/86c950wdc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `HotTableComponent` initialization timing by deferring Handsontable creation to a microtask, which could subtly affect lifecycle-dependent behavior and teardown ordering. Adds safeguards/tests to prevent late initialization after destroy.
> 
> **Overview**
> Fixes Angular `ExpressionChangedAfterItHasBeenCheckedError` in `@handsontable/angular-wrapper` by deferring `Handsontable.Core` initialization in `HotTableComponent.ngAfterViewInit()` to the next microtask, avoiding dev-mode change-detection conflicts when HOT mutates input data during init.
> 
> Adds a `_pendingDestroy` guard so a component destroyed before the microtask runs won’t create a table instance, updates unit tests to await `fixture.whenStable()` (and adds a new teardown race test), adjusts Jest config to pass `tsconfig` via the `transform` config, and includes a changelog entry for the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f827baeb5190383a67c0ac2ebce35157984ae28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->