### PR TITLE
Tweak mobile nav overlay layout and header padding

### DIFF
--- a/docs/src/components/Header.astro
+++ b/docs/src/components/Header.astro
@@ -206,7 +206,7 @@ const frameworks = [
       </a>
     </div>
     <div class="mobile-nav-frameworks-section">
-      <span class="mobile-nav-frameworks-label">Framework</span>
+      <span class="mobile-nav-frameworks-label">Select framework:</span>
       <div class="mobile-nav-frameworks">
         {frameworks.map(fw => (
           <a

--- a/docs/src/styles/layout/page.css
+++ b/docs/src/styles/layout/page.css
@@ -49,6 +49,7 @@
 header.header {
   height: auto !important;
   padding-block: 1rem 0.5rem;
+  padding-right: 8px;
   z-index: 10100;
 }
 

--- a/docs/src/styles/layout/responsive.css
+++ b/docs/src/styles/layout/responsive.css
@@ -55,6 +55,6 @@
 
   /* Remove Starlight's extra header padding for the mobile menu button (we use our own sub-bar) */
   [data-has-sidebar] .header {
-    padding-inline-end: 0.5rem !important;
+    padding-inline-end: 0.25rem !important;
   }
 }

--- a/docs/src/styles/mobile/nav-overlay.css
+++ b/docs/src/styles/mobile/nav-overlay.css
@@ -18,8 +18,8 @@
 
 .mobile-nav-overlay > nav {
   display: flex;
-  flex-direction: column;
-  flex: 1;
+  flex-direction: column-reverse;
+  flex: 0;
 }
 
 .mobile-nav-overlay[hidden] {
@@ -69,7 +69,6 @@
 /* Framework section at bottom of mobile overlay */
 .mobile-nav-frameworks-section {
   margin-top: auto;
-  border-top: 1px solid var(--sl-color-gray-5);
 }
 
 .mobile-nav-frameworks-label {


### PR DESCRIPTION
Move framework switcher above menu links, rename label to "Select framework:", remove duplicate top border, and adjust header right padding for small viewports.

### Context
<!--- Why is this change required? What problem does it solve? -->

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only CSS/markup tweaks to the docs header and mobile navigation overlay; main risk is minor layout regressions on small breakpoints.
> 
> **Overview**
> Updates the docs mobile nav overlay to show the framework switcher above the main links (via `column-reverse`), renames the label to `Select framework:`, and removes an extra border to avoid double dividers.
> 
> Tweaks header spacing by adding a small right padding on `header.header` and slightly reducing Starlight’s mobile-end padding (`padding-inline-end`) to better align the custom menu button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c2b613caa07f9b17377df37be87eb78ec12f5d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->