### PR TITLE
DEV-1643: Fix missing React TypeScript examples for multiselect cell type docs

### DIFF
--- a/docs/content/guides/cell-types/multiselect-cell-type/react/example1.tsx
+++ b/docs/content/guides/cell-types/multiselect-cell-type/react/example1.tsx
@@ -1,0 +1,58 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const shipmentCategories: string[] = [
+  'Electronics and Gadgets',
+  'Medical Supplies',
+  'Auto Parts',
+  'Fresh Produce',
+  'Textiles',
+  'Industrial Equipment',
+  'Pharmaceuticals',
+  'Consumer Goods',
+  'Machine Parts',
+  'Food Products',
+];
+
+const data: (string | string[])[][] = [
+  ['Los Angeles International Airport', ['Electronics and Gadgets', 'Medical Supplies']],
+  ["Chicago O'Hare International Airport", ['Auto Parts', 'Fresh Produce']],
+  ['Charles de Gaulle Airport', ['Textiles', 'Industrial Equipment']],
+  ['Tokyo Haneda Airport', ['Pharmaceuticals', 'Consumer Goods']],
+  ['Singapore Changi Airport', ['Machine Parts', 'Food Products']],
+  ['Luton Airport', ['Electronics and Gadgets', 'Pharmaceuticals']],
+  ['Frankfurt Airport', ['Industrial Equipment', 'Auto Parts', 'Consumer Goods']],
+  ['Sydney Kingsford Smith Airport', ['Fresh Produce', 'Food Products']],
+  ['Toronto Pearson International Airport', ['Medical Supplies', 'Textiles']],
+  ['Hong Kong International Airport', ['Machine Parts', 'Electronics and Gadgets', 'Industrial Equipment']],
+  ['Heathrow Airport', ['Textiles', 'Consumer Goods']],
+];
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+      data={data}
+      columns={[
+        {
+          title: 'Airport',
+        },
+        {
+          type: 'multiselect',
+          source: shipmentCategories,
+          title: 'Shipment',
+        },
+      ]}
+      height="auto"
+      stretchH="last"
+      width="100%"
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/cell-types/multiselect-cell-type/react/example2.tsx
+++ b/docs/content/guides/cell-types/multiselect-cell-type/react/example2.tsx
@@ -1,0 +1,131 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+interface ShipmentCategory {
+  key: string;
+  value: string;
+}
+
+const shipmentCategories: ShipmentCategory[] = [
+  { key: 'electronics', value: 'Electronics and Gadgets' },
+  { key: 'medical', value: 'Medical Supplies' },
+  { key: 'auto-parts', value: 'Auto Parts' },
+  { key: 'fresh-produce', value: 'Fresh Produce' },
+  { key: 'textiles', value: 'Textiles' },
+  { key: 'industrial', value: 'Industrial Equipment' },
+  { key: 'pharmaceuticals', value: 'Pharmaceuticals' },
+  { key: 'consumer', value: 'Consumer Goods' },
+  { key: 'machine-parts', value: 'Machine Parts' },
+  { key: 'food', value: 'Food Products' },
+];
+
+const data: (string | ShipmentCategory[])[][] = [
+  [
+    'Los Angeles International Airport',
+    [
+      { key: 'electronics', value: 'Electronics and Gadgets' },
+      { key: 'medical', value: 'Medical Supplies' },
+    ],
+  ],
+  [
+    "Chicago O'Hare International Airport",
+    [
+      { key: 'auto-parts', value: 'Auto Parts' },
+      { key: 'fresh-produce', value: 'Fresh Produce' },
+    ],
+  ],
+  [
+    'Charles de Gaulle Airport',
+    [
+      { key: 'textiles', value: 'Textiles' },
+      { key: 'industrial', value: 'Industrial Equipment' },
+    ],
+  ],
+  [
+    'Tokyo Haneda Airport',
+    [
+      { key: 'pharmaceuticals', value: 'Pharmaceuticals' },
+      { key: 'consumer', value: 'Consumer Goods' },
+    ],
+  ],
+  [
+    'Singapore Changi Airport',
+    [
+      { key: 'machine-parts', value: 'Machine Parts' },
+      { key: 'food', value: 'Food Products' },
+    ],
+  ],
+  [
+    'Luton Airport',
+    [
+      { key: 'electronics', value: 'Electronics and Gadgets' },
+      { key: 'pharmaceuticals', value: 'Pharmaceuticals' },
+    ],
+  ],
+  [
+    'Frankfurt Airport',
+    [
+      { key: 'industrial', value: 'Industrial Equipment' },
+      { key: 'auto-parts', value: 'Auto Parts' },
+      { key: 'consumer', value: 'Consumer Goods' },
+    ],
+  ],
+  [
+    'Sydney Kingsford Smith Airport',
+    [
+      { key: 'fresh-produce', value: 'Fresh Produce' },
+      { key: 'food', value: 'Food Products' },
+    ],
+  ],
+  [
+    'Toronto Pearson International Airport',
+    [
+      { key: 'medical', value: 'Medical Supplies' },
+      { key: 'textiles', value: 'Textiles' },
+    ],
+  ],
+  [
+    'Hong Kong International Airport',
+    [
+      { key: 'machine-parts', value: 'Machine Parts' },
+      { key: 'electronics', value: 'Electronics and Gadgets' },
+      { key: 'industrial', value: 'Industrial Equipment' },
+    ],
+  ],
+  [
+    'Heathrow Airport',
+    [
+      { key: 'textiles', value: 'Textiles' },
+      { key: 'consumer', value: 'Consumer Goods' },
+    ],
+  ],
+];
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+      data={data}
+      columns={[
+        {
+          title: 'Airport',
+        },
+        {
+          type: 'multiselect',
+          source: shipmentCategories,
+          title: 'Shipment',
+        },
+      ]}
+      height="auto"
+      stretchH="last"
+      width="100%"
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/cell-types/multiselect-cell-type/react/example3.tsx
+++ b/docs/content/guides/cell-types/multiselect-cell-type/react/example3.tsx
@@ -1,0 +1,70 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const requiredItems: string[] = ['Passport', 'Tickets', 'Wallet', 'Phone', 'Keys'];
+const optionalExtras: string[] = ['Snacks', 'Book', 'Camera', 'Umbrella', 'First aid kit'];
+const interests: string[] = ['Art', 'History', 'Nature', 'Food', 'Shopping'];
+
+const sortAlphabetically = (entries: (string | object)[]) =>
+  [...entries].sort((a, b) => String(a).localeCompare(String(b)));
+
+const data: string[][][] = [
+  [['Passport', 'Phone'], ['Snacks', 'Book'], ['Nature']],
+  [['Tickets', 'Wallet'], ['Camera'], []],
+  [['Phone', 'Keys'], ['First aid kit', 'Snacks', 'Umbrella'], ['Nature']],
+  [['Wallet', 'Phone'], [], ['Food', 'Shopping']],
+  [['Passport', 'Tickets'], ['Book'], ['Art', 'History']],
+  [['Phone', 'Keys'], ['First aid kit', 'Snacks', 'Umbrella'], ['Nature']],
+  [['Wallet', 'Phone'], [], ['Food', 'Shopping']],
+  [['Passport', 'Tickets'], ['Book'], ['Art', 'History']],
+  [['Phone', 'Keys'], ['First aid kit', 'Snacks', 'Umbrella'], ['Nature']],
+  [['Wallet', 'Phone'], [], ['Food', 'Shopping']],
+  [['Passport', 'Tickets'], ['Book'], ['Art', 'History']],
+  [['Phone', 'Keys'], ['First aid kit', 'Snacks', 'Umbrella'], ['Nature']],
+  [['Wallet', 'Phone'], [], ['Food', 'Shopping']],
+  [['Passport', 'Tickets'], ['Book'], ['Art', 'History']],
+];
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+      data={data}
+      columns={[
+        {
+          type: 'multiselect',
+          source: requiredItems,
+          title: 'Required items',
+          allowEmpty: false,
+        },
+        {
+          type: 'multiselect',
+          source: optionalExtras,
+          title: 'Optional extras',
+          placeholder: 'Select up to 3',
+          maxSelections: 3,
+          visibleRows: 4,
+          searchInput: false,
+        },
+        {
+          type: 'multiselect',
+          source: interests,
+          title: 'Interests',
+          placeholder: 'Select interests',
+          sourceSortFunction: sortAlphabetically,
+          filteringCaseSensitive: true,
+        },
+      ]}
+      height="auto"
+      stretchH="last"
+      width="100%"
+    />
+  );
+};
+
+export default ExampleComponent;


### PR DESCRIPTION
### Context

The PR fixes broken React TypeScript examples on the multiselect cell type documentation page. The docs referenced three `.tsx` files (`example1.tsx`, `example2.tsx`, `example3.tsx`) that did not exist, causing a "File not found" error for users viewing the TypeScript tab on the React variant of the page.

URL affected: https://dev.handsontable.com/docs/react-data-grid/multiselect-cell-type/

Three TypeScript React example files have been created:
- `example1.tsx` - array-of-values source with typed `string[]` data
- `example2.tsx` - array-of-objects source with a typed `ShipmentCategory` interface
- `example3.tsx` - other options demo with a typed `sourceSortFunction` parameter

### How has this been tested?

- Verified all three `.jsx` source files exist and match the new `.tsx` content
- Verified the docs page references (`@[code]`) point to the correct file paths

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1643

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/86c9qtxzx

[skip changelog]

---
_Generated by [Claude Code](https://claude.ai/code/session_01DRW5EuWsVti9SPfTD3DW28)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that adds missing `.tsx` example files; no runtime/library behavior changes.
> 
> **Overview**
> Fixes broken TypeScript tabs on the React MultiSelect cell type guide by adding the missing example files referenced by the docs.
> 
> Adds three React TypeScript examples: `example1.tsx` (string `source` + typed data), `example2.tsx` (object `source` with typed interface), and `example3.tsx` (demonstrates additional MultiSelect options such as `allowEmpty`, `maxSelections`, and `sourceSortFunction`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29e52d2c1c28913618b34ab8e89d260e39b2ed8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->