### PR TITLE
DEV-1632: Fix search styling in external-search-box recipe examples

### DIFF
--- a/docs/content/recipes/filtering-and-search/external-search-box/angular/example1.ts
+++ b/docs/content/recipes/filtering-and-search/external-search-box/angular/example1.ts
@@ -17,15 +17,16 @@ const data = [
   imports: [HotTableModule],
   selector: 'example1-external-search-box',
   template: `
-    <div style="margin-bottom: 12px;">
-      <label for="external-search-input" style="display: block; margin-bottom: 4px;">Search rows</label>
-      <input
-        id="external-search-input"
-        type="text"
-        placeholder="Type to highlight matching cells..."
-        style="width: 100%; box-sizing: border-box; padding: 8px;"
-        (input)="onSearch($event)"
-      />
+    <div class="example-controls-container">
+      <div class="controls">
+        <label for="external-search-input">Search rows</label>
+        <input
+          id="external-search-input"
+          type="search"
+          placeholder="Type to highlight matching cells..."
+          (input)="onSearch($event)"
+        />
+      </div>
     </div>
     <hot-table [data]="data" [settings]="gridSettings"></hot-table>
   `,

--- a/docs/content/recipes/filtering-and-search/external-search-box/javascript/example1.js
+++ b/docs/content/recipes/filtering-and-search/external-search-box/javascript/example1.js
@@ -18,26 +18,25 @@ const data = [
 const exampleContainer = document.querySelector('#example1');
 
 const searchWrapper = document.createElement('div');
-searchWrapper.style.marginBottom = '12px';
+searchWrapper.className = 'example-controls-container';
+
+const controlsDiv = document.createElement('div');
+controlsDiv.className = 'controls';
 
 const searchLabel = document.createElement('label');
 searchLabel.setAttribute('for', 'external-search-input');
 searchLabel.textContent = 'Search rows';
-searchLabel.style.display = 'block';
-searchLabel.style.marginBottom = '4px';
 
 const searchInput = document.createElement('input');
 searchInput.id = 'external-search-input';
-searchInput.type = 'text';
+searchInput.type = 'search';
 searchInput.placeholder = 'Type to highlight matching cells...';
-searchInput.style.width = '100%';
-searchInput.style.boxSizing = 'border-box';
-searchInput.style.padding = '8px';
 
 const hotContainer = document.createElement('div');
 
-searchWrapper.appendChild(searchLabel);
-searchWrapper.appendChild(searchInput);
+controlsDiv.appendChild(searchLabel);
+controlsDiv.appendChild(searchInput);
+searchWrapper.appendChild(controlsDiv);
 exampleContainer.appendChild(searchWrapper);
 exampleContainer.appendChild(hotContainer);
 

--- a/docs/content/recipes/filtering-and-search/external-search-box/javascript/example1.ts
+++ b/docs/content/recipes/filtering-and-search/external-search-box/javascript/example1.ts
@@ -22,26 +22,25 @@ if (!exampleContainer) {
 }
 
 const searchWrapper = document.createElement('div');
-searchWrapper.style.marginBottom = '12px';
+searchWrapper.className = 'example-controls-container';
+
+const controlsDiv = document.createElement('div');
+controlsDiv.className = 'controls';
 
 const searchLabel = document.createElement('label');
 searchLabel.setAttribute('for', 'external-search-input');
 searchLabel.textContent = 'Search rows';
-searchLabel.style.display = 'block';
-searchLabel.style.marginBottom = '4px';
 
 const searchInput = document.createElement('input');
 searchInput.id = 'external-search-input';
-searchInput.type = 'text';
+searchInput.type = 'search';
 searchInput.placeholder = 'Type to highlight matching cells...';
-searchInput.style.width = '100%';
-searchInput.style.boxSizing = 'border-box';
-searchInput.style.padding = '8px';
 
 const hotContainer = document.createElement('div');
 
-searchWrapper.appendChild(searchLabel);
-searchWrapper.appendChild(searchInput);
+controlsDiv.appendChild(searchLabel);
+controlsDiv.appendChild(searchInput);
+searchWrapper.appendChild(controlsDiv);
 exampleContainer.appendChild(searchWrapper);
 exampleContainer.appendChild(hotContainer);
 

--- a/docs/content/recipes/filtering-and-search/external-search-box/react/example1.jsx
+++ b/docs/content/recipes/filtering-and-search/external-search-box/react/example1.jsx
@@ -47,20 +47,16 @@ const ExampleComponent = () => {
 
   return (
     <div>
-      <div style={{ marginBottom: '12px' }}>
-        <label
-          htmlFor="external-search-input"
-          style={{ display: 'block', marginBottom: '4px' }}
-        >
-          Search rows
-        </label>
-        <input
-          id="external-search-input"
-          type="text"
-          placeholder="Type to highlight matching cells..."
-          style={{ width: '100%', boxSizing: 'border-box', padding: '8px' }}
-          onInput={handleSearchInput}
-        />
+      <div className="example-controls-container">
+        <div className="controls">
+          <label htmlFor="external-search-input">Search rows</label>
+          <input
+            id="external-search-input"
+            type="search"
+            placeholder="Type to highlight matching cells..."
+            onInput={handleSearchInput}
+          />
+        </div>
       </div>
       <HotTable
         ref={hotRef}

--- a/docs/content/recipes/filtering-and-search/external-search-box/react/example1.tsx
+++ b/docs/content/recipes/filtering-and-search/external-search-box/react/example1.tsx
@@ -47,20 +47,16 @@ const ExampleComponent = () => {
 
   return (
     <div>
-      <div style={{ marginBottom: '12px' }}>
-        <label
-          htmlFor="external-search-input"
-          style={{ display: 'block', marginBottom: '4px' }}
-        >
-          Search rows
-        </label>
-        <input
-          id="external-search-input"
-          type="text"
-          placeholder="Type to highlight matching cells..."
-          style={{ width: '100%', boxSizing: 'border-box', padding: '8px' }}
-          onInput={handleSearchInput}
-        />
+      <div className="example-controls-container">
+        <div className="controls">
+          <label htmlFor="external-search-input">Search rows</label>
+          <input
+            id="external-search-input"
+            type="search"
+            placeholder="Type to highlight matching cells..."
+            onInput={handleSearchInput}
+          />
+        </div>
       </div>
       <HotTable
         ref={hotRef}


### PR DESCRIPTION
### Context

The PR fixes incorrect styling in the `external-search-box` recipe examples (JS, TS, React JSX/TSX, Angular). All five examples used ad-hoc inline styles for the search input wrapper, label, and input element, instead of the `example-controls-container` / `controls` CSS classes that are globally defined in `interactive-example.css` and used consistently across all `searching-values` guide examples.

This made the search input look visually inconsistent with the rest of the documentation.

Changes:
- JS/TS: Replace `document.createElement` + `element.style.*` assignments with `className = 'example-controls-container'` / `className = 'controls'` and add an inner `.controls` wrapper div.
- React JSX/TSX: Replace `style={{ ... }}` inline props with `className="example-controls-container"` and `className="controls"`.
- Angular: Replace `style="..."` template attributes with `class="example-controls-container"` and `class="controls"`.
- All examples: Change `type="text"` to `type="search"` on the input to match the searching-values examples.

ClickUp task: https://app.clickup.com/t/86c9px4we

### How has this been tested?

- Visual inspection against the reference example at `/docs/angular-data-grid/searching-values/`
- No logic changes — only DOM structure and CSS class names changed

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1632

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wh3BHHNrtt6qMwEVcAuFjd)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only DOM/CSS-class updates plus input `type` change; no Handsontable/search logic is modified.
> 
> **Overview**
> Updates the `external-search-box` recipe examples (Angular, vanilla JS/TS, React JSX/TSX) to use the shared `example-controls-container` / `controls` wrapper structure instead of ad-hoc inline styles, making the search UI consistent with other docs examples.
> 
> Switches the search input from `type="text"` to `type="search"` across all examples while keeping the search behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f9bdb823bec6a71b5857a616fd2c609f329a68d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->