### PR TITLE
DEV-1644: Fix JS/TS picker dropdown width in documentation examples

### DIFF
--- a/docs/src/styles/interactive-example.css
+++ b/docs/src/styles/interactive-example.css
@@ -405,7 +405,7 @@
   box-shadow: none;
   list-style: none;
   margin: -1px 0 0;
-  min-width: 8rem;
+  min-width: 100%;
   overflow-y: auto;
   padding: 0;
   position: absolute;


### PR DESCRIPTION
### Context

The PR fixes a visual inconsistency in the JS/TS language picker dropdown on documentation example blocks. The dropdown menu (`.hot-example-lang-menu`) had a hardcoded `min-width: 8rem` (128px), causing it to extend wider than the trigger button that shows the currently selected language (e.g., "TypeScript"). Changed `min-width` to `100%` so the menu matches the trigger container width.

### How has this been tested?

- Visually verified by inspecting the picker on documentation example pages - the open dropdown now aligns with the trigger button width instead of overflowing it.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1644

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/86c9qu5j4

[skip changelog]

---
_Generated by [Claude Code](https://claude.ai/code/session_01RE9iiKwDp46yugyURbA59g)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only tweak in docs styling; could only affect dropdown layout/overflow in interactive example blocks.
> 
> **Overview**
> Fixes the JS/TS language picker dropdown in documentation interactive examples so the menu no longer has a hardcoded minimum width.
> 
> Updates `.hot-example-lang-menu` from `min-width: 8rem` to `min-width: 100%`, making the dropdown match the trigger/button width and preventing the menu from appearing wider than its anchor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed19467ec854adece5f619e4ca2a42df9e2f7ea4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->