### PR TITLE
Simplify import-csv-excel recipe: one section + empty state, no preview

### DIFF
--- a/docs/content/recipes/import-export/import-csv-excel/angular/example1.css
+++ b/docs/content/recipes/import-export/import-csv-excel/angular/example1.css
@@ -1,25 +1,118 @@
+.import-csv-excel-wrap {
+  display: flex;
+  flex-direction: column;
+  margin: 0 -1rem;
+}
+
 .import-dropzone {
-  border: 2px dashed var(--ht-border-color, #ccc);
-  border-radius: 8px;
-  padding: 16px;
+  padding: 1.5rem 1rem;
   text-align: center;
-  margin-bottom: 12px;
+  border: 0;
+  border-bottom: 1px solid var(--sl-color-gray-5);
+  border-radius: 0;
+  background: transparent;
+  color: var(--sl-color-gray-2);
+  font-size: var(--sl-text-xs);
+  transition: background 0.15s ease;
   cursor: pointer;
 }
 
-.import-dropzone--active {
-  border-color: var(--ht-accent-color, #1a42e8);
-  background: rgba(26, 66, 232, 0.05);
+.import-dropzone p {
+  margin: 0 0 0.75rem;
 }
 
-.import-preview {
-  border: 1px solid var(--ht-border-color, #e0e0e0);
-  border-radius: 4px;
-  padding: 12px;
-  margin-bottom: 12px;
+.import-dropzone.import-dropzone--active {
+  background: var(--sl-color-gray-6);
+}
+
+.import-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.import-file-label {
+  display: inline-block;
+  cursor: pointer;
+}
+
+.import-file-label span,
+.import-sample-btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.375rem 0.75rem;
+  border: 1px solid var(--sl-color-gray-5);
+  border-radius: 0;
+  background: var(--sl-color-gray-6);
+  color: var(--sl-color-gray-2);
+  font-family: var(--sl-font);
+  font-size: var(--sl-text-xs);
+  font-weight: 500;
+  line-height: 1.4;
+  cursor: pointer;
+  transition: background-color 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.import-file-label:hover span,
+.import-sample-btn:hover {
+  background: var(--sl-color-gray-5);
+  color: var(--sl-color-white);
+}
+
+.import-file-label input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.import-msg {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 0;
+  font-size: var(--sl-text-xs);
 }
 
 .import-msg--error {
-  color: var(--ht-cell-error-color, #c62828);
-  padding: 8px 0;
+  border-bottom: 1px solid var(--sl-color-red, #ef4444);
+  background: var(--sl-color-red-low, rgba(239, 68, 68, 0.12));
+  color: var(--sl-color-red, #ef4444);
+}
+
+.import-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 2.5rem 1rem;
+  min-height: 200px;
+  color: var(--sl-color-gray-2);
+  text-align: center;
+}
+
+.import-empty-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  margin-bottom: 0.25rem;
+  border: 1px solid var(--sl-color-gray-5);
+  color: var(--sl-color-gray-3);
+}
+
+.import-empty-title {
+  margin: 0;
+  color: var(--sl-color-white);
+  font-size: var(--sl-text-sm);
+  font-weight: 600;
+}
+
+.import-empty-text {
+  margin: 0;
+  max-width: 38ch;
+  font-size: var(--sl-text-xs);
+  line-height: 1.5;
 }

--- a/docs/content/recipes/import-export/import-csv-excel/angular/example1.ts
+++ b/docs/content/recipes/import-export/import-csv-excel/angular/example1.ts
@@ -147,29 +147,18 @@ async function parseFile(file: File): Promise<ParsedPayload> {
         (dragleave)="onDragLeave()"
         (drop)="onDrop($event)"
       >
-        <p>Drop a <code>.csv</code> or <code>.xlsx</code> file here, or use the file picker.</p>
-        <label class="import-file-label">
-          <span>Choose file</span>
-          <input
-            type="file"
-            accept=".csv,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,text/csv"
-            (change)="onFileChange($event)"
-            #fileInput
-          />
-        </label>
-      </div>
-
-      <div class="import-sample-block">
-        <label for="import-sample-csv-ng">Sample CSV (click <strong>Parse sample CSV</strong> to preview):</label>
-        <textarea
-          id="import-sample-csv-ng"
-          rows="5"
-          spellcheck="false"
-          [value]="sampleCsv"
-          (input)="sampleCsv = $any($event.target).value"
-        ></textarea>
-        <div class="import-sample-actions">
-          <button type="button" (click)="parseSampleCsv()">Parse sample CSV</button>
+        <p>Drop a <code>.csv</code> or <code>.xlsx</code> file here, or pick a source.</p>
+        <div class="import-actions">
+          <label class="import-file-label">
+            <span>Choose file</span>
+            <input
+              type="file"
+              accept=".csv,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,text/csv"
+              (change)="onFileChange($event)"
+              #fileInput
+            />
+          </label>
+          <button type="button" class="import-sample-btn" (click)="loadSampleData()">Load sample data</button>
         </div>
       </div>
 
@@ -177,19 +166,22 @@ async function parseFile(file: File): Promise<ParsedPayload> {
         <div class="import-msg import-msg--error">{{ errorMessage }}</div>
       }
 
-      @if (showPreview) {
-        <div class="import-preview">
-          <p class="import-preview-title">Detected column headers (not loaded yet):</p>
-          <ul class="import-header-list">
-            @for (h of pending?.headers ?? []; track h) {
-              <li>{{ h }}</li>
-            }
-          </ul>
-          <button type="button" class="import-apply-btn" (click)="applyToGrid()">Load into grid</button>
+      @if (gridData.length === 0) {
+        <div class="import-empty">
+          <span class="import-empty-icon" aria-hidden="true">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="3" y="3" width="18" height="18"/>
+              <path d="M3 9h18M3 15h18M9 3v18M15 3v18"/>
+            </svg>
+          </span>
+          <p class="import-empty-title">No data loaded yet</p>
+          <p class="import-empty-text">
+            Drop a CSV or Excel file above, choose a file, or load the sample data to populate the table.
+          </p>
         </div>
+      } @else {
+        <hot-table [data]="gridData" [settings]="gridSettings"></hot-table>
       }
-
-      <hot-table [data]="gridData" [settings]="gridSettings"></hot-table>
     </div>
   `,
 })
@@ -198,11 +190,9 @@ export class AppComponent {
 
   isDragOver = false;
   errorMessage = '';
-  showPreview = false;
-  pending: ParsedPayload | null = null;
   gridData: Record<string, unknown>[] = [];
 
-  sampleCsv = `Product,Category,In stock,Price
+  private readonly SAMPLE_CSV = `Product,Category,In stock,Price
 Widget A,Hardware,true,19.99
 Widget B,Hardware,false,24.5
 Service Pack,Services,true,0`;
@@ -242,32 +232,14 @@ Service Pack,Services,true,0`;
     input.value = '';
   }
 
-  async parseSampleCsv(): Promise<void> {
+  async loadSampleData(): Promise<void> {
     this.errorMessage = '';
     try {
-      const payload = parseCsvText(this.sampleCsv);
-      this.setPending(payload);
+      const payload = parseCsvText(this.SAMPLE_CSV);
+      this.loadIntoGrid(payload);
     } catch (e) {
-      this.clearPendingPreview();
       this.errorMessage = e instanceof Error ? e.message : String(e);
     }
-  }
-
-  applyToGrid(): void {
-    this.errorMessage = '';
-    if (!this.pending) {
-      this.errorMessage = 'Nothing to load. Import a file first.';
-      return;
-    }
-    const { headers, rows } = this.pending;
-    this.gridSettings = {
-      ...this.gridSettings,
-      colHeaders: headers,
-      columns: this.columnsFromHeaders(headers),
-    };
-    this.gridData = [...rows];
-    this.showPreview = false;
-    this.pending = null;
   }
 
   private async handleFile(file: File): Promise<void> {
@@ -278,30 +250,25 @@ Service Pack,Services,true,0`;
     }
     try {
       const payload = await parseFile(file);
-      this.setPending(payload);
+      this.loadIntoGrid(payload);
     } catch (e) {
-      this.clearPendingPreview();
       this.errorMessage = e instanceof Error ? e.message : String(e);
     }
   }
 
-  private setPending(payload: ParsedPayload): void {
-    this.pending = payload;
-    this.errorMessage = '';
-    this.showPreview = true;
+  private loadIntoGrid(payload: ParsedPayload): void {
+    const { headers, rows } = payload;
+    this.gridSettings = {
+      ...this.gridSettings,
+      colHeaders: headers,
+      columns: this.columnsFromHeaders(headers, rows),
+    };
+    this.gridData = [...rows];
   }
 
-  private clearPendingPreview(): void {
-    this.pending = null;
-    this.showPreview = false;
-  }
-
-  private columnsFromHeaders(headers: string[]): GridSettings['columns'] {
-    if (!this.pending) {
-      return headers.map((data) => ({ data, type: 'text' }));
-    }
+  private columnsFromHeaders(headers: string[], rows: Record<string, unknown>[]): GridSettings['columns'] {
     return headers.map((data) => {
-      const values = (this.pending?.rows ?? [])
+      const values = rows
         .map((row) => row[data])
         .filter((v) => v !== null);
       if (values.length > 0 && values.every((v) => typeof v === 'number')) {

--- a/docs/content/recipes/import-export/import-csv-excel/import-csv-excel.md
+++ b/docs/content/recipes/import-export/import-csv-excel/import-csv-excel.md
@@ -95,18 +95,22 @@ Use `accept` on the file input and check `file.name` to route `.csv` and `.xlsx`
 
 ```html
 <div class="import-dropzone" id="import-dropzone" tabindex="0" role="button">
-  <p>Drop a <code>.csv</code> or <code>.xlsx</code> file here, or use the file picker.</p>
-  <label class="import-file-label">
-    <span>Choose file</span>
-    <input id="import-file" type="file"
-      accept=".csv,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,text/csv" />
-  </label>
+  <p>Drop a <code>.csv</code> or <code>.xlsx</code> file here, or pick a source.</p>
+  <div class="import-actions">
+    <label class="import-file-label">
+      <span>Choose file</span>
+      <input id="import-file" type="file"
+        accept=".csv,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,text/csv" />
+    </label>
+    <button type="button" id="import-load-sample" class="import-sample-btn">Load sample data</button>
+  </div>
 </div>
 ```
 
 **What's happening:**
 - The `accept` attribute restricts the system file picker to `.csv` and `.xlsx`. This is a hint to the browser only -- you must validate the extension in JavaScript as well.
 - The real `<input>` is visually hidden (positioned off-screen with `opacity: 0`) and activated via the wrapping `<label>`. Clicking **Choose file** triggers the file picker without requiring a separate button.
+- **Load sample data** parses a bundled CSV string so users can try the grid without having to upload a file first.
 - The drop zone has `tabindex="0"` and `role="button"` so keyboard users can focus and activate it.
 
 ### Extension detection
@@ -235,7 +239,7 @@ async function parseCsvFile(file, PapaRef) {
 - `dynamicTyping: true` lets PapaParse return native numbers and booleans where possible.
 - Numeric and boolean values are preserved as-is; string values are trimmed, and empty strings are normalized to `null`.
 
-### Parse a CSV text string (for the sample textarea)
+### Parse a CSV text string (for the bundled sample)
 
 ```javascript
 function parseCsvText(text, PapaRef) {
@@ -255,7 +259,7 @@ function parseCsvText(text, PapaRef) {
 **What's happening:**
 - Works identically to `parseCsvFile` but accepts a raw CSV string instead of a `File` object.
 - PapaParse's synchronous `parse(string, opts)` overload is used here (no `complete` callback needed).
-- Used when the user clicks **Parse sample CSV** to process the pre-filled textarea value without picking a file.
+- Used when the user clicks **Load sample data** to parse a CSV string embedded in the script and feed it into the grid.
 
 ## Step 3: Parse Excel with SheetJS
 
@@ -359,51 +363,14 @@ async function parseFile(file) {
 - The library is loaded on demand: PapaParse for CSV, SheetJS for Excel. If only CSV files are imported, SheetJS is never downloaded.
 - Both parsers return the same shape: `{ headers: string[], rows: object[] }` -- the rest of the code does not need to know which parser ran.
 
-## Step 4: Preview headers, then load the grid
-
-### Keep parsed data in a pending buffer
-
-```javascript
-let pending = null;
-
-function setPending(payload) {
-  pending = payload;
-  clearError(errEl);
-  if (headerListEl && previewEl) {
-    renderHeaderPreview(headerListEl, payload.headers);
-    previewEl.hidden = false;
-  }
-}
-```
-
-**What's happening:**
-- `pending` holds the last successfully parsed `{ headers, rows }` object until the user confirms or a new file is loaded.
-- `setPending` clears any previous error, renders the header list, and shows the preview panel -- but does not touch the grid yet. The user must click **Load into grid** to commit.
-- A two-step confirm flow prevents accidental overwrites and gives the user a chance to check that the detected headers match expectations before loading potentially thousands of rows.
-
-### Render the header preview
-
-```javascript
-function renderHeaderPreview(listEl, headers) {
-  listEl.innerHTML = '';
-  for (const h of headers) {
-    const li = document.createElement('li');
-    li.textContent = h;
-    listEl.appendChild(li);
-  }
-}
-```
-
-**What's happening:**
-- Clears the list before re-populating so stale headers from a previous import are not shown.
-- Uses `textContent` (not `innerHTML`) to prevent XSS when column names contain HTML characters.
+## Step 4: Load parsed data into the grid
 
 ### Build column definitions from header names
 
 ```javascript
-function columnsFromHeaders(headers) {
+function columnsFromHeaders(headers, rows) {
   return headers.map((data) => {
-    const values = pending.rows
+    const values = rows
       .map((row) => row[data])
       .filter((v) => v !== null);
 
@@ -422,31 +389,63 @@ function columnsFromHeaders(headers) {
 - Handsontable's `columns` option expects an array of column descriptors. Each descriptor's `data` property is the key used to read from the row objects.
 - The helper infers `numeric` and `checkbox` columns when all non-empty values in that column are numbers or booleans. Mixed columns stay as `'text'`.
 
-### Load the grid
+### Lazy-init the grid on the first load
 
 ```javascript
-applyBtn?.addEventListener('click', () => {
-  clearError(errEl);
-  if (!pending) {
-    showError(errEl, 'Nothing to load. Import a file first.');
+let hot = null;
+
+function loadIntoGrid({ headers, rows }) {
+  const columns = columnsFromHeaders(headers, rows);
+
+  if (!hot) {
+    emptyEl.hidden = true;
+    gridContainer.hidden = false;
+    hot = new Handsontable(gridContainer, {
+      data: rows,
+      columns,
+      colHeaders: headers,
+      rowHeaders: true,
+      height: 'auto',
+      width: '100%',
+      licenseKey: 'non-commercial-and-evaluation',
+    });
     return;
   }
-  const { headers, rows } = pending;
-  hot.updateSettings({
-    colHeaders: headers,
-    columns: columnsFromHeaders(headers),
-  });
+
+  hot.updateSettings({ colHeaders: headers, columns });
   hot.loadData(rows);
-  previewEl.hidden = true;
-  pending = null;
+}
+```
+
+**What's happening:**
+- `hot` is created on the first successful import only. Before that, the page shows an empty-state panel (`emptyEl`) and `gridContainer` (the `#example1` div) is kept `hidden` so users don't see a single blank cell.
+- On the first call: hide the empty state, reveal the grid container, and instantiate Handsontable with the parsed data, columns, and headers.
+- On subsequent calls: reuse the existing instance -- `updateSettings({ colHeaders, columns })` reconfigures the grid's column shape, then `loadData(rows)` replaces the data and triggers a full re-render. `updateSettings` must run before `loadData` so Handsontable knows which keys to read from the row objects.
+
+### Load the bundled sample
+
+```javascript
+const SAMPLE_CSV = `Product,Category,In stock,Price
+Widget A,Hardware,true,19.99
+Widget B,Hardware,false,24.5
+Service Pack,Services,true,0`;
+
+sampleBtn?.addEventListener('click', async () => {
+  clearError(errEl);
+  try {
+    const PapaRef = await ensurePapa();
+    const payload = parseCsvText(SAMPLE_CSV, PapaRef);
+    loadIntoGrid(payload);
+  } catch (e) {
+    showError(errEl, e instanceof Error ? e.message : String(e));
+  }
 });
 ```
 
 **What's happening:**
-1. Guard against clicking **Load into grid** when no file has been parsed yet.
-2. `hot.updateSettings({ colHeaders, columns })` reconfigures the grid for the new column shape. This must happen before `loadData` so Handsontable knows which keys to read from the row objects.
-3. `hot.loadData(rows)` replaces the grid's data source and triggers a full re-render.
-4. After loading, the preview panel is hidden and `pending` is cleared so a stale payload is not accidentally loaded twice.
+- `SAMPLE_CSV` is a small CSV string embedded in the script -- enough to demonstrate the grid without forcing the user to upload anything.
+- The handler ensures PapaParse is available, parses the sample synchronously, and hands the result straight to `loadIntoGrid` -- no preview step in between.
+- File uploads use the same `loadIntoGrid` function (see `handleFile` in [Step 5](#step-5-handle-errors)), so both code paths converge on a single grid-population helper.
 
 ## Step 5: Handle errors
 
@@ -485,7 +484,6 @@ function clearError(el) {
 | Excel sheet is empty | `"The sheet is empty."` |
 | Excel header row is blank | `"No header row found in the Excel sheet."` |
 | Excel has no data rows | `"No data rows after the header."` |
-| **Load into grid** clicked with no file parsed | `"Nothing to load. Import a file first."` |
 
 The `handleFile` async function is the single place where all parse errors are caught and forwarded to `showError`:
 
@@ -499,10 +497,8 @@ async function handleFile(file) {
   }
   try {
     const payload = await parseFile(file);
-    setPending(payload);
+    loadIntoGrid(payload);
   } catch (e) {
-    pending = null;
-    previewEl.hidden = true;
     showError(errEl, e instanceof Error ? e.message : String(e));
   }
 }
@@ -511,30 +507,29 @@ async function handleFile(file) {
 **What's happening:**
 - `file.size === 0` is checked before any async work to give an instant response for empty files.
 - Any error thrown by the parsers bubbles up here and is shown to the user.
-- On error, `pending` is cleared and the preview panel is hidden so the user cannot accidentally load stale data.
-- Apply the same stale-state reset for the sample textarea parser, so failed sample parsing cannot leave old data queued for **Load into grid**.
+- On success, the parsed `{ headers, rows }` payload goes straight to `loadIntoGrid` -- no intermediate state to reset on failure.
+- The **Load sample data** handler uses the same try/catch shape, so sample-parse errors surface in the same error panel.
 
 ## Try it quickly
 
-Use the **Sample CSV** textarea in the example and click **Parse sample CSV**, or save the snippet as `sample.csv` and drop it on the zone.
+Click **Load sample data** in the example to populate the grid from the bundled CSV string, or save the snippet from [Step 4](#load-the-bundled-sample) as `sample.csv` and drop it on the zone.
 
 ## How it works - complete flow
 
-1. **User picks or drops a file** -- the `change` or `drop` event fires and calls `handleFile`.
-2. **File size check** -- zero-byte files are rejected immediately.
-3. **Extension routing** -- `parseFile` reads the extension and loads the right parser library on demand.
+1. **User picks or drops a file (or clicks Load sample data)** -- the `change`, `drop`, or sample button event fires and reaches `handleFile` / the sample handler.
+2. **File size check** -- zero-byte files are rejected immediately (file path only).
+3. **Extension routing** -- `parseFile` reads the extension and loads the right parser library on demand. The sample path always uses PapaParse via `parseCsvText`.
 4. **Parsing** -- CSV goes through PapaParse with `header: true`; Excel is read via SheetJS with `sheet_to_json` and row-0 as the header line.
 5. **Normalization** -- empty cells become `null`, and native numbers/booleans are preserved for CSV and Excel.
-6. **Header preview** -- `setPending` stores the result and shows the detected column names in a list.
-7. **User confirms** -- clicking **Load into grid** calls `hot.updateSettings` followed by `hot.loadData`.
-8. **Grid renders** -- Handsontable re-renders with the new columns and data.
-9. **Errors at any step** -- caught by `handleFile` or the sample-parse path (plus the apply-button guard), then shown in the error panel while pending preview state is cleared.
+6. **Grid population** -- `loadIntoGrid` creates the Handsontable instance on the first call (hiding the empty-state panel) or updates `colHeaders`, `columns`, and data on subsequent calls.
+7. **Grid renders** -- Handsontable re-renders with the new columns and data.
+8. **Errors at any step** -- caught by `handleFile` or the sample-parse handler and shown in the error panel.
 
 ## What you learned
 
 - How to detect the file type by extension and route CSV files through PapaParse and Excel files through SheetJS with a single handler function.
-- How to present a header preview before loading data, so users can confirm the detected columns match their expectations.
-- How to call `hot.updateSettings({ colHeaders, columns })` followed by `hot.loadData(rows)` to replace both the column configuration and the data in one step.
+- How to ship a bundled CSV sample so users can demo the grid without uploading a file first.
+- How to call `hot.updateSettings({ colHeaders, columns })` followed by `hot.loadData(rows)` to replace both the column configuration and the data in one step, and how to lazy-instantiate Handsontable behind an empty-state panel.
 - How to handle errors at each stage -- file size, parsing, and grid load -- and surface them in a dedicated error panel.
 
 ## Next steps

--- a/docs/content/recipes/import-export/import-csv-excel/javascript/example1.css
+++ b/docs/content/recipes/import-export/import-csv-excel/javascript/example1.css
@@ -1,37 +1,61 @@
 .import-csv-excel-wrap {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  margin-bottom: 12px;
+  margin: 0 -1rem;
 }
 
 .import-dropzone {
-  border: 2px dashed var(--sl-color-gray-4, #ccc);
-  border-radius: 8px;
-  padding: 16px;
+  padding: 1.5rem 1rem;
   text-align: center;
-  background: var(--sl-color-bg-inline-code, rgba(0, 0, 0, 0.04));
-  transition: border-color 0.15s ease, background 0.15s ease;
+  border: 0;
+  border-bottom: 1px solid var(--sl-color-gray-5);
+  border-radius: 0;
+  background: transparent;
+  color: var(--sl-color-gray-2);
+  font-size: var(--sl-text-xs);
+  transition: background 0.15s ease;
+}
+
+.import-dropzone p {
+  margin: 0 0 0.75rem;
 }
 
 .import-dropzone.import-dropzone--active {
-  border-color: var(--sl-color-accent, #3b82f6);
-  background: var(--sl-color-accent-low, rgba(59, 130, 246, 0.08));
+  background: var(--sl-color-gray-6);
+}
+
+.import-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .import-file-label {
   display: inline-block;
-  margin-top: 8px;
   cursor: pointer;
 }
 
-.import-file-label span {
-  display: inline-block;
-  padding: 6px 14px;
-  border-radius: 6px;
-  background: var(--sl-color-accent, #3b82f6);
-  color: var(--sl-color-black, #fff);
-  font-size: 0.875rem;
+.import-file-label span,
+.import-sample-btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.375rem 0.75rem;
+  border: 1px solid var(--sl-color-gray-5);
+  border-radius: 0;
+  background: var(--sl-color-gray-6);
+  color: var(--sl-color-gray-2);
+  font-family: var(--sl-font);
+  font-size: var(--sl-text-xs);
+  font-weight: 500;
+  line-height: 1.4;
+  cursor: pointer;
+  transition: background-color 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.import-file-label:hover span,
+.import-sample-btn:hover {
+  background: var(--sl-color-gray-5);
+  color: var(--sl-color-white);
 }
 
 .import-file-label input {
@@ -42,74 +66,65 @@
   pointer-events: none;
 }
 
-.import-sample-block label {
-  display: block;
-  font-size: 0.875rem;
-  margin-bottom: 6px;
-}
-
-#import-sample-csv {
-  width: 100%;
-  box-sizing: border-box;
-  font-family: ui-monospace, monospace;
-  font-size: 0.8rem;
-  padding: 8px;
-  border-radius: 6px;
-  border: 1px solid var(--sl-color-gray-4, #ccc);
-  resize: vertical;
-}
-
-.import-sample-actions {
-  margin-top: 8px;
-}
-
-.import-sample-actions button,
-.import-apply-btn {
-  padding: 6px 14px;
-  border-radius: 6px;
-  border: 1px solid var(--sl-color-gray-4, #ccc);
-  background: var(--sl-color-bg, #fff);
-  cursor: pointer;
-  font-size: 0.875rem;
-}
-
-.import-apply-btn {
-  margin-top: 8px;
-  border-color: var(--sl-color-accent, #3b82f6);
-  color: var(--sl-color-accent, #3b82f6);
-}
-
 .import-msg {
-  padding: 10px 12px;
-  border-radius: 6px;
-  font-size: 0.875rem;
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 0;
+  font-size: var(--sl-text-xs);
 }
 
 .import-msg--error {
+  border-bottom: 1px solid var(--sl-color-red, #ef4444);
   background: var(--sl-color-red-low, rgba(239, 68, 68, 0.12));
-  border: 1px solid var(--sl-color-red, #ef4444);
-  color: var(--sl-color-red-high, #b91c1c);
+  color: var(--sl-color-red, #ef4444);
 }
 
-.import-preview {
-  padding: 12px;
-  border-radius: 8px;
-  border: 1px solid var(--sl-color-gray-4, #ccc);
-  background: var(--sl-color-bg-inline-code, rgba(0, 0, 0, 0.03));
+.import-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 2.5rem 1rem;
+  min-height: 200px;
+  color: var(--sl-color-gray-2);
+  text-align: center;
 }
 
-.import-preview-title {
-  margin: 0 0 8px;
-  font-size: 0.875rem;
+.import-empty[hidden] {
+  display: none;
+}
+
+.import-empty-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  margin-bottom: 0.25rem;
+  border: 1px solid var(--sl-color-gray-5);
+  color: var(--sl-color-gray-3);
+}
+
+.import-empty-title {
+  margin: 0;
+  color: var(--sl-color-white);
+  font-size: var(--sl-text-sm);
   font-weight: 600;
 }
 
-.import-header-list {
+.import-empty-text {
   margin: 0;
-  padding-left: 1.25rem;
-  font-size: 0.875rem;
+  max-width: 38ch;
+  font-size: var(--sl-text-xs);
+  line-height: 1.5;
 }
 
 #example1 {
+  padding: 1rem;
   min-height: 180px;
+}
+
+#example1[hidden] {
+  display: none;
 }

--- a/docs/content/recipes/import-export/import-csv-excel/javascript/example1.html
+++ b/docs/content/recipes/import-export/import-csv-excel/javascript/example1.html
@@ -6,32 +6,28 @@
     role="button"
     aria-label="Drop a CSV or Excel file here"
   >
-    <p>Drop a <code>.csv</code> or <code>.xlsx</code> file here, or use the file picker.</p>
-    <label class="import-file-label">
-      <span>Choose file</span>
-      <input id="import-file" type="file" accept=".csv,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,text/csv" />
-    </label>
-  </div>
-
-  <div class="import-sample-block">
-    <label for="import-sample-csv">Sample CSV (copy into a file or click <strong>Parse sample CSV</strong>):</label>
-    <textarea id="import-sample-csv" rows="5" spellcheck="false">Product,Category,In stock,Price
-Widget A,Hardware,true,19.99
-Widget B,Hardware,false,24.5
-Service Pack,Services,true,0
-</textarea>
-    <div class="import-sample-actions">
-      <button type="button" id="import-parse-sample">Parse sample CSV</button>
+    <p>Drop a <code>.csv</code> or <code>.xlsx</code> file here, or pick a source.</p>
+    <div class="import-actions">
+      <label class="import-file-label">
+        <span>Choose file</span>
+        <input id="import-file" type="file" accept=".csv,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,text/csv" />
+      </label>
+      <button type="button" id="import-load-sample" class="import-sample-btn">Load sample data</button>
     </div>
   </div>
 
   <div id="import-error" class="import-msg import-msg--error" hidden></div>
 
-  <div id="import-preview" class="import-preview" hidden>
-    <p class="import-preview-title">Detected column headers (not loaded yet):</p>
-    <ul id="import-header-list" class="import-header-list"></ul>
-    <button type="button" id="import-apply" class="import-apply-btn">Load into grid</button>
+  <div id="import-empty" class="import-empty">
+    <span class="import-empty-icon" aria-hidden="true">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <rect x="3" y="3" width="18" height="18"/>
+        <path d="M3 9h18M3 15h18M9 3v18M15 3v18"/>
+      </svg>
+    </span>
+    <p class="import-empty-title">No data loaded yet</p>
+    <p class="import-empty-text">Drop a CSV or Excel file above, choose a file, or load the sample data to populate the table.</p>
   </div>
 
-  <div id="example1"></div>
+  <div id="example1" hidden></div>
 </div>

--- a/docs/content/recipes/import-export/import-csv-excel/javascript/example1.js
+++ b/docs/content/recipes/import-export/import-csv-excel/javascript/example1.js
@@ -193,21 +193,13 @@ async function parseFile(file) {
     }
     throw new Error('Unsupported file type. Use a .csv or .xlsx file.');
 }
-let pending = null;
-function renderHeaderPreview(listEl, headers) {
-    listEl.innerHTML = '';
-    for (const h of headers) {
-        const li = document.createElement('li');
-        li.textContent = h;
-        listEl.appendChild(li);
-    }
-}
-function columnsFromHeaders(headers) {
-    if (!pending) {
-        return headers.map((data) => ({ data, type: 'text' }));
-    }
+const SAMPLE_CSV = `Product,Category,In stock,Price
+Widget A,Hardware,true,19.99
+Widget B,Hardware,false,24.5
+Service Pack,Services,true,0`;
+function columnsFromHeaders(headers, rows) {
     return headers.map((data) => {
-        const values = pending?.rows
+        const values = rows
             .map((row) => row[data])
             .filter((v) => v !== null);
         if (values.length > 0 && values.every((v) => typeof v === 'number')) {
@@ -220,36 +212,34 @@ function columnsFromHeaders(headers) {
     });
 }
 const gridContainer = document.querySelector('#example1');
+const emptyEl = document.querySelector('#import-empty');
 const errEl = document.querySelector('#import-error');
-const previewEl = document.querySelector('#import-preview');
-const headerListEl = document.querySelector('#import-header-list');
-const applyBtn = document.querySelector('#import-apply');
 const fileInput = document.querySelector('#import-file');
 const dropzone = document.querySelector('#import-dropzone');
-const sampleTa = document.querySelector('#import-sample-csv');
-const sampleBtn = document.querySelector('#import-parse-sample');
-const initialSettings = {
-    data: [],
-    columns: [],
-    colHeaders: [],
-    rowHeaders: true,
-    height: 'auto',
-    width: '100%',
-    licenseKey: 'non-commercial-and-evaluation',
-};
-const hot = new Handsontable(gridContainer, initialSettings);
-function clearPendingPreview() {
-    pending = null;
-    if (previewEl) {
-        previewEl.hidden = true;
+const sampleBtn = document.querySelector('#import-load-sample');
+let hot = null;
+function loadIntoGrid({ headers, rows }) {
+    const columns = columnsFromHeaders(headers, rows);
+    if (!hot) {
+        if (emptyEl) {
+            emptyEl.hidden = true;
+        }
+        if (gridContainer) {
+            gridContainer.hidden = false;
+        }
+        hot = new Handsontable(gridContainer, {
+            data: rows,
+            columns,
+            colHeaders: headers,
+            rowHeaders: true,
+            height: 'auto',
+            width: '100%',
+            licenseKey: 'non-commercial-and-evaluation',
+        });
     }
-}
-function setPending(payload) {
-    pending = payload;
-    clearError(errEl);
-    if (headerListEl && previewEl) {
-        renderHeaderPreview(headerListEl, payload.headers);
-        previewEl.hidden = false;
+    else {
+        hot.updateSettings({ colHeaders: headers, columns });
+        hot.loadData(rows);
     }
 }
 async function handleFile(file) {
@@ -263,30 +253,12 @@ async function handleFile(file) {
     }
     try {
         const payload = await parseFile(file);
-        setPending(payload);
+        loadIntoGrid(payload);
     }
     catch (e) {
-        clearPendingPreview();
         showError(errEl, e instanceof Error ? e.message : String(e));
     }
 }
-applyBtn?.addEventListener('click', () => {
-    clearError(errEl);
-    if (!pending) {
-        showError(errEl, 'Nothing to load. Import a file first.');
-        return;
-    }
-    const { headers, rows } = pending;
-    hot.updateSettings({
-        colHeaders: headers,
-        columns: columnsFromHeaders(headers),
-    });
-    hot.loadData(rows);
-    if (previewEl) {
-        previewEl.hidden = true;
-    }
-    pending = null;
-});
 fileInput?.addEventListener('change', () => {
     const f = fileInput.files?.[0];
     handleFile(f);
@@ -309,12 +281,10 @@ sampleBtn?.addEventListener('click', async () => {
     clearError(errEl);
     try {
         const PapaRef = await ensurePapa();
-        const text = sampleTa?.value ?? '';
-        const payload = parseCsvText(text, PapaRef);
-        setPending(payload);
+        const payload = parseCsvText(SAMPLE_CSV, PapaRef);
+        loadIntoGrid(payload);
     }
     catch (e) {
-        clearPendingPreview();
         showError(errEl, e instanceof Error ? e.message : String(e));
     }
 });

--- a/docs/content/recipes/import-export/import-csv-excel/javascript/example1.ts
+++ b/docs/content/recipes/import-export/import-csv-excel/javascript/example1.ts
@@ -282,25 +282,14 @@ async function parseFile(file: File): Promise<ParsedPayload> {
   throw new Error('Unsupported file type. Use a .csv or .xlsx file.');
 }
 
-let pending: ParsedPayload | null = null;
+const SAMPLE_CSV = `Product,Category,In stock,Price
+Widget A,Hardware,true,19.99
+Widget B,Hardware,false,24.5
+Service Pack,Services,true,0`;
 
-function renderHeaderPreview(listEl: HTMLElement, headers: string[]): void {
-  listEl.innerHTML = '';
-  for (const h of headers) {
-    const li = document.createElement('li');
-
-    li.textContent = h;
-    listEl.appendChild(li);
-  }
-}
-
-function columnsFromHeaders(headers: string[]): GridSettings['columns'] {
-  if (!pending) {
-    return headers.map((data) => ({ data, type: 'text' as const }));
-  }
-
+function columnsFromHeaders(headers: string[], rows: ParsedRow[]): GridSettings['columns'] {
   return headers.map((data) => {
-    const values = pending?.rows
+    const values = rows
       .map((row) => row[data])
       .filter((v): v is string | number | boolean => v !== null);
 
@@ -317,42 +306,34 @@ function columnsFromHeaders(headers: string[]): GridSettings['columns'] {
 }
 
 const gridContainer = document.querySelector<HTMLElement>('#example1')!;
+const emptyEl = document.querySelector<HTMLElement>('#import-empty');
 const errEl = document.querySelector<HTMLElement>('#import-error');
-const previewEl = document.querySelector<HTMLElement>('#import-preview');
-const headerListEl = document.querySelector<HTMLElement>('#import-header-list');
-const applyBtn = document.querySelector<HTMLButtonElement>('#import-apply');
 const fileInput = document.querySelector<HTMLInputElement>('#import-file');
 const dropzone = document.querySelector<HTMLElement>('#import-dropzone');
-const sampleTa = document.querySelector<HTMLTextAreaElement>('#import-sample-csv');
-const sampleBtn = document.querySelector<HTMLButtonElement>('#import-parse-sample');
+const sampleBtn = document.querySelector<HTMLButtonElement>('#import-load-sample');
 
-const initialSettings: GridSettings = {
-  data: [],
-  columns: [],
-  colHeaders: [],
-  rowHeaders: true,
-  height: 'auto',
-  width: '100%',
-  licenseKey: 'non-commercial-and-evaluation',
-};
+let hot: Handsontable | null = null;
 
-const hot = new Handsontable(gridContainer, initialSettings);
+function loadIntoGrid({ headers, rows }: ParsedPayload): void {
+  const columns = columnsFromHeaders(headers, rows);
 
-function clearPendingPreview(): void {
-  pending = null;
-
-  if (previewEl) {
-    previewEl.hidden = true;
-  }
-}
-
-function setPending(payload: ParsedPayload): void {
-  pending = payload;
-  clearError(errEl);
-
-  if (headerListEl && previewEl) {
-    renderHeaderPreview(headerListEl, payload.headers);
-    previewEl.hidden = false;
+  if (!hot) {
+    if (emptyEl) {
+      emptyEl.hidden = true;
+    }
+    gridContainer.hidden = false;
+    hot = new Handsontable(gridContainer, {
+      data: rows,
+      columns,
+      colHeaders: headers,
+      rowHeaders: true,
+      height: 'auto',
+      width: '100%',
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+  } else {
+    hot.updateSettings({ colHeaders: headers, columns });
+    hot.loadData(rows);
   }
 }
 
@@ -372,37 +353,11 @@ async function handleFile(file: File | null | undefined): Promise<void> {
   try {
     const payload = await parseFile(file);
 
-    setPending(payload);
+    loadIntoGrid(payload);
   } catch (e) {
-    clearPendingPreview();
-
     showError(errEl, e instanceof Error ? e.message : String(e));
   }
 }
-
-applyBtn?.addEventListener('click', () => {
-  clearError(errEl);
-
-  if (!pending) {
-    showError(errEl, 'Nothing to load. Import a file first.');
-
-    return;
-  }
-
-  const { headers, rows } = pending;
-
-  hot.updateSettings({
-    colHeaders: headers,
-    columns: columnsFromHeaders(headers),
-  });
-  hot.loadData(rows);
-
-  if (previewEl) {
-    previewEl.hidden = true;
-  }
-
-  pending = null;
-});
 
 fileInput?.addEventListener('change', () => {
   const f = fileInput.files?.[0];
@@ -433,12 +388,10 @@ sampleBtn?.addEventListener('click', async () => {
 
   try {
     const PapaRef = await ensurePapa();
-    const text = sampleTa?.value ?? '';
-    const payload = parseCsvText(text, PapaRef);
+    const payload = parseCsvText(SAMPLE_CSV, PapaRef);
 
-    setPending(payload);
+    loadIntoGrid(payload);
   } catch (e) {
-    clearPendingPreview();
     showError(errEl, e instanceof Error ? e.message : String(e));
   }
 });

--- a/docs/content/recipes/import-export/import-csv-excel/react/example1.css
+++ b/docs/content/recipes/import-export/import-csv-excel/react/example1.css
@@ -1,37 +1,61 @@
 .import-csv-excel-wrap {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  margin-bottom: 12px;
+  margin: 0 -1rem;
 }
 
 .import-dropzone {
-  border: 2px dashed var(--sl-color-gray-4, #ccc);
-  border-radius: 8px;
-  padding: 16px;
+  padding: 1.5rem 1rem;
   text-align: center;
-  background: var(--sl-color-bg-inline-code, rgba(0, 0, 0, 0.04));
-  transition: border-color 0.15s ease, background 0.15s ease;
+  border: 0;
+  border-bottom: 1px solid var(--sl-color-gray-5);
+  border-radius: 0;
+  background: transparent;
+  color: var(--sl-color-gray-2);
+  font-size: var(--sl-text-xs);
+  transition: background 0.15s ease;
+}
+
+.import-dropzone p {
+  margin: 0 0 0.75rem;
 }
 
 .import-dropzone.import-dropzone--active {
-  border-color: var(--sl-color-accent, #3b82f6);
-  background: var(--sl-color-accent-low, rgba(59, 130, 246, 0.08));
+  background: var(--sl-color-gray-6);
+}
+
+.import-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .import-file-label {
   display: inline-block;
-  margin-top: 8px;
   cursor: pointer;
 }
 
-.import-file-label span {
-  display: inline-block;
-  padding: 6px 14px;
-  border-radius: 6px;
-  background: var(--sl-color-accent, #3b82f6);
-  color: var(--sl-color-black, #fff);
-  font-size: 0.875rem;
+.import-file-label span,
+.import-sample-btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.375rem 0.75rem;
+  border: 1px solid var(--sl-color-gray-5);
+  border-radius: 0;
+  background: var(--sl-color-gray-6);
+  color: var(--sl-color-gray-2);
+  font-family: var(--sl-font);
+  font-size: var(--sl-text-xs);
+  font-weight: 500;
+  line-height: 1.4;
+  cursor: pointer;
+  transition: background-color 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.import-file-label:hover span,
+.import-sample-btn:hover {
+  background: var(--sl-color-gray-5);
+  color: var(--sl-color-white);
 }
 
 .import-file-label input {
@@ -42,70 +66,52 @@
   pointer-events: none;
 }
 
-.import-sample-block label {
-  display: block;
-  font-size: 0.875rem;
-  margin-bottom: 6px;
-}
-
-.import-sample-block textarea {
-  width: 100%;
-  box-sizing: border-box;
-  font-family: ui-monospace, monospace;
-  font-size: 0.8rem;
-  padding: 8px;
-  border-radius: 6px;
-  border: 1px solid var(--sl-color-gray-4, #ccc);
-  resize: vertical;
-}
-
-.import-sample-actions {
-  margin-top: 8px;
-}
-
-.import-sample-actions button,
-.import-apply-btn {
-  padding: 6px 14px;
-  border-radius: 6px;
-  border: 1px solid var(--sl-color-gray-4, #ccc);
-  background: var(--sl-color-bg, #fff);
-  cursor: pointer;
-  font-size: 0.875rem;
-}
-
-.import-apply-btn {
-  margin-top: 8px;
-  border-color: var(--sl-color-accent, #3b82f6);
-  color: var(--sl-color-accent, #3b82f6);
-}
-
 .import-msg {
-  padding: 10px 12px;
-  border-radius: 6px;
-  font-size: 0.875rem;
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 0;
+  font-size: var(--sl-text-xs);
 }
 
 .import-msg--error {
+  border-bottom: 1px solid var(--sl-color-red, #ef4444);
   background: var(--sl-color-red-low, rgba(239, 68, 68, 0.12));
-  border: 1px solid var(--sl-color-red, #ef4444);
-  color: var(--sl-color-red-high, #b91c1c);
+  color: var(--sl-color-red, #ef4444);
 }
 
-.import-preview {
-  padding: 12px;
-  border-radius: 8px;
-  border: 1px solid var(--sl-color-gray-4, #ccc);
-  background: var(--sl-color-bg-inline-code, rgba(0, 0, 0, 0.03));
+.import-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 2.5rem 1rem;
+  min-height: 200px;
+  color: var(--sl-color-gray-2);
+  text-align: center;
 }
 
-.import-preview-title {
-  margin: 0 0 8px;
-  font-size: 0.875rem;
+.import-empty-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  margin-bottom: 0.25rem;
+  border: 1px solid var(--sl-color-gray-5);
+  color: var(--sl-color-gray-3);
+}
+
+.import-empty-title {
+  margin: 0;
+  color: var(--sl-color-white);
+  font-size: var(--sl-text-sm);
   font-weight: 600;
 }
 
-.import-header-list {
+.import-empty-text {
   margin: 0;
-  padding-left: 1.25rem;
-  font-size: 0.875rem;
+  max-width: 38ch;
+  font-size: var(--sl-text-xs);
+  line-height: 1.5;
 }

--- a/docs/content/recipes/import-export/import-csv-excel/react/example1.jsx
+++ b/docs/content/recipes/import-export/import-csv-excel/react/example1.jsx
@@ -243,13 +243,9 @@ async function parseFile(file) {
   throw new Error('Unsupported file type. Use a .csv or .xlsx file.');
 }
 
-function columnsFromHeaders(headers, pendingRows) {
-  if (!pendingRows) {
-    return headers.map((data) => ({ data, type: 'text' }));
-  }
-
+function columnsFromHeaders(headers, rows) {
   return headers.map((data) => {
-    const values = pendingRows
+    const values = rows
       .map((row) => row[data])
       .filter((v) => v !== null);
 
@@ -269,33 +265,24 @@ function columnsFromHeaders(headers, pendingRows) {
 const SAMPLE_CSV = `Product,Category,In stock,Price
 Widget A,Hardware,true,19.99
 Widget B,Hardware,false,24.5
-Service Pack,Services,true,0
-`;
+Service Pack,Services,true,0`;
 /* end:skip-in-preview */
 
 const ExampleComponent = () => {
-  const [pending, setPendingState] = useState(null);
   const [errorMessage, setErrorMessage] = useState('');
-  const [showPreview, setShowPreview] = useState(false);
-  const [sampleCsv, setSampleCsv] = useState(SAMPLE_CSV);
   const [dropzoneActive, setDropzoneActive] = useState(false);
   const [gridData, setGridData] = useState([]);
   const [gridColHeaders, setGridColHeaders] = useState([]);
   const [gridColumns, setGridColumns] = useState([]);
 
-  const clearPendingPreview = () => {
-    setPendingState(null);
-    setShowPreview(false);
-  };
-
-  const handleParsed = (payload) => {
+  const loadIntoGrid = ({ headers, rows }) => {
     setErrorMessage('');
-    setPendingState(payload);
-    setShowPreview(true);
+    setGridColHeaders(headers);
+    setGridColumns(columnsFromHeaders(headers, rows));
+    setGridData(rows);
   };
 
   const handleError = (e) => {
-    clearPendingPreview();
     setErrorMessage(e instanceof Error ? e.message : String(e));
   };
 
@@ -315,7 +302,7 @@ const ExampleComponent = () => {
     try {
       const payload = await parseFile(file);
 
-      handleParsed(payload);
+      loadIntoGrid(payload);
     } catch (e) {
       handleError(e);
     }
@@ -345,35 +332,17 @@ const ExampleComponent = () => {
     handleFile(f);
   };
 
-  const handleParseSample = async () => {
+  const handleLoadSample = async () => {
     setErrorMessage('');
 
     try {
       const PapaRef = await ensurePapa();
-      const payload = parseCsvText(sampleCsv, PapaRef);
+      const payload = parseCsvText(SAMPLE_CSV, PapaRef);
 
-      handleParsed(payload);
+      loadIntoGrid(payload);
     } catch (e) {
       handleError(e);
     }
-  };
-
-  const handleApply = () => {
-    setErrorMessage('');
-
-    if (!pending) {
-      setErrorMessage('Nothing to load. Import a file first.');
-
-      return;
-    }
-
-    const { headers, rows } = pending;
-
-    setGridColHeaders(headers);
-    setGridColumns(columnsFromHeaders(headers, rows));
-    setGridData(rows);
-    setPendingState(null);
-    setShowPreview(false);
   };
 
   return (
@@ -388,32 +357,19 @@ const ExampleComponent = () => {
         onDrop={handleDrop}
       >
         <p>
-          Drop a <code>.csv</code> or <code>.xlsx</code> file here, or use the file picker.
+          Drop a <code>.csv</code> or <code>.xlsx</code> file here, or pick a source.
         </p>
-        <label className="import-file-label">
-          <span>Choose file</span>
-          <input
-            type="file"
-            accept=".csv,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,text/csv"
-            onChange={handleFileInputChange}
-          />
-        </label>
-      </div>
-
-      <div className="import-sample-block">
-        <label htmlFor="import-sample-csv">
-          Sample CSV (copy into a file or click <strong>Parse sample CSV</strong>):
-        </label>
-        <textarea
-          id="import-sample-csv"
-          rows={5}
-          spellCheck={false}
-          value={sampleCsv}
-          onChange={(ev) => setSampleCsv(ev.target.value)}
-        />
-        <div className="import-sample-actions">
-          <button type="button" onClick={handleParseSample}>
-            Parse sample CSV
+        <div className="import-actions">
+          <label className="import-file-label">
+            <span>Choose file</span>
+            <input
+              type="file"
+              accept=".csv,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,text/csv"
+              onChange={handleFileInputChange}
+            />
+          </label>
+          <button type="button" className="import-sample-btn" onClick={handleLoadSample}>
+            Load sample data
           </button>
         </div>
       </div>
@@ -422,29 +378,30 @@ const ExampleComponent = () => {
         <div className="import-msg import-msg--error">{errorMessage}</div>
       )}
 
-      {showPreview && pending && (
-        <div className="import-preview">
-          <p className="import-preview-title">Detected column headers (not loaded yet):</p>
-          <ul className="import-header-list">
-            {pending.headers.map((h) => (
-              <li key={h}>{h}</li>
-            ))}
-          </ul>
-          <button type="button" className="import-apply-btn" onClick={handleApply}>
-            Load into grid
-          </button>
+      {gridData.length === 0 ? (
+        <div className="import-empty">
+          <span className="import-empty-icon" aria-hidden="true">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <rect x="3" y="3" width="18" height="18" />
+              <path d="M3 9h18M3 15h18M9 3v18M15 3v18" />
+            </svg>
+          </span>
+          <p className="import-empty-title">No data loaded yet</p>
+          <p className="import-empty-text">
+            Drop a CSV or Excel file above, choose a file, or load the sample data to populate the table.
+          </p>
         </div>
+      ) : (
+        <HotTable
+          data={gridData}
+          columns={gridColumns}
+          colHeaders={gridColHeaders}
+          rowHeaders={true}
+          height="auto"
+          width="100%"
+          licenseKey="non-commercial-and-evaluation"
+        />
       )}
-
-      <HotTable
-        data={gridData}
-        columns={gridColumns}
-        colHeaders={gridColHeaders}
-        rowHeaders={true}
-        height="auto"
-        width="100%"
-        licenseKey="non-commercial-and-evaluation"
-      />
     </div>
   );
 };

--- a/docs/content/recipes/import-export/import-csv-excel/react/example1.tsx
+++ b/docs/content/recipes/import-export/import-csv-excel/react/example1.tsx
@@ -275,13 +275,9 @@ async function parseFile(file: File): Promise<ParsedPayload> {
   throw new Error('Unsupported file type. Use a .csv or .xlsx file.');
 }
 
-function columnsFromHeaders(headers: string[], pendingRows: Record<string, CellValue>[] | null): ColumnDef[] {
-  if (!pendingRows) {
-    return headers.map((data) => ({ data, type: 'text' }));
-  }
-
+function columnsFromHeaders(headers: string[], rows: Record<string, CellValue>[]): ColumnDef[] {
   return headers.map((data) => {
-    const values = pendingRows
+    const values = rows
       .map((row) => row[data])
       .filter((v) => v !== null);
 
@@ -301,33 +297,24 @@ function columnsFromHeaders(headers: string[], pendingRows: Record<string, CellV
 const SAMPLE_CSV = `Product,Category,In stock,Price
 Widget A,Hardware,true,19.99
 Widget B,Hardware,false,24.5
-Service Pack,Services,true,0
-`;
+Service Pack,Services,true,0`;
 /* end:skip-in-preview */
 
 const ExampleComponent = () => {
-  const [pending, setPendingState] = useState<ParsedPayload | null>(null);
   const [errorMessage, setErrorMessage] = useState<string>('');
-  const [showPreview, setShowPreview] = useState<boolean>(false);
-  const [sampleCsv, setSampleCsv] = useState<string>(SAMPLE_CSV);
   const [dropzoneActive, setDropzoneActive] = useState<boolean>(false);
   const [gridData, setGridData] = useState<Record<string, CellValue>[]>([]);
   const [gridColHeaders, setGridColHeaders] = useState<string[]>([]);
   const [gridColumns, setGridColumns] = useState<ColumnDef[]>([]);
 
-  const clearPendingPreview = (): void => {
-    setPendingState(null);
-    setShowPreview(false);
-  };
-
-  const handleParsed = (payload: ParsedPayload): void => {
+  const loadIntoGrid = ({ headers, rows }: ParsedPayload): void => {
     setErrorMessage('');
-    setPendingState(payload);
-    setShowPreview(true);
+    setGridColHeaders(headers);
+    setGridColumns(columnsFromHeaders(headers, rows));
+    setGridData(rows);
   };
 
   const handleError = (e: unknown): void => {
-    clearPendingPreview();
     setErrorMessage(e instanceof Error ? e.message : String(e));
   };
 
@@ -347,7 +334,7 @@ const ExampleComponent = () => {
     try {
       const payload = await parseFile(file);
 
-      handleParsed(payload);
+      loadIntoGrid(payload);
     } catch (e) {
       handleError(e);
     }
@@ -377,35 +364,17 @@ const ExampleComponent = () => {
     handleFile(f);
   };
 
-  const handleParseSample = async (): Promise<void> => {
+  const handleLoadSample = async (): Promise<void> => {
     setErrorMessage('');
 
     try {
       const PapaRef = await ensurePapa();
-      const payload = parseCsvText(sampleCsv, PapaRef);
+      const payload = parseCsvText(SAMPLE_CSV, PapaRef);
 
-      handleParsed(payload);
+      loadIntoGrid(payload);
     } catch (e) {
       handleError(e);
     }
-  };
-
-  const handleApply = (): void => {
-    setErrorMessage('');
-
-    if (!pending) {
-      setErrorMessage('Nothing to load. Import a file first.');
-
-      return;
-    }
-
-    const { headers, rows } = pending;
-
-    setGridColHeaders(headers);
-    setGridColumns(columnsFromHeaders(headers, rows));
-    setGridData(rows);
-    setPendingState(null);
-    setShowPreview(false);
   };
 
   return (
@@ -420,32 +389,19 @@ const ExampleComponent = () => {
         onDrop={handleDrop}
       >
         <p>
-          Drop a <code>.csv</code> or <code>.xlsx</code> file here, or use the file picker.
+          Drop a <code>.csv</code> or <code>.xlsx</code> file here, or pick a source.
         </p>
-        <label className="import-file-label">
-          <span>Choose file</span>
-          <input
-            type="file"
-            accept=".csv,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,text/csv"
-            onChange={handleFileInputChange}
-          />
-        </label>
-      </div>
-
-      <div className="import-sample-block">
-        <label htmlFor="import-sample-csv">
-          Sample CSV (copy into a file or click <strong>Parse sample CSV</strong>):
-        </label>
-        <textarea
-          id="import-sample-csv"
-          rows={5}
-          spellCheck={false}
-          value={sampleCsv}
-          onChange={(ev) => setSampleCsv(ev.target.value)}
-        />
-        <div className="import-sample-actions">
-          <button type="button" onClick={handleParseSample}>
-            Parse sample CSV
+        <div className="import-actions">
+          <label className="import-file-label">
+            <span>Choose file</span>
+            <input
+              type="file"
+              accept=".csv,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,text/csv"
+              onChange={handleFileInputChange}
+            />
+          </label>
+          <button type="button" className="import-sample-btn" onClick={handleLoadSample}>
+            Load sample data
           </button>
         </div>
       </div>
@@ -454,29 +410,30 @@ const ExampleComponent = () => {
         <div className="import-msg import-msg--error">{errorMessage}</div>
       )}
 
-      {showPreview && pending && (
-        <div className="import-preview">
-          <p className="import-preview-title">Detected column headers (not loaded yet):</p>
-          <ul className="import-header-list">
-            {pending.headers.map((h) => (
-              <li key={h}>{h}</li>
-            ))}
-          </ul>
-          <button type="button" className="import-apply-btn" onClick={handleApply}>
-            Load into grid
-          </button>
+      {gridData.length === 0 ? (
+        <div className="import-empty">
+          <span className="import-empty-icon" aria-hidden="true">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <rect x="3" y="3" width="18" height="18" />
+              <path d="M3 9h18M3 15h18M9 3v18M15 3v18" />
+            </svg>
+          </span>
+          <p className="import-empty-title">No data loaded yet</p>
+          <p className="import-empty-text">
+            Drop a CSV or Excel file above, choose a file, or load the sample data to populate the table.
+          </p>
         </div>
+      ) : (
+        <HotTable
+          data={gridData}
+          columns={gridColumns}
+          colHeaders={gridColHeaders}
+          rowHeaders={true}
+          height="auto"
+          width="100%"
+          licenseKey="non-commercial-and-evaluation"
+        />
       )}
-
-      <HotTable
-        data={gridData}
-        columns={gridColumns}
-        colHeaders={gridColHeaders}
-        rowHeaders={true}
-        height="auto"
-        width="100%"
-        licenseKey="non-commercial-and-evaluation"
-      />
     </div>
   );
 };


### PR DESCRIPTION
- Drop the textarea/preview pattern; Choose file and Load sample data share a single dropzone and feed loadIntoGrid() directly.
- Lazy-init Handsontable behind an empty-state panel so the grid no longer shows a single blank cell before any import.
- Restyle dropzone, buttons, and surrounding UI to match the spreadsheet look (edge-to-edge dividers, border-radius 0, gray-6/gray-5 tokens).
- Align Step 1/2/4/5, "Try it quickly", "How it works", and "What you learned" with the simplified demo.

### Context
<!--- Why is this change required? What problem does it solve? -->

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation examples and styling, with no impact on product/runtime code outside the docs site. Main risk is minor behavioral drift in the demo flow (removal of header preview/confirm step).
> 
> **Overview**
> **Simplifies the `import-csv-excel` recipe UX across JavaScript, React, and Angular demos.** The examples drop the textarea + header-preview/“Load into grid” confirm step and instead provide a single dropzone with **Choose file** and **Load sample data** actions that both feed directly into a shared `loadIntoGrid` path.
> 
> **Improves first-load presentation.** The JS example now lazy-initializes Handsontable and shows an empty-state panel until data is loaded (hiding `#example1` initially), while React/Angular render an equivalent empty state when `gridData` is empty.
> 
> **Updates docs and styling.** Recipe copy is revised to match the new flow (steps, quick-try section, and error coverage), and CSS is refreshed to a more “spreadsheet-like” look (edge-to-edge dividers, gray token usage, new button/error/empty-state styles).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6553ed59f83e86729efa3152be4b11b74e2cb60c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->