### PR TITLE
DEV-1646: Docs - Vue 3 component as a custom cell renderer (#10257)

### DIFF
--- a/docs/content/guides/integrate-with-vue3/vue3-custom-renderer-example/vue/example2.html
+++ b/docs/content/guides/integrate-with-vue3/vue3-custom-renderer-example/vue/example2.html
@@ -1,0 +1,3 @@
+<div id="example2">
+  <hot-table :settings="hotSettings"></hot-table>
+</div>

--- a/docs/content/guides/integrate-with-vue3/vue3-custom-renderer-example/vue/example2.js
+++ b/docs/content/guides/integrate-with-vue3/vue3-custom-renderer-example/vue/example2.js
@@ -1,0 +1,62 @@
+import { defineComponent, h, render } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+// A reusable Vue 3 component that renders a cell value as an image.
+const ImageCell = defineComponent({
+  props: {
+    src: { type: String, required: true },
+  },
+  render() {
+    return h('img', {
+      src: this.src,
+      onMousedown: (event) => event.preventDefault(),
+    });
+  },
+});
+
+// Bridge function that mounts the Vue 3 component into the cell's TD element.
+// Vue's `render()` patches the existing tree on subsequent calls, so the
+// component instance is reused across re-renders.
+function imageComponentRenderer(instance, td, row, col, prop, value) {
+  const vnode = h(ImageCell, { src: value });
+
+  render(vnode, td);
+
+  return td;
+}
+
+const ExampleComponent = defineComponent({
+  data() {
+    return {
+      hotSettings: {
+        data: [
+          ['Professional JavaScript for Web Developers',
+            '/docs/img/examples/professional-javascript-developers-nicholas-zakas.jpg'],
+          ['JavaScript: The Good Parts',
+            '/docs/img/examples/javascript-the-good-parts.jpg'],
+        ],
+        columns: [
+          {},
+          {
+            renderer: imageComponentRenderer,
+          },
+        ],
+        colHeaders: true,
+        rowHeights: 55,
+        height: 'auto',
+        autoWrapRow: true,
+        autoWrapCol: true,
+        licenseKey: 'non-commercial-and-evaluation',
+      },
+    };
+  },
+  components: {
+    HotTable,
+  },
+});
+
+export default ExampleComponent;

--- a/docs/content/guides/integrate-with-vue3/vue3-custom-renderer-example/vue3-custom-renderer-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-custom-renderer-example/vue3-custom-renderer-example.md
@@ -3,7 +3,7 @@ type: tutorial
 id: uu0rzeo6
 title: Custom renderer in Vue 3
 metaTitle: Custom cell renderer - Vue 3 Data Grid | Handsontable
-description: Create a custom cell renderer, and use it in your Vue 3 data grid by declaring it as a function.
+description: Create a custom cell renderer, and use it in your Vue 3 data grid by declaring it as a function or as a Vue 3 component.
 permalink: /vue3-custom-renderer-example
 canonicalUrl: /vue3-custom-renderer-example
 react:
@@ -35,6 +35,21 @@ The following example is an implementation of `@handsontable/vue3` with a custom
 @[code](@/content/guides/integrate-with-vue3/vue3-custom-renderer-example/vue/example1.js)
 
 :::
+
+## Declare a renderer as a Vue 3 component
+
+You can use a Vue 3 component as a custom cell renderer by mounting it into the cell's TD element from inside the renderer function. Use Vue 3's `render(vnode, container)` API to mount the component imperatively and reuse the same component instance across re-renders -- Vue patches the existing tree instead of remounting.
+
+The renderer function receives the same arguments as a regular function-based renderer. You build a VNode from your component with `h(Component, props)` and pass it to `render()` together with the TD element. To pass static props alongside cell data, merge them into the second argument of `h()`.
+
+::: example #example2 :vue3 --html 1 --js 2
+
+@[code](@/content/guides/integrate-with-vue3/vue3-custom-renderer-example/vue/example2.html)
+@[code](@/content/guides/integrate-with-vue3/vue3-custom-renderer-example/vue/example2.js)
+
+:::
+
+If your component needs access to a Vue application context -- for example, global components, plugins, or `provide` / `inject` -- create a dedicated app per cell with `createApp(Component, props).mount(td)` instead of `render()`. Track the returned app instances so you can call `app.unmount()` when the grid is destroyed.
 
 ## Related articles
 
@@ -94,6 +109,7 @@ The following example is an implementation of `@handsontable/vue3` with a custom
 - How to declare a custom renderer function in a Vue 3 application.
 - How to read cell values and render HTML elements -- such as images -- inside cells.
 - How to assign the renderer to a specific column using the `renderer` option.
+- How to mount a Vue 3 component as a custom cell renderer with `render(vnode, td)`.
 
 ## Next steps
 


### PR DESCRIPTION
### Context

The PR adds a documentation example showing how to use a Vue 3 component as a custom cell renderer. Closes [#10257](https://github.com/handsontable/handsontable/issues/10257) — the existing Vue 3 custom renderer page only covered the function-based renderer and there was no equivalent of the Vue 2 component renderer recipe.

The new section "Declare a renderer as a Vue 3 component" demonstrates mounting a Vue 3 SFC into the cell's TD element from inside the `renderer` function via Vue's public `render(vnode, container)` API. No wrapper change is needed — the pattern uses public Vue 3 and Handsontable APIs against the current `@handsontable/vue3@17.0.1`.

A note in the same section points to `createApp(Component, props).mount(td)` for users who need an app context (provide/inject, global components, plugins).

### How has this been tested?

- Syntax-checked `vue/example2.js` with `node --check`.
- Manually reviewed the rendered Markdown structure (frontmatter, `::: example` block, "What you learned" and "Next steps" sections).
- Docs site preview not run locally (requires Node 20); reviewers please run `npm run docs:start --prefix docs` and confirm `#example2` renders an image in the second column.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

Docs-only change.

### Related issue(s):

1. Closes #10257
2. DEV-1646

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

Documentation only (`docs/`).

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1646

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change that adds a new Vue 3 example and expands guide text; no production code paths are modified.
> 
> **Overview**
> Updates the Vue 3 custom renderer guide to cover **component-based renderers** in addition to function-based ones.
> 
> Adds a new `#example2` demonstrating mounting a Vue 3 component into a Handsontable cell via `h()` + `render(vnode, td)`, and expands the guide text/learning checklist with guidance on using `createApp().mount()` when an app context is required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 475ac8643334f019baa582c5b6b6ee797ba4c286. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->