### PR TITLE
DEV-1552: Align Angular theme demo with JS for CSS overrides

### DIFF
--- a/.claude/skills/creating-docs-examples/SKILL.md
+++ b/.claude/skills/creating-docs-examples/SKILL.md
@@ -130,6 +130,8 @@ The `angular/example1.html` file is the outer wrapper (not the component templat
 </div>
 ```
 
+**Edit on StackBlitz:** When you use **Edit on StackBlitz**, `docs/public/example-tabs.js` merges each framework's companion `example*.html` into the generated app shell. `parseDocsExampleHtmlForStackBlitz` uses the browser `DOMParser` to collect `style` nodes for `<head>` and drop `script` nodes from the body fragment. `mergeCompanionHtmlForStackBlitz` wires that into the StackBlitz template. Examples with no HTML tab keep the previous default mount markup.
+
 See skill `angular-wrapper-dev` for the full reference.
 
 **Vue 3:**

--- a/docs/content/guides/styling/theme-customization/angular/example1.html
+++ b/docs/content/guides/styling/theme-customization/angular/example1.html
@@ -1,17 +1,18 @@
-<div class="disable-auto-theme">
-  <style>
-    .ht-theme-main {
-      --ht-accent-color: #2c78d4;
-      --ht-foreground-color: #1a2533;
-      --ht-background-color: #f8f9fa;
-      --ht-row-header-odd-background-color: #f8f9fa;
-      --ht-row-header-even-background-color: #e9ecef;
-      --ht-row-cell-odd-background-color: #f8f9fa;
-      --ht-row-cell-even-background-color: #e9ecef;
-      --ht-cell-horizontal-border-color: #cbd5e0;
-      --ht-cell-vertical-border-color: #cbd5e0;
-      --ht-wrapper-border-color: #a0aec0;
-    }
-  </style>
+<style>
+  .override-theme .ht-theme-main {
+    --ht-accent-color: #2c78d4;
+    --ht-foreground-color: #1a2533;
+    --ht-background-color: #f8f9fa;
+    --ht-row-header-odd-background-color: #f8f9fa;
+    --ht-row-header-even-background-color: #e9ecef;
+    --ht-row-cell-odd-background-color: #f8f9fa;
+    --ht-row-cell-even-background-color: #e9ecef;
+    --ht-cell-horizontal-border-color: #cbd5e0;
+    --ht-cell-vertical-border-color: #cbd5e0;
+    --ht-wrapper-border-color: #a0aec0;
+  }
+</style>
+
+<div class="disable-auto-theme override-theme">
   <example1-demo></example1-demo>
 </div>

--- a/docs/content/guides/styling/theme-customization/angular/example1.ts
+++ b/docs/content/guides/styling/theme-customization/angular/example1.ts
@@ -1,6 +1,7 @@
 /* file: app.component.ts */
 import { Component } from '@angular/core';
-import { GridSettings, HotTableModule} from '@handsontable/angular-wrapper';
+import { GridSettings, HotTableModule } from '@handsontable/angular-wrapper';
+import 'handsontable/styles/ht-theme-main.css';
 
 @Component({
   selector: 'example1-demo',
@@ -20,6 +21,7 @@ export class AppComponent {
   ];
 
   readonly gridSettings: GridSettings = {
+    theme: 'ht-theme-main',
     colHeaders: ['Name', 'Email', 'City', 'Age', 'Position'],
     columns: [
       { data: 0, type: 'text' },
@@ -31,7 +33,6 @@ export class AppComponent {
     rowHeaders: true,
     width: '100%',
     height: 'auto',
-    licenseKey: 'non-commercial-and-evaluation'
   };
 }
 /* end-file */

--- a/docs/content/guides/styling/theme-customization/javascript/example1.html
+++ b/docs/content/guides/styling/theme-customization/javascript/example1.html
@@ -1,5 +1,5 @@
 <style>
-.ht-theme-main {
+.override-theme .ht-theme-main {
   --ht-accent-color: #2c78d4;
   --ht-foreground-color: #1a2533;
   --ht-background-color: #f8f9fa;
@@ -13,4 +13,6 @@
 }
 </style>
 
-<div id="example1" class="disable-auto-theme"></div>
+<div class="disable-auto-theme override-theme">
+  <div id="example1"></div>
+</div>

--- a/docs/public/example-tabs.js
+++ b/docs/public/example-tabs.js
@@ -394,6 +394,80 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   /**
+   * Splits a docs example HTML fragment into style blocks and body markup using the browser's
+   * HTML parser (avoids regex-based sanitization gaps flagged by CodeQL).
+   * All style elements are collected for injection into StackBlitz head; script elements are
+   * removed from the body fragment.
+   *
+   * @param {string} raw
+   * @returns {{ styleChunks: string[], bodyRemainder: string }}
+   */
+  function parseDocsExampleHtmlForStackBlitz(raw) {
+    var styleChunks = [];
+    var text = String(raw || '');
+
+    if (!text.trim()) {
+      return { styleChunks: [], bodyRemainder: '' };
+    }
+
+    var doc = new DOMParser().parseFromString(
+      '<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>' + text + '</body></html>',
+      'text/html',
+    );
+    var body = doc.body;
+
+    if (!body) {
+      return { styleChunks: [], bodyRemainder: text.trim() };
+    }
+
+    var styles = body.querySelectorAll('style');
+    var i;
+
+    for (i = 0; i < styles.length; i++) {
+      styleChunks.push(styles[i].outerHTML);
+      styles[i].remove();
+    }
+
+    var scripts = body.querySelectorAll('script');
+
+    for (i = 0; i < scripts.length; i++) {
+      scripts[i].remove();
+    }
+
+    return { styleChunks: styleChunks, bodyRemainder: body.innerHTML.trim() };
+  }
+
+  function indentMarkupForBody(markup) {
+    return markup.split('\n').map(function (line) {
+      return '  ' + line;
+    }).join('\n');
+  }
+
+  /**
+   * Pushes companion-example `<style>` blocks onto `headParts` and returns indented body HTML.
+   *
+   * @param {string[]} headParts
+   * @param {Record<string,string>} userFiles
+   * @param {string} defaultBodyIndented
+   * @returns {string}
+   */
+  function mergeCompanionHtmlForStackBlitz(headParts, userFiles, defaultBodyIndented) {
+    var wrapperHtmlFile = findFile(userFiles, '.html');
+
+    if (!wrapperHtmlFile || !userFiles[wrapperHtmlFile]) {
+      return defaultBodyIndented;
+    }
+
+    var parsed = parseDocsExampleHtmlForStackBlitz(userFiles[wrapperHtmlFile]);
+
+    for (var i = 0; i < parsed.styleChunks.length; i++) {
+      headParts.push(parsed.styleChunks[i]);
+    }
+
+    return parsed.bodyRemainder ? indentMarkupForBody(parsed.bodyRemainder) : defaultBodyIndented;
+  }
+
+  /**
    * Assembles the full set of project files to send to StackBlitz.
    *
    * @param {string} framework - 'javascript' | 'react' | 'vue' | 'angular'
@@ -447,7 +521,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
     var cdnCssUrl = 'https://unpkg.com/handsontable@' + hotVersion + '/dist/handsontable.full.min.css';
 
-    var html = [
+    var indexParts = [
       '<!DOCTYPE html>',
       '<html lang="en">',
       '<head>',
@@ -456,13 +530,19 @@ document.addEventListener('DOMContentLoaded', function () {
       '  <title>Handsontable Example</title>',
       '  <link rel="stylesheet" href="' + cdnCssUrl + '" />',
       '  <style>body { padding: 1rem; font-family: sans-serif; }</style>',
-      '</head>',
-      '<body>',
-      '  <div id="' + exampleId + '"></div>',
-      '  <script type="module" src="/src/main.js"><\/script>',
-      '</body>',
-      '</html>',
-    ].join('\n');
+    ];
+
+    var defaultMountDiv = '<div id="' + exampleId + '"></div>';
+    var bodyInner = mergeCompanionHtmlForStackBlitz(indexParts, userFiles, '  ' + defaultMountDiv);
+
+    indexParts.push('</head>');
+    indexParts.push('<body>');
+    indexParts.push(bodyInner);
+    indexParts.push('  <script type="module" src="/src/main.js"><\/script>');
+    indexParts.push('</body>');
+    indexParts.push('</html>');
+
+    var html = indexParts.join('\n');
 
     var files = {
       'package.json': pkg,
@@ -522,7 +602,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
     var cdnCssUrl = 'https://unpkg.com/handsontable@' + hotVersion + '/dist/handsontable.full.min.css';
 
-    var html = [
+    var indexPartsR = [
       '<!DOCTYPE html>',
       '<html lang="en">',
       '<head>',
@@ -530,13 +610,19 @@ document.addEventListener('DOMContentLoaded', function () {
       '  <meta name="viewport" content="width=device-width, initial-scale=1.0" />',
       '  <title>Handsontable React Example</title>',
       '  <link rel="stylesheet" href="' + cdnCssUrl + '" />',
-      '</head>',
-      '<body>',
-      '  <div id="' + exampleId + '"></div>',
-      '  <script type="module" src="/src/main.jsx"><\/script>',
-      '</body>',
-      '</html>',
-    ].join('\n');
+    ];
+
+    var defaultMountDivR = '<div id="' + exampleId + '"></div>';
+    var bodyInnerR = mergeCompanionHtmlForStackBlitz(indexPartsR, userFiles, '  ' + defaultMountDivR);
+
+    indexPartsR.push('</head>');
+    indexPartsR.push('<body>');
+    indexPartsR.push(bodyInnerR);
+    indexPartsR.push('  <script type="module" src="/src/main.jsx"><\/script>');
+    indexPartsR.push('</body>');
+    indexPartsR.push('</html>');
+
+    var html = indexPartsR.join('\n');
 
     return {
       'package.json':   pkg,
@@ -588,7 +674,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
     var cdnCssUrl = 'https://unpkg.com/handsontable@' + hotVersion + '/dist/handsontable.full.min.css';
 
-    var html = [
+    var indexPartsV = [
       '<!DOCTYPE html>',
       '<html lang="en">',
       '<head>',
@@ -596,13 +682,19 @@ document.addEventListener('DOMContentLoaded', function () {
       '  <meta name="viewport" content="width=device-width, initial-scale=1.0" />',
       '  <title>Handsontable Vue Example</title>',
       '  <link rel="stylesheet" href="' + cdnCssUrl + '" />',
-      '</head>',
-      '<body>',
-      '  <div id="' + exampleId + '"></div>',
-      '  <script type="module" src="/src/main.js"><\/script>',
-      '</body>',
-      '</html>',
-    ].join('\n');
+    ];
+
+    var defaultMountDivV = '<div id="' + exampleId + '"></div>';
+    var bodyInnerV = mergeCompanionHtmlForStackBlitz(indexPartsV, userFiles, '  ' + defaultMountDivV);
+
+    indexPartsV.push('</head>');
+    indexPartsV.push('<body>');
+    indexPartsV.push(bodyInnerV);
+    indexPartsV.push('  <script type="module" src="/src/main.js"><\/script>');
+    indexPartsV.push('</body>');
+    indexPartsV.push('</html>');
+
+    var html = indexPartsV.join('\n');
 
     return {
       'package.json': pkg,
@@ -775,7 +867,8 @@ document.addEventListener('DOMContentLoaded', function () {
       },
     }, null, 2);
 
-    var indexHtml = [
+    // Merge companion example*.html into StackBlitz (styles in head, markup in body).
+    var indexParts = [
       '<!DOCTYPE html>',
       '<html lang="en">',
       '<head>',
@@ -783,12 +876,18 @@ document.addEventListener('DOMContentLoaded', function () {
       '  <title>Handsontable Angular Example</title>',
       '  <base href="/">',
       '  <link rel="stylesheet" href="' + cdnCssUrl + '" />',
-      '</head>',
-      '<body>',
-      '  <' + selector + '></' + selector + '>',
-      '</body>',
-      '</html>',
-    ].join('\n');
+    ];
+
+    var defaultBodyMarkup = '  <' + selector + '></' + selector + '>';
+    var bodyMarkup = mergeCompanionHtmlForStackBlitz(indexParts, userFiles, defaultBodyMarkup);
+
+    indexParts.push('</head>');
+    indexParts.push('<body>');
+    indexParts.push(bodyMarkup);
+    indexParts.push('</body>');
+    indexParts.push('</html>');
+
+    var indexHtml = indexParts.join('\n');
 
     // NgModule examples bootstrap via platformBrowserDynamic;
     // standalone examples (no app.module.ts) use bootstrapApplication.


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The "Option 3: Override CSS variables" live demo on the Angular Theme Customization guide did not match the JavaScript demo. The Angular example never loaded `ht-theme-main` theme CSS and never set `theme: 'ht-theme-main'`, so the grid did not get the ht-theme-main root class. The custom overrides in the example wrapper target `.ht-theme-main`, so they did not apply and the preview looked wrong compared to JS/React.

This change imports `handsontable/styles/ht-theme-main.css` and sets theme: `'ht-theme-main'` in `gridSettings`, consistent with the JS and React examples for the same section. Redundant `licenseKey` on `gridSettings` was removed because the license is already provided via `HOT_GLOBAL_CONFIG` in `app.config.ts`.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Manual check in the docs dev app: opened Theme Customization for JavaScript and Angular, scrolled to Option 3: Override CSS variables, and confirmed the live previews match (colors, borders, striped row styling).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the shared `docs/public/example-tabs.js` StackBlitz project generator for all frameworks, so mistakes could break the “Edit on StackBlitz” flow or HTML injection behavior. The docs example changes themselves are low risk and scoped to theme demo markup/CSS.
> 
> **Overview**
> Aligns the Theme Customization “override CSS variables” examples by scoping overrides under `.override-theme`, adjusting the wrapper markup, and updating the Angular demo to actually load/apply `ht-theme-main` (imports `handsontable/styles/ht-theme-main.css` and sets `theme: 'ht-theme-main'`).
> 
> Updates the “Edit on StackBlitz” generator (`docs/public/example-tabs.js`) to merge each example’s companion `example*.html` into the generated `index.html` across JS/React/Vue/Angular: parses HTML via `DOMParser`, injects extracted `<style>` blocks into `<head>`, strips `<script>` tags, and uses the remaining markup as the `<body>` (falling back to the default mount element when no HTML tab exists).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acd483c3a7b3fd60ce90505ed2307853f48fd88a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->