### PR TITLE
DEV-1554: Fix light theme highlight for deleted Expressive Code lines

### DIFF
--- a/docs/src/styles/components/code.css
+++ b/docs/src/styles/components/code.css
@@ -68,6 +68,13 @@
   --ec-frm-shdCol: transparent;
   --ec-frm-frameBoxShdCssVal: none;
   --ec-frm-trmTtbBrdBtmCol: var(--sl-color-gray-5);
+  /* Base .expressive-code sets dark-theme fg; block bg is light -- line numbers and code must use dark ink */
+  --ec-codeFg: var(--sl-color-white);
+  --ec-gtrFg: var(--sl-color-gray-2);
+  --ec-gtrHlFg: rgba(36, 41, 47, 0.55);
+  --ec-codeSelBg: rgba(51, 146, 255, 0.28);
+  --ec-uiSelBg: var(--sl-color-gray-5);
+  --ec-uiSelFg: var(--sl-color-white);
 }
 
 :root[data-theme='light'] .expressive-code .copy button {
@@ -141,6 +148,12 @@
 .expressive-code .ec-line.ins {
   background-color: rgba(65, 161, 103, 0.15) !important;
   border-inline-start-color: #41a167 !important;
+}
+
+/* Expressive Code del (deleted) line highlight — light theme only; matches ins subtlety */
+:root[data-theme='light'] .expressive-code .ec-line.del {
+  background-color: rgba(134, 45, 39, 0.15) !important;
+  border-inline-start-color: #862d27 !important;
 }
 
 /* -------------------------------------------------------------------------


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Ensures deleted lines (`.ec-line.del`) have a consistent and subtle highlight in the light theme, matching the existing style for inserted lines.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Manual testing on local dev server

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)


### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CSS-only tweaks limited to docs code block theming; main risk is minor visual regressions in light mode code blocks/diffs.
> 
> **Overview**
> Fixes Expressive Code styling in the docs *light theme* by overriding additional theme variables so code text, gutter/line numbers, and selection colors render with the intended contrast.
> 
> Adds a dedicated light-theme style for deleted diff lines (`.ec-line.del`) to match the existing subtle highlight used for inserted lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ec4881b23017e3ccbf139c0a1f4b6bbb974cdaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->