### PR TITLE
DEV-1556: Use CSS variable for cell function demo background

### DIFF
--- a/docs/content/guides/cell-functions/cell-function/angular/example1.ts
+++ b/docs/content/guides/cell-functions/cell-function/angular/example1.ts
@@ -73,7 +73,7 @@ const stockValidator = (value: Handsontable.CellValue, callback: (valid: boolean
     .htStockBarTrack {
       flex: 1;
       height: 8px;
-      background: #e5e7eb;
+      background: var(--ht-background-secondary-color);
       border-radius: 4px;
       overflow: hidden;
     }

--- a/docs/content/guides/cell-functions/cell-function/javascript/example1.css
+++ b/docs/content/guides/cell-functions/cell-function/javascript/example1.css
@@ -10,7 +10,7 @@
 .htStockBarTrack {
   flex: 1;
   height: 8px;
-  background: #e5e7eb;
+  background: var(--ht-background-secondary-color);
   border-radius: 4px;
   overflow: hidden;
 }

--- a/docs/content/guides/cell-functions/cell-function/react/example1.css
+++ b/docs/content/guides/cell-functions/cell-function/react/example1.css
@@ -10,7 +10,7 @@
 .htStockBarTrack {
   flex: 1;
   height: 8px;
-  background: #e5e7eb;
+  background: var(--ht-background-secondary-color);
   border-radius: 4px;
   overflow: hidden;
 }


### PR DESCRIPTION

### Context
<!--- Why is this change required? What problem does it solve? -->
Replaces hardcoded background color with `--ht-background-secondary-color` for consistent theming in cell function documentation examples.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Manual tests on docs dev server

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only styling change that replaces a hardcoded color with an existing CSS variable; main risk is minor visual differences if the variable isn’t defined in some doc themes.
> 
> **Overview**
> Updates the cell-function “stock bar” demo styles (Angular/JS/React examples) to use the theme token `--ht-background-secondary-color` instead of a hardcoded gray for the `.htStockBarTrack` background, improving consistency with docs theming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe1134a8f159f2b2ff2742b78b3e181ef07e12bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->