### PR TITLE
DEV-1557: docs: Support inline markdown in Starlight aside blocks

### DIFF
--- a/docs/README-EDITING.md
+++ b/docs/README-EDITING.md
@@ -196,6 +196,8 @@ We use the following Markdown containers:
 
 These containers are processed by the `vuepress-preprocessor.mjs` plugin in `src/plugins/`, which converts the VuePress-style syntax into Astro/Starlight-compatible output.
 
+For `tip` / `warning` / `danger` / `note` callouts, the body is not full CommonMark. The preprocessor turns inline `` `code` ``, `**bold**`, and `[label](url)` into HTML (see `aside-inline-markdown.mjs`).
+
 ### Adding code examples
 
 Using the `example` Markdown container, you can add code snippets that show the code's result:

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,6 +13,7 @@
     "docs:code-examples:generate-js": "node scripts/transpile-doc-example.mjs",
     "build": "npm run docs:api && astro build",
     "preview": "astro preview",
+    "docs:test:plugins": "node --test src/plugins/__tests__/*.test.mjs",
     "docs:lint": "eslint --ext .js,.mjs,.ts,.astro src content",
     "docs:lint:fix": "eslint --ext .js,.mjs,.ts,.astro src content --fix",
     "docs:visual-test": "npx playwright test",

--- a/docs/src/plugins/__tests__/aside-inline-markdown.test.mjs
+++ b/docs/src/plugins/__tests__/aside-inline-markdown.test.mjs
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  convertAsideBodyMarkdown,
+  convertAsideInlineMarkdown,
+} from '../aside-inline-markdown.mjs';
+
+test('bold **text** becomes strong', () => {
+  assert.equal(
+    convertAsideInlineMarkdown('**DOMPurify will be removed.** After that, stop.'),
+    '<strong>DOMPurify will be removed.</strong> After that, stop.'
+  );
+});
+
+test('inline code is preserved and not bolded', () => {
+  assert.equal(
+    convertAsideInlineMarkdown('Use the `sanitizer` option.'),
+    'Use the <code>sanitizer</code> option.'
+  );
+});
+
+test('link label may contain inline code', () => {
+  assert.equal(
+    convertAsideInlineMarkdown('See [`sanitizer`](/api/options.md#sanitizer) for details.'),
+    'See <a href="/api/options.md#sanitizer"><code>sanitizer</code></a> for details.'
+  );
+});
+
+test('cell-renderer style caution line', () => {
+  const line =
+    '**DOMPurify will be removed in the next version.** After that, any string containing HTML will be stripped before rendering. To keep sanitized HTML (e.g. with DOMPurify), set the [`sanitizer`](@/api/options.md#sanitizer) option to your own sanitizer function.';
+
+  const out = convertAsideInlineMarkdown(line);
+
+  assert.match(out, /^<strong>DOMPurify will be removed in the next version\.<\/strong>/);
+  assert.match(
+    out,
+    /set the <a href="@\/api\/options\.md#sanitizer"><code>sanitizer<\/code><\/a> option/
+  );
+});
+
+test('bold wrapping a markdown link', () => {
+  assert.equal(
+    convertAsideInlineMarkdown('**See [docs](/guides/foo)** for more.'),
+    '<strong>See <a href="/guides/foo">docs</a></strong> for more.'
+  );
+});
+
+test('bold-wrapped link: query string is not double-escaped', () => {
+  assert.equal(
+    convertAsideInlineMarkdown('**See [docs](/guides/foo?a=1&b=2)** for more.'),
+    '<strong>See <a href="/guides/foo?a=1&amp;b=2">docs</a></strong> for more.'
+  );
+});
+
+test('markdown link wrapping bold label', () => {
+  assert.equal(
+    convertAsideInlineMarkdown('[**Important**](/warn)'),
+    '<a href="/warn"><strong>Important</strong></a>'
+  );
+});
+
+test('convertAsideBodyMarkdown maps each line', () => {
+  assert.equal(
+    convertAsideBodyMarkdown('Line one **bold**.\nLine two `code`.'),
+    'Line one <strong>bold</strong>.\nLine two <code>code</code>.'
+  );
+});

--- a/docs/src/plugins/aside-inline-markdown.mjs
+++ b/docs/src/plugins/aside-inline-markdown.mjs
@@ -1,0 +1,108 @@
+/**
+ * Inline Markdown subsets for Starlight aside directive bodies (`:::tip`, etc.).
+ * Starlight/remark-directive does not parse these; callers run this preprocessor.
+ *
+ * Transformation order:
+ * 1. Inline `` `code` `` → placeholders (shared chunk table for nested/recursive passes).
+ * 2. Markdown links `[label](href)` → placeholders (raw href preserved for one `escapeAttr` pass).
+ * 3. Strong `**text**` → `<strong>` (`escapeHtml` on masked text only -- avoids double-encoding `&` in URLs).
+ * 4. Expand link placeholders to `<a>`; labels are processed via recursive {@link convertAsideInlineMarkdown}
+ *    so patterns like `[**bold**](url)` keep working.
+ * 5. Restore code placeholders to `<code>`.
+ *
+ * @module aside-inline-markdown
+ */
+
+const MAX_RECURSION_DEPTH = 10;
+
+/**
+ * @param {string} text
+ * @returns {string}
+ */
+function escapeHtml(text) {
+  return String(text)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/**
+ * @param {string} text
+ * @returns {string}
+ */
+function escapeAttr(text) {
+  return String(text)
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;');
+}
+
+/**
+ * @param {string} line
+ * @param {{ sharedCodeChunks?: string[], depth?: number }} [options]
+ * @returns {string}
+ */
+export function convertAsideInlineMarkdown(line, options = {}) {
+  const { sharedCodeChunks = null, depth = 0 } = options;
+
+  if (depth > MAX_RECURSION_DEPTH) {
+    return escapeHtml(line);
+  }
+
+  const codeChunks = sharedCodeChunks ?? [];
+
+  let masked = line.replace(/`([^`]+)`/g, (_, code) => {
+    const id = codeChunks.length;
+
+    codeChunks.push(code);
+    return `@@HT_ASIDE_CODE_${id}@@`;
+  });
+
+  const linkEntries = [];
+
+  while (true) {
+    const m = masked.match(/\[([^\]]*)\]\(([^)]*)\)/);
+
+    if (!m) {
+      break;
+    }
+
+    const full = m[0];
+    const at = masked.indexOf(full);
+
+    linkEntries.push({ label: m[1], href: m[2] });
+    masked = `${masked.slice(0, at)}@@HT_ASIDE_LINK_${linkEntries.length - 1}@@${masked.slice(at + full.length)}`;
+  }
+
+  masked = masked.replace(/\*\*(.+?)\*\*/g, (_, inner) =>
+    `<strong>${escapeHtml(inner)}</strong>`
+  );
+
+  for (let i = 0; i < linkEntries.length; i++) {
+    const ph = `@@HT_ASIDE_LINK_${i}@@`;
+    const { label, href } = linkEntries[i];
+    const innerHtml = convertAsideInlineMarkdown(label, {
+      sharedCodeChunks: codeChunks,
+      depth: depth + 1,
+    });
+    const anchor = `<a href="${escapeAttr(href)}">${innerHtml}</a>`;
+
+    masked = masked.split(ph).join(anchor);
+  }
+
+  return masked.replace(/@@HT_ASIDE_CODE_(\d+)@@/g, (_, id) => {
+    const chunk = codeChunks[Number(id)];
+
+    return `<code>${escapeHtml(chunk)}</code>`;
+  });
+}
+
+/**
+ * Applies {@link convertAsideInlineMarkdown} to each line of a block (aside bodies).
+ *
+ * @param {string} body
+ * @returns {string}
+ */
+export function convertAsideBodyMarkdown(body) {
+  return body.split('\n').map(line => convertAsideInlineMarkdown(line)).join('\n');
+}

--- a/docs/src/plugins/framework-loader.mjs
+++ b/docs/src/plugins/framework-loader.mjs
@@ -13,6 +13,7 @@ import { createRequire } from 'module';
 import { fileURLToPath } from 'url';
 import matter from 'gray-matter';
 import { CURRENT_DOCS_VERSION } from './docs-version.mjs';
+import { convertAsideBodyMarkdown } from './aside-inline-markdown.mjs';
 
 // Read the current handsontable library version for StackBlitz package.json.
 const _require = createRequire(import.meta.url);
@@ -845,9 +846,7 @@ function convertAsideBlocks(content) {
     } else if (/^:::\s*$/.test(line)) {
       // Convert markdown syntax to HTML since the body is injected as raw
       // HTML and won't be processed by remark.
-      const body = asideBody.join('\n').trim()
-        .replace(/`([^`]+)`/g, '<code>$1</code>')
-        .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>');
+      const body = convertAsideBodyMarkdown(asideBody.join('\n').trim());
 
       result.push(`<aside class="starlight-aside starlight-aside--${asideType}" aria-label="${asideTitle}">`);
       result.push(`<p class="starlight-aside__title" aria-hidden="true">${asideTitle}</p>`);

--- a/docs/src/plugins/vuepress-preprocessor.mjs
+++ b/docs/src/plugins/vuepress-preprocessor.mjs
@@ -7,6 +7,7 @@
  * - :::: only-for [framework] ... :::: (conditional content blocks)
  * - [[ toc ]] (VuePress TOC macro — Starlight generates ToC automatically)
  * - ::: tip / ::: warning / ::: danger  → :::tip / :::caution / :::danger
+ *     (aside bodies: inline `` `code` ``, **bold**, [text](url) via aside-inline-markdown)
  * - ::: example / ::: example-without-tabs  (strip markers, keep code blocks)
  * - ::: source-code-link URL  (convert to <a> tag)
  * - $withBase('/path') → /path
@@ -16,6 +17,7 @@
  */
 
 import { CURRENT_DOCS_VERSION } from './docs-version.mjs';
+import { convertAsideInlineMarkdown } from './aside-inline-markdown.mjs';
 
 /**
  * @param {{ framework?: string }} options
@@ -57,10 +59,10 @@ function preprocessMarkdown(content, framework) {
   );
   // Closing ::: (3 colons) stays unchanged — Starlight uses the same syntax
 
-  // 3b. Convert backtick inline code to <code> inside aside blocks.
-  //     Starlight/remark-directive does not process inline markdown in aside
-  //     content, so we pre-convert `code` → <code>code</code> ourselves.
-  result = convertInlineCodeInAsides(result);
+  // 3b. Convert inline Markdown inside aside blocks (`:::tip`, `:::caution`, etc.).
+  //     Starlight/remark-directive does not process aside body text; we emit HTML for
+  //     `` `code` ``, **bold**, and [label](href) (see aside-inline-markdown.mjs).
+  result = convertInlineMarkdownInAsides(result);
 
   // 3c. Convert ::: details Title → <details><summary>Title</summary>…</details>
   result = convertDetailsContainers(result);
@@ -316,14 +318,11 @@ function convertDetailsContainers(content) {
 }
 
 /**
- * Converts backtick inline code (`text`) to <code>text</code> inside Starlight
- * aside blocks (:::tip, :::caution, :::danger, :::note).
- *
- * Starlight/remark-directive treats aside body content as plain text and does
- * not process inline markdown. This function pre-converts the backticks so the
- * rendered HTML contains proper <code> elements.
+ * Converts inline Markdown inside Starlight aside blocks (:::tip, :::caution,
+ * :::danger, :::note) to HTML. Starlight/remark-directive treats aside bodies as
+ * plain text; see `./aside-inline-markdown.mjs` for supported syntax.
  */
-function convertInlineCodeInAsides(content) {
+function convertInlineMarkdownInAsides(content) {
   const lines = content.split('\n');
   const result = [];
   let insideAside = false;
@@ -355,7 +354,7 @@ function convertInlineCodeInAsides(content) {
         continue;
       }
 
-      result.push(line.replace(/`([^`]+)`/g, '<code>$1</code>'));
+      result.push(convertAsideInlineMarkdown(line));
       continue;
     }
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Starlight’s remark directives treat `:::tip` / `:::warning` / `:::danger` / `:::note` callout bodies as plain text, so inline Markdown such as `**bold**` was rendered literally (including the asterisks). That broke deprecation notices that mixed bold, `` `inline code` ``, and `[links](url)` (see DEV-1557 / Angular cell renderer docs).
This change adds a shared preprocessor ([`docs/src/plugins/aside-inline-markdown.mjs`](docs/src/plugins/aside-inline-markdown.mjs)) that converts supported inline syntax inside those aside bodies to HTML before Astro parses the page. It is used from both the Vite [`vuepress-preprocessor`](docs/src/plugins/vuepress-preprocessor.mjs) pipeline and [`framework-loader`](docs/src/plugins/framework-loader.mjs) (`convertAsideBlocks`) so behavior stays consistent wherever Markdown is preprocessed. [`docs/README-EDITING.md`](docs/README-EDITING.md) documents that aside bodies are not full CommonMark and lists what the preprocessor handles.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
- `npm run docs:test:plugins --prefix docs` (runs `node:test` on [`docs/src/plugins/__tests__/aside-inline-markdown.test.mjs`](docs/src/plugins/__tests__/aside-inline-markdown.test.mjs)): bold, inline code, links, bold+link combinations, multiline aside bodies, and the cell-renderer-style deprecation line.
- `npm run docs:lint --prefix docs`.
- Manual check on dev server of docs

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the docs markdown preprocessing pipeline and changes how `:::tip`/`:::caution`/`:::danger`/`:::note` bodies are rendered, which could cause subtle formatting or escaping regressions across many pages.
> 
> **Overview**
> Adds a shared `aside-inline-markdown.mjs` preprocessor to render a limited inline-Markdown subset inside Starlight aside bodies, converting `` `code` ``, `**bold**`, and `[links](url)` to HTML with basic escaping and support for nested combinations.
> 
> Wires this converter into both the Vite `vuepress-preprocessor` and the `framework-loader`’s aside conversion so callouts render consistently whether markdown is processed via the build pipeline or the custom loader.
> 
> Introduces `node:test` coverage for the new converter and a `docs:test:plugins` script, and updates `README-EDITING.md` to document the supported (non-CommonMark) aside-body syntax.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eafc8d4e4573fbb7687b46f2281f61d83f4e99aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->