### PR TITLE
DEV-1558: Update text renderer import in Angular cell type demo

### DIFF
--- a/docs/content/guides/cell-types/cell-type/angular/example1.ts
+++ b/docs/content/guides/cell-types/cell-type/angular/example1.ts
@@ -1,16 +1,16 @@
 /* file: app.component.ts */
 import { Component } from '@angular/core';
 import { GridSettings, HotTableModule} from '@handsontable/angular-wrapper';
-import Handsontable from 'handsontable/base';
 import { BaseRenderer } from 'handsontable/renderers';
+import { textRenderer } from 'handsontable/renderers/textRenderer';
 
 const yellowRenderer: BaseRenderer = (instance, td, ...rest) => {
-  Handsontable.renderers.TextRenderer(instance, td, ...rest);
+  textRenderer(instance, td, ...rest);
   td.style.backgroundColor = 'yellow';
 };
 
 const greenRenderer: BaseRenderer = (instance, td, ...rest) => {
-  Handsontable.renderers.TextRenderer(instance, td, ...rest);
+  textRenderer(instance, td, ...rest);
 
   td.style.backgroundColor = 'green';
 };


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The previous method of accessing `TextRenderer` via `Handsontable.renderers` was causing the demo to be broken. Directly import `textRenderer` from `handsontable/renderers/textRenderer` to resolve the issue.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Manual test on docs dev server

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that updates a demo renderer callsite; impact is limited to documentation examples and build-time imports.
> 
> **Overview**
> Fixes the Angular cell-type guide demo by switching from `Handsontable.renderers.TextRenderer` (via `handsontable/base`) to a direct `textRenderer` import from `handsontable/renderers/textRenderer`.
> 
> Both custom renderers in `example1.ts` now call `textRenderer(...)` before applying background colors, preventing the demo from relying on the removed/unsupported renderer access pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35059e66594d93435cdb0f4a38e156088a693e2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->