### PR TITLE
DEV-1478: Row pre-populating docs - simplify examples for better DX

### DIFF
--- a/docs/content/guides/rows/row-prepopulating/angular/example1.ts
+++ b/docs/content/guides/rows/row-prepopulating/angular/example1.ts
@@ -5,19 +5,20 @@ import { GridSettings, HotTableModule } from '@handsontable/angular-wrapper';
 @Component({
   selector: 'app-example1',
   template: `
-    <hot-table [settings]="gridSettings"></hot-table>
+    <hot-table [settings]="gridSettings" [data]="hotData"></hot-table>
   `,
   standalone: true,
   imports: [HotTableModule],
 })
 export class AppComponent {
+  readonly hotData = [
+    ['', 'Tesla', 'Nissan', 'Toyota', 'Honda'],
+    ['2017', 10, 11, 12, 13],
+    ['2018', 20, 11, 14, 13],
+    ['2019', 30, 15, 12, 13],
+  ];
+
   readonly gridSettings: GridSettings = {
-    data: [
-      ['', 'Tesla', 'Nissan', 'Toyota', 'Honda'],
-      ['2017', 10, 11, 12, 13],
-      ['2018', 20, 11, 14, 13],
-      ['2019', 30, 15, 12, 13],
-    ],
     minSpareRows: 1,
     height: 'auto',
     autoWrapRow: true,

--- a/docs/content/guides/rows/row-prepopulating/angular/example2.html
+++ b/docs/content/guides/rows/row-prepopulating/angular/example2.html
@@ -1,0 +1,3 @@
+<div>
+    <app-example2></app-example2>
+</div>

--- a/docs/content/guides/rows/row-prepopulating/angular/example2.ts
+++ b/docs/content/guides/rows/row-prepopulating/angular/example2.ts
@@ -40,19 +40,20 @@ const defaultValueRenderer = (
 @Component({
   selector: 'app-example2',
   template: `
-    <hot-table [settings]="gridSettings"></hot-table>
+    <hot-table [settings]="gridSettings" [data]="hotData"></hot-table>
   `,
   standalone: true,
   imports: [HotTableModule],
 })
 export class AppComponent {
+  readonly hotData = [
+    ['', 'Tesla', 'Nissan', 'Toyota', 'Honda'],
+    ['2017', 10, 11, 12, 13],
+    ['2018', 20, 11, 14, 13],
+    ['2019', 30, 15, 12, 13],
+  ];
+
   readonly gridSettings: GridSettings = {
-    data: [
-      ['', 'Tesla', 'Nissan', 'Toyota', 'Honda'],
-      ['2017', 10, 11, 12, 13],
-      ['2018', 20, 11, 14, 13],
-      ['2019', 30, 15, 12, 13],
-    ],
     minSpareRows: 1,
     height: 'auto',
     autoWrapRow: true,

--- a/docs/content/guides/rows/row-prepopulating/angular/example2.ts
+++ b/docs/content/guides/rows/row-prepopulating/angular/example2.ts
@@ -1,9 +1,44 @@
 /* file: app.component.ts */
 import { Component } from '@angular/core';
 import { GridSettings, HotTableModule } from '@handsontable/angular-wrapper';
+import Handsontable from 'handsontable/base';
+import { textRenderer } from 'handsontable/renderers/textRenderer';
+
+const templateValues = ['one', 'two', 'three'];
+
+function isEmptyRow(instance: Handsontable, row: number) {
+  const rowData = instance.getDataAtRow(row);
+
+  for (let i = 0, ilen = rowData.length; i < ilen; i++) {
+    if (rowData[i] !== null) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+const defaultValueRenderer = (
+  instance: Handsontable,
+  td: HTMLTableCellElement,
+  row: number,
+  col: number,
+  prop: string | number,
+  value: Handsontable.CellValue,
+  cellProperties: Handsontable.CellProperties
+) => {
+  if (value === null && isEmptyRow(instance, row)) {
+    value = templateValues[col];
+    td.style.color = '#999';
+  } else {
+    td.style.color = '';
+  }
+
+  textRenderer(instance, td, row, col, prop, value, cellProperties);
+};
 
 @Component({
-  selector: 'app-example1',
+  selector: 'app-example2',
   template: `
     <hot-table [settings]="gridSettings"></hot-table>
   `,
@@ -22,6 +57,9 @@ export class AppComponent {
     height: 'auto',
     autoWrapRow: true,
     autoWrapCol: true,
+    cells() {
+      return { renderer: defaultValueRenderer };
+    },
   };
 }
 /* end-file */

--- a/docs/content/guides/rows/row-prepopulating/angular/example3.html
+++ b/docs/content/guides/rows/row-prepopulating/angular/example3.html
@@ -1,0 +1,3 @@
+<div>
+    <app-example1></app-example1>
+</div>

--- a/docs/content/guides/rows/row-prepopulating/angular/example3.html
+++ b/docs/content/guides/rows/row-prepopulating/angular/example3.html
@@ -1,3 +1,3 @@
 <div>
-    <app-example1></app-example1>
+    <app-example3></app-example3>
 </div>

--- a/docs/content/guides/rows/row-prepopulating/angular/example3.ts
+++ b/docs/content/guides/rows/row-prepopulating/angular/example3.ts
@@ -18,21 +18,16 @@ export class AppComponent implements AfterViewInit {
   @ViewChild(HotTableComponent, {static: false}) hotTable!: HotTableComponent;
 
   hotData = [
-
+    ['', 'Tesla', 'Nissan', 'Toyota', 'Honda'],
+    ['2017', 10, 11, 12, 13],
+    ['2018', 20, 11, 14, 13],
+    ['2019', 30, 15, 12, 13],
   ];
 
-  hotSettings: GridSettings = {
-
-  };
+  hotSettings: GridSettings = {};
 
   ngAfterViewInit() {
     const templateValues = ['one', 'two', 'three'];
-    const data = [
-      ['', 'Tesla', 'Nissan', 'Toyota', 'Honda'],
-      ['2017', 10, 11, 12, 13],
-      ['2018', 20, 11, 14, 13],
-      ['2019', 30, 15, 12, 13],
-    ];
 
     function isEmptyRow(instance: Handsontable, row: number) {
       const rowData = instance.getDataAtRow(row);
@@ -73,8 +68,6 @@ export class AppComponent implements AfterViewInit {
       );
     };
 
-    const hot = this.hotTable.hotInstance!;
-
     this.hotSettings = {
       startRows: 8,
       startCols: 5,
@@ -85,8 +78,8 @@ export class AppComponent implements AfterViewInit {
       cells() {
         return { renderer: defaultValueRenderer };
       },
-      beforeChange: function (changes) {
-        const instance = hot;
+      beforeChange: (changes) => {
+        const instance = this.hotTable.hotInstance!;
         const columns = instance.countCols();
         const rowColumnSeen: Record<string, boolean> = {};
         const rowsToFill: Record<string, boolean> = {};
@@ -118,7 +111,6 @@ export class AppComponent implements AfterViewInit {
       autoWrapCol: true,
     }
 
-    this.hotTable.hotInstance!.loadData(data);
   }
 
 }

--- a/docs/content/guides/rows/row-prepopulating/angular/example3.ts
+++ b/docs/content/guides/rows/row-prepopulating/angular/example3.ts
@@ -5,7 +5,7 @@ import Handsontable from 'handsontable/base';
 import { textRenderer } from 'handsontable/renderers/textRenderer';
 
 @Component({
-  selector: 'app-example1',
+  selector: 'app-example3',
   template: `
     <hot-table
       [settings]="hotSettings!" [data]="hotData">

--- a/docs/content/guides/rows/row-prepopulating/angular/example3.ts
+++ b/docs/content/guides/rows/row-prepopulating/angular/example3.ts
@@ -1,0 +1,146 @@
+/* file: app.component.ts */
+import { AfterViewInit, Component, ViewChild } from '@angular/core';
+import {GridSettings, HotTableComponent, HotTableModule} from '@handsontable/angular-wrapper';
+import Handsontable from 'handsontable/base';
+import { textRenderer } from 'handsontable/renderers/textRenderer';
+
+@Component({
+  selector: 'app-example1',
+  template: `
+    <hot-table
+      [settings]="hotSettings!" [data]="hotData">
+    </hot-table>
+  `,
+  standalone: true,
+  imports: [HotTableModule],
+})
+export class AppComponent implements AfterViewInit {
+  @ViewChild(HotTableComponent, {static: false}) hotTable!: HotTableComponent;
+
+  hotData = [
+
+  ];
+
+  hotSettings: GridSettings = {
+
+  };
+
+  ngAfterViewInit() {
+    const templateValues = ['one', 'two', 'three'];
+    const data = [
+      ['', 'Tesla', 'Nissan', 'Toyota', 'Honda'],
+      ['2017', 10, 11, 12, 13],
+      ['2018', 20, 11, 14, 13],
+      ['2019', 30, 15, 12, 13],
+    ];
+
+    function isEmptyRow(instance: Handsontable, row: number) {
+      const rowData = instance.getDataAtRow(row);
+
+      for (let i = 0, ilen = rowData.length; i < ilen; i++) {
+        if (rowData[i] !== null) {
+          return false;
+        }
+      }
+
+      return true;
+    }
+
+    const defaultValueRenderer = (
+      instance: Handsontable,
+      td: HTMLTableCellElement,
+      row: number,
+      col: number,
+      prop: string | number,
+      value: Handsontable.CellValue,
+      cellProperties: Handsontable.CellProperties
+    ) => {
+      if (value === null && isEmptyRow(instance, row)) {
+        value = templateValues[col];
+        td.style.color = '#999';
+      } else {
+        td.style.color = '';
+      }
+
+      textRenderer(
+        instance,
+        td,
+        row,
+        col,
+        prop,
+        value,
+        cellProperties
+      );
+    };
+
+    const hot = this.hotTable.hotInstance!;
+
+    this.hotSettings = {
+      startRows: 8,
+      startCols: 5,
+      minSpareRows: 1,
+      contextMenu: true,
+      height: 'auto',
+      licenseKey: 'non-commercial-and-evaluation',
+      cells() {
+        return { renderer: defaultValueRenderer };
+      },
+      beforeChange: function (changes) {
+        const instance = hot;
+        const columns = instance.countCols();
+        const rowColumnSeen: Record<string, boolean> = {};
+        const rowsToFill: Record<string, boolean> = {};
+        const ch = changes === null ? [] : changes!;
+
+        for (let i = 0; i < ch.length; i++) {
+          // if oldVal is empty
+          if (ch[i]![2] === null && ch[i]![3] !== null) {
+            if (isEmptyRow(instance, ch[i]![0])) {
+              // add this row/col combination to the cache so it will not be overwritten by the template
+              rowColumnSeen[`${ch[i]![0]}/${ch[i]![1]}`] = true;
+              rowsToFill[String(ch[i]![0])] = true;
+            }
+          }
+        }
+
+        for (const r in rowsToFill) {
+          if (rowsToFill.hasOwnProperty(r)) {
+            for (let c = 0; c < columns; c++) {
+              // if it is not provided by user in this change set, take the value from the template
+              if (!rowColumnSeen[`${r}/${c}`]) {
+                ch.push([Number(r), c, null, templateValues[c]]);
+              }
+            }
+          }
+        }
+      },
+      autoWrapRow: true,
+      autoWrapCol: true,
+    }
+
+    this.hotTable.hotInstance!.loadData(data);
+  }
+
+}
+/* end-file */
+
+
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+/* end-file */

--- a/docs/content/guides/rows/row-prepopulating/javascript/example1.js
+++ b/docs/content/guides/rows/row-prepopulating/javascript/example1.js
@@ -1,84 +1,18 @@
 import Handsontable from 'handsontable/base';
 import { registerAllModules } from 'handsontable/registry';
-import { textRenderer } from 'handsontable/renderers/textRenderer';
-
-// Register all Handsontable's modules.
 registerAllModules();
-
-const templateValues = ['one', 'two', 'three'];
 const data = [
-  ['', 'Tesla', 'Nissan', 'Toyota', 'Honda'],
-  ['2017', 10, 11, 12, 13],
-  ['2018', 20, 11, 14, 13],
-  ['2019', 30, 15, 12, 13],
+    ['', 'Tesla', 'Nissan', 'Toyota', 'Honda'],
+    ['2017', 10, 11, 12, 13],
+    ['2018', 20, 11, 14, 13],
+    ['2019', 30, 15, 12, 13],
 ];
-
-function isEmptyRow(instance, row) {
-  const rowData = instance.getDataAtRow(row);
-
-  for (let i = 0, ilen = rowData.length; i < ilen; i++) {
-    if (rowData[i] !== null) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-const defaultValueRenderer = (instance, td, row, col, prop, value, cellProperties) => {
-  if (value === null && isEmptyRow(instance, row)) {
-    value = templateValues[col];
-    td.style.color = '#999';
-  } else {
-    td.style.color = '';
-  }
-
-  textRenderer(instance, td, row, col, prop, value, cellProperties);
-};
-
 const container = document.querySelector('#example1');
 const hot = new Handsontable(container, {
-  startRows: 8,
-  startCols: 5,
-  minSpareRows: 1,
-  contextMenu: true,
-  height: 'auto',
-  licenseKey: 'non-commercial-and-evaluation',
-  cells() {
-    return { renderer: defaultValueRenderer };
-  },
-  beforeChange(changes) {
-    const instance = hot;
-    const columns = instance.countCols();
-    const rowColumnSeen = {};
-    const rowsToFill = {};
-    const ch = changes === null ? [] : changes;
-
-    for (let i = 0; i < changes.length; i++) {
-      // if oldVal is empty
-      if (ch[i][2] === null && ch[i][3] !== null) {
-        if (isEmptyRow(instance, ch[i][0])) {
-          // add this row/col combination to the cache so it will not be overwritten by the template
-          rowColumnSeen[`${ch[i][0]}/${ch[i][1]}`] = true;
-          rowsToFill[ch[i][0]] = true;
-        }
-      }
-    }
-
-    for (const r in rowsToFill) {
-      if (rowsToFill.hasOwnProperty(r)) {
-        for (let c = 0; c < columns; c++) {
-          // if it is not provided by user in this change set, take the value from the template
-          if (!rowColumnSeen[`${r}/${c}`]) {
-            changes.push([Number(r), c, null, templateValues[c]]);
-          }
-        }
-      }
-    }
-  },
-  autoWrapRow: true,
-  autoWrapCol: true,
+    data,
+    minSpareRows: 1,
+    height: 'auto',
+    licenseKey: 'non-commercial-and-evaluation',
+    autoWrapRow: true,
+    autoWrapCol: true,
 });
-
-// or, use `updateData()` to replace `data` without resetting states
-hot.loadData(data);

--- a/docs/content/guides/rows/row-prepopulating/javascript/example1.ts
+++ b/docs/content/guides/rows/row-prepopulating/javascript/example1.ts
@@ -1,86 +1,22 @@
 import Handsontable from 'handsontable/base';
 import { registerAllModules } from 'handsontable/registry';
-import { BaseRenderer } from 'handsontable/renderers';
-import { textRenderer } from 'handsontable/renderers/textRenderer';
 
-// Register all Handsontable's modules.
 registerAllModules();
 
-const templateValues: string[] = ['one', 'two', 'three'];
-const data: (string | number)[][] = [
+const data = [
   ['', 'Tesla', 'Nissan', 'Toyota', 'Honda'],
   ['2017', 10, 11, 12, 13],
   ['2018', 20, 11, 14, 13],
   ['2019', 30, 15, 12, 13],
 ];
 
-function isEmptyRow(instance: Handsontable, row: number) {
-  const rowData = instance.getDataAtRow(row);
-
-  for (let i = 0, ilen = rowData.length; i < ilen; i++) {
-    if (rowData[i] !== null) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-const defaultValueRenderer: BaseRenderer = (instance, td, row, col, prop, value, cellProperties) => {
-  if (value === null && isEmptyRow(instance, row)) {
-    value = templateValues[col];
-    td.style.color = '#999';
-  } else {
-    td.style.color = '';
-  }
-
-  textRenderer(instance, td, row, col, prop, value, cellProperties);
-};
-
 const container = document.querySelector('#example1')!;
 
 const hot = new Handsontable(container, {
-  startRows: 8,
-  startCols: 5,
+  data,
   minSpareRows: 1,
-  contextMenu: true,
   height: 'auto',
   licenseKey: 'non-commercial-and-evaluation',
-  cells() {
-    return { renderer: defaultValueRenderer };
-  },
-  beforeChange(changes) {
-    const instance = hot;
-    const columns = instance.countCols();
-    const rowColumnSeen = {};
-    const rowsToFill = {};
-    const ch = changes === null ? [] : (changes as Handsontable.CellChange);
-
-    for (let i = 0; i < changes.length; i++) {
-      // if oldVal is empty
-      if (ch[i][2] === null && ch[i][3] !== null) {
-        if (isEmptyRow(instance, ch[i][0])) {
-          // add this row/col combination to the cache so it will not be overwritten by the template
-          rowColumnSeen[`${ch[i][0]}/${ch[i][1]}`] = true;
-          rowsToFill[ch[i][0]] = true;
-        }
-      }
-    }
-
-    for (const r in rowsToFill) {
-      if (rowsToFill.hasOwnProperty(r)) {
-        for (let c = 0; c < columns; c++) {
-          // if it is not provided by user in this change set, take the value from the template
-          if (!rowColumnSeen[`${r}/${c}`]) {
-            changes.push([Number(r), c, null, templateValues[c]]);
-          }
-        }
-      }
-    }
-  },
   autoWrapRow: true,
   autoWrapCol: true,
 });
-
-// or, use `updateData()` to replace `data` without resetting states
-hot.loadData(data);

--- a/docs/content/guides/rows/row-prepopulating/javascript/example2.js
+++ b/docs/content/guides/rows/row-prepopulating/javascript/example2.js
@@ -1,0 +1,42 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+import { textRenderer } from 'handsontable/renderers/textRenderer';
+registerAllModules();
+const templateValues = ['one', 'two', 'three'];
+const data = [
+    ['', 'Tesla', 'Nissan', 'Toyota', 'Honda'],
+    ['2017', 10, 11, 12, 13],
+    ['2018', 20, 11, 14, 13],
+    ['2019', 30, 15, 12, 13],
+];
+function isEmptyRow(instance, row) {
+    const rowData = instance.getDataAtRow(row);
+    for (let i = 0, ilen = rowData.length; i < ilen; i++) {
+        if (rowData[i] !== null) {
+            return false;
+        }
+    }
+    return true;
+}
+const defaultValueRenderer = (instance, td, row, col, prop, value, cellProperties) => {
+    if (value === null && isEmptyRow(instance, row)) {
+        value = templateValues[col];
+        td.style.color = '#999';
+    }
+    else {
+        td.style.color = '';
+    }
+    textRenderer(instance, td, row, col, prop, value, cellProperties);
+};
+const container = document.querySelector('#example2');
+const hot = new Handsontable(container, {
+    data,
+    minSpareRows: 1,
+    height: 'auto',
+    licenseKey: 'non-commercial-and-evaluation',
+    cells() {
+        return { renderer: defaultValueRenderer };
+    },
+    autoWrapRow: true,
+    autoWrapCol: true,
+});

--- a/docs/content/guides/rows/row-prepopulating/javascript/example2.ts
+++ b/docs/content/guides/rows/row-prepopulating/javascript/example2.ts
@@ -1,0 +1,51 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+import { BaseRenderer } from 'handsontable/renderers';
+import { textRenderer } from 'handsontable/renderers/textRenderer';
+
+registerAllModules();
+
+const templateValues = ['one', 'two', 'three'];
+const data = [
+  ['', 'Tesla', 'Nissan', 'Toyota', 'Honda'],
+  ['2017', 10, 11, 12, 13],
+  ['2018', 20, 11, 14, 13],
+  ['2019', 30, 15, 12, 13],
+];
+
+function isEmptyRow(instance: Handsontable, row: number) {
+  const rowData = instance.getDataAtRow(row);
+
+  for (let i = 0, ilen = rowData.length; i < ilen; i++) {
+    if (rowData[i] !== null) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+const defaultValueRenderer: BaseRenderer = (instance, td, row, col, prop, value, cellProperties) => {
+  if (value === null && isEmptyRow(instance, row)) {
+    value = templateValues[col];
+    td.style.color = '#999';
+  } else {
+    td.style.color = '';
+  }
+
+  textRenderer(instance, td, row, col, prop, value, cellProperties);
+};
+
+const container = document.querySelector('#example2')!;
+
+const hot = new Handsontable(container, {
+  data,
+  minSpareRows: 1,
+  height: 'auto',
+  licenseKey: 'non-commercial-and-evaluation',
+  cells() {
+    return { renderer: defaultValueRenderer };
+  },
+  autoWrapRow: true,
+  autoWrapCol: true,
+});

--- a/docs/content/guides/rows/row-prepopulating/javascript/example3.js
+++ b/docs/content/guides/rows/row-prepopulating/javascript/example3.js
@@ -1,0 +1,84 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+import { textRenderer } from 'handsontable/renderers/textRenderer';
+
+// Register all Handsontable's modules.
+registerAllModules();
+
+const templateValues = ['one', 'two', 'three'];
+const data = [
+  ['', 'Tesla', 'Nissan', 'Toyota', 'Honda'],
+  ['2017', 10, 11, 12, 13],
+  ['2018', 20, 11, 14, 13],
+  ['2019', 30, 15, 12, 13],
+];
+
+function isEmptyRow(instance, row) {
+  const rowData = instance.getDataAtRow(row);
+
+  for (let i = 0, ilen = rowData.length; i < ilen; i++) {
+    if (rowData[i] !== null) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+const defaultValueRenderer = (instance, td, row, col, prop, value, cellProperties) => {
+  if (value === null && isEmptyRow(instance, row)) {
+    value = templateValues[col];
+    td.style.color = '#999';
+  } else {
+    td.style.color = '';
+  }
+
+  textRenderer(instance, td, row, col, prop, value, cellProperties);
+};
+
+const container = document.querySelector('#example1');
+const hot = new Handsontable(container, {
+  startRows: 8,
+  startCols: 5,
+  minSpareRows: 1,
+  contextMenu: true,
+  height: 'auto',
+  licenseKey: 'non-commercial-and-evaluation',
+  cells() {
+    return { renderer: defaultValueRenderer };
+  },
+  beforeChange(changes) {
+    const instance = hot;
+    const columns = instance.countCols();
+    const rowColumnSeen = {};
+    const rowsToFill = {};
+    const ch = changes === null ? [] : changes;
+
+    for (let i = 0; i < changes.length; i++) {
+      // if oldVal is empty
+      if (ch[i][2] === null && ch[i][3] !== null) {
+        if (isEmptyRow(instance, ch[i][0])) {
+          // add this row/col combination to the cache so it will not be overwritten by the template
+          rowColumnSeen[`${ch[i][0]}/${ch[i][1]}`] = true;
+          rowsToFill[ch[i][0]] = true;
+        }
+      }
+    }
+
+    for (const r in rowsToFill) {
+      if (rowsToFill.hasOwnProperty(r)) {
+        for (let c = 0; c < columns; c++) {
+          // if it is not provided by user in this change set, take the value from the template
+          if (!rowColumnSeen[`${r}/${c}`]) {
+            changes.push([Number(r), c, null, templateValues[c]]);
+          }
+        }
+      }
+    }
+  },
+  autoWrapRow: true,
+  autoWrapCol: true,
+});
+
+// or, use `updateData()` to replace `data` without resetting states
+hot.loadData(data);

--- a/docs/content/guides/rows/row-prepopulating/javascript/example3.js
+++ b/docs/content/guides/rows/row-prepopulating/javascript/example3.js
@@ -36,7 +36,7 @@ const defaultValueRenderer = (instance, td, row, col, prop, value, cellPropertie
   textRenderer(instance, td, row, col, prop, value, cellProperties);
 };
 
-const container = document.querySelector('#example1');
+const container = document.querySelector('#example3');
 const hot = new Handsontable(container, {
   startRows: 8,
   startCols: 5,

--- a/docs/content/guides/rows/row-prepopulating/javascript/example3.ts
+++ b/docs/content/guides/rows/row-prepopulating/javascript/example3.ts
@@ -1,0 +1,86 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+import { BaseRenderer } from 'handsontable/renderers';
+import { textRenderer } from 'handsontable/renderers/textRenderer';
+
+// Register all Handsontable's modules.
+registerAllModules();
+
+const templateValues: string[] = ['one', 'two', 'three'];
+const data: (string | number)[][] = [
+  ['', 'Tesla', 'Nissan', 'Toyota', 'Honda'],
+  ['2017', 10, 11, 12, 13],
+  ['2018', 20, 11, 14, 13],
+  ['2019', 30, 15, 12, 13],
+];
+
+function isEmptyRow(instance: Handsontable, row: number) {
+  const rowData = instance.getDataAtRow(row);
+
+  for (let i = 0, ilen = rowData.length; i < ilen; i++) {
+    if (rowData[i] !== null) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+const defaultValueRenderer: BaseRenderer = (instance, td, row, col, prop, value, cellProperties) => {
+  if (value === null && isEmptyRow(instance, row)) {
+    value = templateValues[col];
+    td.style.color = '#999';
+  } else {
+    td.style.color = '';
+  }
+
+  textRenderer(instance, td, row, col, prop, value, cellProperties);
+};
+
+const container = document.querySelector('#example1')!;
+
+const hot = new Handsontable(container, {
+  startRows: 8,
+  startCols: 5,
+  minSpareRows: 1,
+  contextMenu: true,
+  height: 'auto',
+  licenseKey: 'non-commercial-and-evaluation',
+  cells() {
+    return { renderer: defaultValueRenderer };
+  },
+  beforeChange(changes) {
+    const instance = hot;
+    const columns = instance.countCols();
+    const rowColumnSeen = {};
+    const rowsToFill = {};
+    const ch = changes === null ? [] : (changes as Handsontable.CellChange);
+
+    for (let i = 0; i < changes.length; i++) {
+      // if oldVal is empty
+      if (ch[i][2] === null && ch[i][3] !== null) {
+        if (isEmptyRow(instance, ch[i][0])) {
+          // add this row/col combination to the cache so it will not be overwritten by the template
+          rowColumnSeen[`${ch[i][0]}/${ch[i][1]}`] = true;
+          rowsToFill[ch[i][0]] = true;
+        }
+      }
+    }
+
+    for (const r in rowsToFill) {
+      if (rowsToFill.hasOwnProperty(r)) {
+        for (let c = 0; c < columns; c++) {
+          // if it is not provided by user in this change set, take the value from the template
+          if (!rowColumnSeen[`${r}/${c}`]) {
+            changes.push([Number(r), c, null, templateValues[c]]);
+          }
+        }
+      }
+    }
+  },
+  autoWrapRow: true,
+  autoWrapCol: true,
+});
+
+// or, use `updateData()` to replace `data` without resetting states
+hot.loadData(data);

--- a/docs/content/guides/rows/row-prepopulating/javascript/example3.ts
+++ b/docs/content/guides/rows/row-prepopulating/javascript/example3.ts
@@ -37,7 +37,7 @@ const defaultValueRenderer: BaseRenderer = (instance, td, row, col, prop, value,
   textRenderer(instance, td, row, col, prop, value, cellProperties);
 };
 
-const container = document.querySelector('#example1')!;
+const container = document.querySelector('#example3')!;
 
 const hot = new Handsontable(container, {
   startRows: 8,

--- a/docs/content/guides/rows/row-prepopulating/react/example1.jsx
+++ b/docs/content/guides/rows/row-prepopulating/react/example1.jsx
@@ -1,98 +1,25 @@
-import { useRef } from 'react';
 import { HotTable } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
-import { textRenderer } from 'handsontable/renderers/textRenderer';
 
-// register Handsontable's modules
 registerAllModules();
 
+const data = [
+  ['', 'Tesla', 'Nissan', 'Toyota', 'Honda'],
+  ['2017', 10, 11, 12, 13],
+  ['2018', 20, 11, 14, 13],
+  ['2019', 30, 15, 12, 13],
+];
+
 const ExampleComponent = () => {
-  const hotRef = useRef(null);
-  const templateValues = ['one', 'two', 'three'];
-  const data = [
-    ['', 'Tesla', 'Nissan', 'Toyota', 'Honda'],
-    ['2017', 10, 11, 12, 13],
-    ['2018', 20, 11, 14, 13],
-    ['2019', 30, 15, 12, 13],
-  ];
-
-  function isEmptyRow(instance, row) {
-    const rowData = instance.getDataAtRow(row);
-
-    for (let i = 0, ilen = rowData.length; i < ilen; i++) {
-      if (rowData[i] !== null) {
-        return false;
-      }
-    }
-
-    return true;
-  }
-
-  function defaultValueRenderer(instance, td, row, col) {
-    const args = arguments;
-
-    if (args[5] === null && isEmptyRow(instance, row)) {
-      args[5] = templateValues[col];
-      td.style.color = '#999';
-    } else {
-      td.style.color = '';
-    }
-
-    textRenderer.apply(this, args);
-  }
-
   return (
-    <>
-      <HotTable
-        ref={hotRef}
-        data={data}
-        startRows={8}
-        startCols={5}
-        minSpareRows={1}
-        contextMenu={true}
-        height="auto"
-        autoWrapRow={true}
-        autoWrapCol={true}
-        licenseKey="non-commercial-and-evaluation"
-        cells={function (row, col, prop) {
-          const cellProperties = {};
-
-          cellProperties.renderer = defaultValueRenderer;
-
-          return cellProperties;
-        }}
-        beforeChange={function (changes) {
-          const instance = hotRef.current?.hotInstance;
-          const columns = instance?.countCols() || 0;
-          const rowColumnSeen = {};
-          const rowsToFill = {};
-
-          for (let i = 0; i < changes.length; i++) {
-            const cellChanges = changes;
-
-            // if oldVal is empty
-            if (cellChanges[i][2] === null && cellChanges[i][3] !== null) {
-              if (isEmptyRow(instance, cellChanges[i][0])) {
-                // add this row/col combination to the cache so it will not be overwritten by the template
-                rowColumnSeen[`${cellChanges[i][0]}/${cellChanges[i][1]}`] = true;
-                rowsToFill[cellChanges[i][0]] = true;
-              }
-            }
-          }
-
-          for (const r in rowsToFill) {
-            if (rowsToFill.hasOwnProperty(r)) {
-              for (let c = 0; c < columns; c++) {
-                // if it is not provided by user in this change set, take the value from the template
-                if (!rowColumnSeen[`${r}/${c}`]) {
-                  changes.push([r, c, null, templateValues[c]]);
-                }
-              }
-            }
-          }
-        }}
-      />
-    </>
+    <HotTable
+      data={data}
+      minSpareRows={1}
+      height="auto"
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+    />
   );
 };
 

--- a/docs/content/guides/rows/row-prepopulating/react/example1.tsx
+++ b/docs/content/guides/rows/row-prepopulating/react/example1.tsx
@@ -1,107 +1,25 @@
-import { useRef } from 'react';
-import { HotTable, HotTableRef } from '@handsontable/react-wrapper';
+import { HotTable } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
-import { textRenderer } from 'handsontable/renderers/textRenderer';
-import Handsontable from 'handsontable/base';
-import { CellChange } from 'handsontable/common';
 
-// register Handsontable's modules
 registerAllModules();
 
+const data = [
+  ['', 'Tesla', 'Nissan', 'Toyota', 'Honda'],
+  ['2017', 10, 11, 12, 13],
+  ['2018', 20, 11, 14, 13],
+  ['2019', 30, 15, 12, 13],
+];
+
 const ExampleComponent = () => {
-  const hotRef = useRef<HotTableRef>(null);
-
-  const templateValues = ['one', 'two', 'three'];
-  const data = [
-    ['', 'Tesla', 'Nissan', 'Toyota', 'Honda'],
-    ['2017', 10, 11, 12, 13],
-    ['2018', 20, 11, 14, 13],
-    ['2019', 30, 15, 12, 13],
-  ];
-
-  function isEmptyRow(instance: Handsontable, row: number) {
-    const rowData = instance.getDataAtRow(row);
-
-    for (let i = 0, ilen = rowData.length; i < ilen; i++) {
-      if (rowData[i] !== null) {
-        return false;
-      }
-    }
-
-    return true;
-  }
-
-  function defaultValueRenderer(
-    this: Handsontable,
-    instance: Handsontable,
-    td: HTMLTableCellElement,
-    row: number,
-    col: number
-  ) {
-    const args = arguments;
-
-    if (args[5] === null && isEmptyRow(instance, row)) {
-      args[5] = templateValues[col];
-      td.style.color = '#999';
-    } else {
-      td.style.color = '';
-    }
-
-    textRenderer.apply(this, args as any);
-  }
-
   return (
-    <>
-      <HotTable
-        ref={hotRef}
-        data={data}
-        startRows={8}
-        startCols={5}
-        minSpareRows={1}
-        contextMenu={true}
-        height="auto"
-        autoWrapRow={true}
-        autoWrapCol={true}
-        licenseKey="non-commercial-and-evaluation"
-        cells={function (row, col, prop) {
-          const cellProperties: Handsontable.CellMeta = {};
-
-          cellProperties.renderer = defaultValueRenderer;
-
-          return cellProperties;
-        }}
-        beforeChange={function (changes) {
-          const instance = hotRef.current?.hotInstance;
-          const columns = instance?.countCols() || 0;
-          const rowColumnSeen = {};
-          const rowsToFill = {};
-
-          for (let i = 0; i < changes.length; i++) {
-            const cellChanges = changes as CellChange;
-
-            // if oldVal is empty
-            if (cellChanges[i][2] === null && cellChanges[i][3] !== null) {
-              if (isEmptyRow(instance!, cellChanges[i][0])) {
-                // add this row/col combination to the cache so it will not be overwritten by the template
-                rowColumnSeen[`${cellChanges[i][0]}/${cellChanges[i][1]}`] = true;
-                rowsToFill[cellChanges[i][0]] = true;
-              }
-            }
-          }
-
-          for (const r in rowsToFill) {
-            if (rowsToFill.hasOwnProperty(r)) {
-              for (let c = 0; c < columns; c++) {
-                // if it is not provided by user in this change set, take the value from the template
-                if (!rowColumnSeen[`${r}/${c}`]) {
-                  changes.push([r, c, null, templateValues[c]]);
-                }
-              }
-            }
-          }
-        }}
-      />
-    </>
+    <HotTable
+      data={data}
+      minSpareRows={1}
+      height="auto"
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+    />
   );
 };
 

--- a/docs/content/guides/rows/row-prepopulating/react/example2.jsx
+++ b/docs/content/guides/rows/row-prepopulating/react/example2.jsx
@@ -1,0 +1,54 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import { textRenderer } from 'handsontable/renderers/textRenderer';
+
+registerAllModules();
+
+const templateValues = ['one', 'two', 'three'];
+const data = [
+  ['', 'Tesla', 'Nissan', 'Toyota', 'Honda'],
+  ['2017', 10, 11, 12, 13],
+  ['2018', 20, 11, 14, 13],
+  ['2019', 30, 15, 12, 13],
+];
+
+const ExampleComponent = () => {
+  function isEmptyRow(instance, row) {
+    const rowData = instance.getDataAtRow(row);
+
+    for (let i = 0, ilen = rowData.length; i < ilen; i++) {
+      if (rowData[i] !== null) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  function defaultValueRenderer(instance, td, row, col) {
+    const args = arguments;
+
+    if (args[5] === null && isEmptyRow(instance, row)) {
+      args[5] = templateValues[col];
+      td.style.color = '#999';
+    } else {
+      td.style.color = '';
+    }
+
+    textRenderer.apply(this, args);
+  }
+
+  return (
+    <HotTable
+      data={data}
+      minSpareRows={1}
+      height="auto"
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+      cells={() => ({ renderer: defaultValueRenderer })}
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/rows/row-prepopulating/react/example2.tsx
+++ b/docs/content/guides/rows/row-prepopulating/react/example2.tsx
@@ -1,0 +1,61 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import { textRenderer } from 'handsontable/renderers/textRenderer';
+import Handsontable from 'handsontable/base';
+
+registerAllModules();
+
+const templateValues = ['one', 'two', 'three'];
+const data = [
+  ['', 'Tesla', 'Nissan', 'Toyota', 'Honda'],
+  ['2017', 10, 11, 12, 13],
+  ['2018', 20, 11, 14, 13],
+  ['2019', 30, 15, 12, 13],
+];
+
+const ExampleComponent = () => {
+  function isEmptyRow(instance: Handsontable, row: number) {
+    const rowData = instance.getDataAtRow(row);
+
+    for (let i = 0, ilen = rowData.length; i < ilen; i++) {
+      if (rowData[i] !== null) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  function defaultValueRenderer(
+    this: Handsontable,
+    instance: Handsontable,
+    td: HTMLTableCellElement,
+    row: number,
+    col: number
+  ) {
+    const args = arguments;
+
+    if (args[5] === null && isEmptyRow(instance, row)) {
+      args[5] = templateValues[col];
+      td.style.color = '#999';
+    } else {
+      td.style.color = '';
+    }
+
+    textRenderer.apply(this, args as any);
+  }
+
+  return (
+    <HotTable
+      data={data}
+      minSpareRows={1}
+      height="auto"
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+      cells={() => ({ renderer: defaultValueRenderer })}
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/rows/row-prepopulating/react/example3.jsx
+++ b/docs/content/guides/rows/row-prepopulating/react/example3.jsx
@@ -1,0 +1,99 @@
+import { useRef } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import { textRenderer } from 'handsontable/renderers/textRenderer';
+
+// register Handsontable's modules
+registerAllModules();
+
+const ExampleComponent = () => {
+  const hotRef = useRef(null);
+  const templateValues = ['one', 'two', 'three'];
+  const data = [
+    ['', 'Tesla', 'Nissan', 'Toyota', 'Honda'],
+    ['2017', 10, 11, 12, 13],
+    ['2018', 20, 11, 14, 13],
+    ['2019', 30, 15, 12, 13],
+  ];
+
+  function isEmptyRow(instance, row) {
+    const rowData = instance.getDataAtRow(row);
+
+    for (let i = 0, ilen = rowData.length; i < ilen; i++) {
+      if (rowData[i] !== null) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  function defaultValueRenderer(instance, td, row, col) {
+    const args = arguments;
+
+    if (args[5] === null && isEmptyRow(instance, row)) {
+      args[5] = templateValues[col];
+      td.style.color = '#999';
+    } else {
+      td.style.color = '';
+    }
+
+    textRenderer.apply(this, args);
+  }
+
+  return (
+    <>
+      <HotTable
+        ref={hotRef}
+        data={data}
+        startRows={8}
+        startCols={5}
+        minSpareRows={1}
+        contextMenu={true}
+        height="auto"
+        autoWrapRow={true}
+        autoWrapCol={true}
+        licenseKey="non-commercial-and-evaluation"
+        cells={function (row, col, prop) {
+          const cellProperties = {};
+
+          cellProperties.renderer = defaultValueRenderer;
+
+          return cellProperties;
+        }}
+        beforeChange={function (changes) {
+          const instance = hotRef.current?.hotInstance;
+          const columns = instance?.countCols() || 0;
+          const rowColumnSeen = {};
+          const rowsToFill = {};
+
+          for (let i = 0; i < changes.length; i++) {
+            const cellChanges = changes;
+
+            // if oldVal is empty
+            if (cellChanges[i][2] === null && cellChanges[i][3] !== null) {
+              if (isEmptyRow(instance, cellChanges[i][0])) {
+                // add this row/col combination to the cache so it will not be overwritten by the template
+                rowColumnSeen[`${cellChanges[i][0]}/${cellChanges[i][1]}`] = true;
+                rowsToFill[cellChanges[i][0]] = true;
+              }
+            }
+          }
+
+          for (const r in rowsToFill) {
+            if (rowsToFill.hasOwnProperty(r)) {
+              for (let c = 0; c < columns; c++) {
+                // if it is not provided by user in this change set, take the value from the template
+                if (!rowColumnSeen[`${r}/${c}`]) {
+                  changes.push([r, c, null, templateValues[c]]);
+                }
+              }
+            }
+          }
+        }}
+      />
+    </>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/rows/row-prepopulating/react/example3.tsx
+++ b/docs/content/guides/rows/row-prepopulating/react/example3.tsx
@@ -1,0 +1,108 @@
+import { useRef } from 'react';
+import { HotTable, HotTableRef } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import { textRenderer } from 'handsontable/renderers/textRenderer';
+import Handsontable from 'handsontable/base';
+import { CellChange } from 'handsontable/common';
+
+// register Handsontable's modules
+registerAllModules();
+
+const ExampleComponent = () => {
+  const hotRef = useRef<HotTableRef>(null);
+
+  const templateValues = ['one', 'two', 'three'];
+  const data = [
+    ['', 'Tesla', 'Nissan', 'Toyota', 'Honda'],
+    ['2017', 10, 11, 12, 13],
+    ['2018', 20, 11, 14, 13],
+    ['2019', 30, 15, 12, 13],
+  ];
+
+  function isEmptyRow(instance: Handsontable, row: number) {
+    const rowData = instance.getDataAtRow(row);
+
+    for (let i = 0, ilen = rowData.length; i < ilen; i++) {
+      if (rowData[i] !== null) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  function defaultValueRenderer(
+    this: Handsontable,
+    instance: Handsontable,
+    td: HTMLTableCellElement,
+    row: number,
+    col: number
+  ) {
+    const args = arguments;
+
+    if (args[5] === null && isEmptyRow(instance, row)) {
+      args[5] = templateValues[col];
+      td.style.color = '#999';
+    } else {
+      td.style.color = '';
+    }
+
+    textRenderer.apply(this, args as any);
+  }
+
+  return (
+    <>
+      <HotTable
+        ref={hotRef}
+        data={data}
+        startRows={8}
+        startCols={5}
+        minSpareRows={1}
+        contextMenu={true}
+        height="auto"
+        autoWrapRow={true}
+        autoWrapCol={true}
+        licenseKey="non-commercial-and-evaluation"
+        cells={function (row, col, prop) {
+          const cellProperties: Handsontable.CellMeta = {};
+
+          cellProperties.renderer = defaultValueRenderer;
+
+          return cellProperties;
+        }}
+        beforeChange={function (changes) {
+          const instance = hotRef.current?.hotInstance;
+          const columns = instance?.countCols() || 0;
+          const rowColumnSeen = {};
+          const rowsToFill = {};
+
+          for (let i = 0; i < changes.length; i++) {
+            const cellChanges = changes as CellChange;
+
+            // if oldVal is empty
+            if (cellChanges[i][2] === null && cellChanges[i][3] !== null) {
+              if (isEmptyRow(instance!, cellChanges[i][0])) {
+                // add this row/col combination to the cache so it will not be overwritten by the template
+                rowColumnSeen[`${cellChanges[i][0]}/${cellChanges[i][1]}`] = true;
+                rowsToFill[cellChanges[i][0]] = true;
+              }
+            }
+          }
+
+          for (const r in rowsToFill) {
+            if (rowsToFill.hasOwnProperty(r)) {
+              for (let c = 0; c < columns; c++) {
+                // if it is not provided by user in this change set, take the value from the template
+                if (!rowColumnSeen[`${r}/${c}`]) {
+                  changes.push([r, c, null, templateValues[c]]);
+                }
+              }
+            }
+          }
+        }}
+      />
+    </>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/rows/row-prepopulating/row-prepopulating.md
+++ b/docs/content/guides/rows/row-prepopulating/row-prepopulating.md
@@ -3,7 +3,7 @@ type: how-to
 id: 42px61id
 title: Row pre-populating
 metaTitle: Row pre-populating - JavaScript Data Grid | Handsontable
-description: Populate newly-added rows with predefined template values, using cell renderers.
+description: Pre-populate spare rows with default values, from a simple minSpareRows setting to custom placeholder renderers and auto-filling template values.
 permalink: /row-prepopulating
 canonicalUrl: /row-prepopulating
 tags:
@@ -20,13 +20,13 @@ angular:
 searchCategory: Guides
 category: Rows
 ---
-Pre-populate new rows with default values when users add rows to the grid. Use the `afterCreateRow` hook to set initial cell values.
+Pre-populate new rows with default values when users add rows to the grid.
 
 [[toc]]
 
-## Example
+## Basic spare rows
 
-The example below shows how cell renderers can be used to populate the template values in empty rows. When a cell in the empty row is edited, the [`beforeChange`](@/api/hooks.md#beforechange) callback fills the row with the template values.
+The simplest way to keep an empty row at the bottom of the grid is [`minSpareRows`](@/api/options.md#minsparerows). Set it to `1` to always show one empty row below the data.
 
 ::: only-for javascript
 
@@ -56,6 +56,80 @@ The example below shows how cell renderers can be used to populate the template 
 
 @[code](@/content/guides/rows/row-prepopulating/angular/example1.ts)
 @[code](@/content/guides/rows/row-prepopulating/angular/example1.html)
+
+:::
+
+:::
+
+## Spare rows with placeholder styling
+
+To hint what to enter in the spare row, add a custom cell renderer that displays greyed-out placeholder text in empty cells. The renderer checks whether the whole row is empty, then shows a template value in a lighter color.
+
+::: only-for javascript
+
+::: example #example2 --js 1 --ts 2
+
+@[code](@/content/guides/rows/row-prepopulating/javascript/example2.js)
+@[code](@/content/guides/rows/row-prepopulating/javascript/example2.ts)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #example2 :react --js 1 --ts 2
+
+@[code](@/content/guides/rows/row-prepopulating/react/example2.jsx)
+@[code](@/content/guides/rows/row-prepopulating/react/example2.tsx)
+
+:::
+
+:::
+
+::: only-for angular
+
+::: example #example2 :angular --ts 1 --html 2
+
+@[code](@/content/guides/rows/row-prepopulating/angular/example2.ts)
+@[code](@/content/guides/rows/row-prepopulating/angular/example2.html)
+
+:::
+
+:::
+
+## Auto-populating with template values
+
+For full pre-population, use the [`beforeChange`](@/api/hooks.md#beforechange) hook to fill all cells in a spare row with template values the moment the user starts editing. The `isEmptyRow()` helper detects whether the row is untouched, and the hook pushes changes for every column except the one the user is editing.
+
+::: only-for javascript
+
+::: example #example3 --js 1 --ts 2
+
+@[code](@/content/guides/rows/row-prepopulating/javascript/example3.js)
+@[code](@/content/guides/rows/row-prepopulating/javascript/example3.ts)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #example3 :react --js 1 --ts 2
+
+@[code](@/content/guides/rows/row-prepopulating/react/example3.jsx)
+@[code](@/content/guides/rows/row-prepopulating/react/example3.tsx)
+
+:::
+
+:::
+
+::: only-for angular
+
+::: example #example3 :angular --ts 1 --html 2
+
+@[code](@/content/guides/rows/row-prepopulating/angular/example3.ts)
+@[code](@/content/guides/rows/row-prepopulating/angular/example3.html)
 
 :::
 
@@ -103,10 +177,6 @@ const hot = new Handsontable(container, {
   licenseKey: 'non-commercial-and-evaluation',
 });
 ```
-
-## Result
-
-After completing this guide, your grid fills new rows with template values automatically. You can pre-populate rows from static defaults, adjacent row values, or server-fetched data.
 
 ## Related API reference
 

--- a/docs/content/guides/rows/row-prepopulating/row-prepopulating.md
+++ b/docs/content/guides/rows/row-prepopulating/row-prepopulating.md
@@ -3,7 +3,7 @@ type: how-to
 id: 42px61id
 title: Row pre-populating
 metaTitle: Row pre-populating - JavaScript Data Grid | Handsontable
-description: Pre-populate spare rows with default values, from a simple minSpareRows setting to custom placeholder renderers and auto-filling template values.
+description: Pre-populate spare rows with default values using minSpareRows, custom placeholder renderers, or auto-filling template values.
 permalink: /row-prepopulating
 canonicalUrl: /row-prepopulating
 tags:
@@ -26,7 +26,7 @@ Pre-populate new rows with default values when users add rows to the grid.
 
 ## Basic spare rows
 
-The simplest way to keep an empty row at the bottom of the grid is [`minSpareRows`](@/api/options.md#minsparerows). Set it to `1` to always show one empty row below the data.
+To keep one empty row at the bottom of the grid, set [`minSpareRows`](@/api/options.md#minsparerows) to `1`.
 
 ::: only-for javascript
 
@@ -177,6 +177,10 @@ const hot = new Handsontable(container, {
   licenseKey: 'non-commercial-and-evaluation',
 });
 ```
+
+## Result
+
+Your grid keeps one or more empty rows at the bottom. Depending on the approach, spare rows show greyed-out placeholder text or auto-fill all cells with template values when the user starts editing.
 
 ## Related API reference
 


### PR DESCRIPTION
### Context

The PR restructures the Row pre-populating guide from a single complex example into three progressive examples — basic spare rows, placeholder styling, and auto-populating with template values — so developers can stop reading at the level they need.

### How has this been tested?

- Verified all three examples render correctly in the local docs dev server (`npm run dev --prefix docs`)
- Confirmed example 1 shows a spare row, example 2 shows greyed-out placeholder text on the spare row only, example 3 auto-fills all cells on edit
- Verified React and Angular tabs on all three examples work correctly
- Confirmed the adjacent-row and server-default sections still appear below

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. [DEV-1478](https://app.clickup.com/t/9015210959/DEV-1478)

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes that restructure and simplify guide examples; main risk is broken snippets/rendering due to new example files and updated references.
> 
> **Overview**
> Refactors the `Row pre-populating` guide from a single complex snippet into **three progressive sections**: `minSpareRows` basics, spare-row placeholder styling via a custom renderer, and full auto-fill using `beforeChange`.
> 
> Updates the existing `example1` code across JavaScript/TypeScript, React, and Angular to be a minimal `minSpareRows` demo, and adds new `example2`/`example3` source files (plus Angular HTML wrappers) to cover placeholder styling and template-value auto-population.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05e845c02c15c2e358199f31e67f765c221618cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->