### PR TITLE
DEV-1559: Apply boxes style to related links in cell type guide

### DIFF
--- a/docs/content/guides/cell-types/cell-type/cell-type.md
+++ b/docs/content/guides/cell-types/cell-type/cell-type.md
@@ -608,6 +608,8 @@ Empty cells may be treated differently in different contexts, for example, the [
 
 ## Related
 
+<div class="boxes-list">
+
 - [Autocomplete cell type](@/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md)
 - [Checkbox cell type](@/guides/cell-types/checkbox-cell-type/checkbox-cell-type.md)
 - [Date cell type](@/guides/cell-types/date-cell-type/date-cell-type.md)
@@ -618,6 +620,8 @@ Empty cells may be treated differently in different contexts, for example, the [
 - [Password cell type](@/guides/cell-types/password-cell-type/password-cell-type.md)
 - [Select cell type](@/guides/cell-types/select-cell-type/select-cell-type.md)
 - [Time cell type](@/guides/cell-types/time-cell-type/time-cell-type.md)
+
+</div>
 
 ## Related articles
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
On the Cell type guide (`docs/content/guides/cell-types/cell-type/cell-type.md`), the **Related** section used a plain Markdown list, so it rendered as bullets. The **Related guides** block on the same page uses `<div class="boxes-list">`, which the docs preprocessor turns into the card grid (borders, arrows). This change wraps the cell-type links under **Related** in `boxes-list` so both sections match the intended docs UI.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Manual tests in dev docs

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that alters markup/styling for the `Related` links section with no runtime code impact.
> 
> **Overview**
> Updates the Cell type guide so the **Related** list of cell-type links is wrapped in `<div class="boxes-list">`, matching the card/grid styling used by other related-link sections on the page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fadf091e9dbca9375a7a4b753625623527cdbd23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->