### PR TITLE
DEV-1061 - Angular example throws an Uncaught TypeError when `@if/@fo…

### DIFF
--- a/.changelogs/12533.json
+++ b/.changelogs/12533.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed Prevent crash when Handsontable is initialized inside a hidden container, rowsRenderCalculator and columnsRenderCalculator on Viewport are never assigned and remain undefined.",
+  "type": "fixed",
+  "issueOrPR": 12533,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/src/core/_base.js
+++ b/handsontable/src/3rdparty/walkontable/src/core/_base.js
@@ -333,7 +333,7 @@ export default class CoreAbstract {
         return wot.wtTable; // TODO refactoring: it provides itself
       },
       get startColumnRendered() {
-        return wot.wtViewport.columnsRenderCalculator.startColumn;
+        return wot.wtViewport.columnsRenderCalculator?.startColumn ?? null;
       },
       get startColumnVisible() {
         return wot.wtViewport.columnsVisibleCalculator.startColumn;
@@ -342,7 +342,7 @@ export default class CoreAbstract {
         return wot.wtViewport.columnsPartiallyVisibleCalculator.startColumn;
       },
       get endColumnRendered() {
-        return wot.wtViewport.columnsRenderCalculator.endColumn;
+        return wot.wtViewport.columnsRenderCalculator?.endColumn ?? null;
       },
       get endColumnVisible() {
         return wot.wtViewport.columnsVisibleCalculator.endColumn;
@@ -351,13 +351,13 @@ export default class CoreAbstract {
         return wot.wtViewport.columnsPartiallyVisibleCalculator.endColumn;
       },
       get countColumnsRendered() {
-        return wot.wtViewport.columnsRenderCalculator.count;
+        return wot.wtViewport.columnsRenderCalculator?.count ?? null;
       },
       get countColumnsVisible() {
         return wot.wtViewport.columnsVisibleCalculator.count;
       },
       get startRowRendered() {
-        return wot.wtViewport.rowsRenderCalculator.startRow;
+        return wot.wtViewport.rowsRenderCalculator?.startRow ?? null;
       },
       get startRowVisible() {
         return wot.wtViewport.rowsVisibleCalculator.startRow;
@@ -366,7 +366,7 @@ export default class CoreAbstract {
         return wot.wtViewport.rowsPartiallyVisibleCalculator.startRow;
       },
       get endRowRendered() {
-        return wot.wtViewport.rowsRenderCalculator.endRow;
+        return wot.wtViewport.rowsRenderCalculator?.endRow ?? null;
       },
       get endRowVisible() {
         return wot.wtViewport.rowsVisibleCalculator.endRow;
@@ -375,7 +375,7 @@ export default class CoreAbstract {
         return wot.wtViewport.rowsPartiallyVisibleCalculator.endRow;
       },
       get countRowsRendered() {
-        return wot.wtViewport.rowsRenderCalculator.count;
+        return wot.wtViewport.rowsRenderCalculator?.count ?? null;
       },
       get countRowsVisible() {
         return wot.wtViewport.rowsVisibleCalculator.count;

--- a/handsontable/src/3rdparty/walkontable/src/core/_base.js
+++ b/handsontable/src/3rdparty/walkontable/src/core/_base.js
@@ -351,7 +351,7 @@ export default class CoreAbstract {
         return wot.wtViewport.columnsPartiallyVisibleCalculator.endColumn;
       },
       get countColumnsRendered() {
-        return wot.wtViewport.columnsRenderCalculator?.count ?? null;
+        return wot.wtViewport.columnsRenderCalculator?.count ?? 0;
       },
       get countColumnsVisible() {
         return wot.wtViewport.columnsVisibleCalculator.count;
@@ -375,7 +375,7 @@ export default class CoreAbstract {
         return wot.wtViewport.rowsPartiallyVisibleCalculator.endRow;
       },
       get countRowsRendered() {
-        return wot.wtViewport.rowsRenderCalculator?.count ?? null;
+        return wot.wtViewport.rowsRenderCalculator?.count ?? 0;
       },
       get countRowsVisible() {
         return wot.wtViewport.rowsVisibleCalculator.count;

--- a/handsontable/src/3rdparty/walkontable/src/viewport.js
+++ b/handsontable/src/3rdparty/walkontable/src/viewport.js
@@ -487,7 +487,7 @@ class Viewport {
    *                    Returns `false` if at least one proposed visible row is not already rendered (meaning: redraw is needed).
    */
   areAllProposedVisibleRowsAlreadyRendered(proposedFullyVisibleRowsCalculator, proposedPartiallyVisibleRowsCalculator) {
-    if (!this.rowsVisibleCalculator) {
+    if (!this.rowsVisibleCalculator || !this.rowsRenderCalculator) {
       return false;
     }
 
@@ -553,7 +553,7 @@ class Viewport {
     proposedFullyVisibleColumnsCalculator,
     proposedPartiallyVisibleColumnsCalculator
   ) {
-    if (!this.columnsVisibleCalculator) {
+    if (!this.columnsVisibleCalculator || !this.columnsRenderCalculator) {
       return false;
     }
 

--- a/handsontable/src/3rdparty/walkontable/test/spec/table/getFirstRenderedColumn.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/table/getFirstRenderedColumn.spec.js
@@ -156,5 +156,43 @@ describe('WalkontableTable', () => {
 
       expect(wt.wtTable.getFirstRenderedColumn()).toBe(4);
     });
+
+    it('should return -1 without throwing when the table is initialized inside a hidden container', async() => {
+      createDataArray(18, 18);
+      spec().$wrapper.width(250).height(170).css('display', 'none');
+
+      const wt = walkontable({
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
+      });
+
+      // draw() is interrupted because the container is hidden — columnsRenderCalculator stays undefined
+      wt.draw();
+
+      // should return -1 instead of throwing "can't access property 'startColumn', columnsRenderCalculator is undefined"
+      expect(wt.wtTable.getFirstRenderedColumn()).toBe(-1);
+    });
+
+    it('should not throw when draw(fastDraw=true) is called after the container becomes visible for the first time', async() => {
+      createDataArray(18, 18);
+      spec().$wrapper.width(250).height(170).css('display', 'none');
+
+      const wt = walkontable({
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
+      });
+
+      // Initial draw is interrupted — columnsRenderCalculator is never set
+      wt.draw();
+
+      // Container becomes visible (e.g. accordion opens)
+      spec().$wrapper.css('display', '');
+
+      // draw(true) must not throw even though columnsRenderCalculator was undefined
+      expect(() => wt.draw(true)).not.toThrow();
+      expect(wt.wtTable.getFirstRenderedColumn()).toBe(0);
+    });
   });
 });

--- a/handsontable/src/3rdparty/walkontable/test/spec/table/getFirstRenderedRow.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/table/getFirstRenderedRow.spec.js
@@ -178,5 +178,45 @@ describe('WalkontableTable', () => {
       expectWtTable(wt, wtTable => wtTable.getFirstRenderedRow(), 'master').toBe(0);
       expectWtTable(wt, wtTable => wtTable.getFirstRenderedRow(), 'bottom').toBe(0);
     });
+
+    it('should return -1 without throwing when the table is initialized inside a hidden container', async() => {
+      createDataArray(18, 4);
+      spec().$wrapper.width(250).height(170).css('display', 'none');
+
+      const wt = walkontable({
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
+      });
+
+      // draw() is interrupted because the container is hidden — rowsRenderCalculator stays undefined
+      wt.draw();
+
+      // should return -1 instead of throwing "can't access property 'startRow', rowsRenderCalculator is undefined"
+      expect(wt.wtTable.getFirstRenderedRow()).toBe(-1);
+    });
+
+    it('should not throw when draw(fastDraw=true) is called after the container becomes visible for the first time', async() => {
+      createDataArray(18, 4);
+      spec().$wrapper.width(250).height(170).css('display', 'none');
+
+      const wt = walkontable({
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
+      });
+
+      // Initial draw is interrupted — rowsRenderCalculator is never set
+      wt.draw();
+
+      // Container becomes visible (e.g. accordion opens)
+      spec().$wrapper.css('display', '');
+
+      // draw(true) must not throw even though rowsRenderCalculator was undefined;
+      // the guard in areAllProposedVisibleRowsAlreadyRendered forces a full redraw,
+      // which sets rowsRenderCalculator and recovers correctly
+      expect(() => wt.draw(true)).not.toThrow();
+      expect(wt.wtTable.getFirstRenderedRow()).toBe(0);
+    });
   });
 });

--- a/handsontable/src/3rdparty/walkontable/test/spec/table/getRenderedColumnsCount.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/table/getRenderedColumnsCount.spec.js
@@ -92,6 +92,44 @@ describe('WalkontableTable', () => {
       expectWtTable(wt, wtTable => wtTable.getRenderedColumnsCount(), 'top').toBe(3);
     });
 
+    it('should return 0 without throwing when the table is initialized inside a hidden container', async() => {
+      createDataArray(18, 18);
+      spec().$wrapper.width(250).height(170).css('display', 'none');
+
+      const wt = walkontable({
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
+      });
+
+      // draw() is interrupted because the container is hidden — columnsRenderCalculator stays undefined
+      wt.draw();
+
+      // should return 0 instead of throwing "can't access property 'count', columnsRenderCalculator is undefined"
+      expect(wt.wtTable.getRenderedColumnsCount()).toBe(0);
+    });
+
+    it('should return correct count after draw(fastDraw=true) is called once the container becomes visible', async() => {
+      createDataArray(18, 18);
+      spec().$wrapper.width(250).height(170).css('display', 'none');
+
+      const wt = walkontable({
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
+      });
+
+      // Initial draw is interrupted — columnsRenderCalculator is never set
+      wt.draw();
+
+      // Container becomes visible (e.g. accordion opens)
+      spec().$wrapper.css('display', '');
+
+      // draw(true) must not throw and must set columnsRenderCalculator
+      expect(() => wt.draw(true)).not.toThrow();
+      expect(wt.wtTable.getRenderedColumnsCount()).toBeGreaterThan(0);
+    });
+
     it('should return columns count only for fully visible columns', async() => {
       createDataArray(18, 18);
       spec().$wrapper.width(209).height(185);

--- a/handsontable/src/3rdparty/walkontable/test/spec/table/getRenderedRowsCount.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/table/getRenderedRowsCount.spec.js
@@ -92,6 +92,44 @@ describe('WalkontableTable', () => {
       expectWtTable(wt, wtTable => wtTable.getRenderedRowsCount(), 'top').toBe(2);
     });
 
+    it('should return 0 without throwing when the table is initialized inside a hidden container', async() => {
+      createDataArray(18, 4);
+      spec().$wrapper.width(250).height(170).css('display', 'none');
+
+      const wt = walkontable({
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
+      });
+
+      // draw() is interrupted because the container is hidden — rowsRenderCalculator stays undefined
+      wt.draw();
+
+      // should return 0 instead of throwing "can't access property 'count', rowsRenderCalculator is undefined"
+      expect(wt.wtTable.getRenderedRowsCount()).toBe(0);
+    });
+
+    it('should return correct count after draw(fastDraw=true) is called once the container becomes visible', async() => {
+      createDataArray(18, 4);
+      spec().$wrapper.width(250).height(170).css('display', 'none');
+
+      const wt = walkontable({
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
+      });
+
+      // Initial draw is interrupted — rowsRenderCalculator is never set
+      wt.draw();
+
+      // Container becomes visible (e.g. accordion opens)
+      spec().$wrapper.css('display', '');
+
+      // draw(true) must not throw and must set rowsRenderCalculator
+      expect(() => wt.draw(true)).not.toThrow();
+      expect(wt.wtTable.getRenderedRowsCount()).toBeGreaterThan(0);
+    });
+
     it('should return rows count only for fully visible rows', async() => {
       createDataArray(18, 18);
       spec().$wrapper.width(209).height(185);

--- a/handsontable/src/3rdparty/walkontable/test/spec/viewport.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/viewport.spec.js
@@ -417,4 +417,35 @@ describe('WalkontableViewport', () => {
       expect(wt.wtViewport.hasHorizontalScroll()).toBe(true);
     });
   });
+
+  describe('hidden container initialization', () => {
+    it('should not throw when draw(fastDraw=true) is called after container transitions from hidden to visible', async() => {
+      createDataArray(18, 18);
+      spec().$wrapper.width(250).height(170).css('display', 'none');
+
+      const wt = walkontable({
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
+      });
+
+      // draw() is interrupted — rowsRenderCalculator and columnsRenderCalculator stay undefined
+      wt.draw();
+
+      expect(wt.wtViewport.rowsRenderCalculator).toBeUndefined();
+      expect(wt.wtViewport.columnsRenderCalculator).toBeUndefined();
+
+      // Simulate accordion/tab opening: container becomes visible
+      spec().$wrapper.css('display', '');
+
+      // draw(true) triggers areAllProposedVisibleRowsAlreadyRendered() and
+      // areAllProposedVisibleColumnsAlreadyRendered() — both must not throw despite
+      // rowsRenderCalculator / columnsRenderCalculator being undefined;
+      // the guards force a full redraw which sets both calculators
+      expect(() => wt.draw(true)).not.toThrow();
+
+      expect(wt.wtViewport.rowsRenderCalculator).toBeDefined();
+      expect(wt.wtViewport.columnsRenderCalculator).toBeDefined();
+    });
+  });
 });


### PR DESCRIPTION
### Context
The PR fixes Prevent crash when Handsontable is initialized inside a hidden container

### Fix
 When Handsontable is mounted inside a hidden element (e.g. an accordion panel, tab, or any container with display: none), the initial draw() call is interrupted
  because the viewport has no dimensions. As a result, rowsRenderCalculator and columnsRenderCalculator on Viewport are never assigned and remain undefined.

  If something subsequently triggers a draw(fastDraw=true) — for example when the container becomes visible and refreshDimensions() is called by the ResizeObserver —
  Walkontable would call areAllProposedVisibleRowsAlreadyRendered() / areAllProposedVisibleColumnsAlreadyRendered(), which attempted to destructure properties from
  the still-undefined calculators, throwing:

  TypeError: can't access property "startRow", wot.wtViewport.rowsRenderCalculator is undefined


### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/11631
2.
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/86c955ph8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Walkontable viewport rendering/fast-draw logic, which can subtly affect when full redraws occur, but changes are small and covered by new regression tests.
> 
> **Overview**
> Fixes a crash when Walkontable/Handsontable is first initialized in a hidden container (`display: none`) and a later `draw(true)` occurs before `rowsRenderCalculator`/`columnsRenderCalculator` were ever assigned.
> 
> `Viewport.areAllProposedVisible*AlreadyRendered()` now guards against missing render calculators (forcing a full redraw), and table DAO getters for rendered row/column ranges use optional chaining to return `null` instead of throwing. Adds regression specs for `getFirstRenderedRow()`, `getFirstRenderedColumn()`, and `draw(true)` after hidden-to-visible transitions, plus a changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ef9a99ca60846baefe345a6526fbc4ce946c17f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->