### PR TITLE
DEV-1564: Fix formula calculation explainer video 16:9 embed

### DIFF
--- a/docs/content/guides/formulas/formula-calculation/formula-calculation.md
+++ b/docs/content/guides/formulas/formula-calculation/formula-calculation.md
@@ -289,7 +289,7 @@ const hyperformulaInstance = HyperFormula.buildEmpty({
   // initialize it with the `'internal-use-in-handsontable'` license key
   licenseKey: 'internal-use-in-handsontable',
 });
- 
+
 const configurationOptions: GridSettings = {
   formulas: {
     engine: hyperformulaInstance
@@ -722,7 +722,9 @@ For more information about named expressions, refer to the
 
 ## View the explainer video
 
-<iframe width="100%" src="https://www.youtube.com/embed/JJXUmACTDdk" style="border:0"></iframe>
+<div class="docs-video-embed">
+  <iframe src="https://www.youtube.com/embed/JJXUmACTDdk"></iframe>
+</div>
 
 ## Known limitations
 

--- a/docs/src/styles/layout/page.css
+++ b/docs/src/styles/layout/page.css
@@ -37,6 +37,23 @@
   margin-top: 20px;
 }
 
+/* Responsive 16:9 embed (YouTube and similar) */
+.sl-markdown-content .docs-video-embed {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  margin-top: 20px;
+}
+
+.sl-markdown-content .docs-video-embed iframe {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  width: 100%;
+  height: 100%;
+  margin-top: 0;
+}
+
 /* -------------------------------------------------------------------------
  * Constrain entire page layout to ~1500px on wide viewports
  * ------------------------------------------------------------------------- */


### PR DESCRIPTION
### Context

The PR fixes the HyperFormula explainer video on the Formula calculation guide. The YouTube iframe used width only with no responsive 16:9 container, so the embed did not keep the correct aspect ratio (including on `/angular-data-grid/formula-calculation/`).

This adds a `.docs-video-embed` wrapper with `aspect-ratio: 16 / 9` and positions the iframe to fill it.

### How has this been tested?

- Manual test in dev docs server

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1564

### Affected project(s):

Scope: documentation site only (`docs/`). No library package changes.

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates markup/CSS for a single YouTube embed; main risk is minor layout regressions for other iframes/videos if the new wrapper style is reused.
> 
> **Overview**
> Fixes the Formula calculation guide’s explainer video rendering by wrapping the YouTube `iframe` in a new `.docs-video-embed` container.
> 
> Adds global docs CSS for `.docs-video-embed` to enforce a responsive 16:9 aspect ratio and have the `iframe` fill the container (removing reliance on `iframe` sizing attributes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0a22b9d867e6585f51da7efb7ab522a5bd8ae9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->