### PR TITLE
DEV-1565: Boxes style for server-side data subguide related sections

### DIFF
--- a/docs/content/guides/getting-started/server-side-data/server-side-data-configuration.md
+++ b/docs/content/guides/getting-started/server-side-data/server-side-data-configuration.md
@@ -73,7 +73,11 @@ Respect `signal` so outdated requests abort when the user sorts, filters, or cha
 
 ## More in this guide
 
+<div class="boxes-list">
+
 - [Server-side data](@/guides/getting-started/server-side-data/server-side-data.md)
 - [Migrate from client-side data](@/guides/getting-started/server-side-data/server-side-data-migration.md)
 - [Create, update, and remove](@/guides/getting-started/server-side-data/server-side-data-crud.md)
 - [Fetching, hooks, and examples](@/guides/getting-started/server-side-data/server-side-data-fetching.md)
+
+</div>

--- a/docs/content/guides/getting-started/server-side-data/server-side-data-crud.md
+++ b/docs/content/guides/getting-started/server-side-data/server-side-data-crud.md
@@ -84,7 +84,11 @@ When `onRowsUpdate` is set, Handsontable skips stacking certain edit sources on 
 
 ## More in this guide
 
+<div class="boxes-list">
+
 - [Server-side data](@/guides/getting-started/server-side-data/server-side-data.md)
 - [Migrate from client-side data](@/guides/getting-started/server-side-data/server-side-data-migration.md)
 - [Configuration and query parameters](@/guides/getting-started/server-side-data/server-side-data-configuration.md)
 - [Fetching, hooks, and examples](@/guides/getting-started/server-side-data/server-side-data-fetching.md)
+
+</div>

--- a/docs/content/guides/getting-started/server-side-data/server-side-data-fetching.md
+++ b/docs/content/guides/getting-started/server-side-data/server-side-data-fetching.md
@@ -73,19 +73,55 @@ Each folder includes the same Express servers (`server-rest.mjs`, `server-graphq
 
 ## More in this guide
 
+<div class="boxes-list">
+
 - [Server-side data](@/guides/getting-started/server-side-data/server-side-data.md)
 - [Migrate from client-side data](@/guides/getting-started/server-side-data/server-side-data-migration.md)
 - [Configuration and query parameters](@/guides/getting-started/server-side-data/server-side-data-configuration.md)
 - [Create, update, and remove](@/guides/getting-started/server-side-data/server-side-data-crud.md)
 
+</div>
+
 ## Related guides
+
+<div class="boxes-list">
 
 - [Rows pagination](@/guides/rows/rows-pagination/rows-pagination.md)
 - [Rows sorting](@/guides/rows/rows-sorting/rows-sorting.md)
 - [Column filter](@/guides/columns/column-filter/column-filter.md)
 
+</div>
+
 ## Related API reference
 
-- Option: [`dataProvider`](@/api/options.md#dataprovider)
-- Plugin: [`DataProvider`](@/api/dataProvider.md)
-- Hooks: [`beforeDataProviderFetch`](@/api/hooks.md#beforedataproviderfetch), [`afterDataProviderFetch`](@/api/hooks.md#afterdataproviderfetch), [`afterDataProviderFetchError`](@/api/hooks.md#afterdataproviderfetcherror), [`afterDataProviderFetchAbort`](@/api/hooks.md#afterdataproviderfetchabort), [`hasExternalDataSource`](@/api/hooks.md#hasexternaldatasource), [`modifyRowHeader`](@/api/hooks.md#modifyrowheader) (global row index with pagination), [`beforeRowsMutation`](@/api/hooks.md#beforerowsmutation), [`afterRowsMutation`](@/api/hooks.md#afterrowsmutation), [`afterRowsMutationError`](@/api/hooks.md#afterrowsmutationerror)
+**Options**
+
+<div class="boxes-list">
+
+- [`dataProvider`](@/api/options.md#dataprovider)
+
+</div>
+
+**Plugins**
+
+<div class="boxes-list">
+
+- [`DataProvider`](@/api/dataProvider.md)
+
+</div>
+
+**Hooks**
+
+<div class="boxes-list">
+
+- [`beforeDataProviderFetch`](@/api/hooks.md#beforedataproviderfetch)
+- [`afterDataProviderFetch`](@/api/hooks.md#afterdataproviderfetch)
+- [`afterDataProviderFetchError`](@/api/hooks.md#afterdataproviderfetcherror)
+- [`afterDataProviderFetchAbort`](@/api/hooks.md#afterdataproviderfetchabort)
+- [`hasExternalDataSource`](@/api/hooks.md#hasexternaldatasource)
+- [`modifyRowHeader`](@/api/hooks.md#modifyrowheader) (global row index with pagination)
+- [`beforeRowsMutation`](@/api/hooks.md#beforerowsmutation)
+- [`afterRowsMutation`](@/api/hooks.md#afterrowsmutation)
+- [`afterRowsMutationError`](@/api/hooks.md#afterrowsmutationerror)
+
+</div>

--- a/docs/content/guides/getting-started/server-side-data/server-side-data-migration.md
+++ b/docs/content/guides/getting-started/server-side-data/server-side-data-migration.md
@@ -36,10 +36,14 @@ Use this checklist when moving from a full in-memory `data` array and hooks such
 
 ## More in this guide
 
+<div class="boxes-list">
+
 - [Server-side data](@/guides/getting-started/server-side-data/server-side-data.md) — overview, quick start, and demo.
 - [Configuration and query parameters](@/guides/getting-started/server-side-data/server-side-data-configuration.md)
 - [Create, update, and remove](@/guides/getting-started/server-side-data/server-side-data-crud.md)
 - [Fetching, hooks, and examples](@/guides/getting-started/server-side-data/server-side-data-fetching.md)
+
+</div>
 
 ## Result
 


### PR DESCRIPTION
### Context

The PR adds the `boxes-list` card grid wrapper to **More in this guide**, **Related guides**, and **Related API reference** on all Server-side data subpages so cross-links match the hub [Server-side data](https://handsontable.com/docs/server-side-data/) guide. This addresses DEV-1565 (related sections presentation).

### How has this been tested?

- Manual review of the documentation site build and pages.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]