### PR TITLE
DEV-1569: Fix Angular notification example - use afterInit hook instead of ngAfterViewInit

### DIFF
--- a/docs/content/guides/dialog/notification/angular/example1.ts
+++ b/docs/content/guides/dialog/notification/angular/example1.ts
@@ -1,16 +1,15 @@
 /* file: app.component.ts */
-import { Component, AfterViewInit, ViewChild } from '@angular/core';
-import { GridSettings, HotTableModule, HotTableComponent } from '@handsontable/angular-wrapper';
+import { Component } from '@angular/core';
+import { GridSettings, HotTableModule } from '@handsontable/angular-wrapper';
+import type Handsontable from 'handsontable/base';
 
 @Component({
   standalone: true,
   imports: [HotTableModule],
   selector: 'notification-example',
-  template: `<hot-table #hotTable [data]="hotData" [settings]="hotSettings"></hot-table>`,
+  template: `<hot-table [data]="hotData" [settings]="hotSettings"></hot-table>`,
 })
-export class AppComponent implements AfterViewInit {
-  @ViewChild('hotTable', { static: false }) hotTable!: HotTableComponent;
-
+export class AppComponent {
   readonly hotData = [
     ['Review pricing sheet', 'Draft', 'Apr 12', 'Morgan Lee', 'Medium', 'Finance'],
     ['Ship partner samples', 'In progress', 'Apr 14', 'Jordan Kim', 'High', 'Sales'],
@@ -43,46 +42,39 @@ export class AppComponent implements AfterViewInit {
     width: '100%',
     height: 420,
     notification: true,
+    afterInit(this: Handsontable) {
+      const notification = this.getPlugin('notification');
+
+      notification.showMessage({
+        title: 'Top start',
+        message: 'Info toast in the top-start corner.',
+        variant: 'info',
+        position: 'top-start',
+        duration: 0,
+      });
+      notification.showMessage({
+        title: 'Top end',
+        message: 'Success toast in the top-end corner.',
+        variant: 'success',
+        position: 'top-end',
+        duration: 0,
+      });
+      notification.showMessage({
+        title: 'Bottom start',
+        message: 'Warning toast in the bottom-start corner.',
+        variant: 'warning',
+        position: 'bottom-start',
+        duration: 0,
+      });
+      notification.showMessage({
+        title: 'Bottom end',
+        message: 'Error toast in the bottom-end corner.',
+        variant: 'error',
+        position: 'bottom-end',
+        duration: 0,
+      });
+    },
   };
-
-  ngAfterViewInit(): void {
-    const hot = this.hotTable?.hotInstance;
-
-    if (!hot) {
-      return;
-    }
-
-    const notification = hot.getPlugin('notification');
-
-    notification.showMessage({
-      title: 'Top start',
-      message: 'Info toast in the top-start corner.',
-      variant: 'info',
-      position: 'top-start',
-      duration: 0,
-    });
-    notification.showMessage({
-      title: 'Top end',
-      message: 'Success toast in the top-end corner.',
-      variant: 'success',
-      position: 'top-end',
-      duration: 0,
-    });
-    notification.showMessage({
-      title: 'Bottom start',
-      message: 'Warning toast in the bottom-start corner.',
-      variant: 'warning',
-      position: 'bottom-start',
-      duration: 0,
-    });
-    notification.showMessage({
-      title: 'Bottom end',
-      message: 'Error toast in the bottom-end corner.',
-      variant: 'error',
-      position: 'bottom-end',
-      duration: 0,
-    });
-  }
 }
 /* end-file */
 


### PR DESCRIPTION
### Context

The PR fixes broken toast notification demos on https://dev.handsontable.com/docs/angular-data-grid/notification/.

The Angular example used `ngAfterViewInit` to call `notification.showMessage()` via `hotTable.hotInstance`. This worked locally but failed on the dev/build server because `HotTableComponent.ngAfterViewInit` defers Handsontable initialization to a microtask (`Promise.resolve().then()`). The parent component's `ngAfterViewInit` runs synchronously before that microtask resolves, so `hotInstance` is `null` and the early-return guard fires -- no notifications are shown.

The fix replaces `ngAfterViewInit` + `@ViewChild` with an `afterInit` hook placed directly inside `hotSettings`. The `afterInit` hook is called by Handsontable at the end of `hot.init()`, so `this` is the HOT instance and the notification plugin is guaranteed to be enabled regardless of Angular lifecycle timing. This pattern is also required by the Angular docs authoring rules in `docs/CLAUDE.md` (hooks belong in `gridSettings`, not Angular lifecycle methods).

### How has this been tested?

Docs-only change. Verified visually against the local docs dev server -- all four corner toasts appear correctly.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. [DEV-1569](https://app.clickup.com/t/9015210959/DEV-1569)

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only example change that shifts toast initialization timing; low risk aside from potential TypeScript/Angular example compilation issues.
> 
> **Overview**
> Fixes the Angular notification guide example so toast messages reliably display by moving `notification.showMessage()` calls into a Handsontable `afterInit` hook on `hotSettings`.
> 
> This removes the `@ViewChild`/`ngAfterViewInit`-based access to `hotInstance`, simplifies the template to not require a template ref, and adds a typed `Handsontable` `this` context for the hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ff89cf4dbbb1e9d53dc07ca57cf9d2825a54656. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->