### PR TITLE
DEV-1607: Set light theme colors for code block line highlights

### DIFF
--- a/docs/src/styles/components/code.css
+++ b/docs/src/styles/components/code.css
@@ -75,6 +75,9 @@
   --ec-codeSelBg: rgba(51, 146, 255, 0.28);
   --ec-uiSelBg: var(--sl-color-gray-5);
   --ec-uiSelFg: var(--sl-color-white);
+  /* Line / inline "mark" highlights: same RGB as .expressive-code defaults, lower alpha for light */
+  --ec-tm-markBg: #174a9028;
+  --ec-tm-markBrdCol: #4d70bc55;
 }
 
 :root[data-theme='light'] .expressive-code .copy button {


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Adds CSS variables for background and border colors of line/inline "mark" highlights within Expressive Code blocks, ensuring proper visibility and styling for the light theme.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Manual check on docs dev server

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only change that tweaks light-theme styling for Expressive Code highlights with no logic or data handling impact.
> 
> **Overview**
> Adds light-theme overrides for Expressive Code line/inline `mark` highlights by defining `--ec-tm-markBg` and `--ec-tm-markBrdCol` with reduced alpha, improving highlight visibility on light backgrounds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27b560fb822020a83186937ca79fb01391a9e659. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->