### PR TITLE
DEV-1647: Fix built-in cell types example for React and Angular

### DIFF
--- a/docs/content/guides/cell-types/cell-type/angular/example1.ts
+++ b/docs/content/guides/cell-types/cell-type/angular/example1.ts
@@ -1,16 +1,16 @@
 /* file: app.component.ts */
 import { Component } from '@angular/core';
 import { GridSettings, HotTableModule} from '@handsontable/angular-wrapper';
-import Handsontable from 'handsontable/base';
+import { textRenderer } from 'handsontable/renderers/textRenderer';
 import { BaseRenderer } from 'handsontable/renderers';
 
 const yellowRenderer: BaseRenderer = (instance, td, ...rest) => {
-  Handsontable.renderers.TextRenderer(instance, td, ...rest);
+  textRenderer(instance, td, ...rest);
   td.style.backgroundColor = 'yellow';
 };
 
 const greenRenderer: BaseRenderer = (instance, td, ...rest) => {
-  Handsontable.renderers.TextRenderer(instance, td, ...rest);
+  textRenderer(instance, td, ...rest);
 
   td.style.backgroundColor = 'green';
 };

--- a/docs/content/guides/cell-types/cell-type/react/example1.jsx
+++ b/docs/content/guides/cell-types/cell-type/react/example1.jsx
@@ -1,6 +1,6 @@
 import { HotTable } from '@handsontable/react-wrapper';
-import Handsontable from 'handsontable/base';
 import { registerAllModules } from 'handsontable/registry';
+import { textRenderer } from 'handsontable/renderers/textRenderer';
 
 // register Handsontable's modules
 registerAllModules();
@@ -8,12 +8,12 @@ registerAllModules();
 const ExampleComponent = () => {
   const colors = ['yellow', 'red', 'orange', 'green', 'blue', 'gray', 'black', 'white'];
   const yellowRenderer = (instance, td, ...rest) => {
-    Handsontable.renderers.TextRenderer(instance, td, ...rest);
+    textRenderer(instance, td, ...rest);
     td.style.backgroundColor = 'yellow';
   };
 
   const greenRenderer = (instance, td, ...rest) => {
-    Handsontable.renderers.TextRenderer(instance, td, ...rest);
+    textRenderer(instance, td, ...rest);
     td.style.backgroundColor = 'green';
   };
 

--- a/docs/content/guides/cell-types/cell-type/react/example1.tsx
+++ b/docs/content/guides/cell-types/cell-type/react/example1.tsx
@@ -1,6 +1,6 @@
 import { HotTable } from '@handsontable/react-wrapper';
-import Handsontable from 'handsontable/base';
 import { registerAllModules } from 'handsontable/registry';
+import { textRenderer } from 'handsontable/renderers/textRenderer';
 import { BaseRenderer } from 'handsontable/renderers';
 
 // register Handsontable's modules
@@ -10,12 +10,12 @@ const ExampleComponent = () => {
   const colors: string[] = ['yellow', 'red', 'orange', 'green', 'blue', 'gray', 'black', 'white'];
 
   const yellowRenderer: BaseRenderer = (instance, td, ...rest) => {
-    Handsontable.renderers.TextRenderer(instance, td, ...rest);
+    textRenderer(instance, td, ...rest);
     td.style.backgroundColor = 'yellow';
   };
 
   const greenRenderer: BaseRenderer = (instance, td, ...rest) => {
-    Handsontable.renderers.TextRenderer(instance, td, ...rest);
+    textRenderer(instance, td, ...rest);
 
     td.style.backgroundColor = 'green';
   };


### PR DESCRIPTION
### Context

The PR fixes the "Built-in cell types example" on the cell-type docs page, which was broken for React and Angular.

**Root cause:** The React and Angular examples imported `Handsontable from 'handsontable/base'` and used `Handsontable.renderers.TextRenderer`. When using the base module, `Handsontable.renderers` is `undefined` - the namespace is only populated in `src/index.js` (the full entry point). Calling `Handsontable.renderers.TextRenderer(...)` therefore throws `TypeError: Cannot read properties of undefined (reading 'TextRenderer')`, crashing the custom renderers.

The JavaScript example works correctly because it imports `textRenderer` directly from `'handsontable/renderers/textRenderer'`.

**Fix:** Removed the `import Handsontable from 'handsontable/base'` import and replaced `Handsontable.renderers.TextRenderer` with `textRenderer` imported directly from `'handsontable/renderers/textRenderer'` in all three affected files (React JSX, React TSX, Angular TS).

### How has this been tested?

- Verified the root cause by reading `src/base.js` - the `Handsontable.renderers` namespace is not set up there, confirming `TextRenderer` is `undefined`
- Verified the fix pattern matches the working JavaScript example (`javascript/example1.js`)
- Manual code review of all three changed files

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1647

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1647

[skip changelog]

---
_Generated by [Claude Code](https://claude.ai/code/session_01WSB75wJomtoFH5SoWv9CT5)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that swaps renderer imports; impact is limited to code snippets used in docs, but incorrect imports would crash the examples at runtime.
> 
> **Overview**
> Fixes the React (`example1.jsx`/`example1.tsx`) and Angular (`example1.ts`) “built-in cell types” docs snippets to use `textRenderer` imported from `handsontable/renderers/textRenderer`.
> 
> Removes the `handsontable/base` import and replaces `Handsontable.renderers.TextRenderer(...)` calls with `textRenderer(...)` inside the custom `yellowRenderer`/`greenRenderer`, preventing runtime `undefined` renderer errors in these examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 143196c8a5ac7619a589eb238726e4e18d526d7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->