### PR TITLE
DEV-1566: Fix Angular Saving data demo load/save fetch URLs

### DIFF
--- a/docs/content/guides/getting-started/saving-data/angular/example1.ts
+++ b/docs/content/guides/getting-started/saving-data/angular/example1.ts
@@ -68,7 +68,7 @@ export class AppComponent {
         return;
       }
 
-      fetch('https://handsontable.com/docs/scripts/json/save.json', {
+      fetch('/docs/scripts/json/save.json', {
         method: 'POST',
         mode: 'no-cors',
         headers: {
@@ -99,7 +99,7 @@ export class AppComponent {
   loadClickCallback(event: MouseEvent): void {
     const hot = this.hotTable?.hotInstance;
 
-    fetch('https://handsontable.com/docs/scripts/json/load.json').then(
+    fetch('/docs/scripts/json/load.json').then(
       (response) => {
         response.json().then((data) => {
           hot?.loadData(data.data);
@@ -114,7 +114,7 @@ export class AppComponent {
     const hot = this.hotTable?.hotInstance;
 
     // save all cell's data
-    fetch('https://handsontable.com/docs/scripts/json/save.json', {
+    fetch('/docs/scripts/json/save.json', {
       method: 'POST',
       mode: 'no-cors',
       headers: {


### PR DESCRIPTION
### Context

The PR fixes the Angular Saving data guide example on non-production docs hosts (for example `dev.handsontable.com`). The Angular example used absolute `https://handsontable.com/docs/scripts/json/...` URLs for `fetch`, while the JavaScript and React examples use same-origin paths (`/docs/scripts/json/...`). Cross-origin requests from the dev docs origin fail (for example CORS), so **Load data** did not populate the grid. Aligning Angular with the other frameworks restores the demo on any docs deployment.

### How has this been tested?

- `npm run docs:lint --prefix docs`
- Confirmed `docs/public/scripts/json/load.json` parses and contains a `data` array.
- Manual browser check recommended: `npm run dev --prefix docs`, open Saving data, Angular tab, click **Load data**, **Save data**, and exercise **Autosave**.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1566

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that swaps absolute `handsontable.com` fetch URLs for same-origin paths to avoid CORS failures on non-production docs hosts.
> 
> **Overview**
> Updates the Angular Saving Data guide example to use same-origin `fetch` URLs (`/docs/scripts/json/load.json` and `/docs/scripts/json/save.json`) for **Load**, **Save**, and **Autosave**, replacing hardcoded `https://handsontable.com/...` endpoints so the demo works on non-production docs deployments without CORS issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b83f232ecd8b2a1c51ff6d60e6a3d32280ab1bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->