### PR TITLE
DEV-1632: Widen external search input to show full placeholder text

### DIFF
--- a/docs/content/recipes/filtering-and-search/external-search-box/angular/example1.ts
+++ b/docs/content/recipes/filtering-and-search/external-search-box/angular/example1.ts
@@ -24,6 +24,7 @@ const data = [
           id="external-search-input"
           type="search"
           placeholder="Type to highlight matching cells..."
+          style="min-width: 20rem"
           (input)="onSearch($event)"
         />
       </div>

--- a/docs/content/recipes/filtering-and-search/external-search-box/external-search-box.md
+++ b/docs/content/recipes/filtering-and-search/external-search-box/external-search-box.md
@@ -26,10 +26,11 @@ In this tutorial, you will add a search input outside Handsontable that highligh
 
 ::: only-for javascript
 
-::: example #example1 :hot-recipe --js 1 --ts 2
+::: example #example1 :hot-recipe --js 1 --ts 2 --css 3
 
 @[code](@/content/recipes/filtering-and-search/external-search-box/javascript/example1.js)
 @[code](@/content/recipes/filtering-and-search/external-search-box/javascript/example1.ts)
+@[code](@/content/recipes/filtering-and-search/external-search-box/javascript/example1.css)
 
 :::
 
@@ -37,8 +38,9 @@ In this tutorial, you will add a search input outside Handsontable that highligh
 
 ::: only-for react
 
-::: example #example1 :react-advanced --js 1 --ts 2
+::: example #example1 :react-advanced --css 1 --js 2 --ts 3
 
+@[code](@/content/recipes/filtering-and-search/external-search-box/react/example1.css)
 @[code](@/content/recipes/filtering-and-search/external-search-box/react/example1.jsx)
 @[code](@/content/recipes/filtering-and-search/external-search-box/react/example1.tsx)
 :::

--- a/docs/content/recipes/filtering-and-search/external-search-box/javascript/example1.css
+++ b/docs/content/recipes/filtering-and-search/external-search-box/javascript/example1.css
@@ -1,0 +1,3 @@
+#external-search-input {
+  min-width: 20rem;
+}

--- a/docs/content/recipes/filtering-and-search/external-search-box/react/example1.css
+++ b/docs/content/recipes/filtering-and-search/external-search-box/react/example1.css
@@ -1,0 +1,3 @@
+#external-search-input {
+  min-width: 20rem;
+}


### PR DESCRIPTION
### Context

The PR fixes the truncated placeholder text in the `#external-search-input` field on the "External search box" recipe page. The input was too narrow to display "Type to highlight matching cells..." in full - it was cut off at "Type to highlight mat". The fix applies `min-width: 20rem` via CSS for the JS and React examples, and via an inline style for the Angular example (which uses an inline template and cannot use `styleUrls`).

### How has this been tested?

This is a docs-only styling fix. Verified visually by inspecting the affected example files. No library source code was changed.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1632

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/86c9px4we

[skip changelog]

---
_Generated by [Claude Code](https://claude.ai/code/session_01Exsxgtbz56XucH7JLgfsGm)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only styling change that adds simple CSS/inline styles and updates the recipe’s example includes; no library or runtime logic is modified.
> 
> **Overview**
> Widened the `#external-search-input` in the “External search box” recipe to prevent placeholder truncation by applying `min-width: 20rem`.
> 
> JS and React examples now include a new `example1.css` (and the recipe markdown is updated to display it), while the Angular example applies the same rule via an inline `style` on the input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a23865fcb4b49e3ba51118ba0a0efbe62a96203. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->