### PR TITLE
Revert DEV-413 - `minSpareRows` creates a conflict when we ask …

### DIFF
--- a/.changelogs/12519.json
+++ b/.changelogs/12519.json
@@ -1,8 +1,0 @@
-{
-  "issuesOrigin": "public",
-  "title": "Fixed the `@handsontable/angular-wrapper` ERROR RuntimeError: NG0100: ExpressionChangedAfterItHasBeenCheckedError",
-  "type": "fixed",
-  "issueOrPR": 12519,
-  "breaking": false,
-  "framework": "angular"
-}

--- a/wrappers/angular-wrapper/projects/hot-table/jest.config.js
+++ b/wrappers/angular-wrapper/projects/hot-table/jest.config.js
@@ -1,22 +1,18 @@
 module.exports = {
   preset: 'jest-preset-angular',
   setupFilesAfterEnv: ['<rootDir>/setup-jest.ts'],
-  globals: {
-    'jest-preset-angular': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-      stringifyContentPathRegex: '\\.html$'
-    }
-  },
   transform: {
-    '^.+\\.(ts|js|html)$': 'jest-preset-angular'
+    '^.+\\.(ts|js|mjs|html)$': [
+      'jest-preset-angular',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.html$',
+      },
+    ],
   },
   testEnvironment: 'jsdom',
-  moduleNameMapper: {
-    // Map any path aliases from tsconfig if needed
-    '\\.(css|less|scss|sass)$': '<rootDir>/src/__mocks__/styleMock.js'
-  },
   transformIgnorePatterns: [
-    'node_modules/(?!.*\\.mjs$|zone\\.js|@angular|rxjs)'
+    'node_modules/(?!.*\\.mjs$|zone\\.js|@angular|rxjs)',
   ],
   moduleDirectories: ['node_modules', '<rootDir>/../../node_modules'],
   testEnvironmentOptions: {

--- a/wrappers/angular-wrapper/projects/hot-table/jest.config.js
+++ b/wrappers/angular-wrapper/projects/hot-table/jest.config.js
@@ -1,11 +1,14 @@
 module.exports = {
   preset: 'jest-preset-angular',
   setupFilesAfterEnv: ['<rootDir>/setup-jest.ts'],
-  transform: {
-    '^.+\\.(ts|js|html)$': ['jest-preset-angular', {
+  globals: {
+    'jest-preset-angular': {
       tsconfig: '<rootDir>/tsconfig.spec.json',
       stringifyContentPathRegex: '\\.html$'
-    }]
+    }
+  },
+  transform: {
+    '^.+\\.(ts|js|html)$': 'jest-preset-angular'
   },
   testEnvironment: 'jsdom',
   moduleNameMapper: {

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.spec.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.spec.ts
@@ -25,38 +25,35 @@ describe('HotTableComponent', () => {
 
   });
 
-  it(`should render 'hot-table'`, async () => {
+  it(`should render 'hot-table'`, () => {
     fixture = TestBed.createComponent(HotTableComponent);
     fixture.componentInstance.settings = { ...settings };
     fixture.detectChanges();
-    await fixture.whenStable();
 
     const elem = fixture.nativeElement;
     expect(elem.querySelectorAll('.handsontable').length).toBeGreaterThan(0);
     expect(fixture.componentInstance.hotInstance).toBeDefined();
   });
 
-  it(`should render 'hot-table' even when settings are not provided`, async () => {
+  it(`should render 'hot-table' even when settings are not provided`, () => {
     fixture = TestBed.createComponent(HotTableComponent);
     fixture.detectChanges();
-    await fixture.whenStable();
 
     const elem = fixture.nativeElement;
     expect(elem.querySelectorAll('.handsontable').length).toBeGreaterThan(0);
     expect(fixture.componentInstance.hotInstance).toBeDefined();
   });
 
-  it(`should set data`, async () => {
+  it(`should set data`, () => {
     fixture = TestBed.createComponent(HotTableComponent);
     fixture.componentInstance.settings = {};
     fixture.componentInstance.data = createSpreadsheetData(5, 5);
     fixture.detectChanges();
-    await fixture.whenStable();
 
     expect(fixture.componentInstance.hotInstance.getDataAtCell(0, 0)).toBe('A1');
   });
 
-  it(`should be possible to set some option and pass it to Handsontable`, async () => {
+  it(`should be possible to set some option and pass it to Handsontable`, () => {
     fixture = TestBed.createComponent(HotTableComponent);
     fixture.componentInstance.settings = {
       ...settings,
@@ -67,7 +64,6 @@ describe('HotTableComponent', () => {
     };
 
     fixture.detectChanges();
-    await fixture.whenStable();
 
     const handsontableSettings = fixture.componentInstance.hotInstance.getSettings();
     expect(handsontableSettings.rowHeaders).toBe(true);
@@ -77,12 +73,11 @@ describe('HotTableComponent', () => {
   });
 
   describe('ngOnChanges', () => {
-    it('should update Handsontable settings if settings change and it is not the first change', async () => {
+    it('should update Handsontable settings if settings change and it is not the first change', () => {
       const newSettings = { readOnly: true };
       fixture = TestBed.createComponent(HotTableComponent);
       fixture.componentInstance.settings = {};
       fixture.detectChanges();
-      await fixture.whenStable();
       const hotSettingsResolver = fixture.componentRef.injector.get(HotSettingsResolver);
       const component = fixture.componentInstance;
       const applyCustomSettingsSpy = jest.spyOn(hotSettingsResolver, 'applyCustomSettings');
@@ -98,12 +93,11 @@ describe('HotTableComponent', () => {
       expect(updateHotTableSpy).toHaveBeenCalledWith(newSettings, false);
     });
 
-    it('should not update Handsontable settings if it is the first change', async () => {
+    it('should not update Handsontable settings if it is the first change', () => {
       const newSettings = { data: [[1, 2, 3]] };
       fixture = TestBed.createComponent(HotTableComponent);
       fixture.componentInstance.settings = {};
       fixture.detectChanges();
-      await fixture.whenStable();
       const hotSettingsResolver = fixture.componentRef.injector.get(HotSettingsResolver);
       const applyCustomSettingsSpy = jest.spyOn(hotSettingsResolver, 'applyCustomSettings');
       const component = fixture.componentInstance;
@@ -119,12 +113,11 @@ describe('HotTableComponent', () => {
       expect(updateHotTableSpy).not.toHaveBeenCalled();
     });
 
-    it('should update Handsontable data if data change and it is not the first change', async () => {
+    it('should update Handsontable data if data change and it is not the first change', () => {
       const newData = [[1, 2, 3]];
       fixture = TestBed.createComponent(HotTableComponent);
       fixture.componentInstance.settings = {};
       fixture.detectChanges();
-      await fixture.whenStable();
       const component = fixture.componentInstance;
 
       const updateDataSpy = jest.spyOn(component.hotInstance, 'updateData');
@@ -137,12 +130,11 @@ describe('HotTableComponent', () => {
       expect(updateDataSpy).toHaveBeenCalledWith(newData);
     });
 
-    it('should not update Handsontable data if data change and it is the first change', async () => {
+    it('should not update Handsontable data if data change and it is the first change', () => {
       const newData = [[1, 2, 3]];
       fixture = TestBed.createComponent(HotTableComponent);
       fixture.componentInstance.settings = {};
       fixture.detectChanges();
-      await fixture.whenStable();
       const component = fixture.componentInstance;
 
       const updateDataSpy = jest.spyOn(component.hotInstance, 'updateData');
@@ -155,14 +147,13 @@ describe('HotTableComponent', () => {
       expect(updateDataSpy).not.toHaveBeenCalledWith(newData);
     });
 
-    it('should not pass init-only settings to updateSettings after initialization', async () => {
+    it('should not pass init-only settings to updateSettings after initialization', () => {
       fixture = TestBed.createComponent(HotTableComponent);
       fixture.componentInstance.settings = {
         renderAllRows: false,
         width: 300,
       };
       fixture.detectChanges();
-      await fixture.whenStable();
       const component = fixture.componentInstance;
       const updateSettingsSpy = jest.spyOn(component.hotInstance, 'updateSettings');
 
@@ -184,7 +175,7 @@ describe('HotTableComponent', () => {
   });
 
   describe('ngOnDestroy', () => {
-    it('should destroy Handsontable instance and editor component references, when columns property is an array', async () => {
+    it('should destroy Handsontable instance and editor component references, when columns property is an array', () => {
       fixture = TestBed.createComponent(HotTableComponent);
       const editorRefMock = {
         destroy: jest.fn(),
@@ -198,7 +189,6 @@ describe('HotTableComponent', () => {
         ],
       };
       fixture.detectChanges();
-      await fixture.whenStable();
       const hotInstance = fixture.componentInstance.hotInstance;
       const destroySpy = jest.spyOn(hotInstance, 'destroy');
 
@@ -208,7 +198,7 @@ describe('HotTableComponent', () => {
       expect(destroySpy).toHaveBeenCalled();
     });
 
-    it('should destroy Handsontable instance, when columns property is a function', async () => {
+    it('should destroy Handsontable instance, when columns property is a function', () => {
       fixture = TestBed.createComponent(HotTableComponent);
 
       fixture.componentInstance.settings = {
@@ -217,7 +207,6 @@ describe('HotTableComponent', () => {
       };
 
       fixture.detectChanges();
-      await fixture.whenStable();
       const hotInstance = fixture.componentInstance.hotInstance;
       const destroySpy = jest.spyOn(hotInstance, 'destroy');
 
@@ -225,7 +214,7 @@ describe('HotTableComponent', () => {
       expect(destroySpy).toHaveBeenCalled();
     });
 
-    it('should destroy Handsontable instance, when columns property is undefined', async () => {
+    it('should destroy Handsontable instance, when columns property is undefined', () => {
       fixture = TestBed.createComponent(HotTableComponent);
 
       fixture.componentInstance.settings = {
@@ -233,29 +222,16 @@ describe('HotTableComponent', () => {
       };
 
       fixture.detectChanges();
-      await fixture.whenStable();
       const hotInstance = fixture.componentInstance.hotInstance;
       const destroySpy = jest.spyOn(hotInstance, 'destroy');
 
       fixture.componentInstance.ngOnDestroy();
       expect(destroySpy).toHaveBeenCalled();
     });
-
-    it('should not create Handsontable instance if component is destroyed before microtask resolves', async () => {
-      fixture = TestBed.createComponent(HotTableComponent);
-      fixture.componentInstance.settings = { ...settings };
-      fixture.detectChanges();
-
-      // Destroy before the pending Promise resolves
-      fixture.componentInstance.ngOnDestroy();
-      await fixture.whenStable();
-
-      expect(fixture.componentInstance.hotInstance).toBeNull();
-    });
   });
 
   describe('hooks', () => {
-    it(`should use Handsontable as a hook's context, if is defined as a component's method`, async () => {
+    it(`should use Handsontable as a hook's context, if is defined as a component's method`, () => {
       fixture = TestBed.createComponent(HotTableComponent);
       fixture.componentInstance.settings = {
         ...settings,
@@ -264,7 +240,6 @@ describe('HotTableComponent', () => {
         },
       };
       fixture.detectChanges();
-      await fixture.whenStable();
 
       const instance: Handsontable = fixture.componentInstance.hotInstance;
       instance.runHooks('afterInit');
@@ -282,7 +257,6 @@ describe('HotTableComponent', () => {
         },
       };
       fixture.detectChanges();
-      await fixture.whenStable();
 
       const instance: Handsontable = fixture.componentInstance.hotInstance.runHooks('afterInit');
 
@@ -290,7 +264,7 @@ describe('HotTableComponent', () => {
       expect(instance.getPlugin('copyPaste')).toBeTruthy();
     });
 
-    it(`should allow to block 'before*' hooks`, async () => {
+    it(`should allow to block 'before*' hooks`, () => {
       fixture = TestBed.createComponent(HotTableComponent);
       const component = fixture.componentInstance;
       component.settings = {
@@ -307,7 +281,6 @@ describe('HotTableComponent', () => {
       };
       let afterChangeResult = false;
       fixture.detectChanges();
-      await fixture.whenStable();
 
       component.hotInstance.setDataAtCell(0, 0, 'test');
 

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.spec.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.spec.ts
@@ -53,6 +53,24 @@ describe('HotTableComponent', () => {
     expect(fixture.componentInstance.hotInstance.getDataAtCell(0, 0)).toBe('A1');
   });
 
+  it(`should use data from settings when [data] input is not bound`, () => {
+    const settingsData = createSpreadsheetData(3, 3);
+
+    fixture = TestBed.createComponent(HotTableComponent);
+    // GridSettings intentionally omits 'data' (users should use [data] binding),
+    // but we cast here to verify the runtime merge does not override it with null
+    // when [data] is unbound (e.g. JavaScript users or future API changes).
+    fixture.componentInstance.settings = {
+      ...settings,
+      data: settingsData,
+    } as unknown as GridSettings;
+    // [data] input is intentionally not set — remains null (the default)
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.hotInstance.getDataAtCell(0, 0)).toBe('A1');
+    expect(fixture.componentInstance.hotInstance.countRows()).toBe(3);
+  });
+
   it(`should be possible to set some option and pass it to Handsontable`, () => {
     fixture = TestBed.createComponent(HotTableComponent);
     fixture.componentInstance.settings = {

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.spec.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.spec.ts
@@ -266,7 +266,7 @@ describe('HotTableComponent', () => {
       expect(instance.getPlugin('copyPaste')).toBeTruthy();
     });
 
-    it(`should use Handsontable as a hook's context, if is defined as a function in settings object`, async () => {
+    it(`should use Handsontable as a hook's context, if is defined as a function in settings object`, () => {
       fixture = TestBed.createComponent(HotTableComponent);
       fixture.componentInstance.settings = {
         ...settings,

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.ts
@@ -48,7 +48,6 @@ export class HotTableComponent implements AfterViewInit, OnChanges, OnDestroy {
 
   /** The Handsontable instance. */
   private __hotInstance: Handsontable | null = null;
-  private _pendingDestroy = false;
 
   constructor(
     private readonly _hotSettingsResolver: HotSettingsResolver,
@@ -85,32 +84,23 @@ export class HotTableComponent implements AfterViewInit, OnChanges, OnDestroy {
    */
   ngAfterViewInit(): void {
     let options: Handsontable.GridSettings = this._hotSettingsResolver.applyCustomSettings(this.settings);
+
     const negotiatedSettings = this.getNegotiatedSettings(options);
-    options = { ...options, ...negotiatedSettings, ...(this.data != null ? { data: this.data } : {}) };
+    options = { ...options, ...negotiatedSettings, data: this.data };
 
-    // Defer initialization to the next microtask to prevent NG0100
-    // (ExpressionChangedAfterItHasBeenCheckedError). HOT mutates the input
-    // data array during init (e.g. minSpareRows), which Angular's dev-mode
-    // double-check detects as an illegal mid-cycle change.
-    Promise.resolve().then(() => {
-      if (this._pendingDestroy) {
-        return;
+    this.ngZone.runOutsideAngular(() => {
+      this.hotInstance = new Handsontable.Core(this.container.nativeElement, options);
+
+      (this.hotInstance as any)._angularEnvironmentInjector = this.environmentInjector;
+
+      this.hotInstance.init();
+    });
+
+    this._hotConfig.config$.pipe(skip(1), takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+      if (this.hotInstance) {
+        const negotiatedSettings = this.getNegotiatedSettings(this.settings);
+        this.updateHotTable(negotiatedSettings);
       }
-
-      this.ngZone.runOutsideAngular(() => {
-        this.hotInstance = new Handsontable.Core(this.container.nativeElement, options);
-
-        (this.hotInstance as any)._angularEnvironmentInjector = this.environmentInjector;
-
-        this.hotInstance.init();
-      });
-
-      this._hotConfig.config$.pipe(skip(1), takeUntilDestroyed(this.destroyRef)).subscribe(() => {
-        if (this.hotInstance) {
-          const negotiatedSettings = this.getNegotiatedSettings(this.settings);
-          this.updateHotTable(negotiatedSettings);
-        }
-      });
     });
   }
 
@@ -141,8 +131,6 @@ export class HotTableComponent implements AfterViewInit, OnChanges, OnDestroy {
    * Destroys the Handsontable instance and clears the columns from custom editors.
    */
   ngOnDestroy(): void {
-    this._pendingDestroy = true;
-
     if (!this.hotInstance) {
       return;
     }

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.ts
@@ -86,7 +86,7 @@ export class HotTableComponent implements AfterViewInit, OnChanges, OnDestroy {
     let options: Handsontable.GridSettings = this._hotSettingsResolver.applyCustomSettings(this.settings);
 
     const negotiatedSettings = this.getNegotiatedSettings(options);
-    options = { ...options, ...negotiatedSettings, data: this.data };
+    options = { ...options, ...negotiatedSettings, ...(this.data != null ? { data: this.data } : {}) };
 
     this.ngZone.runOutsideAngular(() => {
       this.hotInstance = new Handsontable.Core(this.container.nativeElement, options);


### PR DESCRIPTION
Reverts handsontable/handsontable#12519


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reverts the microtask-deferred Handsontable initialization in `HotTableComponent`, which may reintroduce `ExpressionChangedAfterItHasBeenCheckedError`/timing-sensitive behavior in Angular apps. Test and Jest config changes are low risk but align expectations with the new synchronous init path.
> 
> **Overview**
> Reverts the Angular wrapper change that deferred Handsontable creation to a microtask (and the associated `_pendingDestroy` guard), restoring **synchronous** initialization in `HotTableComponent.ngAfterViewInit()`.
> 
> Updates the wrapper’s Jest setup to also transform `.mjs` files and simplifies the config, and adjusts `HotTableComponent` tests to be synchronous (removing `whenStable()`), adds coverage for using `settings.data` when `[data]` is not bound, and drops the test that relied on deferred init. Also removes the changelog entry for issue `#12519`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7da1df09272ccafc63e1afdbc92ebbea2a14f975. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



[skip changelog]