### PR TITLE
DEV-1612: Print - hide mobile subheader

### DIFF
--- a/docs/src/styles/mobile/subbar.css
+++ b/docs/src/styles/mobile/subbar.css
@@ -6,7 +6,7 @@
   display: none;
 }
 
-@media (max-width: 71.99rem) {
+@media screen and (max-width: 71.99rem) {
   .mobile-subheader {
     display: flex !important;
     align-items: center;
@@ -26,7 +26,7 @@
 }
 
 /* On mobile subheader goes full width; on tablet starts after sidebar */
-@media (max-width: 49.99rem) {
+@media screen and (max-width: 49.99rem) {
   .mobile-subheader {
     left: 0;
   }


### PR DESCRIPTION
### Context

The PR fixes the mobile subheader (`.mobile-subheader`) remaining visible when printing docs pages. The root cause was a CSS cascade conflict: A4 paper width (~794px) falls within the `max-width: 71.99rem` breakpoint, so the `display: flex !important` rule in `subbar.css` (loaded after `print.css`) was overriding the `display: none !important` print rule. Scoping the breakpoint media queries to `screen` prevents the conflict entirely.

### How has this been tested?

Manually verified using browser print preview at narrow viewport widths.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1612

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1612

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only change that narrows responsive rules to `screen`, mainly affecting how the docs header renders in print/preview at A4-like widths.
> 
> **Overview**
> Fixes docs printing so the `.mobile-subheader` stays hidden by scoping its responsive breakpoints to `@media screen`.
> 
> This prevents the mobile `display: flex !important` rule from overriding the `@media print` hide rule when the page is rendered at print-like widths (e.g., A4).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64a14d05ff5213c0911e1bf498ae837f2c729f56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->