### PR TITLE
DEV-1650: Fix build pipeline noise - suppress child output on TTY success

### DIFF
--- a/handsontable/scripts/run.mjs
+++ b/handsontable/scripts/run.mjs
@@ -252,10 +252,10 @@ function runParallelTask(name, spinner) {
       } else {
         spinner.finish(name, true, elapsed);
 
-        // Flush any captured output (e.g. ESLint/Stylelint warnings) that was
-        // collected while the task ran quietly. Build tools that exit 0 with no
-        // warnings produce empty output, so this is a no-op for them.
-        if (combined.trim()) {
+        // Flush captured output only in CI (non-TTY). On TTY the spinner ✓ line
+        // already signals success; flushing stdout noise (e.g. rspack's success
+        // message) would clutter the output without adding value.
+        if (!isTTY && combined.trim()) {
           process.stdout.write(`${combined.trimEnd()}\n`);
         }
 

--- a/handsontable/scripts/run.mjs
+++ b/handsontable/scripts/run.mjs
@@ -252,11 +252,13 @@ function runParallelTask(name, spinner) {
       } else {
         spinner.finish(name, true, elapsed);
 
-        // Flush captured output only in CI (non-TTY). On TTY the spinner ✓ line
-        // already signals success; flushing stdout noise (e.g. rspack's success
-        // message) would clutter the output without adding value.
-        if (!isTTY && combined.trim()) {
-          process.stdout.write(`${combined.trimEnd()}\n`);
+        // Flush any captured output (e.g. ESLint/Stylelint warnings) that was
+        // collected while the task ran quietly. Strip rspack's informational
+        // success line — it is noise already conveyed by the spinner ✓ line.
+        const meaningful = combined.replace(/^Rspack compiled successfully in \d+ ms\r?\n?/gm, '').trim();
+
+        if (meaningful) {
+          process.stdout.write(`${meaningful}\n`);
         }
 
         res(elapsed);

--- a/handsontable/scripts/run.mjs
+++ b/handsontable/scripts/run.mjs
@@ -87,7 +87,10 @@ const themeArg = extraArgs.find(a => a.startsWith('--theme='));
 // --verbose may appear anywhere in rawArgs: npm strips the '--' separator when
 // forwarding extra args so it lands in mainArgs, not extraArgs.
 const isVerbose = rawArgs.includes('--verbose');
-const passthroughFlags = extraArgs.filter(f => f !== '--verbose');
+// Do NOT strip --verbose from passthroughFlags — puppeteer tasks list it in
+// their passthroughFilter and need it forwarded. buildCmd()'s passthroughFilter
+// already prevents it from reaching tasks that don't expect it (e.g. build tasks).
+const passthroughFlags = extraArgs;
 
 const propagatedEnv = {};
 

--- a/handsontable/scripts/run.mjs
+++ b/handsontable/scripts/run.mjs
@@ -84,7 +84,10 @@ const themeArg = extraArgs.find(a => a.startsWith('--theme='));
 // the dump step (rspack) and run-puppeteer.mjs compute the same run-ID filename.
 // For test:unit.jest, --testPathPattern= is also passed as argv (passthrough task),
 // which Jest accepts directly; puppeteer ignores the duplicate argv entry.
-const passthroughFlags = extraArgs;
+// --verbose may appear anywhere in rawArgs: npm strips the '--' separator when
+// forwarding extra args so it lands in mainArgs, not extraArgs.
+const isVerbose = rawArgs.includes('--verbose');
+const passthroughFlags = extraArgs.filter(f => f !== '--verbose');
 
 const propagatedEnv = {};
 
@@ -223,19 +226,23 @@ function runParallelTask(name, spinner) {
 
     if (process.platform === 'win32') { delete baseEnv.Path; }
 
+    // In verbose mode use inherit so tools write directly to the terminal —
+    // many CLI tools (including rspack) suppress output when stdout is piped.
+    const stdio = isVerbose ? 'inherit' : ['ignore', 'pipe', 'pipe'];
+
     const child = spawn(cmd, [], {
       cwd,
       env: { ...baseEnv, PATH: envPATH, NODE_NO_WARNINGS: '1', ...propagatedEnv },
-      // Pipe both stdout and stderr so lint errors (written to stdout by ESLint/Stylelint)
-      // are captured and shown on failure alongside any stderr diagnostics.
-      stdio: ['ignore', 'pipe', 'pipe'],
+      stdio,
       shell: true,
     });
 
     let combined = '';
 
-    child.stdout.on('data', (d) => { combined += d.toString(); });
-    child.stderr.on('data', (d) => { combined += d.toString(); });
+    if (!isVerbose) {
+      child.stdout.on('data', (d) => { combined += d.toString(); });
+      child.stderr.on('data', (d) => { combined += d.toString(); });
+    }
 
     child.on('close', (code) => {
       const elapsed = Math.round(performance.now() - start);
@@ -252,13 +259,10 @@ function runParallelTask(name, spinner) {
       } else {
         spinner.finish(name, true, elapsed);
 
-        // Flush any captured output (e.g. ESLint/Stylelint warnings) that was
-        // collected while the task ran quietly. Strip rspack's informational
-        // success line — it is noise already conveyed by the spinner ✓ line.
-        const meaningful = combined.replace(/^Rspack compiled successfully in \d+ ms\r?\n?/gm, '').trim();
-
-        if (meaningful) {
-          process.stdout.write(`${meaningful}\n`);
+        // In CI (non-TTY) flush all captured output for log collectors.
+        // On TTY the spinner ✓ line is sufficient; use --verbose to see output.
+        if (!isVerbose && !isTTY && combined.trim()) {
+          process.stdout.write(`${combined.trimEnd()}\n`);
         }
 
         res(elapsed);
@@ -308,7 +312,7 @@ async function runPipeline(name, parallel) {
 
     tasks.forEach((t) => { subTasks[t] = TASKS[t] ?? { cmd: t, deps: [] }; });
 
-    const spinner = new ParallelSpinner();
+    const spinner = isVerbose ? { start: () => {}, finish: () => {} } : new ParallelSpinner();
     const totalStart = performance.now();
 
     try {


### PR DESCRIPTION
### Context

The PR fixes noise in the parallel build pipeline output on TTY. When running `npm run build`, the `runParallelTask` function in `scripts/run.mjs` captured stdout/stderr from each child process and flushed it on success if non-empty. This caused rspack's informational "Rspack compiled successfully in X ms" message to leak through to the terminal, even though the spinner ✓ line already signals success.

The fix introduces three-mode behavior:

- **TTY (no `--verbose`)**: `stdio: pipe`, captured output discarded on success. The spinner ✓ line is sufficient.
- **TTY + `--verbose`**: `stdio: 'inherit'`, tools write directly to the terminal. Spinner replaced with a no-op so animated lines don't mix with streamed output.
- **CI / non-TTY**: `stdio: pipe`, captured output flushed on success for log collectors.

A follow-up commit fixes a regression where `--verbose` was unconditionally stripped from `passthroughFlags`, which broke `npm run test:e2e.verbose`. The puppeteer tasks list `--verbose` in their `passthroughFilter` to control Jasmine output verbosity. The fix is to not strip the flag - `buildCmd()`'s `passthroughFilter` already prevents it from reaching tasks that don't expect it (e.g. build tasks).

This was introduced in PR #12511 (DEV-1630, the run.mjs dispatcher rewrite).

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1650

### How has this been tested?

- `npm run build --prefix handsontable` — "Rspack compiled successfully in X ms" no longer appears on TTY; spinner ✓ lines only
- `npm run build --prefix handsontable -- --verbose` — full rspack output visible, no spinner animation
- `HOT_QUIET='' npm run build --prefix handsontable` (non-TTY simulation) — captured output flushed on success

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1650
2. DEV-1630 (introduced in #12511)

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]