### PR TITLE
DEV-1615: Refactor Related section in vue3-formulas-example to boxes view

### DIFF
--- a/docs/content/guides/integrate-with-vue3/vue3-formulas-example/vue3-formulas-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-formulas-example/vue3-formulas-example.md
@@ -15,6 +15,7 @@ angular:
 searchCategory: Guides
 category: Integrate with Vue 3
 ---
+
 In this tutorial, you will integrate the Formulas plugin (powered by HyperFormula) with Handsontable in a Vue 3 application.
 
 [[toc]]
@@ -31,12 +32,14 @@ When using HyperFormula with Vue 3, never let Vue make the HyperFormula instance
 Vue's proxying interferes with the internal state of the engine and leads to subtle bugs and performance issues.
 
 Wrap the instance with `markRaw()`:
+
 ```js
-import { markRaw } from 'vue';
-import { HyperFormula } from 'hyperformula';
+import { markRaw } from "vue";
+import { HyperFormula } from "hyperformula";
 
 const hfInstance = markRaw(HyperFormula.buildEmpty());
 ```
+
 This keeps the engine untouched and ensures it behaves exactly as intended.
 
 ::: example #example1 :vue3 --html 1 --js 2
@@ -48,29 +51,50 @@ This keeps the engine untouched and ensures it behaves exactly as intended.
 
 ## Related articles
 
-### Related guides
+**Related guides**
 
-<div class="boxes-list gray">
+<div class="boxes-list">
 
 - [Formula calculation](@/guides/formulas/formula-calculation/formula-calculation.md)
 
 </div>
 
-### Related API reference
+**Configuration options**
 
-- Configuration options:
-  - [`formulas`](@/api/options.md#formulas)
-- Core methods:
-  - [`getPlugin()`](@/api/core.md#getplugin)
-- Hooks:
-  - [`afterFormulasValuesUpdate`](@/api/hooks.md#afterformulasvaluesupdate)
-  - [`afterNamedExpressionAdded`](@/api/hooks.md#afternamedexpressionadded)
-  - [`afterNamedExpressionRemoved`](@/api/hooks.md#afternamedexpressionremoved)
-  - [`afterSheetAdded`](@/api/hooks.md#aftersheetadded)
-  - [`afterSheetRemoved`](@/api/hooks.md#aftersheetremoved)
-  - [`afterSheetRenamed`](@/api/hooks.md#aftersheetrenamed)
-- Plugins:
-  - [`Formulas`](@/api/formulas.md)
+<div class="boxes-list">
+
+- [formulas](@/api/options.md#formulas)
+
+</div>
+
+**Core methods**
+
+<div class="boxes-list">
+
+- [getPlugin()](@/api/core.md#getplugin)
+
+</div>
+
+**Hooks**
+
+<div class="boxes-list">
+
+- [afterFormulasValuesUpdate](@/api/hooks.md#afterformulasvaluesupdate)
+- [afterNamedExpressionAdded](@/api/hooks.md#afternamedexpressionadded)
+- [afterNamedExpressionRemoved](@/api/hooks.md#afternamedexpressionremoved)
+- [afterSheetAdded](@/api/hooks.md#aftersheetadded)
+- [afterSheetRemoved](@/api/hooks.md#aftersheetremoved)
+- [afterSheetRenamed](@/api/hooks.md#aftersheetrenamed)
+
+</div>
+
+**Plugins**
+
+<div class="boxes-list">
+
+- [Formulas](@/api/formulas.md)
+
+</div>
 
 ## What you learned
 


### PR DESCRIPTION
### Context

The PR refactors the Related articles section in the `vue3-formulas-example` guide page to use the `boxes-list` style consistent with other pages (e.g. `vue3-language-change-example`).

Changes:
- Replaced `### Related guides` subheading with bold text `**Related guides**`
- Changed `boxes-list gray` class to `boxes-list`
- Replaced the `### Related API reference` section (with nested lists) with separate bold-text groups (**Configuration options**, **Core methods**, **Hooks**, **Plugins**), each wrapped in a `<div class="boxes-list">`

### How has this been tested?

Docs-only change. No automated tests needed.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1615

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1615

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that restructures the "Related articles" section and makes minor formatting tweaks; no runtime code or APIs are affected.
> 
> **Overview**
> Refactors the `vue3-formulas-example` guide to use the **boxes-list** layout in the *Related articles* section, replacing the previous subheadings/nested lists with bold group labels and separate boxed link groups.
> 
> Also makes small editorial/formatting tweaks in the `markRaw()` snippet section (quote style and an added clarifying sentence).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eea2c1152fac538db3048979af90b7377157abf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->