### PR TITLE
DEV-1610, DEV-1611: Docs example input focus and focus-scopes debug styling

### DIFF
--- a/docs/content/guides/navigation/focus-scopes/angular/example1.ts
+++ b/docs/content/guides/navigation/focus-scopes/angular/example1.ts
@@ -62,12 +62,22 @@ import { HotTableComponent } from '@handsontable/angular-wrapper';
   styles: `
     .placeholder-input {
       max-width: 20rem;
-      padding: 0.5rem 0.75rem;
-      font-size: 0.875rem;
+      padding: 0.4rem 0.625rem;
+      font-size: var(--sl-text-sm);
       line-height: 1.25rem;
-      color: black;
-      border: 1px solid #e4e4e7;
-      border-radius: 6px;
+      color: var(--sl-color-text);
+      background: none;
+      border: 1px solid var(--sl-color-gray-5);
+      border-radius: 0;
+      outline: none;
+    }
+
+    .placeholder-input::placeholder {
+      color: var(--sl-color-gray-3);
+    }
+
+    .placeholder-input:focus {
+      border-color: var(--sl-color-accent);
     }
 
     .example-container {

--- a/docs/content/guides/navigation/focus-scopes/angular/example1.ts
+++ b/docs/content/guides/navigation/focus-scopes/angular/example1.ts
@@ -85,10 +85,6 @@ import { HotTableComponent } from '@handsontable/angular-wrapper';
       display: flex;
       flex-direction: column;
     }
-
-    .debug-table td {
-      padding: 10px !important;
-    }
   `,
 })
 export class AppComponent implements AfterViewInit, OnDestroy {

--- a/docs/content/guides/navigation/focus-scopes/angular/example2.ts
+++ b/docs/content/guides/navigation/focus-scopes/angular/example2.ts
@@ -62,12 +62,22 @@ import { HotTableComponent } from '@handsontable/angular-wrapper';
   styles: `
     .placeholder-input {
       max-width: 20rem;
-      padding: 0.5rem 0.75rem;
-      font-size: 0.875rem;
+      padding: 0.4rem 0.625rem;
+      font-size: var(--sl-text-sm);
       line-height: 1.25rem;
-      color: black;
-      border: 1px solid #e4e4e7;
-      border-radius: 6px;
+      color: var(--sl-color-text);
+      background: none;
+      border: 1px solid var(--sl-color-gray-5);
+      border-radius: 0;
+      outline: none;
+    }
+
+    .placeholder-input::placeholder {
+      color: var(--sl-color-gray-3);
+    }
+
+    .placeholder-input:focus {
+      border-color: var(--sl-color-accent);
     }
 
     .example-container {

--- a/docs/content/guides/navigation/focus-scopes/angular/example2.ts
+++ b/docs/content/guides/navigation/focus-scopes/angular/example2.ts
@@ -85,10 +85,6 @@ import { HotTableComponent } from '@handsontable/angular-wrapper';
       display: flex;
       flex-direction: column;
     }
-
-    .debug-table td {
-      padding: 10px !important;
-    }
   `,
 })
 export class AppComponent implements AfterViewInit, OnDestroy {

--- a/docs/content/guides/navigation/focus-scopes/javascript/example1.css
+++ b/docs/content/guides/navigation/focus-scopes/javascript/example1.css
@@ -23,30 +23,3 @@
   display: flex;
   flex-direction: column;
 }
-
-.example-container > strong {
-  font-size: 0.875rem;
-  font-weight: 600;
-  color: var(--sl-color-white);
-  margin: 0.5rem 0 0;
-}
-
-.example-container .debug-table {
-  font-size: var(--sl-text-sm);
-  border-collapse: collapse;
-  width: 100%;
-}
-
-.example-container .debug-table td {
-  padding: 0.4rem 0.75rem !important;
-  border-bottom: 1px solid var(--sl-color-gray-5);
-  color: var(--sl-color-gray-2);
-}
-
-.example-container .debug-table td:last-child {
-  font-family: var(--sl-font-mono, ui-monospace, monospace);
-}
-
-.example-container .debug-table td code {
-  font-size: var(--sl-text-xs);
-}

--- a/docs/content/guides/navigation/focus-scopes/javascript/example2.css
+++ b/docs/content/guides/navigation/focus-scopes/javascript/example2.css
@@ -23,30 +23,3 @@
   display: flex;
   flex-direction: column;
 }
-
-.example-container > strong {
-  font-size: 0.875rem;
-  font-weight: 600;
-  color: var(--sl-color-white);
-  margin: 0.5rem 0 0;
-}
-
-.example-container .debug-table {
-  font-size: var(--sl-text-sm);
-  border-collapse: collapse;
-  width: 100%;
-}
-
-.example-container .debug-table td {
-  padding: 0.4rem 0.75rem !important;
-  border-bottom: 1px solid var(--sl-color-gray-5);
-  color: var(--sl-color-gray-2);
-}
-
-.example-container .debug-table td:last-child {
-  font-family: var(--sl-font-mono, ui-monospace, monospace);
-}
-
-.example-container .debug-table td code {
-  font-size: var(--sl-text-xs);
-}

--- a/docs/content/guides/navigation/focus-scopes/react/example1.css
+++ b/docs/content/guides/navigation/focus-scopes/react/example1.css
@@ -23,30 +23,3 @@
   display: flex;
   flex-direction: column;
 }
-
-.example-container > strong {
-  font-size: 0.875rem;
-  font-weight: 600;
-  color: var(--sl-color-white);
-  margin: 0.5rem 0 0;
-}
-
-.example-container .debug-table {
-  font-size: var(--sl-text-sm);
-  border-collapse: collapse;
-  width: 100%;
-}
-
-.example-container .debug-table td {
-  padding: 0.4rem 0.75rem !important;
-  border-bottom: 1px solid var(--sl-color-gray-5);
-  color: var(--sl-color-gray-2);
-}
-
-.example-container .debug-table td:last-child {
-  font-family: var(--sl-font-mono, ui-monospace, monospace);
-}
-
-.example-container .debug-table td code {
-  font-size: var(--sl-text-xs);
-}

--- a/docs/content/guides/navigation/focus-scopes/react/example2.css
+++ b/docs/content/guides/navigation/focus-scopes/react/example2.css
@@ -23,30 +23,3 @@
   display: flex;
   flex-direction: column;
 }
-
-.example-container > strong {
-  font-size: 0.875rem;
-  font-weight: 600;
-  color: var(--sl-color-white);
-  margin: 0.5rem 0 0;
-}
-
-.example-container .debug-table {
-  font-size: var(--sl-text-sm);
-  border-collapse: collapse;
-  width: 100%;
-}
-
-.example-container .debug-table td {
-  padding: 0.4rem 0.75rem !important;
-  border-bottom: 1px solid var(--sl-color-gray-5);
-  color: var(--sl-color-gray-2);
-}
-
-.example-container .debug-table td:last-child {
-  font-family: var(--sl-font-mono, ui-monospace, monospace);
-}
-
-.example-container .debug-table td code {
-  font-size: var(--sl-text-xs);
-}

--- a/docs/src/styles/interactive-example.css
+++ b/docs/src/styles/interactive-example.css
@@ -82,6 +82,15 @@
   /* min-height prevents layout shift; actual height is set by Handsontable */
 }
 
+/* Demo text inputs: in column flex, a second input after a wide Handsontable sibling can
+   shrink (flex min-width: auto). Stretch to match the row above. Per-example CSS may cap with
+   max-width (e.g. 20rem). */
+.hot-example .placeholder-input {
+  box-sizing: border-box;
+  width: 100%;
+  min-width: 0;
+}
+
 /* ── Focus scopes: debug readout (DEV-1610, hooks-aligned) ───────────────
    Matches events-and-hooks event log rhythm (#example1_events in example-specific.css).
    No horizontal negative margin here: .hot-example uses overflow:hidden and would clip. */

--- a/docs/src/styles/interactive-example.css
+++ b/docs/src/styles/interactive-example.css
@@ -82,6 +82,44 @@
   /* min-height prevents layout shift; actual height is set by Handsontable */
 }
 
+/* ── Focus scopes: debug readout (DEV-1610, hooks-aligned) ───────────────
+   Matches events-and-hooks event log rhythm (#example1_events in example-specific.css).
+   No horizontal negative margin here: .hot-example uses overflow:hidden and would clip. */
+
+.hot-example strong:has(+ table.debug-table) {
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--sl-color-white);
+  margin: 0.75rem 0 0;
+  padding: 0.5rem 0 0.35rem;
+  border-top: 1px solid var(--sl-color-gray-5);
+}
+
+.hot-example table.debug-table {
+  width: 100%;
+  border-collapse: collapse;
+  box-sizing: border-box;
+  font-size: 0.8125rem;
+  line-height: 1.6;
+  color: var(--sl-color-gray-2);
+  background: transparent;
+}
+
+.hot-example table.debug-table td {
+  padding: 0.25rem 0.5rem !important;
+  border-bottom: 1px solid var(--sl-color-gray-5);
+  color: var(--sl-color-gray-2);
+}
+
+.hot-example table.debug-table td:last-child {
+  font-family: var(--sl-font-mono, ui-monospace, monospace);
+}
+
+.hot-example table.debug-table td code {
+  font-size: var(--sl-text-xs);
+}
+
 /* ── Example controls (buttons, inputs, labels, output) ───────────────── */
 
 .example-controls-container {

--- a/docs/src/styles/utilities.css
+++ b/docs/src/styles/utilities.css
@@ -20,7 +20,9 @@ html {
   }
 }
 
-:focus-visible:not(.handsontable *, .ht-portal *) {
+/* Omit demo `.placeholder-input` fields: their example CSS uses an accent border on `:focus`;
+   this outline would stack and read as a double ring. */
+:focus-visible:not(.handsontable *, .ht-portal *, .hot-example .placeholder-input) {
   outline: 2px solid var(--sl-color-accent);
   outline-offset: 2px;
 }


### PR DESCRIPTION
### Context

This PR closes two related documentation UX items for live examples on the docs site.

**DEV-1611** ([ClickUp task](https://app.clickup.com/t/9015210959/DEV-1611)): Focusable `.placeholder-input` fields showed a doubled focus ring because the site-wide `:focus-visible` outline stacked with the per-example accent border on `:focus`. The global rule in [docs/src/styles/utilities.css](docs/src/styles/utilities.css) now omits `.hot-example .placeholder-input`, so only the example border indicates focus. Angular focus-scopes text inputs use the same tokens and focus border as JS/React.

**DEV-1610** ([ClickUp task](https://app.clickup.com/t/9015210959/DEV-1610)): The focus-scopes debug readout looked unpolished compared to the events-and-hooks demo. Styles are centralized in [docs/src/styles/interactive-example.css](docs/src/styles/interactive-example.css) (hooks-aligned density, `gray-5` row separators, monospace value column, section title via `strong:has(+ table.debug-table)`). Duplicate rules were removed from focus-scopes JS/React `example*.css` and from Angular inline `styles`.

Horizontal bleed was not applied to the debug strip because `.hot-example` uses `overflow: hidden`, which would clip negative margins.

### How has this been tested?

- `npm run docs:lint --prefix docs`
- Manual: Focus scopes (JavaScript, React, Angular) for both examples; Accessibility guide placeholder inputs; Events and hooks example unchanged for hooks-specific layout

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1610
2. DEV-1611

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

Documentation site only (`docs/`). No library or wrapper package changes.

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only CSS tweaks that adjust focus outlines and centralize demo styling, with no runtime logic or data-handling changes.
> 
> **Overview**
> Fixes focus styling for docs demo `.placeholder-input` fields by excluding them from the global `:focus-visible` outline so they don’t render a double focus ring.
> 
> Centralizes and polishes focus-scopes debug readout styling in `interactive-example.css` (and removes per-example/Angular inline duplicates), and updates Angular focus-scopes examples to use the same design tokens as the JS/React variants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16d6f5b2c6a306a6906310644d1e6230f1bdc65a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->