### PR TITLE
DEV-1651: Unify --testPathPattern argument for unit and e2e tests

### DIFF
--- a/.ai/TESTING.md
+++ b/.ai/TESTING.md
@@ -44,7 +44,7 @@ npm run test:e2e --testPathPattern=filters
 # the same hash as dump to locate the runner HTML, so the flags must match.
 
 # Coverage:
-npm run test:unit --coverage
+npm run test:unit -- --coverage
 ```
 
 **Parallel E2E runs:**
@@ -477,7 +477,7 @@ Additional viewport helpers in `common.js` (globals in E2E):
 
 **View Coverage:**
 ```bash
-npm run test:unit --coverage    # Show coverage after Jest run
+npm run test:unit -- --coverage    # Show coverage after Jest run
 ```
 
 **Coverage Output:**

--- a/.ai/TESTING.md
+++ b/.ai/TESTING.md
@@ -28,25 +28,23 @@ pnpm --filter handsontable run test:unit
 pnpm --filter handsontable run test:e2e
 
 # Run specific unit test pattern (must be run from handsontable/ directory):
-npm run test:unit -- --testPathPattern=cellMeta
+npm run test:unit --testPathPattern=cellMeta
 
 # Run specific E2E test pattern (must be run from handsontable/ directory):
-# Pass --testPathPattern and --theme after `--` so they go to the wrapper script,
-# not to npm's config system (avoids npm deprecation warning).
 # The pattern is baked into the Rspack bundle at dump time via __ENV_ARGS__.testPathPattern.
 # Step 1: rebuild the test bundle with the pattern (skips full UMD build):
-npm run test:e2e.dump -- --testPathPattern=filters
+npm run test:e2e.dump --testPathPattern=filters
 # Step 2: run puppeteer against the filtered bundle:
 npm run test:e2e.puppeteer
 # Or, to do both in one command (also rebuilds UMD bundles):
-npm run test:e2e -- --testPathPattern=filters
+npm run test:e2e --testPathPattern=filters
 # NOTE: changing the pattern requires re-running test:e2e.dump — the pattern is compiled in.
 # NOTE: when invoking the two steps separately, pass --testPathPattern AND --theme to BOTH
 # commands. Each `npm run` is a separate npm process with its own env; puppeteer computes
 # the same hash as dump to locate the runner HTML, so the flags must match.
 
 # Coverage:
-npm run test:unit -- --coverage
+npm run test:unit --coverage
 ```
 
 **Parallel E2E runs:**
@@ -56,7 +54,7 @@ npm run test:unit -- --coverage
 - Per-run Puppeteer runner: `handsontable/test/E2ERunner-<runId>.html`
 - Generic dev runner (always regenerated alongside): `handsontable/test/E2ERunner.html`
 
-`run-puppeteer.mjs` computes the same hash from `npm_config_testpathpattern` / `npm_config_theme` (env vars set by the `test-e2e.mjs` wrapper) and opens the matching HTML. It also binds the local HTTP server to the first free port starting at `8086` (retries on `EADDRINUSE`, up to 100 ports), so each concurrent run gets its own port. Any number of `npm run test:e2e -- --testPathPattern=<X>` invocations with distinct patterns (or themes) can run in parallel without further configuration -- the practical limit is machine resources, not the tooling.
+`run-puppeteer.mjs` computes the same hash from `npm_config_testpathpattern` / `npm_config_theme` (env vars set by the `test-e2e.mjs` wrapper) and opens the matching HTML. It also binds the local HTTP server to the first free port starting at `8086` (retries on `EADDRINUSE`, up to 100 ports), so each concurrent run gets its own port. Any number of `npm run test:e2e --testPathPattern=<X>` invocations with distinct patterns (or themes) can run in parallel without further configuration -- the practical limit is machine resources, not the tooling.
 
 The helper that derives the hash lives in `handsontable/.config/helper/run-id.js` -- used by both the Rspack config and the Puppeteer script so they stay in lockstep.
 
@@ -479,7 +477,7 @@ Additional viewport helpers in `common.js` (globals in E2E):
 
 **View Coverage:**
 ```bash
-npm run test:unit -- --coverage    # Show coverage after Jest run
+npm run test:unit --coverage    # Show coverage after Jest run
 ```
 
 **Coverage Output:**

--- a/.claude/skills/handsontable-css-dev/SKILL.md
+++ b/.claude/skills/handsontable-css-dev/SKILL.md
@@ -139,6 +139,6 @@ Before committing token work, mentally walk the four layers plus tests:
 2. JS token in all 3 runtime files?
 3. Registered in `validation.js` allow-list?
 4. Added to `TokenKey` in `themes.d.ts`?
-5. `npm run test:unit --prefix handsontable -- --testPathPattern=themes` passes?
+5. `npm run test:unit --prefix handsontable --testPathPattern=themes` passes?
 6. `npm run test:types --prefix handsontable` passes?
 7. Docs table updated?

--- a/.claude/skills/handsontable-e2e-testing/SKILL.md
+++ b/.claude/skills/handsontable-e2e-testing/SKILL.md
@@ -131,23 +131,21 @@ Use `it.flaky()` for timing-sensitive tests (auto-retries up to 3 times).
 ## Run commands
 
 - **All:** `npm run test:e2e --prefix handsontable`
-- **Targeted:** `npm run test:e2e --prefix handsontable -- --testPathPattern=<regex>` -- the pattern is matched against test file paths during the Rspack `.dump` step (e.g. `collapsibleColumns`, `ghostTable`, `textEditor`, `nestedHeaders/__tests__/hidingColumns`)
-- **With theme:** `npm run test:e2e --prefix handsontable -- --testPathPattern=<regex> --theme=horizon` (available themes: `classic`, `main`, `horizon`; default when `--theme` is omitted: `main`)
+- **Targeted:** `npm run test:e2e --prefix handsontable --testPathPattern=<regex>` -- the pattern is matched against test file paths during the Rspack `.dump` step (e.g. `collapsibleColumns`, `ghostTable`, `textEditor`, `nestedHeaders/__tests__/hidingColumns`)
+- **With theme:** `npm run test:e2e --prefix handsontable --testPathPattern=<regex> --theme=horizon` (available themes: `classic`, `main`, `horizon`; default when `--theme` is omitted: `main`)
 - **Rebuild first:** The E2E runner loads `dist/handsontable.js`. After changing `src/**`, run `npm run build --prefix handsontable` before running E2E tests.
 
-**Always use `--` before `--testPathPattern` and `--theme`.** The `test:e2e` script is now a Node.js wrapper (`scripts/test-e2e.mjs`) that reads these flags from `process.argv` and propagates them as env vars to both the dump step and Puppeteer. Passing them without `--` triggers an npm deprecation warning and will stop working in a future npm major.
-
-**Parallel runs:** Multiple `npm run test:e2e --prefix handsontable -- --testPathPattern=<X>` invocations with different patterns (or themes) can run simultaneously. The dump step hashes `testPathPattern + theme` into a short run ID and writes per-run artifacts (`test/dist/main.entry.<runId>.js` and `test/E2ERunner-<runId>.html`), and the Puppeteer runner picks its own free port starting at `8086` (retries up to 100 ports). Nothing special needs to be passed -- just launch the commands; the practical limit is machine resources, not the tooling.
+**Parallel runs:** Multiple `npm run test:e2e --prefix handsontable --testPathPattern=<X>` invocations with different patterns (or themes) can run simultaneously. The dump step hashes `testPathPattern + theme` into a short run ID and writes per-run artifacts (`test/dist/main.entry.<runId>.js` and `test/E2ERunner-<runId>.html`), and the Puppeteer runner picks its own free port starting at `8086` (retries up to 100 ports). Nothing special needs to be passed -- just launch the commands; the practical limit is machine resources, not the tooling.
 
 **Iterating on a single area:** Prefer `test:e2e.watch` -- it leaves the dev server running and re-bundles + re-runs on every source change, so you don't have to stop and restart between edits:
 
 ```bash
-npm run test:e2e.watch --prefix handsontable -- --testPathPattern=filters --theme=horizon
+npm run test:e2e.watch --prefix handsontable --testPathPattern=filters --theme=horizon
 ```
 
 Under the hood it spawns the regular Rspack dump in `--watch` mode and reopens the browser page, reusing the generic `test/E2ERunner.html` (no run ID needed -- the dump and puppeteer halves share one npm process, so the flags propagate automatically).
 
-**One-shot run:** Use `npm run test:e2e --prefix handsontable -- --testPathPattern=<regex> --theme=<theme>` -- the wrapper script passes the flags to both dump and puppeteer via env, so there's no risk of a mismatch.
+**One-shot run:** Use `npm run test:e2e --prefix handsontable --testPathPattern=<regex> --theme=<theme>` -- the wrapper script passes the flags to both dump and puppeteer via env, so there's no risk of a mismatch.
 
 **Split dump + puppeteer** (what CI does): if you invoke the two steps in separate `npm run` commands, pass `--testPathPattern` AND `--theme` to **both**. Each `npm run` is its own npm process with its own env, and the Puppeteer script recomputes the same hash as dump to find the runner HTML -- a mismatch fails with "Runner HTML not found at ...". `.github/workflows/test.yml` is the canonical example; the same rule applies to `test:production.dump` + `test:e2e.puppeteer`.
 

--- a/.claude/skills/handsontable-unit-testing/SKILL.md
+++ b/.claude/skills/handsontable-unit-testing/SKILL.md
@@ -40,8 +40,8 @@ For custom mocking, use `jest.fn()` for stubs and `jest.spyOn(object, 'method')`
 ## Run Commands
 
 - **All unit tests:** `npm run test:unit --prefix handsontable`
-- **Targeted:** `npm run test:unit --prefix handsontable -- --testPathPattern=<regex>` -- the pattern is matched against test file paths (e.g. `filters`, `ghostTable.unit`, `metaManager`)
-- **Example:** `npm run test:unit --prefix handsontable -- --testPathPattern=filters`
+- **Targeted:** `npm run test:unit --prefix handsontable --testPathPattern=<regex>` -- the pattern is matched against test file paths (e.g. `filters`, `ghostTable.unit`, `metaManager`)
+- **Example:** `npm run test:unit --prefix handsontable --testPathPattern=filters`
 
 ## Large Dataset Testing
 

--- a/.claude/skills/pr-creation/SKILL.md
+++ b/.claude/skills/pr-creation/SKILL.md
@@ -37,10 +37,10 @@ npm run stylelint --prefix handsontable
 npm run build --prefix handsontable
 
 # Unit tests for the area you changed
-npm run test:unit --prefix handsontable -- --testPathPattern=<regex>
+npm run test:unit --prefix handsontable --testPathPattern=<regex>
 
 # E2E tests for the area you changed
-npm run test:e2e --prefix handsontable -- --testPathPattern=<regex>
+npm run test:e2e --prefix handsontable --testPathPattern=<regex>
 
 # If you touched a wrapper, test it too
 npm run test --prefix wrappers/react-wrapper

--- a/handsontable/AGENTS.md
+++ b/handsontable/AGENTS.md
@@ -52,9 +52,9 @@ For server-backed grids (`dataProvider` with `fetchRows` and CRUD callbacks), en
 - ALL `it()` callbacks in spec files MUST be `async`
 - HOT API calls MUST be `await`-ed
 - E2E helpers are globals (no imports): `handsontable()`, `selectCell()`, `getDataAtCell()`, `createSpreadsheetData()`
-- Targeted unit: `npm run test:unit -- --testPathPattern=<regex>` (regex matched against file paths, e.g. `filters`, `ghostTable.unit`)
-- Targeted e2e: `npm run test:e2e -- --testPathPattern=<regex>` (e.g. `collapsibleColumns`, `textEditor`, `nestedHeaders/__tests__/hidingColumns`)
-- E2E with theme: `npm run test:e2e -- --testPathPattern=<regex> --theme=horizon` (themes: `classic`, `main`, `horizon`; default: `main`)
+- Targeted unit: `npm run test:unit --testPathPattern=<regex>` or `npm run test:unit -- --testPathPattern=<regex>` (regex matched against file paths, e.g. `filters`, `ghostTable.unit`)
+- Targeted e2e: `npm run test:e2e --testPathPattern=<regex>` or `npm run test:e2e -- --testPathPattern=<regex>` (e.g. `collapsibleColumns`, `textEditor`, `nestedHeaders/__tests__/hidingColumns`)
+- E2E with theme: `npm run test:e2e --testPathPattern=<regex> --theme=horizon` (themes: `classic`, `main`, `horizon`; default: `main`)
 - **Rebuild before E2E:** E2E runner loads `dist/handsontable.js` - rebuild after changing `src/`
 
 ## Common Pitfalls

--- a/handsontable/scripts/run.mjs
+++ b/handsontable/scripts/run.mjs
@@ -75,25 +75,30 @@ const extraArgs = normalizeArgs(separatorIdx === -1 ? [] : rawArgs.slice(separat
 const isParallel = mainArgs[0] === '--parallel';
 const isSequential = mainArgs[0] === '--sequential';
 const pipelineName = (isParallel || isSequential) ? mainArgs[1] : null;
+// Normalize before filtering so space-separated `--flag value` pairs are joined
+// into `--flag=value` before the bare value token is discarded.
+const normalizedMain = normalizeArgs(mainArgs);
 // Filter flags out of taskNames: npm sometimes strips '--', landing flags in mainArgs.
-const taskNames = (isParallel || isSequential) ? [] : mainArgs.filter(a => !a.startsWith('--'));
+const taskNames = (isParallel || isSequential) ? [] : normalizedMain.filter(a => !a.startsWith('--'));
 
 // npm sometimes strips the '--' separator when forwarding `npm run cmd -- --flag`
 // extra args, so flags land in mainArgs past the task/pipeline position.
 // Recover them so `npm run task -- --flag` behaves the same as explicit argv.
 const mainFlagStart = pipelineName !== null ? 2 : taskNames.length;
-const recoveredFromMain = normalizeArgs(mainArgs.slice(mainFlagStart).filter(a => a.startsWith('--')));
+const recoveredFromMain = normalizedMain.slice(mainFlagStart).filter(a => a.startsWith('--'));
 
 // `npm run task --flag=val` (no '--') sets npm_config_* in env but never adds
 // to argv. Read those so unit tests behave like e2e (which reads env directly).
 const recoveredFromEnv = [];
 const envPattern = process.env.npm_config_testPathPattern || process.env.npm_config_testpathpattern;
 const envTheme = process.env.npm_config_theme;
+// Dedup against both extraArgs and recoveredFromMain to avoid double-passing a flag.
+const alreadyRecovered = [...extraArgs, ...recoveredFromMain];
 
-if (envPattern && !extraArgs.some(a => a.startsWith('--testPathPattern='))) {
+if (envPattern && !alreadyRecovered.some(a => a.startsWith('--testPathPattern='))) {
   recoveredFromEnv.push(`--testPathPattern=${envPattern}`);
 }
-if (envTheme && !extraArgs.some(a => a.startsWith('--theme='))) {
+if (envTheme && !alreadyRecovered.some(a => a.startsWith('--theme='))) {
   recoveredFromEnv.push(`--theme=${envTheme}`);
 }
 

--- a/handsontable/scripts/run.mjs
+++ b/handsontable/scripts/run.mjs
@@ -75,11 +75,33 @@ const extraArgs = normalizeArgs(separatorIdx === -1 ? [] : rawArgs.slice(separat
 const isParallel = mainArgs[0] === '--parallel';
 const isSequential = mainArgs[0] === '--sequential';
 const pipelineName = (isParallel || isSequential) ? mainArgs[1] : null;
-const taskNames = (isParallel || isSequential) ? [] : mainArgs;
+// Filter flags out of taskNames: npm sometimes strips '--', landing flags in mainArgs.
+const taskNames = (isParallel || isSequential) ? [] : mainArgs.filter(a => !a.startsWith('--'));
 
-// Extract special env-propagated flags from extra args.
-const patternArg = extraArgs.find(a => a.startsWith('--testPathPattern='));
-const themeArg = extraArgs.find(a => a.startsWith('--theme='));
+// npm sometimes strips the '--' separator when forwarding `npm run cmd -- --flag`
+// extra args, so flags land in mainArgs past the task/pipeline position.
+// Recover them so `npm run task -- --flag` behaves the same as explicit argv.
+const mainFlagStart = pipelineName !== null ? 2 : taskNames.length;
+const recoveredFromMain = normalizeArgs(mainArgs.slice(mainFlagStart).filter(a => a.startsWith('--')));
+
+// `npm run task --flag=val` (no '--') sets npm_config_* in env but never adds
+// to argv. Read those so unit tests behave like e2e (which reads env directly).
+const recoveredFromEnv = [];
+const envPattern = process.env.npm_config_testPathPattern || process.env.npm_config_testpathpattern;
+const envTheme = process.env.npm_config_theme;
+
+if (envPattern && !extraArgs.some(a => a.startsWith('--testPathPattern='))) {
+  recoveredFromEnv.push(`--testPathPattern=${envPattern}`);
+}
+if (envTheme && !extraArgs.some(a => a.startsWith('--theme='))) {
+  recoveredFromEnv.push(`--theme=${envTheme}`);
+}
+
+const allExtraArgs = [...extraArgs, ...recoveredFromMain, ...recoveredFromEnv];
+
+// Extract special env-propagated flags from all extra args.
+const patternArg = allExtraArgs.find(a => a.startsWith('--testPathPattern='));
+const themeArg = allExtraArgs.find(a => a.startsWith('--theme='));
 // testPathPattern and theme are propagated as env to all pipeline tasks so that
 // the dump step (rspack) and run-puppeteer.mjs compute the same run-ID filename.
 // For test:unit.jest, --testPathPattern= is also passed as argv (passthrough task),
@@ -90,7 +112,7 @@ const isVerbose = rawArgs.includes('--verbose');
 // Do NOT strip --verbose from passthroughFlags — puppeteer tasks list it in
 // their passthroughFilter and need it forwarded. buildCmd()'s passthroughFilter
 // already prevents it from reaching tasks that don't expect it (e.g. build tasks).
-const passthroughFlags = extraArgs;
+const passthroughFlags = allExtraArgs;
 
 const propagatedEnv = {};
 


### PR DESCRIPTION
### Context

The PR fixes inconsistent `--testPathPattern` flag handling in `scripts/run.mjs`. Running `npm run test:unit -- --testPathPattern=X` or `npm run test:unit --testPathPattern=X` had no effect - Jest always ran the full suite.

Two root causes:
1. `npm run cmd -- --flag` - npm sometimes strips the `--` separator, so the flag lands in `mainArgs` instead of `extraArgs`. `passthroughFlags` stayed empty and Jest never received `--testPathPattern`.
2. `npm run cmd --flag=val` (no `--`) - npm sets `npm_config_*` env vars but never passes the flag as argv. E2E scripts read env vars directly (worked); Jest does not (broken).

Fix: `run.mjs` now recovers flags from both sources and merges them into `passthroughFlags`, so all four combinations work for both `test:unit` and `test:e2e`. All documentation updated to use the shorter no-separator form as the canonical syntax.

### How has this been tested?

- Manually verified `npm run test:unit --testPathPattern=filters` runs only matching tests
- Manually verified `npm run test:unit -- --testPathPattern=filters` runs only matching tests
- Verified existing `npm run test:e2e --testPathPattern=X` behavior unchanged

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1651

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1651

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the central `handsontable/scripts/run.mjs` dispatcher argument parsing and env propagation, so a mistake could break multiple build/test tasks across CI and local runs. Scope is limited to CLI flag handling and documentation updates (no runtime library code).
> 
> **Overview**
> **Unifies targeted test flag handling** by enhancing `handsontable/scripts/run.mjs` to recover `--testPathPattern`/`--theme` from both *argv* (even when npm strips the `--` separator) and `npm_config_*` env vars, then merging/deduping them into a single passthrough set for tasks and pipelines.
> 
> **Documentation refresh:** updates various testing/PR guidelines (`.ai/TESTING.md`, `handsontable/AGENTS.md`, and Claude skills docs) to prefer the shorter `npm run … --testPathPattern=…` syntax (while noting both forms where relevant) and to reflect parallel E2E invocation examples accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f35bbd5d46ce234a606d0bce1334a4cf1d46984b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->