### PR TITLE
DEV-1617: Adjust KBD element spacing and allow table cell wrapping

### DIFF
--- a/docs/src/styles/base/typography.css
+++ b/docs/src/styles/base/typography.css
@@ -44,7 +44,7 @@
 
 kbd:not(.handsontable kbd, .example-controls-container kbd, .hot-example-preview kbd) {
   display: inline-block;
-  margin: 0 0.375rem;
+  margin:  0.25rem 0.375rem;
   padding: 0.075rem 0.375rem;
   font-family: var(--sl-font);
   font-size: var(--sl-text-xs);
@@ -71,10 +71,6 @@ kbd:not(.handsontable kbd, .example-controls-container kbd, .hot-example-preview
   border: none;
   box-shadow: none;
   font-size: inherit;
-}
-
-td:has(kbd) {
-  white-space: nowrap;
 }
 
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Add vertical margin to `kbd` elements for improved visual separation. Remove `white-space: nowrap` from table cells containing `kbd` to enable content wrapping and prevent horizontal overflow.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Manual check on local docs

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: docs-only CSS tweaks that affect visual layout of `kbd` elements and table rendering, with no runtime or data/security impact.
> 
> **Overview**
> Adjusts docs typography CSS to add vertical spacing around `kbd` tags (changing `margin` to include a top/bottom value) for better separation.
> 
> Removes the `td:has(kbd) { white-space: nowrap; }` rule so table cells containing `kbd` can wrap instead of forcing horizontal overflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f6fe88b2c12a72502d61eff2cda0a6263f6a7e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->