### PR TITLE
DEV-1616: Fix third-party licenses page - restore card layout

### DIFF
--- a/docs/content/guides/technical-specification/third-party-licenses/third-party-licenses.md
+++ b/docs/content/guides/technical-specification/third-party-licenses/third-party-licenses.md
@@ -14,70 +14,69 @@ angular:
 searchCategory: Guides
 category: Technical specification
 ---
+
 Learn about the licensing terms of Handsontable's software dependencies.
 
 [[toc]]
 
 ## Open-source software components
 
-<div class="boxes-list gray">
-
-- **numbro.js** (handles numeric data)<br>
-    Author: Benjamin Van Ryseghem<br>
-    License: Open source (MIT)<br>
-    [http://numbrojs.com/](http://numbrojs.com/)
-
-- **Pikaday** (displays a date picker)<br>
-    Author: David Bushell<br>
-    License: Open source (MIT)<br>
-    [https://github.com/handsontable/pikaday](https://github.com/handsontable/pikaday)
-
-- **moment.js** (parses, validates and displays dates)<br>
-    Author: Tim Wood, Tskren Chernev, Moment.js contributors<br>
-    License: Open source (MIT)<br>
-    [http://momentjs.com](http://momentjs.com)
-
-- **javascript-algorithms** (implementation of linked list and merge sort)<br>
-    Author: Minko Gechev<br>
-    License: Open source (MIT)<br>
-    [https://github.com/mgechev/javascript-algorithms](https://github.com/mgechev/javascript-algorithms)
-
-- **DOMPurify** (an XSS sanitizer for HTML)<br>
-    Author: Mario Heiderich<br>
-    License: Open source (Apache 2.0)<br>
-    [https://github.com/cure53/DOMPurify](https://github.com/cure53/DOMPurify)
-
+<div class="ht-card-grid">
+  <div class="ht-info-card">
+    <p class="name"><strong>numbro.js</strong> <span class="desc">(handles numeric data)</span></p>
+    <p class="meta">Author: Benjamin Van Ryseghem<br>License: Open source (MIT)</p>
+    <p class="url"><a href="http://numbrojs.com/" target="_blank" rel="noopener noreferrer">http://numbrojs.com/</a></p>
+  </div>
+  <div class="ht-info-card">
+    <p class="name"><strong>Pikaday</strong> <span class="desc">(displays a date picker)</span></p>
+    <p class="meta">Author: David Bushell<br>License: Open source (MIT)</p>
+    <p class="url"><a href="https://github.com/handsontable/pikaday" target="_blank" rel="noopener noreferrer">https://github.com/handsontable/pikaday</a></p>
+  </div>
+  <div class="ht-info-card">
+    <p class="name"><strong>moment.js</strong> <span class="desc">(parses, validates and displays dates)</span></p>
+    <p class="meta">Author: Tim Wood, Tskren Chernev, Moment.js contributors<br>License: Open source (MIT)</p>
+    <p class="url"><a href="http://momentjs.com" target="_blank" rel="noopener noreferrer">http://momentjs.com</a></p>
+  </div>
+  <div class="ht-info-card">
+    <p class="name"><strong>javascript-algorithms</strong> <span class="desc">(implementation of linked list and merge sort)</span></p>
+    <p class="meta">Author: Minko Gechev<br>License: Open source (MIT)</p>
+    <p class="url"><a href="https://github.com/mgechev/javascript-algorithms" target="_blank" rel="noopener noreferrer">https://github.com/mgechev/javascript-algorithms</a></p>
+  </div>
+  <div class="ht-info-card">
+    <p class="name"><strong>DOMPurify</strong> <span class="desc">(an XSS sanitizer for HTML)</span></p>
+    <p class="meta">Author: Mario Heiderich<br>License: Open source (Apache 2.0)</p>
+    <p class="url"><a href="https://github.com/cure53/DOMPurify" target="_blank" rel="noopener noreferrer">https://github.com/cure53/DOMPurify</a></p>
+  </div>
 </div>
 
 ### Dependencies of the [`Formulas`](@/api/formulas.md) plugin
 
 The dependencies below apply only if you use the [`Formulas`](@/api/formulas.md) [calculation plugin](@/guides/formulas/formula-calculation/formula-calculation.md):
 
-<div class="boxes-list gray">
-
-- **bessel**<br>
-    Author: SheetJS<br>
-    License: Apache v2.0<br>
-    [https://github.com/SheetJS/bessel](https://github.com/SheetJS/bessel)
-
-- **Chevrotain**<br>
-    Author: SAP SE or an SAP affiliate company<br>
-    License: Apache v2.0<br>
-    [https://github.com/SAP/chevrotain](https://github.com/SAP/chevrotain)
-
-- **jStat**<br>
-    Author: jStat<br>
-    License: Open source (MIT)<br>
-    [https://github.com/jstat/jstat](https://github.com/jstat/jstat)
-
-- **tiny-emitter**<br>
-    Author: Scott Corgan<br>
-    License: Open source (MIT)<br>
-    [https://github.com/scottcorgan/tiny-emitter](https://github.com/scottcorgan/tiny-emitter)
-
-- **unorm**<br>
-    Author: Matsuza, Bjarke Walling<br>
-    License: Open source (MIT)<br>
-    [https://github.com/walling/unorm](https://github.com/walling/unorm)
-
+<div class="ht-card-grid">
+  <div class="ht-info-card">
+    <p class="name"><strong>bessel</strong></p>
+    <p class="meta">Author: SheetJS<br>License: Apache v2.0</p>
+    <p class="url"><a href="https://github.com/SheetJS/bessel" target="_blank" rel="noopener noreferrer">https://github.com/SheetJS/bessel</a></p>
+  </div>
+  <div class="ht-info-card">
+    <p class="name"><strong>Chevrotain</strong></p>
+    <p class="meta">Author: SAP SE or an SAP affiliate company<br>License: Apache v2.0</p>
+    <p class="url"><a href="https://github.com/SAP/chevrotain" target="_blank" rel="noopener noreferrer">https://github.com/SAP/chevrotain</a></p>
+  </div>
+  <div class="ht-info-card">
+    <p class="name"><strong>jStat</strong></p>
+    <p class="meta">Author: jStat<br>License: Open source (MIT)</p>
+    <p class="url"><a href="https://github.com/jstat/jstat" target="_blank" rel="noopener noreferrer">https://github.com/jstat/jstat</a></p>
+  </div>
+  <div class="ht-info-card">
+    <p class="name"><strong>tiny-emitter</strong></p>
+    <p class="meta">Author: Scott Corgan<br>License: Open source (MIT)</p>
+    <p class="url"><a href="https://github.com/scottcorgan/tiny-emitter" target="_blank" rel="noopener noreferrer">https://github.com/scottcorgan/tiny-emitter</a></p>
+  </div>
+  <div class="ht-info-card">
+    <p class="name"><strong>unorm</strong></p>
+    <p class="meta">Author: Matsuza, Bjarke Walling<br>License: Open source (MIT)</p>
+    <p class="url"><a href="https://github.com/walling/unorm" target="_blank" rel="noopener noreferrer">https://github.com/walling/unorm</a></p>
+  </div>
 </div>

--- a/docs/src/styles/components/cards.css
+++ b/docs/src/styles/components/cards.css
@@ -100,6 +100,64 @@
 }
 
 /* -------------------------------------------------------------------------
+ * Info card — clickable card for multi-line metadata (e.g. third-party licenses).
+ * Used inside .ht-card-grid alongside .ht-link-card.
+ * ------------------------------------------------------------------------- */
+.ht-info-card {
+  display: flex;
+  flex-direction: column;
+  padding: 1rem;
+  border-right: 1px solid var(--sl-color-gray-5);
+  border-bottom: 1px solid var(--sl-color-gray-5);
+  margin-top: 0;
+  position: relative;
+  transition: background-color 0.15s;
+}
+
+.ht-info-card:hover {
+  background: var(--sl-color-hover-bg, var(--sl-color-gray-6));
+}
+
+.ht-info-card p {
+  margin: 0;
+}
+
+.ht-info-card .name {
+  font-weight: 600;
+  color: var(--sl-color-white);
+  margin-bottom: 0.25rem;
+}
+
+.ht-info-card .name .desc {
+  font-weight: 400;
+  color: var(--sl-color-gray-2);
+}
+
+.ht-info-card .meta {
+  font-size: 0.875rem;
+  color: var(--sl-color-gray-3);
+  line-height: 1.6;
+}
+
+.ht-info-card .url {
+  margin-top: 0.625rem;
+  font-size: 0.875rem;
+}
+
+.ht-info-card .url a {
+  color: var(--sl-color-text-accent);
+  word-break: break-all;
+  text-decoration: none;
+}
+
+/* Clickable overlay for the whole card (same a11y pattern as .ht-link-card). */
+.ht-info-card .url a::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+}
+
+/* -------------------------------------------------------------------------
  * Icon pack grid — spreadsheet-style boxes, 4 per row
  * ------------------------------------------------------------------------- */
 .icons-wrapper {


### PR DESCRIPTION
### Context

The PR fixes a blank-content bug on the third-party licenses page. The page used `<div class="boxes-list gray">` wrappers around rich multi-line list items (library name, author, license, URL). The `convertBoxesListToCardGrid` transformer only handles link-only list items (`- [text](url)`); when it finds none, it returns an empty string, producing blank spaces on the page.

The fix replaces the broken wrappers with raw HTML using the existing `.ht-card-grid` container and a new `.ht-info-card` CSS variant. Each card shows the library name, description, author, license, and a clickable URL link. The entire card surface is clickable via the same `::before` overlay pattern used by `.ht-link-card`.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1616

### How has this been tested?

- Manually verified in the Astro dev server (`npm run dev --prefix docs`) at `/javascript-data-grid/third-party-licenses` -- both card grids (open-source components and Formulas plugin dependencies) render correctly with hover effects and clickable cards.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1616

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation markup and CSS-only changes to restore rendering and styling, with no runtime/business logic impact beyond the docs site UI.
> 
> **Overview**
> Restores the `third-party-licenses` page content by replacing the `<div class="boxes-list">`-wrapped markdown lists with explicit HTML card grids (`.ht-card-grid`) containing new multi-line metadata cards (`.ht-info-card`).
> 
> Adds `.ht-info-card` styles to `cards.css`, including hover state and a full-card clickable overlay via the URL link, matching the existing card-grid look and behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97d55c7c487fa087965a7296d0e527ac35161a30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->