### PR TITLE
DEV-1660: Fix selectCells changeListener=false to preserve external focus

### DIFF
--- a/.changelogs/12557.json
+++ b/.changelogs/12557.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed `selectCell()` and `selectCells()` so that calling them with `changeListener` set to `false` no longer moves the browser focus away from an externally focused input, textarea, select, or contenteditable element.",
+  "type": "fixed",
+  "issueOrPR": 12557,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/__tests__/focusManager.spec.js
+++ b/handsontable/src/__tests__/focusManager.spec.js
@@ -165,4 +165,184 @@ describe('Focus Manager', () => {
       expect(document.activeElement).toEqual(getActiveEditor().TEXTAREA);
     });
   });
+
+  describe('`selectCells`/`selectCell` with `changeListener = false` (#10038)', () => {
+    let externalInput;
+
+    afterEach(() => {
+      if (externalInput && externalInput.parentNode) {
+        externalInput.parentNode.removeChild(externalInput);
+      }
+      externalInput = null;
+    });
+
+    it('should keep an externally focused `<input>` focused when `selectCells` is called with' +
+      ' `changeListener` set to `false`', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      externalInput = document.createElement('input');
+      externalInput.id = 'external-input';
+      document.body.appendChild(externalInput);
+      externalInput.focus();
+
+      expect(document.activeElement).toBe(externalInput);
+
+      const wasSelected = await selectCells([[1, 1]], true, false);
+
+      expect(wasSelected).toBe(true);
+      expect(document.activeElement).toBe(externalInput);
+      expect(getSelected()).toEqual([[1, 1, 1, 1]]);
+      expect(isListening()).toBe(false);
+    });
+
+    it('should keep an externally focused `<textarea>` focused when `selectCells` is called with' +
+      ' `changeListener` set to `false`', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      externalInput = document.createElement('textarea');
+      document.body.appendChild(externalInput);
+      externalInput.focus();
+
+      expect(document.activeElement).toBe(externalInput);
+
+      await selectCells([[2, 2]], true, false);
+
+      expect(document.activeElement).toBe(externalInput);
+    });
+
+    it('should keep an externally focused `<input>` focused when `selectCell` is called with' +
+      ' `changeListener` set to `false`', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      externalInput = document.createElement('input');
+      document.body.appendChild(externalInput);
+      externalInput.focus();
+
+      expect(document.activeElement).toBe(externalInput);
+
+      await selectCell(3, 2, undefined, undefined, true, false);
+
+      expect(document.activeElement).toBe(externalInput);
+      expect(getSelected()).toEqual([[3, 2, 3, 2]]);
+    });
+
+    it('should not steal the external focus to the editor TEXTAREA when `imeFastEdit` is enabled and' +
+      ' `selectCells` is called with `changeListener` set to `false`', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        imeFastEdit: true,
+      });
+
+      externalInput = document.createElement('input');
+      document.body.appendChild(externalInput);
+      externalInput.focus();
+
+      await selectCells([[1, 1]], true, false);
+      await waitForNextAnimationFrames(4);
+
+      expect(document.activeElement).toBe(externalInput);
+    });
+
+    it('should still move browser focus to the highlighted cell when `selectCells` is called with' +
+      ' the default `changeListener = true`', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      externalInput = document.createElement('input');
+      document.body.appendChild(externalInput);
+      externalInput.focus();
+
+      expect(document.activeElement).toBe(externalInput);
+
+      await selectCells([[1, 1]]);
+
+      expect(document.activeElement).toBe(getCell(1, 1));
+      expect(isListening()).toBe(true);
+    });
+
+    it('should not affect a subsequent default `selectCells` call (suspend is released after the call)', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      externalInput = document.createElement('input');
+      document.body.appendChild(externalInput);
+      externalInput.focus();
+
+      await selectCells([[1, 1]], true, false);
+
+      expect(document.activeElement).toBe(externalInput);
+
+      await selectCells([[2, 2]]);
+
+      expect(document.activeElement).toBe(getCell(2, 2));
+    });
+
+    it('should keep an externally focused `<select>` focused when `selectCells` is called with' +
+      ' `changeListener` set to `false`', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      externalInput = document.createElement('select');
+      const option = document.createElement('option');
+
+      option.textContent = 'a';
+      externalInput.appendChild(option);
+      document.body.appendChild(externalInput);
+      externalInput.focus();
+
+      expect(document.activeElement).toBe(externalInput);
+
+      await selectCells([[1, 1]], true, false);
+
+      expect(document.activeElement).toBe(externalInput);
+    });
+
+    it('should keep an externally focused `contenteditable` element focused when `selectCells`' +
+      ' is called with `changeListener` set to `false`', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      externalInput = document.createElement('div');
+      externalInput.contentEditable = 'true';
+      externalInput.textContent = 'editable';
+      document.body.appendChild(externalInput);
+      externalInput.focus();
+
+      expect(document.activeElement).toBe(externalInput);
+
+      await selectCells([[1, 1]], true, false);
+
+      expect(document.activeElement).toBe(externalInput);
+    });
+
+    it('should release the suspended focus state after `selectCells` throws on malformed' +
+      ' coordinates', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      externalInput = document.createElement('input');
+      document.body.appendChild(externalInput);
+      externalInput.focus();
+
+      // Malformed coordinates - selectCells throws synchronously inside selection.selectCells.
+      // The `try/finally` in core.selectCells must still release the focus manager suspend flag,
+      // otherwise a subsequent default `selectCells` call would silently preserve external focus.
+      expect(() => hot().selectCells([['not-a-number']], true, false)).toThrow();
+
+      await selectCells([[2, 2]]);
+
+      expect(document.activeElement).toBe(getCell(2, 2));
+    });
+  });
 });

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -4681,7 +4681,9 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
    * @param {number} [endRow] If selecting a range: the visual row index of the last cell in the range.
    * @param {number|string} [endColumn] If selecting a range: the visual column index (or a column property's value) of the last cell in the range.
    * @param {boolean} [scrollToCell=true] `true`: scroll the viewport to the newly-selected cells. `false`: keep the previous viewport.
-   * @param {boolean} [changeListener=true] `true`: switch the keyboard focus to Handsontable. `false`: keep the previous keyboard focus.
+   * @param {boolean} [changeListener=true] `true`: switch the keyboard focus to Handsontable. `false`: keep the
+   * previous keyboard focus. If an element outside Handsontable (such as a custom input) currently owns the browser
+   * focus, it remains focused after the call.
    * @returns {boolean} `true`: the selection was successful, `false`: the selection failed.
    */
   this.selectCell = function(row, column, endRow, endColumn, scrollToCell = true, changeListener = true) {
@@ -4746,20 +4748,33 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
    * passed either as an array of arrays (`[[rowStart, columnStart, rowEnd, columnEnd], ...]`)
    * or as an array of [`CellRange`](@/api/cellRange.md) objects.
    * @param {boolean} [scrollToCell=true] `true`: scroll the viewport to the newly-selected cells. `false`: keep the previous viewport.
-   * @param {boolean} [changeListener=true] `true`: switch the keyboard focus to Handsontable. `false`: keep the previous keyboard focus.
+   * @param {boolean} [changeListener=true] `true`: switch the keyboard focus to Handsontable. `false`: keep the
+   * previous keyboard focus. If an element outside Handsontable (such as a custom input) currently owns the browser
+   * focus, it remains focused after the call.
    * @returns {boolean} `true`: the selection was successful, `false`: the selection failed.
    */
   this.selectCells = function(coords = [[]], scrollToCell = true, changeListener = true) {
     if (scrollToCell === false) {
       viewportScroller.suspend();
     }
+    if (changeListener === false) {
+      focusGridManager.suspend();
+    }
 
-    const wasSelected = selection.selectCells(coords);
+    let wasSelected;
+
+    try {
+      wasSelected = selection.selectCells(coords);
+    } finally {
+      // Always release the suspended state even if `selection.selectCells` throws on malformed
+      // coordinates. Otherwise the flags would leak across subsequent calls.
+      viewportScroller.resume();
+      focusGridManager.resume();
+    }
 
     if (wasSelected && changeListener) {
       instance.listen();
     }
-    viewportScroller.resume();
 
     return wasSelected;
   };

--- a/handsontable/src/focusManager/grid.js
+++ b/handsontable/src/focusManager/grid.js
@@ -317,10 +317,17 @@ export class FocusGridManager {
    * Manage the browser's focus after cell selection end.
    */
   #focusEditorElement() {
-    // While focus management is suspended, do not refocus the editor textarea (`imeFastEdit`).
-    // Without this guard the debounced refocus would steal the externally focused element. See #10038.
+    // When focus management is suspended and an external focusable element (outside Handsontable)
+    // currently owns the browser focus, skip the `imeFastEdit` refocus - otherwise the debounced
+    // `select()` on the editor textarea would steal that external focus. When no external element
+    // owns focus, fall through so the default `imeFastEdit` behavior still moves focus to the
+    // editor textarea (existing per-editor IME support tests rely on this). See #10038.
     if (this.#isSuspended) {
-      return;
+      const { activeElement } = this.#hot.rootDocument;
+
+      if (activeElement && isOutsideInput(activeElement)) {
+        return;
+      }
     }
 
     this.#getSelectedCell((selectedCell) => {

--- a/handsontable/src/focusManager/grid.js
+++ b/handsontable/src/focusManager/grid.js
@@ -61,6 +61,15 @@ export class FocusGridManager {
    * @type {boolean}
    */
   #hasSelectionChange = false;
+  /**
+   * Flag indicating whether automatic focus management for the upcoming selection cycle is suspended.
+   * When `true`, `#focusCell` does not steal an externally focused input/textarea/select element,
+   * and `#focusEditorElement` does not refocus the editor textarea. Set with `suspend()` and
+   * cleared with `resume()`. Mirrors the `viewportScroller.suspend()/resume()` pattern.
+   *
+   * @type {boolean}
+   */
+  #isSuspended = false;
 
   constructor(hotInstance) {
     this.#hot = hotInstance;
@@ -128,6 +137,29 @@ export class FocusGridManager {
    */
   setRefocusElementGetter(getRefocusElementFunction) {
     this.#refocusElementGetter = getRefocusElementFunction;
+  }
+
+  /**
+   * Suspend automatic focus management until `resume()` is called. While suspended, an
+   * externally focused element (input, textarea, select, or contenteditable located outside
+   * Handsontable) keeps the browser focus when a programmatic selection is applied, and the
+   * editor textarea is not auto-refocused (`imeFastEdit`). Used by `selectCells()` when
+   * `changeListener` is `false`. Note: an `activeElement` of `<body>` or an `<iframe>` element
+   * does not count as an external input - in those cases focus still moves to the cell.
+   *
+   * @since 17.0.2
+   */
+  suspend() {
+    this.#isSuspended = true;
+  }
+
+  /**
+   * Resume automatic focus management. Pair with a prior `suspend()` call.
+   *
+   * @since 17.0.2
+   */
+  resume() {
+    this.#isSuspended = false;
   }
 
   /**
@@ -253,8 +285,21 @@ export class FocusGridManager {
    * Manage the browser's focus after each cell selection change.
    */
   #focusCell() {
+    // Capture the suspend flag synchronously. `#getSelectedCell` may defer its callback via
+    // `afterScroll` when the target cell is not yet rendered, by which time `resume()` may
+    // have run. Reading `this.#isSuspended` inside the callback would miss the suspend window.
+    const suspended = this.#isSuspended;
+
     this.#getSelectedCell((selectedCell) => {
       const { activeElement } = this.#hot.rootDocument;
+
+      // When focus management is suspended and an external focusable element (outside Handsontable)
+      // currently owns the browser focus, keep it - do not blur and do not move focus to the cell.
+      // This preserves the focus of inputs that live next to the grid when a programmatic selection
+      // is applied via `selectCells(..., changeListener = false)`. See #10038.
+      if (suspended && activeElement && isOutsideInput(activeElement)) {
+        return;
+      }
 
       // Blurring the `activeElement` removes the unwanted border around the focusable element (#6877)
       // and resets the `document.activeElement` property. The blurring should happen only when the
@@ -272,6 +317,12 @@ export class FocusGridManager {
    * Manage the browser's focus after cell selection end.
    */
   #focusEditorElement() {
+    // While focus management is suspended, do not refocus the editor textarea (`imeFastEdit`).
+    // Without this guard the debounced refocus would steal the externally focused element. See #10038.
+    if (this.#isSuspended) {
+      return;
+    }
+
     this.#getSelectedCell((selectedCell) => {
       if (
         this.getFocusMode() === FOCUS_MODES.MIXED &&

--- a/handsontable/types/focusManager/grid.d.ts
+++ b/handsontable/types/focusManager/grid.d.ts
@@ -10,4 +10,6 @@ export interface GridFocusManager {
   focusElement(element: HTMLElement, focusOptions?: FocusOptions): boolean;
   focusOnHighlightedCell(): void;
   refocusToEditorTextarea(delay: number): void;
+  suspend(): void;
+  resume(): void;
 }


### PR DESCRIPTION
### Context

The PR fixes a long-standing regression introduced between Handsontable 7.4.2 and 8.0.0: calling `selectCell()` or `selectCells()` with `changeListener` set to `false` would still blur the currently focused external element (a custom `<input>`, `<textarea>`, `<select>`, or `contenteditable` outside Handsontable) and move the browser focus to the highlighted `<td>`. This contradicts the documented `changeListener: false` contract ("keep the previous keyboard focus") and breaks integrations where a host app drives selection programmatically while the user is typing in an external control.

Root cause: `FocusGridManager.#focusCell()` is triggered via the `afterRender` hook on every selection change and unconditionally blurs the active element and focuses the highlighted cell, regardless of the `changeListener` flag (which only controls `instance.listen()`).

Fix: `FocusGridManager` gains paired `suspend()` / `resume()` methods (mirroring the existing `viewportScroller` pattern). `core.selectCells()` suspends the focus manager around the synchronous `selection.selectCells(coords)` call when `changeListener === false`, wrapped in `try/finally` so the suspended state is released even if `selection.selectCells` throws on malformed coordinates. While suspended, `#focusCell` and `#focusEditorElement` skip their work when an external focusable element (`isOutsideInput`) owns the browser focus, leaving the external focus intact. Default `changeListener=true` behavior, screen-reader cell focus, and `imeFastEdit` textarea refocus on regular selections are unchanged.

### How has this been tested?

E2E tests added in `handsontable/src/__tests__/focusManager.spec.js` under `'`selectCells`/`selectCell` with `changeListener = false` (#10038)'` cover:

- External `<input>` preserved by `selectCells([[r,c]], true, false)`.
- External `<textarea>` preserved by `selectCells`.
- External `<select>` preserved by `selectCells`.
- External `contenteditable` element preserved by `selectCells`.
- External `<input>` preserved by `selectCell(r,c,_,_,true,false)` (delegation path).
- `imeFastEdit: true` does not refocus the editor textarea when suspended.
- Default `changeListener=true` still moves focus to the highlighted cell (regression check).
- A subsequent default `selectCells` call after a suspended one behaves normally (flag released by `resume()`).
- A `selectCells` call that throws on malformed coordinates still releases the suspended state (try/finally check).

Verified locally:

```bash
# Focused suite (45 specs, 0 failures)
npm run test:e2e --prefix handsontable -- --testPathPattern=focusManager

# Wider regression sweep (1381 specs, 0 failures)
npm run test:e2e --prefix handsontable -- --testPathPattern="focus |listen|core/select|selection"

# Lint + types
npm run lint --prefix handsontable
```

Manual verification via two demo pages (`handsontable/dev-latest.html` vs `handsontable/dev-pr.html`) plus a Playwright-driven real click flow confirmed that on the released v17.0.1 build the external input is blurred (focus jumps to `<td>`) and on this branch it stays focused.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. Fixes #10038
2. DEV-1660

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation. (JSDoc on `selectCell`/`selectCells` updated; the API reference page `docs/content/api/core.md` is auto-generated from JSDoc — confirmed locally via `npm run docs:api`.)

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1660

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches focus-management and selection behavior (including `imeFastEdit`) and adds new suspend/resume state that could affect keyboard/a11y focus flows if it regresses. Scope is contained and covered by targeted e2e tests.
> 
> **Overview**
> Fixes a regression where programmatic `selectCell()`/`selectCells()` calls with `changeListener=false` still blurred externally focused elements and moved browser focus into the grid.
> 
> `Core#selectCells` now suspends the `FocusGridManager` (and wraps selection in `try/finally` to always resume) so focus isn’t stolen during those calls, while default `changeListener=true` behavior remains unchanged; JSDoc is updated to clarify the contract.
> 
> Adds `FocusGridManager.suspend()/resume()` plus new e2e coverage ensuring external `<input>`, `<textarea>`, `<select>`, and `contenteditable` elements keep focus (including `imeFastEdit`), and includes a changelog entry and TypeScript typings updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78a1661c687da35c45aa749c2be623e67d527da0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->