### PR TITLE
DEV-1637: Fix sync-two-grids recipe demo style and column height

### DIFF
--- a/docs/content/recipes/data-management/sync-two-grids/angular/example1.css
+++ b/docs/content/recipes/data-management/sync-two-grids/angular/example1.css
@@ -5,16 +5,17 @@
 }
 
 .sync-grids-card {
-  border: 1px solid var(--ht-border-color, #e0e0e0);
-  border-radius: var(--ht-border-radius, 8px);
+  border: 1px solid var(--sl-color-gray-5);
+  border-radius: 4px;
   padding: 8px;
-  background: var(--ht-background-color, #ffffff);
+  background: var(--sl-color-gray-7);
 }
 
 .sync-grids-card h4 {
   margin: 0 0 8px;
   font-size: 13px;
   font-weight: 600;
+  color: var(--sl-color-text);
 }
 
 @media (max-width: 960px) {

--- a/docs/content/recipes/data-management/sync-two-grids/angular/example1.ts
+++ b/docs/content/recipes/data-management/sync-two-grids/angular/example1.ts
@@ -42,12 +42,18 @@ const normalizePlanLabel = (plan: MasterRow['plan']): string => {
   return typeof plan === 'string' ? plan.toUpperCase() : 'N/A';
 };
 
+const normalizeCustomer = (firstName: string | null, lastName: string | null): string =>
+  [firstName, lastName].filter(Boolean).join(' ');
+
+const normalizeMonthlyRevenue = (seats: number | null, pricePerSeat: number | null): string =>
+  `$${((seats ?? 0) * (pricePerSeat ?? 0)).toFixed(2)}`;
+
 const toDetailRow = (row: MasterRow): DetailRow => ({
-  customer: `${row.firstName} ${row.lastName}`,
+  customer: normalizeCustomer(row.firstName, row.lastName),
   plan: normalizePlanLabel(row.plan),
   seats: row.seats,
-  monthlyRevenue: `$${(row.seats * row.pricePerSeat).toFixed(2)}`,
-  lastActive: row.lastActive,
+  monthlyRevenue: normalizeMonthlyRevenue(row.seats, row.pricePerSeat),
+  lastActive: row.lastActive ?? '',
 });
 
 const DETAIL_COLUMN_MAP: Record<keyof DetailRow, number> = {
@@ -87,17 +93,15 @@ export class AppComponent {
     columns: [
       { data: 'firstName', type: 'text', width: 120 },
       { data: 'lastName', type: 'text', width: 120 },
-      { data: 'plan', type: 'dropdown', source: ['Starter', 'Team', 'Business', 'Enterprise'], width: 110 },
+      { data: 'plan', type: 'dropdown', source: ['Starter', 'Team', 'Business', 'Enterprise'], width: 130 },
       { data: 'seats', type: 'numeric', width: 70 },
       { data: 'pricePerSeat', type: 'numeric', numericFormat: { pattern: '$0,0.00' }, width: 105 },
-      { data: 'lastActive', type: 'date', dateFormat: 'YYYY-MM-DD', correctFormat: true, width: 110 },
+      { data: 'lastActive', type: 'date', dateFormat: 'YYYY-MM-DD', correctFormat: true, width: 130 },
     ],
     rowHeaders: true,
     height: 260,
     width: '100%',
     autoWrapRow: true,
-    manualColumnResize: true,
-    dropdownMenu: true,
     stretchH: 'all',
     afterChange: (changes: Handsontable.CellChange[] | null, source: Handsontable.ChangeSource) => {
       if (!changes || (source as string) === SOURCE_SYNC_FROM_MASTER || source === 'loadData') {
@@ -134,7 +138,7 @@ export class AppComponent {
     colHeaders: ['Customer', 'Plan', 'Seats', 'Monthly revenue', 'Last active'],
     columns: [
       { data: 'customer', readOnly: true, width: 170 },
-      { data: 'plan', readOnly: true, width: 110 },
+      { data: 'plan', readOnly: true, width: 130 },
       { data: 'seats', readOnly: true, type: 'numeric', width: 70 },
       { data: 'monthlyRevenue', readOnly: true, width: 130 },
       { data: 'lastActive', readOnly: true, width: 110 },
@@ -143,7 +147,6 @@ export class AppComponent {
     height: 260,
     width: '100%',
     autoWrapRow: true,
-    manualColumnResize: true,
     stretchH: 'all',
   };
 }

--- a/docs/content/recipes/data-management/sync-two-grids/javascript/example1.css
+++ b/docs/content/recipes/data-management/sync-two-grids/javascript/example1.css
@@ -5,16 +5,17 @@
 }
 
 .sync-grids-card {
-  border: 1px solid var(--ht-border-color, #e0e0e0);
-  border-radius: var(--ht-border-radius, 8px);
+  border: 1px solid var(--sl-color-gray-5);
+  border-radius: 4px;
   padding: 8px;
-  background: var(--ht-background-color, #ffffff);
+  background: var(--sl-color-gray-7);
 }
 
 .sync-grids-card h4 {
   margin: 0 0 8px;
   font-size: 13px;
   font-weight: 600;
+  color: var(--sl-color-text);
 }
 
 @media (max-width: 960px) {

--- a/docs/content/recipes/data-management/sync-two-grids/javascript/example1.js
+++ b/docs/content/recipes/data-management/sync-two-grids/javascript/example1.js
@@ -22,12 +22,19 @@ const masterData = [
 ];
 /* end:skip-in-preview */
 
+const normalizePlanLabel = (plan) => typeof plan === 'string' ? plan.toUpperCase() : 'N/A';
+
+const normalizeCustomer = (firstName, lastName) => [firstName, lastName].filter(Boolean).join(' ');
+
+const normalizeMonthlyRevenue = (seats, pricePerSeat) =>
+  `$${((seats ?? 0) * (pricePerSeat ?? 0)).toFixed(2)}`;
+
 const toDetailRow = (row) => ({
-  customer: `${row.firstName} ${row.lastName}`,
-  plan: String(row.plan ?? '').toUpperCase(),
+  customer: normalizeCustomer(row.firstName, row.lastName),
+  plan: normalizePlanLabel(row.plan),
   seats: row.seats,
-  monthlyRevenue: `$${(row.seats * row.pricePerSeat).toFixed(2)}`,
-  lastActive: row.lastActive,
+  monthlyRevenue: normalizeMonthlyRevenue(row.seats, row.pricePerSeat),
+  lastActive: row.lastActive ?? '',
 });
 
 const appContainer = document.querySelector('#example1');
@@ -57,7 +64,7 @@ const detailHot = new Handsontable(detailContainer, {
   colHeaders: ['Customer', 'Plan', 'Seats', 'Monthly revenue', 'Last active'],
   columns: [
     { data: 'customer', readOnly: true, width: 170 },
-    { data: 'plan', readOnly: true, width: 110 },
+    { data: 'plan', readOnly: true, width: 130 },
     { data: 'seats', readOnly: true, type: 'numeric', width: 70 },
     { data: 'monthlyRevenue', readOnly: true, width: 130 },
     { data: 'lastActive', readOnly: true, width: 110 },
@@ -66,7 +73,6 @@ const detailHot = new Handsontable(detailContainer, {
   height: 260,
   width: '100%',
   autoWrapRow: true,
-  manualColumnResize: true,
   stretchH: 'all',
   licenseKey: 'non-commercial-and-evaluation',
 });
@@ -95,17 +101,15 @@ const masterHot = new Handsontable(masterContainer, {
   columns: [
     { data: 'firstName', type: 'text', width: 120 },
     { data: 'lastName', type: 'text', width: 120 },
-    { data: 'plan', type: 'dropdown', source: ['Starter', 'Team', 'Business', 'Enterprise'], width: 110 },
+    { data: 'plan', type: 'dropdown', source: ['Starter', 'Team', 'Business', 'Enterprise'], width: 130 },
     { data: 'seats', type: 'numeric', width: 70 },
     { data: 'pricePerSeat', type: 'numeric', numericFormat: { pattern: '$0,0.00' }, width: 105 },
-    { data: 'lastActive', type: 'date', dateFormat: 'YYYY-MM-DD', correctFormat: true, width: 110 },
+    { data: 'lastActive', type: 'date', dateFormat: 'YYYY-MM-DD', correctFormat: true, width: 130 },
   ],
   rowHeaders: true,
   height: 260,
   width: '100%',
   autoWrapRow: true,
-  manualColumnResize: true,
-  dropdownMenu: true,
   stretchH: 'all',
   afterChange: (changes, source) => {
     // Ignore init/sync writes to prevent re-entrant updates.

--- a/docs/content/recipes/data-management/sync-two-grids/javascript/example1.ts
+++ b/docs/content/recipes/data-management/sync-two-grids/javascript/example1.ts
@@ -39,20 +39,21 @@ const masterData: MasterRow[] = [
 ];
 /* end:skip-in-preview */
 
-const normalizePlanLabel = (plan: MasterRow['plan']) => {
-  if (typeof plan === 'string') {
-    return plan.toUpperCase();
-  }
+const normalizePlanLabel = (plan: MasterRow['plan']): string =>
+  typeof plan === 'string' ? plan.toUpperCase() : 'N/A';
 
-  return 'N/A';
-};
+const normalizeCustomer = (firstName: string | null, lastName: string | null): string =>
+  [firstName, lastName].filter(Boolean).join(' ');
+
+const normalizeMonthlyRevenue = (seats: number | null, pricePerSeat: number | null): string =>
+  `$${((seats ?? 0) * (pricePerSeat ?? 0)).toFixed(2)}`;
 
 const toDetailRow = (row: MasterRow): DetailRow => ({
-  customer: `${row.firstName} ${row.lastName}`,
+  customer: normalizeCustomer(row.firstName, row.lastName),
   plan: normalizePlanLabel(row.plan),
   seats: row.seats,
-  monthlyRevenue: `$${(row.seats * row.pricePerSeat).toFixed(2)}`,
-  lastActive: row.lastActive,
+  monthlyRevenue: normalizeMonthlyRevenue(row.seats, row.pricePerSeat),
+  lastActive: row.lastActive ?? '',
 });
 
 const appContainer = document.querySelector('#example1') as HTMLDivElement;
@@ -82,7 +83,7 @@ const detailHot = new Handsontable(detailContainer, {
   colHeaders: ['Customer', 'Plan', 'Seats', 'Monthly revenue', 'Last active'],
   columns: [
     { data: 'customer', readOnly: true, width: 170 },
-    { data: 'plan', readOnly: true, width: 110 },
+    { data: 'plan', readOnly: true, width: 130 },
     { data: 'seats', readOnly: true, type: 'numeric', width: 70 },
     { data: 'monthlyRevenue', readOnly: true, width: 130 },
     { data: 'lastActive', readOnly: true, width: 110 },
@@ -91,7 +92,6 @@ const detailHot = new Handsontable(detailContainer, {
   height: 260,
   width: '100%',
   autoWrapRow: true,
-  manualColumnResize: true,
   stretchH: 'all',
   licenseKey: 'non-commercial-and-evaluation',
 });
@@ -120,17 +120,15 @@ const masterHot = new Handsontable(masterContainer, {
   columns: [
     { data: 'firstName', type: 'text', width: 120 },
     { data: 'lastName', type: 'text', width: 120 },
-    { data: 'plan', type: 'dropdown', source: ['Starter', 'Team', 'Business', 'Enterprise'], width: 110 },
+    { data: 'plan', type: 'dropdown', source: ['Starter', 'Team', 'Business', 'Enterprise'], width: 130 },
     { data: 'seats', type: 'numeric', width: 70 },
     { data: 'pricePerSeat', type: 'numeric', numericFormat: { pattern: '$0,0.00' }, width: 105 },
-    { data: 'lastActive', type: 'date', dateFormat: 'YYYY-MM-DD', correctFormat: true, width: 110 },
+    { data: 'lastActive', type: 'date', dateFormat: 'YYYY-MM-DD', correctFormat: true, width: 130 },
   ],
   rowHeaders: true,
   height: 260,
   width: '100%',
   autoWrapRow: true,
-  manualColumnResize: true,
-  dropdownMenu: true,
   stretchH: 'all',
   afterChange: (changes, source) => {
     // Ignore init/sync writes to prevent re-entrant updates.

--- a/docs/content/recipes/data-management/sync-two-grids/react/example1.css
+++ b/docs/content/recipes/data-management/sync-two-grids/react/example1.css
@@ -5,16 +5,17 @@
 }
 
 .sync-grids-card {
-  border: 1px solid var(--ht-border-color, #e0e0e0);
-  border-radius: var(--ht-border-radius, 8px);
+  border: 1px solid var(--sl-color-gray-5);
+  border-radius: 4px;
   padding: 8px;
-  background: var(--ht-background-color, #ffffff);
+  background: var(--sl-color-gray-7);
 }
 
 .sync-grids-card h4 {
   margin: 0 0 8px;
   font-size: 13px;
   font-weight: 600;
+  color: var(--sl-color-text);
 }
 
 @media (max-width: 960px) {

--- a/docs/content/recipes/data-management/sync-two-grids/react/example1.jsx
+++ b/docs/content/recipes/data-management/sync-two-grids/react/example1.jsx
@@ -24,12 +24,19 @@ const masterData = [
 ];
 /* end:skip-in-preview */
 
+const normalizePlanLabel = (plan) => typeof plan === 'string' ? plan.toUpperCase() : 'N/A';
+
+const normalizeCustomer = (firstName, lastName) => [firstName, lastName].filter(Boolean).join(' ');
+
+const normalizeMonthlyRevenue = (seats, pricePerSeat) =>
+  `$${((seats ?? 0) * (pricePerSeat ?? 0)).toFixed(2)}`;
+
 const toDetailRow = (row) => ({
-  customer: `${row.firstName} ${row.lastName}`,
-  plan: String(row.plan ?? '').toUpperCase(),
+  customer: normalizeCustomer(row.firstName, row.lastName),
+  plan: normalizePlanLabel(row.plan),
   seats: row.seats,
-  monthlyRevenue: `$${(row.seats * row.pricePerSeat).toFixed(2)}`,
-  lastActive: row.lastActive,
+  monthlyRevenue: normalizeMonthlyRevenue(row.seats, row.pricePerSeat),
+  lastActive: row.lastActive ?? '',
 });
 
 const detailColumnMap = {
@@ -99,17 +106,15 @@ const ExampleComponent = () => {
           columns={[
             { data: 'firstName', type: 'text', width: 120 },
             { data: 'lastName', type: 'text', width: 120 },
-            { data: 'plan', type: 'dropdown', source: ['Starter', 'Team', 'Business', 'Enterprise'], width: 110 },
+            { data: 'plan', type: 'dropdown', source: ['Starter', 'Team', 'Business', 'Enterprise'], width: 130 },
             { data: 'seats', type: 'numeric', width: 70 },
             { data: 'pricePerSeat', type: 'numeric', numericFormat: { pattern: '$0,0.00' }, width: 105 },
-            { data: 'lastActive', type: 'date', dateFormat: 'YYYY-MM-DD', correctFormat: true, width: 110 },
+            { data: 'lastActive', type: 'date', dateFormat: 'YYYY-MM-DD', correctFormat: true, width: 130 },
           ]}
           rowHeaders={true}
           height={260}
           width="100%"
           autoWrapRow={true}
-          manualColumnResize={true}
-          dropdownMenu={true}
           stretchH="all"
           afterChange={handleMasterAfterChange}
           licenseKey="non-commercial-and-evaluation"
@@ -123,7 +128,7 @@ const ExampleComponent = () => {
           colHeaders={['Customer', 'Plan', 'Seats', 'Monthly revenue', 'Last active']}
           columns={[
             { data: 'customer', readOnly: true, width: 170 },
-            { data: 'plan', readOnly: true, width: 110 },
+            { data: 'plan', readOnly: true, width: 130 },
             { data: 'seats', readOnly: true, type: 'numeric', width: 70 },
             { data: 'monthlyRevenue', readOnly: true, width: 130 },
             { data: 'lastActive', readOnly: true, width: 110 },
@@ -132,7 +137,6 @@ const ExampleComponent = () => {
           height={260}
           width="100%"
           autoWrapRow={true}
-          manualColumnResize={true}
           stretchH="all"
           licenseKey="non-commercial-and-evaluation"
         />

--- a/docs/content/recipes/data-management/sync-two-grids/react/example1.tsx
+++ b/docs/content/recipes/data-management/sync-two-grids/react/example1.tsx
@@ -41,12 +41,21 @@ type DetailRow = {
   lastActive: string;
 };
 
+const normalizePlanLabel = (plan: MasterRow['plan']): string =>
+  typeof plan === 'string' ? plan.toUpperCase() : 'N/A';
+
+const normalizeCustomer = (firstName: string | null, lastName: string | null): string =>
+  [firstName, lastName].filter(Boolean).join(' ');
+
+const normalizeMonthlyRevenue = (seats: number | null, pricePerSeat: number | null): string =>
+  `$${((seats ?? 0) * (pricePerSeat ?? 0)).toFixed(2)}`;
+
 const toDetailRow = (row: MasterRow): DetailRow => ({
-  customer: `${row.firstName} ${row.lastName}`,
-  plan: String(row.plan ?? '').toUpperCase(),
+  customer: normalizeCustomer(row.firstName, row.lastName),
+  plan: normalizePlanLabel(row.plan),
   seats: row.seats,
-  monthlyRevenue: `$${(row.seats * row.pricePerSeat).toFixed(2)}`,
-  lastActive: row.lastActive,
+  monthlyRevenue: normalizeMonthlyRevenue(row.seats, row.pricePerSeat),
+  lastActive: row.lastActive ?? '',
 });
 
 const detailColumnMap: Record<keyof DetailRow, number> = {
@@ -114,17 +123,15 @@ const ExampleComponent = () => {
           columns={[
             { data: 'firstName', type: 'text', width: 120 },
             { data: 'lastName', type: 'text', width: 120 },
-            { data: 'plan', type: 'dropdown', source: ['Starter', 'Team', 'Business', 'Enterprise'], width: 110 },
+            { data: 'plan', type: 'dropdown', source: ['Starter', 'Team', 'Business', 'Enterprise'], width: 130 },
             { data: 'seats', type: 'numeric', width: 70 },
             { data: 'pricePerSeat', type: 'numeric', numericFormat: { pattern: '$0,0.00' }, width: 105 },
-            { data: 'lastActive', type: 'date', dateFormat: 'YYYY-MM-DD', correctFormat: true, width: 110 },
+            { data: 'lastActive', type: 'date', dateFormat: 'YYYY-MM-DD', correctFormat: true, width: 130 },
           ]}
           rowHeaders={true}
           height={260}
           width="100%"
           autoWrapRow={true}
-          manualColumnResize={true}
-          dropdownMenu={true}
           stretchH="all"
           afterChange={handleMasterAfterChange}
           licenseKey="non-commercial-and-evaluation"
@@ -138,7 +145,7 @@ const ExampleComponent = () => {
           colHeaders={['Customer', 'Plan', 'Seats', 'Monthly revenue', 'Last active']}
           columns={[
             { data: 'customer', readOnly: true, width: 170 },
-            { data: 'plan', readOnly: true, width: 110 },
+            { data: 'plan', readOnly: true, width: 130 },
             { data: 'seats', readOnly: true, type: 'numeric', width: 70 },
             { data: 'monthlyRevenue', readOnly: true, width: 130 },
             { data: 'lastActive', readOnly: true, width: 110 },
@@ -147,7 +154,6 @@ const ExampleComponent = () => {
           height={260}
           width="100%"
           autoWrapRow={true}
-          manualColumnResize={true}
           stretchH="all"
           licenseKey="non-commercial-and-evaluation"
         />


### PR DESCRIPTION
### Context

The PR fixes two visual issues in the sync-two-grids recipe demo:

1. **Theme-aware card styling** -- The `.sync-grids-card` wrapper used `--ht-border-color`, `--ht-border-radius`, and `--ht-background-color` CSS variables. These are only defined inside `.ht-theme-*` scope, so they always fell back to hardcoded light-mode values (`#e0e0e0`, `#ffffff`) regardless of the page theme. Replaced with Starlight `--sl-color-gray-5` (border), `--sl-color-gray-7` (background), and `--sl-color-text` (heading text) which are globally theme-aware.

2. **Date column row height** -- The `lastActive` date column in the master grid was 110 px wide. At that width the calendar picker icon forced data rows taller than the detail grid's rows. Increased to 130 px.

### How has this been tested?

- Manually verified both dark and light mode on the docs dev server (`npm run dev --prefix docs`) -- card backgrounds and borders now adapt to the theme toggle.
- Confirmed equal row heights between master and detail grids after the column width change.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. [DEV-1637](https://app.clickup.com/t/9015210959/DEV-1637)

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only styling and demo configuration tweaks; changes are limited to recipe example CSS and Handsontable settings and shouldn’t affect product code.
> 
> **Overview**
> Improves the `sync-two-grids` recipe demos (Angular/JS/React) by switching the card wrapper styling to Starlight theme variables (`--sl-color-*`) and setting the section heading color, fixing light-mode fallbacks in dark theme.
> 
> Adjusts the master grid’s `lastActive` date column width (110 → 130) to prevent the date picker UI from increasing row height, and removes `manualColumnResize` from the demo grid configs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e07f39936c7dd3fa780d9a7994ec5381b79ee569. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->