### PR TITLE
DEV-1663: Fix beforeValidate/afterValidate hooks receive accessor function as col

### DIFF
--- a/.changelogs/12560.json
+++ b/.changelogs/12560.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed the `beforeValidate`, `afterValidate`, and `postAfterValidate` hooks receiving the data accessor function instead of the visual column index when `columns[i].data` is a function.",
+  "type": "fixed",
+  "issueOrPR": 12560,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -1747,7 +1747,7 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
 
     if (isFunction(validator)) {
       // eslint-disable-next-line no-param-reassign
-      value = instance.runHooks('beforeValidate', value, cellProperties.visualRow, cellProperties.prop, source);
+      value = instance.runHooks('beforeValidate', value, cellProperties.visualRow, cellProperties.visualCol, source);
 
       // To provide consistent behavior, validation should be always asynchronous
       instance._registerMicrotask(() => {
@@ -1757,11 +1757,13 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
           }
           // eslint-disable-next-line no-param-reassign
           valid = instance
-            .runHooks('afterValidate', valid, value, cellProperties.visualRow, cellProperties.prop, source);
+            .runHooks('afterValidate', valid, value, cellProperties.visualRow, cellProperties.visualCol, source);
           cellProperties.valid = valid;
 
           done(valid);
-          instance.runHooks('postAfterValidate', valid, value, cellProperties.visualRow, cellProperties.prop, source);
+          instance.runHooks(
+            'postAfterValidate', valid, value, cellProperties.visualRow, cellProperties.visualCol, source
+          );
         });
       });
 

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -1746,8 +1746,13 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
     }
 
     if (isFunction(validator)) {
+      // When the column data accessor is a function, cellProperties.prop holds the accessor
+      // function itself — not a usable column reference. Fall back to the visual column index
+      // so hook listeners always receive a number or a property string, never a function.
+      const colArg = isFunction(cellProperties.prop) ? cellProperties.visualCol : cellProperties.prop;
+
       // eslint-disable-next-line no-param-reassign
-      value = instance.runHooks('beforeValidate', value, cellProperties.visualRow, cellProperties.visualCol, source);
+      value = instance.runHooks('beforeValidate', value, cellProperties.visualRow, colArg, source);
 
       // To provide consistent behavior, validation should be always asynchronous
       instance._registerMicrotask(() => {
@@ -1757,12 +1762,12 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
           }
           // eslint-disable-next-line no-param-reassign
           valid = instance
-            .runHooks('afterValidate', valid, value, cellProperties.visualRow, cellProperties.visualCol, source);
+            .runHooks('afterValidate', valid, value, cellProperties.visualRow, colArg, source);
           cellProperties.valid = valid;
 
           done(valid);
           instance.runHooks(
-            'postAfterValidate', valid, value, cellProperties.visualRow, cellProperties.visualCol, source
+            'postAfterValidate', valid, value, cellProperties.visualRow, colArg, source
           );
         });
       });

--- a/handsontable/test/e2e/hooks/afterValidate.spec.js
+++ b/handsontable/test/e2e/hooks/afterValidate.spec.js
@@ -48,6 +48,60 @@ describe('Hook', () => {
       expect(onAfterValidate.calls.count()).toBe(1);
     });
 
+    it('should pass a visual column index (not property function) as the col argument with function-based data accessor', async() => {
+      const colArgs = [];
+
+      function model(opts) {
+        const priv = { id: undefined, name: undefined };
+
+        for (const key in opts) {
+          if (Object.prototype.hasOwnProperty.call(opts, key)) {
+            priv[key] = opts[key];
+          }
+        }
+
+        return {
+          attr(attr, val) {
+            if (typeof val === 'undefined') {
+              return priv[attr];
+            }
+
+            priv[attr] = val;
+
+            return this;
+          }
+        };
+      }
+
+      function property(attr) {
+        return (row, value) => row.attr(attr, value);
+      }
+
+      handsontable({
+        data: [
+          model({ id: 1, name: 'Ted' }),
+          model({ id: 2, name: 'Frank' }),
+        ],
+        dataSchema: model,
+        columns: [
+          { data: property('id'), type: 'numeric' },
+          { data: property('name') },
+        ],
+        afterValidate(valid, value, row, col) {
+          colArgs.push(col);
+        }
+      });
+
+      await setDataAtCell(0, 0, 99);
+
+      await waitForNextAnimationFrames(2);
+
+      expect(colArgs.length).toBeGreaterThan(0);
+      colArgs.forEach((col) => {
+        expect(typeof col).toBe('number');
+      });
+    });
+
     it('should call afterValidate when columns is a function', async() => {
       const onAfterValidate = jasmine.createSpy('onAfterValidate');
 

--- a/handsontable/test/e2e/hooks/beforeValidate.spec.js
+++ b/handsontable/test/e2e/hooks/beforeValidate.spec.js
@@ -108,6 +108,29 @@ describe('Hook', () => {
       expect(result).toBe(999);
     });
 
+    it('should pass the property string as the col argument with array-of-objects data source', async() => {
+      const colArgs = [];
+
+      handsontable({
+        data: arrayOfObjects(),
+        columns: [
+          { data: 'id', type: 'numeric' },
+          { data: 'name' },
+          { data: 'lastName' }
+        ],
+        beforeValidate(value, row, col) {
+          colArgs.push(col);
+        }
+      });
+
+      await setDataAtCell(2, 0, 99);
+
+      await waitForNextAnimationFrames(2);
+
+      expect(colArgs.length).toBeGreaterThan(0);
+      expect(colArgs[0]).toBe('id');
+    });
+
     it('should pass a visual column index (not property function) as the col argument with function-based data accessor', async() => {
       const colArgs = [];
 

--- a/handsontable/test/e2e/hooks/beforeValidate.spec.js
+++ b/handsontable/test/e2e/hooks/beforeValidate.spec.js
@@ -108,6 +108,60 @@ describe('Hook', () => {
       expect(result).toBe(999);
     });
 
+    it('should pass a visual column index (not property function) as the col argument with function-based data accessor', async() => {
+      const colArgs = [];
+
+      function model(opts) {
+        const priv = { id: undefined, name: undefined };
+
+        for (const key in opts) {
+          if (Object.prototype.hasOwnProperty.call(opts, key)) {
+            priv[key] = opts[key];
+          }
+        }
+
+        return {
+          attr(attr, val) {
+            if (typeof val === 'undefined') {
+              return priv[attr];
+            }
+
+            priv[attr] = val;
+
+            return this;
+          }
+        };
+      }
+
+      function property(attr) {
+        return (row, value) => row.attr(attr, value);
+      }
+
+      handsontable({
+        data: [
+          model({ id: 1, name: 'Ted' }),
+          model({ id: 2, name: 'Frank' }),
+        ],
+        dataSchema: model,
+        columns: [
+          { data: property('id'), type: 'numeric' },
+          { data: property('name') },
+        ],
+        beforeValidate(value, row, col) {
+          colArgs.push(col);
+        }
+      });
+
+      await setDataAtCell(0, 0, 99);
+
+      await waitForNextAnimationFrames(2);
+
+      expect(colArgs.length).toBeGreaterThan(0);
+      colArgs.forEach((col) => {
+        expect(typeof col).toBe('number');
+      });
+    });
+
     it('beforeValidate can manipulate value when columns is a function', async() => {
       const onAfterValidate = jasmine.createSpy('onAfterValidate');
       let result = null;


### PR DESCRIPTION
### Context

The PR fixes a bug (GH #2966, open since 2015) where `beforeValidate`, `afterValidate`, and `postAfterValidate` hooks received the column data **accessor function** as their `col` argument instead of a usable column reference when `columns[i].data` is a function.

**Root cause:** `validateCell()` in `core.js` passed `cellProperties.prop` as the column argument to all three hooks. For function-based column data accessors, `cellProperties.prop` is the accessor function itself — not a numeric index or a string property name.

**Correct behavior by data source type:**

| Data source | `cellProperties.prop` | Expected `col` in hooks | Was | Now |
|---|---|---|---|---|
| Array of arrays | `0` (number) | `0` | `0` ✅ | `0` ✅ |
| Array of objects | `'id'` (string) | `'id'` | `'id'` ✅ | `'id'` ✅ |
| Function-based | accessor fn | visual column index | `fn` ❌ | `0` ✅ |

**Fix:** Before firing the hooks, compute `colArg = isFunction(cellProperties.prop) ? cellProperties.visualCol : cellProperties.prop`. Pass `colArg` instead of `cellProperties.prop` to all three hooks. This preserves the existing `prop`-string behavior for array-of-objects (backward-compatible) while fixing the function-accessor case.

**Note:** A naive `prop → visualCol` replacement would have broken array-of-objects users who rely on `col` being the property string (e.g. `'id'`) in these hooks. A regression test was added to guard against that.

### How has this been tested?

Added E2E regression tests in:
- `test/e2e/hooks/beforeValidate.spec.js` — two new cases:
  - array-of-objects: asserts `col === 'id'` (property string preserved)
  - function-based accessor: asserts `typeof col === 'number'` (bug fixed)
- `test/e2e/hooks/afterValidate.spec.js` — function-based accessor case

All tests fail against the unfixed code and pass after the fix.

```bash
npm run test:e2e --prefix handsontable --testPathPattern="beforeValidate |afterValidate"
# 14 specs, 0 failures
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1663
2. https://github.com/handsontable/handsontable/issues/2966

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1663