### PR TITLE
DEV-1662: Fix getSourceData/getData with formulas and initial manualColumnMove

### DIFF
--- a/.changelogs/12561.json
+++ b/.changelogs/12561.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed `getSourceData()` and `getData()` returning incorrect values when the `formulas` plugin was used together with an initial `manualColumnMove` (or `manualRowMove`) configuration.",
+  "type": "fixed",
+  "issueOrPR": 12561,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/formulas/__tests__/indexSyncer/axisSyncerInitialOrder.unit.js
+++ b/handsontable/src/plugins/formulas/__tests__/indexSyncer/axisSyncerInitialOrder.unit.js
@@ -1,0 +1,131 @@
+import AxisSyncer from '../../indexSyncer/axisSyncer';
+
+function createMockIndexMapper(indexesSequence, notTrimmedIndexes = indexesSequence) {
+  return {
+    getIndexesSequence: () => indexesSequence,
+    getNotTrimmedIndexes: () => notTrimmedIndexes,
+    getNumberOfIndexes: () => indexesSequence.length,
+  };
+}
+
+function createMockIndexSyncer(engine, sheetId = 0) {
+  return {
+    getEngine: () => engine,
+    getSheetId: () => sheetId,
+    isPerformingUndoRedo: () => false,
+    getPostponeAction: () => () => {},
+  };
+}
+
+function createMockEngine() {
+  const calls = { setRowOrder: [], setColumnOrder: [] };
+
+  return {
+    calls,
+    setRowOrder: (sheetId, transformation) => {
+      calls.setRowOrder.push({ sheetId, transformation });
+    },
+    setColumnOrder: (sheetId, transformation) => {
+      calls.setColumnOrder.push({ sheetId, transformation });
+    },
+    getSheetDimensions: () => ({ width: 4, height: 4 }),
+    batch: callback => callback(),
+  };
+}
+
+describe('AxisSyncer initial order sync', () => {
+  describe('column axis', () => {
+    it('should not call setColumnOrder on the engine when initial sequence is identity', () => {
+      const engine = createMockEngine();
+      const indexMapper = createMockIndexMapper([0, 1, 2, 3]);
+      const indexSyncer = createMockIndexSyncer(engine);
+      const axisSyncer = new AxisSyncer('column', indexMapper, indexSyncer);
+
+      axisSyncer.init();
+
+      expect(engine.calls.setColumnOrder).toEqual([]);
+    });
+
+    it('should call setColumnOrder with the correct transformation when initial sequence is non-identity', () => {
+      const engine = createMockEngine();
+      // manualColumnMove: [0, 2, 1, 3] -> visual order in physical indexes is [0, 2, 1, 3].
+      const indexMapper = createMockIndexMapper([0, 2, 1, 3]);
+      const indexSyncer = createMockIndexSyncer(engine);
+      const axisSyncer = new AxisSyncer('column', indexMapper, indexSyncer);
+
+      axisSyncer.init();
+
+      // Transformation: each currently-physical position i moves to the position
+      // newSequence.indexOf(i). For [0, 2, 1, 3] this yields [0, 2, 1, 3].
+      expect(engine.calls.setColumnOrder).toEqual([
+        { sheetId: 0, transformation: [0, 2, 1, 3] },
+      ]);
+      expect(engine.calls.setRowOrder).toEqual([]);
+    });
+
+    it('should pad the transformation array to match the HF sheet width when HF has extended dimensions', () => {
+      const engine = createMockEngine();
+
+      engine.getSheetDimensions = () => ({ width: 6, height: 4 });
+      const indexMapper = createMockIndexMapper([0, 2, 1, 3]);
+      const indexSyncer = createMockIndexSyncer(engine);
+      const axisSyncer = new AxisSyncer('column', indexMapper, indexSyncer);
+
+      axisSyncer.init();
+
+      expect(engine.calls.setColumnOrder).toEqual([
+        { sheetId: 0, transformation: [0, 2, 1, 3, 4, 5] },
+      ]);
+    });
+  });
+
+  describe('row axis', () => {
+    it('should call setRowOrder when row sequence is non-identity', () => {
+      const engine = createMockEngine();
+      const indexMapper = createMockIndexMapper([2, 0, 1]);
+
+      engine.getSheetDimensions = () => ({ width: 4, height: 3 });
+      const indexSyncer = createMockIndexSyncer(engine);
+      const axisSyncer = new AxisSyncer('row', indexMapper, indexSyncer);
+
+      axisSyncer.init();
+
+      // For [2, 0, 1]: transformation[i] = newSequence.indexOf(i)
+      //   i=0 -> indexOf(0) = 1
+      //   i=1 -> indexOf(1) = 2
+      //   i=2 -> indexOf(2) = 0
+      expect(engine.calls.setRowOrder).toEqual([
+        { sheetId: 0, transformation: [1, 2, 0] },
+      ]);
+      expect(engine.calls.setColumnOrder).toEqual([]);
+    });
+  });
+
+  describe('postponed actions', () => {
+    it('should postpone the sync when the sheet id is null', () => {
+      const engine = createMockEngine();
+      const indexMapper = createMockIndexMapper([0, 2, 1, 3]);
+      const postponedCallbacks = [];
+      const indexSyncer = {
+        getEngine: () => engine,
+        getSheetId: () => null,
+        isPerformingUndoRedo: () => false,
+        getPostponeAction: () => callback => postponedCallbacks.push(callback),
+      };
+      const axisSyncer = new AxisSyncer('column', indexMapper, indexSyncer);
+
+      axisSyncer.init();
+
+      expect(engine.calls.setColumnOrder).toEqual([]);
+      expect(postponedCallbacks.length).toBe(1);
+
+      // Once the endpoint is ready, the postponed action should be executed.
+      indexSyncer.getSheetId = () => 0;
+      postponedCallbacks[0]();
+
+      expect(engine.calls.setColumnOrder).toEqual([
+        { sheetId: 0, transformation: [0, 2, 1, 3] },
+      ]);
+    });
+  });
+});

--- a/handsontable/src/plugins/formulas/__tests__/plugins/initialManualColumnMove.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/plugins/initialManualColumnMove.spec.js
@@ -1,0 +1,199 @@
+import HyperFormula from 'hyperformula';
+
+describe('Formulas: initial manualColumnMove configuration (issue #9952)', () => {
+  beforeEach(function() {
+    this.$container = $('<div id="testContainer"></div>').appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should return correct values from getSourceData() and getData() when grid has initial column order set', async() => {
+    handsontable({
+      data: [
+        ['A1', 'B1', '=SUM(1, 2)', 'D1'],
+        ['A2', 'B2', '=SUM(1, 2)', 'D2'],
+        ['A3', 'B3', '=SUM(1, 2)', 'D3'],
+        ['A4', 'B4', '=SUM(1, 2)', 'D4'],
+        ['A5', 'B5', '=SUM(1, 2)', 'D5'],
+      ],
+      manualColumnMove: [0, 2, 1, 3],
+      formulas: {
+        engine: HyperFormula,
+      },
+    });
+
+    expect(getSourceData()).toEqual([
+      ['A1', 'B1', '=SUM(1, 2)', 'D1'],
+      ['A2', 'B2', '=SUM(1, 2)', 'D2'],
+      ['A3', 'B3', '=SUM(1, 2)', 'D3'],
+      ['A4', 'B4', '=SUM(1, 2)', 'D4'],
+      ['A5', 'B5', '=SUM(1, 2)', 'D5'],
+    ]);
+
+    expect(getData()).toEqual([
+      ['A1', 3, 'B1', 'D1'],
+      ['A2', 3, 'B2', 'D2'],
+      ['A3', 3, 'B3', 'D3'],
+      ['A4', 3, 'B4', 'D4'],
+      ['A5', 3, 'B5', 'D5'],
+    ]);
+  });
+
+  it('should return correct values when formula references another column and initial column order is set', async() => {
+    handsontable({
+      data: [
+        [1, '=A1+10', 100, 1000],
+        [2, '=A2+10', 200, 2000],
+      ],
+      manualColumnMove: [0, 2, 1, 3],
+      formulas: {
+        engine: HyperFormula,
+      },
+    });
+
+    // HF rewrites the formula text after the column order is applied because the formula's relative
+    // references shift with the formula's new visual position. The original `=A1+10` at physical
+    // column 1 moves to visual column 2, so the relative reference shifts from A1 to B1. This
+    // matches HF behavior for runtime `moveColumns` calls.
+    expect(getSourceData()).toEqual([
+      [1, '=B1+10', 100, 1000],
+      [2, '=B2+10', 200, 2000],
+    ]);
+
+    expect(getData()).toEqual([
+      [1, 100, 110, 1000],
+      [2, 200, 210, 2000],
+    ]);
+  });
+
+  it('should keep getSourceData() consistent after performing a runtime move on top of an initial move config', async() => {
+    handsontable({
+      data: [
+        ['A1', 'B1', '=SUM(1, 2)', 'D1'],
+        ['A2', 'B2', '=SUM(1, 2)', 'D2'],
+      ],
+      manualColumnMove: [0, 2, 1, 3],
+      formulas: {
+        engine: HyperFormula,
+      },
+    });
+
+    // Verify initial state is correct first.
+    expect(getSourceData()).toEqual([
+      ['A1', 'B1', '=SUM(1, 2)', 'D1'],
+      ['A2', 'B2', '=SUM(1, 2)', 'D2'],
+    ]);
+
+    // Move column at visual index 0 to visual index 3.
+    getPlugin('manualColumnMove').moveColumn(0, 3);
+    await render();
+
+    // After the runtime move, getData should follow new visual order.
+    // Visual was [A, =SUM, B, D]; after moving visual 0 (=A) to position 3:
+    //   visual = [=SUM, B, D, A] (in terms of original column labels)
+    // So evaluated row: [3, 'B1', 'D1', 'A1'].
+    expect(getData()).toEqual([
+      [3, 'B1', 'D1', 'A1'],
+      [3, 'B2', 'D2', 'A2'],
+    ]);
+
+    // getSourceData remains in physical order. Values stay the same because
+    // SUM has no cell references to rewrite.
+    expect(getSourceData()).toEqual([
+      ['A1', 'B1', '=SUM(1, 2)', 'D1'],
+      ['A2', 'B2', '=SUM(1, 2)', 'D2'],
+    ]);
+  });
+
+  it('should handle initial manualRowMove combined with initial manualColumnMove', async() => {
+    handsontable({
+      data: [
+        ['A1', 'B1', '=SUM(1, 2)', 'D1'],
+        ['A2', 'B2', '=SUM(1, 2)', 'D2'],
+        ['A3', 'B3', '=SUM(1, 2)', 'D3'],
+      ],
+      manualColumnMove: [0, 2, 1, 3],
+      manualRowMove: [2, 0, 1],
+      formulas: {
+        engine: HyperFormula,
+      },
+    });
+
+    expect(getSourceData()).toEqual([
+      ['A1', 'B1', '=SUM(1, 2)', 'D1'],
+      ['A2', 'B2', '=SUM(1, 2)', 'D2'],
+      ['A3', 'B3', '=SUM(1, 2)', 'D3'],
+    ]);
+
+    expect(getData()).toEqual([
+      ['A3', 3, 'B3', 'D3'],
+      ['A1', 3, 'B1', 'D1'],
+      ['A2', 3, 'B2', 'D2'],
+    ]);
+  });
+
+  it('should handle initial manualColumnMove with column sorting', async() => {
+    handsontable({
+      data: [
+        ['A3', 'B3', '=SUM(1, 2)', 'D3'],
+        ['A1', 'B1', '=SUM(1, 2)', 'D1'],
+        ['A2', 'B2', '=SUM(1, 2)', 'D2'],
+      ],
+      manualColumnMove: [0, 2, 1, 3],
+      columnSorting: {
+        initialConfig: { column: 0, sortOrder: 'asc' },
+      },
+      formulas: {
+        engine: HyperFormula,
+      },
+    });
+
+    expect(getSourceData()).toEqual([
+      ['A3', 'B3', '=SUM(1, 2)', 'D3'],
+      ['A1', 'B1', '=SUM(1, 2)', 'D1'],
+      ['A2', 'B2', '=SUM(1, 2)', 'D2'],
+    ]);
+
+    expect(getData()).toEqual([
+      ['A1', 3, 'B1', 'D1'],
+      ['A2', 3, 'B2', 'D2'],
+      ['A3', 3, 'B3', 'D3'],
+    ]);
+  });
+
+  it('should handle initial manualColumnMove applied via updateSettings', async() => {
+    handsontable({
+      data: [
+        ['A1', 'B1', '=SUM(1, 2)', 'D1'],
+        ['A2', 'B2', '=SUM(1, 2)', 'D2'],
+      ],
+      manualColumnMove: true,
+      formulas: {
+        engine: HyperFormula,
+      },
+    });
+
+    await updateSettings({
+      data: [
+        ['A1', 'B1', '=SUM(1, 2)', 'D1'],
+        ['A2', 'B2', '=SUM(1, 2)', 'D2'],
+      ],
+      manualColumnMove: [0, 2, 1, 3],
+    });
+
+    expect(getSourceData()).toEqual([
+      ['A1', 'B1', '=SUM(1, 2)', 'D1'],
+      ['A2', 'B2', '=SUM(1, 2)', 'D2'],
+    ]);
+
+    expect(getData()).toEqual([
+      ['A1', 3, 'B1', 'D1'],
+      ['A2', 3, 'B2', 'D2'],
+    ]);
+  });
+});

--- a/handsontable/src/plugins/formulas/indexSyncer/axisSyncer.js
+++ b/handsontable/src/plugins/formulas/indexSyncer/axisSyncer.js
@@ -219,9 +219,50 @@ class AxisSyncer {
   }
 
   /**
+   * Synchronizes the initial axis order with HF engine. When the IndexMapper's sequence is non-identity at
+   * setup time (for example, an initial `manualColumnMove` or `manualRowMove` configuration), HF needs to
+   * reorder its data so that HF visual order matches HOT visual order. Without this sync, downstream code
+   * that translates visual indexes through `getHfIndexFromVisualIndex` reads the wrong cells.
+   *
+   * @private
+   */
+  #syncInitialOrder() {
+    const sequence = this.#indexMapper.getIndexesSequence();
+    const isIdentity = sequence.every((value, index) => value === index);
+
+    if (isIdentity || sequence.length === 0) {
+      return;
+    }
+
+    const engine = this.#indexSyncer.getEngine();
+    const sheetId = this.#indexSyncer.getSheetId();
+
+    if (engine === null || sheetId === null) {
+      this.#indexSyncer.getPostponeAction()(() => this.#syncInitialOrder());
+
+      return;
+    }
+
+    const SYNC_ORDER_CHANGE_METHOD_NAME = `set${toUpperCaseFirst(this.#axis)}Order`;
+    const sheetDimensions = engine.getSheetDimensions(sheetId);
+    const sizeForAxis = this.#axis === 'row' ? sheetDimensions.height : sheetDimensions.width;
+    // HF currently holds data in physical order ([0..n-1] identity). The transformation tells HF where each
+    // currently-held element should move to, so that HF's visual order matches HOT's visual order. For each
+    // current position `i`, the target position is the visual index of physical `i`, i.e. `sequence.indexOf(i)`.
+    const transformation = Array.from({ length: sequence.length }, (_, i) => sequence.indexOf(i));
+
+    for (let i = transformation.length; i < sizeForAxis; i += 1) {
+      transformation.push(i);
+    }
+
+    engine[SYNC_ORDER_CHANGE_METHOD_NAME](sheetId, transformation);
+  }
+
+  /**
    * Initialize the AxisSyncer.
    */
   init() {
+    this.#syncInitialOrder();
     this.#indexesSequence = this.#indexMapper.getIndexesSequence();
   }
 }


### PR DESCRIPTION
### Context

The PR fixes incorrect values returned by `getSourceData()` and `getData()` when the `formulas` plugin is used together with a non-identity initial `manualColumnMove` (or `manualRowMove`) configuration.

Before the fix, HyperFormula was initialized via `setSheetContent` with physical-ordered data while HOT's `IndexMapper` already reflected the initial move config. Downstream index translation through `getHfIndexFromVisualIndex` then read the wrong cells, producing broken `getSourceData` and `getData` output (e.g. the same formula text reported in two columns).

The fix adds an initial axis-order replay step: `AxisSyncer.init()` now detects a non-identity initial sequence and replays it into HF via `setColumnOrder` / `setRowOrder` so HF's visual order matches HOT's visual order before any reads happen. Identity sequences are skipped. Postponed action queue is reused when the engine endpoint is not ready yet.

Closes #9952

### How has this been tested?

Added unit + E2E coverage and ran the full formulas suite.

```bash
npm run test:unit --prefix handsontable -- --testPathPattern=axisSyncerInitialOrder
npm run test:e2e  --prefix handsontable -- --testPathPattern=initialManualColumnMove
npm run test:e2e  --prefix handsontable -- --testPathPattern=formulas
```

- New unit test `src/plugins/formulas/__tests__/indexSyncer/axisSyncerInitialOrder.unit.js` covers identity skip, column axis, row axis, dimension padding, and postponed sync.
- New E2E spec `src/plugins/formulas/__tests__/plugins/initialManualColumnMove.spec.js` covers the issue scenario plus combinations with `manualRowMove`, `columnSorting`, runtime moves on top, and `updateSettings`.
- Full formulas E2E suite (320 specs) and formulas unit suite (15 tests) pass.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1662
2. #9952

### Affected project(s):

- [x] \`handsontable\`
- [ ] \`@handsontable/angular-wrapper\`
- [ ] \`@handsontable/react-wrapper\`
- [ ] \`@handsontable/vue3\`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1662

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes initialization-time synchronization between Handsontable index mappers and the HyperFormula engine; incorrect transformations or timing could affect formula evaluation and data reads when initial row/column moves are configured.
> 
> **Overview**
> Fixes an initialization bug where using `formulas` with a non-identity initial `manualColumnMove`/`manualRowMove` could cause `getSourceData()` and `getData()` to read the wrong cells.
> 
> `AxisSyncer.init()` now replays the initial index sequence into HyperFormula via `setColumnOrder`/`setRowOrder` (including padding to extended HF dimensions and postponing when the engine/sheet isn’t ready). Adds targeted unit coverage for the new initial-order sync and an E2E spec covering initial moves, combined row+column moves, sorting, runtime moves, and `updateSettings`, plus a changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61b082a1d02674affef3225c5a8d8f3939f9f20e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->