### PR TITLE
DEV-1635: Restyle row validation error summary recipe examples

### DIFF
--- a/docs/content/recipes/editing-validation/row-validation-error-summary/angular/example1.css
+++ b/docs/content/recipes/editing-validation/row-validation-error-summary/angular/example1.css
@@ -2,21 +2,74 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
+  width: 100%;
 }
 
-.row-validation-demo__submit {
-  padding: 6px 14px;
-  background: var(--ht-accent-color, #1a42e8);
-  color: #fff;
-  border: none;
-  cursor: pointer;
+.row-validation-demo__toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.row-validation-demo__toolbar button {
+  border: 1px solid var(--sl-color-gray-5);
+  background: var(--sl-color-bg-nav);
+  color: var(--sl-color-text);
+  font-size: var(--sl-text-sm);
+  line-height: 1.2;
+  padding: 0.4rem 0.75rem;
   border-radius: 4px;
+  cursor: pointer;
+  transition: color 0.15s, background-color 0.15s, border-color 0.15s;
+}
+
+.row-validation-demo__toolbar button:not(:disabled):hover {
+  color: var(--sl-color-white);
+  background: var(--sl-color-gray-6);
+}
+
+.row-validation-demo__toolbar button:focus-visible {
+  outline: 1px solid var(--sl-color-accent);
+  outline-offset: 1px;
+}
+
+.row-validation-demo__toolbar button:disabled {
+  color: var(--sl-color-gray-3);
+  border-color: var(--sl-color-gray-5);
+  background: var(--sl-color-gray-7);
+  opacity: 0.8;
+  cursor: not-allowed;
+}
+
+.row-validation-demo__summary {
+  border: 1px solid var(--sl-color-gray-5);
+  padding: 0.75rem 1rem;
+  background: var(--sl-color-bg-nav);
+}
+
+.row-validation-demo__summary-title {
+  margin: 0 0 0.5rem;
+  font-size: var(--sl-text-sm);
+  font-weight: 600;
+  color: var(--sl-color-text);
+}
+
+.row-validation-demo__summary-list {
+  margin: 0;
+  padding-left: 1.25rem;
+  font-size: var(--sl-text-sm);
+  color: var(--sl-color-text);
 }
 
 .row-validation-demo__summary-list:empty::before {
   content: 'No issues. Click Submit orders to validate.';
+  display: block;
+  margin-left: -1.25rem;
+  color: var(--sl-color-gray-3);
 }
 
-.handsontable td.htInvalid {
+.row-validation-demo .handsontable td.htInvalid {
   background-color: var(--ht-cell-error-background-color, #ffe4e4) !important;
 }

--- a/docs/content/recipes/editing-validation/row-validation-error-summary/angular/example1.ts
+++ b/docs/content/recipes/editing-validation/row-validation-error-summary/angular/example1.ts
@@ -40,7 +40,7 @@ function cellKey(row: number, col: number): string {
   template: `
     <div class="row-validation-demo">
       <div class="row-validation-demo__toolbar">
-        <button type="button" class="row-validation-demo__submit" (click)="onSubmit()">
+        <button type="button" (click)="onSubmit()">
           Submit orders
         </button>
       </div>

--- a/docs/content/recipes/editing-validation/row-validation-error-summary/javascript/example1.css
+++ b/docs/content/recipes/editing-validation/row-validation-error-summary/javascript/example1.css
@@ -10,41 +10,64 @@
   flex-wrap: wrap;
   gap: var(--ht-gap, 8px);
   align-items: center;
+  margin-bottom: 0.75rem;
 }
 
-.row-validation-demo__submit {
-  padding: 6px 14px;
-  font-size: var(--ht-font-size, 14px);
-  border-radius: var(--ht-border-radius, 4px);
-  border: 1px solid var(--ht-border-color, #ccc);
-  background: var(--ht-accent-color, #1a42e8);
-  color: #fff;
+.row-validation-demo__toolbar button {
+  border: 1px solid var(--sl-color-gray-5);
+  background: var(--sl-color-bg-nav);
+  color: var(--sl-color-text);
+  font-size: var(--sl-text-sm);
+  line-height: 1.2;
+  padding: 0.4rem 0.75rem;
+  border-radius: 4px;
   cursor: pointer;
+  transition: color 0.15s, background-color 0.15s, border-color 0.15s;
 }
 
-.row-validation-demo__submit:hover {
-  filter: brightness(1.05);
+.row-validation-demo__toolbar button:not(:disabled):hover {
+  color: var(--sl-color-white);
+  background: var(--sl-color-gray-6);
+}
+
+.row-validation-demo__toolbar button:focus-visible {
+  outline: 1px solid var(--sl-color-accent);
+  outline-offset: 1px;
+}
+
+.row-validation-demo__toolbar button:disabled {
+  color: var(--sl-color-gray-3);
+  border-color: var(--sl-color-gray-5);
+  background: var(--sl-color-gray-7);
+  opacity: 0.8;
+  cursor: not-allowed;
+}
+
+.row-validation-demo__summary {
+  border: 1px solid var(--sl-color-gray-5);
+  padding: 0.75rem 1rem;
+  background: var(--sl-color-bg-nav);
 }
 
 .row-validation-demo__summary-title {
-  margin: 0 0 8px;
-  font-size: var(--ht-font-size, 14px);
+  margin: 0 0 0.5rem;
+  font-size: var(--sl-text-sm);
   font-weight: 600;
+  color: var(--sl-color-text);
 }
 
 .row-validation-demo__summary-list {
   margin: 0;
   padding-left: 1.25rem;
-  font-size: var(--ht-font-size, 14px);
-  color: var(--ht-foreground-color, currentColor);
+  font-size: var(--sl-text-sm);
+  color: var(--sl-color-text);
 }
 
 .row-validation-demo__summary-list:empty::before {
   content: 'No issues. Click Submit orders to validate.';
   display: block;
   margin-left: -1.25rem;
-  color: currentColor;
-  opacity: 0.8;
+  color: var(--sl-color-gray-3);
 }
 
 .row-validation-demo #example1 .handsontable td.htInvalid {

--- a/docs/content/recipes/editing-validation/row-validation-error-summary/javascript/example1.html
+++ b/docs/content/recipes/editing-validation/row-validation-error-summary/javascript/example1.html
@@ -1,6 +1,6 @@
 <div class="row-validation-demo">
   <div class="row-validation-demo__toolbar">
-    <button type="button" id="submit-orders" class="row-validation-demo__submit">Submit orders</button>
+    <button type="button" id="submit-orders">Submit orders</button>
   </div>
   <div id="example1"></div>
   <div class="row-validation-demo__summary" aria-live="polite">

--- a/docs/content/recipes/editing-validation/row-validation-error-summary/react/example1.css
+++ b/docs/content/recipes/editing-validation/row-validation-error-summary/react/example1.css
@@ -10,41 +10,64 @@
   flex-wrap: wrap;
   gap: var(--ht-gap, 8px);
   align-items: center;
+  margin-bottom: 0.75rem;
 }
 
-.row-validation-demo__submit {
-  padding: 6px 14px;
-  font-size: var(--ht-font-size, 14px);
-  border-radius: var(--ht-border-radius, 4px);
-  border: 1px solid var(--ht-border-color, #ccc);
-  background: var(--ht-accent-color, #1a42e8);
-  color: #fff;
+.row-validation-demo__toolbar button {
+  border: 1px solid var(--sl-color-gray-5);
+  background: var(--sl-color-bg-nav);
+  color: var(--sl-color-text);
+  font-size: var(--sl-text-sm);
+  line-height: 1.2;
+  padding: 0.4rem 0.75rem;
+  border-radius: 4px;
   cursor: pointer;
+  transition: color 0.15s, background-color 0.15s, border-color 0.15s;
 }
 
-.row-validation-demo__submit:hover {
-  filter: brightness(1.05);
+.row-validation-demo__toolbar button:not(:disabled):hover {
+  color: var(--sl-color-white);
+  background: var(--sl-color-gray-6);
+}
+
+.row-validation-demo__toolbar button:focus-visible {
+  outline: 1px solid var(--sl-color-accent);
+  outline-offset: 1px;
+}
+
+.row-validation-demo__toolbar button:disabled {
+  color: var(--sl-color-gray-3);
+  border-color: var(--sl-color-gray-5);
+  background: var(--sl-color-gray-7);
+  opacity: 0.8;
+  cursor: not-allowed;
+}
+
+.row-validation-demo__summary {
+  border: 1px solid var(--sl-color-gray-5);
+  padding: 0.75rem 1rem;
+  background: var(--sl-color-bg-nav);
 }
 
 .row-validation-demo__summary-title {
-  margin: 0 0 8px;
-  font-size: var(--ht-font-size, 14px);
+  margin: 0 0 0.5rem;
+  font-size: var(--sl-text-sm);
   font-weight: 600;
+  color: var(--sl-color-text);
 }
 
 .row-validation-demo__summary-list {
   margin: 0;
   padding-left: 1.25rem;
-  font-size: var(--ht-font-size, 14px);
-  color: var(--ht-foreground-color, currentColor);
+  font-size: var(--sl-text-sm);
+  color: var(--sl-color-text);
 }
 
 .row-validation-demo__summary-list:empty::before {
   content: 'No issues. Click Submit orders to validate.';
   display: block;
   margin-left: -1.25rem;
-  color: currentColor;
-  opacity: 0.8;
+  color: var(--sl-color-gray-3);
 }
 
 .row-validation-demo .handsontable td.htInvalid {

--- a/docs/content/recipes/editing-validation/row-validation-error-summary/react/example1.jsx
+++ b/docs/content/recipes/editing-validation/row-validation-error-summary/react/example1.jsx
@@ -140,11 +140,7 @@ const ExampleComponent = () => {
   return (
     <div className="row-validation-demo">
       <div className="row-validation-demo__toolbar">
-        <button
-          type="button"
-          className="row-validation-demo__submit"
-          onClick={handleSubmit}
-        >
+        <button type="button" onClick={handleSubmit}>
           Submit orders
         </button>
       </div>
@@ -164,7 +160,7 @@ const ExampleComponent = () => {
         afterChange={afterChange}
         licenseKey="non-commercial-and-evaluation"
       />
-      <div>
+      <div className="row-validation-demo__summary" aria-live="polite">
         <p className="row-validation-demo__summary-title">Validation summary</p>
         <ul className="row-validation-demo__summary-list">
           {issues.map((issue) => (

--- a/docs/content/recipes/editing-validation/row-validation-error-summary/react/example1.tsx
+++ b/docs/content/recipes/editing-validation/row-validation-error-summary/react/example1.tsx
@@ -150,11 +150,7 @@ const ExampleComponent = () => {
   return (
     <div className="row-validation-demo">
       <div className="row-validation-demo__toolbar">
-        <button
-          type="button"
-          className="row-validation-demo__submit"
-          onClick={handleSubmit}
-        >
+        <button type="button" onClick={handleSubmit}>
           Submit orders
         </button>
       </div>
@@ -174,7 +170,7 @@ const ExampleComponent = () => {
         afterChange={afterChange}
         licenseKey="non-commercial-and-evaluation"
       />
-      <div>
+      <div className="row-validation-demo__summary" aria-live="polite">
         <p className="row-validation-demo__summary-title">Validation summary</p>
         <ul className="row-validation-demo__summary-list">
           {issues.map((issue) => (


### PR DESCRIPTION


### Context
<!--- Why is this change required? What problem does it solve? -->
Update the styling for buttons and the validation summary section in the row validation error summary recipe examples (Angular, React, JavaScript). This applies design system variables to ensure a consistent look and feel across documentation examples.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Manual check

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only styling/markup tweaks for recipe examples; low risk aside from potential minor visual regressions in the docs pages.
> 
> **Overview**
> Applies consistent design-system styling to the row validation error summary recipe examples by replacing the old `.row-validation-demo__submit` styles with toolbar-scoped `button` styling (hover/focus/disabled states) and adding a styled `.row-validation-demo__summary` container.
> 
> Cleans up example markup to drop the submit button’s custom class (Angular/JS/React), adds spacing under the toolbar, and tightens scoping for invalid-cell highlighting selectors; React examples also attach the summary class and `aria-live` directly to the summary container.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e17424ae46798e92d3c8928fab82cce080451163. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->