### PR TITLE
DEV-1639: Use Starlight CSS tokens in keyboard-shortcuts recipe example

### DIFF
--- a/docs/content/recipes/accessibility/keyboard-shortcuts/angular/example1.css
+++ b/docs/content/recipes/accessibility/keyboard-shortcuts/angular/example1.css
@@ -2,9 +2,9 @@
   display: inline-block;
   margin-top: 8px;
   padding: 6px 12px;
-  background: #1a42e8;
+  background: var(--sl-color-accent);
   color: #fff;
-  font-family: monospace;
+  font-family: var(--sl-font-mono, monospace);
   font-size: 13px;
   border-radius: 4px;
   opacity: 0;
@@ -19,11 +19,11 @@
 .submit-log {
   margin-top: 12px;
   padding: 10px 14px;
-  background: #f4f5f7;
-  border-left: 3px solid #1a42e8;
-  font-family: monospace;
+  background: var(--sl-color-bg-nav);
+  border-left: 3px solid var(--sl-color-accent);
+  font-family: var(--sl-font-mono, monospace);
   font-size: 13px;
-  color: #333;
+  color: var(--sl-color-text);
   min-height: 38px;
   border-radius: 0 4px 4px 0;
 }

--- a/docs/content/recipes/accessibility/keyboard-shortcuts/javascript/example1.css
+++ b/docs/content/recipes/accessibility/keyboard-shortcuts/javascript/example1.css
@@ -2,9 +2,9 @@
   display: inline-block;
   margin-top: 8px;
   padding: 6px 12px;
-  background: #1a42e8;
+  background: var(--sl-color-accent);
   color: #fff;
-  font-family: monospace;
+  font-family: var(--sl-font-mono, monospace);
   font-size: 13px;
   border-radius: 4px;
   opacity: 0;
@@ -19,11 +19,11 @@
 #submit-log {
   margin-top: 12px;
   padding: 10px 14px;
-  background: #f4f5f7;
-  border-left: 3px solid #1a42e8;
-  font-family: monospace;
+  background: var(--sl-color-bg-nav);
+  border-left: 3px solid var(--sl-color-accent);
+  font-family: var(--sl-font-mono, monospace);
   font-size: 13px;
-  color: #333;
+  color: var(--sl-color-text);
   min-height: 38px;
   border-radius: 0 4px 4px 0;
 }

--- a/docs/content/recipes/accessibility/keyboard-shortcuts/react/example1.css
+++ b/docs/content/recipes/accessibility/keyboard-shortcuts/react/example1.css
@@ -2,9 +2,9 @@
   display: inline-block;
   margin-top: 8px;
   padding: 6px 12px;
-  background: #1a42e8;
+  background: var(--sl-color-accent);
   color: #fff;
-  font-family: monospace;
+  font-family: var(--sl-font-mono, monospace);
   font-size: 13px;
   border-radius: 4px;
   opacity: 0;
@@ -19,11 +19,11 @@
 .submit-log {
   margin-top: 12px;
   padding: 10px 14px;
-  background: #f4f5f7;
-  border-left: 3px solid #1a42e8;
-  font-family: monospace;
+  background: var(--sl-color-bg-nav);
+  border-left: 3px solid var(--sl-color-accent);
+  font-family: var(--sl-font-mono, monospace);
   font-size: 13px;
-  color: #333;
+  color: var(--sl-color-text);
   min-height: 38px;
   border-radius: 0 4px 4px 0;
 }


### PR DESCRIPTION
### Context

The PR fixes the `recipes/accessibility/keyboard-shortcuts` example styles. The custom UI elements (`shortcut-status` badge and `submit-log` panel) used hardcoded color values that did not adapt to the docs site's light/dark theme toggle.

The root cause was that `--ht-*` CSS variables are scoped to `.ht-root-wrapper` (the grid container element) and do not cascade to sibling elements outside the grid. The fix replaces all hardcoded values and `--ht-*` tokens with Starlight `--sl-*` variables, which are defined at document level and respond to the theme toggle. The badge text color is kept as a static `#fff` because `--sl-color-white` resolves to dark gray in light mode (it is Starlight's semantic foreground text color, not literal white) and the accent blue background always provides sufficient contrast against white.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1639

### How has this been tested?

Visually verified in the docs site in both light and dark mode.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1639

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only CSS token swaps; primary risk is minor visual regressions in these recipe examples across themes.
> 
> **Overview**
> Updates the `recipes/accessibility/keyboard-shortcuts` example styles (Angular/JS/React) to replace hardcoded colors and `monospace` with Starlight CSS tokens (`--sl-color-accent`, `--sl-color-bg-nav`, `--sl-color-text`, `--sl-font-mono`) so the badge and submit log panel follow the docs site theme.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1eeaabcb8547ea6e278c1e29ee3b214d86a53146. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->