### PR TITLE
DEV-1671: Fix formulas not calculated when AoA columns skip indexes

### DIFF
--- a/.changelogs/12569.json
+++ b/.changelogs/12569.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed formulas not being evaluated for array-of-arrays datasets when the `columns` option skips physical column indexes.",
+  "type": "fixed",
+  "issueOrPR": 12569,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/formulas/__tests__/initialization.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/initialization.spec.js
@@ -1306,4 +1306,42 @@ describe('Formulas general', () => {
       HyperFormula.unregisterLanguage(plPL.langCode);
     });
   });
+
+  describe('Data source shape', () => {
+    it('should evaluate formulas on init for array-of-arrays data when `columns` skips physical indexes (#10021)', async() => {
+      handsontable({
+        data: [[1, 2, 3, '=A1']],
+        columns: [{ data: 0 }, { data: 2 }, { data: 3 }],
+        formulas: { engine: HyperFormula },
+      });
+
+      expect(getDataAtCell(0, 0)).toBe(1);
+      expect(getDataAtCell(0, 1)).toBe(3);
+      expect(getDataAtCell(0, 2)).toBe(1);
+    });
+
+    it('should evaluate formulas on init for array-of-objects data when `columns` skips properties', async() => {
+      handsontable({
+        data: [{ a: 1, b: 2, c: 3, d: '=A1' }],
+        columns: [{ data: 'a' }, { data: 'c' }, { data: 'd' }],
+        formulas: { engine: HyperFormula },
+      });
+
+      expect(getDataAtCell(0, 0)).toBe(1);
+      expect(getDataAtCell(0, 1)).toBe(3);
+      expect(getDataAtCell(0, 2)).toBe(1);
+    });
+
+    it('should recalculate dependents when the referenced cell is edited (AoA with skipped columns)', async() => {
+      handsontable({
+        data: [[1, 2, 3, '=A1']],
+        columns: [{ data: 0 }, { data: 2 }, { data: 3 }],
+        formulas: { engine: HyperFormula },
+      });
+
+      await setDataAtCell(0, 0, 42);
+
+      expect(getDataAtCell(0, 2)).toBe(42);
+    });
+  });
 });

--- a/handsontable/src/plugins/formulas/formulas.js
+++ b/handsontable/src/plugins/formulas/formulas.js
@@ -623,10 +623,47 @@ export class Formulas extends BasePlugin {
    * @returns {Array} The source data array to be passed to the formula engine.
    */
   #getProcessedSourceDataArray(row, column, row2, column2) {
-    return this.hot.getSourceDataArray(row, column, row2, column2).map((rowObject, rowIndex) => {
-      return rowObject.map((value, columnIndex) => {
-        return this.#getValueGetterValue(rowIndex, columnIndex, value);
+    const dataArray = this.hot.getSourceDataArray(row, column, row2, column2);
+    const visibleColumnCount = this.hot.countCols();
+    const physicalColumnCount = this.hot.countSourceCols();
+    const isAoAWithSkippedColumns = isArrayOfArrays(this.hot.getSourceData())
+      && visibleColumnCount < physicalColumnCount;
+
+    if (!isAoAWithSkippedColumns) {
+      return dataArray.map((rowObject, rowIndex) => {
+        return rowObject.map((value, columnIndex) => {
+          return this.#getValueGetterValue(rowIndex, columnIndex, value);
+        });
       });
+    }
+
+    // Array-of-objects data is already projected to visible columns by
+    // `dataSource.getAtRow`. Array-of-arrays data returns the full source row,
+    // so when `columns` skips physical indexes the data fed to HF misaligns
+    // with the axis-syncer's visual->HF mapping (issue #10021). Build a row
+    // containing only visible columns so HF cell coordinates stay in sync.
+    const columnOffset = column ?? 0;
+
+    return dataArray.map((rowArray, rowIndex) => {
+      const projected = [];
+
+      for (let visualCol = 0; visualCol < visibleColumnCount; visualCol++) {
+        const physicalCol = this.hot.colToProp(visualCol);
+
+        if (typeof physicalCol !== 'number') {
+          continue;
+        }
+
+        const arrayIndex = physicalCol - columnOffset;
+
+        if (arrayIndex < 0 || arrayIndex >= rowArray.length) {
+          continue;
+        }
+
+        projected.push(this.#getValueGetterValue(rowIndex, visualCol, rowArray[arrayIndex]));
+      }
+
+      return projected;
     });
   }
 

--- a/handsontable/src/plugins/formulas/formulas.js
+++ b/handsontable/src/plugins/formulas/formulas.js
@@ -626,8 +626,8 @@ export class Formulas extends BasePlugin {
     const dataArray = this.hot.getSourceDataArray(row, column, row2, column2);
     const visibleColumnCount = this.hot.countCols();
     const physicalColumnCount = this.hot.countSourceCols();
-    const isAoAWithSkippedColumns = isArrayOfArrays(this.hot.getSourceData())
-      && visibleColumnCount < physicalColumnCount;
+    const isAoAWithSkippedColumns = visibleColumnCount < physicalColumnCount
+      && isArrayOfArrays(this.hot.getSourceData());
 
     if (!isAoAWithSkippedColumns) {
       return dataArray.map((rowObject, rowIndex) => {


### PR DESCRIPTION
### Context

The PR fixes #10021. When the dataset is array-of-arrays (AoA) and the `columns` setting skips one or more physical column indexes (e.g. `data: [[1, 2, 3, '=A1']]` with `columns: [{ data: 0 }, { data: 2 }, { data: 3 }]`), formulas placed in cells were rendered as raw strings (`=A1`) and only recalculated after editing. Array-of-objects (AoO) data with the same shape worked correctly.

Root cause: `Formulas#getProcessedSourceDataArray` feeds HyperFormula via `hot.getSourceDataArray()`. AoO data is already projected to visible columns by `dataSource.getAtRow` (object branch filters via `colToProp`). AoA data returns the full source row, so when `columns` skipped a physical index the HF sheet held more columns than the visible grid. The plugin's `columnAxisSyncer.getHfIndexFromVisualIndex` mapping (sized to visible-count) then resolved formula cells to the wrong HF coordinates - `isFormulaCellType` returned `false` and the raw expression was rendered.

Fix: in `#getProcessedSourceDataArray`, when AoA data has fewer visible columns than physical source columns, project each row to the visible-column subset using `hot.colToProp(visualCol)`. Preserves the original path for AoO, AoA without skips, and `manualColumnMove`-only configurations.

### How has this been tested?

- New E2E specs added to `handsontable/src/plugins/formulas/__tests__/initialization.spec.js` under the "Data source shape" describe block:
  - Formulas evaluate on init for AoA when `columns` skips physical indexes.
  - Formulas evaluate on init for AoO when `columns` skips properties (regression guard).
  - Dependent cells recalculate when the referenced cell is edited (AoA with skipped columns).
- Full formulas suite: `npm run test:e2e --prefix handsontable -- --testPathPattern=formulas` → 323/323 pass.
- Related plugins suite: `npm run test:e2e --prefix handsontable -- --testPathPattern='nestedRows|undoRedo'` → 290/290 pass.
- Manual repro pages (`dev-latest.html` on CDN v17.0.1 vs `dev-pr.html` on the built dist) confirm the bug is reproducible on `develop` and resolved on this branch.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. #10021
2. DEV-1671

### Affected project(s):

- [x] \`handsontable\`
- [ ] \`@handsontable/angular-wrapper\`
- [ ] \`@handsontable/react-wrapper\`
- [ ] \`@handsontable/vue3\`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1671

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the formulas plugin’s data-to-engine projection logic, which can affect how HyperFormula receives sheet content for some configurations. Risk is limited to array-of-arrays sources with `columns` mappings that reduce visible vs source column count, and is covered by new initialization/recalc tests.
> 
> **Overview**
> Fixes a formulas initialization bug where **array-of-arrays** datasets combined with `columns` mappings that *skip physical indexes* could leave formulas unparsed (rendered as raw `=...` strings) until the user edited a cell.
> 
> `#getProcessedSourceDataArray` now detects this AoA/columns-skip scenario and projects each source row down to the **visible columns** (using `colToProp`) before passing data to HyperFormula, keeping HF coordinates aligned with the plugin’s axis mapping. Adds regression tests covering init evaluation for AoA and AoO shapes plus dependent recalculation, and includes a changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e55693c012f8e95c88df03721892e7b5efbe513f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->