### PR TITLE
DEV-1674: Fix memory leak in ThemeManager — unsubscribe from shared theme singleton on destroy

### DIFF
--- a/.changelogs/12570.json
+++ b/.changelogs/12570.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed a memory leak caused by ThemeManager not unsubscribing from the shared theme object on destroy.",
+  "type": "fixed",
+  "issueOrPR": 12570,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/themes/engine/__tests__/manager.unit.js
+++ b/handsontable/src/themes/engine/__tests__/manager.unit.js
@@ -331,6 +331,55 @@ describe('ThemeManager', () => {
 
         expect(mockHot.themeManager).toBeNull();
       });
+
+      it('should unsubscribe from the theme object on destroy (regression: #12568)', () => {
+        const mockHot = createMockHot();
+        const themeObject = createTheme(createValidThemeConfig());
+
+        // eslint-disable-next-line no-unused-vars
+        const manager = new ThemeManager({
+          hot: mockHot,
+          themeObject,
+        });
+
+        manager.destroy();
+        mockHot.render.mockClear();
+        mockHot.stylesHandler.clearCache.mockClear();
+
+        // Changing the theme after destroy must NOT trigger re-renders — the
+        // subscription must have been removed. Before the fix, destroy() did not
+        // call the unsubscribe function returned by themeObject.subscribe(), so
+        // the listener stayed alive and caused a memory leak.
+        themeObject.setColorScheme('dark');
+
+        expect(mockHot.render).not.toHaveBeenCalled();
+        expect(mockHot.stylesHandler.clearCache).not.toHaveBeenCalled();
+      });
+
+      it('should not accumulate subscriptions across multiple update() calls (regression: #12568)', () => {
+        const mockHot = createMockHot();
+        const themeObject = createTheme(createValidThemeConfig());
+
+        // eslint-disable-next-line no-unused-vars
+        const manager = new ThemeManager({
+          hot: mockHot,
+          themeObject,
+        });
+
+        // Simulate React re-mounting the same themeObject on multiple updateSettings calls.
+        // Before the fix, each update() added another listener without removing the previous one.
+        manager.update(themeObject);
+        manager.update(themeObject);
+        manager.update(themeObject);
+
+        mockHot.render.mockClear();
+
+        themeObject.setColorScheme('dark');
+
+        // With the fix, only one listener is active — render called exactly once.
+        // Without the fix, render would be called N times (once per accumulated subscription).
+        expect(mockHot.render).toHaveBeenCalledTimes(1);
+      });
     });
   });
 });

--- a/handsontable/src/themes/engine/manager.js
+++ b/handsontable/src/themes/engine/manager.js
@@ -41,6 +41,13 @@ export class ThemeManager {
   themeConfig;
 
   /**
+   * Unsubscribes from the theme object's change notifications.
+   *
+   * @type {Function|null}
+   */
+  #unsubscribeTheme = null;
+
+  /**
    * The theme manager constructor.
    *
    * @param {object} options - The options object.
@@ -139,7 +146,8 @@ export class ThemeManager {
     this.themeClassName = `${THEME_PREFIX}${this.themeConfig.name}`;
 
     if (typeof themeObject.subscribe === 'function') {
-      themeObject.subscribe((config) => {
+      this.#unsubscribeTheme?.();
+      this.#unsubscribeTheme = themeObject.subscribe((config) => {
         if (!this.hot?.stylesHandler) {
           return;
         }
@@ -176,6 +184,7 @@ export class ThemeManager {
    * Destroys the theme manager.
    */
   destroy() {
+    this.#unsubscribeTheme?.();
     this.unmount();
     this.hot.themeManager = null;
   }


### PR DESCRIPTION
### Context

The PR fixes a memory leak in `ThemeManager` where every HOT instance that was destroyed left a dangling listener on the global shared theme singleton (`staticRegister('themes')`).

`ThemeManager.update()` calls `themeObject.subscribe(callback)` but ignores the returned unsubscribe function. `ThemeManager.destroy()` (called from `hot.destroy()`) never removes the listener. The result is that every destroy+recreate cycle (e.g. switching tabs in a React app via `key` prop) adds one more listener to the shared `'main'` theme object, keeping the entire destroyed HOT instance — and all React renderer roots — alive in memory.

Trigger: the default case (`!theme && !themeName`) hits `initializeThemeManager(undefined)` at `src/core.js:5787`, which registers and subscribes to the shared `'main'` singleton. This is the exact code path exercised by the React wrapper when no `theme`/`themeName` prop is passed.

Reported in: https://github.com/handsontable/handsontable/issues/12568

**Fix** (3 additions to `src/themes/engine/manager.js`):
1. Add `#unsubscribeTheme = null` private field.
2. In `update()`: call `this.#unsubscribeTheme?.()` before re-subscribing; store the return value.
3. In `destroy()`: call `this.#unsubscribeTheme?.()` before unmounting.

### How has this been tested?

**Unit tests (2 new regression tests in `manager.unit.js`):**
```bash
npm run test:unit --prefix handsontable -- --testPathPattern=manager.unit
```
- `destroy() should unsubscribe from the theme object on destroy (regression: #12568)` — verifies that after `destroy()`, changing the theme no longer triggers `hot.render()`.
- `should not accumulate subscriptions across multiple update() calls (regression: #12568)` — verifies that calling `update()` N times leaves exactly one active listener.

**Browser proof via Chrome DevTools MCP:**
- 20 tab switches on v17.0.1 (CDN): **20 leaked subscriptions** on the shared theme singleton.
- 20 tab switches with fix applied: **1 subscription** throughout.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. https://github.com/handsontable/handsontable/issues/12568
2. DEV-1674

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1674

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core theme subscription lifecycle; mistakes could cause missed or duplicated re-renders on theme changes, but the change is small and covered by new unit regressions.
> 
> **Overview**
> Prevents `ThemeManager` from leaking destroyed Handsontable instances by tracking the unsubscribe function returned by `themeObject.subscribe()`, calling it before re-subscribing in `update()` and during `destroy()`.
> 
> Adds regression unit tests ensuring theme changes no longer trigger renders after `destroy()` and that repeated `update()` calls don’t accumulate multiple active subscriptions, plus a changelog entry for the public fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51b317f9cd3f1718ff2667187802e251eb8e460b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->