### PR TITLE
fix(react-wrapper): skip init-only props after mount

### DIFF
--- a/wrappers/react-wrapper/src/settingsMapper.ts
+++ b/wrappers/react-wrapper/src/settingsMapper.ts
@@ -23,11 +23,7 @@ export class SettingsMapper {
       initOnlySettingKeys?: Array<keyof Handsontable.GridSettings>
     } = {}): Handsontable.GridSettings {
     const shouldSkipProp = (key: keyof Handsontable.GridSettings) => {
-      // Omit settings that can be set only during initialization and are intentionally modified.
-      if (!isInit && initOnlySettingKeys.includes(key)) {
-        return prevProps[key] === properties[key];
-      }
-      return false;
+      return !isInit && initOnlySettingKeys.includes(key);
     };
     let newSettings: Handsontable.GridSettings = {};
 

--- a/wrappers/react-wrapper/test/hotTable.spec.tsx
+++ b/wrappers/react-wrapper/test/hotTable.spec.tsx
@@ -123,8 +123,19 @@ describe('Updating the Handsontable settings', () => {
     expect(JSON.stringify(hotInstance.getSettings().data)).toEqual('[[2]]');
   });
 
-  it('should throw an error when trying to update init-only settings after inializing the component', async () => {
-    console.error = jest.fn();
+  it('should not throw an error when trying to update init-only settings after inializing the component', async () => {
+    const errorMock = jest.fn();
+    const originalError = console.error;
+
+    console.error = (...args: unknown[]) => {
+      const message = args[0];
+
+      if (typeof message === 'string' && message.includes('Could not parse CSS stylesheet')) {
+        return;
+      }
+
+      errorMock(...args);
+    };
 
     let updateState = null;
 
@@ -150,11 +161,11 @@ describe('Updating the Handsontable settings', () => {
 
     const updateStateAndRender = () => act(() => (updateState as any)(true));
 
-    await expect(updateStateAndRender).toThrowError(
-      'The `renderAllRows` option can not be updated after the Handsontable is initialized.'
-    );
+    await expect(updateStateAndRender()).resolves.toBeUndefined();
 
-    expect(console.error).toHaveBeenCalled();
+    expect(errorMock).not.toHaveBeenCalled();
+
+    console.error = originalError;
   });
 
   it('should NOT throw an error when trying to update settings after inializing the component if the other settings' +

--- a/wrappers/react-wrapper/test/settingsMapper.spec.tsx
+++ b/wrappers/react-wrapper/test/settingsMapper.spec.tsx
@@ -32,5 +32,40 @@ describe('Settings mapper unit tests', () => {
       expect((result.afterChange as any)()).toEqual('works!');
       expect((result.afterRender as any)()).toEqual('also works!');
     });
+
+    it('should skip init-only settings after initialization, even when they change', () => {
+      const result = SettingsMapper.getSettings(
+        {
+          renderAllRows: true,
+          rowHeaders: true
+        },
+        {
+          prevProps: {
+            renderAllRows: false,
+            rowHeaders: false
+          },
+          initOnlySettingKeys: ['renderAllRows']
+        }
+      );
+
+      expect(result.renderAllRows).toBeUndefined();
+      expect(result.rowHeaders).toBe(true);
+    });
+
+    it('should include init-only settings during initialization', () => {
+      const result = SettingsMapper.getSettings(
+        {
+          renderAllRows: true,
+          rowHeaders: true
+        },
+        {
+          isInit: true,
+          initOnlySettingKeys: ['renderAllRows']
+        }
+      );
+
+      expect(result.renderAllRows).toBe(true);
+      expect(result.rowHeaders).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Summary\n- Skip init-only React wrapper props from post-mount updateSettings calls, even when their values change\n- Add unit coverage for init-only props during init vs after mount\n- Update the component test to expect no crash when an init-only prop changes\n\n## Verification\n- pnpm --dir wrappers/react-wrapper exec jest test/settingsMapper.spec.tsx --runInBand\n- pnpm install --frozen-lockfile (with PUPPETEER_SKIP_DOWNLOAD=1 for the repo install)\n\n## Notes\n- The broader hotTable suite needs the built Handsontable package; I validated the focused mapper test and the code path change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk wrapper behavior change: it only alters how init-only Handsontable options are filtered out of `updateSettings` calls after mount, with added tests to lock in the new behavior.
> 
> **Overview**
> Prevents the React wrapper from attempting to apply *init-only* Handsontable settings after the table has mounted by always omitting keys listed in `initOnlySettingKeys` from non-init `SettingsMapper.getSettings` results.
> 
> Updates tests to reflect that changing an init-only prop (e.g. `renderAllRows`) after mount should no longer throw or log errors, and adds mapper unit coverage for including init-only settings during init vs skipping them post-init.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f1e9140592404944aa4444c289098ab4dc2dc62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->