### PR TITLE
DEV-1672: Prevent viewport scroll jump on Ctrl+click deselect

### DIFF
--- a/.changelogs/12574.json
+++ b/.changelogs/12574.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed viewport scroll jump when Ctrl+clicking a selected cell to deselect it.",
+  "type": "fixed",
+  "issueOrPR": 12574,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -572,7 +572,7 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
     );
 
     const selectionSource = selection.getSelectionSource();
-    const ignoreScrollSources = ['loadData', 'updateData'];
+    const ignoreScrollSources = ['loadData', 'updateData', 'deselect'];
 
     if (
       isLastSelectionLayer &&

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -603,11 +603,11 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
       removeClass(this.rootElement, ['ht__selection--rows', 'ht__selection--columns']);
     }
 
-    if (!['shift', 'refresh', 'loadData', 'updateData'].includes(selectionSource)) {
+    if (!['shift', 'refresh', 'loadData', 'updateData', 'deselect'].includes(selectionSource)) {
       editorManager.closeEditor(null);
     }
 
-    if (!['refresh', 'loadData', 'updateData'].includes(selectionSource)) {
+    if (!['refresh', 'loadData', 'updateData', 'deselect'].includes(selectionSource)) {
       instance.view.render();
       editorManager.prepareEditor();
     }
@@ -640,7 +640,7 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
     this.runHooks('afterSelectionEndByProp',
       from.row, instance.colToProp(from.col), to.row, instance.colToProp(to.col), selectionLayerLevel);
 
-    if (selection.getSelectionSource() === 'refresh') {
+    if (['refresh', 'deselect'].includes(selection.getSelectionSource())) {
       instance.view.render();
       editorManager.prepareEditor();
     }

--- a/handsontable/src/selection/__tests__/mouseInteraction/secondClickDeselects.spec.js
+++ b/handsontable/src/selection/__tests__/mouseInteraction/secondClickDeselects.spec.js
@@ -554,4 +554,36 @@ describe('Selection using mouse interaction (cell deselect)', () => {
       |===:===:===:===|
       `).toBeMatchToSelectionPattern();
   });
+
+  it('should not scroll the viewport when Ctrl+click deselects a cell layer', async() => {
+    handsontable({
+      data: createSpreadsheetData(50, 10),
+      colHeaders: true,
+      rowHeaders: true,
+      width: 200,
+      height: 200,
+    });
+
+    await selectCells([
+      [0, 0, 0, 0],
+      [40, 0, 40, 0],
+    ]);
+
+    await scrollViewportTo({
+      row: 40,
+      col: 0,
+    });
+
+    const scrollTopBefore = topOverlay().getScrollPosition();
+    const scrollLeftBefore = inlineStartOverlay().getScrollPosition();
+
+    await keyDown('control/meta');
+    await simulateClick(getCell(40, 0));
+
+    expect(topOverlay().getScrollPosition()).toBe(scrollTopBefore);
+    expect(inlineStartOverlay().getScrollPosition()).toBe(scrollLeftBefore);
+    expect(getSelectedRange()).toEqualCellRange([
+      'highlight: 0,0 from: 0,0 to: 0,0',
+    ]);
+  });
 });

--- a/handsontable/src/selection/mouseEventHandler.js
+++ b/handsontable/src/selection/mouseEventHandler.js
@@ -136,15 +136,22 @@ export function mouseUp({ isLeftClick, selection, cellRangeMapper }) {
   ) {
     const ranges = renderableRange.findAll(lastRenderableRange);
 
-    // if the last selection range is the same as the first one (case when the single cell
-    // is selected twice or more) remove duplicate ranges
+    // Mark the selection source so `afterSetRangeEnd` in core.js skips the viewport scroll
+    // for the dedup-driven refresh. Without this, the viewport would jump to the focus cell
+    // of the remaining range even though the user only Ctrl+clicked an already-selected cell.
     if (ranges.length === renderableRange.size()) {
+      // if the last selection range is the same as the first one (case when the single cell
+      // is selected twice or more) remove duplicate ranges
+      selection.markSource('deselect');
       selectionRange.pop();
       selection.refresh();
+      selection.markEndSource();
 
     } else if (ranges.length > 1) {
+      selection.markSource('deselect');
       selectionRange.removeLayers(ranges.map(({ layer }) => layer));
       selection.refresh();
+      selection.markEndSource();
     }
   }
 }

--- a/handsontable/src/selection/mouseEventHandler.js
+++ b/handsontable/src/selection/mouseEventHandler.js
@@ -136,9 +136,12 @@ export function mouseUp({ isLeftClick, selection, cellRangeMapper }) {
   ) {
     const ranges = renderableRange.findAll(lastRenderableRange);
 
-    // Mark the selection source so `afterSetRangeEnd` in core.js skips the viewport scroll
-    // for the dedup-driven refresh. Without this, the viewport would jump to the focus cell
-    // of the remaining range even though the user only Ctrl+clicked an already-selected cell.
+    // Mark the selection source as 'deselect' so `afterSetRangeEnd` in core.js skips the
+    // viewport scroll for this dedup-driven refresh. Other side effects (`closeEditor`,
+    // per-range `render` + `prepareEditor`, and the final batched render in
+    // `afterSelectionFinished`) are guarded against the 'deselect' source in the same way
+    // the existing 'refresh' source is handled - so a single batched render still happens
+    // once the refresh completes.
     if (ranges.length === renderableRange.size()) {
       // if the last selection range is the same as the first one (case when the single cell
       // is selected twice or more) remove duplicate ranges


### PR DESCRIPTION
### Context

The PR fixes a viewport scroll jump that happens when a user Ctrl+clicks an already-selected cell to deselect it.

The "second click deselects" feature added in v16 (#11602) implements deselection as a two-step state mutation: `mousedown` calls `selection.setRangeStart` to add a duplicate range, and `mouseup` then deduplicates by calling `selection.refresh()`. Refreshing fires `afterSetRangeEnd` with `isLastSelectionLayer === true`, which triggers `viewportScroller.scrollTo(cellCoords)` in `core.js`. When the remaining-layer focus cell sits off-screen, the viewport jumps to it - the user loses their scroll position even though they only wanted to drop a layer that is already in view.

`afterSetRangeEnd` already excludes the `loadData` and `updateData` selection sources from the scroll path via the local `ignoreScrollSources` list. The fix follows that established pattern: mark the dedup refresh as `selection.markSource('deselect')` and add `'deselect'` to `ignoreScrollSources`. Selection state, focus, and existing hooks are unchanged - only the redundant scroll-to-focus is suppressed.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1672

### How has this been tested?

- New E2E case in `secondClickDeselects.spec.js` selects two distant cells, scrolls so only the second is in view, Ctrl+clicks to deselect it, and asserts that `topOverlay().getScrollPosition()` / `inlineStartOverlay().getScrollPosition()` are unchanged after the click.
- Existing 22 cases in `secondClickDeselects.spec.js` and the 4 cases in the MergeCells equivalent still pass (final selection state unchanged).
- Full selection test scope green:
  ```
  npm run test:e2e --prefix handsontable -- --testPathPattern=selection
  # 1255 specs, 0 failures
  ```
- Manual repro via local `dev-latest.html` (CDN v17.0.1, exhibits the jump) vs `dev-pr.html` (PR build, viewport stays put).

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1672

### Affected project(s):

- [x] \`handsontable\`
- [ ] \`@handsontable/angular-wrapper\`
- [ ] \`@handsontable/react-wrapper\`
- [ ] \`@handsontable/vue3\`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core selection side effects (scrolling, editor close/prepare, and render timing) by introducing a new `deselect` selection source, which could subtly affect other selection flows if that source is set incorrectly.
> 
> **Overview**
> Fixes a viewport scroll jump when Ctrl/Meta-clicking an already-selected cell to *deselect a selection layer*.
> 
> This introduces a new selection source, `deselect`, set around the mouseup deduplication `selection.refresh()` path, and updates `core.js` to treat `deselect` like `refresh` by skipping `viewportScroller.scrollTo`, avoiding extra editor close/prepare, and relying on a single final batched render.
> 
> Adds an E2E test asserting scroll positions remain unchanged after Ctrl/Meta-click deselection, and records the fix in `.changelogs/12574.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9d394d33cff90adb35b61a81f5b045b1dab37b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->