### PR TITLE
DEV-1676: Fix IntersectionObserver leak in observeVisibilityChangeOnce

### DIFF
--- a/.changelogs/12578.json
+++ b/.changelogs/12578.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed a memory leak where IntersectionObserver instances were not properly disconnected when `document.body` had zero height.",
+  "type": "fixed",
+  "issueOrPR": 12578,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/helpers/dom/__tests__/element.spec.js
+++ b/handsontable/src/helpers/dom/__tests__/element.spec.js
@@ -21,6 +21,106 @@ describe('DOM helpers', () => {
 
       document.body.removeChild(element);
     });
+
+    it('should fully disconnect the observer after the element becomes visible', async() => {
+      const observeVisibilityChangeOnce = Handsontable.dom.observeVisibilityChangeOnce;
+      const NativeIntersectionObserver = window.IntersectionObserver;
+      const disconnectSpy = jasmine.createSpy('disconnect');
+      const unobserveSpy = jasmine.createSpy('unobserve');
+
+      window.IntersectionObserver = function(callback, options) {
+        const observer = new NativeIntersectionObserver(callback, options);
+        const originalDisconnect = observer.disconnect.bind(observer);
+        const originalUnobserve = observer.unobserve.bind(observer);
+
+        observer.disconnect = (...args) => {
+          disconnectSpy(...args);
+          originalDisconnect(...args);
+        };
+        observer.unobserve = (...args) => {
+          unobserveSpy(...args);
+          originalUnobserve(...args);
+        };
+
+        return observer;
+      };
+
+      const element = document.createElement('div');
+      const callbackSpy = jasmine.createSpy('callbackSpy');
+
+      element.style.display = 'none';
+      document.body.appendChild(element);
+
+      observeVisibilityChangeOnce(element, callbackSpy);
+
+      element.style.display = 'block';
+
+      await waitForNextAnimationFrames(2);
+
+      expect(callbackSpy).toHaveBeenCalledTimes(1);
+      expect(disconnectSpy).toHaveBeenCalledTimes(1);
+      expect(unobserveSpy).not.toHaveBeenCalled();
+
+      document.body.removeChild(element);
+      window.IntersectionObserver = NativeIntersectionObserver;
+    });
+
+    it('should not leak observers when document.body has zero height', async() => {
+      const observeVisibilityChangeOnce = Handsontable.dom.observeVisibilityChangeOnce;
+      const NativeIntersectionObserver = window.IntersectionObserver;
+      let activeObservers = 0;
+
+      window.IntersectionObserver = function(callback, options) {
+        const observer = new NativeIntersectionObserver(callback, options);
+        const originalDisconnect = observer.disconnect.bind(observer);
+
+        activeObservers += 1;
+        observer.disconnect = (...args) => {
+          activeObservers -= 1;
+          originalDisconnect(...args);
+        };
+
+        return observer;
+      };
+
+      const originalBodyHeight = document.body.style.height;
+      const originalBodyOverflow = document.body.style.overflow;
+
+      document.body.style.height = '0px';
+      document.body.style.overflow = 'hidden';
+
+      const elements = [];
+      const callbackSpies = [];
+
+      for (let i = 0; i < 5; i++) {
+        const element = document.createElement('div');
+        const callbackSpy = jasmine.createSpy(`callbackSpy_${i}`);
+
+        element.style.display = 'none';
+        document.body.appendChild(element);
+
+        elements.push(element);
+        callbackSpies.push(callbackSpy);
+
+        observeVisibilityChangeOnce(element, callbackSpy);
+      }
+
+      elements.forEach((element) => {
+        element.style.display = 'block';
+      });
+
+      await waitForNextAnimationFrames(3);
+
+      callbackSpies.forEach((spy) => {
+        expect(spy).toHaveBeenCalledTimes(1);
+      });
+      expect(activeObservers).toBe(0);
+
+      elements.forEach(element => document.body.removeChild(element));
+      document.body.style.height = originalBodyHeight;
+      document.body.style.overflow = originalBodyOverflow;
+      window.IntersectionObserver = NativeIntersectionObserver;
+    });
   });
 
   describe('isInternalElement', () => {

--- a/handsontable/src/helpers/dom/element.js
+++ b/handsontable/src/helpers/dom/element.js
@@ -1229,7 +1229,7 @@ export function isDetached(element) {
 export function observeVisibilityChangeOnce(elementToBeObserved, callback) {
   const visibilityObserver = new IntersectionObserver((entries, observer) => {
     entries.forEach((entry) => {
-      if (entry.isIntersecting && elementToBeObserved.offsetParent !== null) {
+      if (entry.isIntersecting) {
         callback();
         observer.disconnect();
       }

--- a/handsontable/src/helpers/dom/element.js
+++ b/handsontable/src/helpers/dom/element.js
@@ -1231,11 +1231,9 @@ export function observeVisibilityChangeOnce(elementToBeObserved, callback) {
     entries.forEach((entry) => {
       if (entry.isIntersecting && elementToBeObserved.offsetParent !== null) {
         callback();
-        observer.unobserve(elementToBeObserved);
+        observer.disconnect();
       }
     });
-  }, {
-    root: elementToBeObserved.ownerDocument.body
   });
 
   visibilityObserver.observe(elementToBeObserved);


### PR DESCRIPTION
### Context

The PR fixes a memory leak in `observeVisibilityChangeOnce` (`handsontable/src/helpers/dom/element.js`) reported in #12576. The helper registers a fire-once `IntersectionObserver` with `root: ownerDocument.body`. When `document.body` has a zero-height rect, browsers that strictly follow the IntersectionObserver spec report `entry.isIntersecting === false` for any target, so the `unobserve()` cleanup path never runs and one observer leaks per Handsontable mount-while-hidden cycle (for example, a React tab that mounts the grid while inactive).

Two changes:
- Drop the `root: ownerDocument.body` option so the observer uses the viewport as its intersection root - always non-zero, robust across shadow-DOM and cross-document scenarios.
- Replace `observer.unobserve(target)` with `observer.disconnect()`. The observer only ever watches a single target and is meant to fire once; `disconnect()` is the correct full-cleanup primitive.

### How has this been tested?

Added two regression tests in `handsontable/src/helpers/dom/__tests__/element.spec.js`:

- `should fully disconnect the observer after the element becomes visible` - patches `IntersectionObserver` and asserts `disconnect()` is called once and `unobserve()` is never called.
- `should not leak observers when document.body has zero height` - patches `IntersectionObserver` to count live instances, sets `document.body.style.height = '0px'`, mounts and shows five elements, and asserts the live observer count returns to 0.

Commands run locally:

```
npm run build --prefix handsontable
npm run test:e2e --prefix handsontable --testPathPattern=helpers/dom/__tests__/element
# -> 20 specs, 0 failures

npx eslint src/helpers/dom/element.js src/helpers/dom/__tests__/element.spec.js
# -> No issues found
```

Also verified manually in headless Chrome via two local demo pages (gitignored) that count visibility-observer instances during a mount/destroy loop:
- Released v17.0.1: 20 observers created, 0 cleaned up (`Live: 20`).
- This PR: 20 created, 20 cleaned up via `disconnect()` (`Live: 0`).

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. #12576
2. DEV-1676

### Affected project(s):

- [x] \`handsontable\`
- [ ] \`@handsontable/angular-wrapper\`
- [ ] \`@handsontable/react-wrapper\`
- [ ] \`@handsontable/vue3\`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1676

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `observeVisibilityChangeOnce` cleanup semantics from `unobserve()` with a custom `root` to `disconnect()` with the default root, which could alter when the callback fires in edge visibility scenarios; otherwise scoped to a small DOM helper.
> 
> **Overview**
> Fixes a leak in `observeVisibilityChangeOnce` by **removing the `IntersectionObserver` `root: document.body` option** and **fully cleaning up via `observer.disconnect()`** after the first `isIntersecting` event (instead of `unobserve()` gated by `offsetParent`).
> 
> Adds regression coverage asserting the observer is disconnected (and not unobserved) after firing, and that repeated mounts while `document.body` has `height: 0` do not leave any active observers. Includes a changelog entry for the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d148b65ef7232b861d7588323e195050481669e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->