### PR TITLE
Update Contact support link to HubSpot booking page

### DIFF
--- a/docs/src/components/SupportDropdown.astro
+++ b/docs/src/components/SupportDropdown.astro
@@ -9,7 +9,7 @@
 const links = [
   { label: 'Developers Forum', href: 'https://forum.handsontable.com' },
   { label: 'GitHub Issues', href: 'https://github.com/handsontable/handsontable/issues' },
-  { label: 'Contact support', href: 'https://handsontable.com/contact?category=technical_support' },
+  { label: 'Contact support', href: 'https://meetings-eu1.hubspot.com/aleksandra-budnik/book-a-support-call?uuid=bf30be03-4ef6-4707-97bf-7dce66619b4e' },
 ];
 ---
 


### PR DESCRIPTION
https://app.clickup.com/t/86c7wz76k

### Context
<!--- Why is this change required? What problem does it solve? -->

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a docs-only change that updates a single external URL with no logic or data-handling impact.
> 
> **Overview**
> Updates the **“Contact support”** link in `docs/src/components/SupportDropdown.astro` to route users to a HubSpot support-call booking page instead of the previous `handsontable.com/contact` URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cde6a996ac5a2bf615e70519abac315a3ae605a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->