### PR TITLE
DEV-1569: Use global toolbar classes in notification example2

### DIFF
--- a/docs/content/guides/dialog/notification/angular/example2.ts
+++ b/docs/content/guides/dialog/notification/angular/example2.ts
@@ -7,10 +7,12 @@ import { GridSettings, HotTableModule, HotTableComponent } from '@handsontable/a
   imports: [HotTableModule],
   selector: 'notification-example-2',
   template: `
-    <div style="display:flex;gap:8px;margin-bottom:8px;flex-wrap:wrap;">
-      <button type="button" (click)="onSave()">Save</button>
-      <button type="button" (click)="onSyncError()">Sync error</button>
-      <button type="button" (click)="onLowStock()">Low stock</button>
+    <div class="example-controls-container">
+      <div class="controls">
+        <button type="button" class="button button--primary" (click)="onSave()">Save</button>
+        <button type="button" class="button button--primary" (click)="onSyncError()">Sync error</button>
+        <button type="button" class="button button--primary" (click)="onLowStock()">Low stock</button>
+      </div>
     </div>
     <hot-table #hotTable [data]="hotData" [settings]="hotSettings"></hot-table>
   `,

--- a/docs/content/guides/dialog/notification/javascript/example2.html
+++ b/docs/content/guides/dialog/notification/javascript/example2.html
@@ -1,0 +1,8 @@
+<div class="example-controls-container">
+  <div class="controls">
+    <button type="button" id="example2-save" class="button button--primary">Save</button>
+    <button type="button" id="example2-sync-error" class="button button--primary">Sync error</button>
+    <button type="button" id="example2-low-stock" class="button button--primary">Low stock</button>
+  </div>
+</div>
+<div id="example2"></div>

--- a/docs/content/guides/dialog/notification/javascript/example2.js
+++ b/docs/content/guides/dialog/notification/javascript/example2.js
@@ -14,16 +14,7 @@ const data = [
   ['SKU-008', 'Mechanical keycap set', 112, 20, 'B-01'],
 ];
 
-const root = document.getElementById('example2');
-const toolbar = document.createElement('div');
-
-toolbar.style.cssText =
-  'display:flex;gap:8px;margin-bottom:8px;flex-wrap:wrap;';
-root.appendChild(toolbar);
-
-const container = document.createElement('div');
-
-root.appendChild(container);
+const container = document.getElementById('example2');
 
 const hot = new Handsontable(container, {
   data,
@@ -44,16 +35,7 @@ const hot = new Handsontable(container, {
 
 const plugin = hot.getPlugin('notification');
 
-function addToolButton(text, handler) {
-  const btn = document.createElement('button');
-
-  btn.type = 'button';
-  btn.textContent = text;
-  btn.addEventListener('click', handler);
-  toolbar.appendChild(btn);
-}
-
-addToolButton('Save', () => {
+document.getElementById('example2-save').addEventListener('click', () => {
   plugin.showMessage({
     title: 'Saved',
     message: 'Inventory updates were written.',
@@ -62,7 +44,8 @@ addToolButton('Save', () => {
     duration: 2500,
   });
 });
-addToolButton('Sync error', () => {
+
+document.getElementById('example2-sync-error').addEventListener('click', () => {
   plugin.showMessage({
     title: 'Sync failed',
     message:
@@ -87,7 +70,8 @@ addToolButton('Sync error', () => {
     ],
   });
 });
-addToolButton('Low stock', () => {
+
+document.getElementById('example2-low-stock').addEventListener('click', () => {
   plugin.showMessage({
     title: 'Review quantities',
     message:

--- a/docs/content/guides/dialog/notification/javascript/example2.ts
+++ b/docs/content/guides/dialog/notification/javascript/example2.ts
@@ -14,15 +14,7 @@ const data = [
   ['SKU-008', 'Mechanical keycap set', 112, 20, 'B-01'],
 ];
 
-const root = document.getElementById('example2')!;
-const toolbar = document.createElement('div');
-
-toolbar.style.cssText = 'display:flex;gap:8px;margin-bottom:8px;flex-wrap:wrap;';
-root.appendChild(toolbar);
-
-const container = document.createElement('div');
-
-root.appendChild(container);
+const container = document.getElementById('example2')!;
 
 const hot = new Handsontable(container, {
   data,
@@ -43,16 +35,7 @@ const hot = new Handsontable(container, {
 
 const plugin = hot.getPlugin('notification');
 
-function addToolButton(text: string, handler: () => void) {
-  const btn = document.createElement('button');
-
-  btn.type = 'button';
-  btn.textContent = text;
-  btn.addEventListener('click', handler);
-  toolbar.appendChild(btn);
-}
-
-addToolButton('Save', () => {
+document.getElementById('example2-save')!.addEventListener('click', () => {
   plugin.showMessage({
     title: 'Saved',
     message: 'Inventory updates were written.',
@@ -62,7 +45,7 @@ addToolButton('Save', () => {
   });
 });
 
-addToolButton('Sync error', () => {
+document.getElementById('example2-sync-error')!.addEventListener('click', () => {
   plugin.showMessage({
     title: 'Sync failed',
     message: 'The service is unavailable. Retry when your connection is stable.',
@@ -87,7 +70,7 @@ addToolButton('Sync error', () => {
   });
 });
 
-addToolButton('Low stock', () => {
+document.getElementById('example2-low-stock')!.addEventListener('click', () => {
   plugin.showMessage({
     title: 'Review quantities',
     message:

--- a/docs/content/guides/dialog/notification/notification.md
+++ b/docs/content/guides/dialog/notification/notification.md
@@ -74,10 +74,11 @@ Use separate buttons for save, error recovery, and warnings. Primary and seconda
 
 ::: only-for javascript
 
-::: example #example2 --js 1 --ts 2
+::: example #example2 --js 1 --ts 2 --html 3
 
 @[code](@/content/guides/dialog/notification/javascript/example2.js)
 @[code](@/content/guides/dialog/notification/javascript/example2.ts)
+@[code](@/content/guides/dialog/notification/javascript/example2.html)
 
 :::
 

--- a/docs/content/guides/dialog/notification/react/example2.jsx
+++ b/docs/content/guides/dialog/notification/react/example2.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef } from 'react';
 import { HotTable } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
 
@@ -25,87 +25,66 @@ const columns = [
 
 const ExampleComponent = () => {
   const hotTableRef = useRef(null);
-  const toolbarRef = useRef(null);
 
-  useEffect(() => {
-    const hot = hotTableRef.current?.hotInstance;
-    const toolbar = toolbarRef.current;
+  const getPlugin = () => hotTableRef.current?.hotInstance?.getPlugin('notification');
 
-    if (!hot || !toolbar) {
-      return;
-    }
-
-    const plugin = hot.getPlugin('notification');
-    const addToolButton = (text, handler) => {
-      const btn = document.createElement('button');
-
-      btn.type = 'button';
-      btn.textContent = text;
-      btn.addEventListener('click', handler);
-      toolbar.appendChild(btn);
-    };
-
-    addToolButton('Save', () => {
-      plugin.showMessage({
-        title: 'Saved',
-        message: 'Inventory updates were written.',
-        variant: 'success',
-        position: 'top-end',
-        duration: 2500,
-      });
+  const onSave = () => {
+    getPlugin()?.showMessage({
+      title: 'Saved',
+      message: 'Inventory updates were written.',
+      variant: 'success',
+      position: 'top-end',
+      duration: 2500,
     });
-    addToolButton('Sync error', () => {
-      plugin.showMessage({
-        title: 'Sync failed',
-        message:
-          'The service is unavailable. Retry when your connection is stable.',
-        variant: 'error',
-        position: 'bottom-end',
-        duration: 0,
-        actions: [
-          {
-            label: 'Retry',
-            type: 'primary',
-            callback: () => {
-              plugin.hideAll();
-              plugin.showMessage({
-                message: 'Sync completed.',
-                variant: 'success',
-                position: 'bottom-end',
-              });
-            },
+  };
+
+  const onSyncError = () => {
+    const plugin = getPlugin();
+
+    plugin?.showMessage({
+      title: 'Sync failed',
+      message: 'The service is unavailable. Retry when your connection is stable.',
+      variant: 'error',
+      position: 'bottom-end',
+      duration: 0,
+      actions: [
+        {
+          label: 'Retry',
+          type: 'primary',
+          callback: () => {
+            plugin.hideAll();
+            plugin.showMessage({
+              message: 'Sync completed.',
+              variant: 'success',
+              position: 'bottom-end',
+            });
           },
-          {
-            label: 'Dismiss',
-            type: 'secondary',
-            callback: () => plugin.hideAll(),
-          },
-        ],
-      });
+        },
+        { label: 'Dismiss', type: 'secondary', callback: () => plugin.hideAll() },
+      ],
     });
-    addToolButton('Low stock', () => {
-      plugin.showMessage({
-        title: 'Review quantities',
-        message:
-          'SKUs below reorder: USB-C cable 1m, Wireless mouse, HDMI cable 2m. Out of stock: Notebook A5 ruled, Laptop stand.',
-        variant: 'warning',
-        position: 'top-start',
-        duration: 6000,
-      });
+  };
+
+  const onLowStock = () => {
+    getPlugin()?.showMessage({
+      title: 'Review quantities',
+      message:
+        'SKUs below reorder: USB-C cable 1m, Wireless mouse, HDMI cable 2m. Out of stock: Notebook A5 ruled, Laptop stand.',
+      variant: 'warning',
+      position: 'top-start',
+      duration: 6000,
     });
-  }, []);
+  };
 
   return (
     <div>
-      <div
-        ref={toolbarRef}
-        style={{
-          display: 'flex',
-          gap: 8,
-          marginBottom: 8,
-          flexWrap: 'wrap',
-        }}
-      />
+      <div className="example-controls-container">
+        <div className="controls">
+          <button type="button" className="button button--primary" onClick={onSave}>Save</button>
+          <button type="button" className="button button--primary" onClick={onSyncError}>Sync error</button>
+          <button type="button" className="button button--primary" onClick={onLowStock}>Low stock</button>
+        </div>
+      </div>
       <HotTable
         ref={hotTableRef}
         data={data}

--- a/docs/content/guides/dialog/notification/react/example2.tsx
+++ b/docs/content/guides/dialog/notification/react/example2.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef } from 'react';
 import { HotTable } from '@handsontable/react-wrapper';
 import Handsontable from 'handsontable/base';
 import { registerAllModules } from 'handsontable/registry';
@@ -26,85 +26,66 @@ const columns: Handsontable.ColumnSettings[] = [
 
 const ExampleComponent: React.FC = () => {
   const hotTableRef = useRef<HotTable>(null);
-  const toolbarRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    const hot = hotTableRef.current?.hotInstance;
-    const toolbar = toolbarRef.current;
+  const getPlugin = () => hotTableRef.current?.hotInstance?.getPlugin('notification');
 
-    if (!hot || !toolbar) {
-      return;
-    }
-
-    const plugin = hot.getPlugin('notification');
-
-    const addToolButton = (text: string, handler: () => void) => {
-      const btn = document.createElement('button');
-
-      btn.type = 'button';
-      btn.textContent = text;
-      btn.addEventListener('click', handler);
-      toolbar.appendChild(btn);
-    };
-
-    addToolButton('Save', () => {
-      plugin.showMessage({
-        title: 'Saved',
-        message: 'Inventory updates were written.',
-        variant: 'success',
-        position: 'top-end',
-        duration: 2500,
-      });
+  const onSave = () => {
+    getPlugin()?.showMessage({
+      title: 'Saved',
+      message: 'Inventory updates were written.',
+      variant: 'success',
+      position: 'top-end',
+      duration: 2500,
     });
+  };
 
-    addToolButton('Sync error', () => {
-      plugin.showMessage({
-        title: 'Sync failed',
-        message: 'The service is unavailable. Retry when your connection is stable.',
-        variant: 'error',
-        position: 'bottom-end',
-        duration: 0,
-        actions: [
-          {
-            label: 'Retry',
-            type: 'primary',
-            callback: () => {
-              plugin.hideAll();
-              plugin.showMessage({
-                message: 'Sync completed.',
-                variant: 'success',
-                position: 'bottom-end',
-              });
-            },
+  const onSyncError = () => {
+    const plugin = getPlugin();
+
+    plugin?.showMessage({
+      title: 'Sync failed',
+      message: 'The service is unavailable. Retry when your connection is stable.',
+      variant: 'error',
+      position: 'bottom-end',
+      duration: 0,
+      actions: [
+        {
+          label: 'Retry',
+          type: 'primary',
+          callback: () => {
+            plugin.hideAll();
+            plugin.showMessage({
+              message: 'Sync completed.',
+              variant: 'success',
+              position: 'bottom-end',
+            });
           },
-          { label: 'Dismiss', type: 'secondary', callback: () => plugin.hideAll() },
-        ],
-      });
+        },
+        { label: 'Dismiss', type: 'secondary', callback: () => plugin.hideAll() },
+      ],
     });
+  };
 
-    addToolButton('Low stock', () => {
-      plugin.showMessage({
-        title: 'Review quantities',
-        message:
-          'SKUs below reorder: USB-C cable 1m, Wireless mouse, HDMI cable 2m. Out of stock: Notebook A5 ruled, Laptop stand.',
-        variant: 'warning',
-        position: 'top-start',
-        duration: 6000,
-      });
+  const onLowStock = () => {
+    getPlugin()?.showMessage({
+      title: 'Review quantities',
+      message:
+        'SKUs below reorder: USB-C cable 1m, Wireless mouse, HDMI cable 2m. Out of stock: Notebook A5 ruled, Laptop stand.',
+      variant: 'warning',
+      position: 'top-start',
+      duration: 6000,
     });
-  }, []);
+  };
 
   return (
     <div>
-      <div
-        ref={toolbarRef}
-        style={{
-          display: 'flex',
-          gap: 8,
-          marginBottom: 8,
-          flexWrap: 'wrap',
-        }}
-      />
+      <div className="example-controls-container">
+        <div className="controls">
+          <button type="button" className="button button--primary" onClick={onSave}>Save</button>
+          <button type="button" className="button button--primary" onClick={onSyncError}>Sync error</button>
+          <button type="button" className="button button--primary" onClick={onLowStock}>Low stock</button>
+        </div>
+      </div>
       <HotTable
         ref={hotTableRef}
         data={data}


### PR DESCRIPTION
### Context

The PR replaces the custom inline-styled toolbar in the notification `example2` with the global `example-controls-container` / `controls` / `button button--primary` CSS classes used across all other docs examples. This affects all four framework variants: JavaScript/TypeScript (new separate HTML file + ID-based event listeners), React (JSX buttons replacing dynamic DOM creation), and Angular (CSS classes replacing inline styles in the template).

### How has this been tested?

- Visually inspected the example structure against existing examples that already use the established toolbar pattern (e.g. batch-operations, export-to-PDF recipe).

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1569

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1569

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that standardizes example toolbar markup and event wiring; main risk is broken demo controls if the new HTML/IDs aren’t picked up by the docs renderer.
> 
> **Overview**
> Updates the Notification guide’s `example2` toolbar UI to use the shared docs styling (`example-controls-container`, `controls`, `button button--primary`) instead of per-example inline styles/dynamic DOM creation.
> 
> For the JavaScript/TypeScript variant, the toolbar is moved into a new `example2.html` and the scripts now bind click handlers to fixed button IDs; React examples replace `useEffect` DOM button creation with declarative buttons and simple handler functions; Angular swaps the inline-styled template wrapper for the global classes. The guide markdown is updated to include the new HTML snippet for the JS example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57c07eaedc3510330825fdef5383e89a2553ddfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->