### PR TITLE
DEV-1677: Fix pagination pageSize revert after sort in DataProvider mode

### DIFF
--- a/.changelogs/12582.json
+++ b/.changelogs/12582.json
@@ -1,8 +1,0 @@
-{
-  "issuesOrigin": "internal",
-  "title": "Fixed an issue where the Pagination plugin's user-selected `pageSize` reverted to the value from settings after sorting a column in DataProvider mode.",
-  "type": "fixed",
-  "issueOrPR": 12582,
-  "breaking": false,
-  "framework": "none"
-}

--- a/.changelogs/12582.json
+++ b/.changelogs/12582.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "internal",
+  "title": "Fixed an issue where the Pagination plugin's user-selected `pageSize` reverted to the value from settings after sorting a column in DataProvider mode.",
+  "type": "fixed",
+  "issueOrPR": 12582,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/dataProvider/__tests__/plugins/pagination.spec.js
+++ b/handsontable/src/plugins/dataProvider/__tests__/plugins/pagination.spec.js
@@ -83,6 +83,46 @@ describe('DataProvider integration with Pagination', () => {
     expect(getDataAtCell(0, 0)).toBe(6);
   });
 
+  it('should keep user-selected pageSize when column sort triggers refetch', async() => {
+    const fetchRows = jasmine.createSpy('fetchRows').and.callFake((params) => {
+      const { page, pageSize } = params;
+      const start = (page - 1) * pageSize;
+      const rows = Array.from({ length: Math.min(pageSize, 100 - start) }, (_, i) => ({
+        id: start + i + 1,
+        name: `Item ${start + i + 1}`,
+      }));
+
+      return Promise.resolve({ rows, totalRows: 100 });
+    });
+
+    handsontable({
+      data: [],
+      columns: [{ data: 'id' }, { data: 'name' }],
+      colHeaders: true,
+      columnSorting: true,
+      pagination: { pageSize: 10, initialPage: 1 },
+      dataProvider: createDataProviderConfig({ fetchRows }),
+    });
+
+    await sleep(100);
+
+    getPlugin('pagination').setPageSize(50);
+
+    await sleep(100);
+
+    fetchRows.calls.reset();
+
+    getPlugin('columnSorting').sort({ column: 1, sortOrder: 'asc' });
+
+    await sleep(100);
+
+    expect(fetchRows).toHaveBeenCalledWith(
+      jasmine.objectContaining({ pageSize: 50 }),
+      jasmine.any(Object)
+    );
+    expect(getPlugin('pagination').getPaginationData().pageSize).toBe(50);
+  });
+
   it('should keep current pagination page when column sort triggers refetch', async() => {
     const fetchRows = jasmine.createSpy('fetchRows').and.callFake((params) => {
       const { page, pageSize } = params;

--- a/handsontable/src/plugins/dataProvider/query/__tests__/pagination.unit.js
+++ b/handsontable/src/plugins/dataProvider/query/__tests__/pagination.unit.js
@@ -49,6 +49,45 @@ describe('dataProvider/query/pagination', () => {
       expect(query.page).toBe(4);
     });
 
+    it('should prefer getCurrentPageSize over getSetting("pageSize")', () => {
+      const query = { page: 1, pageSize: 10 };
+      const pagination = {
+        enabled: true,
+        getSetting: key => ({ pageSize: 5, initialPage: 1 }[key]),
+        getCurrentPageSize: () => 50,
+      };
+
+      applyPaginationToQueryParameters(pagination, query);
+
+      expect(query.pageSize).toBe(50);
+    });
+
+    it('should fall back to getSetting("pageSize") when getCurrentPageSize returns "auto"', () => {
+      const query = { page: 1, pageSize: 10 };
+      const pagination = {
+        enabled: true,
+        getSetting: key => ({ pageSize: 25, initialPage: 1 }[key]),
+        getCurrentPageSize: () => 'auto',
+      };
+
+      applyPaginationToQueryParameters(pagination, query);
+
+      expect(query.pageSize).toBe(25);
+    });
+
+    it('should fall back to getSetting("pageSize") when getCurrentPageSize returns non-numeric value', () => {
+      const query = { page: 1, pageSize: 10 };
+      const pagination = {
+        enabled: true,
+        getSetting: key => ({ pageSize: 25, initialPage: 1 }[key]),
+        getCurrentPageSize: () => undefined,
+      };
+
+      applyPaginationToQueryParameters(pagination, query);
+
+      expect(query.pageSize).toBe(25);
+    });
+
     it('should no-op when plugin is missing or disabled', () => {
       const query = { page: 1, pageSize: 10 };
 

--- a/handsontable/src/plugins/dataProvider/query/pagination.js
+++ b/handsontable/src/plugins/dataProvider/query/pagination.js
@@ -5,11 +5,18 @@ const PAGINATION_PLUGIN_KEY = 'pagination';
 /**
  * Copies enabled Pagination `pageSize` and current page into query parameters.
  *
- * Uses [[Pagination#getCurrentPage]] when present so refetches (e.g. after sort) keep the active page
- * without calling [[Pagination#getPaginationData]] (unsafe before DataProvider registers external-pagination hooks).
- * Falls back to `initialPage` from settings when `getCurrentPage` is missing (tests) or returns an invalid value.
+ * Uses [[Pagination#getCurrentPage]] and [[Pagination#getCurrentPageSize]] when present so refetches
+ * (e.g. after sort) keep the user-selected state without calling [[Pagination#getPaginationData]]
+ * (unsafe before DataProvider registers external-pagination hooks).
+ * Falls back to `pageSize` / `initialPage` from settings when the state getters are missing (tests)
+ * or return a non-numeric value (e.g. `'auto'`).
  *
- * @param {{ enabled?: boolean, getSetting: function(string): *, getCurrentPage?: function(): number }|null|undefined} paginationPlugin Pagination plugin instance.
+ * @param {{
+ *   enabled?: boolean,
+ *   getSetting: function(string): *,
+ *   getCurrentPage?: function(): number,
+ *   getCurrentPageSize?: function(): number | 'auto' | undefined,
+ * }|null|undefined} paginationPlugin Pagination plugin instance.
  * @param {{ page: number, pageSize: number }} queryParameters Target object (mutated).
  * @returns {void}
  */
@@ -18,14 +25,19 @@ export function applyPaginationToQueryParameters(paginationPlugin, queryParamete
     return;
   }
 
-  const pageSize = paginationPlugin.getSetting('pageSize');
+  const currentPageSize = typeof paginationPlugin.getCurrentPageSize === 'function'
+    ? paginationPlugin.getCurrentPageSize()
+    : undefined;
+  const settingsPageSize = paginationPlugin.getSetting('pageSize');
   const initialPage = paginationPlugin.getSetting('initialPage');
   const currentPage = typeof paginationPlugin.getCurrentPage === 'function'
     ? paginationPlugin.getCurrentPage()
     : undefined;
 
-  if (typeof pageSize === 'number') {
-    queryParameters.pageSize = pageSize;
+  if (typeof currentPageSize === 'number') {
+    queryParameters.pageSize = currentPageSize;
+  } else if (typeof settingsPageSize === 'number') {
+    queryParameters.pageSize = settingsPageSize;
   }
 
   if (typeof currentPage === 'number' && currentPage >= 1) {

--- a/handsontable/src/plugins/pagination/__tests__/pagination.types.ts
+++ b/handsontable/src/plugins/pagination/__tests__/pagination.types.ts
@@ -62,6 +62,7 @@ const paginationData: {
   lastVisibleRowIndex: number;
 } = plugin.getPaginationData();
 const currentPageIndex: number = plugin.getCurrentPage();
+const currentPageSize: number | 'auto' = plugin.getCurrentPageSize();
 const hasPreviousPage: boolean = plugin.hasPreviousPage();
 const hasNextPage: boolean = plugin.hasNextPage();
 const data: any[][] = plugin.getCurrentPageData();

--- a/handsontable/src/plugins/pagination/pagination.js
+++ b/handsontable/src/plugins/pagination/pagination.js
@@ -471,6 +471,15 @@ export class Pagination extends BasePlugin {
   }
 
   /**
+   * Returns the current page size from internal pagination state. May be `'auto'`.
+   *
+   * @returns {number | 'auto'} Current page size or `'auto'`.
+   */
+  getCurrentPageSize() {
+    return this.#pageSize;
+  }
+
+  /**
    * Allows changing the page for specified page number.
    *
    * @param {number} pageNumber The page number to set (from 1 to N). If `0` is passed, it

--- a/handsontable/types/plugins/pagination/pagination.d.ts
+++ b/handsontable/types/plugins/pagination/pagination.d.ts
@@ -32,6 +32,7 @@ export class Pagination extends BasePlugin {
 
   getPaginationData(): PaginationData;
   getCurrentPage(): number;
+  getCurrentPageSize(): PageSizeOption;
   setPage(pageNumber: number): void;
   resetPage(): void;
   setPageSize(pageSize: PageSizeOption): void;


### PR DESCRIPTION
### Context

The PR fixes a bug where the Pagination plugin's user-selected `pageSize` reverted to the value from `pagination.pageSize` settings whenever the user sorted a column in DataProvider (server-backed) mode.

Root cause: `applyPaginationToQueryParameters` in `handsontable/src/plugins/dataProvider/query/pagination.js` read `pageSize` from `paginationPlugin.getSetting('pageSize')` (option value, never updated by `setPageSize`), while `currentPage` was correctly read from `getCurrentPage()` (state). Sort triggers `#applyQueryParametersFromPlugins()` before `fetchData()`, which overwrote `#queryParameters.pageSize` from settings every time. CRUD, page-change, and filter paths skip `applyQueryParametersFromPlugins`, so only sort exhibited the bug.

Fix:
- Add `getCurrentPageSize()` to the Pagination plugin, returning the private `#pageSize` field (mirrors `getCurrentPage()`).
- Update `applyPaginationToQueryParameters` to prefer `paginationPlugin.getCurrentPageSize()` (numeric) over `paginationPlugin.getSetting('pageSize')`. Falls back to settings when the state getter is missing (defensive for old plugin shapes / tests) or returns a non-number (`'auto'`).

[skip changelog] — DataProvider plugin is unreleased (only in 17.1.0-rc tags; last stable is 17.0.1). The bug never reached users; the fix folds into the upcoming 17.1 release alongside the initial DataProvider feature entry.

### How has this been tested?

- Added 3 unit tests in `handsontable/src/plugins/dataProvider/query/__tests__/pagination.unit.js` covering prefer-state, fallback on `'auto'`, fallback on `undefined`.
- Added 1 E2E test in `handsontable/src/plugins/dataProvider/__tests__/plugins/pagination.spec.js` verifying `setPageSize(50)` followed by `columnSorting.sort(...)` keeps the user-selected pageSize.
- Added TypeScript regression line in `handsontable/src/plugins/pagination/__tests__/pagination.types.ts` for `getCurrentPageSize()`.

Commands:

```
npm run test:unit --prefix handsontable -- --testPathPattern="dataProvider/query/__tests__/pagination"
npm run test:e2e --prefix handsontable -- --testPathPattern="(pagination |dataProvider)"
npm run test:types --prefix handsontable
```

Results: 18/18 unit pass, 326/326 E2E pass (theme=main), TS pass, lint clean.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1677

### Affected project(s):

- [x] \`handsontable\`
- [ ] \`@handsontable/angular-wrapper\`
- [ ] \`@handsontable/react-wrapper\`
- [ ] \`@handsontable/vue3\`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1677

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Pagination public API and DataProvider query-parameter derivation; low complexity but could affect any integration relying on pageSize being taken from settings rather than current state.
> 
> **Overview**
> Fixes a DataProvider-mode bug where sorting triggered a refetch that reset the effective `pageSize` back to the configured setting instead of the user-selected value.
> 
> Adds `Pagination#getCurrentPageSize()` and updates `applyPaginationToQueryParameters` to prefer the current pagination state (`getCurrentPageSize()`/`getCurrentPage()`) over settings, with fallbacks when the state getter is missing or non-numeric (e.g. `'auto'`).
> 
> Extends coverage with new unit/E2E tests and updates TypeScript typings to include `getCurrentPageSize()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37ab27cb8b6b85da5da08e5e24a216eb0d92edcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->