### PR TITLE
Filter prerelease versions for documentation generation

### DIFF
--- a/docs/netlify/getListOrPreviousVersions.mjs
+++ b/docs/netlify/getListOrPreviousVersions.mjs
@@ -32,6 +32,7 @@ async function readFromGitHub() {
 
   releases.data
     .map(item => item.tag_name)
+    .filter(tag => !semver.prerelease(tag))
     .sort((a, b) => semver.rcompare(a, b))
     .forEach((tag) => {
       const minorVersion = `${semver.parse(tag).major}.${


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
This filters out prereleased versions from the list, so the netlify knows which version in latest.

Its cherry pick of https://github.com/handsontable/handsontable/pull/12065

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Manual check

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small filtering change in docs build tooling that only affects which release tags are considered for `LATEST_VERSION`/`PREVIOUS_VERSIONS` generation.
> 
> **Overview**
> Netlify docs version generation now **filters out prerelease GitHub release tags** (via `semver.prerelease`) before sorting and selecting the latest/minor versions, preventing prerelease tags from being picked as `LATEST_VERSION` or included in `PREVIOUS_VERSIONS`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 312c6cda27d8071b2e53ac4f3b8a57ce1fb67b18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->