### PR TITLE
DEV-1682: Fix setSourceDataAtCell crash inside afterLoadData hook

### DIFF
--- a/.changelogs/12585.json
+++ b/.changelogs/12585.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed a crash when calling `setSourceDataAtCell()` inside the `afterLoadData()` hook during initialization.",
+  "type": "fixed",
+  "issueOrPR": 12585,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/__tests__/core/setSourceDataAtCell.spec.js
+++ b/handsontable/src/__tests__/core/setSourceDataAtCell.spec.js
@@ -222,4 +222,24 @@ describe('Core.setSourceDataAtCell', () => {
 
     expect(getSourceData()).toEqual([{ id: 1, name: 'Ted Right', address: '' }]);
   });
+
+  it('should not throw when called inside the `afterLoadData` hook during initialization (#9904)', async() => {
+    let thrownError = null;
+
+    expect(() => {
+      handsontable({
+        data: createSpreadsheetData(3, 3),
+        afterLoadData() {
+          try {
+            this.setSourceDataAtCell(0, 0, 'modified');
+          } catch (e) {
+            thrownError = e;
+          }
+        },
+      });
+    }).not.toThrow();
+
+    expect(thrownError).toBeNull();
+    expect(getSourceData()[0][0]).toBe('modified');
+  });
 });

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -5194,7 +5194,10 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
    * @returns {BaseEditor | undefined} The active editor instance, or `undefined` if no cell is selected.
    */
   this.getActiveEditor = function() {
-    return editorManager.getActiveEditor();
+    // During the first `afterLoadData` hook (fired from `loadData` inside `init`),
+    // `editorManager` has not been assigned yet. Guard so callers (e.g.
+    // `setSourceDataAtCell`) invoked from that hook do not crash.
+    return editorManager?.getActiveEditor();
   };
 
   /**


### PR DESCRIPTION
### Context

The PR fixes a TypeError thrown when `setSourceDataAtCell()` is called inside the `afterLoadData()` hook during Handsontable initialization. Reported in [#9904](https://github.com/handsontable/handsontable/issues/9904) (originally on v12.1.2) and reproducible on v17.0.1 and current `develop`.

Root cause: in `Core.init()` (`handsontable/src/core.js`), the order is:

1. `this.updateSettings(...)` (line 1369) triggers `loadData` -> `replaceData` -> fires `afterLoadData`.
2. `editorManager = EditorManager.getInstance(...)` (line 1373) runs after the hook.

User code calling `setSourceDataAtCell()` inside the first `afterLoadData` writes the source data correctly, then reaches `instance.getActiveEditor()` (`core.js:3645`). `getActiveEditor` dereferenced the module-scoped `editorManager`, which is still `undefined` at that point, throwing `TypeError: Cannot read properties of undefined (reading 'getActiveEditor')`.

Same file already guards `if (editorManager)` in `destroy()` (line 5116), confirming the variable can legitimately be undefined. The hook is documented as a regular post-modification callback with no contract forbidding data writes, so this is a defensive-guard bug, not a usage error.

Fix: optional-chain `editorManager?.getActiveEditor()` in `Core.getActiveEditor`. Downstream code at `core.js:3647-3649` already handles `undefined` activeEditor, so returning `undefined` is safe.

### How has this been tested?

- Added a regression test in `handsontable/src/__tests__/core/setSourceDataAtCell.spec.js` that instantiates Handsontable with an `afterLoadData` hook calling `setSourceDataAtCell(0, 0, 'modified')` and asserts no throw plus the source value is written.

Commands:

```bash
npm run test:e2e --prefix handsontable -- --testPathPattern=setSourceDataAtCell
npm run build --prefix handsontable
```

Manual verification: built `dist/handsontable.full.js` and reproduced both the broken CDN behavior (v17.0.1) and the fixed local-build behavior in side-by-side demo pages. Released build throws in the browser console; PR build runs clean and the source-data write takes effect.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. #9904
2. DEV-1682

### Affected project(s):

- [x] \`handsontable\`
- [ ] \`@handsontable/angular-wrapper\`
- [ ] \`@handsontable/react-wrapper\`
- [ ] \`@handsontable/vue3\`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1682

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk defensive change: `getActiveEditor()` now tolerates an uninitialized `editorManager` during early init; behavior remains the same once initialization completes.
> 
> **Overview**
> Fixes an initialization-time crash when `setSourceDataAtCell()` is called from the first `afterLoadData` hook by guarding `Core.getActiveEditor()` with optional chaining so it returns `undefined` instead of throwing.
> 
> Adds a regression test covering `setSourceDataAtCell()` inside `afterLoadData` during init, and includes a changelog entry for the public fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99c7175e4dcca168cc08e9bbd75de587318ab581. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->