### PR TITLE
DEV-1695: Fix context menu object items dropping plugin callbacks

### DIFF
--- a/.changelogs/12586.json
+++ b/.changelogs/12586.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed context menu items in object form (e.g. `add_child`, `detach_from_parent`) not rendering plugin-provided callbacks and translated labels.",
+  "type": "fixed",
+  "issueOrPR": 12586,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/contextMenu/itemsFactory.js
+++ b/handsontable/src/plugins/contextMenu/itemsFactory.js
@@ -57,16 +57,17 @@ export class ItemsFactory {
       } else {
         // Object-form `contextMenu.items` keys that name a plugin-provided
         // entry (e.g. `add_child` from nestedRows) are unknown to the registry
-        // on the first `getItems` pass, so a bare placeholder is emitted. The
-        // nestedRows plugin then splices its rich entry at the start of the
-        // array via `afterContextMenuDefaultOptions`, placing the bare
-        // placeholder later in iteration order. Without this guard, the
-        // placeholder would overwrite the rich entry's callback, submenu, or
-        // renderer. See issue #9894.
-        const existing = items[value.key];
-        const isRich = item => Boolean(item && (item.callback || item.submenu || item.renderer));
+        // on the first `getItems` pass, so a bare placeholder is emitted.
+        // Plugins later splice their rich entries into the same array via
+        // `afterContextMenuDefaultOptions`. Merging preserves both contributions
+        // regardless of iteration order: rich properties (callback, submenu,
+        // disabled, renderer, name function, etc.) survive when the other side
+        // does not define them, and user overrides still take effect via the
+        // final `getItems` pass that extends the user pattern onto the predefined
+        // entry. See issue #9894.
+        if (items[value.key]) {
+          extend(items[value.key], value);
 
-        if (existing && isRich(existing) && !isRich(value)) {
           return;
         }
 

--- a/handsontable/src/plugins/contextMenu/itemsFactory.js
+++ b/handsontable/src/plugins/contextMenu/itemsFactory.js
@@ -55,6 +55,21 @@ export class ItemsFactory {
         menuItemKey = value.key;
 
       } else {
+        // Object-form `contextMenu.items` keys that name a plugin-provided
+        // entry (e.g. `add_child` from nestedRows) are unknown to the registry
+        // on the first `getItems` pass, so a bare placeholder is emitted. The
+        // nestedRows plugin then splices its rich entry at the start of the
+        // array via `afterContextMenuDefaultOptions`, placing the bare
+        // placeholder later in iteration order. Without this guard, the
+        // placeholder would overwrite the rich entry's callback, submenu, or
+        // renderer. See issue #9894.
+        const existing = items[value.key];
+        const isRich = item => Boolean(item && (item.callback || item.submenu || item.renderer));
+
+        if (existing && isRich(existing) && !isRich(value)) {
+          return;
+        }
+
         items[value.key] = value;
         menuItemKey = value.key;
       }

--- a/handsontable/src/plugins/customBorders/__tests__/contextMenuItem/borders.spec.js
+++ b/handsontable/src/plugins/customBorders/__tests__/contextMenuItem/borders.spec.js
@@ -72,5 +72,45 @@ describe('ContextMenu', () => {
 
       expect(readOnlyItem.hasClass('htDisabled')).toBe(true);
     });
+
+    it('should resolve `borders` to the plugin-provided submenu when items are passed as an object', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        rowHeaders: true,
+        colHeaders: true,
+        customBorders: true,
+        contextMenu: {
+          items: {
+            borders: {},
+          }
+        }
+      });
+
+      await selectCell(1, 1);
+      await contextMenu();
+
+      const $item = $('.htContextMenu tbody tr td').filter(function() {
+        return this.textContent === 'Borders';
+      });
+
+      expect($item.length).toBe(1);
+      expect($item.hasClass('htDisabled')).toBe(false);
+
+      $item.simulate('mouseover');
+
+      await sleep(350);
+
+      const submenuLabels = $('.htContextMenuSub_Borders tbody tr td')
+        .not('.htSeparator')
+        .map(function() {
+          return this.textContent;
+        })
+        .get();
+
+      expect(submenuLabels).toContain('Top');
+      expect(submenuLabels).toContain('Right');
+      expect(submenuLabels).toContain('Bottom');
+      expect(submenuLabels).toContain('Left');
+    });
   });
 });

--- a/handsontable/src/plugins/hiddenColumns/__tests__/contextMenu/hideColumn.spec.js
+++ b/handsontable/src/plugins/hiddenColumns/__tests__/contextMenu/hideColumn.spec.js
@@ -60,5 +60,28 @@ describe('ContextMenu', () => {
 
       expect(compatibleEntries.size()).toEqual(1);
     });
+
+    it('should resolve `hidden_columns_hide` to the plugin-provided full entry when items are passed as an' +
+      ' object', async() => {
+      handsontable({
+        data: createSpreadsheetData(4, 4),
+        rowHeaders: true,
+        colHeaders: true,
+        hiddenColumns: true,
+        contextMenu: {
+          items: {
+            hidden_columns_hide: {},
+          }
+        }
+      });
+
+      await selectColumns(0);
+      await contextMenu();
+
+      const compatibleEntries = getHideColumnCMElement();
+
+      expect(compatibleEntries.size()).toEqual(1);
+      expect(compatibleEntries.hasClass('htDisabled')).toBe(false);
+    });
   });
 });

--- a/handsontable/src/plugins/nestedRows/__tests__/nestedRows.spec.js
+++ b/handsontable/src/plugins/nestedRows/__tests__/nestedRows.spec.js
@@ -438,4 +438,143 @@ describe('NestedRows', () => {
 
     expect(spy).not.toHaveBeenCalled();
   });
+
+  describe('context menu items defined as object', () => {
+    it('should resolve `add_child` to the plugin-provided full entry (translated name + callback)', async() => {
+      handsontable({
+        data: getSimplerNestedData(),
+        nestedRows: true,
+        contextMenu: {
+          items: {
+            add_child: {},
+          }
+        }
+      });
+
+      const initialRowCount = countRows();
+
+      await selectCell(0, 0);
+      await contextMenu();
+
+      const $menuItem = $('.htContextMenu .ht_master .htCore tbody td')
+        .not('.htSeparator')
+        .filter(function() {
+          return $(this).text() === 'Insert child row';
+        });
+
+      expect($menuItem.length).toBe(1);
+
+      await selectContextMenuOption('Insert child row');
+
+      expect(countRows()).toBe(initialRowCount + 1);
+    });
+
+    it('should resolve `detach_from_parent` to the plugin-provided full entry', async() => {
+      handsontable({
+        data: getSimplerNestedData(),
+        nestedRows: true,
+        contextMenu: {
+          items: {
+            add_child: {},
+            detach_from_parent: {},
+          }
+        }
+      });
+
+      await selectCell(0, 0);
+      await contextMenu();
+      await selectContextMenuOption('Insert child row');
+
+      const rowCountAfterAdd = countRows();
+
+      await selectCell(6, 0);
+      await contextMenu();
+
+      const $detachItem = $('.htContextMenu .ht_master .htCore tbody td')
+        .not('.htSeparator')
+        .filter(function() {
+          return $(this).text() === 'Detach from parent';
+        });
+
+      expect($detachItem.length).toBe(1);
+
+      await selectContextMenuOption('Detach from parent');
+
+      expect(countRows()).toBe(rowCountAfterAdd);
+      expect(getPlugin('nestedRows').dataManager.isParent(18)).toBeFalsy();
+    });
+
+    it('should preserve the plugin callback when overriding only the label of `add_child`', async() => {
+      handsontable({
+        data: getSimplerNestedData(),
+        nestedRows: true,
+        contextMenu: {
+          items: {
+            add_child: { name: 'Custom add child label' },
+          }
+        }
+      });
+
+      const initialRowCount = countRows();
+
+      await selectCell(0, 0);
+      await contextMenu();
+      await selectContextMenuOption('Custom add child label');
+
+      expect(countRows()).toBe(initialRowCount + 1);
+    });
+
+    it('should let a user-supplied callback override the plugin callback for `add_child`', async() => {
+      const userCallback = jasmine.createSpy('userCallback');
+
+      handsontable({
+        data: getSimplerNestedData(),
+        nestedRows: true,
+        contextMenu: {
+          items: {
+            add_child: {
+              name: 'Custom add child',
+              callback: userCallback,
+            },
+          }
+        }
+      });
+
+      const initialRowCount = countRows();
+
+      await selectCell(0, 0);
+      await contextMenu();
+      await selectContextMenuOption('Custom add child');
+
+      expect(userCallback).toHaveBeenCalledTimes(1);
+      expect(countRows()).toBe(initialRowCount);
+    });
+
+    it('should resolve a mixed object containing built-in and plugin keys', async() => {
+      handsontable({
+        data: getSimplerNestedData(),
+        nestedRows: true,
+        contextMenu: {
+          items: {
+            row_above: {},
+            add_child: {},
+          }
+        }
+      });
+
+      const initialRowCount = countRows();
+
+      await selectCell(1, 0);
+      await contextMenu();
+      await selectContextMenuOption('Insert row above');
+
+      expect(countRows()).toBe(initialRowCount + 1);
+
+      await selectCell(0, 0);
+      await contextMenu();
+      await selectContextMenuOption('Insert child row');
+
+      expect(countRows()).toBe(initialRowCount + 2);
+    });
+  });
 });


### PR DESCRIPTION
### Context

The PR fixes a bug where configuring `contextMenu` with the object form and referencing a plugin-provided key (e.g. `add_child` or `detach_from_parent` from `nestedRows`) produced menu entries with raw keys as labels and no callbacks. Clicking them was a no-op.

Example that reproduces the issue (see [jsfiddle from #9894](https://jsfiddle.net/footman8899/t7jwy6qc/10/)):

```js
new Handsontable(container, {
  nestedRows: true,
  contextMenu: {
    items: {
      row_above: {},
      row_below: {},
      detach_from_parent: { name: 'detach_from_parent' },
      add_child: { name: 'add_child' }
    }
  },
  // ...
});
```

Root cause is in `ItemsFactory.setPredefinedItems` (`handsontable/src/plugins/contextMenu/itemsFactory.js`). The flow is:

1. `getItems(settings)` resolves user settings against a registry that does not yet contain plugin-provided entries, so unknown keys become bare placeholders.
2. The `afterContextMenuDefaultOptions` hook fires; the `nestedRows` plugin splices its rich entries (with translated `name`, `callback`, and `disabled`) at the start of the array.
3. `setPredefinedItems` iterates the array and assigns `items[value.key] = value` without checking if a rich entry already exists. The bare placeholder appears later in the array than the spliced rich entry, so it overwrites it.

The array form (`contextMenu: ['add_child']`) survives because `setPredefinedItems` assigns bare placeholders under their numeric index key, avoiding the collision.

The fix is a defensive guard in `setPredefinedItems`: skip the assignment when an existing entry has a callback, submenu, or renderer and the incoming entry has none. This preserves the plugin's rich entry while still allowing legitimate later overrides (which carry their own callback or richer fields).

### How has this been tested?

Added E2E tests:

- `handsontable/src/plugins/nestedRows/__tests__/nestedRows.spec.js` - new describe block `context menu items defined as object` covering: `add_child: {}`, `detach_from_parent: {}`, override `{ name: 'Custom add child label' }`, user-supplied full override (`{ name, callback }`), and mixed built-in + plugin keys (5 tests). 4 of these fail on `develop` without the fix, locking down the regression.
- `handsontable/src/plugins/customBorders/__tests__/contextMenuItem/borders.spec.js` - object-form `{ borders: {} }` test asserting the entry renders and the submenu opens with Top/Right/Bottom/Left items (positive coverage; `customBorders` pushes to the end of the items array so it does not hit the original bug, but this pins the behavior).
- `handsontable/src/plugins/hiddenColumns/__tests__/contextMenu/hideColumn.spec.js` - object-form `{ hidden_columns_hide: {} }` test (positive coverage, same rationale as borders).

Commands to reproduce:

```bash
npm run build --prefix handsontable
npm run test:e2e --prefix handsontable -- --testPathPattern='nestedRows/__tests__/nestedRows'
npm run test:e2e --prefix handsontable -- --testPathPattern='customBorders/__tests__/contextMenuItem'
npm run test:e2e --prefix handsontable -- --testPathPattern='hiddenColumns/__tests__/contextMenu'
npm run test:e2e --prefix handsontable -- --testPathPattern='contextMenu/__tests__'
npm run test:e2e --prefix handsontable -- --testPathPattern='dropdownMenu'
```

Full results: 612 specs pass across the relevant suites (`nestedRows`, `customBorders`, `hiddenColumns`, `contextMenu`, `dropdownMenu`), 0 failures. ESLint clean.

Manual repro verified locally against the jsfiddle setup from the linked GitHub issue: on `v17.0.1` from CDN the menu entries are inert; on the PR build the callbacks fire and rows are added/detached as expected.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. #9894
2. DEV-1695

### Affected project(s):

- [x] \`handsontable\`
- [ ] \`@handsontable/angular-wrapper\`
- [ ] \`@handsontable/react-wrapper\`
- [ ] \`@handsontable/vue3\`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1695

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core context-menu item merging logic used by multiple plugins; regression could change how duplicate keys/overrides are resolved, though behavior is now covered by new E2E tests.
> 
> **Overview**
> Fixes object-form `contextMenu.items` handling so plugin-defined entries (e.g. `nestedRows` `add_child`/`detach_from_parent`, `customBorders` `borders`, `hiddenColumns` `hidden_columns_hide`) no longer lose their translated labels, callbacks, or submenus when placeholders and plugin entries collide.
> 
> `ItemsFactory.setPredefinedItems` now merges duplicate keyed items instead of blindly overwriting, preserving the richer plugin entry while still allowing user overrides (including user-supplied callbacks). Adds E2E coverage for these cases and includes a changelog entry (`.changelogs/12586.json`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5246548183f6ecc283bfcb4d10eeacb119ed468. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->