### PR TITLE
DEV-1703: Fix scroll jump on alter('insert_row_above') near bottom

### DIFF
--- a/.changelogs/12587.json
+++ b/.changelogs/12587.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed page scroll jump when inserting or removing a row/column near the bottom of the page on a grid with no fixed height.",
+  "type": "fixed",
+  "issueOrPR": 12587,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/__tests__/core/insertRowAbove.spec.js
+++ b/handsontable/src/__tests__/core/insertRowAbove.spec.js
@@ -591,5 +591,29 @@ describe('Core.alter', () => {
         alter('insert_row_above', 0, 100000);
       }).not.toThrowError();
     });
+
+    it('should not scroll the window when inserting a row above the last row (no fixed height, window scroll)', async() => {
+      handsontable({
+        data: createSpreadsheetData(200, 5),
+      });
+
+      await selectCell(199, 0);
+
+      window.scrollTo(0, document.body.scrollHeight);
+
+      await waitForNextAnimationFrames(2);
+
+      const scrollYBefore = window.scrollY;
+
+      expect(scrollYBefore).toBeGreaterThan(0);
+
+      await alter('insert_row_above', 199);
+
+      await waitForNextAnimationFrames(2);
+
+      expect(window.scrollY).toBe(scrollYBefore);
+
+      window.scrollTo(0, 0);
+    });
   });
 });

--- a/handsontable/src/core.js
+++ b/handsontable/src/core.js
@@ -572,7 +572,7 @@ export default function Core(rootContainer, userSettings, rootInstanceSymbol = f
     );
 
     const selectionSource = selection.getSelectionSource();
-    const ignoreScrollSources = ['loadData', 'updateData', 'deselect'];
+    const ignoreScrollSources = ['loadData', 'updateData', 'deselect', 'shift'];
 
     if (
       isLastSelectionLayer &&


### PR DESCRIPTION
### Context

The PR fixes a page-scroll jump when calling `alter('insert_row_*'|'insert_col_*'|'remove_row'|'remove_col')` on a grid with no fixed height while the window is scrolled near the bottom (e.g. context menu **Insert row above** on the last row).

Root cause: after `alter` mutates data, `selection.shiftRows()` / `shiftColumns()` updates the focused-cell coordinates with source `'shift'` and fires `afterSetRange`. The handler in `core.js` calls `viewportScroller.scrollTo(cellCoords)` because `'shift'` was missing from `ignoreScrollSources` (which already contains `'loadData'`, `'updateData'`, `'deselect'`). With the grid using the window as its scroll container, that `scrollTo` ultimately calls `scrollIntoView()` on the shifted cell and moves the page.

Fix: add `'shift'` to the `ignoreScrollSources` list, matching how the same source is already excluded from the editor-close path a few lines below.

Resolves: https://github.com/handsontable/handsontable/issues/9744

### How has this been tested?

- New E2E regression test in `handsontable/src/__tests__/core/insertRowAbove.spec.js` — scrolls window to bottom on a 200-row grid with no fixed height, calls `alter('insert_row_above', 199)`, asserts `window.scrollY` unchanged. Confirmed red→green: pre-fix `Expected 5110 to be 5081`; post-fix passes.
- Local regression sweep across affected paths (1821 specs, 0 failures):

  ```bash
  npm run test:e2e --prefix handsontable -- \
    --testPathPattern='(insertRow|insertCol|removeRow|removeCol|alter|selection|view\.spec|scroll)'
  ```

- Manual verification via local demo (released v17.0.1 vs PR build) — context menu **Insert row above** on the last row near the bottom of the page no longer scrolls the page.
- Lint clean on changed files (`npx eslint src/core.js src/__tests__/core/insertRowAbove.spec.js`).

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1703
2. #9744

### Affected project(s):

- [x] \`handsontable\`
- [ ] \`@handsontable/angular-wrapper\`
- [ ] \`@handsontable/react-wrapper\`
- [ ] \`@handsontable/vue3\`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1703

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `Core` selection/scroll behavior by skipping `viewportScroller.scrollTo()` for the `shift` selection source, which could subtly change when the viewport auto-scrolls after programmatic selection updates.
> 
> **Overview**
> Fixes a regression where structural `alter()` operations (insert/remove row/column) on tables without a fixed height could trigger an unwanted *window scroll jump* near the bottom of the page.
> 
> The selection `afterSetRangeEnd` handler now treats `shift` as an `ignoreScrollSources` case (alongside `loadData`, `updateData`, `deselect`), preventing `viewportScroller.scrollTo()` from running during selection coordinate shifts. Adds an E2E regression test asserting `window.scrollY` remains unchanged when calling `alter('insert_row_above')` on the last row while the window is scrolled to the bottom.
> 
> Includes a changelog entry for the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9b81cec217344cdcae59045246097a5f95e076e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->