### PR TITLE
DEV-1693: Fix React example in multi-column filter panel recipe

### DIFF
--- a/docs/content/recipes/filtering-search/multi-column-filter-panel/react/example1.css
+++ b/docs/content/recipes/filtering-search/multi-column-filter-panel/react/example1.css
@@ -14,7 +14,3 @@
   gap: 0.25rem;
   min-width: 120px;
 }
-
-.example-controls-container .filter-label--wide {
-  min-width: 160px;
-}

--- a/docs/content/recipes/filtering-search/multi-column-filter-panel/react/example1.jsx
+++ b/docs/content/recipes/filtering-search/multi-column-filter-panel/react/example1.jsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useRef, useState, useEffect } from 'react';
 import { HotTable } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
 import './example1.css';
@@ -27,7 +27,7 @@ const ExampleComponent = () => {
   const [minPrice, setMinPrice] = useState('');
   const [maxPrice, setMaxPrice] = useState('');
 
-  function applyFilters(name, category, min, max) {
+  useEffect(() => {
     const hot = hotRef.current?.hotInstance;
 
     if (!hot) {
@@ -38,29 +38,29 @@ const ExampleComponent = () => {
 
     filtersPlugin.clearConditions();
 
-    if (category) {
-      filtersPlugin.addCondition(1, 'eq', [category]);
+    if (categoryFilter) {
+      filtersPlugin.addCondition(1, 'eq', [categoryFilter]);
     }
 
-    if (name.trim()) {
-      filtersPlugin.addCondition(0, 'contains', [name.trim()]);
+    if (nameFilter.trim()) {
+      filtersPlugin.addCondition(0, 'contains', [nameFilter.trim()]);
     }
 
-    if (min && max) {
-      const lowerBound = Number(min);
-      const upperBound = Number(max);
+    if (minPrice && maxPrice) {
+      const lowerBound = Number(minPrice);
+      const upperBound = Number(maxPrice);
 
       if (Number.isFinite(lowerBound) && Number.isFinite(upperBound)) {
         filtersPlugin.addCondition(2, 'between', [lowerBound, upperBound]);
       }
-    } else if (min) {
-      const lowerBound = Number(min);
+    } else if (minPrice) {
+      const lowerBound = Number(minPrice);
 
       if (Number.isFinite(lowerBound)) {
         filtersPlugin.addCondition(2, 'gte', [lowerBound]);
       }
-    } else if (max) {
-      const upperBound = Number(max);
+    } else if (maxPrice) {
+      const upperBound = Number(maxPrice);
 
       if (Number.isFinite(upperBound)) {
         filtersPlugin.addCondition(2, 'lte', [upperBound]);
@@ -68,54 +68,13 @@ const ExampleComponent = () => {
     }
 
     filtersPlugin.filter();
-    hot.render();
-  }
-
-  function handleNameChange(e) {
-    const value = e.target.value;
-
-    setNameFilter(value);
-    applyFilters(value, categoryFilter, minPrice, maxPrice);
-  }
-
-  function handleCategoryChange(e) {
-    const value = e.target.value;
-
-    setCategoryFilter(value);
-    applyFilters(nameFilter, value, minPrice, maxPrice);
-  }
-
-  function handleMinPriceChange(e) {
-    const value = e.target.value;
-
-    setMinPrice(value);
-    applyFilters(nameFilter, categoryFilter, value, maxPrice);
-  }
-
-  function handleMaxPriceChange(e) {
-    const value = e.target.value;
-
-    setMaxPrice(value);
-    applyFilters(nameFilter, categoryFilter, minPrice, value);
-  }
+  }, [nameFilter, categoryFilter, minPrice, maxPrice]);
 
   function clearFilters() {
     setNameFilter('');
     setCategoryFilter('');
     setMinPrice('');
     setMaxPrice('');
-
-    const hot = hotRef.current?.hotInstance;
-
-    if (!hot) {
-      return;
-    }
-
-    const filtersPlugin = hot.getPlugin('filters');
-
-    filtersPlugin.clearConditions();
-    filtersPlugin.filter();
-    hot.render();
   }
 
   return (
@@ -128,12 +87,12 @@ const ExampleComponent = () => {
               type="text"
               placeholder="Contains..."
               value={nameFilter}
-              onChange={handleNameChange}
+              onChange={(e) => setNameFilter(e.target.value)}
             />
           </label>
           <label className="filter-label filter-label--wide">
             Category
-            <select value={categoryFilter} onChange={handleCategoryChange}>
+            <select value={categoryFilter} onChange={(e) => setCategoryFilter(e.target.value)}>
               <option value="">All categories</option>
               <option value="Bikes">Bikes</option>
               <option value="Safety">Safety</option>
@@ -149,7 +108,7 @@ const ExampleComponent = () => {
               min="0"
               placeholder="0"
               value={minPrice}
-              onChange={handleMinPriceChange}
+              onChange={(e) => setMinPrice(e.target.value)}
             />
           </label>
           <label className="filter-label">
@@ -159,7 +118,7 @@ const ExampleComponent = () => {
               min="0"
               placeholder="2500"
               value={maxPrice}
-              onChange={handleMaxPriceChange}
+              onChange={(e) => setMaxPrice(e.target.value)}
             />
           </label>
           <button type="button" onClick={clearFilters}>

--- a/docs/content/recipes/filtering-search/multi-column-filter-panel/react/example1.jsx
+++ b/docs/content/recipes/filtering-search/multi-column-filter-panel/react/example1.jsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useEffect } from 'react';
+import { useRef } from 'react';
 import { HotTable } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
 import './example1.css';
@@ -20,30 +20,41 @@ const sourceData = [
 ];
 /* end:skip-in-preview */
 
+const FilterLabel = ({ label, children }) => (
+  <label className="filter-label">
+    {label}
+    {children}
+  </label>
+);
+
 const ExampleComponent = () => {
   const hotRef = useRef(null);
-  const [nameFilter, setNameFilter] = useState('');
-  const [categoryFilter, setCategoryFilter] = useState('');
-  const [minPrice, setMinPrice] = useState('');
-  const [maxPrice, setMaxPrice] = useState('');
+  const nameRef = useRef(null);
+  const categoryRef = useRef(null);
+  const minPriceRef = useRef(null);
+  const maxPriceRef = useRef(null);
 
-  useEffect(() => {
+  const applyFilters = () => {
     const hot = hotRef.current?.hotInstance;
 
     if (!hot) {
       return;
     }
 
+    const name = nameRef.current?.value ?? '';
+    const category = categoryRef.current?.value ?? '';
+    const minPrice = minPriceRef.current?.value ?? '';
+    const maxPrice = maxPriceRef.current?.value ?? '';
     const filtersPlugin = hot.getPlugin('filters');
 
     filtersPlugin.clearConditions();
 
-    if (categoryFilter) {
-      filtersPlugin.addCondition(1, 'eq', [categoryFilter]);
+    if (category) {
+      filtersPlugin.addCondition(1, 'eq', [category]);
     }
 
-    if (nameFilter.trim()) {
-      filtersPlugin.addCondition(0, 'contains', [nameFilter.trim()]);
+    if (name.trim()) {
+      filtersPlugin.addCondition(0, 'contains', [name.trim()]);
     }
 
     if (minPrice && maxPrice) {
@@ -68,31 +79,31 @@ const ExampleComponent = () => {
     }
 
     filtersPlugin.filter();
-  }, [nameFilter, categoryFilter, minPrice, maxPrice]);
+  };
 
-  function clearFilters() {
-    setNameFilter('');
-    setCategoryFilter('');
-    setMinPrice('');
-    setMaxPrice('');
-  }
+  const clearFilters = () => {
+    if (nameRef.current) nameRef.current.value = '';
+    if (categoryRef.current) categoryRef.current.value = '';
+    if (minPriceRef.current) minPriceRef.current.value = '';
+    if (maxPriceRef.current) maxPriceRef.current.value = '';
+
+    applyFilters();
+  };
 
   return (
     <div>
       <div className="example-controls-container">
         <div className="filter-panel">
-          <label className="filter-label filter-label--wide">
-            Product name
+          <FilterLabel label="Product name">
             <input
+              ref={nameRef}
               type="text"
               placeholder="Contains..."
-              value={nameFilter}
-              onChange={(e) => setNameFilter(e.target.value)}
+              onChange={applyFilters}
             />
-          </label>
-          <label className="filter-label filter-label--wide">
-            Category
-            <select value={categoryFilter} onChange={(e) => setCategoryFilter(e.target.value)}>
+          </FilterLabel>
+          <FilterLabel label="Category">
+            <select ref={categoryRef} onChange={applyFilters}>
               <option value="">All categories</option>
               <option value="Bikes">Bikes</option>
               <option value="Safety">Safety</option>
@@ -100,27 +111,25 @@ const ExampleComponent = () => {
               <option value="Accessories">Accessories</option>
               <option value="Maintenance">Maintenance</option>
             </select>
-          </label>
-          <label className="filter-label">
-            Min price
+          </FilterLabel>
+          <FilterLabel label="Min price">
             <input
+              ref={minPriceRef}
               type="number"
               min="0"
               placeholder="0"
-              value={minPrice}
-              onChange={(e) => setMinPrice(e.target.value)}
+              onChange={applyFilters}
             />
-          </label>
-          <label className="filter-label">
-            Max price
+          </FilterLabel>
+          <FilterLabel label="Max price">
             <input
+              ref={maxPriceRef}
               type="number"
               min="0"
               placeholder="2500"
-              value={maxPrice}
-              onChange={(e) => setMaxPrice(e.target.value)}
+              onChange={applyFilters}
             />
-          </label>
+          </FilterLabel>
           <button type="button" onClick={clearFilters}>
             Clear all filters
           </button>

--- a/docs/content/recipes/filtering-search/multi-column-filter-panel/react/example1.tsx
+++ b/docs/content/recipes/filtering-search/multi-column-filter-panel/react/example1.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useEffect } from 'react';
+import { useRef, type ReactNode } from 'react';
 import { HotTable, HotTableRef } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
 import './example1.css';
@@ -20,30 +20,46 @@ const sourceData = [
 ];
 /* end:skip-in-preview */
 
+type FilterLabelProps = {
+  label: string;
+  children: ReactNode;
+};
+
+const FilterLabel = ({ label, children }: FilterLabelProps) => (
+  <label className="filter-label">
+    {label}
+    {children}
+  </label>
+);
+
 const ExampleComponent = () => {
   const hotRef = useRef<HotTableRef>(null);
-  const [nameFilter, setNameFilter] = useState('');
-  const [categoryFilter, setCategoryFilter] = useState('');
-  const [minPrice, setMinPrice] = useState('');
-  const [maxPrice, setMaxPrice] = useState('');
+  const nameRef = useRef<HTMLInputElement>(null);
+  const categoryRef = useRef<HTMLSelectElement>(null);
+  const minPriceRef = useRef<HTMLInputElement>(null);
+  const maxPriceRef = useRef<HTMLInputElement>(null);
 
-  useEffect(() => {
+  const applyFilters = () => {
     const hot = hotRef.current?.hotInstance;
 
     if (!hot) {
       return;
     }
 
+    const name = nameRef.current?.value ?? '';
+    const category = categoryRef.current?.value ?? '';
+    const minPrice = minPriceRef.current?.value ?? '';
+    const maxPrice = maxPriceRef.current?.value ?? '';
     const filtersPlugin = hot.getPlugin('filters');
 
     filtersPlugin.clearConditions();
 
-    if (categoryFilter) {
-      filtersPlugin.addCondition(1, 'eq', [categoryFilter]);
+    if (category) {
+      filtersPlugin.addCondition(1, 'eq', [category]);
     }
 
-    if (nameFilter.trim()) {
-      filtersPlugin.addCondition(0, 'contains', [nameFilter.trim()]);
+    if (name.trim()) {
+      filtersPlugin.addCondition(0, 'contains', [name.trim()]);
     }
 
     if (minPrice && maxPrice) {
@@ -68,31 +84,31 @@ const ExampleComponent = () => {
     }
 
     filtersPlugin.filter();
-  }, [nameFilter, categoryFilter, minPrice, maxPrice]);
+  };
 
-  function clearFilters() {
-    setNameFilter('');
-    setCategoryFilter('');
-    setMinPrice('');
-    setMaxPrice('');
-  }
+  const clearFilters = () => {
+    if (nameRef.current) nameRef.current.value = '';
+    if (categoryRef.current) categoryRef.current.value = '';
+    if (minPriceRef.current) minPriceRef.current.value = '';
+    if (maxPriceRef.current) maxPriceRef.current.value = '';
+
+    applyFilters();
+  };
 
   return (
     <div>
       <div className="example-controls-container">
         <div className="filter-panel">
-          <label className="filter-label filter-label--wide">
-            Product name
+          <FilterLabel label="Product name">
             <input
+              ref={nameRef}
               type="text"
               placeholder="Contains..."
-              value={nameFilter}
-              onChange={(e) => setNameFilter(e.target.value)}
+              onChange={applyFilters}
             />
-          </label>
-          <label className="filter-label filter-label--wide">
-            Category
-            <select value={categoryFilter} onChange={(e) => setCategoryFilter(e.target.value)}>
+          </FilterLabel>
+          <FilterLabel label="Category">
+            <select ref={categoryRef} onChange={applyFilters}>
               <option value="">All categories</option>
               <option value="Bikes">Bikes</option>
               <option value="Safety">Safety</option>
@@ -100,27 +116,25 @@ const ExampleComponent = () => {
               <option value="Accessories">Accessories</option>
               <option value="Maintenance">Maintenance</option>
             </select>
-          </label>
-          <label className="filter-label">
-            Min price
+          </FilterLabel>
+          <FilterLabel label="Min price">
             <input
+              ref={minPriceRef}
               type="number"
               min="0"
               placeholder="0"
-              value={minPrice}
-              onChange={(e) => setMinPrice(e.target.value)}
+              onChange={applyFilters}
             />
-          </label>
-          <label className="filter-label">
-            Max price
+          </FilterLabel>
+          <FilterLabel label="Max price">
             <input
+              ref={maxPriceRef}
               type="number"
               min="0"
               placeholder="2500"
-              value={maxPrice}
-              onChange={(e) => setMaxPrice(e.target.value)}
+              onChange={applyFilters}
             />
-          </label>
+          </FilterLabel>
           <button type="button" onClick={clearFilters}>
             Clear all filters
           </button>

--- a/docs/content/recipes/filtering-search/multi-column-filter-panel/react/example1.tsx
+++ b/docs/content/recipes/filtering-search/multi-column-filter-panel/react/example1.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useRef, useState, useEffect } from 'react';
 import { HotTable, HotTableRef } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
 import './example1.css';
@@ -27,7 +27,7 @@ const ExampleComponent = () => {
   const [minPrice, setMinPrice] = useState('');
   const [maxPrice, setMaxPrice] = useState('');
 
-  function applyFilters(name: string, category: string, min: string, max: string) {
+  useEffect(() => {
     const hot = hotRef.current?.hotInstance;
 
     if (!hot) {
@@ -38,29 +38,29 @@ const ExampleComponent = () => {
 
     filtersPlugin.clearConditions();
 
-    if (category) {
-      filtersPlugin.addCondition(1, 'eq', [category]);
+    if (categoryFilter) {
+      filtersPlugin.addCondition(1, 'eq', [categoryFilter]);
     }
 
-    if (name.trim()) {
-      filtersPlugin.addCondition(0, 'contains', [name.trim()]);
+    if (nameFilter.trim()) {
+      filtersPlugin.addCondition(0, 'contains', [nameFilter.trim()]);
     }
 
-    if (min && max) {
-      const lowerBound = Number(min);
-      const upperBound = Number(max);
+    if (minPrice && maxPrice) {
+      const lowerBound = Number(minPrice);
+      const upperBound = Number(maxPrice);
 
       if (Number.isFinite(lowerBound) && Number.isFinite(upperBound)) {
         filtersPlugin.addCondition(2, 'between', [lowerBound, upperBound]);
       }
-    } else if (min) {
-      const lowerBound = Number(min);
+    } else if (minPrice) {
+      const lowerBound = Number(minPrice);
 
       if (Number.isFinite(lowerBound)) {
         filtersPlugin.addCondition(2, 'gte', [lowerBound]);
       }
-    } else if (max) {
-      const upperBound = Number(max);
+    } else if (maxPrice) {
+      const upperBound = Number(maxPrice);
 
       if (Number.isFinite(upperBound)) {
         filtersPlugin.addCondition(2, 'lte', [upperBound]);
@@ -68,54 +68,13 @@ const ExampleComponent = () => {
     }
 
     filtersPlugin.filter();
-    hot.render();
-  }
-
-  function handleNameChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const value = e.target.value;
-
-    setNameFilter(value);
-    applyFilters(value, categoryFilter, minPrice, maxPrice);
-  }
-
-  function handleCategoryChange(e: React.ChangeEvent<HTMLSelectElement>) {
-    const value = e.target.value;
-
-    setCategoryFilter(value);
-    applyFilters(nameFilter, value, minPrice, maxPrice);
-  }
-
-  function handleMinPriceChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const value = e.target.value;
-
-    setMinPrice(value);
-    applyFilters(nameFilter, categoryFilter, value, maxPrice);
-  }
-
-  function handleMaxPriceChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const value = e.target.value;
-
-    setMaxPrice(value);
-    applyFilters(nameFilter, categoryFilter, minPrice, value);
-  }
+  }, [nameFilter, categoryFilter, minPrice, maxPrice]);
 
   function clearFilters() {
     setNameFilter('');
     setCategoryFilter('');
     setMinPrice('');
     setMaxPrice('');
-
-    const hot = hotRef.current?.hotInstance;
-
-    if (!hot) {
-      return;
-    }
-
-    const filtersPlugin = hot.getPlugin('filters');
-
-    filtersPlugin.clearConditions();
-    filtersPlugin.filter();
-    hot.render();
   }
 
   return (
@@ -128,12 +87,12 @@ const ExampleComponent = () => {
               type="text"
               placeholder="Contains..."
               value={nameFilter}
-              onChange={handleNameChange}
+              onChange={(e) => setNameFilter(e.target.value)}
             />
           </label>
           <label className="filter-label filter-label--wide">
             Category
-            <select value={categoryFilter} onChange={handleCategoryChange}>
+            <select value={categoryFilter} onChange={(e) => setCategoryFilter(e.target.value)}>
               <option value="">All categories</option>
               <option value="Bikes">Bikes</option>
               <option value="Safety">Safety</option>
@@ -149,7 +108,7 @@ const ExampleComponent = () => {
               min="0"
               placeholder="0"
               value={minPrice}
-              onChange={handleMinPriceChange}
+              onChange={(e) => setMinPrice(e.target.value)}
             />
           </label>
           <label className="filter-label">
@@ -159,7 +118,7 @@ const ExampleComponent = () => {
               min="0"
               placeholder="2500"
               value={maxPrice}
-              onChange={handleMaxPriceChange}
+              onChange={(e) => setMaxPrice(e.target.value)}
             />
           </label>
           <button type="button" onClick={clearFilters}>


### PR DESCRIPTION
### Context

The PR fixes the React example in the multi-column filter panel recipe where filters were not updating the table when applied.

The root cause: the original code used `setState` to track filter values and called the Handsontable Filters plugin synchronously in the same event handler. React's batched re-renders would trigger a HotTable re-render that reset the plugin's filter state before it could take effect.

**Fix (first commit):** Applied filters inside a `useEffect` that runs after the React render cycle, using controlled inputs and a dependency array `[nameFilter, categoryFilter, minPrice, maxPrice]`.

**Refactor (second commit):** Replaced controlled state + `useEffect` with uncontrolled refs (`useRef<HTMLInputElement>` / `useRef<HTMLSelectElement>`). Reading `.value` directly from DOM refs means no `setState` calls, no React re-renders triggered by filter changes, and no interference with HotTable's plugin state. Also extracted a `FilterLabel` component to remove repeated label/input markup.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1693

### How has this been tested?

- Manually verified in the running docs dev server: all four filter controls (product name, category, min price, max price) update the table on each keystroke/change. The "Clear all filters" button resets all inputs and shows all rows.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. DEV-1693

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to docs React/TS examples and CSS; risk is limited to potential example behavior/regression, not production code.
> 
> **Overview**
> Fixes the multi-column filter panel React recipe so filter inputs reliably update the Handsontable `filters` plugin without being disrupted by React re-renders.
> 
> Reworks the example to use uncontrolled inputs via `useRef` (and a shared `applyFilters` handler) plus a simplified `clearFilters` that resets DOM values then reapplies filtering; also extracts a small `FilterLabel` helper and removes the unused wide-label CSS variant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 077b652104c3026f37d5248fb7b189ff3450c963. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->