### PR TITLE
DEV-1707: Fix NestedRows insert row destroying sibling branches on deep nesting

### DIFF
--- a/.changelogs/12590.json
+++ b/.changelogs/12590.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed NestedRows context menu \"Insert row above/below\" destroying sibling branches on a deeply-nested leaf.",
+  "type": "fixed",
+  "issueOrPR": 12590,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/nestedRows/__tests__/data/dataManager.spec.js
+++ b/handsontable/src/plugins/nestedRows/__tests__/data/dataManager.spec.js
@@ -639,6 +639,57 @@ describe('NestedRows Data Manager', () => {
 
         expect(dataManager.getData()[0].__children[3].a).toEqual('test');
       });
+
+      it('should preserve grandparent\'s other branches when inserting into a deeply-nested ' +
+        'parent (#9670)', async() => {
+        const dataInstance = [
+          {
+            a: 'Group 1',
+            __children: [
+              {
+                a: 'Group 2',
+                __children: [
+                  { a: 'Line 1' }
+                ]
+              },
+              {
+                a: 'Group 3',
+                __children: [
+                  { a: 'Line 2' }
+                ]
+              }
+            ]
+          }
+        ];
+
+        handsontable({
+          data: dataInstance,
+          nestedRows: true,
+        });
+
+        const dataManager = getPlugin('nestedRows').dataManager;
+        const group1 = dataInstance[0];
+        const group2 = group1.__children[0];
+        const group3 = group1.__children[1];
+
+        dataManager.addChildAtIndex(group2, 0, null);
+
+        // Group 1 must retain Group 2 and Group 3 as direct children.
+        expect(group1.__children.length).toEqual(2);
+        expect(group1.__children[0]).toBe(group2);
+        expect(group1.__children[1]).toBe(group3);
+
+        // Group 2 receives the new placeholder before Line 1.
+        expect(group2.__children.length).toEqual(2);
+        expect(group2.__children[1].a).toEqual('Line 1');
+
+        // Group 3 and Line 2 must still be reachable through Group 1.
+        expect(group3.__children.length).toEqual(1);
+        expect(group3.__children[0].a).toEqual('Line 2');
+
+        // Row count must match: Group 1, Group 2, mock, Line 1, Group 3, Line 2.
+        expect(countRows()).toEqual(6);
+      });
     });
 
     describe('addSibling', () => {

--- a/handsontable/src/plugins/nestedRows/__tests__/nestedRows.spec.js
+++ b/handsontable/src/plugins/nestedRows/__tests__/nestedRows.spec.js
@@ -438,4 +438,85 @@ describe('NestedRows', () => {
 
     expect(spy).not.toHaveBeenCalled();
   });
+
+  describe('context menu "Insert row above/below" on a deeply-nested leaf (#9670)', () => {
+    const getDeeplyNestedData = () => [
+      {
+        a: 'Group 1',
+        __children: [
+          { a: 'Group 2', __children: [{ a: 'Line 1' }] },
+          { a: 'Group 3', __children: [{ a: 'Line 2' }] },
+        ]
+      }
+    ];
+
+    it('should preserve sibling branches when inserting a row above a level-2 leaf', async() => {
+      const spy = spyOn(console, 'error');
+
+      handsontable({
+        data: getDeeplyNestedData(),
+        nestedRows: true,
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      expect(countRows()).toEqual(5);
+
+      // Visual row 2 is "Line 1" (Group 1 = 0, Group 2 = 1, Line 1 = 2).
+      await selectCell(2, 0);
+      await contextMenu();
+
+      $('.htContextMenu .ht_master .htCore')
+        .find('tbody td')
+        .not('.htSeparator')
+        .eq(2) // Insert row above
+        .simulate('mousedown')
+        .simulate('mouseup');
+
+      expect(spy).not.toHaveBeenCalled();
+      expect(countRows()).toEqual(6);
+
+      const flatColumnA = getData().map(row => row[0]);
+
+      expect(flatColumnA).toContain('Group 1');
+      expect(flatColumnA).toContain('Group 2');
+      expect(flatColumnA).toContain('Line 1');
+      expect(flatColumnA).toContain('Group 3');
+      expect(flatColumnA).toContain('Line 2');
+    });
+
+    it('should preserve sibling branches when inserting a row below a level-2 leaf', async() => {
+      const spy = spyOn(console, 'error');
+
+      handsontable({
+        data: getDeeplyNestedData(),
+        nestedRows: true,
+        rowHeaders: true,
+        contextMenu: true,
+      });
+
+      expect(countRows()).toEqual(5);
+
+      await selectCell(2, 0);
+      await contextMenu();
+
+      $('.htContextMenu .ht_master .htCore')
+        .find('tbody td')
+        .not('.htSeparator')
+        .eq(3) // Insert row below
+        .simulate('mousedown')
+        .simulate('mouseup');
+
+      expect(spy).not.toHaveBeenCalled();
+      expect(countRows()).toEqual(6);
+
+      const flatColumnA = getData().map(row => row[0]);
+
+      expect(flatColumnA).toContain('Group 1');
+      expect(flatColumnA).toContain('Group 2');
+      expect(flatColumnA).toContain('Line 1');
+      expect(flatColumnA).toContain('Group 3');
+      expect(flatColumnA).toContain('Line 2');
+    });
+  });
 });

--- a/handsontable/src/plugins/nestedRows/data/dataManager.js
+++ b/handsontable/src/plugins/nestedRows/data/dataManager.js
@@ -506,7 +506,7 @@ class DataManager {
       this.plugin.disableCoreAPIModifiers();
 
       this.hot.setSourceDataAtCell(
-        this.getRowIndexWithinParent(parent),
+        parentIndex,
         '__children',
         parent.__children,
         'NestedRows.addChildAtIndex'


### PR DESCRIPTION
### Context

The PR fixes GitHub issue [#9670](https://github.com/handsontable/handsontable/issues/9670). On a NestedRows-enabled grid, right-clicking a leaf at nesting depth >= 2 and selecting "Insert row above" or "Insert row below" silently destroys the parent's sibling branches and leaves dangling index-mapper slots. On v12 this surfaced as `Cannot read properties of undefined`; on current `develop` no exception is thrown but the data is still corrupted.

**Repro tree**

```
Group 1
├─ Group 2
│  └─ Line 1      ← right-click here → Insert row above
└─ Group 3
   └─ Line 2
```

Before the fix, the action wipes `Group 3` and `Line 2` from the source data; the rendered grid shows three populated and three blank rows.

**Root cause**

`DataManager.addChildAtIndex(parent, index, element)` in `handsontable/src/plugins/nestedRows/data/dataManager.js` passes `getRowIndexWithinParent(parent)` as the first argument to `setSourceDataAtCell`. That helper returns the parent's offset within its grandparent's `__children` array, but `setSourceDataAtCell` expects the physical flattened row index. For a depth-1 parent the offset is `0`, so the call writes `parent.__children` onto row 0 (the grandparent), overwriting the grandparent's `__children` array and unlinking every other branch.

The bug was introduced in 2022 (commit `aaf7c8204`, PR #9955) and stayed latent because the existing unit test only exercises depth-1 nesting, where `getRowIndex(parent) === getRowIndexWithinParent(parent) === 0` and the wrong call accidentally yields the same value as the correct one.

**Fix**

Use the already-computed `parentIndex` (= `getRowIndex(parent)`, the physical flattened row of `parent`) instead. One-line change. The `setSourceDataAtCell` call exists only to fire `afterSetSourceData*` for listeners (HyperFormula etc.) - the splice above it already mutated `parent.__children` in place - so the row argument must point at the parent that owns the modified array.

Non-breaking: internal `dataManager` method, not part of the public API; no option/hook/default change; single-level callers are unaffected because both expressions return 0 at that depth.

### How has this been tested?

- New unit-style test in `handsontable/src/plugins/nestedRows/__tests__/data/dataManager.spec.js` builds the 3-level tree above, calls `dataManager.addChildAtIndex(group2, 0, null)` and asserts that Group 1 still has both Group 2 and Group 3, that Group 2's `__children` is `[mock, Line 1]`, that Group 3 still has Line 2, and that `countRows()` is 6.
- New E2E tests in `handsontable/src/plugins/nestedRows/__tests__/nestedRows.spec.js` exercise the context menu paths "Insert row above" and "Insert row below" on the same depth-2 leaf and assert no console error, `countRows()` going from 5 to 6, and every original branch surviving.
- Manual verification with two demo pages (CDN v17.0.1 vs local build) - `dev-latest.html` shows the data corruption, `dev-pr.html` shows the new row appearing inside Group 2 with all other branches intact.
- Commands:
  ```
  npm run build --prefix handsontable
  npm run test:e2e --prefix handsontable -- --testPathPattern=nestedRows
  npx eslint --cache src/
  ```
  All 127 nestedRows specs pass; ESLint clean.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. Fixes #9670
2. DEV-1707

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1707

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches NestedRows' core data-mutation path (`DataManager.addChildAtIndex`) so regressions could corrupt source data, but the change is a one-line index fix with targeted new tests covering deep nesting and context-menu flows.
> 
> **Overview**
> Fixes a NestedRows corruption bug where inserting a row *above/below* a deeply-nested leaf could overwrite the wrong parent’s `__children` array and effectively drop sibling branches.
> 
> Updates `DataManager.addChildAtIndex` to sync `__children` back to source data using the parent’s flattened row index, and adds new unit + E2E tests to ensure sibling branches are preserved when inserting into depth-2+ structures (plus a changelog entry for #9670).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c0fcf843bed8207549d54f01750a5b9a4650602. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->