### PR TITLE
DEV-1711: Fix page scroll when dataProvider loads data into an empty grid

### DIFF
--- a/.changelogs/12591.json
+++ b/.changelogs/12591.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed the browser page scrolling to the grid when `dataProvider` loads rows for the first time into an empty grid with `emptyDataState` enabled.",
+  "type": "fixed",
+  "issueOrPR": 12591,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/emptyDataState/__tests__/plugins/dataProvider.spec.js
+++ b/handsontable/src/plugins/emptyDataState/__tests__/plugins/dataProvider.spec.js
@@ -333,4 +333,38 @@ describe('EmptyDataState with DataProvider plugin', () => {
       .toBe('All rows hidden by filters');
     expect(messageSpy).toHaveBeenCalledWith('filters');
   });
+
+  it('should not scroll the page when fetchRows loads data for the first time', async() => {
+    // Push the grid below the browser viewport so scrollIntoView would actually scroll
+    const spacer = document.createElement('div');
+
+    spacer.style.height = '2000px';
+    document.body.insertBefore(spacer, spec().$container[0]);
+    window.scrollTo(0, 0);
+
+    let resolveFetch;
+    const fetchRows = () => new Promise((resolve) => {
+      resolveFetch = resolve;
+    });
+
+    handsontable({
+      data: [],
+      columns: [{ data: 'id' }, { data: 'name' }],
+      height: 300,
+      emptyDataState: true,
+      dataProvider: createDataProviderConfig({ fetchRows }),
+    });
+
+    await sleep(0);
+
+    const scrollBefore = window.scrollY;
+
+    resolveFetch({ rows: [{ id: 1, name: 'Alice' }], totalRows: 1 });
+
+    await sleep(50);
+
+    expect(window.scrollY).toBe(scrollBefore);
+
+    spacer.remove();
+  });
 });

--- a/handsontable/src/plugins/emptyDataState/emptyDataState.js
+++ b/handsontable/src/plugins/emptyDataState/emptyDataState.js
@@ -575,7 +575,7 @@ export class EmptyDataState extends BasePlugin {
       this.hot.view.render();
       this.#selectionState = null;
     } else {
-      this.hot.selectCell(0, 0);
+      this.hot.selectCell(0, 0, undefined, undefined, false);
     }
 
     this.hot.runHooks('afterEmptyDataStateHide');


### PR DESCRIPTION
### Context

The PR fixes the browser page scrolling down to the grid when `dataProvider` loads rows for the first time into a grid that starts empty with `emptyDataState: true`.

Root cause: `emptyDataState.#hide()` calls `selectCell(0, 0)` after the `'loadData'` source has been cleared, so the existing `ignoreScrollSources` guard in `afterSetRangeEnd` cannot suppress the scroll. The fix calls `selectCell(0, 0, ..., scrollToCell=false)` to restore selection without triggering viewport or window scrolling.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1711

### How has this been tested?

- Run `npm run test:e2e --prefix handsontable -- --testPathPattern=emptyDataState/__tests__/plugins/dataProvider` — all 13 specs pass including the new page-scroll regression test.
- Run `npm run test:e2e --prefix handsontable -- --testPathPattern=emptyDataState` — all 84 specs pass, no regressions.
- Run `npm run test:e2e --prefix handsontable -- --testPathPattern=plugins/dataProvider` — all 131 specs pass.
- Run `npm run test:e2e --prefix handsontable -- --testPathPattern=core/scrollToFocusedCell` — all 14 specs pass.
- Manual verification: open `dev-pr.html` and confirm the page does not scroll when data loads.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1711

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk behavioral tweak limited to `EmptyDataState#hide()` selection logic; main risk is unexpected focus/scroll behavior changes when the overlay closes.
> 
> **Overview**
> Fixes an issue where the browser page could scroll to the grid when `dataProvider` loads the first rows into an initially-empty table with `emptyDataState` enabled.
> 
> The `emptyDataState` overlay now hides by calling `selectCell(0, 0, ..., scrollToCell=false)` to restore a selection without triggering viewport/window scrolling, and adds a regression e2e spec ensuring `window.scrollY` doesn't change when the initial `fetchRows` resolves. A public changelog entry is included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 761a0ccba82e26534aa35a3c258a6950164e4707. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->