### PR TITLE
DEV-1708: Fix crash when updateSettings is called from menu show hook

### DIFF
--- a/.changelogs/12593.json
+++ b/.changelogs/12593.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed a crash when `updateSettings` was called from the `beforeContextMenuShow` or `beforeDropdownMenuShow` hook.",
+  "type": "fixed",
+  "issueOrPR": 12593,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/contextMenu/__tests__/contextMenu.spec.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/contextMenu.spec.js
@@ -3170,4 +3170,49 @@ describe('ContextMenu', () => {
 
     expect($('.htContextMenu').is(':visible')).toBe(false);
   });
+
+  describe('updateSettings called from beforeContextMenuShow', () => {
+    it('should open the menu without throwing when the hook callback calls ' +
+      'updateSettings({ contextMenu })', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        contextMenu: true,
+        height: 200,
+        beforeContextMenuShow() {
+          this.updateSettings({
+            contextMenu: ['row_above'],
+          });
+        },
+      });
+
+      await selectCell(0, 0);
+
+      await expectAsync((async() => {
+        await contextMenu();
+      })()).toBeResolved();
+
+      expect($('.htContextMenu').is(':visible')).toBe(true);
+    });
+
+    it('should apply the updated contextMenu items on the same open', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        contextMenu: true,
+        height: 200,
+        beforeContextMenuShow() {
+          this.updateSettings({
+            contextMenu: ['row_above'],
+          });
+        },
+      });
+
+      await selectCell(0, 0);
+      await contextMenu();
+
+      const items = $('.htContextMenu tbody td').not('.htSeparator');
+
+      expect(items.length).toBe(1);
+      expect(items.text()).toContain('Insert row above');
+    });
+  });
 });

--- a/handsontable/src/plugins/contextMenu/contextMenu.js
+++ b/handsontable/src/plugins/contextMenu/contextMenu.js
@@ -145,7 +145,6 @@ export class ContextMenu extends BasePlugin {
       container: settings.uiContainer || this.hot.rootPortalElement,
     });
 
-    this.menu.addLocalHook('beforeOpen', () => this.#onMenuBeforeOpen());
     this.menu.addLocalHook('afterOpen', () => this.#onMenuAfterOpen());
     this.menu.addLocalHook('afterClose', () => this.#onMenuAfterClose());
     this.menu.addLocalHook('executeCommand', (...params) => this.executeCommand.call(this, ...params));
@@ -256,6 +255,11 @@ export class ContextMenu extends BasePlugin {
     if (this.menu?.isOpened()) {
       return;
     }
+
+    // Fire the user-facing hook before any menu state is committed. If a listener calls
+    // `updateSettings({ contextMenu })`, the plugin reinitializes synchronously, and the
+    // open flow below proceeds on the fresh `this.menu` instance with the new items.
+    this.hot.runHooks('beforeContextMenuShow', this);
 
     this.prepareMenuItems();
     this.menu.open();
@@ -382,13 +386,6 @@ export class ContextMenu extends BasePlugin {
       top: event.clientY + offset.top,
       left: event.clientX + offset.left,
     });
-  }
-
-  /**
-   * On menu before open listener.
-   */
-  #onMenuBeforeOpen() {
-    this.hot.runHooks('beforeContextMenuShow', this);
   }
 
   /**

--- a/handsontable/src/plugins/dropdownMenu/__tests__/dropdownMenu.spec.js
+++ b/handsontable/src/plugins/dropdownMenu/__tests__/dropdownMenu.spec.js
@@ -968,4 +968,65 @@ describe('DropdownMenu', () => {
 
     expect(inlineStartOverlay().getScrollPosition()).toBe(666);
   });
+
+  describe('updateSettings called from beforeDropdownMenuShow', () => {
+    it('should open the menu without throwing when the hook callback calls ' +
+      'updateSettings({ dropdownMenu })', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        dropdownMenu: true,
+        height: 200,
+        beforeDropdownMenuShow() {
+          this.updateSettings({
+            dropdownMenu: ['row_above'],
+          });
+        },
+      });
+
+      await expectAsync((async() => {
+        await dropdownMenu(0);
+      })()).toBeResolved();
+
+      expect($('.htDropdownMenu').is(':visible')).toBe(true);
+    });
+
+    it('should apply the updated dropdownMenu items on the same open', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        dropdownMenu: true,
+        height: 200,
+        beforeDropdownMenuShow() {
+          this.updateSettings({
+            dropdownMenu: ['row_above'],
+          });
+        },
+      });
+
+      await dropdownMenu(0);
+
+      const items = $('.htDropdownMenu tbody td').not('.htSeparator');
+
+      expect(items.length).toBe(1);
+      expect(items.text()).toContain('Insert row above');
+    });
+
+    it('should still apply unrelated settings changed inside the hook immediately', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        dropdownMenu: true,
+        height: 200,
+        beforeDropdownMenuShow() {
+          this.updateSettings({ rowHeaders: false });
+        },
+      });
+
+      await dropdownMenu(0);
+
+      expect(getSettings().rowHeaders).toBe(false);
+    });
+  });
 });

--- a/handsontable/src/plugins/dropdownMenu/dropdownMenu.js
+++ b/handsontable/src/plugins/dropdownMenu/dropdownMenu.js
@@ -225,7 +225,6 @@ export class DropdownMenu extends BasePlugin {
 
       this.menu.setMenuItems(menuItems);
 
-      this.menu.addLocalHook('beforeOpen', () => this.#onMenuBeforeOpen());
       this.menu.addLocalHook('afterOpen', () => this.#onMenuAfterOpen());
       this.menu.addLocalHook('afterSubmenuOpen', subMenuInstance => this.#onSubMenuAfterOpen(subMenuInstance));
       this.menu.addLocalHook('afterClose', () => this.#onMenuAfterClose());
@@ -423,6 +422,11 @@ export class DropdownMenu extends BasePlugin {
     if (this.menu?.isOpened()) {
       return;
     }
+
+    // Fire the user-facing hook before any menu state is committed. If a listener calls
+    // `updateSettings({ dropdownMenu })`, the plugin reinitializes synchronously, and the
+    // open flow below proceeds on the fresh `this.menu` instance with the new items.
+    this.hot.runHooks('beforeDropdownMenuShow', this);
 
     this.menu.open();
 
@@ -622,16 +626,6 @@ export class DropdownMenu extends BasePlugin {
     } else {
       relativeContainer.appendChild(button);
     }
-  }
-
-  /**
-   * On menu before open listener.
-   *
-   * @private
-   * @fires Hooks#beforeDropdownMenuShow
-   */
-  #onMenuBeforeOpen() {
-    this.hot.runHooks('beforeDropdownMenuShow', this);
   }
 
   /**


### PR DESCRIPTION
### Context

The PR fixes a crash that occurs when `updateSettings({ contextMenu })` or `updateSettings({ dropdownMenu })` is called synchronously from inside the `beforeContextMenuShow` / `beforeDropdownMenuShow` hook. Previously, the menu opened empty and the console threw a `TypeError`:

- v17: `Cannot read properties of undefined (reading 'startRow')`
- v12 (originally reported): `Cannot read properties of null (reading 'eventListeners')`

#### Root cause

The user-facing hook was wired to the underlying `Menu` instance's `beforeOpen` local hook and therefore fired while `Menu.open()` was already executing. If the hook callback called `updateSettings`, `updatePlugin()` ran synchronously — `disablePlugin()` destroyed the live `Menu` instance, and the remainder of the in-flight `open()` continued on torn-down state, crashing.

#### Fix

Move the `beforeContextMenuShow` / `beforeDropdownMenuShow` firing out of the `Menu` lifecycle and into the plugin's own `open()` method, **before** `prepareMenuItems()` and `this.menu.open()`. If the hook calls `updateSettings`, the plugin reinitializes synchronously and the open path continues on the fresh `this.menu` instance with the new items - so the updated configuration is applied to the **current** open, not deferred to the next one. No re-entrancy guards, deferred timeouts, or other workarounds are needed.

Closes #9648.

### How has this been tested?

- Added unit/E2E tests in `contextMenu.spec.js` and `dropdownMenu.spec.js` covering the `updateSettings` scenario (menu opens, items updated on the same open, unrelated settings still applied).
- Reproduced the original issue against the released v17.0.1 build via local demo page, then verified the PR build no longer throws and the updated items render on the first open.
- Ran the full menu and Filters test suites:
  - `npm run test:e2e --prefix handsontable -- --testPathPattern="contextMenu/__tests__/contextMenu\.spec"` -> 132/132 pass
  - `npm run test:e2e --prefix handsontable -- --testPathPattern="dropdownMenu/__tests__/dropdownMenu\.spec"` -> 43/43 pass
  - `npm run test:e2e --prefix handsontable -- --testPathPattern="filters/__tests__/.*\.spec"` -> 242/242 pass (Filters listens on `beforeDropdownMenuShow` and was the main external consumer to verify)

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1708
2. #9648

### Affected project(s):

- [x] \`handsontable\`
- [ ] \`@handsontable/angular-wrapper\`
- [ ] \`@handsontable/react-wrapper\`
- [ ] \`@handsontable/vue3\`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1708

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the timing of `beforeContextMenuShow`/`beforeDropdownMenuShow` to fire earlier in the open flow, which could subtly affect hook ordering and menu item preparation for consumers relying on previous behavior, but scope is limited to menu plugins and is covered by new tests.
> 
> **Overview**
> Fixes a crash when `updateSettings({ contextMenu })` or `updateSettings({ dropdownMenu })` is called synchronously inside `beforeContextMenuShow`/`beforeDropdownMenuShow` by **moving those hook invocations from the underlying `Menu`'s `beforeOpen` lifecycle into each plugin’s `open()` method**, before any menu state is committed.
> 
> Adds new E2E tests for both `contextMenu` and `dropdownMenu` ensuring the menu opens without throwing, the updated menu items apply on the same open, and (for dropdown) unrelated settings updated in the hook still take effect immediately. Also adds a changelog entry for the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 453ea19708a6e79796fe607b5f522c36ace0a332. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->