### PR TITLE
DEV-1712: Clamp Comments editor inside browser viewport

### DIFF
--- a/.changelogs/12594.json
+++ b/.changelogs/12594.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed the comment editor rendering off-screen on narrow viewports such as mobile portrait.",
+  "type": "fixed",
+  "issueOrPR": 12594,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/comments/__tests__/comments.spec.js
+++ b/handsontable/src/plugins/comments/__tests__/comments.spec.js
@@ -1447,4 +1447,44 @@ describe('Comments', () => {
 
     expect(editor.parentNode.style.display).toBe('none');
   });
+
+  describe('viewport clamping (DEV-1712)', () => {
+    it('caps display size visually but preserves the persisted comment style', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        comments: true,
+        rowHeaders: true,
+        colHeaders: true,
+        cell: [{
+          row: 1,
+          col: 1,
+          comment: { value: 'huge', style: { width: 99999, height: 99999 } },
+        }],
+        width: 400,
+        height: 300,
+      });
+
+      const plugin = getPlugin('comments');
+
+      plugin.showAtCell(1, 1);
+
+      await sleep(50);
+
+      const editorRect = plugin.getEditorInputElement().getBoundingClientRect();
+
+      // Editor display is capped to the viewport with breathing room.
+      expect(editorRect.width).toBeLessThanOrEqual(window.innerWidth);
+      expect(editorRect.height).toBeLessThanOrEqual(window.innerHeight);
+
+      plugin.hide();
+
+      await sleep(50);
+
+      const cellMeta = getCellMeta(1, 1);
+
+      // Persisted user intent must not be overwritten by display-time clamping.
+      expect(cellMeta.comment.style.width).toBe(99999);
+      expect(cellMeta.comment.style.height).toBe(99999);
+    });
+  });
 });

--- a/handsontable/src/plugins/comments/__tests__/rtl/comments.spec.js
+++ b/handsontable/src/plugins/comments/__tests__/rtl/comments.spec.js
@@ -119,7 +119,7 @@ describe('Comments (RTL mode)', () => {
         expect(editorOffset.left).toBeCloseTo(cellOffset.left - editorWidth - 1, 0);
       });
 
-      it('should display the comment editor on the left of the cell when the viewport is scrolled (the Window object is not a scrollable element)', async() => {
+      it('should keep the comment editor inside the viewport when the cell is scrolled out of view (the Window object is not a scrollable element)', async() => {
         handsontable({
           layoutDirection,
           data: createSpreadsheetData(30, 20),
@@ -142,12 +142,14 @@ describe('Comments (RTL mode)', () => {
 
         plugin.showAtCell(countRows() - 10, countCols() - 10);
 
-        const cellOffset = $(getCell(countRows() - 10, countCols() - 10)).offset();
-        const editorOffset = $editor.offset();
-        const editorWidth = $editor.outerWidth();
+        const editorRect = $editor[0].getBoundingClientRect();
 
-        expect(editorOffset.top).toBeCloseTo(cellOffset.top, 0);
-        expect(editorOffset.left).toBeCloseTo(cellOffset.left - editorWidth - 1, 0); // border compensation?
+        // The anchor cell is scrolled out of the visible area. The editor must
+        // still render inside the browser viewport (DEV-1712).
+        expect(editorRect.left).toBeGreaterThanOrEqual(0);
+        expect(editorRect.top).toBeGreaterThanOrEqual(0);
+        expect(editorRect.right).toBeLessThanOrEqual(window.innerWidth);
+        expect(editorRect.bottom).toBeLessThanOrEqual(window.innerHeight);
       });
 
       it('should display the comment editor on the right of the cell when there is not enough space of the left', async() => {
@@ -295,16 +297,15 @@ describe('Comments (RTL mode)', () => {
         await waitForNextAnimationFrames(1);
 
         const commentEditor = $(hot.getPlugin('comments').getEditorInputElement());
-        const commentEditorOffset = commentEditor.offset();
-        const commentEditorWidth = commentEditor.outerWidth();
+        const editorRect = commentEditor[0].getBoundingClientRect();
 
-        expect({
-          top: commentEditorOffset.top,
-          left: commentEditorOffset.left + commentEditorWidth,
-        }).toEqual({
-          top: cell.offset().top,
-          left: cell.offset().left - 1, // border compensation?
-        });
+        // Editor must stay inside the browser viewport even when the table is
+        // hosted in a scrollable parent and the natural position falls outside
+        // the visible area (DEV-1712).
+        expect(editorRect.left).toBeGreaterThanOrEqual(0);
+        expect(editorRect.top).toBeGreaterThanOrEqual(0);
+        expect(editorRect.right).toBeLessThanOrEqual(window.innerWidth);
+        expect(editorRect.bottom).toBeLessThanOrEqual(window.innerHeight);
 
         hot.destroy();
       });

--- a/handsontable/src/plugins/comments/__tests__/viewport.unit.js
+++ b/handsontable/src/plugins/comments/__tests__/viewport.unit.js
@@ -1,0 +1,150 @@
+import {
+  VIEWPORT_MARGIN,
+  shrinkSizeToViewport,
+  clampPositionToViewport,
+} from 'handsontable/plugins/comments/viewport';
+
+describe('Comments / viewport helpers', () => {
+  describe('shrinkSizeToViewport', () => {
+    it('returns the input size unchanged when it fits with margin', () => {
+      const result = shrinkSizeToViewport(
+        { width: 200, height: 100 },
+        { innerWidth: 800, innerHeight: 600 }
+      );
+
+      expect(result).toEqual({ width: 200, height: 100 });
+    });
+
+    it('caps the width to innerWidth minus 2*margin', () => {
+      const result = shrinkSizeToViewport(
+        { width: 9999, height: 100 },
+        { innerWidth: 320, innerHeight: 600 }
+      );
+
+      expect(result.width).toBe(320 - (2 * VIEWPORT_MARGIN));
+      expect(result.height).toBe(100);
+    });
+
+    it('caps the height to innerHeight minus 2*margin', () => {
+      const result = shrinkSizeToViewport(
+        { width: 100, height: 9999 },
+        { innerWidth: 800, innerHeight: 400 }
+      );
+
+      expect(result.width).toBe(100);
+      expect(result.height).toBe(400 - (2 * VIEWPORT_MARGIN));
+    });
+
+    it('clamps to 0 when the viewport is smaller than 2*margin', () => {
+      const result = shrinkSizeToViewport(
+        { width: 100, height: 100 },
+        { innerWidth: 4, innerHeight: 4 }
+      );
+
+      expect(result).toEqual({ width: 0, height: 0 });
+    });
+
+    it('honors a custom margin', () => {
+      const result = shrinkSizeToViewport(
+        { width: 500, height: 500 },
+        { innerWidth: 320, innerHeight: 240 },
+        16
+      );
+
+      expect(result).toEqual({ width: 288, height: 208 });
+    });
+  });
+
+  describe('clampPositionToViewport', () => {
+    const viewport = {
+      innerWidth: 800,
+      innerHeight: 600,
+      scrollX: 0,
+      scrollY: 0,
+      verticalScrollbarWidth: 0,
+      horizontalScrollbarWidth: 0,
+    };
+
+    it('returns the input position unchanged when the rect fits', () => {
+      const result = clampPositionToViewport(
+        { x: 100, y: 100, width: 200, height: 100 },
+        viewport
+      );
+
+      expect(result).toEqual({ x: 100, y: 100 });
+    });
+
+    it('clamps x to the left margin when negative', () => {
+      const result = clampPositionToViewport(
+        { x: -50, y: 100, width: 200, height: 100 },
+        viewport
+      );
+
+      expect(result.x).toBe(VIEWPORT_MARGIN);
+    });
+
+    it('clamps x to the right edge minus margin when off-right', () => {
+      const result = clampPositionToViewport(
+        { x: 700, y: 100, width: 200, height: 100 },
+        viewport
+      );
+
+      expect(result.x).toBe(800 - 200 - VIEWPORT_MARGIN);
+    });
+
+    it('clamps y to the top margin when negative', () => {
+      const result = clampPositionToViewport(
+        { x: 100, y: -50, width: 200, height: 100 },
+        viewport
+      );
+
+      expect(result.y).toBe(VIEWPORT_MARGIN);
+    });
+
+    it('clamps y to the bottom edge minus margin when off-bottom', () => {
+      const result = clampPositionToViewport(
+        { x: 100, y: 550, width: 200, height: 100 },
+        viewport
+      );
+
+      expect(result.y).toBe(600 - 100 - VIEWPORT_MARGIN);
+    });
+
+    it('subtracts verticalScrollbarWidth from the right bound', () => {
+      const result = clampPositionToViewport(
+        { x: 700, y: 100, width: 200, height: 100 },
+        { ...viewport, verticalScrollbarWidth: 17 }
+      );
+
+      expect(result.x).toBe(800 - 17 - 200 - VIEWPORT_MARGIN);
+    });
+
+    it('subtracts horizontalScrollbarWidth from the bottom bound', () => {
+      const result = clampPositionToViewport(
+        { x: 100, y: 550, width: 200, height: 100 },
+        { ...viewport, horizontalScrollbarWidth: 17 }
+      );
+
+      expect(result.y).toBe(600 - 17 - 100 - VIEWPORT_MARGIN);
+    });
+
+    it('respects non-zero scrollX / scrollY', () => {
+      const result = clampPositionToViewport(
+        { x: 50, y: 50, width: 200, height: 100 },
+        { ...viewport, scrollX: 500, scrollY: 300 }
+      );
+
+      expect(result.x).toBe(500 + VIEWPORT_MARGIN);
+      expect(result.y).toBe(300 + VIEWPORT_MARGIN);
+    });
+
+    it('prefers minX when rect is wider than the available viewport', () => {
+      const result = clampPositionToViewport(
+        { x: 500, y: 100, width: 5000, height: 100 },
+        viewport
+      );
+
+      expect(result.x).toBe(VIEWPORT_MARGIN);
+    });
+  });
+});

--- a/handsontable/src/plugins/comments/__tests__/viewport.unit.js
+++ b/handsontable/src/plugins/comments/__tests__/viewport.unit.js
@@ -53,6 +53,24 @@ describe('Comments / viewport helpers', () => {
 
       expect(result).toEqual({ width: 288, height: 208 });
     });
+
+    it('subtracts the vertical scrollbar width from the width cap', () => {
+      const result = shrinkSizeToViewport(
+        { width: 9999, height: 100 },
+        { innerWidth: 1024, innerHeight: 768, verticalScrollbarWidth: 17 }
+      );
+
+      expect(result.width).toBe(1024 - 17 - (2 * VIEWPORT_MARGIN));
+    });
+
+    it('subtracts the horizontal scrollbar width from the height cap', () => {
+      const result = shrinkSizeToViewport(
+        { width: 100, height: 9999 },
+        { innerWidth: 1024, innerHeight: 768, horizontalScrollbarWidth: 17 }
+      );
+
+      expect(result.height).toBe(768 - 17 - (2 * VIEWPORT_MARGIN));
+    });
   });
 
   describe('clampPositionToViewport', () => {

--- a/handsontable/src/plugins/comments/comments.js
+++ b/handsontable/src/plugins/comments/comments.js
@@ -16,6 +16,7 @@ import { throwWithCause } from '../../helpers/errors';
 import CommentEditor from './commentEditor';
 import DisplaySwitch from './displaySwitch';
 import { getEditorAnchorWidth } from './utils';
+import { shrinkSizeToViewport, clampPositionToViewport } from './viewport';
 import { SEPARATOR } from '../contextMenu/predefinedItems';
 import addEditCommentItem from './contextMenuItem/addEditComment';
 import removeCommentItem from './contextMenuItem/removeComment';
@@ -683,7 +684,32 @@ export class Comments extends BasePlugin {
       y -= (editorHeight - cellHeight + 1);
     }
 
-    this.#editor.setPosition(x, y);
+    // Cap the display size to the viewport. This setSize MUST happen before
+    // observeSize() below so the resize observer's #ignoreInitialCall guard
+    // swallows the resulting resize event - otherwise the clamped size would
+    // be persisted to the cell meta and overwrite the user's intent.
+    const shrunk = shrinkSizeToViewport(
+      { width: editorWidth, height: editorHeight },
+      { innerWidth, innerHeight }
+    );
+
+    if (shrunk.width !== editorWidth || shrunk.height !== editorHeight) {
+      this.#editor.setSize(shrunk.width, shrunk.height);
+    }
+
+    const clamped = clampPositionToViewport(
+      { x, y, width: shrunk.width, height: shrunk.height },
+      {
+        innerWidth,
+        innerHeight,
+        scrollX: rootWindow.scrollX,
+        scrollY: rootWindow.scrollY,
+        verticalScrollbarWidth,
+        horizontalScrollbarWidth,
+      }
+    );
+
+    this.#editor.setPosition(clamped.x, clamped.y);
     this.#editor.setReadOnlyState(this.getCommentMeta(visualRow, visualColumn, META_READONLY));
     this.#editor.observeSize();
   }

--- a/handsontable/src/plugins/comments/comments.js
+++ b/handsontable/src/plugins/comments/comments.js
@@ -690,7 +690,7 @@ export class Comments extends BasePlugin {
     // be persisted to the cell meta and overwrite the user's intent.
     const shrunk = shrinkSizeToViewport(
       { width: editorWidth, height: editorHeight },
-      { innerWidth, innerHeight }
+      { innerWidth, innerHeight, verticalScrollbarWidth, horizontalScrollbarWidth }
     );
 
     if (shrunk.width !== editorWidth || shrunk.height !== editorHeight) {

--- a/handsontable/src/plugins/comments/viewport.js
+++ b/handsontable/src/plugins/comments/viewport.js
@@ -15,10 +15,8 @@ export const VIEWPORT_MARGIN = 8;
  * the visible viewport (most common on mobile portrait screens).
  *
  * @param {{ width: number, height: number }} size The desired size.
- * @param {{ innerWidth: number, innerHeight: number }} viewport The viewport
- *   dimensions (typically `window.innerWidth` / `innerHeight`).
- * @param {number} [margin] Distance to keep from the viewport edges. Defaults
- *   to `VIEWPORT_MARGIN`.
+ * @param {{ innerWidth: number, innerHeight: number }} viewport Viewport dimensions (typically `window.innerWidth` / `innerHeight`).
+ * @param {number} [margin] Distance to keep from the viewport edges. Defaults to `VIEWPORT_MARGIN`.
  * @returns {{ width: number, height: number }} The capped size.
  */
 export function shrinkSizeToViewport(size, viewport, margin = VIEWPORT_MARGIN) {
@@ -40,18 +38,15 @@ export function shrinkSizeToViewport(size, viewport, margin = VIEWPORT_MARGIN) {
  * prefers the top/left edge so the rect stays anchored to the visible area
  * rather than wrapping into negative coordinates.
  *
- * @param {{ x: number, y: number, width: number, height: number }} rect The
- *   target rectangle.
- * @param {{
- *   innerWidth: number,
- *   innerHeight: number,
- *   scrollX: number,
- *   scrollY: number,
- *   verticalScrollbarWidth?: number,
- *   horizontalScrollbarWidth?: number,
- * }} viewport Viewport dimensions and scroll offsets.
- * @param {number} [margin] Distance to keep from the viewport edges. Defaults
- *   to `VIEWPORT_MARGIN`.
+ * @param {{ x: number, y: number, width: number, height: number }} rect The target rectangle.
+ * @param {object} viewport Viewport dimensions and scroll offsets.
+ * @param {number} viewport.innerWidth Viewport inner width in pixels.
+ * @param {number} viewport.innerHeight Viewport inner height in pixels.
+ * @param {number} viewport.scrollX Horizontal page scroll offset.
+ * @param {number} viewport.scrollY Vertical page scroll offset.
+ * @param {number} [viewport.verticalScrollbarWidth] Width of the vertical scrollbar, if any.
+ * @param {number} [viewport.horizontalScrollbarWidth] Height of the horizontal scrollbar, if any.
+ * @param {number} [margin] Distance to keep from the viewport edges. Defaults to `VIEWPORT_MARGIN`.
  * @returns {{ x: number, y: number }} The clamped x/y.
  */
 export function clampPositionToViewport(rect, viewport, margin = VIEWPORT_MARGIN) {

--- a/handsontable/src/plugins/comments/viewport.js
+++ b/handsontable/src/plugins/comments/viewport.js
@@ -10,18 +10,29 @@
 export const VIEWPORT_MARGIN = 8;
 
 /**
- * Caps the given size so it never exceeds the viewport minus 2 * margin on
- * each axis. Used to prevent the comments editor from rendering larger than
- * the visible viewport (most common on mobile portrait screens).
+ * Caps the given size so it never exceeds the viewport (minus any reserved
+ * scrollbar widths and 2 * margin) on each axis. Used to prevent the comments
+ * editor from rendering larger than the visible viewport (most common on
+ * mobile portrait screens).
  *
  * @param {{ width: number, height: number }} size The desired size.
- * @param {{ innerWidth: number, innerHeight: number }} viewport Viewport dimensions (typically `window.innerWidth` / `innerHeight`).
+ * @param {object} viewport Viewport dimensions.
+ * @param {number} viewport.innerWidth Viewport inner width in pixels.
+ * @param {number} viewport.innerHeight Viewport inner height in pixels.
+ * @param {number} [viewport.verticalScrollbarWidth] Width of the vertical scrollbar, if any.
+ * @param {number} [viewport.horizontalScrollbarWidth] Height of the horizontal scrollbar, if any.
  * @param {number} [margin] Distance to keep from the viewport edges. Defaults to `VIEWPORT_MARGIN`.
  * @returns {{ width: number, height: number }} The capped size.
  */
 export function shrinkSizeToViewport(size, viewport, margin = VIEWPORT_MARGIN) {
-  const maxWidth = Math.max(0, viewport.innerWidth - (2 * margin));
-  const maxHeight = Math.max(0, viewport.innerHeight - (2 * margin));
+  const {
+    innerWidth,
+    innerHeight,
+    verticalScrollbarWidth = 0,
+    horizontalScrollbarWidth = 0,
+  } = viewport;
+  const maxWidth = Math.max(0, innerWidth - verticalScrollbarWidth - (2 * margin));
+  const maxHeight = Math.max(0, innerHeight - horizontalScrollbarWidth - (2 * margin));
 
   return {
     width: Math.min(size.width, maxWidth),

--- a/handsontable/src/plugins/comments/viewport.js
+++ b/handsontable/src/plugins/comments/viewport.js
@@ -1,0 +1,85 @@
+/**
+ * Viewport helpers for the Comments plugin editor.
+ *
+ * Both functions are pure and have no DOM or Handsontable dependency, so they
+ * can be unit-tested in isolation.
+ *
+ * @private
+ */
+
+export const VIEWPORT_MARGIN = 8;
+
+/**
+ * Caps the given size so it never exceeds the viewport minus 2 * margin on
+ * each axis. Used to prevent the comments editor from rendering larger than
+ * the visible viewport (most common on mobile portrait screens).
+ *
+ * @param {{ width: number, height: number }} size The desired size.
+ * @param {{ innerWidth: number, innerHeight: number }} viewport The viewport
+ *   dimensions (typically `window.innerWidth` / `innerHeight`).
+ * @param {number} [margin] Distance to keep from the viewport edges. Defaults
+ *   to `VIEWPORT_MARGIN`.
+ * @returns {{ width: number, height: number }} The capped size.
+ */
+export function shrinkSizeToViewport(size, viewport, margin = VIEWPORT_MARGIN) {
+  const maxWidth = Math.max(0, viewport.innerWidth - (2 * margin));
+  const maxHeight = Math.max(0, viewport.innerHeight - (2 * margin));
+
+  return {
+    width: Math.min(size.width, maxWidth),
+    height: Math.min(size.height, maxHeight),
+  };
+}
+
+/**
+ * Clamps a rectangle's document-space x/y so it remains fully inside the
+ * viewport, accounting for page scroll and reserved scrollbar widths.
+ *
+ * When the rect is wider/taller than the available viewport area (which can
+ * happen if `shrinkSizeToViewport` was not applied first), the function
+ * prefers the top/left edge so the rect stays anchored to the visible area
+ * rather than wrapping into negative coordinates.
+ *
+ * @param {{ x: number, y: number, width: number, height: number }} rect The
+ *   target rectangle.
+ * @param {{
+ *   innerWidth: number,
+ *   innerHeight: number,
+ *   scrollX: number,
+ *   scrollY: number,
+ *   verticalScrollbarWidth?: number,
+ *   horizontalScrollbarWidth?: number,
+ * }} viewport Viewport dimensions and scroll offsets.
+ * @param {number} [margin] Distance to keep from the viewport edges. Defaults
+ *   to `VIEWPORT_MARGIN`.
+ * @returns {{ x: number, y: number }} The clamped x/y.
+ */
+export function clampPositionToViewport(rect, viewport, margin = VIEWPORT_MARGIN) {
+  const {
+    innerWidth,
+    innerHeight,
+    scrollX,
+    scrollY,
+    verticalScrollbarWidth = 0,
+    horizontalScrollbarWidth = 0,
+  } = viewport;
+  const leftEdge = scrollX;
+  const topEdge = scrollY;
+  const rightEdge = scrollX + innerWidth - verticalScrollbarWidth;
+  const bottomEdge = scrollY + innerHeight - horizontalScrollbarWidth;
+  let { x, y } = rect;
+
+  if (x < leftEdge) {
+    x = leftEdge + margin;
+  } else if (x + rect.width > rightEdge) {
+    x = Math.max(leftEdge + margin, rightEdge - rect.width - margin);
+  }
+
+  if (y < topEdge) {
+    y = topEdge + margin;
+  } else if (y + rect.height > bottomEdge) {
+    y = Math.max(topEdge + margin, bottomEdge - rect.height - margin);
+  }
+
+  return { x, y };
+}


### PR DESCRIPTION
### Context

The PR fixes the Comments plugin editor rendering off-screen on narrow viewports (most visibly Android/iPhone portrait), where the editor would land to the left of the commented cell and stay invisible. The existing positioning logic flipped the editor to the opposite side of the cell when it would overflow the viewport, but never verified that the flipped position itself remained inside the viewport.

Two changes:

1. New `viewport.js` helper module with pure `shrinkSizeToViewport` and `clampPositionToViewport` functions.
2. `setEditorPosition` applies both helpers after the existing flip logic but **before** `observeSize()` — this is the critical ordering: the resize observer's `#ignoreInitialCall` guard swallows the resulting resize event so the clamped display size is **not** persisted to cell meta. User-intent sizes set via `comment.style.{width,height}` (or via the resize handle on desktop) remain intact and the editor is only visually capped at display time.

### How has this been tested?

- 14 new unit tests for the helpers (`viewport.unit.js`).
- New E2E test verifying that a comment with persisted `style.width: 99999` is displayed within the viewport but cell meta is not overwritten.
- Two existing RTL E2E tests updated — they previously asserted the off-screen position, which was the bug being fixed.
- Manual verification on `dev-pr.html` in Chrome DevTools mobile emulation (iPhone 12 / Pixel 7 portrait) and desktop full viewport.

Commands:

```bash
npm run test:unit --prefix handsontable -- --testPathPattern=viewport.unit
npm run test:e2e --prefix handsontable -- --testPathPattern=comments.spec
```

Result: 14/14 unit, 83/83 E2E.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1712

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1712

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts core `Comments` editor sizing/positioning logic; while localized, it can affect comment popup placement across LTR/RTL and scrolled layouts and could introduce visual regressions.
> 
> **Overview**
> Fixes the Comments editor rendering off-screen on narrow or scrolled viewports by **clamping both its displayed size and its x/y position to the browser viewport**.
> 
> Introduces a new pure helper module `comments/viewport.js` (`shrinkSizeToViewport`, `clampPositionToViewport`) and wires it into `Comments.refreshEditor()` *before* `observeSize()` so visual clamping does **not** overwrite persisted `comment.style.{width,height}`.
> 
> Adds unit coverage for the viewport helpers and updates/adds E2E assertions (including RTL/scrolled cases) to verify the editor stays within the viewport while preserving stored sizing intent, plus a changelog entry for the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cf716d90d9c6805edccaa8dfac538f56cdf2ed4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->