### PR TITLE
DEV-1688: Fix React examples resetting to page 1 on page/sort change

### DIFF
--- a/docs/content/recipes/data-management/load-data-rest-api/react/example3.jsx
+++ b/docs/content/recipes/data-management/load-data-rest-api/react/example3.jsx
@@ -1,13 +1,14 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import { HotTable } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
 
 registerAllModules();
 
+const pagination = { pageSize: 5 };
+
 const ExampleComponent = () => {
   const cachedRowsRef = useRef(null);
-  const [status, setStatus] = useState('Loading...');
-  const [statusColor, setStatusColor] = useState('#202124');
+  const statusRef = useRef(null);
 
   const loadAllRows = useCallback(async (signal) => {
     if (cachedRowsRef.current !== null) {
@@ -70,26 +71,30 @@ const ExampleComponent = () => {
   );
 
   const beforeDataProviderFetch = useCallback((params) => {
-    if (!params.skipLoading) {
-      setStatus('Loading...');
-      setStatusColor('#202124');
-    }
+    if (params.skipLoading || !statusRef.current) return;
+    statusRef.current.textContent = 'Loading...';
+    statusRef.current.style.color = '#202124';
   }, []);
 
   const afterDataProviderFetch = useCallback(() => {
-    setStatus('Loaded from REST API via dataProvider.');
-    setStatusColor('#202124');
+    if (!statusRef.current) return;
+    statusRef.current.textContent = 'Loaded from REST API via dataProvider.';
+    statusRef.current.style.color = '#202124';
   }, []);
 
   const afterDataProviderFetchError = useCallback((error) => {
-    setStatus(`Error: ${error.message}`);
-    setStatusColor('#c62828');
+    if (!statusRef.current) return;
+    statusRef.current.textContent = `Error: ${error.message}`;
+    statusRef.current.style.color = '#c62828';
   }, []);
 
   return (
     <div>
-      <p style={{ margin: '0 0 8px', fontFamily: 'Arial, sans-serif', fontSize: '14px', color: statusColor }}>
-        {status}
+      <p
+        ref={statusRef}
+        style={{ margin: '0 0 8px', fontFamily: 'Arial, sans-serif', fontSize: '14px', color: '#202124' }}
+      >
+        Loading...
       </p>
       <HotTable
         dataProvider={dataProvider}
@@ -102,7 +107,7 @@ const ExampleComponent = () => {
           { data: 'city', type: 'text', width: 140, readOnly: true },
           { data: 'company', type: 'text', width: 180, readOnly: true },
         ]}
-        pagination={{ pageSize: 5 }}
+        pagination={pagination}
         columnSorting={true}
         emptyDataState={true}
         rowHeaders={true}

--- a/docs/content/recipes/data-management/load-data-rest-api/react/example3.tsx
+++ b/docs/content/recipes/data-management/load-data-rest-api/react/example3.tsx
@@ -1,8 +1,10 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import { HotTable } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
 
 registerAllModules();
+
+const pagination = { pageSize: 5 };
 
 type ApiUser = {
   id: number;
@@ -26,8 +28,7 @@ type SortDescriptor = { prop: string; order: 'asc' | 'desc' } | null;
 
 const ExampleComponent = () => {
   const cachedRowsRef = useRef<UserRow[] | null>(null);
-  const [status, setStatus] = useState('Loading...');
-  const [statusColor, setStatusColor] = useState('#202124');
+  const statusRef = useRef<HTMLParagraphElement | null>(null);
 
   const loadAllRows = useCallback(async (signal: AbortSignal): Promise<UserRow[]> => {
     if (cachedRowsRef.current !== null) {
@@ -93,26 +94,30 @@ const ExampleComponent = () => {
   );
 
   const beforeDataProviderFetch = useCallback((params: { skipLoading?: boolean }) => {
-    if (!params.skipLoading) {
-      setStatus('Loading...');
-      setStatusColor('#202124');
-    }
+    if (params.skipLoading || !statusRef.current) return;
+    statusRef.current.textContent = 'Loading...';
+    statusRef.current.style.color = '#202124';
   }, []);
 
   const afterDataProviderFetch = useCallback(() => {
-    setStatus('Loaded from REST API via dataProvider.');
-    setStatusColor('#202124');
+    if (!statusRef.current) return;
+    statusRef.current.textContent = 'Loaded from REST API via dataProvider.';
+    statusRef.current.style.color = '#202124';
   }, []);
 
   const afterDataProviderFetchError = useCallback((error: Error) => {
-    setStatus(`Error: ${error.message}`);
-    setStatusColor('#c62828');
+    if (!statusRef.current) return;
+    statusRef.current.textContent = `Error: ${error.message}`;
+    statusRef.current.style.color = '#c62828';
   }, []);
 
   return (
     <div>
-      <p style={{ margin: '0 0 8px', fontFamily: 'Arial, sans-serif', fontSize: '14px', color: statusColor }}>
-        {status}
+      <p
+        ref={statusRef}
+        style={{ margin: '0 0 8px', fontFamily: 'Arial, sans-serif', fontSize: '14px', color: '#202124' }}
+      >
+        Loading...
       </p>
       <HotTable
         dataProvider={dataProvider}
@@ -125,7 +130,7 @@ const ExampleComponent = () => {
           { data: 'city', type: 'text', width: 140, readOnly: true },
           { data: 'company', type: 'text', width: 180, readOnly: true },
         ]}
-        pagination={{ pageSize: 5 }}
+        pagination={pagination}
         columnSorting={true}
         emptyDataState={true}
         rowHeaders={true}


### PR DESCRIPTION
### Context

The PR fixes the `load-data-rest-api` recipe React examples (`example3.jsx` and `example3.tsx`) where changing pages or sort order appeared to do nothing -- the grid always reset to page 1.

Root cause: both examples used `useState` for the status label (`status`, `statusColor`). Calling `setStatus()` inside `beforeDataProviderFetch` / `afterDataProviderFetch` triggered a React re-render, which caused the React wrapper's `useUpdateEffect` to call `updateSettings` with `dataProvider` in the payload. The DataProvider plugin's `updatePlugin()` then aborted the in-flight fetch and reset `#queryParameters` back to `{ page: 1, ... }`, discarding the requested page change entirely.

Fix: replace `useState` with `useRef` pointing to the `<p>` DOM element and update the text/color via direct DOM mutation (matching the pattern used in the working `getting-started/server-side-data` example). Also move the `pagination` object to module scope so it is a stable reference -- prevents the Pagination plugin's `updatePlugin()` from being called on every render.

### How has this been tested?

- Manual verification in the docs dev server: page changes and column sorting now correctly navigate between pages and re-sort without resetting to page 1.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1688

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1688

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation recipe examples and primarily avoid unnecessary re-renders by switching status display to `useRef` and stabilizing the `pagination` prop.
> 
> **Overview**
> Fixes the `load-data-rest-api` React recipe examples (`example3.jsx`/`example3.tsx`) where page/sort changes could be lost due to re-renders resetting DataProvider query state.
> 
> Replaces status `useState` updates with a DOM `ref` (`statusRef`) to update the label without triggering React renders, and moves the `pagination` object to module scope so `HotTable` receives a stable reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 107d3db72a022371d30de9f1f4ed7b8c914c4a5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->