### PR TITLE
DEV-1715: Fix dynamic HotColumn removal in React wrapper

### DIFF
--- a/.changelogs/12596.json
+++ b/.changelogs/12596.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed an issue where `HotColumn` children removed from a `HotTable` left phantom columns behind in the React wrapper.",
+  "type": "fixed",
+  "issueOrPR": 12596,
+  "breaking": false,
+  "framework": "react"
+}

--- a/wrappers/react-wrapper/src/hotTableContext.tsx
+++ b/wrappers/react-wrapper/src/hotTableContext.tsx
@@ -35,6 +35,14 @@ export interface HotTableContextImpl {
   readonly emitColumnSettings: (columnSettings: Handsontable.ColumnSettings, columnIndex: number) => void;
 
   /**
+   * Trim the column settings array to the given length. Used to drop slots
+   * left over from HotColumn children that have unmounted.
+   *
+   * @param {Number} length Target length for the column settings array.
+   */
+  readonly trimColumnSettings: (length: number) => void;
+
+  /**
    * Return a renderer wrapper function for the provided renderer component.
    *
    * @param {ComponentType<HotRendererProps>} Renderer React renderer component.
@@ -72,6 +80,10 @@ const HotTableContextProvider: FC<PropsWithChildren> = ({ children }) => {
 
   const setHotColumnSettings = useCallback((columnSettings: Handsontable.ColumnSettings, columnIndex: number) => {
     columnsSettings.current[columnIndex] = columnSettings;
+  }, [])
+
+  const trimColumnSettings = useCallback((length: number) => {
+    columnsSettings.current.length = length;
   }, [])
 
   const componentRendererColumns = useRef<Map<number | 'global', boolean>>(new Map());
@@ -144,12 +156,13 @@ const HotTableContextProvider: FC<PropsWithChildren> = ({ children }) => {
     componentRendererColumns: componentRendererColumns.current,
     columnsSettings: columnsSettings.current,
     emitColumnSettings: setHotColumnSettings,
+    trimColumnSettings,
     getRendererWrapper,
     clearPortalCache,
     clearRenderedCellCache,
     setRenderersPortalManagerRef,
     pushCellPortalsIntoPortalManager
-  }), [setHotColumnSettings, getRendererWrapper, clearRenderedCellCache, setRenderersPortalManagerRef, pushCellPortalsIntoPortalManager]);
+  }), [setHotColumnSettings, trimColumnSettings, getRendererWrapper, clearRenderedCellCache, setRenderersPortalManagerRef, pushCellPortalsIntoPortalManager]);
 
   return (
     <HotTableContext.Provider value={contextImpl}>{children}</HotTableContext.Provider>

--- a/wrappers/react-wrapper/src/hotTableInner.tsx
+++ b/wrappers/react-wrapper/src/hotTableInner.tsx
@@ -164,6 +164,14 @@ const HotTableInner = forwardRef<
    * Initialize Handsontable after the component has mounted.
    */
   useEffect(() => {
+    // React guarantees child effects run before parent effects on each
+    // commit, so by the time this parent useEffect runs, every HotColumn
+    // has already written its slot. Trim to drop any leftover slots from
+    // a previous mount (e.g. StrictMode's double-invoke or HMR).
+    const hotColumnCount = Children.toArray(props.children).filter(isHotColumn).length;
+
+    context.trimColumnSettings(hotColumnCount);
+
     const newGlobalSettings = createNewGlobalSettings(true);
 
     // Update prevProps with the current props
@@ -210,6 +218,14 @@ const HotTableInner = forwardRef<
     clearCache();
 
     const hotInstance = getHotInstance();
+
+    // React guarantees child effects run before parent effects on each
+    // commit, so by the time this parent useUpdateEffect runs, every
+    // surviving HotColumn has already written its slot. Trim to drop
+    // stale entries left behind by HotColumns that unmounted.
+    const hotColumnCount = Children.toArray(props.children).filter(isHotColumn).length;
+
+    context.trimColumnSettings(hotColumnCount);
 
     const newGlobalSettings = createNewGlobalSettings(false, prevProps.current);
 

--- a/wrappers/react-wrapper/test/hotColumn.spec.tsx
+++ b/wrappers/react-wrapper/test/hotColumn.spec.tsx
@@ -509,6 +509,293 @@ describe('Dynamic HotColumn configuration changes', () => {
   }, 15000);
 });
 
+describe('Dynamic HotColumn add/remove', () => {
+  it('should drop column settings when a HotColumn is removed from the end', async () => {
+    const hotTableRef = React.createRef<HotTableRef>();
+    const baseProps: HotTableProps = {
+      licenseKey: 'non-commercial-and-evaluation',
+      data: createSpreadsheetData(2, 3),
+      width: 300,
+      height: 300,
+      rowHeights: 23,
+      colWidths: 50,
+      autoRowSize: false,
+      autoColumnSize: false,
+    };
+
+    renderHotTableWithProps({
+      ...baseProps,
+      children: [
+        <HotColumn title="A" key="a" />,
+        <HotColumn title="B" key="b" />,
+        <HotColumn title="C" key="c" />,
+      ],
+    }, true, hotTableRef);
+
+    const hotInstance = hotTableRef.current!.hotInstance!;
+
+    expect(hotInstance.countCols()).toBe(3);
+    expect((hotInstance.getSettings().columns as Handsontable.ColumnSettings[]).map(c => c.title))
+      .toEqual(['A', 'B', 'C']);
+
+    act(() => {
+      renderHotTableWithProps({
+        ...baseProps,
+        children: [
+          <HotColumn title="A" key="a" />,
+          <HotColumn title="B" key="b" />,
+        ],
+      }, true, hotTableRef);
+    });
+
+    await sleep(50);
+
+    expect(hotInstance.countCols()).toBe(2);
+    expect((hotInstance.getSettings().columns as Handsontable.ColumnSettings[]).map(c => c.title))
+      .toEqual(['A', 'B']);
+  });
+
+  it('should drop column settings when a HotColumn is removed from the middle (stable keys)', async () => {
+    const hotTableRef = React.createRef<HotTableRef>();
+    const baseProps: HotTableProps = {
+      licenseKey: 'non-commercial-and-evaluation',
+      data: createSpreadsheetData(2, 3),
+      width: 300,
+      height: 300,
+      rowHeights: 23,
+      colWidths: 50,
+      autoRowSize: false,
+      autoColumnSize: false,
+    };
+
+    renderHotTableWithProps({
+      ...baseProps,
+      children: [
+        <HotColumn title="A" key="a" />,
+        <HotColumn title="B" key="b" />,
+        <HotColumn title="C" key="c" />,
+      ],
+    }, true, hotTableRef);
+
+    const hotInstance = hotTableRef.current!.hotInstance!;
+
+    expect(hotInstance.countCols()).toBe(3);
+
+    act(() => {
+      renderHotTableWithProps({
+        ...baseProps,
+        children: [
+          <HotColumn title="A" key="a" />,
+          <HotColumn title="C" key="c" />,
+        ],
+      }, true, hotTableRef);
+    });
+
+    await sleep(50);
+
+    expect(hotInstance.countCols()).toBe(2);
+    expect((hotInstance.getSettings().columns as Handsontable.ColumnSettings[]).map(c => c.title))
+      .toEqual(['A', 'C']);
+  });
+
+  it('should reduce columns to one when all-but-one HotColumns are removed', async () => {
+    const hotTableRef = React.createRef<HotTableRef>();
+    const baseProps: HotTableProps = {
+      licenseKey: 'non-commercial-and-evaluation',
+      data: createSpreadsheetData(2, 3),
+      width: 300,
+      height: 300,
+      rowHeights: 23,
+      colWidths: 50,
+      autoRowSize: false,
+      autoColumnSize: false,
+    };
+
+    renderHotTableWithProps({
+      ...baseProps,
+      children: [
+        <HotColumn title="A" key="a" />,
+        <HotColumn title="B" key="b" />,
+        <HotColumn title="C" key="c" />,
+      ],
+    }, true, hotTableRef);
+
+    const hotInstance = hotTableRef.current!.hotInstance!;
+
+    act(() => {
+      renderHotTableWithProps({
+        ...baseProps,
+        children: [
+          <HotColumn title="A" key="a" />,
+        ],
+      }, true, hotTableRef);
+    });
+
+    await sleep(50);
+
+    expect(hotInstance.countCols()).toBe(1);
+    expect((hotInstance.getSettings().columns as Handsontable.ColumnSettings[]).map(c => c.title))
+      .toEqual(['A']);
+  });
+
+  it('should keep a component renderer on a surviving column when an earlier column is removed', async () => {
+    const hotTableRef = React.createRef<HotTableRef>();
+    const baseProps: HotTableProps = {
+      licenseKey: 'non-commercial-and-evaluation',
+      data: createSpreadsheetData(2, 3),
+      width: 300,
+      height: 300,
+      rowHeights: 23,
+      colWidths: 50,
+      autoRowSize: false,
+      autoColumnSize: false,
+    };
+
+    renderHotTableWithProps({
+      ...baseProps,
+      children: [
+        <HotColumn title="A" key="a" />,
+        <HotColumn title="B" key="b" renderer={RendererComponent} />,
+        <HotColumn title="C" key="c" />,
+      ],
+    }, true, hotTableRef);
+
+    const hotInstance = hotTableRef.current!.hotInstance!;
+
+    expect(hotInstance.getCell(0, 1)!.innerHTML).toEqual('<div>value: B1</div>');
+
+    act(() => {
+      renderHotTableWithProps({
+        ...baseProps,
+        children: [
+          <HotColumn title="B" key="b" renderer={RendererComponent} />,
+          <HotColumn title="C" key="c" />,
+        ],
+      }, true, hotTableRef);
+    });
+
+    await sleep(100);
+
+    expect(hotInstance.countCols()).toBe(2);
+    expect((hotInstance.getSettings().columns as Handsontable.ColumnSettings[]).map(c => c.title))
+      .toEqual(['B', 'C']);
+    expect(hotInstance.getCell(0, 0)!.innerHTML).toEqual('<div>value: A1</div>');
+    expect(hotInstance.getCell(0, 1)!.innerHTML).toEqual('B1');
+  });
+
+  it('should reflect a keyed reorder of HotColumn children', async () => {
+    const hotTableRef = React.createRef<HotTableRef>();
+    const baseProps: HotTableProps = {
+      licenseKey: 'non-commercial-and-evaluation',
+      data: createSpreadsheetData(2, 3),
+      width: 300,
+      height: 300,
+      rowHeights: 23,
+      colWidths: 50,
+      autoRowSize: false,
+      autoColumnSize: false,
+    };
+
+    renderHotTableWithProps({
+      ...baseProps,
+      children: [
+        <HotColumn title="A" key="a" />,
+        <HotColumn title="B" key="b" />,
+        <HotColumn title="C" key="c" />,
+      ],
+    }, true, hotTableRef);
+
+    const hotInstance = hotTableRef.current!.hotInstance!;
+
+    act(() => {
+      renderHotTableWithProps({
+        ...baseProps,
+        children: [
+          <HotColumn title="C" key="c" />,
+          <HotColumn title="A" key="a" />,
+          <HotColumn title="B" key="b" />,
+        ],
+      }, true, hotTableRef);
+    });
+
+    await sleep(100);
+
+    expect(hotInstance.countCols()).toBe(3);
+    expect((hotInstance.getSettings().columns as Handsontable.ColumnSettings[]).map(c => c.title))
+      .toEqual(['C', 'A', 'B']);
+  });
+
+  it('should restore correct column settings through an add -> remove -> add cycle', async () => {
+    const hotTableRef = React.createRef<HotTableRef>();
+    const baseProps: HotTableProps = {
+      licenseKey: 'non-commercial-and-evaluation',
+      data: createSpreadsheetData(2, 3),
+      width: 300,
+      height: 300,
+      rowHeights: 23,
+      colWidths: 50,
+      autoRowSize: false,
+      autoColumnSize: false,
+    };
+
+    renderHotTableWithProps({
+      ...baseProps,
+      children: [
+        <HotColumn title="A" key="a" />,
+        <HotColumn title="B" key="b" />,
+      ],
+    }, true, hotTableRef);
+
+    const hotInstance = hotTableRef.current!.hotInstance!;
+
+    act(() => {
+      renderHotTableWithProps({
+        ...baseProps,
+        children: [
+          <HotColumn title="A" key="a" />,
+          <HotColumn title="B" key="b" />,
+          <HotColumn title="C" key="c" />,
+        ],
+      }, true, hotTableRef);
+    });
+
+    await sleep(50);
+
+    expect(hotInstance.countCols()).toBe(3);
+
+    act(() => {
+      renderHotTableWithProps({
+        ...baseProps,
+        children: [
+          <HotColumn title="A" key="a" />,
+        ],
+      }, true, hotTableRef);
+    });
+
+    await sleep(50);
+
+    expect(hotInstance.countCols()).toBe(1);
+    expect((hotInstance.getSettings().columns as Handsontable.ColumnSettings[]).map(c => c.title))
+      .toEqual(['A']);
+
+    act(() => {
+      renderHotTableWithProps({
+        ...baseProps,
+        children: [
+          <HotColumn title="A" key="a" />,
+          <HotColumn title="X" key="x" />,
+        ],
+      }, true, hotTableRef);
+    });
+
+    await sleep(50);
+
+    expect(hotInstance.countCols()).toBe(2);
+    expect((hotInstance.getSettings().columns as Handsontable.ColumnSettings[]).map(c => c.title))
+      .toEqual(['A', 'X']);
+  });
+});
+
 describe('Miscellaneous scenarios with `HotColumn` config', () => {
   it('should validate all cells correctly in a `dropdown`-typed column after populating data through it', async () => {
     const onAfterValidate = jest.fn();


### PR DESCRIPTION
### Context

The PR fixes [issue #9573](https://github.com/handsontable/handsontable/issues/9573): in the `@handsontable/react-wrapper`, removing a `HotColumn` child from a `HotTable` left a phantom column behind. `countCols()` and `getSettings().columns` kept reporting the original column count, with stale titles, renderers, and editors.

Root cause: `hotTableContext.tsx` stored column settings in a `useRef` array that was only ever appended to in `HotColumn`'s `useEffect`. There was no path to shrink the array when a `HotColumn` child unmounted, so the next `updateSettings()` call forwarded stale entries to Handsontable. Middle removal was also broken because surviving `HotColumn`s overwrote slots `0..n-1` based on their new positional index, leaving the trailing slot untouched.

Fix: a new internal `trimColumnSettings(length)` method on the context truncates the ref array. `HotTableInner` counts the current `HotColumn` children and calls it inside both the init `useEffect` and `useUpdateEffect`, before `createNewGlobalSettings`. React guarantees child effects commit before parent effects, so surviving `HotColumn` children have already rewritten slots `0..n-1` by the time we trim the tail — no data loss, only stale entries dropped.

### How has this been tested?

New tests in `wrappers/react-wrapper/test/hotColumn.spec.tsx` under `describe('Dynamic HotColumn add/remove')`. Each runs under `React.StrictMode`:

- Remove `HotColumn` from the end.
- Remove a middle `HotColumn` with stable React keys.
- Reduce three columns to one.
- Keyed reorder (`A, B, C` -> `C, A, B`).
- Surviving column with a React component renderer after an earlier column is removed (proves `componentRendererColumns` stays consistent at the new index).
- Add -> remove -> add cycle.

All four originally failed against the buggy code path and pass after the fix.

Run them with:

```bash
npm run build --prefix handsontable
npm run test --prefix wrappers/react-wrapper
```

Full wrapper suite: 73/73 pass.

Manual verification: built local UMD of the wrapper and exercised remove-last / remove-middle / remove-all-but-first / add cycle against released v17.0.1 (bug present) and the PR build (fixed).

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. Fixes #9573
2. DEV-1715

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [x] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1715

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the React wrapper’s column-settings lifecycle and relies on effect ordering to keep settings aligned; regressions could impact dynamic column add/remove/reorder behavior. Changes are localized and covered by new add/remove/reorder tests.
> 
> **Overview**
> Fixes a React wrapper bug where removing `HotColumn` children could leave *stale/phantom* column definitions in Handsontable settings.
> 
> Adds `trimColumnSettings(length)` to `HotTableContext` and calls it from `HotTableInner` on mount and on updates (based on current `HotColumn` child count) to truncate leftover entries before building/updating settings.
> 
> Adds a new `Dynamic HotColumn add/remove` test suite covering end/middle removals, reduction to one column, keyed reorders, renderer survival, and add→remove→add cycles, plus a changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c68d12a2aa2c7e47e8176d903abed03e470d4a98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->