### PR TITLE
Add "Schedule a call" link and update "Contact support" URL in docs Support menu

### DIFF
--- a/docs/src/components/SupportDropdown.astro
+++ b/docs/src/components/SupportDropdown.astro
@@ -9,7 +9,8 @@
 const links = [
   { label: 'Developers Forum', href: 'https://forum.handsontable.com' },
   { label: 'GitHub Issues', href: 'https://github.com/handsontable/handsontable/issues' },
-  { label: 'Contact support', href: 'https://meetings-eu1.hubspot.com/aleksandra-budnik/book-a-support-call?uuid=bf30be03-4ef6-4707-97bf-7dce66619b4e' },
+  { label: 'Contact support', href: 'https://handsontable.com/contact?category=technical_support' },
+  { label: 'Schedule a call', href: 'https://meetings-eu1.hubspot.com/aleksandra-budnik/book-a-support-call' },
 ];
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Context
Update the Support dropdown menu in the docs header:
- Change the "Contact support" link from the HubSpot booking URL to `https://handsontable.com/contact?category=technical_support`
- Add a new "Schedule a call" menu item linking to `https://meetings-eu1.hubspot.com/aleksandra-budnik/book-a-support-call`

[skip changelog]

### How has this been tested?
This is a static link change in the `SupportDropdown.astro` component. The links array is declarative data - verified the Astro file is syntactically correct and the link URLs are valid.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-95caae61-dca3-440c-b4f0-147aede9dde4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95caae61-dca3-440c-b4f0-147aede9dde4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

