### PR TITLE
DEV-1683: Fix color picker JS example stuck on loading

### DIFF
--- a/docs/content/recipes/cell-types/color-picker/color-picker.md
+++ b/docs/content/recipes/cell-types/color-picker/color-picker.md
@@ -26,8 +26,8 @@ This tutorial shows you how to integrate the Pickr color picker library as a cus
 
 ::: example #example1 :hot-recipe --js 1 --ts 2 --css 3 --deps @simonwep/pickr
 
-@[code collapse={11-196}](@/recipes/cell-types/color-picker/javascript/example1.js)
-@[code collapse={11-198}](@/recipes/cell-types/color-picker/javascript/example1.ts)
+@[code collapse={11-196}](@/content/recipes/cell-types/color-picker/javascript/example1.js)
+@[code collapse={11-198}](@/content/recipes/cell-types/color-picker/javascript/example1.ts)
 @[code](@/content/recipes/cell-types/color-picker/javascript/example1.css)
 
 :::


### PR DESCRIPTION
### Context

The JavaScript live preview on the [Color picker recipe](https://handsontable.com/docs/javascript-data-grid/recipes/cell-types/color-picker/) stayed on the loading shimmer and never mounted Handsontable. React and Angular previews worked.

The `@[code]` paths for `example1.js` and `example1.ts` used `@/recipes/...` instead of `@/content/recipes/...`. The docs `framework-loader` only registers files referenced with the `@/content/` prefix, so only the CSS file was wired to the example runner (`data-example-css` without `data-example-js`). The runner never imported the script and never cleared the loading state.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1683

[skip changelog]

### How has this been tested?

- Verified `@[code]` paths in `color-picker.md` resolve to JS, TS, and CSS under `docs/content/recipes/cell-types/color-picker/javascript/`.
- Manual: open `/docs/javascript-data-grid/recipes/cell-types/color-picker/` in the docs dev server and confirm the grid renders and the loading shimmer disappears.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1683

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that fixes broken example wiring by updating `@[code]` include paths; no runtime/library code is modified.
> 
> **Overview**
> Fixes the JavaScript/Vue live example for the Color picker recipe by updating the `@[code]` include paths for `example1.js` and `example1.ts` to use the `@/content/…` prefix, ensuring the docs example runner can register and load the scripts (instead of hanging on the loading state).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2c71271b9b267ae419092dde71da74a24520c38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->