### PR TITLE
DEV-1698: Fix Expressive Code file tab bar in light mode

### DIFF
--- a/docs/src/styles/components/code.css
+++ b/docs/src/styles/components/code.css
@@ -12,16 +12,16 @@
   --ec-frm-edBg: var(--sl-color-block-bg);
   --ec-frm-termBg: var(--sl-color-block-bg);
   --ec-frm-trmTtbBg: var(--sl-color-block-bg);
-  --ec-frm-trmTtbBrdBtmCol: #1b1f23;
+  --ec-frm-trmTtbBrdBtmCol: var(--sl-color-gray-5);
   /* Border */
   --ec-brdCol: var(--sl-color-gray-5);
   --ec-brdWd: 1px;
   --ec-brdRad: 0;
   /* Tab bar */
-  --ec-frm-edTabBarBg: #262626;
+  --ec-frm-edTabBarBg: var(--sl-color-gray-7);
   --ec-frm-edActTabBg: var(--sl-color-block-bg);
-  --ec-frm-edTabBarBrdCol: #1b1f23;
-  --ec-frm-edTabBarBrdBtmCol: #1b1f23;
+  --ec-frm-edTabBarBrdCol: var(--sl-color-gray-5);
+  --ec-frm-edTabBarBrdBtmCol: var(--sl-color-gray-5);
   --ec-frm-edActTabIndHt: 1px;
   --ec-frm-edActTabIndTopCol: #f9826c;
   --ec-frm-edActTabIndBtmCol: var(--sl-color-block-bg);
@@ -56,7 +56,7 @@
 
 .expressive-code figure.frame {
   border-radius: 0;
-  border: 1px solid #1b1f23;
+  border: 1px solid var(--sl-color-gray-5);
 }
 
 :root[data-theme='light'] .expressive-code figure.frame {


### PR DESCRIPTION
### Context

The PR fixes aggressive dark styling on Expressive Code editor frames in the docs light theme. The file tab bar (filename row above code blocks) used hardcoded `#262626` and `#1b1f23` values that did not switch with the site theme, so light mode showed a black strip behind the file tab while the code panel was light gray.

Tab bar, frame border, and terminal titlebar border colors now use `var(--sl-color-gray-7)` and `var(--sl-color-gray-5)`, which follow the Starlight palette in both themes.

### How has this been tested?

- Manual verification on the color-picker recipe page in light and dark mode (`npm run dev --prefix docs`)
- Confirmed the `example1.js` file tab bar matches the light code block background in light mode
- Confirmed dark mode tab bar appearance is unchanged

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1698

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only change that swaps hardcoded dark colors for theme variables, which could slightly alter code block frame/tab appearance across themes.
> 
> **Overview**
> Fixes Expressive Code editor/terminal frame styling in docs by replacing hardcoded dark border/tab-bar colors with Starlight palette variables (`--sl-color-gray-5`/`--sl-color-gray-7`).
> 
> This ensures the file tab bar and frame borders correctly adapt in light mode while preserving the intended look in dark mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93a4b3358106fcdc1ad9933dec3c5ad020cd9dd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->