### PR TITLE
DEV-1696, DEV-1697: Fix load-data recipe toolbar styling in dark mode

### DIFF
--- a/docs/content/recipes/data-management/load-data-graphql/angular/example1.ts
+++ b/docs/content/recipes/data-management/load-data-graphql/angular/example1.ts
@@ -44,20 +44,15 @@ const USERS_QUERY = `
   imports: [HotTableModule],
   selector: 'example1-load-data-graphql',
   template: `
-    <div>
-      <div style="display: flex; gap: 12px; align-items: center; margin-bottom: 8px;">
-        <p
-          style="margin: 0; font-family: Arial, sans-serif; font-size: 14px;"
-          [style.color]="hasError ? '#c62828' : '#202124'"
-        >
-          {{ status }}
-        </p>
+    <div class="example-controls-container">
+      <div class="controls">
         @if (hasError) {
           <button type="button" (click)="loadUsers()">Retry</button>
         }
       </div>
-      <hot-table [data]="rows" [settings]="gridSettings"></hot-table>
+      <output [class.is-error]="hasError">{{ status }}</output>
     </div>
+    <hot-table [data]="rows" [settings]="gridSettings"></hot-table>
   `,
 })
 export class AppComponent implements OnInit {

--- a/docs/content/recipes/data-management/load-data-graphql/angular/example2.ts
+++ b/docs/content/recipes/data-management/load-data-graphql/angular/example2.ts
@@ -44,23 +44,18 @@ const USERS_QUERY = `
   imports: [HotTableModule],
   selector: 'example2-load-data-graphql',
   template: `
-    <div>
-      <div style="display: flex; gap: 12px; align-items: center; margin-bottom: 8px;">
-        <p
-          style="margin: 0; font-family: Arial, sans-serif; font-size: 14px;"
-          [style.color]="hasError ? '#c62828' : '#202124'"
-        >
-          {{ status }}
-        </p>
+    <div class="example-controls-container">
+      <div class="controls">
         @if (showRefresh && !hasError) {
-          <button type="button" (click)="refreshUsers()" style="margin-bottom: 0">Refresh</button>
+          <button type="button" (click)="refreshUsers()">Refresh</button>
         }
         @if (hasError) {
-          <button type="button" (click)="initialLoad()" style="margin-bottom: 0">Retry</button>
+          <button type="button" (click)="initialLoad()">Retry</button>
         }
       </div>
-      <hot-table [settings]="gridSettings"></hot-table>
+      <output [class.is-error]="hasError">{{ status }}</output>
     </div>
+    <hot-table [settings]="gridSettings"></hot-table>
   `,
 })
 export class AppComponent implements AfterViewInit {

--- a/docs/content/recipes/data-management/load-data-graphql/javascript/example1.js
+++ b/docs/content/recipes/data-management/load-data-graphql/javascript/example1.js
@@ -32,27 +32,24 @@ if (!container) {
   throw new Error('Missing #example1 element.');
 }
 
-const statusBar = document.createElement('div');
-const statusLabel = document.createElement('p');
+const controlsContainer = document.createElement('div');
+const controls = document.createElement('div');
+const statusOutput = document.createElement('output');
 const retryButton = document.createElement('button');
 const gridContainer = document.createElement('div');
 
-statusBar.style.display = 'flex';
-statusBar.style.gap = '12px';
-statusBar.style.alignItems = 'center';
-statusBar.style.marginBottom = '8px';
-
-statusLabel.style.margin = '0';
-statusLabel.style.fontFamily = 'Arial, sans-serif';
-statusLabel.style.fontSize = '14px';
+controlsContainer.className = 'example-controls-container';
+controls.className = 'controls';
+statusOutput.id = 'example1-status';
 
 retryButton.type = 'button';
 retryButton.textContent = 'Retry';
 retryButton.hidden = true;
 
-container.appendChild(statusBar);
-statusBar.appendChild(statusLabel);
-statusBar.appendChild(retryButton);
+controls.appendChild(retryButton);
+controlsContainer.appendChild(controls);
+controlsContainer.appendChild(statusOutput);
+container.appendChild(controlsContainer);
 container.appendChild(gridContainer);
 
 const hot = new Handsontable(gridContainer, {
@@ -75,8 +72,8 @@ const hot = new Handsontable(gridContainer, {
 });
 
 function setUiState({ loading = false, hasError = false, message = '' } = {}) {
-  statusLabel.textContent = message;
-  statusLabel.style.color = hasError ? '#c62828' : '#202124';
+  statusOutput.textContent = message;
+  statusOutput.classList.toggle('is-error', hasError);
   retryButton.hidden = !hasError;
   retryButton.disabled = loading;
 }

--- a/docs/content/recipes/data-management/load-data-graphql/javascript/example1.ts
+++ b/docs/content/recipes/data-management/load-data-graphql/javascript/example1.ts
@@ -41,27 +41,24 @@ if (!container) {
   throw new Error('Missing #example1 element.');
 }
 
-const statusBar = document.createElement('div');
-const statusLabel = document.createElement('p');
+const controlsContainer = document.createElement('div');
+const controls = document.createElement('div');
+const statusOutput = document.createElement('output');
 const retryButton = document.createElement('button');
 const gridContainer = document.createElement('div');
 
-statusBar.style.display = 'flex';
-statusBar.style.gap = '12px';
-statusBar.style.alignItems = 'center';
-statusBar.style.marginBottom = '8px';
-
-statusLabel.style.margin = '0';
-statusLabel.style.fontFamily = 'Arial, sans-serif';
-statusLabel.style.fontSize = '14px';
+controlsContainer.className = 'example-controls-container';
+controls.className = 'controls';
+statusOutput.id = 'example1-status';
 
 retryButton.type = 'button';
 retryButton.textContent = 'Retry';
 retryButton.hidden = true;
 
-container.appendChild(statusBar);
-statusBar.appendChild(statusLabel);
-statusBar.appendChild(retryButton);
+controls.appendChild(retryButton);
+controlsContainer.appendChild(controls);
+controlsContainer.appendChild(statusOutput);
+container.appendChild(controlsContainer);
 container.appendChild(gridContainer);
 
 const hot = new Handsontable(gridContainer, {
@@ -92,8 +89,8 @@ function setUiState({
   hasError?: boolean;
   message?: string;
 }) {
-  statusLabel.textContent = message;
-  statusLabel.style.color = hasError ? '#c62828' : '#202124';
+  statusOutput.textContent = message;
+  statusOutput.classList.toggle('is-error', hasError);
   retryButton.hidden = !hasError;
   retryButton.disabled = loading;
 }

--- a/docs/content/recipes/data-management/load-data-graphql/javascript/example2.js
+++ b/docs/content/recipes/data-management/load-data-graphql/javascript/example2.js
@@ -35,35 +35,30 @@ if (!container) {
   throw new Error('Missing #example2 element.');
 }
 
-const statusBar = document.createElement('div');
-const statusLabel = document.createElement('p');
+const controlsContainer = document.createElement('div');
+const controls = document.createElement('div');
+const statusOutput = document.createElement('output');
 const refreshButton = document.createElement('button');
 const retryButton = document.createElement('button');
 const gridContainer = document.createElement('div');
 
-statusBar.style.display = 'flex';
-statusBar.style.gap = '12px';
-statusBar.style.alignItems = 'center';
-statusBar.style.marginBottom = '8px';
-
-statusLabel.style.margin = '0';
-statusLabel.style.fontFamily = 'Arial, sans-serif';
-statusLabel.style.fontSize = '14px';
+controlsContainer.className = 'example-controls-container';
+controls.className = 'controls';
+statusOutput.id = 'example2-status';
 
 refreshButton.type = 'button';
 refreshButton.textContent = 'Refresh';
 refreshButton.hidden = true;
-refreshButton.style.marginBottom = '0';
 
 retryButton.type = 'button';
 retryButton.textContent = 'Retry';
 retryButton.hidden = true;
-retryButton.style.marginBottom = '0';
 
-container.appendChild(statusBar);
-statusBar.appendChild(statusLabel);
-statusBar.appendChild(refreshButton);
-statusBar.appendChild(retryButton);
+controls.appendChild(refreshButton);
+controls.appendChild(retryButton);
+controlsContainer.appendChild(controls);
+controlsContainer.appendChild(statusOutput);
+container.appendChild(controlsContainer);
 container.appendChild(gridContainer);
 
 // Step 1: Initialize the grid with columnSorting enabled and an empty dataset.
@@ -90,8 +85,8 @@ const hot = new Handsontable(gridContainer, {
 
 // Step 2: A helper that keeps the toolbar consistent with the current request state.
 function setUiState({ loading = false, hasError = false, message = '' } = {}) {
-  statusLabel.textContent = message;
-  statusLabel.style.color = hasError ? '#c62828' : '#202124';
+  statusOutput.textContent = message;
+  statusOutput.classList.toggle('is-error', hasError);
   // Show "Retry" only when there is an error.
   retryButton.hidden = !hasError;
   // Show "Refresh" only when the grid has data and no error is active.

--- a/docs/content/recipes/data-management/load-data-graphql/javascript/example2.ts
+++ b/docs/content/recipes/data-management/load-data-graphql/javascript/example2.ts
@@ -44,35 +44,30 @@ if (!container) {
   throw new Error('Missing #example2 element.');
 }
 
-const statusBar = document.createElement('div');
-const statusLabel = document.createElement('p');
+const controlsContainer = document.createElement('div');
+const controls = document.createElement('div');
+const statusOutput = document.createElement('output');
 const refreshButton = document.createElement('button');
 const retryButton = document.createElement('button');
 const gridContainer = document.createElement('div');
 
-statusBar.style.display = 'flex';
-statusBar.style.gap = '12px';
-statusBar.style.alignItems = 'center';
-statusBar.style.marginBottom = '8px';
-
-statusLabel.style.margin = '0';
-statusLabel.style.fontFamily = 'Arial, sans-serif';
-statusLabel.style.fontSize = '14px';
+controlsContainer.className = 'example-controls-container';
+controls.className = 'controls';
+statusOutput.id = 'example2-status';
 
 refreshButton.type = 'button';
 refreshButton.textContent = 'Refresh';
 refreshButton.hidden = true;
-refreshButton.style.marginBottom = '0';
 
 retryButton.type = 'button';
 retryButton.textContent = 'Retry';
 retryButton.hidden = true;
-retryButton.style.marginBottom = '0';
 
-container.appendChild(statusBar);
-statusBar.appendChild(statusLabel);
-statusBar.appendChild(refreshButton);
-statusBar.appendChild(retryButton);
+controls.appendChild(refreshButton);
+controls.appendChild(retryButton);
+controlsContainer.appendChild(controls);
+controlsContainer.appendChild(statusOutput);
+container.appendChild(controlsContainer);
 container.appendChild(gridContainer);
 
 // Step 1: Initialize the grid with columnSorting enabled and an empty dataset.
@@ -107,9 +102,9 @@ function setUiState({
   hasError?: boolean;
   message?: string;
 }) {
-  statusLabel.textContent = message;
-  statusLabel.style.color = hasError ? '#c62828' : '#202124';
-  // Show "Retry" only when there is an error.
+  statusOutput.textContent = message;
+  statusOutput.classList.toggle('is-error', hasError);
+    // Show "Retry" only when there is an error.
   retryButton.hidden = !hasError;
   // Show "Refresh" only when the grid has data and no error is active.
   refreshButton.hidden = hasError || loading;

--- a/docs/content/recipes/data-management/load-data-graphql/react/example1.jsx
+++ b/docs/content/recipes/data-management/load-data-graphql/react/example1.jsx
@@ -85,15 +85,15 @@ const ExampleComponent = () => {
 
   return (
     <div>
-      <div style={{ display: 'flex', gap: '12px', alignItems: 'center', marginBottom: '8px' }}>
-        <p style={{ margin: 0, fontFamily: 'Arial, sans-serif', fontSize: '14px', color: hasError ? '#c62828' : '#202124' }}>
-          {status}
-        </p>
-        {hasError && (
-          <button type="button" onClick={loadUsers}>
-            Retry
-          </button>
-        )}
+      <div className="example-controls-container">
+        <div className="controls">
+          {hasError && (
+            <button type="button" onClick={loadUsers} disabled={status === STATUS_LOADING}>
+              Retry
+            </button>
+          )}
+        </div>
+        <output className={hasError ? 'is-error' : undefined}>{status}</output>
       </div>
       <HotTable
         data={rows}

--- a/docs/content/recipes/data-management/load-data-graphql/react/example1.tsx
+++ b/docs/content/recipes/data-management/load-data-graphql/react/example1.tsx
@@ -106,15 +106,15 @@ const ExampleComponent = () => {
 
   return (
     <div>
-      <div style={{ display: 'flex', gap: '12px', alignItems: 'center', marginBottom: '8px' }}>
-        <p style={{ margin: 0, fontFamily: 'Arial, sans-serif', fontSize: '14px', color: hasError ? '#c62828' : '#202124' }}>
-          {status}
-        </p>
-        {hasError && (
-          <button type="button" onClick={loadUsers}>
-            Retry
-          </button>
-        )}
+      <div className="example-controls-container">
+        <div className="controls">
+          {hasError && (
+            <button type="button" onClick={loadUsers} disabled={status === STATUS_LOADING}>
+              Retry
+            </button>
+          )}
+        </div>
+        <output className={hasError ? 'is-error' : undefined}>{status}</output>
       </div>
       <HotTable
         data={rows}

--- a/docs/content/recipes/data-management/load-data-graphql/react/example2.jsx
+++ b/docs/content/recipes/data-management/load-data-graphql/react/example2.jsx
@@ -112,20 +112,28 @@ const ExampleComponent = () => {
 
   return (
     <div>
-      <div style={{ display: 'flex', gap: '12px', alignItems: 'center', marginBottom: '8px' }}>
-        <p style={{ margin: 0, fontFamily: 'Arial, sans-serif', fontSize: '14px', color: hasError ? '#c62828' : '#202124' }}>
-          {status}
-        </p>
-        {showRefresh && !hasError && (
-          <button type="button" onClick={refreshUsers} style={{ marginBottom: 0 }}>
-            Refresh
-          </button>
-        )}
-        {hasError && (
-          <button type="button" onClick={initialLoad} style={{ marginBottom: 0 }}>
-            Retry
-          </button>
-        )}
+      <div className="example-controls-container">
+        <div className="controls">
+          {showRefresh && !hasError && (
+            <button
+              type="button"
+              onClick={refreshUsers}
+              disabled={status === STATUS_LOADING || status === STATUS_REFRESHING}
+            >
+              Refresh
+            </button>
+          )}
+          {hasError && (
+            <button
+              type="button"
+              onClick={initialLoad}
+              disabled={status === STATUS_LOADING || status === STATUS_REFRESHING}
+            >
+              Retry
+            </button>
+          )}
+        </div>
+        <output className={hasError ? 'is-error' : undefined}>{status}</output>
       </div>
       <HotTable
         ref={hotRef}

--- a/docs/content/recipes/data-management/load-data-graphql/react/example2.tsx
+++ b/docs/content/recipes/data-management/load-data-graphql/react/example2.tsx
@@ -133,20 +133,28 @@ const ExampleComponent = () => {
 
   return (
     <div>
-      <div style={{ display: 'flex', gap: '12px', alignItems: 'center', marginBottom: '8px' }}>
-        <p style={{ margin: 0, fontFamily: 'Arial, sans-serif', fontSize: '14px', color: hasError ? '#c62828' : '#202124' }}>
-          {status}
-        </p>
-        {showRefresh && !hasError && (
-          <button type="button" onClick={refreshUsers} style={{ marginBottom: 0 }}>
-            Refresh
-          </button>
-        )}
-        {hasError && (
-          <button type="button" onClick={initialLoad} style={{ marginBottom: 0 }}>
-            Retry
-          </button>
-        )}
+      <div className="example-controls-container">
+        <div className="controls">
+          {showRefresh && !hasError && (
+            <button
+              type="button"
+              onClick={refreshUsers}
+              disabled={status === STATUS_LOADING || status === STATUS_REFRESHING}
+            >
+              Refresh
+            </button>
+          )}
+          {hasError && (
+            <button
+              type="button"
+              onClick={initialLoad}
+              disabled={status === STATUS_LOADING || status === STATUS_REFRESHING}
+            >
+              Retry
+            </button>
+          )}
+        </div>
+        <output className={hasError ? 'is-error' : undefined}>{status}</output>
       </div>
       <HotTable
         ref={hotRef}

--- a/docs/content/recipes/data-management/load-data-rest-api/angular/example1.ts
+++ b/docs/content/recipes/data-management/load-data-rest-api/angular/example1.ts
@@ -38,14 +38,13 @@ function mapUsersToGridRows(users: Array<{
   standalone: true,
   imports: [HotTableModule],
   template: `
-    <div style="display: flex; gap: 12px; align-items: center; margin-bottom: 8px;">
-      <p style="margin: 0; font-family: Arial, sans-serif; font-size: 14px;"
-         [style.color]="hasError ? 'var(--ht-cell-error-foreground-color, #c62828)' : 'var(--ht-foreground-color, #202124)'">
-        {{ statusMessage }}
-      </p>
-      @if (hasError) {
-        <button type="button" [disabled]="loading" (click)="loadUsers()">Retry</button>
-      }
+    <div class="example-controls-container">
+      <div class="controls">
+        @if (hasError) {
+          <button type="button" [disabled]="loading" (click)="loadUsers()">Retry</button>
+        }
+      </div>
+      <output [class.is-error]="hasError">{{ statusMessage }}</output>
     </div>
     <hot-table [settings]="gridSettings"></hot-table>
   `,

--- a/docs/content/recipes/data-management/load-data-rest-api/angular/example2.ts
+++ b/docs/content/recipes/data-management/load-data-rest-api/angular/example2.ts
@@ -43,16 +43,15 @@ function mapUsersToGridRows(users: ApiUser[]): UserRow[] {
   standalone: true,
   imports: [HotTableModule],
   template: `
-    <div style="display: flex; gap: 12px; align-items: center; margin-bottom: 8px;">
-      <p style="margin: 0; font-family: Arial, sans-serif; font-size: 14px;"
-         [style.color]="hasError ? 'var(--ht-cell-error-foreground-color, #c62828)' : 'var(--ht-foreground-color, #202124)'">
-        {{ statusMessage }}
-      </p>
-      @if (hasData && !hasError) {
-        <button type="button" [disabled]="loading" (click)="refreshUsers()">Refresh</button>
-      } @else if (hasError) {
-        <button type="button" [disabled]="loading" (click)="initialLoad()">Retry</button>
-      }
+    <div class="example-controls-container">
+      <div class="controls">
+        @if (hasData && !hasError) {
+          <button type="button" [disabled]="loading" (click)="refreshUsers()">Refresh</button>
+        } @else if (hasError) {
+          <button type="button" [disabled]="loading" (click)="initialLoad()">Retry</button>
+        }
+      </div>
+      <output [class.is-error]="hasError">{{ statusMessage }}</output>
     </div>
     <hot-table [settings]="gridSettings"></hot-table>
   `,

--- a/docs/content/recipes/data-management/load-data-rest-api/angular/example3.ts
+++ b/docs/content/recipes/data-management/load-data-rest-api/angular/example3.ts
@@ -21,29 +21,28 @@ type UserRow = {
   standalone: true,
   imports: [HotTableModule],
   template: `
-    <p style="margin: 0 0 8px; font-family: Arial, sans-serif; font-size: 14px;"
-       [style.color]="statusColor">
-      {{ statusMessage }}
-    </p>
+    <div class="example-controls-container">
+      <output [class.is-error]="statusIsError">{{ statusMessage }}</output>
+    </div>
     <hot-table [settings]="hotSettings"></hot-table>
   `,
 })
 export class AppComponent {
   private readonly ngZone = inject(NgZone);
 
+  statusIsError = false;
   statusMessage = 'Loading...';
-  statusColor = 'var(--ht-foreground-color, #202124)';
 
   private cachedRows: UserRow[] | null = null;
 
   readonly hotSettings: GridSettings;
 
   /** Defers binding updates so sync data-provider hooks do not trigger NG0100 in dev mode. */
-  private setFetchStatus(message: string, color = 'var(--ht-foreground-color, #202124)'): void {
+  private setFetchStatus(message: string, isError = false): void {
     setTimeout(() => {
       this.ngZone.run(() => {
         this.statusMessage = message;
-        this.statusColor = color;
+        this.statusIsError = isError;
       });
     }, 0);
   }
@@ -98,17 +97,14 @@ export class AppComponent {
       autoWrapRow: true,
       beforeDataProviderFetch: (params: DataProviderBeforeFetchParameters) => {
         if (!params.skipLoading) {
-          this.setFetchStatus('Loading...');
+          this.setFetchStatus('Loading...', false);
         }
       },
       afterDataProviderFetch: () => {
-        this.setFetchStatus('Loaded from REST API via dataProvider.');
+        this.setFetchStatus('Loaded from REST API via dataProvider.', false);
       },
       afterDataProviderFetchError: (error: Error) => {
-        this.setFetchStatus(
-          `Error: ${error.message}`,
-          'var(--ht-cell-error-foreground-color, #c62828)'
-        );
+        this.setFetchStatus(`Error: ${error.message}`, true);
       },
     };
   }

--- a/docs/content/recipes/data-management/load-data-rest-api/javascript/example1.js
+++ b/docs/content/recipes/data-management/load-data-rest-api/javascript/example1.js
@@ -13,30 +13,24 @@ if (!container) {
   throw new Error('Missing #example1 element.');
 }
 
-const status = document.createElement('p');
+const controlsContainer = document.createElement('div');
+const controls = document.createElement('div');
+const statusOutput = document.createElement('output');
 const retryButton = document.createElement('button');
+const gridContainer = document.createElement('div');
 
-status.textContent = STATUS_LOADING;
-status.style.margin = '0';
-status.style.fontFamily = 'Arial, sans-serif';
-status.style.fontSize = '14px';
+controlsContainer.className = 'example-controls-container';
+controls.className = 'controls';
+statusOutput.id = 'example1-status';
 
 retryButton.type = 'button';
 retryButton.textContent = 'Retry';
 retryButton.hidden = true;
-retryButton.style.marginBottom = '0';
 
-const statusBar = document.createElement('div');
-const gridContainer = document.createElement('div');
-
-statusBar.style.display = 'flex';
-statusBar.style.gap = '12px';
-statusBar.style.alignItems = 'center';
-statusBar.style.marginBottom = '8px';
-
-container.appendChild(statusBar);
-statusBar.appendChild(status);
-statusBar.appendChild(retryButton);
+controls.appendChild(retryButton);
+controlsContainer.appendChild(controls);
+controlsContainer.appendChild(statusOutput);
+container.appendChild(controlsContainer);
 container.appendChild(gridContainer);
 
 const hot = new Handsontable(gridContainer, {
@@ -59,10 +53,8 @@ const hot = new Handsontable(gridContainer, {
 });
 
 function setUiState({ loading = false, hasError = false, message = '' } = {}) {
-  status.textContent = message;
-  status.style.color = hasError
-    ? 'var(--ht-cell-error-foreground-color, #c62828)'
-    : 'var(--ht-foreground-color, #202124)';
+  statusOutput.textContent = message;
+  statusOutput.classList.toggle('is-error', hasError);
   retryButton.hidden = !hasError;
   retryButton.disabled = loading;
 }

--- a/docs/content/recipes/data-management/load-data-rest-api/javascript/example1.ts
+++ b/docs/content/recipes/data-management/load-data-rest-api/javascript/example1.ts
@@ -18,27 +18,24 @@ const STATUS_ERROR = 'Failed to load users. Try again.';
 
 const rootContainer = document.querySelector('#example1') as HTMLDivElement;
 
-const statusBar = document.createElement('div');
-const statusLabel = document.createElement('p');
+const controlsContainer = document.createElement('div');
+const controls = document.createElement('div');
+const statusOutput = document.createElement('output');
 const retryButton = document.createElement('button');
 const gridContainer = document.createElement('div');
 
-statusBar.style.display = 'flex';
-statusBar.style.gap = '12px';
-statusBar.style.alignItems = 'center';
-statusBar.style.marginBottom = '8px';
-
-statusLabel.style.margin = '0';
-statusLabel.style.fontFamily = 'Arial, sans-serif';
-statusLabel.style.fontSize = '14px';
+controlsContainer.className = 'example-controls-container';
+controls.className = 'controls';
+statusOutput.id = 'example1-status';
 
 retryButton.type = 'button';
 retryButton.textContent = 'Retry';
 retryButton.hidden = true;
 
-rootContainer.appendChild(statusBar);
-statusBar.appendChild(statusLabel);
-statusBar.appendChild(retryButton);
+controls.appendChild(retryButton);
+controlsContainer.appendChild(controls);
+controlsContainer.appendChild(statusOutput);
+rootContainer.appendChild(controlsContainer);
 rootContainer.appendChild(gridContainer);
 
 const hot = new Handsontable(gridContainer, {
@@ -69,10 +66,8 @@ function setUiState({
   hasError?: boolean;
   message?: string;
 }) {
-  statusLabel.textContent = message;
-  statusLabel.style.color = hasError
-    ? 'var(--ht-cell-error-foreground-color, #c62828)'
-    : 'var(--ht-foreground-color, #202124)';
+  statusOutput.textContent = message;
+  statusOutput.classList.toggle('is-error', hasError);
   retryButton.hidden = !hasError;
   retryButton.disabled = loading;
 }

--- a/docs/content/recipes/data-management/load-data-rest-api/javascript/example2.js
+++ b/docs/content/recipes/data-management/load-data-rest-api/javascript/example2.js
@@ -16,35 +16,30 @@ if (!container) {
   throw new Error('Missing #example2 element.');
 }
 
-const statusBar = document.createElement('div');
-const status = document.createElement('p');
+const controlsContainer = document.createElement('div');
+const controls = document.createElement('div');
+const statusOutput = document.createElement('output');
 const refreshButton = document.createElement('button');
 const retryButton = document.createElement('button');
 const gridContainer = document.createElement('div');
 
-statusBar.style.display = 'flex';
-statusBar.style.gap = '12px';
-statusBar.style.alignItems = 'center';
-statusBar.style.marginBottom = '8px';
-
-status.style.margin = '0';
-status.style.fontFamily = 'Arial, sans-serif';
-status.style.fontSize = '14px';
+controlsContainer.className = 'example-controls-container';
+controls.className = 'controls';
+statusOutput.id = 'example2-status';
 
 refreshButton.type = 'button';
 refreshButton.textContent = 'Refresh';
 refreshButton.hidden = true;
-refreshButton.style.marginBottom = '0';
 
 retryButton.type = 'button';
 retryButton.textContent = 'Retry';
 retryButton.hidden = true;
-retryButton.style.marginBottom = '0';
 
-container.appendChild(statusBar);
-statusBar.appendChild(status);
-statusBar.appendChild(refreshButton);
-statusBar.appendChild(retryButton);
+controls.appendChild(refreshButton);
+controls.appendChild(retryButton);
+controlsContainer.appendChild(controls);
+controlsContainer.appendChild(statusOutput);
+container.appendChild(controlsContainer);
 container.appendChild(gridContainer);
 
 // Step 1: Initialize the grid with columnSorting enabled and an empty dataset.
@@ -71,10 +66,8 @@ const hot = new Handsontable(gridContainer, {
 
 // Step 2: A helper that keeps the toolbar consistent with the current request state.
 function setUiState({ loading = false, hasError = false, message = '' } = {}) {
-  status.textContent = message;
-  status.style.color = hasError
-    ? 'var(--ht-cell-error-foreground-color, #c62828)'
-    : 'var(--ht-foreground-color, #202124)';
+  statusOutput.textContent = message;
+  statusOutput.classList.toggle('is-error', hasError);
   // Show "Retry" only when there is an error.
   retryButton.hidden = !hasError;
   // Show "Refresh" only when the grid has data and no error is active.

--- a/docs/content/recipes/data-management/load-data-rest-api/javascript/example2.ts
+++ b/docs/content/recipes/data-management/load-data-rest-api/javascript/example2.ts
@@ -21,35 +21,30 @@ const STATUS_ERROR = 'Failed to load users. Try again.';
 
 const rootContainer = document.querySelector('#example2') as HTMLDivElement;
 
-const statusBar = document.createElement('div');
-const statusLabel = document.createElement('p');
+const controlsContainer = document.createElement('div');
+const controls = document.createElement('div');
+const statusOutput = document.createElement('output');
 const refreshButton = document.createElement('button');
 const retryButton = document.createElement('button');
 const gridContainer = document.createElement('div');
 
-statusBar.style.display = 'flex';
-statusBar.style.gap = '12px';
-statusBar.style.alignItems = 'center';
-statusBar.style.marginBottom = '8px';
-
-statusLabel.style.margin = '0';
-statusLabel.style.fontFamily = 'Arial, sans-serif';
-statusLabel.style.fontSize = '14px';
+controlsContainer.className = 'example-controls-container';
+controls.className = 'controls';
+statusOutput.id = 'example2-status';
 
 refreshButton.type = 'button';
 refreshButton.textContent = 'Refresh';
 refreshButton.hidden = true;
-refreshButton.style.marginBottom = '0';
 
 retryButton.type = 'button';
 retryButton.textContent = 'Retry';
 retryButton.hidden = true;
-retryButton.style.marginBottom = '0';
 
-rootContainer.appendChild(statusBar);
-statusBar.appendChild(statusLabel);
-statusBar.appendChild(refreshButton);
-statusBar.appendChild(retryButton);
+controls.appendChild(refreshButton);
+controls.appendChild(retryButton);
+controlsContainer.appendChild(controls);
+controlsContainer.appendChild(statusOutput);
+rootContainer.appendChild(controlsContainer);
 rootContainer.appendChild(gridContainer);
 
 // Step 1: Initialize the grid with columnSorting enabled and an empty dataset.
@@ -84,10 +79,8 @@ function setUiState({
   hasError?: boolean;
   message?: string;
 }) {
-  statusLabel.textContent = message;
-  statusLabel.style.color = hasError
-    ? 'var(--ht-cell-error-foreground-color, #c62828)'
-    : 'var(--ht-foreground-color, #202124)';
+  statusOutput.textContent = message;
+  statusOutput.classList.toggle('is-error', hasError);
   // Show "Retry" only when there is an error.
   retryButton.hidden = !hasError;
   // Show "Refresh" only when the grid has data and no error is active.

--- a/docs/content/recipes/data-management/load-data-rest-api/javascript/example3.js
+++ b/docs/content/recipes/data-management/load-data-rest-api/javascript/example3.js
@@ -39,21 +39,16 @@ if (!container) {
   throw new Error('Missing #example3 element.');
 }
 
-const statusBar = document.createElement('div');
-const status = document.createElement('p');
+const controlsContainer = document.createElement('div');
+const statusOutput = document.createElement('output');
 const gridContainer = document.createElement('div');
 
-statusBar.style.display = 'flex';
-statusBar.style.alignItems = 'center';
-statusBar.style.marginBottom = '8px';
+controlsContainer.className = 'example-controls-container';
+statusOutput.id = 'example3-status';
+statusOutput.textContent = 'Loading...';
 
-status.style.margin = '0';
-status.style.fontFamily = 'Arial, sans-serif';
-status.style.fontSize = '14px';
-status.textContent = 'Loading...';
-
-container.appendChild(statusBar);
-statusBar.appendChild(status);
+container.appendChild(controlsContainer);
+controlsContainer.appendChild(statusOutput);
 container.appendChild(gridContainer);
 
 new Handsontable(gridContainer, {
@@ -127,16 +122,16 @@ new Handsontable(gridContainer, {
   // in those cases so the grid does not flash a spinner on every column header click.
   beforeDataProviderFetch: ({ skipLoading }) => {
     if (!skipLoading) {
-      status.textContent = 'Loading...';
-      status.style.color = 'var(--ht-foreground-color, #202124)';
+      statusOutput.textContent = 'Loading...';
+      statusOutput.classList.remove('is-error');
     }
   },
   afterDataProviderFetch: () => {
-    status.textContent = 'Loaded from REST API via dataProvider.';
-    status.style.color = 'var(--ht-foreground-color, #202124)';
+    statusOutput.textContent = 'Loaded from REST API via dataProvider.';
+    statusOutput.classList.remove('is-error');
   },
   afterDataProviderFetchError: (error) => {
-    status.textContent = `Error: ${error.message}`;
-    status.style.color = 'var(--ht-notification-error-accent, #c62828)';
+    statusOutput.textContent = `Error: ${error.message}`;
+    statusOutput.classList.add('is-error');
   },
 });

--- a/docs/content/recipes/data-management/load-data-rest-api/javascript/example3.ts
+++ b/docs/content/recipes/data-management/load-data-rest-api/javascript/example3.ts
@@ -56,22 +56,16 @@ async function loadAllRows(signal: AbortSignal): Promise<UserRow[]> {
 
 const rootContainer = document.querySelector('#example3') as HTMLDivElement;
 
-const statusBar = document.createElement('div');
-const statusLabel = document.createElement('p');
+const controlsContainer = document.createElement('div');
+const statusOutput = document.createElement('output');
 const gridContainer = document.createElement('div');
 
-statusBar.style.display = 'flex';
-statusBar.style.alignItems = 'center';
-statusBar.style.marginBottom = '8px';
+controlsContainer.className = 'example-controls-container';
+statusOutput.id = 'example3-status';
+statusOutput.textContent = 'Loading...';
 
-statusLabel.style.margin = '0';
-statusLabel.style.fontFamily = 'Arial, sans-serif';
-statusLabel.style.fontSize = '14px';
-statusLabel.style.color = 'var(--ht-foreground-color, #202124)';
-statusLabel.textContent = 'Loading...';
-
-rootContainer.appendChild(statusBar);
-statusBar.appendChild(statusLabel);
+rootContainer.appendChild(controlsContainer);
+controlsContainer.appendChild(statusOutput);
 rootContainer.appendChild(gridContainer);
 
 new Handsontable(gridContainer, {
@@ -148,16 +142,16 @@ new Handsontable(gridContainer, {
   // in those cases so the grid does not flash a spinner on every column header click.
   beforeDataProviderFetch: ({ skipLoading }: DataProviderBeforeFetchParameters) => {
     if (!skipLoading) {
-      statusLabel.textContent = 'Loading...';
-      statusLabel.style.color = 'var(--ht-foreground-color, #202124)';
+      statusOutput.textContent = 'Loading...';
+      statusOutput.classList.remove('is-error');
     }
   },
   afterDataProviderFetch: () => {
-    statusLabel.textContent = 'Loaded from REST API via dataProvider.';
-    statusLabel.style.color = 'var(--ht-foreground-color, #202124)';
+    statusOutput.textContent = 'Loaded from REST API via dataProvider.';
+    statusOutput.classList.remove('is-error');
   },
   afterDataProviderFetchError: (error: Error) => {
-    statusLabel.textContent = `Error: ${error.message}`;
-    statusLabel.style.color = 'var(--ht-notification-error-accent, #c62828)';
+    statusOutput.textContent = `Error: ${error.message}`;
+    statusOutput.classList.add('is-error');
   },
 });

--- a/docs/content/recipes/data-management/load-data-rest-api/load-data-rest-api.md
+++ b/docs/content/recipes/data-management/load-data-rest-api/load-data-rest-api.md
@@ -162,9 +162,8 @@ const refreshButton = document.createElement('button');
 refreshButton.type = 'button';
 refreshButton.textContent = 'Refresh';
 refreshButton.hidden = true; // hidden until the initial load succeeds
-refreshButton.style.marginBottom = '0';
 
-statusBar.appendChild(refreshButton);
+controls.appendChild(refreshButton);
 ```
 
 **What's happening:**
@@ -196,10 +195,8 @@ The helper controls the "Refresh" button alongside the existing "Retry" button.
 
 ```javascript
 function setUiState({ loading = false, hasError = false, message = '' } = {}) {
-  status.textContent = message;
-  status.style.color = hasError
-    ? 'var(--ht-cell-error-foreground-color, #c62828)'
-    : 'var(--ht-foreground-color, #202124)';
+  statusOutput.textContent = message;
+  statusOutput.classList.toggle('is-error', hasError);
   retryButton.hidden = !hasError;            // visible only on error
   refreshButton.hidden = hasError || loading; // visible only when data is ready
   refreshButton.disabled = loading;
@@ -499,15 +496,17 @@ emptyDataState: true,
 ```javascript
 beforeDataProviderFetch: ({ skipLoading }) => {
   if (!skipLoading) {
-    status.textContent = 'Loading...';
+    statusOutput.textContent = 'Loading...';
+    statusOutput.classList.remove('is-error');
   }
 },
 afterDataProviderFetch: () => {
-  status.textContent = 'Loaded from REST API via dataProvider.';
+  statusOutput.textContent = 'Loaded from REST API via dataProvider.';
+  statusOutput.classList.remove('is-error');
 },
 afterDataProviderFetchError: (error) => {
-  status.textContent = `Error: ${error.message}`;
-  status.style.color = 'var(--ht-cell-error-foreground-color, #c62828)';
+  statusOutput.textContent = `Error: ${error.message}`;
+  statusOutput.classList.add('is-error');
 },
 ```
 

--- a/docs/content/recipes/data-management/load-data-rest-api/react/example1.jsx
+++ b/docs/content/recipes/data-management/load-data-rest-api/react/example1.jsx
@@ -55,15 +55,15 @@ const ExampleComponent = () => {
 
   return (
     <div>
-      <div style={{ display: 'flex', gap: '12px', alignItems: 'center', marginBottom: '8px' }}>
-        <p style={{ margin: 0, fontFamily: 'Arial, sans-serif', fontSize: '14px', color: hasError ? '#c62828' : '#202124' }}>
-          {status}
-        </p>
-        {hasError && (
-          <button type="button" onClick={loadUsers}>
-            Retry
-          </button>
-        )}
+      <div className="example-controls-container">
+        <div className="controls">
+          {hasError && (
+            <button type="button" onClick={loadUsers} disabled={status === STATUS_LOADING}>
+              Retry
+            </button>
+          )}
+        </div>
+        <output className={hasError ? 'is-error' : undefined}>{status}</output>
       </div>
       <HotTable
         data={rows}

--- a/docs/content/recipes/data-management/load-data-rest-api/react/example1.tsx
+++ b/docs/content/recipes/data-management/load-data-rest-api/react/example1.tsx
@@ -73,15 +73,15 @@ const ExampleComponent = () => {
 
   return (
     <div>
-      <div style={{ display: 'flex', gap: '12px', alignItems: 'center', marginBottom: '8px' }}>
-        <p style={{ margin: 0, fontFamily: 'Arial, sans-serif', fontSize: '14px', color: hasError ? '#c62828' : '#202124' }}>
-          {status}
-        </p>
-        {hasError && (
-          <button type="button" onClick={loadUsers}>
-            Retry
-          </button>
-        )}
+      <div className="example-controls-container">
+        <div className="controls">
+          {hasError && (
+            <button type="button" onClick={loadUsers} disabled={status === STATUS_LOADING}>
+              Retry
+            </button>
+          )}
+        </div>
+        <output className={hasError ? 'is-error' : undefined}>{status}</output>
       </div>
       <HotTable
         data={rows}

--- a/docs/content/recipes/data-management/load-data-rest-api/react/example2.jsx
+++ b/docs/content/recipes/data-management/load-data-rest-api/react/example2.jsx
@@ -78,20 +78,28 @@ const ExampleComponent = () => {
 
   return (
     <div>
-      <div style={{ display: 'flex', gap: '12px', alignItems: 'center', marginBottom: '8px' }}>
-        <p style={{ margin: 0, fontFamily: 'Arial, sans-serif', fontSize: '14px', color: hasError ? '#c62828' : '#202124' }}>
-          {status}
-        </p>
-        {showRefresh && !hasError && (
-          <button type="button" onClick={refreshUsers} style={{ marginBottom: 0 }}>
-            Refresh
-          </button>
-        )}
-        {hasError && (
-          <button type="button" onClick={initialLoad} style={{ marginBottom: 0 }}>
-            Retry
-          </button>
-        )}
+      <div className="example-controls-container">
+        <div className="controls">
+          {showRefresh && !hasError && (
+            <button
+              type="button"
+              onClick={refreshUsers}
+              disabled={status === STATUS_LOADING || status === STATUS_REFRESHING}
+            >
+              Refresh
+            </button>
+          )}
+          {hasError && (
+            <button
+              type="button"
+              onClick={initialLoad}
+              disabled={status === STATUS_LOADING || status === STATUS_REFRESHING}
+            >
+              Retry
+            </button>
+          )}
+        </div>
+        <output className={hasError ? 'is-error' : undefined}>{status}</output>
       </div>
       <HotTable
         ref={hotRef}

--- a/docs/content/recipes/data-management/load-data-rest-api/react/example2.tsx
+++ b/docs/content/recipes/data-management/load-data-rest-api/react/example2.tsx
@@ -96,20 +96,28 @@ const ExampleComponent = () => {
 
   return (
     <div>
-      <div style={{ display: 'flex', gap: '12px', alignItems: 'center', marginBottom: '8px' }}>
-        <p style={{ margin: 0, fontFamily: 'Arial, sans-serif', fontSize: '14px', color: hasError ? '#c62828' : '#202124' }}>
-          {status}
-        </p>
-        {showRefresh && !hasError && (
-          <button type="button" onClick={refreshUsers} style={{ marginBottom: 0 }}>
-            Refresh
-          </button>
-        )}
-        {hasError && (
-          <button type="button" onClick={initialLoad} style={{ marginBottom: 0 }}>
-            Retry
-          </button>
-        )}
+      <div className="example-controls-container">
+        <div className="controls">
+          {showRefresh && !hasError && (
+            <button
+              type="button"
+              onClick={refreshUsers}
+              disabled={status === STATUS_LOADING || status === STATUS_REFRESHING}
+            >
+              Refresh
+            </button>
+          )}
+          {hasError && (
+            <button
+              type="button"
+              onClick={initialLoad}
+              disabled={status === STATUS_LOADING || status === STATUS_REFRESHING}
+            >
+              Retry
+            </button>
+          )}
+        </div>
+        <output className={hasError ? 'is-error' : undefined}>{status}</output>
       </div>
       <HotTable
         ref={hotRef}

--- a/docs/content/recipes/data-management/load-data-rest-api/react/example3.jsx
+++ b/docs/content/recipes/data-management/load-data-rest-api/react/example3.jsx
@@ -73,29 +73,28 @@ const ExampleComponent = () => {
   const beforeDataProviderFetch = useCallback((params) => {
     if (params.skipLoading || !statusRef.current) return;
     statusRef.current.textContent = 'Loading...';
-    statusRef.current.style.color = '#202124';
+    statusRef.current.classList.remove('is-error');
   }, []);
 
   const afterDataProviderFetch = useCallback(() => {
     if (!statusRef.current) return;
     statusRef.current.textContent = 'Loaded from REST API via dataProvider.';
-    statusRef.current.style.color = '#202124';
+    statusRef.current.classList.remove('is-error');
   }, []);
 
   const afterDataProviderFetchError = useCallback((error) => {
     if (!statusRef.current) return;
     statusRef.current.textContent = `Error: ${error.message}`;
-    statusRef.current.style.color = '#c62828';
+    statusRef.current.classList.add('is-error');
   }, []);
 
   return (
     <div>
-      <p
-        ref={statusRef}
-        style={{ margin: '0 0 8px', fontFamily: 'Arial, sans-serif', fontSize: '14px', color: '#202124' }}
-      >
-        Loading...
-      </p>
+      <div className="example-controls-container">
+        <output ref={statusRef} className="console">
+          Loading...
+        </output>
+      </div>
       <HotTable
         dataProvider={dataProvider}
         colHeaders={['ID', 'Name', 'Username', 'Email', 'City', 'Company']}

--- a/docs/content/recipes/data-management/load-data-rest-api/react/example3.tsx
+++ b/docs/content/recipes/data-management/load-data-rest-api/react/example3.tsx
@@ -96,29 +96,28 @@ const ExampleComponent = () => {
   const beforeDataProviderFetch = useCallback((params: { skipLoading?: boolean }) => {
     if (params.skipLoading || !statusRef.current) return;
     statusRef.current.textContent = 'Loading...';
-    statusRef.current.style.color = '#202124';
+    statusRef.current.classList.remove('is-error');
   }, []);
 
   const afterDataProviderFetch = useCallback(() => {
     if (!statusRef.current) return;
     statusRef.current.textContent = 'Loaded from REST API via dataProvider.';
-    statusRef.current.style.color = '#202124';
+    statusRef.current.classList.remove('is-error');
   }, []);
 
   const afterDataProviderFetchError = useCallback((error: Error) => {
     if (!statusRef.current) return;
     statusRef.current.textContent = `Error: ${error.message}`;
-    statusRef.current.style.color = '#c62828';
+    statusRef.current.classList.add('is-error');
   }, []);
 
   return (
     <div>
-      <p
-        ref={statusRef}
-        style={{ margin: '0 0 8px', fontFamily: 'Arial, sans-serif', fontSize: '14px', color: '#202124' }}
-      >
-        Loading...
-      </p>
+      <div className="example-controls-container">
+        <output ref={statusRef} className="console">
+          Loading...
+        </output>
+      </div>
       <HotTable
         dataProvider={dataProvider}
         colHeaders={['ID', 'Name', 'Username', 'Email', 'City', 'Company']}

--- a/docs/src/styles/interactive-example.css
+++ b/docs/src/styles/interactive-example.css
@@ -149,6 +149,16 @@
   gap: 0.5rem;
 }
 
+/* display on buttons below overrides the UA [hidden] rule; keep hidden controls invisible */
+.example-controls-container button[hidden],
+.example-controls-container .button[hidden] {
+  display: none !important;
+}
+
+.example-controls-container .controls:not(:has(button:not([hidden]))) {
+  display: none;
+}
+
 .example-controls-container button,
 .example-controls-container .button,
 .hot-example-preview > button,
@@ -256,6 +266,10 @@
   font-family: var(--sl-font);
   font-size: var(--sl-text-xs);
   line-height: 1.4;
+}
+
+.example-controls-container output.is-error {
+  color: var(--ht-notification-error-accent, #c62828);
 }
 
 /* ── Toolbar ───────────────────────────────────────────────────────────── */


### PR DESCRIPTION
### Context

The PR fixes unreadable Retry and Refresh buttons and status text on the GraphQL and REST API load-data recipe pages in docs dark mode. The examples used ad-hoc markup and hardcoded colors instead of the shared `example-controls-container` pattern from `interactive-example.css`.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1696
ClickUp task: https://app.clickup.com/t/9015210959/DEV-1697

[skip changelog]

### How has this been tested?

- Manual: `cd docs && npm run dev`
- Verified `/recipes/data-management/load-data-graphql` and `/recipes/data-management/load-data-rest-api` in light and dark mode
- Checked JavaScript, React, and Angular tabs for examples 1–2 (REST: example 3 status label as well)
- Confirmed error state styling via `output.is-error`

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1696
2. DEV-1697

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes shared `interactive-example.css` and refactors markup across many recipe examples, which could unintentionally affect other interactive example toolbars or hidden-button behavior.
> 
> **Overview**
> Fixes the load-data GraphQL and REST API recipe examples to use the shared `example-controls-container` pattern (with `<output>` + `is-error` state) instead of inline styling/hardcoded colors, improving readability in dark mode.
> 
> Updates JS/TS, React, and Angular examples to restructure the toolbar DOM, remove ad-hoc styles, and disable Refresh/Retry buttons while requests are in flight. Enhances `interactive-example.css` to correctly hide `[hidden]` controls and add consistent error coloring for `output.is-error`, and aligns the REST API recipe markdown snippets with the new toolbar structure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 921af81d357561cc3a1f78197d560f77b075f213. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->