### PR TITLE
DEV-1699: Fix server-side recipe docs examples and code embeds

### DIFF
--- a/docs/content/recipes/data-management/server-side-laravel/angular/example1.ts
+++ b/docs/content/recipes/data-management/server-side-laravel/angular/example1.ts
@@ -84,6 +84,8 @@ export class AppComponent {
       { data: 'price', type: 'numeric', numericFormat: { pattern: '$0,0.00' } },
       { data: 'stock', type: 'numeric' },
     ],
+    height: 360,
+    width: '100%',
   };
 
   async fetchRows(params: DataProviderQueryParameters, signal: AbortSignal): Promise<{ rows: SourceRowData[]; totalRows: number }> {

--- a/docs/content/recipes/data-management/server-side-laravel/javascript/example1.js
+++ b/docs/content/recipes/data-management/server-side-laravel/javascript/example1.js
@@ -185,5 +185,10 @@ const hot = new Handsontable(container, {
     { data: 'price', type: 'numeric', numericFormat: { pattern: '$0,0.00' } },
     { data: 'stock', type: 'numeric' },
   ],
+
+  // Fixed height keeps the docs preview compact when fetchRows fails (no local API).
+  height: 360,
+  width: '100%',
+
   licenseKey: 'non-commercial-and-evaluation',
 });

--- a/docs/content/recipes/data-management/server-side-laravel/javascript/example1.ts
+++ b/docs/content/recipes/data-management/server-side-laravel/javascript/example1.ts
@@ -197,5 +197,10 @@ const hot = new Handsontable(container, {
     { data: 'price', type: 'numeric', numericFormat: { pattern: '$0,0.00' } },
     { data: 'stock', type: 'numeric' },
   ],
+
+  // Fixed height keeps the docs preview compact when fetchRows fails (no local API).
+  height: 360,
+  width: '100%',
+
   licenseKey: 'non-commercial-and-evaluation',
 } as Handsontable.GridSettings);

--- a/docs/content/recipes/data-management/server-side-laravel/react/example1.jsx
+++ b/docs/content/recipes/data-management/server-side-laravel/react/example1.jsx
@@ -198,6 +198,8 @@ const ExampleComponent = () => {
           { data: 'price', type: 'numeric', numericFormat: { pattern: '$0,0.00' } },
           { data: 'stock', type: 'numeric' },
         ]}
+        height={360}
+        width="100%"
         licenseKey="non-commercial-and-evaluation"
       />
     </div>

--- a/docs/content/recipes/data-management/server-side-laravel/react/example1.tsx
+++ b/docs/content/recipes/data-management/server-side-laravel/react/example1.tsx
@@ -168,6 +168,8 @@ const ExampleComponent = () => {
           { data: 'price', type: 'numeric', numericFormat: { pattern: '$0,0.00' } },
           { data: 'stock', type: 'numeric' },
         ]}
+        height={360}
+        width="100%"
         licenseKey="non-commercial-and-evaluation"
       />
     </div>

--- a/docs/content/recipes/data-management/server-side-laravel/server-side-laravel.md
+++ b/docs/content/recipes/data-management/server-side-laravel/server-side-laravel.md
@@ -69,7 +69,7 @@ php artisan make:seeder ProductSeeder
 
 Replace the generated migration's `up()` method with the products schema:
 
-@[code php](@/recipes/data-management/server-side-laravel/server/migration.php)
+@[code php](@/content/recipes/data-management/server-side-laravel/server/migration.php)
 
 **What's happening:**
 - `id()` creates an auto-increment primary key. This is the value Handsontable uses as `rowId`.
@@ -87,7 +87,7 @@ php artisan migrate
 
 Open `app/Models/Product.php` and set `$fillable` and `$casts`:
 
-@[code php](@/recipes/data-management/server-side-laravel/server/Product.php)
+@[code php](@/content/recipes/data-management/server-side-laravel/server/Product.php)
 
 **What's happening:**
 - `$fillable` lists the columns that `Product::create()` and `update()` may write to, protecting the `id` from mass-assignment.
@@ -97,7 +97,7 @@ Open `app/Models/Product.php` and set `$fillable` and `$casts`:
 
 Open `database/seeders/ProductSeeder.php` and add at least 50 rows so that pagination spans multiple pages:
 
-@[code php](@/recipes/data-management/server-side-laravel/server/seeder.php)
+@[code php](@/content/recipes/data-management/server-side-laravel/server/seeder.php)
 
 **What's happening:**
 - `Product::create($data)` inserts each row through Eloquent so the `$fillable` guard and timestamps apply.
@@ -113,7 +113,7 @@ php artisan db:seed --class=ProductSeeder
 
 `ProductController` handles all four HTTP verbs. Each method maps to one Handsontable `dataProvider` callback:
 
-@[code php](@/recipes/data-management/server-side-laravel/server/ProductController.php)
+@[code php collapse={12-150}](@/content/recipes/data-management/server-side-laravel/server/ProductController.php)
 
 **What's happening:**
 
@@ -177,7 +177,7 @@ After a cell edit, `onRowsUpdate` calls `PATCH /api/products` with:
 
 Open `routes/api.php` and add the four product routes:
 
-@[code php](@/recipes/data-management/server-side-laravel/server/routes-api.php)
+@[code php](@/content/recipes/data-management/server-side-laravel/server/routes-api.php)
 
 **What's happening:**
 - All four routes share the same `/api/products` path. Laravel matches them by HTTP method.
@@ -207,21 +207,25 @@ Open `config/cors.php` and allow your frontend origin:
 
 With the server running (`php artisan serve`), configure Handsontable to use the `dataProvider` plugin. The complete frontend code is in the files below.
 
-::: only-for javascript
+::: only-for javascript vue
 
-@[code js](@/recipes/data-management/server-side-laravel/javascript/example1.js)
+::: example #example1 :hot-recipe --js 1 --ts 2
+
+@[code collapse={16-140}](@/content/recipes/data-management/server-side-laravel/javascript/example1.js)
+@[code collapse={16-140}](@/content/recipes/data-management/server-side-laravel/javascript/example1.ts)
 
 :::
-
-::: only-for typescript
-
-@[code ts](@/recipes/data-management/server-side-laravel/javascript/example1.ts)
 
 :::
 
 ::: only-for react
 
-@[code](@/content/recipes/data-management/server-side-laravel/react/example1.jsx)
+::: example #example1 :react-advanced --js 1 --ts 2
+
+@[code collapse={17-165}](@/content/recipes/data-management/server-side-laravel/react/example1.jsx)
+@[code collapse={17-165}](@/content/recipes/data-management/server-side-laravel/react/example1.tsx)
+
+:::
 
 :::
 
@@ -229,7 +233,7 @@ With the server running (`php artisan serve`), configure Handsontable to use the
 
 ::: example #example1 :angular --ts 1 --html 2
 
-@[code](@/content/recipes/data-management/server-side-laravel/angular/example1.ts)
+@[code collapse={7-120}](@/content/recipes/data-management/server-side-laravel/angular/example1.ts)
 @[code](@/content/recipes/data-management/server-side-laravel/angular/example1.html)
 
 :::

--- a/docs/content/recipes/data-management/server-side-nestjs/angular/example1.ts
+++ b/docs/content/recipes/data-management/server-side-nestjs/angular/example1.ts
@@ -82,7 +82,7 @@ export class AppComponent {
       { data: 'createdAt', type: 'date', dateFormat: 'YYYY-MM-DD', width: 110 },
     ],
     rowHeaders: true,
-    height: 'auto',
+    height: 360,
     width: '100%',
     autoWrapRow: true,
   };

--- a/docs/content/recipes/data-management/server-side-nestjs/javascript/example1.js
+++ b/docs/content/recipes/data-management/server-side-nestjs/javascript/example1.js
@@ -191,7 +191,7 @@ const hotOptions = {
   ],
 
   rowHeaders: true,
-  height: 'auto',
+  height: 360,
   width: '100%',
   autoWrapRow: true,
   licenseKey: 'non-commercial-and-evaluation',

--- a/docs/content/recipes/data-management/server-side-nestjs/javascript/example1.ts
+++ b/docs/content/recipes/data-management/server-side-nestjs/javascript/example1.ts
@@ -198,7 +198,7 @@ const hotOptions: Handsontable.GridSettings = {
   ],
 
   rowHeaders: true,
-  height: 'auto',
+  height: 360,
   width: '100%',
   autoWrapRow: true,
   licenseKey: 'non-commercial-and-evaluation',

--- a/docs/content/recipes/data-management/server-side-nestjs/react/example1.jsx
+++ b/docs/content/recipes/data-management/server-side-nestjs/react/example1.jsx
@@ -149,7 +149,7 @@ const ExampleComponent = () => {
           { data: 'createdAt', type: 'date', dateFormat: 'YYYY-MM-DD', width: 110 },
         ]}
         rowHeaders={true}
-        height="auto"
+        height={360}
         width="100%"
         autoWrapRow={true}
         licenseKey="non-commercial-and-evaluation"

--- a/docs/content/recipes/data-management/server-side-nestjs/react/example1.tsx
+++ b/docs/content/recipes/data-management/server-side-nestjs/react/example1.tsx
@@ -157,7 +157,7 @@ const ExampleComponent = () => {
           { data: 'createdAt', type: 'date', dateFormat: 'YYYY-MM-DD', width: 110 },
         ]}
         rowHeaders={true}
-        height="auto"
+        height={360}
         width="100%"
         autoWrapRow={true}
         licenseKey="non-commercial-and-evaluation"

--- a/docs/content/recipes/data-management/server-side-nestjs/server-side-nestjs.md
+++ b/docs/content/recipes/data-management/server-side-nestjs/server-side-nestjs.md
@@ -78,7 +78,7 @@ Together these two libraries give you end-to-end type safety from the HTTP reque
 
 Copy `ticket.entity.ts` into `src/tickets/`:
 
-@[code typescript](@/recipes/data-management/server-side-nestjs/server/ticket.entity.ts)
+@[code typescript](@/content/recipes/data-management/server-side-nestjs/server/ticket.entity.ts)
 
 **What's happening:**
 - `TicketStatus` and `TicketPriority` are union types that match the `source` arrays in the Handsontable column definitions. Sharing these types between server and client prevents mismatched values.
@@ -92,7 +92,7 @@ Replace the interface and array with a `@Entity()` class and inject `Repository<
 
 Copy `fetch-tickets.dto.ts` into `src/tickets/dto/`:
 
-@[code typescript](@/recipes/data-management/server-side-nestjs/server/fetch-tickets.dto.ts)
+@[code typescript](@/content/recipes/data-management/server-side-nestjs/server/fetch-tickets.dto.ts)
 
 **What's happening:**
 
@@ -122,7 +122,7 @@ A filter condition can carry one or two values depending on the condition type (
 
 Copy `main.ts` into `src/`:
 
-@[code typescript](@/recipes/data-management/server-side-nestjs/server/main.ts)
+@[code typescript](@/content/recipes/data-management/server-side-nestjs/server/main.ts)
 
 **What's happening:**
 
@@ -158,7 +158,7 @@ export class AppModule {}
 
 Copy `tickets.service.ts` into `src/tickets/`:
 
-@[code typescript](@/recipes/data-management/server-side-nestjs/server/tickets.service.ts)
+@[code typescript collapse={42-130}](@/content/recipes/data-management/server-side-nestjs/server/tickets.service.ts)
 
 **What's happening:**
 
@@ -201,7 +201,7 @@ After inserting a row the service returns it with its server-assigned `id`. The 
 
 Copy `tickets.controller.ts` into `src/tickets/`:
 
-@[code typescript](@/recipes/data-management/server-side-nestjs/server/tickets.controller.ts)
+@[code typescript](@/content/recipes/data-management/server-side-nestjs/server/tickets.controller.ts)
 
 **What's happening:**
 - `@Controller('tickets')` sets the base path. All four endpoints share the `/tickets` prefix.
@@ -223,21 +223,25 @@ Copy `tickets.controller.ts` into `src/tickets/`:
 
 With the server running on `http://localhost:3000`, configure Handsontable to use the `dataProvider` plugin. The complete frontend code is below.
 
-::: only-for javascript
+::: only-for javascript vue
 
-@[code js](@/recipes/data-management/server-side-nestjs/javascript/example1.js)
+::: example #example1 :hot-recipe --js 1 --ts 2
+
+@[code collapse={16-140}](@/content/recipes/data-management/server-side-nestjs/javascript/example1.js)
+@[code collapse={16-140}](@/content/recipes/data-management/server-side-nestjs/javascript/example1.ts)
 
 :::
-
-::: only-for typescript
-
-@[code ts](@/recipes/data-management/server-side-nestjs/javascript/example1.ts)
 
 :::
 
 ::: only-for react
 
-@[code](@/content/recipes/data-management/server-side-nestjs/react/example1.jsx)
+::: example #example1 :react-advanced --js 1 --ts 2
+
+@[code collapse={17-165}](@/content/recipes/data-management/server-side-nestjs/react/example1.jsx)
+@[code collapse={17-165}](@/content/recipes/data-management/server-side-nestjs/react/example1.tsx)
+
+:::
 
 :::
 
@@ -245,7 +249,7 @@ With the server running on `http://localhost:3000`, configure Handsontable to us
 
 ::: example #example1 :angular --ts 1 --html 2
 
-@[code](@/content/recipes/data-management/server-side-nestjs/angular/example1.ts)
+@[code collapse={7-120}](@/content/recipes/data-management/server-side-nestjs/angular/example1.ts)
 @[code](@/content/recipes/data-management/server-side-nestjs/angular/example1.html)
 
 :::

--- a/docs/content/recipes/data-management/server-side-spring/server-side-spring.md
+++ b/docs/content/recipes/data-management/server-side-spring/server-side-spring.md
@@ -116,7 +116,7 @@ Create or update `src/main/resources/application.properties`:
 
 ## Step 3: Create the Product entity
 
-@[code java](@/recipes/data-management/server-side-spring/server/Product.java)
+@[code java](@/content/recipes/data-management/server-side-spring/server/Product.java)
 
 **What's happening:**
 - `@Entity` and `@Table(name = "products")` tell JPA to map this class to the `products` table.
@@ -129,7 +129,7 @@ Each field maps directly to a column the Handsontable grid displays. Adding only
 
 ## Step 4: Add the repository interface
 
-@[code java](@/recipes/data-management/server-side-spring/server/ProductRepository.java)
+@[code java](@/content/recipes/data-management/server-side-spring/server/ProductRepository.java)
 
 **What's happening:**
 - `JpaRepository<Product, Long>` provides `save`, `findById`, `deleteAllById`, and `count` methods -- everything needed for CRUD without writing any SQL.
@@ -137,7 +137,7 @@ Each field maps directly to a column the Handsontable grid displays. Adding only
 
 ## Step 5: Seed the database
 
-@[code java](@/recipes/data-management/server-side-spring/server/DataInitializer.java)
+@[code java](@/content/recipes/data-management/server-side-spring/server/DataInitializer.java)
 
 **What's happening:**
 - `CommandLineRunner` is a Spring Boot callback that runs after the application context starts. Returning it from a `@Bean` method registers it automatically.
@@ -149,7 +149,7 @@ The default `pagination.pageSize` is 10, so 55 rows creates 6 pages. This makes 
 
 ## Step 6: Build the service
 
-@[code java](@/recipes/data-management/server-side-spring/server/ProductService.java)
+@[code java collapse={47-195}](@/content/recipes/data-management/server-side-spring/server/ProductService.java)
 
 **What's happening:**
 
@@ -201,7 +201,7 @@ The class-level `@Transactional` annotation wraps every public method in a singl
 
 ## Step 7: Create the REST controller
 
-@[code java](@/recipes/data-management/server-side-spring/server/ProductController.java)
+@[code java](@/content/recipes/data-management/server-side-spring/server/ProductController.java)
 
 **What's happening:**
 - `@RestController` combines `@Controller` and `@ResponseBody`, so every method return value is serialized to JSON automatically.
@@ -220,7 +220,7 @@ The class-level `@Transactional` annotation wraps every public method in a singl
 
 ## Step 8: Configure CORS
 
-@[code java](@/recipes/data-management/server-side-spring/server/CorsConfig.java)
+@[code java](@/content/recipes/data-management/server-side-spring/server/CorsConfig.java)
 
 **What's happening:**
 - `WebMvcConfigurer` is a Spring MVC callback interface. Implementing `addCorsMappings` is the idiomatic way to configure CORS globally without annotations on every controller.
@@ -231,21 +231,25 @@ The class-level `@Transactional` annotation wraps every public method in a singl
 
 With the server running on `http://localhost:8080`, configure Handsontable to use the `dataProvider` plugin. The complete frontend code is in the files below.
 
-::: only-for javascript
+::: only-for javascript vue
 
-@[code js](@/recipes/data-management/server-side-spring/javascript/example1.js)
+::: example #example1 :hot-recipe --js 1 --ts 2
+
+@[code collapse={16-140}](@/content/recipes/data-management/server-side-spring/javascript/example1.js)
+@[code collapse={16-140}](@/content/recipes/data-management/server-side-spring/javascript/example1.ts)
 
 :::
-
-::: only-for typescript
-
-@[code ts](@/recipes/data-management/server-side-spring/javascript/example1.ts)
 
 :::
 
 ::: only-for react
 
-@[code](@/content/recipes/data-management/server-side-spring/react/example1.jsx)
+::: example #example1 :react-advanced --js 1 --ts 2
+
+@[code collapse={17-165}](@/content/recipes/data-management/server-side-spring/react/example1.jsx)
+@[code collapse={17-165}](@/content/recipes/data-management/server-side-spring/react/example1.tsx)
+
+:::
 
 :::
 
@@ -253,7 +257,7 @@ With the server running on `http://localhost:8080`, configure Handsontable to us
 
 ::: example #example1 :angular --ts 1 --html 2
 
-@[code](@/content/recipes/data-management/server-side-spring/angular/example1.ts)
+@[code collapse={7-120}](@/content/recipes/data-management/server-side-spring/angular/example1.ts)
 @[code](@/content/recipes/data-management/server-side-spring/angular/example1.html)
 
 :::

--- a/docs/src/plugins/framework-loader.mjs
+++ b/docs/src/plugins/framework-loader.mjs
@@ -74,6 +74,19 @@ const EXT_TO_LANG = {
   html: 'html',
   css: 'css',
   vue: 'vue',
+  php: 'php',
+  java: 'java',
+  properties: 'properties',
+};
+
+/** Language tags that may appear as the first token in @[code LANG ...](...) meta. */
+const META_LANG = {
+  php: 'php',
+  java: 'java',
+  typescript: 'typescript',
+  ts: 'typescript',
+  js: 'javascript',
+  properties: 'properties',
 };
 
 const EXT_TO_LABEL = {
@@ -316,6 +329,57 @@ ${fences}
 }
 
 /**
+ * Converts standalone @[code](@/content/...) directives to markdown fenced code
+ * blocks (Expressive Code). Must run after processExampleBlocks so directives
+ * inside ::: example containers are not converted twice.
+ *
+ * @param {string} content - Markdown body (after example block processing)
+ * @param {string} contentDir - Absolute path to docs/content/
+ * @returns {string}
+ */
+function processCodeEmbedDirectives(content, contentDir) {
+  const lineRe = /^@\[code(?:\s+([^\]]*))?\]\(@\/content\/(.+)\)\s*$/;
+  const lines = content.split('\n');
+  const result = [];
+
+  for (const line of lines) {
+    const m = line.match(lineRe);
+
+    if (!m) {
+      result.push(line);
+      continue;
+    }
+
+    const meta = (m[1] || '').trim();
+    const relPath = m[2].trim();
+    const absPath = join(contentDir, relPath);
+    let code = '';
+
+    try {
+      code = readFileSync(absPath, 'utf-8').trimEnd();
+      code = code.replace(/\{\{\s*\$basePath\s*\}\}/g, '/docs');
+    } catch {
+      result.push('```text');
+      result.push(`// File not found: ${relPath}`);
+      result.push('```');
+      continue;
+    }
+
+    const ext = relPath.split('.').pop().toLowerCase();
+    const metaFirst = meta.split(/\s+/).filter(Boolean)[0];
+    let lang = (metaFirst && META_LANG[metaFirst]) || EXT_TO_LANG[ext] || 'text';
+    const collapsePart = meta.match(/collapse=\{[^}]+\}/);
+    const fenceLang = collapsePart ? `${lang} ${collapsePart[0]}` : lang;
+
+    result.push(`\`\`\`${fenceLang}`);
+    result.push(code);
+    result.push('```');
+  }
+
+  return result.join('\n');
+}
+
+/**
  * Processes ::: example and ::: example-without-tabs blocks in the markdown body.
  * Replaces them with HTML + markdown code fences (rendered by Expressive Code).
  * Must be called AFTER filterOnlyFor so only the current framework's blocks remain.
@@ -407,7 +471,7 @@ const PREFIXES = {
 
 // Bump this when the loader logic changes to force Astro's data store to
 // re-process all entries (the store skips entries whose digest hasn't changed).
-const LOADER_VERSION = 'v34';
+const LOADER_VERSION = 'v35';
 
 // ---------------------------------------------------------------------------
 // File listing (recursive, no external glob)
@@ -1250,7 +1314,9 @@ export function frameworkLoader({ contentDir }) {
         // Root content/index.md: framework-agnostic splash — emit once as bare "index".
         if (relPath === 'index.md') {
           const exampleProcessedBody = await processExampleBlocks(body, contentDir);
-          const processedBody = applyVuepressPreprocessing(exampleProcessedBody);
+          const processedBody = applyVuepressPreprocessing(
+            processCodeEmbedDirectives(exampleProcessedBody, contentDir)
+          );
           const digest = generateDigest(raw + LOADER_VERSION);
           let data;
 
@@ -1310,8 +1376,11 @@ export function frameworkLoader({ contentDir }) {
           // 2. Process ::: example blocks into Shiki-highlighted HTML tabs
           const exampleProcessedBody = await processExampleBlocks(filteredBody, contentDir);
 
-          // 3. Apply remaining VuePress preprocessing
-          const processedBody = applyVuepressPreprocessing(exampleProcessedBody, prefix, contentDir);
+          // 3. Convert remaining standalone @[code] embeds to fenced code blocks
+          const codeEmbeddedBody = processCodeEmbedDirectives(exampleProcessedBody, contentDir);
+
+          // 4. Apply remaining VuePress preprocessing
+          const processedBody = applyVuepressPreprocessing(codeEmbeddedBody, prefix, contentDir);
 
           // Make each framework entry unique; include LOADER_VERSION to bust
           // Astro's data store cache when the loader logic changes.


### PR DESCRIPTION
### Context

The PR fixes broken server-side recipe documentation (Laravel, Spring Boot, NestJS) under Data Management. Standalone `@[code]` directives in prose were not processed by the docs loader, so backend snippets disappeared. Step 8 live examples used `emptyDataState` without a fixed grid height, which made the preview grow into a tall empty container when `/api/products` is unavailable on the docs site.

Changes:
- Add `processCodeEmbedDirectives()` in `framework-loader.mjs` so remaining `@[code](@/content/...)` lines render as fenced code blocks (PHP, Java, TypeScript, properties).
- Restructure server-side recipe pages: backend code as direct embeds; Step 8 front-end examples in `::: example` blocks.
- Set `height: 360` (and `width: '100%'`) on Laravel and NestJS Step 8 examples to match other dataProvider recipes.

### How has this been tested?

- Manual verification on local docs dev server:
  - `npm run dev --prefix docs`
  - `/docs/javascript-data-grid/recipes/data-management/server-side-laravel` (Step 8 preview height, backend snippets visible)
  - Same checks for server-side-spring and server-side-nestjs pages (JS tab)

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1699

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the docs content loader pipeline (markdown transformation and caching), which can affect rendering across many pages even though it’s limited to documentation output.
> 
> **Overview**
> Fixes broken server-side recipe docs by teaching the Astro `framework-loader` to convert standalone `@[code](@/content/...)` directives into fenced code blocks (now recognizing `php`, `java`, and `properties`), and bumps `LOADER_VERSION` to invalidate cached entries.
> 
> Updates the Laravel/NestJS/Spring server-side recipe pages to reference backend snippets from `@/content/...` and restructures Step “Wire up Handsontable” to use `::: example` blocks with collapsible code tabs. Frontend examples in Laravel and NestJS now set a fixed `height: 360` (and `width: '100%'`) so the docs preview doesn’t expand excessively when the API is unavailable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 801b9ed93170c58ab0d4499aacf645c64efd3c51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->