### PR TITLE
DEV-1704: Fix Angular Feedback, Date picker & Star rating recipe examples

### DIFF
--- a/docs/content/recipes/cell-types/feedback/angular/example1.ts
+++ b/docs/content/recipes/cell-types/feedback/angular/example1.ts
@@ -22,7 +22,6 @@ const inputData = [
       }
     </div>
   `,
-  styleUrls: ['./example1.css'],
 })
 export class FeedbackEditorComponent extends HotCellEditorAdvancedComponent<string> {
   override config = ['👍', '👎', '🤷'];

--- a/docs/content/recipes/cell-types/guide-datepicker-angular/angular/example1.ts
+++ b/docs/content/recipes/cell-types/guide-datepicker-angular/angular/example1.ts
@@ -156,7 +156,7 @@ const DATE_FORMAT_US = 'MM/dd/yyyy';
 const DATE_FORMAT_EU = 'dd/MM/yyyy';
 
 @Component({
-  selector: 'app-root',
+  selector: 'example1-guide-datepicker-angular',
   standalone: true,
   imports: [HotTableModule],
   template: ` <div>

--- a/docs/content/recipes/cell-types/rating/angular/example1.ts
+++ b/docs/content/recipes/cell-types/rating/angular/example1.ts
@@ -36,7 +36,6 @@ const inputData = [
         <span class="rating-star" [class.active]="$index < value" [innerHTML]="starSvgMarkup"></span>
       }
     </div>`,
-  styleUrls: ['./example1.css'],
 })
 export class StarRendererComponent extends HotCellRendererAdvancedComponent<number> {
   readonly stars = Array(5);
@@ -59,7 +58,6 @@ export class StarRendererComponent extends HotCellRendererAdvancedComponent<numb
       }
     </div>
   `,
-  styleUrls: ['./example1.css'],
 })
 export class StarEditorComponent extends HotCellEditorAdvancedComponent<number> {
   readonly stars = Array(5);


### PR DESCRIPTION
### Context

The PR fixes three Angular recipe examples that failed to render due to two issues:

1. **`styleUrls` in standalone components** — Angular JIT mode (used by the docs example runner) cannot fetch external files at runtime. The `HotSettingsResolver` checks whether component resources are resolved before using a component as an editor, and `styleUrls` requires `resolveComponentResources()` to run first — which never happens in JIT bootstrapping. This caused a fatal `"Component is not resolved"` error that prevented the grid from rendering entirely. Fixed by removing `styleUrls` from the affected components (CSS is already injected globally via the `--css` slot in the example directive).

2. **`AppComponent` selector mismatch** — The date picker guide had `selector: 'app-root'` on `AppComponent` while the HTML wrapper contained `<example1-guide-datepicker-angular>`. Angular bootstraps against the DOM element matching the component's selector, so the grid was never mounted. Fixed by aligning the selector with the HTML wrapper.

### How has this been tested?

Tested manually in the local docs dev server (`npm run dev --prefix docs`):
- `angular-data-grid/recipes/cell-types/feedback/` — grid renders, emoji editor opens on click ✓
- `angular-data-grid/recipes/cell-types/rating/` — grid renders, star rating visible ✓
- `angular-data-grid/recipes/cell-types/datepicker/` — grid renders, dates shown in EU and US formats ✓

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1704

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/86c9u6pg7

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that adjusts Angular example component metadata; main risk is unintended styling/bootstrapping regressions limited to the docs examples.
> 
> **Overview**
> Fixes broken Angular recipe examples in the docs runner by removing `styleUrls` from standalone cell editor/renderer components (feedback and rating), avoiding unresolved component resource errors in JIT.
> 
> Aligns the datepicker guide `AppComponent` selector with the embedded wrapper element (`example1-guide-datepicker-angular`) so the example bootstraps and renders correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51f28763511a2200cb4eb0ce13ecb9bf25dd99cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->