### PR TITLE
DEV-1701: Add auto-flag and crossed-out mine features to 404 Minesweeper

### DIFF
--- a/docs/src/scripts/minesweeper-404.ts
+++ b/docs/src/scripts/minesweeper-404.ts
@@ -235,6 +235,8 @@ function minesweeperRenderer(
 
     if (row === state.hitRow && col === state.hitCol) {
       td.classList.add('ms-hit');
+    } else if (state.gameOver && state.flagged[row][col]) {
+      td.classList.add('ms-flagged-correct');
     }
   } else {
     td.classList.add('ms-revealed');

--- a/docs/src/scripts/minesweeper-404.ts
+++ b/docs/src/scripts/minesweeper-404.ts
@@ -171,6 +171,14 @@ function reveal(state: GameState, row: number, col: number) {
 
   if (unrevealedSafe === 0) {
     state.won = true;
+
+    for (let r = 0; r < ROWS; r++) {
+      for (let c = 0; c < COLS; c++) {
+        if (state.mines[r][c] && !state.flagged[r][c]) {
+          state.flagged[r][c] = true;
+        }
+      }
+    }
   }
 }
 

--- a/docs/src/styles/components/minesweeper.css
+++ b/docs/src/styles/components/minesweeper.css
@@ -230,6 +230,24 @@
   text-decoration-color: #c0392b;
 }
 
+/* Correctly flagged mine (game over - deactivated) */
+.minesweeper-grid td.ms-flagged-correct {
+  position: relative;
+}
+
+.minesweeper-grid td.ms-flagged-correct::after {
+  content: '✕';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: #c0392b;
+  font-size: 22px;
+  font-weight: 900;
+  line-height: 1;
+  pointer-events: none;
+}
+
 /* Number colors (classic Minesweeper palette) */
 .minesweeper-grid td.ms-1 { color: #2563eb; }
 .minesweeper-grid td.ms-2 { color: #16a34a; }


### PR DESCRIPTION
### Context

The PR adds two missing UX features to the Minesweeper game on the docs 404 page:

1. **Auto-flag on win** -- when all safe cells are revealed, the remaining unflagged mines are automatically flagged and the mine counter drops to `000`.
2. **Crossed-out mine on loss** -- when the player hits a mine, correctly flagged cells show the bomb icon with a grey background and a red ✕ overlay, distinguishing them from unflagged mines and the hit mine (red background).

ClickUp task: https://app.clickup.com/t/86c9u5qc4

[skip changelog]

### How has this been tested?

Manual testing on the docs dev server (`npm run dev --prefix docs`, navigate to `/404`):

- Won a game: all remaining mines auto-flagged, mine counter reads `000`, timer stopped, 😎 shown.
- Lost a game with correctly flagged mines: flagged cells show bomb icon + grey background + red ✕ overlay; incorrectly flagged cells show red strikethrough flag (`ms-wrong`); hit mine shows red background; all other mines show grey background.
- Verified in both light and dark themes.

Automated:
- `npm run docs:test:plugins --prefix docs` -- 15/15 pass
- `npm run docs:lint --prefix docs` -- no errors

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. DEV-1701

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are isolated to the docs 404 Minesweeper script and CSS, affecting only end-of-game UI behavior and styling.
> 
> **Overview**
> Improves the docs `/404` Minesweeper end-game UX.
> 
> On win, the game now **auto-flags any remaining mines** by setting `state.flagged` for all mine cells, which also drives the mine counter to `000`.
> 
> On loss, correctly flagged mines are now visually distinguished by adding a `ms-flagged-correct` state in the renderer and styling it with a red ✕ overlay in `minesweeper.css`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4211f8292780cc7463b4b068bddcef9f23c5108. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->