### PR TITLE
DEV-1684: Align toolbar pattern in column visibility recipe

### DIFF
--- a/docs/content/recipes/column-management/column-visibility/angular/example1.ts
+++ b/docs/content/recipes/column-management/column-visibility/angular/example1.ts
@@ -50,18 +50,20 @@ const data = [
   imports: [HotTableModule],
   selector: 'example1-column-visibility',
   template: `
-    <div style="margin-bottom: 10px;">
-      @for (col of allColumns; track col.data; let i = $index) {
-        <label style="margin-right: 12px; display: inline-flex; align-items: center; gap: 4px;">
-          <input
-            type="checkbox"
-            [checked]="visibleIndices.has(i)"
-            [disabled]="visibleIndices.size === 1 && visibleIndices.has(i)"
-            (change)="toggleColumn(i, $event)"
-          />
-          {{ col.title }}
-        </label>
-      }
+    <div class="example-controls-container">
+      <div class="controls">
+        @for (col of allColumns; track col.data; let i = $index) {
+          <label>
+            <input
+              type="checkbox"
+              [checked]="visibleIndices.has(i)"
+              [disabled]="visibleIndices.size === 1 && visibleIndices.has(i)"
+              (change)="toggleColumn(i, $event)"
+            />
+            {{ col.title }}
+          </label>
+        }
+      </div>
     </div>
     <hot-table [data]="data" [settings]="gridSettings"></hot-table>
   `,

--- a/docs/content/recipes/column-management/column-visibility/column-visibility.md
+++ b/docs/content/recipes/column-management/column-visibility/column-visibility.md
@@ -75,7 +75,7 @@ This recipe uses only the built-in Handsontable API. No extra dependencies are r
 
 The example uses HR/workforce data with seven columns: Name, Department, Role, Salary, Start Date, Location, and Status. The Salary column uses the `numeric` type with formatting. The Status column uses the `dropdown` type. This variety demonstrates that `hot.updateSettings()` restores each column's full configuration -- not just its header text.
 
-## Step 1 -- Define the full columns config
+## Step 1: Define the full columns config
 
 ```javascript
 const allColumns = [
@@ -105,7 +105,7 @@ const allColumns = [
 
 **Why not mutate?** If you splice or delete entries from `allColumns`, you lose the config for hidden columns and cannot restore them. An immutable source lets you re-derive the visible set at any time.
 
-## Step 2 -- Track visible column indices
+## Step 2: Track visible column indices
 
 ```javascript
 const visibleIndices = new Set(allColumns.map((_, i) => i));
@@ -127,7 +127,7 @@ function getVisibleHeaders() {
 
 These two helpers produce the arguments that `hot.updateSettings()` needs on every toggle. They are pure functions with no side effects.
 
-## Step 3 -- Initialize Handsontable
+## Step 3: Initialize Handsontable
 
 ```javascript
 const hot = new Handsontable(container, {
@@ -144,7 +144,7 @@ const hot = new Handsontable(container, {
 
 **What's happening:** The grid starts with all columns visible, so `getVisibleColumns()` and `getVisibleHeaders()` return full arrays at this point. The initial state of the grid and the initial checkbox state both derive from `visibleIndices`, so they are always in sync.
 
-## Step 4 -- Generate the checkbox list
+## Step 4: Generate the checkbox list
 
 ```javascript
 const togglesContainer = document.querySelector('#column-toggles');
@@ -167,7 +167,7 @@ allColumns.forEach((col, index) => {
 
 **Why generate checkboxes in JS rather than hardcode them in HTML?** Generating them from the same `allColumns` array means a single source of truth. If you add or rename a column config entry, the checkbox list updates automatically.
 
-## Step 5 -- Implement the toggle handler
+## Step 5: Implement the toggle handler
 
 ```javascript
 checkbox.addEventListener('change', () => {

--- a/docs/content/recipes/column-management/column-visibility/column-visibility.md
+++ b/docs/content/recipes/column-management/column-visibility/column-visibility.md
@@ -25,9 +25,8 @@ In this tutorial, you will build a checkbox list outside the grid that shows or 
 
 ::: only-for javascript
 
-::: example #example1 :hot-recipe --html 1 --js 2
+::: example #example1 :hot-recipe --js 1
 
-@[code](@/content/recipes/column-management/column-visibility/javascript/example1.html)
 @[code](@/content/recipes/column-management/column-visibility/javascript/example1.js)
 
 :::

--- a/docs/content/recipes/column-management/column-visibility/javascript/example1.html
+++ b/docs/content/recipes/column-management/column-visibility/javascript/example1.html
@@ -1,3 +1,0 @@
-<div id="column-toggles" style="margin-bottom: 10px;"></div>
-
-<div id="example1"></div>

--- a/docs/content/recipes/column-management/column-visibility/javascript/example1.js
+++ b/docs/content/recipes/column-management/column-visibility/javascript/example1.js
@@ -56,6 +56,12 @@ function getVisibleHeaders() {
 
 const container = document.querySelector('#example1');
 
+const toolbar = document.createElement('div');
+
+toolbar.classList.add('example-controls-container');
+toolbar.innerHTML = '<div class="controls"></div>';
+container.before(toolbar);
+
 const hot = new Handsontable(container, {
   data,
   columns: getVisibleColumns(),
@@ -68,15 +74,10 @@ const hot = new Handsontable(container, {
 });
 
 // Build a checkbox for each column and attach toggle logic.
-const togglesContainer = document.querySelector('#column-toggles');
+const togglesContainer = toolbar.querySelector('.controls');
 
 allColumns.forEach((col, index) => {
   const label = document.createElement('label');
-  label.style.marginRight = '12px';
-  label.style.display = 'inline-flex';
-  label.style.alignItems = 'center';
-  label.style.gap = '4px';
-
   const checkbox = document.createElement('input');
 
   checkbox.type = 'checkbox';

--- a/docs/content/recipes/column-management/column-visibility/react/example1.jsx
+++ b/docs/content/recipes/column-management/column-visibility/react/example1.jsx
@@ -77,24 +77,21 @@ const ExampleComponent = () => {
   );
 
   return (
-    <div>
-      <div id="column-toggles" style={{ marginBottom: '10px' }}>
-        {allColumns.map((col, index) => (
-          <label
-            key={col.data}
-            style={{ marginRight: '12px', display: 'inline-flex', alignItems: 'center', gap: '4px' }}
-          >
-            <input
-              type="checkbox"
-              checked={visibleIndices.has(index)}
-              // When only one column remains visible, disable its checkbox so the user
-              // cannot produce an empty grid.
-              disabled={visibleIndices.size === 1 && visibleIndices.has(index)}
-              onChange={() => handleToggle(index)}
-            />
-            {col.title}
-          </label>
-        ))}
+    <>
+      <div className="example-controls-container">
+        <div className="controls">
+          {allColumns.map((col, index) => (
+            <label key={col.data}>
+              <input
+                type="checkbox"
+                checked={visibleIndices.has(index)}
+                disabled={visibleIndices.size === 1 && visibleIndices.has(index)}
+                onChange={() => handleToggle(index)}
+              />
+              {col.title}
+            </label>
+          ))}
+        </div>
       </div>
       <HotTable
         data={data}
@@ -106,7 +103,7 @@ const ExampleComponent = () => {
         autoWrapRow={true}
         licenseKey="non-commercial-and-evaluation"
       />
-    </div>
+    </>
   );
 };
 

--- a/docs/content/recipes/column-management/column-visibility/react/example1.tsx
+++ b/docs/content/recipes/column-management/column-visibility/react/example1.tsx
@@ -88,24 +88,21 @@ const ExampleComponent = () => {
   );
 
   return (
-    <div>
-      <div id="column-toggles" style={{ marginBottom: '10px' }}>
-        {allColumns.map((col, index) => (
-          <label
-            key={col.data as string}
-            style={{ marginRight: '12px', display: 'inline-flex', alignItems: 'center', gap: '4px' }}
-          >
-            <input
-              type="checkbox"
-              checked={visibleIndices.has(index)}
-              // When only one column remains visible, disable its checkbox so the user
-              // cannot produce an empty grid.
-              disabled={visibleIndices.size === 1 && visibleIndices.has(index)}
-              onChange={() => handleToggle(index)}
-            />
-            {col.title}
-          </label>
-        ))}
+    <>
+      <div className="example-controls-container">
+        <div className="controls">
+          {allColumns.map((col, index) => (
+            <label key={col.data as string}>
+              <input
+                type="checkbox"
+                checked={visibleIndices.has(index)}
+                disabled={visibleIndices.size === 1 && visibleIndices.has(index)}
+                onChange={() => handleToggle(index)}
+              />
+              {col.title}
+            </label>
+          ))}
+        </div>
       </div>
       <HotTable
         data={data}
@@ -117,7 +114,7 @@ const ExampleComponent = () => {
         autoWrapRow={true}
         licenseKey="non-commercial-and-evaluation"
       />
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
### Context

The PR updates the column visibility recipe examples to use the established `example-controls-container` / `controls` toolbar pattern used across all other recipes (e.g. row-operations, highlight-search-matches). Previously the examples used inline styles and a custom `id`-based container. The step headings also had `--` separators replaced with `:` for consistency.

Changes across all three framework variants (JavaScript, React, Angular):
- Replaced inline styles with `example-controls-container` + `controls` class structure
- JS example now builds the toolbar in JS (`container.before(toolbar)`) instead of using a static HTML file
- Deleted the now-unused `javascript/example1.html`
- Updated the `.md` example directive accordingly

### How has this been tested?

Docs-only change -- no library source code modified.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. DEV-1684

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/86c9tyhr8

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only changes that mainly adjust example markup and how the JS demo injects its controls; no library/runtime code paths are modified.
> 
> **Overview**
> Aligns the column visibility recipe examples (Angular/React/JS) to the shared toolbar markup by replacing inline-styled checkbox wrappers with `example-controls-container` + `controls`.
> 
> For the JavaScript variant, the controls container is now created/injected in `example1.js` (instead of relying on a static `example1.html`), and the markdown example directive is updated accordingly; the obsolete HTML snippet is removed.
> 
> Additionally standardizes the recipe step headings from `--` to `:` for consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59c2e50aed7e27355d5cad717f57df05884b1654. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->