### PR TITLE
DEV-1686: Align toolbar pattern in freeze columns recipe

### DIFF
--- a/docs/content/recipes/column-management/freeze-columns/angular/example1.css
+++ b/docs/content/recipes/column-management/freeze-columns/angular/example1.css
@@ -1,45 +1,8 @@
-.freeze-controls {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  margin-bottom: 8px;
+.example-controls-container .controls + .controls {
+  margin-top: 0.5rem;
 }
 
-.freeze-controls__freeze-btns {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-}
-
-.freeze-controls__footer {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.freeze-controls button {
-  border: 1px solid var(--sl-color-gray-5);
-  background: var(--sl-color-bg-nav);
-  color: var(--sl-color-text);
-  font-size: var(--sl-text-sm);
-  line-height: 1.2;
-  padding: 0.4rem 0.75rem;
-  border-radius: 0;
-  cursor: pointer;
-  transition: color 0.15s, background-color 0.15s, border-color 0.15s;
-}
-
-.freeze-controls button:hover {
-  color: var(--sl-color-white);
-  background: var(--sl-color-gray-6);
-}
-
-.freeze-controls button:focus-visible {
-  outline: 1px solid var(--sl-color-accent);
-  outline-offset: 1px;
-}
-
-.freeze-controls__status {
+.freeze-status {
   font-size: var(--sl-text-sm);
   font-style: italic;
   color: var(--sl-color-gray-2);

--- a/docs/content/recipes/column-management/freeze-columns/angular/example1.ts
+++ b/docs/content/recipes/column-management/freeze-columns/angular/example1.ts
@@ -33,20 +33,17 @@ const colHeaders = ['Campaign', 'Channel', 'Impressions', 'Clicks', 'Conversions
   imports: [HotTableModule],
   selector: 'example1-freeze-columns',
   template: `
-    <div class="freeze-controls">
-      <div class="freeze-controls__freeze-btns">
+    <div class="example-controls-container">
+      <div class="controls">
         @for (header of colHeaders; track header; let i = $index) {
-          <button
-            type="button"
-            (click)="freezeUpTo(i + 1)"
-          >
+          <button type="button" (click)="freezeUpTo(i + 1)">
             Freeze up to "{{ header }}"
           </button>
         }
       </div>
-      <div class="freeze-controls__footer">
+      <div class="controls">
         <button type="button" (click)="unfreezeAll()">Unfreeze all</button>
-        <span class="freeze-controls__status">{{ statusText }}</span>
+        <span class="freeze-status">{{ statusText }}</span>
       </div>
     </div>
     <hot-table [data]="data" [settings]="gridSettings"></hot-table>

--- a/docs/content/recipes/column-management/freeze-columns/freeze-columns.md
+++ b/docs/content/recipes/column-management/freeze-columns/freeze-columns.md
@@ -80,7 +80,7 @@ This recipe uses only the built-in Handsontable API. No extra dependencies are r
 
 The example uses marketing analytics data with eight columns: Campaign, Channel, Impressions, Clicks, Conversions, CPC, Revenue, and ROI. With many columns the grid scrolls horizontally, making frozen columns genuinely useful -- the identifier columns stay visible while metric columns scroll.
 
-## Step 1 -- Set up the grid with fixedColumnsStart and manualColumnMove
+## Step 1: Set up the grid with fixedColumnsStart and manualColumnMove
 
 ```javascript
 const hot = new Handsontable(container, {
@@ -110,7 +110,7 @@ const hot = new Handsontable(container, {
 
 **Why set `fixedColumnsStart: 0` explicitly?** The default is `0`, but declaring it makes the initial state visible in the config and makes the runtime change more explicit to anyone reading the code.
 
-## Step 2 -- Track state and apply the freeze boundary
+## Step 2: Track state and apply the freeze boundary
 
 ```javascript
 let frozenCount = 0;
@@ -130,7 +130,7 @@ function freezeUpTo(n) {
 
 **Why `Math.min(n, total)`?** If `fixedColumnsStart` exceeds the number of rendered columns, Handsontable clamps it internally -- but being explicit in application code prevents confusion and makes the guard visible.
 
-## Step 3 -- Generate freeze buttons from the column headers
+## Step 3: Generate freeze buttons from the column headers
 
 ```javascript
 const colHeaders = ['Campaign', 'Channel', 'Impressions', 'Clicks', 'Conversions', 'CPC ($)', 'Revenue ($)', 'ROI'];
@@ -154,7 +154,7 @@ colHeaders.forEach((header, index) => {
 
 **Why `index + 1`?** `fixedColumnsStart` is a count, not an index. To freeze the column at visual index `i`, you set the count to `i + 1`.
 
-## Step 4 -- Add the Unfreeze all button
+## Step 4: Add the Unfreeze all button
 
 ```javascript
 document.querySelector('#unfreeze-btn').addEventListener('click', () => {
@@ -166,7 +166,7 @@ document.querySelector('#unfreeze-btn').addEventListener('click', () => {
 
 **What's happening:** Setting `fixedColumnsStart: 0` releases all frozen columns. The grid re-renders without any pinned column overlay. The status indicator is updated to "No columns frozen".
 
-## Step 5 -- Show a frozen column count indicator
+## Step 5: Show a frozen column count indicator
 
 ```javascript
 function updateStatus() {

--- a/docs/content/recipes/column-management/freeze-columns/freeze-columns.md
+++ b/docs/content/recipes/column-management/freeze-columns/freeze-columns.md
@@ -26,10 +26,9 @@ In this tutorial, you will freeze and unfreeze columns at runtime using external
 
 ::: only-for javascript
 
-::: example #example1 :hot-recipe --js 1 --html 2 --css 3
+::: example #example1 :hot-recipe --js 1 --css 2
 
 @[code](@/content/recipes/column-management/freeze-columns/javascript/example1.js)
-@[code](@/content/recipes/column-management/freeze-columns/javascript/example1.html)
 @[code](@/content/recipes/column-management/freeze-columns/javascript/example1.css)
 
 :::

--- a/docs/content/recipes/column-management/freeze-columns/javascript/example1.css
+++ b/docs/content/recipes/column-management/freeze-columns/javascript/example1.css
@@ -1,45 +1,8 @@
-.freeze-controls {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  margin-bottom: 8px;
+.example-controls-container .controls + .controls {
+  margin-top: 0.5rem;
 }
 
-.freeze-controls__freeze-btns {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-}
-
-.freeze-controls__footer {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.freeze-controls button {
-  border: 1px solid var(--sl-color-gray-5);
-  background: var(--sl-color-bg-nav);
-  color: var(--sl-color-text);
-  font-size: var(--sl-text-sm);
-  line-height: 1.2;
-  padding: 0.4rem 0.75rem;
-  border-radius: 0;
-  cursor: pointer;
-  transition: color 0.15s, background-color 0.15s, border-color 0.15s;
-}
-
-.freeze-controls button:hover {
-  color: var(--sl-color-white);
-  background: var(--sl-color-gray-6);
-}
-
-.freeze-controls button:focus-visible {
-  outline: 1px solid var(--sl-color-accent);
-  outline-offset: 1px;
-}
-
-.freeze-controls__status {
+.freeze-status {
   font-size: var(--sl-text-sm);
   font-style: italic;
   color: var(--sl-color-gray-2);

--- a/docs/content/recipes/column-management/freeze-columns/javascript/example1.html
+++ b/docs/content/recipes/column-management/freeze-columns/javascript/example1.html
@@ -1,8 +1,0 @@
-<div class="freeze-controls">
-  <div id="freeze-buttons" class="freeze-controls__freeze-btns"></div>
-  <div class="freeze-controls__footer">
-    <button id="unfreeze-btn" type="button">Unfreeze all</button>
-    <span id="freeze-status" class="freeze-controls__status"></span>
-  </div>
-</div>
-<div id="example1"></div>

--- a/docs/content/recipes/column-management/freeze-columns/javascript/example1.js
+++ b/docs/content/recipes/column-management/freeze-columns/javascript/example1.js
@@ -22,8 +22,26 @@ let frozenCount = 0;
 const colHeaders = ['Campaign', 'Channel', 'Impressions', 'Clicks', 'Conversions', 'CPC ($)', 'Revenue ($)', 'ROI'];
 
 const container = document.querySelector('#example1');
-const controlsContainer = document.querySelector('#freeze-buttons');
-const statusEl = document.querySelector('#freeze-status');
+
+const toolbar = document.createElement('div');
+
+toolbar.classList.add('example-controls-container');
+
+const freezeRow = document.createElement('div');
+
+freezeRow.className = 'controls';
+
+const unfreezeRow = document.createElement('div');
+
+unfreezeRow.className = 'controls';
+
+const statusEl = document.createElement('span');
+
+statusEl.className = 'freeze-status';
+
+toolbar.appendChild(freezeRow);
+toolbar.appendChild(unfreezeRow);
+container.before(toolbar);
 
 const hot = new Handsontable(container, {
   data,
@@ -70,20 +88,27 @@ colHeaders.forEach((header, index) => {
 
   btn.type = 'button';
   btn.textContent = `Freeze up to "${header}"`;
-  btn.dataset.colIndex = String(index);
 
   btn.addEventListener('click', () => {
     freezeUpTo(index + 1);
   });
 
-  controlsContainer.appendChild(btn);
+  freezeRow.appendChild(btn);
 });
 
 // "Unfreeze all" resets fixedColumnsStart to 0.
-document.querySelector('#unfreeze-btn').addEventListener('click', () => {
+const unfreezeBtn = document.createElement('button');
+
+unfreezeBtn.type = 'button';
+unfreezeBtn.textContent = 'Unfreeze all';
+
+unfreezeBtn.addEventListener('click', () => {
   frozenCount = 0;
   hot.updateSettings({ fixedColumnsStart: 0 });
   updateStatus();
 });
+
+unfreezeRow.appendChild(unfreezeBtn);
+unfreezeRow.appendChild(statusEl);
 
 updateStatus();

--- a/docs/content/recipes/column-management/freeze-columns/react/example1.css
+++ b/docs/content/recipes/column-management/freeze-columns/react/example1.css
@@ -1,45 +1,8 @@
-.freeze-controls {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  margin-bottom: 8px;
+.example-controls-container .controls + .controls {
+  margin-top: 0.5rem;
 }
 
-.freeze-controls__freeze-btns {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-}
-
-.freeze-controls__footer {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.freeze-controls button {
-  border: 1px solid var(--sl-color-gray-5);
-  background: var(--sl-color-bg-nav);
-  color: var(--sl-color-text);
-  font-size: var(--sl-text-sm);
-  line-height: 1.2;
-  padding: 0.4rem 0.75rem;
-  border-radius: 0;
-  cursor: pointer;
-  transition: color 0.15s, background-color 0.15s, border-color 0.15s;
-}
-
-.freeze-controls button:hover {
-  color: var(--sl-color-white);
-  background: var(--sl-color-gray-6);
-}
-
-.freeze-controls button:focus-visible {
-  outline: 1px solid var(--sl-color-accent);
-  outline-offset: 1px;
-}
-
-.freeze-controls__status {
+.freeze-status {
   font-size: var(--sl-text-sm);
   font-style: italic;
   color: var(--sl-color-gray-2);

--- a/docs/content/recipes/column-management/freeze-columns/react/example1.jsx
+++ b/docs/content/recipes/column-management/freeze-columns/react/example1.jsx
@@ -51,9 +51,9 @@ const ExampleComponent = () => {
     : `${frozenCount} column${frozenCount > 1 ? 's' : ''} frozen`;
 
   return (
-    <div>
-      <div className="freeze-controls">
-        <div className="freeze-controls__freeze-btns">
+    <>
+      <div className="example-controls-container">
+        <div className="controls">
           {colHeaders.map((header, index) => (
             <button
               key={header}
@@ -64,9 +64,9 @@ const ExampleComponent = () => {
             </button>
           ))}
         </div>
-        <div className="freeze-controls__footer">
+        <div className="controls">
           <button type="button" onClick={unfreezeAll}>Unfreeze all</button>
-          <span className="freeze-controls__status">{statusText}</span>
+          <span className="freeze-status">{statusText}</span>
         </div>
       </div>
       <HotTable
@@ -82,7 +82,7 @@ const ExampleComponent = () => {
         autoWrapRow={true}
         licenseKey="non-commercial-and-evaluation"
       />
-    </div>
+    </>
   );
 };
 

--- a/docs/content/recipes/column-management/freeze-columns/react/example1.tsx
+++ b/docs/content/recipes/column-management/freeze-columns/react/example1.tsx
@@ -63,9 +63,9 @@ const ExampleComponent = () => {
     : `${frozenCount} column${frozenCount > 1 ? 's' : ''} frozen`;
 
   return (
-    <div>
-      <div className="freeze-controls">
-        <div className="freeze-controls__freeze-btns">
+    <>
+      <div className="example-controls-container">
+        <div className="controls">
           {colHeaders.map((header, index) => (
             <button
               key={header}
@@ -76,9 +76,9 @@ const ExampleComponent = () => {
             </button>
           ))}
         </div>
-        <div className="freeze-controls__footer">
+        <div className="controls">
           <button type="button" onClick={unfreezeAll}>Unfreeze all</button>
-          <span className="freeze-controls__status">{statusText}</span>
+          <span className="freeze-status">{statusText}</span>
         </div>
       </div>
       <HotTable
@@ -94,7 +94,7 @@ const ExampleComponent = () => {
         autoWrapRow={true}
         licenseKey="non-commercial-and-evaluation"
       />
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
### Context

The PR aligns the freeze columns recipe examples with the `example-controls-container` toolbar pattern used across other up-to-date recipe examples.

Changes:
- Replace `Step N --` heading style with `Step N:` in the markdown page
- Remove custom `freeze-controls*` CSS in favor of the shared `example-controls-container` / `controls` classes
- JS: delete the HTML file and build the toolbar programmatically (two `.controls` rows — freeze buttons row and unfreeze/status row)
- React and Angular: replace custom wrapper and class names with `example-controls-container` / `controls` structure
- Add `.controls + .controls` row-gap rule to all three CSS files so the gap between rows matches the button gap within a row

### How has this been tested?

Manual review of all three variant files (JS, React, Angular) for structural consistency with established recipe examples (row-operations, multi-column-filter-panel).

`[skip changelog]`

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1686

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/86c9tym4h

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs/example refactor that mostly changes markup/CSS structure for the freeze-columns recipe; main risk is minor breakage in the embedded JS example due to removing the static HTML scaffold.
> 
> **Overview**
> Updates the freeze-columns recipe examples to use the shared `example-controls-container`/`controls` toolbar layout instead of the bespoke `freeze-controls*` wrappers, and renames the status class to `freeze-status` across Angular/React/JS.
> 
> For the JavaScript variant, removes `example1.html` and builds the toolbar DOM (freeze buttons row + unfreeze/status row) programmatically in `example1.js`, while CSS is reduced to a shared row-gap rule plus status styling.
> 
> In `freeze-columns.md`, drops the JavaScript HTML snippet from the embedded example and standardizes headings from `Step N --` to `Step N:`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb947e0ccb0ea25c549f5b280e0ff48f858733cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->