### PR TITLE
DEV-1717: Fix NestedHeaders rendering with manualColumnMove + hiddenColumns

### DIFF
--- a/.changelogs/12610.json
+++ b/.changelogs/12610.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed nested headers rendering incorrectly when manualColumnMove and hiddenColumns are combined.",
+  "type": "fixed",
+  "issueOrPR": 12610,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/nestedHeaders/__tests__/generalFunctionality.spec.js
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/generalFunctionality.spec.js
@@ -698,7 +698,7 @@ describe('NestedHeaders', () => {
         height: 300,
       });
 
-      const rowMapperHooks = columnIndexMapper().__localHooks.cacheUpdated.length;
+      const rowMapperHooks = rowIndexMapper().__localHooks.cacheUpdated.length;
       const columnMapperHooks = columnIndexMapper().__localHooks.cacheUpdated.length;
 
       await updateSettings({

--- a/handsontable/src/plugins/nestedHeaders/__tests__/hidingColumns.spec.js
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/hidingColumns.spec.js
@@ -1849,5 +1849,153 @@ describe('NestedHeaders', () => {
           `);
       });
     });
+
+    describe('with cooperation with the ManualColumnMove plugin (#9565)', () => {
+      it('should render multi-column parent header correctly when a hidden column ' +
+        'maps to a different visual index due to manualColumnMove (initial settings)', async() => {
+        handsontable({
+          data: createSpreadsheetData(2, 7),
+          colHeaders: true,
+          nestedHeaders: [
+            ['A', 'B', 'C', { label: 'PARENT', colspan: 3 }, 'G'],
+            ['A', 'B', 'C', 'D', 'E', 'F', 'G'],
+          ],
+          manualColumnMove: [3, 0, 1, 2, 4, 5, 6],
+          hiddenColumns: {
+            columns: [2],
+          },
+        });
+
+        expect(extractDOMStructure(getTopClone(), getMaster())).toMatchHTML(`
+          <thead>
+            <tr>
+              <th class="">A</th>
+              <th class="">B</th>
+              <th class="">C</th>
+              <th class="" colspan="2">PARENT</th>
+              <th class="hiddenHeader"></th>
+              <th class="">G</th>
+            </tr>
+            <tr>
+              <th class="">A</th>
+              <th class="">B</th>
+              <th class="">C</th>
+              <th class="">E</th>
+              <th class="">F</th>
+              <th class="">G</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="ht__row_odd">
+              <td class="">D1</td>
+              <td class="">A1</td>
+              <td class="">B1</td>
+              <td class="afterHiddenColumn">E1</td>
+              <td class="">F1</td>
+              <td class="">G1</td>
+            </tr>
+          </tbody>
+          `);
+      });
+
+      it('should translate physical to visual when the hiding map changes while ' +
+        'manualColumnMove is active', async() => {
+        handsontable({
+          data: createSpreadsheetData(2, 7),
+          colHeaders: true,
+          nestedHeaders: [
+            ['A', 'B', 'C', { label: 'PARENT', colspan: 3 }, 'G'],
+            ['A', 'B', 'C', 'D', 'E', 'F', 'G'],
+          ],
+          manualColumnMove: [3, 0, 1, 2, 4, 5, 6],
+        });
+
+        const hidingMap = columnIndexMapper().createAndRegisterIndexMap('my-hiding-map', 'hiding');
+
+        hidingMap.setValueAtIndex(2, true); // hide physical column "C" (visual 3 after move)
+        await render();
+
+        expect(extractDOMStructure(getTopClone(), getMaster())).toMatchHTML(`
+          <thead>
+            <tr>
+              <th class="">A</th>
+              <th class="">B</th>
+              <th class="">C</th>
+              <th class="" colspan="2">PARENT</th>
+              <th class="hiddenHeader"></th>
+              <th class="">G</th>
+            </tr>
+            <tr>
+              <th class="">A</th>
+              <th class="">B</th>
+              <th class="">C</th>
+              <th class="">E</th>
+              <th class="">F</th>
+              <th class="">G</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="ht__row_odd">
+              <td class="">D1</td>
+              <td class="">A1</td>
+              <td class="">B1</td>
+              <td class="">E1</td>
+              <td class="">F1</td>
+              <td class="">G1</td>
+            </tr>
+          </tbody>
+          `);
+      });
+
+      it('should re-sync the nested header tree when columns are moved at runtime ' +
+        'while a hidden column already exists', async() => {
+        handsontable({
+          data: createSpreadsheetData(2, 7),
+          colHeaders: true,
+          nestedHeaders: [
+            ['A', 'B', 'C', { label: 'PARENT', colspan: 3 }, 'G'],
+            ['A', 'B', 'C', 'D', 'E', 'F', 'G'],
+          ],
+          manualColumnMove: true,
+          hiddenColumns: {
+            columns: [2],
+          },
+        });
+
+        getPlugin('manualColumnMove').moveColumn(3, 0); // physical 3 to visual 0
+        await render();
+
+        expect(extractDOMStructure(getTopClone(), getMaster())).toMatchHTML(`
+          <thead>
+            <tr>
+              <th class="">A</th>
+              <th class="">B</th>
+              <th class="">C</th>
+              <th class="" colspan="2">PARENT</th>
+              <th class="hiddenHeader"></th>
+              <th class="">G</th>
+            </tr>
+            <tr>
+              <th class="">A</th>
+              <th class="">B</th>
+              <th class="">C</th>
+              <th class="">E</th>
+              <th class="">F</th>
+              <th class="">G</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="ht__row_odd">
+              <td class="">D1</td>
+              <td class="">A1</td>
+              <td class="">B1</td>
+              <td class="afterHiddenColumn">E1</td>
+              <td class="">F1</td>
+              <td class="">G1</td>
+            </tr>
+          </tbody>
+          `);
+      });
+    });
   });
 });

--- a/handsontable/src/plugins/nestedHeaders/nestedHeaders.js
+++ b/handsontable/src/plugins/nestedHeaders/nestedHeaders.js
@@ -232,6 +232,7 @@ export class NestedHeaders extends BasePlugin {
     this.addHook('modifyFocusedElement', (...args) => this.#onModifyFocusedElement(...args));
     this.hot.columnIndexMapper.addLocalHook('cacheUpdated', this.#updateFocusHighlightPosition);
     this.hot.rowIndexMapper.addLocalHook('cacheUpdated', this.#updateFocusHighlightPosition);
+    this.hot.columnIndexMapper.addLocalHook('cacheUpdated', this.#onColumnIndexMapperCacheUpdated);
 
     super.enablePlugin();
     this.updatePlugin(); // @TODO: Workaround for broken plugin initialization abstraction.
@@ -277,26 +278,28 @@ export class NestedHeaders extends BasePlugin {
       // This line covers the case when a developer uses the external hiding maps to manipulate
       // the columns' visibility. The tree state built from the settings - which is always built
       // as if all the columns are visible, needs to be modified to be in sync with a dataset.
-      this.hot.columnIndexMapper
-        .hidingMapsCollection
-        .getMergedValues()
-        .forEach((isColumnHidden, physicalColumnIndex) => {
-          const actionName = isColumnHidden === true ? 'hide-column' : 'show-column';
-
-          this.#stateManager.triggerColumnModification(actionName, physicalColumnIndex);
-        });
+      this.#syncHiddenColumnsFromMapper();
     }
 
     if (!this.#hidingIndexMapObserver && this.enabled) {
       this.#hidingIndexMapObserver = this.hot.columnIndexMapper
         .createChangesObserver('hiding')
         .subscribe((changes) => {
-          changes.forEach(({ op, index: columnIndex, newValue }) => {
-            if (op === 'replace') {
-              const actionName = newValue === true ? 'hide-column' : 'show-column';
-
-              this.#stateManager.triggerColumnModification(actionName, columnIndex);
+          changes.forEach(({ op, index: physicalColumnIndex, newValue }) => {
+            if (op !== 'replace') {
+              return;
             }
+
+            const visualColumnIndex = this.hot.columnIndexMapper
+              .getVisualFromPhysicalIndex(physicalColumnIndex);
+
+            if (visualColumnIndex === null) {
+              return;
+            }
+
+            const actionName = newValue === true ? 'hide-column' : 'show-column';
+
+            this.#stateManager.triggerColumnModification(actionName, visualColumnIndex);
           });
 
           this.ghostTable.buildWidthsMap();
@@ -316,6 +319,8 @@ export class NestedHeaders extends BasePlugin {
       .removeLocalHook('cacheUpdated', this.#updateFocusHighlightPosition);
     this.hot.columnIndexMapper
       .removeLocalHook('cacheUpdated', this.#updateFocusHighlightPosition);
+    this.hot.columnIndexMapper
+      .removeLocalHook('cacheUpdated', this.#onColumnIndexMapperCacheUpdated);
 
     this.clearColspans();
     this.#stateManager.clear();
@@ -1340,6 +1345,51 @@ export class NestedHeaders extends BasePlugin {
       return this.hot.getCell(row, this.#stateManager.findLeftMostColumnIndex(row, column), true);
     }
   }
+
+  /**
+   * Synchronizes the nested-headers tree hide state with the column index mapper.
+   * The hiding map is indexed by physical column; the state manager operates on
+   * visual column indexes. The mapping between the two can change at runtime when
+   * columns are moved, so this method walks all currently-known physical indexes,
+   * translates each to its visual position, and applies the matching hide/show
+   * action on the tree.
+   */
+  #syncHiddenColumnsFromMapper() {
+    const { columnIndexMapper } = this.hot;
+
+    columnIndexMapper
+      .hidingMapsCollection
+      .getMergedValues()
+      .forEach((isColumnHidden, physicalColumnIndex) => {
+        const visualColumnIndex = columnIndexMapper.getVisualFromPhysicalIndex(physicalColumnIndex);
+
+        if (visualColumnIndex === null) {
+          return;
+        }
+
+        const actionName = isColumnHidden === true ? 'hide-column' : 'show-column';
+
+        this.#stateManager.triggerColumnModification(actionName, visualColumnIndex);
+      });
+  }
+
+  /**
+   * Re-syncs the nested-headers hide state when the column index mapper reports
+   * a sequence change (for example, after `manualColumnMove`). The "hiding" change
+   * observer only fires on hidden/visible value changes, so a move that does not
+   * change which physical columns are hidden would otherwise leave the tree state
+   * pointing at stale visual indexes.
+   *
+   * @param {object} payload The `cacheUpdated` payload.
+   * @param {boolean} payload.indexesSequenceChanged True when the column order changed.
+   */
+  #onColumnIndexMapperCacheUpdated = ({ indexesSequenceChanged }) => {
+    if (!indexesSequenceChanged) {
+      return;
+    }
+
+    this.#syncHiddenColumnsFromMapper();
+  };
 
   /**
    * Updates the plugin state after HoT initialization.


### PR DESCRIPTION
### Context

The PR fixes [GH issue #9565](https://github.com/handsontable/handsontable/issues/9565). When `nestedHeaders`, `manualColumnMove`, and `hiddenColumns` were combined, the multi-column parent header at the moved-from-hidden position disappeared entirely and the wrong leaf was marked hidden in the bottom row.

Root cause: the plugin pulled hidden-column state from `hidingMapsCollection.getMergedValues()` (array indexed by **physical** column) and forwarded each index to `triggerColumnModification`, which the state manager documents as expecting a **visual** column index (see `stateManager/index.js`). Without `manualColumnMove`, physical == visual and the bug is invisible. With a move active, the tree marks the wrong leaf as hidden and the multi-column root anchored at the actually-hidden visual position is never rendered.

Three changes:

1. New private `#syncHiddenColumnsFromMapper()` helper translates physical → visual via `getVisualFromPhysicalIndex` before calling `triggerColumnModification`. Replaces the buggy inline forEach in `updatePlugin()`.
2. The runtime hiding observer in `updatePlugin()` now translates each `replace` change's index from physical → visual and skips changes where translation returns null (trimmed columns).
3. New `#onColumnIndexMapperCacheUpdated` listener registered on the column index mapper in `enablePlugin()` (and unregistered in `disablePlugin()`) re-runs the sync helper when `indexesSequenceChanged` is true. This covers the runtime `manualColumnMove` case where the hiding observer would not fire on its own.

A pre-existing test bug was also fixed in `generalFunctionality.spec.js` where `rowMapperHooks` was being captured from `columnIndexMapper()`. Pre-fix this masked an asymmetry between row and column hook counts.

### How has this been tested?

Three new E2E specs added in `nestedHeaders/__tests__/hidingColumns.spec.js` covering:

- init-time settings with move + hide together
- runtime hide via custom hiding index map while `manualColumnMove` is active
- runtime move via `manualColumnMove` plugin while `hiddenColumns` already set

Manual verification via demo pages (gitignored): `handsontable/dev-latest.html` (released v17.0.1) vs `handsontable/dev-pr.html` (local build) — all three cases reproduce the bug on released and render correctly on the PR build.

```
npm run test:e2e --prefix handsontable --testPathPattern=nestedHeaders
# 141 specs, 0 failures

npm run test:e2e --prefix handsontable --testPathPattern=manualColumnMove
# 210 specs, 0 failures

npm run test:e2e --prefix handsontable --testPathPattern=hiddenColumns
# 289 specs, 0 failures

npm run test:unit --prefix handsontable -- --testPathPattern=nestedHeaders
# 132 passed
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. #9565
2. DEV-1717

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1717

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches NestedHeaders’ core hide/show synchronization and adds a new mapper hook, so regressions are possible in column hiding/moving interactions across plugins.
> 
> **Overview**
> Fixes a NestedHeaders rendering bug when `hiddenColumns` is used alongside `manualColumnMove` by translating *physical* hidden-column indexes to *visual* indexes before updating the nested-header tree, including during hiding-map change events.
> 
> Adds a `columnIndexMapper` `cacheUpdated` listener to re-sync hidden state when column order changes (so moves without hide-value changes don’t leave stale tree state), and updates tests/fixtures to cover these scenarios plus correct a mapper-hook-count assertion; includes a changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6826d9938ed020720dd68dbf03f2234937622dc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->