### PR TITLE
DEV-1718: Fix Comments popup not shown for sparse object data

### DIFF
--- a/.changelogs/12611.json
+++ b/.changelogs/12611.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed the Comments plugin not showing the popup when the first row of object data has fewer keys than the columns declared via `dataSchema` or `columns`.",
+  "type": "fixed",
+  "issueOrPR": 12611,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/comments/__tests__/comments.spec.js
+++ b/handsontable/src/plugins/comments/__tests__/comments.spec.js
@@ -720,6 +720,34 @@ describe('Comments', () => {
 
       expect(editor.parentNode.style.display).toEqual('none');
     });
+
+    it('should show the comment editor for a column outside the first row\'s keys when using sparse object data (#9513)', async() => {
+      handsontable({
+        data: [
+          { C0: 'A0', C1: 'B0' },
+          { C0: 'A1', C1: 'B1', C2: 'C1', C3: 'D1', C4: 'E1', C5: 'F1' },
+        ],
+        dataSchema: { C0: null, C1: null, C2: null, C3: null, C4: null, C5: null },
+        columns: [
+          { data: 'C0' },
+          { data: 'C1' },
+          { data: 'C2' },
+          { data: 'C3' },
+          { data: 'C4' },
+          { data: 'C5' },
+        ],
+        comments: true,
+        cell: [
+          { row: 0, col: 3, comment: { value: 'Comment at C3' } },
+        ],
+      });
+
+      const plugin = getPlugin('comments');
+      const editor = plugin.getEditorInputElement();
+
+      expect(plugin.showAtCell(0, 3)).toBe(true);
+      expect(editor.parentNode.style.display).toEqual('block');
+    });
   });
 
   it('`updateCommentMeta` & `setComment` functions should extend cellMetaObject properly', async() => {

--- a/handsontable/src/plugins/comments/comments.js
+++ b/handsontable/src/plugins/comments/comments.js
@@ -554,7 +554,7 @@ export class Comments extends BasePlugin {
 
     const { row, col } = this.#getRangeCoords();
 
-    if (row < 0 || row > this.hot.countSourceRows() - 1 || col < 0 || col > this.hot.countSourceCols() - 1) {
+    if (row < 0 || row > this.hot.countRows() - 1 || col < 0 || col > this.hot.countCols() - 1) {
       return false;
     }
 


### PR DESCRIPTION
### Context

The PR fixes [#9513](https://github.com/handsontable/handsontable/issues/9513). When using object-shaped data where the first row contains fewer keys than the columns declared via `dataSchema`/`columns`, the Comments plugin renders the cell marker (`htCommentCell` corner triangle) correctly but suppresses the popup on hover or `showAtCell()` for any column index beyond the sparse first-row count.

Root cause: the bounds check in `Comments.show()` (`src/plugins/comments/comments.js`) used `countSourceRows()` / `countSourceCols()`. For object data, `countSourceCols()` returns `deepObjectSize(data[0])`, i.e. the number of keys in the actual first row — not the configured column count. Any column index `> data[0].keys.length - 1` failed the check and the method early-returned.

Fix: swap the bounds check to `countRows()` / `countCols()`, the visual-coord-aware counts that match the coordinate system of the `show()` / `showAtCell()` input (visual coords from `setRange()`, `mouseover` via `getCoords`, or the public `showAtCell(row, column)` contract).

### How has this been tested?

Added an E2E test reproducing the bug in `src/plugins/comments/__tests__/comments.spec.js`:

- Sparse first row `{ C0, C1 }` with `dataSchema` + `columns` for `C0..C5`.
- `comments: true` + `cell` meta with a comment at `(0, 3)`.
- Asserts `showAtCell(0, 3) === true` and editor `display === 'block'`.

Confirmed RED (fails on `develop`) → GREEN (passes after fix). Full comments E2E suite passes:

```
npm run test:e2e --prefix handsontable -- --testPathPattern=plugins/comments/__tests__
# 135 specs, 0 failures
```

Manual verification via a CDN-vs-local A/B demo page confirms popups now appear for in-keys and out-of-keys columns across all rows (cells `(0,0..5)`, `(1,0)`, `(1,5)`, `(2,2)`, `(3,3)`, `(3,5)`).

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. https://github.com/handsontable/handsontable/issues/9513
2. DEV-1718

### Affected project(s):

- [x] \`handsontable\`
- [ ] \`@handsontable/angular-wrapper\`
- [ ] \`@handsontable/react-wrapper\`
- [ ] \`@handsontable/vue3\`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1718

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small bounds-check change in `Comments.show()` plus a targeted regression test; behavior change is limited to when the comment editor is requested for valid visual rows/cols on object data.
> 
> **Overview**
> Fixes a bug where the Comments popup could fail to open for object-shaped data when the first row has fewer keys than the configured columns.
> 
> `Comments.show()` now validates coordinates using visual `countRows()`/`countCols()` instead of source counts, and an E2E regression test asserts `showAtCell()` works for a column not present in the first row’s keys. A changelog entry documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da9d533fd4601e562ab3d73bad5370cc2040641a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->