### PR TITLE
DEV-1719: Refresh filter_by_value snapshots after updateData

### DIFF
--- a/.changelogs/12613.json
+++ b/.changelogs/12613.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed the \"Filter by value\" list not showing newly added values after `updateData` is called while a filter is active.",
+  "type": "fixed",
+  "issueOrPR": 12613,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
@@ -214,6 +214,77 @@ describe('Filters UI', () => {
     expect(checkboxes.length).toBe(2);
   });
 
+  it('should refresh the "Filter by value" list to include newly added values after `updateData` ' +
+    'is called while a `by_value` filter is active #9259', async() => {
+    handsontable({
+      data: [['Adam']],
+      colHeaders: true,
+      dropdownMenu: true,
+      filters: true,
+      width: 500,
+      height: 300
+    });
+
+    const plugin = getPlugin('filters');
+
+    plugin.addCondition(0, 'by_value', [['Adam']]);
+    plugin.filter();
+
+    await updateData([['Adam'], ['John'], ['Tim']]);
+
+    await dropdownMenu(0);
+    await sleep(112);
+
+    const items = byValueMultipleSelect().getItems();
+    const values = items.map(item => item.value);
+    const checked = items.map(item => item.checked);
+
+    expect(values).toEqual(['Adam', 'John', 'Tim']);
+    expect(checked).toEqual([true, false, false]);
+  });
+
+  it('should refresh the "Filter by value" list on every filtered column after `updateData` #9259', async() => {
+    handsontable({
+      data: [['Adam', 'NY']],
+      colHeaders: true,
+      dropdownMenu: true,
+      filters: true,
+      width: 500,
+      height: 300
+    });
+
+    const plugin = getPlugin('filters');
+
+    plugin.addCondition(0, 'by_value', [['Adam']]);
+    plugin.addCondition(1, 'by_value', [['NY']]);
+    plugin.filter();
+
+    await updateData([
+      ['Adam', 'NY'],
+      ['Adam', 'LA'],
+      ['John', 'SF'],
+    ]);
+
+    await dropdownMenu(0);
+    await sleep(112);
+
+    const col0Items = byValueMultipleSelect().getItems();
+
+    expect(col0Items.map(i => i.value)).toEqual(['Adam', 'John']);
+    expect(col0Items.map(i => i.checked)).toEqual([true, false]);
+
+    await dropdownMenu(1);
+    await sleep(112);
+
+    // The "Filter by value" picker for column 1 lists values from source rows that pass
+    // all preceding columns' conditions (standard pivot behavior). Column 0 keeps `by_value=[Adam]`,
+    // so only rows with `Adam` contribute: values `NY` and `LA`.
+    const col1Items = byValueMultipleSelect().getItems();
+
+    expect(col1Items.map(i => i.value)).toEqual(['LA', 'NY']);
+    expect(col1Items.map(i => i.checked)).toEqual([false, true]);
+  });
+
   it('should restore correct components\' state after altering columns', async() => {
     handsontable({
       data: [

--- a/handsontable/src/plugins/filters/filters.js
+++ b/handsontable/src/plugins/filters/filters.js
@@ -303,6 +303,7 @@ export class Filters extends BasePlugin {
     this.addHook('afterDropdownMenuShow', () => this.#onAfterDropdownMenuShow());
     this.addHook('afterDropdownMenuHide', () => this.#onAfterDropdownMenuHide());
     this.addHook('afterChange', changes => this.#onAfterChange(changes));
+    this.addHook('afterUpdateData', (data, firstRun) => this.#onAfterUpdateData(firstRun));
     this.addHook('afterDataProviderFetch', result => this.#onAfterDataProviderFetch(result));
     this.addHook('afterDataProviderFetchError', () => this.#onAfterDataProviderFetchError());
 
@@ -1095,6 +1096,31 @@ export class Filters extends BasePlugin {
     });
 
     this.updateDependentComponentsVisibility();
+  }
+
+  /**
+   * `afterUpdateData` listener. `updateData` replaces the source data but keeps
+   * conditions intact. The `filter_by_value` snapshots were computed against the
+   * previous dataset, so they need to be rebuilt so newly introduced values appear
+   * in the dropdown. When `dataProvider` drives the grid, snapshot refresh is owned
+   * by the fetch flow (`afterDataProviderFetch` -> `importConditions`).
+   *
+   * @param {boolean} firstRun `true` for the initial data load.
+   */
+  #onAfterUpdateData(firstRun) {
+    if (firstRun || this.#isDataProviderActive || !this.conditionCollection) {
+      return;
+    }
+
+    const filteredColumns = this.conditionCollection.getFilteredColumns();
+
+    if (filteredColumns.length === 0) {
+      return;
+    }
+
+    arrayEach(filteredColumns, (physicalColumn) => {
+      this.conditionUpdateObserver.updateStatesAtColumn(physicalColumn);
+    });
   }
 
   /**


### PR DESCRIPTION
### Context

The PR fixes [#9259](https://github.com/handsontable/handsontable/issues/9259). When a `by_value` filter is active and `updateData` is called, the dropdown's "Filter by value" list keeps showing only values from the previous (filtered) dataset — newly introduced source values are missing, and the user has no way to opt in to them.

Root cause: `ValueComponent` persists `itemsSnapshot` per column when conditions are added/changed via `ConditionUpdateObserver`. `updateData` replaces the source data but keeps conditions intact and never triggers a snapshot refresh, so on the next dropdown open `restoreState` reads a stale snapshot.

Fix: register an `afterUpdateData` listener in the Filters plugin. For each column with an active condition, call `ConditionUpdateObserver.updateStatesAtColumn(physicalColumn)`. That re-runs the existing `update` flow, which reads source data via `getDataMapAtColumn` and rebuilds the snapshot honoring conditions defined before that column in the stack (preserves standard pivot semantics).

DataProvider flow is unaffected — it uses `loadData` (fires `afterLoadData`), not `updateData`. The handler is also guarded with `#isDataProviderActive` so that `updateData([], 'updateSettings')` issued by `updateSettings` on an external-source grid is skipped (the dataProvider fetch flow owns the refresh in that case).

### How has this been tested?

Two new E2E tests in `handsontable/src/plugins/filters/__tests__/filtersUI.spec.js`:

1. Single column `by_value` filter, then `updateData` introduces new values — picker lists all new values, original selection still checked.
2. Two filtered columns — both pickers refresh, and column 2's picker still respects column 1's condition (pivot behavior preserved).

Commands:

```bash
npm run build --prefix handsontable
npm run test:e2e --prefix handsontable -- --testPathPattern=filters
# 258 specs, 0 failures
npx eslint handsontable/src/plugins/filters/filters.js handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
# clean
```

Manual verification via `dev-latest.html` (v17.0.1, CDN) vs `dev-pr.html` (local build): bug reproduces on released; fixed on PR build.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. Fixes #9259
2. DEV-1719

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1719

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches filter UI state refresh logic triggered by a core data lifecycle hook (`afterUpdateData`), which could affect filtering behavior across multiple columns, but the change is small and guarded for first run and external data sources.
> 
> **Overview**
> Fixes a stale “Filter by value” dropdown after calling `updateData` with active `by_value` filters by adding an `afterUpdateData` hook in `Filters` that rebuilds per-column value snapshots for all currently filtered columns.
> 
> Adds E2E coverage to verify newly introduced values appear (while preserving existing checked selections) and that multi-column filtering still refreshes each column’s list while respecting preceding column conditions (pivot semantics).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01357065e7267bb603affa3e4fe409133a7e5d1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->