### PR TITLE
DEV-1681: Fix: Correct DocSearch styling for keyboard shortcuts and search bar

### DIFF
--- a/docs/src/styles/base/typography.css
+++ b/docs/src/styles/base/typography.css
@@ -42,7 +42,7 @@
   letter-spacing: -0.005em;
 }
 
-kbd:not(.handsontable kbd, .example-controls-container kbd, .hot-example-preview kbd) {
+kbd:not(.handsontable kbd, .example-controls-container kbd, .hot-example-preview kbd, .DocSearch-Container kbd) {
   display: inline-block;
   margin:  0.25rem 0.375rem;
   padding: 0.075rem 0.375rem;
@@ -61,11 +61,11 @@ kbd:not(.handsontable kbd, .example-controls-container kbd, .hot-example-preview
   -webkit-box-decoration-break: clone;
 }
 
-kbd:first-child:not(.handsontable kbd, .example-controls-container kbd, .hot-example-preview kbd) {
+kbd:first-child:not(.handsontable kbd, .example-controls-container kbd, .hot-example-preview kbd, .DocSearch-Container kbd) {
   margin-left: 0;
 }
 
-kbd:not(.handsontable kbd, .example-controls-container kbd, .hot-example-preview kbd) kbd {
+kbd:not(.handsontable kbd, .example-controls-container kbd, .hot-example-preview kbd, .DocSearch-Container kbd) kbd {
   padding: 0;
   background: none;
   border: none;

--- a/docs/src/styles/layout/page.css
+++ b/docs/src/styles/layout/page.css
@@ -75,6 +75,29 @@ header.header {
   z-index: 10200 !important;
 }
 
+/* Search bar: starlight-docsearch adds a ::before icon on .DocSearch-Button-Keys and
+   @docsearch/js injects a "/" .DocSearch-Button-Key — together they read as a broken
+   shortcut hint (DEV-1681). */
+@media (min-width: 50rem) {
+  sl-doc-search .DocSearch-Button-Keys::before {
+    display: none;
+  }
+
+  sl-doc-search .DocSearch-Button-Key {
+    display: none;
+  }
+}
+
+/* Modal footer: global kbd styles add margin and box-shadow that throw off centering. */
+.DocSearch-Button-Key,
+.DocSearch-Commands-Key {
+  align-items: center;
+  justify-content: center;
+  top: 0;
+  line-height: 1;
+  padding-bottom: 0;
+}
+
 header.header > .header {
   max-width: 1500px;
   margin-inline: auto;


### PR DESCRIPTION


### Context
<!--- Why is this change required? What problem does it solve? -->
Fixes styling issue on the Algolia search component

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Manual test

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. DEV-1681

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only changes scoped to documentation DocSearch components; main risk is minor visual regressions across breakpoints or in the DocSearch modal.
> 
> **Overview**
> Fixes DocSearch keyboard shortcut rendering and alignment in the docs UI.
> 
> Updates global `kbd` typography styles to *exclude* keys rendered inside the DocSearch modal, and adds DocSearch-specific CSS to hide the duplicated shortcut hint in the search bar (desktop) while tightening footer key centering/line-height so shortcuts render cleanly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7af44695f006764f06d4754e9142c110b9e0d058. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->