### PR TITLE
DEV-1700: Show Ruby on Rails recipe in React and Angular sidebars

### DIFF
--- a/docs/content/recipes/data-management/server-side-rails/angular/example1.html
+++ b/docs/content/recipes/data-management/server-side-rails/angular/example1.html
@@ -1,0 +1,3 @@
+<div>
+  <example1-server-side-rails></example1-server-side-rails>
+</div>

--- a/docs/content/recipes/data-management/server-side-rails/angular/example1.ts
+++ b/docs/content/recipes/data-management/server-side-rails/angular/example1.ts
@@ -1,0 +1,170 @@
+/* file: app.component.ts */
+import { Component, ViewChild } from '@angular/core';
+import { GridSettings, HotTableComponent, HotTableModule } from '@handsontable/angular-wrapper';
+import type {
+  DataProviderFetchOptions,
+  DataProviderQueryParameters,
+  RowUpdatePayload,
+  RowsCreatePayload,
+} from 'handsontable/plugins/dataProvider';
+import type { SourceRowData } from 'handsontable/common';
+
+function buildUrl(base: string, params: DataProviderQueryParameters): string {
+  const query = new URLSearchParams();
+
+  query.set('page', String(params.page));
+  query.set('page_size', String(params.pageSize));
+
+  if (params.sort?.prop) {
+    query.set('sort_prop', params.sort.prop);
+    query.set('sort_order', params.sort.order ?? 'asc');
+  }
+
+  if (params.filters?.length) {
+    params.filters.forEach((filter, i) => {
+      const condition = filter.conditions[0];
+
+      query.set(`filters[${i}][prop]`, filter.prop);
+
+      if (condition?.name) {
+        query.set(`filters[${i}][condition]`, condition.name);
+      }
+
+      if (condition?.args?.[0] != null) {
+        query.set(`filters[${i}][value]`, String(condition.args[0]));
+      }
+
+      if (condition?.args?.[1] != null) {
+        query.set(`filters[${i}][value2]`, String(condition.args[1]));
+      }
+    });
+  }
+
+  return `${base}?${query.toString()}`;
+}
+
+function buildOrderRowsFromCreatePayload({ rowsAmount }: RowsCreatePayload): SourceRowData[] {
+  const stamp = Date.now();
+
+  return Array.from({ length: rowsAmount }, (_, i) => ({
+    order_number: `ORD-NEW-${stamp}-${i}`,
+    customer: 'New customer',
+    status: 'pending',
+    total: 0,
+  }));
+}
+
+@Component({
+  standalone: true,
+  imports: [HotTableModule],
+  selector: 'example1-server-side-rails',
+  template: `
+    <div>
+      <hot-table [settings]="gridSettings"></hot-table>
+    </div>
+  `,
+})
+export class AppComponent {
+  @ViewChild(HotTableComponent, { static: false }) readonly hotTable!: HotTableComponent;
+
+  readonly gridSettings: GridSettings = {
+    dataProvider: {
+      rowId: 'id',
+      fetchRows: (params: DataProviderQueryParameters, options: DataProviderFetchOptions) =>
+        this.fetchRows(params, options.signal),
+      onRowsCreate: (payload: RowsCreatePayload) => this.onRowsCreate(payload),
+      onRowsUpdate: (rows: RowUpdatePayload[]) => this.onRowsUpdate(rows),
+      onRowsRemove: (rowIds: unknown[]) => this.onRowsRemove(rowIds),
+    },
+    pagination: { pageSize: 10 },
+    columnSorting: true,
+    filters: true,
+    dropdownMenu: ['filter_by_condition', 'filter_action_bar'],
+    emptyDataState: true,
+    notification: true,
+    colHeaders: ['Order #', 'Customer', 'Status', 'Total', 'Created'],
+    columns: [
+      { data: 'order_number', type: 'text' },
+      { data: 'customer', type: 'text' },
+      { data: 'status', type: 'text' },
+      { data: 'total', type: 'numeric', numericFormat: { pattern: '$0,0.00' } },
+      { data: 'created_at', type: 'date', dateFormat: 'YYYY-MM-DD', readOnly: true },
+    ],
+    rowHeaders: true,
+    height: 400,
+    width: '100%',
+  };
+
+  async fetchRows(params: DataProviderQueryParameters, signal: AbortSignal): Promise<{ rows: SourceRowData[]; totalRows: number }> {
+    const url = buildUrl('/api/orders', params);
+    const res = await fetch(url, { signal });
+
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
+    }
+
+    const json = await res.json() as { rows: SourceRowData[]; total_rows: number };
+
+    return { rows: json.rows, totalRows: json.total_rows };
+  }
+
+  async onRowsCreate(payload: RowsCreatePayload): Promise<void> {
+    const rows = buildOrderRowsFromCreatePayload(payload);
+    const res = await fetch('/api/orders/create_rows', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rows }),
+    });
+
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
+    }
+
+    await res.json();
+  }
+
+  async onRowsUpdate(rows: RowUpdatePayload[]): Promise<void> {
+    const res = await fetch('/api/orders/update_rows', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        rows: rows.map((r) => ({ id: r.id, changes: r.changes })),
+      }),
+    });
+
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
+    }
+  }
+
+  async onRowsRemove(rowIds: unknown[]): Promise<void> {
+    const res = await fetch('/api/orders/remove_rows', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ row_ids: rowIds }),
+    });
+
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
+    }
+  }
+}
+/* end-file */
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+/* end-file */

--- a/docs/content/recipes/data-management/server-side-rails/javascript/example1.js
+++ b/docs/content/recipes/data-management/server-side-rails/javascript/example1.js
@@ -1,0 +1,110 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+registerAllModules();
+// Serializes fetchRows query parameters into a URL query string that Rails
+// reads via params[:page], params[:sort_prop], and params[:filters].
+function buildUrl(base, { page, pageSize, sort, filters }) {
+    const params = new URLSearchParams();
+    params.set('page', String(page));
+    params.set('page_size', String(pageSize));
+    if (sort?.prop) {
+        params.set('sort_prop', sort.prop);
+        params.set('sort_order', sort.order ?? 'asc');
+    }
+    if (filters?.length) {
+        filters.forEach((filter, i) => {
+            const condition = filter.conditions[0];
+            params.set(`filters[${i}][prop]`, filter.prop);
+            if (condition?.name) {
+                params.set(`filters[${i}][condition]`, condition.name);
+            }
+            if (condition?.args?.[0] != null) {
+                params.set(`filters[${i}][value]`, String(condition.args[0]));
+            }
+            if (condition?.args?.[1] != null) {
+                params.set(`filters[${i}][value2]`, String(condition.args[1]));
+            }
+        });
+    }
+    return `${base}?${params.toString()}`;
+}
+// dataProvider passes { position, referenceRowId, rowsAmount }, not row field
+// values. Build placeholder orders that satisfy the Rails model validations.
+function buildOrderRowsFromCreatePayload({ rowsAmount }) {
+    const stamp = Date.now();
+    return Array.from({ length: rowsAmount }, (_, i) => ({
+        order_number: `ORD-NEW-${stamp}-${i}`,
+        customer: 'New customer',
+        status: 'pending',
+        total: 0,
+    }));
+}
+const container = document.querySelector('#example1');
+// eslint-disable-next-line no-unused-vars
+const hot = new Handsontable(container, {
+    dataProvider: {
+        rowId: 'id',
+        fetchRows: async (queryParameters, { signal }) => {
+            const url = buildUrl('/api/orders', queryParameters);
+            const res = await fetch(url, { signal });
+            if (!res.ok)
+                throw new Error(`HTTP ${res.status}`);
+            const json = await res.json();
+            return { rows: json.rows, totalRows: json.total_rows };
+        },
+        // Context-menu insert sends RowsCreatePayload; Rails create_rows expects
+        // { rows: [ { order_number, customer, status, total }, ... ] }.
+        onRowsCreate: async (payload) => {
+            const rows = buildOrderRowsFromCreatePayload(payload);
+            const res = await fetch('/api/orders/create_rows', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ rows }),
+            });
+            if (!res.ok)
+                throw new Error(`HTTP ${res.status}`);
+            const json = await res.json();
+            return json.rows;
+        },
+        // RowUpdatePayload.changes holds only the edited columns.
+        onRowsUpdate: async (rows) => {
+            const res = await fetch('/api/orders/update_rows', {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    rows: rows.map((r) => ({ id: r.id, changes: r.changes })),
+                }),
+            });
+            if (!res.ok)
+                throw new Error(`HTTP ${res.status}`);
+        },
+        onRowsRemove: async (rowIds) => {
+            const res = await fetch('/api/orders/remove_rows', {
+                method: 'DELETE',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ row_ids: rowIds }),
+            });
+            if (!res.ok)
+                throw new Error(`HTTP ${res.status}`);
+        },
+    },
+    pagination: { pageSize: 10 },
+    columnSorting: true,
+    filters: true,
+    dropdownMenu: ['filter_by_condition', 'filter_action_bar'],
+    emptyDataState: true,
+    notification: true,
+    colHeaders: ['Order #', 'Customer', 'Status', 'Total', 'Created'],
+    columns: [
+        { data: 'order_number', type: 'text' },
+        { data: 'customer', type: 'text' },
+        { data: 'status', type: 'text' },
+        { data: 'total', type: 'numeric', numericFormat: { pattern: '$0,0.00' } },
+        { data: 'created_at', type: 'date', dateFormat: 'YYYY-MM-DD', readOnly: true },
+    ],
+    rowHeaders: true,
+    height: 400,
+    width: '100%',
+    licenseKey: 'non-commercial-and-evaluation',
+});
+export { hot };

--- a/docs/content/recipes/data-management/server-side-rails/javascript/example1.ts
+++ b/docs/content/recipes/data-management/server-side-rails/javascript/example1.ts
@@ -1,0 +1,140 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+import type {
+  DataProviderFetchOptions,
+  DataProviderQueryParameters,
+  RowUpdatePayload,
+  RowsCreatePayload,
+} from 'handsontable/plugins/dataProvider';
+
+registerAllModules();
+
+// Serializes fetchRows query parameters into a URL query string that Rails
+// reads via params[:page], params[:sort_prop], and params[:filters].
+function buildUrl(base: string, { page, pageSize, sort, filters }: DataProviderQueryParameters): string {
+  const params = new URLSearchParams();
+
+  params.set('page', String(page));
+  params.set('page_size', String(pageSize));
+
+  if (sort?.prop) {
+    params.set('sort_prop', sort.prop);
+    params.set('sort_order', sort.order ?? 'asc');
+  }
+
+  if (filters?.length) {
+    filters.forEach((filter, i) => {
+      const condition = filter.conditions[0];
+
+      params.set(`filters[${i}][prop]`, filter.prop);
+
+      if (condition?.name) {
+        params.set(`filters[${i}][condition]`, condition.name);
+      }
+
+      if (condition?.args?.[0] != null) {
+        params.set(`filters[${i}][value]`, String(condition.args[0]));
+      }
+
+      if (condition?.args?.[1] != null) {
+        params.set(`filters[${i}][value2]`, String(condition.args[1]));
+      }
+    });
+  }
+
+  return `${base}?${params.toString()}`;
+}
+
+// dataProvider passes { position, referenceRowId, rowsAmount }, not row field
+// values. Build placeholder orders that satisfy the Rails model validations.
+function buildOrderRowsFromCreatePayload({ rowsAmount }: RowsCreatePayload) {
+  const stamp = Date.now();
+
+  return Array.from({ length: rowsAmount }, (_, i) => ({
+    order_number: `ORD-NEW-${stamp}-${i}`,
+    customer: 'New customer',
+    status: 'pending',
+    total: 0,
+  }));
+}
+
+const container = document.querySelector('#example1')!;
+
+// eslint-disable-next-line no-unused-vars
+const hot = new Handsontable(container, {
+  dataProvider: {
+    rowId: 'id',
+
+    fetchRows: async (queryParameters, { signal }) => {
+      const url = buildUrl('/api/orders', queryParameters);
+      const res = await fetch(url, { signal });
+
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+      const json = await res.json();
+
+      return { rows: json.rows, totalRows: json.total_rows };
+    },
+
+    // Context-menu insert sends RowsCreatePayload; Rails create_rows expects
+    // { rows: [ { order_number, customer, status, total }, ... ] }.
+    onRowsCreate: async (payload: RowsCreatePayload) => {
+      const rows = buildOrderRowsFromCreatePayload(payload);
+      const res = await fetch('/api/orders/create_rows', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ rows }),
+      });
+
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+      const json = await res.json();
+
+      return json.rows;
+    },
+
+    // RowUpdatePayload.changes holds only the edited columns.
+    onRowsUpdate: async (rows: RowUpdatePayload[]) => {
+      const res = await fetch('/api/orders/update_rows', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          rows: rows.map((r) => ({ id: r.id, changes: r.changes })),
+        }),
+      });
+
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    },
+
+    onRowsRemove: async (rowIds) => {
+      const res = await fetch('/api/orders/remove_rows', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ row_ids: rowIds }),
+      });
+
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    },
+  },
+
+  pagination: { pageSize: 10 },
+  columnSorting: true,
+  filters: true,
+  dropdownMenu: ['filter_by_condition', 'filter_action_bar'],
+  emptyDataState: true,
+  notification: true,
+  colHeaders: ['Order #', 'Customer', 'Status', 'Total', 'Created'],
+  columns: [
+    { data: 'order_number', type: 'text' },
+    { data: 'customer', type: 'text' },
+    { data: 'status', type: 'text' },
+    { data: 'total', type: 'numeric', numericFormat: { pattern: '$0,0.00' } },
+    { data: 'created_at', type: 'date', dateFormat: 'YYYY-MM-DD', readOnly: true },
+  ],
+  rowHeaders: true,
+  height: 400,
+  width: '100%',
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+export { hot };

--- a/docs/content/recipes/data-management/server-side-rails/react/example1.jsx
+++ b/docs/content/recipes/data-management/server-side-rails/react/example1.jsx
@@ -1,0 +1,139 @@
+import { useCallback, useMemo } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+function buildUrl(base, { page, pageSize, sort, filters }) {
+  const params = new URLSearchParams();
+
+  params.set('page', String(page));
+  params.set('page_size', String(pageSize));
+
+  if (sort?.prop) {
+    params.set('sort_prop', sort.prop);
+    params.set('sort_order', sort.order ?? 'asc');
+  }
+
+  if (filters?.length) {
+    filters.forEach((filter, i) => {
+      const condition = filter.conditions[0];
+
+      params.set(`filters[${i}][prop]`, filter.prop);
+
+      if (condition?.name) {
+        params.set(`filters[${i}][condition]`, condition.name);
+      }
+
+      if (condition?.args?.[0] != null) {
+        params.set(`filters[${i}][value]`, String(condition.args[0]));
+      }
+
+      if (condition?.args?.[1] != null) {
+        params.set(`filters[${i}][value2]`, String(condition.args[1]));
+      }
+    });
+  }
+
+  return `${base}?${params.toString()}`;
+}
+
+function buildOrderRowsFromCreatePayload({ rowsAmount }) {
+  const stamp = Date.now();
+
+  return Array.from({ length: rowsAmount }, (_, i) => ({
+    order_number: `ORD-NEW-${stamp}-${i}`,
+    customer: 'New customer',
+    status: 'pending',
+    total: 0,
+  }));
+}
+
+const ExampleComponent = () => {
+  const fetchRows = useCallback(async (params, { signal }) => {
+    const url = buildUrl('/api/orders', params);
+    const res = await fetch(url, { signal });
+
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+    const json = await res.json();
+
+    return { rows: json.rows, totalRows: json.total_rows };
+  }, []);
+
+  const onRowsCreate = useCallback(async (payload) => {
+    const rows = buildOrderRowsFromCreatePayload(payload);
+    const res = await fetch('/api/orders/create_rows', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rows }),
+    });
+
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+    const json = await res.json();
+
+    return json.rows;
+  }, []);
+
+  const onRowsUpdate = useCallback(async (rows) => {
+    const res = await fetch('/api/orders/update_rows', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        rows: rows.map((r) => ({ id: r.id, changes: r.changes })),
+      }),
+    });
+
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  }, []);
+
+  const onRowsRemove = useCallback(async (rowIds) => {
+    const res = await fetch('/api/orders/remove_rows', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ row_ids: rowIds }),
+    });
+
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  }, []);
+
+  const dataProvider = useMemo(
+    () => ({
+      rowId: 'id',
+      fetchRows,
+      onRowsCreate,
+      onRowsUpdate,
+      onRowsRemove,
+    }),
+    [fetchRows, onRowsCreate, onRowsUpdate, onRowsRemove]
+  );
+
+  return (
+    <div>
+      <HotTable
+        dataProvider={dataProvider}
+        pagination={{ pageSize: 10 }}
+        columnSorting={true}
+        filters={true}
+        dropdownMenu={['filter_by_condition', 'filter_action_bar']}
+        emptyDataState={true}
+        notification={true}
+        colHeaders={['Order #', 'Customer', 'Status', 'Total', 'Created']}
+        columns={[
+          { data: 'order_number', type: 'text' },
+          { data: 'customer', type: 'text' },
+          { data: 'status', type: 'text' },
+          { data: 'total', type: 'numeric', numericFormat: { pattern: '$0,0.00' } },
+          { data: 'created_at', type: 'date', dateFormat: 'YYYY-MM-DD', readOnly: true },
+        ]}
+        rowHeaders={true}
+        height={400}
+        width="100%"
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </div>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/data-management/server-side-rails/react/example1.tsx
+++ b/docs/content/recipes/data-management/server-side-rails/react/example1.tsx
@@ -1,0 +1,152 @@
+import { useCallback, useMemo } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import type {
+  DataProviderFetchOptions,
+  DataProviderQueryParameters,
+  DataProviderFetchResult,
+  RowUpdatePayload,
+  RowsCreatePayload,
+} from 'handsontable/plugins/dataProvider';
+
+registerAllModules();
+
+function buildUrl(base: string, { page, pageSize, sort, filters }: DataProviderQueryParameters): string {
+  const params = new URLSearchParams();
+
+  params.set('page', String(page));
+  params.set('page_size', String(pageSize));
+
+  if (sort?.prop) {
+    params.set('sort_prop', sort.prop);
+    params.set('sort_order', sort.order ?? 'asc');
+  }
+
+  if (filters?.length) {
+    filters.forEach((filter, i) => {
+      const condition = filter.conditions[0];
+
+      params.set(`filters[${i}][prop]`, filter.prop);
+
+      if (condition?.name) {
+        params.set(`filters[${i}][condition]`, condition.name);
+      }
+
+      if (condition?.args?.[0] != null) {
+        params.set(`filters[${i}][value]`, String(condition.args[0]));
+      }
+
+      if (condition?.args?.[1] != null) {
+        params.set(`filters[${i}][value2]`, String(condition.args[1]));
+      }
+    });
+  }
+
+  return `${base}?${params.toString()}`;
+}
+
+function buildOrderRowsFromCreatePayload({ rowsAmount }: RowsCreatePayload) {
+  const stamp = Date.now();
+
+  return Array.from({ length: rowsAmount }, (_, i) => ({
+    order_number: `ORD-NEW-${stamp}-${i}`,
+    customer: 'New customer',
+    status: 'pending',
+    total: 0,
+  }));
+}
+
+const ExampleComponent = () => {
+  const fetchRows = useCallback(
+    async (
+      params: DataProviderQueryParameters,
+      { signal }: DataProviderFetchOptions
+    ): Promise<DataProviderFetchResult> => {
+      const url = buildUrl('/api/orders', params);
+      const res = await fetch(url, { signal });
+
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+      const json = await res.json() as { rows: unknown[]; total_rows: number };
+
+      return { rows: json.rows, totalRows: json.total_rows };
+    },
+    []
+  );
+
+  const onRowsCreate = useCallback(async (payload: RowsCreatePayload): Promise<unknown> => {
+    const rows = buildOrderRowsFromCreatePayload(payload);
+    const res = await fetch('/api/orders/create_rows', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rows }),
+    });
+
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+    const json = await res.json() as { rows: unknown[] };
+
+    return json.rows;
+  }, []);
+
+  const onRowsUpdate = useCallback(async (rows: RowUpdatePayload[]): Promise<void> => {
+    const res = await fetch('/api/orders/update_rows', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        rows: rows.map((r) => ({ id: r.id, changes: r.changes })),
+      }),
+    });
+
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  }, []);
+
+  const onRowsRemove = useCallback(async (rowIds: unknown[]): Promise<void> => {
+    const res = await fetch('/api/orders/remove_rows', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ row_ids: rowIds }),
+    });
+
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  }, []);
+
+  const dataProvider = useMemo(
+    () => ({
+      rowId: 'id',
+      fetchRows,
+      onRowsCreate,
+      onRowsUpdate,
+      onRowsRemove,
+    }),
+    [fetchRows, onRowsCreate, onRowsUpdate, onRowsRemove]
+  );
+
+  return (
+    <div>
+      <HotTable
+        dataProvider={dataProvider}
+        pagination={{ pageSize: 10 }}
+        columnSorting={true}
+        filters={true}
+        dropdownMenu={['filter_by_condition', 'filter_action_bar']}
+        emptyDataState={true}
+        notification={true}
+        colHeaders={['Order #', 'Customer', 'Status', 'Total', 'Created']}
+        columns={[
+          { data: 'order_number', type: 'text' },
+          { data: 'customer', type: 'text' },
+          { data: 'status', type: 'text' },
+          { data: 'total', type: 'numeric', numericFormat: { pattern: '$0,0.00' } },
+          { data: 'created_at', type: 'date', dateFormat: 'YYYY-MM-DD', readOnly: true },
+        ]}
+        rowHeaders={true}
+        height={400}
+        width="100%"
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </div>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/data-management/server-side-rails/server-side-rails.md
+++ b/docs/content/recipes/data-management/server-side-rails/server-side-rails.md
@@ -11,6 +11,12 @@ tags:
   - server-side
   - data-provider
   - recipe
+react:
+  id: v76z3enw
+  metaTitle: Server-side data with Ruby on Rails - React Data Grid | Handsontable
+angular:
+  id: dg0cfnxy
+  metaTitle: Server-side data with Ruby on Rails - Angular Data Grid | Handsontable
 searchCategory: Recipes
 category: Data Management
 type: how-to

--- a/docs/content/recipes/data-management/server-side-rails/server-side-rails.md
+++ b/docs/content/recipes/data-management/server-side-rails/server-side-rails.md
@@ -29,8 +29,8 @@ This tutorial shows how to wire Handsontable's `dataProvider` plugin to a [Ruby 
   View full example on GitHub
 </a>
 
-**Difficulty:** Intermediate  
-**Time:** ~30 minutes  
+**Difficulty:** Intermediate
+**Time:** ~30 minutes
 **Backend:** Ruby 3.2+, Rails 7.1+, `kaminari` for pagination, `rack-cors` for CORS
 
 ## What you'll build
@@ -362,10 +362,18 @@ function buildUrl(base, { page, pageSize, sort, filters }) {
   }
 
   if (filters?.length) {
-    filters.forEach(({ prop, value, condition }, i) => {
-      params.set(`filters[${i}][prop]`, prop);
-      params.set(`filters[${i}][value]`, value);
-      params.set(`filters[${i}][condition]`, condition);
+    filters.forEach((filter, i) => {
+      const condition = filter.conditions[0];
+
+      params.set(`filters[${i}][prop]`, filter.prop);
+
+      if (condition?.name) {
+        params.set(`filters[${i}][condition]`, condition.name);
+      }
+
+      if (condition?.args?.[0] != null) {
+        params.set(`filters[${i}][value]`, String(condition.args[0]));
+      }
     });
   }
 
@@ -377,79 +385,44 @@ function buildUrl(base, { page, pageSize, sort, filters }) {
 
 - `pageSize` is converted to `page_size` because Rails and kaminari use snake_case parameter names.
 - `sort` is split into two flat params, `sort_prop` and `sort_order`. The controller's `apply_sort` reads them directly.
-- Each filter condition becomes a `filters[N][prop]`, `filters[N][value]`, `filters[N][condition]` triplet. Rails converts the bracket notation to a nested hash automatically.
+- Each active filter column becomes a `filters[N][prop]`, `filters[N][condition]`, and `filters[N][value]` triplet. `dataProvider` passes `conditions[0].name` and `conditions[0].args[0]` from the Filters plugin; map those to the flat params Rails expects. Rails converts the bracket notation to a nested hash automatically.
 
-## Step 10 -- Initialize Handsontable
+## Step 10 -- Wire up Handsontable
 
-Wire everything into `dataProvider`:
+With the server running (`rails server`) and the database seeded, configure Handsontable to use the `dataProvider` plugin. The complete frontend code is in the files below.
 
-```javascript
-const hot = new Handsontable(container, {
-  dataProvider: {
-    rowId: 'id',
+::: only-for javascript vue
 
-    fetchRows: async ({ page, pageSize, sort, filters }, { signal }) => {
-      const url = buildUrl('http://localhost:3000/api/orders', {
-        page, pageSize, sort, filters,
-      });
-      const res = await fetch(url, { signal });
+::: example #example1 :hot-recipe --js 1 --ts 2
 
-      if (!res.ok) throw new Error(`Fetch failed: ${res.status}`);
+@[code collapse={14-109}](@/content/recipes/data-management/server-side-rails/javascript/example1.js)
+@[code collapse={14-137}](@/content/recipes/data-management/server-side-rails/javascript/example1.ts)
 
-      const json = await res.json();
+:::
 
-      // Rails returns snake_case; dataProvider expects camelCase for totalRows.
-      return { rows: json.rows, totalRows: json.total_rows };
-    },
+:::
 
-    onRowsCreate: async (rows) => {
-      const res = await fetch('http://localhost:3000/api/orders/create_rows', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ rows }),
-      });
-      const json = await res.json();
+::: only-for react
 
-      return json.rows; // dataProvider updates its row map with server-assigned ids
-    },
+::: example #example1 :react-advanced --js 1 --ts 2
 
-    onRowsUpdate: async (rows) => {
-      await fetch('http://localhost:3000/api/orders/update_rows', {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ rows: rows.map((r) => ({ id: r.id, changes: r })) }),
-      });
-    },
+@[code collapse={14-135}](@/content/recipes/data-management/server-side-rails/react/example1.jsx)
+@[code collapse={14-149}](@/content/recipes/data-management/server-side-rails/react/example1.tsx)
 
-    onRowsRemove: async (rowIds) => {
-      await fetch('http://localhost:3000/api/orders/remove_rows', {
-        method: 'DELETE',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ row_ids: rowIds }),
-      });
-    },
-  },
+:::
 
-  pagination:     { pageSize: 10 },
-  columnSorting:  true,
-  filters:        true,
-  dropdownMenu:   ['filter_by_condition', 'filter_action_bar'],
-  emptyDataState: true,
-  notification:   true,
+:::
 
-  colHeaders: ['Order #', 'Customer', 'Status', 'Total', 'Created'],
-  columns: [
-    { data: 'order_number', type: 'text' },
-    { data: 'customer',     type: 'text' },
-    { data: 'status',       type: 'text' },
-    { data: 'total',        type: 'numeric', numericFormat: { pattern: '$0,0.00' } },
-    { data: 'created_at',   type: 'date', dateFormat: 'YYYY-MM-DD', readOnly: true },
-  ],
+::: only-for angular
 
-  rowHeaders: true,
-  licenseKey: 'non-commercial-and-evaluation',
-});
-```
+::: example #example1 :angular --ts 1 --html 2
+
+@[code collapse={7-152}](@/content/recipes/data-management/server-side-rails/angular/example1.ts)
+@[code](@/content/recipes/data-management/server-side-rails/angular/example1.html)
+
+:::
+
+:::
 
 **Key options explained:**
 

--- a/docs/content/recipes/sidebar.js
+++ b/docs/content/recipes/sidebar.js
@@ -22,7 +22,7 @@ const dataManagementItems = [
   { path: 'data-management/server-side-django/server-side-django', title: 'Server-side data with Django', onlyFor: ['javascript', 'angular', 'react'] },
   { path: 'data-management/server-side-laravel/server-side-laravel', title: 'Server-side data with Laravel', onlyFor: ['javascript', 'angular', 'react'] },
   { path: 'data-management/server-side-nestjs/server-side-nestjs', title: 'Server-side data with NestJS', onlyFor: ['javascript', 'angular', 'react'] },
-  { path: 'data-management/server-side-rails/server-side-rails', title: 'Server-side data with Ruby on Rails', onlyFor: ['javascript'] },
+  { path: 'data-management/server-side-rails/server-side-rails', title: 'Server-side data with Ruby on Rails', onlyFor: ['javascript', 'angular', 'react'] },
   { path: 'data-management/server-side-spring/server-side-spring', title: 'Server-side data with Spring Boot', onlyFor: ['javascript', 'angular', 'react'] },
 ];
 


### PR DESCRIPTION
### Context

The PR fixes the React and Angular docs navigation for the **Server-side data with Ruby on Rails** recipe. The recipe page was reachable by URL, but the left sidebar skipped from NestJS to Spring Boot because `docs/content/recipes/sidebar.js` restricted the entry to `onlyFor: ['javascript']`. Footer prev/next links were missing for the same reason (the page was not in the framework sidebar tree).

The change extends `onlyFor` to `['javascript', 'angular', 'react']`, matching other server-side backend recipes.

### How has this been tested?

Manual testing with the docs dev server (`pnpm dev` in `docs/`).

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1700

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that mainly adjusts navigation visibility and adds sample frontend snippets; no production code paths affected.
> 
> **Overview**
> Makes the **Server-side data with Ruby on Rails** recipe available for React and Angular in the docs sidebar/prev-next by expanding `onlyFor` in `docs/content/recipes/sidebar.js`.
> 
> Updates the recipe page to be multi-framework: adds React/Angular frontmatter metadata, replaces the inline Handsontable wiring snippet with framework-specific embedded examples, and updates the filter query-serialization example to match `dataProvider`’s `conditions[0]` shape.
> 
> Adds new runnable frontend example files for React (`example1.jsx`/`example1.tsx`) and Angular (`example1.ts`/`example1.html`), alongside JS (`example1.js`/`example1.ts`), demonstrating `dataProvider` pagination/sort/filter and CRUD calls to the Rails endpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eba2db6c0b3a958a0abcb8e75bfef22da5abf605. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->