### PR TITLE
DEV-1702: Fix Ant Design recipe embed and update Fluent UI example

### DIFF
--- a/docs/content/recipes/themes/ant-design/ant-design.md
+++ b/docs/content/recipes/themes/ant-design/ant-design.md
@@ -27,22 +27,22 @@ type: how-to
 
 In this tutorial, you will integrate Handsontable into a React app that uses Ant Design and align the grid with your design system tokens through the Theme API. You will learn how to map Ant Design tokens to Handsontable theme parameters so the grid matches your existing styles.
 
-<iframe src="https://codesandbox.io/p/devbox/github/handsontable/examples/tree/master/examples/ant-design?view=preview"
+<iframe src="https://codesandbox.io/embed/n3c25x?view=preview&module=%2Fsrc%2FApp.tsx"
   style="width:100%; height: 500px; border:0; border-radius: 4px; overflow:hidden;"
-  title="Handsontable with Ant Design recipe"
+  title="Handsontable with AntDesign"
   allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
 ></iframe>
 
-[**Open in CodeSandbox**](https://codesandbox.io/p/devbox/github/handsontable/examples/tree/master/examples/ant-design)
+[**Open in CodeSandbox**](https://codesandbox.io/p/sandbox/handsontable-with-antdesign-n3c25x)
 [**View source on GitHub**](https://github.com/handsontable/examples/tree/master/examples/ant-design)
 
 ## Overview
 
 This recipe uses the official [handsontable/examples Ant Design demo](https://github.com/handsontable/examples/tree/master/examples/ant-design) as the live reference implementation. It shows how to integrate Handsontable into a React app that uses [Ant Design](https://ant.design/) by registering a custom theme and mapping Handsontable theme colors and tokens to Ant Design table-like styles.
 
-**Difficulty:** Beginner  
-**Time:** ~15 minutes  
+**Difficulty:** Beginner
+**Time:** ~15 minutes
 **Stack:** React, Ant Design, Handsontable, `@handsontable/react-wrapper`
 
 ## What You'll Get

--- a/docs/content/recipes/themes/fluent-ui/fluent-ui.md
+++ b/docs/content/recipes/themes/fluent-ui/fluent-ui.md
@@ -24,21 +24,21 @@ type: how-to
 
 In this tutorial, you will integrate Handsontable into a React app with Fluent UI so your grid follows Fluent colors, typography, and spacing. You will learn how to map Fluent UI tokens to Handsontable theme parameters through the Theme API.
 
-<iframe src="https://stackblitz.com/edit/vitejs-vite-3jyuy1rk?embed=1&file=src%2FApp.jsx&view=preview"
-     style="width:100%; height: 500px; border:0; border-radius: 4px; overflow:hidden;"
-     title="Handsontable with Fluent UI recipe"
-     allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
-     sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
-   ></iframe>
+<iframe src="https://codesandbox.io/embed/2y26vw?view=preview&module=%2Fsrc%2FApp.tsx"
+  style="width:100%; height: 500px; border:0; border-radius: 4px; overflow:hidden;"
+  title="Handsontable with Fluent UI"
+  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+></iframe>
 
-[**Open in stackblitz**](https://stackblitz.com/edit/vitejs-vite-3jyuy1rk?file=src%2FApp.jsx&file=src%2FApp.jsx)
+[**Open in CodeSandbox**](https://codesandbox.io/p/sandbox/2y26vw)
 
 ## Overview
 
 This recipe shows how to integrate Handsontable into a React app that uses [Fluent UI](https://react.fluentui.dev/) by registering a custom theme with Theme API colors and tokens. The grid follows your Fluent design language.
 
-**Difficulty:** Beginner  
-**Time:** ~15 minutes  
+**Difficulty:** Beginner
+**Time:** ~15 minutes
 **Stack:** React, Fluent UI, Handsontable, `@handsontable/react-wrapper`
 
 ## What You'll Get


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->

Updates the embedded CodeSandbox example for the Ant Design recipe, addressing an issue where it was not loading. The Fluent UI example's embed is also updated from StackBlitz to CodeSandbox for consistency and improved reliability across documentation recipes.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Manual tests

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. DEV-1702

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates external demo embeds/links; main risk is broken or unavailable third-party sandbox URLs.
> 
> **Overview**
> Fixes the Ant Design theme recipe’s live demo by replacing the broken CodeSandbox devbox iframe/link with a new CodeSandbox embed and updated “Open in CodeSandbox” URL.
> 
> Standardizes the Fluent UI theme recipe by swapping the StackBlitz embed/link for a CodeSandbox embed/link, plus minor formatting tweaks to the Difficulty/Time lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 628e3a2d52a1ef2b8719110dc6dbaccd8b9ff748. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->