### PR TITLE
DEV-1722: Format date/time formula cells in afterFormulasValuesUpdate (#9051)

### DIFF
--- a/.changelogs/12618.json
+++ b/.changelogs/12618.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed the `afterFormulasValuesUpdate` hook and `getDataAtCell` returning raw HyperFormula numerics for formula cells of type `time` or `date`.",
+  "type": "fixed",
+  "issueOrPR": 12618,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/formulas/__tests__/hooks.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/hooks.spec.js
@@ -140,6 +140,84 @@ describe('Formulas general', () => {
         expect(afterFormulasValuesUpdate.calls.count()).toEqual(2);
         expect(afterFormulasValuesUpdate.calls.mostRecent().args[0][0].newValue).toEqual('test');
       });
+
+      it('should pass a formatted time string (not a raw HF time fraction) as `newValue` for cells with' +
+        ' `type: \'time\'`', async() => {
+        const afterFormulasValuesUpdate = jasmine.createSpy('afterFormulasValuesUpdate');
+
+        handsontable({
+          data: [
+            ['16:00', '=A1']
+          ],
+          columns: [
+            { type: 'time', timeFormat: 'HH:mm' },
+            { type: 'time', timeFormat: 'HH:mm' },
+          ],
+          formulas: {
+            engine: spec().hfInstance
+          },
+          afterFormulasValuesUpdate,
+        });
+
+        await setDataAtCell(0, 0, '18:00');
+
+        const lastChanges = afterFormulasValuesUpdate.calls.mostRecent().args[0];
+        const b1Change = lastChanges.find(change => change.address &&
+          change.address.row === 0 && change.address.col === 1);
+
+        expect(typeof b1Change.newValue).toBe('string');
+        expect(b1Change.newValue).toBe('18:00');
+      });
+
+      it('should pass a formatted date string (not a raw HF date number) as `newValue` for cells with' +
+        ' `type: \'date\'`', async() => {
+        const afterFormulasValuesUpdate = jasmine.createSpy('afterFormulasValuesUpdate');
+
+        handsontable({
+          data: [
+            ['01/03/2020', '=A1']
+          ],
+          columns: [
+            { type: 'date', dateFormat: 'MM/DD/YYYY' },
+            { type: 'date', dateFormat: 'MM/DD/YYYY' },
+          ],
+          formulas: {
+            engine: spec().hfInstance
+          },
+          afterFormulasValuesUpdate,
+        });
+
+        await setDataAtCell(0, 0, '02/04/2021');
+
+        const lastChanges = afterFormulasValuesUpdate.calls.mostRecent().args[0];
+        const b1Change = lastChanges.find(change => change.address &&
+          change.address.row === 0 && change.address.col === 1);
+
+        expect(typeof b1Change.newValue).toBe('string');
+        expect(b1Change.newValue).toBe('02/04/2021');
+      });
+
+      it('should return a formatted time string (not a raw HF time fraction) from `getDataAtCell` for a formula' +
+        ' cell of `type: \'time\'`', async() => {
+        handsontable({
+          data: [
+            ['16:00', '=A1']
+          ],
+          columns: [
+            { type: 'time', timeFormat: 'HH:mm' },
+            { type: 'time', timeFormat: 'HH:mm' },
+          ],
+          formulas: {
+            engine: spec().hfInstance
+          },
+        });
+
+        expect(getDataAtCell(0, 1)).toBe('16:00');
+
+        await setDataAtCell(0, 0, '18:00');
+
+        expect(getDataAtCell(0, 1)).toBe('18:00');
+      });
     });
   });
 });

--- a/handsontable/src/plugins/formulas/__tests__/utils.unit.js
+++ b/handsontable/src/plugins/formulas/__tests__/utils.unit.js
@@ -7,6 +7,7 @@ import {
   getDateInHotFormat,
   getDateInHfFormat,
   getDateFromExcelDate,
+  getTimeFromHfTimeFraction,
   normalizeValueForFormulaEngine,
 } from '../utils';
 
@@ -95,6 +96,21 @@ describe('Formulas utils', () => {
       expect(getDateFromExcelDate(366, 'DD/MM/YYYY')).toEqual('31/12/1900');
       // Values are the same for GS, Excel and HF.
       expect(getDateFromExcelDate(366, 'YYYY-MM-DD')).toEqual('1900-12-31');
+    });
+  });
+
+  describe('getTimeFromHfTimeFraction', () => {
+    it('should format a day-fraction time as a string in the provided time format', () => {
+      expect(getTimeFromHfTimeFraction(0, 'HH:mm')).toBe('00:00');
+      expect(getTimeFromHfTimeFraction(0.25, 'HH:mm')).toBe('06:00');
+      expect(getTimeFromHfTimeFraction(0.5, 'HH:mm')).toBe('12:00');
+      expect(getTimeFromHfTimeFraction(0.75, 'HH:mm')).toBe('18:00');
+      expect(getTimeFromHfTimeFraction(0.5, 'h:mm:ss a')).toBe('12:00:00 pm');
+    });
+
+    it('should ignore the integer day part and only format the fractional time part', () => {
+      expect(getTimeFromHfTimeFraction(1.5, 'HH:mm')).toBe('12:00');
+      expect(getTimeFromHfTimeFraction(43891.75, 'HH:mm')).toBe('18:00');
     });
   });
 

--- a/handsontable/src/plugins/formulas/formulas.js
+++ b/handsontable/src/plugins/formulas/formulas.js
@@ -9,6 +9,7 @@ import {
   getDateFromExcelDate,
   getDateInHfFormat,
   getDateInHotFormat,
+  getTimeFromHfTimeFraction,
   isDate,
   isDateValid,
   isFormula,
@@ -691,6 +692,8 @@ export class Formulas extends BasePlugin {
 
       if (cellMeta.type === 'date' && isNumeric(cellValue)) {
         cellValue = getDateFromExcelDate(cellValue, cellMeta.dateFormat);
+      } else if (cellMeta.type === 'time' && isNumeric(cellValue)) {
+        cellValue = getTimeFromHfTimeFraction(cellValue, cellMeta.timeFormat);
       }
 
       // If `cellValue` is an object it is expected to be an error
@@ -920,6 +923,8 @@ export class Formulas extends BasePlugin {
 
     if (cellMeta.type === 'date' && isNumeric(cellValue)) {
       cellValue = getDateFromExcelDate(cellValue, cellMeta.dateFormat);
+    } else if (cellMeta.type === 'time' && isNumeric(cellValue)) {
+      cellValue = getTimeFromHfTimeFraction(cellValue, cellMeta.timeFormat);
     }
 
     // If `cellValue` is an object it is expected to be an error
@@ -1284,13 +1289,54 @@ export class Formulas extends BasePlugin {
   }
 
   /**
+   * Maps a HyperFormula `ExportedCellChange` to the same change with `newValue` translated to a
+   * Handsontable-formatted string when the target cell is of type `date` or `time`. For other cells
+   * (or non-numeric values, or named expressions, or trimmed cells, or cells on other sheets), the
+   * original change is returned unchanged.
+   *
+   * @param {object} change The HyperFormula exported change.
+   * @returns {object}
+   */
+  #exportChangeValue(change) {
+    if (!change.address || change.address.sheet !== this.sheetId || typeof change.newValue !== 'number') {
+      return change;
+    }
+
+    const visualRow = this.rowAxisSyncer.getVisualIndexFromHfIndex(change.address.row);
+    const visualColumn = this.columnAxisSyncer.getVisualIndexFromHfIndex(change.address.col);
+
+    if (visualRow < 0 || visualColumn < 0) {
+      return change;
+    }
+
+    const cellMeta = this.hot.getCellMeta(visualRow, visualColumn, { skipMetaExtension: true });
+    let newValue;
+
+    if (cellMeta.type === 'date') {
+      newValue = getDateFromExcelDate(change.newValue, cellMeta.dateFormat);
+    } else if (cellMeta.type === 'time') {
+      newValue = getTimeFromHfTimeFraction(change.newValue, cellMeta.timeFormat);
+    } else {
+      return change;
+    }
+
+    const clone = Object.assign(Object.create(Object.getPrototypeOf(change)), change);
+
+    clone.newValue = newValue;
+
+    return clone;
+  }
+
+  /**
    * Called when a value is updated in the engine.
    *
    * @fires Hooks#afterFormulasValuesUpdate
    * @param {Array} changes The values and location of applied changes.
    */
   #onEngineValuesUpdated(changes) {
-    this.hot.runHooks('afterFormulasValuesUpdate', changes);
+    const exportedChanges = changes.map(change => this.#exportChangeValue(change));
+
+    this.hot.runHooks('afterFormulasValuesUpdate', exportedChanges);
   }
 
   /**

--- a/handsontable/src/plugins/formulas/indexSyncer/axisSyncer.js
+++ b/handsontable/src/plugins/formulas/indexSyncer/axisSyncer.js
@@ -110,6 +110,25 @@ class AxisSyncer {
   }
 
   /**
+   * Gets corresponding visual index for a HyperFormula index. Inverse of {@link getHfIndexFromVisualIndex}.
+   * Returns -1 when the HF index points to a trimmed element (not visible to the user).
+   *
+   * @param {number} hfIndex HyperFormula index.
+   * @returns {number}
+   */
+  getVisualIndexFromHfIndex(hfIndex) {
+    const indexesSequence = this.#indexMapper.getIndexesSequence();
+    const notTrimmedIndexes = this.#indexMapper.getNotTrimmedIndexes();
+    const physicalIndex = indexesSequence[hfIndex];
+
+    if (physicalIndex === undefined) {
+      return -1;
+    }
+
+    return notTrimmedIndexes.indexOf(physicalIndex);
+  }
+
+  /**
    * Synchronizes moves done on HOT to HF engine (based on previously calculated positions).
    *
    * @private

--- a/handsontable/src/plugins/formulas/utils.js
+++ b/handsontable/src/plugins/formulas/utils.js
@@ -78,6 +78,27 @@ export function getDateInHotFormat(date, dateFormat) {
 }
 
 /**
+ * Converts an HF day-fraction representation of a time value into a string formatted with the cell's
+ * `timeFormat`. HyperFormula represents date-time values as a single number, where the integer part
+ * encodes the date (days since the HF epoch) and the fractional part encodes the time. This helper
+ * ignores the integer part and formats the fractional part as a time string.
+ *
+ * @param {number} numericTime A number whose fractional part represents the time as a fraction of a day.
+ * @param {string} timeFormat The moment.js-compatible format used to render the output time string.
+ * @returns {string}
+ */
+export function getTimeFromHfTimeFraction(numericTime, timeFormat) {
+  const SECONDS_IN_DAY = 86400;
+  const dayFraction = numericTime - Math.floor(numericTime);
+  const totalSeconds = Math.round(dayFraction * SECONDS_IN_DAY);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  return moment({ hour: hours, minute: minutes, second: seconds }).format(timeFormat);
+}
+
+/**
  * Converts Excel-like dates into strings and formats them based on the handled date format.
  *
  * @param {number} numericDate An integer representing numbers of days from January 1, 1900.


### PR DESCRIPTION
### Context

The PR fixes #9051. The `afterFormulasValuesUpdate` hook fired with raw HyperFormula numerics (Excel-like serials for `date`, day-fractions for `time`) on its `change.newValue` for formula cells whose target meta type is `date` or `time`. The same issue caused `getDataAtCell` and the `time` validator to receive numerics for `type: 'time'` formula cells; `type: 'date'` already had a translation path in `#onModifyData` / `#onBeforeValidate` but `time` did not.

Changes:

- New utility `getTimeFromHfTimeFraction(numericTime, timeFormat)` in `handsontable/src/plugins/formulas/utils.js` — formats the fractional part of an HF day-fraction using moment.
- New inverse mapper `getVisualIndexFromHfIndex(hfIndex)` in `handsontable/src/plugins/formulas/indexSyncer/axisSyncer.js` — needed to resolve the visual coordinate of a change so `getCellMeta` can be consulted.
- Private `#exportChangeValue(change)` in `handsontable/src/plugins/formulas/formulas.js` — clones the HF `ExportedCellChange` and replaces `newValue` with a formatted date/time string when the resolved cell has `type: 'date'` or `type: 'time'`. `#onEngineValuesUpdated` maps changes via this helper before running the hook.
- Added the `time` branch (mirroring the existing `date` branch) in `#onModifyData` and `#onBeforeValidate`.

### How has this been tested?

- Unit tests for `getTimeFromHfTimeFraction` in `handsontable/src/plugins/formulas/__tests__/utils.unit.js` (format from fraction, ignore integer day part).
- New E2E specs in `handsontable/src/plugins/formulas/__tests__/hooks.spec.js`:
  - `afterFormulasValuesUpdate` passes a formatted time string (not a raw HF time fraction) as `newValue` for `type: 'time'`.
  - `afterFormulasValuesUpdate` passes a formatted date string (not a raw HF date number) as `newValue` for `type: 'date'`.
  - `getDataAtCell` returns a formatted time string for a formula cell of `type: 'time'`.
- Verification commands:
  ```bash
  npm run test:unit --prefix handsontable -- --testPathPattern='plugins/formulas/__tests__/utils'
  npm run test:e2e --prefix handsontable -- --testPathPattern='plugins/formulas'
  ```
- Manual A/B comparison vs CDN v17.0.1 confirmed the released build still emits numerics while this branch emits formatted strings for both the hook and `getDataAtCell`.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. #9051
2. DEV-1722

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1722

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `afterFormulasValuesUpdate` payload (and formula-cell reads/validation) to return formatted date/time strings instead of HyperFormula numeric serials, which may affect consumers that relied on the previous numeric `newValue` values.
> 
> **Overview**
> Fixes formula cells typed as `date`/`time` to consistently expose **formatted strings** (per `dateFormat`/`timeFormat`) instead of raw HyperFormula numerics.
> 
> This adds `getTimeFromHfTimeFraction()` and applies it when reading/validating formula cells and when emitting `afterFormulasValuesUpdate` by mapping exported engine changes back to visual coordinates (new `AxisSyncer.getVisualIndexFromHfIndex()`) and rewriting `change.newValue` for `date`/`time` targets. Coverage is expanded with unit tests for time-fraction formatting and e2e tests asserting the hook payload and `getDataAtCell` output for `time`/`date` formula cells, plus a changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e7d6b4176fe8c9929fb645c1120a194f7c7c10e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->