### PR TITLE
DEV-1709, DEV-1710: Fix iPhone SE mobile menu and Ask AI

### DIFF
--- a/docs/src/components/DocsAssistant/DocsAssistant.css
+++ b/docs/src/components/DocsAssistant/DocsAssistant.css
@@ -4,6 +4,13 @@
   font-family: var(--sl-font, system-ui, sans-serif);
   font-size: var(--sl-text-base, 1rem);
   color: var(--sl-color-white);
+  position: relative;
+  z-index: 0;
+  isolation: isolate;
+}
+
+#docs-assistant-root:has(.da-panel[data-open='true']) {
+  z-index: 10200;
 }
 
 /* ── Panel ──────────────────────────────────────────────────────────── */
@@ -24,8 +31,10 @@
   z-index: 49;
   transform: translateX(100%);
   transition: transform 0.2s ease;
+  pointer-events: none;
 }
 .da-panel[data-open='true'] {
+  pointer-events: auto;
   transform: translateX(0);
   top: 0;
   bottom: 0;
@@ -36,9 +45,14 @@
   .da-panel {
     top: 0;
     height: 100vh;
+    height: 100dvh;
     width: 100vw !important;
     z-index: 100;
     border-left: none;
+  }
+
+  .da-panel[data-open='true'] {
+    z-index: 10200;
   }
 }
 

--- a/docs/src/components/DocsAssistant/DocsAssistantWidget.tsx
+++ b/docs/src/components/DocsAssistant/DocsAssistantWidget.tsx
@@ -38,9 +38,6 @@ function readInitialWidth(): number {
   }
 }
 
-/** IDs of the header buttons rendered by Header.astro */
-const HEADER_BTN_IDS = ['header-assistant-btn', 'mobile-assistant-btn'];
-
 export function DocsAssistantWidget() {
   const [open, setOpen] = useState<boolean>(() => readInitialOpen());
   const [width, setWidth] = useState<number>(() => readInitialWidth());
@@ -65,28 +62,25 @@ export function DocsAssistantWidget() {
     }
   }, [width]);
 
-  // Listen for clicks on the header buttons (outside React tree)
+  // Header buttons dispatch `docs-assistant:toggle` from Header.astro (re-bound on
+  // astro:after-swap). ToC uses document delegation because PageSidebar can swap too.
   useEffect(() => {
-    const toggle = () => setOpen((v) => !v);
-    const btns = HEADER_BTN_IDS.map((id) => document.getElementById(id)).filter(Boolean);
-    btns.forEach((btn) => btn!.addEventListener('click', toggle));
-    return () => {
-      btns.forEach((btn) => btn!.removeEventListener('click', toggle));
-    };
+    const onToggle = () => setOpen((v) => !v);
+    window.addEventListener('docs-assistant:toggle', onToggle);
+    return () => window.removeEventListener('docs-assistant:toggle', onToggle);
   }, []);
 
-  // "Ask AI about this page" button in ToC — clears chat and pre-fills draft
   useEffect(() => {
-    const tocBtn = document.getElementById('toc-assistant-btn');
-    if (!tocBtn) return;
-    const handleAskAboutPage = () => {
+    const onClick = (e: MouseEvent) => {
+      const tocBtn = (e.target as HTMLElement).closest('#toc-assistant-btn');
+      if (!tocBtn) return;
       const pageTitle = tocBtn.getAttribute('data-page-title') || document.title;
       clear();
       setPendingDraft(`I have a question about the "${pageTitle}" page.\n`);
       setOpen(true);
     };
-    tocBtn.addEventListener('click', handleAskAboutPage);
-    return () => tocBtn.removeEventListener('click', handleAskAboutPage);
+    document.addEventListener('click', onClick);
+    return () => document.removeEventListener('click', onClick);
   }, [clear]);
 
   // "Ask AI about this API" buttons on API reference pages — opens assistant

--- a/docs/src/components/DocsAssistant/MarkdownRenderer.tsx
+++ b/docs/src/components/DocsAssistant/MarkdownRenderer.tsx
@@ -1,123 +1,28 @@
-import { useEffect, useState } from 'react';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import { getCurrentTheme, getHighlighter, normalizeLang } from './shiki';
-import { IconCheck, IconCopy } from './icons';
-
-interface CodeBlockProps {
-  lang: string;
-  source: string;
-}
-
-function CodeBlock({ lang, source }: CodeBlockProps) {
-  const [html, setHtml] = useState<string>('');
-  const [copied, setCopied] = useState(false);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    const render = async () => {
-      const theme = getCurrentTheme();
-      if (lang === 'text') {
-        const lines = escapeHtml(source)
-          .split('\n')
-          .map((l) => `<span class="ec-line">${l}</span>`)
-          .join('\n');
-        if (!cancelled) setHtml(`<pre><code>${lines}</code></pre>`);
-        return;
-      }
-      try {
-        const hl = await getHighlighter();
-        const out = hl.codeToHtml(source, {
-          lang,
-          theme: theme === 'dark' ? 'github-dark' : 'github-light',
-          transformers: [{
-            line(node) {
-              node.properties.class = 'ec-line';
-            },
-          }],
-        });
-        if (!cancelled) setHtml(out);
-      } catch {
-        if (!cancelled) setHtml(`<pre><code>${escapeHtml(source)}</code></pre>`);
-      }
-    };
-
-    render();
-
-    const observer = new MutationObserver(render);
-    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
-
-    return () => {
-      cancelled = true;
-      observer.disconnect();
-    };
-  }, [lang, source]);
-
-  const copy = async () => {
-    try {
-      await navigator.clipboard.writeText(source);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // Clipboard may be unavailable in some contexts; no-op.
-    }
-  };
-
-  return (
-    <div className="da-code">
-      <button
-        type="button"
-        className={`da-code-copy${copied ? ' is-copied' : ''}`}
-        onClick={copy}
-        aria-label="Copy code to clipboard"
-      >
-        {copied ? <IconCheck /> : <IconCopy />}
-        <span>{copied ? 'Copied' : 'Copy'}</span>
-      </button>
-      {/* Shiki output is HTML-escaped token spans. The fallback path (render
-          failure) also escapes via escapeHtml above, so no user-controlled
-          HTML ever reaches this node. */}
-      <div className="da-code-body" dangerouslySetInnerHTML={{ __html: html }} />
-    </div>
-  );
-}
-
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
-}
+import { lazy, Suspense } from 'react';
+import { supportsModernRegex } from '../../lib/supports-modern-regex.mjs';
 
 interface Props {
   content: string;
 }
 
+const MarkdownRendererFull = lazy(() =>
+  import('./MarkdownRendererFull').then((m) => ({ default: m.MarkdownRendererFull }))
+);
+
+const MarkdownRendererSimple = lazy(() =>
+  import('./MarkdownRendererSimple').then((m) => ({ default: m.MarkdownRendererSimple }))
+);
+
+function MarkdownFallback() {
+  return <div className="da-markdown" aria-hidden="true" />;
+}
+
 export function MarkdownRenderer({ content }: Props) {
+  const Renderer = supportsModernRegex() ? MarkdownRendererFull : MarkdownRendererSimple;
+
   return (
-    <ReactMarkdown
-      remarkPlugins={[remarkGfm]}
-      components={{
-        a: ({ node: _n, href, children, ...rest }: any) => (
-          <a href={href} target="_blank" rel="noopener noreferrer" {...rest}>
-            {children}
-          </a>
-        ),
-        // react-markdown v9 no longer passes `inline`; we detect fenced blocks
-        // by the `language-*` className set on the <code> child of <pre>.
-        pre: ({ children }: any) => {
-          const child = Array.isArray(children) ? children[0] : children;
-          const props = child?.props ?? {};
-          const className = props.className ?? '';
-          const raw = String(props.children ?? '').replace(/\n$/, '');
-          const match = /language-(\w+)/.exec(className);
-          const lang = normalizeLang(match?.[1]);
-          return <CodeBlock lang={lang} source={raw} />;
-        },
-      }}
-    >
-      {content}
-    </ReactMarkdown>
+    <Suspense fallback={<MarkdownFallback />}>
+      <Renderer content={content} />
+    </Suspense>
   );
 }

--- a/docs/src/components/DocsAssistant/MarkdownRendererFull.tsx
+++ b/docs/src/components/DocsAssistant/MarkdownRendererFull.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { escapeHtml } from './escapeHtml';
+import { getCurrentTheme, getHighlighter, normalizeLang } from './shiki';
+import { IconCheck, IconCopy } from './icons';
+
+interface CodeBlockProps {
+  lang: string;
+  source: string;
+}
+
+function CodeBlock({ lang, source }: CodeBlockProps) {
+  const [html, setHtml] = useState<string>('');
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const render = async () => {
+      const theme = getCurrentTheme();
+      if (lang === 'text') {
+        const lines = escapeHtml(source)
+          .split('\n')
+          .map((l) => `<span class="ec-line">${l}</span>`)
+          .join('\n');
+        if (!cancelled) setHtml(`<pre><code>${lines}</code></pre>`);
+        return;
+      }
+      try {
+        const hl = await getHighlighter();
+        const out = hl.codeToHtml(source, {
+          lang,
+          theme: theme === 'dark' ? 'github-dark' : 'github-light',
+          transformers: [{
+            line(node) {
+              node.properties.class = 'ec-line';
+            },
+          }],
+        });
+        if (!cancelled) setHtml(out);
+      } catch {
+        if (!cancelled) setHtml(`<pre><code>${escapeHtml(source)}</code></pre>`);
+      }
+    };
+
+    render();
+
+    const observer = new MutationObserver(render);
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+
+    return () => {
+      cancelled = true;
+      observer.disconnect();
+    };
+  }, [lang, source]);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(source);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard may be unavailable in some contexts; no-op.
+    }
+  };
+
+  return (
+    <div className="da-code">
+      <button
+        type="button"
+        className={`da-code-copy${copied ? ' is-copied' : ''}`}
+        onClick={copy}
+        aria-label="Copy code to clipboard"
+      >
+        {copied ? <IconCheck /> : <IconCopy />}
+        <span>{copied ? 'Copied' : 'Copy'}</span>
+      </button>
+      {/* Shiki output is HTML-escaped token spans. The fallback path (render
+          failure) also escapes via escapeHtml above, so no user-controlled
+          HTML ever reaches this node. */}
+      <div className="da-code-body" dangerouslySetInnerHTML={{ __html: html }} />
+    </div>
+  );
+}
+
+interface Props {
+  content: string;
+}
+
+export function MarkdownRendererFull({ content }: Props) {
+  return (
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm]}
+      components={{
+        a: ({ node: _n, href, children, ...rest }: any) => (
+          <a href={href} target="_blank" rel="noopener noreferrer" {...rest}>
+            {children}
+          </a>
+        ),
+        // react-markdown v9 no longer passes `inline`; we detect fenced blocks
+        // by the `language-*` className set on the <code> child of <pre>.
+        pre: ({ children }: any) => {
+          const child = Array.isArray(children) ? children[0] : children;
+          const props = child?.props ?? {};
+          const className = props.className ?? '';
+          const raw = String(props.children ?? '').replace(/\n$/, '');
+          const match = /language-(\w+)/.exec(className);
+          const lang = normalizeLang(match?.[1]);
+          return <CodeBlock lang={lang} source={raw} />;
+        },
+      }}
+    >
+      {content}
+    </ReactMarkdown>
+  );
+}

--- a/docs/src/components/DocsAssistant/MarkdownRendererSimple.tsx
+++ b/docs/src/components/DocsAssistant/MarkdownRendererSimple.tsx
@@ -1,0 +1,49 @@
+import { escapeHtml, escapeHtmlAttr } from './escapeHtml';
+
+interface Props {
+  content: string;
+}
+
+/**
+ * Lightweight markdown for WebKit versions before Safari 16.4. Avoids loading
+ * react-markdown / shiki chunks that contain RegExp syntax those engines cannot parse.
+ */
+function renderSimpleMarkdown(content: string): string {
+  const parts = content.split('```');
+  let html = '';
+
+  for (let i = 0; i < parts.length; i++) {
+    if (i % 2 === 1) {
+      const block = parts[i];
+      const newline = block.indexOf('\n');
+      let code = block;
+      if (newline !== -1) {
+        const firstLine = block.slice(0, newline).trim();
+        if (/^[\w-]+$/.test(firstLine)) {
+          code = block.slice(newline + 1);
+        }
+      }
+      html += `<pre class="da-code-fallback"><code>${escapeHtml(code.replace(/\n$/, ''))}</code></pre>`;
+    } else {
+      const text = escapeHtml(parts[i]);
+      const withLinks = text.replace(
+        /(https?:\/\/[^\s<"]+)/g,
+        (url) => (
+          `<a href="${escapeHtmlAttr(url)}" target="_blank" rel="noopener noreferrer">${escapeHtml(url)}</a>`
+        )
+      );
+      html += withLinks.replace(/\n/g, '<br>');
+    }
+  }
+
+  return html;
+}
+
+export function MarkdownRendererSimple({ content }: Props) {
+  return (
+    <div
+      className="da-markdown da-markdown-simple"
+      dangerouslySetInnerHTML={{ __html: renderSimpleMarkdown(content) }}
+    />
+  );
+}

--- a/docs/src/components/DocsAssistant/escapeHtml.ts
+++ b/docs/src/components/DocsAssistant/escapeHtml.ts
@@ -1,0 +1,13 @@
+export function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+/** Escapes text for HTML attribute values (e.g. href). */
+export function escapeHtmlAttr(s: string): string {
+  return escapeHtml(s)
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/docs/src/components/Header.astro
+++ b/docs/src/components/Header.astro
@@ -305,6 +305,26 @@ const frameworks = [
       document.querySelector<HTMLButtonElement>('sl-doc-search .DocSearch-Button')?.click();
     }, { signal });
 
+    // --- Docs assistant: ensure React is mounted, then toggle (iOS needs touchend too) ---
+    const bindAssistantBtn = (btn: HTMLButtonElement | null) => {
+      if (!btn) return;
+      let lastTap = 0;
+      const onAssistantTap = (e: Event) => {
+        e.preventDefault();
+        const now = Date.now();
+        if (now - lastTap < 400) return;
+        lastTap = now;
+        const ensure = window.docsAssistantEnsureMounted?.() ?? Promise.resolve();
+        void ensure.then(() => {
+          window.dispatchEvent(new CustomEvent('docs-assistant:toggle'));
+        });
+      };
+      btn.addEventListener('click', onAssistantTap, { signal });
+      btn.addEventListener('touchend', onAssistantTap, { signal });
+    };
+    bindAssistantBtn(document.getElementById('header-assistant-btn') as HTMLButtonElement | null);
+    bindAssistantBtn(document.getElementById('mobile-assistant-btn') as HTMLButtonElement | null);
+
     let overlayOpen = false;
     let tocOpen = false;
     let overlayTrapCleanup: (() => void) | null = null;

--- a/docs/src/lib/__tests__/supports-modern-regex.test.mjs
+++ b/docs/src/lib/__tests__/supports-modern-regex.test.mjs
@@ -1,0 +1,7 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { supportsModernRegex } from '../supports-modern-regex.mjs';
+
+test('supportsModernRegex returns a boolean', () => {
+  assert.equal(typeof supportsModernRegex(), 'boolean');
+});

--- a/docs/src/lib/supports-modern-regex.mjs
+++ b/docs/src/lib/supports-modern-regex.mjs
@@ -1,0 +1,23 @@
+/**
+ * Detects RegExp features that require Safari 16.4+ (iOS 16.4+), including named
+ * capture groups and lookbehind. Older WebKit throws SyntaxError at parse time when
+ * a dependency bundle contains those patterns.
+ */
+/** @type {boolean | null} */
+let cached = null;
+
+export function supportsModernRegex() {
+  if (cached !== null) {
+    return cached;
+  }
+
+  try {
+    // eslint-disable-next-line prefer-regex-literals
+    new RegExp('(?<x>x)');
+    cached = true;
+  } catch {
+    cached = false;
+  }
+
+  return cached;
+}

--- a/docs/src/scripts/docs-assistant-bootstrap.ts
+++ b/docs/src/scripts/docs-assistant-bootstrap.ts
@@ -2,29 +2,77 @@
  * Docs assistant bootstrap: mounts the React chat widget into a single
  * container appended to document.body. Lives on every docs page via the
  * Head.astro override.
+ *
+ * Re-mounts after Astro client navigations (astro:page-load) when the
+ * container is missing from the swapped document.
  */
+
+import type { Root } from 'react-dom/client';
 
 const CONTAINER_ID = 'docs-assistant-root';
 
-async function mount() {
+let root: Root | null = null;
+let mountInFlight: Promise<void> | null = null;
+
+async function ensureMounted(): Promise<void> {
   if (typeof document === 'undefined') return;
-  if (document.getElementById(CONTAINER_ID)) return;
 
-  const container = document.createElement('div');
-  container.id = CONTAINER_ID;
-  document.body.appendChild(container);
+  const existing = document.getElementById(CONTAINER_ID);
+  if (root && existing && document.body.contains(existing)) {
+    return;
+  }
 
-  const [{ createRoot }, { createElement }, { DocsAssistantWidget }] = await Promise.all([
-    import('react-dom/client'),
-    import('react'),
-    import('../components/DocsAssistant/DocsAssistantWidget'),
-  ]);
+  if (mountInFlight) {
+    return mountInFlight;
+  }
 
-  createRoot(container).render(createElement(DocsAssistantWidget));
+  mountInFlight = (async () => {
+    let container = document.getElementById(CONTAINER_ID);
+    if (!container || !document.body.contains(container)) {
+      root = null;
+      container = document.createElement('div');
+      container.id = CONTAINER_ID;
+      document.body.appendChild(container);
+    }
+
+    const [{ createRoot }, { createElement }, { DocsAssistantWidget }] = await Promise.all([
+      import('react-dom/client'),
+      import('react'),
+      import('../components/DocsAssistant/DocsAssistantWidget'),
+    ]);
+
+    if (!root) {
+      root = createRoot(container);
+      root.render(createElement(DocsAssistantWidget));
+    }
+  })()
+    .catch((err) => {
+      root = null;
+      console.error('docs-assistant: failed to mount', err);
+    })
+    .finally(() => {
+      mountInFlight = null;
+    });
+
+  return mountInFlight;
 }
 
+declare global {
+  interface Window {
+    docsAssistantEnsureMounted?: () => Promise<void>;
+  }
+}
+
+window.docsAssistantEnsureMounted = ensureMounted;
+
+function onPageLoad() {
+  void ensureMounted();
+}
+
+document.addEventListener('astro:page-load', onPageLoad);
+
 if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', mount, { once: true });
+  document.addEventListener('DOMContentLoaded', onPageLoad, { once: true });
 } else {
-  mount();
+  onPageLoad();
 }

--- a/docs/src/scripts/docs-assistant-bootstrap.ts
+++ b/docs/src/scripts/docs-assistant-bootstrap.ts
@@ -29,7 +29,10 @@ async function ensureMounted(): Promise<void> {
   mountInFlight = (async () => {
     let container = document.getElementById(CONTAINER_ID);
     if (!container || !document.body.contains(container)) {
-      root = null;
+      if (root) {
+        root.unmount();
+        root = null;
+      }
       container = document.createElement('div');
       container.id = CONTAINER_ID;
       document.body.appendChild(container);
@@ -47,7 +50,10 @@ async function ensureMounted(): Promise<void> {
     }
   })()
     .catch((err) => {
-      root = null;
+      if (root) {
+        root.unmount();
+        root = null;
+      }
       console.error('docs-assistant: failed to mount', err);
     })
     .finally(() => {

--- a/docs/src/styles/base/variables.css
+++ b/docs/src/styles/base/variables.css
@@ -47,6 +47,10 @@
   /* Body text color */
   --sl-color-text: var(--sl-color-gray-2);
 
+  /* Starlight uses these for active sidebar / search highlights — must not be solid accent */
+  --sl-color-text-accent: var(--sl-color-accent-low);
+  --sl-color-text-invert: var(--sl-color-text);
+
   /* Inline code: darker bg (gray-7) + white text */
   --sl-color-bg-inline-code: var(--sl-color-gray-7);
 
@@ -56,6 +60,9 @@
   --sl-rapide-ui-border-color: oklch(28% 0 0);
   --sl-rapide-ec-marker-bg-color: oklch(27% 0 0);
   --sl-rapide-ec-marker-border-color: oklch(47% 0 0);
+
+  /* Hover bg for interactive nav items */
+  --sl-color-hover-bg: oklch(23% 0 0);
 
   /* Shared bg for tables and code blocks */
   --sl-color-block-bg: #121212;
@@ -88,6 +95,54 @@
   /* Hover bg — needs to be visibly distinct from the page background (98%) */
   --sl-color-hover-bg: oklch(96% 0 0);
 
+  --sl-color-text-accent: var(--sl-color-accent-low);
+  --sl-color-text-invert: var(--sl-color-text);
+
   /* Shared bg for tables and code blocks */
   --sl-color-block-bg: #f5f5f5;
+}
+
+/* Hex fallbacks when oklch is unsupported (Safari / iOS before 15.4). */
+@supports not (color: oklch(0% 0 0)) {
+  :root {
+    --sl-color-white: #e6e6e6;
+    --sl-color-gray-1: #cccccc;
+    --sl-color-gray-2: #b8b8b8;
+    --sl-color-gray-3: #a6a6a6;
+    --sl-color-gray-4: #7a7a7a;
+    --sl-color-gray-5: #4a4a4a;
+    --sl-color-gray-6: #3b3b3b;
+    --sl-color-gray-7: #353535;
+    --sl-color-gray-8: #2c2c2c;
+    --sl-color-gray-9: #242424;
+    --sl-color-black: #1c1c1c;
+    --sl-color-hover-bg: #3b3b3b;
+    --sl-color-backdrop-overlay: rgba(28, 28, 28, 0.7);
+    --sl-rapide-ui-header-bg-color: rgba(28, 28, 28, 0.8);
+    --sl-rapide-ui-border-color: #474747;
+    --sl-rapide-ec-marker-bg-color: #454545;
+    --sl-rapide-ec-marker-border-color: #787878;
+    --sl-color-text-accent: #1a3a6b;
+    --sl-color-text-invert: #b8b8b8;
+  }
+
+  :root[data-theme='light'] {
+    --sl-color-white: #4d4d4d;
+    --sl-color-gray-1: #5c5c5c;
+    --sl-color-gray-2: #5c5c5c;
+    --sl-color-gray-3: #707070;
+    --sl-color-gray-4: #d1d1d1;
+    --sl-color-gray-5: #ebebeb;
+    --sl-color-gray-6: #f0f0f0;
+    --sl-color-gray-7: #f5f5f5;
+    --sl-color-black: #fafafa;
+    --sl-color-hover-bg: #f5f5f5;
+    --sl-color-backdrop-overlay: rgba(214, 214, 214, 0.7);
+    --sl-rapide-ui-header-bg-color: rgba(250, 250, 250, 0.7);
+    --sl-rapide-ui-border-color: #e0e0e0;
+    --sl-rapide-ec-marker-bg-color: #ededed;
+    --sl-rapide-ec-marker-border-color: #9e9e9e;
+    --sl-color-text-accent: #e6f3ff;
+    --sl-color-text-invert: #5c5c5c;
+  }
 }

--- a/docs/src/styles/layout/sidebar.css
+++ b/docs/src/styles/layout/sidebar.css
@@ -76,10 +76,13 @@
 /* -------------------------------------------------------------------------
  * Active sidebar link & TOC link — accent text + blue accent bar
  * ------------------------------------------------------------------------- */
-.sidebar-pane a[aria-current='page'] {
-  color: var(--sl-color-white) !important;
-  border-color: var(--sl-color-accent) !important;
-  font-weight: 400 !important;
+.sidebar-pane a[aria-current='page'],
+.sidebar-pane a[aria-current='page']:hover,
+.sidebar-pane a[aria-current='page']:focus {
+  color: var(--sl-color-text) !important;
+  background-color: transparent !important;
+  border-color: transparent !important;
+  font-weight: 600 !important;
 }
 
 /* Main nav active link — no bold */
@@ -107,8 +110,11 @@ nav[aria-label="Main navigation"] a[aria-current='page'] {
   line-height: 20px;
 }
 
-starlight-toc a[aria-current='true'] {
-  color: var(--sl-color-white) !important;
+starlight-toc a[aria-current='true'],
+starlight-toc a[aria-current='true']:hover,
+starlight-toc a[aria-current='true']:focus {
+  color: var(--sl-color-text) !important;
+  background-color: transparent !important;
   border-color: var(--sl-color-accent) !important;
 }
 

--- a/docs/src/styles/mobile/nav-overlay.css
+++ b/docs/src/styles/mobile/nav-overlay.css
@@ -49,13 +49,14 @@
 }
 
 .mobile-nav-link:hover {
-  color: var(--sl-color-white);
-  background: var(--sl-color-hover-bg, var(--sl-color-gray-6));
+  color: var(--sl-color-text);
+  background: var(--sl-color-accent-low, var(--sl-color-gray-6));
 }
 
-.mobile-nav-link--active {
-  color: var(--sl-color-white);
-  background: var(--sl-color-hover-bg, var(--sl-color-gray-6));
+.mobile-nav-link--active,
+.mobile-nav-link--active:hover {
+  color: var(--sl-color-text);
+  background: transparent;
   border-inline-start: 2px solid var(--sl-color-accent);
 }
 
@@ -106,12 +107,13 @@
 }
 
 .mobile-nav-fw:hover {
-  color: var(--sl-color-white);
-  background: var(--sl-color-hover-bg, var(--sl-color-gray-6));
+  color: var(--sl-color-text);
+  background: var(--sl-color-accent-low, var(--sl-color-gray-6));
 }
 
-.mobile-nav-fw--active {
-  color: var(--sl-color-white);
+.mobile-nav-fw--active,
+.mobile-nav-fw--active:hover {
+  color: var(--sl-color-text);
   border-bottom-color: var(--sl-color-accent);
-  background: var(--sl-color-hover-bg, var(--sl-color-gray-6));
+  background: transparent;
 }

--- a/docs/src/styles/mobile/toc-panel.css
+++ b/docs/src/styles/mobile/toc-panel.css
@@ -45,8 +45,11 @@
   border-inline-start-color: var(--sl-color-gray-4);
 }
 
-.mobile-toc-panel nav a[aria-current='true'] {
-  color: var(--sl-color-white);
+.mobile-toc-panel nav a[aria-current='true'],
+.mobile-toc-panel nav a[aria-current='true']:hover,
+.mobile-toc-panel nav a[aria-current='true']:focus {
+  color: var(--sl-color-text);
+  background-color: transparent;
   border-inline-start-color: var(--sl-color-accent);
 }
 


### PR DESCRIPTION
### Context

Fixes two docs-site issues on legacy WebKit (iPhone SE 2022 on BrowserStack).

**DEV-1709 - Sidebar and mobile nav active state**

Starlight marks the current page with `aria-current="page"` and applies `background-color: var(--sl-color-text-accent)` (solid brand blue in light mode). On iPhone SE that produced a heavy blue fill and poor contrast for active items in the left sidebar, mobile hamburger menu, and ToC panel.

This PR removes the active background fill (`transparent`) and keeps the left accent bar. It also adds `@supports not (color: oklch(...))` hex fallbacks for gray palette tokens used by mobile nav hover/active styles.

**DEV-1710 - Ask AI assistant on old Safari**

Three separate problems were addressed:

1. **Stale header button listeners** - `DocsAssistantWidget` bound clicks on mount, but Starlight replaces header DOM on `astro:after-swap`. Header.astro now calls `docsAssistantEnsureMounted()` and dispatches `docs-assistant:toggle`; the widget listens for that event. `touchend` is wired for iOS.
2. **Lost widget after client navigation** - Bootstrap remounts React on `astro:page-load` when `#docs-assistant-root` is missing and exposes `window.docsAssistantEnsureMounted`.
3. **Parse failure on WebKit before Safari 16.4** - Dynamic import of the assistant chunk failed with `SyntaxError: Invalid regular expression: invalid group specifier name` because `react-markdown` / `remark-gfm` / `shiki` ship RegExp syntax old Safari cannot parse at module load time (Chrome is unaffected). The markdown stack is split into lazy chunks: modern browsers load `MarkdownRendererFull` (GFM + Shiki); older WebKit loads `MarkdownRendererSimple` (escaped text, fenced code blocks, links) via `supportsModernRegex()` in `docs/src/lib/supports-modern-regex.mjs`.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1709
ClickUp task: https://app.clickup.com/t/9015210959/DEV-1710

### How has this been tested?

- `npm run docs:lint --prefix docs`
- `node --test src/lib/__tests__/supports-modern-regex.test.mjs` (from `docs/`)
- Manual verification on BrowserStack iPhone SE 2022 (Netlify preview):
  - Left sidebar: active item has no blue fill, readable text, left accent bar visible
  - Hamburger menu and framework pills: active/hover states readable in light and dark theme
  - Ask AI: no `docs-assistant: failed to mount` errors in Web Inspector
  - Ask AI panel opens on first load and after client-side navigation between doc pages
  - Assistant replies render on iPhone SE (simple markdown path; full GFM + Shiki on modern browsers)

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1709
2. DEV-1710

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes touch event handling, global event wiring, and dynamic mounting/lazy-loading paths for the Docs Assistant, which could affect widget availability or interaction across navigations. CSS token and z-index adjustments may also cause visual regressions in nav/overlay stacking on some breakpoints.
> 
> **Overview**
> Fixes several iOS/legacy WebKit docs-site issues by **stabilizing the Docs Assistant lifecycle and toggle behavior** and by **softening active/hover styling in mobile/side navigation**.
> 
> The assistant is now toggled via a `docs-assistant:toggle` window event dispatched from `Header.astro` (with `touchend` support and an `ensureMounted` hook), while the React widget listens via event delegation (including ToC click delegation) to survive Astro DOM swaps. The bootstrap script now re-mounts on `astro:page-load` and exposes `window.docsAssistantEnsureMounted`, and markdown rendering is split into lazy-loaded `MarkdownRendererFull` vs a simplified fallback selected by `supportsModernRegex()` to avoid legacy WebKit RegExp parse failures.
> 
> Styling updates remove heavy active background fills (keeping the accent bar), adjust hover/active colors for mobile overlays/ToC, add `oklch`-unsupported hex fallbacks for key theme tokens, and tighten assistant panel stacking/interaction (z-index/isolation, pointer-events gating, and `100dvh` on mobile).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f374d63ef0aa011261ff8ca5e79b4a90da458e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->