### PR TITLE
DEV-1723: Fix Filter by value lost when editing earlier filtered column

### DIFF
--- a/.changelogs/12620.json
+++ b/.changelogs/12620.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed `Filter by value` selection being lost in dependent column when editing an earlier filtered column",
+  "type": "fixed",
+  "issueOrPR": 12620,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/filters/__tests__/filters.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/filters.spec.js
@@ -922,4 +922,39 @@ describe('Filters', () => {
       expect(hotInstance.getDataAtCol).toHaveBeenCalledWith(visualColumn);
     });
   });
+
+  describe('Editing a cell in an earlier filtered column (issue #8874)', () => {
+    it('should keep dependent column by_value selection in cached state after editing earlier filtered column',
+      async() => {
+        handsontable({
+          data: [
+            { id: 1, country: 'Germany', company: 'BMW' },
+            { id: 2, country: 'Germany', company: 'Mercedes' },
+            { id: 3, country: 'Italy', company: 'Fiat' },
+            { id: 4, country: 'France', company: 'Renault' },
+          ],
+          columns: [
+            { data: 'id', type: 'numeric' },
+            { data: 'country' },
+            { data: 'company' },
+          ],
+          colHeaders: ['ID', 'Country', 'Company'],
+          dropdownMenu: true,
+          filters: true,
+        });
+
+        const filters = getPlugin('filters');
+
+        filters.addCondition(1, 'by_value', [['Germany', 'France']]);
+        filters.filter();
+        filters.addCondition(2, 'by_value', [['Mercedes', 'Renault']]);
+        filters.filter();
+
+        await setDataAtCell(0, 1, 'France');
+
+        const valueComponentState = filters.components.get('filter_by_value').state.getValueAtIndex(2);
+
+        expect(valueComponentState.args[0]).toEqual(['Mercedes', 'Renault']);
+      });
+  });
 });

--- a/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
@@ -2150,4 +2150,90 @@ describe('Filters UI', () => {
       expect(items[2].value).toBe('15/12/2023');
     });
   });
+
+  describe('Editing a cell in an earlier filtered column (issue #8874)', () => {
+    it('should preserve dependent column "Filter by value" checkboxes when editing earlier filtered column',
+      async() => {
+        handsontable({
+          data: [
+            { id: 1, country: 'Germany', company: 'BMW' },
+            { id: 2, country: 'Germany', company: 'Mercedes' },
+            { id: 3, country: 'Italy', company: 'Fiat' },
+            { id: 4, country: 'France', company: 'Renault' },
+          ],
+          columns: [
+            { data: 'id', type: 'numeric' },
+            { data: 'country' },
+            { data: 'company' },
+          ],
+          colHeaders: true,
+          dropdownMenu: true,
+          filters: true,
+          width: 500,
+          height: 300,
+        });
+
+        const filters = getPlugin('filters');
+
+        filters.addCondition(1, 'by_value', [['Germany', 'France']]);
+        filters.filter();
+        filters.addCondition(2, 'by_value', [['Mercedes', 'Renault']]);
+        filters.filter();
+
+        await setDataAtCell(0, 1, 'France');
+
+        await dropdownMenu(2);
+        await sleep(112);
+
+        const items = byValueMultipleSelect().getItems();
+        const checkedValues = items.filter(item => item.checked).map(item => item.value);
+
+        expect(checkedValues).toEqual(['Mercedes', 'Renault']);
+      });
+
+    it('should preserve dependent column checkboxes when edit reintroduces a filtered-out value (issue repro)',
+      async() => {
+        handsontable({
+          data: [
+            { id: 1, country: 'Germany', company: 'BMW' },
+            { id: 2, country: 'Germany', company: 'Mercedes' },
+            { id: 3, country: 'Germany', company: 'Fiat' },
+            { id: 4, country: 'France', company: 'Renault' },
+            { id: 5, country: 'Italy', company: 'Ferrari' },
+            { id: 6, country: 'France', company: 'Peugeot' },
+            { id: 7, country: 'Italy', company: 'Lamborghini' },
+            { id: 8, country: 'Germany', company: 'Audi' },
+          ],
+          columns: [
+            { data: 'id', type: 'numeric' },
+            { data: 'country' },
+            { data: 'company' },
+          ],
+          colHeaders: true,
+          dropdownMenu: true,
+          filters: true,
+          width: 500,
+          height: 360,
+        });
+
+        const filters = getPlugin('filters');
+
+        filters.addCondition(1, 'by_value', [['Germany', 'France']]);
+        filters.filter();
+        filters.addCondition(2, 'by_value',
+          [['Mercedes', 'Fiat', 'Renault', 'Ferrari', 'Peugeot', 'Lamborghini', 'Audi']]);
+        filters.filter();
+
+        await setDataAtCell(2, 1, 'Italy');
+
+        await dropdownMenu(2);
+        await sleep(112);
+
+        const items = byValueMultipleSelect().getItems();
+        const checkedValues = items.filter(item => item.checked).map(item => item.value);
+
+        expect(checkedValues).toEqual(
+          jasmine.arrayWithExactContents(['Mercedes', 'Fiat', 'Renault', 'Ferrari', 'Peugeot', 'Lamborghini', 'Audi']));
+      });
+  });
 });

--- a/handsontable/src/plugins/filters/component/value.js
+++ b/handsontable/src/plugins/filters/component/value.js
@@ -186,11 +186,13 @@ export class ValueComponent extends BaseComponent {
     // Update the next "by_value" component (filter column conditions added after this condition).
     // Its list of values has to be updated. As the new values by default are unchecked,
     // the further component update is unnecessary.
+    // `conditionArgsChange` is scoped to the edited column and must not be reapplied here -
+    // doing so overwrites the dependent column's by_value args with the edited column's value set (issue #8874).
     if (stateInfo.dependentConditionStacks.length) {
       updateColumnState(
         stateInfo.dependentConditionStacks[0].column,
         stateInfo.dependentConditionStacks[0].conditions,
-        stateInfo.conditionArgsChange,
+        undefined,
         stateInfo.filteredRowsFactory,
         stateInfo.editedConditionStack
       );


### PR DESCRIPTION
### Context

The PR fixes #8874. Editing a cell in column X (already filtered with "Filter by value") wiped the "Filter by value" selection of any later-filtered column Y. Reopening Y's dropdown menu showed every checkbox unchecked, silently losing the user's previous selection.

Root cause is in `handsontable/src/plugins/filters/component/value.js`. The `update` hook payload includes `conditionArgsChange` — the value set for the edited column — and `updateState` previously passed it to `updateColumnState` for both the edited column AND its dependent columns. The dependent invocation overwrote `firstByValueCondition.args[0]` with values from the edited column, so the subsequent `intersectValues` produced zero matches and every checkbox rendered unchecked.

`conditionArgsChange` is column-scoped. The fix passes `undefined` for it on the dependent-column invocation, preserving the dependent column's by_value args.

### How has this been tested?

Red → green TDD. Added two regression tests, confirmed they fail on `develop` and pass after the fix.

- `handsontable/src/plugins/filters/__tests__/filters.spec.js` — asserts the cached `ValueComponent` state for column 2 keeps `['Mercedes', 'Renault']` after editing column 1.
- `handsontable/src/plugins/filters/__tests__/filtersUI.spec.js` — two specs:
  - basic edit (Country → France) — Company dropdown keeps `['Mercedes', 'Renault']` checked.
  - faithful repro from the issue (Fiat's Country → Italy) — Company dropdown keeps all non-BMW values checked.

```bash
npm run test:e2e --prefix handsontable -- --testPathPattern="filters"
npm run test:unit --prefix handsontable -- --testPathPattern=filters
```

Filters E2E: 258 specs, 0 failures. Filters unit: 235 tests, 0 failures. Manually verified in the browser using the dev demo pages (released v17.0.1 reproduces; local build is clean).

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. #8874
2. DEV-1723

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1723

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Filters plugin state propagation; a small argument-handling change could affect how dependent `by_value` filters refresh after edits, but is narrowly scoped and covered by new regression tests.
> 
> **Overview**
> Fixes issue #8874 where editing data in an earlier filtered column incorrectly reset the *dependent* column’s `Filter by value` selection by no longer propagating `conditionArgsChange` into the dependent column state update.
> 
> Adds regression coverage in both unit and UI specs to ensure dependent `by_value` cached state and dropdown checkbox selections remain intact after edits (including a scenario that reintroduces previously filtered-out values), and includes a changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac12b4550a96ed845cb0b14aa0c9ced3e7a92140. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->