### PR TITLE
DEV-1724: Fix merged cells column widths after loadData (#8864)

### DIFF
--- a/.changelogs/12622.json
+++ b/.changelogs/12622.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed column widths widening for merged cells after `loadData` when `autoColumnSize` is enabled.",
+  "type": "fixed",
+  "issueOrPR": 12622,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/autoColumnSize/autoColumnSize.js
+++ b/handsontable/src/plugins/autoColumnSize/autoColumnSize.js
@@ -213,6 +213,11 @@ export class AutoColumnSize extends BasePlugin {
     const cellMeta = this.hot.getCellMeta(row, column);
     let cellValue = '';
 
+    if (cellMeta.hidden) {
+      // do not generate samples for cells that are covered by merged cell (null values)
+      return false;
+    }
+
     if (!cellMeta.spanned) {
       cellValue = this.hot.getDataAtCell(row, column);
 

--- a/handsontable/src/plugins/mergeCells/__tests__/mergeCells.spec.js
+++ b/handsontable/src/plugins/mergeCells/__tests__/mergeCells.spec.js
@@ -454,6 +454,50 @@ describe('MergeCells', () => {
     });
   });
 
+  describe('loadData', () => {
+    it('should preserve column widths after loadData when autoColumnSize and mergeCells are enabled (#8864)', async() => {
+      const data = [
+        ['', 'Group 2', 'Group 2', 'Group 2'],
+        ['', 'Col1', 'Group 1', 'Group 1'],
+        ['', 'Col1', 'Col2', 'Col3'],
+        ['Row1', '', '', ''],
+      ];
+
+      handsontable({
+        data: data.map(row => row.slice()),
+        mergeCells: [
+          { row: 0, col: 1, rowspan: 1, colspan: 3 },
+          { row: 1, col: 1, rowspan: 2, colspan: 1 },
+          { row: 1, col: 2, rowspan: 1, colspan: 2 },
+        ],
+        autoColumnSize: true,
+      });
+
+      const widthsBefore = [0, 1, 2, 3].map(col => getColWidth(col));
+
+      await loadData(data.map(row => row.slice()));
+
+      const widthsAfter = [0, 1, 2, 3].map(col => getColWidth(col));
+
+      expect(widthsAfter).toEqual(widthsBefore);
+    });
+
+    it('should restore `spanned` and `hidden` cell metas after loadData', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        mergeCells: [
+          { row: 0, col: 1, rowspan: 1, colspan: 3 },
+        ],
+      });
+
+      await loadData(createSpreadsheetData(5, 5));
+
+      expect(getCellMeta(0, 1).spanned).toBe(true);
+      expect(getCellMeta(0, 2).hidden).toBe(true);
+      expect(getCellMeta(0, 3).hidden).toBe(true);
+    });
+  });
+
   describe('mergeCells copy', () => {
     it('should not copy text of cells that are merged into another cell', async() => {
       handsontable({

--- a/handsontable/src/plugins/mergeCells/mergeCells.js
+++ b/handsontable/src/plugins/mergeCells/mergeCells.js
@@ -1106,10 +1106,12 @@ export class MergeCells extends BasePlugin {
     if (mergeParent) {
       if (mergeParent.row !== row || mergeParent.col !== col) {
         cellProperties.copyable = false;
+        cellProperties.hidden = true;
 
       } else {
         cellProperties.rowspan = mergeParent.rowspan;
         cellProperties.colspan = mergeParent.colspan;
+        cellProperties.spanned = true;
       }
     }
   }


### PR DESCRIPTION
### Context

The PR fixes a regression where columns containing merged cells incorrectly widen after `loadData()` is called when `autoColumnSize` is enabled.

Root cause: two issues compound.
1. `mergeCells` sets `spanned`/`hidden` cell metas statically inside `mergeRange()` via `setCellMeta()`. `core.loadData()` calls `metaManager.clearCellsCache()`, wiping those metas. After the wipe, the next `getCellMeta()` rebuilds defaults without restoring `spanned`/`hidden`, so `autoColumnSize` samples the merge anchor's full value (e.g. `"Group 2"`) and widens the column.
2. `autoColumnSize`'s sampler skips merge anchors via `cellMeta.spanned` but does not skip merge-interior cells via `cellMeta.hidden`, unlike `autoRowSize` which already does.

Fix:
- `mergeCells.#onAfterGetCellMeta`: derive `spanned` (anchor) and `hidden` (interior) from `mergedCellsCollection` on every meta read. Single source of truth; no hook-ordering dependency since `autoColumnSize` (priority 10) runs before `mergeCells` (priority 150).
- `autoColumnSize` sampler: skip cells where `cellMeta.hidden`, matching `autoRowSize`.

### How has this been tested?

New E2E specs in `mergeCells.spec.js` under `describe('loadData')`:
- preserves column widths after `loadData` with `autoColumnSize` + `mergeCells` (#8864)
- restores `spanned` and `hidden` cell metas after `loadData`

Red-green TDD: confirmed both tests fail on develop, pass after fix.

Regression suites (all pass):

```bash
npm run test:unit --prefix handsontable
npm run test:e2e --prefix handsontable --testPathPattern="mergeCells |autoColumnSize|autoRowSize|ghostTable|nestedHeaders|hiddenRows|hiddenColumns|validators|hooks|setDataAtCell|getCellMeta|loadData|updateSettings|copyPaste|columnSorting|filters|undoRedo"
```

Manual demo pages (jsfiddle from issue, 6 rows + 3 merges):
- Released v17.1.0 (CDN): cols 2-3 widen on Reload data — BUG
- PR build (local): widths stable — FIX

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. Fixes #8864
2. DEV-1724

### Affected project(s):

- [x] \`handsontable\`
- [ ] \`@handsontable/angular-wrapper\`
- [ ] \`@handsontable/react-wrapper\`
- [ ] \`@handsontable/vue3\`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1724

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `mergeCells` cell meta derivation and `autoColumnSize` sampling behavior, which can affect sizing/rendering for merged-cell tables beyond the reported regression. Changes are localized and covered by new tests, but interact with hook-driven meta resolution.
> 
> **Overview**
> Fixes a regression where columns with merged cells could **unexpectedly widen after `loadData()`** when `autoColumnSize` is enabled.
> 
> `mergeCells` now derives `spanned` (merge anchor) and `hidden` (merge interior) flags via `afterGetCellMeta`, and `autoColumnSize` skips generating width samples for `hidden` (merge-covered) cells. Adds E2E coverage ensuring column widths remain stable across `loadData` and that `spanned`/`hidden` metas are restored after data reload.
> 
> Also adds a changelog entry for the public fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ceb7acc64203b7d6c9a304fa834ddc992d281530. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->