### PR TITLE
DEV-1761: Fix scrollViewportTo ignoring height when preventOverflow is set (#8233)

### DIFF
--- a/.changelogs/12624.json
+++ b/.changelogs/12624.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed `scrollViewportTo()` not scrolling when a constrained dimension (`height` or `width`) is combined with the matching `preventOverflow` value.",
+  "type": "fixed",
+  "issueOrPR": 12624,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/src/overlay/_base.js
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/_base.js
@@ -124,8 +124,20 @@ export class Overlay {
     const computedOverflow = rootWindow.getComputedStyle(wtTable.wtRootElement.parentNode)
       .getPropertyValue('overflow');
 
-    if (computedOverflow === 'hidden' || computedOverflow === 'clip') {
+    const preventOverflow = this.wtSettings.getSetting('preventOverflow');
+
+    if (preventOverflow === true) {
+      this.mainTableScrollableElement = rootWindow;
+
+    } else if (computedOverflow === 'hidden' || computedOverflow === 'clip') {
       this.mainTableScrollableElement = this.wot.wtTable.holder;
+
+    } else if (
+      preventOverflow === 'horizontal' && this.type === CLONE_TOP ||
+      preventOverflow === 'vertical' && this.type === CLONE_INLINE_START
+    ) {
+      this.mainTableScrollableElement = rootWindow;
+
     } else {
       this.mainTableScrollableElement = getScrollableElement(wtTable.TABLE);
     }
@@ -335,13 +347,17 @@ export class Overlay {
     const computedOverflow = rootWindow.getComputedStyle(tableParent)
       .getPropertyValue('overflow');
 
-    if (preventOverflow === true ||
-      preventOverflow === 'horizontal' && this.type === CLONE_TOP ||
-      preventOverflow === 'vertical' && this.type === CLONE_INLINE_START) {
+    if (preventOverflow === true) {
       this.mainTableScrollableElement = rootWindow;
 
     } else if (computedOverflow === 'hidden' || computedOverflow === 'clip') {
       this.mainTableScrollableElement = wtTable.holder;
+
+    } else if (
+      preventOverflow === 'horizontal' && this.type === CLONE_TOP ||
+      preventOverflow === 'vertical' && this.type === CLONE_INLINE_START
+    ) {
+      this.mainTableScrollableElement = rootWindow;
 
     } else {
       this.mainTableScrollableElement = getScrollableElement(wtTable.TABLE);

--- a/handsontable/src/__tests__/core/scrollViewportTo.spec.js
+++ b/handsontable/src/__tests__/core/scrollViewportTo.spec.js
@@ -923,6 +923,43 @@ describe('Core.scrollViewportTo', () => {
     )[0]).toEqual(hot.getCell(29, 29));
   });
 
+  describe('with `preventOverflow` and a constrained dimension (#8233)', () => {
+    it('should scroll vertically when `height` is set together with `preventOverflow: "horizontal"`', async() => {
+      handsontable({
+        data: createSpreadsheetData(200, 10),
+        width: 300,
+        height: 300,
+        preventOverflow: 'horizontal',
+      });
+
+      const result = await scrollViewportTo({
+        row: 150,
+        col: 0,
+      });
+
+      expect(result).toBe(true);
+      expect(topOverlay().getScrollPosition()).toBeGreaterThan(0);
+    });
+
+    it('should scroll horizontally when `width` is set together with `preventOverflow: "vertical"`', async() => {
+      handsontable({
+        data: createSpreadsheetData(10, 200),
+        width: 300,
+        height: 300,
+        colWidths: 60,
+        preventOverflow: 'vertical',
+      });
+
+      const result = await scrollViewportTo({
+        row: 0,
+        col: 150,
+      });
+
+      expect(result).toBe(true);
+      expect(inlineStartOverlay().getScrollPosition()).toBeGreaterThan(0);
+    });
+  });
+
   describe('using backward-compatible arguments', () => {
     it('should scroll the viewport using default snapping (top, start)', async() => {
       handsontable({


### PR DESCRIPTION
### Context

The PR fixes [#8233](https://github.com/handsontable/handsontable/issues/8233): `scrollViewportTo()` is a no-op on the constrained axis when a table dimension and an axis-specific `preventOverflow` collide.

Repro:

- `height` set + `preventOverflow: 'horizontal'` -> vertical `scrollViewportTo()` does nothing.
- `width` set + `preventOverflow: 'vertical'` -> symmetric horizontal no-op.

Root cause is the branch order in `Overlay#makeClone()` (and the mirror in `updateMainScrollableElement()`). The axis `preventOverflow` shortcut forced the matching overlay (`CLONE_TOP` / `CLONE_INLINE_START`) onto `window` even when the root parent had `overflow: clip` because of the set dimension. The overlay then tried to scroll the (short) window instead of the holder, so the request was lost.

Fix: reorder the branches so `computedOverflow === 'clip' | 'hidden'` is evaluated before the axis-specific `preventOverflow` shortcut. `preventOverflow === true` still wins outright; sticky-header behavior (axis `preventOverflow` without clipping) is preserved.

### How has this been tested?

Added regression specs in `src/__tests__/core/scrollViewportTo.spec.js`:

- vertical scroll under `height` + `preventOverflow: 'horizontal'`
- horizontal scroll under `width` + `preventOverflow: 'vertical'`

Both fail without the fix and pass with it. Full suites green:

```bash
npm run test:e2e --prefix handsontable -- --testPathPattern='core/scrollViewportTo'                 # 41/0
npm run test:e2e --prefix handsontable -- --testPathPattern='core/scrollViewportTo' --theme=horizon # 41/0
npm run test:e2e --prefix handsontable -- --testPathPattern='core/scrollViewportTo' --theme=classic # 41/0
npm run test:e2e --prefix handsontable -- --testPathPattern='settings/(height|width|preventOverflow)' # 21/0
npm run test:e2e --prefix handsontable -- --testPathPattern='scrollViewport'                       # 41/0
npm run test:e2e --prefix handsontable -- --testPathPattern='core/'                                # 1147/0
npm run test:walkontable --prefix handsontable -- --testPathPattern='preventOverflow|scroll|overlay' # 220/0
npx eslint src/3rdparty/walkontable/src/overlay/_base.js src/__tests__/core/scrollViewportTo.spec.js # clean
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. #8233
2. DEV-1761

### Affected project(s):

- [x] \`handsontable\`
- [ ] \`@handsontable/angular-wrapper\`
- [ ] \`@handsontable/react-wrapper\`
- [ ] \`@handsontable/vue3\`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/86c9wmcbn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes overlay scroll-container selection logic for `preventOverflow`, which can affect scrolling and fixed overlay behavior across configurations. Regression tests reduce risk but behavior differences may surface in edge-case overflow setups.
> 
> **Overview**
> Fixes a `scrollViewportTo()` regression where scrolling on the constrained axis became a no-op when `height`/`width` is set alongside axis-specific `preventOverflow`.
> 
> Walkontable overlay logic now prefers the table holder as the scroll container when the root parent has `overflow: hidden|clip`, only falling back to window scrolling for `preventOverflow: true` or for axis-specific modes when not clipped. Adds regression specs covering `height`+`preventOverflow: "horizontal"` and `width`+`preventOverflow: "vertical"`, and includes a changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4faeec0ef15b35c117a3a01857a521a0df3ce85c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->