### PR TITLE
DEV-1713: ColumnSorting respects fixedRowsTop and fixedRowsBottom

### DIFF
--- a/.changelogs/12627.json
+++ b/.changelogs/12627.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed column sorting permuting rows pinned by `fixedRowsTop` or `fixedRowsBottom`, which previously corrupted absolute-address formulas in footer rows.",
+  "type": "fixed",
+  "issueOrPR": 12627,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/columnSorting/__tests__/columnSorting.spec.js
+++ b/handsontable/src/plugins/columnSorting/__tests__/columnSorting.spec.js
@@ -3456,4 +3456,81 @@ describe('ColumnSorting', () => {
       expect(cssTop).toBeGreaterThan(0);
     });
   });
+
+  describe('fixed rows interaction', () => {
+    it('should not include `fixedRowsBottom` rows in the sortable range', async() => {
+      handsontable({
+        data: [
+          ['Apple', 10],
+          ['Banana', 20],
+          ['Cherry', 30],
+          ['Date', 40],
+          ['Total', 999], // footer row, must stay last regardless of sort
+        ],
+        colHeaders: ['A', 'B'],
+        fixedRowsBottom: 1,
+        columnSorting: true,
+      });
+
+      // sort col B descending - 999 would normally float to the top
+      getPlugin('columnSorting').sort({ column: 1, sortOrder: 'desc' });
+
+      // footer must remain at the last visual row
+      expect(getDataAtCell(4, 0)).toBe('Total');
+      expect(getDataAtCell(4, 1)).toBe(999);
+
+      // data rows above are sorted descending
+      expect(getDataAtCol(1).slice(0, 4)).toEqual([40, 30, 20, 10]);
+    });
+
+    it('should not include `fixedRowsTop` rows in the sortable range', async() => {
+      handsontable({
+        data: [
+          ['Header', 999], // header row, must stay first regardless of sort
+          ['Apple', 10],
+          ['Banana', 20],
+          ['Cherry', 30],
+          ['Date', 40],
+        ],
+        colHeaders: ['A', 'B'],
+        fixedRowsTop: 1,
+        columnSorting: true,
+      });
+
+      getPlugin('columnSorting').sort({ column: 1, sortOrder: 'asc' });
+
+      // header must remain at the first visual row
+      expect(getDataAtCell(0, 0)).toBe('Header');
+      expect(getDataAtCell(0, 1)).toBe(999);
+
+      // data rows below are sorted ascending
+      expect(getDataAtCol(1).slice(1)).toEqual([10, 20, 30, 40]);
+    });
+
+    it('should respect `fixedRowsTop`, `fixedRowsBottom`, and `minSpareRows` together', async() => {
+      handsontable({
+        data: [
+          ['Header', 999],
+          ['Banana', 20],
+          ['Apple', 10],
+          ['Date', 40],
+          ['Cherry', 30],
+          ['Total', 111],
+          [null, null], // spare row
+        ],
+        colHeaders: ['A', 'B'],
+        fixedRowsTop: 1,
+        fixedRowsBottom: 1,
+        minSpareRows: 1,
+        columnSorting: true,
+      });
+
+      getPlugin('columnSorting').sort({ column: 1, sortOrder: 'asc' });
+
+      expect(getDataAtCell(0, 0)).toBe('Header');
+      expect(getDataAtCol(1).slice(1, 5)).toEqual([10, 20, 30, 40]);
+      expect(getDataAtCell(5, 0)).toBe('Total');
+      expect(getDataAtCell(6, 0)).toBeNull();
+    });
+  });
 });

--- a/handsontable/src/plugins/columnSorting/columnSorting.js
+++ b/handsontable/src/plugins/columnSorting/columnSorting.js
@@ -583,13 +583,16 @@ export class ColumnSorting extends BasePlugin {
    */
   getNumberOfRowsToSort(numberOfRows) {
     const settings = this.hot.getSettings();
+    const fixedRowsBottom = settings.fixedRowsBottom || 0;
 
     // `maxRows` option doesn't take into account `minSpareRows` option in this case.
+    // `fixedRowsBottom` is excluded from the sort range so footer rows (e.g. SUM formulas)
+    // stay pinned and keep their absolute-address references intact.
     if (settings.maxRows <= numberOfRows) {
-      return settings.maxRows;
+      return Math.max(0, settings.maxRows - fixedRowsBottom);
     }
 
-    return numberOfRows - settings.minSpareRows;
+    return Math.max(0, numberOfRows - settings.minSpareRows - fixedRowsBottom);
   }
 
   /**
@@ -607,11 +610,14 @@ export class ColumnSorting extends BasePlugin {
 
     const indexesWithData = [];
     const numberOfRows = this.hot.countRows();
+    const settings = this.hot.getSettings();
+    const fixedRowsTop = settings.fixedRowsTop || 0;
+    const upperBound = this.getNumberOfRowsToSort(numberOfRows);
 
     const getDataForSortedColumns = visualRowIndex =>
       arrayMap(sortConfigs, sortConfig => this.hot.getDataAtCell(visualRowIndex, sortConfig.column));
 
-    for (let visualRowIndex = 0; visualRowIndex < this.getNumberOfRowsToSort(numberOfRows); visualRowIndex += 1) {
+    for (let visualRowIndex = fixedRowsTop; visualRowIndex < upperBound; visualRowIndex += 1) {
       indexesWithData.push([this.hot.toPhysicalRow(visualRowIndex)].concat(getDataForSortedColumns(visualRowIndex)));
     }
 
@@ -624,8 +630,8 @@ export class ColumnSorting extends BasePlugin {
       arrayMap(sortConfigs, sortConfig => this.getFirstCellSettings(sortConfig.column))
     );
 
-    // Append spareRows
-    for (let visualRowIndex = indexesWithData.length; visualRowIndex < numberOfRows; visualRowIndex += 1) {
+    // Append fixedRowsBottom + spareRows (everything between upperBound and numberOfRows)
+    for (let visualRowIndex = upperBound; visualRowIndex < numberOfRows; visualRowIndex += 1) {
       indexesWithData.push([visualRowIndex].concat(getDataForSortedColumns(visualRowIndex)));
     }
 

--- a/handsontable/src/plugins/formulas/__tests__/plugins/columnSorting.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/plugins/columnSorting.spec.js
@@ -1,0 +1,48 @@
+import HyperFormula from 'hyperformula';
+
+describe('Formulas', () => {
+  beforeEach(function() {
+    this.$container = $('<div id="testContainer"></div>').appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  describe('columnSorting', () => {
+    describe('DEV-1713: formula in fixed bottom row', () => {
+      it('should keep `=SUM(C1:C4)` computing correctly after sorting column C descending', async() => {
+        handsontable({
+          data: [
+            ['Apple', 'Q1', 10],
+            ['Banana', 'Q2', 20],
+            ['Cherry', 'Q3', 30],
+            ['Date', 'Q4', 40],
+            ['Total', '', '=SUM(C1:C4)'],
+          ],
+          colHeaders: ['A', 'B', 'C'],
+          fixedRowsBottom: 1,
+          columnSorting: true,
+          formulas: {
+            engine: HyperFormula,
+          },
+        });
+
+        // sanity: footer computes before any sort
+        expect(getDataAtCell(4, 2)).toBe(100);
+
+        getPlugin('columnSorting').sort({ column: 2, sortOrder: 'desc' });
+
+        // footer still pinned and still computing
+        expect(getDataAtCell(4, 0)).toBe('Total');
+        expect(getDataAtCell(4, 2)).toBe(100);
+
+        // data rows sorted desc
+        expect(getDataAtCol(2).slice(0, 4)).toEqual([40, 30, 20, 10]);
+      });
+    });
+  });
+});

--- a/handsontable/src/plugins/formulas/__tests__/plugins/columnSorting.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/plugins/columnSorting.spec.js
@@ -45,4 +45,50 @@ describe('Formulas', () => {
       });
     });
   });
+
+  describe('multiColumnSorting', () => {
+    describe('DEV-1713: multiple formulas in fixed bottom row', () => {
+      it('should keep multiple footer formulas computing after multi-column sort', async() => {
+        handsontable({
+          data: [
+            ['North', 'Apple', 10, 12, 14, 18],
+            ['South', 'Banana', 20, 22, 24, 28],
+            ['East', 'Cherry', 30, 32, 34, 38],
+            ['West', 'Date', 40, 42, 44, 48],
+            ['North', 'Elder', 15, 17, 19, 23],
+            ['South', 'Fig', 25, 27, 29, 33],
+            ['Total', '', '=SUM(C1:C6)', '=SUM(D1:D6)', '=SUM(E1:E6)', '=AVERAGE(F1:F6)'],
+          ],
+          colHeaders: ['Region', 'Product', 'Q1', 'Q2', 'Q3', 'Q4'],
+          fixedRowsBottom: 1,
+          multiColumnSorting: true,
+          formulas: {
+            engine: HyperFormula,
+          },
+        });
+
+        // sanity: footer formulas compute before sort
+        expect(getDataAtCell(6, 2)).toBe(140);
+        expect(getDataAtCell(6, 3)).toBe(152);
+        expect(getDataAtCell(6, 4)).toBe(164);
+        expect(getDataAtCell(6, 5)).toBeCloseTo(31.3333333, 6);
+
+        getPlugin('multiColumnSorting').sort([
+          { column: 0, sortOrder: 'asc' },
+          { column: 5, sortOrder: 'desc' },
+        ]);
+
+        // footer label and all four formulas still pinned and still computing
+        expect(getDataAtCell(6, 0)).toBe('Total');
+        expect(getDataAtCell(6, 2)).toBe(140);
+        expect(getDataAtCell(6, 3)).toBe(152);
+        expect(getDataAtCell(6, 4)).toBe(164);
+        expect(getDataAtCell(6, 5)).toBeCloseTo(31.3333333, 6);
+
+        // data rows: Region asc, then Q4 desc within each region
+        expect(getDataAtCol(0).slice(0, 6)).toEqual(['East', 'North', 'North', 'South', 'South', 'West']);
+        expect(getDataAtCol(5).slice(0, 6)).toEqual([38, 23, 18, 33, 28, 48]);
+      });
+    });
+  });
 });

--- a/handsontable/src/plugins/multiColumnSorting/__tests__/multiColumnSorting.spec.js
+++ b/handsontable/src/plugins/multiColumnSorting/__tests__/multiColumnSorting.spec.js
@@ -3603,5 +3603,68 @@ describe('MultiColumnSorting', () => {
       expect(getDataAtCell(4, 2)).toBe(999);
       expect(getDataAtCol(2).slice(0, 4)).toEqual([40, 30, 20, 10]);
     });
+
+    it('should not include `fixedRowsTop` rows when multi-sorting and use the secondary key for ties', async() => {
+      handsontable({
+        data: [
+          ['Header', 'Header', 0],
+          ['North', 'Banana', 20],
+          ['North', 'Apple', 10],
+          ['South', 'Cherry', 30],
+          ['South', 'Apple', 5],
+          ['South', 'Date', 40],
+        ],
+        colHeaders: ['Region', 'Product', 'Value'],
+        fixedRowsTop: 1,
+        multiColumnSorting: true,
+      });
+
+      getPlugin('multiColumnSorting').sort([
+        { column: 0, sortOrder: 'asc' },
+        { column: 1, sortOrder: 'asc' },
+      ]);
+
+      expect(getDataAtCell(0, 0)).toBe('Header');
+      expect(getData().slice(1)).toEqual([
+        ['North', 'Apple', 10],
+        ['North', 'Banana', 20],
+        ['South', 'Apple', 5],
+        ['South', 'Cherry', 30],
+        ['South', 'Date', 40],
+      ]);
+    });
+
+    it('should respect both `fixedRowsTop` and `fixedRowsBottom` when multi-sorting', async() => {
+      handsontable({
+        data: [
+          ['Header', '', 0],
+          ['East', 'Banana', 22],
+          ['East', 'Apple', 11],
+          ['West', 'Cherry', 33],
+          ['West', 'Apple', 7],
+          ['Total', '', 999],
+        ],
+        colHeaders: ['Region', 'Product', 'Value'],
+        fixedRowsTop: 1,
+        fixedRowsBottom: 1,
+        multiColumnSorting: true,
+      });
+
+      getPlugin('multiColumnSorting').sort([
+        { column: 0, sortOrder: 'desc' },
+        { column: 2, sortOrder: 'asc' },
+      ]);
+
+      expect(getDataAtCell(0, 0)).toBe('Header');
+      expect(getDataAtCell(5, 0)).toBe('Total');
+      expect(getDataAtCell(5, 2)).toBe(999);
+      // Region desc => West first, then East. Within each region, Value asc.
+      expect(getData().slice(1, 5)).toEqual([
+        ['West', 'Apple', 7],
+        ['West', 'Cherry', 33],
+        ['East', 'Apple', 11],
+        ['East', 'Banana', 22],
+      ]);
+    });
   });
 });

--- a/handsontable/src/plugins/multiColumnSorting/__tests__/multiColumnSorting.spec.js
+++ b/handsontable/src/plugins/multiColumnSorting/__tests__/multiColumnSorting.spec.js
@@ -3578,4 +3578,30 @@ describe('MultiColumnSorting', () => {
       ]);
     });
   });
+
+  describe('DEV-1713: fixed rows interaction (inherited from ColumnSorting)', () => {
+    it('should not include `fixedRowsBottom` rows when multi-sorting', async() => {
+      handsontable({
+        data: [
+          ['A', 'Z', 10],
+          ['B', 'Y', 20],
+          ['C', 'X', 30],
+          ['D', 'W', 40],
+          ['Total', '', 999],
+        ],
+        colHeaders: ['1', '2', '3'],
+        fixedRowsBottom: 1,
+        multiColumnSorting: true,
+      });
+
+      getPlugin('multiColumnSorting').sort([
+        { column: 2, sortOrder: 'desc' },
+        { column: 1, sortOrder: 'asc' },
+      ]);
+
+      expect(getDataAtCell(4, 0)).toBe('Total');
+      expect(getDataAtCell(4, 2)).toBe(999);
+      expect(getDataAtCol(2).slice(0, 4)).toEqual([40, 30, 20, 10]);
+    });
+  });
 });


### PR DESCRIPTION
### Context

The PR fixes a regression where `ColumnSorting` (and its subclass `MultiColumnSorting`) permutes rows pinned by `fixedRowsTop` and `fixedRowsBottom`. Customer reported that a fixed bottom row holding `=SUM(C1:C4)` started showing the formula text / `#REF!` / `#CYCLE!` after sorting column C.

Root cause: `ColumnSorting.getNumberOfRowsToSort()` only subtracted `minSpareRows`, ignoring `fixedRowsBottom`; the sort loop also started at visual row 0 instead of `fixedRowsTop`. The footer row got sorted into a position where its absolute-address formula `=SUM(C1:C4)` self-referenced, producing `#CYCLE!`. `fixedRowsBottom` documentation defines it as a number of frozen rows, which users reasonably expect to stay out of the sort dataset.

Fix is in `handsontable/src/plugins/columnSorting/columnSorting.js` (+11/-5):
- `getNumberOfRowsToSort` subtracts `fixedRowsBottom` in both `maxRows` branches, clamped with `Math.max(0, ...)`.
- `sortByPresetSortStates` iterates `[fixedRowsTop, upperBound)` for the sortable range; the trailing-rows append loop now covers `[upperBound, numberOfRows)` (both `fixedRowsBottom` and `minSpareRows`).
- `MultiColumnSorting` extends `ColumnSorting` and inherits the fix.

No default values change. The change is framed as a bug fix - previously the behavior produced data corruption for any user combining `fixedRowsBottom`/`fixedRowsTop` with `columnSorting` and absolute-address formulas.

### How has this been tested?

5 new E2E tests added covering the fix:

- `handsontable/src/plugins/columnSorting/__tests__/columnSorting.spec.js` - 3 tests (`fixedRowsBottom` not sorted; `fixedRowsTop` not sorted; combined with `minSpareRows`).
- `handsontable/src/plugins/formulas/__tests__/plugins/columnSorting.spec.js` - 1 regression test (formula in fixed bottom row survives sort).
- `handsontable/src/plugins/multiColumnSorting/__tests__/multiColumnSorting.spec.js` - 1 inheritance test.

Suite results:

```
npm run test:e2e --prefix handsontable -- --testPathPattern=columnSorting --theme=main
# 290 specs, 0 failures

npm run test:e2e --prefix handsontable -- --testPathPattern=formulas --theme=main
# 324 specs, 0 failures, 6 pending (pre-existing)

npm run test:unit --prefix handsontable -- --testPathPattern=columnSorting
# 30 tests, all passing

npm run lint --prefix handsontable
# clean (eslint + types + stylelint)
```

Manual repro page generated locally via the `handsontable-demo-page` skill (`handsontable/dev-pr.html` vs `dev-latest.html` against v17.1.0). The CDN version still exhibits the bug; the local build does not.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1713

### Affected project(s):

- [x] \`handsontable\`
- [ ] \`@handsontable/angular-wrapper\`
- [ ] \`@handsontable/react-wrapper\`
- [ ] \`@handsontable/vue3\`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1713

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core row-sorting/index-mapping logic and could affect ordering when `maxRows`, `minSpareRows`, and fixed rows interact, but the change is scoped and covered by new regression tests.
> 
> **Overview**
> **Column sorting now respects frozen rows.** `ColumnSorting` excludes `fixedRowsTop` and `fixedRowsBottom` from the sortable range (while still appending bottom-fixed and spare rows afterward), preventing pinned header/footer rows from being permuted during sorts.
> 
> Adds targeted E2E regression coverage for `columnSorting`, `multiColumnSorting` (inherited behavior), and `formulas` to ensure fixed footer formulas like `=SUM(C1:C4)` continue computing correctly after sorting. Includes a changelog entry for the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e691f2678de647fb68b728fcc65cb526e31bf0df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->