### PR TITLE
DEV-1765: Fix #8039 undo restores hidden row data

### DIFF
--- a/.changelogs/12629.json
+++ b/.changelogs/12629.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed undoing row removal to restore all source-data fields, including columns that are not exposed via the `columns` configuration.",
+  "type": "fixed",
+  "issueOrPR": 12629,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/undoRedo/__tests__/actions/removeRow.spec.js
+++ b/handsontable/src/plugins/undoRedo/__tests__/actions/removeRow.spec.js
@@ -76,4 +76,104 @@ describe('UndoRedo -> RemoveRow action', () => {
 
     expect(getDataAtCol(0)).toEqual(['A5', 'A2', 'A3', 'A4']);
   });
+
+  describe('#8039: undo restores hidden source-data fields', () => {
+    it('should restore a hidden source-data field (not present in `columns`) after undo', async() => {
+      handsontable({
+        data: [
+          { artist: 'Foo Fighters', category: 'rock', label: 'Roswell Records' },
+          { artist: 'Alabama Shakes', category: 'blues', label: 'ATO Records' },
+          { artist: 'Radiohead', category: 'rock', label: 'XL Recordings' },
+        ],
+        columns: [{ data: 'category' }, { data: 'label' }],
+      });
+
+      await alter('remove_row', 1, 1);
+
+      expect(getSourceDataAtRow(1)).toEqual({ artist: 'Radiohead', category: 'rock', label: 'XL Recordings' });
+
+      getPlugin('undoRedo').undo();
+
+      expect(getSourceDataAtRow(1)).toEqual({
+        artist: 'Alabama Shakes', category: 'blues', label: 'ATO Records',
+      });
+    });
+
+    it('should restore a deep dot-notation prop (not exposed via `columns`) after undo', async() => {
+      handsontable({
+        data: [
+          { id: 1, meta: { deep: { field: 'keep-1' } }, label: 'one' },
+          { id: 2, meta: { deep: { field: 'keep-2' } }, label: 'two' },
+          { id: 3, meta: { deep: { field: 'keep-3' } }, label: 'three' },
+        ],
+        columns: [{ data: 'label' }],
+        dataDotNotation: true,
+      });
+
+      await alter('remove_row', 1, 1);
+      getPlugin('undoRedo').undo();
+
+      expect(getSourceDataAtRow(1).meta.deep.field).toBe('keep-2');
+      expect(getSourceDataAtRow(1).id).toBe(2);
+    });
+
+    it('should still restore array-data rows correctly (no regression)', async() => {
+      handsontable({
+        data: createSpreadsheetData(4, 3),
+      });
+
+      await alter('remove_row', 1, 1);
+      getPlugin('undoRedo').undo();
+
+      expect(getDataAtRow(1)).toEqual(['A2', 'B2', 'C2']);
+      expect(getSourceDataAtRow(1)).toEqual(['A2', 'B2', 'C2']);
+    });
+
+    it('should restore hidden fields when removing multiple object rows in a single action', async() => {
+      handsontable({
+        data: [
+          { artist: 'A1', category: 'c1', label: 'l1' },
+          { artist: 'A2', category: 'c2', label: 'l2' },
+          { artist: 'A3', category: 'c3', label: 'l3' },
+          { artist: 'A4', category: 'c4', label: 'l4' },
+        ],
+        columns: [{ data: 'category' }, { data: 'label' }],
+      });
+
+      await alter('remove_row', 1, 2);
+      getPlugin('undoRedo').undo();
+
+      expect(getSourceDataAtRow(1).artist).toBe('A2');
+      expect(getSourceDataAtRow(2).artist).toBe('A3');
+      expect(getSourceDataAtRow(1).category).toBe('c2');
+      expect(getSourceDataAtRow(2).category).toBe('c3');
+    });
+
+    it('should fire `afterSetSourceDataAtCell` with source `UndoRedo.undo` covering hidden props on undo', async() => {
+      const afterSetSourceDataAtCell = jasmine.createSpy('afterSetSourceDataAtCell');
+
+      handsontable({
+        data: [
+          { artist: 'Foo Fighters', category: 'rock', label: 'Roswell Records' },
+          { artist: 'Alabama Shakes', category: 'blues', label: 'ATO Records' },
+        ],
+        columns: [{ data: 'category' }, { data: 'label' }],
+        afterSetSourceDataAtCell,
+      });
+
+      await alter('remove_row', 1, 1);
+      afterSetSourceDataAtCell.calls.reset();
+
+      getPlugin('undoRedo').undo();
+
+      const undoCalls = afterSetSourceDataAtCell.calls.allArgs().filter(args => args[1] === 'UndoRedo.undo');
+
+      expect(undoCalls.length).toBeGreaterThan(0);
+      const changedProps = undoCalls.flatMap(args => args[0]).map(change => change[1]);
+
+      expect(changedProps).toContain('artist');
+      expect(changedProps).toContain('category');
+      expect(changedProps).toContain('label');
+    });
+  });
 });

--- a/handsontable/src/plugins/undoRedo/actions/removeRow.js
+++ b/handsontable/src/plugins/undoRedo/actions/removeRow.js
@@ -63,11 +63,20 @@ export class RemoveRowAction extends BaseAction {
       const wrappedAction = () => {
         const physicalRowIndex = hot.toPhysicalRow(index);
         const lastRowIndex = physicalRowIndex + amount - 1;
-        const removedData = deepClone(
-          hot.getSourceData(
-            physicalRowIndex, 0, physicalRowIndex + amount - 1, hot.countSourceCols() - 1
-          )
-        );
+        const removedData = [];
+
+        for (let i = 0; i < amount; i++) {
+          const rowData = deepClone(hot.getSourceDataAtRow(physicalRowIndex + i));
+
+          // `nestedRows` manages its `__children` tree restoration on undo
+          // independently; writing `__children` back via `setSourceDataAtCell`
+          // would clash with the plugin's internal state.
+          if (rowData && typeof rowData === 'object' && !Array.isArray(rowData)) {
+            delete rowData.__children;
+          }
+
+          removedData.push(rowData);
+        }
 
         return new RemoveRowAction({
           index: physicalRowIndex,


### PR DESCRIPTION
### Context

The PR fixes [#8039](https://github.com/handsontable/handsontable/issues/8039). Undoing a row removal does not restore source-data fields that are not exposed by the `columns` config (\"hidden\" props on object data).

Root cause: `handsontable/src/plugins/undoRedo/actions/removeRow.js` snapshots the removed rows via `hot.getSourceData(physicalRow, 0, physicalRow + amount - 1, countSourceCols - 1)`. That call routes through `DataSource.getByRange` → `getAtRow(row, 0, countSourceCols - 1)`, which walks only column-mapped props via `colToProp`. Hidden fields (e.g. `artist` when `columns: [{data:'category'},{data:'label'}]`) are stripped from the snapshot, so on undo `setSourceDataAtCell(changes)` writes only the captured keys and the hidden field stays at its post-insert `null` default.

Fix: switch the snapshot to per-row `hot.getSourceDataAtRow(physicalRow + i)`. That call uses the `getAllProps=true` branch (`objectEach(dataRow, ...)`), which enumerates every own property of the row object including hidden ones. `__children` is filtered out so `nestedRows` retains exclusive ownership of its tree restoration (the plugin's own state would clash with `setSourceDataAtCell` writing back the `__children` array).

### How has this been tested?

5 new E2E tests added in `handsontable/src/plugins/undoRedo/__tests__/actions/removeRow.spec.js`:

- Hidden source field (`artist`) restored on undo after object-data row removal (the issue's exact repro).
- Deep dot-notation prop (`meta.deep.field`) restored with `dataDotNotation: true`.
- Array-data row regression (no behavior change for non-object data).
- Multi-row removal + undo with hidden props.
- `afterSetSourceDataAtCell` fires with `source: 'UndoRedo.undo'` covering hidden props.

Suite results on `main` theme:

\`\`\`
npm run test:e2e --prefix handsontable -- --testPathPattern=undoRedo --theme=main
# 178 specs, 0 failures, 3 pending

npm run test:e2e --prefix handsontable -- --testPathPattern=nestedRows --theme=main
# 132 specs, 0 failures

npm run test:unit --prefix handsontable -- --testPathPattern=dataMap
# 184 tests, all passing

npm run lint --prefix handsontable
# clean (eslint + types + stylelint)
\`\`\`

Manual verification via local demo pages (gitignored) confirmed bug present on v17.1.0 CDN build and fixed on this branch: removing a row with hidden \`artist\` field then undoing restores the field instead of leaving it null.

### Out of scope

\`nestedRows\` child-row remove + undo loses the child's hidden fields too, but its restoration path goes through the plugin's own tree state rather than UndoRedo's snapshot. Filed as a separate concern.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. #8039
2. DEV-1765

### Affected project(s):

- [x] \`handsontable\`
- [ ] \`@handsontable/angular-wrapper\`
- [ ] \`@handsontable/react-wrapper\`
- [ ] \`@handsontable/vue3\`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1765

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `UndoRedo` row-removal snapshotting, which can affect data integrity on undo/redo across different data shapes and plugins (e.g. `nestedRows`). Changes are localized and covered by new tests, but the behavior impacts a widely-used action.
> 
> **Overview**
> Fixes `UndoRedo` `remove_row` undo so removed rows are snapshotted via per-row `getSourceDataAtRow()` (instead of a column-mapped range), ensuring *hidden object properties* and dot-notation data are restored on undo; `__children` is explicitly excluded to avoid clashing with `nestedRows` restoration.
> 
> Adds a changelog entry and expands `removeRow.spec.js` with coverage for hidden props, dot-notation, multi-row removal, array-data regression, and verifying `afterSetSourceDataAtCell` fires on undo with the expected source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35a20727a3427aa78356caee351475fb4a50a205. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->