### PR TITLE
DEV-1766: Fix nestedHeaders not re-expanding columns when colWidths reset to undefined (#7604)

### DIFF
--- a/.changelogs/12630.json
+++ b/.changelogs/12630.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed nested headers not expanding column widths to content after resetting `colWidths` to `undefined` via `updateSettings`.",
+  "type": "fixed",
+  "issueOrPR": 12630,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/autoColumnSize/autoColumnSize.js
+++ b/handsontable/src/plugins/autoColumnSize/autoColumnSize.js
@@ -315,7 +315,7 @@ export class AutoColumnSize extends BasePlugin {
     this.addHook('beforeChangeRender', (...args) => this.#onBeforeChange(...args));
     this.addHook('afterFormulasValuesUpdate', (...args) => this.#onAfterFormulasValuesUpdate(...args));
     this.addHook('beforeRender', () => this.#onBeforeRender());
-    this.addHook('modifyColWidth', (width, col) => this.getColumnWidth(col, width));
+    this.addHook('modifyColWidth', (width, col) => this.getColumnWidth(col, width), -10);
     this.addHook('init', () => this.#onInit());
 
     this.#disposeMapObserver = this.hot.columnIndexMapper

--- a/handsontable/src/plugins/nestedHeaders/__tests__/nestedHeaders.spec.js
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/nestedHeaders.spec.js
@@ -66,6 +66,46 @@ describe('NestedHeaders', () => {
       expect(getColWidth(2)).toBe(50);
       expect(getColWidth(3)).toBe(50);
     });
+
+    it('should re-expand columns to content width after `updateSettings({ colWidths: undefined })` when `nestedHeaders` is enabled (#7604)', async() => {
+      const longContent = 'this is a very long cell content that should expand the column';
+
+      handsontable({
+        data: [
+          [longContent, 'b', 'c', 'd', 'e'],
+          ['a', 'b', 'c', 'd', 'e'],
+        ],
+        colHeaders: true,
+        colWidths: 100,
+        nestedHeaders: [
+          [{ label: 'h', colspan: 2 }, 'c', 'd', 'e'],
+          ['a', 'b', 'c', 'd', 'e'],
+        ],
+      });
+
+      expect(getColWidth(0)).toBe(100);
+
+      await updateSettings({ colWidths: undefined });
+
+      expect(getColWidth(0)).toBeGreaterThan(200);
+    });
+
+    it('should not override a programmatically narrowed column width when `nestedHeaders` and `manualColumnResize` are enabled', async() => {
+      handsontable({
+        data: [
+          ['this is a very long cell content', 'b', 'c', 'd', 'e'],
+          ['a', 'b', 'c', 'd', 'e'],
+        ],
+        colHeaders: true,
+        manualColumnResize: [30, 50, 50, 50, 50],
+        nestedHeaders: [
+          [{ label: 'h', colspan: 2 }, 'c', 'd', 'e'],
+          ['a', 'b', 'c', 'd', 'e'],
+        ],
+      });
+
+      expect(getColWidth(0)).toBe(30);
+    });
   });
 
   describe('cooperation with drop-down menu element', () => {

--- a/handsontable/src/plugins/nestedHeaders/nestedHeaders.js
+++ b/handsontable/src/plugins/nestedHeaders/nestedHeaders.js
@@ -1287,19 +1287,8 @@ export class NestedHeaders extends BasePlugin {
     }
 
     const cachedWidth = this.ghostTable.getWidth(column);
-    let floor = cachedWidth;
 
-    const autoColumnSize = this.hot.getPlugin('autoColumnSize');
-
-    if (autoColumnSize?.enabled) {
-      const contentWidth = autoColumnSize.getColumnWidth(column, undefined, false);
-
-      if (typeof contentWidth === 'number') {
-        floor = Math.max(floor, contentWidth);
-      }
-    }
-
-    return width > floor ? width : floor;
+    return width > cachedWidth ? width : cachedWidth;
   }
 
   /**

--- a/handsontable/src/plugins/nestedHeaders/nestedHeaders.js
+++ b/handsontable/src/plugins/nestedHeaders/nestedHeaders.js
@@ -1287,8 +1287,19 @@ export class NestedHeaders extends BasePlugin {
     }
 
     const cachedWidth = this.ghostTable.getWidth(column);
+    let floor = cachedWidth;
 
-    return width > cachedWidth ? width : cachedWidth;
+    const autoColumnSize = this.hot.getPlugin('autoColumnSize');
+
+    if (autoColumnSize?.enabled) {
+      const contentWidth = autoColumnSize.getColumnWidth(column, undefined, false);
+
+      if (typeof contentWidth === 'number') {
+        floor = Math.max(floor, contentWidth);
+      }
+    }
+
+    return width > floor ? width : floor;
   }
 
   /**


### PR DESCRIPTION
### Context

The PR fixes [#7604](https://github.com/handsontable/handsontable/issues/7604). When `nestedHeaders` is enabled and the table is initialised with a defined `colWidths` value, calling `updateSettings({ colWidths: undefined })` later did not re-expand columns to fit content. The same call on a table with plain `colHeaders` worked as expected.

Root cause: `AutoColumnSize.isEnabled()` returns `!colWidths`, so ACS was disabled at init when `colWidths: 100` was set. The `updateSettings` call re-enabled ACS, but its `modifyColWidth` hook then registered after `NestedHeaders#onModifyColWidth`. Execution order became:

1. `NestedHeaders` ran first and returned the ghost-header floor width.
2. `AutoColumnSize.getColumnWidth(col, defaultWidth)` returned `defaultWidth` verbatim when defined, never consulting its own measured content width.

Net effect: the column stayed at the narrow ghost-header floor instead of expanding to content.

Fix: `NestedHeaders#onModifyColWidth` now factors in the ACS-measured content width when ACS is enabled. Hook registration order is unchanged, so `ManualColumnResize` / `HiddenColumns` / `StretchColumns` still run after `NestedHeaders` and retain final say.

Verified end-to-end against the issue scenario (manual headless-browser run):

| Build | Plain colHeaders 100 -> ? | nestedHeaders 100 -> ? |
|---|---|---|
| Released v17.1.0 | 100 -> 518 (correct) | 100 -> 28.53 (bug) |
| PR build | 100 -> 518 (correct) | 100 -> 518 (correct) |

### How has this been tested?

- New E2E tests in `handsontable/src/plugins/nestedHeaders/__tests__/nestedHeaders.spec.js`:
  - Bug repro: `colWidths: 100` + `nestedHeaders` + long content, then `updateSettings({ colWidths: undefined })`, asserts `getColWidth(0) > 200`.
  - Regression guard: `nestedHeaders` + `manualColumnResize: [30, ...]` + long content, asserts column stays at 30 (not clamped to ghost floor).
- Confirmed red on develop, green after fix.
- Regression suites (all green):
  - `npm run test:e2e --prefix handsontable --testPathPattern='nestedHeaders'` -- 143/143
  - `npm run test:e2e --prefix handsontable --testPathPattern='autoColumnSize'` -- 60/60
  - `npm run test:e2e --prefix handsontable --testPathPattern='hiddenColumns'` -- 289/289
  - `npm run test:e2e --prefix handsontable --testPathPattern='manualColumnResize'` -- 75/75
- Lint clean: `npm run stylelint --prefix handsontable` and ESLint on touched files.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. Fixes #7604
2. DEV-1766

### Affected project(s):

- [x] \`handsontable\`
- [ ] \`@handsontable/angular-wrapper\`
- [ ] \`@handsontable/react-wrapper\`
- [ ] \`@handsontable/vue3\`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1766

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small hook-priority change in column width pipeline with targeted E2E tests; manual resize and later plugins still run afterward.
> 
> **Overview**
> Fixes **#7604**: with `nestedHeaders` and an initial `colWidths`, clearing widths via `updateSettings({ colWidths: undefined })` left columns stuck at the narrow nested-header ghost minimum instead of auto-sizing to cell content.
> 
> **`AutoColumnSize`** now registers `modifyColWidth` at priority **`-10`**, so measured content widths are applied **before** `NestedHeaders` applies its header ghost-table floor. Previously, when ACS was re-enabled after the settings change, its hook often ran after `NestedHeaders`; `getColumnWidth` then kept the incoming (too-small) width when it was already defined and never used the content cache.
> 
> Adds E2E coverage for the reset-to-`undefined` scenario and a guard that **`manualColumnResize`** widths are not overridden when both plugins are on. Changelog entry for the public fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b6768848c5f4115d9fa413d0e774f89fbb3dc98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->