### PR TITLE
fix(docs): fix React demo empty screen in Stackblitz (DEV-1778)

### DIFF
--- a/docs/content/guides/getting-started/demo/react/example2.jsx
+++ b/docs/content/guides/getting-started/demo/react/example2.jsx
@@ -1,6 +1,3 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import Handsontable from 'handsontable/base';
 import { registerAllModules } from 'handsontable/registry';
 import { HotTable, HotColumn } from '@handsontable/react-wrapper';
 
@@ -181,11 +178,4 @@ const App = () => {
   );
 };
 
-const rootElement = document.getElementById('example2');
-const root = ReactDOM.createRoot(rootElement);
-
-rootElement._reactRoot = root;
-root.render(<App />);
-console.log(
-  `Handsontable: v${Handsontable.version} (${Handsontable.buildDate}) Wrapper: v${HotTable.version} React: v${React.version}`
-);
+export default App;

--- a/docs/content/guides/getting-started/demo/react/example2.tsx
+++ b/docs/content/guides/getting-started/demo/react/example2.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
 import Handsontable from 'handsontable/base';
 import { registerAllModules } from 'handsontable/registry';
 import { HotTable, HotColumn } from '@handsontable/react-wrapper';
@@ -189,12 +187,4 @@ const App = () => {
   );
 };
 
-const rootElement = document.getElementById('example2')!;
-const root = ReactDOM.createRoot(rootElement);
-
-rootElement._reactRoot = root;
-root.render(<App />);
-
-console.log(
-  `Handsontable: v${Handsontable.version} (${Handsontable.buildDate}) Wrapper: v${HotTable.version} React: v${React.version}`
-);
+export default App;

--- a/docs/public/example-tabs.js
+++ b/docs/public/example-tabs.js
@@ -499,7 +499,11 @@ document.addEventListener('DOMContentLoaded', function () {
     var jsFile = findFile(userFiles, '.js') || 'index.js';
     var jsCode = userFiles[jsFile] || '';
 
-    var deps = Object.assign({ handsontable: hotVersion, vite: 'latest' }, extraDeps);
+    // Pin Vite to v5 to avoid Vite 8/rolldown aggressively tree-shaking filter condition
+    // registration side effects due to sideEffects:false in the handsontable package.json.
+    // Once handsontable's package.json sideEffects is updated to include condition files,
+    // this can be changed back to 'latest'.
+    var deps = Object.assign({ handsontable: hotVersion, vite: '^5.4.0' }, extraDeps);
 
     var pkg = JSON.stringify({
       name: 'handsontable-example',
@@ -570,8 +574,12 @@ document.addEventListener('DOMContentLoaded', function () {
         '@handsontable/react-wrapper': hotVersion,
         react:                     '18.x',
         'react-dom':               '18.x',
-        vite:                      'latest',
-        '@vitejs/plugin-react':    'latest',
+        // Pin Vite to v5 to avoid Vite 8/rolldown aggressively tree-shaking filter condition
+        // registration side effects due to sideEffects:false in the handsontable package.json.
+        // Once handsontable's package.json sideEffects is updated to include condition files,
+        // this can be changed back to 'latest'.
+        vite:                      '^5.4.0',
+        '@vitejs/plugin-react':    '^4.0.0',
       },
       extraDeps,
     );

--- a/handsontable/package.json
+++ b/handsontable/package.json
@@ -258,7 +258,9 @@
   },
   "sideEffects": [
     "**/*.css",
-    "./languages/*"
+    "./languages/*",
+    "./plugins/filters/condition/**",
+    "./plugins/filters/logicalOperations/**"
   ],
   "publishConfig": {
     "directory": "tmp",


### PR DESCRIPTION
## Summary

Two bugs fixed in the `/demo` page Stackblitz examples:

### Bug 1 — React: empty screen in Stackblitz

`example2.jsx` and `example2.tsx` were manually mounting themselves via `ReactDOM.createRoot()` instead of exporting a default component. The Stackblitz-generated `main.jsx` does `import App from "./App"` (default import), so it received `undefined`, causing `React.createElement(undefined)` to throw.

**Fix:** removed manual mounting code, added `export default App` to both files.

### Bug 2 — JS + React: `Filter condition "eq" does not exist.` when opening dropdown menu

**Root cause:** Vite 8 / rolldown aggressively tree-shakes filter condition registration side effects. Each condition file (`equal.ts`, `empty.ts`, etc.) calls `registerCondition()` at module level. The `handsontable` package.json declares `sideEffects: ['**/*.css', './languages/*']`, marking all JS files as side-effect-free. Rolldown inlines the `CONDITION_NAME` string constants and eliminates the condition modules entirely — so `registerCondition('eq', ...)` never runs.

**Fixes:**
- `handsontable/package.json`: added `./plugins/filters/condition/**` and `./plugins/filters/logicalOperations/**` to `sideEffects` so future npm releases correctly preserve their registrations with Vite 8.
- `docs/public/example-tabs.js`: pinned Vite to `^5.4.0` for JS and React Stackblitz projects as a workaround for the currently published package (v17.1.0 on npm still has the old `sideEffects`). Can be reverted to `'latest'` once an updated package with the fixed `sideEffects` is published.

## Test plan

- [ ] Open the `/demo` docs page
- [ ] Click "Open in Stackblitz" on the **React** tab — verify the demo renders (not empty screen)
- [ ] Click "Open in Stackblitz" on the **JavaScript** tab — verify the demo renders
- [ ] In both demos, click the column header dropdown button — verify no console error and the filter conditions menu opens correctly
- [ ] Verify the `intl-date` column's dropdown shows date filter conditions (before/after/between etc.)
- [ ] Angular tab — verify still OK

Fixes DEV-1778.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and demo wiring plus a narrow package.json sideEffects expansion; no auth, security, or core runtime API changes.
> 
> **Overview**
> Fixes the **React `/demo` StackBlitz** flow by aligning `example2.jsx` / `example2.tsx` with the generated `src/main.jsx`: manual `ReactDOM.createRoot` mounting and related imports/logging are removed, and **`export default App`** is added so the default import is defined.
> 
> **StackBlitz project generation** (`example-tabs.js`) pins **`vite` to `^5.4.0`** (and **`@vitejs/plugin-react` to `^4.0.0`** for React) so newer Vite/Rolldown does not drop filter registration side effects while `handsontable` still marks most JS as side-effect-free.
> 
> The **`handsontable` package** declares **`./plugins/filters/condition/**`** and **`./plugins/filters/logicalOperations/**`** under **`sideEffects`**, matching that bundler behavior for real consumers as well as docs demos.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 913b63684662cd614189d8f02aa0710016fc1654. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->