### PR TITLE
DEV-1237 - [GH #8414] Touch/click events not propagated to clickable …

### DIFF
--- a/.changelogs/12637.json
+++ b/.changelogs/12637.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed checkbox cells not toggling on mobile touch when disableVisualSelection is 'current' or true.",
+  "type": "fixed",
+  "issueOrPR": 12637,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/src/event.ts
+++ b/handsontable/src/3rdparty/walkontable/src/event.ts
@@ -642,9 +642,10 @@ class Event {
           !interactiveElements.includes(target!.tagName)) {
         event.preventDefault();
 
-      } else if (!this.selectedCellWasTouched(target)) {
+      } else if (!this.selectedCellWasTouched(target) && !interactiveElements.includes(target!.tagName)) {
         // For other browsers, prevent default is fired only for the first tap and only when the previous
-        // highlighted cell was different.
+        // highlighted cell was different. Interactive elements (INPUT, BUTTON, A) are excluded so that
+        // e.g. checkboxes with disableVisualSelection can still be toggled via touch.
         event.preventDefault();
       }
     }

--- a/handsontable/src/3rdparty/walkontable/src/event.ts
+++ b/handsontable/src/3rdparty/walkontable/src/event.ts
@@ -642,10 +642,12 @@ class Event {
           !interactiveElements.includes(target!.tagName)) {
         event.preventDefault();
 
-      } else if (!this.selectedCellWasTouched(target) && !interactiveElements.includes(target!.tagName)) {
+      } else if (!this.selectedCellWasTouched(target) &&
+                 !(target!.tagName === 'INPUT' && (target as HTMLInputElement).type === 'checkbox')) {
         // For other browsers, prevent default is fired only for the first tap and only when the previous
-        // highlighted cell was different. Interactive elements (INPUT, BUTTON, A) are excluded so that
-        // e.g. checkboxes with disableVisualSelection can still be toggled via touch.
+        // highlighted cell was different. Checkbox inputs are excluded so that checkboxes with
+        // disableVisualSelection can still be toggled via touch (the focus cellRange is never populated
+        // when visual selection is disabled, so selectedCellWasTouched always returns false for them).
         event.preventDefault();
       }
     }

--- a/handsontable/src/__tests__/mobile/events.spec.js
+++ b/handsontable/src/__tests__/mobile/events.spec.js
@@ -307,4 +307,40 @@ describe('Events', () => {
       await triggerTouchEvent('touchend', cell);
     });
   });
+
+  describe('disableVisualSelection with checkbox', () => {
+    it('should not "preventDefault" touchend on checkbox INPUT when disableVisualSelection is "current"', async() => {
+      handsontable({
+        data: [[true], [false]],
+        width: 400,
+        height: 400,
+        columns: [{ type: 'checkbox', disableVisualSelection: 'current' }],
+      });
+
+      const checkboxInput = hot.getCell(0, 0).querySelector('input[type="checkbox"]');
+
+      await triggerTouchEvent('touchstart', checkboxInput);
+
+      const event = await triggerTouchEvent('touchend', checkboxInput);
+
+      expect(event.defaultPrevented).toBeFalse();
+    });
+
+    it('should not "preventDefault" touchend on checkbox INPUT when disableVisualSelection is true', async() => {
+      handsontable({
+        data: [[true], [false]],
+        width: 400,
+        height: 400,
+        columns: [{ type: 'checkbox', disableVisualSelection: true }],
+      });
+
+      const checkboxInput = hot.getCell(0, 0).querySelector('input[type="checkbox"]');
+
+      await triggerTouchEvent('touchstart', checkboxInput);
+
+      const event = await triggerTouchEvent('touchend', checkboxInput);
+
+      expect(event.defaultPrevented).toBeFalse();
+    });
+  });
 });

--- a/handsontable/src/__tests__/mobile/events.spec.js
+++ b/handsontable/src/__tests__/mobile/events.spec.js
@@ -342,5 +342,23 @@ describe('Events', () => {
 
       expect(event.defaultPrevented).toBeFalse();
     });
+
+    it('should still "preventDefault" touchend on link element in unselected cell when disableVisualSelection is set', async() => {
+      handsontable({
+        data: [['<a href="#test">link</a>']],
+        width: 400,
+        height: 400,
+        renderer: 'html',
+        columns: [{ disableVisualSelection: 'current' }],
+      });
+
+      const linkElement = hot.getCell(0, 0).querySelector('a');
+
+      await triggerTouchEvent('touchstart', linkElement);
+
+      const event = await triggerTouchEvent('touchend', linkElement);
+
+      expect(event.defaultPrevented).toBeTrue();
+    });
   });
 });


### PR DESCRIPTION
### Context
 Fixed an issue where checkbox cells with disableVisualSelection: 'current' or disableVisualSelection: true could not be toggled via touch on mobile devices. The touchend event was always preventDefault-ed because   ▎ the focus selection cell range is never populated when visual selection is disabled, causing selectedCellWasTouched() to always return false. Interactive elements (INPUT, BUTTON, A) are now excluded from the 
  ▎ preventDefault call, consistent with the existing iOS WebKit handling.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #8414
2. DEV-1237
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.


ClickUp task: https://app.clickup.com/t/9015210959/DEV-1766


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Walkontable touch handling change with new regression tests; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **checkbox cells** that could not be toggled on mobile when `disableVisualSelection` is `'current'` or `true`. Walkontable’s `onTouchEnd` logic was calling `preventDefault` whenever the touched cell did not match the stored focus range; with visual selection disabled that range is never set, so every tap on the checkbox was blocked.
> 
> The non‑iOS branch now **skips `preventDefault` for checkbox `INPUT` targets**, matching the intent of the existing interactive-element handling on iOS WebKit. **Mobile tests** cover checkbox columns with both `disableVisualSelection` values and confirm links in cells with `disableVisualSelection` still get `preventDefault` on first tap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 586eee8f585063952e650c3dff0147b93b5cdcb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->