### PR TITLE
DEV-1771: Skip Ctrl+click dedup when disableVisualSelection is set

### DIFF
--- a/.changelogs/12638.json
+++ b/.changelogs/12638.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed Ctrl/Cmd+click selection highlight jumping between cells when `disableVisualSelection` is set to a non-`false` value.",
+  "type": "fixed",
+  "issueOrPR": 12638,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -2095,6 +2095,11 @@ export default (): Record<string, unknown> => {
      * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
      * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
+     * When set to any non-`false` value, the second-click deselect behavior
+     * (Ctrl/Cmd+click on an already-selected cell removing it from a multi-cell selection)
+     * is also skipped. Without visible feedback, toggling layers off can cause unexpected
+     * highlight jumps.
+     *
      * Read more:
      * - [Selection](@/guides/cell-features/selection/selection.md)
      *

--- a/handsontable/src/selection/__tests__/mouseInteraction/secondClickDeselects.spec.js
+++ b/handsontable/src/selection/__tests__/mouseInteraction/secondClickDeselects.spec.js
@@ -555,6 +555,164 @@ describe('Selection using mouse interaction (cell deselect)', () => {
       `).toBeMatchToSelectionPattern();
   });
 
+  describe('with `disableVisualSelection` enabled', () => {
+    it('should skip the dedup behavior when `disableVisualSelection: true`', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        disableVisualSelection: true,
+      });
+
+      await selectCells([
+        [0, 0, 0, 0],
+        [1, 0, 1, 0],
+        [1, 1, 1, 1],
+      ]);
+
+      await keyDown('control/meta');
+      await simulateClick(getCell(1, 0));
+      await keyUp('control/meta');
+
+      // Ctrl+click on an already-selected cell adds a new layer; no dedup runs,
+      // so the just-clicked cell stays as the active selection.
+      expect(getSelectedRange()).toEqualCellRange([
+        'highlight: 0,0 from: 0,0 to: 0,0',
+        'highlight: 1,0 from: 1,0 to: 1,0',
+        'highlight: 1,1 from: 1,1 to: 1,1',
+        'highlight: 1,0 from: 1,0 to: 1,0',
+      ]);
+    });
+
+    it('should skip the dedup behavior when `disableVisualSelection: \'current\'`', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        disableVisualSelection: 'current',
+      });
+
+      await selectCells([
+        [0, 0, 0, 0],
+        [1, 0, 1, 0],
+        [1, 1, 1, 1],
+      ]);
+
+      await keyDown('control/meta');
+      await simulateClick(getCell(1, 0));
+      await keyUp('control/meta');
+
+      expect(getSelectedRange()).toEqualCellRange([
+        'highlight: 0,0 from: 0,0 to: 0,0',
+        'highlight: 1,0 from: 1,0 to: 1,0',
+        'highlight: 1,1 from: 1,1 to: 1,1',
+        'highlight: 1,0 from: 1,0 to: 1,0',
+      ]);
+    });
+
+    it('should skip the dedup behavior when `disableVisualSelection` is passed as an array', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        disableVisualSelection: ['current', 'area'],
+      });
+
+      await selectCells([
+        [0, 0, 0, 0],
+        [1, 0, 1, 0],
+        [1, 1, 1, 1],
+      ]);
+
+      await keyDown('control/meta');
+      await simulateClick(getCell(1, 0));
+      await keyUp('control/meta');
+
+      expect(getSelectedRange()).toEqualCellRange([
+        'highlight: 0,0 from: 0,0 to: 0,0',
+        'highlight: 1,0 from: 1,0 to: 1,0',
+        'highlight: 1,1 from: 1,1 to: 1,1',
+        'highlight: 1,0 from: 1,0 to: 1,0',
+      ]);
+    });
+
+    it('should skip the dedup behavior when `disableVisualSelection: \'area\'`', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        disableVisualSelection: 'area',
+      });
+
+      await selectCells([
+        [0, 0, 0, 0],
+        [1, 0, 1, 0],
+        [1, 1, 1, 1],
+      ]);
+
+      await keyDown('control/meta');
+      await simulateClick(getCell(1, 0));
+      await keyUp('control/meta');
+
+      expect(getSelectedRange()).toEqualCellRange([
+        'highlight: 0,0 from: 0,0 to: 0,0',
+        'highlight: 1,0 from: 1,0 to: 1,0',
+        'highlight: 1,1 from: 1,1 to: 1,1',
+        'highlight: 1,0 from: 1,0 to: 1,0',
+      ]);
+    });
+
+    it('should still run the dedup branch when `disableVisualSelection` is an empty array', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        disableVisualSelection: [],
+      });
+
+      await selectCells([
+        [0, 0, 0, 0],
+        [1, 0, 1, 0],
+        [1, 1, 1, 1],
+      ]);
+
+      await keyDown('control/meta');
+      await simulateClick(getCell(1, 0));
+      await keyUp('control/meta');
+
+      // [] means nothing disabled, so dedup must still run as if `false`.
+      expect(getSelectedRange()).toEqualCellRange([
+        'highlight: 0,0 from: 0,0 to: 0,0',
+        'highlight: 1,1 from: 1,1 to: 1,1',
+      ]);
+    });
+
+    it('should still run the dedup branch when `disableVisualSelection` is `false`', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        colHeaders: true,
+        rowHeaders: true,
+        disableVisualSelection: false,
+      });
+
+      await selectCells([
+        [0, 0, 0, 0],
+        [1, 0, 1, 0],
+        [1, 1, 1, 1],
+      ]);
+
+      await keyDown('control/meta');
+      await simulateClick(getCell(1, 0));
+      await keyUp('control/meta');
+
+      // dedup removes the duplicate layers, leaving the two unique selections
+      expect(getSelectedRange()).toEqualCellRange([
+        'highlight: 0,0 from: 0,0 to: 0,0',
+        'highlight: 1,1 from: 1,1 to: 1,1',
+      ]);
+    });
+  });
+
   it('should not scroll the viewport when Ctrl+click deselects a cell layer', async() => {
     handsontable({
       data: createSpreadsheetData(50, 10),

--- a/handsontable/src/selection/mouseEventHandler.ts
+++ b/handsontable/src/selection/mouseEventHandler.ts
@@ -148,8 +148,16 @@ interface MouseUpOptions {
  */
 export function mouseUp({ isLeftClick, selection, cellRangeMapper }: MouseUpOptions) {
   const sel = selection;
+  const dvs = sel.settings.disableVisualSelection;
+  // Treat empty string and empty array as equivalent to `false` (nothing is actually disabled),
+  // matching how the rest of the codebase normalizes this setting.
+  const visualSelectionDisabled = dvs === true
+    || (typeof dvs === 'string' && dvs.length > 0)
+    || (Array.isArray(dvs) && dvs.length > 0);
 
-  if (!isLeftClick || sel.settings.selectionMode !== 'multiple') {
+  // The dedup-on-second-click behavior relies on visible selection feedback; without it,
+  // toggling invisible layers produces highlight jumps once any visible range repaints.
+  if (!isLeftClick || sel.settings.selectionMode !== 'multiple' || visualSelectionDisabled) {
     return;
   }
 

--- a/handsontable/src/selection/types.ts
+++ b/handsontable/src/selection/types.ts
@@ -55,6 +55,7 @@ export interface SelectionSettings {
   autoWrapRow?: boolean;
   autoWrapCol?: boolean;
   selectionMode?: 'single' | 'range' | 'multiple';
+  disableVisualSelection?: boolean | string | string[];
   fillHandle?: unknown;
   [key: string]: unknown;
 }


### PR DESCRIPTION
### Context

The PR fixes [DEV-1771](https://app.clickup.com/t/9015210959/DEV-1771). When `disableVisualSelection` is set to any non-`false` value (`true`, `'current'`, `'area'`, `'header'`, or a non-empty array), Ctrl/Cmd+clicking on an already-selected cell in a multi-cell selection caused the active highlight to "jump back" to a previous range on the next render.

Root cause: the second-click dedup feature introduced in 16.0 (#11602) silently toggled layers off in `mouseUp()`. With visual selection hidden, the user has no warning that a layer was just dropped, so the next render snaps the highlight to whatever range remains current.

Fix: gate the dedup block in `mouseUp()` behind `disableVisualSelection === false`. Empty strings/arrays normalize to `false` to match how the rest of the codebase treats this option (it is the "nothing actually disabled" case).

The default `disableVisualSelection: false` path is untouched — existing dedup behavior is preserved for the common case.

### How has this been tested?

- New E2E specs in `handsontable/src/selection/__tests__/mouseInteraction/secondClickDeselects.spec.js`:
  - `disableVisualSelection: true` — dedup skipped, all layers preserved.
  - `disableVisualSelection: 'current'` — dedup skipped.
  - `disableVisualSelection: 'area'` — dedup skipped.
  - `disableVisualSelection: ['current', 'area']` — dedup skipped.
  - `disableVisualSelection: []` — dedup still runs (empty array normalizes to `false`).
  - `disableVisualSelection: false` — regression guard, dedup runs as before.
- Regression suites (all green):
  - `npm run test:e2e --testPathPattern=secondClickDeselects` — 29/29
  - `npm run test:e2e --testPathPattern=selection/__tests__/mouseInteraction` — 58/58
  - `npm run test:e2e --testPathPattern=disableVisualSelection` — 6/6
- Lint clean: ESLint on touched files.
- Manual repro: side-by-side comparison via local HTML demo (CDN v17.1.0 reproduces the jump, local PR build does not), using `disableVisualSelection: 'area'`.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1771

### Affected project(s):

- [x] \`handsontable\`
- [ ] \`@handsontable/angular-wrapper\`
- [ ] \`@handsontable/react-wrapper\`
- [ ] \`@handsontable/vue3\`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1771