### PR TITLE
DEV-1770: Fix single Excel cell paste blanking the row below when sanitizer strips HTML

### DIFF
--- a/.changelogs/12640.json
+++ b/.changelogs/12640.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed pasting a single cell from Excel erasing the cell below the paste target when a custom `sanitizer` strips the HTML.",
+  "type": "fixed",
+  "issueOrPR": 12640,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/copyPaste/__tests__/settings/sanitizer.spec.js
+++ b/handsontable/src/plugins/copyPaste/__tests__/settings/sanitizer.spec.js
@@ -35,5 +35,73 @@ describe('CopyPaste', () => {
 
       expect(sanitizer).toHaveBeenCalledWith('<div>test</div>', 'CopyPaste.paste');
     });
+
+    it('should not blank the cell below the target when a single Excel cell is pasted and the' +
+      ' sanitizer strips the HTML to plain text', async() => {
+      const sanitizer = (content) => {
+        const tpl = document.createElement('template');
+
+        tpl.innerHTML = content;
+
+        const text = tpl.content.textContent ?? '';
+
+        return text
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;')
+          .replace(/'/g, '&#39;');
+      };
+
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        copyPaste: true,
+        sanitizer,
+      });
+
+      const clipboardEvent = getClipboardEvent();
+      const plugin = getPlugin('CopyPaste');
+
+      // Excel terminates the single copied cell with a trailing CRLF.
+      clipboardEvent.clipboardData.setData('text/html', '<table><tbody><tr><td>X</td></tr></tbody></table>');
+      clipboardEvent.clipboardData.setData('text/plain', 'X\r\n');
+
+      await selectCell(3, 1);
+
+      plugin.onPaste(clipboardEvent);
+
+      expect(getDataAtCell(3, 1)).toBe('X');
+      expect(getDataAtCell(4, 1)).toBe('B5');
+    });
+
+    it('should paste a multi-row Excel selection without appending an extra empty row when the' +
+      ' sanitizer strips the HTML to plain text', async() => {
+      const sanitizer = (content) => {
+        const tpl = document.createElement('template');
+
+        tpl.innerHTML = content;
+
+        return tpl.content.textContent ?? '';
+      };
+
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        copyPaste: true,
+        sanitizer,
+      });
+
+      const clipboardEvent = getClipboardEvent();
+      const plugin = getPlugin('CopyPaste');
+
+      clipboardEvent.clipboardData.setData('text/plain', 'A\r\nB\r\n');
+
+      await selectCell(0, 0);
+
+      plugin.onPaste(clipboardEvent);
+
+      expect(getDataAtCell(0, 0)).toBe('A');
+      expect(getDataAtCell(1, 0)).toBe('B');
+      expect(getDataAtCell(2, 0)).toBe('A3');
+    });
   });
 });

--- a/handsontable/src/plugins/copyPaste/copyPaste.ts
+++ b/handsontable/src/plugins/copyPaste/copyPaste.ts
@@ -816,6 +816,14 @@ export class CopyPaste extends BasePlugin {
         pastedData = parsedConfig.data;
       } else {
         pastedData = clipboardData.getData('text/plain');
+
+        // Excel terminates every row (including the last) with a CRLF. For a single-cell copy that
+        // produces a trailing newline, which `SheetClip.parse` would read as a row separator and emit
+        // an extra empty row, blanking the cell below the paste target. Treat a single trailing
+        // newline as a terminator, not a separator.
+        if (typeof pastedData === 'string') {
+          pastedData = pastedData.replace(/(\r\n|\r|\n)$/, '');
+        }
       }
 
     } else if (typeof ClipboardEvent === 'undefined' &&


### PR DESCRIPTION
### Context

The PR fixes a bug where pasting a single cell copied from Excel blanks the cell directly below the paste target, but only when a custom `sanitizer` flattens HTML to plain text.

When the sanitizer strips the `<table>` markup, the paste path falls back to `text/plain`. Excel terminates every row (including the last) with a CRLF, so `SheetClip.parse('value\r\n')` reads the trailing newline as a row separator and emits an extra empty trailing row. `populateValues` then writes that empty row into the cell below the target, erasing its data. Google Sheets is unaffected because its `text/plain` payload has no trailing newline.

The custom `sanitizer` option was introduced in v17 (#12016); before that the HTML path was always taken, so this latent SheetClip behavior was never exposed.

The fix trims a single trailing newline from the `text/plain` fallback so it acts as a row terminator, not a separator. `SheetClip.parse` is left untouched (it has explicit tests for the trailing-empty-row contract).

### How has this been tested?

Added two E2E tests in `copyPaste/__tests__/settings/sanitizer.spec.js`:

- single-cell Excel paste (`text/plain="X\r\n"`) with a strip-HTML sanitizer into B4 → B4 = `X`, B5 unchanged
- multi-row Excel paste (`text/plain="A\r\nB\r\n"`) → two rows, no extra empty third row

Verified both tests fail without the fix and pass with it.

```bash
npm run test:e2e --prefix handsontable --testPathPattern=copyPaste/__tests__/settings/sanitizer
npm run test:e2e --prefix handsontable --testPathPattern=copyPaste/__tests__/paste
npm run eslint --prefix handsontable
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1770

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/DEV-1770

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to plain-text paste preprocessing in CopyPaste with targeted E2E coverage; no auth or data-model changes.
> 
> **Overview**
> Fixes **CopyPaste** when paste falls back to `text/plain` because a custom **`sanitizer`** removes Excel’s `<table>` HTML. Excel’s plain text ends each row with **CRLF**, so a single cell like `X\r\n` was parsed by **SheetClip** as two rows and **`populateValues`** overwrote the cell below the target.
> 
> **`copyPaste.ts`** strips one trailing `\r\n`, `\r`, or `\n` from that plain string before **`parse()`**, treating it as a row terminator instead of an extra row. Multi-row pastes like `A\r\nB\r\n` are unchanged. New E2E cases in **`sanitizer.spec.js`** cover single-cell and multi-row Excel paste with HTML-stripping sanitizers; changelog **12640** documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c98f80b29fcc1078fda56585cbb7358f867e3b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->