### PR TITLE
DEV-1781: Fix Algolia search highlight color visibility in docs

### DIFF
--- a/docs/src/styles/base/variables.css
+++ b/docs/src/styles/base/variables.css
@@ -47,8 +47,8 @@
   /* Body text color */
   --sl-color-text: var(--sl-color-gray-2);
 
-  /* Starlight uses these for active sidebar / search highlights — must not be solid accent */
-  --sl-color-text-accent: var(--sl-color-accent-low);
+  /* Starlight uses these for active sidebar / search highlights and DocSearch matched text */
+  --sl-color-text-accent: var(--sl-color-accent-high);
   --sl-color-text-invert: var(--sl-color-text);
 
   /* Inline code: darker bg (gray-7) + white text */
@@ -95,7 +95,7 @@
   /* Hover bg — needs to be visibly distinct from the page background (98%) */
   --sl-color-hover-bg: oklch(96% 0 0);
 
-  --sl-color-text-accent: var(--sl-color-accent-low);
+  --sl-color-text-accent: var(--sl-color-accent);
   --sl-color-text-invert: var(--sl-color-text);
 
   /* Shared bg for tables and code blocks */
@@ -122,7 +122,7 @@
     --sl-rapide-ui-border-color: #474747;
     --sl-rapide-ec-marker-bg-color: #454545;
     --sl-rapide-ec-marker-border-color: #787878;
-    --sl-color-text-accent: #1a3a6b;
+    --sl-color-text-accent: #a8c8ff;
     --sl-color-text-invert: #b8b8b8;
   }
 
@@ -142,7 +142,7 @@
     --sl-rapide-ui-border-color: #e0e0e0;
     --sl-rapide-ec-marker-bg-color: #ededed;
     --sl-rapide-ec-marker-border-color: #9e9e9e;
-    --sl-color-text-accent: #e6f3ff;
+    --sl-color-text-accent: #1A42E8;
     --sl-color-text-invert: #5c5c5c;
   }
 }


### PR DESCRIPTION
### Context

The PR fixes invisible Algolia DocSearch matched-text highlights in both light and dark themes of the documentation site.

The `starlight-docsearch` package maps `--docsearch-primary-color: var(--sl-color-text-accent)`, and `--docsearch-highlight-color` inherits from that. The DEV-1709 fix introduced `--sl-color-text-accent` overrides using `accent-low` values:

- **Dark mode**: `#1a3a6b` (dark navy) — nearly invisible on dark modal backgrounds
- **Light mode**: `#e6f3ff` (very light blue) — nearly invisible on light modal backgrounds

This made matched search text invisible in both themes.

**Fix:** Use `--sl-color-accent-high` (`#a8c8ff`) in dark mode and `--sl-color-accent` (`#1A42E8`) in light mode. These values provide proper contrast against the DocSearch modal backgrounds and are consistent with the hex fallbacks for older Safari/iOS.

Task: https://app.clickup.com/t/9015210959/DEV-1781

### How has this been tested?

- Verified the CSS variable chain: `--sl-color-text-accent` → `--docsearch-primary-color` → `--docsearch-highlight-color`
- Compared before/after values against the preview at `rc-handsontable-17-1-0.netlify.app`
- Change is limited to `docs/src/styles/base/variables.css` — no JS changes, no dependency changes

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1781

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

---
_Generated by [Claude Code](https://claude.ai/code/session_015MwNMgMYn5cJcRzuQTofd6)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file CSS token swap for docs theming only; no runtime, auth, or data-path changes.
> 
> **Overview**
> Fixes **invisible Algolia DocSearch match highlights** by retargeting `--sl-color-text-accent` away from low-contrast `accent-low` colors.
> 
> In **dark** mode it now uses `--sl-color-accent-high` (and fallback `#a8c8ff`); in **light** mode it uses `--sl-color-accent` (and fallback `#1A42E8`). That token feeds Starlight sidebar/search styling and DocSearch’s primary/highlight colors, so matched query text is readable on both modal backgrounds. Comments note DocSearch explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d19a41b01b13ce841a67dff4cccafd0ebd97c2ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->