### PR TITLE
DEV-24: Clear skip-on-paste meta when a hidden row/column is shown

### DIFF
--- a/.changelogs/12647.json
+++ b/.changelogs/12647.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed autofill and paste skipping a row or column that was hidden and then shown again, when `hiddenRows`/`hiddenColumns` had `copyPasteEnabled` set to `false`.",
+  "type": "fixed",
+  "issueOrPR": 12647,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/hiddenColumns/__tests__/plugins/copyPaste.spec.js
+++ b/handsontable/src/plugins/hiddenColumns/__tests__/plugins/copyPaste.spec.js
@@ -248,6 +248,34 @@ describe('hiddenColumns', () => {
       expect(getCellMeta(0, 2).skipColumnOnPaste).toBe(false);
     });
 
+    it('should not overwrite the user-defined `skipColumnOnPaste: true` on a non-hidden column, when ' +
+      '"copyPasteEnabled" property is set to false', async() => {
+      handsontable({
+        data: createSpreadsheetData(2, 5),
+        hiddenColumns: {
+          copyPasteEnabled: false,
+          columns: [2],
+        },
+        columns: [
+          {},
+          {},
+          {},
+          { skipColumnOnPaste: true },
+          {},
+        ],
+      });
+
+      expect(getCellMeta(0, 3).skipColumnOnPaste).toBe(true);
+      expect(getCellMeta(0, 0).skipColumnOnPaste).toBe(false);
+      expect(getCellMeta(0, 2).skipColumnOnPaste).toBe(true);
+
+      getPlugin('hiddenColumns').showColumns([2]);
+      await render();
+
+      expect(getCellMeta(0, 3).skipColumnOnPaste).toBe(true);
+      expect(getCellMeta(0, 2).skipColumnOnPaste).toBe(false);
+    });
+
     it('should paste data into a column that was hidden and then shown again, when ' +
       '"copyPasteEnabled" property is set to false', async() => {
       handsontable({

--- a/handsontable/src/plugins/hiddenColumns/__tests__/plugins/copyPaste.spec.js
+++ b/handsontable/src/plugins/hiddenColumns/__tests__/plugins/copyPaste.spec.js
@@ -225,6 +225,54 @@ describe('hiddenColumns', () => {
       expect(getSelectedRangeLast().to.col).toBe(2);
     });
 
+    it('should clear the `skipColumnOnPaste` meta after a hidden column is shown again, when ' +
+      '"copyPasteEnabled" property is set to false', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        hiddenColumns: {
+          copyPasteEnabled: false,
+        },
+      });
+
+      const plugin = getPlugin('hiddenColumns');
+
+      plugin.hideColumns([2]);
+      await render();
+
+      // Reading the meta while the column is hidden caches `skipColumnOnPaste: true` on the cell.
+      expect(getCellMeta(0, 2).skipColumnOnPaste).toBe(true);
+
+      plugin.showColumns([2]);
+      await render();
+
+      expect(getCellMeta(0, 2).skipColumnOnPaste).toBe(false);
+    });
+
+    it('should paste data into a column that was hidden and then shown again, when ' +
+      '"copyPasteEnabled" property is set to false', async() => {
+      handsontable({
+        data: createSpreadsheetData(1, 5),
+        hiddenColumns: {
+          copyPasteEnabled: false,
+        },
+      });
+
+      const plugin = getPlugin('hiddenColumns');
+
+      plugin.hideColumns([2]);
+      await render();
+      // Force the skip flag to be cached on the hidden column.
+      getCellMeta(0, 2);
+      plugin.showColumns([2]);
+      await render();
+
+      await selectCell(0, 0);
+      getPlugin('CopyPaste').paste('v\tw\tx\ty\tz');
+
+      expect(getDataAtCell(0, 2)).toBe('x');
+      expect(getData()[0]).toEqual(['v', 'w', 'x', 'y', 'z']);
+    });
+
     it('should keep the same number of columns if all columns are hidden', async() => {
       handsontable({
         data: createSpreadsheetData(1, 2),

--- a/handsontable/src/plugins/hiddenColumns/__tests__/plugins/copyPaste.spec.js
+++ b/handsontable/src/plugins/hiddenColumns/__tests__/plugins/copyPaste.spec.js
@@ -276,6 +276,33 @@ describe('hiddenColumns', () => {
       expect(getCellMeta(0, 2).skipColumnOnPaste).toBe(false);
     });
 
+    it('should preserve the user-defined `skipColumnOnPaste: true` on a column that is hidden and ' +
+      'then shown again, when "copyPasteEnabled" property is set to false', async() => {
+      handsontable({
+        data: createSpreadsheetData(2, 5),
+        hiddenColumns: {
+          copyPasteEnabled: false,
+          columns: [3],
+        },
+        columns: [
+          {},
+          {},
+          {},
+          { skipColumnOnPaste: true },
+          {},
+        ],
+      });
+
+      // Force the meta to be cached while the column is hidden.
+      expect(getCellMeta(0, 3).skipColumnOnPaste).toBe(true);
+
+      getPlugin('hiddenColumns').showColumns([3]);
+      await render();
+
+      // The user-defined `skipColumnOnPaste: true` must survive after the column is shown again.
+      expect(getCellMeta(0, 3).skipColumnOnPaste).toBe(true);
+    });
+
     it('should paste data into a column that was hidden and then shown again, when ' +
       '"copyPasteEnabled" property is set to false', async() => {
       handsontable({

--- a/handsontable/src/plugins/hiddenColumns/hiddenColumns.ts
+++ b/handsontable/src/plugins/hiddenColumns/hiddenColumns.ts
@@ -16,6 +16,8 @@ Hooks.getSingleton().register('afterUnhideColumns');
 export const PLUGIN_KEY = 'hiddenColumns';
 export const PLUGIN_PRIORITY = 310;
 
+const SKIP_COLUMN_ON_PASTE_BY_PLUGIN = Symbol('skipColumnOnPasteByHiddenColumns');
+
 /* eslint-disable jsdoc/require-description-complete-sentence */
 
 /**
@@ -409,7 +411,12 @@ export class HiddenColumns extends BasePlugin {
    */
   resetCellsMeta() {
     arrayEach(this.hot.getCellsMeta(), (meta) => {
-      (meta as Record<string, unknown>).skipColumnOnPaste = false;
+      const cellMeta = meta as Record<string | symbol, unknown>;
+
+      if (cellMeta[SKIP_COLUMN_ON_PASTE_BY_PLUGIN]) {
+        delete cellMeta.skipColumnOnPaste;
+        delete cellMeta[SKIP_COLUMN_ON_PASTE_BY_PLUGIN];
+      }
     });
   }
 
@@ -445,9 +452,18 @@ export class HiddenColumns extends BasePlugin {
    */
   #onAfterGetCellMeta = (row: number, column: number, cellProperties: Record<string, unknown>) => {
     if (this.getSetting('copyPasteEnabled') === false) {
-      // Cell property handled by the `Autofill` and the `CopyPaste` plugins. Assigned on every
-      // `afterGetCellMeta` call so the flag clears itself once a previously hidden column is shown again.
-      cellProperties.skipColumnOnPaste = this.isHidden(column);
+      // Cell property handled by the `Autofill` and the `CopyPaste` plugins. Marked with a Symbol so
+      // the flag clears itself once a previously hidden column is shown again, without overwriting
+      // `skipColumnOnPaste` values set by the user via `columns`, `cells`, or `cell` configuration.
+      const cellPropsWithMarker = cellProperties as Record<string | symbol, unknown>;
+
+      if (this.isHidden(column)) {
+        cellProperties.skipColumnOnPaste = true;
+        cellPropsWithMarker[SKIP_COLUMN_ON_PASTE_BY_PLUGIN] = true;
+      } else if (cellPropsWithMarker[SKIP_COLUMN_ON_PASTE_BY_PLUGIN]) {
+        delete cellProperties.skipColumnOnPaste;
+        delete cellPropsWithMarker[SKIP_COLUMN_ON_PASTE_BY_PLUGIN];
+      }
     }
 
     if (this.isHidden(column - 1)) {

--- a/handsontable/src/plugins/hiddenColumns/hiddenColumns.ts
+++ b/handsontable/src/plugins/hiddenColumns/hiddenColumns.ts
@@ -452,14 +452,17 @@ export class HiddenColumns extends BasePlugin {
    */
   #onAfterGetCellMeta = (row: number, column: number, cellProperties: Record<string, unknown>) => {
     if (this.getSetting('copyPasteEnabled') === false) {
-      // Cell property handled by the `Autofill` and the `CopyPaste` plugins. Marked with a Symbol so
-      // the flag clears itself once a previously hidden column is shown again, without overwriting
-      // `skipColumnOnPaste` values set by the user via `columns`, `cells`, or `cell` configuration.
+      // Cell property handled by the `Autofill` and the `CopyPaste` plugins. The plugin only sets
+      // and marks cells whose `skipColumnOnPaste` it actually flips to `true`. Cells that already
+      // had `true` from user configuration (`columns`, `cells`, or `cell`) are left untouched,
+      // so that unhiding the column does not erase the user-defined value.
       const cellPropsWithMarker = cellProperties as Record<string | symbol, unknown>;
 
       if (this.isHidden(column)) {
-        cellProperties.skipColumnOnPaste = true;
-        cellPropsWithMarker[SKIP_COLUMN_ON_PASTE_BY_PLUGIN] = true;
+        if (cellProperties.skipColumnOnPaste !== true) {
+          cellProperties.skipColumnOnPaste = true;
+          cellPropsWithMarker[SKIP_COLUMN_ON_PASTE_BY_PLUGIN] = true;
+        }
       } else if (cellPropsWithMarker[SKIP_COLUMN_ON_PASTE_BY_PLUGIN]) {
         delete cellProperties.skipColumnOnPaste;
         delete cellPropsWithMarker[SKIP_COLUMN_ON_PASTE_BY_PLUGIN];

--- a/handsontable/src/plugins/hiddenColumns/hiddenColumns.ts
+++ b/handsontable/src/plugins/hiddenColumns/hiddenColumns.ts
@@ -444,9 +444,10 @@ export class HiddenColumns extends BasePlugin {
    * @param {object} cellProperties Object containing the cell properties.
    */
   #onAfterGetCellMeta = (row: number, column: number, cellProperties: Record<string, unknown>) => {
-    if (this.getSetting('copyPasteEnabled') === false && this.isHidden(column)) {
-      // Cell property handled by the `Autofill` and the `CopyPaste` plugins.
-      cellProperties.skipColumnOnPaste = true;
+    if (this.getSetting('copyPasteEnabled') === false) {
+      // Cell property handled by the `Autofill` and the `CopyPaste` plugins. Assigned on every
+      // `afterGetCellMeta` call so the flag clears itself once a previously hidden column is shown again.
+      cellProperties.skipColumnOnPaste = this.isHidden(column);
     }
 
     if (this.isHidden(column - 1)) {

--- a/handsontable/src/plugins/hiddenRows/__tests__/plugins/copyPaste.spec.js
+++ b/handsontable/src/plugins/hiddenRows/__tests__/plugins/copyPaste.spec.js
@@ -299,6 +299,31 @@ describe('HiddenRows', () => {
       expect(getCellMeta(2, 0).skipRowOnPaste).toBe(false);
     });
 
+    it('should preserve the user-defined `skipRowOnPaste: true` on a row that is hidden and ' +
+      'then shown again, when "copyPasteEnabled" property is set to false', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 2),
+        hiddenRows: {
+          copyPasteEnabled: false,
+          rows: [3],
+        },
+        cells(row) {
+          if (row === 3) {
+            return { skipRowOnPaste: true };
+          }
+        },
+      });
+
+      // Force the meta to be cached while the row is hidden.
+      expect(getCellMeta(3, 0).skipRowOnPaste).toBe(true);
+
+      getPlugin('hiddenRows').showRows([3]);
+      await render();
+
+      // The user-defined `skipRowOnPaste: true` must survive after the row is shown again.
+      expect(getCellMeta(3, 0).skipRowOnPaste).toBe(true);
+    });
+
     it('should paste data into a row that was hidden and then shown again, when ' +
       '"copyPasteEnabled" property is set to false', async() => {
       handsontable({

--- a/handsontable/src/plugins/hiddenRows/__tests__/plugins/copyPaste.spec.js
+++ b/handsontable/src/plugins/hiddenRows/__tests__/plugins/copyPaste.spec.js
@@ -250,6 +250,54 @@ describe('HiddenRows', () => {
       expect(getSelectedRangeLast().to.col).toBe(0);
     });
 
+    it('should clear the `skipRowOnPaste` meta after a hidden row is shown again, when ' +
+      '"copyPasteEnabled" property is set to false', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        hiddenRows: {
+          copyPasteEnabled: false,
+        },
+      });
+
+      const plugin = getPlugin('hiddenRows');
+
+      plugin.hideRows([2]);
+      await render();
+
+      // Reading the meta while the row is hidden caches `skipRowOnPaste: true` on the cell.
+      expect(getCellMeta(2, 0).skipRowOnPaste).toBe(true);
+
+      plugin.showRows([2]);
+      await render();
+
+      expect(getCellMeta(2, 0).skipRowOnPaste).toBe(false);
+    });
+
+    it('should paste data into a row that was hidden and then shown again, when ' +
+      '"copyPasteEnabled" property is set to false', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 1),
+        hiddenRows: {
+          copyPasteEnabled: false,
+        },
+      });
+
+      const plugin = getPlugin('hiddenRows');
+
+      plugin.hideRows([2]);
+      await render();
+      // Force the skip flag to be cached on the hidden row.
+      getCellMeta(2, 0);
+      plugin.showRows([2]);
+      await render();
+
+      await selectCell(0, 0);
+      getPlugin('CopyPaste').paste('v\nw\nx\ny\nz');
+
+      expect(getDataAtCell(2, 0)).toBe('x');
+      expect(getData().map(([cell]) => cell)).toEqual(['v', 'w', 'x', 'y', 'z']);
+    });
+
     it('should keep same number of rows if all rows are hidden', async() => {
       handsontable({
         data: createSpreadsheetData(2, 1),

--- a/handsontable/src/plugins/hiddenRows/__tests__/plugins/copyPaste.spec.js
+++ b/handsontable/src/plugins/hiddenRows/__tests__/plugins/copyPaste.spec.js
@@ -273,6 +273,32 @@ describe('HiddenRows', () => {
       expect(getCellMeta(2, 0).skipRowOnPaste).toBe(false);
     });
 
+    it('should not overwrite the user-defined `skipRowOnPaste: true` on a non-hidden row, when ' +
+      '"copyPasteEnabled" property is set to false', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 2),
+        hiddenRows: {
+          copyPasteEnabled: false,
+          rows: [2],
+        },
+        cells(row) {
+          if (row === 3) {
+            return { skipRowOnPaste: true };
+          }
+        },
+      });
+
+      expect(getCellMeta(3, 0).skipRowOnPaste).toBe(true);
+      expect(getCellMeta(0, 0).skipRowOnPaste).toBe(false);
+      expect(getCellMeta(2, 0).skipRowOnPaste).toBe(true);
+
+      getPlugin('hiddenRows').showRows([2]);
+      await render();
+
+      expect(getCellMeta(3, 0).skipRowOnPaste).toBe(true);
+      expect(getCellMeta(2, 0).skipRowOnPaste).toBe(false);
+    });
+
     it('should paste data into a row that was hidden and then shown again, when ' +
       '"copyPasteEnabled" property is set to false', async() => {
       handsontable({

--- a/handsontable/src/plugins/hiddenRows/hiddenRows.ts
+++ b/handsontable/src/plugins/hiddenRows/hiddenRows.ts
@@ -433,9 +433,10 @@ export class HiddenRows extends BasePlugin {
    * @param {object} cellProperties Object containing the cell properties.
    */
   #onAfterGetCellMeta = (row: number, column: number, cellProperties: Record<string, unknown>) => {
-    if (this.getSetting('copyPasteEnabled') === false && this.isHidden(row)) {
-      // Cell property handled by the `Autofill` and the `CopyPaste` plugins.
-      cellProperties.skipRowOnPaste = true;
+    if (this.getSetting('copyPasteEnabled') === false) {
+      // Cell property handled by the `Autofill` and the `CopyPaste` plugins. Assigned on every
+      // `afterGetCellMeta` call so the flag clears itself once a previously hidden row is shown again.
+      cellProperties.skipRowOnPaste = this.isHidden(row);
     }
 
     if (this.isHidden(row - 1)) {

--- a/handsontable/src/plugins/hiddenRows/hiddenRows.ts
+++ b/handsontable/src/plugins/hiddenRows/hiddenRows.ts
@@ -16,6 +16,8 @@ Hooks.getSingleton().register('afterUnhideRows');
 export const PLUGIN_KEY = 'hiddenRows';
 export const PLUGIN_PRIORITY = 320;
 
+const SKIP_ROW_ON_PASTE_BY_PLUGIN = Symbol('skipRowOnPasteByHiddenRows');
+
 /* eslint-disable jsdoc/require-description-complete-sentence */
 
 /**
@@ -404,7 +406,12 @@ export class HiddenRows extends BasePlugin {
    */
   resetCellsMeta() {
     arrayEach(this.hot.getCellsMeta(), (meta) => {
-      (meta as Record<string, unknown>).skipRowOnPaste = false;
+      const cellMeta = meta as Record<string | symbol, unknown>;
+
+      if (cellMeta[SKIP_ROW_ON_PASTE_BY_PLUGIN]) {
+        delete cellMeta.skipRowOnPaste;
+        delete cellMeta[SKIP_ROW_ON_PASTE_BY_PLUGIN];
+      }
     });
   }
 
@@ -434,9 +441,18 @@ export class HiddenRows extends BasePlugin {
    */
   #onAfterGetCellMeta = (row: number, column: number, cellProperties: Record<string, unknown>) => {
     if (this.getSetting('copyPasteEnabled') === false) {
-      // Cell property handled by the `Autofill` and the `CopyPaste` plugins. Assigned on every
-      // `afterGetCellMeta` call so the flag clears itself once a previously hidden row is shown again.
-      cellProperties.skipRowOnPaste = this.isHidden(row);
+      // Cell property handled by the `Autofill` and the `CopyPaste` plugins. Marked with a Symbol so
+      // the flag clears itself once a previously hidden row is shown again, without overwriting
+      // `skipRowOnPaste` values set by the user via `cells`, or `cell` configuration.
+      const cellPropsWithMarker = cellProperties as Record<string | symbol, unknown>;
+
+      if (this.isHidden(row)) {
+        cellProperties.skipRowOnPaste = true;
+        cellPropsWithMarker[SKIP_ROW_ON_PASTE_BY_PLUGIN] = true;
+      } else if (cellPropsWithMarker[SKIP_ROW_ON_PASTE_BY_PLUGIN]) {
+        delete cellProperties.skipRowOnPaste;
+        delete cellPropsWithMarker[SKIP_ROW_ON_PASTE_BY_PLUGIN];
+      }
     }
 
     if (this.isHidden(row - 1)) {

--- a/handsontable/src/plugins/hiddenRows/hiddenRows.ts
+++ b/handsontable/src/plugins/hiddenRows/hiddenRows.ts
@@ -441,14 +441,17 @@ export class HiddenRows extends BasePlugin {
    */
   #onAfterGetCellMeta = (row: number, column: number, cellProperties: Record<string, unknown>) => {
     if (this.getSetting('copyPasteEnabled') === false) {
-      // Cell property handled by the `Autofill` and the `CopyPaste` plugins. Marked with a Symbol so
-      // the flag clears itself once a previously hidden row is shown again, without overwriting
-      // `skipRowOnPaste` values set by the user via `cells`, or `cell` configuration.
+      // Cell property handled by the `Autofill` and the `CopyPaste` plugins. The plugin only sets
+      // and marks cells whose `skipRowOnPaste` it actually flips to `true`. Cells that already
+      // had `true` from user configuration (`cells`, or `cell`) are left untouched, so that
+      // unhiding the row does not erase the user-defined value.
       const cellPropsWithMarker = cellProperties as Record<string | symbol, unknown>;
 
       if (this.isHidden(row)) {
-        cellProperties.skipRowOnPaste = true;
-        cellPropsWithMarker[SKIP_ROW_ON_PASTE_BY_PLUGIN] = true;
+        if (cellProperties.skipRowOnPaste !== true) {
+          cellProperties.skipRowOnPaste = true;
+          cellPropsWithMarker[SKIP_ROW_ON_PASTE_BY_PLUGIN] = true;
+        }
       } else if (cellPropsWithMarker[SKIP_ROW_ON_PASTE_BY_PLUGIN]) {
         delete cellProperties.skipRowOnPaste;
         delete cellPropsWithMarker[SKIP_ROW_ON_PASTE_BY_PLUGIN];


### PR DESCRIPTION
### Context

The PR fixes autofill (and paste) silently skipping a row or column that was hidden and then shown again, when `hiddenRows`/`hiddenColumns` is configured with `copyPasteEnabled: false`.

Reproduction (object data, single column, `hiddenRows.copyPasteEnabled: false`):
1. Type `111` in A1, autofill down to fill all rows.
2. Hide rows 3 and 4 (context menu), then show them again.
3. Type `222` in A1, autofill down again.
4. Rows 3 and 4 keep `111` — they are skipped.

Root cause: `#onAfterGetCellMeta` in both plugins set `skipRowOnPaste` / `skipColumnOnPaste` to `true` while a row/column was hidden, but never reset it to `false`. The flag is cached on the cell meta, and `resetCellsMeta()` only runs on `disablePlugin()`, not on show. So once a hidden cell's meta was read, the stale flag made autofill/paste skip it permanently.

Fix: when `copyPasteEnabled === false`, assign the flag from `isHidden()` on every `afterGetCellMeta` call (`true` when hidden, `false` when not), so it self-heals when the row/column is shown. The flag is left untouched when `copyPasteEnabled` is its default `true`, so user-set values are preserved.

### How has this been tested?

Added regression tests to both plugins' copy-paste specs (meta-state assertion + behavioral paste into a hidden-then-shown line):

```
npm run test:e2e --prefix handsontable --testPathPattern='hiddenRows/__tests__/plugins/copyPaste|hiddenColumns/__tests__/plugins/copyPaste|autofill/__tests__/autofill|formulas/__tests__/plugins/autofill'
# 118 specs, 0 failures, 2 pending
```

Also verified manually in the browser (real fill-handle drag + context-menu hide/show) against a local build: every row fills correctly and `skipRowOnPaste` is cleared after show.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-24

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-24

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted copy/paste meta lifecycle fix with regression tests; no auth or data-model changes.
> 
> **Overview**
> Fixes **autofill and paste** still skipping rows/columns after they were **hidden and shown again** when `hiddenRows` / `hiddenColumns` use **`copyPasteEnabled: false`**.
> 
> **`HiddenRows`** and **`HiddenColumns`** now track plugin-owned `skipRowOnPaste` / `skipColumnOnPaste` with internal symbols, set them only while a line is hidden, and **remove them when the line is visible again** (including in `resetCellsMeta` on disable). **User-defined** skip flags are not cleared on unhide.
> 
> Regression tests and a changelog entry were added for both plugins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b8842d38a7cc42fb04647f9e425b6ac831c1d49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->