### PR TITLE
docs: fix misleading pageX/pageY wording in ContextMenu/DropdownMenu open() and add 14.0 migration note

### DIFF
--- a/docs/content/guides/upgrade-and-migration/migrating-from-13.1-to-14.0/migrating-from-13.1-to-14.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-13.1-to-14.0/migrating-from-13.1-to-14.0.md
@@ -58,6 +58,19 @@ To make the table more accessible, this release changes the color of the invalid
 | Autocomplete-typed cells arrow: `#eeeeee`  | Autocomplete-typed cells arrow: `#bbbbbb`   |
 | Invalid autocomplete-typed cells arrow: `#eeeeee`  | Invalid autocomplete-typed cells arrow: `#555555`   |
 | Invalid autocomplete-typed cells arrow on hover: `#777777`   | Invalid autocomplete-typed cells arrow on hover: `#1a1a1a`    |
+### Update `ContextMenu.open()` and `DropdownMenu.open()` calls
+
+Handsontable 14.0 refactors the internal positioning logic for context menus and dropdown menus. The `open()` method now uses `instanceof Event` to distinguish between a native browser event and a literal position object.
+
+If you pass a native `Event` (e.g., a `MouseEvent` from a `contextmenu` listener), the menu reads `pageX` and `pageY` from it automatically. This works the same as before.
+
+If you pass a plain object, it **must** use `{ top, left }` properties -- not `{ pageX, pageY }`. In versions prior to 14.0, passing `{ pageX, pageY }` as a plain object worked because the internal code translated those properties. Starting with 14.0, a plain object with `pageX`/`pageY` falls through to the literal positioning path, which reads `top`/`left` and results in `NaN` coordinates.
+
+| Before (13.x and earlier) | After (14.0+) |
+| --- | --- |
+| `menu.open({ pageX: 200, pageY: 300 })` | `menu.open({ left: 200, top: 300 })` |
+| `menu.open(event)` (native `Event`) | `menu.open(event)` (unchanged) |
+
 ## Result
 
 Your application now runs on Handsontable 14.0.

--- a/docs/content/guides/upgrade-and-migration/migrating-from-13.1-to-14.0/migrating-from-13.1-to-14.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-13.1-to-14.0/migrating-from-13.1-to-14.0.md
@@ -61,12 +61,13 @@ To make the table more accessible, this release changes the color of the invalid
 
 ### Update `ContextMenu.open()` and `DropdownMenu.open()` calls
 
-Handsontable 14.0 changes the accepted `position` argument for `ContextMenu.open()` and `DropdownMenu.open()`. When you open the menu programmatically with a literal position, use an object with `top` and `left` properties. Passing a native browser `Event` instance still works the same as before.
+Handsontable 14.0 changes the accepted `position` argument for `ContextMenu.open()` and `DropdownMenu.open()`. When you open the menu programmatically with a literal position, use an object with `top` and `left` properties instead of `pageX` and `pageY`. Passing a native browser `Event` instance still works the same as before.
 
 ```javascript
 const menu = hot.getPlugin('contextMenu');
 
-// Literal position -- use { top, left }:
+// Before (13.x): menu.open({ pageX: 200, pageY: 300 });
+// After (14.0+): use { top, left }:
 menu.open({ top: 300, left: 200 });
 
 // Native event -- works unchanged:

--- a/docs/content/guides/upgrade-and-migration/migrating-from-13.1-to-14.0/migrating-from-13.1-to-14.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-13.1-to-14.0/migrating-from-13.1-to-14.0.md
@@ -58,18 +58,22 @@ To make the table more accessible, this release changes the color of the invalid
 | Autocomplete-typed cells arrow: `#eeeeee`  | Autocomplete-typed cells arrow: `#bbbbbb`   |
 | Invalid autocomplete-typed cells arrow: `#eeeeee`  | Invalid autocomplete-typed cells arrow: `#555555`   |
 | Invalid autocomplete-typed cells arrow on hover: `#777777`   | Invalid autocomplete-typed cells arrow on hover: `#1a1a1a`    |
+
 ### Update `ContextMenu.open()` and `DropdownMenu.open()` calls
 
-Handsontable 14.0 refactors the internal positioning logic for context menus and dropdown menus. The `open()` method now uses `instanceof Event` to distinguish between a native browser event and a literal position object.
+Handsontable 14.0 changes the accepted `position` argument for `ContextMenu.open()` and `DropdownMenu.open()`. When you open the menu programmatically with a literal position, use an object with `top` and `left` properties. Passing a native browser `Event` instance still works the same as before.
 
-If you pass a native `Event` (e.g., a `MouseEvent` from a `contextmenu` listener), the menu reads `pageX` and `pageY` from it automatically. This works the same as before.
+```javascript
+const menu = hot.getPlugin('contextMenu');
 
-If you pass a plain object, it **must** use `{ top, left }` properties -- not `{ pageX, pageY }`. In versions prior to 14.0, passing `{ pageX, pageY }` as a plain object worked because the internal code translated those properties. Starting with 14.0, a plain object with `pageX`/`pageY` falls through to the literal positioning path, which reads `top`/`left` and results in `NaN` coordinates.
+// Literal position -- use { top, left }:
+menu.open({ top: 300, left: 200 });
 
-| Before (13.x and earlier) | After (14.0+) |
-| --- | --- |
-| `menu.open({ pageX: 200, pageY: 300 })` | `menu.open({ left: 200, top: 300 })` |
-| `menu.open(event)` (native `Event`) | `menu.open(event)` (unchanged) |
+// Native event -- works unchanged:
+element.addEventListener('contextmenu', (event) => {
+  menu.open(event);
+});
+```
 
 ## Result
 

--- a/handsontable/src/plugins/contextMenu/contextMenu.ts
+++ b/handsontable/src/plugins/contextMenu/contextMenu.ts
@@ -261,14 +261,21 @@ export class ContextMenu extends BasePlugin {
   }
 
   /**
-   * Opens menu and re-position it based on the passed coordinates.
+   * Opens the menu and positions it based on the passed coordinates.
    *
-   * @param {{ top: number, left: number }|Event} position An object with `top` and `left` properties
-   * which contains coordinates relative to the browsers viewport (without included scroll offsets).
-   * Or if the native event is passed the menu will be positioned based on the `pageX` and `pageY`
-   * coordinates.
-   * @param {{ above: number, below: number, left: number, right: number }} offset An object allows applying
-   * the offset to the menu position.
+   * The `position` argument accepts either:
+   * - An object with `top` and `left` properties (coordinates relative to the browser viewport,
+   *   without scroll offsets).
+   * - A native browser `Event` (e.g., a `MouseEvent`). The menu reads `pageX` and `pageY`
+   *   from the event to determine its position.
+   *
+   * Passing a plain object with `pageX`/`pageY` properties (not a real `Event` instance) is
+   * **not supported** and results in incorrect positioning. Use `{ top, left }` instead.
+   *
+   * @param {{ top: number, left: number }|Event} position An object with `top` and `left` properties,
+   * or a native browser `Event` instance.
+   * @param {{ above: number, below: number, left: number, right: number }} offset An object that applies
+   * an offset to the menu position.
    * @fires Hooks#beforeContextMenuShow
    * @fires Hooks#afterContextMenuShow
    * @example

--- a/handsontable/src/plugins/contextMenu/contextMenu.ts
+++ b/handsontable/src/plugins/contextMenu/contextMenu.ts
@@ -263,17 +263,9 @@ export class ContextMenu extends BasePlugin {
   /**
    * Opens the menu and positions it based on the passed coordinates.
    *
-   * The `position` argument accepts either:
-   * - An object with `top` and `left` properties (coordinates relative to the browser viewport,
-   *   without scroll offsets).
-   * - A native browser `Event` (e.g., a `MouseEvent`). The menu reads `pageX` and `pageY`
-   *   from the event to determine its position.
-   *
-   * Passing a plain object with `pageX`/`pageY` properties (not a real `Event` instance) is
-   * **not supported** and results in incorrect positioning. Use `{ top, left }` instead.
-   *
-   * @param {{ top: number, left: number }|Event} position An object with `top` and `left` properties,
-   * or a native browser `Event` instance.
+   * @param {{ top: number, left: number }|Event} position An object with `top` and `left` properties
+   * (coordinates relative to the browser viewport, without scroll offsets), or a native browser
+   * `Event` instance (e.g., a `MouseEvent`).
    * @param {{ above: number, below: number, left: number, right: number }} offset An object that applies
    * an offset to the menu position.
    * @fires Hooks#beforeContextMenuShow

--- a/handsontable/src/plugins/dropdownMenu/dropdownMenu.ts
+++ b/handsontable/src/plugins/dropdownMenu/dropdownMenu.ts
@@ -431,14 +431,21 @@ export class DropdownMenu extends BasePlugin {
   }
 
   /**
-   * Opens menu and re-position it based on the passed coordinates.
+   * Opens the menu and positions it based on the passed coordinates.
    *
-   * @param {{ top: number, left: number }|Event} position An object with `top` and `left` properties
-   * which contains coordinates relative to the browsers viewport (without included scroll offsets).
-   * Or if the native event is passed the menu will be positioned based on the `pageX` and `pageY`
-   * coordinates.
-   * @param {{ above: number, below: number, left: number, right: number }} offset An object allows applying
-   * the offset to the menu position.
+   * The `position` argument accepts either:
+   * - An object with `top` and `left` properties (coordinates relative to the browser viewport,
+   *   without scroll offsets).
+   * - A native browser `Event` (e.g., a `MouseEvent`). The menu reads `pageX` and `pageY`
+   *   from the event to determine its position.
+   *
+   * Passing a plain object with `pageX`/`pageY` properties (not a real `Event` instance) is
+   * **not supported** and results in incorrect positioning. Use `{ top, left }` instead.
+   *
+   * @param {{ top: number, left: number }|Event} position An object with `top` and `left` properties,
+   * or a native browser `Event` instance.
+   * @param {{ above: number, below: number, left: number, right: number }} offset An object that applies
+   * an offset to the menu position.
    * @fires Hooks#beforeDropdownMenuShow
    * @fires Hooks#afterDropdownMenuShow
    * @example

--- a/handsontable/src/plugins/dropdownMenu/dropdownMenu.ts
+++ b/handsontable/src/plugins/dropdownMenu/dropdownMenu.ts
@@ -433,17 +433,9 @@ export class DropdownMenu extends BasePlugin {
   /**
    * Opens the menu and positions it based on the passed coordinates.
    *
-   * The `position` argument accepts either:
-   * - An object with `top` and `left` properties (coordinates relative to the browser viewport,
-   *   without scroll offsets).
-   * - A native browser `Event` (e.g., a `MouseEvent`). The menu reads `pageX` and `pageY`
-   *   from the event to determine its position.
-   *
-   * Passing a plain object with `pageX`/`pageY` properties (not a real `Event` instance) is
-   * **not supported** and results in incorrect positioning. Use `{ top, left }` instead.
-   *
-   * @param {{ top: number, left: number }|Event} position An object with `top` and `left` properties,
-   * or a native browser `Event` instance.
+   * @param {{ top: number, left: number }|Event} position An object with `top` and `left` properties
+   * (coordinates relative to the browser viewport, without scroll offsets), or a native browser
+   * `Event` instance (e.g., a `MouseEvent`).
    * @param {{ above: number, below: number, left: number, right: number }} offset An object that applies
    * an offset to the menu position.
    * @fires Hooks#beforeDropdownMenuShow


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Context

The `ContextMenu.open()` and `DropdownMenu.open()` JSDoc incorrectly stated that passing a plain object with `pageX`/`pageY` properties is supported. Since 14.0, the `Cursor` class uses `instanceof Event` to distinguish between a native event and a literal position object. A plain object with `pageX`/`pageY` falls through to the literal path, which reads `top`/`left` -- resulting in `NaN` positioning.

This PR:
- Fixes the JSDoc for both `ContextMenu.open()` and `DropdownMenu.open()` to clarify the accepted `position` argument formats.
- Adds a migration guide section for 14.0 documenting this behavior change and the required update from `{ pageX, pageY }` to `{ top, left }`.

### How has this been tested?

Documentation-only change. Verified ESLint passes on both modified TypeScript files.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #12634

### Affected project(s):
- [x] `handsontable`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa57b702-40b5-4b1d-be6f-abc462fdc147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa57b702-40b5-4b1d-be6f-abc462fdc147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

