### PR TITLE
fix(docs): correct three Cloudflare redirect bugs found by bugbot in PR #12646

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -22,7 +22,7 @@ report-check-links.xlsx
 /.build-tmp/
 
 /docker/redirect-page-ids.json
-/content/api/
+/content/api/*
 !/content/api/introduction.md
 !/content/api/plugins.md
 !/content/api/sidebar.js

--- a/docs/cloudflare/_worker.js
+++ b/docs/cloudflare/_worker.js
@@ -1039,9 +1039,13 @@ export default {
           }
 
           // redirectPath may be an absolute path (starts with /) or a relative slug.
+          // An empty redirectPath (e.g. FLAT_HTML_MAP['tutorial-introduction'] === '')
+          // must not produce a double-slash like `/docs/javascript-data-grid//`.
           const dest = redirectPath.startsWith('/')
             ? `/docs/${framework}${redirectPath}`
-            : `/docs/${framework}/${redirectPath}/`;
+            : redirectPath
+              ? `/docs/${framework}/${redirectPath}/`
+              : `/docs/${framework}/`;
 
           return redirect302(abs(dest, url));
         }
@@ -1064,7 +1068,12 @@ export default {
           const framework = getFrameworkFromCookie(cookieValue);
           let redirectPath = FLAT_PAGES_REMAP[page];
 
-          redirectPath = redirectPath.endsWith('/') ? redirectPath : `${redirectPath}/`;
+          // Do not append a trailing slash when the path contains a fragment
+          // (#anchor), as that would place the slash inside the fragment identifier
+          // and break anchor navigation.
+          const hasFragment = redirectPath.includes('#');
+
+          redirectPath = hasFragment || redirectPath.endsWith('/') ? redirectPath : `${redirectPath}/`;
           redirectPath = redirectPath.startsWith('/') ? redirectPath : `/${redirectPath}`;
           const dest = `/docs/${framework}${redirectPath}`;
 


### PR DESCRIPTION
### Context

The PR fixes three bugs in the Cloudflare docs redirect layer that were flagged by Cursor Bugbot in PR #12646.

**1. `docs/.gitignore` — directory exclusion breaks negation patterns**
The pattern `/content/api/` (directory form) caused git to stop descending into that directory entirely, making the `!/content/api/introduction.md`, `!/content/api/plugins.md`, and `!/content/api/sidebar.js` negation lines silently ineffective. Changed to `/content/api/*` (wildcard) so git processes the negations.

**2. `docs/cloudflare/_worker.js` — empty `redirectPath` produces double-slash URL**
`FLAT_HTML_MAP['tutorial-introduction']` is `''` (empty string). The relative-slug branch in the FLAT_HTML_MAP handler constructed `` `/docs/${framework}/${redirectPath}/` `` which evaluated to `/docs/javascript-data-grid//`. Added an explicit branch for empty `redirectPath` to produce `/docs/${framework}/` instead.

**3. `docs/cloudflare/_worker.js` — trailing-slash normalisation corrupts `#` fragment anchors**
The FLAT_PAGES_REMAP handler unconditionally appended `/` to any path not already ending with `/`, without checking for fragment identifiers. The entry `'i18n/missing-language-code': '/language/#loading-the-prepared-language-files'` was transformed to `/language/#loading-the-prepared-language-files/`, placing the slash inside the fragment and silently breaking anchor navigation. Added a `hasFragment` guard to skip the trailing-slash step when the path contains `#`.

### How has this been tested?

- Code-reviewed against the original bugbot findings in PR #12646
- The `.gitignore` fix can be verified with `git check-ignore -v docs/content/api/introduction.md` (should be unignored after the fix)
- The worker.js fixes are logic-only; manual verification requires deploying the worker and hitting `/docs/tutorial-introduction.html` and `/docs/i18n/missing-language-code`

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. https://github.com/handsontable/handsontable/pull/12646 (original PR where bugbot flagged these)

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvbqxEVdTT8oBVDM6Y7j4U)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only gitignore and redirect URL construction fixes; no auth, data, or product runtime changes.
> 
> **Overview**
> This PR fixes three small but user-visible docs issues: **gitignore**, **legacy `.html` redirects**, and **fragment-aware remaps**.
> 
> In **`docs/.gitignore`**, `/content/api/` is changed to `/content/api/*` so git still evaluates the `!` exceptions for `introduction.md`, `plugins.md`, and `sidebar.js` instead of ignoring the whole tree.
> 
> In **`docs/cloudflare/_worker.js`**, flat `.html` redirects now treat an **empty** `FLAT_HTML_MAP` slug (e.g. `tutorial-introduction`) as the framework home (`/docs/{framework}/`) instead of a double-slash URL. **`FLAT_PAGES_REMAP`** no longer appends a trailing slash when the target path includes a `#` fragment, so anchors like `#loading-the-prepared-language-files` stay valid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 349d1ebf6df7a399f39090b079d14eed14779ca2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->