### PR TITLE
DEV-1789: Replace react-star-rating-component with inline StarRating component

### DIFF
--- a/docs/content/guides/getting-started/react-redux/react-redux.md
+++ b/docs/content/guides/getting-started/react-redux/react-redux.md
@@ -45,11 +45,11 @@ The following example implements the `@handsontable/react-wrapper` component wit
 
 This example shows:
 - A [custom editor](@/guides/cell-functions/cell-editor/cell-editor.md#component-based-editors) component (built with an external dependency, `HexColorPicker`). This component acts both as an editor and as a renderer.
-- A [custom renderer](@/guides/cell-functions/cell-renderer/cell-renderer.md#declare-a-custom-renderer-as-a-component) component, built with an external dependency (`StarRatingComponent`).
+- A [custom renderer](@/guides/cell-functions/cell-renderer/cell-renderer.md#declare-a-custom-renderer-as-a-component) component, built with a local `StarRating` component.
 
 The editor component changes the behavior of the renderer component, by passing information through Redux (and the `connect()` method of `react-redux`).
 
-::: example #example6 :react-advanced --js 1 --ts 2 --deps redux@4 react-redux@7.2.4 react-colorful@5.5.1 react-star-rating-component@1.4.1
+::: example #example6 :react-advanced --js 1 --ts 2 --deps redux@4 react-redux@7.2.4 react-colorful@5.5.1
 
 @[code](@/content/guides/getting-started/react-redux/react/example6.jsx)
 @[code](@/content/guides/getting-started/react-redux/react/example6.tsx)

--- a/docs/content/guides/getting-started/react-redux/react/example6.jsx
+++ b/docs/content/guides/getting-started/react-redux/react/example6.jsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
 import { HexColorPicker } from 'react-colorful';
-import StarRatingComponent from 'react-star-rating-component';
 import { Provider, connect, useDispatch } from 'react-redux';
 import { createStore, combineReducers } from 'redux';
 import { HotTable, HotColumn, useHotEditor } from '@handsontable/react-wrapper';
@@ -8,6 +7,21 @@ import { registerAllModules } from 'handsontable/registry';
 
 // register Handsontable's modules
 registerAllModules();
+
+function StarRating({ name, value = 0, starCount = 5, starColor = '#ffb400', emptyStarColor = '#d3d3d3' }) {
+  return (
+    <div style={{ display: 'inline-flex', gap: '1px' }}>
+      {Array.from({ length: starCount }, (_, i) => (
+        <span
+          key={`${name}-${i + 1}`}
+          style={{ fontSize: '18px', color: i + 1 <= value ? starColor : emptyStarColor, lineHeight: 1 }}
+        >
+          ★
+        </span>
+      ))}
+    </div>
+  );
+}
 
 const UnconnectedColorPickerEditor = () => {
   const dispatch = useDispatch();
@@ -167,13 +181,12 @@ const reduxStore = createStore(actionReducers);
 // a custom renderer component
 const UnconnectedStarRatingRenderer = ({ row, col, value, activeColors, inactiveColors }) => {
   return (
-    <StarRatingComponent
+    <StarRating
       name={`${row}-${col}`}
       value={value}
       starCount={5}
       starColor={activeColors?.[row || 0]}
       emptyStarColor={inactiveColors?.[row || 0]}
-      editing={true}
     />
   );
 };

--- a/docs/content/guides/getting-started/react-redux/react/example6.tsx
+++ b/docs/content/guides/getting-started/react-redux/react/example6.tsx
@@ -1,7 +1,6 @@
 import { useEffect, MouseEvent, KeyboardEvent, useRef, useState } from 'react';
 import Handsontable from 'handsontable/base';
 import { HexColorPicker } from 'react-colorful';
-import StarRatingComponent from 'react-star-rating-component';
 import { Provider, connect, useDispatch } from 'react-redux';
 import { createStore, combineReducers } from 'redux';
 import { HotTable, HotColumn, useHotEditor } from '@handsontable/react-wrapper';
@@ -9,6 +8,29 @@ import { registerAllModules } from 'handsontable/registry';
 
 // register Handsontable's modules
 registerAllModules();
+
+interface StarRatingProps {
+  name: string;
+  value?: number;
+  starCount?: number;
+  starColor?: string;
+  emptyStarColor?: string;
+}
+
+function StarRating({ name, value = 0, starCount = 5, starColor = '#ffb400', emptyStarColor = '#d3d3d3' }: StarRatingProps) {
+  return (
+    <div style={{ display: 'inline-flex', gap: '1px' }}>
+      {Array.from({ length: starCount }, (_, i) => (
+        <span
+          key={`${name}-${i + 1}`}
+          style={{ fontSize: '18px', color: i + 1 <= value ? starColor : emptyStarColor, lineHeight: 1 }}
+        >
+          ★
+        </span>
+      ))}
+    </div>
+  );
+}
 
 type RendererProps = {
   TD?: HTMLTableCellElement;
@@ -206,13 +228,12 @@ const UnconnectedStarRatingRenderer = ({
   inactiveColors?: string;
 }) => {
   return (
-    <StarRatingComponent
+    <StarRating
       name={`${row}-${col}`}
       value={value}
       starCount={5}
       starColor={activeColors?.[row || 0]}
       emptyStarColor={inactiveColors?.[row || 0]}
-      editing={true}
     />
   );
 };

--- a/docs/content/recipes/cell-types/guide-rating-angular/guide-rating.md
+++ b/docs/content/recipes/cell-types/guide-rating-angular/guide-rating.md
@@ -773,5 +773,5 @@ You built an SVG star rating cell in Angular using `HotCellEditorAdvancedCompone
 ## Next steps
 
 - [Star Rating (JavaScript)](@/javascript/recipes/cell-types/rating/rating.md) - The same concept using `editorFactory` and `rendererFactory`.
-- [Star Rating (React)](@/react/recipes/cell-types/react-rating/react-rating.md) - The React version using `EditorComponent` and `react-star-rating-component`.
+- [Star Rating (React)](@/react/recipes/cell-types/react-rating/react-rating.md) - The React version using `EditorComponent` and a local star rating component.
 - [Feedback Editor (Angular)](@/angular/recipes/cell-types/guide-feedback-angular/guide-feedback.md) - Another Angular editor using `HotCellEditorAdvancedComponent`.

--- a/docs/content/recipes/cell-types/rating/rating.md
+++ b/docs/content/recipes/cell-types/rating/rating.md
@@ -608,6 +608,6 @@ You built an SVG star rating cell using `editorFactory` and `rendererFactory`. Y
 
 ## Next steps
 
-- [Star Rating (React)](@/react/recipes/cell-types/react-rating/react-rating.md) - The same concept using React's `EditorComponent` and `react-star-rating-component`.
+- [Star Rating (React)](@/react/recipes/cell-types/react-rating/react-rating.md) - The same concept using React's `EditorComponent` and a local star rating component.
 - [Star Rating Editor (Angular)](@/angular/recipes/cell-types/guide-rating-angular/guide-rating.md) - The Angular version using `HotCellEditorAdvancedComponent`.
 - [Feedback](@/recipes/cell-types/feedback/feedback.md) - Another no-library custom editor using `editorFactory` and CSS tokens.

--- a/docs/content/recipes/cell-types/react-rating/react-rating.md
+++ b/docs/content/recipes/cell-types/react-rating/react-rating.md
@@ -23,11 +23,11 @@ searchCategory: Recipes
 category: Cell Types
 ---
 
-This tutorial shows you how to build a star rating cell in React using the `react-star-rating-component` library and Handsontable's `EditorComponent`, with a custom renderer for view mode.
+This tutorial shows you how to build a star rating cell in React using Handsontable's `EditorComponent`, a custom renderer, and a local React component for the stars.
 
 ::: only-for react
 
-::: example #example1 :react-advanced --css 1 --js 2 --ts 3 --deps react-star-rating-component
+::: example #example1 :react-advanced --css 1 --js 2 --ts 3
 
 @[code](@/content/recipes/cell-types/react-rating/react/example1.css)
 @[code](@/content/recipes/cell-types/react-rating/react/example1.jsx)
@@ -39,11 +39,11 @@ This tutorial shows you how to build a star rating cell in React using the `reac
 
 ## Overview
 
-This guide shows how to create a star rating editor cell using `react-star-rating-component` with React's `EditorComponent`. Perfect for product reviews, feedback forms, or any scenario where users need to select a numeric rating (e.g., 1–5 stars).
+This guide shows how to create a star rating editor cell using React's `EditorComponent`. Use this pattern for product reviews, feedback forms, or any scenario where users select a numeric rating, such as 1-5 stars.
 
 **Difficulty:** Beginner
 **Time:** ~15 minutes
-**Libraries:** react-star-rating-component
+**Libraries:** No external rating library.
 
 ## What You'll Build
 
@@ -51,21 +51,20 @@ A cell that:
 - Displays interactive star rating when editing
 - Shows stars in view mode via a custom React renderer
 - Supports hover preview before selection
-- Stores values as numbers (1–5)
-- Validates rating range (e.g., 0–100)
+- Stores values as numbers (1-5)
+- Validates rating range, such as 0-100
 - Provides click-to-select functionality
 - Works with React's component-based architecture
 
 ## Prerequisites
 
 ```bash
-npm install @handsontable/react-wrapper react-star-rating-component
+npm install handsontable @handsontable/react-wrapper
 ```
 
 **What you need:**
 - React 16.8+ (hooks support)
 - `@handsontable/react-wrapper` package
-- `react-star-rating-component` package for the star rating UI
 - Basic React knowledge (hooks, JSX)
 
 ## Step 1: Import Dependencies
@@ -73,7 +72,6 @@ npm install @handsontable/react-wrapper react-star-rating-component
 ```tsx
 import { HotTable, HotColumn, EditorComponent } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
-import StarRatingComponent from 'react-star-rating-component';
 
 registerAllModules();
 ```
@@ -81,10 +79,46 @@ registerAllModules();
 **What we're importing:**
 - `EditorComponent` - React component for creating custom editors
 - `HotTable` and `HotColumn` - React wrapper components
-- `StarRatingComponent` - Star rating UI from `react-star-rating-component`
 - `registerAllModules()` - Registers Handsontable modules (required when using the wrapper)
 
-## Step 2: Create the Editor Component
+## Step 2: Create the Star Rating Component
+
+Create a local component that renders five stars and reports hover and click events.
+
+```tsx
+interface StarRatingProps {
+  name: string;
+  value: number;
+  editing?: boolean;
+  onStarHover?: (value: number) => void;
+  onStarClick?: (value: number) => void;
+}
+
+function StarRating({ name, value, editing = true, onStarHover, onStarClick }: StarRatingProps) {
+  return (
+    <div className="star-rating" aria-label={`Rating: ${value} out of 5`}>
+      {[1, 2, 3, 4, 5].map((star) => (
+        <span
+          key={`${name}-${star}`}
+          className={star <= value ? 'star filled' : 'star'}
+          onMouseEnter={editing ? () => onStarHover?.(star) : undefined}
+          onClick={editing ? () => onStarClick?.(star) : undefined}
+        >
+          ★
+        </span>
+      ))}
+    </div>
+  );
+}
+```
+
+**What's happening:**
+- The `name` prop creates stable keys for each star.
+- The `editing` prop disables hover and click handlers in view mode.
+- `onStarHover` previews the value before the user commits it.
+- `onStarClick` commits the selected value.
+
+## Step 3: Create the Editor Component
 
 Create a React component that uses `EditorComponent` with the render prop pattern.
 
@@ -94,11 +128,11 @@ export const RatingEditor = () => {
     <EditorComponent<number>>
       {({ value, setValue, finishEditing }) => (
         <div className="rating-editor">
-          <StarRatingComponent
+          <StarRating
             name="rating"
             value={Number(value) || 0}
-            onStarHover={(nextValue: number) => setValue(nextValue)}
-            onStarClick={(nextValue: number) => {
+            onStarHover={(nextValue) => setValue(nextValue)}
+            onStarClick={(nextValue) => {
               setValue(nextValue);
               finishEditing();
             }}
@@ -115,23 +149,24 @@ export const RatingEditor = () => {
 2. `value` - Current cell value (numeric rating)
 3. `setValue` - Function to update the value
 4. `finishEditing` - Function to save and close the editor
-5. `onStarHover` - Updates preview as user hovers over stars
-6. `onStarClick` - Saves the selected rating and closes the editor
-7. The `rating-editor` div is inside the render prop so styling applies to the visible editor area.
+5. `StarRating` - Renders the local star picker
+6. `onStarHover` - Updates preview as the user hovers over stars
+7. `onStarClick` - Saves the selected rating and closes the editor
+8. The `rating-editor` div is inside the render prop so styling applies to the visible editor area.
 
 **Key concepts:**
 - **Render prop pattern**: `EditorComponent` uses a function as children
 - **Hover preview**: `onStarHover` lets users preview before committing
 - **Click to confirm**: `onStarClick` saves and closes the editor
 
-## Step 3: Add a Custom Renderer for View Mode
+## Step 4: Add a Custom Renderer for View Mode
 
 Use a React component as the cell renderer so stars are shown when not editing.
 
 ```tsx
 const RatingCellRenderer = ({ value }: { value: unknown }) => (
   <div className="rating-cell">
-    <StarRatingComponent
+    <StarRating
       name="rating-cell"
       value={Number(value) || 0}
       editing={false}
@@ -141,13 +176,13 @@ const RatingCellRenderer = ({ value }: { value: unknown }) => (
 ```
 
 **What's happening:**
-- The renderer receives `value` and displays it with `StarRatingComponent`
+- The renderer receives `value` and displays it with `StarRating`
 - `editing={false}` keeps the stars non-interactive in view mode
-- Use a unique `name` (e.g. `"rating-cell"`) to avoid conflicts with the editor instance
+- Use a unique `name` (for example, `"rating-cell"`) to keep stable React keys for the renderer
 
-## Step 4: Add a Validator (Optional)
+## Step 5: Add a Validator (Optional)
 
-Validate that the rating is within an allowed range (e.g., 0–100):
+Validate that the rating is within an allowed range, such as 0-100:
 
 ```tsx
 const ratingValidator = (value: string | number, callback: (valid: boolean) => void) => {
@@ -156,13 +191,35 @@ const ratingValidator = (value: string | number, callback: (valid: boolean) => v
 };
 ```
 
-For a strict 1–5 star scale, use `parsed >= 1 && parsed <= 5` instead.
+For a strict 1-5 star scale, use `parsed >= 1 && parsed <= 5` instead.
 
-## Step 5: Add Styling
+## Step 6: Add Styling
 
 Style the cell and editor so the star rating fits and matches the grid.
 
 ```css
+.star-rating {
+  display: inline-flex;
+  gap: 1px;
+}
+
+.star-rating .star {
+  font-size: 18px;
+  color: #d3d3d3;
+  line-height: 1;
+  cursor: default;
+  user-select: none;
+  transition: color 0.1s;
+}
+
+.rating-editor .star-rating .star {
+  cursor: pointer;
+}
+
+.star-rating .star.filled {
+  color: #ffb400;
+}
+
 .rating-cell {
   display: flex;
   align-items: center;
@@ -190,10 +247,12 @@ Style the cell and editor so the star rating fits and matches the grid.
 ```
 
 **What's happening:**
+- `.star-rating` lays out the local star component
+- `.star-rating .star.filled` colors the selected stars
 - `.rating-cell` aligns the stars in the cell when not editing
 - `.rating-editor` uses Handsontable CSS variables for focus border, background, and padding so the editor matches the grid theme
 
-## Step 6: Prepare Sample Data
+## Step 7: Prepare Sample Data
 
 Use data with a `rating` property (and any other columns you need). Example for a product table:
 
@@ -214,7 +273,7 @@ export const data = [
 - Each row has `product`, `category`, `rating`, `reviews`, and `price`
 - The `rating` column uses the star editor and renderer; other columns can be text or numeric
 
-## Step 7: Use in Handsontable
+## Step 8: Use in Handsontable
 
 Wire the editor, renderer, and validator to the rating column:
 
@@ -251,24 +310,24 @@ const ExampleComponent = () => {
 **What's happening:**
 - `editor={RatingEditor}` - Star rating editor when the cell is active
 - `renderer={RatingCellRenderer}` - Shows stars in view mode
-- `validator={ratingValidator}` - Ensures rating is within the allowed range (e.g., 0–100)
+- `validator={ratingValidator}` - Ensures rating is within the allowed range, such as 0-100
 - `data="rating"` - Binds to the `rating` property in each row
 
 **Key features:**
 - Stars in both view and edit mode
-- Values stored as numbers (1–5)
+- Values stored as numbers (1-5)
 - Validation and type-safe setup with TypeScript
 
 ## How It Works - Complete Flow
 
-1. **Initial Render**: `RatingCellRenderer` displays stars for the current rating (e.g., 3 filled stars).
+1. **Initial Render**: `RatingCellRenderer` displays stars for the current rating, such as 3 filled stars.
 2. **User Double-Clicks or Enter**: Editor opens.
 3. **Editor Opens**: `EditorComponent` shows the star picker in the cell.
-4. **Star Rating Display**: Stars show current value; empty stars show remaining.
+4. **Star Rating Display**: `StarRating` shows the current value; empty stars show the remaining scale.
 5. **User Interaction**:
    - Hover over stars → `onStarHover` updates preview via `setValue`
    - Click a star → `onStarClick` saves value and calls `finishEditing()`
-6. **Validation**: `ratingValidator` runs (e.g., value must be 0–100).
+6. **Validation**: `ratingValidator` runs, such as checking that the value is 0-100.
 7. **Save**: Numeric value is saved to the cell.
 8. **Editor Closes**: `RatingCellRenderer` shows the updated stars in view mode.
 
@@ -276,37 +335,50 @@ const ExampleComponent = () => {
 
 ### 1. Custom Star Count
 
-Change the number of stars (e.g., 10-point scale):
+Change the number of stars, such as a 10-point scale:
 
 ```tsx
-<StarRatingComponent
-  name="rating"
-  starCount={10}
-  value={Number(value) || 0}
-  onStarHover={(nextValue) => setValue(nextValue)}
-  onStarClick={(nextValue) => {
-    setValue(nextValue);
-    finishEditing();
-  }}
-/>
+interface StarRatingProps {
+  name: string;
+  value: number;
+  starCount?: number;
+  editing?: boolean;
+  onStarHover?: (value: number) => void;
+  onStarClick?: (value: number) => void;
+}
+
+function StarRating({ name, value, starCount = 5, editing = true, onStarHover, onStarClick }: StarRatingProps) {
+  const stars = Array.from({ length: starCount }, (_, index) => index + 1);
+
+  return (
+    <div className="star-rating" aria-label={`Rating: ${value} out of ${starCount}`}>
+      {stars.map((star) => (
+        <span
+          key={`${name}-${star}`}
+          className={star <= value ? 'star filled' : 'star'}
+          onMouseEnter={editing ? () => onStarHover?.(star) : undefined}
+          onClick={editing ? () => onStarClick?.(star) : undefined}
+        >
+          ★
+        </span>
+      ))}
+    </div>
+  );
+}
 ```
 
 ### 2. Custom Star Colors
 
 Customize the appearance:
 
-```tsx
-<StarRatingComponent
-  name="rating"
-  value={Number(value) || 0}
-  starColor="#ffd700"
-  emptyStarColor="#e0e0e0"
-  onStarHover={(nextValue) => setValue(nextValue)}
-  onStarClick={(nextValue) => {
-    setValue(nextValue);
-    finishEditing();
-  }}
-/>
+```css
+.star-rating .star {
+  color: #e0e0e0;
+}
+
+.star-rating .star.filled {
+  color: #ffd700;
+}
 ```
 
 ### 3. Alternative: HTML-Based Renderer
@@ -339,7 +411,7 @@ const starRenderer = rendererFactory(({ td, value }) => {
 
 ### 4. Read Config from Cell Properties (Advanced)
 
-Use `onPrepare` for per-column configuration (e.g., star count):
+Use `onPrepare` for per-column configuration, such as star count:
 
 ```tsx
 const RatingEditor = () => {
@@ -355,7 +427,7 @@ const RatingEditor = () => {
     <div className="rating-editor">
       <EditorComponent<number> onPrepare={onPrepare}>
         {({ value, setValue, finishEditing }) => (
-          <StarRatingComponent
+          <StarRating
             name="rating"
             starCount={starCount}
             value={Number(value) || 0}
@@ -388,24 +460,23 @@ This displays empty stars when the cell has no value.
 
 ## Accessibility
 
-The `StarRatingComponent` uses radio inputs. Enhance with ARIA:
+The local `StarRating` component sets `aria-label` on the rating container. To add keyboard support, render each star as a button:
 
 ```tsx
-<StarRatingComponent
-  name="rating"
-  value={Number(value) || 0}
-  onStarHover={(nextValue) => setValue(nextValue)}
-  onStarClick={(nextValue) => {
-    setValue(nextValue);
-    finishEditing();
-  }}
-  aria-label="Select rating"
-/>
+<button
+  type="button"
+  className={star <= value ? 'star filled' : 'star'}
+  onMouseEnter={editing ? () => onStarHover?.(star) : undefined}
+  onClick={editing ? () => onStarClick?.(star) : undefined}
+  aria-label={`Set rating to ${star}`}
+>
+  ★
+</button>
 ```
 
 **Keyboard navigation:**
 - **Tab**: Navigate to editor
-- **Arrow keys**: Navigate between stars (if supported by library)
+- **Arrow keys**: Navigate between stars after you add key handlers
 - **Enter/Space**: Select star
 - **Escape**: Cancel editing
 
@@ -413,10 +484,10 @@ The `StarRatingComponent` uses radio inputs. Enhance with ARIA:
 
 ### Why This Is Fast
 
-1. **Lightweight library**: react-star-rating-component is small and focused
-2. **React Virtual DOM**: Efficient updates only when value changes
-3. **Focused callbacks**: `onStarHover` and `onStarClick` each do one thing
-4. **No unnecessary re-renders**: Editor unmounts when closed
+1. **No external rating package**: The star UI uses a small local component.
+2. **React Virtual DOM**: Updates happen only when the value changes.
+3. **Focused callbacks**: `onStarHover` and `onStarClick` each do one thing.
+4. **No unnecessary re-renders**: The editor unmounts when closed.
 
 ## TypeScript Support
 
@@ -428,11 +499,11 @@ The `StarRatingComponent` uses radio inputs. Enhance with ARIA:
     // TypeScript knows value is number | undefined
     // TypeScript knows setValue accepts number
     return (
-      <StarRatingComponent
+      <StarRating
         name="rating"
         value={Number(value) || 0}
-        onStarHover={(nextValue: number) => setValue(nextValue)}
-        onStarClick={(nextValue: number) => {
+        onStarHover={(nextValue) => setValue(nextValue)}
+        onStarClick={(nextValue) => {
           setValue(nextValue);
           finishEditing();
         }}
@@ -445,18 +516,18 @@ The `StarRatingComponent` uses radio inputs. Enhance with ARIA:
 ## Best Practices
 
 1. **Coerce value to number** - Use `Number(value) || 0` since cell values may be strings.
-2. **Provide `name` prop** - Required by `react-star-rating-component` for radio inputs; use different names for editor and renderer (e.g. `"rating"` and `"rating-cell"`) to avoid conflicts.
+2. **Provide `name` prop** - Use different names for editor and renderer, such as `"rating"` and `"rating-cell"`, to keep stable React keys.
 3. **Call `finishEditing()` on click** - Star click confirms the selection and closes the editor.
 4. **Use `onStarHover` for preview** - Improves UX by showing the selection before commit.
 5. **Use a custom renderer** - `RatingCellRenderer` with `editing={false}` shows stars in view mode and keeps the UI consistent.
-6. **Add a validator** - Use `ratingValidator` to restrict values (e.g., 0–100 or 1–5) and give immediate feedback.
+6. **Add a validator** - Use `ratingValidator` to restrict values, such as 0-100 or 1-5, and give immediate feedback.
 
 ---
 
 
 ## What you learned
 
-You integrated the `react-star-rating-component` library as a Handsontable cell editor in React. You used `EditorComponent` with the render prop pattern to manage hover preview and click-to-confirm selection, and a React component renderer to display stars in view mode.
+You created a local `StarRating` component and integrated it as a Handsontable cell editor in React. You used `EditorComponent` with the render prop pattern to manage hover preview and click-to-confirm selection, and a React component renderer to display stars in view mode.
 
 ## Next steps
 

--- a/docs/content/recipes/cell-types/react-rating/react/example1.css
+++ b/docs/content/recipes/cell-types/react-rating/react/example1.css
@@ -1,3 +1,25 @@
+.star-rating {
+  display: inline-flex;
+  gap: 1px;
+}
+
+.star-rating .star {
+  font-size: 18px;
+  color: #d3d3d3;
+  line-height: 1;
+  cursor: default;
+  user-select: none;
+  transition: color 0.1s;
+}
+
+.rating-editor .star-rating .star {
+  cursor: pointer;
+}
+
+.star-rating .star.filled {
+  color: #ffb400;
+}
+
 .rating-cell {
   display: flex;
   align-items: center;

--- a/docs/content/recipes/cell-types/react-rating/react/example1.jsx
+++ b/docs/content/recipes/cell-types/react-rating/react/example1.jsx
@@ -1,9 +1,25 @@
 import { HotTable, HotColumn, EditorComponent } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
-import StarRatingComponent from 'react-star-rating-component';
 import './example1.css';
 
 registerAllModules();
+
+function StarRating({ name, value, editing = true, onStarHover, onStarClick }) {
+  return (
+    <div className="star-rating" aria-label={`Rating: ${value} out of 5`}>
+      {[1, 2, 3, 4, 5].map((star) => (
+        <span
+          key={`${name}-${star}`}
+          className={star <= value ? 'star filled' : 'star'}
+          onMouseEnter={editing ? () => onStarHover?.(star) : undefined}
+          onClick={editing ? () => onStarClick?.(star) : undefined}
+        >
+          ★
+        </span>
+      ))}
+    </div>
+  );
+}
 
 /* start:skip-in-preview */
 export const data = [
@@ -20,7 +36,7 @@ export const data = [
 
 const RatingCellRenderer = ({ value }) => (
   <div className="rating-cell">
-    <StarRatingComponent
+    <StarRating
       name="rating-cell"
       value={Number(value) || 0}
       editing={false}
@@ -38,7 +54,7 @@ export const RatingEditor = () => {
     <EditorComponent>
       {({ value, setValue, finishEditing }) => (
         <div className="rating-editor">
-          <StarRatingComponent
+          <StarRating
             name="rating"
             value={Number(value) || 0}
             onStarHover={(nextValue) => setValue(nextValue)}

--- a/docs/content/recipes/cell-types/react-rating/react/example1.tsx
+++ b/docs/content/recipes/cell-types/react-rating/react/example1.tsx
@@ -1,9 +1,33 @@
 import { HotTable, HotColumn, EditorComponent } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
-import StarRatingComponent from 'react-star-rating-component';
 import './example1.css';
 
 registerAllModules();
+
+interface StarRatingProps {
+  name: string;
+  value: number;
+  editing?: boolean;
+  onStarHover?: (value: number) => void;
+  onStarClick?: (value: number) => void;
+}
+
+function StarRating({ name, value, editing = true, onStarHover, onStarClick }: StarRatingProps) {
+  return (
+    <div className="star-rating" aria-label={`Rating: ${value} out of 5`}>
+      {[1, 2, 3, 4, 5].map((star) => (
+        <span
+          key={`${name}-${star}`}
+          className={star <= value ? 'star filled' : 'star'}
+          onMouseEnter={editing ? () => onStarHover?.(star) : undefined}
+          onClick={editing ? () => onStarClick?.(star) : undefined}
+        >
+          ★
+        </span>
+      ))}
+    </div>
+  );
+}
 
 /* start:skip-in-preview */
 
@@ -22,7 +46,7 @@ export const data = [
 
 const RatingCellRenderer = ({ value }: { value: unknown }) => (
   <div className="rating-cell">
-    <StarRatingComponent
+    <StarRating
       name="rating-cell"
       value={Number(value) || 0}
       editing={false}
@@ -40,11 +64,11 @@ export const RatingEditor = () => {
     <EditorComponent<number>>
       {({ value, setValue, finishEditing }) => (
         <div className="rating-editor">
-          <StarRatingComponent
+          <StarRating
             name="rating"
             value={Number(value) || 0}
-            onStarHover={(nextValue: number) => setValue(nextValue)}
-            onStarClick={(nextValue: number) => {
+            onStarHover={(nextValue) => setValue(nextValue)}
+            onStarClick={(nextValue) => {
               setValue(nextValue);
               finishEditing();
             }}

--- a/docs/package.json
+++ b/docs/package.json
@@ -48,7 +48,6 @@
     "react-dom": "^18.3.1",
     "react-markdown": "^9.1.0",
     "react-redux": "^9.2.0",
-    "react-star-rating-component": "^1.4.1",
     "redux": "^5.0.1",
     "remark-gfm": "^4.0.0",
     "shiki": "^1.22.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
       "node-gyp>tar": "^7.5.11",
       "cacache>tar": "^7.5.11",
       "undici": "^6.24.0",
-      "react-star-rating-component>react": "18.3.1",
       "@astrojs/mdx": "^6.0.1"
     },
     "auditConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,6 @@ overrides:
   node-gyp>tar: ^7.5.11
   cacache>tar: ^7.5.11
   undici: ^6.24.0
-  react-star-rating-component>react: 18.3.1
   '@astrojs/mdx': ^6.0.1
 
 packageExtensionsChecksum: sha256-HW0fEgNzl97t+n6OP9YhjxMaqHuFQdiKyvrxqn9AYp4=
@@ -235,9 +234,6 @@ importers:
       react-redux:
         specifier: ^9.2.0
         version: 9.3.0(@types/react@18.3.29)(react@18.3.1)(redux@5.0.1)
-      react-star-rating-component:
-        specifier: ^1.4.1
-        version: 1.4.1(react@18.3.1)
       redux:
         specifier: ^5.0.1
         version: 5.0.1
@@ -5884,9 +5880,6 @@ packages:
   cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
 
-  classnames@2.5.1:
-    resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
-
   cli-cursor@2.1.0:
     resolution: {integrity: sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==}
     engines: {node: '>=4'}
@@ -10013,12 +10006,6 @@ packages:
         optional: true
       redux:
         optional: true
-
-  react-star-rating-component@1.4.1:
-    resolution: {integrity: sha512-i0YEvQzToS0s0GDkxn01Jy4EeLpVEyh023NXJTJ+/1+xkvhpACyD4d1YeBhYWZab53ppUnUxs5gmp75gJr3khA==}
-    engines: {node: '>=8.0.0', npm: '>=5.5.0'}
-    peerDependencies:
-      react: 18.3.1
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
@@ -18111,8 +18098,6 @@ snapshots:
 
   cjs-module-lexer@1.4.3: {}
 
-  classnames@2.5.1: {}
-
   cli-cursor@2.1.0:
     dependencies:
       restore-cursor: 2.0.0
@@ -23836,12 +23821,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.29
       redux: 5.0.1
-
-  react-star-rating-component@1.4.1(react@18.3.1):
-    dependencies:
-      classnames: 2.5.1
-      prop-types: 15.8.1
-      react: 18.3.1
 
   react@18.3.1:
     dependencies:


### PR DESCRIPTION
### Context

The PR fixes a production React error reported in Sentry (HANDSONTABLE-DOCS-1G0): "Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined."

The root cause is `react-star-rating-component@1.4.1` — a CJS module last published in 2022, compiled with Babel 5. When Astro's production build (Rollup + `@rollup/plugin-commonjs`) processes the package, the default import `import StarRatingComponent from 'react-star-rating-component'` resolves to `undefined` due to CJS/ESM interop differences between esbuild (used in dev) and Rollup (used in production).

Two docs example files were affected:
- `docs/content/recipes/cell-types/react-rating/react/example1.{jsx,tsx}`
- `docs/content/guides/getting-started/react-redux/react/example6.{jsx,tsx}`

The fix replaces the external dependency with a small self-contained `StarRating` component defined inline in each example. This also makes the examples more educational — readers can see exactly how the star renderer works without needing an external package.

### How has this been tested?

- Code review: confirmed all `StarRatingComponent` usages replaced, import removed from both `.jsx` and `.tsx` variants of both examples
- `react-star-rating-component` removed from `docs/package.json`
- Manual verification: the inline `StarRating` component renders the same visual output (★ characters with filled/empty color states)

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1789

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1789

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkuFE8aZ72GiFoYMFtAccQ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only and dependency cleanup; no changes to Handsontable packages or runtime product code beyond documentation site examples.
> 
> **Overview**
> Fixes a **production docs crash** where `react-star-rating-component` default-imported as `undefined` under Astro’s Rollup production build (CJS/ESM interop), causing invalid React element errors.
> 
> **`react-star-rating-component` is removed** from `docs/package.json`, root `package.json` overrides, and `pnpm-lock.yaml`. Docs examples now use an **inline `StarRating`** component (★ characters, filled/empty colors, hover/click in the recipe) in `react-rating` examples (`example1.jsx/tsx`, CSS) and Redux advanced example `example6.jsx/tsx`. Live example `--deps` no longer list the old package.
> 
> **Docs are updated** so the React star-rating tutorial and cross-links describe a local star component (new steps, CSS, accessibility/performance notes) instead of the third-party library.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca7638a5d94dccf933aff6a0323c9817ef7a1b6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->