### PR TITLE
DEV-1790: Fix SyntaxError in StarlightTOC on browsers without :has() support

### DIFF
--- a/docs/src/components/Head.astro
+++ b/docs/src/components/Head.astro
@@ -22,7 +22,7 @@ import Default from '@astrojs/starlight/components/Head.astro';
 <script is:inline>
   // Patch StarlightTOC to silently handle browsers that don't support :has() (Chrome < 105,
   // e.g. Chrome Mobile 75 on Android 6.0). The TOC uses :has() inside querySelectorAll which
-  // throws a SyntaxError in those browsers. Catching it degrades gracefully: the TOC renders
+  // throws a DOMException named "SyntaxError" in those browsers. Catching it degrades gracefully: the TOC renders
   // but doesn't highlight the active section while scrolling.
   customElements.whenDefined('starlight-toc').then(function () {
     var StarlightTOC = customElements.get('starlight-toc');
@@ -32,7 +32,7 @@ import Default from '@astrojs/starlight/components/Head.astro';
       try {
         _originalInit.call(this);
       } catch (e) {
-        if (e instanceof SyntaxError) return;
+        if (e instanceof DOMException && e.name === 'SyntaxError') return;
         throw e;
       }
     };

--- a/docs/src/components/Head.astro
+++ b/docs/src/components/Head.astro
@@ -19,6 +19,26 @@ import Default from '@astrojs/starlight/components/Head.astro';
   document.querySelector('link[rel="shortcut icon"]')?.remove();
 </script>
 
+<script is:inline>
+  // Patch StarlightTOC to silently handle browsers that don't support :has() (Chrome < 105,
+  // e.g. Chrome Mobile 75 on Android 6.0). The TOC uses :has() inside querySelectorAll which
+  // throws a SyntaxError in those browsers. Catching it degrades gracefully: the TOC renders
+  // but doesn't highlight the active section while scrolling.
+  customElements.whenDefined('starlight-toc').then(function () {
+    var StarlightTOC = customElements.get('starlight-toc');
+    if (!StarlightTOC || !StarlightTOC.prototype.init) return;
+    var _originalInit = StarlightTOC.prototype.init;
+    StarlightTOC.prototype.init = function () {
+      try {
+        _originalInit.call(this);
+      } catch (e) {
+        if (e instanceof SyntaxError) return;
+        throw e;
+      }
+    };
+  });
+</script>
+
 <script>
   import Handsontable from 'handsontable/base';
 


### PR DESCRIPTION
### Context

The PR fixes a SyntaxError thrown by Starlight's `StarlightTOC` custom element on browsers that don't support the CSS `:has()` pseudo-class (Chrome < 105, e.g. Chrome Mobile 75 on Android 6.0).

Starlight's Table of Contents component builds a complex `querySelectorAll` selector that includes `:has()` to track active headings while scrolling. On unsupported browsers, calling `querySelectorAll` with this selector throws `SyntaxError: Failed to execute 'querySelectorAll' on 'Document'`, which surfaced in Sentry as issue [HANDSONTABLE-DOCS-1GA](https://handsoncode.sentry.io/issues/7495461995/).

The fix patches the `StarlightTOC` prototype's `init` method in `Head.astro` (via `customElements.whenDefined`) to catch `SyntaxError` and bail out silently. The TOC still renders correctly on all browsers — it just doesn't highlight the active section during scrolling on browsers that predate `:has()` support.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1790

### How has this been tested?

- The Sentry error originates from Chrome 75 on Android 6.0 — a browser that predates `:has()` support (added in Chrome 105). The patch wraps the failing `init()` call so it exits cleanly instead of throwing.
- Verified the fix logic: `customElements.whenDefined('starlight-toc')` resolves as a microtask after `customElements.define()` is called, which is before the async `setTimeout`-deferred `init()` call fires — so the patch is always applied in time.
- Manual verification on modern browsers: TOC scroll-tracking continues to work normally since no `SyntaxError` is thrown and the `catch` branch is never entered.

[skip changelog]

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. DEV-1790

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWB7xnzW2q5Wy3YNhnpByJ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only inline prototype patch with narrow error handling; modern browsers are unchanged and no auth or data paths are touched.
> 
> **Overview**
> Adds an **inline client-side patch** in `Head.astro` for Starlight’s `starlight-toc` custom element so docs pages don’t throw on browsers without CSS `:has()` (e.g. Chrome &lt; 105).
> 
> After `customElements.whenDefined('starlight-toc')`, the change wraps `StarlightTOC.prototype.init` in a try/catch that **swallows only `DOMException` with name `SyntaxError`** (from invalid `:has()` selectors in `querySelectorAll`) and rethrows anything else. The table of contents still renders; **scroll-based active-section highlighting is skipped** on those browsers instead of breaking the page or reporting to Sentry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b96002846c1ff2f2faf7da7f7d71bd06a3088e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->