### PR TITLE
DEV-1791: Reload page once on stale-chunk import failure in docs assistant

### DIFF
--- a/docs/src/scripts/docs-assistant-bootstrap.ts
+++ b/docs/src/scripts/docs-assistant-bootstrap.ts
@@ -10,9 +10,27 @@
 import type { Root } from 'react-dom/client';
 
 const CONTAINER_ID = 'docs-assistant-root';
+const CHUNK_RELOAD_FLAG = 'docs-assistant-chunk-reload';
 
 let root: Root | null = null;
 let mountInFlight: Promise<void> | null = null;
+
+/**
+ * Returns true when the error is a failed dynamic-import caused by a stale
+ * deployment: the browser has a cached HTML page that references old
+ * content-hashed chunk filenames that no longer exist on the CDN.
+ * Different browsers surface this as different TypeError messages.
+ */
+function isChunkLoadError(err: unknown): boolean {
+  if (!(err instanceof TypeError)) return false;
+  const msg = err.message;
+
+  return (
+    msg.includes('Failed to fetch dynamically imported module') || // Chrome
+    msg.includes('error loading dynamically imported module') || // Firefox
+    msg.includes('Importing a module script failed') // Safari
+  );
+}
 
 async function ensureMounted(): Promise<void> {
   if (typeof document === 'undefined') return;
@@ -48,12 +66,36 @@ async function ensureMounted(): Promise<void> {
       root = createRoot(container);
       root.render(createElement(DocsAssistantWidget));
     }
+
+    // Successful mount — clear the stale-chunk reload guard so a future
+    // deployment can trigger a reload again if needed.
+    try {
+      sessionStorage.removeItem(CHUNK_RELOAD_FLAG);
+    } catch {
+      // ignore – private browsing may block sessionStorage
+    }
   })()
     .catch((err) => {
       if (root) {
         root.unmount();
         root = null;
       }
+
+      // Stale deployment: reload once to fetch fresh HTML with updated chunk
+      // hashes. The session flag prevents an infinite reload loop when the
+      // server itself is broken.
+      if (isChunkLoadError(err)) {
+        try {
+          if (!sessionStorage.getItem(CHUNK_RELOAD_FLAG)) {
+            sessionStorage.setItem(CHUNK_RELOAD_FLAG, '1');
+            window.location.reload();
+            return;
+          }
+        } catch {
+          // ignore – private browsing may block sessionStorage
+        }
+      }
+
       console.error('docs-assistant: failed to mount', err);
     })
     .finally(() => {


### PR DESCRIPTION
### Context

The PR fixes a recurring Sentry error (`HANDSONTABLE-DOCS-1DQ`) in the docs assistant widget. When a new version of the docs site is deployed, Astro/Vite replaces old content-hashed JS chunks (e.g. `DocsAssistantWidget.D2fw3ORt.js`) with new ones. Users who still have the old HTML cached in their browser attempt to dynamically import the old chunk URL, which no longer exists on the CDN. This causes an unhandled `TypeError: Failed to fetch dynamically imported module` that surfaces as a Sentry error.

The fix detects this class of error in the bootstrap catch handler and reloads the page once. The reload fetches fresh HTML containing the updated chunk hashes. A `sessionStorage` flag (`docs-assistant-chunk-reload`) prevents an infinite reload loop if the server itself is broken. The flag is cleared on every successful mount so future deployments can trigger a reload again.

### How has this been tested?

The fix targets a production-only failure path that requires a stale cache + new deployment to reproduce naturally. The logic was verified by code review:

- `isChunkLoadError` covers all three major browser error messages (Chrome, Firefox, Safari)
- The `sessionStorage` guard is wrapped in try/catch to handle private browsing mode
- The flag is cleared on successful mount so the guard resets between deployments
- No new dependencies introduced

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1791

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1791
Sentry issue: https://handsoncode.sentry.io/issues/7395738076/

[skip changelog]

---
_Generated by [Claude Code](https://claude.ai/code/session_01VyYagVMxWP3Z3JCUJNtoT1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only recovery in the docs assistant mount path; limited to one guarded reload and does not touch auth or data.
> 
> **Overview**
> The docs assistant bootstrap now recovers when **stale cached HTML** points at **removed Vite/Astro chunk URLs** after a deploy. A new `isChunkLoadError` helper treats browser-specific `TypeError` messages from failed dynamic imports as that case.
> 
> On mount failure, if it looks like a chunk load error and `sessionStorage` does not yet have `docs-assistant-chunk-reload`, the page **reloads once** so fresh HTML can load current hashes; otherwise behavior stays the same (`console.error`). After a **successful** mount, that flag is cleared so a later deploy can trigger another one-time reload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27dc24535a004f7d0c4a7f54ef9c4b2ab0fd6a59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->