### PR TITLE
DEV-1792: Prevent browser auto-translate from corrupting Preact DOM in docs

### DIFF
--- a/docs/src/components/Head.astro
+++ b/docs/src/components/Head.astro
@@ -14,6 +14,15 @@ import Default from '@astrojs/starlight/components/Head.astro';
 <link rel="icon" media="(prefers-color-scheme: light)" href="/docs/img/favicon.png" />
 <link rel="icon" media="(prefers-color-scheme: dark)" href="/docs/img/favicon-dark.png" />
 
+{/* Prevent browser auto-translate (Edge, Chrome, Google Translate) from
+    mutating text nodes in the DOM. When translation wraps text in <font>
+    elements, Preact's virtual-DOM reconciliation can no longer find its
+    reference nodes, causing NotFoundError: Failed to execute 'insertBefore'.
+    Technical documentation with code samples should not be machine-translated
+    anyway — API names, configuration keys, and code snippets must stay as-is. */}
+<meta name="google" content="notranslate" />
+<script is:inline>document.documentElement.setAttribute('translate','no');</script>
+
 <script is:inline>
   // Remove Starlight's default favicon in favor of light/dark media-query versions above.
   document.querySelector('link[rel="shortcut icon"]')?.remove();


### PR DESCRIPTION
### Context

The PR fixes a Sentry error ([HANDSONTABLE-DOCS-1BT](https://handsoncode.sentry.io/issues/7323876274/)) affecting 15 users across 21 occurrences, all on Microsoft Edge (Windows) from regions where browser auto-translate is common (China, Singapore).

Microsoft Edge's built-in page translator -- and other browser translation tools -- mutates the DOM by wrapping text nodes in `<font>` elements. Starlight's interactive components (search bar, sidebar, mobile nav) are rendered by Preact. When a translation-modified DOM is then re-reconciled by Preact's virtual DOM, its `placeChild` function calls `insertBefore` with a reference node that was moved by the translator:

```
NotFoundError: Failed to execute 'insertBefore' on 'Node':
The node before which the new node is to be inserted is not a child of this node.
  at Do (/docs/_astro/index.mZKjvrN9.js:1:3412)
```

The fix adds two standard signals to tell browsers not to translate the page:
- `<meta name="google" content="notranslate">` — respected by Google Translate
- `document.documentElement.setAttribute('translate', 'no')` via an early inline script — respected by Edge's built-in translator and Chromium-based translators

Technical documentation with code samples, API names, and configuration keys should not be machine-translated regardless, so this is the correct long-term behavior.

[skip changelog]

### How has this been tested?

- Verified the change renders correct `<meta>` and `translate` attribute by reviewing the diff.
- The fix targets a browser-triggered race condition (translation + Preact re-render) that is not reproducible via automated tests; the Sentry issue should stop receiving new events once the fix ships.
- Manual test: load any docs page in Edge with translation enabled — Edge should no longer offer to translate the page after this attribute is set.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1792

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1792

---
_Generated by [Claude Code](https://claude.ai/code/session_01GrqZ6xtv7KzeCQyakAYp7o)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only head markup; no auth, data, or runtime library behavior changes.
> 
> **Overview**
> Fixes **Preact `NotFoundError` on `insertBefore`** when Edge (and similar) auto-translate wraps text in `<font>` nodes and Starlight’s Preact UI can no longer reconcile the DOM.
> 
> **`docs/src/components/Head.astro`** now opts the whole docs site out of machine translation: a `<meta name="google" content="notranslate">` tag and an early inline script that sets `translate="no"` on `<html>`. That matches the intent that API names and code samples stay untranslated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f635fb666470cb6a2e764f34c4379ab88beaa540. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->