### PR TITLE
DEV-1796: Fix TypeError when ResizeObserver fires with undefined hot.view

### DIFF
--- a/.changelogs/12655.json
+++ b/.changelogs/12655.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed a TypeError thrown when the StretchColumns ResizeObserver callback fires while the table view is not yet available.",
+  "type": "fixed",
+  "issueOrPR": 12655,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/stretchColumns/__tests__/stretchColumns.spec.js
+++ b/handsontable/src/plugins/stretchColumns/__tests__/stretchColumns.spec.js
@@ -379,4 +379,30 @@ describe('StretchColumns', () => {
 
     expect($('.handsontable .ht_master table').outerWidth()).toBe(680);
   });
+
+  it('should not throw when the ResizeObserver fires while hot.view is not yet available', async() => {
+    handsontable({
+      data: createSpreadsheetData(5, 3),
+      stretchH: 'all',
+    });
+
+    await waitForNextAnimationFrames(2);
+
+    const hot = spec();
+    const savedView = hot.view;
+
+    // Simulate the race condition where hot.view is undefined when the rAF callback fires
+    // (e.g. during initialization or after destruction)
+    hot.view = undefined;
+
+    // Trigger a resize to queue a ResizeObserver callback
+    document.body.style.overflowY = 'scroll';
+
+    // Wait for the ResizeObserver and requestAnimationFrame to execute
+    await waitForNextAnimationFrames(3);
+
+    // Restore for proper cleanup
+    hot.view = savedView;
+    document.body.style.overflowY = '';
+  });
 });

--- a/handsontable/src/plugins/stretchColumns/stretchColumns.ts
+++ b/handsontable/src/plugins/stretchColumns/stretchColumns.ts
@@ -100,7 +100,7 @@ export class StretchColumns extends BasePlugin {
    */
   #resizeObserver = new ResizeObserver((entries) => {
     requestAnimationFrame(() => {
-      if (!this.hot?.view.isHorizontallyScrollableByWindow()) {
+      if (!this.hot?.view?.isHorizontallyScrollableByWindow()) {
         return;
       }
 


### PR DESCRIPTION
### Context

The PR fixes a `TypeError: Cannot read property 'isHorizontallyScrollableByWindow' of undefined` reported via Sentry (HANDSONTABLE-DOCS-1GD). The error originates in the `StretchColumns` plugin's `ResizeObserver` callback.

The callback schedules a `requestAnimationFrame` to check `this.hot?.view.isHorizontallyScrollableByWindow()`. Optional chaining (`?.`) protected against `this.hot` being `undefined`, but not against `this.hot.view` being `undefined`. In a race condition — where the observer fires and queues a frame, but the HOT instance's view is not yet available or has been torn down by the time the frame executes — `this.hot.view` is `undefined`, causing the crash.

The fix adds optional chaining to `view` as well: `this.hot?.view?.isHorizontallyScrollableByWindow()`, so the callback safely returns when the view is unavailable.

Sentry issue: https://handsoncode.sentry.io/issues/7496653600/
ClickUp task: https://app.clickup.com/t/9015210959/DEV-1796

### How has this been tested?

- Added an E2E regression test that simulates the race condition by setting `hot.view = undefined`, triggering a resize, and waiting for the `requestAnimationFrame` callback to execute. Before the fix this would throw; after the fix it returns early safely.

```bash
npm run test:e2e --prefix handsontable --testPathPattern=stretchColumns
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1796

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJu8CxJDtwmUQhsNY4wJzH)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single optional-chaining guard and a targeted regression test in a non-critical layout path; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes a **TypeError** in the **StretchColumns** plugin when a deferred **ResizeObserver** / `requestAnimationFrame` handler runs while `hot.view` is missing (e.g. init race or teardown).
> 
> The guard now uses `this.hot?.view?.isHorizontallyScrollableByWindow()` so the callback exits safely instead of calling a method on `undefined`. An e2e test forces `hot.view = undefined`, triggers a layout resize, and asserts no throw; a changelog entry documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 818d2d2cbed3affc38d5a70f3ed59a9172763b40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->