### PR TITLE
DEV-1223 - Expand Angular wrapper test coverage — unit, e2e, and regr…

### DIFF
--- a/.changelogs/12657.json
+++ b/.changelogs/12657.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "public",
-  "title": "Fixed subscription leak, missing EmbeddedViewRef cleanup, repeated registerRenderer calls, wrong constructor.name, incorrect prop type, missing null guard in ngOnDestroy, and premature editor destruction.",
+  "title": "Fixed subscription leak, missing EmbeddedViewRef cleanup, repeated registerRenderer calls, wrong constructor.name, incorrect prop type, missing null guard in ngOnDestroy, premature editor destruction, redundant double-destroy of already-swept renderer refs, and stale editor reuse when a different column takes an index.",
   "type": "fixed",
   "issueOrPR": 12657,
   "breaking": false,

--- a/.changelogs/12657.json
+++ b/.changelogs/12657.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed subscription leak, missing EmbeddedViewRef cleanup, repeated registerRenderer calls, wrong constructor.name, incorrect prop type, missing null guard in ngOnDestroy, and premature editor destruction.",
+  "type": "fixed",
+  "issueOrPR": 12657,
+  "breaking": false,
+  "framework": "angular"
+}

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/base-editor-adapter.spec.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/base-editor-adapter.spec.ts
@@ -95,6 +95,41 @@ describe('BaseEditorAdapter', () => {
 
       expect(destroySpy).toHaveBeenCalled();
     });
+
+    it('should unsubscribe finish/cancel edit subscriptions on afterDestroy hook (no subscription leak)', () => {
+      adapter.prepare(0, 0, 'prop', document.createElement('td'), 1, <CellProperties>{});
+      const finishSub = (adapter as any)._finishEditSubscription;
+      const cancelSub = (adapter as any)._cancelEditSubscription;
+      const finishUnsubSpy = jest.spyOn(finishSub, 'unsubscribe');
+      const cancelUnsubSpy = jest.spyOn(cancelSub, 'unsubscribe');
+
+      instance.runHooks('afterDestroy');
+
+      expect(finishUnsubSpy).toHaveBeenCalled();
+      expect(cancelUnsubSpy).toHaveBeenCalled();
+      expect((adapter as any)._finishEditSubscription).toBeUndefined();
+      expect((adapter as any)._cancelEditSubscription).toBeUndefined();
+    });
+  });
+
+  describe('guards when refs are not initialized (called before prepare)', () => {
+    it('should not throw when focus() is called before prepare()', () => {
+      expect(() => adapter.focus()).not.toThrow();
+    });
+
+    it('should not throw when open() is called before prepare()', () => {
+      expect(() => adapter.open()).not.toThrow();
+    });
+
+    it('should not throw when setValue() is called before prepare()', () => {
+      expect(() => adapter.setValue(1)).not.toThrow();
+    });
+
+    it('should not throw when close() runs while opened but refs are not initialized', () => {
+      jest.spyOn(adapter, 'isOpened').mockReturnValue(true);
+
+      expect(() => adapter.close()).not.toThrow();
+    });
   });
 
   describe('prepare', () => {

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/base-editor-adapter.spec.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/base-editor-adapter.spec.ts
@@ -62,6 +62,10 @@ describe('BaseEditorAdapter', () => {
   });
 
   describe('hot table hooks', () => {
+    it('should not throw when afterDestroy hook fires before prepare() is called', () => {
+      expect(() => instance.runHooks('afterDestroy')).not.toThrow();
+    });
+
     it('should call setInput on custom editor when afterRowResize hook is triggered', () => {
       const setInputSpy = jest.spyOn(customEditor.componentRef, 'setInput');
       adapter.prepare(0, 0, 'prop', document.createElement('td'), 1, <CellProperties>{});
@@ -80,6 +84,16 @@ describe('BaseEditorAdapter', () => {
       instance.runHooks('afterColumnResize');
 
       expect(setInputSpy).toHaveBeenCalledTimes(5);
+    });
+
+    it('should destroy editor placeholder on afterDestroy hook', () => {
+      adapter.prepare(0, 0, 'prop', document.createElement('td'), 1, <CellProperties>{});
+      const placeholder = (adapter as any)._editorPlaceHolderRef;
+      const destroySpy = jest.spyOn(placeholder, 'destroy');
+
+      instance.runHooks('afterDestroy');
+
+      expect(destroySpy).toHaveBeenCalled();
     });
   });
 
@@ -209,6 +223,26 @@ describe('BaseEditorAdapter', () => {
 
       expect(setValueSpy).toHaveBeenCalledWith(2);
       expect(detectChangesSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('finishEdit / cancelEdit event subscriptions', () => {
+    it('should call finishEditing when custom editor emits finishEdit', () => {
+      adapter.prepare(0, 0, 'prop', document.createElement('td'), 1, <CellProperties>{});
+      const finishEditingSpy = jest.spyOn(adapter, 'finishEditing').mockImplementation(() => {});
+
+      customEditor.componentInstance.finishEdit.emit();
+
+      expect(finishEditingSpy).toHaveBeenCalled();
+    });
+
+    it('should call cancelChanges when custom editor emits cancelEdit', () => {
+      adapter.prepare(0, 0, 'prop', document.createElement('td'), 1, <CellProperties>{});
+      const cancelChangesSpy = jest.spyOn(adapter, 'cancelChanges').mockImplementation(() => {});
+
+      customEditor.componentInstance.cancelEdit.emit();
+
+      expect(cancelChangesSpy).toHaveBeenCalled();
     });
   });
 });

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/base-editor-adapter.spec.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/base-editor-adapter.spec.ts
@@ -203,6 +203,15 @@ describe('BaseEditorAdapter', () => {
 
       expect(getValueSpy).toHaveBeenCalled();
     });
+
+    it('should not throw and return undefined when called before prepare() sets the component ref', () => {
+      let value: any;
+
+      expect(() => {
+        value = adapter.getValue();
+      }).not.toThrow();
+      expect(value).toBeUndefined();
+    });
   });
 
   describe('open', () => {

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/base-editor-adapter.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/base-editor-adapter.ts
@@ -71,15 +71,7 @@ export class BaseEditorAdapter extends Handsontable.editors.BaseEditor {
 
       this._componentRef = columnMeta._editorComponentReference;
 
-      if (this._finishEditSubscription) {
-        this._finishEditSubscription.unsubscribe();
-        this._finishEditSubscription = undefined;
-      }
-
-      if (this._cancelEditSubscription) {
-        this._cancelEditSubscription.unsubscribe();
-        this._cancelEditSubscription = undefined;
-      }
+      this.cleanupSubscriptions();
 
       this._finishEditSubscription = this._componentRef.instance.finishEdit
         .pipe(take(1))
@@ -101,9 +93,9 @@ export class BaseEditorAdapter extends Handsontable.editors.BaseEditor {
   close(): void {
     if (this.isOpened()) {
       this.resetEditorState();
-      this._editorPlaceHolderRef.changeDetectorRef.detectChanges();
-      this._editorPlaceHolderRef.instance.detachEditor();
-      this._componentRef.instance.onClose();
+      this._editorPlaceHolderRef?.changeDetectorRef.detectChanges();
+      this._editorPlaceHolderRef?.instance.detachEditor();
+      this._componentRef?.instance.onClose();
     }
   }
 
@@ -111,7 +103,7 @@ export class BaseEditorAdapter extends Handsontable.editors.BaseEditor {
    * Focuses the editor. This event is triggered by Handsontable.
    */
   focus(): void {
-    this._componentRef.instance.onFocus();
+    this._componentRef?.instance.onFocus();
   }
 
   /**
@@ -132,7 +124,7 @@ export class BaseEditorAdapter extends Handsontable.editors.BaseEditor {
   open(event?: Event): void {
     this.hot.getShortcutManager().setActiveContextName('editor');
     this.applyPropsToEditor();
-    this._componentRef.instance.onOpen(event);
+    this._componentRef?.instance.onOpen(event);
   }
 
   /**
@@ -140,14 +132,18 @@ export class BaseEditorAdapter extends Handsontable.editors.BaseEditor {
    * @param newValue The value to set.
    */
   setValue(newValue?: any): void {
-    this._componentRef.instance?.setValue(newValue);
-    this._componentRef.changeDetectorRef.detectChanges();
+    this._componentRef?.instance?.setValue(newValue);
+    this._componentRef?.changeDetectorRef.detectChanges();
   }
 
   /**
    * Applies properties to the custom editor and editor placeholder.
    */
   private applyPropsToEditor(): void {
+    if (!this._componentRef || !this._editorPlaceHolderRef) {
+      return;
+    }
+
     const rect = this.getEditedCellRect();
 
     if (!this.isInFullEditMode()) {
@@ -210,7 +206,25 @@ export class BaseEditorAdapter extends Handsontable.editors.BaseEditor {
    * Handles the after destroy event.
    */
   private onAfterDestroy(): void {
+    this.cleanupSubscriptions();
     this._editorPlaceHolderRef?.destroy();
+  }
+
+  /**
+   * Unsubscribes the finish/cancel edit subscriptions if they are still active.
+   * Without this, destroying the table while an editor was prepared but never
+   * finished/cancelled leaves the `take(1)` subscriptions hanging (they never emit).
+   */
+  private cleanupSubscriptions(): void {
+    if (this._finishEditSubscription) {
+      this._finishEditSubscription.unsubscribe();
+      this._finishEditSubscription = undefined;
+    }
+
+    if (this._cancelEditSubscription) {
+      this._cancelEditSubscription.unsubscribe();
+      this._cancelEditSubscription = undefined;
+    }
   }
 
   /**
@@ -219,6 +233,10 @@ export class BaseEditorAdapter extends Handsontable.editors.BaseEditor {
    * to store multiple references to the custom editor.
    */
   private resetEditorState(): void {
+    if (!this._editorPlaceHolderRef) {
+      return;
+    }
+
     this._editorPlaceHolderRef.setInput('top', undefined);
     this._editorPlaceHolderRef.setInput('left', undefined);
     this._editorPlaceHolderRef.setInput('height', undefined);

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/base-editor-adapter.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/base-editor-adapter.ts
@@ -111,7 +111,7 @@ export class BaseEditorAdapter extends Handsontable.editors.BaseEditor {
    * @returns The value from the editor.
    */
   getValue(): any {
-    return this._componentRef.instance?.getValue();
+    return this._componentRef?.instance?.getValue();
   }
 
   /**

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/custom-editor-placeholder.component.spec.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/custom-editor-placeholder.component.spec.ts
@@ -93,4 +93,22 @@ describe('CustomEditorPlaceholderComponent', () => {
 
     expect(detachSpy).toHaveBeenCalled();
   });
+
+  it('should have default placeholderCustomClass of "handsontableInputHolder ht_clone_master"', () => {
+    expect(component.placeholderCustomClass).toBe('handsontableInputHolder ht_clone_master');
+  });
+
+  it('should apply the default class to the host div', () => {
+    const div = fixture.nativeElement.querySelector('div');
+    expect(div.className).toContain('handsontableInputHolder');
+    expect(div.className).toContain('ht_clone_master');
+  });
+
+  it('should reflect a custom placeholderCustomClass when changed', () => {
+    fixture.componentRef.setInput('placeholderCustomClass', 'my-custom-class');
+    fixture.detectChanges();
+
+    const div = fixture.nativeElement.querySelector('div');
+    expect(div.className).toBe('my-custom-class');
+  });
 });

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/editor-factory-adapter.spec.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/editor-factory-adapter.spec.ts
@@ -79,6 +79,27 @@ describe('FactoryEditorAdapter', () => {
       expect(adapter._afterDestroyCallback).toBeDefined();
       expect(typeof adapter._afterDestroyCallback).toBe('function');
     });
+
+    it('should not throw when _angularEnvironmentInjector is not set on the HOT instance', () => {
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      const EditorClass = FactoryEditorAdapter(customEditor.componentRef);
+      const testInstance = new Handsontable(container, {
+        licenseKey: 'non-commercial-and-evaluation',
+        columns: [{ editor: EditorClass }],
+        data: [[1]],
+      });
+
+      testInstance.selectCell(0, 0);
+      expect(() => testInstance.getActiveEditor().beginEditing()).not.toThrow();
+
+      const editorWithoutInjector = testInstance.getActiveEditor() as any;
+      expect(editorWithoutInjector._editorPlaceHolderRef).toBeUndefined();
+      expect(editorWithoutInjector.input).toBeInstanceOf(HTMLElement);
+
+      testInstance.destroy();
+      container.remove();
+    });
   });
 
   describe('hot table hooks', () => {
@@ -106,6 +127,16 @@ describe('FactoryEditorAdapter', () => {
       instance.runHooks('afterDestroy');
 
       expect(destroySpy).toHaveBeenCalled();
+    });
+
+    it('should unsubscribe finishEdit and cancelEdit subscriptions when afterDestroy hook fires', () => {
+      const finishSpy = jest.spyOn(adapter._finishEditSubscription, 'unsubscribe');
+      const cancelSpy = jest.spyOn(adapter._cancelEditSubscription, 'unsubscribe');
+
+      instance.runHooks('afterDestroy');
+
+      expect(finishSpy).toHaveBeenCalled();
+      expect(cancelSpy).toHaveBeenCalled();
     });
   });
 
@@ -210,6 +241,24 @@ describe('FactoryEditorAdapter', () => {
     });
   });
 
+  describe('finishEdit / cancelEdit event subscriptions', () => {
+    it('should call finishEditing when custom editor emits finishEdit', () => {
+      const finishEditingSpy = jest.spyOn(adapter, 'finishEditing').mockImplementation(() => {});
+
+      customEditor.componentInstance.finishEdit.emit();
+
+      expect(finishEditingSpy).toHaveBeenCalled();
+    });
+
+    it('should call cancelChanges when custom editor emits cancelEdit', () => {
+      const cancelChangesSpy = jest.spyOn(adapter, 'cancelChanges').mockImplementation(() => {});
+
+      customEditor.componentInstance.cancelEdit.emit();
+
+      expect(cancelChangesSpy).toHaveBeenCalled();
+    });
+  });
+
   describe('getValue', () => {
     it('should call custom editor getValue', () => {
       const getValueSpy = jest.spyOn(customEditor.componentInstance, 'getValue');
@@ -242,6 +291,34 @@ describe('FactoryEditorAdapter', () => {
       adapter.setValue(42);
 
       expect(detectChangesSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('defensive early returns', () => {
+    it('should not throw in applyPropsToEditor when _editorPlaceHolderRef is null', () => {
+      adapter._editorPlaceHolderRef = null;
+
+      expect(() => instance.runHooks('afterRowResize')).not.toThrow();
+    });
+
+    it('should not throw in applyPropsToEditor when _componentRef is null', () => {
+      adapter._componentRef = null;
+
+      expect(() => instance.runHooks('afterColumnResize')).not.toThrow();
+    });
+
+    it('should not throw in resetEditorState when _editorPlaceHolderRef is undefined', () => {
+      adapter._editorPlaceHolderRef = undefined;
+
+      expect(() => adapter.finishEditing()).not.toThrow();
+    });
+
+    it('should handle cleanupSubscriptions when subscriptions are null', () => {
+      adapter._finishEditSubscription = undefined;
+      adapter._cancelEditSubscription = undefined;
+
+      instance.selectCell(0, 0);
+      expect(() => adapter.beginEditing()).not.toThrow();
     });
   });
 });

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/editor-factory-adapter.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/editor-factory-adapter.ts
@@ -1,6 +1,6 @@
 import { ComponentRef, createComponent, EnvironmentInjector } from '@angular/core';
 import { CustomEditorPlaceholderComponent } from './custom-editor-placeholder.component';
-import { AngularEditorProperties } from './models/factory-editor-properties';
+import { AngularEditorProperties, HotInstanceWithAngularInjector } from './models/factory-editor-properties';
 import { editorFactory, ExtendedEditor } from 'handsontable/editors/factory';
 import { take } from 'rxjs/operators';
 import { HotCellEditorAdvancedComponent } from './hot-cell-editor-advanced.component';
@@ -32,7 +32,7 @@ export const FactoryEditorAdapter = (componentRef: ComponentRef<HotCellEditorAdv
       editor._finishEditSubscription = undefined;
       editor._cancelEditSubscription = undefined;
 
-      createEditorPlaceholder(editor, (editor.hot as any)._angularEnvironmentInjector);
+      createEditorPlaceholder(editor, (editor.hot as HotInstanceWithAngularInjector)._angularEnvironmentInjector);
       editor.input = editor._editorPlaceHolderRef?.location.nativeElement ?? document.createElement('div');
 
       editor._afterRowResizeCallback = (): void => {

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/editor-factory-adapter.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/editor-factory-adapter.ts
@@ -33,7 +33,7 @@ export const FactoryEditorAdapter = (componentRef: ComponentRef<HotCellEditorAdv
       editor._cancelEditSubscription = undefined;
 
       createEditorPlaceholder(editor, (editor.hot as any)._angularEnvironmentInjector);
-      editor.input = editor._editorPlaceHolderRef.location.nativeElement;
+      editor.input = editor._editorPlaceHolderRef?.location.nativeElement ?? document.createElement('div');
 
       editor._afterRowResizeCallback = (): void => {
         if (editor.isOpened()) {
@@ -48,6 +48,7 @@ export const FactoryEditorAdapter = (componentRef: ComponentRef<HotCellEditorAdv
       };
 
       editor._afterDestroyCallback = (): void => {
+        cleanupSubscriptions(editor);
         if (editor._editorPlaceHolderRef) {
           editor._editorPlaceHolderRef.destroy();
         }
@@ -80,8 +81,8 @@ export const FactoryEditorAdapter = (componentRef: ComponentRef<HotCellEditorAdv
     onFocus: (editor) => editor._componentRef.instance.onFocus?.(editor),
     afterClose: (editor: EditorInstance) => {
       resetEditorState(editor);
-      editor._editorPlaceHolderRef.changeDetectorRef.detectChanges();
-      editor._editorPlaceHolderRef.instance.detachEditor();
+      editor._editorPlaceHolderRef?.changeDetectorRef.detectChanges();
+      editor._editorPlaceHolderRef?.instance.detachEditor();
       editor._componentRef.instance.afterClose?.(editor);
     },
     getValue: (editor) => editor._componentRef.instance.getValue(),

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/hot-cell-editor-advanced.component.spec.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/hot-cell-editor-advanced.component.spec.ts
@@ -100,14 +100,18 @@ describe('HotCellEditorAdvancedComponent', () => {
   describe('@Output events', () => {
     it('should emit finishEdit', () => {
       let emitted = false;
-      component.finishEdit.subscribe(() => { emitted = true; });
+      component.finishEdit.subscribe(() => {
+        emitted = true;
+      });
       component.finishEdit.emit();
       expect(emitted).toBe(true);
     });
 
     it('should emit cancelEdit', () => {
       let emitted = false;
-      component.cancelEdit.subscribe(() => { emitted = true; });
+      component.cancelEdit.subscribe(() => {
+        emitted = true;
+      });
       component.cancelEdit.emit();
       expect(emitted).toBe(true);
     });

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/hot-cell-editor-advanced.component.spec.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/hot-cell-editor-advanced.component.spec.ts
@@ -1,0 +1,202 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component } from '@angular/core';
+import { HotCellEditorAdvancedComponent } from './hot-cell-editor-advanced.component';
+import { HotCellEditorComponent } from './hot-cell-editor.component';
+
+@Component({
+  selector: 'hot-mock-advanced-editor',
+  template: '',
+  standalone: true,
+})
+class ConcreteAdvancedEditorComponent extends HotCellEditorAdvancedComponent<string> {}
+
+describe('HotCellEditorAdvancedComponent', () => {
+  let fixture: ComponentFixture<ConcreteAdvancedEditorComponent>;
+  let component: ConcreteAdvancedEditorComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ConcreteAdvancedEditorComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ConcreteAdvancedEditorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('EDITOR_MARKER should be a Symbol', () => {
+    expect(typeof HotCellEditorAdvancedComponent.EDITOR_MARKER).toBe('symbol');
+  });
+
+  it('EDITOR_MARKER should differ from HotCellEditorComponent.EDITOR_MARKER', () => {
+    expect(HotCellEditorAdvancedComponent.EDITOR_MARKER).not.toBe(HotCellEditorComponent.EDITOR_MARKER);
+  });
+
+  describe('host bindings', () => {
+    it('should set height 100% on host element', () => {
+      expect(fixture.nativeElement.style.height).toBe('100%');
+    });
+
+    it('should set width 100% on host element', () => {
+      expect(fixture.nativeElement.style.width).toBe('100%');
+    });
+  });
+
+  describe('default property values', () => {
+    it('position should default to "container"', () => {
+      expect(component.position).toBe('container');
+    });
+
+    it('shortcuts should be undefined by default', () => {
+      expect(component.shortcuts).toBeUndefined();
+    });
+
+    it('shortcutsGroup should be undefined by default', () => {
+      expect(component.shortcutsGroup).toBeUndefined();
+    });
+
+    it('config should be undefined by default', () => {
+      expect(component.config).toBeUndefined();
+    });
+  });
+
+  describe('@Input properties', () => {
+    it('should accept row input', () => {
+      fixture.componentRef.setInput('row', 2);
+      expect(component.row).toBe(2);
+    });
+
+    it('should accept column input', () => {
+      fixture.componentRef.setInput('column', 4);
+      expect(component.column).toBe(4);
+    });
+
+    it('should accept prop as string', () => {
+      fixture.componentRef.setInput('prop', 'id');
+      expect(component.prop).toBe('id');
+    });
+
+    it('should accept prop as number', () => {
+      fixture.componentRef.setInput('prop', 0);
+      expect(component.prop).toBe(0);
+    });
+
+    it('should accept originalValue', () => {
+      fixture.componentRef.setInput('originalValue', 'original');
+      expect(component.originalValue).toBe('original');
+    });
+
+    it('should accept cellProperties', () => {
+      const props = { type: 'text' } as any;
+      fixture.componentRef.setInput('cellProperties', props);
+      expect(component.cellProperties).toBe(props);
+    });
+  });
+
+  describe('@Output events', () => {
+    it('should emit finishEdit', () => {
+      let emitted = false;
+      component.finishEdit.subscribe(() => { emitted = true; });
+      component.finishEdit.emit();
+      expect(emitted).toBe(true);
+    });
+
+    it('should emit cancelEdit', () => {
+      let emitted = false;
+      component.cancelEdit.subscribe(() => { emitted = true; });
+      component.cancelEdit.emit();
+      expect(emitted).toBe(true);
+    });
+  });
+
+  describe('getValue / setValue', () => {
+    it('should return undefined before setValue is called', () => {
+      expect(component.getValue()).toBeUndefined();
+    });
+
+    it('should return value after setValue', () => {
+      component.setValue('advanced-value');
+      expect(component.getValue()).toBe('advanced-value');
+    });
+
+    it('should overwrite value on subsequent setValue calls', () => {
+      component.setValue('first');
+      component.setValue('second');
+      expect(component.getValue()).toBe('second');
+    });
+  });
+
+  describe('configurable public properties', () => {
+    it('should allow setting position to "portal"', () => {
+      component.position = 'portal';
+      expect(component.position).toBe('portal');
+    });
+
+    it('should allow setting position back to "container"', () => {
+      component.position = 'portal';
+      component.position = 'container';
+      expect(component.position).toBe('container');
+    });
+
+    it('should allow setting shortcuts', () => {
+      const shortcuts = [{ keys: [['Enter']], callback: () => {} }];
+      component.shortcuts = shortcuts;
+      expect(component.shortcuts).toBe(shortcuts);
+    });
+
+    it('should allow setting shortcutsGroup', () => {
+      component.shortcutsGroup = 'myGroup';
+      expect(component.shortcutsGroup).toBe('myGroup');
+    });
+
+    it('should allow setting config', () => {
+      const config = { foo: 'bar' };
+      component.config = config;
+      expect(component.config).toEqual(config);
+    });
+  });
+
+  describe('lifecycle hooks', () => {
+    it('onFocus() should be callable without argument', () => {
+      expect(() => component.onFocus()).not.toThrow();
+    });
+
+    it('onFocus() should be callable with editor argument', () => {
+      expect(() => component.onFocus({} as any)).not.toThrow();
+    });
+
+    it('afterOpen() should be callable with editor only', () => {
+      expect(() => component.afterOpen({} as any)).not.toThrow();
+    });
+
+    it('afterOpen() should be callable with editor and event', () => {
+      const event = new Event('open');
+      expect(() => component.afterOpen({} as any, event)).not.toThrow();
+    });
+
+    it('afterClose() should be callable', () => {
+      expect(() => component.afterClose({} as any)).not.toThrow();
+    });
+
+    it('afterInit() should be callable', () => {
+      expect(() => component.afterInit({} as any)).not.toThrow();
+    });
+
+    it('beforeOpen() should be callable with all required arguments', () => {
+      expect(() =>
+        component.beforeOpen({} as any, {
+          row: 0,
+          col: 0,
+          prop: 'test',
+          td: document.createElement('td'),
+          originalValue: 'val',
+          cellProperties: {} as any,
+        })
+      ).not.toThrow();
+    });
+  });
+});

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/hot-cell-editor-advanced.component.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/hot-cell-editor-advanced.component.ts
@@ -1,89 +1,44 @@
-import { Directive, EventEmitter, HostBinding, Input, Output } from '@angular/core';
+import { Directive } from '@angular/core';
 import { ExtendedEditor } from 'handsontable/editors/factory';
 import { CellProperties } from 'handsontable/settings';
 import { KeyboardShortcutConfig } from './models/keyboard-shortcut-config';
+import { HotCellEditorBase } from './hot-cell-editor-base.directive';
 
 /**
- * Abstract class representing a Handsontable editor in angular.
+ * Abstract class representing an advanced Handsontable cell editor in Angular.
+ *
+ * Extend this class and decorate the subclass with `@Component()` to implement a custom editor.
+ * Unlike {@link HotCellEditorComponent}, this variant also accepts object and array values
+ * and provides additional lifecycle hooks and positioning options.
  */
 @Directive()
-export abstract class HotCellEditorAdvancedComponent<T extends string | number | boolean | Record<string, any> | Array<any>> {
+export abstract class HotCellEditorAdvancedComponent<
+  T extends string | number | boolean | Record<string, any> | Array<any>
+> extends HotCellEditorBase<T> {
   static readonly EDITOR_MARKER = Symbol('HotCellEditorAdvancedComponent');
 
-  /** The height of the editor as a percentage of the parent container. */
-  @HostBinding('style.height.%') protected heightFitParentContainer = 100;
-
-  /** The width of the editor as a percentage of the parent container. */
-  @HostBinding('style.width.%') protected widthFitParentContainer = 100;
-
-  /** The row index of the cell being edited. */
-  @Input() row: number;
-
-  /** The column index of the cell being edited. */
-  @Input() column: number;
-
-  /** The property name of the cell being edited. */
-  @Input() prop: string | number;
-
-  /** The original value of the cell being edited. */
-  @Input() originalValue: T;
-
-  /** The cell properties of the cell being edited. */
-  @Input() cellProperties: CellProperties;
-
-  /** Event emitted when the edit is finished.
-   * The data will be saved to the model.
-   */
-  @Output() finishEdit = new EventEmitter<void>();
-
-  /** Event emitted when the edit is canceled.
-   * The entered data will be reverted to the original value.
-   */
-  @Output() cancelEdit = new EventEmitter<void>();
-
-  /** The current value of the editor. */
-  protected value: T;
-
-  /** Event triggered by Handsontable on focus the editor.
-   * The user have to define focus logic.
-   */
+  /** Event triggered by Handsontable on focusing the editor. Available in advanced mode. */
   onFocus(editor?: ExtendedEditor<T>): void {}
 
-  /**
-   * Gets the current value of the editor.
-   * @returns The current value of the editor.
-   */
-  getValue(): T {
-    return this.value;
-  }
-
-  /**
-   * Sets the current value of the editor.
-   * @param value The value to set.
-   */
-  setValue(value: T): void {
-    this.value = value;
-  }
-
-  /** The position of the editor in the DOM. Used by Handsontable API. Available in advanced mode. */
+  /** The position of the editor in the DOM. Available in advanced mode. */
   position: 'container' | 'portal' = 'container';
 
   /** The shortcuts available for the editor. Available in advanced mode. */
   shortcuts?: KeyboardShortcutConfig[];
 
-  /** The group name for the shortcuts. Available in advanced mode.*/
+  /** The group name for the shortcuts. Available in advanced mode. */
   shortcutsGroup?: string;
 
-  /** Configuration. Available in advanced mode. */
+  /** Configuration object. Available in advanced mode. */
   config?: any;
 
-  /** Lifecycle hook called after the editor is opened. Available in advanced mode.*/
+  /** Lifecycle hook called after the editor is opened. Available in advanced mode. */
   afterOpen(editor: ExtendedEditor<T>, event?: Event): void {}
 
   /** Lifecycle hook called after the editor is closed. Available in advanced mode. */
   afterClose(editor: ExtendedEditor<T>): void {}
 
-  /** Lifecycle hook called after the editor is initialized. Available in advanced mode.*/
+  /** Lifecycle hook called after the editor is initialized. Available in advanced mode. */
   afterInit(editor: ExtendedEditor<T>): void {}
 
   /** Lifecycle hook called before the editor is opened. Available in advanced mode. */

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/hot-cell-editor-base.directive.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/hot-cell-editor-base.directive.ts
@@ -1,0 +1,35 @@
+import Handsontable from 'handsontable/base';
+import { Directive, EventEmitter, HostBinding, Input, Output } from '@angular/core';
+
+/**
+ * Shared base directive for HotCellEditorComponent and HotCellEditorAdvancedComponent.
+ * Holds all @Input(), @Output() and @HostBinding() declarations that both editor variants share.
+ *
+ * @template T - The type of the edited cell value.
+ */
+@Directive()
+export abstract class HotCellEditorBase<
+  T extends string | number | boolean | Record<string, any> | Array<any>
+> {
+  @HostBinding('style.height.%') protected heightFitParentContainer = 100;
+  @HostBinding('style.width.%') protected widthFitParentContainer = 100;
+
+  @Input() row: number;
+  @Input() column: number;
+  @Input() prop: string | number;
+  @Input() originalValue: T;
+  @Input() cellProperties: Handsontable.CellProperties;
+
+  @Output() finishEdit = new EventEmitter<void>();
+  @Output() cancelEdit = new EventEmitter<void>();
+
+  protected value: T;
+
+  getValue(): T {
+    return this.value;
+  }
+
+  setValue(value: T): void {
+    this.value = value;
+  }
+}

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/hot-cell-editor.component.spec.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/hot-cell-editor.component.spec.ts
@@ -91,14 +91,18 @@ describe('HotCellEditorComponent', () => {
   describe('@Output events', () => {
     it('should emit finishEdit', () => {
       let emitted = false;
-      component.finishEdit.subscribe(() => { emitted = true; });
+      component.finishEdit.subscribe(() => {
+        emitted = true;
+      });
       component.finishEdit.emit();
       expect(emitted).toBe(true);
     });
 
     it('should emit cancelEdit', () => {
       let emitted = false;
-      component.cancelEdit.subscribe(() => { emitted = true; });
+      component.cancelEdit.subscribe(() => {
+        emitted = true;
+      });
       component.cancelEdit.emit();
       expect(emitted).toBe(true);
     });

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/hot-cell-editor.component.spec.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/hot-cell-editor.component.spec.ts
@@ -1,0 +1,142 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component } from '@angular/core';
+import { HotCellEditorComponent } from './hot-cell-editor.component';
+
+@Component({
+  selector: 'hot-mock-basic-editor',
+  template: '',
+  standalone: true,
+})
+class ConcreteEditorComponent extends HotCellEditorComponent<string> {
+  onFocus(): void {}
+}
+
+describe('HotCellEditorComponent', () => {
+  let fixture: ComponentFixture<ConcreteEditorComponent>;
+  let component: ConcreteEditorComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ConcreteEditorComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ConcreteEditorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('EDITOR_MARKER should be a Symbol', () => {
+    expect(typeof HotCellEditorComponent.EDITOR_MARKER).toBe('symbol');
+  });
+
+  describe('host bindings', () => {
+    it('should set tabindex=-1 on host element', () => {
+      expect(fixture.nativeElement.getAttribute('tabindex')).toBe('-1');
+    });
+
+    it('should set data-hot-input attribute on host element', () => {
+      expect(fixture.nativeElement.hasAttribute('data-hot-input')).toBe(true);
+    });
+
+    it('should add handsontableInput class to host element', () => {
+      expect(fixture.nativeElement.classList.contains('handsontableInput')).toBe(true);
+    });
+
+    it('should set height 100% on host element', () => {
+      expect(fixture.nativeElement.style.height).toBe('100%');
+    });
+
+    it('should set width 100% on host element', () => {
+      expect(fixture.nativeElement.style.width).toBe('100%');
+    });
+  });
+
+  describe('@Input properties', () => {
+    it('should accept row input', () => {
+      fixture.componentRef.setInput('row', 3);
+      expect(component.row).toBe(3);
+    });
+
+    it('should accept column input', () => {
+      fixture.componentRef.setInput('column', 5);
+      expect(component.column).toBe(5);
+    });
+
+    it('should accept prop as string', () => {
+      fixture.componentRef.setInput('prop', 'name');
+      expect(component.prop).toBe('name');
+    });
+
+    it('should accept prop as number', () => {
+      fixture.componentRef.setInput('prop', 2);
+      expect(component.prop).toBe(2);
+    });
+
+    it('should accept originalValue', () => {
+      fixture.componentRef.setInput('originalValue', 'hello');
+      expect(component.originalValue).toBe('hello');
+    });
+
+    it('should accept cellProperties', () => {
+      const props = { readOnly: true } as any;
+      fixture.componentRef.setInput('cellProperties', props);
+      expect(component.cellProperties).toBe(props);
+    });
+  });
+
+  describe('@Output events', () => {
+    it('should emit finishEdit', () => {
+      let emitted = false;
+      component.finishEdit.subscribe(() => { emitted = true; });
+      component.finishEdit.emit();
+      expect(emitted).toBe(true);
+    });
+
+    it('should emit cancelEdit', () => {
+      let emitted = false;
+      component.cancelEdit.subscribe(() => { emitted = true; });
+      component.cancelEdit.emit();
+      expect(emitted).toBe(true);
+    });
+  });
+
+  describe('getValue / setValue', () => {
+    it('should return undefined before setValue is called', () => {
+      expect(component.getValue()).toBeUndefined();
+    });
+
+    it('should return the value set by setValue', () => {
+      component.setValue('test-value');
+      expect(component.getValue()).toBe('test-value');
+    });
+
+    it('should update value on subsequent setValue calls', () => {
+      component.setValue('first');
+      component.setValue('second');
+      expect(component.getValue()).toBe('second');
+    });
+  });
+
+  describe('lifecycle hooks', () => {
+    it('onClose() should be callable without throwing', () => {
+      expect(() => component.onClose()).not.toThrow();
+    });
+
+    it('onOpen() should be callable without event argument', () => {
+      expect(() => component.onOpen()).not.toThrow();
+    });
+
+    it('onOpen() should be callable with an Event argument', () => {
+      const event = new Event('click');
+      expect(() => component.onOpen(event)).not.toThrow();
+    });
+
+    it('onFocus() should be callable', () => {
+      expect(() => component.onFocus()).not.toThrow();
+    });
+  });
+});

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/hot-cell-editor.component.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/hot-cell-editor.component.ts
@@ -1,11 +1,15 @@
-import Handsontable from 'handsontable/base';
-import { Directive, EventEmitter, HostBinding, Input, Output } from '@angular/core';
+import { Directive, HostBinding } from '@angular/core';
+import { HotCellEditorBase } from './hot-cell-editor-base.directive';
 
 /**
- * Abstract class representing a Handsontable editor in angular.
+ * Abstract class representing a basic Handsontable cell editor in Angular.
+ *
+ * Extend this class and decorate the subclass with `@Component()` to implement a custom editor.
+ * Value type is limited to primitives (`string | number | boolean`).
+ * For object and array values use {@link HotCellEditorAdvancedComponent}.
  */
 @Directive()
-export abstract class HotCellEditorComponent<T extends string | number | boolean> {
+export abstract class HotCellEditorComponent<T extends string | number | boolean> extends HotCellEditorBase<T> {
   static readonly EDITOR_MARKER = Symbol('HotCellEditorComponent');
 
   /** The tabindex attribute for the editor. */
@@ -17,81 +21,23 @@ export abstract class HotCellEditorComponent<T extends string | number | boolean
   /** The handsontableInput class for the editor. */
   @HostBinding('class.handsontableInput') protected handsontableInputClass = true;
 
-  /** The height of the editor as a percentage of the parent container. */
-  @HostBinding('style.height.%') protected heightFitParentContainer = 100;
-
-  /** The width of the editor as a percentage of the parent container. */
-  @HostBinding('style.width.%') protected widthFitParentContainer = 100;
-
-  /** The row index of the cell being edited. */
-  @Input() row: number;
-
-  /** The column index of the cell being edited. */
-  @Input() column: number;
-
-  /** The property name of the cell being edited. */
-  @Input() prop: string | number;
-
-  /** The original value of the cell being edited. */
-  @Input() originalValue: T;
-
-  /** The cell properties of the cell being edited. */
-  @Input() cellProperties: Handsontable.CellProperties;
-
-  /** Event emitted when the edit is finished.
-   * The data will be saved to the model.
-   */
-  @Output() finishEdit = new EventEmitter<void>();
-
-  /** Event emitted when the edit is canceled.
-   * The entered data will be reverted to the original value.
-   */
-  @Output() cancelEdit = new EventEmitter<void>();
-
-  /** The current value of the editor. */
-  private _value: T;
-
-  /** Event triggered by Handsontable on closing the editor.
-   * The user can define their own actions for
-   * the custom editor to be called after the base logic. */
+  /** Event triggered by Handsontable on closing the editor. */
   onClose(): void {}
 
-  /** Event triggered by Handsontable on open the editor.
-   * The user can define their own actions for
-   * the custom editor to be called after the base logic. */
+  /** Event triggered by Handsontable on opening the editor. */
   onOpen(event?: Event): void {}
 
-  /** Event triggered by Handsontable on focus the editor.
-   * The user have to define focus logic.
+  /**
+   * Event triggered by Handsontable on focusing the editor.
+   * Must be implemented by the subclass to move focus to the actual input element.
    * @example
    * ```typescript
-   * component({
-   *  template: `<input #inputElement>`
-   * })
-   * class CustomEditor extends HotEditor<string> {
+   * @Component({ template: `<input #inputElement>` })
+   * class CustomEditor extends HotCellEditorComponent<string> {
    *   @ViewChild('inputElement') inputElement!: ElementRef;
-   *
-   *   onFocus(): void {
-   *     this.inputElement.nativeElement.focus();
-   *   }
+   *   onFocus(): void { this.inputElement.nativeElement.focus(); }
    * }
    * ```
    */
   abstract onFocus(): void;
-
-  /**
-   * Gets the current value of the editor.
-   * @returns The current value of the editor.
-   */
-  getValue(): T {
-    return this._value;
-  }
-
-  /**
-   * Sets the current value of the editor.
-   * @param value The value to set.
-   */
-  setValue(value: T): void {
-    this._value = value;
-  }
 }

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/models/factory-editor-properties.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/editor/models/factory-editor-properties.ts
@@ -1,7 +1,16 @@
-import { ComponentRef } from '@angular/core';
+import { ComponentRef, EnvironmentInjector } from '@angular/core';
 import { CustomEditorPlaceholderComponent } from '../custom-editor-placeholder.component';
 import { Subscription } from 'rxjs';
 import { HotCellEditorAdvancedComponent } from '../hot-cell-editor-advanced.component';
+
+/**
+ * Handsontable core instance augmented with the Angular `EnvironmentInjector` that the wrapper
+ * stores on it (in `HotTableComponent`) so editor adapters can create components with the right
+ * injection context. Typed here to avoid scattered `as any` casts at the assignment/read sites.
+ */
+export interface HotInstanceWithAngularInjector {
+  _angularEnvironmentInjector?: EnvironmentInjector;
+}
 
 /**
  * Angular-specific properties that will be added to the editor instance.

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.spec.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.spec.ts
@@ -197,6 +197,28 @@ describe('HotTableComponent', () => {
       expect(editorRefMock.destroy).toHaveBeenCalled();
     });
 
+    it('should NOT destroy old editor refs when new settings do not include columns', () => {
+      const editorRefMock = { destroy: jest.fn() } as any;
+      fixture = TestBed.createComponent(HotTableComponent);
+      fixture.componentInstance.settings = {
+        ...settings,
+        columns: [{ _editorComponentReference: editorRefMock }],
+      };
+      fixture.detectChanges();
+
+      const changes: SimpleChanges = {
+        settings: new SimpleChange(
+          fixture.componentInstance.settings,
+          { ...settings, readOnly: true },
+          false
+        ),
+      };
+
+      fixture.componentInstance.ngOnChanges(changes);
+
+      expect(editorRefMock.destroy).not.toHaveBeenCalled();
+    });
+
     it('should not pass init-only settings to updateSettings after initialization', () => {
       fixture = TestBed.createComponent(HotTableComponent);
       fixture.componentInstance.settings = {

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.spec.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.spec.ts
@@ -117,7 +117,8 @@ describe('HotTableComponent', () => {
 
       component.ngOnChanges(changes);
 
-      expect(applyCustomSettingsSpy).toHaveBeenCalledWith(newSettings);
+      // Second arg is the previous columns (undefined here — no columns configured) used for editor recycling.
+      expect(applyCustomSettingsSpy).toHaveBeenCalledWith(newSettings, undefined);
       expect(updateHotTableSpy).toHaveBeenCalledWith(newSettings, false);
     });
 
@@ -195,6 +196,35 @@ describe('HotTableComponent', () => {
       fixture.componentInstance.ngOnChanges(changes);
 
       expect(editorRefMock.destroy).toHaveBeenCalled();
+    });
+
+    it('should NOT destroy an editor ref that was recycled into the new columns', () => {
+      const editorRefMock = { destroy: jest.fn(), componentType: class {} } as any;
+      fixture = TestBed.createComponent(HotTableComponent);
+      fixture.componentInstance.settings = {
+        ...settings,
+        columns: [{ _editorComponentReference: editorRefMock }],
+      };
+      fixture.detectChanges();
+
+      // Resolver recycles the same ref into the new column (same editor type at the same index).
+      const hotSettingsResolver = fixture.componentRef.injector.get(HotSettingsResolver);
+      jest.spyOn(hotSettingsResolver, 'applyCustomSettings').mockReturnValue({
+        ...settings,
+        columns: [{ _editorComponentReference: editorRefMock }],
+      } as any);
+
+      const changes: SimpleChanges = {
+        settings: new SimpleChange(
+          fixture.componentInstance.settings,
+          { ...settings, columns: [{}] },
+          false
+        ),
+      };
+
+      fixture.componentInstance.ngOnChanges(changes);
+
+      expect(editorRefMock.destroy).not.toHaveBeenCalled();
     });
 
     it('should NOT destroy old editor refs when new settings do not include columns', () => {
@@ -381,10 +411,12 @@ describe('HotTableComponent', () => {
       const dynamicComponentService = TestBed.inject(DynamicComponentService);
       const cleanupSpy = jest.spyOn(dynamicComponentService, 'cleanupContainer');
       const containerEl = (fixture.componentInstance as any).container.nativeElement;
+      const hotInstance = fixture.componentInstance.hotInstance;
 
       fixture.componentInstance.ngOnDestroy();
 
-      expect(cleanupSpy).toHaveBeenCalledWith(containerEl);
+      // The instance is passed so the service can tear down that table's per-instance registries.
+      expect(cleanupSpy).toHaveBeenCalledWith(containerEl, hotInstance);
     });
   });
 

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.spec.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.spec.ts
@@ -1,13 +1,14 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { CUSTOM_ELEMENTS_SCHEMA, SimpleChange, SimpleChanges } from '@angular/core';
+import { CUSTOM_ELEMENTS_SCHEMA, NgZone, SimpleChange, SimpleChanges } from '@angular/core';
 import Handsontable from 'handsontable';
 import { registerPlugin, CopyPaste } from 'handsontable/plugins';
 import { HotTableModule } from './hot-table.module';
-import { HotTableComponent } from './hot-table.component';
+import { HOT_DESTROYED_WARNING, HotTableComponent } from './hot-table.component';
 import { GridSettings } from './models/grid-settings';
 import { createSpreadsheetData } from './test-helpers/create-spreadsheet-data';
 import { HotSettingsResolver } from './services/hot-settings-resolver.service';
-import { NON_COMMERCIAL_LICENSE } from './services/hot-global-config.service';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfigService, NON_COMMERCIAL_LICENSE } from './services/hot-global-config.service';
+import { DynamicComponentService } from './renderer/hot-dynamic-renderer-component.service';
 
 registerPlugin(CopyPaste);
 
@@ -51,6 +52,15 @@ describe('HotTableComponent', () => {
     fixture.detectChanges();
 
     expect(fixture.componentInstance.hotInstance.getDataAtCell(0, 0)).toBe('A1');
+  });
+
+  it(`should render with empty data array`, () => {
+    fixture = TestBed.createComponent(HotTableComponent);
+    fixture.componentInstance.settings = { ...settings };
+    fixture.componentInstance.data = [];
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.hotInstance.countRows()).toBe(0);
   });
 
   it(`should use data from settings when [data] input is not bound`, () => {
@@ -165,6 +175,28 @@ describe('HotTableComponent', () => {
       expect(updateDataSpy).not.toHaveBeenCalledWith(newData);
     });
 
+    it('should destroy old editor component refs when settings change with new column objects', () => {
+      const editorRefMock = { destroy: jest.fn() } as any;
+      fixture = TestBed.createComponent(HotTableComponent);
+      fixture.componentInstance.settings = {
+        ...settings,
+        columns: [{ _editorComponentReference: editorRefMock }],
+      };
+      fixture.detectChanges();
+
+      const changes: SimpleChanges = {
+        settings: new SimpleChange(
+          fixture.componentInstance.settings,
+          { ...settings, columns: [{}] },
+          false
+        ),
+      };
+
+      fixture.componentInstance.ngOnChanges(changes);
+
+      expect(editorRefMock.destroy).toHaveBeenCalled();
+    });
+
     it('should not pass init-only settings to updateSettings after initialization', () => {
       fixture = TestBed.createComponent(HotTableComponent);
       fixture.componentInstance.settings = {
@@ -189,6 +221,78 @@ describe('HotTableComponent', () => {
 
       expect(passedSettings.renderAllRows).toBe(void 0);
       expect(passedSettings.width).toBe(500);
+    });
+
+    it('should apply each change when settings change multiple times rapidly', () => {
+      fixture = TestBed.createComponent(HotTableComponent);
+      fixture.componentInstance.settings = { ...settings };
+      fixture.detectChanges();
+      const component = fixture.componentInstance;
+      const updateSettingsSpy = jest.spyOn(component.hotInstance, 'updateSettings');
+
+      const rapidChanges = [
+        { readOnly: true },
+        { readOnly: false },
+        { width: 200 },
+      ];
+
+      rapidChanges.forEach((next, i) => {
+        const prev = i === 0 ? component.settings : rapidChanges[i - 1];
+        component.ngOnChanges({
+          settings: new SimpleChange(prev, next, false),
+        });
+      });
+
+      expect(updateSettingsSpy).toHaveBeenCalledTimes(3);
+      expect(updateSettingsSpy.mock.calls[2][0]).toMatchObject({ width: 200 });
+    });
+
+    it('should handle data changed to empty array', () => {
+      fixture = TestBed.createComponent(HotTableComponent);
+      fixture.componentInstance.settings = { ...settings };
+      fixture.componentInstance.data = createSpreadsheetData(3, 3);
+      fixture.detectChanges();
+      const component = fixture.componentInstance;
+      const updateDataSpy = jest.spyOn(component.hotInstance, 'updateData');
+
+      component.ngOnChanges({
+        data: new SimpleChange(component.data, [], false),
+      });
+
+      expect(updateDataSpy).toHaveBeenCalledWith([]);
+    });
+
+    it('should handle data changed to null', () => {
+      fixture = TestBed.createComponent(HotTableComponent);
+      fixture.componentInstance.settings = { ...settings };
+      fixture.componentInstance.data = createSpreadsheetData(3, 3);
+      fixture.detectChanges();
+      const component = fixture.componentInstance;
+      const updateDataSpy = jest.spyOn(component.hotInstance, 'updateData');
+
+      component.ngOnChanges({
+        data: new SimpleChange(component.data, null, false),
+      });
+
+      expect(updateDataSpy).toHaveBeenCalledWith(null);
+    });
+
+    it('should update both settings and data when both change simultaneously', () => {
+      fixture = TestBed.createComponent(HotTableComponent);
+      fixture.componentInstance.settings = { ...settings };
+      fixture.detectChanges();
+      const component = fixture.componentInstance;
+      const updateSettingsSpy = jest.spyOn(component.hotInstance, 'updateSettings');
+      const updateDataSpy = jest.spyOn(component.hotInstance, 'updateData');
+
+      const newData = [[1, 2, 3]];
+      component.ngOnChanges({
+        settings: new SimpleChange(component.settings, { readOnly: true }, false),
+        data: new SimpleChange(null, newData, false),
+      });
+
+      expect(updateSettingsSpy).toHaveBeenCalled();
+      expect(updateDataSpy).toHaveBeenCalledWith(newData);
     });
   });
 
@@ -246,26 +350,23 @@ describe('HotTableComponent', () => {
       fixture.componentInstance.ngOnDestroy();
       expect(destroySpy).toHaveBeenCalled();
     });
+
+    it('should call cleanupContainer on DynamicComponentService before destroying the HOT instance', () => {
+      fixture = TestBed.createComponent(HotTableComponent);
+      fixture.componentInstance.settings = { ...settings };
+      fixture.detectChanges();
+
+      const dynamicComponentService = TestBed.inject(DynamicComponentService);
+      const cleanupSpy = jest.spyOn(dynamicComponentService, 'cleanupContainer');
+      const containerEl = (fixture.componentInstance as any).container.nativeElement;
+
+      fixture.componentInstance.ngOnDestroy();
+
+      expect(cleanupSpy).toHaveBeenCalledWith(containerEl);
+    });
   });
 
   describe('hooks', () => {
-    it(`should use Handsontable as a hook's context, if is defined as a component's method`, () => {
-      fixture = TestBed.createComponent(HotTableComponent);
-      fixture.componentInstance.settings = {
-        ...settings,
-        afterInit: function () {
-          return this;
-        },
-      };
-      fixture.detectChanges();
-
-      const instance: Handsontable = fixture.componentInstance.hotInstance;
-      instance.runHooks('afterInit');
-
-      expect(instance.getPlugin).toBeDefined();
-      expect(instance.getPlugin('copyPaste')).toBeTruthy();
-    });
-
     it(`should use Handsontable as a hook's context, if is defined as a function in settings object`, () => {
       fixture = TestBed.createComponent(HotTableComponent);
       fixture.componentInstance.settings = {
@@ -303,6 +404,168 @@ describe('HotTableComponent', () => {
       component.hotInstance.setDataAtCell(0, 0, 'test');
 
       expect(afterChangeResult).toBe(false);
+    });
+  });
+
+  describe('getNegotiatedSettings', () => {
+    it('should return early from ngOnChanges when hotInstance is null', () => {
+      fixture = TestBed.createComponent(HotTableComponent);
+      fixture.componentInstance.settings = { ...settings };
+      fixture.detectChanges();
+
+      jest.spyOn(fixture.componentInstance, 'hotInstance', 'get').mockReturnValue(null);
+
+      const hotSettingsResolver = fixture.componentRef.injector.get(HotSettingsResolver);
+      const applyCustomSettingsSpy = jest.spyOn(hotSettingsResolver, 'applyCustomSettings');
+
+      const changes: SimpleChanges = {
+        settings: new SimpleChange(null, { readOnly: true }, false),
+      };
+
+      fixture.componentInstance.ngOnChanges(changes);
+
+      expect(applyCustomSettingsSpy).not.toHaveBeenCalled();
+    });
+
+    it('should pass theme from global config to Handsontable init options', () => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [HotTableModule],
+        providers: [
+          { provide: HOT_GLOBAL_CONFIG, useValue: { license: NON_COMMERCIAL_LICENSE, theme: 'ht-theme-main' } },
+        ],
+        schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      });
+      fixture = TestBed.createComponent(HotTableComponent);
+      fixture.componentInstance.settings = {};
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.hotInstance).toBeTruthy();
+    });
+
+    it('should pass themeName from settings to Handsontable init options', () => {
+      fixture = TestBed.createComponent(HotTableComponent);
+      fixture.componentInstance.settings = {
+        ...settings,
+        themeName: 'ht-theme-main' as any,
+      };
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.hotInstance).toBeTruthy();
+    });
+
+    it('should update Handsontable when global config changes after initialization', () => {
+      fixture = TestBed.createComponent(HotTableComponent);
+      fixture.componentInstance.settings = { ...settings };
+      fixture.detectChanges();
+      const updateSettingsSpy = jest.spyOn(fixture.componentInstance.hotInstance, 'updateSettings');
+
+      TestBed.inject(HotGlobalConfigService).setConfig({ license: NON_COMMERCIAL_LICENSE });
+
+      expect(updateSettingsSpy).toHaveBeenCalled();
+    });
+
+    it('should pass language from global config when settings does not specify it', () => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [HotTableModule],
+        providers: [
+          { provide: HOT_GLOBAL_CONFIG, useValue: { license: NON_COMMERCIAL_LICENSE, language: 'en-US' } },
+        ],
+        schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      });
+      fixture = TestBed.createComponent(HotTableComponent);
+      fixture.componentInstance.settings = {};
+      fixture.detectChanges();
+      const updateSettingsSpy = jest.spyOn(fixture.componentInstance.hotInstance, 'updateSettings');
+
+      TestBed.inject(HotGlobalConfigService).setConfig({ license: NON_COMMERCIAL_LICENSE, language: 'en-US' });
+
+      expect(updateSettingsSpy).toHaveBeenCalled();
+      const calledWith = updateSettingsSpy.mock.calls[0][0];
+      expect(calledWith.language).toBe('en-US');
+    });
+
+    it('should not pass layoutDirection from global config when triggered after initialization', () => {
+      fixture = TestBed.createComponent(HotTableComponent);
+      fixture.componentInstance.settings = { ...settings };
+      fixture.detectChanges();
+      const updateSettingsSpy = jest.spyOn(fixture.componentInstance.hotInstance, 'updateSettings');
+
+      TestBed.inject(HotGlobalConfigService).setConfig({ license: NON_COMMERCIAL_LICENSE, layoutDirection: 'rtl' });
+
+      expect(updateSettingsSpy).toHaveBeenCalled();
+      const calledWith = updateSettingsSpy.mock.calls[0][0];
+      expect(calledWith.layoutDirection).toBeUndefined();
+    });
+
+    it('should prefer theme over themeName when both are provided in global config', () => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [HotTableModule],
+        providers: [
+          {
+            provide: HOT_GLOBAL_CONFIG,
+            useValue: { license: NON_COMMERCIAL_LICENSE, theme: 'ht-theme-main', themeName: 'ht-theme-horizon' },
+          },
+        ],
+        schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      });
+      fixture = TestBed.createComponent(HotTableComponent);
+      fixture.componentInstance.settings = {};
+      fixture.detectChanges();
+      const updateSettingsSpy = jest.spyOn(fixture.componentInstance.hotInstance, 'updateSettings');
+
+      TestBed.inject(HotGlobalConfigService).setConfig({
+        license: NON_COMMERCIAL_LICENSE,
+        theme: 'ht-theme-main',
+        themeName: 'ht-theme-horizon',
+      });
+
+      expect(updateSettingsSpy).toHaveBeenCalled();
+      const calledWith = updateSettingsSpy.mock.calls[0][0];
+      expect(calledWith.theme).toBe('ht-theme-main');
+      expect(calledWith.themeName).toBeUndefined();
+    });
+  });
+
+  describe('hotInstance getter', () => {
+    it('should return null and emit HOT_DESTROYED_WARNING when the HOT instance has been destroyed', () => {
+      fixture = TestBed.createComponent(HotTableComponent);
+      fixture.componentInstance.settings = { ...settings };
+      fixture.detectChanges();
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      // Destroy HOT directly — bypasses ngOnDestroy so the private ref stays set
+      (fixture.componentInstance as any).__hotInstance.destroy();
+
+      const result = fixture.componentInstance.hotInstance;
+
+      expect(result).toBeNull();
+      expect(warnSpy).toHaveBeenCalledWith(HOT_DESTROYED_WARNING);
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe('NgZone hook wrapping', () => {
+    it('should run hook callbacks inside Angular zone even when triggered from outside', () => {
+      fixture = TestBed.createComponent(HotTableComponent);
+      const ngZone = TestBed.inject(NgZone);
+      let capturedZoneState = false;
+
+      fixture.componentInstance.settings = {
+        ...settings,
+        afterInit: function () {
+          capturedZoneState = NgZone.isInAngularZone();
+        },
+      };
+      fixture.detectChanges();
+
+      ngZone.runOutsideAngular(() => {
+        fixture.componentInstance.hotInstance.runHooks('afterInit');
+      });
+
+      expect(capturedZoneState).toBe(true);
     });
   });
 });

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.ts
@@ -19,6 +19,7 @@ import { HotSettingsResolver } from './services/hot-settings-resolver.service';
 import { HotGlobalConfigService } from './services/hot-global-config.service';
 import { GridSettings } from './models/grid-settings';
 import { DynamicComponentService } from './renderer/hot-dynamic-renderer-component.service';
+import { HotInstanceWithAngularInjector } from './editor/models/factory-editor-properties';
 import { skip } from 'rxjs/operators';
 
 export const HOT_DESTROYED_WARNING = 'The Handsontable instance bound to this component was destroyed and cannot be' + ' used properly.';
@@ -94,7 +95,7 @@ export class HotTableComponent implements AfterViewInit, OnChanges, OnDestroy {
     this.ngZone.runOutsideAngular(() => {
       this.hotInstance = new Handsontable.Core(this.container.nativeElement, options);
 
-      (this.hotInstance as any)._angularEnvironmentInjector = this.environmentInjector;
+      (this.hotInstance as HotInstanceWithAngularInjector)._angularEnvironmentInjector = this.environmentInjector;
 
       this.hotInstance.init();
     });

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.ts
@@ -123,7 +123,10 @@ export class HotTableComponent implements AfterViewInit, OnChanges, OnDestroy {
       // updateHotTable closes any active editor via HOT.updateSettings before we destroy old refs.
       this.updateHotTable(newOptions);
 
-      if (Array.isArray(prevColumns)) {
+      // Only destroy old editor refs when new settings actually replace columns.
+      // If newOptions has no columns, HOT keeps the old column objects active — destroying
+      // their refs would crash FactoryEditorAdapter / BaseEditorAdapter on next edit.
+      if (Array.isArray(prevColumns) && Array.isArray(newOptions.columns)) {
         prevColumns.forEach((column) => {
           if (column._editorComponentReference) {
             column._editorComponentReference.destroy();

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.ts
@@ -1,6 +1,7 @@
 import {
   AfterViewInit,
   Component,
+  DestroyRef,
   ElementRef,
   EnvironmentInjector,
   Input,
@@ -9,13 +10,16 @@ import {
   OnDestroy,
   SimpleChanges,
   ViewChild,
-  ViewEncapsulation
+  ViewEncapsulation,
+  inject
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import Handsontable from 'handsontable/base';
 import { HotSettingsResolver } from './services/hot-settings-resolver.service';
 import { HotGlobalConfigService } from './services/hot-global-config.service';
 import { GridSettings } from './models/grid-settings';
-import { Subscription } from 'rxjs';
+import { DynamicComponentService } from './renderer/hot-dynamic-renderer-component.service';
+import { skip } from 'rxjs/operators';
 
 export const HOT_DESTROYED_WARNING = 'The Handsontable instance bound to this component was destroyed and cannot be' + ' used properly.';
 
@@ -45,13 +49,14 @@ export class HotTableComponent implements AfterViewInit, OnChanges, OnDestroy {
 
   /** The Handsontable instance. */
   private __hotInstance: Handsontable | null = null;
-  private configSubscription: Subscription;
+  private readonly _destroyRef = inject(DestroyRef);
 
   constructor(
     private _hotSettingsResolver: HotSettingsResolver,
     private _hotConfig: HotGlobalConfigService,
     public ngZone: NgZone,
-    private readonly environmentInjector: EnvironmentInjector
+    private readonly environmentInjector: EnvironmentInjector,
+    private readonly _dynamicComponentService: DynamicComponentService
   ) {}
 
   /**
@@ -59,7 +64,7 @@ export class HotTableComponent implements AfterViewInit, OnChanges, OnDestroy {
    * @returns The Handsontable instance or `null` if it's not yet been created or has been destroyed.
    */
   public get hotInstance(): Handsontable | null {
-    if (!this.__hotInstance || (this.__hotInstance && !this.__hotInstance.isDestroyed)) {
+    if (!this.__hotInstance || !this.__hotInstance.isDestroyed) {
       // Will return the Handsontable instance or `null` if it's not yet been created.
       return this.__hotInstance;
     } else {
@@ -94,7 +99,7 @@ export class HotTableComponent implements AfterViewInit, OnChanges, OnDestroy {
       this.hotInstance.init();
     });
 
-    this.configSubscription = this._hotConfig.config$.subscribe((config) => {
+    this._hotConfig.config$.pipe(skip(1), takeUntilDestroyed(this._destroyRef)).subscribe((config) => {
       if (this.hotInstance) {
         const negotiatedSettings = this.getNegotiatedSettings(this.settings);
         this.updateHotTable(negotiatedSettings);
@@ -108,11 +113,23 @@ export class HotTableComponent implements AfterViewInit, OnChanges, OnDestroy {
     }
 
     if (changes.settings && !changes.settings.firstChange) {
+      // Capture old editor refs before applying new settings so HOT can close any active editor first.
+      const prevColumns = this.__hotInstance?.getSettings().columns;
+
       const newOptions: Handsontable.GridSettings = this._hotSettingsResolver.applyCustomSettings(
         changes.settings.currentValue
       );
 
+      // updateHotTable closes any active editor via HOT.updateSettings before we destroy old refs.
       this.updateHotTable(newOptions);
+
+      if (Array.isArray(prevColumns)) {
+        prevColumns.forEach((column) => {
+          if (column._editorComponentReference) {
+            column._editorComponentReference.destroy();
+          }
+        });
+      }
     }
 
     if (changes.data && !changes.data.firstChange) {
@@ -125,11 +142,16 @@ export class HotTableComponent implements AfterViewInit, OnChanges, OnDestroy {
    */
   ngOnDestroy(): void {
     this.ngZone.runOutsideAngular(() => {
-      if (!this.hotInstance) {
+      if (!this.__hotInstance || this.__hotInstance.isDestroyed) {
         return;
       }
 
-      const columns = this.hotInstance.getSettings().columns;
+      // Destroy renderer Angular components attached to table cells before HOT removes the DOM.
+      if (this.container) {
+        this._dynamicComponentService.cleanupContainer(this.container.nativeElement);
+      }
+
+      const columns = this.__hotInstance.getSettings().columns;
 
       if (columns && Array.isArray(columns)) {
         columns.forEach((column) => {
@@ -139,10 +161,8 @@ export class HotTableComponent implements AfterViewInit, OnChanges, OnDestroy {
         });
       }
 
-      this.hotInstance.destroy();
+      this.__hotInstance.destroy();
     });
-
-    this.configSubscription.unsubscribe();
   }
 
   /**

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.ts
@@ -115,9 +115,13 @@ export class HotTableComponent implements AfterViewInit, OnChanges, OnDestroy {
     if (changes.settings && !changes.settings.firstChange) {
       // Capture old editor refs before applying new settings so HOT can close any active editor first.
       const prevColumns = this.__hotInstance?.getSettings().columns;
+      const prevColumnsArray = Array.isArray(prevColumns) ? prevColumns : undefined;
 
+      // Pass the previous columns so unchanged editor types recycle their existing component
+      // instead of creating a fresh one on every settings change.
       const newOptions: Handsontable.GridSettings = this._hotSettingsResolver.applyCustomSettings(
-        changes.settings.currentValue
+        changes.settings.currentValue,
+        prevColumnsArray
       );
 
       // updateHotTable closes any active editor via HOT.updateSettings before we destroy old refs.
@@ -126,9 +130,16 @@ export class HotTableComponent implements AfterViewInit, OnChanges, OnDestroy {
       // Only destroy old editor refs when new settings actually replace columns.
       // If newOptions has no columns, HOT keeps the old column objects active — destroying
       // their refs would crash FactoryEditorAdapter / BaseEditorAdapter on next edit.
-      if (Array.isArray(prevColumns) && Array.isArray(newOptions.columns)) {
-        prevColumns.forEach((column) => {
-          if (column._editorComponentReference) {
+      if (prevColumnsArray && Array.isArray(newOptions.columns)) {
+        // Refs recycled into the new columns must survive — destroy only the ones left behind.
+        const reusedRefs = new Set(
+          newOptions.columns
+            .map((column) => column._editorComponentReference)
+            .filter((ref): ref is NonNullable<typeof ref> => !!ref)
+        );
+
+        prevColumnsArray.forEach((column) => {
+          if (column._editorComponentReference && !reusedRefs.has(column._editorComponentReference)) {
             column._editorComponentReference.destroy();
           }
         });
@@ -151,7 +162,7 @@ export class HotTableComponent implements AfterViewInit, OnChanges, OnDestroy {
 
       // Destroy renderer Angular components attached to table cells before HOT removes the DOM.
       if (this.container) {
-        this._dynamicComponentService.cleanupContainer(this.container.nativeElement);
+        this._dynamicComponentService.cleanupContainer(this.container.nativeElement, this.__hotInstance);
       }
 
       const columns = this.__hotInstance.getSettings().columns;

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.module.spec.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.module.spec.ts
@@ -1,0 +1,32 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HotTableModule } from './hot-table.module';
+import { HotTableComponent } from './hot-table.component';
+import { NON_COMMERCIAL_LICENSE } from './services/hot-global-config.service';
+
+describe('HotTableModule', () => {
+  it('version should be a non-empty string', () => {
+    expect(typeof HotTableModule.version).toBe('string');
+    expect(HotTableModule.version.length).toBeGreaterThan(0);
+  });
+
+  describe('HotTableComponent export', () => {
+    let fixture: ComponentFixture<HotTableComponent>;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [HotTableModule],
+      });
+      fixture = TestBed.createComponent(HotTableComponent);
+      fixture.componentInstance.settings = { licenseKey: NON_COMMERCIAL_LICENSE };
+      fixture.detectChanges();
+    });
+
+    afterEach(() => {
+      fixture.destroy();
+    });
+
+    it('should create HotTableComponent via the module', () => {
+      expect(fixture.componentInstance).toBeTruthy();
+    });
+  });
+});

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/renderer/hot-cell-renderer-advanced.component.spec.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/renderer/hot-cell-renderer-advanced.component.spec.ts
@@ -1,0 +1,121 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component } from '@angular/core';
+import { HotCellRendererAdvancedComponent } from './hot-cell-renderer-advanced.component';
+import { HotCellRendererComponent } from './hot-cell-renderer.component';
+
+@Component({
+  selector: 'hot-mock-advanced-renderer',
+  template: '<span>{{ value }}</span>',
+  standalone: true,
+})
+class ConcreteAdvancedRendererComponent extends HotCellRendererAdvancedComponent<string> {}
+
+describe('HotCellRendererAdvancedComponent', () => {
+  let fixture: ComponentFixture<ConcreteAdvancedRendererComponent>;
+  let component: ConcreteAdvancedRendererComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ConcreteAdvancedRendererComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ConcreteAdvancedRendererComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('RENDERER_MARKER should be a Symbol', () => {
+    expect(typeof HotCellRendererAdvancedComponent.RENDERER_MARKER).toBe('symbol');
+  });
+
+  it('RENDERER_MARKER should differ from HotCellRendererComponent.RENDERER_MARKER', () => {
+    expect(HotCellRendererAdvancedComponent.RENDERER_MARKER).not.toBe(HotCellRendererComponent.RENDERER_MARKER);
+  });
+
+  describe('default values', () => {
+    it('value should default to empty string', () => {
+      expect(component.value).toBe('');
+    });
+
+    it('getProps() should return empty object when cellProperties is not set', () => {
+      expect(component.getProps()).toEqual({});
+    });
+  });
+
+  describe('@Input properties', () => {
+    it('should accept string value input', () => {
+      fixture.componentRef.setInput('value', 'advanced-cell');
+      expect(component.value).toBe('advanced-cell');
+    });
+
+    it('should accept object value input', () => {
+      fixture.componentRef.setInput('value', { key: 'val' } as any);
+      expect(component.value).toEqual({ key: 'val' });
+    });
+
+    it('should accept array value input', () => {
+      fixture.componentRef.setInput('value', [1, 2, 3] as any);
+      expect(component.value).toEqual([1, 2, 3]);
+    });
+
+    it('should accept row input', () => {
+      fixture.componentRef.setInput('row', 5);
+      expect(component.row).toBe(5);
+    });
+
+    it('should accept col input', () => {
+      fixture.componentRef.setInput('col', 3);
+      expect(component.col).toBe(3);
+    });
+
+    it('should accept prop input', () => {
+      fixture.componentRef.setInput('prop', 'amount');
+      expect(component.prop).toBe('amount');
+    });
+
+    it('should accept td input', () => {
+      const td = document.createElement('td');
+      fixture.componentRef.setInput('td', td);
+      expect(component.td).toBe(td);
+    });
+
+    it('should accept instance input', () => {
+      const mockInstance = {} as any;
+      fixture.componentRef.setInput('instance', mockInstance);
+      expect(component.instance).toBe(mockInstance);
+    });
+
+    it('should accept cellProperties input', () => {
+      const props = { type: 'numeric', rendererProps: { format: '#,##0' } } as any;
+      fixture.componentRef.setInput('cellProperties', props);
+      expect(component.cellProperties).toBe(props);
+    });
+  });
+
+  describe('getProps()', () => {
+    it('should return rendererProps when present in cellProperties', () => {
+      const rendererProps = { format: '#,##0' };
+      fixture.componentRef.setInput('cellProperties', { rendererProps } as any);
+      expect(component.getProps()).toBe(rendererProps);
+    });
+
+    it('should return empty object when cellProperties has no rendererProps', () => {
+      fixture.componentRef.setInput('cellProperties', { type: 'numeric' } as any);
+      expect(component.getProps()).toEqual({});
+    });
+
+    it('should return empty object when cellProperties is null', () => {
+      fixture.componentRef.setInput('cellProperties', null);
+      expect(component.getProps()).toEqual({});
+    });
+
+    it('should return empty object when rendererProps is null', () => {
+      fixture.componentRef.setInput('cellProperties', { rendererProps: null } as any);
+      expect(component.getProps()).toEqual({});
+    });
+  });
+});

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/renderer/hot-cell-renderer-advanced.component.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/renderer/hot-cell-renderer-advanced.component.ts
@@ -1,10 +1,11 @@
-import Handsontable from 'handsontable/base';
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { HotCellRendererBase } from './hot-cell-renderer-base.directive';
 
 /**
  * Abstract base component for creating advanced custom cell renderer components for Handsontable.
  *
- * This class provides a common interface and properties required by any custom cell renderer.
+ * Extend this component and provide your own template to implement a custom renderer.
+ * Unlike {@link HotCellRendererComponent}, this variant also accepts object and array values.
  *
  * @template TValue - The type of the component renderer.
  * @template TProps - The type of additional renderer properties.
@@ -16,33 +17,8 @@ import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export abstract class HotCellRendererAdvancedComponent<
-  TValue extends string |
-  number |
-  boolean |
-  Record<string, any> | Array<any> = string,
+  TValue extends string | number | boolean | Record<string, any> | Array<any> = string,
   TProps extends {} = any
-> {
+> extends HotCellRendererBase<TValue, TProps> {
   static readonly RENDERER_MARKER = Symbol('HotCellRendererAdvancedComponent');
-
-  @Input() value: TValue = '' as TValue;
-
-  @Input() instance: Handsontable;
-  @Input() td: HTMLTableCellElement;
-  @Input() row: number;
-  @Input() col: number;
-  @Input() prop: string;
-
-  /**
-   * The cell properties provided by Handsontable, extended with optional renderer-specific properties.
-   */
-  @Input() cellProperties: Handsontable.CellProperties & { rendererProps?: TProps };
-
-  /**
-   * Retrieves the renderer-specific properties from the cell properties.
-   *
-   * @returns The additional properties for the renderer.
-   */
-  public getProps(): TProps {
-    return this.cellProperties?.rendererProps ?? ({} as TProps);
-  }
 }

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/renderer/hot-cell-renderer-base.directive.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/renderer/hot-cell-renderer-base.directive.ts
@@ -1,0 +1,29 @@
+import Handsontable from 'handsontable/base';
+import { Directive, Input } from '@angular/core';
+
+/**
+ * Shared base directive for HotCellRendererComponent and HotCellRendererAdvancedComponent.
+ * Holds all @Input() properties and getProps() that both renderer variants share.
+ *
+ * @template TValue - The type of the rendered cell value.
+ * @template TProps - The type of additional renderer properties.
+ */
+@Directive()
+export abstract class HotCellRendererBase<
+  TValue extends string | number | boolean | Record<string, any> | Array<any> = string,
+  TProps extends {} = any
+> {
+  @Input() value: TValue = '' as TValue;
+
+  @Input() instance: Handsontable;
+  @Input() td: HTMLTableCellElement;
+  @Input() row: number;
+  @Input() col: number;
+  @Input() prop: string | number;
+
+  @Input() cellProperties: Handsontable.CellProperties & { rendererProps?: TProps };
+
+  public getProps(): TProps {
+    return this.cellProperties?.rendererProps ?? ({} as TProps);
+  }
+}

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/renderer/hot-cell-renderer.component.spec.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/renderer/hot-cell-renderer.component.spec.ts
@@ -1,0 +1,106 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component } from '@angular/core';
+import { HotCellRendererComponent } from './hot-cell-renderer.component';
+
+@Component({
+  selector: 'hot-mock-basic-renderer',
+  template: '<span>{{ value }}</span>',
+  standalone: true,
+})
+class ConcreteRendererComponent extends HotCellRendererComponent<string> {}
+
+describe('HotCellRendererComponent', () => {
+  let fixture: ComponentFixture<ConcreteRendererComponent>;
+  let component: ConcreteRendererComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ConcreteRendererComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ConcreteRendererComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('RENDERER_MARKER should be a Symbol', () => {
+    expect(typeof HotCellRendererComponent.RENDERER_MARKER).toBe('symbol');
+  });
+
+  describe('default values', () => {
+    it('value should default to empty string', () => {
+      expect(component.value).toBe('');
+    });
+
+    it('getProps() should return empty object when cellProperties is not set', () => {
+      expect(component.getProps()).toEqual({});
+    });
+  });
+
+  describe('@Input properties', () => {
+    it('should accept value input', () => {
+      fixture.componentRef.setInput('value', 'cell-value');
+      expect(component.value).toBe('cell-value');
+    });
+
+    it('should accept row input', () => {
+      fixture.componentRef.setInput('row', 1);
+      expect(component.row).toBe(1);
+    });
+
+    it('should accept col input', () => {
+      fixture.componentRef.setInput('col', 2);
+      expect(component.col).toBe(2);
+    });
+
+    it('should accept prop input', () => {
+      fixture.componentRef.setInput('prop', 'country');
+      expect(component.prop).toBe('country');
+    });
+
+    it('should accept td input', () => {
+      const td = document.createElement('td');
+      fixture.componentRef.setInput('td', td);
+      expect(component.td).toBe(td);
+    });
+
+    it('should accept instance input', () => {
+      const mockInstance = {} as any;
+      fixture.componentRef.setInput('instance', mockInstance);
+      expect(component.instance).toBe(mockInstance);
+    });
+
+    it('should accept cellProperties input', () => {
+      const props = { type: 'text', rendererProps: { bold: true } } as any;
+      fixture.componentRef.setInput('cellProperties', props);
+      expect(component.cellProperties).toBe(props);
+    });
+  });
+
+  describe('getProps()', () => {
+    it('should return rendererProps when present in cellProperties', () => {
+      const rendererProps = { color: 'red' };
+      fixture.componentRef.setInput('cellProperties', { rendererProps } as any);
+      expect(component.getProps()).toBe(rendererProps);
+    });
+
+    it('should return empty object when cellProperties has no rendererProps', () => {
+      fixture.componentRef.setInput('cellProperties', { type: 'text' } as any);
+      expect(component.getProps()).toEqual({});
+    });
+
+    it('should return empty object when cellProperties is null', () => {
+      fixture.componentRef.setInput('cellProperties', null);
+      expect(component.getProps()).toEqual({});
+    });
+
+    it('should return empty object when rendererProps is null', () => {
+      fixture.componentRef.setInput('cellProperties', { rendererProps: null } as any);
+      expect(component.getProps()).toEqual({});
+    });
+  });
+});

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/renderer/hot-cell-renderer.component.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/renderer/hot-cell-renderer.component.ts
@@ -1,10 +1,12 @@
-import Handsontable from 'handsontable/base';
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { HotCellRendererBase } from './hot-cell-renderer-base.directive';
 
 /**
  * Abstract base component for creating custom cell renderer components for Handsontable.
  *
- * This class provides a common interface and properties required by any custom cell renderer.
+ * Extend this component and provide your own template to implement a custom renderer.
+ * Value type is limited to primitives (`string | number | boolean`).
+ * For object and array values use {@link HotCellRendererAdvancedComponent}.
  *
  * @template TValue - The type of the component renderer.
  * @template TProps - The type of additional renderer properties.
@@ -15,28 +17,7 @@ import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export abstract class HotCellRendererComponent<TValue extends string | number | boolean = string, TProps extends {} = any> {
+export abstract class HotCellRendererComponent<TValue extends string | number | boolean = string, TProps extends {} = any>
+  extends HotCellRendererBase<TValue, TProps> {
   static readonly RENDERER_MARKER = Symbol('HotCellRendererComponent');
-
-  @Input() value: TValue = '' as TValue;
-
-  @Input() instance: Handsontable;
-  @Input() td: HTMLTableCellElement;
-  @Input() row: number;
-  @Input() col: number;
-  @Input() prop: string;
-
-  /**
-   * The cell properties provided by Handsontable, extended with optional renderer-specific properties.
-   */
-  @Input() cellProperties: Handsontable.CellProperties & { rendererProps?: TProps };
-
-  /**
-   * Retrieves the renderer-specific properties from the cell properties.
-   *
-   * @returns The additional properties for the renderer.
-   */
-  public getProps(): TProps {
-    return this.cellProperties?.rendererProps ?? ({} as TProps);
-  }
 }

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/renderer/hot-dynamic-renderer-component.service.spec.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/renderer/hot-dynamic-renderer-component.service.spec.ts
@@ -1,4 +1,7 @@
-import { ApplicationRef, Component, createComponent, CUSTOM_ELEMENTS_SCHEMA, EnvironmentInjector, TemplateRef, ViewChild, ViewContainerRef } from '@angular/core';
+import {
+  ApplicationRef, Component, createComponent, CUSTOM_ELEMENTS_SCHEMA,
+  EnvironmentInjector, TemplateRef, ViewChild, ViewContainerRef
+} from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import {
   DynamicComponentService,

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/renderer/hot-dynamic-renderer-component.service.spec.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/renderer/hot-dynamic-renderer-component.service.spec.ts
@@ -463,6 +463,34 @@ describe('DynamicComponentService - sweepDetachedViews (virtual scroll cleanup)'
     expect(detachSpy).toHaveBeenCalledTimes(2);
   });
 
+  it('should re-render a TD recycled after its ref was swept, without re-destroying the stale ref', () => {
+    const { instance, fireAfterViewRender } = createHookableInstance();
+    const td = createConnectedTD();
+
+    const rendererFn = service.createRendererFromComponent(DummyRendererComponent, {}, false);
+    rendererFn(instance, td, 0, 0, 'prop', 'first', {} as any);
+    appRef.tick();
+
+    // Row leaves the viewport: the sweep destroys the ref but leaves the stale entry in _tdComponentRefs.
+    td.remove();
+    fireAfterViewRender();
+
+    // Handsontable recycles the same TD for a new row. Re-rendering must not touch the stale (already
+    // destroyed) ref — only attach the fresh component.
+    document.body.appendChild(td);
+    const detachSpy = jest.spyOn(appRef, 'detachView');
+
+    expect(() => {
+      rendererFn(instance, td, 1, 0, 'prop', 'second', {} as any);
+      appRef.tick();
+    }).not.toThrow();
+
+    // The guard skips detaching the stale ref; the path only creates/attaches the new component.
+    expect(detachSpy).not.toHaveBeenCalled();
+    expect(td.innerHTML).toContain('Component Renderer: second');
+    expect(td.innerHTML).not.toContain('Component Renderer: first');
+  });
+
   it('should register the afterViewRender sweep hook only once per instance', () => {
     const { instance } = createHookableInstance();
     const addHookSpy = jest.spyOn(instance, 'addHook');
@@ -505,6 +533,24 @@ describe('DynamicComponentService - destroyComponent', () => {
 
     expect(detachSpy).toHaveBeenCalledWith(compRef.hostView);
     expect(destroySpy).toHaveBeenCalled();
+  });
+
+  it('should be idempotent when called twice on the same ref', () => {
+    const compRef = createComponent(DummyRendererComponent, {
+      environmentInjector: TestBed.inject(EnvironmentInjector),
+    });
+    appRef.attachView(compRef.hostView);
+
+    service.destroyComponent(compRef);
+
+    const detachSpy = jest.spyOn(appRef, 'detachView');
+    const destroySpy = jest.spyOn(compRef, 'destroy');
+
+    // A recycled TD can still map to this already-destroyed ref in _tdComponentRefs, so the next
+    // render path may reach destroyComponent again. The destroyed guard must skip the redundant work.
+    expect(() => service.destroyComponent(compRef)).not.toThrow();
+    expect(detachSpy).not.toHaveBeenCalled();
+    expect(destroySpy).not.toHaveBeenCalled();
   });
 });
 

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/renderer/hot-dynamic-renderer-component.service.spec.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/renderer/hot-dynamic-renderer-component.service.spec.ts
@@ -1,6 +1,6 @@
 import {
   ApplicationRef, Component, createComponent, CUSTOM_ELEMENTS_SCHEMA,
-  EnvironmentInjector, TemplateRef, ViewChild, ViewContainerRef
+  EmbeddedViewRef, EnvironmentInjector, TemplateRef, ViewChild, ViewContainerRef
 } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import {
@@ -115,6 +115,36 @@ describe('DynamicComponentService - createRendererFromComponent', () => {
       expect(detachSpy).toHaveBeenCalledTimes(1);
       expect(td.innerHTML).toContain('Component Renderer: second');
       expect(td.innerHTML).not.toContain('Component Renderer: first');
+    });
+  });
+
+  describe('when re-rendering a connected TD with the same component type', () => {
+    it('should recycle the existing ComponentRef instead of recreating it', () => {
+      const rendererFn = service.createRendererFromComponent(DummyRendererComponent, {}, false);
+      const td = createDummyTD();
+      // Connected TD so isViewConnected() is true and the recycling path is taken (mirrors a live grid).
+      document.body.appendChild(td);
+      const cellProperties: Handsontable.CellProperties = {} as any;
+
+      try {
+        rendererFn(dummyHTInstance, td, 0, 0, 'prop', 'first', cellProperties);
+        appRef.tick();
+        expect(td.innerHTML).toContain('Component Renderer: first');
+
+        const detachSpy = jest.spyOn(appRef, 'detachView');
+        const attachSpy = jest.spyOn(appRef, 'attachView');
+
+        rendererFn(dummyHTInstance, td, 0, 0, 'prop', 'second', cellProperties);
+        appRef.tick();
+
+        // No teardown/instantiation churn: the component is reused, only its input is refreshed.
+        expect(detachSpy).not.toHaveBeenCalled();
+        expect(attachSpy).not.toHaveBeenCalled();
+        expect(td.innerHTML).toContain('Component Renderer: second');
+        expect(td.innerHTML).not.toContain('Component Renderer: first');
+      } finally {
+        td.remove();
+      }
     });
   });
 
@@ -281,6 +311,169 @@ describe('DynamicComponentService - createRendererWithFactory', () => {
         rendererFn(dummyHTInstance, createDummyTD(), 0, 0, 'prop', 'value', {} as any);
       }).not.toThrow();
     });
+  });
+
+  describe('when applying the base renderer', () => {
+    it('should run baseRenderer on the cell (factory path is consistent with createRendererFromComponent)', () => {
+      const rendererFn = service.createRendererWithFactory(DummyRendererAdvancedComponent, {}, false);
+      const cellProperties: Handsontable.CellProperties = {} as any;
+
+      rendererFn(dummyHTInstance, createDummyTD(), 0, 0, 'prop', 'value', cellProperties);
+
+      // baseRenderer flags the cell meta; its presence proves baseRenderer ran in the factory path.
+      expect((cellProperties as any)._isBaseRendererCalled).toBe(true);
+    });
+
+    it('should apply cellProperties.className to the TD via baseRenderer', () => {
+      const rendererFn = service.createRendererWithFactory(DummyRendererAdvancedComponent, {}, false);
+      const td = createDummyTD();
+
+      rendererFn(dummyHTInstance, td, 0, 0, 'prop', 'value', { className: 'my-base-class' } as any);
+
+      expect(td.classList.contains('my-base-class')).toBe(true);
+    });
+  });
+});
+
+describe('DynamicComponentService - sweepDetachedViews (virtual scroll cleanup)', () => {
+  let service: DynamicComponentService;
+  let appRef: ApplicationRef;
+  let fixtureTemplate: ComponentFixture<DummyTemplateHostComponent>;
+  let templateHost: DummyTemplateHostComponent;
+  const attachedTds: HTMLTableCellElement[] = [];
+
+  // Minimal HOT instance stub exposing a real addHook so the service can wire its sweep hook,
+  // plus a trigger that fires the captured afterViewRender callbacks on demand.
+  function createHookableInstance(): { instance: Handsontable.Core; fireAfterViewRender: () => void } {
+    const hooks: Record<string, Array<() => void>> = {};
+    const instance = {
+      addHook(name: string, callback: () => void): void {
+        (hooks[name] = hooks[name] ?? []).push(callback);
+      },
+    } as unknown as Handsontable.Core;
+
+    return {
+      instance,
+      fireAfterViewRender: () => (hooks['afterViewRender'] ?? []).forEach((cb) => cb()),
+    };
+  }
+
+  // Create a TD that is actually connected to the document, so node.isConnected reflects reality.
+  function createConnectedTD(): HTMLTableCellElement {
+    const td = createDummyTD();
+    document.body.appendChild(td);
+    attachedTds.push(td);
+    return td;
+  }
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DummyRendererComponent, DummyTemplateHostComponent],
+      providers: [DynamicComponentService],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+
+    appRef = TestBed.inject(ApplicationRef);
+    service = TestBed.inject(DynamicComponentService);
+    fixtureTemplate = TestBed.createComponent(DummyTemplateHostComponent);
+    templateHost = fixtureTemplate.componentInstance;
+    fixtureTemplate.detectChanges();
+  });
+
+  afterEach(() => {
+    attachedTds.splice(0).forEach((td) => td.remove());
+  });
+
+  it('should destroy a component whose TD left the DOM, on afterViewRender', () => {
+    const { instance, fireAfterViewRender } = createHookableInstance();
+    const td = createConnectedTD();
+
+    const rendererFn = service.createRendererFromComponent(DummyRendererComponent, {}, false);
+    rendererFn(instance, td, 0, 0, 'prop', 'value', {} as any);
+    appRef.tick();
+
+    const detachSpy = jest.spyOn(appRef, 'detachView');
+
+    // Simulate the row leaving Handsontable's virtual viewport.
+    td.remove();
+    fireAfterViewRender();
+
+    expect(detachSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should NOT destroy a component whose TD is still connected', () => {
+    const { instance, fireAfterViewRender } = createHookableInstance();
+    const td = createConnectedTD();
+
+    const rendererFn = service.createRendererFromComponent(DummyRendererComponent, {}, false);
+    rendererFn(instance, td, 0, 0, 'prop', 'value', {} as any);
+    appRef.tick();
+
+    const detachSpy = jest.spyOn(appRef, 'detachView');
+
+    fireAfterViewRender();
+
+    expect(detachSpy).not.toHaveBeenCalled();
+  });
+
+  it('should destroy an embedded view (TemplateRef) whose TD left the DOM', () => {
+    const { instance, fireAfterViewRender } = createHookableInstance();
+    const td = createConnectedTD();
+
+    let createdView: EmbeddedViewRef<any> | undefined;
+    const originalCreate = templateHost.dummyTemplate.createEmbeddedView.bind(templateHost.dummyTemplate);
+    jest.spyOn(templateHost.dummyTemplate, 'createEmbeddedView').mockImplementation((ctx: any) => {
+      createdView = originalCreate(ctx);
+      jest.spyOn(createdView, 'destroy');
+      return createdView;
+    });
+
+    const rendererFn = service.createRendererFromComponent(templateHost.dummyTemplate, {}, false);
+    rendererFn(instance, td, 0, 0, 'prop', 'value', {} as any);
+    appRef.tick();
+
+    td.remove();
+    fireAfterViewRender();
+
+    expect(createdView?.destroy).toHaveBeenCalled();
+  });
+
+  it('should only sweep the refs of the instance whose afterViewRender fired', () => {
+    const tableA = createHookableInstance();
+    const tableB = createHookableInstance();
+    const tdA = createConnectedTD();
+    const tdB = createConnectedTD();
+
+    const rendererFn = service.createRendererFromComponent(DummyRendererComponent, {}, false);
+    rendererFn(tableA.instance, tdA, 0, 0, 'prop', 'a', {} as any);
+    rendererFn(tableB.instance, tdB, 0, 0, 'prop', 'b', {} as any);
+    appRef.tick();
+
+    const detachSpy = jest.spyOn(appRef, 'detachView');
+
+    // Both cells leave the DOM, but only table A re-renders. Table B's ref must survive.
+    tdA.remove();
+    tdB.remove();
+    tableA.fireAfterViewRender();
+
+    expect(detachSpy).toHaveBeenCalledTimes(1);
+
+    // Table B's ref is destroyed only once its own render cycle sweeps it.
+    tableB.fireAfterViewRender();
+    expect(detachSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('should register the afterViewRender sweep hook only once per instance', () => {
+    const { instance } = createHookableInstance();
+    const addHookSpy = jest.spyOn(instance, 'addHook');
+
+    const rendererFn = service.createRendererFromComponent(DummyRendererComponent, {}, false);
+    rendererFn(instance, createConnectedTD(), 0, 0, 'prop', 'a', {} as any);
+    rendererFn(instance, createConnectedTD(), 0, 1, 'prop', 'b', {} as any);
+    rendererFn(instance, createConnectedTD(), 1, 0, 'prop', 'c', {} as any);
+
+    expect(addHookSpy).toHaveBeenCalledTimes(1);
+    expect(addHookSpy).toHaveBeenCalledWith('afterViewRender', expect.any(Function));
   });
 });
 

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/renderer/hot-dynamic-renderer-component.service.spec.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/renderer/hot-dynamic-renderer-component.service.spec.ts
@@ -1,6 +1,13 @@
-import { ApplicationRef, Component, CUSTOM_ELEMENTS_SCHEMA, TemplateRef, ViewChild, ViewContainerRef } from '@angular/core';
+import { ApplicationRef, Component, createComponent, CUSTOM_ELEMENTS_SCHEMA, EnvironmentInjector, TemplateRef, ViewChild, ViewContainerRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { DynamicComponentService } from './hot-dynamic-renderer-component.service';
+import {
+  DynamicComponentService,
+  INVALID_RENDERER_WARNING,
+  INVALID_ADVANCED_RENDERER_WARNING,
+  isTemplateRef,
+  isHotCellRendererComponent,
+  isAdvancedHotCellRendererComponent,
+} from './hot-dynamic-renderer-component.service';
 import Handsontable from 'handsontable';
 import { HotCellRendererComponent } from './hot-cell-renderer.component';
 import { rendererFactory } from 'handsontable/renderers';
@@ -87,6 +94,27 @@ describe('DynamicComponentService - createRendererFromComponent', () => {
     });
   });
 
+  describe('when re-rendering the same TD with a component', () => {
+    it('should destroy the previous ComponentRef and not duplicate content', () => {
+      const rendererFn = service.createRendererFromComponent(DummyRendererComponent, {}, false);
+      const td = createDummyTD();
+      const cellProperties: Handsontable.CellProperties = {} as any;
+
+      rendererFn(dummyHTInstance, td, 0, 0, 'prop', 'first', cellProperties);
+      appRef.tick();
+      expect(td.innerHTML).toContain('Component Renderer: first');
+
+      const detachSpy = jest.spyOn(appRef, 'detachView');
+
+      rendererFn(dummyHTInstance, td, 0, 0, 'prop', 'second', cellProperties);
+      appRef.tick();
+
+      expect(detachSpy).toHaveBeenCalledTimes(1);
+      expect(td.innerHTML).toContain('Component Renderer: second');
+      expect(td.innerHTML).not.toContain('Component Renderer: first');
+    });
+  });
+
   describe('when using a TemplateRef as renderer', () => {
     it('should create a renderer function that attaches an embedded view to the TD element', () => {
       const rendererFn = service.createRendererFromComponent(templateHost.dummyTemplate, {}, false);
@@ -104,6 +132,68 @@ describe('DynamicComponentService - createRendererFromComponent', () => {
 
       expect(td.innerHTML).toContain('Template Renderer: Template Test');
       expect(td.innerHTML).toContain('(Row: 3, Col: 4)');
+    });
+  });
+
+  describe('when re-rendering the same TD with a TemplateRef', () => {
+    it('should destroy the previous embedded view and not duplicate content', () => {
+      const rendererFn = service.createRendererFromComponent(templateHost.dummyTemplate, {}, false);
+      const td = createDummyTD();
+      const cellProperties: Handsontable.CellProperties = {} as any;
+
+      rendererFn(dummyHTInstance, td, 0, 0, 'prop', 'first', cellProperties);
+      appRef.tick();
+      expect(td.textContent).toContain('Template Renderer: first');
+
+      rendererFn(dummyHTInstance, td, 0, 0, 'prop', 'second', cellProperties);
+      appRef.tick();
+
+      expect(td.textContent).toContain('Template Renderer: second');
+      expect(td.textContent).not.toContain('Template Renderer: first');
+    });
+  });
+
+  describe('when passing an invalid renderer', () => {
+    it('should log a warning when component is neither TemplateRef nor HotCellRendererComponent', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const rendererFn = service.createRendererFromComponent({} as any, {}, false);
+      rendererFn(dummyHTInstance, createDummyTD(), 0, 0, 'prop', 'value', {} as any);
+
+      expect(warnSpy).toHaveBeenCalledWith(INVALID_RENDERER_WARNING);
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe('when register=true', () => {
+    it('should call Handsontable.renderers.registerRenderer with a valid HotCellRendererComponent', () => {
+      if (!(Handsontable.renderers as any).registerRenderer) {
+        (Handsontable.renderers as any).registerRenderer = jest.fn();
+      }
+      const registerSpy = jest.spyOn(Handsontable.renderers as any, 'registerRenderer').mockImplementation(() => {});
+
+      const rendererFn = service.createRendererFromComponent(DummyRendererComponent, {}, true);
+      rendererFn(dummyHTInstance, createDummyTD(), 0, 0, 'prop', 'value', {} as any);
+
+      expect(registerSpy).toHaveBeenCalled();
+      registerSpy.mockRestore();
+    });
+
+    it('should call registerRenderer only once even when the renderer function is called multiple times', () => {
+      if (!(Handsontable.renderers as any).registerRenderer) {
+        (Handsontable.renderers as any).registerRenderer = jest.fn();
+      }
+      const registerSpy = jest.spyOn(Handsontable.renderers as any, 'registerRenderer').mockImplementation(() => {});
+      const td = createDummyTD();
+      const cellProperties: Handsontable.CellProperties = {} as any;
+
+      const rendererFn = service.createRendererFromComponent(DummyRendererComponent, {}, true);
+      rendererFn(dummyHTInstance, td, 0, 0, 'prop', 'first', cellProperties);
+      rendererFn(dummyHTInstance, td, 0, 0, 'prop', 'second', cellProperties);
+      rendererFn(dummyHTInstance, td, 0, 0, 'prop', 'third', cellProperties);
+
+      expect(registerSpy).toHaveBeenCalledTimes(1);
+      registerSpy.mockRestore();
     });
   });
 });
@@ -145,6 +235,209 @@ describe('DynamicComponentService - createRendererWithFactory', () => {
 
       // eslint-disable-next-line max-len
       expect(td.innerHTML).toContain('<hot-dummy-renderer-advanced><div>Component Renderer: Component Test</div></hot-dummy-renderer-advanced>');
+    });
+  });
+
+  describe('when re-rendering the same TD', () => {
+    it('should destroy the previous ComponentRef and not duplicate content', () => {
+      const rendererFn = service.createRendererWithFactory(DummyRendererAdvancedComponent, {}, false);
+      const td = createDummyTD();
+      const cellProperties: Handsontable.CellProperties = {} as any;
+
+      rendererFn(dummyHTInstance, td, 0, 0, 'prop', 'first', cellProperties);
+      appRef.tick();
+      expect(td.innerHTML).toContain('Component Renderer: first');
+
+      const detachSpy = jest.spyOn(appRef, 'detachView');
+
+      rendererFn(dummyHTInstance, td, 0, 0, 'prop', 'second', cellProperties);
+      appRef.tick();
+
+      expect(detachSpy).toHaveBeenCalledTimes(1);
+      expect(td.innerHTML).toContain('Component Renderer: second');
+      expect(td.innerHTML).not.toContain('Component Renderer: first');
+    });
+  });
+
+  describe('when passing an invalid advanced renderer', () => {
+    it('should log a warning when component does not extend HotCellRendererAdvancedComponent', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const rendererFn = service.createRendererWithFactory({} as any, {}, false);
+      rendererFn(dummyHTInstance, createDummyTD(), 0, 0, 'prop', 'value', {} as any);
+
+      expect(warnSpy).toHaveBeenCalledWith(INVALID_ADVANCED_RENDERER_WARNING);
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe('when register=true', () => {
+    it('should call registerRenderer with a valid HotCellRendererAdvancedComponent', () => {
+      expect(() => {
+        const rendererFn = service.createRendererWithFactory(DummyRendererAdvancedComponent, {}, true);
+        rendererFn(dummyHTInstance, createDummyTD(), 0, 0, 'prop', 'value', {} as any);
+      }).not.toThrow();
+    });
+  });
+});
+
+describe('DynamicComponentService - destroyComponent', () => {
+  let service: DynamicComponentService;
+  let appRef: ApplicationRef;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DummyRendererComponent],
+      providers: [DynamicComponentService],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+
+    appRef = TestBed.inject(ApplicationRef);
+    service = TestBed.inject(DynamicComponentService);
+  });
+
+  it('should detach the view and destroy the component', () => {
+    const compRef = createComponent(DummyRendererComponent, {
+      environmentInjector: TestBed.inject(EnvironmentInjector),
+    });
+    appRef.attachView(compRef.hostView);
+
+    const detachSpy = jest.spyOn(appRef, 'detachView');
+    const destroySpy = jest.spyOn(compRef, 'destroy');
+
+    service.destroyComponent(compRef);
+
+    expect(detachSpy).toHaveBeenCalledWith(compRef.hostView);
+    expect(destroySpy).toHaveBeenCalled();
+  });
+});
+
+describe('DynamicComponentService - cleanupContainer', () => {
+  let service: DynamicComponentService;
+  let appRef: ApplicationRef;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DummyRendererComponent],
+      providers: [DynamicComponentService],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+
+    appRef = TestBed.inject(ApplicationRef);
+    service = TestBed.inject(DynamicComponentService);
+  });
+
+  function buildContainer(...tds: HTMLTableCellElement[]): HTMLElement {
+    const container = document.createElement('div');
+    const table = document.createElement('table');
+    const tbody = document.createElement('tbody');
+    const tr = document.createElement('tr');
+    tds.forEach((td) => tr.appendChild(td));
+    tbody.appendChild(tr);
+    table.appendChild(tbody);
+    container.appendChild(table);
+    return container;
+  }
+
+  it('should detach and destroy all renderer components within the container', () => {
+    const td1 = createDummyTD();
+    const td2 = createDummyTD();
+    const container = buildContainer(td1, td2);
+    const cellProperties: Handsontable.CellProperties = {} as any;
+
+    const rendererFn = service.createRendererFromComponent(DummyRendererComponent, {}, false);
+    rendererFn(dummyHTInstance, td1, 0, 0, 'prop', 'v1', cellProperties);
+    rendererFn(dummyHTInstance, td2, 0, 1, 'prop', 'v2', cellProperties);
+    appRef.tick();
+
+    const detachSpy = jest.spyOn(appRef, 'detachView');
+
+    service.cleanupContainer(container);
+
+    expect(detachSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('should be a no-op when no renderer components are attached in the container', () => {
+    const container = buildContainer(createDummyTD());
+
+    expect(() => service.cleanupContainer(container)).not.toThrow();
+  });
+
+  it('should not destroy components on subsequent calls after cleanup', () => {
+    const td = createDummyTD();
+    const container = buildContainer(td);
+    const cellProperties: Handsontable.CellProperties = {} as any;
+
+    const rendererFn = service.createRendererFromComponent(DummyRendererComponent, {}, false);
+    rendererFn(dummyHTInstance, td, 0, 0, 'prop', 'val', cellProperties);
+    appRef.tick();
+
+    service.cleanupContainer(container); // First cleanup — destroys component
+
+    const detachSpy = jest.spyOn(appRef, 'detachView');
+    service.cleanupContainer(container); // Second cleanup — should be a no-op
+
+    expect(detachSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('exported type guards', () => {
+  describe('isTemplateRef', () => {
+    it('should return true for an object with createEmbeddedView method', () => {
+      const fakeTemplateRef = { createEmbeddedView: () => {} };
+      expect(isTemplateRef(fakeTemplateRef)).toBe(true);
+    });
+
+    it('should return false for a plain object without createEmbeddedView', () => {
+      expect(isTemplateRef({})).toBe(false);
+    });
+
+    it('should return false for null', () => {
+      expect(isTemplateRef(null)).toBe(false);
+    });
+
+    it('should return false for undefined', () => {
+      expect(isTemplateRef(undefined)).toBe(false);
+    });
+
+    it('should return false for a component class', () => {
+      expect(isTemplateRef(DummyRendererComponent)).toBe(false);
+    });
+  });
+
+  describe('isHotCellRendererComponent', () => {
+    it('should return true for a class that extends HotCellRendererComponent', () => {
+      expect(isHotCellRendererComponent(DummyRendererComponent)).toBe(true);
+    });
+
+    it('should return false for a class that extends HotCellRendererAdvancedComponent', () => {
+      expect(isHotCellRendererComponent(DummyRendererAdvancedComponent)).toBe(false);
+    });
+
+    it('should return false for a plain object', () => {
+      expect(isHotCellRendererComponent({})).toBe(false);
+    });
+
+    it('should return false for null', () => {
+      expect(isHotCellRendererComponent(null)).toBe(false);
+    });
+  });
+
+  describe('isAdvancedHotCellRendererComponent', () => {
+    it('should return true for a class that extends HotCellRendererAdvancedComponent', () => {
+      expect(isAdvancedHotCellRendererComponent(DummyRendererAdvancedComponent)).toBe(true);
+    });
+
+    it('should return false for a class that extends HotCellRendererComponent', () => {
+      expect(isAdvancedHotCellRendererComponent(DummyRendererComponent)).toBe(false);
+    });
+
+    it('should return false for a plain object', () => {
+      expect(isAdvancedHotCellRendererComponent({})).toBe(false);
+    });
+
+    it('should return false for null', () => {
+      expect(isAdvancedHotCellRendererComponent(null)).toBe(false);
     });
   });
 });

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/renderer/hot-dynamic-renderer-component.service.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/renderer/hot-dynamic-renderer-component.service.ts
@@ -10,6 +10,7 @@ import {
 } from '@angular/core';
 import { baseRenderer, BaseRenderer, registerRenderer, rendererFactory } from 'handsontable/renderers';
 import Handsontable from 'handsontable/base';
+import { HotCellRendererBase } from './hot-cell-renderer-base.directive';
 import { HotCellRendererComponent } from './hot-cell-renderer.component';
 import { HotCellRendererAdvancedComponent } from './hot-cell-renderer-advanced.component';
 
@@ -45,7 +46,7 @@ interface BaseRendererParametersObject {
  * @returns True if the object is a TemplateRef; otherwise, false.
  */
 export function isTemplateRef<T>(obj: any): obj is TemplateRef<T> {
-  return obj && typeof obj.createEmbeddedView === 'function';
+  return !!obj && typeof obj.createEmbeddedView === 'function';
 }
 
 /**
@@ -82,6 +83,11 @@ export function isAdvancedHotCellRendererComponent(obj: any): obj is Type<HotCel
   providedIn: 'root',
 })
 export class DynamicComponentService {
+  // Track Angular component refs and embedded views keyed by the TD element they are attached to.
+  // When a cell is re-rendered the previous component is destroyed before a new one is created.
+  private readonly _tdComponentRefs = new WeakMap<HTMLTableCellElement, ComponentRef<any>>();
+  private readonly _tdEmbeddedViews = new WeakMap<HTMLTableCellElement, EmbeddedViewRef<any>>();
+
   constructor(private appRef: ApplicationRef, private environmentInjector: EnvironmentInjector) {}
 
   /**
@@ -98,6 +104,8 @@ export class DynamicComponentService {
     componentProps: Record<string, any> = {},
     register: boolean = false
   ) {
+    let registered = false;
+
     return (
       instance: Handsontable.Core,
       td: HTMLTableCellElement,
@@ -117,27 +125,40 @@ export class DynamicComponentService {
         cellProperties,
       };
 
-      if (componentProps) {
-        Object.assign(cellProperties, { rendererProps: componentProps });
-      }
+      Object.assign(cellProperties, { rendererProps: componentProps });
 
       const rendererParameters: BaseRendererParameters = [instance, td, row, col, prop, value, cellProperties];
 
       baseRenderer.apply(this, rendererParameters);
 
+      // Destroy previously attached component/view for this cell before replacing its content.
+      const prevRef = this._tdComponentRefs.get(td);
+      if (prevRef) {
+        this.destroyComponent(prevRef);
+        this._tdComponentRefs.delete(td);
+      }
+      const prevView = this._tdEmbeddedViews.get(td);
+      if (prevView) {
+        prevView.destroy();
+        this._tdEmbeddedViews.delete(td);
+      }
+
       td.innerHTML = '';
 
       if (isTemplateRef(component)) {
-        this.attachTemplateToElement(component, td, properties);
+        const embeddedView = this.attachTemplateToElement(component, td, properties);
+        this._tdEmbeddedViews.set(td, embeddedView);
       } else if (isHotCellRendererComponent(component)) {
         const componentRef = this.createComponent(component, properties);
         this.attachComponentToElement(componentRef, td);
+        this._tdComponentRefs.set(td, componentRef);
       } else {
         console.warn(INVALID_RENDERER_WARNING);
       }
 
-      if (register && isHotCellRendererComponent(component)) {
-        Handsontable.renderers.registerRenderer(component.constructor.name, component as any as BaseRenderer);
+      if (register && !registered && isHotCellRendererComponent(component)) {
+        Handsontable.renderers.registerRenderer((component as Type<any>).name, component as any as BaseRenderer);
+        registered = true;
       }
 
       return td;
@@ -158,6 +179,8 @@ export class DynamicComponentService {
     componentProps: Record<string, any> = {},
     register: boolean = false
   ) {
+    let registered = false;
+
     return rendererFactory(({
       instance,
       td,
@@ -177,8 +200,18 @@ export class DynamicComponentService {
         cellProperties,
       };
 
-      if (componentProps) {
-        Object.assign(cellProperties, { rendererProps: componentProps });
+      Object.assign(cellProperties, { rendererProps: componentProps });
+
+      // Destroy previously attached component/view for this cell before replacing its content.
+      const prevRef = this._tdComponentRefs.get(td);
+      if (prevRef) {
+        this.destroyComponent(prevRef);
+        this._tdComponentRefs.delete(td);
+      }
+      const prevView = this._tdEmbeddedViews.get(td);
+      if (prevView) {
+        prevView.destroy();
+        this._tdEmbeddedViews.delete(td);
       }
 
       td.innerHTML = '';
@@ -186,12 +219,35 @@ export class DynamicComponentService {
       if (isAdvancedHotCellRendererComponent(component)) {
         const componentRef = this.createComponent(component, properties);
         this.attachComponentToElement(componentRef, td);
+        this._tdComponentRefs.set(td, componentRef);
       } else {
         console.warn(INVALID_ADVANCED_RENDERER_WARNING);
       }
 
-      if (register && isAdvancedHotCellRendererComponent(component)) {
-        registerRenderer(component.constructor.name, component as any as BaseRenderer);
+      if (register && !registered && isAdvancedHotCellRendererComponent(component)) {
+        registerRenderer(component.name, component as any as BaseRenderer);
+        registered = true;
+      }
+    });
+  }
+
+  /**
+   * Destroys all renderer components and embedded views attached to cells within a container element.
+   * Must be called before destroying the Handsontable instance to prevent Angular component leaks.
+   *
+   * @param container - The root DOM element of the Handsontable instance.
+   */
+  cleanupContainer(container: HTMLElement): void {
+    container.querySelectorAll<HTMLTableCellElement>('td').forEach((td) => {
+      const compRef = this._tdComponentRefs.get(td);
+      if (compRef) {
+        this.destroyComponent(compRef);
+        this._tdComponentRefs.delete(td);
+      }
+      const embView = this._tdEmbeddedViews.get(td);
+      if (embView) {
+        embView.destroy();
+        this._tdEmbeddedViews.delete(td);
       }
     });
   }
@@ -202,8 +258,9 @@ export class DynamicComponentService {
    * @param template - The TemplateRef to create an embedded view from.
    * @param tdEl - The target DOM element (a table cell) to which the view will be appended.
    * @param properties - Context object providing properties to be used within the template.
+   * @returns The created EmbeddedViewRef so the caller can track and destroy it later.
    */
-  private attachTemplateToElement(template: TemplateRef<any>, tdEl: HTMLTableCellElement, properties: BaseRendererParametersObject) {
+  private attachTemplateToElement(template: TemplateRef<any>, tdEl: HTMLTableCellElement, properties: BaseRendererParametersObject): EmbeddedViewRef<any> {
     const embeddedView: EmbeddedViewRef<any> = template.createEmbeddedView({
       $implicit: properties.value,
       ...properties,
@@ -213,6 +270,8 @@ export class DynamicComponentService {
     embeddedView.rootNodes.forEach((node) => {
       tdEl.appendChild(node);
     });
+
+    return embeddedView;
   }
 
   /**
@@ -222,7 +281,7 @@ export class DynamicComponentService {
    * @param rendererParameters - An object containing input properties to assign to the component instance.
    * @returns The ComponentRef of the dynamically created component.
    */
-  private createComponent<T extends HotCellRendererComponent>(
+  private createComponent<T extends HotCellRendererBase>(
     component: Type<T>,
     rendererParameters: BaseRendererParametersObject
   ): ComponentRef<T> {
@@ -230,12 +289,8 @@ export class DynamicComponentService {
       environmentInjector: this.environmentInjector,
     });
 
-    Object.keys(rendererParameters).forEach((key) => {
-      if (Object.prototype.hasOwnProperty.call(rendererParameters, key)) {
-        componentRef.setInput(key, rendererParameters[key]);
-      } else {
-        console.warn(`Input property "${key}" does not exist on component instance: ${component?.name}.`);
-      }
+    (Object.keys(rendererParameters) as (keyof BaseRendererParametersObject)[]).forEach((key) => {
+      componentRef.setInput(key, rendererParameters[key]);
     });
     componentRef.changeDetectorRef.detectChanges();
 

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/renderer/hot-dynamic-renderer-component.service.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/renderer/hot-dynamic-renderer-component.service.ts
@@ -247,7 +247,7 @@ export class DynamicComponentService {
       }
       const embView = this._tdEmbeddedViews.get(td);
       if (embView) {
-        embView.destroy();
+        this.destroyEmbeddedView(embView);
         this._tdEmbeddedViews.delete(td);
         embViews?.delete(embView);
       }
@@ -259,7 +259,7 @@ export class DynamicComponentService {
     // the per-instance registries so a repeated cleanup call is a no-op. (Entries removed in the
     // loop above are already gone from these sets, so nothing is destroyed twice.)
     compRefs?.forEach((ref) => this.destroyComponent(ref));
-    embViews?.forEach((view) => view.destroy());
+    embViews?.forEach((view) => this.destroyEmbeddedView(view));
 
     if (instance) {
       this._instanceComponentRefs.delete(instance);
@@ -304,7 +304,7 @@ export class DynamicComponentService {
     const embViews = this._instanceEmbeddedViews.get(instance);
     embViews?.forEach((view) => {
       if (!this.isViewConnected(view)) {
-        view.destroy();
+        this.destroyEmbeddedView(view);
         embViews.delete(view);
       }
     });
@@ -334,7 +334,7 @@ export class DynamicComponentService {
 
     const prevView = this._tdEmbeddedViews.get(td);
     if (prevView) {
-      prevView.destroy();
+      this.destroyEmbeddedView(prevView);
       this._tdEmbeddedViews.delete(td);
       this._instanceEmbeddedViews.get(instance)?.delete(prevView);
     }
@@ -483,10 +483,32 @@ export class DynamicComponentService {
   /**
    * Destroys a dynamically created component and detaches its view from the Angular application.
    *
+   * Idempotent: a TD recycled after `sweepDetachedViews` already destroyed its ref still maps to that
+   * stale ref in `_tdComponentRefs`, so the next render path may reach this with an already-destroyed
+   * ref. Guarding on `destroyed` skips the redundant detach/destroy instead of relying on Angular's
+   * internal no-op behaviour.
+   *
    * @param componentRef - The reference to the component to be destroyed.
    */
   destroyComponent<T>(componentRef: ComponentRef<T>): void {
-    this.appRef.detachView(componentRef.hostView);
+    const hostView = componentRef.hostView as EmbeddedViewRef<T>;
+    if (hostView.destroyed) {
+      return;
+    }
+    this.appRef.detachView(hostView);
     componentRef.destroy();
+  }
+
+  /**
+   * Destroys an embedded view. Idempotent for the same reason as {@link destroyComponent}: a recycled
+   * TD can still map to an already-destroyed view in `_tdEmbeddedViews`.
+   *
+   * @param view - The embedded view to destroy.
+   */
+  private destroyEmbeddedView(view: EmbeddedViewRef<any>): void {
+    if (view.destroyed) {
+      return;
+    }
+    view.destroy();
   }
 }

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/renderer/hot-dynamic-renderer-component.service.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/renderer/hot-dynamic-renderer-component.service.ts
@@ -260,7 +260,9 @@ export class DynamicComponentService {
    * @param properties - Context object providing properties to be used within the template.
    * @returns The created EmbeddedViewRef so the caller can track and destroy it later.
    */
-  private attachTemplateToElement(template: TemplateRef<any>, tdEl: HTMLTableCellElement, properties: BaseRendererParametersObject): EmbeddedViewRef<any> {
+  private attachTemplateToElement(
+    template: TemplateRef<any>, tdEl: HTMLTableCellElement, properties: BaseRendererParametersObject
+  ): EmbeddedViewRef<any> {
     const embeddedView: EmbeddedViewRef<any> = template.createEmbeddedView({
       $implicit: properties.value,
       ...properties,

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/renderer/hot-dynamic-renderer-component.service.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/renderer/hot-dynamic-renderer-component.service.ts
@@ -88,6 +88,21 @@ export class DynamicComponentService {
   private readonly _tdComponentRefs = new WeakMap<HTMLTableCellElement, ComponentRef<any>>();
   private readonly _tdEmbeddedViews = new WeakMap<HTMLTableCellElement, EmbeddedViewRef<any>>();
 
+  // Per-instance registries of every renderer ref/view currently attached to the application.
+  // The WeakMaps above only allow per-TD lookup; these sets let us sweep refs whose TD was dropped
+  // from Handsontable's virtual viewport (scrolling, updateData), which would otherwise stay
+  // attached to ApplicationRef forever and leak both memory and change-detection work.
+  //
+  // The registries are scoped per Handsontable instance (not one global set) because this service
+  // is a root singleton shared by every <hot-table>. A global sweep would scan the cells of every
+  // table on the page on each `afterViewRender`, i.e. on every scroll frame of any one of them.
+  // Keying by instance bounds each sweep to the cells of the table that actually re-rendered.
+  private readonly _instanceComponentRefs = new WeakMap<Handsontable.Core, Set<ComponentRef<any>>>();
+  private readonly _instanceEmbeddedViews = new WeakMap<Handsontable.Core, Set<EmbeddedViewRef<any>>>();
+
+  // Instances we already wired the sweep hook into, so each instance is hooked at most once.
+  private readonly _hookedInstances = new WeakSet<Handsontable.Core>();
+
   constructor(private appRef: ApplicationRef, private environmentInjector: EnvironmentInjector) {}
 
   /**
@@ -131,27 +146,15 @@ export class DynamicComponentService {
 
       baseRenderer.apply(this, rendererParameters);
 
-      // Destroy previously attached component/view for this cell before replacing its content.
-      const prevRef = this._tdComponentRefs.get(td);
-      if (prevRef) {
-        this.destroyComponent(prevRef);
-        this._tdComponentRefs.delete(td);
-      }
-      const prevView = this._tdEmbeddedViews.get(td);
-      if (prevView) {
-        prevView.destroy();
-        this._tdEmbeddedViews.delete(td);
-      }
-
-      td.innerHTML = '';
+      this.registerSweepHook(instance);
 
       if (isTemplateRef(component)) {
+        // Embedded views carry a per-render context, so they are always rebuilt.
+        this.replaceCellContent(instance, td);
         const embeddedView = this.attachTemplateToElement(component, td, properties);
-        this._tdEmbeddedViews.set(td, embeddedView);
+        this.trackEmbeddedView(instance, td, embeddedView);
       } else if (isHotCellRendererComponent(component)) {
-        const componentRef = this.createComponent(component, properties);
-        this.attachComponentToElement(componentRef, td);
-        this._tdComponentRefs.set(td, componentRef);
+        this.renderComponent(td, component, properties);
       } else {
         console.warn(INVALID_RENDERER_WARNING);
       }
@@ -202,24 +205,15 @@ export class DynamicComponentService {
 
       Object.assign(cellProperties, { rendererProps: componentProps });
 
-      // Destroy previously attached component/view for this cell before replacing its content.
-      const prevRef = this._tdComponentRefs.get(td);
-      if (prevRef) {
-        this.destroyComponent(prevRef);
-        this._tdComponentRefs.delete(td);
-      }
-      const prevView = this._tdEmbeddedViews.get(td);
-      if (prevView) {
-        prevView.destroy();
-        this._tdEmbeddedViews.delete(td);
-      }
+      // Apply the base renderer so the TD gets the same base classes/attributes as the
+      // createRendererFromComponent path (rendererFactory itself does not call it).
+      const rendererParameters: BaseRendererParameters = [instance, td, row, column, prop, value, cellProperties];
+      baseRenderer.apply(this, rendererParameters);
 
-      td.innerHTML = '';
+      this.registerSweepHook(instance);
 
       if (isAdvancedHotCellRendererComponent(component)) {
-        const componentRef = this.createComponent(component, properties);
-        this.attachComponentToElement(componentRef, td);
-        this._tdComponentRefs.set(td, componentRef);
+        this.renderComponent(td, component, properties);
       } else {
         console.warn(INVALID_ADVANCED_RENDERER_WARNING);
       }
@@ -236,20 +230,149 @@ export class DynamicComponentService {
    * Must be called before destroying the Handsontable instance to prevent Angular component leaks.
    *
    * @param container - The root DOM element of the Handsontable instance.
+   * @param instance - The Handsontable instance whose registries should be torn down. When omitted
+   *   (e.g. test stubs), only refs reachable through TDs still in the container are destroyed.
    */
-  cleanupContainer(container: HTMLElement): void {
+  cleanupContainer(container: HTMLElement, instance?: Handsontable.Core): void {
+    const compRefs = instance ? this._instanceComponentRefs.get(instance) : undefined;
+    const embViews = instance ? this._instanceEmbeddedViews.get(instance) : undefined;
+
     container.querySelectorAll<HTMLTableCellElement>('td').forEach((td) => {
       const compRef = this._tdComponentRefs.get(td);
       if (compRef) {
         this.destroyComponent(compRef);
         this._tdComponentRefs.delete(td);
+        compRefs?.delete(compRef);
       }
       const embView = this._tdEmbeddedViews.get(td);
       if (embView) {
         embView.destroy();
         this._tdEmbeddedViews.delete(td);
+        embViews?.delete(embView);
       }
     });
+
+    // The loop above only reaches TDs still present in the container. Refs for cells already
+    // dropped from the viewport (but not yet swept) would otherwise be orphaned once this
+    // instance's afterViewRender hook is gone after destroy. Tear down whatever is left and drop
+    // the per-instance registries so a repeated cleanup call is a no-op. (Entries removed in the
+    // loop above are already gone from these sets, so nothing is destroyed twice.)
+    compRefs?.forEach((ref) => this.destroyComponent(ref));
+    embViews?.forEach((view) => view.destroy());
+
+    if (instance) {
+      this._instanceComponentRefs.delete(instance);
+      this._instanceEmbeddedViews.delete(instance);
+    }
+  }
+
+  /**
+   * Registers a one-time `afterViewRender` hook on the given Handsontable instance that sweeps
+   * renderer refs whose TD is no longer connected to the document. Handsontable recycles a pool of
+   * TD elements while virtualizing rows; cells that leave the viewport are never re-rendered, so
+   * without this sweep their Angular components stay attached to ApplicationRef and leak.
+   *
+   * Guarded against instances that do not expose `addHook` (e.g. test stubs).
+   *
+   * @param instance - The Handsontable instance whose render cycle drives the sweep.
+   */
+  private registerSweepHook(instance: Handsontable.Core): void {
+    if (this._hookedInstances.has(instance) || typeof (instance as any)?.addHook !== 'function') {
+      return;
+    }
+
+    this._hookedInstances.add(instance);
+    instance.addHook('afterViewRender', () => this.sweepDetachedViews(instance));
+  }
+
+  /**
+   * Destroys every renderer ref/view tracked for the given instance whose root node is no longer
+   * attached to the document.
+   *
+   * @param instance - The Handsontable instance whose registries should be swept.
+   */
+  private sweepDetachedViews(instance: Handsontable.Core): void {
+    const compRefs = this._instanceComponentRefs.get(instance);
+    compRefs?.forEach((ref) => {
+      if (!this.isViewConnected(ref.hostView as EmbeddedViewRef<any>)) {
+        this.destroyComponent(ref);
+        compRefs.delete(ref);
+      }
+    });
+
+    const embViews = this._instanceEmbeddedViews.get(instance);
+    embViews?.forEach((view) => {
+      if (!this.isViewConnected(view)) {
+        view.destroy();
+        embViews.delete(view);
+      }
+    });
+  }
+
+  /**
+   * @returns True if any of the view's root nodes is still connected to the document.
+   */
+  private isViewConnected(view: EmbeddedViewRef<any>): boolean {
+    return view.rootNodes.some((node: Node) => !!node?.isConnected);
+  }
+
+  /**
+   * Destroys the renderer ref/view previously attached to a cell and clears the cell content,
+   * so a fresh renderer can take over the TD without leaking the old one.
+   *
+   * @param instance - The Handsontable instance owning the cell, used to update its registries.
+   * @param td - The table cell whose previous content should be torn down.
+   */
+  private replaceCellContent(instance: Handsontable.Core, td: HTMLTableCellElement): void {
+    const prevRef = this._tdComponentRefs.get(td);
+    if (prevRef) {
+      this.destroyComponent(prevRef);
+      this._tdComponentRefs.delete(td);
+      this._instanceComponentRefs.get(instance)?.delete(prevRef);
+    }
+
+    const prevView = this._tdEmbeddedViews.get(td);
+    if (prevView) {
+      prevView.destroy();
+      this._tdEmbeddedViews.delete(td);
+      this._instanceEmbeddedViews.get(instance)?.delete(prevView);
+    }
+
+    td.innerHTML = '';
+  }
+
+  /**
+   * Tracks a component ref both by its TD (for fast replacement) and in the instance registry
+   * (for sweeping and full teardown).
+   */
+  private trackComponentRef(
+    instance: Handsontable.Core, td: HTMLTableCellElement, ref: ComponentRef<any>
+  ): void {
+    this._tdComponentRefs.set(td, ref);
+    this.registryFor(this._instanceComponentRefs, instance).add(ref);
+  }
+
+  /**
+   * Tracks an embedded view both by its TD (for fast replacement) and in the instance registry
+   * (for sweeping and full teardown).
+   */
+  private trackEmbeddedView(
+    instance: Handsontable.Core, td: HTMLTableCellElement, view: EmbeddedViewRef<any>
+  ): void {
+    this._tdEmbeddedViews.set(td, view);
+    this.registryFor(this._instanceEmbeddedViews, instance).add(view);
+  }
+
+  /**
+   * Returns the per-instance registry set for the given instance, creating it on first use.
+   */
+  private registryFor<T>(registry: WeakMap<Handsontable.Core, Set<T>>, instance: Handsontable.Core): Set<T> {
+    let set = registry.get(instance);
+    if (!set) {
+      set = new Set<T>();
+      registry.set(instance, set);
+    }
+    return set;
   }
 
   /**
@@ -291,14 +414,57 @@ export class DynamicComponentService {
       environmentInjector: this.environmentInjector,
     });
 
-    (Object.keys(rendererParameters) as (keyof BaseRendererParametersObject)[]).forEach((key) => {
-      componentRef.setInput(key, rendererParameters[key]);
-    });
+    this.applyInputs(componentRef, rendererParameters);
     componentRef.changeDetectorRef.detectChanges();
 
     this.appRef.attachView(componentRef.hostView);
 
     return componentRef;
+  }
+
+  /**
+   * Renders an Angular component into the given cell, recycling the component already attached to
+   * the TD when it is of the same type. Handsontable recycles its pool of TD elements heavily while
+   * virtualizing rows, so recreating an Angular component on every re-render would cause needless
+   * teardown/instantiation churn and GC pressure. When the type matches we only refresh the inputs.
+   *
+   * @param td - The target table cell.
+   * @param component - The renderer component type to render.
+   * @param properties - The renderer parameters to feed as component inputs.
+   */
+  private renderComponent<T extends HotCellRendererBase>(
+    td: HTMLTableCellElement,
+    component: Type<T>,
+    properties: BaseRendererParametersObject
+  ): void {
+    const prevRef = this._tdComponentRefs.get(td);
+
+    if (
+      prevRef &&
+      prevRef.componentType === component &&
+      this.isViewConnected(prevRef.hostView as EmbeddedViewRef<any>)
+    ) {
+      this.applyInputs(prevRef, properties);
+      prevRef.changeDetectorRef.detectChanges();
+      return;
+    }
+
+    this.replaceCellContent(properties.instance, td);
+    const componentRef = this.createComponent(component, properties);
+    this.attachComponentToElement(componentRef, td);
+    this.trackComponentRef(properties.instance, td, componentRef);
+  }
+
+  /**
+   * Assigns every renderer parameter as an input on the given component ref.
+   *
+   * @param componentRef - The component ref whose inputs should be set.
+   * @param rendererParameters - The renderer parameters to assign.
+   */
+  private applyInputs<T>(componentRef: ComponentRef<T>, rendererParameters: BaseRendererParametersObject): void {
+    (Object.keys(rendererParameters) as (keyof BaseRendererParametersObject)[]).forEach((key) => {
+      componentRef.setInput(key, rendererParameters[key]);
+    });
   }
 
   /**
@@ -308,8 +474,9 @@ export class DynamicComponentService {
    * @param container - The target DOM element to which the component's root node will be appended.
    */
   private attachComponentToElement<T>(componentRef: ComponentRef<T>, container: HTMLElement): void {
-    const domElem = (componentRef.hostView as EmbeddedViewRef<T>).rootNodes[0] as HTMLElement;
-    container.appendChild(domElem);
+    (componentRef.hostView as EmbeddedViewRef<T>).rootNodes.forEach((node) => {
+      container.appendChild(node);
+    });
   }
 
   /**

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/renderer/hot-dynamic-renderer-component.service.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/renderer/hot-dynamic-renderer-component.service.ts
@@ -14,8 +14,6 @@ import { HotCellRendererBase } from './hot-cell-renderer-base.directive';
 import { HotCellRendererComponent } from './hot-cell-renderer.component';
 import { HotCellRendererAdvancedComponent } from './hot-cell-renderer-advanced.component';
 
-type BaseRendererParameters = Parameters<BaseRenderer>;
-
 export const INVALID_RENDERER_WARNING =
   'The provided renderer component was not recognized as a valid custom renderer. ' +
   'It must either extend HotCellRendererComponent or be a valid TemplateRef. ' +
@@ -38,6 +36,12 @@ interface BaseRendererParametersObject {
   value: any;
   cellProperties: Handsontable.CellProperties;
 }
+
+// Renderer component inputs, listed once at module scope so the per-cell render path can set them
+// without allocating a fresh key array (via Object.keys) on every cell of every render frame.
+const RENDERER_INPUT_KEYS: (keyof BaseRendererParametersObject)[] = [
+  'instance', 'td', 'row', 'col', 'prop', 'value', 'cellProperties',
+];
 
 /**
  * Type guard that checks if the given object is a TemplateRef.
@@ -140,11 +144,9 @@ export class DynamicComponentService {
         cellProperties,
       };
 
-      Object.assign(cellProperties, { rendererProps: componentProps });
+      (cellProperties as any).rendererProps = componentProps;
 
-      const rendererParameters: BaseRendererParameters = [instance, td, row, col, prop, value, cellProperties];
-
-      baseRenderer.apply(this, rendererParameters);
+      baseRenderer.call(this, instance, td, row, col, prop, value, cellProperties);
 
       this.registerSweepHook(instance);
 
@@ -203,12 +205,11 @@ export class DynamicComponentService {
         cellProperties,
       };
 
-      Object.assign(cellProperties, { rendererProps: componentProps });
+      (cellProperties as any).rendererProps = componentProps;
 
       // Apply the base renderer so the TD gets the same base classes/attributes as the
       // createRendererFromComponent path (rendererFactory itself does not call it).
-      const rendererParameters: BaseRendererParameters = [instance, td, row, column, prop, value, cellProperties];
-      baseRenderer.apply(this, rendererParameters);
+      baseRenderer.call(this, instance, td, row, column, prop, value, cellProperties);
 
       this.registerSweepHook(instance);
 
@@ -462,7 +463,7 @@ export class DynamicComponentService {
    * @param rendererParameters - The renderer parameters to assign.
    */
   private applyInputs<T>(componentRef: ComponentRef<T>, rendererParameters: BaseRendererParametersObject): void {
-    (Object.keys(rendererParameters) as (keyof BaseRendererParametersObject)[]).forEach((key) => {
+    RENDERER_INPUT_KEYS.forEach((key) => {
       componentRef.setInput(key, rendererParameters[key]);
     });
   }

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/services/hot-global-config.service.spec.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/services/hot-global-config.service.spec.ts
@@ -3,6 +3,7 @@ import {
   HotGlobalConfigService,
   HotGlobalConfig,
   NON_COMMERCIAL_LICENSE,
+  PredefinedTheme,
   ThemeName, HOT_GLOBAL_CONFIG,
 } from './hot-global-config.service';
 import { take } from 'rxjs/operators';
@@ -82,20 +83,23 @@ describe('HotGlobalConfigService', () => {
 
     // Listen to config$ and take three emissions:
     // one for the initial default config and two for the updated config.
-    service.config$.pipe(take(3)).subscribe((config) => {
-      if (emitCounter === 0) {
-        expect(config.license).toEqual(undefined);
-      } else if (emitCounter === 1) {
-        expect(config.license).toEqual('updated-license--1');
-      } else  if (emitCounter === 2) {
-        expect(config.license).toEqual('updated-license--2');
-      } else {
-        throw new Error('Unexpected 4th call');
-      }
-      emitCounter++;
-
-      expect(config.license).toEqual('updated-license--2');
-      done();
+    service.config$.pipe(take(3)).subscribe({
+      next: (config) => {
+        if (emitCounter === 0) {
+          expect(config.license).toEqual(undefined);
+        } else if (emitCounter === 1) {
+          expect(config.license).toEqual('updated-license--1');
+        } else if (emitCounter === 2) {
+          expect(config.license).toEqual('updated-license--2');
+        } else {
+          throw new Error('Unexpected 4th call');
+        }
+        emitCounter++;
+      },
+      complete: () => {
+        expect(emitCounter).toBe(3);
+        done();
+      },
     });
 
     // invoke update method after observable is set to receive an events
@@ -152,5 +156,21 @@ describe('HotGlobalConfigService', () => {
     expect(config.themeName).toEqual('ht-theme-main');
     expect(config.language).toEqual('en-US');
     expect(config.layoutDirection).toEqual('ltr');
+  });
+});
+
+describe('PredefinedTheme enum', () => {
+  it('should expose all expected theme name constants', () => {
+    expect(PredefinedTheme.Main).toBe('ht-theme-main');
+    expect(PredefinedTheme.MainDark).toBe('ht-theme-main-dark');
+    expect(PredefinedTheme.MainDarkAuto).toBe('ht-theme-main-dark-auto');
+    expect(PredefinedTheme.Horizon).toBe('ht-theme-horizon');
+    expect(PredefinedTheme.HorizonDark).toBe('ht-theme-horizon-dark');
+    expect(PredefinedTheme.HorizonDarkAuto).toBe('ht-theme-horizon-dark-auto');
+  });
+
+  it('should be usable as themeName in HotGlobalConfig', () => {
+    TestBed.inject(HotGlobalConfigService).setConfig({ themeName: PredefinedTheme.Horizon });
+    expect(TestBed.inject(HotGlobalConfigService).getConfig().themeName).toBe('ht-theme-horizon');
   });
 });

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/services/hot-settings-resolver.service.spec.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/services/hot-settings-resolver.service.spec.ts
@@ -171,7 +171,8 @@ describe('HotSettingsResolver', () => {
     const settings = mergedSettings.columns[0] as ColumnSettingsInternal;
     expect(settings.editor).toBeDefined();
     expect(typeof settings.editor).toBe('function');
-    expect(settings._editorComponentReference).toBeUndefined();
+    // ComponentRef is stored so ngOnDestroy can destroy it — advanced editors do NOT set _environmentInjector.
+    expect(settings._editorComponentReference.instance instanceof TestEditorAdvancedComponent).toBe(true);
     expect(settings._environmentInjector).toBeUndefined();
   });
 
@@ -256,6 +257,34 @@ describe('HotSettingsResolver', () => {
     expect(mergedSettings.columns[0].validator.length).toBe(2);
   });
 
+  it('should invoke the custom validator and pass its result to the HOT callback', () => {
+    // validator must have .length === 1 to be recognised as a custom (single-arg) validator
+    const mergedSettings: GridSettings = {
+      columns: [{ validator: (v: any): boolean => v === 'valid' } as ColumnSettings],
+    };
+    service.applyCustomSettings(mergedSettings);
+
+    const wrappedValidator = mergedSettings.columns[0].validator as Function;
+    const callback = jest.fn();
+    wrappedValidator('valid', callback);
+
+    expect(callback).toHaveBeenCalledWith(true);
+  });
+
+  it('should pass false to HOT callback when custom validator returns false', () => {
+    const mergedSettings: GridSettings = {
+      columns: [{ validator: (v: any): boolean => v !== null } as ColumnSettings],
+    };
+    service.applyCustomSettings(mergedSettings);
+
+    const wrappedValidator = mergedSettings.columns[0].validator as Function;
+    const cbFalse = jest.fn();
+
+    wrappedValidator(null, cbFalse);
+
+    expect(cbFalse).toHaveBeenCalledWith(false);
+  });
+
   it('should handle multiple columns with different renderer render modes', () => {
     const mergedSettings: GridSettings = {
       columns: [
@@ -298,8 +327,81 @@ describe('HotSettingsResolver', () => {
     const settings1 = mergedSettings.columns[1] as ColumnSettingsInternal;
     const settings2 = mergedSettings.columns[2] as ColumnSettingsInternal;
 
-    expect(settings0._editorComponentReference).toBeUndefined();
+    expect(settings0._editorComponentReference).toBeDefined(); // advanced — tracked for cleanup
     expect(settings1._editorComponentReference).toBeDefined();
     expect(settings2._editorComponentReference).toBeDefined();
+  });
+
+  describe('null / undefined columns edge cases', () => {
+    it('should not throw when columns is null', () => {
+      const mergedSettings = { columns: null } as unknown as GridSettings;
+
+      expect(() => service.applyCustomSettings(mergedSettings)).not.toThrow();
+      expect(dynamicComponentService.createRendererFromComponent).not.toHaveBeenCalled();
+      expect(dynamicComponentService.createRendererWithFactory).not.toHaveBeenCalled();
+    });
+
+    it('should not throw when columns is undefined', () => {
+      const mergedSettings: GridSettings = {};
+
+      expect(() => service.applyCustomSettings(mergedSettings)).not.toThrow();
+      expect(dynamicComponentService.createRendererFromComponent).not.toHaveBeenCalled();
+    });
+
+    it('should not throw when columns is an empty array', () => {
+      const mergedSettings: GridSettings = { columns: [] };
+
+      expect(() => service.applyCustomSettings(mergedSettings)).not.toThrow();
+      expect(dynamicComponentService.createRendererFromComponent).not.toHaveBeenCalled();
+    });
+
+    it('should not throw when settings object itself has no keys', () => {
+      expect(() => service.applyCustomSettings({} as GridSettings)).not.toThrow();
+    });
+  });
+
+  describe('wrapHooksInNgZone', () => {
+    it('should leave array-valued hooks unchanged and not wrap them', () => {
+      const fn1 = jest.fn();
+      const fn2 = jest.fn();
+      const hookArray = [fn1, fn2];
+      const mergedSettings = { afterChange: hookArray } as unknown as GridSettings;
+
+      service.applyCustomSettings(mergedSettings);
+
+      expect((mergedSettings as any).afterChange).toBe(hookArray);
+    });
+
+    it('should wrap function hooks so they run inside NgZone', () => {
+      const hookFn = jest.fn().mockReturnValue('result');
+      const mergedSettings = { afterChange: hookFn } as unknown as GridSettings;
+
+      service.applyCustomSettings(mergedSettings);
+
+      const wrappedHook = (mergedSettings as any).afterChange;
+      expect(wrappedHook).not.toBe(hookFn);
+      expect(typeof wrappedHook).toBe('function');
+    });
+
+    it('should not wrap non-hook keys', () => {
+      const mergedSettings = { readOnly: true } as GridSettings;
+
+      service.applyCustomSettings(mergedSettings);
+
+      expect((mergedSettings as any).readOnly).toBe(true);
+    });
+
+    it('should not double-wrap a hook when applyCustomSettings is called twice with the same settings object', () => {
+      const hookFn = jest.fn();
+      const mergedSettings = { afterChange: hookFn } as unknown as GridSettings;
+
+      service.applyCustomSettings(mergedSettings);
+      const wrappedOnce = (mergedSettings as any).afterChange;
+
+      service.applyCustomSettings(mergedSettings);
+      const wrappedTwice = (mergedSettings as any).afterChange;
+
+      expect(wrappedTwice).toBe(wrappedOnce);
+    });
   });
 });

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/services/hot-settings-resolver.service.spec.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/services/hot-settings-resolver.service.spec.ts
@@ -378,6 +378,28 @@ describe('HotSettingsResolver', () => {
       expect((second.columns[0] as ColumnSettingsInternal)._editorComponentReference).not.toBe(firstRef);
     });
 
+    it('should recycle by index + editor type even when a different logical column occupies the index', () => {
+      // Regression guard: reordering/reshuffling columns so a *different* logical column (different
+      // `data`/`title`) lands on an index with the same editor type must still recycle the ref. This
+      // is safe because the editor is re-prepared per edit (BaseEditorAdapter.prepare re-reads the ref
+      // from the current column meta and re-applies the full cell context on open) — no stale editor
+      // state leaks to the cell. See HotSettingsResolver.reusableEditorRef.
+      const first = service.applyCustomSettings({
+        columns: [{ data: 'firstName', editor: TestEditorComponent } as ColumnSettings],
+      });
+      const firstRef = (first.columns[0] as ColumnSettingsInternal)._editorComponentReference;
+      const destroySpy = jest.spyOn(firstRef, 'destroy');
+
+      // Same index, same editor type, but a different logical column (different `data`).
+      const second = service.applyCustomSettings(
+        { columns: [{ data: 'lastName', editor: TestEditorComponent } as ColumnSettings] },
+        first.columns as ColumnSettings[]
+      );
+
+      expect((second.columns[0] as ColumnSettingsInternal)._editorComponentReference).toBe(firstRef);
+      expect(destroySpy).not.toHaveBeenCalled();
+    });
+
     it('should not recycle when no previous columns are provided', () => {
       const first = service.applyCustomSettings({ columns: [{ editor: TestEditorComponent } as ColumnSettings] });
       const firstRef = (first.columns[0] as ColumnSettingsInternal)._editorComponentReference;

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/services/hot-settings-resolver.service.spec.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/services/hot-settings-resolver.service.spec.ts
@@ -378,26 +378,38 @@ describe('HotSettingsResolver', () => {
       expect((second.columns[0] as ColumnSettingsInternal)._editorComponentReference).not.toBe(firstRef);
     });
 
-    it('should recycle by index + editor type even when a different logical column occupies the index', () => {
-      // Regression guard: reordering/reshuffling columns so a *different* logical column (different
-      // `data`/`title`) lands on an index with the same editor type must still recycle the ref. This
-      // is safe because the editor is re-prepared per edit (BaseEditorAdapter.prepare re-reads the ref
-      // from the current column meta and re-applies the full cell context on open) — no stale editor
-      // state leaks to the cell. See HotSettingsResolver.reusableEditorRef.
+    it('should recycle when the same logical column (same `data`) keeps the index', () => {
       const first = service.applyCustomSettings({
         columns: [{ data: 'firstName', editor: TestEditorComponent } as ColumnSettings],
       });
       const firstRef = (first.columns[0] as ColumnSettingsInternal)._editorComponentReference;
       const destroySpy = jest.spyOn(firstRef, 'destroy');
 
-      // Same index, same editor type, but a different logical column (different `data`).
       const second = service.applyCustomSettings(
-        { columns: [{ data: 'lastName', editor: TestEditorComponent } as ColumnSettings] },
+        { columns: [{ data: 'firstName', editor: TestEditorComponent } as ColumnSettings] },
         first.columns as ColumnSettings[]
       );
 
       expect((second.columns[0] as ColumnSettingsInternal)._editorComponentReference).toBe(firstRef);
       expect(destroySpy).not.toHaveBeenCalled();
+    });
+
+    it('should build a fresh editor when a different logical column (different `data`) takes the index', () => {
+      // Defensive guard: when columns are reordered/shortened so a *different* logical column lands on
+      // an index with the same editor type, we must NOT carry the previous column's component over —
+      // otherwise a custom editor that caches column-specific config at construction could leak stale
+      // state into the new cell. See HotSettingsResolver.reusableEditorRef.
+      const first = service.applyCustomSettings({
+        columns: [{ data: 'firstName', editor: TestEditorComponent } as ColumnSettings],
+      });
+      const firstRef = (first.columns[0] as ColumnSettingsInternal)._editorComponentReference;
+
+      const second = service.applyCustomSettings(
+        { columns: [{ data: 'lastName', editor: TestEditorComponent } as ColumnSettings] },
+        first.columns as ColumnSettings[]
+      );
+
+      expect((second.columns[0] as ColumnSettingsInternal)._editorComponentReference).not.toBe(firstRef);
     });
 
     it('should not recycle when no previous columns are provided', () => {

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/services/hot-settings-resolver.service.spec.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/services/hot-settings-resolver.service.spec.ts
@@ -149,12 +149,30 @@ describe('HotSettingsResolver', () => {
       ],
     };
     const envInjector = TestBed.inject(EnvironmentInjector);
-    service.applyCustomSettings(mergedSettings);
+    const result = service.applyCustomSettings(mergedSettings);
 
-    const settings = mergedSettings.columns[0] as ColumnSettingsInternal;
+    const settings = result.columns[0] as ColumnSettingsInternal;
     expect(settings.editor).toBeDefined();
     expect(settings._editorComponentReference.instance instanceof TestEditorComponent).toBe(true);
     expect(settings._environmentInjector).toBe(envInjector);
+  });
+
+  it('should not mutate the input settings object or its columns', () => {
+    const column = { editor: TestEditorComponent, validator: (v: any) => true } as ColumnSettings;
+    const inputSettings: GridSettings = { afterChange: jest.fn(), columns: [column] };
+
+    const result = service.applyCustomSettings(inputSettings);
+
+    // Returned (cloned) object carries the resolved editor/validator/hook.
+    const resolvedColumn = result.columns[0] as ColumnSettingsInternal;
+    expect(resolvedColumn._editorComponentReference).toBeDefined();
+    expect(result).not.toBe(inputSettings);
+    expect(result.columns[0]).not.toBe(column);
+
+    // Input object and its column are left untouched, so they can be safely reused across tables.
+    expect((inputSettings.columns[0] as ColumnSettingsInternal)._editorComponentReference).toBeUndefined();
+    expect(inputSettings.columns[0].editor).toBe(TestEditorComponent);
+    expect((column.validator as Function).length).toBe(1);
   });
 
   it('should use advanced editor mode when editor is Advanced component', () => {
@@ -166,9 +184,9 @@ describe('HotSettingsResolver', () => {
       ],
     };
 
-    service.applyCustomSettings(mergedSettings);
+    const result = service.applyCustomSettings(mergedSettings);
 
-    const settings = mergedSettings.columns[0] as ColumnSettingsInternal;
+    const settings = result.columns[0] as ColumnSettingsInternal;
     expect(settings.editor).toBeDefined();
     expect(typeof settings.editor).toBe('function');
     // ComponentRef is stored so ngOnDestroy can destroy it — advanced editors do NOT set _environmentInjector.
@@ -186,9 +204,9 @@ describe('HotSettingsResolver', () => {
     };
     const envInjector = TestBed.inject(EnvironmentInjector);
 
-    service.applyCustomSettings(mergedSettings);
+    const result = service.applyCustomSettings(mergedSettings);
 
-    const settings = mergedSettings.columns[0] as ColumnSettingsInternal;
+    const settings = result.columns[0] as ColumnSettingsInternal;
     expect(settings.editor).toBeDefined();
     expect(settings._editorComponentReference.instance instanceof TestEditorComponent).toBe(true);
     expect(settings._environmentInjector).toBe(envInjector);
@@ -224,9 +242,9 @@ describe('HotSettingsResolver', () => {
     const mergedSettings: GridSettings = {
       columns: [{ validator: (value: any) => true } as ColumnSettings],
     };
-    service.applyCustomSettings(mergedSettings);
-    expect(mergedSettings.columns[0].validator).toBeDefined();
-    expect(mergedSettings.columns[0].validator.length).toBe(2);
+    const result = service.applyCustomSettings(mergedSettings);
+    expect(result.columns[0].validator).toBeDefined();
+    expect(result.columns[0].validator.length).toBe(2);
   });
 
   it('should not update column validator when validator is string', () => {
@@ -262,9 +280,9 @@ describe('HotSettingsResolver', () => {
     const mergedSettings: GridSettings = {
       columns: [{ validator: (v: any): boolean => v === 'valid' } as ColumnSettings],
     };
-    service.applyCustomSettings(mergedSettings);
+    const result = service.applyCustomSettings(mergedSettings);
 
-    const wrappedValidator = mergedSettings.columns[0].validator as Function;
+    const wrappedValidator = result.columns[0].validator as Function;
     const callback = jest.fn();
     wrappedValidator('valid', callback);
 
@@ -275,9 +293,9 @@ describe('HotSettingsResolver', () => {
     const mergedSettings: GridSettings = {
       columns: [{ validator: (v: any): boolean => v !== null } as ColumnSettings],
     };
-    service.applyCustomSettings(mergedSettings);
+    const result = service.applyCustomSettings(mergedSettings);
 
-    const wrappedValidator = mergedSettings.columns[0].validator as Function;
+    const wrappedValidator = result.columns[0].validator as Function;
     const cbFalse = jest.fn();
 
     wrappedValidator(null, cbFalse);
@@ -321,15 +339,53 @@ describe('HotSettingsResolver', () => {
       ],
     };
 
-    service.applyCustomSettings(mergedSettings);
+    const result = service.applyCustomSettings(mergedSettings);
 
-    const settings0 = mergedSettings.columns[0] as ColumnSettingsInternal;
-    const settings1 = mergedSettings.columns[1] as ColumnSettingsInternal;
-    const settings2 = mergedSettings.columns[2] as ColumnSettingsInternal;
+    const settings0 = result.columns[0] as ColumnSettingsInternal;
+    const settings1 = result.columns[1] as ColumnSettingsInternal;
+    const settings2 = result.columns[2] as ColumnSettingsInternal;
 
     expect(settings0._editorComponentReference).toBeDefined(); // advanced — tracked for cleanup
     expect(settings1._editorComponentReference).toBeDefined();
     expect(settings2._editorComponentReference).toBeDefined();
+  });
+
+  describe('editor component recycling across settings changes', () => {
+    it('should recycle the editor component when the same editor type sits at the same index', () => {
+      const first = service.applyCustomSettings({ columns: [{ editor: TestEditorComponent } as ColumnSettings] });
+      const firstRef = (first.columns[0] as ColumnSettingsInternal)._editorComponentReference;
+      const destroySpy = jest.spyOn(firstRef, 'destroy');
+
+      const second = service.applyCustomSettings(
+        { columns: [{ editor: TestEditorComponent } as ColumnSettings] },
+        first.columns as ColumnSettings[]
+      );
+
+      // Same component instance is reused, not recreated or destroyed.
+      expect((second.columns[0] as ColumnSettingsInternal)._editorComponentReference).toBe(firstRef);
+      expect(destroySpy).not.toHaveBeenCalled();
+    });
+
+    it('should create a fresh editor component when the editor type at the index changes', () => {
+      const first = service.applyCustomSettings({ columns: [{ editor: TestEditorComponent } as ColumnSettings] });
+      const firstRef = (first.columns[0] as ColumnSettingsInternal)._editorComponentReference;
+
+      const second = service.applyCustomSettings(
+        { columns: [{ editor: TestEditorAdvancedComponent } as ColumnSettings] },
+        first.columns as ColumnSettings[]
+      );
+
+      expect((second.columns[0] as ColumnSettingsInternal)._editorComponentReference).not.toBe(firstRef);
+    });
+
+    it('should not recycle when no previous columns are provided', () => {
+      const first = service.applyCustomSettings({ columns: [{ editor: TestEditorComponent } as ColumnSettings] });
+      const firstRef = (first.columns[0] as ColumnSettingsInternal)._editorComponentReference;
+
+      const second = service.applyCustomSettings({ columns: [{ editor: TestEditorComponent } as ColumnSettings] });
+
+      expect((second.columns[0] as ColumnSettingsInternal)._editorComponentReference).not.toBe(firstRef);
+    });
   });
 
   describe('null / undefined columns edge cases', () => {
@@ -376,9 +432,9 @@ describe('HotSettingsResolver', () => {
       const hookFn = jest.fn().mockReturnValue('result');
       const mergedSettings = { afterChange: hookFn } as unknown as GridSettings;
 
-      service.applyCustomSettings(mergedSettings);
+      const result = service.applyCustomSettings(mergedSettings);
 
-      const wrappedHook = (mergedSettings as any).afterChange;
+      const wrappedHook = (result as any).afterChange;
       expect(wrappedHook).not.toBe(hookFn);
       expect(typeof wrappedHook).toBe('function');
     });
@@ -391,15 +447,16 @@ describe('HotSettingsResolver', () => {
       expect((mergedSettings as any).readOnly).toBe(true);
     });
 
-    it('should not double-wrap a hook when applyCustomSettings is called twice with the same settings object', () => {
+    it('should not double-wrap a hook that is already zone-wrapped', () => {
       const hookFn = jest.fn();
-      const mergedSettings = { afterChange: hookFn } as unknown as GridSettings;
 
-      service.applyCustomSettings(mergedSettings);
-      const wrappedOnce = (mergedSettings as any).afterChange;
+      const firstResult = service.applyCustomSettings({ afterChange: hookFn } as unknown as GridSettings);
+      const wrappedOnce = (firstResult as any).afterChange;
+      expect(wrappedOnce).not.toBe(hookFn);
 
-      service.applyCustomSettings(mergedSettings);
-      const wrappedTwice = (mergedSettings as any).afterChange;
+      // Feeding the already-wrapped hook back in must not wrap it a second time.
+      const secondResult = service.applyCustomSettings({ afterChange: wrappedOnce } as unknown as GridSettings);
+      const wrappedTwice = (secondResult as any).afterChange;
 
       expect(wrappedTwice).toBe(wrappedOnce);
     });

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/services/hot-settings-resolver.service.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/services/hot-settings-resolver.service.ts
@@ -11,6 +11,7 @@ import { HotCellRendererAdvancedComponent } from '../renderer/hot-cell-renderer-
 import { HotCellEditorAdvancedComponent } from '../editor/hot-cell-editor-advanced.component';
 
 const AVAILABLE_HOOKS_SET = new Set<string>(Handsontable.hooks.getRegistered());
+const HOT_ZONE_WRAPPED = Symbol('hotZoneWrapped');
 
 /**
  * Service to resolve and apply custom settings for Handsontable settings object.
@@ -37,7 +38,7 @@ export class HotSettingsResolver {
 
     this.wrapHooksInNgZone(mergedSettings);
 
-    return (mergedSettings as GridSettingsInternal) ?? {};
+    return mergedSettings as GridSettingsInternal;
   }
 
   /**
@@ -48,13 +49,19 @@ export class HotSettingsResolver {
   private wrapHooksInNgZone(settings: GridSettings): void {
     const ngZone = this.ngZone;
 
-    AVAILABLE_HOOKS_SET.forEach((key) => {
+    // Iterate only the keys actually present in settings instead of all ~100 registered HOT hooks.
+    Object.keys(settings).forEach((key) => {
+      if (!AVAILABLE_HOOKS_SET.has(key)) {
+        return;
+      }
       const option = settings[key];
 
-      if (typeof option === 'function') {
-        settings[key] = function (...args: any) {
+      if (typeof option === 'function' && !(option as any)[HOT_ZONE_WRAPPED]) {
+        const wrapped = function (...args: any) {
           return ngZone.run(() => option.apply(this, args));
         };
+        (wrapped as any)[HOT_ZONE_WRAPPED] = true;
+        settings[key] = wrapped;
       }
     });
   }
@@ -98,6 +105,8 @@ export class HotSettingsResolver {
           const component = createComponent(cellSettings.editor, {
             environmentInjector: this.environmentInjector,
           });
+          // Store the ref so ngOnDestroy / ngOnChanges can destroy it alongside basic editors.
+          cellSettings['_editorComponentReference'] = component;
           cellSettings.editor = FactoryEditorAdapter(component);
         } else {
           const component = createComponent(cellSettings.editor as Type<HotCellEditorComponent<any>>, {

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/services/hot-settings-resolver.service.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/services/hot-settings-resolver.service.ts
@@ -1,8 +1,8 @@
-import { createComponent, EnvironmentInjector, Injectable, NgZone, TemplateRef, Type } from '@angular/core';
+import { ComponentRef, createComponent, EnvironmentInjector, Injectable, NgZone, TemplateRef, Type } from '@angular/core';
 import { DynamicComponentService } from '../renderer/hot-dynamic-renderer-component.service';
 import { BaseEditorAdapter } from '../editor/base-editor-adapter';
 import { GridSettings, GridSettingsInternal } from '../models/grid-settings';
-import { CustomValidatorFn, ColumnSettings } from '../models/column-settings';
+import { CustomValidatorFn, ColumnSettings, ColumnSettingsInternal } from '../models/column-settings';
 import { HotCellRendererComponent } from '../renderer/hot-cell-renderer.component';
 import { HotCellEditorComponent } from '../editor/hot-cell-editor.component';
 import Handsontable from 'handsontable/base';
@@ -27,13 +27,25 @@ export class HotSettingsResolver {
   /**
    * Applies custom settings to the provided GridSettings.
    * @param settings The original grid settings.
+   * @param previousColumns The previously resolved columns (from the prior settings cycle). When
+   *   supplied, an editor component already created for a column whose editor type is unchanged is
+   *   recycled instead of being recreated, avoiding needless Angular component teardown/rebuild.
    * @returns The merged grid settings with custom settings applied.
    */
-  applyCustomSettings(settings: GridSettings): GridSettingsInternal {
-    const mergedSettings: GridSettings = settings;
+  applyCustomSettings(settings: GridSettings, previousColumns?: ColumnSettings[]): GridSettingsInternal {
+    // Shallow-clone the user settings (and each column) before mutating. Otherwise we would
+    // write generated renderers/editors and `_editorComponentReference` straight onto the
+    // caller's objects. When the same settings/columns are shared across two <hot-table>
+    // instances, the second resolution would overwrite the first instance's editor refs,
+    // leaking them and cross-wiring a single editor component between tables.
+    const mergedSettings: GridSettings = { ...settings };
+
+    if (Array.isArray(mergedSettings.columns)) {
+      mergedSettings.columns = mergedSettings.columns.map((column) => ({ ...column }));
+    }
 
     this.updateColumnRendererForGivenCustomRenderer(mergedSettings);
-    this.updateColumnEditorForGivenCustomEditor(mergedSettings);
+    this.updateColumnEditorForGivenCustomEditor(mergedSettings, previousColumns);
     this.updateColumnValidatorForGivenCustomValidator(mergedSettings);
 
     this.wrapHooksInNgZone(mergedSettings);
@@ -91,32 +103,64 @@ export class HotSettingsResolver {
 
   /**
    * Updates the column editor for columns with a custom editor.
+   *
+   * Iterates by original column index (not a filtered subset) so each column can be matched against
+   * the column at the same index in `previousColumns` for editor-component recycling.
+   *
    * @param mergedSettings The merged grid settings.
+   * @param previousColumns The previously resolved columns, used to recycle editor components.
    */
-  private updateColumnEditorForGivenCustomEditor(mergedSettings: GridSettings): void {
+  private updateColumnEditorForGivenCustomEditor(mergedSettings: GridSettings, previousColumns?: ColumnSettings[]): void {
     if (!Array.isArray(mergedSettings?.columns)) {
       return;
     }
 
-    (mergedSettings?.columns as ColumnSettings[])
-      ?.filter((settings) => this.isEditorComponentRefType(settings.editor) || this.isAdvancedEditorComponentRefType(settings.editor))
-      ?.forEach((cellSettings) => {
-        if (this.isAdvancedEditorComponentRefType(cellSettings.editor)) {
-          const component = createComponent(cellSettings.editor, {
-            environmentInjector: this.environmentInjector,
-          });
-          // Store the ref so ngOnDestroy / ngOnChanges can destroy it alongside basic editors.
-          cellSettings['_editorComponentReference'] = component;
-          cellSettings.editor = FactoryEditorAdapter(component);
-        } else {
-          const component = createComponent(cellSettings.editor as Type<HotCellEditorComponent<any>>, {
-            environmentInjector: this.environmentInjector,
-          });
-          cellSettings['_editorComponentReference'] = component;
-          cellSettings['_environmentInjector'] = this.environmentInjector;
-          cellSettings.editor = BaseEditorAdapter;
-        }
+    (mergedSettings.columns as ColumnSettings[]).forEach((cellSettings, index) => {
+      const isAdvanced = this.isAdvancedEditorComponentRefType(cellSettings.editor);
+      const isBasic = this.isEditorComponentRefType(cellSettings.editor);
+
+      if (!isAdvanced && !isBasic) {
+        return;
+      }
+
+      const editorType = cellSettings.editor as Type<HotCellEditorComponent<any>> | Type<HotCellEditorAdvancedComponent<any>>;
+      const reusableRef = this.reusableEditorRef(previousColumns?.[index], editorType);
+      const internalSettings = cellSettings as ColumnSettingsInternal;
+
+      // Recycle the editor component from the previous settings cycle when the same editor type
+      // sits at the same column index. Recreating it on every settings change would tear down and
+      // rebuild an Angular component (and its DOM/internal state) for no reason. The reused ref is
+      // carried into the new column; HotTableComponent.ngOnChanges detects it by identity and skips
+      // destroying it.
+      const component = reusableRef ?? createComponent(editorType as Type<any>, {
+        environmentInjector: this.environmentInjector,
       });
+
+      internalSettings._editorComponentReference = component as ComponentRef<HotCellEditorComponent<any>>;
+
+      if (isAdvanced) {
+        cellSettings.editor = FactoryEditorAdapter(component as ComponentRef<HotCellEditorAdvancedComponent<any>>);
+      } else {
+        internalSettings._environmentInjector = this.environmentInjector;
+        cellSettings.editor = BaseEditorAdapter;
+      }
+    });
+  }
+
+  /**
+   * Returns the previous column's editor component ref when it can be reused for the new editor
+   * type (same component type at the same index), or `undefined` to signal a fresh component is
+   * needed.
+   *
+   * @param previousColumn The column at the same index in the previous settings cycle.
+   * @param editorType The editor component type requested for the new column.
+   */
+  private reusableEditorRef(
+    previousColumn: ColumnSettings | undefined,
+    editorType: Type<unknown>
+  ): ComponentRef<any> | undefined {
+    const previousRef = (previousColumn as ColumnSettingsInternal | undefined)?._editorComponentReference;
+    return previousRef && previousRef.componentType === editorType ? previousRef : undefined;
   }
 
   /**

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/services/hot-settings-resolver.service.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/services/hot-settings-resolver.service.ts
@@ -152,6 +152,15 @@ export class HotSettingsResolver {
    * type (same component type at the same index), or `undefined` to signal a fresh component is
    * needed.
    *
+   * Matching by index + component type (rather than by logical column identity) is intentional and
+   * safe even when columns are reordered, shortened, or otherwise reshuffled so a different logical
+   * column lands on an index. A Handsontable editor is not per-cell rendered state: it is a single
+   * on-demand component that `BaseEditorAdapter`/`FactoryEditorAdapter` re-prepare on every edit —
+   * `prepare()` re-reads the ref from the *current* column meta and `applyPropsToEditor()` re-applies
+   * the full cell context (value, row, column, prop, cellProperties) on each `open()`. Reusing a
+   * same-type ref for a different logical column is therefore observationally identical to creating a
+   * fresh one, minus the Angular teardown/rebuild — no stale editor state leaks to the cell.
+   *
    * @param previousColumn The column at the same index in the previous settings cycle.
    * @param editorType The editor component type requested for the new column.
    */

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/services/hot-settings-resolver.service.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/services/hot-settings-resolver.service.ts
@@ -124,14 +124,14 @@ export class HotSettingsResolver {
       }
 
       const editorType = cellSettings.editor as Type<HotCellEditorComponent<any>> | Type<HotCellEditorAdvancedComponent<any>>;
-      const reusableRef = this.reusableEditorRef(previousColumns?.[index], editorType);
+      const reusableRef = this.reusableEditorRef(previousColumns?.[index], cellSettings, editorType);
       const internalSettings = cellSettings as ColumnSettingsInternal;
 
       // Recycle the editor component from the previous settings cycle when the same editor type
-      // sits at the same column index. Recreating it on every settings change would tear down and
-      // rebuild an Angular component (and its DOM/internal state) for no reason. The reused ref is
-      // carried into the new column; HotTableComponent.ngOnChanges detects it by identity and skips
-      // destroying it.
+      // sits at the same column index AND the same logical column (by `data`) still occupies it.
+      // Recreating it on every settings change would tear down and rebuild an Angular component
+      // (and its DOM/internal state) for no reason. The reused ref is carried into the new column;
+      // HotTableComponent.ngOnChanges detects it by identity and skips destroying it.
       const component = reusableRef ?? createComponent(editorType as Type<any>, {
         environmentInjector: this.environmentInjector,
       });
@@ -148,28 +148,41 @@ export class HotSettingsResolver {
   }
 
   /**
-   * Returns the previous column's editor component ref when it can be reused for the new editor
-   * type (same component type at the same index), or `undefined` to signal a fresh component is
-   * needed.
+   * Returns the previous column's editor component ref when it can be reused for the new column, or
+   * `undefined` to signal a fresh component is needed.
    *
-   * Matching by index + component type (rather than by logical column identity) is intentional and
-   * safe even when columns are reordered, shortened, or otherwise reshuffled so a different logical
-   * column lands on an index. A Handsontable editor is not per-cell rendered state: it is a single
-   * on-demand component that `BaseEditorAdapter`/`FactoryEditorAdapter` re-prepare on every edit —
-   * `prepare()` re-reads the ref from the *current* column meta and `applyPropsToEditor()` re-applies
-   * the full cell context (value, row, column, prop, cellProperties) on each `open()`. Reusing a
-   * same-type ref for a different logical column is therefore observationally identical to creating a
-   * fresh one, minus the Angular teardown/rebuild — no stale editor state leaks to the cell.
+   * A ref is only recycled when, at the same index, both the editor component type AND the logical
+   * column identity (its `data` binding) are unchanged. The component-type check alone would already
+   * be functionally safe — a Handsontable editor is not per-cell rendered state but a single
+   * on-demand component that `BaseEditorAdapter`/`FactoryEditorAdapter` re-prepare on every edit
+   * (`prepare()` re-reads the ref from the *current* column meta and `applyPropsToEditor()` re-applies
+   * the full cell context on each `open()`). The extra `data` check is a defensive guard: when columns
+   * are reordered/shortened so a *different* logical column lands on an index, we build a fresh editor
+   * rather than carry the previous column's instance over, so no custom editor that caches
+   * column-specific config at construction can leak stale state into the new cell.
    *
    * @param previousColumn The column at the same index in the previous settings cycle.
+   * @param currentColumn The column now occupying this index.
    * @param editorType The editor component type requested for the new column.
    */
   private reusableEditorRef(
     previousColumn: ColumnSettings | undefined,
+    currentColumn: ColumnSettings,
     editorType: Type<unknown>
   ): ComponentRef<any> | undefined {
     const previousRef = (previousColumn as ColumnSettingsInternal | undefined)?._editorComponentReference;
-    return previousRef && previousRef.componentType === editorType ? previousRef : undefined;
+
+    if (!previousRef || previousRef.componentType !== editorType) {
+      return undefined;
+    }
+
+    // Same logical column still occupies this index. Columns without a `data` binding are identified
+    // purely by position, so two `undefined` data values compare equal and recycle as before.
+    const sameLogicalColumn =
+      (previousColumn as Handsontable.ColumnSettings | undefined)?.data ===
+      (currentColumn as Handsontable.ColumnSettings).data;
+
+    return sameLogicalColumn ? previousRef : undefined;
   }
 
   /**

--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/test-helpers/create-spreadsheet-data.spec.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/test-helpers/create-spreadsheet-data.spec.ts
@@ -1,0 +1,82 @@
+import { createSpreadsheetData, spreadsheetColumnLabel } from './create-spreadsheet-data';
+
+describe('spreadsheetColumnLabel', () => {
+  it('should return "A" for index 0', () => {
+    expect(spreadsheetColumnLabel(0)).toBe('A');
+  });
+
+  it('should return "B" for index 1', () => {
+    expect(spreadsheetColumnLabel(1)).toBe('B');
+  });
+
+  it('should return "Z" for index 25', () => {
+    expect(spreadsheetColumnLabel(25)).toBe('Z');
+  });
+
+  it('should return "AA" for index 26', () => {
+    expect(spreadsheetColumnLabel(26)).toBe('AA');
+  });
+
+  it('should return "AB" for index 27', () => {
+    expect(spreadsheetColumnLabel(27)).toBe('AB');
+  });
+
+  it('should return "AZ" for index 51', () => {
+    expect(spreadsheetColumnLabel(51)).toBe('AZ');
+  });
+
+  it('should return "BA" for index 52', () => {
+    expect(spreadsheetColumnLabel(52)).toBe('BA');
+  });
+
+  it('should return "ZZ" for index 701', () => {
+    expect(spreadsheetColumnLabel(701)).toBe('ZZ');
+  });
+});
+
+describe('createSpreadsheetData', () => {
+  it('should create 100x4 array with default arguments', () => {
+    const data = createSpreadsheetData();
+    expect(data.length).toBe(100);
+    expect(data[0].length).toBe(4);
+  });
+
+  it('should create array with specified dimensions', () => {
+    const data = createSpreadsheetData(3, 3);
+    expect(data.length).toBe(3);
+    expect(data[0].length).toBe(3);
+  });
+
+  it('should generate correct Excel-like cell labels', () => {
+    const data = createSpreadsheetData(3, 3);
+    expect(data[0][0]).toBe('A1');
+    expect(data[0][1]).toBe('B1');
+    expect(data[0][2]).toBe('C1');
+    expect(data[1][0]).toBe('A2');
+    expect(data[2][0]).toBe('A3');
+    expect(data[2][2]).toBe('C3');
+  });
+
+  it('should return empty array when rows=0', () => {
+    const data = createSpreadsheetData(0, 5);
+    expect(data.length).toBe(0);
+  });
+
+  it('should return rows of empty arrays when columns=0', () => {
+    const data = createSpreadsheetData(3, 0);
+    expect(data.length).toBe(3);
+    data.forEach(row => expect(row.length).toBe(0));
+  });
+
+  it('should generate "AA1" for column index 26', () => {
+    const data = createSpreadsheetData(1, 27);
+    expect(data[0][26]).toBe('AA1');
+  });
+
+  it('should produce unique values for each cell', () => {
+    const data = createSpreadsheetData(5, 5);
+    const allCells = data.flat();
+    const uniqueCells = new Set(allCells);
+    expect(uniqueCells.size).toBe(allCells.length);
+  });
+});


### PR DESCRIPTION
### Context
Fixed 7 bugs: subscription leak in FactoryEditorAdapter, missing EmbeddedViewRef cleanup in renderer service, repeated registerRenderer calls, wrong constructor.name usage, incorrect prop type (string
  instead of string | number), missing this.container null guard in ngOnDestroy, and editor component destroyed before HOT could close it.

Added unit tests for all major components and services: HotCellEditorComponent, HotCellEditorAdvancedComponent, HotCellRendererComponent, HotCellRendererAdvancedComponent, HotTableComponent,
  HotTableModule, FactoryEditorAdapter, BaseEditorAdapter, DynamicComponentService, HotSettingsResolver, and HotGlobalConfigService. Coverage includes happy paths, edge cases, memory management,
  and lifecycle hooks.



### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. DEV-1223

### Affected project(s):
- [ ] `handsontable`
- [x] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.


ClickUp task: https://app.clickup.com/t/9015210959/DEV-1223

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core table destroy, settings updates, and dynamic renderer/editor lifecycle; behavior is heavily tested but mistakes could cause edit crashes or renderer leaks in production grids.
> 
> **Overview**
> Fixes **memory and lifecycle bugs** in the Angular wrapper around custom **editors** and **cell renderers**, and adds broad **unit test** coverage.
> 
> **Editors:** `BaseEditorAdapter` and `FactoryEditorAdapter` now **unsubscribe** `finishEdit`/`cancelEdit` on destroy and reuse a shared `cleanupSubscriptions` path; editor APIs use **null-safe** access when `prepare()` has not run or the Angular injector is missing. **`HotTableComponent`** defers destroying column editor `ComponentRef`s until after `updateSettings` (so HOT can close an active editor), **recycles** refs when the resolver reuses them, and only tears down refs left behind when columns actually change.
> 
> **Settings:** `HotSettingsResolver` **shallow-clones** settings/columns before attaching generated renderers/editors (avoids cross-table corruption), **recycles** editor components when the same editor type and column `data` stay at the same index, and improves **NgZone** hook wrapping (no double-wrap). Shared **`HotCellEditorBase`** / **`HotCellRendererBase`** consolidate inputs; renderer `prop` is typed as `string | number`.
> 
> **Renderers:** `DynamicComponentService` tracks component and template refs per cell and per HOT instance, **destroys** prior content on re-render, **recycles** same-type components on connected TDs, sweeps **detached** views on `afterViewRender` (virtual scroll), exposes **`cleanupContainer`** (called from `ngOnDestroy`), registers renderers **once** via `component.name`, and tears down **embedded views** safely with idempotent destroy guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fc6f936446b535216e93586f7a9b1721e7e99d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->