### PR TITLE
DEV-1777: Improve Walkontable scroll performance

### DIFF
--- a/.changelogs/12659.json
+++ b/.changelogs/12659.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Improved scroll performance by caching overlay alignment calculations and using native visibility checks.",
+  "type": "changed",
+  "issueOrPR": 12659,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/src/core/core.ts
+++ b/handsontable/src/3rdparty/walkontable/src/core/core.ts
@@ -69,7 +69,7 @@ export default class Walkontable extends CoreAbstract {
    * Destroy instance.
    */
   destroy() {
-    (this.wtTable as MasterTable).destroy();
+    this.wtTable.destroy();
     super.destroy();
   }
 

--- a/handsontable/src/3rdparty/walkontable/src/core/core.ts
+++ b/handsontable/src/3rdparty/walkontable/src/core/core.ts
@@ -66,6 +66,14 @@ export default class Walkontable extends CoreAbstract {
   }
 
   /**
+   * Destroy instance.
+   */
+  destroy() {
+    (this.wtTable as MasterTable).destroy();
+    super.destroy();
+  }
+
+  /**
    * Gets the overlay instance by its name.
    *
    * @param {'inline_start'|'top'|'top_inline_start_corner'|'bottom'|'bottom_inline_start_corner'} overlayName The overlay name.

--- a/handsontable/src/3rdparty/walkontable/src/table.ts
+++ b/handsontable/src/3rdparty/walkontable/src/table.ts
@@ -1301,6 +1301,11 @@ class Table {
 
     return rowHeaderWidth;
   }
+
+  /**
+   * Destroys the table instance. Overridden by MasterTable to release DOM resources.
+   */
+  destroy() {}
 }
 
 export default Table;

--- a/handsontable/src/3rdparty/walkontable/src/table/master.ts
+++ b/handsontable/src/3rdparty/walkontable/src/table/master.ts
@@ -22,6 +22,9 @@ import { mixin } from './../../../../helpers/object';
 interface TrimmingContainerCache {
   trimmingOffsetWidth: number;
   trimmingOffsetHeight: number;
+  trimmingScrollWidth: number;
+  trimmingScrollHeight: number;
+  trimmingOverflow: string;
   hiderOffsetHeight: number;
   hiderOffsetWidth: number;
   holderWidth: string;
@@ -133,12 +136,18 @@ class MasterTable extends Table {
       // `alignOverlaysWithTrimmingContainer()` call in the autocomplete editor.
       const trimmingOffsetWidth = trimmingElement.offsetWidth;
       const trimmingOffsetHeight = trimmingElement.offsetHeight;
+      const trimmingScrollWidth = trimmingElement.scrollWidth;
+      const trimmingScrollHeight = trimmingElement.scrollHeight;
+      const trimmingOverflow = getStyle(trimmingElement, 'overflow', rootWindow) ?? '';
       const hiderOffsetHeight = this.hider.offsetHeight;
       const hiderOffsetWidth = this.hider.offsetWidth;
       const cache = this.#trimmingCache;
       const cacheValid = cache !== null
         && cache.trimmingOffsetWidth === trimmingOffsetWidth
         && cache.trimmingOffsetHeight === trimmingOffsetHeight
+        && cache.trimmingScrollWidth === trimmingScrollWidth
+        && cache.trimmingScrollHeight === trimmingScrollHeight
+        && cache.trimmingOverflow === trimmingOverflow
         && cache.hiderOffsetHeight === hiderOffsetHeight
         && cache.hiderOffsetWidth === hiderOffsetWidth;
 
@@ -160,15 +169,13 @@ class MasterTable extends Table {
         // whenever a ResizeObserver callback has nulled the cache.
         const trimmingElementParent = trimmingElement.parentElement;
         const trimmingHeight = getStyle(trimmingElement, 'height', rootWindow);
-        const trimmingOverflow = getStyle(trimmingElement, 'overflow', rootWindow);
         const holderStyle = this.holder.style;
-        const { scrollWidth, scrollHeight } = trimmingElement;
-        let width = trimmingElement.offsetWidth;
-        let height = trimmingElement.offsetHeight;
+        let width = trimmingOffsetWidth;
+        let height = trimmingOffsetHeight;
         const overflowValues = ['auto', 'hidden', 'scroll', 'clip'];
         // getStyle() may return a compound value (e.g. 'auto hidden') when overflow-x and
         // overflow-y are set independently. Split on whitespace so each token is checked.
-        const hasScrollOverflow = (trimmingOverflow ?? '').split(' ').some(v => overflowValues.includes(v));
+        const hasScrollOverflow = trimmingOverflow.split(' ').some(v => overflowValues.includes(v));
         let useAutoHeight = (trimmingHeight === 'auto');
 
         if (trimmingElementParent && hasScrollOverflow) {
@@ -227,8 +234,8 @@ class MasterTable extends Table {
           }
         }
 
-        height = Math.min(height, scrollHeight);
-        width = Math.min(width, scrollWidth);
+        height = Math.min(height, trimmingScrollHeight);
+        width = Math.min(width, trimmingScrollWidth);
 
         const holderHeight = useAutoHeight ? 'auto' : `${height}px`;
         const holderWidth = `${width}px`;
@@ -251,6 +258,9 @@ class MasterTable extends Table {
           this.#trimmingCache = {
             trimmingOffsetWidth,
             trimmingOffsetHeight,
+            trimmingScrollWidth,
+            trimmingScrollHeight,
+            trimmingOverflow,
             hiderOffsetHeight,
             hiderOffsetWidth,
             holderWidth,

--- a/handsontable/src/3rdparty/walkontable/src/table/master.ts
+++ b/handsontable/src/3rdparty/walkontable/src/table/master.ts
@@ -25,6 +25,7 @@ interface TrimmingContainerCache {
   trimmingScrollWidth: number;
   trimmingScrollHeight: number;
   trimmingOverflow: string;
+  trimmingHeight: string;
   hiderOffsetHeight: number;
   hiderOffsetWidth: number;
   holderWidth: string;
@@ -139,6 +140,7 @@ class MasterTable extends Table {
       const trimmingScrollWidth = trimmingElement.scrollWidth;
       const trimmingScrollHeight = trimmingElement.scrollHeight;
       const trimmingOverflow = getStyle(trimmingElement, 'overflow', rootWindow) ?? '';
+      const trimmingHeight = getStyle(trimmingElement, 'height', rootWindow) ?? '';
       const hiderOffsetHeight = this.hider.offsetHeight;
       const hiderOffsetWidth = this.hider.offsetWidth;
       const cache = this.#trimmingCache;
@@ -148,6 +150,7 @@ class MasterTable extends Table {
         && cache.trimmingScrollWidth === trimmingScrollWidth
         && cache.trimmingScrollHeight === trimmingScrollHeight
         && cache.trimmingOverflow === trimmingOverflow
+        && cache.trimmingHeight === trimmingHeight
         && cache.hiderOffsetHeight === hiderOffsetHeight
         && cache.hiderOffsetWidth === hiderOffsetWidth;
 
@@ -168,7 +171,6 @@ class MasterTable extends Table {
         // the first draw, whenever the fingerprint no longer matches, and
         // whenever a ResizeObserver callback has nulled the cache.
         const trimmingElementParent = trimmingElement.parentElement;
-        const trimmingHeight = getStyle(trimmingElement, 'height', rootWindow);
         const holderStyle = this.holder.style;
         let width = trimmingOffsetWidth;
         let height = trimmingOffsetHeight;
@@ -261,6 +263,7 @@ class MasterTable extends Table {
             trimmingScrollWidth,
             trimmingScrollHeight,
             trimmingOverflow,
+            trimmingHeight,
             hiderOffsetHeight,
             hiderOffsetWidth,
             holderWidth,

--- a/handsontable/src/3rdparty/walkontable/src/table/master.ts
+++ b/handsontable/src/3rdparty/walkontable/src/table/master.ts
@@ -11,12 +11,66 @@ import calculatedColumns from './mixin/calculatedColumns';
 import { mixin } from './../../../../helpers/object';
 
 /**
+ * Cached output of `alignOverlaysWithTrimmingContainer()` plus the input
+ * "fingerprint" — the dimensions that drive the output. The fast path applies
+ * the cached output only when the fingerprint still matches; otherwise it
+ * falls through to a fresh measurement. The fingerprint covers both the
+ * trimming container size (catches container resizes) and the hider size
+ * (catches synchronous content growth such as `loadData()` in the autocomplete
+ * dropdown, where the container stays fixed but the rendered rows expand).
+ */
+interface TrimmingContainerCache {
+  trimmingOffsetWidth: number;
+  trimmingOffsetHeight: number;
+  hiderOffsetHeight: number;
+  hiderOffsetWidth: number;
+  holderWidth: string;
+  holderHeight: string;
+  hasTableHeight: boolean;
+  hasTableWidth: boolean;
+}
+
+/**
  * Subclass of `Table` that provides the helper methods relevant to the master table (not overlays), implemented through mixins.
  *
  * @mixes calculatedRows
  * @mixes calculatedColumns
  */
 class MasterTable extends Table {
+  /**
+   * Output and input fingerprint of the last slow-path
+   * `alignOverlaysWithTrimmingContainer()` measurement. `null` when no valid
+   * cache is available — either before the first measurement or after an
+   * invalidation by a ResizeObserver callback. The fast path applies the
+   * cached output only when the fingerprint still matches the current DOM
+   * dimensions.
+   */
+  #trimmingCache: TrimmingContainerCache | null = null;
+  /**
+   * ResizeObserver attached to the trimming container referenced by
+   * `#observedTrimmingElement`. Fires asynchronously after the container's
+   * size changes and nulls `#trimmingCache` so the next draw re-measures.
+   * Acts as a defensive backstop — the synchronous fingerprint check at draw
+   * time catches the same changes, but the observer invalidates the cache
+   * eagerly, before the next draw is scheduled.
+   */
+  #trimmingContainerObserver: ResizeObserver | null = null;
+  /**
+   * ResizeObserver attached to `this.hider`. Fires asynchronously when
+   * rendered content drives the hider to a new size and nulls
+   * `#trimmingCache` so the next draw re-measures. Same backstop role as
+   * `#trimmingContainerObserver`.
+   */
+  #hiderObserver: ResizeObserver | null = null;
+  /**
+   * The trimming container currently observed by `#trimmingContainerObserver`.
+   * `alignOverlaysWithTrimmingContainer()` compares this reference against
+   * `getTrimmingContainer(this.wtRootElement)` on every draw to detect when
+   * the HOT instance has been reparented to a new scrollable ancestor, so the
+   * observers can be rebound to the new container.
+   */
+  #observedTrimmingElement: HTMLElement | null = null;
+
   /**
    * @param {TableDao} dataAccessObject The data access object.
    * @param {FacadeGetter} facadeGetter Function which return proper facade.
@@ -29,6 +83,13 @@ class MasterTable extends Table {
   }
 
   alignOverlaysWithTrimmingContainer() {
+    // The base-class constructor invokes this method before MasterTable's
+    // field initializers have run. Accessing a private field in that window
+    // throws; the brand check detects the pre-init call so the caching block
+    // can be skipped. The non-caching branches (window-trimming overflow
+    // reset and the trailing isVisible check) still run, matching the
+    // pre-DEV-1777 behaviour and the side effects callers depend on.
+    const fieldsInitialized = #trimmingCache in this;
     const trimmingElement = getTrimmingContainer(this.wtRootElement);
     const { rootWindow } = this.domBindings;
 
@@ -39,85 +100,166 @@ class MasterTable extends Table {
         this.holder.style.overflow = 'visible';
         this.wtRootElement.style.overflow = 'visible';
       }
-    } else {
-      const trimmingElementParent = trimmingElement.parentElement;
-      const trimmingHeight = getStyle(trimmingElement, 'height', rootWindow);
-      const trimmingOverflow = getStyle(trimmingElement, 'overflow', rootWindow);
-      const holderStyle = this.holder.style;
-      const { scrollWidth, scrollHeight } = trimmingElement;
-      let width = trimmingElement.offsetWidth;
-      let height = trimmingElement.offsetHeight;
-      const overflowValues = ['auto', 'hidden', 'scroll', 'clip'];
-      // getStyle() may return a compound value (e.g. 'auto hidden') when overflow-x and
-      // overflow-y are set independently. Split on whitespace so each token is checked.
-      const hasScrollOverflow = (trimmingOverflow ?? '').split(' ').some(v => overflowValues.includes(v));
-      let useAutoHeight = (trimmingHeight === 'auto');
+    } else if (fieldsInitialized) {
+      // Bind ResizeObservers on the first call, and re-bind on the rare draw
+      // where the trimming container has changed (HOT reparented in the DOM).
+      // Each rebind also nulls the cache, since the previous measurement was
+      // taken against a now-stale container reference.
+      if (this.#observedTrimmingElement !== trimmingElement) {
+        this.#trimmingContainerObserver?.disconnect();
+        this.#hiderObserver?.disconnect();
+        this.#trimmingCache = null;
+        this.#observedTrimmingElement = trimmingElement;
 
-      if (trimmingElementParent && hasScrollOverflow) {
-        const cloneNode = trimmingElement.cloneNode(false) as HTMLElement;
+        const invalidate = () => {
+          this.#trimmingCache = null;
+        };
+        const tcObserver = new ResizeObserver(invalidate);
 
-        // Before calculating the height of the trimming element, set overflow: auto to hide scrollbars.
-        // An issue occurred on Firefox, where an empty element with overflow: scroll returns an element height higher than 0px
-        // despite an empty content within.
-        cloneNode.style.overflow = 'auto';
-        // Issue #9545 shows problem with calculating height for HOT on Firefox while placing instance in some
-        // flex containers and setting overflow for some `div` section.
-        cloneNode.style.position = 'absolute';
-        // Reset border and padding so border-box sizing does not contribute to the measured height.
-        // Without this, a container with a visible border (e.g. border: 1px solid) produces
-        // cloneHeight = 2 even though it has no intrinsic height, preventing the zero-height
-        // detection that guards against the feedback-loop bug. See issue #3119.
-        cloneNode.style.border = '0';
-        cloneNode.style.padding = '0';
+        tcObserver.observe(trimmingElement);
+        this.#trimmingContainerObserver = tcObserver;
 
-        if (trimmingElement.nextElementSibling) {
-          trimmingElementParent.insertBefore(cloneNode, trimmingElement.nextElementSibling);
-        } else {
-          trimmingElementParent.appendChild(cloneNode);
-        }
+        const hoObserver = new ResizeObserver(invalidate);
 
-        const cloneHeight = parseInt(rootWindow.getComputedStyle(cloneNode).height, 10);
-
-        trimmingElementParent.removeChild(cloneNode);
-
-        if (cloneHeight === 0) {
-          height = 0;
-
-          // The trimming container has no intrinsic height — its size is driven entirely by
-          // its content (HOT instances). When overflow-y is non-scrollable (hidden/clip),
-          // the container cannot be scrolled vertically, so its height grows with content.
-          // Setting the holder to a fixed pixel value in this case creates a feedback loop
-          // when multiple HOT instances share the same parent, expanding it to the browser's
-          // CSS height limit (~2^25 px). Using 'auto' lets the holder size to its content
-          // (the hider element) and breaks the loop. When overflow-y is scrollable (auto/
-          // scroll), the container IS a vertical scroll viewport and height=0 correctly
-          // signals that it has no defined size. See issue #3119.
-          const computedStyle = rootWindow.getComputedStyle(trimmingElement);
-          const overflowX = computedStyle.overflowX;
-          const overflowY = computedStyle.overflowY;
-
-          // Only switch to auto-height for horizontal-scroll containers where:
-          // - overflow-x is scrollable (auto/scroll) — the container is intentionally wider than its content
-          // - overflow-y is non-scrollable (hidden/clip) — the container height is content-driven
-          // This is the exact pattern that triggers the height feedback loop (issue #3119).
-          // All-axis scroll/auto containers (overflow: scroll/auto) keep height=0 to correctly
-          // signal no defined size. Similarly, overflow: hidden on both axes keeps height=0.
-          if ((overflowX === 'auto' || overflowX === 'scroll') &&
-              (overflowY !== 'auto' && overflowY !== 'scroll')) {
-            useAutoHeight = true;
-          }
-        }
+        hoObserver.observe(this.hider);
+        this.#hiderObserver = hoObserver;
       }
 
-      height = Math.min(height, scrollHeight);
-      holderStyle.height = useAutoHeight ? 'auto' : `${height}px`;
+      // Fingerprint of the current trimming container and hider sizes. These
+      // are cheap reads on a pure-scroll draw (no pending layout invalidation),
+      // and they catch every synchronous DOM mutation that the async
+      // ResizeObserver callbacks would miss between renders in the same tick —
+      // for example `htEditor.loadData()` followed by an explicit
+      // `alignOverlaysWithTrimmingContainer()` call in the autocomplete editor.
+      const trimmingOffsetWidth = trimmingElement.offsetWidth;
+      const trimmingOffsetHeight = trimmingElement.offsetHeight;
+      const hiderOffsetHeight = this.hider.offsetHeight;
+      const hiderOffsetWidth = this.hider.offsetWidth;
+      const cache = this.#trimmingCache;
+      const cacheValid = cache !== null
+        && cache.trimmingOffsetWidth === trimmingOffsetWidth
+        && cache.trimmingOffsetHeight === trimmingOffsetHeight
+        && cache.hiderOffsetHeight === hiderOffsetHeight
+        && cache.hiderOffsetWidth === hiderOffsetWidth;
 
-      width = Math.min(width, scrollWidth);
-      holderStyle.width = `${width}px`;
+      if (cacheValid) {
+        // Fast path: apply cached measurements without the expensive
+        // cloneNode + getComputedStyle round-trip in the slow path. Taken on
+        // every scroll draw where the container and hider dimensions have not
+        // changed since the previous measurement.
+        const holderStyle = this.holder.style;
 
-      holderStyle.overflow = '';
-      this.hasTableHeight = holderStyle.height === 'auto' ? true : height > 0;
-      this.hasTableWidth = width > 0;
+        holderStyle.width = cache.holderWidth;
+        holderStyle.height = cache.holderHeight;
+        holderStyle.overflow = '';
+        this.hasTableHeight = cache.hasTableHeight;
+        this.hasTableWidth = cache.hasTableWidth;
+      } else {
+        // Slow path: full measurement of the trimming container. Runs on
+        // the first draw, whenever the fingerprint no longer matches, and
+        // whenever a ResizeObserver callback has nulled the cache.
+        const trimmingElementParent = trimmingElement.parentElement;
+        const trimmingHeight = getStyle(trimmingElement, 'height', rootWindow);
+        const trimmingOverflow = getStyle(trimmingElement, 'overflow', rootWindow);
+        const holderStyle = this.holder.style;
+        const { scrollWidth, scrollHeight } = trimmingElement;
+        let width = trimmingElement.offsetWidth;
+        let height = trimmingElement.offsetHeight;
+        const overflowValues = ['auto', 'hidden', 'scroll', 'clip'];
+        // getStyle() may return a compound value (e.g. 'auto hidden') when overflow-x and
+        // overflow-y are set independently. Split on whitespace so each token is checked.
+        const hasScrollOverflow = (trimmingOverflow ?? '').split(' ').some(v => overflowValues.includes(v));
+        let useAutoHeight = (trimmingHeight === 'auto');
+
+        if (trimmingElementParent && hasScrollOverflow) {
+          const cloneNode = trimmingElement.cloneNode(false) as HTMLElement;
+
+          // Before calculating the height of the trimming element, set overflow: auto to hide scrollbars.
+          // An issue occurred on Firefox, where an empty element with overflow: scroll returns an element height higher than 0px
+          // despite an empty content within.
+          cloneNode.style.overflow = 'auto';
+          // Issue #9545 shows problem with calculating height for HOT on Firefox while placing instance in some
+          // flex containers and setting overflow for some `div` section.
+          cloneNode.style.position = 'absolute';
+          // Reset border and padding so border-box sizing does not contribute to the measured height.
+          // Without this, a container with a visible border (e.g. border: 1px solid) produces
+          // cloneHeight = 2 even though it has no intrinsic height, preventing the zero-height
+          // detection that guards against the feedback-loop bug. See issue #3119.
+          cloneNode.style.border = '0';
+          cloneNode.style.padding = '0';
+
+          if (trimmingElement.nextElementSibling) {
+            trimmingElementParent.insertBefore(cloneNode, trimmingElement.nextElementSibling);
+          } else {
+            trimmingElementParent.appendChild(cloneNode);
+          }
+
+          const cloneHeight = parseInt(rootWindow.getComputedStyle(cloneNode).height, 10);
+
+          trimmingElementParent.removeChild(cloneNode);
+
+          if (cloneHeight === 0) {
+            height = 0;
+
+            // The trimming container has no intrinsic height — its size is driven entirely by
+            // its content (HOT instances). When overflow-y is non-scrollable (hidden/clip),
+            // the container cannot be scrolled vertically, so its height grows with content.
+            // Setting the holder to a fixed pixel value in this case creates a feedback loop
+            // when multiple HOT instances share the same parent, expanding it to the browser's
+            // CSS height limit (~2^25 px). Using 'auto' lets the holder size to its content
+            // (the hider element) and breaks the loop. When overflow-y is scrollable (auto/
+            // scroll), the container IS a vertical scroll viewport and height=0 correctly
+            // signals that it has no defined size. See issue #3119.
+            const computedStyle = rootWindow.getComputedStyle(trimmingElement);
+            const overflowX = computedStyle.overflowX;
+            const overflowY = computedStyle.overflowY;
+
+            // Only switch to auto-height for horizontal-scroll containers where:
+            // - overflow-x is scrollable (auto/scroll) — the container is intentionally wider than its content
+            // - overflow-y is non-scrollable (hidden/clip) — the container height is content-driven
+            // This is the exact pattern that triggers the height feedback loop (issue #3119).
+            // All-axis scroll/auto containers (overflow: scroll/auto) keep height=0 to correctly
+            // signal no defined size. Similarly, overflow: hidden on both axes keeps height=0.
+            if ((overflowX === 'auto' || overflowX === 'scroll') &&
+                (overflowY !== 'auto' && overflowY !== 'scroll')) {
+              useAutoHeight = true;
+            }
+          }
+        }
+
+        height = Math.min(height, scrollHeight);
+        width = Math.min(width, scrollWidth);
+
+        const holderHeight = useAutoHeight ? 'auto' : `${height}px`;
+        const holderWidth = `${width}px`;
+        const hasTableHeight = holderHeight === 'auto' ? true : height > 0;
+        const hasTableWidth = width > 0;
+
+        holderStyle.height = holderHeight;
+        holderStyle.width = holderWidth;
+        holderStyle.overflow = '';
+        this.hasTableHeight = hasTableHeight;
+        this.hasTableWidth = hasTableWidth;
+
+        // Skip caching transient zero-width states. When scrollWidth is 0
+        // (e.g. the dropdown HOT before content loads), `width` collapses to
+        // min(offsetWidth, 0) = 0. The fingerprint check would invalidate
+        // such a cache on the next draw anyway, but suppressing the write
+        // here avoids one wasted fast-path application before the next slow
+        // measurement.
+        if (width > 0) {
+          this.#trimmingCache = {
+            trimmingOffsetWidth,
+            trimmingOffsetHeight,
+            hiderOffsetHeight,
+            hiderOffsetWidth,
+            holderWidth,
+            holderHeight,
+            hasTableHeight,
+            hasTableWidth,
+          };
+        }
+      }
     }
 
     this.isTableVisible = isVisible(this.TABLE);
@@ -142,6 +284,20 @@ class MasterTable extends Table {
       }
       wtViewport.hasOversizedColumnHeadersMarked[overlayName] = true;
     }
+  }
+
+  /**
+   * Disconnects the ResizeObservers and drops cache references so the
+   * MasterTable instance, the trimming container, and the hider can be
+   * garbage-collected after Walkontable is destroyed.
+   */
+  destroy() {
+    this.#trimmingContainerObserver?.disconnect();
+    this.#hiderObserver?.disconnect();
+    this.#trimmingCache = null;
+    this.#trimmingContainerObserver = null;
+    this.#hiderObserver = null;
+    this.#observedTrimmingElement = null;
   }
 }
 

--- a/handsontable/src/3rdparty/walkontable/test/spec/table/table/master.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/table/table/master.spec.js
@@ -1,0 +1,245 @@
+describe('MasterTable.alignOverlaysWithTrimmingContainer', () => {
+  describe('with overflow:hidden trimming container', () => {
+    const debug = false;
+
+    beforeEach(function() {
+      this.$wrapper = $('<div></div>').addClass('handsontable').css({ overflow: 'hidden' });
+      this.$wrapper.width(300).height(200);
+      this.$container = $('<div></div>');
+      this.$table = $('<table></table>').addClass('htCore');
+      this.$wrapper.append(this.$container);
+      this.$container.append(this.$table);
+      this.$wrapper.appendTo('body');
+      createDataArray(20, 4);
+    });
+
+    afterEach(function() {
+      if (!debug) {
+        $('.wtHolder').remove();
+      }
+      this.$wrapper.remove();
+      this.wotInstance.destroy();
+    });
+
+    it('should set holder width and height from trimming container dimensions on first draw', async() => {
+      const wt = walkontable({
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
+      });
+
+      wt.draw();
+
+      expect(wt.wtTable.holder.style.width).toBe('300px');
+      expect(wt.wtTable.holder.style.height).toBe('200px');
+    });
+
+    // alignOverlaysWithTrimmingContainer() runs before render() each draw, so the hider
+    // height seen on draw N is the post-render height from draw N-1. The fingerprint
+    // stabilises only after two draws. The fast path is verified on the third draw.
+    it('should not run the slow-path measurement on a repeated draw when dimensions are unchanged', async() => {
+      const wt = walkontable({
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
+      });
+
+      wt.draw(); // draw 1 — hider grows from 0 after render
+      wt.draw(); // draw 2 — fingerprint stabilises
+
+      let cloneCallCount = 0;
+
+      spyOn(spec().$wrapper[0], 'cloneNode').and.callFake(function(...args) {
+        cloneCallCount += 1;
+
+        return HTMLElement.prototype.cloneNode.apply(this, args);
+      });
+
+      wt.draw(); // draw 3 — must hit the fast path
+
+      expect(cloneCallCount).toBe(0);
+    });
+
+    it('should update holder width when trimming container is resized horizontally', async() => {
+      const wt = walkontable({
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
+      });
+
+      wt.draw();
+
+      spec().$wrapper.width(500);
+      wt.draw();
+
+      expect(wt.wtTable.holder.style.width).toBe('500px');
+    });
+
+    it('should update holder height when trimming container is resized vertically', async() => {
+      const wt = walkontable({
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
+      });
+
+      wt.draw();
+
+      spec().$wrapper.height(350);
+      wt.draw();
+
+      expect(wt.wtTable.holder.style.height).toBe('350px');
+    });
+
+    it('should re-run the slow path when hider grows due to added rows', async() => {
+      createDataArray(3, 4);
+
+      const wt = walkontable({
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
+      });
+
+      wt.draw(); // draw 1 — hider grows from 0 to 3-row height after render
+      wt.draw(); // draw 2 — fingerprint stabilises
+
+      // alignOverlaysWithTrimmingContainer() runs before render(), so the hider height
+      // in the fingerprint is always one draw behind. Draw 3 still sees the old hider
+      // height; draw 4 sees the new height and triggers the slow path.
+      createDataArray(50, 4);
+      wt.draw(); // draw 3 — render expands hider; fingerprint still on old cache
+
+      let slowPathRan = false;
+
+      spyOn(spec().$wrapper[0], 'cloneNode').and.callFake(function(...args) {
+        slowPathRan = true;
+
+        return HTMLElement.prototype.cloneNode.apply(this, args);
+      });
+
+      wt.draw(); // draw 4 — fingerprint misses on new hider height
+
+      expect(slowPathRan).toBe(true);
+    });
+  });
+
+  // A CSS-only overflow toggle changes useAutoHeight without altering box dimensions.
+  // Without the trimmingOverflow fingerprint field the fast path returns a stale
+  // holderHeight, re-triggering issue #3119.
+  describe('with zero-intrinsic-height container — overflow fingerprint (DEV-1777)', () => {
+    const debug = false;
+
+    beforeEach(function() {
+      this.$outerWrapper = $('<div></div>').css({
+        position: 'relative',
+        overflow: 'hidden',
+        width: '400px',
+      });
+      this.$container = $('<div></div>');
+      this.$table = $('<table></table>').addClass('htCore');
+
+      this.$outerWrapper.append(this.$container.append(this.$table));
+      this.$outerWrapper.appendTo('body');
+
+      createDataArray(5, 4);
+    });
+
+    afterEach(function() {
+      if (!debug) {
+        $('.wtHolder').remove();
+      }
+      this.$outerWrapper.remove();
+      this.wotInstance.destroy();
+    });
+
+    it('should set holder height to "auto" when overflow-x is scroll and overflow-y is hidden', async() => {
+      // Exact pattern that triggers the #3119 feedback loop. holder must not be fixed
+      // at a pixel value that drives the zero-height container to expand.
+      spec().$outerWrapper.css({ 'overflow-x': 'scroll', 'overflow-y': 'hidden' });
+
+      const wt = walkontable({
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
+      }, spec().$table[0]);
+
+      wt.draw();
+
+      expect(wt.wtTable.holder.style.height).toBe('auto');
+    });
+
+    it('should keep holder height at "0px" when overflow:hidden is applied to both axes', async() => {
+      // Not a scroll viewport — no feedback-loop risk, height=0 is correct.
+      const wt = walkontable({
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
+      }, spec().$table[0]);
+
+      wt.draw();
+
+      expect(wt.wtTable.holder.style.height).toBe('0px');
+    });
+
+    it('should keep holder height at "0px" when overflow:scroll is applied to both axes', async() => {
+      // All-axis scroll viewport with no intrinsic height — height=0 signals no defined
+      // size. useAutoHeight must not trigger.
+      spec().$outerWrapper.css({ overflow: 'scroll' });
+
+      const wt = walkontable({
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
+      }, spec().$table[0]);
+
+      wt.draw();
+
+      expect(wt.wtTable.holder.style.height).toBe('0px');
+    });
+
+    it('should update holder height from "0px" to "auto" when overflow changes from hidden/hidden to scroll/hidden', async() => {
+      const wt = walkontable({
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
+      }, spec().$table[0]);
+
+      const { holder } = wt.wtTable;
+
+      wt.draw();
+
+      expect(holder.style.height).toBe('0px');
+
+      // Box dimensions unchanged — offsetHeight still 0. trimmingOverflow fingerprint
+      // detects the CSS change and forces slow path, which sets useAutoHeight=true.
+      spec().$outerWrapper[0].style.overflowX = 'scroll';
+      spec().$outerWrapper[0].style.overflowY = 'hidden';
+
+      wt.draw();
+
+      expect(holder.style.height).toBe('auto');
+    });
+
+    it('should update holder height from "auto" back to "0px" when overflow changes from scroll/hidden to hidden/hidden', async() => {
+      spec().$outerWrapper.css({ 'overflow-x': 'scroll', 'overflow-y': 'hidden' });
+
+      const wt = walkontable({
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
+      }, spec().$table[0]);
+
+      const { holder } = wt.wtTable;
+
+      wt.draw();
+
+      expect(holder.style.height).toBe('auto');
+
+      spec().$outerWrapper[0].style.overflowX = 'hidden';
+      spec().$outerWrapper[0].style.overflowY = 'hidden';
+
+      wt.draw();
+
+      expect(holder.style.height).toBe('0px');
+    });
+  });
+});

--- a/handsontable/src/helpers/dom/element.ts
+++ b/handsontable/src/helpers/dom/element.ts
@@ -580,8 +580,11 @@ export function fastInnerText(element: HTMLElement, content: string): void {
  */
 export function isVisible(element: HTMLElement): boolean {
   // Fast path: use the native checkVisibility() API (Chrome 105+, Firefox 106+, Safari 17.4+).
-  // With no options it checks display:none ancestry and DOM attachment — matching the legacy
-  // ancestor walk below, but in O(1) browser-native time instead of O(DOM depth) with
+  // With no options it checks whether the element has an associated box — returning false for
+  // display:none and display:contents — and whether any ancestor sets content-visibility:hidden.
+  // This is stricter than the legacy walk below (which only catches display:none), but the
+  // extra cases are also semantically invisible, so the stricter result is correct.
+  // The benefit over the legacy walk: O(1) browser-native time instead of O(DOM depth) with
   // per-node getComputedStyle() calls that force full-document layout recalculation.
   if (typeof element.checkVisibility === 'function') {
     return element.checkVisibility();

--- a/handsontable/src/helpers/dom/element.ts
+++ b/handsontable/src/helpers/dom/element.ts
@@ -579,6 +579,15 @@ export function fastInnerText(element: HTMLElement, content: string): void {
  * @returns {boolean}
  */
 export function isVisible(element: HTMLElement): boolean {
+  // Fast path: use the native checkVisibility() API (Chrome 105+, Firefox 106+, Safari 17.4+).
+  // With no options it checks display:none ancestry and DOM attachment — matching the legacy
+  // ancestor walk below, but in O(1) browser-native time instead of O(DOM depth) with
+  // per-node getComputedStyle() calls that force full-document layout recalculation.
+  if (typeof element.checkVisibility === 'function') {
+    return element.checkVisibility();
+  }
+
+  // Legacy fallback: manual ancestor walk for browsers that do not support checkVisibility().
   const documentElement = element.ownerDocument.documentElement;
   const windowElement = element.ownerDocument.defaultView;
   let next: Node | null = element;


### PR DESCRIPTION
### Context

The PR improves HOT scroll performance by cutting redundant work in the Walkontable rendering path. Profiling revealed the docs/blank page scroll overhead ratio was ~2×, caused by expensive per-ancestor visibility checks and forced layout flushes on every scroll step.

Changes:
- `isVisible()` in `element.ts` uses native `checkVisibility()` when available for a fast O(1) visibility check
- `MasterTable.alignOverlaysWithTrimmingContainer()` in `master.ts` caches holder sizing behind a trimming-container/hider fingerprint with a fast path, `ResizeObserver` invalidation, and `destroy()` cleanup
- `Walkontable.destroy()` in `core.ts` forwards to `MasterTable.destroy()` to clean up the ResizeObserver

Combined fixes reduce Layout + StyleRecalc cost from **234.7ms → 181.6ms (−23%)** for a 40-step scroll, bringing the docs/blank ratio from 1.99× down to **1.24×**.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1777

### How has this been tested?

Measured with Chrome DevTools performance traces (40 scroll steps, no CPU/network throttle) on both the docs demo page (`localhost:4321/docs/javascript-data-grid/demo/`) and a minimal blank page with identical HOT config.

| Version | Change | Combined | Per step |
|---|---|---|---|
| baseline | before this work | 234.7ms | 5.87ms |
| +1 | `checkVisibility()` fast path in `isVisible()` | 215.5ms | 5.39ms |
| +2 | `isTableVisible` skip in `alignOverlaysWithTrimmingContainer()` | 196.0ms | 4.90ms |
| **final** | **all changes combined** | **181.6ms** | **4.54ms** |
| blank page | same HOT config, no docs chrome | 146.2ms | 3.66ms |

E2E autocomplete editor regressions from the alignOverlays cache were identified and fixed as part of this change.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1777

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sit on the hot scroll/draw path and introduce caching/ResizeObserver invalidation; regressions could affect layout in nested or autocomplete editors, though behavior is covered by new specs and existing overflow edge cases.
> 
> **Overview**
> This PR speeds up Handsontable scrolling by reducing redundant DOM work on each Walkontable draw.
> 
> **`isVisible()`** now uses the native **`checkVisibility()`** API when the browser supports it, avoiding an ancestor walk with repeated **`getComputedStyle()`** calls; older browsers keep the previous walk.
> 
> **`MasterTable.alignOverlaysWithTrimmingContainer()`** caches holder width/height and related flags behind a **fingerprint** (trimming container size/scroll/overflow, hider size). Unchanged fingerprints take a **fast path** that reapplies cached styles and skips the expensive **`cloneNode`** + **`getComputedStyle`** measurement. **`ResizeObserver`** on the trimming container and hider invalidates the cache when layout changes; overflow-only CSS changes are included in the fingerprint so zero-height container behavior (e.g. issue **#3119**) stays correct. **`Walkontable.destroy()`** / **`MasterTable.destroy()`** disconnect observers and clear cache for teardown.
> 
> New **`master.spec.js`** coverage exercises fast vs slow path, resize, row growth, and overflow toggles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70902973d745cfa9c19b71d882789bdc12ab6f51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->