### PR TITLE
DEV-1777: Optimize docs CSS to reduce scroll StyleRecalc cost

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -678,6 +678,14 @@ export default defineConfig({
           tag: 'script',
           attrs: { src: '/docs/example-tabs.js', defer: true },
         },
+        // Prevent HOT from injecting a duplicate <style id="handsontable-core-styles"> at runtime.
+        // StylesHandler.#injectCoreStyles() skips injection when it finds an element with this ID.
+        // The actual HOT CSS is already loaded by handsontable-import.css via customCss above.
+        {
+          tag: 'style',
+          attrs: { id: 'handsontable-core-styles' },
+          content: '/* HOT base styles loaded via handsontable-import.css */',
+        },
         // ── All-environment 3rd-party scripts ──────────────────────────────
         // Sentry error monitoring
         {

--- a/docs/src/styles/base/scrollbars.css
+++ b/docs/src/styles/base/scrollbars.css
@@ -1,23 +1,55 @@
-/* Custom scrollbar styling — subtle (exclude Handsontable internals) */
-*:not(.handsontable *) {
+/* Custom scrollbar styling — subtle.
+ *
+ * Use a plain universal `*` base rule + a positive `.handsontable *` reset rather
+ * than `*:not(.handsontable *)`.  The negative descendant form forces Blink to
+ * walk the ancestor chain for every element during HOT DOM mutations (O(depth)
+ * per cell); the positive override is indexed on the `.handsontable` class and
+ * is evaluated only for elements that already have a `.handsontable` ancestor.
+ */
+* {
   scrollbar-width: thin;
   scrollbar-color: var(--sl-color-gray-5) transparent;
 }
 
-*:not(.handsontable *)::-webkit-scrollbar {
+/* HOT manages its own scrollbar UX — restore native defaults for all HOT internals */
+.handsontable,
+.handsontable * {
+  scrollbar-width: auto;
+  scrollbar-color: auto;
+}
+
+*::-webkit-scrollbar {
   width: 4px;
   height: 4px;
 }
 
-*:not(.handsontable *)::-webkit-scrollbar-track {
+.handsontable *::-webkit-scrollbar {
+  width: revert;
+  height: revert;
+}
+
+*::-webkit-scrollbar-track {
   background: transparent;
 }
 
-*:not(.handsontable *)::-webkit-scrollbar-thumb {
+.handsontable *::-webkit-scrollbar-track {
+  background: revert;
+}
+
+*::-webkit-scrollbar-thumb {
   background-color: var(--sl-color-gray-5);
   border-radius: 2px;
 }
 
+.handsontable *::-webkit-scrollbar-thumb {
+  background-color: revert;
+  border-radius: revert;
+}
+
 *::-webkit-scrollbar-thumb:hover {
   background-color: var(--sl-color-gray-4);
+}
+
+.handsontable *::-webkit-scrollbar-thumb:hover {
+  background-color: revert;
 }

--- a/docs/src/styles/components/tables.css
+++ b/docs/src/styles/components/tables.css
@@ -155,10 +155,6 @@
   margin: 0;
 }
 
-.sl-markdown-content .handsontable :not(a, strong, em, del, span, input, code, br) + :not(a, strong, em, del, span, input, code, br, :where(.not-content *)) {
-  margin-top: 0;
-}
-
 /* -------------------------------------------------------------------------
  * Markdown tables — scoped re-styling
  *

--- a/docs/src/styles/interactive-example.css
+++ b/docs/src/styles/interactive-example.css
@@ -60,6 +60,12 @@
 .hot-example-preview {
   padding: 1rem;
   border-left: 1px solid var(--sl-color-gray-5);
+  /* Scope layout recalculation to this subtree. Any geometry reads inside HOT
+     (offsetWidth, clientHeight, scrollHeight) only need to flush layout within
+     this container rather than the entire document, cutting forced-reflow cost
+     on heavy pages with many stylesheets. Safe because HOT uses no
+     position:fixed descendants. */
+  contain: layout;
 }
 
 /* Shield example internals from Starlight's content spacing rules

--- a/docs/src/styles/utilities.css
+++ b/docs/src/styles/utilities.css
@@ -52,11 +52,13 @@ html {
 
 /* ── Global checkbox styling ─────────────────────────────────────────── */
 
-/* Use :not(.htCheckboxRendererInput) — an O(1) self-class check — instead of
- * :not(.handsontable input) which forces an O(depth) ancestor walk for every
- * HOT checkbox cell rendered during scroll. */
+/* .sl-markdown-content is the prose area — no HOT instance lives there, so
+ * an O(1) class check is safe. .hot-example contains the HOT instance itself,
+ * so we must exclude all HOT-internal inputs with :not(.handsontable input)
+ * to avoid overriding the multiSelectEditor's own checkbox appearance. The
+ * cost is low because the subject is a scoped input selector, not * . */
 .sl-markdown-content input[type="checkbox"]:not(.htCheckboxRendererInput),
-.hot-example input[type="checkbox"]:not(.htCheckboxRendererInput) {
+.hot-example input[type="checkbox"]:not(.handsontable input) {
   appearance: none;
   width: 1rem;
   height: 1rem;
@@ -70,13 +72,13 @@ html {
 }
 
 .sl-markdown-content input[type="checkbox"]:checked:not(.htCheckboxRendererInput),
-.hot-example input[type="checkbox"]:checked:not(.htCheckboxRendererInput) {
+.hot-example input[type="checkbox"]:checked:not(.handsontable input) {
   background: var(--sl-color-accent);
   border-color: var(--sl-color-accent);
 }
 
 .sl-markdown-content input[type="checkbox"]:checked:not(.htCheckboxRendererInput)::after,
-.hot-example input[type="checkbox"]:checked:not(.htCheckboxRendererInput)::after {
+.hot-example input[type="checkbox"]:checked:not(.handsontable input)::after {
   content: '';
   position: absolute;
   left: 4px;

--- a/docs/src/styles/utilities.css
+++ b/docs/src/styles/utilities.css
@@ -52,8 +52,11 @@ html {
 
 /* ── Global checkbox styling ─────────────────────────────────────────── */
 
-.sl-markdown-content input[type="checkbox"]:not(.handsontable input),
-.hot-example input[type="checkbox"]:not(.handsontable input) {
+/* Use :not(.htCheckboxRendererInput) — an O(1) self-class check — instead of
+ * :not(.handsontable input) which forces an O(depth) ancestor walk for every
+ * HOT checkbox cell rendered during scroll. */
+.sl-markdown-content input[type="checkbox"]:not(.htCheckboxRendererInput),
+.hot-example input[type="checkbox"]:not(.htCheckboxRendererInput) {
   appearance: none;
   width: 1rem;
   height: 1rem;
@@ -66,14 +69,14 @@ html {
   vertical-align: middle;
 }
 
-.sl-markdown-content input[type="checkbox"]:checked:not(.handsontable input),
-.hot-example input[type="checkbox"]:checked:not(.handsontable input) {
+.sl-markdown-content input[type="checkbox"]:checked:not(.htCheckboxRendererInput),
+.hot-example input[type="checkbox"]:checked:not(.htCheckboxRendererInput) {
   background: var(--sl-color-accent);
   border-color: var(--sl-color-accent);
 }
 
-.sl-markdown-content input[type="checkbox"]:checked:not(.handsontable input)::after,
-.hot-example input[type="checkbox"]:checked:not(.handsontable input)::after {
+.sl-markdown-content input[type="checkbox"]:checked:not(.htCheckboxRendererInput)::after,
+.hot-example input[type="checkbox"]:checked:not(.htCheckboxRendererInput)::after {
   content: '';
   position: absolute;
   left: 4px;


### PR DESCRIPTION
### Context

The PR cleans up docs CSS to eliminate selector patterns that cause expensive per-ancestor DOM walks on every scroll step. These changes complement the Walkontable core improvements in #12659.

Changes:
- `scrollbars.css`: replaces `*:not(.handsontable *)` (O(depth) ancestor walk per element) with `* {}` + `.handsontable * { revert }` override
- `utilities.css`: replaces `:not(.handsontable input)` (O(depth) ancestor walk) with `:not(.htCheckboxRendererInput)` (O(1) self-class check)
- `tables.css`: removes dead margin-top counter-selector (`.sl-markdown-content .handsontable :not(...) + :not(...)` — HOT is always inside `.not-content` so this rule never matched)
- `interactive-example.css`: adds `contain: layout` on `.hot-example-preview` to scope layout recalculations
- `astro.config.mjs`: prevents runtime injection of duplicate HOT core CSS via a placeholder `handsontable-core-styles` style tag

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1777

### How has this been tested?

Measured with Chrome DevTools performance traces (40 scroll steps, no CPU/network throttle) on the docs demo page (`localhost:4321/docs/javascript-data-grid/demo/`).

Manual verification: HOT instance renders correctly on the demo page, scrolling and cell interaction work as expected, scrollbar hover styles function correctly.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1777

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only styling and a noop placeholder style tag; no runtime grid or auth changes, with behavior validated on the demo page.
> 
> **Overview**
> Reduces **scroll-time StyleRecalc** on docs pages that embed Handsontable by replacing expensive universal selectors and scoping layout work.
> 
> **Scrollbar and checkbox CSS** no longer use `*:not(.handsontable *)` or `:not(.handsontable input)` (ancestor walks on every HOT DOM update). Global thin scrollbars apply via `*` with `.handsontable *` **revert** overrides; prose checkboxes use `:not(.htCheckboxRendererInput)` instead of excluding the whole grid subtree.
> 
> **Dead rule removed** from `tables.css` (a sibling margin counter that never matched because HOT lives under `.not-content`).
> 
> **`.hot-example-preview`** gets `contain: layout` so HOT geometry reads flush layout inside the preview, not the full document.
> 
> **`astro.config.mjs`** injects a placeholder `<style id="handsontable-core-styles">` so Handsontable skips injecting duplicate core CSS at runtime (styles already come from `handsontable-import.css`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec6e21b6fb46b8e2527618904036ef1efbb1d72a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->