### PR TITLE
DEV-1801: Fix export * as syntax in i18n/registry + add regression guard

### DIFF
--- a/handsontable/scripts/downlevel-dts.mjs
+++ b/handsontable/scripts/downlevel-dts.mjs
@@ -202,14 +202,13 @@ for await (const filePath of walkEsm(tmpDir)) {
 
 if (violations.length > 0) {
   console.error(
-    `downlevel-dts: FATAL — "export * as" found in ESM output.\n` +
-    `This syntax crashes Parcel v1 consumers. Fix the source file by replacing:\n` +
-    `  export * as X from 'y';\n` +
-    `with:\n` +
-    `  import * as X from 'y';\n` +
-    `  export { X };\n\n` +
-    `Offending locations:\n` +
-    `${violations.join('\n')}`
+    'downlevel-dts: FATAL — "export * as" found in ESM output.\n' +
+    'This syntax crashes Parcel v1 consumers. Fix the source file by replacing:\n' +
+    '  export * as X from \'y\';\n' +
+    'with:\n' +
+    '  import * as X from \'y\';\n' +
+    '  export { X };\n\n' +
+    `Offending locations:\n${violations.join('\n')}`
   );
   process.exit(1);
 }

--- a/handsontable/scripts/downlevel-dts.mjs
+++ b/handsontable/scripts/downlevel-dts.mjs
@@ -202,14 +202,14 @@ for await (const filePath of walkEsm(tmpDir)) {
 
 if (violations.length > 0) {
   console.error(
-    'downlevel-dts: FATAL — "export * as" found in ESM output.\n' +
-    'This syntax crashes Parcel v1 consumers. Fix the source file by replacing:\n' +
-    "  export * as X from 'y';\n" +
-    'with:\n' +
-    "  import * as X from 'y';\n" +
-    '  export { X };\n\n' +
-    'Offending locations:\n' +
-    violations.join('\n')
+    `downlevel-dts: FATAL — "export * as" found in ESM output.\n` +
+    `This syntax crashes Parcel v1 consumers. Fix the source file by replacing:\n` +
+    `  export * as X from 'y';\n` +
+    `with:\n` +
+    `  import * as X from 'y';\n` +
+    `  export { X };\n\n` +
+    `Offending locations:\n` +
+    `${violations.join('\n')}`
   );
   process.exit(1);
 }

--- a/handsontable/scripts/downlevel-dts.mjs
+++ b/handsontable/scripts/downlevel-dts.mjs
@@ -161,6 +161,59 @@ async function* walkDts(dir) {
   }
 }
 
+const EXPORT_STAR_AS_RE = /\bexport\s+\*\s+as\b/;
+
+/**
+ * Recursively yields all *.mjs and *.js file paths under `dir`.
+ *
+ * @param {string} dir - Directory to walk.
+ * @returns {AsyncGenerator<string>}
+ */
+async function* walkEsm(dir) {
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const fullPath = join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      yield* walkEsm(fullPath);
+    } else if (
+      entry.isFile() &&
+      (entry.name.endsWith('.mjs') || entry.name.endsWith('.js'))
+    ) {
+      yield fullPath;
+    }
+  }
+}
+
+// Regression guard: fail if "export * as" appears in ESM runtime output.
+// This syntax crashes Parcel v1 silently. The fix belongs in the source file,
+// not here — this check only detects regressions.
+const violations = [];
+
+for await (const filePath of walkEsm(tmpDir)) {
+  const content = await readFile(filePath, 'utf8');
+  const lines = content.split('\n');
+
+  for (let i = 0; i < lines.length; i++) {
+    if (EXPORT_STAR_AS_RE.test(lines[i])) {
+      violations.push(`  ${filePath}:${i + 1}: ${lines[i].trim()}`);
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error(
+    'downlevel-dts: FATAL — "export * as" found in ESM output.\n' +
+    'This syntax crashes Parcel v1 consumers. Fix the source file by replacing:\n' +
+    "  export * as X from 'y';\n" +
+    'with:\n' +
+    "  import * as X from 'y';\n" +
+    '  export { X };\n\n' +
+    'Offending locations:\n' +
+    violations.join('\n')
+  );
+  process.exit(1);
+}
+
 let filesRewrote = 0;
 let totalReplacements = 0;
 

--- a/handsontable/scripts/downlevel-dts.mjs
+++ b/handsontable/scripts/downlevel-dts.mjs
@@ -140,76 +140,87 @@ function replaceGenericType(str, typeName, replacement) {
 }
 
 /**
- * Recursively yields all *.d.ts file paths under `dir`, skipping *.d.ts.map.
+ * Recursively yields file paths under `dir` whose names satisfy `predicate`.
  *
  * @param {string} dir - Directory to walk.
+ * @param {function(string): boolean} predicate - Returns true for file names to include.
  * @returns {AsyncGenerator<string>}
  */
-async function* walkDts(dir) {
+async function* walkFiles(dir, predicate) {
   for (const entry of await readdir(dir, { withFileTypes: true })) {
     const fullPath = join(dir, entry.name);
 
     if (entry.isDirectory()) {
-      yield* walkDts(fullPath);
-    } else if (
-      entry.isFile() &&
-      entry.name.endsWith('.d.ts') &&
-      !entry.name.endsWith('.d.ts.map')
-    ) {
+      yield* walkFiles(fullPath, predicate);
+    } else if (entry.isFile() && predicate(entry.name)) {
       yield fullPath;
     }
   }
 }
-
-const EXPORT_STAR_AS_RE = /\bexport\s+\*\s+as\b/;
 
 /**
- * Recursively yields all *.mjs and *.js file paths under `dir`.
- *
- * @param {string} dir - Directory to walk.
- * @returns {AsyncGenerator<string>}
+ * @param {string} name - File name to test.
+ * @returns {boolean}
  */
-async function* walkEsm(dir) {
-  for (const entry of await readdir(dir, { withFileTypes: true })) {
-    const fullPath = join(dir, entry.name);
+const isDts = name => name.endsWith('.d.ts') && !name.endsWith('.d.ts.map');
 
-    if (entry.isDirectory()) {
-      yield* walkEsm(fullPath);
-    } else if (
-      entry.isFile() &&
-      (entry.name.endsWith('.mjs') || entry.name.endsWith('.js'))
-    ) {
-      yield fullPath;
-    }
-  }
-}
+/**
+ * @param {string} name - File name to test.
+ * @returns {boolean}
+ */
+const isEsm = name => name.endsWith('.mjs') || name.endsWith('.js');
 
-// Regression guard: fail if "export * as" appears in ESM runtime output.
-// This syntax crashes Parcel v1 silently. The fix belongs in the source file,
-// not here — this check only detects regressions.
-const violations = [];
+/**
+ * Patterns that must never appear in the ESM runtime output (`tmp/**\/*.mjs`,
+ * `tmp/**\/*.js`). Each entry is checked line-by-line; a match causes the
+ * script to exit with a non-zero code and print the offending file:line.
+ *
+ * To add a new guard, append an entry:
+ *   { pattern: /your-regex/, message: 'human-readable description of the problem and fix' }
+ *
+ * @type {Array<{ pattern: RegExp, message: string }>}
+ */
+const ESM_FORBIDDEN = [
+  {
+    pattern: /\bexport\s+\*\s+as\b/,
+    message:
+      '"export * as" found in ESM output. ' +
+      'This syntax crashes Parcel v1 consumers. Fix the source file by replacing:\n' +
+      '  export * as X from \'y\';\n' +
+      'with:\n' +
+      '  import * as X from \'y\';\n' +
+      '  export { X };',
+  },
+];
 
-for await (const filePath of walkEsm(tmpDir)) {
+// Regression guard: scan ESM output for forbidden patterns.
+// Fixes belong in source files — this check only detects regressions.
+let esmGuardFailed = false;
+
+for await (const filePath of walkFiles(tmpDir, isEsm)) {
   const content = await readFile(filePath, 'utf8');
   const lines = content.split('\n');
 
-  for (let i = 0; i < lines.length; i++) {
-    if (EXPORT_STAR_AS_RE.test(lines[i])) {
-      violations.push(`  ${filePath}:${i + 1}: ${lines[i].trim()}`);
+  for (const { pattern, message } of ESM_FORBIDDEN) {
+    const violations = [];
+
+    for (let i = 0; i < lines.length; i++) {
+      if (pattern.test(lines[i])) {
+        violations.push(`  ${filePath}:${i + 1}: ${lines[i].trim()}`);
+      }
+    }
+
+    if (violations.length > 0) {
+      console.error(
+        `downlevel-dts: FATAL — ${message}\n\n` +
+        `Offending locations:\n${violations.join('\n')}`
+      );
+      esmGuardFailed = true;
     }
   }
 }
 
-if (violations.length > 0) {
-  console.error(
-    'downlevel-dts: FATAL — "export * as" found in ESM output.\n' +
-    'This syntax crashes Parcel v1 consumers. Fix the source file by replacing:\n' +
-    '  export * as X from \'y\';\n' +
-    'with:\n' +
-    '  import * as X from \'y\';\n' +
-    '  export { X };\n\n' +
-    `Offending locations:\n${violations.join('\n')}`
-  );
+if (esmGuardFailed) {
   process.exit(1);
 }
 
@@ -217,7 +228,7 @@ let filesRewrote = 0;
 let totalReplacements = 0;
 
 try {
-  for await (const filePath of walkDts(tmpDir)) {
+  for await (const filePath of walkFiles(tmpDir, isDts)) {
     const original = await readFile(filePath, 'utf8');
     let updated = original;
     let fileReplacements = 0;

--- a/handsontable/src/i18n/registry.ts
+++ b/handsontable/src/i18n/registry.ts
@@ -5,7 +5,9 @@ import { staticRegister } from '../utils/staticRegister';
 import { getPhraseFormatters } from './phraseFormatters';
 import DEFAULT_DICTIONARY from './languages/en-US';
 
-export * as dictionaryKeys from './constants';
+import * as dictionaryKeys from './constants';
+
+export { dictionaryKeys };
 export const DEFAULT_LANGUAGE_CODE = DEFAULT_DICTIONARY.languageCode;
 
 const {


### PR DESCRIPTION
### Context

The PR fixes a silent crash when downstream projects bundle Handsontable with Parcel v1 (`parcel-bundler@1.12.5`). The root cause: `src/i18n/registry.ts` used `export * as dictionaryKeys from './constants'` (ES2020 export namespace syntax). This compiles verbatim into `tmp/i18n/registry.mjs`. Parcel v1's bundled Babel lacks `@babel/plugin-transform-export-namespace-from`, so it throws internally and the dev server exits on a random port — silently, with no visible error in the terminal.

**Fix:** rewrote the export as two equivalent statements that any bundler can handle:

```ts
// before
export * as dictionaryKeys from './constants';

// after
import * as dictionaryKeys from './constants';
export { dictionaryKeys };
```

**Regression guard:** extended `scripts/downlevel-dts.mjs` (which already runs as part of `npm run build`) to walk `tmp/**/*.mjs` and `tmp/**/*.js` and fail with `exit 1` + precise file:line output if `export * as` is ever reintroduced.

### How has this been tested?

- Verified the pattern no longer appears in the built `tmp/i18n/registry.mjs` output
- `downlevel-dts.mjs` guard confirmed to detect the pattern and exit non-zero when present
- No unit or E2E tests needed — the change is a source-level syntax rewrite with identical runtime semantics

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1801

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1801

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Equivalent export shape and a build-only regression check; no auth, data, or API contract changes beyond syntax compatibility.
> 
> **Overview**
> Fixes **Parcel v1** bundling failures caused by **`export * as`** in built ESM (notably `i18n/registry`). **`registry.ts`** now re-exports `dictionaryKeys` via `import *` + `export { dictionaryKeys }` with the same public API.
> 
> **`downlevel-dts.mjs`** refactors directory walking to a shared **`walkFiles`** helper, scans **`tmp/**/*.mjs` and `*.js`** for forbidden **`export * as`** before downleveling `.d.ts`, and **fails the build** with file:line errors if it reappears.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3114e6b356173da7c6f7b4a88636443074b71c77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->