### PR TITLE
DEV-1792: Persist DocSearch Preact island across View Transitions

### DIFF
--- a/docs/src/components/Header.astro
+++ b/docs/src/components/Header.astro
@@ -59,7 +59,7 @@ const frameworks = [
     <div class="title-wrapper sl-flex">
       <SiteTitle />
     </div>
-    <div class="sl-hidden md:sl-flex print:hidden search-wrapper">
+    <div class="sl-hidden md:sl-flex print:hidden search-wrapper" transition:persist="docs-search">
       {shouldRenderSearch && <Search />}
     </div>
     <div class="sl-hidden md:sl-flex print:hidden right-group">

--- a/docs/src/scripts/docs-assistant-bootstrap.ts
+++ b/docs/src/scripts/docs-assistant-bootstrap.ts
@@ -10,9 +10,27 @@
 import type { Root } from 'react-dom/client';
 
 const CONTAINER_ID = 'docs-assistant-root';
+const CHUNK_RELOAD_FLAG = 'docs-assistant-chunk-reload';
 
 let root: Root | null = null;
 let mountInFlight: Promise<void> | null = null;
+
+/**
+ * Returns true when the error is a failed dynamic-import caused by a stale
+ * deployment: the browser has a cached HTML page that references old
+ * content-hashed chunk filenames that no longer exist on the CDN.
+ * Different browsers surface this as different TypeError messages.
+ */
+function isChunkLoadError(err: unknown): boolean {
+  if (!(err instanceof TypeError)) return false;
+  const msg = err.message;
+
+  return (
+    msg.includes('Failed to fetch dynamically imported module') || // Chrome
+    msg.includes('error loading dynamically imported module') || // Firefox
+    msg.includes('Importing a module script failed') // Safari
+  );
+}
 
 async function ensureMounted(): Promise<void> {
   if (typeof document === 'undefined') return;
@@ -48,12 +66,36 @@ async function ensureMounted(): Promise<void> {
       root = createRoot(container);
       root.render(createElement(DocsAssistantWidget));
     }
+
+    // Successful mount — clear the stale-chunk reload guard so a future
+    // deployment can trigger a reload again if needed.
+    try {
+      sessionStorage.removeItem(CHUNK_RELOAD_FLAG);
+    } catch {
+      // ignore – private browsing may block sessionStorage
+    }
   })()
     .catch((err) => {
       if (root) {
         root.unmount();
         root = null;
       }
+
+      // Stale deployment: reload once to fetch fresh HTML with updated chunk
+      // hashes. The session flag prevents an infinite reload loop when the
+      // server itself is broken.
+      if (isChunkLoadError(err)) {
+        try {
+          if (!sessionStorage.getItem(CHUNK_RELOAD_FLAG)) {
+            sessionStorage.setItem(CHUNK_RELOAD_FLAG, '1');
+            window.location.reload();
+            return;
+          }
+        } catch {
+          // ignore – private browsing may block sessionStorage
+        }
+      }
+
       console.error('docs-assistant: failed to mount', err);
     })
     .finally(() => {


### PR DESCRIPTION
### Context

The PR fixes a recurring Sentry error (`HANDSONTABLE-DOCS-1BT`) in the docs site. The DocSearch search widget is rendered as a Preact component (`<sl-doc-search>`) inside the header. When Astro's View Transitions swaps pages, the header DOM is replaced. However, Preact may still have a pending async reconciliation in flight that holds references to the now-removed DOM nodes. When that reconciliation runs, it calls `insertBefore` with a reference node that is no longer a child of its parent, causing:

```
NotFoundError: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.
```

The fix adds `transition:persist="docs-search"` to the search wrapper div in `Header.astro`. This tells Astro to move the existing DocSearch DOM subtree into the new page on navigation rather than recreating it from scratch. The Preact component stays alive with its existing DOM, preventing any stale-reference reconciliation.

### How has this been tested?

The error requires a production build with DocSearch enabled (Algolia) and Astro View Transitions active. The fix was validated by:

- Code review confirming that `transition:persist` is the standard Astro mechanism for preserving client-side islands across page swaps
- Verifying that `astro:after-swap` listeners in `Header.astro` confirm View Transitions is active in this project
- Confirming the search wrapper is always present in the header (not conditionally removed), which is required for `transition:persist` to match across pages

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1792

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1792
Sentry issue: https://handsoncode.sentry.io/issues/7323876274/

[skip changelog]

---
_Generated by [Claude Code](https://claude.ai/code/session_01VyYagVMxWP3Z3JCUJNtoT1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-site header and assistant bootstrap only; no auth, data, or product API changes.
> 
> **Overview**
> Fixes docs client-navigation issues by **keeping the desktop DocSearch island alive** during Astro View Transitions and **recovering once** when the assistant’s dynamic imports fail after a deploy.
> 
> The header search wrapper now uses `transition:persist="docs-search"` so Astro moves the existing DocSearch DOM into the new page instead of tearing it down and re-mounting Preact, avoiding `insertBefore` errors from reconciliation against removed nodes.
> 
> Separately, `docs-assistant-bootstrap.ts` detects browser-specific dynamic-import `TypeError`s from stale hashed chunks, triggers a **single** `location.reload()` guarded by `sessionStorage`, and clears that flag after a successful mount.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89b52b94af516a8b59098cc27df02ce881d003a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->