### PR TITLE
fix(docs): fix broken "Find the code on GitHub" links on the demo page

### DIFF
--- a/docs/content/guides/getting-started/demo/demo.md
+++ b/docs/content/guides/getting-started/demo/demo.md
@@ -53,11 +53,11 @@ Explore Handsontable core features in this interactive demo. Click cells, sort c
 
 <div class="boxes-list gray">
 
-- [JavaScript demo app](https://github.com/handsontable/handsontable/tree/prod-docs/{{$currentMinorVersion}}/examples/next/docs/js/demo/)
-- [TypeScript demo app](https://github.com/handsontable/handsontable/tree/prod-docs/{{$currentMinorVersion}}/examples/next/docs/ts/demo/)
-- [Angular demo app](https://github.com/handsontable/handsontable/tree/prod-docs/{{$currentMinorVersion}}/examples/next/docs/angular-wrapper/demo/)
-- [React demo app](https://github.com/handsontable/handsontable/tree/prod-docs/{{$currentMinorVersion}}/examples/next/docs/react-wrapper/demo/)
-- [Vue demo app](https://github.com/handsontable/handsontable/tree/prod-docs/{{$currentMinorVersion}}/examples/next/docs/vue3/demo/)
+- [JavaScript demo app](https://github.com/handsontable/handsontable/tree/{{$currentMinorVersion}}/examples/next/docs/js/demo/)
+- [TypeScript demo app](https://github.com/handsontable/handsontable/tree/{{$currentMinorVersion}}/examples/next/docs/ts/demo/)
+- [Angular demo app](https://github.com/handsontable/handsontable/tree/{{$currentMinorVersion}}/examples/next/docs/angular-wrapper/demo/)
+- [React demo app](https://github.com/handsontable/handsontable/tree/{{$currentMinorVersion}}/examples/next/docs/react-wrapper/demo/)
+- [Vue demo app](https://github.com/handsontable/handsontable/tree/{{$currentMinorVersion}}/examples/next/docs/vue3/demo/)
 
 </div>
 

--- a/docs/content/guides/getting-started/demo/demo.md
+++ b/docs/content/guides/getting-started/demo/demo.md
@@ -53,11 +53,11 @@ Explore Handsontable core features in this interactive demo. Click cells, sort c
 
 <div class="boxes-list gray">
 
-- [JavaScript demo app](https://github.com/handsontable/handsontable/tree/prod-docs/{{$currentVersion}}/examples/next/docs/js/demo/)
-- [TypeScript demo app](https://github.com/handsontable/handsontable/tree/prod-docs/{{$currentVersion}}/examples/next/docs/ts/demo/)
-- [Angular demo app](https://github.com/handsontable/handsontable/tree/prod-docs/{{$currentVersion}}/examples/next/docs/angular-wrapper/demo/)
-- [React demo app](https://github.com/handsontable/handsontable/tree/prod-docs/{{$currentVersion}}/examples/next/docs/react-wrapper/demo/)
-- [Vue demo app](https://github.com/handsontable/handsontable/tree/prod-docs/{{$currentVersion}}/examples/next/docs/vue3/demo/)
+- [JavaScript demo app](https://github.com/handsontable/handsontable/tree/prod-docs/{{$currentMinorVersion}}/examples/next/docs/js/demo/)
+- [TypeScript demo app](https://github.com/handsontable/handsontable/tree/prod-docs/{{$currentMinorVersion}}/examples/next/docs/ts/demo/)
+- [Angular demo app](https://github.com/handsontable/handsontable/tree/prod-docs/{{$currentMinorVersion}}/examples/next/docs/angular-wrapper/demo/)
+- [React demo app](https://github.com/handsontable/handsontable/tree/prod-docs/{{$currentMinorVersion}}/examples/next/docs/react-wrapper/demo/)
+- [Vue demo app](https://github.com/handsontable/handsontable/tree/prod-docs/{{$currentMinorVersion}}/examples/next/docs/vue3/demo/)
 
 </div>
 

--- a/docs/src/plugins/docs-version.mjs
+++ b/docs/src/plugins/docs-version.mjs
@@ -96,3 +96,23 @@ function computeDocsVersion() {
  * @type {string}
  */
 export const CURRENT_DOCS_VERSION = computeDocsVersion();
+
+/**
+ * The major.minor version used for prod-docs GitHub branch links.
+ *
+ * Production builds strip the patch segment from CURRENT_DOCS_VERSION
+ * (e.g. "17.1.0" → "17.1") to match the prod-docs/X.Y branch naming convention.
+ * Non-production builds fall back to "develop" so the links point to the
+ * always-current develop branch.
+ *
+ * @type {string}
+ */
+export const CURRENT_DOCS_MINOR_VERSION = (() => {
+  if (process.env.BUILD_MODE === 'production') {
+    const match = CURRENT_DOCS_VERSION.match(/^(\d+\.\d+)/);
+
+    return match ? match[1] : CURRENT_DOCS_VERSION;
+  }
+
+  return 'develop';
+})();

--- a/docs/src/plugins/docs-version.mjs
+++ b/docs/src/plugins/docs-version.mjs
@@ -98,20 +98,24 @@ function computeDocsVersion() {
 export const CURRENT_DOCS_VERSION = computeDocsVersion();
 
 /**
- * The major.minor version used for prod-docs GitHub branch links.
+ * The GitHub branch path used for source-code links in documentation pages.
  *
- * Production builds strip the patch segment from CURRENT_DOCS_VERSION
- * (e.g. "17.1.0" → "17.1") to match the prod-docs/X.Y branch naming convention.
- * Non-production builds fall back to "develop" so the links point to the
- * always-current develop branch.
+ * Production builds produce a `prod-docs/X.Y` path (e.g. `prod-docs/17.1`)
+ * by stripping the patch segment from CURRENT_DOCS_VERSION, matching the
+ * prod-docs/X.Y branch naming convention used in the repository.
+ *
+ * Non-production builds fall back to `develop` so that links point directly
+ * to the always-current develop branch. The `prod-docs/` prefix is intentionally
+ * omitted in this case because the `prod-docs/develop` branch does not exist.
  *
  * @type {string}
  */
 export const CURRENT_DOCS_MINOR_VERSION = (() => {
   if (process.env.BUILD_MODE === 'production') {
     const match = CURRENT_DOCS_VERSION.match(/^(\d+\.\d+)/);
+    const minorVersion = match ? match[1] : CURRENT_DOCS_VERSION;
 
-    return match ? match[1] : CURRENT_DOCS_VERSION;
+    return `prod-docs/${minorVersion}`;
   }
 
   return 'develop';

--- a/docs/src/plugins/framework-loader.mjs
+++ b/docs/src/plugins/framework-loader.mjs
@@ -1212,10 +1212,10 @@ function applyVuepressPreprocessing(content, prefix, contentDir) {
   // CodeSandbox links resolve to the correct in-progress build artifact.
   result = result.replace(/\{\{\s*\$currentVersion\s*\}\}/g, CURRENT_DOCS_VERSION);
 
-  // Fix {{$currentMinorVersion}} → major.minor version string.
-  // Production builds strip the patch (e.g. "17.1.0" → "17.1") to match the
-  // prod-docs/X.Y branch naming convention used for GitHub source-code links.
-  // Staging/dev builds resolve to "develop".
+  // Fix {{$currentMinorVersion}} → GitHub branch path for source-code links.
+  // Production builds produce "prod-docs/X.Y" (e.g. "prod-docs/17.1").
+  // Staging/dev builds resolve to "develop" (no prod-docs/ prefix, since
+  // the prod-docs/develop branch does not exist).
   result = result.replace(/\{\{\s*\$currentMinorVersion\s*\}\}/g, CURRENT_DOCS_MINOR_VERSION);
 
   // Transform @/framework/path.md links to absolute Starlight URLs using permalinks.

--- a/docs/src/plugins/framework-loader.mjs
+++ b/docs/src/plugins/framework-loader.mjs
@@ -12,7 +12,7 @@ import { join, relative, dirname } from 'path';
 import { createRequire } from 'module';
 import { fileURLToPath } from 'url';
 import matter from 'gray-matter';
-import { CURRENT_DOCS_VERSION } from './docs-version.mjs';
+import { CURRENT_DOCS_VERSION, CURRENT_DOCS_MINOR_VERSION } from './docs-version.mjs';
 import { convertAsideBodyMarkdown } from './aside-inline-markdown.mjs';
 
 // Read the current handsontable library version for StackBlitz package.json.
@@ -1211,6 +1211,12 @@ function applyVuepressPreprocessing(content, prefix, contentDir) {
   // Staging/dev builds use "0.0.0-next-{shortSHA}-{YYYYMMDD}" so that
   // CodeSandbox links resolve to the correct in-progress build artifact.
   result = result.replace(/\{\{\s*\$currentVersion\s*\}\}/g, CURRENT_DOCS_VERSION);
+
+  // Fix {{$currentMinorVersion}} → major.minor version string.
+  // Production builds strip the patch (e.g. "17.1.0" → "17.1") to match the
+  // prod-docs/X.Y branch naming convention used for GitHub source-code links.
+  // Staging/dev builds resolve to "develop".
+  result = result.replace(/\{\{\s*\$currentMinorVersion\s*\}\}/g, CURRENT_DOCS_MINOR_VERSION);
 
   // Transform @/framework/path.md links to absolute Starlight URLs using permalinks.
   // When prefix/contentDir are available (framework pages), do full permalink resolution.

--- a/docs/src/plugins/vuepress-preprocessor.mjs
+++ b/docs/src/plugins/vuepress-preprocessor.mjs
@@ -12,7 +12,7 @@
  * - ::: source-code-link URL  (convert to <a> tag)
  * - $withBase('/path') → /path
  * - {{$currentVersion}} → resolved Handsontable version string (full semver, e.g. "17.1.0")
- * - {{$currentMinorVersion}} → major.minor version (e.g. "17.1") for prod-docs GitHub branch links
+ * - {{$currentMinorVersion}} → GitHub branch path for source-code links (e.g. "prod-docs/17.1" or "develop")
  * - @/framework/path links  → /path (cross-framework alias)
  * - <div class="boxes-list"> ... </div>  → Starlight-styled card grid HTML
  */
@@ -93,10 +93,10 @@ function preprocessMarkdown(content, framework) {
   //     CodeSandbox links resolve to the correct in-progress build artifact.
   result = result.replace(/\{\{\s*\$currentVersion\s*\}\}/g, CURRENT_DOCS_VERSION);
 
-  // 6d. Fix {{$currentMinorVersion}} → major.minor version string.
-  //     Production builds strip the patch (e.g. "17.1.0" → "17.1") to match the
-  //     prod-docs/X.Y branch naming convention used for GitHub source-code links.
-  //     Staging/dev builds resolve to "develop".
+  // 6d. Fix {{$currentMinorVersion}} → GitHub branch path for source-code links.
+  //     Production builds produce "prod-docs/X.Y" (e.g. "prod-docs/17.1").
+  //     Staging/dev builds resolve to "develop" (no prod-docs/ prefix, since
+  //     the prod-docs/develop branch does not exist).
   result = result.replace(/\{\{\s*\$currentMinorVersion\s*\}\}/g, CURRENT_DOCS_MINOR_VERSION);
 
   // 7. Transform @/framework/... cross-framework alias links to absolute paths.

--- a/docs/src/plugins/vuepress-preprocessor.mjs
+++ b/docs/src/plugins/vuepress-preprocessor.mjs
@@ -11,12 +11,13 @@
  * - ::: example / ::: example-without-tabs  (strip markers, keep code blocks)
  * - ::: source-code-link URL  (convert to <a> tag)
  * - $withBase('/path') → /path
- * - {{$currentVersion}} → resolved Handsontable version string
+ * - {{$currentVersion}} → resolved Handsontable version string (full semver, e.g. "17.1.0")
+ * - {{$currentMinorVersion}} → major.minor version (e.g. "17.1") for prod-docs GitHub branch links
  * - @/framework/path links  → /path (cross-framework alias)
  * - <div class="boxes-list"> ... </div>  → Starlight-styled card grid HTML
  */
 
-import { CURRENT_DOCS_VERSION } from './docs-version.mjs';
+import { CURRENT_DOCS_VERSION, CURRENT_DOCS_MINOR_VERSION } from './docs-version.mjs';
 import { convertAsideInlineMarkdown } from './aside-inline-markdown.mjs';
 
 /**
@@ -91,6 +92,12 @@ function preprocessMarkdown(content, framework) {
   //     Staging/dev builds use "0.0.0-next-{shortSHA}-{YYYYMMDD}" so that
   //     CodeSandbox links resolve to the correct in-progress build artifact.
   result = result.replace(/\{\{\s*\$currentVersion\s*\}\}/g, CURRENT_DOCS_VERSION);
+
+  // 6d. Fix {{$currentMinorVersion}} → major.minor version string.
+  //     Production builds strip the patch (e.g. "17.1.0" → "17.1") to match the
+  //     prod-docs/X.Y branch naming convention used for GitHub source-code links.
+  //     Staging/dev builds resolve to "develop".
+  result = result.replace(/\{\{\s*\$currentMinorVersion\s*\}\}/g, CURRENT_DOCS_MINOR_VERSION);
 
   // 7. Transform @/framework/... cross-framework alias links to absolute paths.
   //    e.g. @/react/guides/foo/foo.md → /guides/foo/foo


### PR DESCRIPTION
## Summary

- The five "Find the code on GitHub" links on `/demo` were 404-ing because they pointed to `prod-docs/17.1.0` -- but the CI workflow names prod-docs branches using `major.minor` only (e.g. `prod-docs/17.1`).
- Adds a new `{{$currentMinorVersion}}` template variable that strips the patch segment from the version string (`17.1.0` → `17.1`). For non-production builds it falls back to `develop`.
- Switches the five GitHub source-code links in `demo.md` from `{{$currentVersion}}` to `{{$currentMinorVersion}}`.

## Root cause

`docs-version.mjs` returns the full semver string (`17.1.0`) from `handsontable/package.json`, which was being embedded directly into the GitHub tree URL. The prod-docs CI workflow (`docs-production.yml`, line 41) extracts the branch version with the regex `/(\d+\.\d+)$/`, which only matches `major.minor`. This means the prod-docs branch is always `prod-docs/17.1`, never `prod-docs/17.1.0`, so all generated links returned 404.

## Test plan

- [ ] Visit https://handsontable.com/docs/javascript-data-grid/demo/ after the next docs deployment.
- [ ] Click each of the five "Find the code on GitHub" links:
  - JavaScript demo app → should open `examples/next/docs/js/demo/`
  - TypeScript demo app → should open `examples/next/docs/ts/demo/`
  - Angular demo app → should open `examples/next/docs/angular-wrapper/demo/`
  - React demo app → should open `examples/next/docs/react-wrapper/demo/`
  - Vue demo app → should open `examples/next/docs/vue3/demo/`
- [ ] Verify all five links resolve to the correct GitHub directory (no 404).
- [ ] Confirm the CodeSandbox links on the Introduction page still work (they use `{{$currentVersion}}` and must not be changed).

[skip changelog]

https://claude.ai/code/session_01AuhCE32R7bNKuzpcoGgkzq

---
_Generated by [Claude Code](https://claude.ai/code/session_01AuhCE32R7bNKuzpcoGgkzq)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only template variable and link substitution; no runtime product or auth changes.
> 
> **Overview**
> Fixes **404 "Find the code on GitHub"** links on the demo page by aligning GitHub tree URLs with how **prod-docs** branches are named (`prod-docs/17.1`, not full semver).
> 
> Introduces **`{{$currentMinorVersion}}`**, resolved at build time in `docs-version.mjs` as **`prod-docs/X.Y`** in production (patch stripped from package version) and **`develop`** elsewhere. **`framework-loader.mjs`** and **`vuepress-preprocessor.mjs`** substitute it like **`{{$currentVersion}}`**. The five demo links in **`demo.md`** now use **`{{$currentMinorVersion}}`** instead of **`{{$currentVersion}}`**; Introduction **CodeSandbox** links stay on full semver.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11565b00ff555ed53bb8b54943b95187797905ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->