### PR TITLE
DEV-1727: Add vue to the framework registry

### DIFF
--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -2,8 +2,8 @@
  * Astro content collection schema.
  *
  * Uses a custom framework-loader that reads all .md files from docs/content/
- * and creates 3 entries per file — one per framework (JavaScript, React,
- * Angular). The loader applies per-framework only-for content filtering and
+ * and creates 4 entries per file — one per framework (JavaScript, React,
+ * Angular, Vue). The loader applies per-framework only-for content filtering and
  * all other VuePress preprocessing at load time.
  *
  * Entry IDs follow the pattern: {framework-prefix}/{slug}

--- a/docs/src/plugins/framework-loader.mjs
+++ b/docs/src/plugins/framework-loader.mjs
@@ -485,17 +485,18 @@ function processExampleBlocks(content, contentDir) {
   return result.join('\n');
 }
 
-const FRAMEWORKS = ['javascript', 'react', 'angular'];
+const FRAMEWORKS = ['javascript', 'react', 'angular', 'vue'];
 
 const PREFIXES = {
   javascript: 'javascript-data-grid',
   react: 'react-data-grid',
   angular: 'angular-data-grid',
+  vue: 'vue-data-grid',
 };
 
 // Bump this when the loader logic changes to force Astro's data store to
 // re-process all entries (the store skips entries whose digest hasn't changed).
-const LOADER_VERSION = 'v35';
+const LOADER_VERSION = 'v36';
 
 // ---------------------------------------------------------------------------
 // File listing (recursive, no external glob)


### PR DESCRIPTION
### Context

The PR adds `vue` as a fourth framework variant to the docs content loader. Previously `framework-loader.mjs` only iterated over `javascript`, `react`, and `angular`, producing three sets of URL-prefixed pages (`javascript-data-grid/`, `react-data-grid/`, `angular-data-grid/`). This change extends `FRAMEWORKS` and `PREFIXES` to include `vue` / `vue-data-grid`, so the build now produces a fourth page set under `vue-data-grid/` for every `.md` file in `docs/content/`. `LOADER_VERSION` is bumped to `v36` to force Astro's data store to re-process all entries and pick up the new Vue entries.

### How has this been tested?

- Manual: run `npm run dev` inside `docs/` and verify the build completes without errors and `vue-data-grid/*` routes are served alongside the existing three framework variants.
- The existing three framework variants are unaffected (only additive changes to FRAMEWORKS, PREFIXES, and LOADER_VERSION).

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. DEV-1727

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]
