### PR TITLE
DEV-1727, DEV-1731: Add Vue as a first-class framework, register routes and populate frontmatter

### DIFF
--- a/docs/content/api/introduction.md
+++ b/docs/content/api/introduction.md
@@ -13,6 +13,9 @@ react:
 angular:
   id: 48gjbys8
   metaTitle: API reference - Angular Data Grid | Handsontable
+vue:
+  id: lk8x28al
+  metaTitle: API reference - Vue Data Grid | Handsontable
 ---
 This page describes the Handsontable API -- the methods, hooks, and plugin interfaces you use to control the grid programmatically.
 

--- a/docs/content/api/plugins.md
+++ b/docs/content/api/plugins.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: gueng7dm
   metaTitle: 'API reference: Plugins - Angular Data Grid | Handsontable'
+vue:
+  id: mvftxzxh
+  metaTitle: 'API reference: Plugins - Vue Data Grid | Handsontable'
 ---
 |Plugin Name  | Description |
 |--|--|

--- a/docs/content/guides/accessibility/accessibility-conformance-report/accessibility-conformance-report.md
+++ b/docs/content/guides/accessibility/accessibility-conformance-report/accessibility-conformance-report.md
@@ -20,6 +20,9 @@ react:
 angular:
   id: r7vpat03
   metaTitle: Accessibility conformance report (VPAT) - Angular Data Grid | Handsontable
+vue:
+  id: vvtwmknl
+  metaTitle: Accessibility conformance report (VPAT) - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Accessibility
 ---

--- a/docs/content/guides/accessibility/accessibility/accessibility.md
+++ b/docs/content/guides/accessibility/accessibility/accessibility.md
@@ -24,6 +24,9 @@ react:
 angular:
   id: 99l3uae8
   metaTitle: Accessibility - Angular Data Grid | Handsontable
+vue:
+  id: br13tylp
+  metaTitle: Accessibility - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Accessibility
 ---

--- a/docs/content/guides/accessories-and-menus/context-menu/context-menu.md
+++ b/docs/content/guides/accessories-and-menus/context-menu/context-menu.md
@@ -17,6 +17,9 @@ react:
 angular:
   id: 3xspgb3u
   metaTitle: Context menu - Angular Data Grid | Handsontable
+vue:
+  id: qgm3koe6
+  metaTitle: Context menu - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Accessories and menus
 menuTag: updated

--- a/docs/content/guides/accessories-and-menus/drag-to-scroll/drag-to-scroll.md
+++ b/docs/content/guides/accessories-and-menus/drag-to-scroll/drag-to-scroll.md
@@ -18,6 +18,9 @@ react:
 angular:
   id: h2vz7cfs
   metaTitle: Drag to scroll - Angular Data Grid | Handsontable
+vue:
+  id: axdawq9z
+  metaTitle: Drag to scroll - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Accessories and menus
 menuTag: new

--- a/docs/content/guides/accessories-and-menus/empty-data-state/empty-data-state.md
+++ b/docs/content/guides/accessories-and-menus/empty-data-state/empty-data-state.md
@@ -19,6 +19,9 @@ react:
 angular:
   id: 9f2e8c4a
   metaTitle: Empty Data State - Angular Data Grid | Handsontable
+vue:
+  id: qx83am9a
+  metaTitle: Empty Data State - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Accessories and Menus
 ---

--- a/docs/content/guides/accessories-and-menus/export-to-csv/export-to-csv.md
+++ b/docs/content/guides/accessories-and-menus/export-to-csv/export-to-csv.md
@@ -15,6 +15,9 @@ react:
 angular:
   id: hwhzgoir
   metaTitle: Export to CSV - Angular Data Grid | Handsontable
+vue:
+  id: z1ogjdj0
+  metaTitle: Export to CSV - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Accessories and menus
 menuTag: updated

--- a/docs/content/guides/accessories-and-menus/export-to-excel/export-to-excel.md
+++ b/docs/content/guides/accessories-and-menus/export-to-excel/export-to-excel.md
@@ -17,6 +17,9 @@ react:
 angular:
   id: wm5j9ry1
   metaTitle: Export to Excel - Angular Data Grid | Handsontable
+vue:
+  id: 2a0aqf2z
+  metaTitle: Export to Excel - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Accessories and menus
 menuTag: new

--- a/docs/content/guides/accessories-and-menus/icon-pack/icon-pack.md
+++ b/docs/content/guides/accessories-and-menus/icon-pack/icon-pack.md
@@ -15,6 +15,9 @@ react:
 angular:
   id: 5qu8t28e
   metaTitle: Icon pack - Angular Data Grid | Handsontable
+vue:
+  id: x2vg8kb0
+  metaTitle: Icon pack - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Accessories and menus
 ---

--- a/docs/content/guides/accessories-and-menus/undo-redo/undo-redo.md
+++ b/docs/content/guides/accessories-and-menus/undo-redo/undo-redo.md
@@ -20,6 +20,9 @@ react:
 angular:
   id: o21k5bjr
   metaTitle: Undo and redo - Angular Data Grid | Handsontable
+vue:
+  id: lf37v5ul
+  metaTitle: Undo and redo - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Accessories and menus
 ---

--- a/docs/content/guides/cell-features/autofill-values/autofill-values.md
+++ b/docs/content/guides/cell-features/autofill-values/autofill-values.md
@@ -20,6 +20,9 @@ react:
 angular:
   id: 8tftfxgq
   metaTitle: Autofill values - Angular Data Grid | Handsontable
+vue:
+  id: mhnmzkay
+  metaTitle: Autofill values - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features
 ---

--- a/docs/content/guides/cell-features/clipboard/clipboard.md
+++ b/docs/content/guides/cell-features/clipboard/clipboard.md
@@ -16,6 +16,9 @@ react:
 angular:
   id: q473yaal
   metaTitle: Clipboard - Angular Data Grid | Handsontable
+vue:
+  id: hiuseqwy
+  metaTitle: Clipboard - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features
 ---

--- a/docs/content/guides/cell-features/comments/comments.md
+++ b/docs/content/guides/cell-features/comments/comments.md
@@ -14,6 +14,9 @@ react:
 angular:
   id: o4jcn137
   metaTitle: Comments - Angular Data Grid | Handsontable
+vue:
+  id: 5vq1pcjg
+  metaTitle: Comments - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features
 ---

--- a/docs/content/guides/cell-features/conditional-formatting/conditional-formatting.md
+++ b/docs/content/guides/cell-features/conditional-formatting/conditional-formatting.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: uz3qc620
   metaTitle: Conditional formatting - Angular Data Grid | Handsontable
+vue:
+  id: 6w0okh8i
+  metaTitle: Conditional formatting - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features
 ---

--- a/docs/content/guides/cell-features/disabled-cells/disabled-cells.md
+++ b/docs/content/guides/cell-features/disabled-cells/disabled-cells.md
@@ -18,6 +18,9 @@ react:
 angular:
   id: 2epog9e1
   metaTitle: Disabled cells - Angular Data Grid | Handsontable
+vue:
+  id: jn1egqb7
+  metaTitle: Disabled cells - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features
 ---

--- a/docs/content/guides/cell-features/formatting-cells/formatting-cells.md
+++ b/docs/content/guides/cell-features/formatting-cells/formatting-cells.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: 0eswjne7
   metaTitle: Formatting cells - Angular Data Grid | Handsontable
+vue:
+  id: dqqkqp0d
+  metaTitle: Formatting cells - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features
 ---

--- a/docs/content/guides/cell-features/merge-cells/merge-cells.md
+++ b/docs/content/guides/cell-features/merge-cells/merge-cells.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: pbcdsao1
   metaTitle: Merge cells - Angular Data Grid | Handsontable
+vue:
+  id: lo9jkbbq
+  metaTitle: Merge cells - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features
 ---

--- a/docs/content/guides/cell-features/selection/selection.md
+++ b/docs/content/guides/cell-features/selection/selection.md
@@ -15,6 +15,9 @@ react:
 angular:
   id: 8l4fmyur
   metaTitle: Selection - Angular Data Grid | Handsontable
+vue:
+  id: tnavl8bq
+  metaTitle: Selection - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features
 ---

--- a/docs/content/guides/cell-features/text-alignment/text-alignment.md
+++ b/docs/content/guides/cell-features/text-alignment/text-alignment.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: h6sbjq1g
   metaTitle: Text alignment - Angular Data Grid | Handsontable
+vue:
+  id: bqfjy5q5
+  metaTitle: Text alignment - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features
 ---

--- a/docs/content/guides/cell-functions/cell-editor/cell-editor.md
+++ b/docs/content/guides/cell-functions/cell-editor/cell-editor.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: 7qb4y4u4
   metaTitle: Cell editor - Angular Data Grid | Handsontable
+vue:
+  id: qwv2hoqe
+  metaTitle: Cell editor - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell functions
 ---

--- a/docs/content/guides/cell-functions/cell-function/cell-function.md
+++ b/docs/content/guides/cell-functions/cell-function/cell-function.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: 377lnttu
   metaTitle: Cell functions - Angular Data Grid | Handsontable
+vue:
+  id: bc7idv59
+  metaTitle: Cell functions - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell functions
 ---

--- a/docs/content/guides/cell-functions/cell-renderer/cell-renderer.md
+++ b/docs/content/guides/cell-functions/cell-renderer/cell-renderer.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: 36rymylj
   metaTitle: Cell renderer - Angular Data Grid | Handsontable
+vue:
+  id: hsxnm2ev
+  metaTitle: Cell renderer - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell functions
 ---

--- a/docs/content/guides/cell-functions/cell-validator/cell-validator.md
+++ b/docs/content/guides/cell-functions/cell-validator/cell-validator.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: ut7amcaz
   metaTitle: Cell validator - Angular Data Grid | Handsontable
+vue:
+  id: bcog8al2
+  metaTitle: Cell validator - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell functions
 ---

--- a/docs/content/guides/cell-functions/custom-cells/custom-cells.md
+++ b/docs/content/guides/cell-functions/custom-cells/custom-cells.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: 29d3662c
   metaTitle: Custom Cell Definitions - Angular Data Grid | Handsontable
+vue:
+  id: q319vaao
+  metaTitle: Custom Cell Definitions - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell functions
 ---

--- a/docs/content/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md
@@ -17,6 +17,9 @@ react:
 angular:
   id: md3vhixm
   metaTitle: Autocomplete cell type - Angular Data Grid | Handsontable
+vue:
+  id: 1w3x57l3
+  metaTitle: Autocomplete cell type - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types
 ---

--- a/docs/content/guides/cell-types/cell-type/cell-type.md
+++ b/docs/content/guides/cell-types/cell-type/cell-type.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: aho23taw
   metaTitle: Cell type - Angular Data Grid | Handsontable
+vue:
+  id: 8y6p0z00
+  metaTitle: Cell type - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types
 ---

--- a/docs/content/guides/cell-types/checkbox-cell-type/checkbox-cell-type.md
+++ b/docs/content/guides/cell-types/checkbox-cell-type/checkbox-cell-type.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: 4cn9mp6z
   metaTitle: Checkbox cell type - Angular Data Grid | Handsontable
+vue:
+  id: 2a1x3jgu
+  metaTitle: Checkbox cell type - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types
 ---

--- a/docs/content/guides/cell-types/date-cell-type/date-cell-type.md
+++ b/docs/content/guides/cell-types/date-cell-type/date-cell-type.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: 9vvupwbx
   metaTitle: Date cell type - Angular Data Grid | Handsontable
+vue:
+  id: 0t5rmi6v
+  metaTitle: Date cell type - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types
 ---

--- a/docs/content/guides/cell-types/dropdown-cell-type/dropdown-cell-type.md
+++ b/docs/content/guides/cell-types/dropdown-cell-type/dropdown-cell-type.md
@@ -17,6 +17,9 @@ react:
 angular:
   id: yatyane1
   metaTitle: Dropdown cell type - Angular Data Grid | Handsontable
+vue:
+  id: k3c8d136
+  metaTitle: Dropdown cell type - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types
 ---

--- a/docs/content/guides/cell-types/handsontable-cell-type/handsontable-cell-type.md
+++ b/docs/content/guides/cell-types/handsontable-cell-type/handsontable-cell-type.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: cewiknc8
   metaTitle: Handsontable cell type - Angular Data Grid | Handsontable
+vue:
+  id: wd9yzry6
+  metaTitle: Handsontable cell type - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types
 ---

--- a/docs/content/guides/cell-types/multiselect-cell-type/multiselect-cell-type.md
+++ b/docs/content/guides/cell-types/multiselect-cell-type/multiselect-cell-type.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: mdg4dixm
   metaTitle: MultiSelect cell type - Angular Data Grid | Handsontable
+vue:
+  id: 6zrsi767
+  metaTitle: MultiSelect cell type - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types
 ---

--- a/docs/content/guides/cell-types/numeric-cell-type/numeric-cell-type.md
+++ b/docs/content/guides/cell-types/numeric-cell-type/numeric-cell-type.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: odhu846f
   metaTitle: Numeric cell type - Angular Data Grid | Handsontable
+vue:
+  id: 31btf76b
+  metaTitle: Numeric cell type - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types
 ---

--- a/docs/content/guides/cell-types/password-cell-type/password-cell-type.md
+++ b/docs/content/guides/cell-types/password-cell-type/password-cell-type.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: 2x5025ww
   metaTitle: Password cell type - Angular Data Grid | Handsontable
+vue:
+  id: lfsxgjsp
+  metaTitle: Password cell type - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types
 ---

--- a/docs/content/guides/cell-types/select-cell-type/select-cell-type.md
+++ b/docs/content/guides/cell-types/select-cell-type/select-cell-type.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: dtzqxytv
   metaTitle: Select cell type - Angular Data Grid | Handsontable
+vue:
+  id: phqvirxa
+  metaTitle: Select cell type - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types
 ---

--- a/docs/content/guides/cell-types/time-cell-type/time-cell-type.md
+++ b/docs/content/guides/cell-types/time-cell-type/time-cell-type.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: fu9fqphw
   metaTitle: Time cell type - Angular Data Grid | Handsontable
+vue:
+  id: bxoffcid
+  metaTitle: Time cell type - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types
 ---

--- a/docs/content/guides/columns/column-filter/column-filter.md
+++ b/docs/content/guides/columns/column-filter/column-filter.md
@@ -25,6 +25,9 @@ react:
 angular:
   id: woyi876m
   metaTitle: Column filter - Angular Data Grid | Handsontable
+vue:
+  id: mv5nc30h
+  metaTitle: Column filter - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Columns
 ---

--- a/docs/content/guides/columns/column-freezing/column-freezing.md
+++ b/docs/content/guides/columns/column-freezing/column-freezing.md
@@ -17,6 +17,9 @@ react:
 angular:
   id: i85vqeao
   metaTitle: Column freezing - Angular Data Grid | Handsontable
+vue:
+  id: yfngr43j
+  metaTitle: Column freezing - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Columns
 ---

--- a/docs/content/guides/columns/column-groups/column-groups.md
+++ b/docs/content/guides/columns/column-groups/column-groups.md
@@ -18,6 +18,9 @@ react:
 angular:
   id: 2k8cam98
   metaTitle: Column groups - Angular Data Grid | Handsontable
+vue:
+  id: ogbyqaox
+  metaTitle: Column groups - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Columns
 menuTag: updated

--- a/docs/content/guides/columns/column-header/column-header.md
+++ b/docs/content/guides/columns/column-header/column-header.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: owl7h4t1
   metaTitle: Column headers - Angular Data Grid | Handsontable
+vue:
+  id: j4ac3057
+  metaTitle: Column headers - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Columns
 ---

--- a/docs/content/guides/columns/column-hiding/column-hiding.md
+++ b/docs/content/guides/columns/column-hiding/column-hiding.md
@@ -14,6 +14,9 @@ react:
 angular:
   id: 69k5r1oh
   metaTitle: Column hiding - Angular Data Grid | Handsontable
+vue:
+  id: hwodm9tg
+  metaTitle: Column hiding - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Columns
 ---

--- a/docs/content/guides/columns/column-menu/column-menu.md
+++ b/docs/content/guides/columns/column-menu/column-menu.md
@@ -14,6 +14,9 @@ react:
 angular:
   id: zclxcsij
   metaTitle: Column menu - Angular Data Grid | Handsontable
+vue:
+  id: km8rip58
+  metaTitle: Column menu - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Columns
 ---

--- a/docs/content/guides/columns/column-moving/column-moving.md
+++ b/docs/content/guides/columns/column-moving/column-moving.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: fsfvsoi3
   metaTitle: Column moving - Angular Data Grid | Handsontable
+vue:
+  id: 79rgvlew
+  metaTitle: Column moving - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Columns
 ---

--- a/docs/content/guides/columns/column-summary/column-summary.md
+++ b/docs/content/guides/columns/column-summary/column-summary.md
@@ -20,6 +20,9 @@ react:
 angular:
   id: 1rptt5bu
   metaTitle: Column summary - Angular Data Grid | Handsontable
+vue:
+  id: hqbq312j
+  metaTitle: Column summary - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Columns
 ---

--- a/docs/content/guides/columns/column-virtualization/column-virtualization.md
+++ b/docs/content/guides/columns/column-virtualization/column-virtualization.md
@@ -16,6 +16,9 @@ react:
 angular:
   id: qhqjtdsr
   metaTitle: Column virtualization - Angular Data Grid | Handsontable
+vue:
+  id: y0yzk8sd
+  metaTitle: Column virtualization - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Columns
 ---

--- a/docs/content/guides/columns/column-width/column-width.md
+++ b/docs/content/guides/columns/column-width/column-width.md
@@ -21,6 +21,9 @@ react:
 angular:
   id: eourt93b
   metaTitle: Column widths - Angular Data Grid | Handsontable
+vue:
+  id: tp1u20zm
+  metaTitle: Column widths - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Columns
 ---

--- a/docs/content/guides/dialog/dialog/dialog.md
+++ b/docs/content/guides/dialog/dialog/dialog.md
@@ -19,6 +19,9 @@ react:
 angular:
   id: vq1llzfz
   metaTitle: Dialog - Angular Data Grid | Handsontable
+vue:
+  id: r8xzqxzt
+  metaTitle: Dialog - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Dialog
 ---

--- a/docs/content/guides/dialog/loading/loading.md
+++ b/docs/content/guides/dialog/loading/loading.md
@@ -19,6 +19,9 @@ react:
 angular:
   id: wq2llzfz
   metaTitle: Loading - Angular Data Grid | Handsontable
+vue:
+  id: odrgfc3c
+  metaTitle: Loading - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Dialog
 ---

--- a/docs/content/guides/dialog/notification/notification.md
+++ b/docs/content/guides/dialog/notification/notification.md
@@ -17,6 +17,9 @@ react:
 angular:
   id: xr3llzfz
   metaTitle: Notification - Angular Data Grid | Handsontable
+vue:
+  id: i9f864ry
+  metaTitle: Notification - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Dialog
 menuTag: new

--- a/docs/content/guides/formulas/formula-calculation/formula-calculation.md
+++ b/docs/content/guides/formulas/formula-calculation/formula-calculation.md
@@ -22,6 +22,9 @@ react:
 angular:
   id: hqzll0fz
   metaTitle: Formula calculation - Angular Data Grid | Handsontable
+vue:
+  id: 57yg2rca
+  metaTitle: Formula calculation - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Formulas
 ---

--- a/docs/content/guides/getting-started/binding-to-data/binding-to-data.md
+++ b/docs/content/guides/getting-started/binding-to-data/binding-to-data.md
@@ -16,6 +16,9 @@ react:
 angular:
   id: xnqn2zg9
   metaTitle: Binding to data - Angular Data Grid | Handsontable
+vue:
+  id: lahmb9og
+  metaTitle: Binding to data - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Getting started
 ---

--- a/docs/content/guides/getting-started/configuration-options/configuration-options.md
+++ b/docs/content/guides/getting-started/configuration-options/configuration-options.md
@@ -16,6 +16,9 @@ react:
 angular:
   id: 16bofyho
   metaTitle: Configuration options - Angular Data Grid | Handsontable
+vue:
+  id: 4xi8scx0
+  metaTitle: Configuration options - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Getting started
 ---

--- a/docs/content/guides/getting-started/demo/demo.md
+++ b/docs/content/guides/getting-started/demo/demo.md
@@ -17,6 +17,9 @@ angular:
   id: i2n378hh
   metaTitle: Demo - Angular Data Grid | Handsontable
   description: Play around with a demo of Handsontable in Angular.
+vue:
+  id: c104k1nn
+  metaTitle: Demo - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Getting started
 ---

--- a/docs/content/guides/getting-started/events-and-hooks/events-and-hooks.md
+++ b/docs/content/guides/getting-started/events-and-hooks/events-and-hooks.md
@@ -22,6 +22,9 @@ react:
 angular:
   id: iifvbgu0
   metaTitle: Events and hooks - Angular Data Grid | Handsontable
+vue:
+  id: nmvkusp7
+  metaTitle: Events and hooks - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Data management
 ---

--- a/docs/content/guides/getting-started/grid-size/grid-size.md
+++ b/docs/content/guides/getting-started/grid-size/grid-size.md
@@ -17,6 +17,9 @@ react:
 angular:
   id: w6lvb55f
   metaTitle: Grid size - Angular Data Grid | Handsontable
+vue:
+  id: ej8mo5um
+  metaTitle: Grid size - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Getting started
 ---

--- a/docs/content/guides/getting-started/installation/installation.md
+++ b/docs/content/guides/getting-started/installation/installation.md
@@ -14,6 +14,9 @@ react:
 angular:
   id: y52wtu7t
   metaTitle: Installation - Angular Data Grid | Handsontable
+vue:
+  id: gflge7lk
+  metaTitle: Installation - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Getting started
 ---

--- a/docs/content/guides/getting-started/introduction/introduction.md
+++ b/docs/content/guides/getting-started/introduction/introduction.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: igd8lqh8
   metaTitle: Angular Data Grid - Documentation | Handsontable
+vue:
+  id: xpwj6wcn
+  metaTitle: Vue Data Grid - Documentation | Handsontable
 searchCategory: Guides
 category: Getting started
 ---

--- a/docs/content/guides/getting-started/license-key/license-key.md
+++ b/docs/content/guides/getting-started/license-key/license-key.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: bcvwr25r
   metaTitle: License key - Angular Data Grid | Handsontable
+vue:
+  id: 7pgm711u
+  metaTitle: License key - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Getting started
 ---

--- a/docs/content/guides/getting-started/react-methods/react-methods.md
+++ b/docs/content/guides/getting-started/react-methods/react-methods.md
@@ -17,6 +17,9 @@ react:
 angular:
   id: 7a8puryp
   metaTitle: Instance methods - Angular Data Grid | Handsontable
+vue:
+  id: dzj81kmk
+  metaTitle: Instance methods - Vue Data Grid | Handsontable
 searchCategory: Guides
 onlyFor: react
 category: Getting started

--- a/docs/content/guides/getting-started/saving-data/saving-data.md
+++ b/docs/content/guides/getting-started/saving-data/saving-data.md
@@ -16,6 +16,9 @@ react:
 angular:
   id: uny2nvqk
   metaTitle: Saving data - Angular Data Grid | Handsontable
+vue:
+  id: qnevlxum
+  metaTitle: Saving data - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Getting started
 ---

--- a/docs/content/guides/getting-started/server-side-data/server-side-data-configuration.md
+++ b/docs/content/guides/getting-started/server-side-data/server-side-data-configuration.md
@@ -16,6 +16,9 @@ react:
 angular:
   id: u7x3q0n5
   metaTitle: Server-side configuration - Angular Data Grid | Handsontable
+vue:
+  id: fqk72s67
+  metaTitle: Server-side configuration - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Server-side data
 ---

--- a/docs/content/guides/getting-started/server-side-data/server-side-data-crud.md
+++ b/docs/content/guides/getting-started/server-side-data/server-side-data-crud.md
@@ -16,6 +16,9 @@ react:
 angular:
   id: w9z5s1q7
   metaTitle: Server-side CRUD - Angular Data Grid | Handsontable
+vue:
+  id: aryloxoj
+  metaTitle: Server-side CRUD - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Server-side data
 ---

--- a/docs/content/guides/getting-started/server-side-data/server-side-data-fetching.md
+++ b/docs/content/guides/getting-started/server-side-data/server-side-data-fetching.md
@@ -17,6 +17,9 @@ react:
 angular:
   id: y1b7u3s9
   metaTitle: Server-side fetching and examples - Angular Data Grid | Handsontable
+vue:
+  id: 5wb5dzit
+  metaTitle: Server-side fetching and examples - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Server-side data
 ---

--- a/docs/content/guides/getting-started/server-side-data/server-side-data-migration.md
+++ b/docs/content/guides/getting-started/server-side-data/server-side-data-migration.md
@@ -16,6 +16,9 @@ react:
 angular:
   id: s5p9n3l8
   metaTitle: Migrate to server-side data - Angular Data Grid | Handsontable
+vue:
+  id: 0c1h1cah
+  metaTitle: Migrate to server-side data - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Server-side data
 ---

--- a/docs/content/guides/getting-started/server-side-data/server-side-data.md
+++ b/docs/content/guides/getting-started/server-side-data/server-side-data.md
@@ -17,6 +17,9 @@ react:
 angular:
   id: zn7h5m6s
   metaTitle: Server-side data - Angular Data Grid | Handsontable
+vue:
+  id: 8ct2kiul
+  metaTitle: Server-side data - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Getting started
 menuTag: new

--- a/docs/content/guides/integrate-with-vue3/vue3-custom-context-menu-example/vue3-custom-context-menu-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-custom-context-menu-example/vue3-custom-context-menu-example.md
@@ -12,6 +12,8 @@ react:
 angular:
   id: fp49yb44
   metaTitle: Custom context menu - Vue 3 Data Grid | Handsontable
+vue:
+  id: 8wqgvxxv
 searchCategory: Guides
 category: Integrate with Vue 3
 ---

--- a/docs/content/guides/integrate-with-vue3/vue3-custom-editor-example/vue3-custom-editor-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-custom-editor-example/vue3-custom-editor-example.md
@@ -12,6 +12,8 @@ react:
 angular:
   id: nmw9ha36
   metaTitle: Custom cell editor - Vue 3 Data Grid | Handsontable
+vue:
+  id: 9a852yq1
 searchCategory: Guides
 category: Integrate with Vue 3
 ---

--- a/docs/content/guides/integrate-with-vue3/vue3-custom-id-class-style/vue3-custom-id-class-style.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-custom-id-class-style/vue3-custom-id-class-style.md
@@ -12,6 +12,8 @@ react:
 angular:
   id: 9zzwqp3r
   metaTitle: Custom ID, class, and style - Vue 3 Data Grid | Handsontable
+vue:
+  id: g8a1yt31
 searchCategory: Guides
 category: Integrate with Vue 3
 ---

--- a/docs/content/guides/integrate-with-vue3/vue3-custom-renderer-example/vue3-custom-renderer-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-custom-renderer-example/vue3-custom-renderer-example.md
@@ -12,6 +12,8 @@ react:
 angular:
   id: karjf4av
   metaTitle: Custom cell renderer - Vue 3 Data Grid | Handsontable
+vue:
+  id: 3a3ut00h
 searchCategory: Guides
 category: Integrate with Vue 3
 ---

--- a/docs/content/guides/integrate-with-vue3/vue3-formulas-example/vue3-formulas-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-formulas-example/vue3-formulas-example.md
@@ -12,6 +12,8 @@ react:
 angular:
   id: 4h37k7c4
   metaTitle: Formulas integration in Vue 3 - Vue 3 Data Grid | Handsontable
+vue:
+  id: u9v86qrr
 searchCategory: Guides
 category: Integrate with Vue 3
 ---

--- a/docs/content/guides/integrate-with-vue3/vue3-hot-column/vue3-hot-column.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-hot-column/vue3-hot-column.md
@@ -12,6 +12,8 @@ react:
 angular:
   id: 65dx0xyo
   metaTitle: HotColumn component - Vue 3 Data Grid | Handsontable
+vue:
+  id: xhip154b
 searchCategory: Guides
 category: Integrate with Vue 3
 ---

--- a/docs/content/guides/integrate-with-vue3/vue3-hot-reference/vue3-hot-reference.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-hot-reference/vue3-hot-reference.md
@@ -12,6 +12,8 @@ react:
 angular:
   id: 7d76fp5u
   metaTitle: Referencing Handsontable - Vue 3 Data Grid | Handsontable
+vue:
+  id: u812ka23
 searchCategory: Guides
 category: Integrate with Vue 3
 ---

--- a/docs/content/guides/integrate-with-vue3/vue3-installation/vue3-installation.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-installation/vue3-installation.md
@@ -12,6 +12,8 @@ react:
 angular:
   id: od7j5cpt
   metaTitle: Installation - Vue 3 Data Grid | Handsontable
+vue:
+  id: zt7xpt7w
 searchCategory: Guides
 category: Integrate with Vue 3
 ---

--- a/docs/content/guides/integrate-with-vue3/vue3-language-change-example/vue3-language-change-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-language-change-example/vue3-language-change-example.md
@@ -12,6 +12,8 @@ react:
 angular:
   id: zjy408sj
   metaTitle: Language change - Vue 3 Data Grid | Handsontable
+vue:
+  id: jvniuywb
 searchCategory: Guides
 category: Integrate with Vue 3
 ---

--- a/docs/content/guides/integrate-with-vue3/vue3-modules/vue3-modules.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-modules/vue3-modules.md
@@ -12,6 +12,8 @@ react:
 angular:
   id: p3omli89
   metaTitle: Modules - Vue 3 Data Grid | Handsontable
+vue:
+  id: 7e5s8exy
 searchCategory: Guides
 category: Integrate with Vue 3
 ---

--- a/docs/content/guides/integrate-with-vue3/vue3-setting-up-a-language/vue3-setting-up-a-language.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-setting-up-a-language/vue3-setting-up-a-language.md
@@ -12,6 +12,8 @@ react:
 angular:
   id: wangjjlr
   metaTitle: Setting up a translation - Vue 3 Data Grid | Handsontable
+vue:
+  id: luusja1i
 searchCategory: Guides
 category: Integrate with Vue 3
 ---

--- a/docs/content/guides/integrate-with-vue3/vue3-simple-example/vue3-simple-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-simple-example/vue3-simple-example.md
@@ -12,6 +12,8 @@ react:
 angular:
   id: kojv7mkj
   metaTitle: Basic example - Vue 3 Data Grid | Handsontable
+vue:
+  id: 5vt9e553
 searchCategory: Guides
 category: Integrate with Vue 3
 ---

--- a/docs/content/guides/integrate-with-vue3/vue3-vuex-example/vue3-vuex-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-vuex-example/vue3-vuex-example.md
@@ -12,6 +12,8 @@ react:
 angular:
   id: b16i0n4r
   metaTitle: Integration with Vuex - Vue 3 Data Grid - Handsontable
+vue:
+  id: tv2zzko8
 searchCategory: Guides
 category: Integrate with Vue 3
 ---

--- a/docs/content/guides/internationalization/ime-support/ime-support.md
+++ b/docs/content/guides/internationalization/ime-support/ime-support.md
@@ -18,6 +18,9 @@ react:
 angular:
   id: 7u4izjbt
   metaTitle: IME support - Angular Data Grid | Handsontable
+vue:
+  id: 0m1fmtge
+  metaTitle: IME support - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Internationalization
 ---

--- a/docs/content/guides/internationalization/language/language.md
+++ b/docs/content/guides/internationalization/language/language.md
@@ -18,6 +18,9 @@ react:
 angular:
   id: eujz2e6s
   metaTitle: Language - Angular Data Grid | Handsontable
+vue:
+  id: np656che
+  metaTitle: Language - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Internationalization
 ---

--- a/docs/content/guides/internationalization/layout-direction/layout-direction.md
+++ b/docs/content/guides/internationalization/layout-direction/layout-direction.md
@@ -23,6 +23,9 @@ react:
 angular:
   id: orgwjmih
   metaTitle: Layout direction - Angular Data Grid | Handsontable
+vue:
+  id: ubzdplj2
+  metaTitle: Layout direction - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Internationalization
 ---

--- a/docs/content/guides/internationalization/locale/locale.md
+++ b/docs/content/guides/internationalization/locale/locale.md
@@ -17,6 +17,9 @@ react:
 angular:
   id: arpg1wyq
   metaTitle: Locale - Angular Data Grid | Handsontable
+vue:
+  id: rt5nxjxz
+  metaTitle: Locale - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Internationalization
 ---

--- a/docs/content/guides/navigation/custom-shortcuts/custom-shortcuts.md
+++ b/docs/content/guides/navigation/custom-shortcuts/custom-shortcuts.md
@@ -23,6 +23,9 @@ react:
 angular:
   id: lqk5kuws
   metaTitle: Custom shortcuts - Angular Data Grid | Handsontable
+vue:
+  id: 8i6v370n
+  metaTitle: Custom shortcuts - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Navigation
 ---

--- a/docs/content/guides/navigation/focus-scopes/focus-scopes.md
+++ b/docs/content/guides/navigation/focus-scopes/focus-scopes.md
@@ -20,6 +20,9 @@ react:
 angular:
   id: xat52y9g
   metaTitle: Focus scopes - Angular Data Grid | Handsontable
+vue:
+  id: 42scu64a
+  metaTitle: Focus scopes - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Navigation
 ---

--- a/docs/content/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md
+++ b/docs/content/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md
@@ -22,6 +22,9 @@ react:
 angular:
   id: v7sq2x22
   metaTitle: Keyboard shortcuts - Angular Data Grid | Handsontable
+vue:
+  id: h8l2k0pm
+  metaTitle: Keyboard shortcuts - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Navigation
 ---

--- a/docs/content/guides/navigation/searching-values/searching-values.md
+++ b/docs/content/guides/navigation/searching-values/searching-values.md
@@ -16,6 +16,9 @@ react:
 angular:
   id: q7wwbzzr
   metaTitle: Searching values - Angular Data Grid | Handsontable
+vue:
+  id: bzxlya7r
+  metaTitle: Searching values - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Navigation
 ---

--- a/docs/content/guides/optimization/batch-operations/batch-operations.md
+++ b/docs/content/guides/optimization/batch-operations/batch-operations.md
@@ -16,6 +16,9 @@ react:
 angular:
   id: tnvv2pjr
   metaTitle: Batch operations - Angular Data Grid | Handsontable
+vue:
+  id: 2h71fwls
+  metaTitle: Batch operations - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Optimization
 ---

--- a/docs/content/guides/optimization/bundle-size/bundle-size.md
+++ b/docs/content/guides/optimization/bundle-size/bundle-size.md
@@ -14,6 +14,9 @@ react:
 angular:
   id: qdq3dmts
   metaTitle: Bundle size - Angular Data Grid | Handsontable
+vue:
+  id: 3hb79ptx
+  metaTitle: Bundle size - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Optimization
 ---

--- a/docs/content/guides/optimization/performance/performance.md
+++ b/docs/content/guides/optimization/performance/performance.md
@@ -14,6 +14,9 @@ react:
 angular:
   id: 34wyxzpj
   metaTitle: Performance - Angular Data Grid | Handsontable
+vue:
+  id: 983rpyud
+  metaTitle: Performance - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Optimization
 menuTag: updated

--- a/docs/content/guides/rows/row-freezing/row-freezing.md
+++ b/docs/content/guides/rows/row-freezing/row-freezing.md
@@ -16,6 +16,9 @@ react:
 angular:
   id: mskor25j
   metaTitle: Row freezing - Angular Data Grid | Handsontable
+vue:
+  id: 42j169m6
+  metaTitle: Row freezing - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Rows
 ---

--- a/docs/content/guides/rows/row-header/row-header.md
+++ b/docs/content/guides/rows/row-header/row-header.md
@@ -16,6 +16,9 @@ react:
 angular:
   id: jtqk0t2p
   metaTitle: Row headers - Angular Data Grid | Handsontable
+vue:
+  id: 27seavlh
+  metaTitle: Row headers - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Rows
 ---

--- a/docs/content/guides/rows/row-height/row-height.md
+++ b/docs/content/guides/rows/row-height/row-height.md
@@ -23,6 +23,9 @@ react:
 angular:
   id: h42skmvo
   metaTitle: Row heights - Angular Data Grid | Handsontable
+vue:
+  id: xj52ap5s
+  metaTitle: Row heights - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Rows
 ---

--- a/docs/content/guides/rows/row-hiding/row-hiding.md
+++ b/docs/content/guides/rows/row-hiding/row-hiding.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: 2dxb42jh
   metaTitle: Row hiding - Angular Data Grid | Handsontable
+vue:
+  id: e9gf8ukv
+  metaTitle: Row hiding - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Rows
 ---

--- a/docs/content/guides/rows/row-moving/row-moving.md
+++ b/docs/content/guides/rows/row-moving/row-moving.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: ntz1a9ns
   metaTitle: Row moving - Angular Data Grid | Handsontable
+vue:
+  id: hhbbqpe7
+  metaTitle: Row moving - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Rows
 ---

--- a/docs/content/guides/rows/row-parent-child/row-parent-child.md
+++ b/docs/content/guides/rows/row-parent-child/row-parent-child.md
@@ -21,6 +21,9 @@ react:
 angular:
   id: ojdl5nkd
   metaTitle: Row parent-child - Angular Data Grid | Handsontable
+vue:
+  id: 9ww894yr
+  metaTitle: Row parent-child - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Rows
 ---

--- a/docs/content/guides/rows/row-prepopulating/row-prepopulating.md
+++ b/docs/content/guides/rows/row-prepopulating/row-prepopulating.md
@@ -17,6 +17,9 @@ react:
 angular:
   id: me99ozqr
   metaTitle: Row pre-populating - Angular Data Grid | Handsontable
+vue:
+  id: 8y54l1cw
+  metaTitle: Row pre-populating - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Rows
 ---

--- a/docs/content/guides/rows/row-trimming/row-trimming.md
+++ b/docs/content/guides/rows/row-trimming/row-trimming.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: fhh1b0n6
   metaTitle: Row trimming - Angular Data Grid | Handsontable
+vue:
+  id: 0dah88rc
+  metaTitle: Row trimming - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Rows
 ---

--- a/docs/content/guides/rows/row-virtualization/row-virtualization.md
+++ b/docs/content/guides/rows/row-virtualization/row-virtualization.md
@@ -16,6 +16,9 @@ react:
 angular:
   id: 2imqjvmp
   metaTitle: Row virtualization - Angular Data Grid | Handsontable
+vue:
+  id: 0d3wrjhf
+  metaTitle: Row virtualization - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Rows
 ---

--- a/docs/content/guides/rows/rows-pagination/rows-pagination.md
+++ b/docs/content/guides/rows/rows-pagination/rows-pagination.md
@@ -25,6 +25,9 @@ react:
 angular:
   id: lt6sgwts
   metaTitle: Row pagination - Angular Data Grid | Handsontable
+vue:
+  id: 57pnumth
+  metaTitle: Row pagination - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Rows
 menuTag: updated

--- a/docs/content/guides/rows/rows-sorting/rows-sorting.md
+++ b/docs/content/guides/rows/rows-sorting/rows-sorting.md
@@ -31,6 +31,9 @@ react:
 angular:
   id: kzkj37v5
   metaTitle: Rows sorting - Angular Data Grid | Handsontable
+vue:
+  id: d43129gx
+  metaTitle: Rows sorting - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Rows
 ---

--- a/docs/content/guides/security/security/security.md
+++ b/docs/content/guides/security/security/security.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: 25m4fmia
   metaTitle: Security - Angular Data Grid | Handsontable
+vue:
+  id: jwm6n1b7
+  metaTitle: Security - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Security
 ---

--- a/docs/content/guides/styling/design-system/design-system.md
+++ b/docs/content/guides/styling/design-system/design-system.md
@@ -23,6 +23,9 @@ react:
 angular:
   id: vru7jook
   metaTitle: Design System / UI Kit - Angular Data Grid | Handsontable
+vue:
+  id: ehyr1ulk
+  metaTitle: Design System / UI Kit - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Styling
 ---

--- a/docs/content/guides/styling/legacy-style/legacy-style.md
+++ b/docs/content/guides/styling/legacy-style/legacy-style.md
@@ -19,6 +19,9 @@ react:
 angular:
   id: 1sco7djp
   metaTitle: Legacy Style - Angular Data Grid | Handsontable
+vue:
+  id: 6xwhqf4v
+  metaTitle: Legacy Style - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Styling
 ---

--- a/docs/content/guides/styling/theme-customization/theme-customization.md
+++ b/docs/content/guides/styling/theme-customization/theme-customization.md
@@ -23,6 +23,9 @@ react:
 angular:
   id: xau2jfok
   metaTitle: Theme Customization - Angular Data Grid | Handsontable
+vue:
+  id: 2t881imb
+  metaTitle: Theme Customization - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Styling
 menuTag: updated

--- a/docs/content/guides/styling/themes/themes.md
+++ b/docs/content/guides/styling/themes/themes.md
@@ -28,6 +28,9 @@ react:
 angular:
   id: 1sco6djp
   metaTitle: Themes - Angular Data Grid | Handsontable
+vue:
+  id: ioop937e
+  metaTitle: Themes - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Styling
 ---

--- a/docs/content/guides/technical-specification/documentation-license/documentation-license.md
+++ b/docs/content/guides/technical-specification/documentation-license/documentation-license.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: g9ytiw67
   metaTitle: Documentation license - Angular Data Grid | Handsontable
+vue:
+  id: cr13gd09
+  metaTitle: Documentation license - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Technical specification
 ---

--- a/docs/content/guides/technical-specification/software-license/software-license.md
+++ b/docs/content/guides/technical-specification/software-license/software-license.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: fe9wliki
   metaTitle: Software license - Angular Data Grid | Handsontable
+vue:
+  id: l0bvmbpl
+  metaTitle: Software license - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Technical specification
 ---

--- a/docs/content/guides/technical-specification/supported-browsers/supported-browsers.md
+++ b/docs/content/guides/technical-specification/supported-browsers/supported-browsers.md
@@ -14,6 +14,9 @@ react:
 angular:
   id: a7fpjwud
   metaTitle: Supported browsers - Angular Data Grid | Handsontable
+vue:
+  id: 6kn7722c
+  metaTitle: Supported browsers - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Technical specification
 ---

--- a/docs/content/guides/technical-specification/third-party-licenses/third-party-licenses.md
+++ b/docs/content/guides/technical-specification/third-party-licenses/third-party-licenses.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: kc0urkyj
   metaTitle: Third-party licenses - Angular Data Grid | Handsontable
+vue:
+  id: ztyi7ggq
+  metaTitle: Third-party licenses - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Technical specification
 ---

--- a/docs/content/guides/tools-and-building/custom-builds/custom-builds.md
+++ b/docs/content/guides/tools-and-building/custom-builds/custom-builds.md
@@ -16,6 +16,9 @@ react:
 angular:
   id: 098p9wiw
   metaTitle: Custom builds - Angular Data Grid | Handsontable
+vue:
+  id: kg9fj032
+  metaTitle: Custom builds - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Tools and building
 ---

--- a/docs/content/guides/tools-and-building/custom-plugins/custom-plugins.md
+++ b/docs/content/guides/tools-and-building/custom-plugins/custom-plugins.md
@@ -16,6 +16,9 @@ react:
 angular:
   id: ompl9j5i
   metaTitle: Custom plugins - Angular Data Grid | Handsontable
+vue:
+  id: 8w2zb1ze
+  metaTitle: Custom plugins - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Tools and building
 ---

--- a/docs/content/guides/tools-and-building/modules/modules.md
+++ b/docs/content/guides/tools-and-building/modules/modules.md
@@ -14,6 +14,9 @@ react:
 angular:
   id: 9i62e6cn
   metaTitle: Modules - Angular Data Grid | Handsontable
+vue:
+  id: xvedd0on
+  metaTitle: Modules - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Tools and building
 menuTag: updated

--- a/docs/content/guides/tools-and-building/testing/testing.md
+++ b/docs/content/guides/tools-and-building/testing/testing.md
@@ -19,6 +19,9 @@ react:
 angular:
   id: zggveqea
   metaTitle: Testing - Angular Data Grid | Handsontable
+vue:
+  id: kx1qz7jh
+  metaTitle: Testing - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Tools and building
 ---

--- a/docs/content/guides/tools-and-building/typescript-types/typescript-types.md
+++ b/docs/content/guides/tools-and-building/typescript-types/typescript-types.md
@@ -17,6 +17,9 @@ react:
 angular:
   id: a5vj6hsz
   metaTitle: TypeScript types - Angular Data Grid | Handsontable
+vue:
+  id: v8j6vpbp
+  metaTitle: TypeScript types - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Tools and building
 menuTag: new

--- a/docs/content/guides/upgrade-and-migration/changelog-10/changelog-10.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-10/changelog-10.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: jizop4f1
   metaTitle: Changelog 10.0 - Angular Data Grid | Handsontable
+vue:
+  id: 3ycojv99
+  metaTitle: Changelog 10.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/changelog-11/changelog-11.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-11/changelog-11.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: 9fzgv1of
   metaTitle: Changelog 11.0 - Angular Data Grid | Handsontable
+vue:
+  id: aitghfh1
+  metaTitle: Changelog 11.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/changelog-12/changelog-12.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-12/changelog-12.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: w26ga6t8
   metaTitle: Changelog 12.0 - Angular Data Grid | Handsontable
+vue:
+  id: c2zp1wav
+  metaTitle: Changelog 12.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/changelog-13/changelog-13.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-13/changelog-13.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: yf3kyziz
   metaTitle: Changelog 13.0 - Angular Data Grid | Handsontable
+vue:
+  id: wltmh28p
+  metaTitle: Changelog 13.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/changelog-14/changelog-14.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-14/changelog-14.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: d5haqby0
   metaTitle: Changelog 14.0 - Angular Data Grid | Handsontable
+vue:
+  id: st0v0t8a
+  metaTitle: Changelog 14.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/changelog-15/changelog-15.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-15/changelog-15.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: m8s84zjg
   metaTitle: Changelog 15.0 - Angular Data Grid | Handsontable
+vue:
+  id: 6tqfgd15
+  metaTitle: Changelog 15.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/changelog-16/changelog-16.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-16/changelog-16.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: hjp86je4
   metaTitle: Changelog 16.0 - Angular Data Grid | Handsontable
+vue:
+  id: szp3hgw3
+  metaTitle: Changelog 16.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/changelog-17/changelog-17.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-17/changelog-17.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: wyn633o3
   metaTitle: Changelog 17.0 - Angular Data Grid | Handsontable
+vue:
+  id: ubusl9gr
+  metaTitle: Changelog 17.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/changelog-7/changelog-7.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-7/changelog-7.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: fqniwvjh
   metaTitle: Older versions - Angular Data Grid | Handsontable
+vue:
+  id: v80zhxm8
+  metaTitle: Older versions - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/changelog-8/changelog-8.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-8/changelog-8.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: m4tjxvhx
   metaTitle: Changelog 8.0 - Angular Data Grid | Handsontable
+vue:
+  id: ck0vyddl
+  metaTitle: Changelog 8.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/changelog-9/changelog-9.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-9/changelog-9.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: 0q8lci2y
   metaTitle: Changelog 9.0 - Angular Data Grid | Handsontable
+vue:
+  id: wxwai6xr
+  metaTitle: Changelog 9.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/changelog/changelog.md
+++ b/docs/content/guides/upgrade-and-migration/changelog/changelog.md
@@ -19,6 +19,9 @@ react:
 angular:
   id: um6ros3a
   metaTitle: Changelog - Angular Data Grid | Handsontable
+vue:
+  id: a5q6rij8
+  metaTitle: Changelog - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/deprecation-policy/deprecation-policy.md
+++ b/docs/content/guides/upgrade-and-migration/deprecation-policy/deprecation-policy.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: d5ac977b
   metaTitle: Deprecation policy - Angular Data Grid | Handsontable
+vue:
+  id: yqn3hlb4
+  metaTitle: Deprecation policy - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/long-term-support/long-term-support.md
+++ b/docs/content/guides/upgrade-and-migration/long-term-support/long-term-support.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: 0dc19b1b
   metaTitle: Long Term Support (LTS) - Angular Data Grid | Handsontable
+vue:
+  id: tydr1bbr
+  metaTitle: Long Term Support (LTS) - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/migrating-from-10.0-to-11.0/migrating-from-10.0-to-11.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-10.0-to-11.0/migrating-from-10.0-to-11.0.md
@@ -13,6 +13,9 @@ react:
 angular:
   id: 1fc8toqq
   metaTitle: Migrate from 10.0 to 11.0 - Angular Data Grid | Handsontable
+vue:
+  id: cvsqifxl
+  metaTitle: Migrate from 10.0 to 11.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/migrating-from-11.1-to-12.0/migrating-from-11.1-to-12.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-11.1-to-12.0/migrating-from-11.1-to-12.0.md
@@ -13,6 +13,9 @@ react:
 angular:
   id: e9gbxrvk
   metaTitle: Migrate from 11.1 to 12.0 - Angular Data Grid | Handsontable
+vue:
+  id: cxu9kcv7
+  metaTitle: Migrate from 11.1 to 12.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/migrating-from-12.4-to-13.0/migrating-from-12.4-to-13.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-12.4-to-13.0/migrating-from-12.4-to-13.0.md
@@ -13,6 +13,9 @@ react:
 angular:
   id: kgutwhxo
   metaTitle: Migrate from 12.4 to 13.0 - Angular Data Grid | Handsontable
+vue:
+  id: i1ljbb3p
+  metaTitle: Migrate from 12.4 to 13.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/migrating-from-13.1-to-14.0/migrating-from-13.1-to-14.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-13.1-to-14.0/migrating-from-13.1-to-14.0.md
@@ -13,6 +13,9 @@ react:
 angular:
   id: rxlauyd8-13.1-to-14.0-react
   metaTitle: Migrate from 13.1 to 14.0 - Angular Data Grid | Handsontable
+vue:
+  id: 40f19qus
+  metaTitle: Migrate from 13.1 to 14.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/migrating-from-14.6-to-15.0/migrating-from-14.6-to-15.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-14.6-to-15.0/migrating-from-14.6-to-15.0.md
@@ -13,6 +13,9 @@ react:
 angular:
   id: 7kr2r20j-14.6-to-15.0-react
   metaTitle: Migrate from 14.6 to 15.0 - Angular Data Grid | Handsontable
+vue:
+  id: d0lcx03j
+  metaTitle: Migrate from 14.6 to 15.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/migrating-from-15.3-to-16.0/migrating-from-15.3-to-16.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-15.3-to-16.0/migrating-from-15.3-to-16.0.md
@@ -13,6 +13,9 @@ react:
 angular:
   id: 9v65a4pd
   metaTitle: Migrate from 15.3 to 16.0 - Angular Data Grid | Handsontable
+vue:
+  id: qe6ypgg9
+  metaTitle: Migrate from 15.3 to 16.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/migrating-from-16.0-to-16.1/migrating-from-16.0-to-16.1.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-16.0-to-16.1/migrating-from-16.0-to-16.1.md
@@ -13,6 +13,9 @@ react:
 angular:
   id: bv25a4sd
   metaTitle: Migrate from 16.0 to 16.1 - Angular Data Grid | Handsontable
+vue:
+  id: d7wjzk8v
+  metaTitle: Migrate from 16.0 to 16.1 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md
@@ -13,6 +13,9 @@ react:
 angular:
   id: 9r25a4sd
   metaTitle: Migrate from 16.2 to 17.0 - Angular Data Grid | Handsontable
+vue:
+  id: pv0dplqt
+  metaTitle: Migrate from 16.2 to 17.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md
@@ -13,6 +13,9 @@ react:
 angular:
   id: k3jb6ts0
   metaTitle: Migrate from 17.1 to 18.0 - Angular Data Grid | Handsontable
+vue:
+  id: 205js05l
+  metaTitle: Migrate from 17.1 to 18.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/migrating-from-7.4-to-8.0/migrating-from-7.4-to-8.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-7.4-to-8.0/migrating-from-7.4-to-8.0.md
@@ -13,6 +13,9 @@ react:
 angular:
   id: wo49dhyu
   metaTitle: Migrate from 7.4 to 8.0 - Angular Data Grid | Handsontable
+vue:
+  id: 0nffktzd
+  metaTitle: Migrate from 7.4 to 8.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/migrating-from-8.4-to-9.0/migrating-from-8.4-to-9.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-8.4-to-9.0/migrating-from-8.4-to-9.0.md
@@ -13,6 +13,9 @@ react:
 angular:
   id: tulale8x
   metaTitle: Migrate from 8.4 to 9.0 - Angular Data Grid | Handsontable
+vue:
+  id: cdw8pqqn
+  metaTitle: Migrate from 8.4 to 9.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/migrating-from-9.0-to-10.0/migrating-from-9.0-to-10.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-9.0-to-10.0/migrating-from-9.0-to-10.0.md
@@ -13,6 +13,9 @@ react:
 angular:
   id: a1bu3jwp
   metaTitle: Migrate from 9.0 to 10.0 - Angular Data Grid | Handsontable
+vue:
+  id: k9w710b0
+  metaTitle: Migrate from 9.0 to 10.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/guides/upgrade-and-migration/versioning-policy/versioning-policy.md
+++ b/docs/content/guides/upgrade-and-migration/versioning-policy/versioning-policy.md
@@ -12,6 +12,9 @@ react:
 angular:
   id: 1q96vyfn
   metaTitle: Versioning policy - Angular Data Grid | Handsontable
+vue:
+  id: x4d3c7e7
+  metaTitle: Versioning policy - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration
 ---

--- a/docs/content/recipes/accessibility/accessibility.md
+++ b/docs/content/recipes/accessibility/accessibility.md
@@ -15,6 +15,9 @@ react:
 angular:
   id: v3c5d7e9
   metaTitle: Accessibility and UX Recipes - Angular Data Grid | Handsontable
+vue:
+  id: 88pek0th
+  metaTitle: Accessibility and UX Recipes - Vue Data Grid | Handsontable
 ---
 [[toc]]
 

--- a/docs/content/recipes/accessibility/aria-grid/aria-grid.md
+++ b/docs/content/recipes/accessibility/aria-grid/aria-grid.md
@@ -17,6 +17,9 @@ react:
 angular:
   id: b3e9f1a2
   metaTitle: ARIA-Friendly Grid with Row Descriptions - Angular Data Grid | Handsontable
+vue:
+  id: huyklmef
+  metaTitle: ARIA-Friendly Grid with Row Descriptions - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Accessibility & UX
 type: how-to

--- a/docs/content/recipes/accessibility/keyboard-shortcuts/keyboard-shortcuts.md
+++ b/docs/content/recipes/accessibility/keyboard-shortcuts/keyboard-shortcuts.md
@@ -17,6 +17,9 @@ react:
 angular:
   id: c4f03e47
   metaTitle: Custom keyboard shortcuts - Angular Data Grid | Handsontable
+vue:
+  id: 423pgfmi
+  metaTitle: Custom keyboard shortcuts - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Accessibility & UX
 type: how-to

--- a/docs/content/recipes/cell-types/cell-types.md
+++ b/docs/content/recipes/cell-types/cell-types.md
@@ -15,6 +15,9 @@ react:
 angular:
   id: e149d2af
   metaTitle: Cell Recipes - Angular Data Grid | Handsontable
+vue:
+  id: um7f5xlt
+  metaTitle: Cell Recipes - Vue Data Grid | Handsontable
 ---
 [[toc]]
 

--- a/docs/content/recipes/cell-types/color-picker/color-picker.md
+++ b/docs/content/recipes/cell-types/color-picker/color-picker.md
@@ -16,6 +16,9 @@ react:
 angular:
   id: a471c83c
   metaTitle: Color Picker Cell Type - Angular Data Grid | Handsontable
+vue:
+  id: y6983gwr
+  metaTitle: Color Picker Cell Type - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Cell Types
 ---

--- a/docs/content/recipes/cell-types/colorful-picker/colorful-picker.md
+++ b/docs/content/recipes/cell-types/colorful-picker/colorful-picker.md
@@ -16,6 +16,8 @@ react:
 angular:
   id: 4f6678f9
   metaTitle: Color Picker Cell Type - Angular Data Grid | Handsontable
+vue:
+  id: hvnfgr8y
 searchCategory: Recipes
 category: Cell Types
 ---

--- a/docs/content/recipes/cell-types/feedback-react/feedback-react.md
+++ b/docs/content/recipes/cell-types/feedback-react/feedback-react.md
@@ -16,6 +16,8 @@ react:
 angular:
   id: 6af717ed
   metaTitle: Feedback Cell Type - Angular Data Grid | Handsontable
+vue:
+  id: onjzuhn9
 searchCategory: Recipes
 category: Cell Types
 ---

--- a/docs/content/recipes/cell-types/feedback/feedback.md
+++ b/docs/content/recipes/cell-types/feedback/feedback.md
@@ -16,6 +16,9 @@ react:
 angular:
   id: 8e13e6d5
   metaTitle: Feedback Cell Type - Angular Data Grid | Handsontable
+vue:
+  id: n99hdtp4
+  metaTitle: Feedback Cell Type - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Cell Types
 ---

--- a/docs/content/recipes/cell-types/flatpickr/flatpickr.md
+++ b/docs/content/recipes/cell-types/flatpickr/flatpickr.md
@@ -16,6 +16,9 @@ react:
 angular:
   id: 8748f2d9
   metaTitle: Flatpickr Cell Type - Angular Data Grid | Handsontable
+vue:
+  id: 9gjg0yyt
+  metaTitle: Flatpickr Cell Type - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Cell Types
 ---

--- a/docs/content/recipes/cell-types/guide-color-picker-angular/guide-color-picker.md
+++ b/docs/content/recipes/cell-types/guide-color-picker-angular/guide-color-picker.md
@@ -16,6 +16,9 @@ react:
 angular:
   id: tgb1xbxy
   metaTitle: Color Picker Cell - Angular Data Grid | Handsontable
+vue:
+  id: 7l56ycyn
+  metaTitle: Color Picker Cell - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Cell Types
 ---

--- a/docs/content/recipes/cell-types/guide-datepicker-angular/guide-datepicker.md
+++ b/docs/content/recipes/cell-types/guide-datepicker-angular/guide-datepicker.md
@@ -16,6 +16,9 @@ react:
 angular:
   id: o1ijr8z3
   metaTitle: Date picker - Angular Data Grid | Handsontable
+vue:
+  id: mgyg0ys8
+  metaTitle: "Date picker - Vue Data Grid | Handsontable"
 searchCategory: Recipes
 category: Cells
 ---

--- a/docs/content/recipes/cell-types/guide-feedback-angular/guide-feedback.md
+++ b/docs/content/recipes/cell-types/guide-feedback-angular/guide-feedback.md
@@ -16,6 +16,9 @@ react:
 angular:
   id: dg9oi3jt
   metaTitle: "Feedback Editor - Angular Data Grid | Handsontable"
+vue:
+  id: 5dtfu7cq
+  metaTitle: "Feedback Editor - Vue Data Grid | Handsontable"
 searchCategory: Recipes
 category: Cells
 ---

--- a/docs/content/recipes/cell-types/guide-rating-angular/guide-rating.md
+++ b/docs/content/recipes/cell-types/guide-rating-angular/guide-rating.md
@@ -16,6 +16,9 @@ react:
 angular:
   id: 66fxpbip
   metaTitle: "Star Rating Editor - Angular Data Grid | Handsontable"
+vue:
+  id: lod409ks
+  metaTitle: "Star Rating Editor - Vue Data Grid | Handsontable"
 searchCategory: Recipes
 category: Cell Types
 ---

--- a/docs/content/recipes/cell-types/moment-date/moment-date.md
+++ b/docs/content/recipes/cell-types/moment-date/moment-date.md
@@ -18,6 +18,9 @@ react:
 angular:
   id: 3d23a45b
   metaTitle: Moment.js date Cell Type - Angular Data Grid | Handsontable
+vue:
+  id: q6egngqa
+  metaTitle: Moment.js date Cell Type - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Cell Types
 ---

--- a/docs/content/recipes/cell-types/moment-time/moment-time.md
+++ b/docs/content/recipes/cell-types/moment-time/moment-time.md
@@ -18,6 +18,9 @@ react:
 angular:
   id: 3c87f9e1
   metaTitle: Moment.js time Cell Type - Angular Data Grid | Handsontable
+vue:
+  id: jplnv73m
+  metaTitle: Moment.js time Cell Type - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Cell Types
 ---

--- a/docs/content/recipes/cell-types/numbro/numbro.md
+++ b/docs/content/recipes/cell-types/numbro/numbro.md
@@ -17,6 +17,9 @@ react:
 angular:
   id: 1e23a45b
   metaTitle: Numbro Cell Type - Angular Data Grid | Handsontable
+vue:
+  id: teohjohf
+  metaTitle: Numbro Cell Type - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Cell Types
 ---

--- a/docs/content/recipes/cell-types/pikaday/pikaday.md
+++ b/docs/content/recipes/cell-types/pikaday/pikaday.md
@@ -16,6 +16,9 @@ react:
 angular:
   id: b83502de
   metaTitle: Pikaday Cell Type - Angular Data Grid | Handsontable
+vue:
+  id: lnh85yd3
+  metaTitle: Pikaday Cell Type - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Cell Types
 ---

--- a/docs/content/recipes/cell-types/rating/rating.md
+++ b/docs/content/recipes/cell-types/rating/rating.md
@@ -16,6 +16,9 @@ react:
 angular:
   id: e51f625c
   metaTitle: Star Rating Cell Type - Angular Data Grid | Handsontable"
+vue:
+  id: c6hrb6zp
+  metaTitle: Star Rating Cell Type - Vue Data Grid | Handsontable"
 searchCategory: Recipes
 category: Cell Types
 ---

--- a/docs/content/recipes/cell-types/react-rating/react-rating.md
+++ b/docs/content/recipes/cell-types/react-rating/react-rating.md
@@ -16,6 +16,8 @@ react:
 angular:
   id: 3a4f760c
   metaTitle: Star Rating Cell Type - Angular Data Grid | Handsontable
+vue:
+  id: cmt6617x
 searchCategory: Recipes
 category: Cell Types
 ---

--- a/docs/content/recipes/column-management/column-management.md
+++ b/docs/content/recipes/column-management/column-management.md
@@ -15,6 +15,9 @@ react:
 angular:
   id: b9i1j3k5
   metaTitle: Column Management Recipes - Angular Data Grid | Handsontable
+vue:
+  id: xhr39rj8
+  metaTitle: Column Management Recipes - Vue Data Grid | Handsontable
 ---
 [[toc]]
 

--- a/docs/content/recipes/column-management/column-visibility/column-visibility.md
+++ b/docs/content/recipes/column-management/column-visibility/column-visibility.md
@@ -16,6 +16,9 @@ react:
 angular:
   id: c7d4e5f6
   metaTitle: Dynamic Column Visibility Toggle - Angular Data Grid | Handsontable
+vue:
+  id: jqwr4haq
+  metaTitle: Dynamic Column Visibility Toggle - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Column Management
 type: how-to

--- a/docs/content/recipes/column-management/freeze-columns/freeze-columns.md
+++ b/docs/content/recipes/column-management/freeze-columns/freeze-columns.md
@@ -17,6 +17,9 @@ react:
 angular:
   id: a7b2c5d9
   metaTitle: Freeze and unfreeze columns at runtime - Angular Data Grid | Handsontable
+vue:
+  id: 1r6wwd0v
+  metaTitle: Freeze and unfreeze columns at runtime - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Column Management
 type: how-to

--- a/docs/content/recipes/context-menu/context-menu.md
+++ b/docs/content/recipes/context-menu/context-menu.md
@@ -15,6 +15,9 @@ react:
 angular:
   id: e2l4m6n8
   metaTitle: Context Menu Recipes - Angular Data Grid | Handsontable
+vue:
+  id: s4tb6gp7
+  metaTitle: Context Menu Recipes - Vue Data Grid | Handsontable
 ---
 [[toc]]
 

--- a/docs/content/recipes/context-menu/custom-context-menu/custom-context-menu.md
+++ b/docs/content/recipes/context-menu/custom-context-menu/custom-context-menu.md
@@ -16,6 +16,9 @@ react:
 angular:
   id: c5e3a907
   metaTitle: Custom context menu actions - Angular Data Grid | Handsontable
+vue:
+  id: hq16t08r
+  metaTitle: Custom context menu actions - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Context Menu
 type: how-to

--- a/docs/content/recipes/context-menu/row-operations/row-operations.md
+++ b/docs/content/recipes/context-menu/row-operations/row-operations.md
@@ -15,6 +15,9 @@ react:
 angular:
   id: c5d8e3f6
   metaTitle: Programmatic row operations - Angular Data Grid | Handsontable
+vue:
+  id: f2cq2guh
+  metaTitle: Programmatic row operations - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Context Menu and Interaction
 type: how-to

--- a/docs/content/recipes/data-management/auto-save-backend/auto-save-backend.md
+++ b/docs/content/recipes/data-management/auto-save-backend/auto-save-backend.md
@@ -18,6 +18,9 @@ react:
 angular:
   id: b5c2q9k7
   metaTitle: Auto-save changes to a backend - Angular Data Grid | Handsontable
+vue:
+  id: 5v0khjzx
+  metaTitle: Auto-save changes to a backend - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Data Management
 type: how-to

--- a/docs/content/recipes/data-management/data-management.md
+++ b/docs/content/recipes/data-management/data-management.md
@@ -15,6 +15,9 @@ react:
 angular:
   id: 6e1c8b3d
   metaTitle: Data Management Recipes - Angular Data Grid | Handsontable
+vue:
+  id: ikay0eju
+  metaTitle: Data Management Recipes - Vue Data Grid | Handsontable
 ---
 [[toc]]
 

--- a/docs/content/recipes/data-management/load-data-graphql/load-data-graphql.md
+++ b/docs/content/recipes/data-management/load-data-graphql/load-data-graphql.md
@@ -18,6 +18,9 @@ react:
 angular:
   id: f1d4a6c9
   metaTitle: Load Data from a GraphQL API - Angular Data Grid | Handsontable
+vue:
+  id: oo25pxah
+  metaTitle: Load Data from a GraphQL API - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Data Management
 type: how-to

--- a/docs/content/recipes/data-management/load-data-rest-api/load-data-rest-api.md
+++ b/docs/content/recipes/data-management/load-data-rest-api/load-data-rest-api.md
@@ -21,6 +21,9 @@ react:
 angular:
   id: a3b8c2d1
   metaTitle: Load Data from a REST API - Angular Data Grid | Handsontable
+vue:
+  id: o4k4wnz7
+  metaTitle: Load Data from a REST API - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Data Management
 type: how-to

--- a/docs/content/recipes/data-management/server-side-django/server-side-django.md
+++ b/docs/content/recipes/data-management/server-side-django/server-side-django.md
@@ -17,6 +17,9 @@ react:
 angular:
   id: q1s3u5w7
   metaTitle: Server-side Data with Django - Angular Data Grid | Handsontable
+vue:
+  id: avzy0eqi
+  metaTitle: Server-side Data with Django - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Data Management
 type: how-to

--- a/docs/content/recipes/data-management/server-side-expressjs/server-side-expressjs.md
+++ b/docs/content/recipes/data-management/server-side-expressjs/server-side-expressjs.md
@@ -18,6 +18,9 @@ react:
 angular:
   id: 4n6q9v2w
   metaTitle: Server-side Data with Express.js - Angular Data Grid | Handsontable
+vue:
+  id: 7r84584r
+  metaTitle: Server-side Data with Express.js - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Data Management
 ---

--- a/docs/content/recipes/data-management/server-side-laravel/server-side-laravel.md
+++ b/docs/content/recipes/data-management/server-side-laravel/server-side-laravel.md
@@ -18,6 +18,9 @@ react:
 angular:
   id: v9x1z3b5
   metaTitle: Server-side data with Laravel - Angular Data Grid | Handsontable
+vue:
+  id: vzywhp2f
+  metaTitle: Server-side data with Laravel - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Data Management
 ---

--- a/docs/content/recipes/data-management/server-side-nestjs/server-side-nestjs.md
+++ b/docs/content/recipes/data-management/server-side-nestjs/server-side-nestjs.md
@@ -18,6 +18,9 @@ react:
 angular:
   id: n3p5r7t9
   metaTitle: Server-side Data with NestJS - Angular Data Grid | Handsontable
+vue:
+  id: f362z4hr
+  metaTitle: Server-side Data with NestJS - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Data Management
 ---

--- a/docs/content/recipes/data-management/server-side-rails/server-side-rails.md
+++ b/docs/content/recipes/data-management/server-side-rails/server-side-rails.md
@@ -17,6 +17,9 @@ react:
 angular:
   id: s6n1q8t3
   metaTitle: Server-side Data with Ruby on Rails - Angular Data Grid | Handsontable
+vue:
+  id: adgrh6zv
+  metaTitle: Server-side Data with Ruby on Rails - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Data Management
 type: how-to

--- a/docs/content/recipes/data-management/server-side-spring/server-side-spring.md
+++ b/docs/content/recipes/data-management/server-side-spring/server-side-spring.md
@@ -18,6 +18,9 @@ react:
 angular:
   id: d7f9h1j3
   metaTitle: Server-side Data with Spring Boot - Angular Data Grid | Handsontable
+vue:
+  id: yllq4802
+  metaTitle: Server-side Data with Spring Boot - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Data Management
 ---

--- a/docs/content/recipes/data-management/server-side-symfony/server-side-symfony.md
+++ b/docs/content/recipes/data-management/server-side-symfony/server-side-symfony.md
@@ -18,6 +18,9 @@ react:
 angular:
   id: h7j2m4n6
   metaTitle: Server-side data with Symfony - Angular Data Grid | Handsontable
+vue:
+  id: nwl1vnb4
+  metaTitle: Server-side data with Symfony - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Data Management
 ---

--- a/docs/content/recipes/data-management/sync-two-grids/sync-two-grids.md
+++ b/docs/content/recipes/data-management/sync-two-grids/sync-two-grids.md
@@ -16,6 +16,9 @@ react:
 angular:
   id: a6d4c1b8
   metaTitle: Sync two grids - Angular Data Grid | Handsontable
+vue:
+  id: cjulyg8p
+  metaTitle: Sync two grids - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Data Management
 type: how-to

--- a/docs/content/recipes/data-management/undo-redo-custom-ui/undo-redo-custom-ui.md
+++ b/docs/content/recipes/data-management/undo-redo-custom-ui/undo-redo-custom-ui.md
@@ -18,6 +18,9 @@ react:
 angular:
   id: c4e9b8a1
   metaTitle: Undo / redo with a custom UI - Angular Data Grid | Handsontable
+vue:
+  id: 3ku6qxps
+  metaTitle: Undo / redo with a custom UI - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Data Management
 type: how-to

--- a/docs/content/recipes/editing-validation/dependent-dropdowns/dependent-dropdowns.md
+++ b/docs/content/recipes/editing-validation/dependent-dropdowns/dependent-dropdowns.md
@@ -17,6 +17,9 @@ react:
 angular:
   id: d8k4t7u1
   metaTitle: Dependent Dropdowns Recipe - Angular Data Grid | Handsontable
+vue:
+  id: 499xqog9
+  metaTitle: Dependent Dropdowns Recipe - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Editing and Validation
 type: how-to

--- a/docs/content/recipes/editing-validation/editing-validation.md
+++ b/docs/content/recipes/editing-validation/editing-validation.md
@@ -15,6 +15,9 @@ react:
 angular:
   id: j7v2y6h9
   metaTitle: Editing and Validation Recipes - Angular Data Grid | Handsontable
+vue:
+  id: ack3fz98
+  metaTitle: Editing and Validation Recipes - Vue Data Grid | Handsontable
 ---
 [[toc]]
 

--- a/docs/content/recipes/editing-validation/row-validation-error-summary/row-validation-error-summary.md
+++ b/docs/content/recipes/editing-validation/row-validation-error-summary/row-validation-error-summary.md
@@ -16,6 +16,9 @@ react:
 angular:
   id: h8s4n9q6
   metaTitle: Row Validation Error Summary Recipe - Angular Data Grid | Handsontable
+vue:
+  id: 94krzohb
+  metaTitle: Row Validation Error Summary Recipe - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Editing and Validation
 type: how-to

--- a/docs/content/recipes/filtering-and-search/external-search-box/external-search-box.md
+++ b/docs/content/recipes/filtering-and-search/external-search-box/external-search-box.md
@@ -17,6 +17,9 @@ react:
 angular:
   id: d2f7b43a
   metaTitle: External search box recipe - Angular Data Grid | Handsontable
+vue:
+  id: 226dbr7q
+  metaTitle: External search box recipe - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Filtering and Search
 type: how-to

--- a/docs/content/recipes/filtering-and-search/filtering-and-search.md
+++ b/docs/content/recipes/filtering-and-search/filtering-and-search.md
@@ -15,6 +15,9 @@ react:
 angular:
   id: a4p7c2v9
   metaTitle: Filtering and Search Recipes - Angular Data Grid | Handsontable
+vue:
+  id: h9ns5cm2
+  metaTitle: Filtering and Search Recipes - Vue Data Grid | Handsontable
 ---
 [[toc]]
 

--- a/docs/content/recipes/filtering-and-search/highlight-search-matches/highlight-search-matches.md
+++ b/docs/content/recipes/filtering-and-search/highlight-search-matches/highlight-search-matches.md
@@ -17,6 +17,9 @@ react:
 angular:
   id: c4d8e1b5
   metaTitle: Highlight Search Matches - Angular Data Grid | Handsontable
+vue:
+  id: trf4mxau
+  metaTitle: Highlight Search Matches - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Filtering and Search
 type: how-to

--- a/docs/content/recipes/filtering-search/filtering-search.md
+++ b/docs/content/recipes/filtering-search/filtering-search.md
@@ -15,6 +15,9 @@ react:
 angular:
   id: d8a41e6f
   metaTitle: Filtering and Search Recipes - Angular Data Grid | Handsontable
+vue:
+  id: g6b02455
+  metaTitle: Filtering and Search Recipes - Vue Data Grid | Handsontable
 ---
 [[toc]]
 

--- a/docs/content/recipes/filtering-search/multi-column-filter-panel/multi-column-filter-panel.md
+++ b/docs/content/recipes/filtering-search/multi-column-filter-panel/multi-column-filter-panel.md
@@ -18,6 +18,9 @@ react:
 angular:
   id: f6b25d0a
   metaTitle: Multi-column Filter Panel - Angular Data Grid | Handsontable
+vue:
+  id: ypksrbh0
+  metaTitle: Multi-column Filter Panel - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Filtering and Search
 type: how-to

--- a/docs/content/recipes/import-export/export-to-pdf/export-to-pdf.md
+++ b/docs/content/recipes/import-export/export-to-pdf/export-to-pdf.md
@@ -15,6 +15,9 @@ react:
 angular:
   id: b9c5e04a
   metaTitle: Export Handsontable to PDF - Angular Data Grid | Handsontable
+vue:
+  id: m4s0kgub
+  metaTitle: Export Handsontable to PDF - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Import and Export
 type: how-to

--- a/docs/content/recipes/import-export/import-csv-excel/import-csv-excel.md
+++ b/docs/content/recipes/import-export/import-csv-excel/import-csv-excel.md
@@ -17,6 +17,9 @@ react:
 angular:
   id: s9t2u7v0
   metaTitle: Import CSV or Excel - Angular Data Grid | Handsontable
+vue:
+  id: 9z4rb007
+  metaTitle: Import CSV or Excel - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Import and Export
 type: how-to

--- a/docs/content/recipes/import-export/import-export.md
+++ b/docs/content/recipes/import-export/import-export.md
@@ -15,6 +15,9 @@ react:
 angular:
   id: e6f0c13b
   metaTitle: Import and Export Recipes - Angular Data Grid | Handsontable
+vue:
+  id: z9gel8zf
+  metaTitle: Import and Export Recipes - Vue Data Grid | Handsontable
 ---
 [[toc]]
 

--- a/docs/content/recipes/introduction.md
+++ b/docs/content/recipes/introduction.md
@@ -13,6 +13,9 @@ react:
 angular:
   id: d2815b7b
   metaTitle: Recipes - Angular Data Grid | Handsontable
+vue:
+  id: 5axgi4x9
+  metaTitle: Recipes - Vue Data Grid | Handsontable
 ---
 
 This is a collection of practical, production-ready recipes for common Handsontable development tasks. Each recipe provides step-by-step instructions, complete working code, and real-world use cases.

--- a/docs/content/recipes/performance/lazy-loading/lazy-loading.md
+++ b/docs/content/recipes/performance/lazy-loading/lazy-loading.md
@@ -19,6 +19,9 @@ react:
 angular:
   id: d5f8e2a9
   metaTitle: Lazy loading with pagination - Angular Data Grid | Handsontable
+vue:
+  id: agk0hqm7
+  metaTitle: Lazy loading with pagination - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Performance
 type: how-to

--- a/docs/content/recipes/performance/performance.md
+++ b/docs/content/recipes/performance/performance.md
@@ -15,6 +15,9 @@ react:
 angular:
   id: a9e5d3cb
   metaTitle: Performance Recipes - Angular Data Grid | Handsontable
+vue:
+  id: u4oumcn2
+  metaTitle: Performance Recipes - Vue Data Grid | Handsontable
 ---
 [[toc]]
 

--- a/docs/content/recipes/performance/persist-column-layout/persist-column-layout.md
+++ b/docs/content/recipes/performance/persist-column-layout/persist-column-layout.md
@@ -20,6 +20,9 @@ react:
 angular:
   id: b5d3e7f0
   metaTitle: Persist and restore column widths and order - Angular Data Grid | Handsontable
+vue:
+  id: zohalhhu
+  metaTitle: Persist and restore column widths and order - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Performance
 type: how-to

--- a/docs/content/recipes/real-time/chartjs-sync/chartjs-sync.md
+++ b/docs/content/recipes/real-time/chartjs-sync/chartjs-sync.md
@@ -17,6 +17,9 @@ react:
 angular:
   id: c6f9e2a5
   metaTitle: Sync selected rows to a Chart.js chart - Angular Data Grid | Handsontable
+vue:
+  id: w5h61ok1
+  metaTitle: Sync selected rows to a Chart.js chart - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Real-time and Integrations
 type: how-to

--- a/docs/content/recipes/real-time/real-time.md
+++ b/docs/content/recipes/real-time/real-time.md
@@ -15,6 +15,9 @@ react:
 angular:
   id: y6f8g0h2
   metaTitle: Real-time and Integration Recipes - Angular Data Grid | Handsontable
+vue:
+  id: g4d4zmrv
+  metaTitle: Real-time and Integration Recipes - Vue Data Grid | Handsontable
 ---
 [[toc]]
 

--- a/docs/content/recipes/real-time/websocket-updates/websocket-updates.md
+++ b/docs/content/recipes/real-time/websocket-updates/websocket-updates.md
@@ -18,6 +18,9 @@ react:
 angular:
   id: d9b1e5f3
   metaTitle: Real-time WebSocket Updates - Angular Data Grid | Handsontable
+vue:
+  id: fvoen1lx
+  metaTitle: Real-time WebSocket Updates - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Real-time & Integrations
 type: how-to

--- a/docs/content/recipes/rendering-styling/conditional-row-coloring/conditional-row-coloring.md
+++ b/docs/content/recipes/rendering-styling/conditional-row-coloring/conditional-row-coloring.md
@@ -16,6 +16,9 @@ react:
 angular:
   id: b2d804e6
   metaTitle: Conditional row coloring - Angular Data Grid | Handsontable
+vue:
+  id: 99nmgb2v
+  metaTitle: Conditional row coloring - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Rendering and styling
 type: how-to

--- a/docs/content/recipes/rendering-styling/frozen-summary-row/frozen-summary-row.md
+++ b/docs/content/recipes/rendering-styling/frozen-summary-row/frozen-summary-row.md
@@ -17,6 +17,9 @@ react:
 angular:
   id: h3j6vs2b
   metaTitle: Frozen summary row recipe - Angular Data Grid | Handsontable
+vue:
+  id: 3udunsuv
+  metaTitle: Frozen summary row recipe - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Rendering and styling
 type: how-to

--- a/docs/content/recipes/rendering-styling/rendering-styling.md
+++ b/docs/content/recipes/rendering-styling/rendering-styling.md
@@ -15,6 +15,9 @@ react:
 angular:
   id: c7f1a92e
   metaTitle: Rendering and styling recipes - Angular Data Grid | Handsontable
+vue:
+  id: l2jehwoc
+  metaTitle: Rendering and styling recipes - Vue Data Grid | Handsontable
 ---
 [[toc]]
 

--- a/docs/content/recipes/rendering-styling/sparkline-cell-renderer/sparkline-cell-renderer.md
+++ b/docs/content/recipes/rendering-styling/sparkline-cell-renderer/sparkline-cell-renderer.md
@@ -16,6 +16,9 @@ react:
 angular:
   id: a1c9e582
   metaTitle: Sparkline cell renderer - Angular Data Grid | Handsontable
+vue:
+  id: x00kh9c9
+  metaTitle: Sparkline cell renderer - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Rendering and styling
 type: how-to

--- a/docs/content/recipes/themes/ant-design/ant-design.md
+++ b/docs/content/recipes/themes/ant-design/ant-design.md
@@ -20,6 +20,8 @@ react:
 angular:
   id: c4b7e1a9
   metaTitle: Handsontable with Ant Design - Angular Data Grid | Handsontable
+vue:
+  id: 1idm09eu
 searchCategory: Recipes
 category: Themes
 type: how-to

--- a/docs/content/recipes/themes/base-theme/base-theme.md
+++ b/docs/content/recipes/themes/base-theme/base-theme.md
@@ -22,6 +22,8 @@ react:
 angular:
   id: w5r2d8h4
   metaTitle: Handsontable with Base Web - Angular Data Grid | Handsontable
+vue:
+  id: x4lqd0rx
 searchCategory: Recipes
 category: Themes
 ---

--- a/docs/content/recipes/themes/custom-theme/custom-theme.md
+++ b/docs/content/recipes/themes/custom-theme/custom-theme.md
@@ -23,6 +23,8 @@ react:
 angular:
   id: b582k93d
   metaTitle: Handsontable with shadcn/ui - Angular Data Grid | Handsontable
+vue:
+  id: jo0cv4kp
 searchCategory: Recipes
 category: Themes
 ---

--- a/docs/content/recipes/themes/mui-theme/mui-theme.md
+++ b/docs/content/recipes/themes/mui-theme/mui-theme.md
@@ -22,6 +22,9 @@ react:
 angular:
   id: a3b7c9e1
   metaTitle: Handsontable with MUI - Angular Data Grid | Handsontable
+vue:
+  id: 6qpczr7i
+  metaTitle: Handsontable with MUI - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Themes
 ---

--- a/docs/content/recipes/themes/themes.md
+++ b/docs/content/recipes/themes/themes.md
@@ -15,6 +15,9 @@ react:
 angular:
   id: c5f6d93e
   metaTitle: Theme Recipes - Angular Data Grid | Handsontable
+vue:
+  id: iyf124u6
+  metaTitle: Theme Recipes - Vue Data Grid | Handsontable
 ---
 [[toc]]
 

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -49,7 +49,7 @@ export const collections = {
         /** Framework-specific frontmatter overrides (Phase 3). */
         react: z.record(z.string(), z.unknown()).optional(),
         angular: z.record(z.string(), z.unknown()).optional(),
-        vue3: z.record(z.string(), z.unknown()).optional(),
+        vue: z.record(z.string(), z.unknown()).optional(),
 
         /** Sidebar badge label (e.g. "Updated", "New"). */
         menuTag: z.string().optional(),

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -2,8 +2,8 @@
  * Astro content collection schema.
  *
  * Uses a custom framework-loader that reads all .md files from docs/content/
- * and creates 3 entries per file — one per framework (JavaScript, React,
- * Angular). The loader applies per-framework only-for content filtering and
+ * and creates 4 entries per file — one per framework (JavaScript, React,
+ * Angular, Vue). The loader applies per-framework only-for content filtering and
  * all other VuePress preprocessing at load time.
  *
  * Entry IDs follow the pattern: {framework-prefix}/{slug}

--- a/docs/src/plugins/framework-loader.mjs
+++ b/docs/src/plugins/framework-loader.mjs
@@ -485,17 +485,18 @@ function processExampleBlocks(content, contentDir) {
   return result.join('\n');
 }
 
-const FRAMEWORKS = ['javascript', 'react', 'angular'];
+const FRAMEWORKS = ['javascript', 'react', 'angular', 'vue'];
 
 const PREFIXES = {
   javascript: 'javascript-data-grid',
   react: 'react-data-grid',
   angular: 'angular-data-grid',
+  vue: 'vue-data-grid',
 };
 
 // Bump this when the loader logic changes to force Astro's data store to
 // re-process all entries (the store skips entries whose digest hasn't changed).
-const LOADER_VERSION = 'v35';
+const LOADER_VERSION = 'v36';
 
 // ---------------------------------------------------------------------------
 // File listing (recursive, no external glob)

--- a/docs/src/plugins/framework-loader.mjs
+++ b/docs/src/plugins/framework-loader.mjs
@@ -1052,6 +1052,7 @@ const FRAMEWORK_PREFIX_MAP = {
   javascript: 'javascript-data-grid',
   react: 'react-data-grid',
   angular: 'angular-data-grid',
+  vue: 'vue-data-grid',
 };
 
 /**
@@ -1072,7 +1073,7 @@ function resolveAtLink(rawLink, prefix, contentDir) {
   let targetPrefix = prefix;
   let filePath = rawLink;
 
-  const frameworkMatch = rawLink.match(/^(javascript|react|angular)\/(.+)/);
+  const frameworkMatch = rawLink.match(/^(javascript|react|angular|vue)\/(.+)/);
 
   if (frameworkMatch) {
     targetPrefix = FRAMEWORK_PREFIX_MAP[frameworkMatch[1]];


### PR DESCRIPTION
### Context

The PR adds Vue 3 as a first-class framework in the docs site, covering two sub-tasks:

**DEV-1727** registers `vue` in the framework loader so the build produces `vue-data-grid/*` routes alongside `javascript-data-grid/*`, `react-data-grid/*`, and `angular-data-grid/*`.

**DEV-1731** adds the `vue:` field to the Astro content schema (`docs/src/content.config.ts`) and populates it on every guide and recipe page that already carries `react:` and `angular:` blocks (206 pages updated). The `vue.id` is a unique 8-char alphanumeric; the `vue.metaTitle` follows the same pattern as the other frameworks — replacing "JavaScript Data Grid" with "Vue Data Grid". API reference pages (60 files) already had `vue:` blocks from a prior commit on `develop`.

### How has this been tested?

- Verified schema rename (`vue3:` → `vue:`) does not break any existing markdown files — no file used the old key.
- Confirmed 266 total pages have `vue:` blocks after the change: `grep -rl "^vue:" docs/content/ | wc -l`
- Confirmed no duplicate `vue.id` values: `grep -A1 "^vue:" docs/content/**/*.md | grep "id:" | sort | uniq -d` (no output)
- Confirmed only the two intentionally React-only pages (`react-redux.md`, `fluent-ui.md`) are missing `vue:`.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1727
2. DEV-1731

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`
- [x] `handsontable-documentation`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and build-metadata only; no runtime grid or auth changes.
> 
> **Overview**
> Vue 3 is promoted to a **first-class docs framework** alongside JavaScript, React, and Angular.
> 
> The Astro **framework loader** now emits a fourth site variant (`vue-data-grid/*`), treats `vue` in `@/` links like the other frameworks, and bumps the loader digest. **Content config** renames the optional frontmatter key from `vue3` to **`vue`**.
> 
> Across guides, recipes, and API intro pages, this PR adds matching **`vue:`** blocks (`id` + **Vue Data Grid** `metaTitle`) wherever `react`/`angular` overrides already exist—no body copy changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b625046739e1aa3832bf3a913f2602197355e8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->