### PR TITLE
DEV-1732, DEV-1733, DEV-1734, DEV-1735: Add Vue 3 to docs site navigation (switcher, sidebar, header, breadcrumb)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -735,15 +735,18 @@ export default defineConfig({
       ],
 
       sidebar: [
-        { label: 'JavaScript', collapsed: true, items: allSidebars.javascript },
-        { label: 'React', collapsed: true, items: allSidebars.react },
-        { label: 'Angular', collapsed: true, items: allSidebars.angular },
-        { label: 'JavaScript Recipes', collapsed: true, items: allSidebars.javascriptRecipes },
-        { label: 'React Recipes', collapsed: true, items: allSidebars.reactRecipes },
-        { label: 'Angular Recipes', collapsed: true, items: allSidebars.angularRecipes },
+        { label: 'JavaScript',           collapsed: true, items: allSidebars.javascript },
+        { label: 'React',                collapsed: true, items: allSidebars.react },
+        { label: 'Angular',              collapsed: true, items: allSidebars.angular },
+        { label: 'Vue 3',                collapsed: true, items: allSidebars.vue },
+        { label: 'JavaScript Recipes',   collapsed: true, items: allSidebars.javascriptRecipes },
+        { label: 'React Recipes',        collapsed: true, items: allSidebars.reactRecipes },
+        { label: 'Angular Recipes',      collapsed: true, items: allSidebars.angularRecipes },
+        { label: 'Vue 3 Recipes',        collapsed: true, items: allSidebars.vueRecipes },
         { label: 'JavaScript Changelog', collapsed: true, items: allSidebars.javascriptChangelog },
-        { label: 'React Changelog', collapsed: true, items: allSidebars.reactChangelog },
-        { label: 'Angular Changelog', collapsed: true, items: allSidebars.angularChangelog },
+        { label: 'React Changelog',      collapsed: true, items: allSidebars.reactChangelog },
+        { label: 'Angular Changelog',    collapsed: true, items: allSidebars.angularChangelog },
+        { label: 'Vue 3 Changelog',      collapsed: true, items: allSidebars.vueChangelog },
       ],
 
       components: {

--- a/docs/src/components/FrameworkSwitcher.astro
+++ b/docs/src/components/FrameworkSwitcher.astro
@@ -16,12 +16,15 @@ const currentPrefix = pathname.includes('/react-data-grid/')
   ? 'react-data-grid'
   : pathname.includes('/angular-data-grid/')
     ? 'angular-data-grid'
-    : 'javascript-data-grid';
+    : pathname.includes('/vue-data-grid/')
+      ? 'vue-data-grid'
+      : 'javascript-data-grid';
 
 const frameworks = [
   { id: 'javascript-data-grid', label: 'JS', fullName: 'JavaScript', icon: 'i-javascript' },
   { id: 'react-data-grid', label: 'React', fullName: 'React', icon: 'i-react' },
   { id: 'angular-data-grid', label: 'Angular', fullName: 'Angular', icon: 'i-angular' },
+  { id: 'vue-data-grid', label: 'Vue', fullName: 'Vue 3', icon: 'i-vue' },
 ];
 
 const current = frameworks.find((f) => f.id === currentPrefix)!;
@@ -142,5 +145,10 @@ const items = frameworks.map((fw) => ({
   .i-angular {
     -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='1' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath stroke='none' d='M0 0h24v24H0z' fill='none'/%3E%3Cpath d='M5.428 17.245l6.076 3.471a1 1 0 0 0 .992 0l6.076 -3.471a1 1 0 0 0 .495 -.734l1.323 -9.704a1 1 0 0 0 -.658 -1.078l-7.4 -2.612a1 1 0 0 0 -.665 0l-7.399 2.613a1 1 0 0 0 -.658 1.078l1.323 9.704a1 1 0 0 0 .495 .734l0 -.001'/%3E%3Cpath d='M9 15l3 -8l3 8'/%3E%3Cpath d='M10 13h4'/%3E%3C/svg%3E");
     mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='1' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath stroke='none' d='M0 0h24v24H0z' fill='none'/%3E%3Cpath d='M5.428 17.245l6.076 3.471a1 1 0 0 0 .992 0l6.076 -3.471a1 1 0 0 0 .495 -.734l1.323 -9.704a1 1 0 0 0 -.658 -1.078l-7.4 -2.612a1 1 0 0 0 -.665 0l-7.399 2.613a1 1 0 0 0 -.658 1.078l1.323 9.704a1 1 0 0 0 .495 .734l0 -.001'/%3E%3Cpath d='M9 15l3 -8l3 8'/%3E%3Cpath d='M10 13h4'/%3E%3C/svg%3E");
+  }
+
+  .i-vue {
+    -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='1' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath stroke='none' d='M0 0h24v24H0z' fill='none'/%3E%3Cpath d='M16.5 4l-4.5 8l-4.5 -8'/%3E%3Cpath d='M3 4l9 16l9 -16'/%3E%3C/svg%3E");
+    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='1' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath stroke='none' d='M0 0h24v24H0z' fill='none'/%3E%3Cpath d='M16.5 4l-4.5 8l-4.5 -8'/%3E%3Cpath d='M3 4l9 16l9 -16'/%3E%3C/svg%3E");
   }
 </style>

--- a/docs/src/components/Header.astro
+++ b/docs/src/components/Header.astro
@@ -30,7 +30,9 @@ const currentPrefix = pathname.includes('/react-data-grid/')
   ? 'react-data-grid'
   : pathname.includes('/angular-data-grid/')
     ? 'angular-data-grid'
-    : 'javascript-data-grid';
+    : pathname.includes('/vue-data-grid/')
+      ? 'vue-data-grid'
+      : 'javascript-data-grid';
 
 const guidesUrl = `/docs/${currentPrefix}/`;
 const recipesUrl = `/docs/${currentPrefix}/recipes/`;
@@ -50,6 +52,7 @@ const frameworks = [
   { id: 'javascript-data-grid', label: 'JavaScript' },
   { id: 'react-data-grid', label: 'React' },
   { id: 'angular-data-grid', label: 'Angular' },
+  { id: 'vue-data-grid', label: 'Vue' },
 ];
 ---
 

--- a/docs/src/components/PageTitle.astro
+++ b/docs/src/components/PageTitle.astro
@@ -65,6 +65,7 @@ const FRAMEWORK_LABELS: Record<string, string> = {
   'javascript-data-grid': 'JavaScript Data Grid',
   'react-data-grid':      'React Data Grid',
   'angular-data-grid':    'Angular Data Grid',
+  'vue-data-grid':        'Vue Data Grid',
 };
 
 // ── Current page data ─────────────────────────────────────────────────────────
@@ -76,7 +77,9 @@ const prefix = pathname.includes('/react-data-grid/')
   ? 'react-data-grid'
   : pathname.includes('/angular-data-grid/')
     ? 'angular-data-grid'
-    : 'javascript-data-grid';
+    : pathname.includes('/vue-data-grid/')
+      ? 'vue-data-grid'
+      : 'javascript-data-grid';
 
 const frameworkLabel = FRAMEWORK_LABELS[prefix];
 const homeLabel      = hotVersion ? `${hotVersion} ${frameworkLabel}` : frameworkLabel;

--- a/docs/src/components/Sidebar.astro
+++ b/docs/src/components/Sidebar.astro
@@ -47,24 +47,29 @@ const prefix = pathname.includes('/react-data-grid/')
   ? 'react-data-grid'
   : pathname.includes('/angular-data-grid/')
     ? 'angular-data-grid'
-    : 'javascript-data-grid';
+    : pathname.includes('/vue-data-grid/')
+      ? 'vue-data-grid'
+      : 'javascript-data-grid';
 
 const GUIDE_LABELS: Record<string, string> = {
   'javascript-data-grid': 'JavaScript',
   'react-data-grid': 'React',
   'angular-data-grid': 'Angular',
+  'vue-data-grid': 'Vue 3',
 };
 
 const RECIPE_LABELS: Record<string, string> = {
   'javascript-data-grid': 'JavaScript Recipes',
   'react-data-grid': 'React Recipes',
   'angular-data-grid': 'Angular Recipes',
+  'vue-data-grid': 'Vue 3 Recipes',
 };
 
 const CHANGELOG_LABELS: Record<string, string> = {
   'javascript-data-grid': 'JavaScript Changelog',
   'react-data-grid': 'React Changelog',
   'angular-data-grid': 'Angular Changelog',
+  'vue-data-grid': 'Vue 3 Changelog',
 };
 
 const isRecipePage = pathname.includes('/recipes/');

--- a/docs/src/sidebar.mjs
+++ b/docs/src/sidebar.mjs
@@ -26,6 +26,7 @@ const FRAMEWORK_PREFIXES = {
   javascript: 'javascript-data-grid',
   react: 'react-data-grid',
   angular: 'angular-data-grid',
+  vue: 'vue-data-grid',
 };
 
 // ---------------------------------------------------------------------------
@@ -371,8 +372,9 @@ export function buildSidebar(framework = 'javascript', prefix = 'javascript-data
 /**
  * Builds sidebar configs for all supported frameworks, including recipes.
  *
- * @returns {{ javascript: Array, react: Array, angular: Array,
- *             javascriptRecipes: Array, reactRecipes: Array, angularRecipes: Array }}
+ * @returns {{ javascript: Array, react: Array, angular: Array, vue: Array,
+ *             javascriptRecipes: Array, reactRecipes: Array, angularRecipes: Array, vueRecipes: Array,
+ *             javascriptChangelog: Array, reactChangelog: Array, angularChangelog: Array, vueChangelog: Array }}
  */
 export function buildAllSidebars() {
   const result = {};


### PR DESCRIPTION
### Context

The PR wires Vue 3 into the docs site navigation layer. It covers four subtasks (DEV-1732 – DEV-1735) that register `vue-data-grid` as a first-class framework across all header and sidebar components:

- **DEV-1732** (`FrameworkSwitcher.astro`): Adds a fourth "Vue" tab to the header framework switcher, including the `.i-vue` CSS mask icon.
- **DEV-1733** (`Sidebar.astro`): Extends prefix detection and adds `vue-data-grid` to `GUIDE_LABELS`, `RECIPE_LABELS`, and `CHANGELOG_LABELS`.
- **DEV-1734** (`PageTitle.astro`, `Header.astro`): Adds `'Vue Data Grid'` to the breadcrumb label map and extends prefix detection in both components. Also adds Vue to the mobile nav framework switcher.
- **DEV-1735** (`sidebar.mjs`, `astro.config.mjs`): Adds `vue: 'vue-data-grid'` to `FRAMEWORK_PREFIXES` so `buildAllSidebars()` generates Vue guide, recipes, and changelog sidebars automatically. Wires the three new sidebar groups into the Starlight config with labels matching `Sidebar.astro`.

> **Blocked by:** https://github.com/handsontable/handsontable/pull/12669 — this PR must be merged first so the base branch (`feature/DEV-1727-1731_Add-vue-framework-and-frontmatter-schema`) is in place.

### How has this been tested?

- Manual: ran `npm run dev` in `docs/` (Node 20), navigated to `javascript-data-grid/` pages and confirmed all four framework tabs are visible and functional.
- Verified the Vue tab navigates to the `vue-data-grid/` equivalent of the current page.
- Verified the breadcrumb reads "Vue Data Grid" on `vue-data-grid/` pages.
- Verified the sidebar shows correct Vue 3 guide sections on `vue-data-grid/` pages.
- Verified JS, React, and Angular pages show no regressions.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1732
2. DEV-1733
3. DEV-1734
4. DEV-1735

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only navigation and labeling changes; no runtime product logic, auth, or data handling.
> 
> **Overview**
> This PR registers **Vue 3** (`vue-data-grid`) as a fourth framework in the docs site navigation, alongside JavaScript, React, and Angular.
> 
> **Sidebar generation** adds `vue: 'vue-data-grid'` to `FRAMEWORK_PREFIXES` in `sidebar.mjs`, so `buildAllSidebars()` produces Vue guide, recipes, and changelog trees automatically. **Starlight** wires those into `astro.config.mjs` as collapsed groups labeled *Vue 3*, *Vue 3 Recipes*, and *Vue 3 Changelog*.
> 
> **Header and chrome** detect `/vue-data-grid/` in the URL path: the framework switcher gets a Vue tab (with `.i-vue` icon), mobile framework links include Vue, breadcrumbs show *Vue Data Grid*, and `Sidebar.astro` filters to the correct Vue-labeled sidebar groups on guide, API, recipe, and changelog pages. Switching frameworks still rewrites the path prefix so the equivalent page loads for the selected stack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9d6b1bb3d08fc2cffd3eeedf27bb6c8bd281c31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->