### PR TITLE
fix(ci): update gh-find-current-pr to v1.3.5 (Node.js 24)

### DIFF
--- a/.github/workflows/docs-staging.yml
+++ b/.github/workflows/docs-staging.yml
@@ -62,7 +62,7 @@ jobs:
             }
 
       - name: Find PR
-        uses: jwalton/gh-find-current-pr@89ee5799558265a1e0e31fab792ebb4ee91c016b # https://github.com/jwalton/gh-find-current-pr/tree/v1.3.3
+        uses: jwalton/gh-find-current-pr@f3d61b485d2801773f7a07b2aaa3306bd8f8e653 # https://github.com/jwalton/gh-find-current-pr/releases/tag/v1.3.5
         id: pr-finder
 
       - name: Resolve PR number


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Fixes Netlify preview builds not working (failing run: https://github.com/handsontable/handsontable/actions/runs/26737819522)
- Updates `jwalton/gh-find-current-pr` from v1.3.3 (node20) → v1.3.5 (node24) in the Docs Staging Deployment workflow
- GitHub Actions is deprecating node20 with enforcement starting June 16, 2026; this action was already triggering deprecation warnings and causing the workflow to fail

## Root cause

The `Find PR` step in `.github/workflows/docs-staging.yml` used `jwalton/gh-find-current-pr@v1.3.3`, which specifies `using: 'node20'`. GitHub began enforcing the node20 deprecation, causing this step to fail with exit code 1 before any Netlify build steps could run.

v1.3.5 (released March 15, 2026) updates the action runtime to node24.

## Test plan

- [ ] Trigger a docs staging deployment (push docs change to a branch or add `ci:docs-deploy` label to a PR)
- [ ] Verify the "Find PR" step completes without error
- [ ] Verify a Netlify preview URL is posted to the PR

[skip changelog]

https://claude.ai/code/session_01RaixAY9H3A8tPjzzamt9ix
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaixAY9H3A8tPjzzamt9ix)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single workflow dependency pin with no application or security logic changes; only affects docs staging CI PR resolution.
> 
> **Overview**
> Updates the **Find PR** step in the Docs Staging Deployment workflow to pin **`jwalton/gh-find-current-pr`** at **v1.3.5** (commit `f3d61b48…`) instead of **v1.3.3**, so the action runs on **Node.js 24** and aligns with GitHub Actions’ Node 20 deprecation.
> 
> This is intended to unblock **Netlify docs preview** runs that were failing when the older action exited before later deploy steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 477d25216e8fe96c01e61ec5dd9b2bf0ee863de8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->