### PR TITLE
Fix resize handle position during resize interactions

### DIFF
--- a/.changelogs/12675.json
+++ b/.changelogs/12675.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed resize handles staying at the old position after double-click auto-sizing.",
+  "type": "fixed",
+  "issueOrPR": 12675,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/12675.json
+++ b/.changelogs/12675.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "public",
-  "title": "Fixed resize handles staying at the old position after double-click auto-sizing.",
+  "title": "Fixed resize handles moving out of sync during manual resize and after double-click auto-sizing.",
   "type": "fixed",
   "issueOrPR": 12675,
   "breaking": false,

--- a/handsontable/src/plugins/manualColumnResize/__tests__/manualColumnResize.spec.js
+++ b/handsontable/src/plugins/manualColumnResize/__tests__/manualColumnResize.spec.js
@@ -796,7 +796,7 @@ describe('manualColumnResize', () => {
     const headerRight = $columnHeader.offset().left + $columnHeader.width();
 
     expect(colWidth(spec().$container, 0)).toBeLessThan(150);
-    expect(headerRight - 5).toBeCloseTo(handleLeft, 0);
+    expect(Math.abs(headerRight - 5 - handleLeft)).toBeLessThanOrEqual(1);
   });
 
   it('should autosize column after double click (when initial width is defined by the `colWidths` option)', async() => {

--- a/handsontable/src/plugins/manualColumnResize/__tests__/manualColumnResize.spec.js
+++ b/handsontable/src/plugins/manualColumnResize/__tests__/manualColumnResize.spec.js
@@ -799,6 +799,40 @@ describe('manualColumnResize', () => {
     expect(Math.abs(headerRight - 5 - handleLeft)).toBeLessThanOrEqual(1);
   });
 
+  it('should keep the resize handle and guide position after the drag timer fires', async() => {
+    handsontable({
+      data: createSpreadsheetData(10, 10),
+      colHeaders: true,
+      autoColumnSize: false,
+      manualColumnResize: true,
+    });
+
+    const $columnHeader = getTopClone().find('thead tr:eq(0) th:eq(1)');
+
+    $columnHeader.simulate('mouseover');
+
+    const $resizer = spec().$container.find('.manualColumnResizer');
+    const guide = spec().$container.find('.manualColumnResizerGuide')[0];
+    const handleLeft = $resizer[0].getBoundingClientRect().left;
+
+    $resizer.simulate('mousedown', { clientX: handleLeft });
+    $resizer.simulate('mousemove', { clientX: handleLeft + 40 });
+
+    const handleBoxAfterMove = $resizer[0].getBoundingClientRect();
+    const guideBoxAfterMove = guide.getBoundingClientRect();
+
+    await waitForNextAnimationFrames(63);
+
+    const handleBoxAfterTimeout = $resizer[0].getBoundingClientRect();
+    const guideBoxAfterTimeout = guide.getBoundingClientRect();
+
+    $resizer.simulate('mouseup');
+
+    expect(handleBoxAfterTimeout.left).toBeCloseTo(handleBoxAfterMove.left, 0);
+    expect(guideBoxAfterTimeout.left).toBeCloseTo(guideBoxAfterMove.left, 0);
+    expect(handleBoxAfterTimeout.left).toBeCloseTo(guideBoxAfterTimeout.left, 0);
+  });
+
   it('should autosize column after double click (when initial width is defined by the `colWidths` option)', async() => {
     handsontable({
       data: createSpreadsheetData(3, 3),

--- a/handsontable/src/plugins/manualColumnResize/__tests__/manualColumnResize.spec.js
+++ b/handsontable/src/plugins/manualColumnResize/__tests__/manualColumnResize.spec.js
@@ -812,10 +812,11 @@ describe('manualColumnResize', () => {
     $columnHeader.simulate('mouseover');
 
     const $resizer = spec().$container.find('.manualColumnResizer');
-    const guide = spec().$container.find('.manualColumnResizerGuide')[0];
     const handleLeft = $resizer[0].getBoundingClientRect().left;
 
     $resizer.simulate('mousedown', { clientX: handleLeft });
+    const guide = spec().$container.find('.manualColumnResizerGuide')[0];
+
     $resizer.simulate('mousemove', { clientX: handleLeft + 40 });
 
     const handleBoxAfterMove = $resizer[0].getBoundingClientRect();

--- a/handsontable/src/plugins/manualColumnResize/__tests__/manualColumnResize.spec.js
+++ b/handsontable/src/plugins/manualColumnResize/__tests__/manualColumnResize.spec.js
@@ -776,6 +776,29 @@ describe('manualColumnResize', () => {
     expect(widthAfter).toBe(hot().getColWidth(2));
   });
 
+  it('should reposition the resize handle after double click auto-size', async() => {
+    handsontable({
+      data: createSpreadsheetData(3, 3),
+      colHeaders: true,
+      manualColumnResize: true,
+    });
+
+    await resizeColumn(0, 150);
+
+    const $resizer = spec().$container.find('.manualColumnResizer');
+    const resizerPosition = $resizer.position();
+
+    await mouseDoubleClick($resizer, { clientX: resizerPosition.left });
+    await waitForNextAnimationFrames(63);
+
+    const $columnHeader = getTopClone().find('thead tr:eq(0) th:eq(0)');
+    const handleLeft = $resizer.offset().left;
+    const headerRight = $columnHeader.offset().left + $columnHeader.width();
+
+    expect(colWidth(spec().$container, 0)).toBeLessThan(150);
+    expect(headerRight - 5).toBeCloseTo(handleLeft, 0);
+  });
+
   it('should autosize column after double click (when initial width is defined by the `colWidths` option)', async() => {
     handsontable({
       data: createSpreadsheetData(3, 3),

--- a/handsontable/src/plugins/manualColumnResize/__tests__/manualColumnResize.spec.js
+++ b/handsontable/src/plugins/manualColumnResize/__tests__/manualColumnResize.spec.js
@@ -821,6 +821,7 @@ describe('manualColumnResize', () => {
 
     const handleBoxAfterMove = $resizer[0].getBoundingClientRect();
     const guideBoxAfterMove = guide.getBoundingClientRect();
+    const distanceBetweenHandleAndGuide = guideBoxAfterMove.left - handleBoxAfterMove.left;
 
     await waitForNextAnimationFrames(63);
 
@@ -831,7 +832,7 @@ describe('manualColumnResize', () => {
 
     expect(handleBoxAfterTimeout.left).toBeCloseTo(handleBoxAfterMove.left, 0);
     expect(guideBoxAfterTimeout.left).toBeCloseTo(guideBoxAfterMove.left, 0);
-    expect(handleBoxAfterTimeout.left).toBeCloseTo(guideBoxAfterTimeout.left, 0);
+    expect(guideBoxAfterTimeout.left - handleBoxAfterTimeout.left).toBeCloseTo(distanceBetweenHandleAndGuide, 0);
   });
 
   it('should autosize column after double click (when initial width is defined by the `colWidths` option)', async() => {

--- a/handsontable/src/plugins/manualColumnResize/__tests__/utils.unit.js
+++ b/handsontable/src/plugins/manualColumnResize/__tests__/utils.unit.js
@@ -1,4 +1,8 @@
-import { getElementScaleFactor, normalizeVisualDelta } from 'handsontable/plugins/manualColumnResize/utils';
+import {
+  getElementScaleFactor,
+  normalizeVisualDelta,
+  shouldSkipResizeHandlePositioning,
+} from 'handsontable/plugins/manualColumnResize/utils';
 
 describe('manualColumnResize/utils', () => {
   describe('getElementScaleFactor', () => {
@@ -85,6 +89,20 @@ describe('manualColumnResize/utils', () => {
     it('should return unchanged delta for invalid scale factor', () => {
       expect(normalizeVisualDelta(25, 0)).toBe(25);
       expect(normalizeVisualDelta(25, NaN)).toBe(25);
+    });
+  });
+
+  describe('shouldSkipResizeHandlePositioning', () => {
+    it('should allow positioning for an attached header before double-click auto-size starts', () => {
+      expect(shouldSkipResizeHandlePositioning({ parentNode: {} }, 1)).toBe(false);
+    });
+
+    it('should skip positioning for a detached header', () => {
+      expect(shouldSkipResizeHandlePositioning({ parentNode: null }, 1)).toBe(true);
+    });
+
+    it('should skip positioning while double-click auto-size is pending', () => {
+      expect(shouldSkipResizeHandlePositioning({ parentNode: {} }, 2)).toBe(true);
     });
   });
 });

--- a/handsontable/src/plugins/manualColumnResize/__tests__/utils.unit.js
+++ b/handsontable/src/plugins/manualColumnResize/__tests__/utils.unit.js
@@ -1,6 +1,7 @@
 import {
   getElementScaleFactor,
   normalizeVisualDelta,
+  shouldRefreshHandleAfterAutoResize,
   shouldSkipResizeHandlePositioning,
 } from 'handsontable/plugins/manualColumnResize/utils';
 
@@ -103,6 +104,21 @@ describe('manualColumnResize/utils', () => {
 
     it('should skip positioning while double-click auto-size is pending', () => {
       expect(shouldSkipResizeHandlePositioning({ parentNode: {} }, 2)).toBe(true);
+    });
+  });
+
+  describe('shouldRefreshHandleAfterAutoResize', () => {
+    it('should refresh positioning for an attached header after double-click auto-size', () => {
+      expect(shouldRefreshHandleAfterAutoResize({ parentNode: {} }, 2)).toBe(true);
+    });
+
+    it('should not refresh positioning after a single drag click', () => {
+      expect(shouldRefreshHandleAfterAutoResize({ parentNode: {} }, 1)).toBe(false);
+    });
+
+    it('should not refresh positioning for a detached or missing header', () => {
+      expect(shouldRefreshHandleAfterAutoResize({ parentNode: null }, 2)).toBe(false);
+      expect(shouldRefreshHandleAfterAutoResize(null, 2)).toBe(false);
     });
   });
 });

--- a/handsontable/src/plugins/manualColumnResize/manualColumnResize.ts
+++ b/handsontable/src/plugins/manualColumnResize/manualColumnResize.ts
@@ -14,7 +14,7 @@ import {
 import { arrayEach } from '../../helpers/array';
 import { rangeEach } from '../../helpers/number';
 import { PhysicalIndexToValueMap as IndexToValueMap } from '../../translations';
-import { getElementScaleFactor, normalizeVisualDelta } from './utils';
+import { getElementScaleFactor, normalizeVisualDelta, shouldSkipResizeHandlePositioning } from './utils';
 
 // Developer note! Whenever you make a change in this file, make an analogous change in manualRowResize.js
 
@@ -286,7 +286,7 @@ export class ManualColumnResize extends BasePlugin {
    * @param {HTMLCellElement} TH TH HTML element.
    */
   setupHandlePosition(TH: HTMLTableHeaderCellElement) {
-    if (!TH.parentNode || this.#dblclick > 1) {
+    if (shouldSkipResizeHandlePositioning(TH, this.#dblclick)) {
       return;
     }
 
@@ -544,8 +544,12 @@ export class ManualColumnResize extends BasePlugin {
         });
       }
     }
-    this.#dblclick = 0;
     this.#autoresizeTimeout = null;
+    this.#dblclick = 0;
+
+    if (this.#currentTH) {
+      this.setupHandlePosition(this.#currentTH);
+    }
   }
 
   /**

--- a/handsontable/src/plugins/manualColumnResize/manualColumnResize.ts
+++ b/handsontable/src/plugins/manualColumnResize/manualColumnResize.ts
@@ -14,7 +14,12 @@ import {
 import { arrayEach } from '../../helpers/array';
 import { rangeEach } from '../../helpers/number';
 import { PhysicalIndexToValueMap as IndexToValueMap } from '../../translations';
-import { getElementScaleFactor, normalizeVisualDelta, shouldSkipResizeHandlePositioning } from './utils';
+import {
+  getElementScaleFactor,
+  normalizeVisualDelta,
+  shouldRefreshHandleAfterAutoResize,
+  shouldSkipResizeHandlePositioning,
+} from './utils';
 
 // Developer note! Whenever you make a change in this file, make an analogous change in manualRowResize.js
 
@@ -506,6 +511,10 @@ export class ManualColumnResize extends BasePlugin {
    * @fires Hooks#afterColumnResize
    */
   afterMouseDownTimeout() {
+    const shouldRefreshHandlePosition = shouldRefreshHandleAfterAutoResize(
+      this.#currentTH,
+      this.#dblclick,
+    );
     const render = () => {
       this.hot.view.adjustElementsSize();
       this.hot.render();
@@ -547,7 +556,7 @@ export class ManualColumnResize extends BasePlugin {
     this.#autoresizeTimeout = null;
     this.#dblclick = 0;
 
-    if (this.#currentTH) {
+    if (shouldRefreshHandlePosition && this.#currentTH) {
       this.setupHandlePosition(this.#currentTH);
     }
   }

--- a/handsontable/src/plugins/manualColumnResize/utils.ts
+++ b/handsontable/src/plugins/manualColumnResize/utils.ts
@@ -1,5 +1,6 @@
 export {
   getElementScaleFactor,
   normalizeVisualDelta,
+  shouldRefreshHandleAfterAutoResize,
   shouldSkipResizeHandlePositioning,
 } from '../manualResize/utils';

--- a/handsontable/src/plugins/manualColumnResize/utils.ts
+++ b/handsontable/src/plugins/manualColumnResize/utils.ts
@@ -1,1 +1,5 @@
-export { getElementScaleFactor, normalizeVisualDelta } from '../manualResize/utils';
+export {
+  getElementScaleFactor,
+  normalizeVisualDelta,
+  shouldSkipResizeHandlePositioning,
+} from '../manualResize/utils';

--- a/handsontable/src/plugins/manualResize/utils.ts
+++ b/handsontable/src/plugins/manualResize/utils.ts
@@ -45,3 +45,17 @@ export function normalizeVisualDelta(visualDelta: number, scaleFactor: number): 
 
   return Math.round(visualDelta / scaleFactor);
 }
+
+/**
+ * Checks if the resize handle positioning should be skipped.
+ *
+ * @param {{ parentNode: ParentNode | null }} header The header element to position the handle against.
+ * @param {number} resizeClickCount The resize handle click count.
+ * @returns {boolean}
+ */
+export function shouldSkipResizeHandlePositioning(
+  header: { parentNode: ParentNode | null },
+  resizeClickCount: number,
+): boolean {
+  return !header.parentNode || resizeClickCount > 1;
+}

--- a/handsontable/src/plugins/manualResize/utils.ts
+++ b/handsontable/src/plugins/manualResize/utils.ts
@@ -59,3 +59,17 @@ export function shouldSkipResizeHandlePositioning(
 ): boolean {
   return !header.parentNode || resizeClickCount > 1;
 }
+
+/**
+ * Checks if resize handle position should be refreshed after auto-size.
+ *
+ * @param {{ parentNode: ParentNode | null } | null} header The header element.
+ * @param {number} resizeClickCount The resize handle click count.
+ * @returns {boolean}
+ */
+export function shouldRefreshHandleAfterAutoResize(
+  header: { parentNode: ParentNode | null } | null,
+  resizeClickCount: number,
+): boolean {
+  return !!header?.parentNode && resizeClickCount >= 2;
+}

--- a/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
+++ b/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
@@ -484,7 +484,7 @@ describe('manualRowResize', () => {
     const headerBottom = $rowHeader.offset().top + $rowHeader.height();
 
     expect(rowHeight(spec().$container, 0)).toBeLessThan(120);
-    expect(headerBottom - 5).toBeCloseTo(handleTop, 0);
+    expect(Math.abs(headerBottom - 5 - handleTop)).toBeLessThanOrEqual(1);
   });
 
   it('should autosize row after double click (when initial height is defined by the `rowHeights` option)', async() => {

--- a/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
+++ b/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
@@ -499,10 +499,11 @@ describe('manualRowResize', () => {
     $rowHeader.simulate('mouseover');
 
     const $resizer = spec().$container.find('.manualRowResizer');
-    const guide = spec().$container.find('.manualRowResizerGuide')[0];
     const handleTop = $resizer[0].getBoundingClientRect().top;
 
     $resizer.simulate('mousedown', { clientY: handleTop });
+    const guide = spec().$container.find('.manualRowResizerGuide')[0];
+
     $resizer.simulate('mousemove', { clientY: handleTop + 40 });
 
     const handleBoxAfterMove = $resizer[0].getBoundingClientRect();

--- a/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
+++ b/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
@@ -487,6 +487,39 @@ describe('manualRowResize', () => {
     expect(Math.abs(headerBottom - 5 - handleTop)).toBeLessThanOrEqual(1);
   });
 
+  it('should keep the resize handle and guide position after the drag timer fires', async() => {
+    handsontable({
+      data: createSpreadsheetData(10, 10),
+      rowHeaders: true,
+      manualRowResize: true,
+    });
+
+    const $rowHeader = getInlineStartClone().find('tbody tr:eq(1) th:eq(0)');
+
+    $rowHeader.simulate('mouseover');
+
+    const $resizer = spec().$container.find('.manualRowResizer');
+    const guide = spec().$container.find('.manualRowResizerGuide')[0];
+    const handleTop = $resizer[0].getBoundingClientRect().top;
+
+    $resizer.simulate('mousedown', { clientY: handleTop });
+    $resizer.simulate('mousemove', { clientY: handleTop + 40 });
+
+    const handleBoxAfterMove = $resizer[0].getBoundingClientRect();
+    const guideBoxAfterMove = guide.getBoundingClientRect();
+
+    await waitForNextAnimationFrames(63);
+
+    const handleBoxAfterTimeout = $resizer[0].getBoundingClientRect();
+    const guideBoxAfterTimeout = guide.getBoundingClientRect();
+
+    $resizer.simulate('mouseup');
+
+    expect(handleBoxAfterTimeout.top).toBeCloseTo(handleBoxAfterMove.top, 0);
+    expect(guideBoxAfterTimeout.top).toBeCloseTo(guideBoxAfterMove.top, 0);
+    expect(handleBoxAfterTimeout.top).toBeCloseTo(guideBoxAfterTimeout.top, 0);
+  });
+
   it('should autosize row after double click (when initial height is defined by the `rowHeights` option)', async() => {
     handsontable({
       data: createSpreadsheetData(3, 3),

--- a/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
+++ b/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
@@ -464,6 +464,29 @@ describe('manualRowResize', () => {
       3);
   });
 
+  it('should reposition the resize handle after double click auto-size', async() => {
+    handsontable({
+      data: createSpreadsheetData(3, 3),
+      rowHeaders: true,
+      manualRowResize: true,
+    });
+
+    await resizeRow(0, 120);
+
+    const $resizer = spec().$container.find('.manualRowResizer');
+    const resizerPosition = $resizer.position();
+
+    await mouseDoubleClick($resizer, { clientY: resizerPosition.top });
+    await waitForNextAnimationFrames(63);
+
+    const $rowHeader = getInlineStartClone().find('tbody tr:eq(0) th:eq(0)');
+    const handleTop = $resizer.offset().top;
+    const headerBottom = $rowHeader.offset().top + $rowHeader.height();
+
+    expect(rowHeight(spec().$container, 0)).toBeLessThan(120);
+    expect(headerBottom - 5).toBeCloseTo(handleTop, 0);
+  });
+
   it('should autosize row after double click (when initial height is defined by the `rowHeights` option)', async() => {
     handsontable({
       data: createSpreadsheetData(3, 3),

--- a/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
+++ b/handsontable/src/plugins/manualRowResize/__tests__/manualRowResize.spec.js
@@ -508,6 +508,7 @@ describe('manualRowResize', () => {
 
     const handleBoxAfterMove = $resizer[0].getBoundingClientRect();
     const guideBoxAfterMove = guide.getBoundingClientRect();
+    const distanceBetweenHandleAndGuide = guideBoxAfterMove.top - handleBoxAfterMove.top;
 
     await waitForNextAnimationFrames(63);
 
@@ -518,7 +519,7 @@ describe('manualRowResize', () => {
 
     expect(handleBoxAfterTimeout.top).toBeCloseTo(handleBoxAfterMove.top, 0);
     expect(guideBoxAfterTimeout.top).toBeCloseTo(guideBoxAfterMove.top, 0);
-    expect(handleBoxAfterTimeout.top).toBeCloseTo(guideBoxAfterTimeout.top, 0);
+    expect(guideBoxAfterTimeout.top - handleBoxAfterTimeout.top).toBeCloseTo(distanceBetweenHandleAndGuide, 0);
   });
 
   it('should autosize row after double click (when initial height is defined by the `rowHeights` option)', async() => {

--- a/handsontable/src/plugins/manualRowResize/manualRowResize.ts
+++ b/handsontable/src/plugins/manualRowResize/manualRowResize.ts
@@ -14,7 +14,7 @@ import {
 import { arrayEach } from '../../helpers/array';
 import { rangeEach } from '../../helpers/number';
 import { PhysicalIndexToValueMap as IndexToValueMap } from '../../translations';
-import { getElementScaleFactor, normalizeVisualDelta } from '../manualResize/utils';
+import { getElementScaleFactor, normalizeVisualDelta, shouldSkipResizeHandlePositioning } from '../manualResize/utils';
 
 // Developer note! Whenever you make a change in this file, make an analogous change in manualColumnResize.js
 
@@ -259,7 +259,7 @@ export class ManualRowResize extends BasePlugin {
    * @param {HTMLCellElement} TH TH HTML element.
    */
   setupHandlePosition(TH: HTMLTableHeaderCellElement) {
-    if (!TH.parentNode || this.#dblclick > 1) {
+    if (shouldSkipResizeHandlePositioning(TH, this.#dblclick)) {
       return;
     }
 
@@ -542,8 +542,12 @@ export class ManualRowResize extends BasePlugin {
         });
       }
     }
-    this.#dblclick = 0;
     this.#autoresizeTimeout = null;
+    this.#dblclick = 0;
+
+    if (this.#currentTH) {
+      this.setupHandlePosition(this.#currentTH);
+    }
   }
 
   /**

--- a/handsontable/src/plugins/manualRowResize/manualRowResize.ts
+++ b/handsontable/src/plugins/manualRowResize/manualRowResize.ts
@@ -14,7 +14,12 @@ import {
 import { arrayEach } from '../../helpers/array';
 import { rangeEach } from '../../helpers/number';
 import { PhysicalIndexToValueMap as IndexToValueMap } from '../../translations';
-import { getElementScaleFactor, normalizeVisualDelta, shouldSkipResizeHandlePositioning } from '../manualResize/utils';
+import {
+  getElementScaleFactor,
+  normalizeVisualDelta,
+  shouldRefreshHandleAfterAutoResize,
+  shouldSkipResizeHandlePositioning,
+} from '../manualResize/utils';
 
 // Developer note! Whenever you make a change in this file, make an analogous change in manualColumnResize.js
 
@@ -504,6 +509,10 @@ export class ManualRowResize extends BasePlugin {
    * @fires Hooks#afterRowResize
    */
   afterMouseDownTimeout() {
+    const shouldRefreshHandlePosition = shouldRefreshHandleAfterAutoResize(
+      this.#currentTH,
+      this.#dblclick,
+    );
     const render = () => {
       this.hot.view.adjustElementsSize();
       this.hot.render();
@@ -545,7 +554,7 @@ export class ManualRowResize extends BasePlugin {
     this.#autoresizeTimeout = null;
     this.#dblclick = 0;
 
-    if (this.#currentTH) {
+    if (shouldRefreshHandlePosition && this.#currentTH) {
       this.setupHandlePosition(this.#currentTH);
     }
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Context
The PR fixes #12670 and the follow-up drag-timer regression in manual row and column resize. After double-click auto-size, the handle is recalculated from the resized header. During a single active drag, the 500 ms double-click timer no longer resets the handle from the header while the guide remains at the dragged offset.

### How has this been tested?
- `pnpm --filter handsontable run test:unit --testPathPattern=manualColumnResize/__tests__/utils.unit`
- `pnpm --filter handsontable run build`
- `pnpm --filter handsontable run test:e2e --testPathPattern='manual(Column|Row)Resize'`
- `pnpm --filter handsontable run eslint -- "src/plugins/manualResize/utils.ts" "src/plugins/manualColumnResize/utils.ts" "src/plugins/manualColumnResize/manualColumnResize.ts" "src/plugins/manualRowResize/manualRowResize.ts" "src/plugins/manualColumnResize/__tests__/utils.unit.js" "src/plugins/manualColumnResize/__tests__/manualColumnResize.spec.js" "src/plugins/manualRowResize/__tests__/manualRowResize.spec.js"`

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #12670

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1779b8e1-1de9-4b1a-879a-218e78b75392"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1779b8e1-1de9-4b1a-879a-218e78b75392"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

