### PR TITLE
DEV-1736: Add Vue 3 variants to installation and introduction pages

### DIFF
--- a/docs/content/guides/getting-started/installation/installation.md
+++ b/docs/content/guides/getting-started/installation/installation.md
@@ -38,6 +38,12 @@ Install Handsontable through your preferred package manager, and control your gr
 
 :::
 
+::: only-for vue
+
+Install Handsontable through your preferred package manager, and control your grid through the `HotTable` component's props.
+
+:::
+
 [[toc]]
 
 <div class="instalationPage">
@@ -421,6 +427,89 @@ To set Handsontable's [configuration options](@/guides/getting-started/configura
 @[code](@/content/guides/getting-started/installation/react/example.tsx)
 
 :::
+
+:::
+
+::: only-for vue
+
+## Install Handsontable
+
+To install Handsontable locally using a package manager, run one of these commands:
+
+<code-group>
+  <code-block title="npm">
+
+  ```bash
+  npm install handsontable @handsontable/vue3
+  ```
+
+  </code-block>
+  <code-block title="Yarn">
+
+  ```bash
+  yarn add handsontable @handsontable/vue3
+  ```
+
+  </code-block>
+  <code-block title="pnpm">
+
+  ```bash
+  pnpm add handsontable @handsontable/vue3
+  ```
+
+  </code-block>
+</code-group>
+
+## Register Handsontable's modules
+
+Import and register all of Handsontable's modules with a single function call:
+
+```js
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+```
+
+Or, to reduce the size of your JavaScript bundle, [import only the modules that you need](@/guides/tools-and-building/modules/modules.md).
+
+## Use the `HotTable` component
+
+The main Handsontable component is called `HotTable`.
+
+```js
+import { HotTable } from '@handsontable/vue3';
+```
+
+To set Handsontable's [configuration options](@/guides/getting-started/configuration-options/configuration-options.md), use `HotTable`'s props. For example:
+
+```html
+<HotTable
+  :data="data"
+  :row-headers="true"
+  :col-headers="true"
+  height="auto"
+  :auto-wrap-row="true"
+  :auto-wrap-col="true"
+  license-key="non-commercial-and-evaluation"
+/>
+```
+
+### Preview the result
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/getting-started/installation/vue/example1.vue)
+
+:::
+
+## Supported versions of Vue
+
+`@handsontable/vue3` requires Vue 3. Vue 2 is not supported -- use [Handsontable 16.2.0](https://handsontable.com/docs/16.2/javascript-data-grid/vue-installation/) if you need Vue 2.
+
+| Handsontable version | Vue 3 version      |
+| -------------------- | ------------------ |
+| `11.0.0` and lower   | No Vue 3 support   |
+| `11.1.0` and higher  | `3.2.0` and higher |
 
 :::
 

--- a/docs/content/guides/getting-started/installation/vue/example1.vue
+++ b/docs/content/guides/getting-started/installation/vue/example1.vue
@@ -1,0 +1,29 @@
+<script setup>
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const hotSettings = ref({
+  data: [
+    ['', 'Tesla', 'Volvo', 'Toyota', 'Ford'],
+    ['2019', 10, 11, 12, 13],
+    ['2020', 20, 11, 14, 13],
+    ['2021', 30, 15, 12, 13],
+    ['2022', 25, 20, 11, 14],
+  ],
+  rowHeaders: true,
+  colHeaders: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/getting-started/introduction/introduction.md
+++ b/docs/content/guides/getting-started/introduction/introduction.md
@@ -35,7 +35,7 @@ Use Handsontable with plain JavaScript, TypeScript, or your favorite framework. 
 - <i class="ico i-angular"></i>
 [Angular](@/angular/guides/getting-started/installation/installation.md)
 - <i class="ico i-vue"></i>
-[Vue 3](@/guides/integrate-with-vue3/vue3-installation/vue3-installation.md)
+[Vue 3](@/vue/guides/getting-started/installation/installation.md)
 
 </div>
 


### PR DESCRIPTION
### Context

The PR adds Vue 3 variants to the two getting-started pages: `installation` and `introduction`. Both pages already had `vue:` frontmatter metadata (IDs and metaTitles) but were missing actual content and example files for the Vue variant.

Changes:
- `installation.md` — adds a `::: only-for vue` intro blurb and a full Vue content section (install via npm/yarn/pnpm, register modules, `HotTable` component usage, live example, Vue 3 version support table, Vue 2 legacy note)
- `installation/vue/example1.vue` — new Vue 3 SFC example using `<script setup>` and `@handsontable/vue3`
- `introduction.md` — updates the Vue 3 link from the old `integrate-with-vue3/vue3-installation` path to the unified `vue-data-grid/installation` page

[skip changelog]

### How has this been tested?

Manual verification in the docs dev server:
- Navigate to `vue-data-grid/installation` — Vue content section renders, example mounts without errors
- Navigate to `vue-data-grid/` (introduction) — Vue 3 link navigates to `vue-data-grid/installation`

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1736

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`
- [x] `handsontable-documentation`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API impact; link updates may need follow-up elsewhere that still reference the old vue3-installation path.
> 
> **Overview**
> Adds **Vue 3** getting-started content to the shared installation and introduction docs so the Vue site variant is no longer empty despite existing `vue:` frontmatter.
> 
> On **installation**, a `::: only-for vue` intro matches React, plus a full section: install `handsontable` and `@handsontable/vue3`, `registerAllModules`, configure **`HotTable`**, a live **`:vue3`** example, and a Vue 3 / legacy Vue 2 support table. New **`installation/vue/example1.vue`** uses `<script setup>` and `:settings` for the embedded demo.
> 
> On **introduction**, the Vue 3 install link now points at **`@/vue/guides/getting-started/installation/installation.md`** instead of the older **`integrate-with-vue3/vue3-installation`** path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f7541d09b8ac817aaa31857baf2e4c1ab485147. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->