### PR TITLE
DEV-1737: Add Vue 3 examples for binding-to-data, configuration-options, saving-data

### DIFF
--- a/docs/content/guides/getting-started/binding-to-data/binding-to-data.md
+++ b/docs/content/guides/getting-started/binding-to-data/binding-to-data.md
@@ -69,6 +69,16 @@ Array of arrays is a good choice for the more grid-like scenarios where you need
 
 :::
 
+::: only-for vue
+
+::: example #example1 :vue --js 1
+
+@[code](@/content/guides/getting-started/binding-to-data/vue/example1.vue)
+
+:::
+
+:::
+
 ### Array of arrays with a selective display of columns
 
 The following example shows how you would use the array of arrays with a selective display of columns. This scenario uses the same data source as in the previous example, this time omitting the `Tesla` column from the grid.
@@ -101,6 +111,16 @@ The following example shows how you would use the array of arrays with a selecti
 
 @[code](@/content/guides/getting-started/binding-to-data/angular/example2.ts)
 @[code](@/content/guides/getting-started/binding-to-data/angular/example2.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example2 :vue --js 1
+
+@[code](@/content/guides/getting-started/binding-to-data/vue/example2.vue)
 
 :::
 
@@ -143,6 +163,16 @@ An array of objects can be used as a data source as follows:
 
 :::
 
+::: only-for vue
+
+::: example #example3 :vue --js 1
+
+@[code](@/content/guides/getting-started/binding-to-data/vue/example3.vue)
+
+:::
+
+:::
+
 ### Array of objects with column as a function
 
 You can set the [`columns`](@/api/options.md#columns) configuration option to a function. This is good practice when you want to bind data more dynamically.
@@ -180,6 +210,16 @@ You can set the [`columns`](@/api/options.md#columns) configuration option to a 
 
 :::
 
+::: only-for vue
+
+::: example #example4 .custom-class :vue --js 1
+
+@[code](@/content/guides/getting-started/binding-to-data/vue/example4.vue)
+
+:::
+
+:::
+
 ### Array of objects with column mapping
 
 In a scenario where you have nested objects, you can use them as the data source by mapping the columns using the [`columns`](@/api/options.md#columns) option.
@@ -212,6 +252,16 @@ In a scenario where you have nested objects, you can use them as the data source
 
 @[code](@/content/guides/getting-started/binding-to-data/angular/example5.ts)
 @[code](@/content/guides/getting-started/binding-to-data/angular/example5.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example5 :vue --js 1
+
+@[code](@/content/guides/getting-started/binding-to-data/vue/example5.vue)
 
 :::
 
@@ -256,6 +306,16 @@ In a scenario where you start with an empty data source, you will need to provid
 
 :::
 
+::: only-for vue
+
+::: example #example6 :vue --js 1
+
+@[code](@/content/guides/getting-started/binding-to-data/vue/example6.vue)
+
+:::
+
+:::
+
 ### Function data source and schema
 
 If your [`dataSchema`](@/api/options.md#dataschema) is a constructor of an object that doesn't directly expose its members, you can specify functions for the [`data`](@/api/options.md#data) member of each [`columns`](@/api/options.md#columns) item.
@@ -295,6 +355,16 @@ The example below shows how to use such objects:
 
 :::
 
+::: only-for vue
+
+::: example #example7 :vue --js 1
+
+@[code](@/content/guides/getting-started/binding-to-data/vue/example7.vue)
+
+:::
+
+:::
+
 ### No data
 
 By default, if you don't provide any data, Handsontable renders as an empty 5x5 grid.
@@ -327,6 +397,16 @@ By default, if you don't provide any data, Handsontable renders as an empty 5x5 
 
 @[code](@/content/guides/getting-started/binding-to-data/angular/example9.ts)
 @[code](@/content/guides/getting-started/binding-to-data/angular/example9.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example9 :vue --js 1
+
+@[code](@/content/guides/getting-started/binding-to-data/vue/example9.vue)
 
 :::
 
@@ -386,6 +466,16 @@ the [`setDataAtCell()`](@/api/core.md#setdataatcell) method.
 
 :::
 
+::: only-for vue
+
+::: example #example10 :vue --js 1
+
+@[code](@/content/guides/getting-started/binding-to-data/vue/example10.vue)
+
+:::
+
+:::
+
 There are multiple ways you can insert your data into Handsontable. Let's go through the most useful ones:
 
 ### The [`data`](@/api/options.md#data) configuration option
@@ -431,6 +521,28 @@ gridSettings: GridSettings = {};
 
 :::
 
+::: only-for vue
+
+You will probably want to initialize the table with some data (if you don't, the table will render an empty 5x5 grid for you). The easiest way to do it is by passing your data array inside the `hotSettings` ref bound to `HotTable`:
+
+```vue
+<script setup>
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+
+const hotSettings = ref({
+  data: newDataset,
+  // ... other config options
+});
+</script>
+
+<template>
+  <HotTable :settings="hotSettings" />
+</template>
+```
+
+:::
+
 ### The data-loading API methods
 
 ::: only-for react
@@ -453,6 +565,16 @@ To use the Handsontable API, you'll need access to the Handsontable instance. Yo
 to the `HotTableComponent`, and reading its `hotInstance` property.
 
 For more information, see the [Instance access](@/guides/getting-started/angular-hot-instance/angular-hot-instance.md) page.
+:::
+
+:::
+
+::: only-for vue
+
+::: tip
+
+To use the Handsontable API, you'll need access to the Handsontable instance. You can do that by adding a template `ref` to the `HotTable` component and reading its `hotInstance` property.
+
 :::
 
 :::
@@ -641,6 +763,16 @@ When working with a copy of data for Handsontable, it is best practice is to clo
 
 @[code](@/content/guides/getting-started/binding-to-data/angular/example11.ts)
 @[code](@/content/guides/getting-started/binding-to-data/angular/example11.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example11 :vue --js 1
+
+@[code](@/content/guides/getting-started/binding-to-data/vue/example11.vue)
 
 :::
 

--- a/docs/content/guides/getting-started/binding-to-data/vue/example1.vue
+++ b/docs/content/guides/getting-started/binding-to-data/vue/example1.vue
@@ -1,0 +1,33 @@
+<script setup>
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const hotSettings = ref({
+  data: [
+    ['', 'Tesla', 'Nissan', 'Toyota', 'Honda', 'Mazda', 'Ford'],
+    ['2017', 10, 11, 12, 13, 15, 16],
+    ['2018', 10, 11, 12, 13, 15, 16],
+    ['2019', 10, 11, 12, 13, 15, 16],
+    ['2020', 10, 11, 12, 13, 15, 16],
+    ['2021', 10, 11, 12, 13, 15, 16],
+  ],
+  startRows: 5,
+  startCols: 5,
+  height: 'auto',
+  width: 'auto',
+  colHeaders: true,
+  minSpareRows: 1,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/getting-started/binding-to-data/vue/example10.vue
+++ b/docs/content/guides/getting-started/binding-to-data/vue/example10.vue
@@ -1,0 +1,34 @@
+<script setup>
+import { ref, onMounted } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const hotRef = ref(null);
+
+const hotSettings = ref({
+  data: [
+    ['', 'Tesla', 'Nissan', 'Toyota', 'Honda', 'Mazda', 'Ford'],
+    ['2017', 10, 11, 12, 13, 15, 16],
+    ['2018', 10, 11, 12, 13, 15, 16],
+    ['2019', 10, 11, 12, 13, 15, 16],
+    ['2020', 10, 11, 12, 13, 15, 16],
+    ['2021', 10, 11, 12, 13, 15, 16],
+  ],
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+onMounted(() => {
+  hotRef.value?.hotInstance?.setDataAtCell(0, 1, 'Ford');
+});
+</script>
+
+<template>
+  <div id="example10">
+    <HotTable ref="hotRef" :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/getting-started/binding-to-data/vue/example11.vue
+++ b/docs/content/guides/getting-started/binding-to-data/vue/example11.vue
@@ -1,0 +1,30 @@
+<script setup>
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const data = [
+  ['', 'Tesla', 'Nissan', 'Toyota', 'Honda', 'Mazda', 'Ford'],
+  ['2017', 10, 11, 12, 13, 15, 16],
+  ['2018', 10, 11, 12, 13, 15, 16],
+  ['2019', 10, 11, 12, 13, 15, 16],
+  ['2020', 10, 11, 12, 13, 15, 16],
+  ['2021', 10, 11, 12, 13, 15, 16],
+];
+
+const hotSettings = ref({
+  data: structuredClone(data),
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example11">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/getting-started/binding-to-data/vue/example2.vue
+++ b/docs/content/guides/getting-started/binding-to-data/vue/example2.vue
@@ -1,0 +1,40 @@
+<script setup>
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const hotSettings = ref({
+  data: [
+    ['', 'Tesla', 'Nissan', 'Toyota', 'Honda', 'Mazda', 'Ford'],
+    ['2017', 10, 11, 12, 13, 15, 16],
+    ['2018', 10, 11, 12, 13, 15, 16],
+    ['2019', 10, 11, 12, 13, 15, 16],
+    ['2020', 10, 11, 12, 13, 15, 16],
+    ['2021', 10, 11, 12, 13, 15, 16],
+  ],
+  colHeaders: true,
+  minSpareRows: 1,
+  height: 'auto',
+  width: 'auto',
+  columns: [
+    { data: 0 },
+    // skip the second column
+    { data: 2 },
+    { data: 3 },
+    { data: 4 },
+    { data: 5 },
+    { data: 6 },
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example2">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/getting-started/binding-to-data/vue/example3.vue
+++ b/docs/content/guides/getting-started/binding-to-data/vue/example3.vue
@@ -1,0 +1,30 @@
+<script setup>
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const hotSettings = ref({
+  data: [
+    { id: 1, name: 'Ted Right', address: '' },
+    { id: 2, name: 'Frank Honest', address: '' },
+    { id: 3, name: 'Joan Well', address: '' },
+    { id: 4, name: 'Gail Polite', address: '' },
+    { id: 5, name: 'Michael Fair', address: '' },
+  ],
+  colHeaders: true,
+  height: 'auto',
+  width: 'auto',
+  minSpareRows: 1,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example3">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/getting-started/binding-to-data/vue/example4.vue
+++ b/docs/content/guides/getting-started/binding-to-data/vue/example4.vue
@@ -1,0 +1,45 @@
+<script setup>
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const hotSettings = ref({
+  data: [
+    { id: 1, name: { first: 'Ted', last: 'Right' }, address: '' },
+    { id: 2, address: '' },
+    { id: 3, name: { first: 'Joan', last: 'Well' }, address: '' },
+  ],
+  colHeaders: true,
+  height: 'auto',
+  width: 'auto',
+  columns(column) {
+    let columnMeta = {};
+
+    if (column === 0) {
+      columnMeta.data = 'id';
+    } else if (column === 1) {
+      columnMeta.data = 'name.first';
+    } else if (column === 2) {
+      columnMeta.data = 'name.last';
+    } else if (column === 3) {
+      columnMeta.data = 'address';
+    } else {
+      columnMeta = {};
+    }
+
+    return columnMeta;
+  },
+  minSpareRows: 1,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example4">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/getting-started/binding-to-data/vue/example5.vue
+++ b/docs/content/guides/getting-started/binding-to-data/vue/example5.vue
@@ -1,0 +1,29 @@
+<script setup>
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const hotSettings = ref({
+  data: [
+    { id: 1, name: { first: 'Ted', last: 'Right' }, address: '' },
+    { id: 2, address: '' },
+    { id: 3, name: { first: 'Joan', last: 'Well' }, address: '' },
+  ],
+  colHeaders: true,
+  height: 'auto',
+  width: 'auto',
+  columns: [{ data: 'id' }, { data: 'name.first' }, { data: 'name.last' }, { data: 'address' }],
+  minSpareRows: 1,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example5">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/getting-started/binding-to-data/vue/example6.vue
+++ b/docs/content/guides/getting-started/binding-to-data/vue/example6.vue
@@ -1,0 +1,35 @@
+<script setup>
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const hotSettings = ref({
+  data: [],
+  dataSchema: {
+    id: null,
+    name: {
+      first: null,
+      last: null,
+    },
+    address: null,
+  },
+  startRows: 5,
+  startCols: 4,
+  colHeaders: ['ID', 'First Name', 'Last Name', 'Address'],
+  height: 'auto',
+  width: 'auto',
+  columns: [{ data: 'id' }, { data: 'name.first' }, { data: 'name.last' }, { data: 'address' }],
+  minSpareRows: 1,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example6">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/getting-started/binding-to-data/vue/example7.vue
+++ b/docs/content/guides/getting-started/binding-to-data/vue/example7.vue
@@ -1,0 +1,64 @@
+<script setup>
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+function model(opts) {
+  const _pub = {
+    id: undefined,
+    name: undefined,
+    address: undefined,
+    attr: undefined,
+  };
+  const _priv = {};
+
+  for (const i in opts) {
+    if (opts.hasOwnProperty && opts.hasOwnProperty(i)) {
+      _priv[i] = opts[i];
+    }
+  }
+
+  _pub.attr = function(attr, val) {
+    if (typeof val === 'undefined') {
+      window.console && console.log('GET the', attr, 'value of', _pub);
+      return _priv[attr];
+    }
+    window.console && console.log('SET the', attr, 'value of', _pub);
+    _priv[attr] = val;
+    return _pub;
+  };
+
+  return _pub;
+}
+
+function property(attr) {
+  return (row, value) => row.attr(attr, value);
+}
+
+const hotSettings = ref({
+  data: [
+    model({ id: 1, name: 'Ted Right', address: '' }),
+    model({ id: 2, name: 'Frank Honest', address: '' }),
+    model({ id: 3, name: 'Joan Well', address: '' }),
+    model({ id: 4, name: 'Gail Polite', address: '' }),
+    model({ id: 5, name: 'Michael Fair', address: '' }),
+  ],
+  dataSchema: model,
+  height: 'auto',
+  width: 'auto',
+  colHeaders: ['ID', 'Name', 'Address'],
+  columns: [{ data: property('id') }, { data: property('name') }, { data: property('address') }],
+  minSpareRows: 1,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example7">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/getting-started/binding-to-data/vue/example9.vue
+++ b/docs/content/guides/getting-started/binding-to-data/vue/example9.vue
@@ -1,0 +1,20 @@
+<script setup>
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const hotSettings = ref({
+  autoWrapRow: true,
+  autoWrapCol: true,
+  height: 'auto',
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example9">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/getting-started/configuration-options/configuration-options.md
+++ b/docs/content/guides/getting-started/configuration-options/configuration-options.md
@@ -119,6 +119,44 @@ gridSettings: GridSettings = {
 
 :::
 
+::: only-for vue
+
+To apply configuration options in Vue 3, pass them inside a `hotSettings` ref bound to the `HotTable` component with the `:settings` prop:
+
+```vue
+<script setup>
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const hotSettings = ref({
+  licenseKey: 'non-commercial-and-evaluation',
+  data: [
+    ['A1', 'B1', 'C1', 'D1'],
+    ['A2', 'B2', 'C2', 'D2'],
+    ['A3', 'B3', 'C3', 'D3'],
+  ],
+  width: 400,
+  height: 300,
+  colHeaders: true,
+  rowHeaders: true,
+  customBorders: true,
+  dropdownMenu: true,
+  multiColumnSorting: true,
+  filters: true,
+  manualRowMove: true,
+});
+</script>
+
+<template>
+  <HotTable :settings="hotSettings" />
+</template>
+```
+
+:::
+
 Depending on your needs, you can apply configuration options to different elements of your grid, such as:
 
 - [The entire grid](#set-grid-options)
@@ -234,6 +272,22 @@ gridSettings: GridSettings = {
 
 :::
 
+::: only-for vue
+
+```ts
+const hotSettings = ref({
+  // top-level grid options that apply to the entire grid
+  width: 400,
+  height: 300,
+});
+```
+
+```html
+<HotTable :settings="hotSettings" />
+```
+
+:::
+
 ### Example
 
 To configure each cell in the grid as read-only, apply the [`readOnly`](@/api/options.md#readonly) option as a top-level grid option.
@@ -273,6 +327,16 @@ As a result, each cell in the grid is read-only:
 
 @[code](@/content/guides/getting-started/configuration-options/angular/example1.ts)
 @[code](@/content/guides/getting-started/configuration-options/angular/example1.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example1 :vue --js 1
+
+@[code](@/content/guides/getting-started/configuration-options/vue/example1.vue)
 
 :::
 
@@ -343,6 +407,24 @@ gridSettings: GridSettings = {
 
 :::
 
+::: only-for vue
+
+```ts
+const hotSettings = ref({
+  columns: [
+    { width: 100 }, // column options for the first (by physical index) column
+    { width: 100 }, // column options for the second (by physical index) column
+    { width: 100 }, // column options for the third (by physical index) column
+  ],
+});
+```
+
+```html
+<HotTable :settings="hotSettings" />
+```
+
+:::
+
 ### Example
 
 In the example below, the [`columns`](@/api/options.md#columns) option is set to a function.
@@ -384,6 +466,16 @@ As a result, each cell in the third and ninth columns is read-only:
 
 @[code](@/content/guides/getting-started/configuration-options/angular/example2.ts)
 @[code](@/content/guides/getting-started/configuration-options/angular/example2.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example2 :vue --js 1
+
+@[code](@/content/guides/getting-started/configuration-options/vue/example2.vue)
 
 :::
 
@@ -481,6 +573,28 @@ gridSettings: GridSettings = {
 
 :::
 
+::: only-for vue
+
+```ts
+const hotSettings = ref({
+  cells(row, col, prop) {
+    if (row === 1 || row === 4) {
+      return {
+        // row options, which apply to each cell of the second row
+        // and to each cell of the fifth row
+        readOnly: true,
+      };
+    }
+  },
+});
+```
+
+```html
+<HotTable :settings="hotSettings" />
+```
+
+:::
+
 ### Example
 
 In the example below, the [`cells`](@/api/options.md#cells) option sets each cell in the first and fourth row as [`readOnly`](@/api/options.md#readonly).
@@ -515,6 +629,16 @@ Options modified through [`cells`](@/api/options.md#cells) overwrite all other o
 
 @[code](@/content/guides/getting-started/configuration-options/angular/example3.ts)
 @[code](@/content/guides/getting-started/configuration-options/angular/example3.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example3 :vue --js 1
+
+@[code](@/content/guides/getting-started/configuration-options/vue/example3.vue)
 
 :::
 
@@ -598,6 +722,35 @@ gridSettings: GridSettings = {
 
 :::
 
+::: only-for vue
+
+```ts
+const hotSettings = ref({
+  cell: [
+    {
+      // cell options, apply only to a cell with coordinates (0, 0)
+      row: 0,
+      col: 0,
+      readOnly: true,
+    },
+    {
+      // cell options, apply only to a cell with coordinates (1, 1)
+      row: 1,
+      col: 1,
+      readOnly: true,
+    },
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+});
+```
+
+```html
+<HotTable :settings="hotSettings" />
+```
+
+:::
+
 ### Example
 
 In the example below, the [`cell`](@/api/options.md#cell) option sets cell `A1`(`0, 0`) and cell `B2`(`1, 1`) as [`readOnly`](@/api/options.md#readonly).
@@ -635,6 +788,16 @@ The modified [`cell`](@/api/options.md#cell) options:
 
 @[code](@/content/guides/getting-started/configuration-options/angular/example4.ts)
 @[code](@/content/guides/getting-started/configuration-options/angular/example4.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example4 :vue --js 1
+
+@[code](@/content/guides/getting-started/configuration-options/vue/example4.vue)
 
 :::
 
@@ -751,6 +914,23 @@ hotTable.hotInstance.getCellMeta(1, 1).readOnly;
 
 :::
 
+::: only-for vue
+
+```ts
+// Access the Handsontable instance via the template ref:
+const hot = hotRef.value?.hotInstance;
+
+// for cell (0, 0), the `readOnly` option is the default (`false`)
+// returns `false`
+hot?.getCellMeta(0, 0).readOnly;
+
+// for cell (1, 1), the `cell` option overwrote the default `readOnly` value
+// returns `true`
+hot?.getCellMeta(1, 1).readOnly;
+```
+
+:::
+
 ### Change cell options
 
 When Handsontable is running, you can change the initial cell options, using the [`setCellMeta()`](@/api/core.md#setcellmeta) method.
@@ -825,6 +1005,20 @@ hotTable.hotInstance.getCellMeta(1, 1).readOnly;
 
 ```html
 <hot-table [settings]="gridSettings" />
+```
+
+:::
+
+::: only-for vue
+
+```ts
+const hot = hotRef.value?.hotInstance;
+
+// changes the `readOnly` option of cell (1, 1) back to `false`
+hot?.setCellMeta(1, 1, 'readOnly', false);
+
+// returns `false`
+hot?.getCellMeta(1, 1).readOnly;
 ```
 
 :::
@@ -915,6 +1109,26 @@ gridSettings: GridSettings = {
 
 :::
 
+::: only-for vue
+
+```ts
+const hotSettings = ref({
+  cells(row, col) {
+    if ((row === 1 || row === 5) && col === 1) {
+      return {
+        readOnly: true,
+      };
+    }
+  },
+});
+```
+
+```html
+<HotTable :settings="hotSettings" />
+```
+
+:::
+
 ### Example
 
 In the example below, the modified [`cells`](@/api/options.md#cells) options overwrite the top-level grid options.
@@ -970,6 +1184,28 @@ hot.getCellMeta(1, 1).readOnly;
 
 :::
 
+::: only-for vue
+
+```ts
+const hot = hotRef.value?.hotInstance;
+
+// for cell (0, 0), the `readOnly` option is the default (`false`)
+// returns `false`
+hot?.getCellMeta(0, 0).readOnly;
+
+// for cell (1, 1), the `cell` option overwrote the default `readOnly` value
+// returns `true`
+hot?.getCellMeta(1, 1).readOnly;
+
+// changes the `readOnly` option of cell (1, 1) back to `false`
+hot?.setCellMeta(1, 1, 'readOnly', false);
+
+// returns `false`
+hot?.getCellMeta(1, 1).readOnly;
+```
+
+:::
+
 ## Configuration example
 
 In the example below, some cells are read-only, and some cells are editable:
@@ -1013,7 +1249,7 @@ In the example below, some cells are read-only, and some cells are editable:
 
 A non-idempotent option is one that produces different results when applied multiple times. In the context of Handsontable and `<HotTable/>` component, options like `manualColumnMove=[1, 0]` will swap columns every time they're applied - first application swaps columns, second application swaps them back, third swaps again, and so on.
 
-### Problem 
+### Problem
 
 Non-idempotent options like `manualColumnMove` and `manualRowMove` cause unwanted visual changes on every React re-render because they operate on visual indexes.
 
@@ -1040,7 +1276,7 @@ Use [`initialState`](@/api/options.md#initialstate) to apply these options only 
 
 ```jsx
 <HotTable
-  initialState={{ 
+  initialState={{
     manualColumnMove: [1, 0]  // Applied only once
   }}
   data={[['A', 'B'], [0, 1]]}
@@ -1059,6 +1295,16 @@ Use [`initialState`](@/api/options.md#initialstate) to apply these options only 
 
 @[code](@/content/guides/getting-started/configuration-options/angular/example6.ts)
 @[code](@/content/guides/getting-started/configuration-options/angular/example6.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example6 :vue --js 1
+
+@[code](@/content/guides/getting-started/configuration-options/vue/example6.vue)
 
 :::
 

--- a/docs/content/guides/getting-started/configuration-options/vue/example1.vue
+++ b/docs/content/guides/getting-started/configuration-options/vue/example1.vue
@@ -1,0 +1,31 @@
+<script setup>
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const hotSettings = ref({
+  data: [
+    ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1', 'J1'],
+    ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2', 'H2', 'I2', 'J2'],
+    ['A3', 'B3', 'C3', 'D3', 'E3', 'F3', 'G3', 'H3', 'I3', 'J3'],
+    ['A4', 'B4', 'C4', 'D4', 'E4', 'F4', 'G4', 'H4', 'I4', 'J4'],
+    ['A5', 'B5', 'C5', 'D5', 'E5', 'F5', 'G5', 'H5', 'I5', 'J5'],
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+  readOnly: true,
+  width: 'auto',
+  height: 'auto',
+  rowHeaders: true,
+  colHeaders: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/getting-started/configuration-options/vue/example2.vue
+++ b/docs/content/guides/getting-started/configuration-options/vue/example2.vue
@@ -1,0 +1,37 @@
+<script setup>
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const hotSettings = ref({
+  data: [
+    ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1', 'J1'],
+    ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2', 'H2', 'I2', 'J2'],
+    ['A3', 'B3', 'C3', 'D3', 'E3', 'F3', 'G3', 'H3', 'I3', 'J3'],
+    ['A4', 'B4', 'C4', 'D4', 'E4', 'F4', 'G4', 'H4', 'I4', 'J4'],
+    ['A5', 'B5', 'C5', 'D5', 'E5', 'F5', 'G5', 'H5', 'I5', 'J5'],
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+  width: 'auto',
+  height: 'auto',
+  rowHeaders: true,
+  colHeaders: true,
+  readOnly: false,
+  columns(index) {
+    return {
+      type: index > 0 ? 'numeric' : 'text',
+      readOnly: index === 2 || index === 8,
+    };
+  },
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example2">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/getting-started/configuration-options/vue/example3.vue
+++ b/docs/content/guides/getting-started/configuration-options/vue/example3.vue
@@ -1,0 +1,36 @@
+<script setup>
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const hotSettings = ref({
+  data: [
+    ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1', 'J1'],
+    ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2', 'H2', 'I2', 'J2'],
+    ['A3', 'B3', 'C3', 'D3', 'E3', 'F3', 'G3', 'H3', 'I3', 'J3'],
+    ['A4', 'B4', 'C4', 'D4', 'E4', 'F4', 'G4', 'H4', 'I4', 'J4'],
+    ['A5', 'B5', 'C5', 'D5', 'E5', 'F5', 'G5', 'H5', 'I5', 'J5'],
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+  width: 'auto',
+  height: 'auto',
+  rowHeaders: true,
+  colHeaders: true,
+  cells(row) {
+    if (row === 1 || row === 4) {
+      return { readOnly: true };
+    }
+    return {};
+  },
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example3">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/getting-started/configuration-options/vue/example4.vue
+++ b/docs/content/guides/getting-started/configuration-options/vue/example4.vue
@@ -1,0 +1,35 @@
+<script setup>
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const hotSettings = ref({
+  data: [
+    ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1', 'J1'],
+    ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2', 'H2', 'I2', 'J2'],
+    ['A3', 'B3', 'C3', 'D3', 'E3', 'F3', 'G3', 'H3', 'I3', 'J3'],
+    ['A4', 'B4', 'C4', 'D4', 'E4', 'F4', 'G4', 'H4', 'I4', 'J4'],
+    ['A5', 'B5', 'C5', 'D5', 'E5', 'F5', 'G5', 'H5', 'I5', 'J5'],
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+  readOnly: false,
+  width: 'auto',
+  height: 'auto',
+  rowHeaders: true,
+  colHeaders: true,
+  cell: [
+    { row: 0, col: 0, readOnly: true },
+    { row: 1, col: 1, readOnly: true },
+  ],
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example4">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/getting-started/configuration-options/vue/example6.vue
+++ b/docs/content/guides/getting-started/configuration-options/vue/example6.vue
@@ -1,0 +1,52 @@
+<script setup>
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const hotSettings = ref({
+  data: [
+    ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1', 'J1'],
+    ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2', 'H2', 'I2', 'J2'],
+    ['A3', 'B3', 'C3', 'D3', 'E3', 'F3', 'G3', 'H3', 'I3', 'J3'],
+    ['A4', 'B4', 'C4', 'D4', 'E4', 'F4', 'G4', 'H4', 'I4', 'J4'],
+    ['A5', 'B5', 'C5', 'D5', 'E5', 'F5', 'G5', 'H5', 'I5', 'J5'],
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+  readOnly: true,
+  width: 'auto',
+  height: 'auto',
+  rowHeaders: true,
+  colHeaders: true,
+  columns: [
+    { readOnly: false, className: '' },
+    {},
+    {},
+    {},
+    {},
+    {},
+    {},
+    {},
+    {},
+    {},
+  ],
+  cell: [
+    { row: 0, col: 0, readOnly: true },
+  ],
+  cells(row, col) {
+    if (row === 2 && col === 2) {
+      return { readOnly: false, className: '' };
+    }
+    return {};
+  },
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example6">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/getting-started/saving-data/saving-data.md
+++ b/docs/content/guides/getting-started/saving-data/saving-data.md
@@ -68,6 +68,16 @@ The example below handles data by using `fetch`. Note that this is just a mockup
 
 :::
 
+::: only-for vue
+
+::: example #example1 :vue --js 1
+
+@[code](@/content/guides/getting-started/saving-data/vue/example1.vue)
+
+:::
+
+:::
+
 ## Save data locally
 
 To persist table state (e.g. column order, column widths, row order) across page reloads, use the browser's [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) API or [`sessionStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage) in your application. Listen to the appropriate hooks (e.g. `afterColumnMove`, `afterColumnResize`) and save or restore state as needed.

--- a/docs/content/guides/getting-started/saving-data/vue/example1.vue
+++ b/docs/content/guides/getting-started/saving-data/vue/example1.vue
@@ -1,0 +1,102 @@
+<script setup>
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const hotRef = ref(null);
+const output = ref('Click "Load" to load data from server');
+const isAutosave = ref(false);
+
+function autosaveClickCallback(event) {
+  isAutosave.value = event.target.checked;
+  output.value = event.target.checked
+    ? 'Changes will be autosaved'
+    : 'Changes will not be autosaved';
+}
+
+function loadClickCallback() {
+  const hot = hotRef.value?.hotInstance;
+
+  fetch('/docs/scripts/json/load.json').then((response) => {
+    response.json().then((data) => {
+      hot?.loadData(data.data);
+      output.value = 'Data loaded';
+    });
+  });
+}
+
+function saveClickCallback() {
+  const hot = hotRef.value?.hotInstance;
+
+  fetch('/docs/scripts/json/save.json', {
+    method: 'POST',
+    mode: 'no-cors',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ data: hot?.getData() }),
+  }).then(() => {
+    output.value = 'Data saved';
+    console.log('The POST request is only used here for the demo purposes');
+  });
+}
+
+function afterChange(change, source) {
+  if (source === 'loadData') {
+    return;
+  }
+
+  if (!isAutosave.value) {
+    return;
+  }
+
+  fetch('/docs/scripts/json/save.json', {
+    method: 'POST',
+    mode: 'no-cors',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ data: change }),
+  }).then(() => {
+    output.value = `Autosaved (${change?.length} cell${(change?.length || 0) > 1 ? 's' : ''})`;
+    console.log('The POST request is only used here for the demo purposes');
+  });
+}
+
+const hotSettings = ref({
+  startRows: 8,
+  startCols: 6,
+  rowHeaders: true,
+  colHeaders: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+  afterChange,
+});
+</script>
+
+<template>
+  <div id="example1">
+    <div class="example-controls-container">
+      <div class="controls">
+        <button id="load" class="button button--primary button--blue" @click="loadClickCallback">
+          Load data
+        </button>
+        <button id="save" class="button button--primary button--blue" @click="saveClickCallback">
+          Save data
+        </button>
+        <label>
+          <input
+            type="checkbox"
+            name="autosave"
+            id="autosave"
+            :checked="isAutosave"
+            @click="autosaveClickCallback"
+          />
+          Autosave
+        </label>
+      </div>
+      <output class="console" id="output">{{ output }}</output>
+    </div>
+    <HotTable ref="hotRef" :settings="hotSettings" />
+  </div>
+</template>


### PR DESCRIPTION
### Context

The PR adds Vue 3 SFC examples and `::: only-for vue` prose sections to three getting-started guide pages, so they render correctly under the `/vue-data-grid/` URL prefix introduced in DEV-1732–1735.

Each page now has:
- A `vue/` directory with `.vue` SFC files (one per example)
- `::: only-for vue` blocks in the page markdown mirroring the JS/React/Angular blocks

**Pages updated:**
- `binding-to-data` — 10 Vue SFC examples (example1–7, 9–11) + Vue prose for the data-config and API-access sections
- `configuration-options` — 5 embedded Vue examples (example1–4, 6) + 9 inline Vue code snippets covering all config-level sub-sections
- `saving-data` — 1 Vue SFC example with reactive state, autosave toggle, and load/save controls

[skip changelog]

### How has this been tested?

- `npm run docs:test:plugins` in `docs/` — 16/16 tests pass
- Manual: `npm run dev` in `docs/` (Node 20), navigated to `/vue-data-grid/binding-to-data`, `/vue-data-grid/configuration-options`, `/vue-data-grid/saving-data` — all Vue examples render; FrameworkSwitcher switches between all four frameworks without regressions

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1737

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`
- [x] `handsontable-documentation` (docs site only)

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (markdown and demo SFCs); no changes to the core grid or wrapper packages.
> 
> **Overview**
> Adds **Vue 3** coverage to three getting-started docs so they work under the `/vue-data-grid/` routes, matching the existing JS/React/Angular pattern.
> 
> For **binding-to-data**, **configuration-options**, and **saving-data**, the PR inserts `::: only-for vue` blocks (embedded examples and inline snippets) and new `vue/*.vue` SFCs that use `@handsontable/vue3`, a `hotSettings` ref with `:settings`, and `hotRef` + `hotInstance` where API access is needed. **binding-to-data** gets ten examples plus prose for initializing data and instance access; **configuration-options** gets five live examples and Vue snippets across grid/column/row/cell/`cells` topics; **saving-data** adds one demo with load/save buttons and optional autosave via `afterChange`.
> 
> Also includes a tiny React-doc whitespace tweak in `configuration-options.md` (unrelated to Vue).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58f7d4a647756cf21f00535286d4a07ccca818c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->