### PR TITLE
DEV-1739: Add Vue 3 variants for grid-size, events-and-hooks, and demo pages

### DIFF
--- a/docs/content/guides/getting-started/demo/demo.md
+++ b/docs/content/guides/getting-started/demo/demo.md
@@ -52,6 +52,16 @@ Explore Handsontable core features in this interactive demo. Click cells, sort c
 
 :::
 
+::: only-for vue
+
+::: example-without-tabs #example3 :vue
+
+@[code](@/content/guides/getting-started/demo/vue/example3.vue)
+
+:::
+
+:::
+
 ## Find the code on GitHub
 
 <div class="boxes-list gray">

--- a/docs/content/guides/getting-started/demo/vue/example3.vue
+++ b/docs/content/guides/getting-started/demo/vue/example3.vue
@@ -1,0 +1,182 @@
+<script setup>
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const SELECTED_CLASS = 'selected';
+
+function addClassesToRows(TD, row, column, _prop, _value, cellProperties) {
+  if (column !== 0) {
+    return;
+  }
+
+  const parentElement = TD.parentElement;
+
+  if (parentElement === null) {
+    return;
+  }
+
+  if (cellProperties.instance.getDataAtRowProp(row, '0')) {
+    parentElement.classList.add(SELECTED_CLASS);
+  } else {
+    parentElement.classList.remove(SELECTED_CLASS);
+  }
+}
+
+const data = [
+  [false, 'Tagcat', 'United Kingdom', 'Classic Vest', '2025-10-11', '01-2331942', true, '172', 2, 2],
+  [true, 'Zoomzone', 'Indonesia', 'Cycling Cap', '2025-05-03', '88-2768633', true, '188', 6, 2],
+  [true, 'Meeveo', 'United States', 'Full-Finger Gloves', '2025-03-27', '51-6775945', true, '162', 1, 3],
+  [false, 'Buzzdog', 'Philippines', 'HL Mountain Frame', '2025-08-29', '44-4028109', true, '133', 7, 1],
+  [true, 'Katz', 'India', 'Half-Finger Gloves', '2025-10-02', '08-2758492', true, '87', 1, 3],
+  [false, 'Jaxbean', 'China', 'HL Road Frame', '2025-09-28', '84-3557705', false, '26', 8, 1],
+  [false, 'Wikido', 'Brazil', 'HL Touring Frame', '2025-06-24', '20-9397637', false, '110', 4, 1],
+  [false, 'Browsedrive', 'United States', 'LL Mountain Frame', '2025-03-13', '36-0079556', true, '50', 4, 4],
+  [false, 'Twinder', 'United Kingdom', 'LL Road Frame', '2025-04-06', '41-1489542', false, '160', 6, 1],
+  [false, 'Jetwire', 'China', 'LL Touring Frame', '2025-02-01', '37-1531629', true, '30', 8, 5],
+  [false, 'Chatterpoint', 'China', 'Long-Sleeve Logo Jersey', '2025-07-14', '25-5083429', true, '39', 7, 2],
+  [false, 'Twinder', 'Egypt', "Men's Bib-Shorts", '2025-08-31', '04-4281278', false, '96', 6, 1],
+  [false, 'Midel', 'United States', "Men's Sports Shorts", '2025-06-27', '55-1711908', true, '108', 10, 3],
+  [false, 'Yodo', 'India', 'ML Mountain Frame', '2025-03-16', '58-8360815', false, '46', 1, 1],
+  [false, 'Camido', 'Russia', 'ML Mountain Frame-W', '2025-09-13', '10-3786104', true, '97', 8, 3],
+  [false, 'Eire', 'Thailand', 'ML Road Frame', '2025-04-10', '45-1186054', true, '161', 1, 4],
+  [false, 'Vinte', 'United Kingdom', 'ML Road Frame-W', '2025-01-22', '62-6202742', true, '58', 4, 3],
+  [false, 'Twitterlist', 'China', 'Mountain Bike Socks', '2025-11-09', '88-9646223', true, '92', 8, 3],
+  [false, 'Eidel', 'Bangladesh', 'Mountain-100', '2025-09-19', '45-5588112', true, '5', 6, 5],
+  [false, 'Trunyx', 'Nigeria', 'Mountain-200', '2025-03-09', '66-6271819', true, '158', 4, 1],
+  [false, 'Katz', 'Turkey', 'Mountain-300', '2025-03-05', '38-9245023', false, '121', 5, 4],
+  [false, 'Kaymbo', 'United States', 'Mountain-400-W', '2025-12-24', '44-5916927', false, '61', 5, 4],
+  [false, 'Ozu', 'Pakistan', 'Mountain-500', '2025-06-13', '31-5449914', true, '155', 2, 2],
+  [false, 'Rhynyx', 'India', 'Racing Socks', '2025-12-05', '19-9413869', true, '162', 2, 4],
+  [false, 'Flashset', 'Iran', 'Road-150', '2025-12-14', '25-9807605', false, '46', 7, 1],
+  [false, 'Yata', 'Congo (Kinshasa)', 'Road-250', '2025-06-12', '74-4291983', true, '47', 4, 4],
+  [false, 'Brainlounge', 'Vietnam', 'Road-350-W', '2025-03-10', '83-0980643', true, '104', 2, 3],
+  [false, 'Babblestorm', 'United States', 'Road-450', '2025-10-10', '19-2878430', true, '101', 6, 4],
+  [false, 'Youspan', 'Brazil', 'Road-550-W', '2025-12-16', '19-1838230', true, '150', 10, 3],
+  [false, 'Nlounge', 'China', 'Road-650', '2025-10-31', '32-2267938', true, '42', 4, 2],
+  [false, 'Twinte', 'India', 'Road-750', '2025-08-17', '79-2821972', true, '144', 9, 3],
+  [false, 'Oyonder', 'United Kingdom', 'Short-Sleeve Classic Jersey', '2025-12-04', '46-6597557', true, '195', 4, 1],
+  [false, 'Gigabox', 'Pakistan', 'Sport-100', '2025-02-03', '15-1793960', true, '199', 4, 4],
+  [false, 'Livetube', 'France', 'Touring-1000', '2025-05-16', '86-0811003', true, '110', 4, 5],
+  [false, 'Voomm', 'United Kingdom', 'Touring-2000', '2025-07-15', '95-3068680', true, '51', 4, 4],
+  [false, 'Voonyx', 'China', 'Touring-3000', '2025-11-27', '35-3085360', false, '69', 2, 5],
+  [false, 'Zoombeat', 'United States', "Women's Mountain Shorts", '2025-11-03', '56-8673088', false, '53', 2, 3],
+  [false, 'Roomm', 'China', "Women's Tights", '2025-03-16', '76-0085918', true, '168', 1, 1],
+  [false, 'Leenti', 'China', 'Mountain-400', '2025-05-16', '03-0893276', false, '58', 1, 4],
+  [false, 'Jetpulse', 'United States', 'Road-550', '2025-02-08', '79-9013306', true, '152', 9, 3],
+  [false, 'Katz', 'Peru', 'Road-350', '2025-02-15', '55-7799920', true, '66', 4, 2],
+  [false, 'Cogidoo', 'India', 'LL Mountain Front Wheel', '2025-06-04', '07-0881122', false, '112', 9, 2],
+  [false, 'Divavu', 'Colombia', 'Touring Rear Wheel', '2025-02-24', '58-6157387', true, '50', 10, 4],
+  [false, 'Mydeo', 'China', 'Touring Front Wheel', '2025-12-07', '12-2810010', false, '31', 3, 5],
+  [false, 'Browsebug', 'Japan', 'ML Mountain Front Wheel', '2025-01-14', '64-9249984', true, '132', 5, 5],
+  [false, 'Layo', 'China', 'HL Mountain Front Wheel', '2025-04-24', '45-0739652', true, '45', 1, 5],
+  [false, 'Snaptags', 'United Kingdom', 'LL Touring Handlebars', '2025-08-06', '09-5712761', true, '197', 4, 2],
+  [false, 'Cogilith', 'China', 'HL Touring Handlebars', '2025-05-31', '01-7345008', true, '190', 4, 3],
+  [false, 'Reallinks', 'United Kingdom', 'LL Road Front Wheel', '2025-05-14', '62-1065350', true, '184', 3, 4],
+  [false, 'Quaxo', 'United States', 'ML Road Front Wheel', '2025-03-23', '44-7241323', true, '169', 3, 4],
+  [false, 'Devify', 'China', 'HL Road Front Wheel', '2025-12-12', '52-0295699', false, '152', 4, 4],
+  [false, 'Youopia', 'Angola', 'LL Mountain Handlebars', '2025-04-01', '52-2650922', false, '182', 6, 4],
+  [false, 'Ainyx', 'China', 'Touring Pedal', '2025-02-27', '48-3618525', true, '141', 6, 1],
+  [false, 'Browsetype', 'Malaysia', 'ML Mountain Handlebars', '2025-04-28', '51-8893923', true, '169', 7, 1],
+  [false, 'Muxo', 'China', 'HL Mountain Handlebars', '2025-08-22', '68-5911361', false, '39', 7, 1],
+  [false, 'Bubbletube', 'China', 'LL Road Handlebars', '2025-10-04', '41-5880042', true, '71', 8, 3],
+  [false, 'Fadeo', 'Vietnam', 'ML Road Handlebars', '2025-04-23', '90-5913983', true, '148', 10, 3],
+  [false, 'Yadel', 'United Kingdom', 'HL Road Handlebars', '2025-04-18', '92-0960699', true, '116', 8, 1],
+  [false, 'Blognation', 'China', 'LL Headset', '2025-01-10', '06-9493898', true, '96', 10, 1],
+  [false, 'Devpoint', 'China', 'ML Headset', '2025-12-25', '69-5878565', true, '35', 4, 2],
+  [false, 'Aibox', 'United Kingdom', 'HL Headset', '2025-03-18', '13-1133017', true, '16', 8, 2],
+  [false, 'Brightdog', 'China', 'LL Mountain Pedal', '2025-09-11', '39-6530433', true, '194', 2, 5],
+  [false, 'Gabcube', 'Nigeria', 'ML Mountain Pedal', '2025-04-22', '96-6860388', true, '24', 1, 3],
+  [false, 'Muxo', 'China', 'HL Mountain Pedal', '2025-06-05', '30-0356137', true, '170', 4, 4],
+  [false, 'Tambee', 'China', 'ML Touring Seat/Saddle', '2025-02-22', '93-9058255', true, '184', 9, 5],
+  [false, 'Cogilith', 'India', 'LL Touring Seat/Saddle', '2025-04-06', '82-9268909', false, '153', 10, 4],
+  [false, 'Dynabox', 'Hong Kong', 'HL Touring Seat/Saddle', '2025-01-10', '20-6913815', false, '88', 10, 1],
+  [false, 'Shuffledrive', 'Sudan', 'LL Road Pedal', '2025-09-16', '08-8238817', true, '57', 9, 2],
+  [false, 'Fivechat', 'China', 'ML Road Pedal', '2025-08-26', '44-7370350', false, '62', 4, 1],
+  [false, 'Meembee', 'United States', 'HL Road Pedal', '2025-12-27', '01-3525949', true, '123', 2, 4],
+  [false, 'Dynazzy', 'United Kingdom', 'LL Mountain Seat/Saddle 1', '2025-12-15', '04-2414623', true, '77', 10, 5],
+  [false, 'Eare', 'China', 'ML Mountain Seat/Saddle 1', '2025-04-04', '15-1917509', false, '199', 9, 4],
+  [false, 'Yozio', 'China', 'HL Mountain Seat/Saddle 1', '2025-03-15', '06-2526845', true, '149', 8, 2],
+  [false, 'Jazzy', 'United Kingdom', 'ML Road Seat/Saddle 1', '2025-08-07', '00-8892524', true, '150', 10, 2],
+  [false, 'Thoughtsphere', 'China', 'HL Road Seat/Saddle 1', '2025-11-28', '39-5538991', true, '130', 7, 3],
+  [false, 'Leenti', 'China', 'ML Road Rear Wheel', '2025-12-29', '06-9002973', true, '179', 1, 2],
+  [false, 'Quaxo', 'United Kingdom', 'HL Road Rear Wheel', '2025-09-06', '73-6104901', true, '98', 5, 3],
+  [false, 'Tanoodle', 'Chile', 'LL Mountain Seat/Saddle 2', '2025-05-24', '68-7384479', true, '175', 2, 3],
+  [false, 'Feednation', 'China', 'ML Mountain Seat/Saddle 2', '2025-11-21', '26-7757763', true, '11', 1, 3],
+  [false, 'Kayveo', 'China', 'HL Mountain Seat/Saddle 2', '2025-06-21', '07-4873562', false, '184', 7, 4],
+  [false, 'Meevee', 'Saudi Arabia', 'LL Road Seat/Saddle 1', '2025-11-16', '46-5819554', false, '27', 9, 3],
+  [false, 'Twitterworks', 'China', 'ML Road Seat/Saddle 2', '2025-04-19', '01-2666826', true, '186', 3, 2],
+  [false, 'Wikizz', 'Tanzania', 'HL Road Seat/Saddle 2', '2025-03-08', '54-7090503', true, '20', 3, 3],
+  [false, 'Yoveo', 'United States', 'LL Mountain Tire', '2025-10-14', '78-7658520', false, '153', 2, 1],
+  [false, 'Yakidoo', 'China', 'ML Mountain Tire', '2025-10-12', '23-9926318', true, '161', 8, 5],
+  [false, 'Oyope', 'China', 'HL Mountain Tire', '2025-09-20', '20-0179517', true, '98', 10, 5],
+  [false, 'Skipstorm', 'United States', 'LL Road Tire', '2025-10-01', '02-9543343', true, '30', 7, 3],
+  [false, 'Minyx', 'United States', 'ML Road Tire', '2025-07-07', '98-3938169', true, '73', 10, 2],
+  [false, 'Miboo', 'China', 'HL Road Tire', '2025-07-25', '68-5197934', true, '158', 9, 1],
+  [false, 'Realfire', 'United States', 'Touring Tire', '2025-08-27', '39-8260460', true, '122', 5, 2],
+  [false, 'Shufflester', 'China', 'Mountain Tire Tube', '2025-06-08', '45-9776170', true, '33', 2, 4],
+  [false, 'Ntag', 'China', 'Road Tire Tube', '2025-12-06', '45-0858451', true, '107', 6, 2],
+  [false, 'Jabberbean', 'United States', 'Touring Tire Tube', '2025-04-26', '15-4247305', true, '15', 1, 2],
+  [false, 'Thoughtblab', 'China', 'LL Bottom Bracket', '2025-05-21', '15-8534931', true, '168', 5, 2],
+  [false, 'Jabbertype', 'China', 'Classic Vest', '2025-07-25', '23-1251557', true, '135', 4, 2],
+  [false, 'Buzzshare', 'United Kingdom', 'Cycling Cap', '2025-07-07', '86-5920601', true, '11', 1, 4],
+  [false, 'Roodel', 'United States', 'Full-Finger Gloves', '2025-01-13', '48-1055459', true, '41', 6, 4],
+  [false, 'Zoovu', 'China', 'Half-Finger Gloves', '2025-06-03', '12-7842022', true, '144', 6, 1],
+  [false, 'Photofeed', 'China', 'HL Mountain Frame', '2025-07-14', '94-5088099', true, '106', 1, 4],
+];
+
+const hotSettings = ref({
+  data,
+  height: 450,
+  width: '100%',
+  colWidths: [180, 220, 140, 120, 120, 120, 140],
+  colHeaders: ['Company Name', 'Name', 'Sell date', 'In stock', 'Quantity', 'Order ID', 'Country'],
+  contextMenu: [
+    'cut',
+    'copy',
+    '---------',
+    'row_above',
+    'row_below',
+    'remove_row',
+    '---------',
+    'alignment',
+    'make_read_only',
+    'clear_column',
+  ],
+  dropdownMenu: true,
+  hiddenColumns: {
+    indicators: true,
+  },
+  multiColumnSorting: true,
+  filters: true,
+  rowHeaders: true,
+  headerClassName: 'htLeft',
+  beforeRenderer: addClassesToRows,
+  manualRowMove: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  autoRowSize: true,
+  manualRowResize: true,
+  manualColumnResize: true,
+  navigableHeaders: true,
+  imeFastEdit: true,
+  columns: [
+    { data: 1 },
+    { data: 3 },
+    { data: 4, type: 'intl-date' },
+    { data: 6, type: 'checkbox', className: 'htCenter' },
+    { data: 7, type: 'numeric' },
+    { data: 5 },
+    { data: 2 },
+  ],
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example3">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/getting-started/events-and-hooks/events-and-hooks.md
+++ b/docs/content/guides/getting-started/events-and-hooks/events-and-hooks.md
@@ -70,6 +70,19 @@ hotTable.hotInstance.addHook("afterCreateRow", (row, amount) => {
 
 :::
 
+::: only-for vue
+
+```js
+const hotSettings = ref({
+  afterCreateRow(row, amount) {
+    console.log(`${amount} row(s) were created, starting at index ${row}`);
+  },
+  // ...other settings
+});
+```
+
+:::
+
 ## Middleware
 
 Middleware is a concept known in the JavaScript world from Node.js frameworks such as Express or Koa. Middleware is a callback that can pipe to a process and allow the developer to modify it. We're no longer just reacting to an emitted event, but we can influence what's happening inside the component and modify the process.
@@ -114,6 +127,21 @@ gridSettings: GridSettings = {
 
 ```html
 <hot-table [settings]="gridSettings" />
+```
+
+:::
+
+::: only-for vue
+
+```js
+const hotSettings = ref({
+  modifyColWidth(width, column) {
+    if (column > 10) {
+      return 150;
+    }
+  },
+  // ...other settings
+});
 ```
 
 :::
@@ -173,6 +201,21 @@ gridSettings: GridSettings = {
 
 :::
 
+::: only-for vue
+
+```js
+const hotSettings = ref({
+  beforeCreateRow(row, amount) {
+    if (!hyperFormula.isItPossibleToAddRows(0, [row, amount])) {
+      return false;
+    }
+  },
+  // ...other settings
+});
+```
+
+:::
+
 The first argument may be modified and passed on through the Handsontable hooks that are next in the queue. This characteristic is shared between `before` and `after` hooks but is more common with the former. Before something happens, we can run the data through a pipeline of hooks that may modify or reject the operation. This provides many possibilities to extend the default Handsontable functionality and customize it for your application.
 
 ::: only-for react
@@ -195,6 +238,16 @@ The first argument may be modified and passed on through the Handsontable hooks 
 
 @[code](@/content/guides/getting-started/events-and-hooks/angular/example3.ts)
 @[code](@/content/guides/getting-started/events-and-hooks/angular/example3.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example3 :vue --js 1
+
+@[code](@/content/guides/getting-started/events-and-hooks/vue/example3.vue)
 
 :::
 
@@ -304,6 +357,16 @@ The following demo uses [`beforeKeyDown`](@/api/hooks.md#beforekeydown) callback
 
 @[code](@/content/guides/getting-started/events-and-hooks/angular/example2.ts)
 @[code](@/content/guides/getting-started/events-and-hooks/angular/example2.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example2 :vue --js 1
+
+@[code](@/content/guides/getting-started/events-and-hooks/vue/example2.vue)
 
 :::
 

--- a/docs/content/guides/getting-started/events-and-hooks/vue/example2.vue
+++ b/docs/content/guides/getting-started/events-and-hooks/vue/example2.vue
@@ -1,0 +1,63 @@
+<script setup>
+import { ref, onMounted } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import { stopImmediatePropagation } from 'handsontable/helpers/dom/event';
+
+registerAllModules();
+
+const hotRef = ref(null);
+let lastChange = null;
+
+onMounted(() => {
+  const hot = hotRef.value?.hotInstance;
+
+  hot?.updateSettings({
+    beforeKeyDown(e) {
+      const selection = hot?.getSelected()?.[0];
+
+      if (!selection) return;
+      if (selection[0] < 0 || selection[1] < 0) return;
+
+      if (e.keyCode === 8 || e.keyCode === 46) {
+        stopImmediatePropagation(e);
+        hot.spliceCol(selection[1], selection[0], 1);
+        e.preventDefault();
+      } else if (e.keyCode === 13) {
+        if (lastChange && lastChange.length === 1 && lastChange[0][2] == lastChange[0][3]) {
+          stopImmediatePropagation(e);
+          hot.spliceCol(selection[1], selection[0], 0, '');
+          hot.selectCell(selection[0], selection[1]);
+        }
+      }
+
+      lastChange = null;
+    },
+  });
+});
+
+const hotSettings = ref({
+  data: [
+    ['Tesla', 2017, 'black', 'black'],
+    ['Nissan', 2018, 'blue', 'blue'],
+    ['Chrysler', 2019, 'yellow', 'black'],
+    ['Volvo', 2020, 'yellow', 'gray'],
+  ],
+  colHeaders: true,
+  rowHeaders: true,
+  height: 'auto',
+  minSpareRows: 1,
+  beforeChange(changes, source) {
+    lastChange = changes;
+  },
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example2">
+    <HotTable ref="hotRef" :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/getting-started/events-and-hooks/vue/example3.vue
+++ b/docs/content/guides/getting-started/events-and-hooks/vue/example3.vue
@@ -1,0 +1,79 @@
+<script setup>
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const hotSettings = ref({
+  data: [
+    ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1', 'J1', 'K1', 'L1'],
+    ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2', 'H2', 'I2', 'J2', 'K2', 'L2'],
+    ['A3', 'B3', 'C3', 'D3', 'E3', 'F3', 'G3', 'H3', 'I3', 'J3', 'K3', 'L3'],
+    ['A4', 'B4', 'C4', 'D4', 'E4', 'F4', 'G4', 'H4', 'I4', 'J4', 'K4', 'L4'],
+    ['A5', 'B5', 'C5', 'D5', 'E5', 'F5', 'G5', 'H5', 'I5', 'J5', 'K5', 'L5'],
+    ['A6', 'B6', 'C6', 'D6', 'E6', 'F6', 'G6', 'H6', 'I6', 'J6', 'K6', 'L6'],
+    ['A7', 'B7', 'C7', 'D7', 'E7', 'F7', 'G7', 'H7', 'I7', 'J7', 'K7', 'L7'],
+    ['A8', 'B8', 'C8', 'D8', 'E8', 'F8', 'G8', 'H8', 'I8', 'J8', 'K8', 'L8'],
+    ['A9', 'B9', 'C9', 'D9', 'E9', 'F9', 'G9', 'H9', 'I9', 'J9', 'K9', 'L9'],
+    ['A10', 'B10', 'C10', 'D10', 'E10', 'F10', 'G10', 'H10', 'I10', 'J10', 'K10', 'L10'],
+    ['A11', 'B11', 'C11', 'D11', 'E11', 'F11', 'G11', 'H11', 'I11', 'J11', 'K11', 'L11'],
+    ['A12', 'B12', 'C12', 'D12', 'E12', 'F12', 'G12', 'H12', 'I12', 'J12', 'K12', 'L12'],
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+  height: 240,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+function onFixedRowsChange(event) {
+  hotSettings.value = { ...hotSettings.value, fixedRowsTop: event.target.checked ? 2 : 0 };
+}
+
+function onFixedColumnsChange(event) {
+  hotSettings.value = { ...hotSettings.value, fixedColumnsStart: event.target.checked ? 2 : 0 };
+}
+
+function onRowHeadersChange(event) {
+  hotSettings.value = { ...hotSettings.value, rowHeaders: event.target.checked };
+}
+
+function onColHeadersChange(event) {
+  hotSettings.value = { ...hotSettings.value, colHeaders: event.target.checked };
+}
+</script>
+
+<template>
+  <div id="example3">
+    <div class="example-controls-container">
+      <div class="controls">
+        <label>
+          <input type="checkbox" @change="onFixedRowsChange" />
+          Add fixed rows
+        </label>
+        <br />
+        <label>
+          <input type="checkbox" @change="onFixedColumnsChange" />
+          Add fixed columns
+        </label>
+        <br />
+        <label>
+          <input type="checkbox" @change="onRowHeadersChange" />
+          Enable row headers
+        </label>
+        <br />
+        <label>
+          <input type="checkbox" @change="onColHeadersChange" />
+          Enable column headers
+        </label>
+      </div>
+    </div>
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>
+
+<style>
+#example3 {
+  max-width: 440px;
+}
+</style>

--- a/docs/content/guides/getting-started/grid-size/grid-size.md
+++ b/docs/content/guides/getting-started/grid-size/grid-size.md
@@ -134,6 +134,35 @@ gridSettings: GridSettings = {
 
 :::
 
+::: only-for vue
+
+```js
+const hotSettings = ref({
+  width: '100px',
+  height: '100px',
+});
+```
+
+or
+
+```js
+const hotSettings = ref({
+  width: '75%',
+  height: '75%',
+});
+```
+
+or
+
+```js
+const hotSettings = ref({
+  width: 100,
+  height: 100,
+});
+```
+
+:::
+
 These dimensions will be set as inline styles in a container element, and `overflow: hidden` will be added automatically.
 
 If container is a block element, then its parent has to have defined `height`. By default block element is `0px` height, so `100%` from `0px` is still `0px`.
@@ -200,6 +229,25 @@ gridSettings: GridSettings = {
 
 :::
 
+::: only-for vue
+
+```js
+const hotSettings = ref({
+  height: 'auto',
+});
+```
+
+You can combine it with `width: 'auto'` to let the grid follow its parent container's width:
+
+```js
+const hotSettings = ref({
+  height: 'auto',
+  width: 'auto',
+});
+```
+
+:::
+
 `height: 'auto'` is different from leaving `height` unset:
 
 | Setting            | Inline styles on root                                       | Scroll parent                                                                  | Row virtualization          |
@@ -216,14 +264,14 @@ With `height: 'auto'`, every row is laid out in the DOM at once. Avoid this valu
 
 ### Troubleshooting with 100% height
 
-When the `height` option is set to 100%, there are three ways to define the container’s height. Assuming you're creating an Handsontable instance that has `100% height` and container is element with id `#example`. 
+When the `height` option is set to 100%, there are three ways to define the container’s height. Assuming you're creating an Handsontable instance that has `100% height` and container is element with id `#example`.
 
 ```js
 const container = document.querySelector('#example');
 
 const hot = new Handsontable(container, {
   height: '100%',
-  // ...rest of config 
+  // ...rest of config
 }
 ```
 
@@ -329,6 +377,16 @@ gridSettings: GridSettings = {
 
 :::
 
+::: only-for vue
+
+```js
+const hotSettings = ref({
+  beforeRefreshDimensions() { return false; },
+});
+```
+
+:::
+
 ## Manual resizing
 
 The Handsontable instance exposes the [`refreshDimensions()`](@/api/core.md#refreshdimensions) method, which helps you to resize grid elements properly.
@@ -353,6 +411,18 @@ To use the Handsontable API, you'll need access to the Handsontable instance. Yo
 to the `HotTableComponent`, and reading its `hotInstance` property.
 
 For more information, see the [Instance access](@/guides/getting-started/angular-hot-instance/angular-hot-instance.md) page.
+:::
+
+:::
+
+::: only-for vue
+
+::: tip
+
+To use the Handsontable API, you'll need access to the Handsontable instance. Use a template ref on the `HotTable` component and read its `hotInstance` property.
+
+For more information, see the [Referencing the Handsontable instance in Vue 3](@/guides/integrate-with-vue3/vue3-hot-reference/vue3-hot-reference.md) page.
+
 :::
 
 :::
@@ -394,6 +464,16 @@ You can listen for two hooks, [`beforeRefreshDimensions`](@/api/hooks.md#beforer
 
 @[code](@/content/guides/getting-started/grid-size/angular/example.ts)
 @[code](@/content/guides/getting-started/grid-size/angular/example.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example :vue --js 1
+
+@[code](@/content/guides/getting-started/grid-size/vue/example.vue)
 
 :::
 

--- a/docs/content/guides/getting-started/grid-size/vue/example.vue
+++ b/docs/content/guides/getting-started/grid-size/vue/example.vue
@@ -1,0 +1,63 @@
+<script setup>
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const data = new Array(100)
+  .fill(null)
+  .map((_, row) =>
+    new Array(50)
+      .fill(null)
+      .map((_, column) => `${row}, ${column}`)
+  );
+
+const isContainerExpanded = ref(false);
+const hotRef = ref(null);
+
+function triggerBtnClickCallback() {
+  isContainerExpanded.value = !isContainerExpanded.value;
+  const parent = document.getElementById('exampleParent');
+
+  parent.style.height = isContainerExpanded.value ? '410px' : '157px';
+  hotRef.value?.hotInstance?.refreshDimensions();
+}
+
+const hotSettings = ref({
+  data,
+  rowHeaders: true,
+  colHeaders: true,
+  width: '100%',
+  height: '100%',
+  colWidths: 100,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example">
+    <div class="example-controls-container">
+      <div class="controls">
+        <button id="triggerBtn" class="button button--primary" @click="triggerBtnClickCallback">
+          {{ isContainerExpanded ? 'Collapse container' : 'Expand container' }}
+        </button>
+      </div>
+    </div>
+    <div id="exampleParent" class="exampleParent">
+      <HotTable ref="hotRef" :settings="hotSettings" />
+    </div>
+  </div>
+</template>
+
+<style>
+#exampleParent {
+  height: 157px;
+}
+
+#exampleParent > div {
+  height: 100%;
+}
+</style>


### PR DESCRIPTION
### Context

The PR adds Vue 3 SFC variants to three getting-started guide pages that were missing them: `grid-size`, `events-and-hooks`, and `demo`. This is the second batch of Vue 3 docs work, continuing from DEV-1737 which covered `binding-to-data`, `configuration-options`, and `saving-data`.

For each page:
- New `vue/example*.vue` SFC files using `<script setup>` + Composition API
- `:::only-for vue` sections in the markdown for inline code snippets and example embeds

**Pages updated:**
- `grid-size` — `vue/example.vue` (expand/collapse container + `refreshDimensions()`) + 4 `only-for vue` blocks (pass-size config, auto-sizing, `beforeRefreshDimensions`, instance-access tip + example embed)
- `events-and-hooks` — `vue/example2.vue` (`beforeKeyDown` + `onMounted`/`updateSettings`) + `vue/example3.vue` (external control via checkboxes) + 5 `only-for vue` blocks (Events, Middleware, Handsontable hooks inline snippets + example2 + example3 embeds)
- `demo` — `vue/example3.vue` (full 100-row product grid with context menu, sorting, filters, and row highlighting)

[skip changelog]

### How has this been tested?

Docs-only change — no source code modified. Verified manually via the docs dev server (`npm run dev` in `docs/`, Node 20):
- `/vue-data-grid/grid-size` — configuration snippets, auto-sizing snippets, Vue tip for instance access, interactive resize example
- `/vue-data-grid/events-and-hooks` — Events/Middleware/Hooks inline snippets, external-control example (checkboxes), `beforeKeyDown` example
- `/vue-data-grid/demo` — full product grid with context menu, sorting, filters, and row highlighting

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1739

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`
- [x] `handsontable-documentation` (docs site only)

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and example SFCs only; no runtime library or API changes.
> 
> **Overview**
> Adds **Vue 3** coverage to three getting-started docs so they match the other frameworks: new `::: only-for vue` snippets and embedded SFC examples under `docs/content/guides/getting-started/`.
> 
> On **grid-size**, Vue readers get `hotSettings` examples for fixed/`%`/numeric size, `height`/`width: 'auto'`, blocking autoresize via `beforeRefreshDimensions`, a tip for `hotRef` + `hotInstance`, and a live demo that toggles the parent height and calls `refreshDimensions()`.
> 
> On **events-and-hooks**, inline snippets show hooks in `ref({ ... })` for events, middleware, and `before*` hooks; two demos cover `beforeKeyDown` (via `onMounted` + `updateSettings`) and external control by spreading updated settings from checkboxes.
> 
> On **demo**, a Vue-only embed adds the full product-grid showcase (`example3.vue`) with context menu, filters, sorting, and row highlighting.
> 
> Also fixes a minor whitespace typo in the shared **100% height** troubleshooting paragraph in `grid-size.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 038c56856c6af0cba2312241387016a57416383d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->