### PR TITLE
DEV-1822: Hot reload docs content in astro dev

### DIFF
--- a/docs/README-EDITING.md
+++ b/docs/README-EDITING.md
@@ -80,7 +80,7 @@ searchCategory: API Reference
 
 When editing the documentation content, follow the guidelines below.
 
-> **Note:** Content `.md` files are cached by Astro's data store. After editing content files, you need to restart the dev server with `npm run dev -- --force` to see changes. CSS and JS changes are picked up by HMR automatically.
+> **Note:** Content `.md` files and the example source files they embed hot reload automatically in `npm run dev`. The custom content loader (`src/plugins/framework-loader.mjs`) watches `content/` and re-syncs the affected pages on each change. If content ever looks stale, restart the dev server with `npm run dev -- --force` to rebuild Astro's data store from scratch.
 
 ### Editing the `next` documentation version
 

--- a/docs/src/plugins/__tests__/framework-loader.test.mjs
+++ b/docs/src/plugins/__tests__/framework-loader.test.mjs
@@ -1,0 +1,254 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { EventEmitter } from 'node:events';
+import { mkdtempSync, mkdirSync, writeFileSync, utimesSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { frameworkLoader } from '../framework-loader.mjs';
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+/**
+ * Builds a temp content tree with one embedded JS example and returns paths.
+ *
+ * @returns {{ contentDir: string, root: string, introMd: string, exampleJs: string }}
+ */
+function createFixture() {
+  const root = mkdtempSync(join(tmpdir(), 'hot-loader-'));
+  const contentDir = join(root, 'content');
+  const introDir = join(contentDir, 'guides', 'intro');
+  const jsDir = join(introDir, 'javascript');
+
+  mkdirSync(jsDir, { recursive: true });
+
+  // Root splash page (special-cased as the bare "index" entry).
+  writeFileSync(join(contentDir, 'index.md'), '---\ntitle: Home\n---\n\nWelcome.\n');
+
+  const introMd = join(introDir, 'intro.md');
+
+  writeFileSync(
+    introMd,
+    [
+      '---',
+      'title: Introduction',
+      'permalink: /intro',
+      '---',
+      '',
+      'Intro body v1.',
+      '',
+      '::: example #ex1',
+      '@[code](@/content/guides/intro/javascript/example1.js)',
+      ':::',
+      '',
+    ].join('\n')
+  );
+
+  const exampleJs = join(jsDir, 'example1.js');
+
+  writeFileSync(exampleJs, "const grid = 'EXAMPLE_CODE_V1';\n");
+
+  return { contentDir, root, introMd, exampleJs };
+}
+
+/**
+ * Builds a fake Astro loader context with a Map-backed store that mirrors
+ * Astro's digest-skip semantics (set() is a no-op when the digest is unchanged).
+ *
+ * @returns {{ ctx: object, store: Map<string, object>, watcher: EventEmitter }}
+ */
+function createContext() {
+  const entries = new Map();
+  const watcher = new EventEmitter();
+
+  watcher.add = () => {};
+
+  const store = {
+    set(entry) {
+      const existing = entries.get(entry.id);
+
+      if (existing && existing.digest === entry.digest) {
+        return false;
+      }
+
+      entries.set(entry.id, entry);
+
+      return true;
+    },
+    get: id => entries.get(id),
+    has: id => entries.has(id),
+    delete: id => entries.delete(id),
+    keys: () => [...entries.keys()],
+  };
+
+  const ctx = {
+    store,
+    watcher,
+    parseData: async ({ data }) => data,
+    generateDigest: data => String(data),
+    renderMarkdown: async body => ({
+      html: body,
+      metadata: { headings: [], imagePaths: [], frontmatter: {} },
+    }),
+    logger: { warn() {}, info() {}, debug() {}, error() {} },
+  };
+
+  return { ctx, store: entries, watcher };
+}
+
+test('initial load emits one entry per framework and inlines example code', async () => {
+  const { contentDir, root } = createFixture();
+
+  try {
+    const { ctx, store } = createContext();
+
+    await frameworkLoader({ contentDir }).load(ctx);
+
+    for (const prefix of ['javascript-data-grid', 'react-data-grid', 'angular-data-grid', 'vue-data-grid']) {
+      assert.ok(store.has(`${prefix}/intro`), `missing entry for ${prefix}`);
+    }
+
+    assert.ok(store.has('index'), 'missing root index entry');
+    assert.match(store.get('javascript-data-grid/intro').rendered.html, /EXAMPLE_CODE_V1/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('editing a markdown file hot reloads its entries', async () => {
+  const { contentDir, root, introMd } = createFixture();
+
+  try {
+    const { ctx, store, watcher } = createContext();
+
+    await frameworkLoader({ contentDir }).load(ctx);
+
+    const before = store.get('javascript-data-grid/intro').rendered.html;
+
+    assert.match(before, /Intro body v1\./);
+
+    writeFileSync(
+      introMd,
+      [
+        '---',
+        'title: Introduction',
+        'permalink: /intro',
+        '---',
+        '',
+        'Intro body v2 EDITED.',
+        '',
+        '::: example #ex1',
+        '@[code](@/content/guides/intro/javascript/example1.js)',
+        ':::',
+        '',
+      ].join('\n')
+    );
+
+    watcher.emit('change', introMd);
+    await sleep(250);
+
+    const after = store.get('javascript-data-grid/intro').rendered.html;
+
+    assert.match(after, /Intro body v2 EDITED\./);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('editing an embedded example source hot reloads the pages that embed it', async () => {
+  const { contentDir, root, exampleJs } = createFixture();
+
+  try {
+    const { ctx, store, watcher } = createContext();
+
+    await frameworkLoader({ contentDir }).load(ctx);
+
+    assert.match(store.get('react-data-grid/intro').rendered.html, /EXAMPLE_CODE_V1/);
+
+    // Rewrite the example and force a distinct mtime so the digest changes even
+    // on filesystems with coarse mtime granularity.
+    writeFileSync(exampleJs, "const grid = 'EXAMPLE_CODE_V2';\n");
+    const future = new Date(Date.now() + 10_000);
+
+    utimesSync(exampleJs, future, future);
+
+    watcher.emit('change', exampleJs);
+    await sleep(250);
+
+    assert.match(store.get('react-data-grid/intro').rendered.html, /EXAMPLE_CODE_V2/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('deleting a markdown file removes its entries from the store', async () => {
+  const { contentDir, root, introMd } = createFixture();
+
+  try {
+    const { ctx, store, watcher } = createContext();
+
+    await frameworkLoader({ contentDir }).load(ctx);
+
+    assert.ok(store.has('vue-data-grid/intro'));
+
+    watcher.emit('unlink', introMd);
+    await sleep(250);
+
+    for (const prefix of ['javascript-data-grid', 'react-data-grid', 'angular-data-grid', 'vue-data-grid']) {
+      assert.ok(!store.has(`${prefix}/intro`), `entry for ${prefix} should be removed`);
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('renaming a permalink removes the entries at the old URL', async () => {
+  const { contentDir, root, introMd } = createFixture();
+
+  try {
+    const { ctx, store, watcher } = createContext();
+
+    await frameworkLoader({ contentDir }).load(ctx);
+
+    assert.ok(store.has('javascript-data-grid/intro'));
+
+    writeFileSync(
+      introMd,
+      [
+        '---',
+        'title: Introduction',
+        'permalink: /getting-started',
+        '---',
+        '',
+        'Body.',
+        '',
+      ].join('\n')
+    );
+
+    watcher.emit('change', introMd);
+    await sleep(250);
+
+    assert.ok(!store.has('javascript-data-grid/intro'), 'stale entry at old permalink should be removed');
+    assert.ok(store.has('javascript-data-grid/getting-started'), 'entry at new permalink should exist');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('changes outside the content directory are ignored', async () => {
+  const { contentDir, root } = createFixture();
+
+  try {
+    const { ctx, store, watcher } = createContext();
+
+    await frameworkLoader({ contentDir }).load(ctx);
+
+    const keysBefore = store.size;
+
+    watcher.emit('change', join(root, 'src', 'components', 'Header.astro'));
+    await sleep(250);
+
+    assert.equal(store.size, keysBefore);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/docs/src/plugins/framework-loader.mjs
+++ b/docs/src/plugins/framework-loader.mjs
@@ -7,7 +7,7 @@
  * e.g. react-data-grid/guides/getting-started/introduction
  */
 
-import { readdirSync, readFileSync, existsSync } from 'fs';
+import { readdirSync, readFileSync, existsSync, statSync } from 'fs';
 import { join, relative, dirname } from 'path';
 import { createRequire } from 'module';
 import { fileURLToPath } from 'url';
@@ -491,7 +491,7 @@ const PREFIXES = {
 
 // Bump this when the loader logic changes to force Astro's data store to
 // re-process all entries (the store skips entries whose digest hasn't changed).
-const LOADER_VERSION = 'v36';
+const LOADER_VERSION = 'v37';
 
 // ---------------------------------------------------------------------------
 // File listing (recursive, no external glob)
@@ -1249,11 +1249,276 @@ export function frameworkLoader({ contentDir }) {
   return {
     name: 'framework-loader',
 
-    async load({ store, parseData, generateDigest, renderMarkdown, logger }) {
+    async load({ store, parseData, generateDigest, renderMarkdown, logger, watcher }) {
       // Site root is the parent of contentDir (docs/content/ → docs/).
       // Used to compute filePaths relative to site root, as required by Astro.
       const siteRoot = dirname(contentDir.replace(/[/\\]$/, ''));
-      const allFiles = listMdFiles(contentDir);
+
+      // Reverse indexes kept across the dev session so the file watcher can
+      // reload the minimum set of entries on each change:
+      //   pathToIds    — md file → store entry ids it produced (cleanup on unlink)
+      //   pathToRefs   — md file → embed source refs it references
+      //   embedToPages — embed source ref → md files that embed it (reverse lookup)
+      const pathToIds = new Map();
+      const pathToRefs = new Map();
+      const embedToPages = new Map();
+
+      /**
+       * Extracts @/content/... embed references (example sources, CSS, HTML,
+       * etc.) from a markdown body. Returns paths relative to contentDir.
+       *
+       * @param {string} body
+       * @returns {string[]}
+       */
+      const extractEmbedRefs = (body) => {
+        const refs = [];
+
+        for (const m of body.matchAll(/@\/content\/([^\s)'"]+)/g)) {
+          refs.push(m[1]);
+        }
+
+        return refs;
+      };
+
+      /**
+       * Builds a signature from the mtimes of a page's embed sources. Folding it
+       * into the digest makes an embed-file edit change the digest of every page
+       * that references it, so the watcher can trigger a reload. Without it,
+       * `store.set` skips entries whose digest is unchanged.
+       *
+       * @param {string[]} refs
+       * @returns {string}
+       */
+      const embedSignature = (refs) => {
+        let sig = '';
+
+        for (const ref of refs) {
+          try {
+            sig += `${ref}:${statSync(join(contentDir, ref)).mtimeMs};`;
+          } catch {
+            // Referenced file is missing — ignore. buildExampleHtml emits a
+            // "File not found" placeholder for it.
+          }
+        }
+
+        return sig;
+      };
+
+      /**
+       * Refreshes the embed reverse index for a single md file.
+       *
+       * @param {string} absPath
+       * @param {string[]} refs
+       */
+      const indexEmbedRefs = (absPath, refs) => {
+        for (const ref of pathToRefs.get(absPath) ?? []) {
+          embedToPages.get(ref)?.delete(absPath);
+        }
+
+        const refSet = new Set(refs);
+
+        for (const ref of refSet) {
+          let pages = embedToPages.get(ref);
+
+          if (!pages) {
+            pages = new Set();
+            embedToPages.set(ref, pages);
+          }
+
+          pages.add(absPath);
+        }
+
+        pathToRefs.set(absPath, refSet);
+      };
+
+      /**
+       * Reads one md file, (re)creates its store entries, and refreshes the
+       * embed reverse index. Returns the entry ids it set.
+       *
+       * @param {string} absPath
+       * @returns {Promise<string[]>}
+       */
+      const syncContentFile = async (absPath) => {
+        const filename = absPath.split('/').pop();
+
+        // Skip sidebars.js (not a content file) and partials (start with _).
+        if (filename === 'sidebars.js' || filename.startsWith('_')) return [];
+
+        let raw;
+
+        try {
+          raw = readFileSync(absPath, 'utf-8');
+        } catch (err) {
+          logger.warn(`framework-loader: could not read ${absPath}: ${err.message}`);
+
+          return [];
+        }
+
+        const { data: frontmatter, content: body } = matter(raw);
+
+        const previousIds = pathToIds.get(absPath) ?? [];
+
+        /**
+         * Records the page's new entry ids and removes any it no longer
+         * produces — e.g. after a permalink change or a page losing its title,
+         * which would otherwise leave a stale entry at the old URL.
+         *
+         * @param {string[]} newIds
+         * @returns {string[]}
+         */
+        const commit = (newIds) => {
+          for (const id of previousIds) {
+            if (!newIds.includes(id)) store.delete(id);
+          }
+
+          pathToIds.set(absPath, newIds);
+
+          return newIds;
+        };
+
+        // Skip files without a title (they are not standalone pages).
+        if (!frontmatter.title) return commit([]);
+
+        const refs = extractEmbedRefs(body);
+        // Embed mtimes only matter to the dev watcher; keep production digests
+        // purely content-based.
+        const embedSig = watcher ? embedSignature(refs) : '';
+
+        indexEmbedRefs(absPath, refs);
+
+        const relPath = relative(contentDir, absPath);
+
+        // Root content/index.md: framework-agnostic splash — emit once as bare "index".
+        if (relPath === 'index.md') {
+          const exampleProcessedBody = await processExampleBlocks(body, contentDir);
+          const processedBody = applyVuepressPreprocessing(
+            processCodeEmbedDirectives(exampleProcessedBody, contentDir)
+          );
+          const digest = generateDigest(raw + LOADER_VERSION + embedSig);
+          let data;
+
+          try {
+            data = await parseData({ id: 'index', data: frontmatter });
+          } catch (err) {
+            // Astro 6 / Zod 4 schema validation may fail during migration;
+            // fall back to raw frontmatter with Starlight-required defaults.
+            data = {
+              ...frontmatter,
+              head: frontmatter.head || [],
+              sidebar: frontmatter.sidebar || { hidden: false, attrs: {} },
+              template: frontmatter.template || 'doc',
+              editUrl: frontmatter.editUrl ?? true,
+              pagefind: frontmatter.pagefind ?? true,
+              draft: frontmatter.draft ?? false,
+            };
+          }
+
+          const rendered = await renderMarkdown(processedBody);
+          postProcessRenderedHtml(rendered);
+
+          store.set({
+            id: 'index',
+            data,
+            body: processedBody,
+            rendered,
+            filePath: relative(siteRoot, absPath),
+            digest,
+          });
+
+          return commit(['index']);
+        }
+
+        // All other pages: URL is derived from the `permalink` frontmatter field,
+        // which VuePress used to define flat, canonical URLs (e.g. /installation).
+        // Pages without a permalink are not standalone routable pages — skip them.
+        const permalink = frontmatter.permalink;
+
+        if (!permalink) return commit([]);
+
+        // Convert permalink to slug: '/' → 'index', '/installation' → 'installation',
+        // '/api/' → 'api', '/api/hidden-columns' → 'api/hidden-columns'.
+        const permalinkSlug = permalink === '/'
+          ? 'index'
+          : permalink.replace(/^\//, '').replace(/\/$/, '') || 'index';
+
+        const ids = [];
+
+        for (const framework of FRAMEWORKS) {
+          const prefix = PREFIXES[framework];
+          const id = `${prefix}/${permalinkSlug}`;
+
+          // 1. Apply only-for filtering for this framework
+          const filteredBody = filterOnlyFor(body, framework);
+
+          // 2. Process ::: example blocks into Shiki-highlighted HTML tabs
+          const exampleProcessedBody = await processExampleBlocks(filteredBody, contentDir);
+
+          // 3. Convert remaining standalone @[code] embeds to fenced code blocks
+          const codeEmbeddedBody = processCodeEmbedDirectives(exampleProcessedBody, contentDir);
+
+          // 4. Apply remaining VuePress preprocessing
+          const processedBody = applyVuepressPreprocessing(codeEmbeddedBody, prefix, contentDir);
+
+          // Make each framework entry unique; include LOADER_VERSION to bust
+          // Astro's data store cache when the loader logic changes, and embedSig
+          // so editing an embedded example source busts every page using it.
+          const digest = generateDigest(raw + framework + LOADER_VERSION + embedSig);
+
+          let data;
+
+          try {
+            data = await parseData({ id, data: frontmatter });
+          } catch (err) {
+            // Astro 6 / Zod 4 schema validation may fail during migration;
+            // fall back to raw frontmatter with Starlight-required defaults.
+            data = {
+              ...frontmatter,
+              head: frontmatter.head || [],
+              sidebar: frontmatter.sidebar || { hidden: false, attrs: {} },
+              template: frontmatter.template || 'doc',
+              editUrl: frontmatter.editUrl ?? true,
+              pagefind: frontmatter.pagefind ?? true,
+              draft: frontmatter.draft ?? false,
+            };
+          }
+
+          // Astro 5 content layer reads from entry.rendered.html, not entry.body.
+          // Pre-render the processed markdown here so Starlight's page template
+          // gets actual HTML content.
+          const rendered = await renderMarkdown(processedBody);
+          postProcessRenderedHtml(rendered);
+
+          store.set({
+            id,
+            data,
+            body: processedBody,
+            rendered,
+            filePath: relative(siteRoot, absPath),
+            digest,
+          });
+
+          ids.push(id);
+        }
+
+        return commit(ids);
+      };
+
+      /**
+       * Removes a deleted md file's entries from the store and reverse index.
+       *
+       * @param {string} absPath
+       */
+      const removeContentFile = (absPath) => {
+        for (const id of pathToIds.get(absPath) ?? []) store.delete(id);
+
+        pathToIds.delete(absPath);
+
+        for (const ref of pathToRefs.get(absPath) ?? []) {
+          embedToPages.get(ref)?.delete(absPath);
+        }
+
+        pathToRefs.delete(absPath);
+      };
 
       // ── 404 page ────────────────────────────────────────────────────────
       // Starlight looks for getEntry('docs', '404'). Emit a custom entry so
@@ -1307,139 +1572,104 @@ export function frameworkLoader({ contentDir }) {
         });
       }
 
-      for (const absPath of allFiles) {
-        const filename = absPath.split('/').pop();
+      // Initial full load of every content file.
+      for (const absPath of listMdFiles(contentDir)) {
+        await syncContentFile(absPath);
+      }
 
-        // Skip sidebars.js (not a content file)
-        if (filename === 'sidebars.js') continue;
+      // ── Dev hot reload ──────────────────────────────────────────────────
+      // In `astro dev`, Astro provides a filesystem watcher. This loader reads
+      // every file once at startup with `fs`, so Astro has no idea the content
+      // files are inputs to this collection — they never hot reload on their
+      // own. Subscribe to the watcher and re-sync the affected entries on each
+      // change, matching how Astro's built-in `file` loader behaves.
+      //
+      // `store.set` skips entries whose digest is unchanged, so the digest of
+      // every entry folds in the source content (md raw + embed mtimes); see
+      // syncContentFile. Production builds get no watcher and skip this block.
+      if (watcher) {
+        // Only react to events under content/. The watcher is project-wide, so
+        // editing components, config, or scripts must not trigger a content
+        // reload. (Those changes already hot reload through Vite.)
+        const watchRoot = contentDir.replace(/[/\\]$/, '');
 
-        // Skip files starting with _
-        if (filename.startsWith('_')) continue;
+        watcher.add(contentDir);
 
-        let raw;
+        // Editors fire several events per save, so batch them: collect changed
+        // paths, then process the batch sequentially to avoid racing on the
+        // shared indexes.
+        const pending = new Map();
+        let flushTimer = null;
+        let flushing = false;
 
-        try {
-          raw = readFileSync(absPath, 'utf-8');
-        } catch (err) {
-          logger.warn(`framework-loader: could not read ${absPath}: ${err.message}`);
-          continue;
-        }
+        const handleChange = async (absPath, type) => {
+          // Markdown pages map 1:1 to a source file — re-sync (or drop) directly.
+          if (absPath.endsWith('.md')) {
+            if (type === 'unlink') {
+              removeContentFile(absPath);
+            } else {
+              await syncContentFile(absPath);
+            }
 
-        const { data: frontmatter, content: body } = matter(raw);
-
-        // Skip files without a title (they are not standalone pages)
-        if (!frontmatter.title) continue;
-
-        const relPath = relative(contentDir, absPath);
-
-        // Root content/index.md: framework-agnostic splash — emit once as bare "index".
-        if (relPath === 'index.md') {
-          const exampleProcessedBody = await processExampleBlocks(body, contentDir);
-          const processedBody = applyVuepressPreprocessing(
-            processCodeEmbedDirectives(exampleProcessedBody, contentDir)
-          );
-          const digest = generateDigest(raw + LOADER_VERSION);
-          let data;
-
-          try {
-            data = await parseData({ id: 'index', data: frontmatter });
-          } catch (err) {
-            // Astro 6 / Zod 4 schema validation may fail during migration;
-            // fall back to raw frontmatter with Starlight-required defaults.
-            data = {
-              ...frontmatter,
-              head: frontmatter.head || [],
-              sidebar: frontmatter.sidebar || { hidden: false, attrs: {} },
-              template: frontmatter.template || 'doc',
-              editUrl: frontmatter.editUrl ?? true,
-              pagefind: frontmatter.pagefind ?? true,
-              draft: frontmatter.draft ?? false,
-            };
+            return;
           }
 
-          const rendered = await renderMarkdown(processedBody);
-          postProcessRenderedHtml(rendered);
+          // Otherwise it is an embedded example source (.js/.ts/.vue/.css/...).
+          // Re-sync only the pages that embed it. Snapshot the set first:
+          // syncContentFile re-indexes each page, mutating this same set.
+          const ref = relative(contentDir, absPath);
 
-          store.set({
-            id: 'index',
-            data,
-            body: processedBody,
-            rendered,
-            filePath: relative(siteRoot, absPath),
-            digest,
-          });
+          for (const mdPath of [...(embedToPages.get(ref) ?? [])]) {
+            await syncContentFile(mdPath);
+          }
+        };
 
-          continue;
-        }
+        const flush = async () => {
+          flushTimer = null;
 
-        // All other pages: URL is derived from the `permalink` frontmatter field,
-        // which VuePress used to define flat, canonical URLs (e.g. /installation).
-        // Pages without a permalink are not standalone routable pages — skip them.
-        const permalink = frontmatter.permalink;
+          // A previous batch is still running — retry shortly so we never run
+          // two passes concurrently.
+          if (flushing) {
+            flushTimer = setTimeout(flush, 50);
 
-        if (!permalink) continue;
-
-        // Convert permalink to slug: '/' → 'index', '/installation' → 'installation',
-        // '/api/' → 'api', '/api/hidden-columns' → 'api/hidden-columns'.
-        // Trailing slashes are stripped so Astro generates the correct /path/ URL
-        // rather than a malformed /path// double-slash route.
-        const permalinkSlug = permalink === '/'
-          ? 'index'
-          : permalink.replace(/^\//, '').replace(/\/$/, '') || 'index';
-
-        for (const framework of FRAMEWORKS) {
-          const prefix = PREFIXES[framework];
-          const id = `${prefix}/${permalinkSlug}`;
-
-          // 1. Apply only-for filtering for this framework
-          const filteredBody = filterOnlyFor(body, framework);
-
-          // 2. Process ::: example blocks into Shiki-highlighted HTML tabs
-          const exampleProcessedBody = await processExampleBlocks(filteredBody, contentDir);
-
-          // 3. Convert remaining standalone @[code] embeds to fenced code blocks
-          const codeEmbeddedBody = processCodeEmbedDirectives(exampleProcessedBody, contentDir);
-
-          // 4. Apply remaining VuePress preprocessing
-          const processedBody = applyVuepressPreprocessing(codeEmbeddedBody, prefix, contentDir);
-
-          // Make each framework entry unique; include LOADER_VERSION to bust
-          // Astro's data store cache when the loader logic changes.
-          const digest = generateDigest(raw + framework + LOADER_VERSION);
-
-          let data;
-
-          try {
-            data = await parseData({ id, data: frontmatter });
-          } catch (err) {
-            // Astro 6 / Zod 4 schema validation may fail during migration;
-            // fall back to raw frontmatter with Starlight-required defaults.
-            data = {
-              ...frontmatter,
-              head: frontmatter.head || [],
-              sidebar: frontmatter.sidebar || { hidden: false, attrs: {} },
-              template: frontmatter.template || 'doc',
-              editUrl: frontmatter.editUrl ?? true,
-              pagefind: frontmatter.pagefind ?? true,
-              draft: frontmatter.draft ?? false,
-            };
+            return;
           }
 
-          // Astro 5 content layer reads from entry.rendered.html, not entry.body.
-          // Pre-render the processed markdown here so Starlight's page template
-          // gets actual HTML content.
-          const rendered = await renderMarkdown(processedBody);
-          postProcessRenderedHtml(rendered);
+          flushing = true;
 
-          store.set({
-            id,
-            data,
-            body: processedBody,
-            rendered,
-            filePath: relative(siteRoot, absPath),
-            digest,
-          });
-        }
+          const batch = [...pending.entries()];
+
+          pending.clear();
+
+          for (const [absPath, type] of batch) {
+            try {
+              await handleChange(absPath, type);
+            } catch (err) {
+              logger.warn(`framework-loader: failed to reload ${absPath}: ${err.message}`);
+            }
+          }
+
+          flushing = false;
+
+          if (pending.size > 0) {
+            flushTimer = setTimeout(flush, 50);
+          }
+        };
+
+        const queueChange = type => (changedPath) => {
+          if (!changedPath.startsWith(watchRoot)) return;
+
+          // Latest event for a path wins (e.g. change-then-unlink → unlink).
+          pending.set(changedPath, type);
+
+          if (!flushTimer) {
+            flushTimer = setTimeout(flush, 100);
+          }
+        };
+
+        watcher.on('add', queueChange('add'));
+        watcher.on('change', queueChange('change'));
+        watcher.on('unlink', queueChange('unlink'));
       }
     },
   };


### PR DESCRIPTION
### Context

The PR adds content hot reload to the docs dev server (`docs/`, `npm run dev` / `astro dev`).

Today the dev server hot reloads the site's code (`.astro` components, config, client scripts, CSS — everything in Vite's module graph) but not the content. Editing a `.md` page under `docs/content/` or an embedded example source (`.js`/`.ts`/`.vue`/`.css`/`.html`) shows no change until the dev server is restarted with `npm run dev -- --force`.

The cause is the custom Astro Content Layer loader, `docs/src/plugins/framework-loader.mjs`. It reads every `.md` file once at startup with `fs` and writes the results into Astro's data store, but never subscribes to the dev file watcher — so Astro has no idea those files are inputs to the collection and nothing re-runs on change.

This PR subscribes the loader to the dev watcher (the `watcher` it already receives in dev), matching how Astro's built-in `file` loader behaves:

- Per-file processing is extracted into a `syncContentFile()` helper (behavior unchanged).
- On change, only the affected entries re-sync: a `.md` edit re-syncs that page's framework entries; an embedded example source re-syncs only the pages that embed it (via an `embedToPages` reverse index); a delete removes the entries.
- Events are debounced and processed sequentially. Changes outside `content/` are ignored (already covered by Vite HMR).
- `store.set` skips entries whose digest is unchanged, so the digest now folds in embed-file mtimes — editing an example source busts the cache for every page that embeds it. This is gated behind dev, so production (`astro build`) digests stay purely content-based.
- Permalink renames now delete the stale entry at the old URL.

A Set-mutation-during-iteration bug surfaced during implementation (the embed branch iterated the live `embedToPages` set while `syncContentFile` re-indexed it, re-visiting the re-added element forever) and is fixed by iterating a snapshot.

[skip changelog]

### How has this been tested?

- New unit tests in `docs/src/plugins/__tests__/framework-loader.test.mjs` (initial load, `.md` reload, embedded-example-source reload, delete, permalink rename, out-of-tree changes ignored):

  ```shell
  cd docs
  node --test src/plugins/__tests__/*.test.mjs src/lib/__tests__/*.test.mjs
  # 22 tests, 22 pass
  ```

- ESLint on the changed files is clean:

  ```shell
  cd docs
  ./node_modules/.bin/eslint --ext .mjs src/plugins/framework-loader.mjs src/plugins/__tests__/framework-loader.test.mjs
  ```

- Manual end-to-end round-trip against the real dev server: started `astro dev`, edited a live `.md` page, confirmed the change appeared in the browser with no restart, then reverted and confirmed it disappeared.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1822

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`
- [x] `handsontable-documentation` (docs site tooling only)

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation. (Updated `docs/README-EDITING.md`.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-site dev tooling only; production builds skip the watcher and embed-mtime digests, with behavior covered by new unit tests.
> 
> **Overview**
> **Docs dev** now hot-reloads `content/` markdown and embedded example sources without a full restart. The custom **`framework-loader`** refactors per-file work into **`syncContentFile`**, wires Astro’s dev **`watcher`** with debounced sequential updates, and keeps reverse indexes so only affected store entries refresh (including pages that reference changed embeds via **`embedToPages`**).
> 
> Dev-only **digest** logic folds embed **mtimes** so `store.set` actually updates when example files change; **permalink** edits remove stale entry IDs. **`README-EDITING.md`** documents the new workflow. New **`framework-loader.test.mjs`** covers reload, delete, permalink rename, and ignored out-of-tree paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c42ab1a781d420a8a4cc3a70507574f6387c3d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->