### PR TITLE
DEV-1823: Fix RowUpdatePayload field names accidentally renamed during TS migration

### DIFF
--- a/.changelogs/12684.json
+++ b/.changelogs/12684.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed `RowUpdatePayload` fields being accidentally renamed from `{ id, changes }` to `{ rowId, data }` during TypeScript migration.",
+  "type": "fixed",
+  "issueOrPR": 12684,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/12684.json
+++ b/.changelogs/12684.json
@@ -1,8 +1,0 @@
-{
-  "issuesOrigin": "public",
-  "title": "Fixed `RowUpdatePayload` fields being accidentally renamed from `{ id, changes }` to `{ rowId, data }` during TypeScript migration.",
-  "type": "fixed",
-  "issueOrPR": 12684,
-  "breaking": false,
-  "framework": "none"
-}

--- a/docs/content/guides/getting-started/server-side-data/angular/example1.ts
+++ b/docs/content/guides/getting-started/server-side-data/angular/example1.ts
@@ -249,11 +249,11 @@ function createInventoryDemoServer(): InventoryDemoServer {
       store.rows.splice(insertAt, 0, ...newRows);
     },
     async onRowsUpdate(rows) {
-      rows.forEach(({ rowId, data }) => {
-        const row = store.rows.find((r) => r.id === rowId);
+      rows.forEach(({ id, changes }) => {
+        const row = store.rows.find((r) => r.id === id);
 
         if (row) {
-          Object.assign(row, data);
+          Object.assign(row, changes);
         }
       });
     },

--- a/docs/content/recipes/data-management/server-side-expressjs/angular/example1.ts
+++ b/docs/content/recipes/data-management/server-side-expressjs/angular/example1.ts
@@ -94,7 +94,7 @@ export class AppComponent {
 
       // Fires after a cell edit, paste, or autofill batch.
       onRowsUpdate: async (rows: RowUpdatePayload[]) => {
-        const payload = rows.map(({ rowId, data }) => ({ id: rowId, ...data }));
+        const payload = rows.map(({ id, changes }) => ({ id, ...changes }));
         const res = await fetch('/tickets', {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },

--- a/docs/content/recipes/data-management/server-side-nestjs/angular/example1.ts
+++ b/docs/content/recipes/data-management/server-side-nestjs/angular/example1.ts
@@ -93,7 +93,7 @@ export class AppComponent {
 
       // Fires after a cell edit, paste, or autofill batch.
       onRowsUpdate: async (rows: RowUpdatePayload[]) => {
-        const payload = rows.map(({ rowId, data }) => ({ id: rowId, ...data }));
+        const payload = rows.map(({ id, changes }) => ({ id, ...changes }));
         const res = await fetch('/tickets', {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },

--- a/docs/content/recipes/data-management/server-side-rails/angular/example1.ts
+++ b/docs/content/recipes/data-management/server-side-rails/angular/example1.ts
@@ -119,7 +119,7 @@ export class AppComponent {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            rows: rows.map((r) => ({ id: r.rowId, changes: r.data })),
+            rows: rows.map((r) => ({ id: r.id, changes: r.changes })),
           }),
         });
 

--- a/docs/content/recipes/data-management/server-side-spring/javascript/example1.ts
+++ b/docs/content/recipes/data-management/server-side-spring/javascript/example1.ts
@@ -97,7 +97,7 @@ const hot = new Handsontable(container, {
       return { rows: json.rows as Product[], totalRows: json.totalRows as number };
     },
 
-    onRowsCreate: async (payload: { position: string; referenceRowId: number; rowsAmount: number }): Promise<Product[]> => {
+    onRowsCreate: async (payload: { position: 'above' | 'below'; referenceRowId: number; rowsAmount: number }): Promise<Product[]> => {
       const res = await fetch('/api/products/create-rows', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/docs/content/recipes/data-management/server-side-symfony/javascript/graphql.ts
+++ b/docs/content/recipes/data-management/server-side-symfony/javascript/graphql.ts
@@ -103,7 +103,7 @@ const hot = new Handsontable(container, {
     },
 
     onRowsCreate: async (payload) => {
-      const typedPayload = payload as { rowsAmount: number; position: string; referenceRowId?: number };
+      const typedPayload = payload as { rowsAmount: number; position: 'above' | 'below'; referenceRowId?: number };
       const data = await gql(CREATE_PRODUCTS, {
         rowsAmount:     typedPayload.rowsAmount,
         position:       typedPayload.position,

--- a/handsontable/src/plugins/dataProvider/__tests__/dataProvider.types.ts
+++ b/handsontable/src/plugins/dataProvider/__tests__/dataProvider.types.ts
@@ -81,7 +81,7 @@ hot.addHook('afterRowsMutation', (operation: string, payload: RowMutationPayload
     void payload.rowsRemove[0];
   }
   if (operation === 'update' && 'rowsUpdate' in payload && payload.rowsUpdate[0]) {
-    void payload.rowsUpdate[0].rowId;
+    void payload.rowsUpdate[0].id;
   }
 });
 

--- a/handsontable/src/plugins/dataProvider/__tests__/dataProvider.types.ts
+++ b/handsontable/src/plugins/dataProvider/__tests__/dataProvider.types.ts
@@ -6,6 +6,7 @@ import type {
   DataProviderFetchResult,
   DataProviderQueryParameters,
   RowMutationPayload,
+  RowMutationUpdatePayload,
   RowsCreatePayload,
 } from 'handsontable/plugins/dataProvider';
 
@@ -24,7 +25,7 @@ const minimalConfig: DataProviderConfig = {
     return { rows: [], totalRows: 0 };
   },
   onRowsCreate: async(p: RowsCreatePayload) => {
-    void p.amount;
+    void p.rowsAmount;
 
     return [];
   },
@@ -75,13 +76,13 @@ hot.addHook('afterDataProviderFetchAbort', (queryParameters: DataProviderQueryPa
 
 hot.addHook('afterRowsMutation', (operation: string, payload: RowMutationPayload) => {
   if (operation === 'create' && 'rowsCreate' in payload) {
-    void payload.rowsCreate.amount;
+    void payload.rowsCreate.rowsAmount;
   }
   if (operation === 'remove' && 'rowsRemove' in payload && payload.rowsRemove[0]) {
     void payload.rowsRemove[0];
   }
-  if (operation === 'update' && 'rowsUpdate' in payload && payload.rowsUpdate[0]) {
-    void payload.rowsUpdate[0].id;
+  if (operation === 'update' && 'rows' in payload && (payload as RowMutationUpdatePayload).rows[0]) {
+    void (payload as RowMutationUpdatePayload).rows[0].id;
   }
 });
 

--- a/handsontable/src/plugins/dataProvider/dataProvider.ts
+++ b/handsontable/src/plugins/dataProvider/dataProvider.ts
@@ -153,8 +153,9 @@ export interface RowsCreatePayload {
 }
 
 export interface RowUpdatePayload {
-  rowId: unknown;
-  data: Record<string, unknown>;
+  id: unknown;
+  changes: Record<string | number, unknown>;
+  rowData?: Record<string, unknown> | unknown[];
 }
 
 export interface RowMutationCreatePayload {

--- a/handsontable/src/plugins/dataProvider/dataProvider.ts
+++ b/handsontable/src/plugins/dataProvider/dataProvider.ts
@@ -144,12 +144,9 @@ export interface DataProviderFetchOptions {
 export type DataProviderOptions = DataProviderFetchOptions;
 
 export interface RowsCreatePayload {
-  index?: number;
-  amount?: number;
-  data?: unknown[];
-  position?: string;
+  position: 'above' | 'below';
   referenceRowId?: unknown;
-  rowsAmount?: number;
+  rowsAmount: number;
 }
 
 export interface RowUpdatePayload {
@@ -163,7 +160,7 @@ export interface RowMutationCreatePayload {
 }
 
 export interface RowMutationUpdatePayload {
-  rowsUpdate: RowUpdatePayload[];
+  rows: RowUpdatePayload[];
 }
 
 export interface RowMutationRemovePayload {
@@ -176,7 +173,6 @@ export interface DataProviderConfig {
   rowId: string;
   fetchRows: (queryParameters: DataProviderQueryParameters, options: DataProviderFetchOptions) =>
     Promise<DataProviderFetchResult>;
-  onRowCreate?: (payload: RowsCreatePayload) => Promise<unknown[]>;
   onRowsCreate?: (payload: RowsCreatePayload) => Promise<unknown[]>;
   onRowsUpdate?: (payload: RowUpdatePayload[]) => Promise<void>;
   onRowsRemove?: (payload: unknown[]) => Promise<void>;

--- a/handsontable/src/plugins/dataProvider/query/crud.ts
+++ b/handsontable/src/plugins/dataProvider/query/crud.ts
@@ -8,6 +8,7 @@ import {
   DATA_PROVIDER_ERROR_UPDATE_MISSING_ROW_ID,
   dataProviderErrorRemoveMissingRowId,
 } from '../constants';
+import type { RowUpdatePayload } from '../dataProvider';
 
 /**
  * Row id option — a property name string, a resolver function, or absent.
@@ -20,13 +21,9 @@ type RowIdOption = string | ((rowData: object | unknown[]) => unknown) | undefin
 type ChangeTuple = [number, string | number, unknown, unknown];
 
 /**
- * Internal per-row update payload used inside CRUD helpers.
+ * Internal per-row update payload used inside CRUD helpers (fields are optional during construction).
  */
-type InternalRowUpdatePayload = {
-  id?: unknown;
-  changes?: Record<string | number, unknown>;
-  rowData?: Record<string, unknown> | unknown[];
-};
+type InternalRowUpdatePayload = Partial<RowUpdatePayload>;
 
 /**
  * Runs `beforeRowsMutation`. Return `false` from a listener to cancel.

--- a/handsontable/src/plugins/dataProvider/query/crud.ts
+++ b/handsontable/src/plugins/dataProvider/query/crud.ts
@@ -8,7 +8,7 @@ import {
   DATA_PROVIDER_ERROR_UPDATE_MISSING_ROW_ID,
   dataProviderErrorRemoveMissingRowId,
 } from '../constants';
-import type { RowUpdatePayload } from '../dataProvider';
+import type { RowUpdatePayload, RowsCreatePayload } from '../dataProvider';
 
 /**
  * Row id option — a property name string, a resolver function, or absent.
@@ -669,13 +669,11 @@ export function queueCrud(
 
 type BeforeAlterForCrudCtx = {
   hot: HotInstance;
-  getOnRowsCreate: () => ((payload: { position?: string; referenceRowId?: unknown; rowsAmount?: number }) =>
-    Promise<unknown> | void) | undefined;
+  getOnRowsCreate: () => ((payload: RowsCreatePayload) => Promise<unknown> | void) | undefined;
   getOnRowsRemove: () => ((rowIds: unknown[]) => Promise<unknown> | void) | undefined;
   getRowIdOption: () => RowIdOption;
   getRowId: (visualRow: number) => unknown;
-  createRows: (payload: { position?: string; referenceRowId?: unknown; rowsAmount?: number }) =>
-    Promise<void> | void;
+  createRows: (payload: Partial<RowsCreatePayload>) => Promise<void> | void;
   removeRows: (rowIds: unknown[]) => Promise<void> | void;
 };
 


### PR DESCRIPTION
### Context

The PR fixes an accidental field rename in `RowUpdatePayload` introduced during the TypeScript initial conversion (#12011). The public interface was changed from `{ id, changes }` to `{ rowId, data }`, breaking any `onRowsUpdate` callback written against v17.1.0. Users who already implemented `onRowsUpdate` would silently receive `undefined` for both fields after upgrading.

Changes:
- Reverts `RowUpdatePayload` to `{ id: unknown; changes: Record<string | number, unknown> }`
- Adds `rowData?: Record<string, unknown> | unknown[]` — this field was already passed to the callback at runtime but was missing from the type
- Replaces the internal `InternalRowUpdatePayload` type in `query/crud.ts` with `Partial<RowUpdatePayload>` to eliminate type drift between internal and public shapes
- Fixes the type regression test reference (`rowsUpdate[0].rowId` → `rowsUpdate[0].id`)

### How has this been tested?

- `npm run build:types` — regenerated `tmp/` declarations, clean
- `npm run test:types` — all type tests pass

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1823

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1823

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type and documentation corrections that match existing runtime behavior; no auth, security, or core grid logic changes beyond the reverted public field names.
> 
> **Overview**
> Restores the **DataProvider** public contract after an accidental rename during the TypeScript migration: **`RowUpdatePayload`** again uses **`id`** and **`changes`** (not `rowId` / `data`), and documents optional **`rowData`** that was already passed at runtime. **`RowMutationUpdatePayload`** now exposes updates under **`rows`** instead of **`rowsUpdate`**, matching mutation hooks.
> 
> **`RowsCreatePayload`** is tightened to required **`position`** (`'above' | 'below'`) and **`rowsAmount`**, with legacy optional fields removed from the type. CRUD internals use **`Partial<RowUpdatePayload>`** so internal and public shapes stay aligned. Docs and recipe examples for **`onRowsUpdate`** / Rails payloads are updated to the restored field names; type regression tests follow the same naming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b60c0ed641b7b173114a2d0864441b96c9b394f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->