### PR TITLE
DEV-1825: Fix RowUpdatePayload field names in Angular data-provider example

### DIFF
--- a/examples/next/docs/angular-wrapper/data-provider/src/app/data-provider-clients.ts
+++ b/examples/next/docs/angular-wrapper/data-provider/src/app/data-provider-clients.ts
@@ -172,7 +172,7 @@ export function createWarehouseDataProvider(restApi: string) {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          updates: rows.map(({ rowId, data }) => ({ id: String(rowId), changes: data })),
+          updates: rows.map(({ id, changes }) => ({ id: String(id), changes })),
         }),
       });
 
@@ -217,9 +217,9 @@ export function createTicketsDataProvider(graphqlUrl: string) {
       await gqlFetch(graphqlUrl, {
         query: M_UPDATE,
         variables: {
-          updates: rows.map(({ rowId, data }) => ({
-            id: String(rowId),
-            changes: data,
+          updates: rows.map(({ id, changes }) => ({
+            id: String(id),
+            changes,
           })),
         },
       });


### PR DESCRIPTION
### Context

The PR fixes a TypeScript build failure in CI introduced after PR #12684 renamed `RowUpdatePayload` fields from `rowId`/`data` to `id`/`changes`. The Angular data-provider example (`examples/next/docs/angular-wrapper/data-provider/src/app/data-provider-clients.ts`) still used the old field names in both `onRowsUpdate` handlers (REST and GraphQL clients).

### How has this been tested?

- TypeScript compilation of the Angular data-provider example (`npm run build` in `examples/next/docs/angular-wrapper/data-provider`)

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1825

### Affected project(s):

- [ ] `handsontable`
- [x] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1825
