### PR TITLE
docs: link header logo to handsontable.com

### DIFF
--- a/docs/src/components/SiteTitle.astro
+++ b/docs/src/components/SiteTitle.astro
@@ -2,17 +2,47 @@
 /**
  * SiteTitle component override.
  *
- * Renders the default Starlight site title (logo) with a "dev" badge
- * when BUILD_MODE is not 'production' (local development, staging, etc.).
- * The framework switcher has been moved to the header nav row
- * (FrameworkSwitcher.astro), next to the versions dropdown.
+ * Renders the logo as a link to handsontable.com (the marketing site)
+ * instead of the docs root, matching the pre-Astro behavior so the docs
+ * header still offers a direct path back to the main website.
+ *
+ * Adds a "dev" badge when BUILD_MODE is not 'production'. The framework
+ * switcher lives in the header nav row (FrameworkSwitcher.astro).
  */
-import Default from '@astrojs/starlight/components/SiteTitle.astro';
+import { logos } from 'virtual:starlight/user-images';
+import config from 'virtual:starlight/user-config';
 
+const { siteTitle } = Astro.locals.starlightRoute;
 const isProduction = import.meta.env.PUBLIC_BUILD_MODE === 'production';
 ---
 <div class="site-title-wrapper">
-  <Default {...Astro.props} />
+  <a href="https://handsontable.com" class="site-title sl-flex">
+    {
+      config.logo && logos.dark && (
+        <>
+          <img
+            class:list={{ 'light:sl-hidden print:hidden': !('src' in config.logo) }}
+            alt={config.logo.alt}
+            src={logos.dark.src}
+            width={logos.dark.width}
+            height={logos.dark.height}
+          />
+          {!('src' in config.logo) && (
+            <img
+              class="dark:sl-hidden print:block"
+              alt={config.logo.alt}
+              src={logos.light?.src}
+              width={logos.light?.width}
+              height={logos.light?.height}
+            />
+          )}
+        </>
+      )
+    }
+    <span class:list={{ 'sr-only': config.logo?.replacesTitle }} translate="no">
+      {siteTitle}
+    </span>
+  </a>
   {!isProduction && <span class="dev-badge" aria-label="Development build">dev</span>}
 </div>
 


### PR DESCRIPTION
### Context

The PR restores the docs site's pre-Astro behavior where the header logo linked to the marketing site at https://handsontable.com. After the Astro/Starlight migration the logo points at the docs root, so visitors on the docs landing page have no direct link back to the main website. This swap brings the link target back in line with the older docs.

Only the docs site is affected — no library source code, public API, or CSS class changes.

### How has this been tested?

- Ran the docs dev server (`npm run dev --prefix docs`) and confirmed the rendered `<a class="site-title">` resolves to `href="https://handsontable.com"` (verified via DOM query and HTML inspection on `/docs/javascript-data-grid/`).
- Visual check via screenshot — the logo, dev badge, and surrounding header layout render unchanged.
- `npm run docs:lint --prefix docs` — passes.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

- N/A — small docs-site UX fix surfaced manually.

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

(Docs site only — `docs/`.)

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only header UX change with no library, API, or auth impact.
> 
> **Overview**
> The docs header **logo link** no longer uses Starlight’s default `SiteTitle` (docs home). `SiteTitle.astro` now renders the configured light/dark logos and site title inside an anchor to **https://handsontable.com**, restoring the pre-Astro path back to the marketing site.
> 
> The non-production **dev** badge and wrapper layout are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88b307e050ba228c76168db544b814fa63a59603. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->