### PR TITLE
DEV-1738: Add Vue 3 SFC examples for columns guide pages

### DIFF
--- a/.claude/skills/creating-docs-examples/SKILL.md
+++ b/.claude/skills/creating-docs-examples/SKILL.md
@@ -25,15 +25,14 @@ docs/content/guides/category/feature/
     example1.ts
     example1.html            # Template file
   vue/                       # Vue 3 variants
-    example1.js
-    example1.html            # Template file
+    example1.vue             # TypeScript SFC (`<script setup lang="ts">`)
 ```
 
 ## Key Rules
 
 - **25-60 lines per example.** Keep examples focused and scannable.
 - **One concept per example.** Use progressive numbering for complexity: `example1` = basic setup, `example2` = a configuration variation, `example3` = advanced usage.
-- **TypeScript is primary.** Always write the `.ts` / `.tsx` file first. From `docs/`, generate the JS variant with: `npm run docs:code-examples:generate-js -- <path-to-ts-file>` (path relative to `docs/`). Never hand-edit generated JS files.
+- **TypeScript is primary.** Always write the `.ts` / `.tsx` file first for JavaScript and React examples. From `docs/`, generate the JS variant with: `npm run docs:code-examples:generate-js -- <path-to-ts-file>` (path relative to `docs/`). Never hand-edit generated JS files. For Vue, write TypeScript inside the `.vue` file with `<script setup lang="ts">` — there is no separate JS variant to generate.
 - **Use realistic data.** Prefer `createSpreadsheetData()` or domain-appropriate sample data (product names, dates, currencies). Avoid trivial arrays like `[1, 2, 3]`.
 
 ## Required Elements in Every Example
@@ -135,8 +134,70 @@ The `angular/example1.html` file is the outer wrapper (not the component templat
 See skill `angular-wrapper-dev` for the full reference.
 
 **Vue 3:**
-- Component logic goes in the `.js` file.
-- Template markup goes in the `.html` file using `<hot-table>`.
+
+Write every new or updated Vue example as a **TypeScript Single-File Component (`.vue`)** using the **Composition API** and **`<script setup lang="ts">`**. The docs example-runner loads `vue/example*.vue` modules and mounts them with `createApp()` (see `docs/src/scripts/example-runner.ts`).
+
+- ✅ **Do:** one `exampleN.vue` file per example, with `<script setup lang="ts">`.
+- ❌ **Do not:** use plain `<script setup>` without `lang="ts"`.
+- ❌ **Do not:** split logic into `exampleN.js` + `exampleN.html` (legacy pattern). When you touch an old split example, migrate it to a `.vue` SFC.
+- ❌ **Do not:** use the Options API (`defineComponent` with `data()`, `methods`, etc.) in new examples.
+
+**SFC skeleton:**
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['Acme Corp', 'Q1 2025', '$4.2M'],
+    ['Vertex Industries', 'Q1 2025', '$18.7M'],
+  ],
+  colHeaders: true,
+  height: 'auto',
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>
+```
+
+**Vue-specific rules:**
+
+- Always use `<script setup lang="ts">`. Type grid options with `GridSettings` from `handsontable/settings`. Add local `type` aliases for row or domain data when the example uses object rows.
+- Call `registerAllModules()` once at the top level of `<script setup>` (not inside `onMounted`).
+- Import `HotTable` and `HotColumn` from `@handsontable/vue3`. Register them by using them in `<template>` (no global `app.component()` registration).
+- Put `licenseKey: 'non-commercial-and-evaluation'` inside the settings object passed to `HotTable`.
+- The root `<div>` in `<template>` must use an `id` that matches the example container in the guide (`#example1` in `::: example #example1 :vue3`).
+- Prefer a single `:settings` object for grid options. Use individual props only when the guide text highlights a specific prop.
+- Put Handsontable hooks (`afterChange`, `beforeDataProviderFetch`, etc.) inside the settings object, not as Vue event listeners on `<HotTable>`.
+- Use `ref()` from `vue` for reactive state that the template or handlers update. Use a plain `const` for `hotSettings` when reactive deep updates would trigger unwanted `updateSettings()` calls (for example, when only a status label changes beside the grid).
+- Access the underlying instance with a template ref when needed: `const hotRef = ref(null)` and `<HotTable ref="hotRef" :settings="hotSettings" />`, then `hotRef.value?.hotInstance`.
+- For `HotColumn`, nest it inside `<HotTable>` in `<template>` and pass column options via `:settings` on each `HotColumn`.
+- Optional `<style scoped>` is allowed for example-only UI (buttons, status text). Example-runner CSS from the guide's `--css` slot still applies globally.
+
+**Presets** on the `::: example` directive select dependencies: `:vue3` (default), `:vue3-numbro`, `:vue3-languages`, `:vue3-vuex`. Match the preset to the feature the page demonstrates.
+
+**Embedding a Vue SFC** (single tab, no `--html` / `--js`):
+
+```markdown
+::: example #example1 :vue3
+
+@[code](@/content/guides/category/feature/vue/example1.vue)
+
+:::
+```
+
+See skill `vue-wrapper-dev` for wrapper behavior (`HotTable`, `HotColumn`, settings propagation).
 
 ## Embedding in the Guide
 
@@ -144,9 +205,10 @@ After creating example files, embed them in the guide's `.md` file using the `@[
 
 ## Checklist
 
-- [ ] TypeScript source written and tested.
-- [ ] JS variant generated (not hand-written).
+- [ ] TypeScript source written and tested (`.ts`/`.tsx`, or Vue `.vue` with `lang="ts"`).
+- [ ] JS variant generated for JavaScript/React examples (not hand-written). Vue examples have no JS variant.
 - [ ] `licenseKey: 'non-commercial-and-evaluation'` present.
 - [ ] Imports use `handsontable/base` + registration pattern.
 - [ ] Example stays within 25-60 lines.
 - [ ] One concept per example with realistic data.
+- [ ] Vue examples use `.vue` SFC with `<script setup lang="ts">` and Composition API (no split `.js`/`.html`, no Options API).

--- a/.claude/skills/writing-docs-pages/SKILL.md
+++ b/.claude/skills/writing-docs-pages/SKILL.md
@@ -81,9 +81,21 @@ Embed runnable code examples using this pattern. The `--js 1 --ts 2` flags set t
 :::
 
 :::
+
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/category/feature/vue/example1.vue)
+
+:::
+
+:::
 ```
 
-For Vue examples, use `:vue3` with `--html 1 --js 2`. For Angular, use `:angular` with `--ts 1 --html 2`.
+**Vue 3:** Embed a single TypeScript SFC (`vue/example1.vue` with `<script setup lang="ts">`). Use the `:vue3` preset (or `:vue3-numbro`, `:vue3-languages`, `:vue3-vuex` when the feature needs extra dependencies). Do not use `--html` / `--js` tabs for new Vue examples. See skill `creating-docs-examples` for the full Vue SFC pattern.
+
+**Angular:** Use `:angular` with `--ts 1 --html 2`.
 
 ## 5. Writing Style
 
@@ -111,13 +123,15 @@ Use `onlyFor: ['react']` or `onlyFor: ['angular']` if the page is framework-spec
 
 ## 8. Code Example Generation
 
-Always edit the TypeScript example file first (it is the primary source). Then generate the JavaScript variant from the `docs/` directory:
+For **JavaScript** and **React** examples, edit the TypeScript source first (`.ts` or `.tsx`). Then generate the JavaScript variant from the `docs/` directory:
 
 ```bash
 cd docs && npm run docs:code-examples:generate-js -- <path-to-ts-file>
 ```
 
 Use a path relative to `docs/` (for example `content/recipes/foo/javascript/example1.ts`).
+
+For **Vue** examples, write TypeScript directly in the `.vue` file (`<script setup lang="ts">`). There is no separate JS file to generate.
 
 ## Reference
 

--- a/docs/content/guides/columns/column-filter/column-filter.md
+++ b/docs/content/guides/columns/column-filter/column-filter.md
@@ -91,6 +91,16 @@ this behavior, set
 
 :::
 
+::: only-for vue
+
+::: example #exampleFilterBasicDemo :vue3
+
+@[code](@/content/guides/columns/column-filter/vue/exampleFilterBasicDemo.vue)
+
+:::
+
+:::
+
 ## Enable filtering
 
 To enable the filtering interface for all columns, you need to do two things:
@@ -144,6 +154,23 @@ const configurationOptions = {
 
 :::
 
+::: only-for vue
+
+```js
+const hotSettings = {
+  // enable filtering
+  filters: true,
+  // enable the column menu
+  dropdownMenu: true,
+};
+```
+
+```html
+<HotTable :settings="hotSettings" />
+```
+
+:::
+
 <span style="display: none;"></span>
 
 By default, the column menu presents the filtering interface along with other default items such as
@@ -185,6 +212,16 @@ the configuration.
 
 :::
 
+::: only-for vue
+
+::: example #exampleShowFilterItemsOnly :vue3
+
+@[code](@/content/guides/columns/column-filter/vue/exampleShowFilterItemsOnly.vue)
+
+:::
+
+:::
+
 ### Enable filtering for individual columns
 
 You have control over which columns are filterable and for which columns the column menu is enabled.
@@ -221,6 +258,16 @@ useful items in the menu such as **Clear column**.
 
 @[code](@/content/guides/columns/column-filter/angular/example3.ts)
 @[code](@/content/guides/columns/column-filter/angular/example3.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #exampleEnableFilterInColumns :vue3
+
+@[code](@/content/guides/columns/column-filter/vue/exampleEnableFilterInColumns.vue)
 
 :::
 
@@ -279,6 +326,25 @@ const configurationOptions = {
 
 :::
 
+::: only-for vue
+
+```js
+const hotSettings = {
+  // enable filtering
+  filters: {
+    searchMode: 'apply'
+  },
+  // enable the column menu
+  dropdownMenu: true,
+};
+```
+
+```html
+<HotTable :settings="hotSettings" />
+```
+
+:::
+
 ::: only-for javascript
 
 ::: example #exampleSearchMode --html 1 --js 2 --ts 3
@@ -308,6 +374,16 @@ const configurationOptions = {
 
 @[code](@/content/guides/columns/column-filter/angular/example12.ts)
 @[code](@/content/guides/columns/column-filter/angular/example12.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #exampleSearchMode :vue3
+
+@[code](@/content/guides/columns/column-filter/vue/exampleSearchMode.vue)
 
 :::
 
@@ -349,6 +425,16 @@ each data type.
 
 @[code](@/content/guides/columns/column-filter/angular/example4.ts)
 @[code](@/content/guides/columns/column-filter/angular/example4.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #exampleFilterDifferentTypes :vue3
+
+@[code](@/content/guides/columns/column-filter/vue/exampleFilterDifferentTypes.vue)
 
 :::
 
@@ -417,6 +503,20 @@ with a pre-applied filter to display only items priced less than $200.
 
 :::
 
+::: only-for vue
+
+To do this, use the API provided by the [`Filters`](@/api/filters.md) plugin. For instance, the demo
+below demonstrates how you can start with a pre-applied filter to display only items priced less
+than $200.
+
+::: example #exampleFilterOnInitialization :vue3
+
+@[code](@/content/guides/columns/column-filter/vue/exampleFilterOnInitialization.vue)
+
+:::
+
+:::
+
 
 ## External quick filter
 
@@ -455,6 +555,16 @@ accomplish this, use methods [`filters.addCondition()`](@/api/filters.md#addcond
 
 @[code](@/content/guides/columns/column-filter/angular/example6.ts)
 @[code](@/content/guides/columns/column-filter/angular/example6.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #exampleQuickFilter :vue3
+
+@[code](@/content/guides/columns/column-filter/vue/exampleQuickFilter.vue)
 
 :::
 
@@ -502,6 +612,16 @@ down icon.
 
 :::
 
+::: only-for vue
+
+::: example #exampleCustomFilterButton :vue3
+
+@[code](@/content/guides/columns/column-filter/vue/exampleCustomFilterButton.vue)
+
+:::
+
+:::
+
 The column menu button is always visible, but if you want it to appear only when the mouse cursor is
 over the header, apply additional styling to `th .relative:hover .changeType`.
 
@@ -536,6 +656,16 @@ over the header, apply additional styling to `th .relative:hover .changeType`.
 
 @[code](@/content/guides/columns/column-filter/angular/example8.ts)
 @[code](@/content/guides/columns/column-filter/angular/example8.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #exampleCustomFilterButton2 :vue3
+
+@[code](@/content/guides/columns/column-filter/vue/exampleCustomFilterButton2.vue)
 
 :::
 
@@ -594,6 +724,16 @@ filtering doesn't affect them.
 
 :::
 
+::: only-for vue
+
+::: example #exampleExcludeRowsFromFiltering :vue3
+
+@[code](@/content/guides/columns/column-filter/vue/exampleExcludeRowsFromFiltering.vue)
+
+:::
+
+:::
+
 ## Server-side filtering
 
 You can decide to use Handsontable as an intuitive filtering interface, but perform the actual
@@ -639,6 +779,16 @@ filters is logged to the console.
 
 @[code](@/content/guides/columns/column-filter/angular/example10.ts)
 @[code](@/content/guides/columns/column-filter/angular/example10.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #exampleServerSideFilter :vue3
+
+@[code](@/content/guides/columns/column-filter/vue/exampleServerSideFilter.vue)
 
 :::
 
@@ -707,6 +857,26 @@ this.hotTable.hotInstance!.updateSettings({
 });
 
 this.hotTable.hotInstance!.updateSettings({
+  // disable filtering
+  filters: false,
+});
+```
+
+:::
+
+::: only-for vue
+
+```js
+const hotTableRef = ref(null);
+
+hotTableRef.value.hotInstance.updateSettings({
+  // enable filtering
+  filters: true,
+  // enable the column menu
+  dropdownMenu: true,
+});
+
+hotTableRef.value.hotInstance.updateSettings({
   // disable filtering
   filters: false,
 });
@@ -814,6 +984,40 @@ this.hotTable.hotInstance!.updateSettings({
 
 :::
 
+::: only-for vue
+
+```js
+const hotTableRef = ref(null);
+
+hotTableRef.value.hotInstance.updateSettings({
+  // enable filtering for all columns
+  filters: true,
+  // enable the column menu for all columns
+  // but display only the 'Filter by value' list and the 'OK' and
+  // 'Cancel' buttons
+  dropdownMenu: {
+    items: {
+      filter_by_value: {
+        // hide the 'Filter by value' list from all columns but the
+        // first one
+        hidden() {
+          return this.getSelectedRangeLast().to.col > 0;
+        },
+      },
+      filter_action_bar: {
+        // hide the 'OK' and 'Cancel' buttons from all columns but the
+        // first one
+        hidden() {
+          return this.getSelectedRangeLast().to.col > 0;
+        },
+      },
+    },
+  },
+});
+```
+
+:::
+
 
 ### Filter data programmatically
 
@@ -852,6 +1056,16 @@ Mind that before you apply new filter conditions, you need to clear the previous
 
 @[code](@/content/guides/columns/column-filter/angular/example11.ts)
 @[code](@/content/guides/columns/column-filter/angular/example11.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #exampleFilterThroughAPI1 :vue3
+
+@[code](@/content/guides/columns/column-filter/vue/exampleFilterThroughAPI1.vue)
 
 :::
 

--- a/docs/content/guides/columns/column-filter/vue/exampleCustomFilterButton.vue
+++ b/docs/content/guides/columns/column-filter/vue/exampleCustomFilterButton.vue
@@ -1,0 +1,126 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    {
+      brand: 'Jetpulse',
+      model: 'Racing Socks',
+      price: 30,
+      sellDate: '2023-10-11',
+      sellTime: '01:23',
+      inStock: false,
+    },
+    {
+      brand: 'Gigabox',
+      model: 'HL Mountain Frame',
+      price: 1890.9,
+      sellDate: '2023-05-03',
+      sellTime: '11:27',
+      inStock: false,
+    },
+    {
+      brand: 'Camido',
+      model: 'Cycling Cap',
+      price: 130.1,
+      sellDate: '2023-03-27',
+      sellTime: '03:17',
+      inStock: true,
+    },
+    {
+      brand: 'Chatterpoint',
+      model: 'Road Tire Tube',
+      price: 59,
+      sellDate: '2023-08-28',
+      sellTime: '08:01',
+      inStock: true,
+    },
+    {
+      brand: 'Eidel',
+      model: 'HL Road Tire',
+      price: 279.99,
+      sellDate: '2023-10-02',
+      sellTime: '01:23',
+      inStock: true,
+    },
+  ],
+  columns: [
+    {
+      title: 'Brand',
+      type: 'text',
+      data: 'brand',
+    },
+    {
+      title: 'Model',
+      type: 'text',
+      data: 'model',
+    },
+    {
+      title: 'Price',
+      type: 'numeric',
+      data: 'price',
+      locale: 'en-US',
+      numericFormat: {
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: 2,
+      },
+    },
+    {
+      title: 'Date',
+      type: 'intl-date',
+      data: 'sellDate',
+      locale: 'en-US',
+      dateFormat: { month: 'short', day: 'numeric', year: 'numeric' },
+      className: 'htRight',
+    },
+    {
+      title: 'Time',
+      type: 'intl-time',
+      data: 'sellTime',
+      locale: 'en-US',
+      timeFormat: { hour: '2-digit', minute: '2-digit', hour12: true },
+      className: 'htRight',
+    },
+    {
+      title: 'In stock',
+      type: 'checkbox',
+      data: 'inStock',
+      className: 'htCenter',
+    },
+  ],
+  // enable filtering
+  filters: true,
+  // enable the column menu
+  dropdownMenu: true,
+  // to differentiate this example's CSS from other examples on this page
+  className: 'customFilterButtonExample1',
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="exampleCustomFilterButton">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>
+
+<style>
+.handsontable.customFilterButtonExample1 .changeType {
+  --ht-icon-button-background-color: #e2e2e263;
+  --ht-icon-button-border-radius: 100%;
+}
+
+.handsontable.customFilterButtonExample1 .changeType::before {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width=%2716%27 height=%2716%27 viewBox=%270 0 16 16%27 fill=%27none%27 xmlns=%27http://www.w3.org/2000/svg%27%3E%3Cpath d=%27M6.83337 7.99984C6.83337 8.30926 6.95629 8.606 7.17508 8.8248C7.39388 9.04359 7.69062 9.1665 8.00004 9.1665C8.30946 9.1665 8.60621 9.04359 8.825 8.8248C9.04379 8.606 9.16671 8.30926 9.16671 7.99984C9.16671 7.69042 9.04379 7.39367 8.825 7.17488C8.60621 6.95609 8.30946 6.83317 8.00004 6.83317C7.69062 6.83317 7.39388 6.95609 7.17508 7.17488C6.95629 7.39367 6.83337 7.69042 6.83337 7.99984Z%27 fill=%27%23222222%27/%3E%3Cpath d=%27M6.83337 12.4165C6.83337 12.7259 6.95629 13.0227 7.17508 13.2415C7.39388 13.4603 7.69062 13.5832 8.00004 13.5832C8.30946 13.5832 8.60621 13.4603 8.825 13.2415C9.04379 13.0227 9.16671 12.7259 9.16671 12.4165C9.16671 12.1071 9.04379 11.8103 8.825 11.5915C8.60621 11.3728 8.30946 11.2498 8.00004 11.2498C7.69062 11.2498 7.39388 11.3728 7.17508 11.5915C6.95629 11.8103 6.83337 12.1071 6.83337 12.4165Z%27 fill=%27%23222222%27/%3E%3Cpath d=%27M6.83337 3.58317C6.83337 3.89259 6.95629 4.18934 7.17508 4.40813C7.39388 4.62692 7.69062 4.74984 8.00004 4.74984C8.30946 4.74984 8.60621 4.62692 8.825 4.40813C9.04379 4.18934 9.16671 3.89259 9.16671 3.58317C9.16671 3.27375 9.04379 2.97701 8.825 2.75821C8.60621 2.53942 8.30946 2.4165 8.00004 2.4165C7.69062 2.4165 7.39388 2.53942 7.17508 2.75821C6.95629 2.97701 6.83337 3.27375 6.83337 3.58317Z%27 fill=%27currentColor%27/%3E%3C/svg%3E");
+}
+</style>

--- a/docs/content/guides/columns/column-filter/vue/exampleCustomFilterButton2.vue
+++ b/docs/content/guides/columns/column-filter/vue/exampleCustomFilterButton2.vue
@@ -1,0 +1,127 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    {
+      brand: 'Jetpulse',
+      model: 'Racing Socks',
+      price: 30,
+      sellDate: '2023-10-11',
+      sellTime: '01:23',
+      inStock: false,
+    },
+    {
+      brand: 'Gigabox',
+      model: 'HL Mountain Frame',
+      price: 1890.9,
+      sellDate: '2023-05-03',
+      sellTime: '11:27',
+      inStock: false,
+    },
+    {
+      brand: 'Camido',
+      model: 'Cycling Cap',
+      price: 130.1,
+      sellDate: '2023-03-27',
+      sellTime: '03:17',
+      inStock: true,
+    },
+    {
+      brand: 'Chatterpoint',
+      model: 'Road Tire Tube',
+      price: 59,
+      sellDate: '2023-08-28',
+      sellTime: '08:01',
+      inStock: true,
+    },
+    {
+      brand: 'Eidel',
+      model: 'HL Road Tire',
+      price: 279.99,
+      sellDate: '2023-10-02',
+      sellTime: '01:23',
+      inStock: true,
+    },
+  ],
+  columns: [
+    {
+      title: 'Brand',
+      type: 'text',
+      data: 'brand',
+    },
+    {
+      title: 'Model',
+      type: 'text',
+      data: 'model',
+    },
+    {
+      title: 'Price',
+      type: 'numeric',
+      data: 'price',
+      locale: 'en-US',
+      numericFormat: {
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: 2,
+      },
+    },
+    {
+      title: 'Date',
+      type: 'intl-date',
+      data: 'sellDate',
+      locale: 'en-US',
+      dateFormat: { month: 'short', day: 'numeric', year: 'numeric' },
+      className: 'htRight',
+    },
+    {
+      title: 'Time',
+      type: 'intl-time',
+      data: 'sellTime',
+      locale: 'en-US',
+      timeFormat: { hour: '2-digit', minute: '2-digit', hour12: true },
+      className: 'htRight',
+    },
+    {
+      title: 'In stock',
+      type: 'checkbox',
+      data: 'inStock',
+      className: 'htCenter',
+    },
+  ],
+  // enable filtering
+  filters: true,
+  // enable the column menu
+  dropdownMenu: true,
+  // to differentiate this example's CSS from other examples on this page
+  className: 'customFilterButtonExample2',
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="exampleCustomFilterButton2">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>
+
+<style>
+/* hide the column menu button by default */
+.customFilterButtonExample2 .changeType {
+  visibility: hidden;
+}
+
+/* show the column menu button on hover */
+.customFilterButtonExample2 th .relative:hover .changeType {
+  visibility: visible;
+}
+</style>

--- a/docs/content/guides/columns/column-filter/vue/exampleEnableFilterInColumns.vue
+++ b/docs/content/guides/columns/column-filter/vue/exampleEnableFilterInColumns.vue
@@ -1,0 +1,151 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+// remove the column menu button from the 'Brand', 'Price', and 'Date' columns
+const removeColumnMenuButton = (col: number, TH: { querySelector: (value: string) => any }) => {
+  if (col > 1) {
+    const button = TH.querySelector('.changeType');
+
+    if (!button) {
+      return;
+    }
+
+    button.parentElement.removeChild(button);
+  }
+};
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    {
+      brand: 'Jetpulse',
+      model: 'Racing Socks',
+      price: 30,
+      sellDate: '2023-10-11',
+      sellTime: '01:23',
+      inStock: false,
+    },
+    {
+      brand: 'Gigabox',
+      model: 'HL Mountain Frame',
+      price: 1890.9,
+      sellDate: '2023-05-03',
+      sellTime: '11:27',
+      inStock: false,
+    },
+    {
+      brand: 'Camido',
+      model: 'Cycling Cap',
+      price: 130.1,
+      sellDate: '2023-03-27',
+      sellTime: '03:17',
+      inStock: true,
+    },
+    {
+      brand: 'Chatterpoint',
+      model: 'Road Tire Tube',
+      price: 59,
+      sellDate: '2023-08-28',
+      sellTime: '08:01',
+      inStock: true,
+    },
+    {
+      brand: 'Eidel',
+      model: 'HL Road Tire',
+      price: 279.99,
+      sellDate: '2023-10-02',
+      sellTime: '01:23',
+      inStock: true,
+    },
+  ],
+  columns: [
+    {
+      title: 'Brand',
+      type: 'text',
+      data: 'brand',
+    },
+    {
+      title: 'Model',
+      type: 'text',
+      data: 'model',
+    },
+    {
+      title: 'Price',
+      type: 'numeric',
+      data: 'price',
+      locale: 'en-US',
+      numericFormat: {
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: 2,
+      },
+    },
+    {
+      title: 'Date',
+      type: 'intl-date',
+      data: 'sellDate',
+      locale: 'en-US',
+      dateFormat: { month: 'short', day: 'numeric', year: 'numeric' },
+      className: 'htRight',
+    },
+    {
+      title: 'Time',
+      type: 'intl-time',
+      data: 'sellTime',
+      locale: 'en-US',
+      timeFormat: { hour: '2-digit', minute: '2-digit', hour12: true },
+      className: 'htRight',
+    },
+    {
+      title: 'In stock',
+      type: 'checkbox',
+      data: 'inStock',
+      className: 'htCenter',
+    },
+  ],
+  // enable filtering for all columns
+  filters: true,
+  // enable the column menu for all columns
+  // but display only the 'Filter by value' list and the 'OK' and 'Cancel' buttons
+  dropdownMenu: {
+    items: {
+      filter_by_value: {
+        // hide the 'Filter by value' list from all columns but the first one
+        hidden() {
+          return this.getSelectedRangeLast()!.to.col > 0;
+        },
+      },
+      filter_action_bar: {
+        // hide the 'OK' and 'Cancel' buttons from all columns but the first one
+        hidden() {
+          return this.getSelectedRangeLast()!.to.col > 0;
+        },
+      },
+      clear_column: {
+        // hide the 'Clear column' menu item from the first column
+        hidden() {
+          return this.getSelectedRangeLast()!.to.col < 1;
+        },
+      },
+    },
+  },
+  // `afterGetColHeader()` is a Handsontable hook
+  // it's fired after Handsontable appends information about a column header to the table header
+  afterGetColHeader: removeColumnMenuButton,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="exampleEnableFilterInColumns">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-filter/vue/exampleExcludeRowsFromFiltering.vue
+++ b/docs/content/guides/columns/column-filter/vue/exampleExcludeRowsFromFiltering.vue
@@ -1,0 +1,202 @@
+<script setup lang="ts">
+// you need a template ref to call Handsontable's instance methods
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotTableRef = ref<any>(null);
+
+const exclude = () => {
+  const hotInstance = hotTableRef.value?.hotInstance;
+  // @ts-ignore
+  const filtersRowsMap = hotInstance?.getPlugin('filters').filtersRowsMap;
+
+  filtersRowsMap.setValueAtIndex(0, false);
+  filtersRowsMap.setValueAtIndex(filtersRowsMap.indexedValues.length - 1, false);
+};
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    {
+      brand: 'Gigabox',
+      model: 'HL Mountain Frame',
+      price: 1890.9,
+      sellDate: '2023-05-03',
+      sellTime: '11:27',
+      inStock: 11,
+    },
+    {
+      brand: 'Camido',
+      model: 'Cycling Cap',
+      price: 130.1,
+      sellDate: '2023-03-27',
+      sellTime: '03:17',
+      inStock: 0,
+    },
+    {
+      brand: 'Chatterpoint',
+      model: 'Road Tire Tube',
+      price: 59,
+      sellDate: '2023-08-28',
+      sellTime: '08:01',
+      inStock: 1,
+    },
+    {
+      brand: 'Eidel',
+      model: 'HL Road Tire',
+      price: 279.99,
+      sellDate: '2023-10-02',
+      sellTime: '13:23',
+      inStock: 3,
+    },
+    {
+      brand: 'Jetpulse',
+      model: 'Racing Socks',
+      price: 30,
+      sellDate: '2023-10-11',
+      sellTime: '01:23',
+      inStock: 5,
+    },
+    {
+      brand: 'Gigabox',
+      model: 'HL Mountain Frame',
+      price: 1890.9,
+      sellDate: '2023-05-03',
+      sellTime: '11:27',
+      inStock: 22,
+    },
+    {
+      brand: 'Camido',
+      model: 'Cycling Cap',
+      price: 130.1,
+      sellDate: '2023-03-27',
+      sellTime: '03:17',
+      inStock: 13,
+    },
+    {
+      brand: 'Chatterpoint',
+      model: 'Road Tire Tube',
+      price: 59,
+      sellDate: '2023-08-28',
+      sellTime: '08:01',
+      inStock: 0,
+    },
+    {
+      brand: 'Eidel',
+      model: 'HL Road Tire',
+      price: 279.99,
+      sellDate: '2023-10-02',
+      sellTime: '13:23',
+      inStock: 14,
+    },
+    {
+      brand: 'Jetpulse',
+      model: 'Racing Socks',
+      price: 30,
+      sellDate: '2023-10-11',
+      sellTime: '01:23',
+      inStock: 16,
+    },
+    {
+      brand: 'Gigabox',
+      model: 'HL Mountain Frame',
+      price: 1890.9,
+      sellDate: '2023-05-03',
+      sellTime: '11:27',
+      inStock: 18,
+    },
+    {
+      brand: 'Camido',
+      model: 'Cycling Cap',
+      price: 130.1,
+      sellDate: '2023-03-27',
+      sellTime: '03:17',
+      inStock: 3,
+    },
+    {
+      brand: 'Chatterpoint',
+      model: 'Road Tire Tube',
+      price: 59,
+      sellDate: '2023-08-28',
+      sellTime: '08:01',
+      inStock: 0,
+    },
+    {
+      brand: 'Vinte',
+      model: 'ML Road Frame-W',
+      price: 30,
+      sellDate: '2023-10-11',
+      sellTime: '01:23',
+      inStock: 2,
+    },
+  ],
+  columns: [
+    {
+      title: 'Brand',
+      type: 'text',
+      data: 'brand',
+    },
+    {
+      title: 'Model',
+      type: 'text',
+      data: 'model',
+    },
+    {
+      title: 'Price',
+      type: 'numeric',
+      data: 'price',
+      locale: 'en-US',
+      numericFormat: {
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: 2,
+      },
+      className: 'htRight',
+    },
+    {
+      title: 'Date',
+      type: 'intl-date',
+      data: 'sellDate',
+      locale: 'en-US',
+      dateFormat: { month: 'short', day: 'numeric', year: 'numeric' },
+      className: 'htRight',
+    },
+    {
+      title: 'Time',
+      type: 'intl-time',
+      data: 'sellTime',
+      locale: 'en-US',
+      timeFormat: { hour: '2-digit', minute: '2-digit', hour12: true },
+      className: 'htRight',
+    },
+    {
+      title: 'In stock',
+      type: 'numeric',
+      data: 'inStock',
+      className: 'htCenter',
+    },
+  ],
+  height: 200,
+  colWidths: [120, 150, 120, 140, 120, 120],
+  fixedRowsTop: 1,
+  fixedRowsBottom: 1,
+  minSpareRows: 1,
+  colHeaders: true,
+  filters: true,
+  dropdownMenu: true,
+  afterFilter: exclude,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="exampleExcludeRowsFromFiltering">
+    <HotTable ref="hotTableRef" :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-filter/vue/exampleFilterBasicDemo.vue
+++ b/docs/content/guides/columns/column-filter/vue/exampleFilterBasicDemo.vue
@@ -1,0 +1,114 @@
+<script setup lang="ts">
+// to import filtering as an individual module, see the 'Import the filtering module' section of this page
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    {
+      brand: 'Jetpulse',
+      model: 'Racing Socks',
+      price: 30,
+      sellDate: '2023-10-11',
+      sellTime: '01:23',
+      inStock: false,
+    },
+    {
+      brand: 'Gigabox',
+      model: 'HL Mountain Frame',
+      price: 1890.9,
+      sellDate: '2023-05-03',
+      sellTime: '11:27',
+      inStock: false,
+    },
+    {
+      brand: 'Camido',
+      model: 'Cycling Cap',
+      price: 130.1,
+      sellDate: '2023-03-27',
+      sellTime: '03:17',
+      inStock: true,
+    },
+    {
+      brand: 'Chatterpoint',
+      model: 'Road Tire Tube',
+      price: 59,
+      sellDate: '2023-08-28',
+      sellTime: '08:01',
+      inStock: true,
+    },
+    {
+      brand: 'Eidel',
+      model: 'HL Road Tire',
+      price: 279.99,
+      sellDate: '2023-10-02',
+      sellTime: '01:23',
+      inStock: true,
+    },
+  ],
+  columns: [
+    {
+      title: 'Brand',
+      type: 'text',
+      data: 'brand',
+    },
+    {
+      title: 'Model',
+      type: 'text',
+      data: 'model',
+    },
+    {
+      title: 'Price',
+      type: 'numeric',
+      data: 'price',
+      locale: 'en-US',
+      numericFormat: {
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: 2,
+      },
+    },
+    {
+      title: 'Date',
+      type: 'intl-date',
+      data: 'sellDate',
+      locale: 'en-US',
+      dateFormat: { month: 'short', day: 'numeric', year: 'numeric' },
+      className: 'htRight',
+    },
+    {
+      title: 'Time',
+      type: 'intl-time',
+      data: 'sellTime',
+      locale: 'en-US',
+      timeFormat: { hour: '2-digit', minute: '2-digit', hour12: true },
+      className: 'htRight',
+    },
+    {
+      title: 'In stock',
+      type: 'checkbox',
+      data: 'inStock',
+      className: 'htCenter',
+    },
+  ],
+  // enable filtering
+  filters: true,
+  // enable the column menu
+  dropdownMenu: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="exampleFilterBasicDemo">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-filter/vue/exampleFilterDifferentTypes.vue
+++ b/docs/content/guides/columns/column-filter/vue/exampleFilterDifferentTypes.vue
@@ -1,0 +1,134 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    {
+      model: 'Racing Socks',
+      size: 'S',
+      price: 30,
+      sellDate: '2023-10-11',
+      sellTime: '01:23',
+      inStock: false,
+      color: 'Black',
+    },
+    {
+      model: 'HL Mountain Shirt',
+      size: 'XS',
+      price: 1890.9,
+      sellDate: '2023-05-03',
+      sellTime: '11:27',
+      inStock: false,
+      color: 'White',
+    },
+    {
+      model: 'Cycling Cap',
+      size: 'L',
+      price: 130.1,
+      sellDate: '2023-03-27',
+      sellTime: '03:17',
+      inStock: true,
+      color: 'Green',
+    },
+    {
+      model: 'Ski Jacket',
+      size: 'M',
+      price: 59,
+      sellDate: '2023-08-28',
+      sellTime: '08:01',
+      inStock: true,
+      color: 'Blue',
+    },
+    {
+      model: 'HL Goggles',
+      size: 'XL',
+      price: 279.99,
+      sellDate: '2023-10-02',
+      sellTime: '01:23',
+      inStock: true,
+      color: 'Black',
+    },
+  ],
+  columns: [
+    {
+      title: 'Model',
+      // set the type of the 'Model' column
+      type: 'text', // 'text' is the default type, so you can omit this line
+      data: 'model',
+    },
+    {
+      title: 'Price',
+      // set the type of the 'Price' column
+      type: 'numeric',
+      data: 'price',
+      locale: 'en-US',
+      numericFormat: {
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: 2,
+      },
+    },
+    {
+      title: 'Sold on',
+      // set the type of the 'Date' column
+      type: 'intl-date',
+      data: 'sellDate',
+      locale: 'en-US',
+      dateFormat: { month: 'short', day: 'numeric', year: 'numeric' },
+      className: 'htRight',
+    },
+    {
+      title: 'Time',
+      // set the type of the 'Time' column
+      type: 'intl-time',
+      data: 'sellTime',
+      locale: 'en-US',
+      timeFormat: { hour: '2-digit', minute: '2-digit', hour12: true },
+      className: 'htRight',
+    },
+    {
+      title: 'In stock',
+      // set the type of the 'In stock' column
+      type: 'checkbox',
+      data: 'inStock',
+      className: 'htCenter',
+    },
+    {
+      title: 'Size',
+      // set the type of the 'Size' column
+      type: 'dropdown',
+      data: 'size',
+      source: ['XS', 'S', 'M', 'L', 'XL'],
+      className: 'htCenter',
+    },
+    {
+      title: 'Color',
+      // set the type of the 'Size' column
+      type: 'autocomplete',
+      data: 'color',
+      source: ['White', 'Black', 'Yellow', 'Blue', 'Green'],
+      className: 'htCenter',
+    },
+  ],
+  // enable filtering
+  filters: true,
+  // enable the column menu
+  dropdownMenu: true,
+  height: 175,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="exampleFilterDifferentTypes">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-filter/vue/exampleFilterOnInitialization.vue
+++ b/docs/content/guides/columns/column-filter/vue/exampleFilterOnInitialization.vue
@@ -1,0 +1,127 @@
+<script setup lang="ts">
+// you need a template ref to call Handsontable's instance methods
+import { ref, onMounted } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotTableRef = ref<any>(null);
+
+onMounted(() => {
+  const handsontableInstance = hotTableRef.value?.hotInstance;
+  // get the `Filters` plugin, so you can use its API
+  const filters = handsontableInstance?.getPlugin('filters');
+
+  // filter data by the 'Price' column (column at index 2)
+  // to display only items that are less than ('lt') $200
+  filters?.addCondition(2, 'lt', [200]);
+  filters?.filter();
+});
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    {
+      brand: 'Jetpulse',
+      model: 'Racing Socks',
+      price: 30,
+      sellDate: '2023-10-11',
+      sellTime: '01:23',
+      inStock: false,
+    },
+    {
+      brand: 'Gigabox',
+      model: 'HL Mountain Frame',
+      price: 1890.9,
+      sellDate: '2023-05-03',
+      sellTime: '11:27',
+      inStock: false,
+    },
+    {
+      brand: 'Camido',
+      model: 'Cycling Cap',
+      price: 130.1,
+      sellDate: '2023-03-27',
+      sellTime: '03:17',
+      inStock: true,
+    },
+    {
+      brand: 'Chatterpoint',
+      model: 'Road Tire Tube',
+      price: 59,
+      sellDate: '2023-08-28',
+      sellTime: '08:01',
+      inStock: true,
+    },
+    {
+      brand: 'Eidel',
+      model: 'HL Road Tire',
+      price: 279.99,
+      sellDate: '2023-10-02',
+      sellTime: '01:23',
+      inStock: true,
+    },
+  ],
+  columns: [
+    {
+      title: 'Brand',
+      type: 'text',
+      data: 'brand',
+    },
+    {
+      title: 'Model',
+      type: 'text',
+      data: 'model',
+    },
+    {
+      title: 'Price',
+      type: 'numeric',
+      data: 'price',
+      locale: 'en-US',
+      numericFormat: {
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: 2,
+      },
+    },
+    {
+      title: 'Date',
+      type: 'intl-date',
+      data: 'sellDate',
+      locale: 'en-US',
+      dateFormat: { month: 'short', day: 'numeric', year: 'numeric' },
+      className: 'htRight',
+    },
+    {
+      title: 'Time',
+      type: 'intl-time',
+      data: 'sellTime',
+      locale: 'en-US',
+      timeFormat: { hour: '2-digit', minute: '2-digit', hour12: true },
+      className: 'htRight',
+    },
+    {
+      title: 'In stock',
+      type: 'checkbox',
+      data: 'inStock',
+      className: 'htCenter',
+    },
+  ],
+  // enable filtering
+  filters: true,
+  // enable the column menu
+  dropdownMenu: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="exampleFilterOnInitialization">
+    <HotTable ref="hotTableRef" :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-filter/vue/exampleFilterThroughAPI1.vue
+++ b/docs/content/guides/columns/column-filter/vue/exampleFilterThroughAPI1.vue
@@ -1,0 +1,153 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotTableRef = ref<any>(null);
+
+const filterBelow200 = () => {
+  // get the `Filters` plugin, so you can use its API
+  const filters = hotTableRef.value?.hotInstance?.getPlugin('filters');
+
+  // clear any existing filters
+  filters?.clearConditions();
+  // filter data by the 'Price' column (column at index 2)
+  // to display only items that are less than ('lt') $200
+  filters?.addCondition(2, 'lt', [200]);
+  filters?.filter();
+};
+
+const filterAbove200 = () => {
+  // get the `Filters` plugin, so you can use its API
+  const filters = hotTableRef.value?.hotInstance?.getPlugin('filters');
+
+  filters?.clearConditions();
+  // display only items that are more than ('gt') $200
+  filters?.addCondition(2, 'gt', [200]);
+  filters?.filter();
+};
+
+const clearAllFilters = () => {
+  // get the `Filters` plugin, so you can use its API
+  const filters = hotTableRef.value?.hotInstance?.getPlugin('filters');
+
+  // clear all filters
+  filters?.clearConditions();
+  filters?.filter();
+};
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    {
+      brand: 'Jetpulse',
+      model: 'Racing Socks',
+      price: 30,
+      sellDate: '2023-10-11',
+      sellTime: '01:23',
+      inStock: false,
+    },
+    {
+      brand: 'Gigabox',
+      model: 'HL Mountain Frame',
+      price: 1890.9,
+      sellDate: '2023-05-03',
+      sellTime: '11:27',
+      inStock: false,
+    },
+    {
+      brand: 'Camido',
+      model: 'Cycling Cap',
+      price: 130.1,
+      sellDate: '2023-03-27',
+      sellTime: '03:17',
+      inStock: true,
+    },
+    {
+      brand: 'Chatterpoint',
+      model: 'Road Tire Tube',
+      price: 59,
+      sellDate: '2023-08-28',
+      sellTime: '08:01',
+      inStock: true,
+    },
+    {
+      brand: 'Eidel',
+      model: 'HL Road Tire',
+      price: 279.99,
+      sellDate: '2023-10-02',
+      sellTime: '01:23',
+      inStock: true,
+    },
+  ],
+  columns: [
+    {
+      title: 'Brand',
+      type: 'text',
+      data: 'brand',
+    },
+    {
+      title: 'Model',
+      type: 'text',
+      data: 'model',
+    },
+    {
+      title: 'Price',
+      type: 'numeric',
+      data: 'price',
+      locale: 'en-US',
+      numericFormat: {
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: 2,
+      },
+    },
+    {
+      title: 'Date',
+      type: 'intl-date',
+      data: 'sellDate',
+      locale: 'en-US',
+      dateFormat: { month: 'short', day: 'numeric', year: 'numeric' },
+      className: 'htRight',
+    },
+    {
+      title: 'Time',
+      type: 'intl-time',
+      data: 'sellTime',
+      locale: 'en-US',
+      timeFormat: { hour: '2-digit', minute: '2-digit', hour12: true },
+      className: 'htRight',
+    },
+    {
+      title: 'In stock',
+      type: 'checkbox',
+      data: 'inStock',
+      className: 'htCenter',
+    },
+  ],
+  // enable filtering
+  filters: true,
+  // enable the column menu
+  dropdownMenu: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="exampleFilterThroughAPI1">
+    <div class="example-controls-container">
+      <div class="controls">
+        <button @click="filterBelow200">Show items &lt; $200</button>
+        <button @click="filterAbove200">Show items &gt; $200</button>
+        <button @click="clearAllFilters">Clear filters</button>
+      </div>
+    </div>
+    <HotTable ref="hotTableRef" :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-filter/vue/exampleQuickFilter.vue
+++ b/docs/content/guides/columns/column-filter/vue/exampleQuickFilter.vue
@@ -1,0 +1,318 @@
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted, computed } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const columnOptions = [
+  { value: '0', label: 'Brand' },
+  { value: '1', label: 'Model' },
+  { value: '2', label: 'Price' },
+  { value: '3', label: 'Date' },
+  { value: '4', label: 'Time' },
+  { value: '5', label: 'In stock' },
+];
+
+const hotTableRef = ref<any>(null);
+const dropdownRef = ref<HTMLDivElement | null>(null);
+const selectedColumn = ref('0');
+const open = ref(false);
+
+const selectedLabel = computed(
+  () => columnOptions.find((c) => c.value === selectedColumn.value)?.label || 'Brand'
+);
+
+const handleClickOutside = (e: MouseEvent) => {
+  if (dropdownRef.value && !dropdownRef.value.contains(e.target as Node)) {
+    open.value = false;
+  }
+};
+
+onMounted(() => {
+  document.addEventListener('click', handleClickOutside);
+});
+
+onUnmounted(() => {
+  document.removeEventListener('click', handleClickOutside);
+});
+
+const handleFilter = (event: KeyboardEvent) => {
+  const handsontableInstance = hotTableRef.value?.hotInstance;
+  const filtersPlugin = handsontableInstance?.getPlugin('filters');
+
+  filtersPlugin?.removeConditions(Number(selectedColumn.value));
+  filtersPlugin?.addCondition(Number(selectedColumn.value), 'contains', [
+    (event.target as HTMLInputElement).value,
+  ]);
+  filtersPlugin?.filter();
+  handsontableInstance?.render();
+};
+
+const handleSelect = (col: { value: string; label: string }) => {
+  selectedColumn.value = col.value;
+  open.value = false;
+};
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    {
+      brand: 'Jetpulse',
+      model: 'Racing Socks',
+      price: 30,
+      sellDate: '2023-10-11',
+      sellTime: '01:23',
+      inStock: false,
+    },
+    {
+      brand: 'Gigabox',
+      model: 'HL Mountain Frame',
+      price: 1890.9,
+      sellDate: '2023-05-03',
+      sellTime: '11:27',
+      inStock: false,
+    },
+    {
+      brand: 'Camido',
+      model: 'Cycling Cap',
+      price: 130.1,
+      sellDate: '2023-03-27',
+      sellTime: '03:17',
+      inStock: true,
+    },
+    {
+      brand: 'Chatterpoint',
+      model: 'Road Tire Tube',
+      price: 59,
+      sellDate: '2023-08-28',
+      sellTime: '08:01',
+      inStock: true,
+    },
+    {
+      brand: 'Eidel',
+      model: 'HL Road Tire',
+      price: 279.99,
+      sellDate: '2023-10-02',
+      sellTime: '01:23',
+      inStock: true,
+    },
+  ],
+  columns: [
+    {
+      title: 'Brand',
+      type: 'text',
+      data: 'brand',
+    },
+    {
+      title: 'Model',
+      type: 'text',
+      data: 'model',
+    },
+    {
+      title: 'Price',
+      type: 'numeric',
+      data: 'price',
+      locale: 'en-US',
+      numericFormat: {
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: 2,
+      },
+    },
+    {
+      title: 'Date',
+      type: 'intl-date',
+      data: 'sellDate',
+      locale: 'en-US',
+      dateFormat: { month: 'short', day: 'numeric', year: 'numeric' },
+      className: 'htRight',
+    },
+    {
+      title: 'Time',
+      type: 'intl-time',
+      data: 'sellTime',
+      locale: 'en-US',
+      timeFormat: { hour: '2-digit', minute: '2-digit', hour12: true },
+      className: 'htRight',
+    },
+    {
+      title: 'In stock',
+      type: 'checkbox',
+      data: 'inStock',
+      className: 'htCenter',
+    },
+  ],
+  filters: true,
+  height: 'auto',
+  className: 'exampleQuickFilter',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="exampleQuickFilter">
+    <div class="example-controls-container">
+      <div class="controlsQuickFilter">
+        <div ref="dropdownRef" class="filter-dropdown">
+          <span class="filter-dropdown-label">Select a column:</span>
+          <button
+            class="filter-dropdown-trigger"
+            type="button"
+            aria-haspopup="listbox"
+            :aria-expanded="open"
+            @click="open = !open"
+          >
+            <span class="filter-dropdown-text">{{ selectedLabel }}</span>
+            <svg class="filter-dropdown-chevron" aria-hidden="true" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6l6 -6"/></svg>
+          </button>
+          <ul v-if="open" class="filter-dropdown-menu" role="listbox">
+            <li
+              v-for="col in columnOptions"
+              :key="col.value"
+              role="option"
+              :aria-selected="col.value === selectedColumn"
+              @click="handleSelect(col)"
+            >
+              {{ col.label }}
+            </li>
+          </ul>
+        </div>
+        <input id="filterField" type="text" placeholder="Filter" @keyup="handleFilter" />
+      </div>
+    </div>
+    <HotTable ref="hotTableRef" :settings="hotSettings" />
+  </div>
+</template>
+
+<style>
+.controlsQuickFilter {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+}
+
+#filterField {
+  border: 1px solid var(--sl-color-gray-5, #e0e0e0);
+  background: none;
+  color: var(--sl-color-text, #333333);
+  font-size: var(--sl-text-sm, 0.875rem);
+  padding: 0.4rem 0.625rem;
+  outline: none;
+  width: 140px;
+}
+
+#filterField::placeholder {
+  color: var(--sl-color-gray-3, #777777);
+}
+
+#filterField:focus {
+  border-color: var(--sl-color-accent, #1A42E8);
+}
+
+#filterField:focus-visible {
+  border-color: var(--sl-color-accent, #1A42E8);
+  box-shadow: 0 0 0 1px var(--sl-color-accent, #1A42E8);
+}
+
+/* Filter dropdown */
+.filter-dropdown {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.filter-dropdown-label {
+  color: var(--sl-color-gray-2, #555555);
+  font-size: var(--sl-text-sm, 0.875rem);
+  white-space: nowrap;
+}
+
+.filter-dropdown-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: none;
+  border: 1px solid var(--sl-color-gray-5, #e0e0e0);
+  color: var(--sl-color-gray-2, #555555);
+  cursor: pointer;
+  font-size: var(--sl-text-sm, 0.875rem);
+  font-weight: 500;
+  padding: 0.4rem 0.625rem;
+  transition: color 0.15s, background-color 0.15s;
+  white-space: nowrap;
+  border-radius: 0;
+}
+
+.filter-dropdown-trigger:hover {
+  color: var(--sl-color-white, #333333);
+  background: var(--sl-color-gray-7, var(--sl-color-gray-6, #eeeeee));
+}
+
+.filter-dropdown-chevron {
+  flex-shrink: 0;
+  margin-inline-start: 0.15rem;
+  transition: transform 0.15s;
+}
+
+.filter-dropdown-trigger[aria-expanded='true'] .filter-dropdown-chevron {
+  transform: rotate(180deg);
+}
+
+.filter-dropdown-menu {
+  background: var(--sl-color-bg-nav, #ffffff);
+  border: 1px solid var(--sl-color-gray-5, #e0e0e0);
+  border-radius: 0;
+  box-shadow: none;
+  inset-inline-start: 0;
+  list-style: none;
+  margin: 0;
+  min-width: 100%;
+  overflow-y: auto;
+  padding: 0;
+  position: absolute;
+  top: 100%;
+  z-index: 9999;
+}
+
+.filter-dropdown-menu[hidden] {
+  display: none !important;
+}
+
+.filter-dropdown-menu li {
+  align-items: center;
+  color: var(--sl-color-text, #333333);
+  display: flex;
+  font-size: var(--sl-text-sm, 0.875rem);
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  border-bottom: 1px solid var(--sl-color-gray-5, #e0e0e0);
+  transition: background 0.1s, color 0.1s;
+  white-space: nowrap;
+  list-style: none;
+  margin: 0;
+}
+
+.filter-dropdown-menu li:last-child {
+  border-bottom: none;
+}
+
+.filter-dropdown-menu li:hover,
+.filter-dropdown-menu li:focus-visible {
+  background: var(--sl-color-gray-6, #eeeeee);
+  color: var(--sl-color-white, #333333);
+  outline: none;
+}
+
+.filter-dropdown-menu li[aria-selected='true'] {
+  color: var(--sl-color-white, #333333);
+  box-shadow: inset 0 0 0 1px var(--sl-color-accent, #1A42E8);
+}
+</style>

--- a/docs/content/guides/columns/column-filter/vue/exampleSearchMode.vue
+++ b/docs/content/guides/columns/column-filter/vue/exampleSearchMode.vue
@@ -1,0 +1,114 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    {
+      brand: 'Jetpulse',
+      model: 'Racing Socks',
+      price: 30,
+      sellDate: '2023-10-11',
+      sellTime: '01:23',
+      inStock: false,
+    },
+    {
+      brand: 'Gigabox',
+      model: 'HL Mountain Frame',
+      price: 1890.9,
+      sellDate: '2023-05-03',
+      sellTime: '11:27',
+      inStock: false,
+    },
+    {
+      brand: 'Camido',
+      model: 'Cycling Cap',
+      price: 130.1,
+      sellDate: '2023-03-27',
+      sellTime: '03:17',
+      inStock: true,
+    },
+    {
+      brand: 'Chatterpoint',
+      model: 'Road Tire Tube',
+      price: 59,
+      sellDate: '2023-08-28',
+      sellTime: '08:01',
+      inStock: true,
+    },
+    {
+      brand: 'Eidel',
+      model: 'HL Road Tire',
+      price: 279.99,
+      sellDate: '2023-10-02',
+      sellTime: '01:23',
+      inStock: true,
+    },
+  ],
+  columns: [
+    {
+      title: 'Brand',
+      type: 'text',
+      data: 'brand',
+    },
+    {
+      title: 'Model',
+      type: 'text',
+      data: 'model',
+    },
+    {
+      title: 'Price',
+      type: 'numeric',
+      data: 'price',
+      locale: 'en-US',
+      numericFormat: {
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: 2,
+      },
+    },
+    {
+      title: 'Date',
+      type: 'intl-date',
+      data: 'sellDate',
+      locale: 'en-US',
+      dateFormat: { month: 'short', day: 'numeric', year: 'numeric' },
+      className: 'htRight',
+    },
+    {
+      title: 'Time',
+      type: 'intl-time',
+      data: 'sellTime',
+      locale: 'en-US',
+      timeFormat: { hour: '2-digit', minute: '2-digit', hour12: true },
+      className: 'htRight',
+    },
+    {
+      title: 'In stock',
+      type: 'checkbox',
+      data: 'inStock',
+      className: 'htCenter',
+    },
+  ],
+  // enable filtering with option
+  filters: {
+    searchMode: 'apply',
+  },
+  dropdownMenu: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="exampleSearchMode">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-filter/vue/exampleServerSideFilter.vue
+++ b/docs/content/guides/columns/column-filter/vue/exampleServerSideFilter.vue
@@ -1,0 +1,126 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    {
+      brand: 'Jetpulse',
+      model: 'Racing Socks',
+      price: 30,
+      sellDate: '2023-10-11',
+      sellTime: '01:23',
+      inStock: false,
+    },
+    {
+      brand: 'Gigabox',
+      model: 'HL Mountain Frame',
+      price: 1890.9,
+      sellDate: '2023-05-03',
+      sellTime: '11:27',
+      inStock: false,
+    },
+    {
+      brand: 'Camido',
+      model: 'Cycling Cap',
+      price: 130.1,
+      sellDate: '2023-03-27',
+      sellTime: '03:17',
+      inStock: true,
+    },
+    {
+      brand: 'Chatterpoint',
+      model: 'Road Tire Tube',
+      price: 59,
+      sellDate: '2023-08-28',
+      sellTime: '08:01',
+      inStock: true,
+    },
+    {
+      brand: 'Eidel',
+      model: 'HL Road Tire',
+      price: 279.99,
+      sellDate: '2023-10-02',
+      sellTime: '01:23',
+      inStock: true,
+    },
+  ],
+  columns: [
+    {
+      title: 'Brand',
+      type: 'text',
+      data: 'brand',
+    },
+    {
+      title: 'Model',
+      type: 'text',
+      data: 'model',
+    },
+    {
+      title: 'Price',
+      type: 'numeric',
+      data: 'price',
+      locale: 'en-US',
+      numericFormat: {
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: 2,
+      },
+    },
+    {
+      title: 'Date',
+      type: 'intl-date',
+      data: 'sellDate',
+      locale: 'en-US',
+      dateFormat: { month: 'short', day: 'numeric', year: 'numeric' },
+      className: 'htRight',
+    },
+    {
+      title: 'Time',
+      type: 'intl-time',
+      data: 'sellTime',
+      locale: 'en-US',
+      timeFormat: { hour: '2-digit', minute: '2-digit', hour12: true },
+      className: 'htRight',
+    },
+    {
+      title: 'In stock',
+      type: 'checkbox',
+      data: 'inStock',
+      className: 'htCenter',
+    },
+  ],
+  // enable filtering
+  filters: true,
+  // enable the column menu
+  dropdownMenu: true,
+  height: 'auto',
+  // `beforeFilter()` is a Handsontable hook
+  // it's fired after Handsontable gathers information about the filters, but before the filters are applied
+  beforeFilter(conditionsStack) {
+    // gather information about the filters
+    console.log(`The amount of filters: ${conditionsStack.length}`);
+    console.log(`The last changed column index: ${conditionsStack[0].column}`);
+    console.log(`The amount of filters added to this column: ${conditionsStack[0].conditions.length}`);
+    // the list of filter conditions
+    console.log(conditionsStack[0].conditions);
+
+    // return `false` to disable filtering on the client side
+    return false;
+  },
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="exampleServerSideFilter">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-filter/vue/exampleShowFilterItemsOnly.vue
+++ b/docs/content/guides/columns/column-filter/vue/exampleShowFilterItemsOnly.vue
@@ -1,0 +1,113 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    {
+      brand: 'Jetpulse',
+      model: 'Racing Socks',
+      price: 30,
+      sellDate: '2023-10-11',
+      sellTime: '01:23',
+      inStock: false,
+    },
+    {
+      brand: 'Gigabox',
+      model: 'HL Mountain Frame',
+      price: 1890.9,
+      sellDate: '2023-05-03',
+      sellTime: '11:27',
+      inStock: false,
+    },
+    {
+      brand: 'Camido',
+      model: 'Cycling Cap',
+      price: 130.1,
+      sellDate: '2023-03-27',
+      sellTime: '03:17',
+      inStock: true,
+    },
+    {
+      brand: 'Chatterpoint',
+      model: 'Road Tire Tube',
+      price: 59,
+      sellDate: '2023-08-28',
+      sellTime: '08:01',
+      inStock: true,
+    },
+    {
+      brand: 'Eidel',
+      model: 'HL Road Tire',
+      price: 279.99,
+      sellDate: '2023-10-02',
+      sellTime: '01:23',
+      inStock: true,
+    },
+  ],
+  columns: [
+    {
+      title: 'Brand',
+      type: 'text',
+      data: 'brand',
+    },
+    {
+      title: 'Model',
+      type: 'text',
+      data: 'model',
+    },
+    {
+      title: 'Price',
+      type: 'numeric',
+      data: 'price',
+      locale: 'en-US',
+      numericFormat: {
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: 2,
+      },
+    },
+    {
+      title: 'Date',
+      type: 'intl-date',
+      data: 'sellDate',
+      locale: 'en-US',
+      dateFormat: { month: 'short', day: 'numeric', year: 'numeric' },
+      className: 'htRight',
+    },
+    {
+      title: 'Time',
+      type: 'intl-time',
+      data: 'sellTime',
+      locale: 'en-US',
+      timeFormat: { hour: '2-digit', minute: '2-digit', hour12: true },
+      className: 'htRight',
+    },
+    {
+      title: 'In stock',
+      type: 'checkbox',
+      data: 'inStock',
+      className: 'htCenter',
+    },
+  ],
+  // enable filtering
+  filters: true,
+  // enable the column menu, but display only the filter menu items
+  dropdownMenu: ['filter_by_condition', 'filter_by_value', 'filter_action_bar'],
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="exampleShowFilterItemsOnly">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-freezing/column-freezing.md
+++ b/docs/content/guides/columns/column-freezing/column-freezing.md
@@ -74,6 +74,16 @@ If your [layout direction](@/guides/internationalization/layout-direction/layout
 
 :::
 
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/columns/column-freezing/vue/example1.vue)
+
+:::
+
+:::
+
 ## User-triggered freeze
 
 To enable manual column freezing, set [`manualColumnFreeze`](@/api/options.md#manualcolumnfreeze) to `true`. This lets you freeze and unfreeze columns by using the grid's [context menu](@/guides/accessories-and-menus/context-menu/context-menu.md).
@@ -108,6 +118,16 @@ Mind that when you unfreeze a frozen column, it doesn't go back to the original 
 
 @[code](@/content/guides/columns/column-freezing/angular/example2.ts)
 @[code](@/content/guides/columns/column-freezing/angular/example2.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example2 :vue3
+
+@[code](@/content/guides/columns/column-freezing/vue/example2.vue)
 
 :::
 

--- a/docs/content/guides/columns/column-freezing/vue/example1.vue
+++ b/docs/content/guides/columns/column-freezing/vue/example1.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+// generate an array of arrays with dummy data
+const data = new Array(100) // number of rows
+  .fill(null)
+  .map((_, row) =>
+    new Array(50) // number of columns
+      .fill(null)
+      .map((_, column) => `${row}, ${column}`)
+  );
+
+const hotSettings = ref<GridSettings>({
+  data,
+  colWidths: 100,
+  width: '100%',
+  height: 320,
+  rowHeaders: true,
+  colHeaders: true,
+  fixedColumnsStart: 1,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-freezing/vue/example2.vue
+++ b/docs/content/guides/columns/column-freezing/vue/example2.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+// generate an array of arrays with dummy data
+const data = new Array(100) // number of rows
+  .fill(null)
+  .map((_, row) =>
+    new Array(50) // number of columns
+      .fill(null)
+      .map((_, column) => `${row}, ${column}`)
+  );
+
+const hotSettings = ref<GridSettings>({
+  data,
+  colWidths: 100,
+  width: '100%',
+  height: 320,
+  rowHeaders: true,
+  colHeaders: true,
+  fixedColumnsStart: 2,
+  contextMenu: true,
+  manualColumnFreeze: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example2">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-groups/column-groups.md
+++ b/docs/content/guides/columns/column-groups/column-groups.md
@@ -66,6 +66,19 @@ nestedHeaders={[
 
 :::
 
+::: only-for vue
+
+```js
+nestedHeaders: [
+  ['A', { label: 'B', colspan: 8 }, 'C'],
+  ['D', { label: 'E', colspan: 4 }, { label: 'F', colspan: 4 }, 'G'],
+  ['H', { label: 'I', colspan: 2 }, { label: 'J', colspan: 2 }, { label: 'K', colspan: 2 }, { label: 'L', colspan: 2 }, 'M'],
+  ['N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W'],
+],
+```
+
+:::
+
 ### Example
 
 ::: only-for javascript
@@ -96,6 +109,16 @@ nestedHeaders={[
 
 @[code](@/content/guides/columns/column-groups/angular/example1.ts)
 @[code](@/content/guides/columns/column-groups/angular/example1.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/columns/column-groups/vue/example1.vue)
 
 :::
 
@@ -138,6 +161,17 @@ nestedHeaders: [
   [{ label: 'A', rowspan: 2 }, { label: 'B', colspan: 2 }],
   ['', 'C', 'D'],
 ];
+```
+
+:::
+
+::: only-for vue
+
+```js
+nestedHeaders: [
+  [{ label: 'A', rowspan: 2 }, { label: 'B', colspan: 2 }],
+  ['', 'C', 'D'],
+],
 ```
 
 :::
@@ -191,6 +225,17 @@ collapsibleColumns: [
 
 :::
 
+::: only-for vue
+
+```js
+collapsibleColumns: [
+  { row: -4, col: 1, collapsible: true }, // Add the button to the 4th-level header of the 1st column - counting from the first table row upwards.
+  { row: -3, col: 5, collapsible: true }, // Add the button to the 3rd-level header of the 5th column - counting from the first table row upwards.
+],
+```
+
+:::
+
 ### Example
 
 ::: only-for javascript
@@ -221,6 +266,16 @@ collapsibleColumns: [
 
 @[code](@/content/guides/columns/column-groups/angular/example2.ts)
 @[code](@/content/guides/columns/column-groups/angular/example2.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example2 :vue3
+
+@[code](@/content/guides/columns/column-groups/vue/example2.vue)
 
 :::
 

--- a/docs/content/guides/columns/column-groups/vue/example1.vue
+++ b/docs/content/guides/columns/column-groups/vue/example1.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1', 'J1'],
+    ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2', 'H2', 'I2', 'J2'],
+    ['A3', 'B3', 'C3', 'D3', 'E3', 'F3', 'G3', 'H3', 'I3', 'J3'],
+    ['A4', 'B4', 'C4', 'D4', 'E4', 'F4', 'G4', 'H4', 'I4', 'J4'],
+    ['A5', 'B5', 'C5', 'D5', 'E5', 'F5', 'G5', 'H5', 'I5', 'J5'],
+  ],
+  colHeaders: true,
+  rowHeaders: true,
+  height: 'auto',
+  nestedHeaders: [
+    ['A', { label: 'B', colspan: 8 }, 'C'],
+    ['D', { label: 'E', colspan: 4 }, { label: 'F', colspan: 4 }, 'G'],
+    [
+      'H',
+      { label: 'I', colspan: 2 },
+      { label: 'J', colspan: 2 },
+      { label: 'K', colspan: 2 },
+      { label: 'L', colspan: 2 },
+      'M',
+    ],
+    ['N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W'],
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-groups/vue/example2.vue
+++ b/docs/content/guides/columns/column-groups/vue/example2.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1', 'J1'],
+    ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2', 'H2', 'I2', 'J2'],
+    ['A3', 'B3', 'C3', 'D3', 'E3', 'F3', 'G3', 'H3', 'I3', 'J3'],
+    ['A4', 'B4', 'C4', 'D4', 'E4', 'F4', 'G4', 'H4', 'I4', 'J4'],
+    ['A5', 'B5', 'C5', 'D5', 'E5', 'F5', 'G5', 'H5', 'I5', 'J5'],
+  ],
+  colHeaders: true,
+  rowHeaders: true,
+  colWidths: 60,
+  height: 'auto',
+  nestedHeaders: [
+    ['A', { label: 'B', colspan: 8 }, 'C'],
+    ['D', { label: 'E', colspan: 4 }, { label: 'F', colspan: 4 }, 'G'],
+    [
+      'H',
+      { label: 'I', colspan: 2 },
+      { label: 'J', colspan: 2 },
+      { label: 'K', colspan: 2 },
+      { label: 'L', colspan: 2 },
+      'M',
+    ],
+    ['N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W'],
+  ],
+  collapsibleColumns: [
+    { row: -4, col: 1, collapsible: true },
+    { row: -3, col: 1, collapsible: true },
+    { row: -2, col: 1, collapsible: true },
+    { row: -2, col: 3, collapsible: true },
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example2">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-header/column-header.md
+++ b/docs/content/guides/columns/column-header/column-header.md
@@ -54,6 +54,16 @@ Setting the [`colHeaders`](@/api/options.md#colheaders) option to `true` enables
 
 :::
 
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/columns/column-header/vue/example1.vue)
+
+:::
+
+:::
+
 ::: only-for angular
 
 ::: example #example1 :angular --ts 1 --html 2
@@ -90,6 +100,16 @@ An array of labels can be used to set the [`colHeaders`](@/api/options.md#colhea
 
 :::
 
+::: only-for vue
+
+::: example #example2 :vue3
+
+@[code](@/content/guides/columns/column-header/vue/example2.vue)
+
+:::
+
+:::
+
 ::: only-for angular
 
 ::: example #example2 :angular --ts 1 --html 2
@@ -121,6 +141,16 @@ The [`colHeaders`](@/api/options.md#colheaders) can also be populated using a fu
 
 @[code](@/content/guides/columns/column-header/react/example3.jsx)
 @[code](@/content/guides/columns/column-header/react/example3.tsx)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example3 :vue3
+
+@[code](@/content/guides/columns/column-header/vue/example3.vue)
 
 :::
 
@@ -165,6 +195,16 @@ You can also set the alignment for a specific column by using the [`columns`](@/
 
 :::
 
+::: only-for vue
+
+::: example #example4 :vue3
+
+@[code](@/content/guides/columns/column-header/vue/example4.vue)
+
+:::
+
+:::
+
 ::: only-for angular
 
 ::: example #example4 :angular --ts 1 --html 2
@@ -197,6 +237,16 @@ If you want to style the header labels, you can pass any number of class names, 
 @[code](@/content/guides/columns/column-header/react/example5.css)
 @[code](@/content/guides/columns/column-header/react/example5.jsx)
 @[code](@/content/guides/columns/column-header/react/example5.tsx)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example5 :vue3
+
+@[code](@/content/guides/columns/column-header/vue/example5.vue)
 
 :::
 

--- a/docs/content/guides/columns/column-header/vue/example1.vue
+++ b/docs/content/guides/columns/column-header/vue/example1.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1', 'J1', 'K1'],
+    ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2', 'H2', 'I2', 'J2', 'K2'],
+    ['A3', 'B3', 'C3', 'D3', 'E3', 'F3', 'G3', 'H3', 'I3', 'J3', 'K3'],
+  ],
+  colHeaders: true,
+  rowHeaders: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-header/vue/example2.vue
+++ b/docs/content/guides/columns/column-header/vue/example2.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1'],
+    ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2', 'H2', 'I2'],
+    ['A3', 'B3', 'C3', 'D3', 'E3', 'F3', 'G3', 'H3', 'I3'],
+  ],
+  colHeaders: ['ID', 'Full name', 'Position', 'Country', 'City', 'Address', 'Zip code', 'Mobile', 'E-mail'],
+  rowHeaders: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example2">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-header/vue/example3.vue
+++ b/docs/content/guides/columns/column-header/vue/example3.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1', 'J1', 'K1'],
+    ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2', 'H2', 'I2', 'J2', 'K2'],
+    ['A3', 'B3', 'C3', 'D3', 'E3', 'F3', 'G3', 'H3', 'I3', 'J3', 'K3'],
+  ],
+  colHeaders: (index) => {
+    return `Col ${index + 1}`;
+  },
+  rowHeaders: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example3">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-header/vue/example4.vue
+++ b/docs/content/guides/columns/column-header/vue/example4.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['A1', 'B1', 'C1', 'D1'],
+    ['A2', 'B2', 'C2', 'D2'],
+    ['A3', 'B3', 'C3', 'D3'],
+  ],
+  colHeaders: true,
+  rowHeaders: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  height: 'auto',
+  headerClassName: 'htCenter',
+  columns: [
+    { headerClassName: 'htRight' },
+    { headerClassName: 'htLeft' },
+    {},
+    {},
+  ],
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example4">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-header/vue/example5.vue
+++ b/docs/content/guides/columns/column-header/vue/example5.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['A1', 'B1', 'C1', 'D1'],
+    ['A2', 'B2', 'C2', 'D2'],
+    ['A3', 'B3', 'C3', 'D3'],
+  ],
+  colHeaders: true,
+  rowHeaders: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  height: 'auto',
+  headerClassName: 'htLeft',
+  columns: [
+    { headerClassName: 'italic-text' },
+    { headerClassName: 'bold-text italic-text' },
+    { headerClassName: 'htRight bold-text italic-text' },
+    {},
+  ],
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example5">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>
+
+<style>
+.bold-text {
+  font-weight: bold;
+}
+
+.italic-text {
+  font-style: italic;
+}
+</style>

--- a/docs/content/guides/columns/column-hiding/column-hiding.md
+++ b/docs/content/guides/columns/column-hiding/column-hiding.md
@@ -76,6 +76,16 @@ To enable column hiding, use the [`hiddenColumns`](@/api/options.md#hiddencolumn
 
 :::
 
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/columns/column-hiding/vue/example1.vue)
+
+:::
+
+:::
+
 ## Set up column hiding
 
 To set up your column hiding configuration, follow the steps below.
@@ -120,6 +130,16 @@ Now, those columns are hidden by default:
 @[code](@/content/guides/columns/column-hiding/angular/example2.html)
 
 :::
+:::
+
+::: only-for vue
+
+::: example #example2 :vue3
+
+@[code](@/content/guides/columns/column-hiding/vue/example2.vue)
+
+:::
+
 :::
 
 ### Step 2: Show UI indicators
@@ -172,6 +192,16 @@ If you use both the [`NestedHeaders`](@/api/nestedHeaders.md) plugin and the
 
 :::
 
+::: only-for vue
+
+::: example #example3 :vue3
+
+@[code](@/content/guides/columns/column-hiding/vue/example3.vue)
+
+:::
+
+:::
+
 ### Step 3: Set up context menu items
 
 To easily hide and unhide columns, add column hiding items to Handsontable's
@@ -214,6 +244,16 @@ additional items for hiding and unhiding columns.
 :::
 :::
 
+::: only-for vue
+
+::: example #example4 :vue3
+
+@[code](@/content/guides/columns/column-hiding/vue/example4.vue)
+
+:::
+
+:::
+
 You can also add the column hiding menu items individually, by adding the
 [`hidden_columns_show`](@/guides/accessories-and-menus/context-menu/context-menu.md#context-menu-with-specific-options)
 and
@@ -251,6 +291,16 @@ strings to the[ `contextMenu`](@/api/contextMenu.md) parameter:
 @[code](@/content/guides/columns/column-hiding/angular/example5.html)
 
 :::
+:::
+
+::: only-for vue
+
+::: example #example5 :vue3
+
+@[code](@/content/guides/columns/column-hiding/vue/example5.vue)
+
+:::
+
 :::
 
 ### Step 4: Set up copy and paste behavior
@@ -293,6 +343,16 @@ object, set the [`copyPasteEnabled`](@/api/hiddenColumns.md) property to `false`
 
 :::
 
+::: only-for vue
+
+::: example #example6 :vue3
+
+@[code](@/content/guides/columns/column-hiding/vue/example6.vue)
+
+:::
+
+:::
+
 ## Column hiding API methods
 
 For the most popular column hiding tasks, use the API methods below.
@@ -305,6 +365,19 @@ To use the Handsontable API, you'll need access to the Handsontable instance. Yo
 utilizing a reference to the `HotTable` component, and reading its `hotInstance` property.
 
 For more information, see the [Instance methods](@/guides/getting-started/react-methods/react-methods.md) page.
+
+:::
+
+:::
+
+::: only-for vue
+
+::: tip
+
+To use the Handsontable API, you'll need access to the Handsontable instance. You can do that by
+utilizing a reference to the `HotTable` component, and reading its `hotInstance` property.
+
+For more information, see the [Referencing the Handsontable instance](@/guides/integrate-with-vue3/vue3-hot-reference/vue3-hot-reference.md) page.
 
 :::
 

--- a/docs/content/guides/columns/column-hiding/vue/example1.vue
+++ b/docs/content/guides/columns/column-hiding/vue/example1.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  autoWrapRow: true,
+  autoWrapCol: true,
+  data: [
+    ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1', 'J1', 'K1', 'L1'],
+    ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2', 'H2', 'I2', 'J2', 'K2', 'L2'],
+    ['A3', 'B3', 'C3', 'D3', 'E3', 'F3', 'G3', 'H3', 'I3', 'J3', 'K3', 'L3'],
+    ['A4', 'B4', 'C4', 'D4', 'E4', 'F4', 'G4', 'H4', 'I4', 'J4', 'K4', 'L4'],
+    ['A5', 'B5', 'C5', 'D5', 'E5', 'F5', 'G5', 'H5', 'I5', 'J5', 'K5', 'L5'],
+  ],
+  height: 'auto',
+  colHeaders: true,
+  rowHeaders: true,
+  contextMenu: true,
+  // enable the `HiddenColumns` plugin
+  hiddenColumns: {
+    columns: [2, 4, 6],
+    indicators: true,
+  },
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-hiding/vue/example2.vue
+++ b/docs/content/guides/columns/column-hiding/vue/example2.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  autoWrapRow: true,
+  autoWrapCol: true,
+  data: [
+    ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1', 'J1', 'K1', 'L1'],
+    ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2', 'H2', 'I2', 'J2', 'K2', 'L2'],
+    ['A3', 'B3', 'C3', 'D3', 'E3', 'F3', 'G3', 'H3', 'I3', 'J3', 'K3', 'L3'],
+    ['A4', 'B4', 'C4', 'D4', 'E4', 'F4', 'G4', 'H4', 'I4', 'J4', 'K4', 'L4'],
+    ['A5', 'B5', 'C5', 'D5', 'E5', 'F5', 'G5', 'H5', 'I5', 'J5', 'K5', 'L5'],
+  ],
+  height: 'auto',
+  colHeaders: true,
+  rowHeaders: true,
+  // enable the `HiddenColumns` plugin
+  hiddenColumns: {
+    // specify columns hidden by default
+    columns: [3, 5, 9],
+  },
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example2">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-hiding/vue/example3.vue
+++ b/docs/content/guides/columns/column-hiding/vue/example3.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  autoWrapRow: true,
+  autoWrapCol: true,
+  data: [
+    ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1', 'J1', 'K1', 'L1'],
+    ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2', 'H2', 'I2', 'J2', 'K2', 'L2'],
+    ['A3', 'B3', 'C3', 'D3', 'E3', 'F3', 'G3', 'H3', 'I3', 'J3', 'K3', 'L3'],
+    ['A4', 'B4', 'C4', 'D4', 'E4', 'F4', 'G4', 'H4', 'I4', 'J4', 'K4', 'L4'],
+    ['A5', 'B5', 'C5', 'D5', 'E5', 'F5', 'G5', 'H5', 'I5', 'J5', 'K5', 'L5'],
+  ],
+  height: 'auto',
+  colHeaders: true,
+  rowHeaders: true,
+  hiddenColumns: {
+    columns: [3, 5, 9],
+    // show UI indicators to mark hidden columns
+    indicators: true,
+  },
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example3">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-hiding/vue/example4.vue
+++ b/docs/content/guides/columns/column-hiding/vue/example4.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  autoWrapRow: true,
+  autoWrapCol: true,
+  data: [
+    ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1', 'J1', 'K1', 'L1'],
+    ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2', 'H2', 'I2', 'J2', 'K2', 'L2'],
+    ['A3', 'B3', 'C3', 'D3', 'E3', 'F3', 'G3', 'H3', 'I3', 'J3', 'K3', 'L3'],
+    ['A4', 'B4', 'C4', 'D4', 'E4', 'F4', 'G4', 'H4', 'I4', 'J4', 'K4', 'L4'],
+    ['A5', 'B5', 'C5', 'D5', 'E5', 'F5', 'G5', 'H5', 'I5', 'J5', 'K5', 'L5'],
+  ],
+  height: 'auto',
+  colHeaders: true,
+  rowHeaders: true,
+  // enable the context menu
+  contextMenu: true,
+  // enable the `HiddenColumns` plugin
+  // automatically adds the context menu's column hiding items
+  hiddenColumns: {
+    columns: [3, 5, 9],
+    indicators: true,
+  },
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example4">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-hiding/vue/example5.vue
+++ b/docs/content/guides/columns/column-hiding/vue/example5.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  autoWrapRow: true,
+  autoWrapCol: true,
+  data: [
+    ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1', 'J1', 'K1', 'L1'],
+    ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2', 'H2', 'I2', 'J2', 'K2', 'L2'],
+    ['A3', 'B3', 'C3', 'D3', 'E3', 'F3', 'G3', 'H3', 'I3', 'J3', 'K3', 'L3'],
+    ['A4', 'B4', 'C4', 'D4', 'E4', 'F4', 'G4', 'H4', 'I4', 'J4', 'K4', 'L4'],
+    ['A5', 'B5', 'C5', 'D5', 'E5', 'F5', 'G5', 'H5', 'I5', 'J5', 'K5', 'L5'],
+  ],
+  height: 'auto',
+  colHeaders: true,
+  rowHeaders: true,
+  contextMenu: ['hidden_columns_show', 'hidden_columns_hide'],
+  hiddenColumns: {
+    columns: [3, 5, 9],
+    indicators: true,
+  },
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example5">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-hiding/vue/example6.vue
+++ b/docs/content/guides/columns/column-hiding/vue/example6.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  autoWrapRow: true,
+  autoWrapCol: true,
+  data: [
+    ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1', 'J1', 'K1', 'L1'],
+    ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2', 'H2', 'I2', 'J2', 'K2', 'L2'],
+    ['A3', 'B3', 'C3', 'D3', 'E3', 'F3', 'G3', 'H3', 'I3', 'J3', 'K3', 'L3'],
+    ['A4', 'B4', 'C4', 'D4', 'E4', 'F4', 'G4', 'H4', 'I4', 'J4', 'K4', 'L4'],
+    ['A5', 'B5', 'C5', 'D5', 'E5', 'F5', 'G5', 'H5', 'I5', 'J5', 'K5', 'L5'],
+  ],
+  height: 'auto',
+  colHeaders: true,
+  rowHeaders: true,
+  contextMenu: ['hidden_columns_show', 'hidden_columns_hide'],
+  hiddenColumns: {
+    columns: [3, 5, 9],
+    indicators: true,
+    // exclude hidden columns from copying and pasting
+    copyPasteEnabled: false,
+  },
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example6">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-menu/column-menu.md
+++ b/docs/content/guides/columns/column-menu/column-menu.md
@@ -66,6 +66,16 @@ To enable the plugin, set the [`dropdownMenu`](@/api/options.md#dropdownmenu) co
 
 :::
 
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/columns/column-menu/vue/example1.vue)
+
+:::
+
+:::
+
 ## Plugin configuration
 
 To use the default dropdown contents, set it to `true`, or to customize it by setting it to use a custom list of actions. For the available entry options reference, see the [Context Menu demo](@/guides/accessories-and-menus/context-menu/context-menu.md#page-specific).
@@ -98,6 +108,16 @@ To use the default dropdown contents, set it to `true`, or to customize it by se
 
 @[code](@/content/guides/columns/column-menu/angular/example2.ts)
 @[code](@/content/guides/columns/column-menu/angular/example2.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example2 :vue3
+
+@[code](@/content/guides/columns/column-menu/vue/example2.vue)
 
 :::
 

--- a/docs/content/guides/columns/column-menu/vue/example1.vue
+++ b/docs/content/guides/columns/column-menu/vue/example1.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1'],
+    ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2'],
+    ['A3', 'B3', 'C3', 'D3', 'E3', 'F3', 'G3'],
+  ],
+  colHeaders: true,
+  dropdownMenu: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-menu/vue/example2.vue
+++ b/docs/content/guides/columns/column-menu/vue/example2.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1'],
+    ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2'],
+    ['A3', 'B3', 'C3', 'D3', 'E3', 'F3', 'G3'],
+  ],
+  colHeaders: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  height: 'auto',
+  dropdownMenu: ['remove_col', '---------', 'make_read_only', '---------', 'alignment'],
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example2">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-moving/column-moving.md
+++ b/docs/content/guides/columns/column-moving/column-moving.md
@@ -61,6 +61,16 @@ A draggable move handle appears above the selected column header. You can click 
 
 :::
 
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/columns/column-moving/vue/example1.vue)
+
+:::
+
+:::
+
 #### Move column headers
 
 When you move columns, the default column headers (A, B, C) stay in place.
@@ -98,6 +108,16 @@ When you move columns, the default column headers (A, B, C) stay in place.
 
 :::
 
+::: only-for vue
+
+::: example #example2 :vue3
+
+@[code](@/content/guides/columns/column-moving/vue/example2.vue)
+
+:::
+
+:::
+
 But, if you configure the [`colHeaders`](@/api/options.md#colheaders) option with your own column labels (e.g., One, Two, Three), your headers move along with the columns.
 
 ::: only-for javascript
@@ -128,6 +148,16 @@ But, if you configure the [`colHeaders`](@/api/options.md#colheaders) option wit
 
 @[code](@/content/guides/columns/column-moving/angular/example3.ts)
 @[code](@/content/guides/columns/column-moving/angular/example3.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example3 :vue3
+
+@[code](@/content/guides/columns/column-moving/vue/example3.vue)
 
 :::
 

--- a/docs/content/guides/columns/column-moving/vue/example1.vue
+++ b/docs/content/guides/columns/column-moving/vue/example1.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+// generate an array of arrays with dummy data
+const data = new Array(200) // number of rows
+  .fill(null)
+  .map((_, row) =>
+    new Array(20) // number of columns
+      .fill(null)
+      .map((_, column) => `${row}, ${column}`)
+  );
+
+const hotSettings = ref<GridSettings>({
+  data,
+  width: '100%',
+  height: 320,
+  rowHeaders: true,
+  colHeaders: true,
+  colWidths: 100,
+  manualColumnMove: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-moving/vue/example2.vue
+++ b/docs/content/guides/columns/column-moving/vue/example2.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['A1', 'B1', 'C1'],
+    ['A2', 'B2', 'C2'],
+    ['A3', 'B3', 'C3'],
+  ],
+  colHeaders: true,
+  rowHeaders: true,
+  manualColumnMove: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  height: 'auto',
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example2">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-moving/vue/example3.vue
+++ b/docs/content/guides/columns/column-moving/vue/example3.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['A1', 'B1', 'C1'],
+    ['A2', 'B2', 'C2'],
+    ['A3', 'B3', 'C3'],
+  ],
+  colHeaders: ['One', 'Two', 'Three'],
+  rowHeaders: true,
+  manualColumnMove: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  height: 'auto',
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example3">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-summary/column-summary.md
+++ b/docs/content/guides/columns/column-summary/column-summary.md
@@ -79,6 +79,16 @@ This example calculates and displays five different column summaries:
 
 :::
 
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/columns/column-summary/vue/example1.vue)
+
+:::
+
+:::
+
 ### Built-in summary functions
 
 To decide how a column summary is calculated, you can use one of the following summary functions:
@@ -193,6 +203,38 @@ const configurationOptions: GridSettings = {
 
 :::
 
+::: only-for vue
+
+```js
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const hotSettings = {
+  licenseKey: 'non-commercial-and-evaluation',
+  data: [
+    [1, 2, 3, 4, 5],
+    [6, 7, 8, 9, 10],
+    [11, 12, 13, 14, 15]
+  ],
+  colHeaders: true,
+  rowHeaders: true,
+  // set the `columnSummary` configuration option to an array of
+  // objects
+  columnSummary: [
+    {},
+    {}
+  ],
+};
+```
+
+```html
+<HotTable :settings="hotSettings" />
+```
+
+:::
+
 You can also set the [`columnSummary`](@/api/options.md#columnsummary) option [to a function](#set-up-column-summaries-using-a-function).
 
 ### Step 2: Select cells that you want to summarize
@@ -254,6 +296,25 @@ columnSummary: [
     sourceColumn: 1,
   },
 ];
+```
+
+:::
+
+::: only-for vue
+
+```js
+columnSummary: [
+  {
+    // set this column summary to summarize the first column
+    // (i.e. a column with physical index `0`)
+    sourceColumn: 0,
+  },
+  {
+    // set this column summary to summarize the second column
+    // (i.e. a column with physical index `1`)
+    sourceColumn: 1,
+  }
+]
 ```
 
 :::
@@ -331,6 +392,31 @@ columnSummary: [
 
 :::
 
+::: only-for vue
+
+```js
+columnSummary: [
+  {
+    sourceColumn: 0,
+    // set this column summary to only summarize rows with physical
+    // indexes 0-2, 4, and 6-8
+    ranges: [
+      [0, 2], [4], [6, 8]
+    ],
+  },
+  {
+    sourceColumn: 0,
+    // set this column summary to only summarize rows with physical
+    // indexes 0-5
+    ranges: [
+      [0, 5]
+    ],
+  }
+]
+```
+
+:::
+
 ### Step 3: Calculate your summary
 
 Now, decide how you want to calculate your column summary.
@@ -399,6 +485,27 @@ columnSummary: [
     type: "min",
   },
 ];
+```
+
+:::
+
+::: only-for vue
+
+```js
+columnSummary: [
+  {
+    sourceColumn: 0,
+    // set this column summary to return the sum all values in the
+    // summarized column
+    type: 'sum',
+  },
+  {
+    sourceColumn: 1,
+    // set this column summary to return the lowest value in the
+    // summarized column
+    type: 'min',
+  }
+]
 ```
 
 :::
@@ -478,6 +585,29 @@ columnSummary: [
 
 :::
 
+::: only-for vue
+
+```js
+columnSummary: [
+  {
+    sourceColumn: 0,
+    type: 'sum',
+    // set this column summary to display its result in cell (4, 0)
+    destinationRow: 4,
+    destinationColumn: 0
+  },
+  {
+    sourceColumn: 1,
+    type: 'min',
+    // set this column summary to display its result in cell (4, 1)
+    destinationRow: 4,
+    destinationColumn: 1
+  }
+]
+```
+
+:::
+
 ::: tip
 
 Don't change the [`className`](@/api/options.md#classname) metadata of the summary row.
@@ -534,6 +664,16 @@ To reverse row coordinates for your column summary, set the [`reversedRowCoords`
 
 :::
 
+::: only-for vue
+
+::: example #example2 :vue3
+
+@[code](@/content/guides/columns/column-summary/vue/example2.vue)
+
+:::
+
+:::
+
 ## Set up column summaries, using a function
 
 Instead of [setting up the column summary options manually](#set-up-a-column-summary), you can provide the whole column summary configuration as a function that returns a required array of objects.
@@ -579,6 +719,16 @@ The example below sets up five different column summaries. To do this, it:
 
 :::
 
+::: only-for vue
+
+::: example #example7 :vue3
+
+@[code](@/content/guides/columns/column-summary/vue/example7.vue)
+
+:::
+
+:::
+
 Using a function to provide a column summary configuration lets you set up all sorts of more complex column summaries. For example, you can sum subtotals for nested groups:
 
 ::: only-for javascript
@@ -609,6 +759,16 @@ Using a function to provide a column summary configuration lets you set up all s
 
 @[code](@/content/guides/columns/column-summary/angular/example4.ts)
 @[code](@/content/guides/columns/column-summary/angular/example4.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example8 :vue3
+
+@[code](@/content/guides/columns/column-summary/vue/example8.vue)
 
 :::
 
@@ -670,6 +830,21 @@ columnSummary: [
 
 :::
 
+::: only-for vue
+
+```js
+columnSummary: [{
+    sourceColumn: 1,
+    // set the `type` option to `'custom'`
+    type: 'custom',
+    destinationRow: 0,
+    destinationColumn: 5,
+    reversedRowCoords: true
+}]
+```
+
+:::
+
 3. In your column summary object, add your custom summary function:
 
 ::: only-for javascript
@@ -725,6 +900,23 @@ columnSummary: [
 
 :::
 
+::: only-for vue
+
+```js
+columnSummary: [{
+    type: 'custom',
+    destinationRow: 0,
+    destinationColumn: 5,
+    reversedRowCoords: true,
+    // add your custom summary function
+    customFunction: function(endpoint) {
+      // implement your function here
+    }
+}]
+```
+
+:::
+
 This example implements a function that counts the number of even values in a column:
 
 ::: only-for javascript
@@ -755,6 +947,16 @@ This example implements a function that counts the number of even values in a co
 
 @[code](@/content/guides/columns/column-summary/angular/example5.ts)
 @[code](@/content/guides/columns/column-summary/angular/example5.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example9 :vue3
+
+@[code](@/content/guides/columns/column-summary/vue/example9.vue)
 
 :::
 
@@ -795,6 +997,16 @@ See the following example:
 
 @[code](@/content/guides/columns/column-summary/angular/example6.ts)
 @[code](@/content/guides/columns/column-summary/angular/example6.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example12 :vue3
+
+@[code](@/content/guides/columns/column-summary/vue/example12.vue)
 
 :::
 
@@ -869,6 +1081,16 @@ To enable this feature, set the [`forceNumeric`](@/api/columnSummary.md) option 
 
 :::
 
+::: only-for vue
+
+::: example #example10 :vue3
+
+@[code](@/content/guides/columns/column-summary/vue/example10.vue)
+
+:::
+
+:::
+
 ### Throw data type errors
 
 You can throw a data type error whenever a non-numeric value is passed to your column summary.
@@ -903,6 +1125,16 @@ To throw data type errors, set the [`suppressDataTypeErrors`](@/api/columnSummar
 
 @[code](@/content/guides/columns/column-summary/angular/example8.ts)
 @[code](@/content/guides/columns/column-summary/angular/example8.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example11 :vue3
+
+@[code](@/content/guides/columns/column-summary/vue/example11.vue)
 
 :::
 

--- a/docs/content/guides/columns/column-summary/vue/example1.vue
+++ b/docs/content/guides/columns/column-summary/vue/example1.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+  data: [[1, 2, 3, 4, 5], [6, 7, 8, 9, 10], [11, 12, 13, 14, 15], [null]],
+  colHeaders: ['sum', 'min', 'max', 'count', 'average'],
+  rowHeaders: true,
+  columnSummary: [
+    {
+      sourceColumn: 0,
+      type: 'sum',
+      destinationRow: 3,
+      destinationColumn: 0,
+      // force this column summary to treat non-numeric values as numeric values
+      forceNumeric: true,
+    },
+    {
+      sourceColumn: 1,
+      type: 'min',
+      destinationRow: 3,
+      destinationColumn: 1,
+    },
+    {
+      sourceColumn: 2,
+      type: 'max',
+      destinationRow: 3,
+      destinationColumn: 2,
+    },
+    {
+      sourceColumn: 3,
+      type: 'count',
+      destinationRow: 3,
+      destinationColumn: 3,
+    },
+    {
+      sourceColumn: 4,
+      type: 'average',
+      destinationRow: 3,
+      destinationColumn: 4,
+    },
+  ],
+  height: 'auto',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-summary/vue/example10.vue
+++ b/docs/content/guides/columns/column-summary/vue/example10.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+  data: [[0, 1, 2], ['3c', '4b', 5], [], []],
+  colHeaders: true,
+  rowHeaders: true,
+  columnSummary: [
+    {
+      type: 'sum',
+      destinationRow: 0,
+      destinationColumn: 0,
+      reversedRowCoords: true,
+      // force this column summary to treat non-numeric values as numeric values
+      forceNumeric: true,
+    },
+    {
+      type: 'sum',
+      destinationRow: 0,
+      destinationColumn: 1,
+      reversedRowCoords: true,
+      // force this column summary to treat non-numeric values as numeric values
+      forceNumeric: true,
+    },
+  ],
+  height: 'auto',
+});
+</script>
+
+<template>
+  <div id="example10">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-summary/vue/example11.vue
+++ b/docs/content/guides/columns/column-summary/vue/example11.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+  data: [[0, 1, 2], ['3c', '4b', 5], [], []],
+  colHeaders: true,
+  rowHeaders: true,
+  columnSummary: [
+    {
+      type: 'sum',
+      destinationRow: 0,
+      destinationColumn: 0,
+      reversedRowCoords: true,
+      // enable throwing data type errors for this column summary
+      suppressDataTypeErrors: false,
+    },
+    {
+      type: 'sum',
+      destinationRow: 0,
+      destinationColumn: 1,
+      reversedRowCoords: true,
+      // enable throwing data type errors for this column summary
+      suppressDataTypeErrors: false,
+    },
+  ],
+  height: 'auto',
+});
+</script>
+
+<template>
+  <div id="example11">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-summary/vue/example12.vue
+++ b/docs/content/guides/columns/column-summary/vue/example12.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+  data: [[0.5, 0.5], [0.5, 0.5], [1, 1], [], []],
+  colHeaders: true,
+  rowHeaders: true,
+  columnSummary: [
+    {
+      type: 'average',
+      destinationRow: 0,
+      destinationColumn: 0,
+      reversedRowCoords: true,
+    },
+    {
+      type: 'average',
+      destinationRow: 0,
+      destinationColumn: 1,
+      reversedRowCoords: true,
+      // round this column summary result to two digits after the decimal point
+      roundFloat: 2,
+    },
+  ],
+  height: 'auto',
+});
+</script>
+
+<template>
+  <div id="example12">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-summary/vue/example2.vue
+++ b/docs/content/guides/columns/column-summary/vue/example2.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+  data: [
+    [1, 2, 3, 4, 5],
+    [6, 7, 8, 9, 10],
+    [11, 12, 13, 14, 15],
+    // add an empty row
+    [null],
+  ],
+  colHeaders: true,
+  rowHeaders: true,
+  columnSummary: [
+    {
+      sourceColumn: 0,
+      type: 'sum',
+      // for this column summary, count row coordinates backward
+      reversedRowCoords: true,
+      // now, to always display this column summary in the bottom row,
+      // set `destinationRow` to `0` (i.e. the last possible row)
+      destinationRow: 0,
+      destinationColumn: 0,
+    },
+    {
+      sourceColumn: 1,
+      type: 'min',
+      // for this column summary, count row coordinates backward
+      reversedRowCoords: true,
+      // now, to always display this column summary in the bottom row,
+      // set `destinationRow` to `0` (i.e. the last possible row)
+      destinationRow: 0,
+      destinationColumn: 1,
+    },
+  ],
+  height: 'auto',
+});
+</script>
+
+<template>
+  <div id="example2">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-summary/vue/example7.vue
+++ b/docs/content/guides/columns/column-summary/vue/example7.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+import type { DetailedSettings } from 'handsontable/plugins/columnSummary';
+
+// register Handsontable's modules
+registerAllModules();
+
+//  generate an array of arrays with dummy numeric data
+const generateData = (rows = 3, columns = 7, additionalRows = true) => {
+  let counter = 0;
+
+  const array2d = [...new Array(rows)].map((_) => [...new Array(columns)].map((_) => counter++));
+
+  // add an empty row at the bottom, to display column summaries
+  if (additionalRows) {
+    array2d.push([]);
+  }
+
+  return array2d;
+};
+
+const hotSettings = ref<GridSettings>({
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+  data: generateData(5, 5, true),
+  height: 'auto',
+  rowHeaders: true,
+  colHeaders: ['sum', 'min', 'max', 'count', 'average'],
+  columnSummary: function () {
+    const configArray = [];
+    const summaryTypes = ['sum', 'min', 'max', 'count', 'average'];
+
+    for (let i = 0; i < this.hot.countCols(); i++) {
+      // iterate over visible columns
+      // for each visible column, add a column summary with a configuration
+      configArray.push({
+        sourceColumn: i,
+        type: summaryTypes[i],
+        // count row coordinates backward
+        reversedRowCoords: true,
+        // display the column summary in the bottom row (because of the reversed row coordinates)
+        destinationRow: 0,
+        destinationColumn: i,
+        forceNumeric: true,
+      });
+    }
+
+    return configArray as DetailedSettings[];
+  },
+});
+</script>
+
+<template>
+  <div id="example7">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-summary/vue/example8.vue
+++ b/docs/content/guides/columns/column-summary/vue/example8.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+type RowObject = {
+  value?: number | null;
+  __children?: RowObject[];
+};
+
+const hotSettings = ref<GridSettings>({
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+  data: [
+    {
+      value: null,
+      __children: [{ value: 5 }, { value: 6 }, { value: 7 }],
+    },
+    {
+      __children: [{ value: 15 }, { value: 16 }, { value: 17 }],
+    },
+  ] as RowObject[],
+  columns: [{ data: 'value' }],
+  nestedRows: true,
+  rowHeaders: true,
+  colHeaders: ['sum', 'min', 'max', 'count', 'average'],
+  columnSummary: function () {
+    const endpoints = [];
+    const nestedRowsPlugin = this.hot.getPlugin('nestedRows');
+    const getRowIndex = nestedRowsPlugin.dataManager.getRowIndex.bind(nestedRowsPlugin.dataManager);
+
+    const resultColumn = 0;
+
+    let tempEndpoint = null;
+    let nestedRowsCache = null;
+
+    if (nestedRowsPlugin.isEnabled()) {
+      nestedRowsCache = this.hot.getPlugin('nestedRows').dataManager.cache;
+    } else {
+      return;
+    }
+
+    for (let i = 0; i < nestedRowsCache.levels[0].length; i++) {
+      tempEndpoint = {};
+
+      if (!nestedRowsCache.levels[0][i].__children || nestedRowsCache.levels[0][i].__children.length === 0) {
+        continue;
+      }
+
+      tempEndpoint.destinationColumn = resultColumn;
+      tempEndpoint.destinationRow = getRowIndex(nestedRowsCache.levels[0][i]);
+      tempEndpoint.type = 'sum';
+      tempEndpoint.forceNumeric = true;
+      tempEndpoint.ranges = [];
+
+      tempEndpoint.ranges.push([
+        getRowIndex(nestedRowsCache.levels[0][i].__children[0]),
+        getRowIndex(nestedRowsCache.levels[0][i].__children[nestedRowsCache.levels[0][i].__children.length - 1]),
+      ]);
+
+      endpoints.push(tempEndpoint);
+      tempEndpoint = null;
+    }
+
+    return endpoints;
+  },
+  height: 'auto',
+});
+</script>
+
+<template>
+  <div id="example8">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-summary/vue/example9.vue
+++ b/docs/content/guides/columns/column-summary/vue/example9.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+//  generate an array of arrays with dummy numeric data
+const generateData = (rows = 3, columns = 7, additionalRows = true) => {
+  let counter = 0;
+
+  const array2d = [...new Array(rows)].map((_) => [...new Array(columns)].map((_) => counter++));
+
+  if (additionalRows) {
+    array2d.push([]);
+    array2d.push([]);
+  }
+
+  return array2d;
+};
+
+const hotSettings = ref<GridSettings>({
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+  data: generateData(5, 7),
+  height: 'auto',
+  colHeaders: true,
+  rowHeaders: true,
+  columnSummary: [
+    // configure a column summary
+    {
+      // set the `type` option to `'custom'`
+      type: 'custom',
+      destinationRow: 0,
+      destinationColumn: 5,
+      reversedRowCoords: true,
+      // add your custom summary function
+      customFunction(endpoint) {
+        // implement a function that counts the number of even values in the column
+        const hotInstance = this.hot;
+        let evenCount = 0;
+
+        // a helper function
+        const checkRange = (rowRange: number[]) => {
+          let i = rowRange[1] || rowRange[0];
+          let counter = 0;
+
+          do {
+            if (parseInt(hotInstance.getDataAtCell(i, endpoint.sourceColumn), 10) % 2 === 0) {
+              counter++;
+            }
+
+            i--;
+          } while (i >= rowRange[0]);
+
+          return counter;
+        };
+
+        // go through all declared ranges
+        for (const r in endpoint.ranges) {
+          if (endpoint.ranges.hasOwnProperty(r)) {
+            evenCount += checkRange(endpoint.ranges[r]);
+          }
+        }
+
+        return evenCount;
+      },
+      forceNumeric: true,
+    },
+  ],
+});
+</script>
+
+<template>
+  <div id="example9">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-virtualization/column-virtualization.md
+++ b/docs/content/guides/columns/column-virtualization/column-virtualization.md
@@ -84,6 +84,16 @@ The demo below presents a data grid displaying one million cells (1000 rows x 10
 
 :::
 
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/columns/column-virtualization/vue/example1.vue)
+
+:::
+
+:::
+
 ## Known limitations
 
 Using column virtualization has the following side effects:

--- a/docs/content/guides/columns/column-virtualization/vue/example1.vue
+++ b/docs/content/guides/columns/column-virtualization/vue/example1.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+// generate an array of arrays with dummy data
+const data = new Array(1000) // number of rows
+  .fill(null)
+  .map((_, row) =>
+    new Array(1000) // number of columns
+      .fill(null)
+      .map((_, column) => `${row}, ${column}`)
+  );
+
+const hotSettings = ref<GridSettings>({
+  data,
+  colWidths: 100,
+  width: '100%',
+  height: 320,
+  rowHeaders: true,
+  colHeaders: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-width/column-width.md
+++ b/docs/content/guides/columns/column-width/column-width.md
@@ -74,6 +74,16 @@ In this example we set the same width of `100px` for all columns across the enti
 
 :::
 
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/columns/column-width/vue/example1.vue)
+
+:::
+
+:::
+
 ## Set the column width in an array
 
 In this example, the width is only set for the first four columns. Each additional column would automatically adjust to the content.
@@ -107,6 +117,16 @@ In this example, the width is only set for the first four columns. Each addition
 
 @[code](@/content/guides/columns/column-width/angular/example2.ts)
 @[code](@/content/guides/columns/column-width/angular/example2.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example2 :vue3
+
+@[code](@/content/guides/columns/column-width/vue/example2.vue)
 
 :::
 
@@ -149,6 +169,16 @@ In this example, the size of all columns is set using a function by taking a col
 
 :::
 
+::: only-for vue
+
+::: example #example3 :vue3
+
+@[code](@/content/guides/columns/column-width/vue/example3.vue)
+
+:::
+
+:::
+
 ## Adjust the column width manually
 
 Set the option [`manualColumnResize`](@/api/options.md#manualcolumnresize) to `true` to allow users to manually resize the column width by dragging the handle between the adjacent column headers. If you double-click on that handle, the width will be instantly adjusted to the size of the longest value in the column. Don't forget to enable column headers by setting [`colHeaders`](@/api/options.md#colheaders) to `true`.
@@ -183,6 +213,16 @@ You can adjust the size of one or multiple columns simultaneously, even if the s
 
 @[code](@/content/guides/columns/column-width/angular/example4.ts)
 @[code](@/content/guides/columns/column-width/angular/example4.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example4 :vue3
+
+@[code](@/content/guides/columns/column-width/vue/example4.vue)
 
 :::
 
@@ -235,6 +275,16 @@ This example fits all columns to the container's width equally by setting the op
 
 :::
 
+::: only-for vue
+
+::: example #example5 :vue3
+
+@[code](@/content/guides/columns/column-width/vue/example5.vue)
+
+:::
+
+:::
+
 ### Stretch only the last column
 
 In this example, the first three columns are set to be 80px wide, and the last column automatically fills the remaining space. This is achieved by setting the option [`stretchH: 'last'`](@/api/options.md#stretchh).
@@ -268,6 +318,16 @@ In this example, the first three columns are set to be 80px wide, and the last c
 
 @[code](@/content/guides/columns/column-width/angular/example6.ts)
 @[code](@/content/guides/columns/column-width/angular/example6.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example6 :vue3
+
+@[code](@/content/guides/columns/column-width/vue/example6.vue)
 
 :::
 

--- a/docs/content/guides/columns/column-width/vue/example1.vue
+++ b/docs/content/guides/columns/column-width/vue/example1.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1', 'J1', 'K1', 'L1', 'M1', 'N1', 'O1'],
+    ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2', 'H2', 'I2', 'J2', 'K2', 'L2', 'M2', 'N2', 'O2'],
+    ['A3', 'B3', 'C3', 'D3', 'E3', 'F3', 'G3', 'H3', 'I3', 'J3', 'K3', 'L3', 'M3', 'N3', 'O3'],
+    ['A4', 'B4', 'C4', 'D4', 'E4', 'F4', 'G4', 'H4', 'I4', 'J4', 'K4', 'L4', 'M4', 'N4', 'O4'],
+    ['A5', 'B5', 'C5', 'D5', 'E5', 'F5', 'G5', 'H5', 'I5', 'J5', 'K5', 'L5', 'M5', 'N5', 'O5'],
+  ],
+  width: '100%',
+  height: 'auto',
+  colHeaders: true,
+  rowHeaders: true,
+  colWidths: 100,
+  manualColumnResize: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-width/vue/example2.vue
+++ b/docs/content/guides/columns/column-width/vue/example2.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['A1', 'B1', 'C1', 'D1', 'E1'],
+    ['A2', 'B2', 'C2', 'D2', 'E2'],
+    ['A3', 'B3', 'C3', 'D3', 'E3'],
+    ['A4', 'B4', 'C4', 'D4', 'E4'],
+    ['A5', 'B5', 'C5', 'D5', 'E5'],
+  ],
+  width: '100%',
+  height: 'auto',
+  colHeaders: true,
+  rowHeaders: true,
+  colWidths: [50, 100, 200, 400],
+  manualColumnResize: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example2">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-width/vue/example3.vue
+++ b/docs/content/guides/columns/column-width/vue/example3.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['A1', 'B1', 'C1', 'D1', 'E1'],
+    ['A2', 'B2', 'C2', 'D2', 'E2'],
+    ['A3', 'B3', 'C3', 'D3', 'E3'],
+    ['A4', 'B4', 'C4', 'D4', 'E4'],
+    ['A5', 'B5', 'C5', 'D5', 'E5'],
+  ],
+  width: '100%',
+  height: 'auto',
+  colHeaders: true,
+  rowHeaders: true,
+  colWidths(index) {
+    return (index + 1) * 40;
+  },
+  manualColumnResize: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example3">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-width/vue/example4.vue
+++ b/docs/content/guides/columns/column-width/vue/example4.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['A1', 'B1', 'C1', 'D1', 'E1', 'F1'],
+    ['A2', 'B2', 'C2', 'D2', 'E2', 'F2'],
+    ['A3', 'B3', 'C3', 'D3', 'E3', 'F3'],
+    ['A4', 'B4', 'C4', 'D4', 'E4', 'F4'],
+    ['A5', 'B5', 'C5', 'D5', 'E5', 'F5'],
+  ],
+  width: '100%',
+  height: 'auto',
+  colHeaders: true,
+  rowHeaders: true,
+  colWidths: [200, 100, 100],
+  manualColumnResize: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example4">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-width/vue/example5.vue
+++ b/docs/content/guides/columns/column-width/vue/example5.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['A1', 'B1', 'C1'],
+    ['A2', 'B2', 'C2'],
+    ['A3', 'B3', 'C3'],
+    ['A4', 'B4', 'C4'],
+    ['A5', 'B5', 'C5'],
+  ],
+  width: '100%',
+  height: 'auto',
+  colHeaders: true,
+  rowHeaders: true,
+  stretchH: 'all',
+  contextMenu: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example5">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-width/vue/example6.vue
+++ b/docs/content/guides/columns/column-width/vue/example6.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['A1', 'B1', 'C1', 'D1'],
+    ['A2', 'B2', 'C2', 'D2'],
+    ['A3', 'B3', 'C3', 'D3'],
+    ['A4', 'B4', 'C4', 'D4'],
+    ['A5', 'B5', 'C5', 'D5'],
+  ],
+  width: '100%',
+  height: 'auto',
+  colWidths: 80,
+  colHeaders: true,
+  rowHeaders: true,
+  stretchH: 'last',
+  contextMenu: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example6">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>


### PR DESCRIPTION
### Context

The PR adds Vue 3 SFC variants to all 10 Columns guide pages. These pages previously had JavaScript, React, and Angular examples but no Vue variant, leaving the `vue-data-grid/columns/*` routes without working demos.

Each page now has full parity with React/Angular: every existing example has an equivalent `vue/<id>.vue` Single File Component (using `<script setup lang="ts">`, `@handsontable/vue3`, and `registerAllModules()`) and a corresponding `::: only-for vue` block in the guide's `.md` file.

Pages covered (47 Vue SFC files total):
- `column-filter` (12 examples, incl. interactive ports: quick filter, custom filter buttons, server-side filter, filter-through-API)
- `column-freezing` (2)
- `column-groups` (2)
- `column-header` (5, incl. `headerClassName` styling via non-scoped `<style>`)
- `column-hiding` (6)
- `column-menu` (2)
- `column-moving` (3)
- `column-summary` (8)
- `column-virtualization` (1)
- `column-width` (6)

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1738

### How has this been tested?

- Manually visited each `vue-data-grid/columns/*` route on the local dev server and confirmed every example renders a live grid with no console errors.
- Verified interactive controls (filter buttons, quick filter, server-side filter, API-driven filter actions) work as expected.
- Confirmed Edit-on-StackBlitz opens and renders the grid for representative examples.
- Spot-checked that existing JavaScript, React, and Angular variants are unchanged.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1738

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only additions (markdown and example SFCs); no production package or API surface changes.
> 
> **Overview**
> This PR brings **Vue 3 documentation parity** to all ten **Columns** guides by adding TypeScript SFC examples and wiring them into the docs site.
> 
> **Docs authoring** — `creating-docs-examples` and `writing-docs-pages` now standardize Vue on **single `.vue` files** with `<script setup lang="ts">`, `:vue3` embeds, and no legacy `--html` / `--js` split tabs.
> 
> **Guide content** — Each columns page (`column-filter`, `column-freezing`, `column-groups`, `column-header`, `column-hiding`, `column-menu`, `column-moving`, `column-summary`, `column-virtualization`, `column-width`) gains `::: only-for vue` blocks that reference new `vue/*.vue` demos. Examples follow the same patterns as other frameworks (`HotTable`, `registerAllModules()`, `licenseKey`, template refs for `hotInstance` where needed). Heavier ports include **column-filter** (quick filter UI, custom filter button CSS, server-side `beforeFilter`, API-driven filters) and **column-summary** (function-based `columnSummary`, nested rows, custom summaries).
> 
> **Scope** — Documentation and example assets only; no changes to `@handsontable/vue3` or core grid behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 156df65640aa4e06a97e60286207c40d8ac77c4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->