### PR TITLE
DEV-1742: Add Vue 3 variants to cell features guides

### DIFF
--- a/docs/content/guides/cell-features/autofill-values/autofill-values.md
+++ b/docs/content/guides/cell-features/autofill-values/autofill-values.md
@@ -69,6 +69,16 @@ Using the tiny square known as the 'fill handle' in the corner of the selected c
 
 :::
 
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/cell-features/autofill-values/vue/example1.vue)
+
+:::
+
+:::
+
 ## Autofill in a vertical direction only and creating new rows
 
 In this configuration, the fill handle is restricted to move only vertically. New rows are automatically added to the bottom of the table by changing [`autoInsertRow`](@/api/options.md#fillhandle) to `true`.
@@ -101,6 +111,16 @@ In this configuration, the fill handle is restricted to move only vertically. Ne
 
 @[code](@/content/guides/cell-features/autofill-values/angular/example2.ts)
 @[code](@/content/guides/cell-features/autofill-values/angular/example2.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example2 :vue3
+
+@[code](@/content/guides/cell-features/autofill-values/vue/example2.vue)
 
 :::
 

--- a/docs/content/guides/cell-features/autofill-values/vue/example1.vue
+++ b/docs/content/guides/cell-features/autofill-values/vue/example1.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const data: (string | number)[][] = [
+  ['', 'Tesla', 'Nissan', 'Toyota', 'Honda'],
+  ['2017', 10, 11, 12, 13],
+  ['2018', 20, 11, 14, 13],
+  ['2019', 30, 15, 12, 13],
+  ['2020', '', '', '', ''],
+  ['2021', '', '', '', ''],
+];
+
+const hotSettings = ref<GridSettings>({
+  data,
+  rowHeaders: true,
+  colHeaders: true,
+  fillHandle: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-features/autofill-values/vue/example2.vue
+++ b/docs/content/guides/cell-features/autofill-values/vue/example2.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const data: (string | number)[][] = [
+  ['', 'Tesla', 'Nissan', 'Toyota', 'Honda'],
+  ['2017', 10, 11, 12, 13],
+  ['2018', 20, 11, 14, 13],
+  ['2019', 30, 15, 12, 13],
+  ['2020', '', '', '', ''],
+  ['2021', '', '', '', ''],
+];
+
+const hotSettings = ref<GridSettings>({
+  data,
+  rowHeaders: true,
+  colHeaders: true,
+  fillHandle: {
+    direction: 'vertical',
+    autoInsertRow: true,
+  },
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example2">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-features/clipboard/clipboard.md
+++ b/docs/content/guides/cell-features/clipboard/clipboard.md
@@ -86,6 +86,14 @@ You can use them in the same way as the rest of the predefined items in the [con
 :::
 :::
 
+::: only-for vue
+::: example #example1 :vue3
+
+@[code](@/content/guides/cell-features/clipboard/vue/example1.vue)
+
+:::
+:::
+
 ### Trigger copy & cut programmatically
 
 ::: only-for react
@@ -104,6 +112,14 @@ For more information, see the [Instance methods](@/guides/getting-started/react-
 To use the Handsontable API, you'll need access to the Handsontable instance. You can do that by utilizing a reference to the `HotTable` component, and reading its `hotInstance` property.
 
 For more information, see the [Instance access](@/guides/getting-started/angular-hot-instance/angular-hot-instance.md) page.
+
+:::
+:::
+
+::: only-for vue
+::: tip
+
+To use the Handsontable API, add a template `ref` on `<HotTable>` and read `hotTableRef.value?.hotInstance`.
 
 :::
 :::
@@ -145,6 +161,14 @@ The [`CopyPaste`](@/api/copyPaste.md) plugin listens to the browser's `copy` and
 
 @[code](@/content/guides/cell-features/clipboard/angular/example3.ts)
 @[code](@/content/guides/cell-features/clipboard/angular/example3.html)
+
+:::
+:::
+
+::: only-for vue
+::: example #example3 :vue3
+
+@[code](@/content/guides/cell-features/clipboard/vue/example3.vue)
 
 :::
 :::
@@ -207,6 +231,14 @@ Right-click on a cell to try it out:
 :::
 :::
 
+::: only-for vue
+::: example #example2 :vue3
+
+@[code](@/content/guides/cell-features/clipboard/vue/example2.vue)
+
+:::
+:::
+
 To add the context menu items, configure the [`CopyPaste`](@/api/copyPaste.md) plugin with these options:
 
 - [`copyColumnHeaders`](@/api/options.md#copypaste-additional-options)
@@ -243,6 +275,14 @@ For more information, see the [Instance methods](@/guides/getting-started/react-
 To use the Handsontable API, you'll need access to the Handsontable instance. You can do that by utilizing a reference to the `HotTable` component, and reading its `hotInstance` property.
 
 For more information, see the [Instance access](@/guides/getting-started/angular-hot-instance/angular-hot-instance.md) page.
+
+:::
+:::
+
+::: only-for vue
+::: tip
+
+To use the Handsontable API, add a template `ref` on `<HotTable>` and read `hotTableRef.value?.hotInstance`.
 
 :::
 :::

--- a/docs/content/guides/cell-features/clipboard/vue/example1.vue
+++ b/docs/content/guides/cell-features/clipboard/vue/example1.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['A1', 'B1', 'C1', 'D1', 'E1'],
+    ['A2', 'B2', 'C2', 'D2', 'E2'],
+    ['A3', 'B3', 'C3', 'D3', 'E3'],
+    ['A4', 'B4', 'C4', 'D4', 'E4'],
+    ['A5', 'B5', 'C5', 'D5', 'E5'],
+  ],
+  rowHeaders: true,
+  colHeaders: true,
+  contextMenu: ['copy', 'cut'],
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-features/clipboard/vue/example2.vue
+++ b/docs/content/guides/cell-features/clipboard/vue/example2.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1', 'J1'],
+    ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2', 'H2', 'I2', 'J2'],
+    ['A3', 'B3', 'C3', 'D3', 'E3', 'F3', 'G3', 'H3', 'I3', 'J3'],
+    ['A4', 'B4', 'C4', 'D4', 'E4', 'F4', 'G4', 'H4', 'I4', 'J4'],
+    ['A5', 'B5', 'C5', 'D5', 'E5', 'F5', 'G5', 'H5', 'I5', 'J5'],
+  ],
+  contextMenu: true,
+  copyPaste: {
+    copyColumnHeaders: true,
+    copyColumnGroupHeaders: true,
+    copyColumnHeadersOnly: true,
+  },
+  colHeaders: true,
+  rowHeaders: true,
+  height: 'auto',
+  nestedHeaders: [
+    [
+      'A',
+      { label: 'B', colspan: 2 },
+      { label: 'C', colspan: 2 },
+      { label: 'D', colspan: 2 },
+      { label: 'E', colspan: 2 },
+      'F',
+    ],
+    ['G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P'],
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example2">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-features/clipboard/vue/example3.vue
+++ b/docs/content/guides/cell-features/clipboard/vue/example3.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotTableRef = ref<InstanceType<typeof HotTable> | null>(null);
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['A1', 'B1', 'C1', 'D1', 'E1'],
+    ['A2', 'B2', 'C2', 'D2', 'E2'],
+    ['A3', 'B3', 'C3', 'D3', 'E3'],
+    ['A4', 'B4', 'C4', 'D4', 'E4'],
+    ['A5', 'B5', 'C5', 'D5', 'E5'],
+  ],
+  rowHeaders: true,
+  colHeaders: true,
+  outsideClickDeselects: false,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+const copyBtnClickCallback = () => {
+  document.execCommand('copy');
+};
+
+const cutBtnClickCallback = () => {
+  document.execCommand('cut');
+};
+
+const copyBtnMousedownCallback = () => {
+  hotTableRef.value?.hotInstance?.selectCell(1, 1);
+};
+
+const cutBtnMousedownCallback = () => {
+  hotTableRef.value?.hotInstance?.selectCell(1, 1);
+};
+</script>
+
+<template>
+  <div id="example3">
+    <div class="example-controls-container">
+      <div class="controls">
+        <button
+          id="copy"
+          type="button"
+          @mousedown="copyBtnMousedownCallback"
+          @click="copyBtnClickCallback"
+        >
+          Select and copy cell B2
+        </button>
+        <button
+          id="cut"
+          type="button"
+          @mousedown="cutBtnMousedownCallback"
+          @click="cutBtnClickCallback"
+        >
+          Select and cut cell B2
+        </button>
+      </div>
+    </div>
+    <HotTable ref="hotTableRef" :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-features/comments/comments.md
+++ b/docs/content/guides/cell-features/comments/comments.md
@@ -78,6 +78,23 @@ settings = {
 
 :::
 
+::: only-for vue
+
+```js
+const hotSettings = {
+  data: [
+    ['A1', 'B1', 'C1'],
+    ['A2', 'B2', 'C2'],
+  ],
+  comments: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+};
+```
+
+:::
+
 ## Add comments via the context menu
 
 After you've enabled the plugin, the [Context Menu](@/guides/accessories-and-menus/context-menu/context-menu.md) gains a few new items:
@@ -120,6 +137,18 @@ settings = {
 
 :::
 
+::: only-for vue
+
+```js
+const hotSettings = {
+  cell: [
+    { row: 1, col: 1, comment: { value: 'Hello world!' } },
+  ],
+};
+```
+
+:::
+
 In this example, the comment "Hello world!" is added to the cell at `(1,1)`.
 
 ## Basic example
@@ -152,6 +181,16 @@ In this example, the comment "Hello world!" is added to the cell at `(1,1)`.
 
 @[code](@/content/guides/cell-features/comments/angular/example1.ts)
 @[code](@/content/guides/cell-features/comments/angular/example1.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/cell-features/comments/vue/example1.vue)
 
 :::
 
@@ -194,6 +233,16 @@ By default, all comments are editable. To change this, set the [`readOnly`](@/ap
 
 :::
 
+::: only-for vue
+
+::: example #example2 :vue3
+
+@[code](@/content/guides/cell-features/comments/vue/example2.vue)
+
+:::
+
+:::
+
 ## Set a comment box's size
 
 To set the width and height of a comment box, use the [`style`](@/api/options.md#comments) parameter.
@@ -231,6 +280,16 @@ To set the width and height of a comment box, use the [`style`](@/api/options.md
 
 :::
 
+::: only-for vue
+
+::: example #example3 :vue3
+
+@[code](@/content/guides/cell-features/comments/vue/example3.vue)
+
+:::
+
+:::
+
 ## Set a delay for displaying comments
 
 To display comments after a pre-configured time delay, use the [`displayDelay`](@/api/options.md#comments) parameter.
@@ -263,6 +322,16 @@ To display comments after a pre-configured time delay, use the [`displayDelay`](
 
 @[code](@/content/guides/cell-features/comments/angular/example4.ts)
 @[code](@/content/guides/cell-features/comments/angular/example4.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example4 :vue3
+
+@[code](@/content/guides/cell-features/comments/vue/example4.vue)
 
 :::
 

--- a/docs/content/guides/cell-features/comments/vue/example1.vue
+++ b/docs/content/guides/cell-features/comments/vue/example1.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['', 'Tesla', 'Nissan', 'Toyota', 'Honda', 'Mazda', 'Ford'],
+    ['2017', 10, 11, 12, 13, 15, 16],
+    ['2018', 10, 11, 12, 13, 15, 16],
+    ['2019', 10, 11, 12, 13, 15, 16],
+    ['2020', 10, 11, 12, 13, 15, 16],
+    ['2021', 10, 11, 12, 13, 15, 16],
+  ],
+  rowHeaders: true,
+  colHeaders: true,
+  contextMenu: true,
+  comments: true,
+  cell: [
+    { row: 1, col: 1, comment: { value: 'Some comment' } },
+    { row: 2, col: 2, comment: { value: 'More comments' } },
+  ],
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-features/comments/vue/example2.vue
+++ b/docs/content/guides/cell-features/comments/vue/example2.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['', 'Tesla', 'Toyota', 'Honda', 'Ford'],
+    ['2018', 10, 11, 12, 13, 15, 16],
+    ['2019', 10, 11, 12, 13, 15, 16],
+    ['2020', 10, 11, 12, 13, 15, 16],
+  ],
+  rowHeaders: true,
+  colHeaders: true,
+  contextMenu: true,
+  comments: true,
+  cell: [
+    {
+      row: 0,
+      col: 1,
+      comment: { value: 'A read-only comment.', readOnly: true },
+    },
+    { row: 0, col: 3, comment: { value: 'You can edit this comment' } },
+  ],
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example2">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-features/comments/vue/example3.vue
+++ b/docs/content/guides/cell-features/comments/vue/example3.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['', 'Tesla', 'Nissan', 'Toyota', 'Honda', 'Mazda', 'Ford'],
+    ['2017', 10, 11, 12, 13, 15, 16],
+    ['2018', 10, 11, 12, 13, 15, 16],
+    ['2019', 10, 11, 12, 13, 15, 16],
+  ],
+  rowHeaders: true,
+  colHeaders: true,
+  contextMenu: true,
+  comments: true,
+  cell: [
+    { row: 1, col: 1, comment: { value: 'Some comment' } },
+    {
+      row: 2,
+      col: 2,
+      comment: {
+        value: 'Comment 200x50 px',
+        style: { width: 200, height: 50 },
+      },
+    },
+  ],
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example3">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-features/comments/vue/example4.vue
+++ b/docs/content/guides/cell-features/comments/vue/example4.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['', 'Tesla', 'Toyota', 'Honda', 'Ford'],
+    ['2018', 10, 11, 12, 13, 15, 16],
+    ['2019', 10, 11, 12, 13, 15, 16],
+    ['2020', 10, 11, 12, 13, 15, 16],
+  ],
+  rowHeaders: true,
+  colHeaders: true,
+  contextMenu: true,
+  comments: {
+    displayDelay: 2000,
+  },
+  cell: [{ row: 1, col: 1, comment: { value: 'Some comment' } }],
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example4">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-features/conditional-formatting/conditional-formatting.md
+++ b/docs/content/guides/cell-features/conditional-formatting/conditional-formatting.md
@@ -72,6 +72,16 @@ This demo shows how to use the cell type renderer feature to make some condition
 
 :::
 
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/cell-features/conditional-formatting/vue/example1.vue)
+
+:::
+
+:::
+
 ## Related articles
 
 **Related guides**

--- a/docs/content/guides/cell-features/conditional-formatting/vue/example1.vue
+++ b/docs/content/guides/cell-features/conditional-formatting/vue/example1.vue
@@ -1,0 +1,102 @@
+<script setup lang="ts">
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import { registerRenderer } from 'handsontable/renderers';
+import type { BaseRenderer } from 'handsontable/renderers';
+import { textRenderer } from 'handsontable/renderers/textRenderer';
+import type { GridSettings } from 'handsontable/settings';
+import type Handsontable from 'handsontable/base';
+import { ref } from 'vue';
+
+registerAllModules();
+
+const data: (string | number)[][] = [
+  ['', 'Tesla', 'Nissan', 'Toyota', 'Honda'],
+  ['2017', -5, '', 12, 13],
+  ['2018', '', -11, 14, 13],
+  ['2019', '', 15, -12, 'readOnly'],
+];
+
+const firstRowRenderer: BaseRenderer = (instance, td, ...rest) => {
+  textRenderer(instance, td, ...rest);
+  td.style.fontWeight = 'bold';
+  td.style.color = 'green';
+  td.style.background = '#CEC';
+};
+
+const negativeValueRenderer: BaseRenderer = (instance, td, row, col, prop, value, cellProperties) => {
+  textRenderer(instance, td, row, col, prop, value, cellProperties);
+
+  if (parseInt(String(value), 10) < 0) {
+    td.className = 'make-me-red';
+  }
+
+  if (!value || value === '') {
+    td.style.background = 'rgb(238, 238, 238, 0.4)';
+  } else {
+    if (instance.getDataAtCell(0, col) === 'Nissan') {
+      td.style.fontStyle = 'italic';
+    }
+
+    td.style.background = '';
+  }
+};
+
+registerRenderer('negativeValueRenderer', negativeValueRenderer);
+
+const hotTableRef = ref<InstanceType<typeof HotTable> | null>(null);
+
+const hotSettings: GridSettings = {
+  data,
+  licenseKey: 'non-commercial-and-evaluation',
+  height: 'auto',
+  afterSelection(_row, _col, row2, col2) {
+    const hot = hotTableRef.value?.hotInstance;
+
+    if (!hot) {
+      return;
+    }
+
+    const meta = hot.getCellMeta(row2, col2);
+
+    if (meta.readOnly) {
+      hot.updateSettings({
+        fillHandle: false,
+      });
+    } else {
+      hot.updateSettings({
+        fillHandle: true,
+      });
+    }
+  },
+  cells(row, col) {
+    const cellProperties: Handsontable.CellMeta = {};
+
+    if (row === 0 || (data[row] && data[row][col] === 'readOnly')) {
+      cellProperties.readOnly = true;
+    }
+
+    if (row === 0) {
+      cellProperties.renderer = firstRowRenderer;
+    } else {
+      cellProperties.renderer = 'negativeValueRenderer';
+    }
+
+    return cellProperties;
+  },
+  autoWrapRow: true,
+  autoWrapCol: true,
+};
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable ref="hotTableRef" :settings="hotSettings" />
+  </div>
+</template>
+
+<style>
+.make-me-red {
+  color: #FF5A12 !important;
+}
+</style>

--- a/docs/content/guides/cell-features/disabled-cells/disabled-cells.md
+++ b/docs/content/guides/cell-features/disabled-cells/disabled-cells.md
@@ -78,6 +78,16 @@ To make the entire grid read-only, set [`readOnly`](@/api/options.md#readonly) t
 
 :::
 
+::: only-for vue
+
+::: example #exampleReadOnlyGrid :vue3
+
+@[code](@/content/guides/cell-features/disabled-cells/vue/exampleReadOnlyGrid.vue)
+
+:::
+
+:::
+
 ## To disable a column
 
 To make a column read-only, declare it in the [`columns`](@/api/options.md#columns) configuration option. The column remains available for keyboard navigation and copying data (<kbd>**Ctrl**</kbd>/<kbd>**Cmd**</kbd>+<kbd>**C**</kbd>), but editing and pasting are disabled. You can also define a special renderer function that will dim the read-only values, providing a visual cue for the user that the cells are read-only.
@@ -117,6 +127,16 @@ To make a column read-only, declare it in the [`columns`](@/api/options.md#colum
 
 :::
 
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/cell-features/disabled-cells/vue/example1.vue)
+
+:::
+
+:::
+
 ## To disable a row
 
 To make specific cells read-only, use the [`cells`](@/api/options.md#cells) function to set the [`readOnly`](@/api/options.md#readonly) property conditionally. The example below makes cells that contain the word "Nissan" read-only.
@@ -149,6 +169,16 @@ To make specific cells read-only, use the [`cells`](@/api/options.md#cells) func
 
 @[code](@/content/guides/cell-features/disabled-cells/angular/example2.ts)
 @[code](@/content/guides/cell-features/disabled-cells/angular/example2.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example2 :vue3
+
+@[code](@/content/guides/cell-features/disabled-cells/vue/example2.vue)
 
 :::
 
@@ -193,6 +223,16 @@ To make a column non-editable, declare it in the [`columns`](@/api/options.md#co
 
 :::
 
+::: only-for vue
+
+::: example #example3 :vue3
+
+@[code](@/content/guides/cell-features/disabled-cells/vue/example3.vue)
+
+:::
+
+:::
+
 ## To disable a cell
 
 To make specific cells non-editable, set `editor: false` in the cell configuration. The following example shows a table with non-editable cells containing the word "Nissan".
@@ -225,6 +265,16 @@ To make specific cells non-editable, set `editor: false` in the cell configurati
 
 @[code](@/content/guides/cell-features/disabled-cells/angular/example4.ts)
 @[code](@/content/guides/cell-features/disabled-cells/angular/example4.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example4 :vue3
+
+@[code](@/content/guides/cell-features/disabled-cells/vue/example4.vue)
 
 :::
 

--- a/docs/content/guides/cell-features/disabled-cells/vue/example1.vue
+++ b/docs/content/guides/cell-features/disabled-cells/vue/example1.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    { car: 'Tesla', year: 2017, chassis: 'black', bumper: 'black' },
+    { car: 'Nissan', year: 2018, chassis: 'blue', bumper: 'blue' },
+    { car: 'Chrysler', year: 2019, chassis: 'yellow', bumper: 'black' },
+    { car: 'Volvo', year: 2020, chassis: 'white', bumper: 'gray' },
+  ],
+  height: 'auto',
+  colHeaders: ['Car', 'Year', 'Chassis color', 'Bumper color'],
+  licenseKey: 'non-commercial-and-evaluation',
+  columns: [
+    {
+      data: 'car',
+      readOnly: true,
+    },
+    {
+      data: 'year',
+    },
+    {
+      data: 'chassis',
+    },
+    {
+      data: 'bumper',
+    },
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-features/disabled-cells/vue/example2.vue
+++ b/docs/content/guides/cell-features/disabled-cells/vue/example2.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+type CarRow = {
+  car: string;
+  year: number;
+  chassis: string;
+  bumper: string;
+};
+
+const data: CarRow[] = [
+  { car: 'Tesla', year: 2017, chassis: 'black', bumper: 'black' },
+  { car: 'Nissan', year: 2018, chassis: 'blue', bumper: 'blue' },
+  { car: 'Chrysler', year: 2019, chassis: 'yellow', bumper: 'black' },
+  { car: 'Volvo', year: 2020, chassis: 'white', bumper: 'gray' },
+];
+
+const columnKeys: (keyof CarRow)[] = ['car', 'year', 'chassis', 'bumper'];
+
+const hotSettings: GridSettings = {
+  data,
+  colHeaders: ['Car', 'Year', 'Chassis color', 'Bumper color'],
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+  cells(row, col) {
+    const key = columnKeys[col];
+
+    if (key !== undefined && data[row]?.[key] === 'Nissan') {
+      return { readOnly: true };
+    }
+
+    return {};
+  },
+};
+</script>
+
+<template>
+  <div id="example2">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-features/disabled-cells/vue/example3.vue
+++ b/docs/content/guides/cell-features/disabled-cells/vue/example3.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    { car: 'Tesla', year: 2017, chassis: 'black', bumper: 'black' },
+    { car: 'Nissan', year: 2018, chassis: 'blue', bumper: 'blue' },
+    { car: 'Chrysler', year: 2019, chassis: 'yellow', bumper: 'black' },
+    { car: 'Volvo', year: 2020, chassis: 'white', bumper: 'gray' },
+  ],
+  height: 'auto',
+  colHeaders: ['Car', 'Year', 'Chassis color', 'Bumper color'],
+  licenseKey: 'non-commercial-and-evaluation',
+  columns: [
+    {
+      data: 'car',
+      editor: false,
+    },
+    {
+      data: 'year',
+      editor: 'numeric',
+    },
+    {
+      data: 'chassis',
+      editor: 'text',
+    },
+    {
+      data: 'bumper',
+      editor: 'text',
+    },
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+});
+</script>
+
+<template>
+  <div id="example3">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-features/disabled-cells/vue/example4.vue
+++ b/docs/content/guides/cell-features/disabled-cells/vue/example4.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+type CarRow = {
+  car: string;
+  year: number;
+  chassis: string;
+  bumper: string;
+};
+
+const data: CarRow[] = [
+  { car: 'Tesla', year: 2017, chassis: 'black', bumper: 'black' },
+  { car: 'Nissan', year: 2018, chassis: 'blue', bumper: 'blue' },
+  { car: 'Chrysler', year: 2019, chassis: 'yellow', bumper: 'black' },
+  { car: 'Volvo', year: 2020, chassis: 'white', bumper: 'gray' },
+];
+
+const hotSettings: GridSettings = {
+  data,
+  colHeaders: ['Car', 'Year', 'Chassis color', 'Bumper color'],
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+  cells(row, _col, prop) {
+    const propName = prop as keyof CarRow;
+
+    if (data[row]?.[propName] === 'Nissan') {
+      return { editor: false };
+    }
+
+    return { editor: 'text' };
+  },
+};
+</script>
+
+<template>
+  <div id="example4">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-features/disabled-cells/vue/exampleReadOnlyGrid.vue
+++ b/docs/content/guides/cell-features/disabled-cells/vue/exampleReadOnlyGrid.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    { car: 'Tesla', year: 2017, chassis: 'black', bumper: 'black' },
+    { car: 'Nissan', year: 2018, chassis: 'blue', bumper: 'blue' },
+    { car: 'Chrysler', year: 2019, chassis: 'yellow', bumper: 'black' },
+    { car: 'Volvo', year: 2020, chassis: 'white', bumper: 'gray' },
+  ],
+  height: 'auto',
+  colHeaders: ['Car', 'Year', 'Chassis color', 'Bumper color'],
+  licenseKey: 'non-commercial-and-evaluation',
+  readOnly: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+});
+</script>
+
+<template>
+  <div id="exampleReadOnlyGrid">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-features/formatting-cells/formatting-cells.md
+++ b/docs/content/guides/cell-features/formatting-cells/formatting-cells.md
@@ -70,6 +70,16 @@ In this example, we add a custom class `custom-cell` to the cell in the top left
 
 :::
 
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/cell-features/formatting-cells/vue/example1.vue)
+
+:::
+
+:::
+
 ## Apply inline styles
 
 You can apply inline styles directly to the DOM element using its `style` property. You can use the [`renderer`](@/api/options.md#renderer) option to do that.
@@ -102,6 +112,16 @@ You can apply inline styles directly to the DOM element using its `style` proper
 
 @[code](@/content/guides/cell-features/formatting-cells/angular/example2.ts)
 @[code](@/content/guides/cell-features/formatting-cells/angular/example2.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example2 :vue3
+
+@[code](@/content/guides/cell-features/formatting-cells/vue/example2.vue)
 
 :::
 
@@ -158,6 +178,16 @@ The example below demonstrates different border styles applied to various cell r
 
 @[code](@/content/guides/cell-features/formatting-cells/angular/example3.ts)
 @[code](@/content/guides/cell-features/formatting-cells/angular/example3.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example3 :vue3
+
+@[code](@/content/guides/cell-features/formatting-cells/vue/example3.vue)
 
 :::
 

--- a/docs/content/guides/cell-features/formatting-cells/vue/example1.vue
+++ b/docs/content/guides/cell-features/formatting-cells/vue/example1.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['A1', 'B1', 'C1', 'D1', 'E1'],
+    ['A2', 'B2', 'C2', 'D2', 'E2'],
+    ['A3', 'B3', 'C3', 'D3', 'E3'],
+    ['A4', 'B4', 'C4', 'D4', 'E4'],
+    ['A5', 'B5', 'C5', 'D5', 'E5'],
+  ],
+  rowHeaders: true,
+  colHeaders: true,
+  stretchH: 'all',
+  className: 'custom-table',
+  cell: [
+    {
+      row: 0,
+      col: 0,
+      className: 'custom-cell',
+    },
+  ],
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>
+
+<style>
+td.custom-cell {
+  color: #fff !important;
+  background-color: #254ac6 !important;
+}
+.custom-table thead th:nth-child(even),
+.custom-table tbody tr:nth-child(odd) th {
+  color: #fff !important;
+  background-color: #254ac6 !important;
+}
+</style>

--- a/docs/content/guides/cell-features/formatting-cells/vue/example2.vue
+++ b/docs/content/guides/cell-features/formatting-cells/vue/example2.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import { registerRenderer } from 'handsontable/renderers';
+import { textRenderer } from 'handsontable/renderers/textRenderer';
+import type { BaseRenderer } from 'handsontable/renderers';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const customStylesRenderer: BaseRenderer = (hotInstance, TD, ...rest) => {
+  textRenderer(hotInstance, TD, ...rest);
+  TD.style.fontWeight = 'bold';
+  TD.style.color = 'green';
+  TD.style.background = '#d7f1e1';
+};
+
+registerRenderer('customStylesRenderer', customStylesRenderer);
+
+const hotSettings: GridSettings = {
+  data: [
+    ['A1', 'B1', 'C1', 'D1', 'E1'],
+    ['A2', 'B2', 'C2', 'D2', 'E2'],
+    ['A3', 'B3', 'C3', 'D3', 'E3'],
+    ['A4', 'B4', 'C4', 'D4', 'E4'],
+    ['A5', 'B5', 'C5', 'D5', 'E5'],
+  ],
+  rowHeaders: true,
+  colHeaders: true,
+  stretchH: 'all',
+  cell: [
+    {
+      row: 0,
+      col: 0,
+      renderer: customStylesRenderer,
+    },
+  ],
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+};
+</script>
+
+<template>
+  <div id="example2">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-features/formatting-cells/vue/example3.vue
+++ b/docs/content/guides/cell-features/formatting-cells/vue/example3.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['A1', 'B1', 'C1', 'D1', 'E1', 'F1'],
+    ['A2', 'B2', 'C2', 'D2', 'E2', 'F2'],
+    ['A3', 'B3', 'C3', 'D3', 'E3', 'F3'],
+    ['A4', 'B4', 'C4', 'D4', 'E4', 'F4'],
+    ['A5', 'B5', 'C5', 'D5', 'E5', 'F5'],
+  ],
+  rowHeaders: true,
+  colHeaders: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  stretchH: 'all',
+  height: 'auto',
+  licenseKey: 'non-commercial-and-evaluation',
+  customBorders: [
+    {
+      range: {
+        from: {
+          row: 1,
+          col: 1,
+        },
+        to: {
+          row: 3,
+          col: 4,
+        },
+      },
+      top: {
+        width: 2,
+        color: '#5292F7',
+        style: 'dotted',
+      },
+      bottom: {
+        width: 2,
+        color: 'red',
+      },
+      start: {
+        width: 2,
+        color: 'orange',
+        style: 'dashed',
+      },
+      end: {
+        width: 2,
+        color: 'magenta',
+      },
+    },
+    {
+      row: 2,
+      col: 2,
+      start: {
+        width: 2,
+        color: 'red',
+      },
+      end: {
+        width: 1,
+        color: 'green',
+      },
+    },
+  ],
+});
+</script>
+
+<template>
+  <div id="example3">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-features/merge-cells/merge-cells.md
+++ b/docs/content/guides/cell-features/merge-cells/merge-cells.md
@@ -52,6 +52,16 @@ To initialize Handsontable with predefined merged cells, provide merged cells de
 
 :::
 
+::: only-for vue
+
+```js
+const hotSettings = {
+  mergeCells: [{ row: 1, col: 1, rowspan: 2, colspan: 2 }],
+};
+```
+
+:::
+
 ::: only-for javascript
 
 ::: example #example1 --js 1 --ts 2
@@ -80,6 +90,16 @@ To initialize Handsontable with predefined merged cells, provide merged cells de
 
 @[code](@/content/guides/cell-features/merge-cells/angular/example1.ts)
 @[code](@/content/guides/cell-features/merge-cells/angular/example1.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/cell-features/merge-cells/vue/example1.vue)
 
 :::
 
@@ -126,6 +146,19 @@ settings = {
 
 :::
 
+::: only-for vue
+
+```js
+const hotSettings = {
+  mergeCells: {
+    virtualized: true,
+    cells: [{ row: 1, col: 1, rowspan: 200, colspan: 2 }],
+  },
+};
+```
+
+:::
+
 The example below uses virtualized merged cells. It's also recommended to increase the buffer of rendered rows/columns to minimize the flickering effects.
 
 ::: only-for javascript
@@ -156,6 +189,16 @@ The example below uses virtualized merged cells. It's also recommended to increa
 
 @[code](@/content/guides/cell-features/merge-cells/angular/example2.ts)
 @[code](@/content/guides/cell-features/merge-cells/angular/example2.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example2 :vue3
+
+@[code](@/content/guides/cell-features/merge-cells/vue/example2.vue)
 
 :::
 

--- a/docs/content/guides/cell-features/merge-cells/vue/example1.vue
+++ b/docs/content/guides/cell-features/merge-cells/vue/example1.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const data = new Array(100)
+  .fill(null)
+  .map((_, row) =>
+    new Array(50)
+      .fill(null)
+      .map((_, column) => `${row}, ${column}`)
+  );
+
+const hotSettings = ref<GridSettings>({
+  data,
+  height: 320,
+  autoColumnSize: {
+    allowSampleDuplicates: true,
+    samplingRatio: 100,
+  },
+  rowHeaders: true,
+  colHeaders: true,
+  contextMenu: true,
+  mergeCells: [
+    { row: 1, col: 1, rowspan: 3, colspan: 3 },
+    { row: 3, col: 4, rowspan: 2, colspan: 2 },
+    { row: 5, col: 6, rowspan: 3, colspan: 3 },
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-features/merge-cells/vue/example2.vue
+++ b/docs/content/guides/cell-features/merge-cells/vue/example2.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const data = new Array(50)
+  .fill(null)
+  .map((_, row) =>
+    new Array(500)
+      .fill(null)
+      .map((_, column) => `${row}, ${column}`)
+  );
+
+const hotSettings = ref<GridSettings>({
+  data,
+  height: 320,
+  colWidths: 100,
+  rowHeaders: true,
+  colHeaders: true,
+  contextMenu: true,
+  mergeCells: {
+    virtualized: true,
+    cells: [{ row: 1, col: 1, rowspan: 3, colspan: 498 }],
+  },
+  viewportColumnRenderingOffset: 15,
+  viewportColumnRenderingThreshold: 5,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example2">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-features/selection/selection.md
+++ b/docs/content/guides/cell-features/selection/selection.md
@@ -84,6 +84,16 @@ Possible values of [`selectionMode`](@/api/options.md#selectionmode):
 
 :::
 
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/cell-features/selection/vue/example1.vue)
+
+:::
+
+:::
+
 ## Get data from the selected ranges
 
 To retrieve the selected cells as an array of arrays, you use the [`getSelected()`](@/api/core.md#getselected) or [`getSelectedRange()`](@/api/core.md#getselectedrange) methods.
@@ -117,6 +127,16 @@ To retrieve the selected cells as an array of arrays, you use the [`getSelected(
 
 @[code](@/content/guides/cell-features/selection/angular/example2.ts)
 @[code](@/content/guides/cell-features/selection/angular/example2.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example2 :vue3
+
+@[code](@/content/guides/cell-features/selection/vue/example2.vue)
 
 :::
 
@@ -157,6 +177,16 @@ You may want to delete, format, or otherwise change the selected cells. For exam
 
 @[code](@/content/guides/cell-features/selection/angular/example3.ts)
 @[code](@/content/guides/cell-features/selection/angular/example3.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example3 :vue3
+
+@[code](@/content/guides/cell-features/selection/vue/example3.vue)
 
 :::
 
@@ -206,6 +236,16 @@ The example below customizes the color of each selection layer using these CSS c
 
 :::
 
+::: only-for vue
+
+::: example #example4 :vue3
+
+@[code](@/content/guides/cell-features/selection/vue/example4.vue)
+
+:::
+
+:::
+
 Unfortunately, there is no easy way to change the border color of the selection.
 
 ## Select cells programmatically
@@ -241,6 +281,16 @@ Use [`selectCell()`](@/api/core.md#selectcell) to select a single cell or a rang
 
 @[code](@/content/guides/cell-features/selection/angular/example5.ts)
 @[code](@/content/guides/cell-features/selection/angular/example5.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example5 :vue3
+
+@[code](@/content/guides/cell-features/selection/vue/example5.vue)
 
 :::
 

--- a/docs/content/guides/cell-features/selection/vue/example1.vue
+++ b/docs/content/guides/cell-features/selection/vue/example1.vue
@@ -1,0 +1,116 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const options = [
+  { value: 'single', label: 'Single selection' },
+  { value: 'range', label: 'Range selection' },
+  { value: 'multiple', label: 'Multiple ranges selection' },
+] as const;
+
+const dropdownRef = ref<HTMLDivElement | null>(null);
+const isOpen = ref(false);
+const selected = ref<'single' | 'range' | 'multiple'>('multiple');
+
+const selectedLabel = computed(() => options.find((o) => o.value === selected.value)?.label);
+
+const hotSettings = computed<GridSettings>(() => ({
+  data: [
+    ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1'],
+    ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2', 'H2', 'I2'],
+    ['A3', 'B3', 'C3', 'D3', 'E3', 'F3', 'G3', 'H3', 'I3'],
+    ['A4', 'B4', 'C4', 'D4', 'E4', 'F4', 'G4', 'H4', 'I4'],
+    ['A5', 'B5', 'C5', 'D5', 'E5', 'F5', 'G5', 'H5', 'I5'],
+    ['A6', 'B6', 'C6', 'D6', 'E6', 'F6', 'G6', 'H6', 'I6'],
+    ['A7', 'B7', 'C7', 'D7', 'E7', 'F7', 'G7', 'H7', 'I7'],
+    ['A8', 'B8', 'C8', 'D8', 'E8', 'F8', 'G8', 'H8', 'I8'],
+    ['A9', 'B9', 'C9', 'D9', 'E9', 'F9', 'G9', 'H9', 'I9'],
+  ],
+  width: 'auto',
+  height: 'auto',
+  colWidths: 100,
+  rowHeaders: true,
+  colHeaders: true,
+  selectionMode: selected.value,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+}));
+
+const handleOutsideClick = (e: MouseEvent) => {
+  if (dropdownRef.value && !dropdownRef.value.contains(e.target as Node)) {
+    isOpen.value = false;
+  }
+};
+
+const handleEscape = (e: KeyboardEvent) => {
+  if (e.key === 'Escape') {
+    isOpen.value = false;
+  }
+};
+
+onMounted(() => {
+  document.addEventListener('click', handleOutsideClick);
+  document.addEventListener('keydown', handleEscape);
+});
+
+onUnmounted(() => {
+  document.removeEventListener('click', handleOutsideClick);
+  document.removeEventListener('keydown', handleEscape);
+});
+
+const handleSelect = (value: 'single' | 'range' | 'multiple') => {
+  selected.value = value;
+  isOpen.value = false;
+};
+</script>
+
+<template>
+  <div id="example1">
+    <div class="example-controls-container">
+      <div class="controls">
+        <div ref="dropdownRef" class="theme-dropdown">
+          <button
+            class="theme-dropdown-trigger"
+            type="button"
+            aria-haspopup="listbox"
+            :aria-expanded="isOpen"
+            @click="isOpen = !isOpen"
+          >
+            <span>{{ selectedLabel }}</span>
+            <svg
+              class="theme-dropdown-chevron"
+              aria-hidden="true"
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="M6 9l6 6l6 -6" />
+            </svg>
+          </button>
+          <ul v-if="isOpen" class="theme-dropdown-menu" role="listbox">
+            <li
+              v-for="opt in options"
+              :key="opt.value"
+              role="option"
+              :aria-selected="selected === opt.value"
+              @click="handleSelect(opt.value)"
+            >
+              {{ opt.label }}
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <HotTable :key="selected" :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-features/selection/vue/example2.vue
+++ b/docs/content/guides/cell-features/selection/vue/example2.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type Handsontable from 'handsontable/base';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotTableRef = ref<InstanceType<typeof HotTable> | null>(null);
+const output = ref('');
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1'],
+    ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2', 'H2', 'I2'],
+    ['A3', 'B3', 'C3', 'D3', 'E3', 'F3', 'G3', 'H3', 'I3'],
+    ['A4', 'B4', 'C4', 'D4', 'E4', 'F4', 'G4', 'H4', 'I4'],
+    ['A5', 'B5', 'C5', 'D5', 'E5', 'F5', 'G5', 'H5', 'I5'],
+    ['A6', 'B6', 'C6', 'D6', 'E6', 'F6', 'G6', 'H6', 'I6'],
+    ['A7', 'B7', 'C7', 'D7', 'E7', 'F7', 'G7', 'H7', 'I7'],
+    ['A8', 'B8', 'C8', 'D8', 'E8', 'F8', 'G8', 'H8', 'I8'],
+    ['A9', 'B9', 'C9', 'D9', 'E9', 'F9', 'G9', 'H9', 'I9'],
+  ],
+  width: 'auto',
+  height: 'auto',
+  colWidths: 100,
+  rowHeaders: true,
+  colHeaders: true,
+  outsideClickDeselects: false,
+  selectionMode: 'multiple',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+const getButtonClickCallback = () => {
+  const hot = hotTableRef.value?.hotInstance;
+  const selected = hot?.getSelected() || [];
+  let data: Handsontable.CellValue[] = [];
+
+  if (selected.length === 1) {
+    data = hot?.getData(...selected[0]!) || [];
+  } else {
+    for (let i = 0; i < selected.length; i += 1) {
+      const item = selected[i];
+
+      data.push(hot?.getData(...item!));
+    }
+  }
+
+  output.value = JSON.stringify(data);
+};
+</script>
+
+<template>
+  <div id="example2">
+    <div class="example-controls-container">
+      <div class="controls">
+        <button id="getButton" type="button" @click="getButtonClickCallback">
+          Get data
+        </button>
+      </div>
+      <output id="output" class="console">{{ output }}</output>
+    </div>
+    <HotTable ref="hotTableRef" :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-features/selection/vue/example3.vue
+++ b/docs/content/guides/cell-features/selection/vue/example3.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotTableRef = ref<InstanceType<typeof HotTable> | null>(null);
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1'],
+    ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2', 'H2', 'I2'],
+    ['A3', 'B3', 'C3', 'D3', 'E3', 'F3', 'G3', 'H3', 'I3'],
+    ['A4', 'B4', 'C4', 'D4', 'E4', 'F4', 'G4', 'H4', 'I4'],
+    ['A5', 'B5', 'C5', 'D5', 'E5', 'F5', 'G5', 'H5', 'I5'],
+    ['A6', 'B6', 'C6', 'D6', 'E6', 'F6', 'G6', 'H6', 'I6'],
+    ['A7', 'B7', 'C7', 'D7', 'E7', 'F7', 'G7', 'H7', 'I7'],
+    ['A8', 'B8', 'C8', 'D8', 'E8', 'F8', 'G8', 'H8', 'I8'],
+    ['A9', 'B9', 'C9', 'D9', 'E9', 'F9', 'G9', 'H9', 'I9'],
+  ],
+  width: 'auto',
+  height: 'auto',
+  colWidths: 100,
+  rowHeaders: true,
+  colHeaders: true,
+  outsideClickDeselects: false,
+  selectionMode: 'multiple',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+const buttonClickCallback = () => {
+  const hot = hotTableRef.value?.hotInstance;
+  const selected = hot?.getSelected() || [];
+
+  hot?.suspendRender();
+
+  for (let index = 0; index < selected.length; index += 1) {
+    const [row1, column1, row2, column2] = selected[index];
+    const startRow = Math.max(Math.min(row1, row2), 0);
+    const endRow = Math.max(row1, row2);
+    const startCol = Math.max(Math.min(column1, column2), 0);
+    const endCol = Math.max(column1, column2);
+
+    for (let rowIndex = startRow; rowIndex <= endRow; rowIndex += 1) {
+      for (let columnIndex = startCol; columnIndex <= endCol; columnIndex += 1) {
+        hot?.setDataAtCell(rowIndex, columnIndex, 'data changed');
+        hot?.setCellMeta(rowIndex, columnIndex, 'className', 'c-red');
+      }
+    }
+  }
+
+  hot?.render();
+  hot?.resumeRender();
+};
+</script>
+
+<template>
+  <div id="example3">
+    <div class="example-controls-container">
+      <div class="controls">
+        <button id="set-data-action" type="button" @click="buttonClickCallback">
+          Click to modify the selected cells
+        </button>
+      </div>
+    </div>
+    <HotTable ref="hotTableRef" :settings="hotSettings" />
+  </div>
+</template>
+
+<style>
+.c-red {
+  color: red;
+}
+</style>

--- a/docs/content/guides/cell-features/selection/vue/example4.vue
+++ b/docs/content/guides/cell-features/selection/vue/example4.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1'],
+    ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2', 'H2', 'I2'],
+    ['A3', 'B3', 'C3', 'D3', 'E3', 'F3', 'G3', 'H3', 'I3'],
+    ['A4', 'B4', 'C4', 'D4', 'E4', 'F4', 'G4', 'H4', 'I4'],
+    ['A5', 'B5', 'C5', 'D5', 'E5', 'F5', 'G5', 'H5', 'I5'],
+    ['A6', 'B6', 'C6', 'D6', 'E6', 'F6', 'G6', 'H6', 'I6'],
+  ],
+  width: 'auto',
+  height: 'auto',
+  colWidths: 100,
+  rowHeaders: true,
+  colHeaders: true,
+  outsideClickDeselects: false,
+  selectionMode: 'multiple',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example4">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>
+
+<style>
+#example4 td.area {
+  background-color: rgba(75, 137, 255, 0.2);
+}
+
+#example4 td.area.area-1 {
+  background-color: rgba(75, 137, 255, 0.4);
+}
+
+#example4 td.area.area-2 {
+  background-color: rgba(75, 137, 255, 0.6);
+}
+</style>

--- a/docs/content/guides/cell-features/selection/vue/example5.vue
+++ b/docs/content/guides/cell-features/selection/vue/example5.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotTableRef = ref<InstanceType<typeof HotTable> | null>(null);
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['A1', 'B1', 'C1', 'D1', 'E1', 'F1'],
+    ['A2', 'B2', 'C2', 'D2', 'E2', 'F2'],
+    ['A3', 'B3', 'C3', 'D3', 'E3', 'F3'],
+    ['A4', 'B4', 'C4', 'D4', 'E4', 'F4'],
+    ['A5', 'B5', 'C5', 'D5', 'E5', 'F5'],
+    ['A6', 'B6', 'C6', 'D6', 'E6', 'F6'],
+  ],
+  width: 'auto',
+  height: 'auto',
+  colWidths: 100,
+  rowHeaders: true,
+  colHeaders: true,
+  outsideClickDeselects: false,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+const selectCell = () => {
+  hotTableRef.value?.hotInstance?.selectCell(1, 1);
+};
+
+const selectRange = () => {
+  hotTableRef.value?.hotInstance?.selectCell(1, 1, 3, 3);
+};
+
+const deselect = () => {
+  hotTableRef.value?.hotInstance?.deselectCell();
+};
+</script>
+
+<template>
+  <div id="example5">
+    <div class="example-controls-container">
+      <div class="controls">
+        <button type="button" @click="selectCell">
+          Select cell B2
+        </button>
+        <button type="button" @click="selectRange">
+          Select range B2:D4
+        </button>
+        <button type="button" @click="deselect">
+          Deselect
+        </button>
+      </div>
+    </div>
+    <HotTable ref="hotTableRef" :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-features/text-alignment/text-alignment.md
+++ b/docs/content/guides/cell-features/text-alignment/text-alignment.md
@@ -61,6 +61,16 @@ settings = { className: "htCenter" };
 
 :::
 
+::: only-for vue
+
+```js
+const hotSettings = {
+  className: 'htCenter',
+};
+```
+
+:::
+
 ## Basic example
 
 The following code sample configures the grid to use `htCenter` and configures individual cells to use different alignments.
@@ -93,6 +103,16 @@ The following code sample configures the grid to use `htCenter` and configures i
 
 @[code](@/content/guides/cell-features/text-alignment/angular/example1.ts)
 @[code](@/content/guides/cell-features/text-alignment/angular/example1.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/cell-features/text-alignment/vue/example1.vue)
 
 :::
 

--- a/docs/content/guides/cell-features/text-alignment/vue/example1.vue
+++ b/docs/content/guides/cell-features/text-alignment/vue/example1.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const data = new Array(100)
+  .fill(null)
+  .map((_, row) =>
+    new Array(18)
+      .fill(null)
+      .map((_, column) => `${row}, ${column}`)
+  );
+
+const hotSettings = ref<GridSettings>({
+  data,
+  colWidths: 100,
+  height: 320,
+  rowHeaders: true,
+  colHeaders: true,
+  contextMenu: true,
+  licenseKey: 'non-commercial-and-evaluation',
+  mergeCells: [
+    { row: 1, col: 1, rowspan: 3, colspan: 3 },
+    { row: 3, col: 4, rowspan: 2, colspan: 2 },
+  ],
+  className: 'htCenter',
+  cell: [
+    { row: 0, col: 0, className: 'htRight' },
+    { row: 1, col: 1, className: 'htLeft htMiddle' },
+    { row: 3, col: 4, className: 'htLeft htBottom' },
+  ],
+  afterSetCellMeta(row, col, key, val) {
+    console.log('cell meta changed', row, col, key, val);
+  },
+  autoWrapRow: true,
+  autoWrapCol: true,
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>


### PR DESCRIPTION
### Context

The PR adds Vue 3 documentation variants for all nine Cell features guides (`autofill-values`, `clipboard`, `comments`, `conditional-formatting`, `disabled-cells`, `formatting-cells`, `merge-cells`, `selection`, `text-alignment`). Each page now includes `::: only-for vue` blocks and runnable `.vue` SFC examples using `@handsontable/vue3`, so the guides work under `vue-data-grid/` with the framework switcher.

[skip changelog]

### How has this been tested?

- Manual verification on local docs dev server (`pnpm dev` in `docs/`)
- Confirmed all nine pages load on `vue-data-grid/` with working live examples
- Spot-checked StackBlitz for representative examples
- Verified JS, React, and Angular tabs unchanged on sample pages

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1742

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example SFCs only; no runtime or API changes to Handsontable libraries.
> 
> **Overview**
> Adds **Vue 3** coverage to all nine **Cell features** guides so they match JS/React/Angular on `vue-data-grid/`.
> 
> Each guide gets `::: only-for vue` sections with `:vue3` live examples and new `vue/*.vue` SFCs using `@handsontable/vue3`, `registerAllModules()`, and `hotSettings` passed to `<HotTable>`. Where the topic needs the API, examples use a template **`ref`** and `hotInstance` (clipboard, selection, conditional formatting).
> 
> **Comments**, **merge-cells**, and **text-alignment** also add Vue-only setup snippets. **Clipboard** adds a Vue tip for instance access. No changes to the core packages—docs and examples only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4de50e04ddd05769f2fb9341eae077c27a71b0ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->