### PR TITLE
DEV-1743: Add Vue 3 variants to the 11 cell-type guides

### DIFF
--- a/.ai/STRUCTURE.md
+++ b/.ai/STRUCTURE.md
@@ -22,7 +22,7 @@ handsontable/
 │   ├── react-wrapper/          # @handsontable/react-wrapper
 │   ├── angular-wrapper/        # @handsontable/angular-wrapper
 │   └── vue3/                   # @handsontable/vue3
-├── docs/                       # Astro Starlight documentation site (Node 20)
+├── docs/                       # Astro Starlight documentation site (Node 22)
 │   └── angular-type-check/     # Internal Angular type-check workspace (docs-angular-type-check)
 ├── examples/                   # Code examples
 ├── visual-tests/               # Playwright visual regression tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ In every directory, `CLAUDE.md` is a symlink to its sibling `AGENTS.md`. Edit `A
 | `@handsontable/vue3` | `wrappers/vue3/` | Vue 3 wrapper |
 | `handsontable-visual-tests` | `visual-tests/` | Playwright visual regression tests |
 | `handsontable-examples-internal` | `examples/` | Code examples |
-| `handsontable-documentation` | `docs/` | Documentation site (requires Node 20) |
+| `handsontable-documentation` | `docs/` | Documentation site (requires Node 22) |
 
 The authoritative workspace list is `pnpm-workspace.yaml`.
 
@@ -190,6 +190,6 @@ Follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format. Changel
 - The Angular wrapper tests use `NODE_OPTIONS=--openssl-legacy-provider`; this is wired into the `test` script.
 - `pnpm-workspace.yaml` has `ignoredBuiltDependencies` and `onlyBuiltDependencies` lists. If pnpm warns about ignored build scripts (e.g., `less`), this is expected.
 - Root-level `npm run lint` and `npm run test` use a custom `translate-to-native-npm.mjs` script to fan out across all workspace packages.
-- The docs site (`docs/`) uses Node 20 (its own `.nvmrc`) and is not needed for core library development.
+- The docs site (`docs/`) uses Node 22 (its own `.nvmrc`) and is not needed for core library development.
 - Walkontable (the rendering engine) lives inside `handsontable/src/3rdparty/walkontable/` and has its **own test runner** — do not mix Walkontable tests with main E2E tests.
 - No Docker, databases, or external services are required.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -2,7 +2,7 @@
 
 This document is written for both human authors and AI agents. All rules are stated explicitly so both roles can apply them without ambiguity.
 
-Astro Starlight-based documentation site. **Requires Node 20** (separate from core's Node 22).
+Astro Starlight-based documentation site. **Requires Node 22**.
 
 For detailed authoring guidance, use skills `writing-docs-pages` and `creating-docs-examples`.
 

--- a/docs/content/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md
@@ -78,6 +78,16 @@ This example uses the `autocomplete` feature in the default flexible mode. In th
 
 :::
 
+::: only-for vue
+
+::: example #example1 .docs-height-small :vue3
+
+@[code](@/content/guides/cell-types/autocomplete-cell-type/vue/example1.vue)
+
+:::
+
+:::
+
 ## Autocomplete strict mode
 
 This is the same example as above, the difference being that `autocomplete` now runs in strict mode. In this mode, the autocomplete cells will only accept values that are defined in the source array. The mouse and keyboard bindings are identical to the `Handsontable` cell type but with the differences below:
@@ -123,6 +133,16 @@ In strict mode, the [`allowInvalid`](@/api/options.md#allowinvalid) option deter
 
 :::
 
+::: only-for vue
+
+::: example #example2 .docs-height-large :vue3
+
+@[code](@/content/guides/cell-types/autocomplete-cell-type/vue/example2.vue)
+
+:::
+
+:::
+
 ## Autocomplete strict mode (Ajax)
 
 Autocomplete can also be used with Ajax data sources. In the example below, suggestions for the "Car" column are loaded from the server. To load data from a remote *asynchronous* source, assign a function to the 'source' property. The function should perform the server-side request and call the callback function when the result is available.
@@ -155,6 +175,16 @@ Autocomplete can also be used with Ajax data sources. In the example below, sugg
 
 @[code](@/content/guides/cell-types/autocomplete-cell-type/angular/example3.ts)
 @[code](@/content/guides/cell-types/autocomplete-cell-type/angular/example3.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example3 .docs-height-small :vue3
+
+@[code](@/content/guides/cell-types/autocomplete-cell-type/vue/example3.vue)
 
 :::
 
@@ -195,6 +225,16 @@ You can provide the `source` option as an array of values that will be used as t
 :::
 :::
 
+::: only-for vue
+
+::: example #example4 .docs-height-small :vue3
+
+@[code](@/content/guides/cell-types/autocomplete-cell-type/vue/example4.vue)
+
+:::
+
+:::
+
 ### Array of objects
 
 You can provide the `source` option as an array of objects with `key` and `value` properties. The `value` property will be used as the autocomplete suggestion, while the entire object will be used as the value of the cell.
@@ -226,6 +266,15 @@ You can provide the `source` option as an array of objects with `key` and `value
 :::
 :::
 
+::: only-for vue
+
+::: example #example5 .docs-height-small :vue3
+
+@[code](@/content/guides/cell-types/autocomplete-cell-type/vue/example5.vue)
+
+:::
+
+:::
 
 #### API methods
 
@@ -278,6 +327,16 @@ The left column uses the default behavior (`filter: true`) — options are narro
 
 :::
 
+::: only-for vue
+
+::: example #example6 .docs-height-small :vue3
+
+@[code](@/content/guides/cell-types/autocomplete-cell-type/vue/example6.vue)
+
+:::
+
+:::
+
 ## The `filteringCaseSensitive` option
 
 By default, the autocomplete search is case-insensitive — typing `"bl"` matches both `"Black"` and `"blue"`. Set `filteringCaseSensitive: true` to require an exact case match when filtering suggestions.
@@ -312,6 +371,16 @@ The left column uses the default case-insensitive behavior. The right column has
 
 @[code](@/content/guides/cell-types/autocomplete-cell-type/angular/example7.ts)
 @[code](@/content/guides/cell-types/autocomplete-cell-type/angular/example7.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example7 .docs-height-small :vue3
+
+@[code](@/content/guides/cell-types/autocomplete-cell-type/vue/example7.vue)
 
 :::
 

--- a/docs/content/guides/cell-types/autocomplete-cell-type/vue/example1.vue
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/vue/example1.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const colors = [
+  'yellow',
+  'red',
+  'orange and another color',
+  'green',
+  'blue',
+  'gray',
+  'black',
+  'white',
+  'purple',
+  'lime',
+  'olive',
+  'cyan',
+];
+
+const hotSettings = ref<GridSettings>({
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  data: [
+    ['BMW', 2017, 'black', 'black'],
+    ['Nissan', 2018, 'blue', 'blue'],
+    ['Chrysler', 2019, 'yellow', 'black'],
+    ['Volvo', 2020, 'white', 'gray'],
+  ],
+  colHeaders: ['Car', 'Year', 'Chassis color', 'Bumper color'],
+  columns: [
+    {
+      type: 'autocomplete',
+      source: ['BMW', 'Chrysler', 'Nissan', 'Suzuki', 'Toyota', 'Volvo'],
+      strict: false,
+    },
+    { type: 'numeric' },
+    {
+      type: 'autocomplete',
+      source: colors,
+      strict: false,
+      visibleRows: 4,
+    },
+    {
+      type: 'autocomplete',
+      source: colors,
+      strict: false,
+      trimDropdown: false,
+    },
+  ],
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-types/autocomplete-cell-type/vue/example2.vue
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/vue/example2.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const colors = [
+  'yellow',
+  'red',
+  'orange',
+  'green',
+  'blue',
+  'gray',
+  'black',
+  'white',
+  'purple',
+  'lime',
+  'olive',
+  'cyan',
+];
+
+const cars = ['BMW', 'Chrysler', 'Nissan', 'Suzuki', 'Toyota', 'Volvo'];
+
+const hotSettings = ref<GridSettings>({
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  data: [
+    ['BMW', 2017, 'black', 'black'],
+    ['Nissan', 2018, 'blue', 'blue'],
+    ['Chrysler', 2019, 'yellow', 'black'],
+    ['Volvo', 2020, 'white', 'gray'],
+  ],
+  colHeaders: ['Car<br>(allowInvalid true)', 'Year', 'Chassis color', 'Bumper color<br>(allowInvalid true)'],
+  columns: [
+    {
+      type: 'autocomplete',
+      source: cars,
+      strict: true,
+      // allowInvalid: true // true is default
+    },
+    {},
+    {
+      type: 'autocomplete',
+      source: colors,
+      strict: true,
+    },
+    {
+      type: 'autocomplete',
+      source: colors,
+      strict: true,
+      allowInvalid: true, // true is default
+    },
+  ],
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example2">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-types/autocomplete-cell-type/vue/example3.vue
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/vue/example3.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  data: [
+    ['BMW', 2017, 'black', 'black'],
+    ['Nissan', 2018, 'blue', 'blue'],
+    ['Chrysler', 2019, 'yellow', 'black'],
+    ['Volvo', 2020, 'white', 'gray'],
+  ],
+  colHeaders: ['Car', 'Year', 'Chassis color', 'Bumper color'],
+  columns: [
+    {
+      type: 'autocomplete',
+      source(_query: string, process: (data: string[]) => void) {
+        fetch('/docs/scripts/json/autocomplete.json')
+          .then((response) => response.json())
+          .then((response) => process(response.data));
+      },
+      strict: true,
+    },
+    {}, // Year is a default text column
+    {}, // Chassis color is a default text column
+    {}, // Bumper color is a default text column
+  ],
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example3">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-types/autocomplete-cell-type/vue/example4.vue
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/vue/example4.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const shipmentKVData = [
+  ['Electronics and Gadgets', 'Los Angeles International Airport'],
+  ['Medical Supplies', 'John F. Kennedy International Airport'],
+  ['Auto Parts', "Chicago O'Hare International Airport"],
+  ['Fresh Produce', 'London Heathrow Airport'],
+  ['Textiles', 'Charles de Gaulle Airport'],
+  ['Industrial Equipment', 'Dubai International Airport'],
+  ['Pharmaceuticals', 'Tokyo Haneda Airport'],
+  ['Consumer Goods', 'Beijing Capital International Airport'],
+  ['Machine Parts', 'Singapore Changi Airport'],
+  ['Food Products', 'Amsterdam Airport Schiphol'],
+];
+
+const airportKVData = [
+  'Los Angeles International Airport',
+  'John F. Kennedy International Airport',
+  "Chicago O'Hare International Airport",
+  'London Heathrow Airport',
+  'Charles de Gaulle Airport',
+  'Dubai International Airport',
+  'Tokyo Haneda Airport',
+  'Beijing Capital International Airport',
+  'Singapore Changi Airport',
+  'Amsterdam Airport Schiphol',
+  'Frankfurt Airport',
+  'Seoul Incheon International Airport',
+  'Toronto Pearson International Airport',
+  'Madrid-Barajas Airport',
+  'Bangkok Suvarnabhumi Airport',
+  'Munich International Airport',
+  'Sydney Kingsford Smith Airport',
+  'Barcelona-El Prat Airport',
+  'Kuala Lumpur International Airport',
+  'Zurich Airport',
+];
+
+const hotSettings = ref<GridSettings>({
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  data: shipmentKVData,
+  columns: [
+    {
+      title: 'Shipment',
+    },
+    {
+      type: 'autocomplete',
+      source: airportKVData,
+      title: 'Airport',
+    },
+  ],
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example4">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-types/autocomplete-cell-type/vue/example5.vue
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/vue/example5.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const shipmentKVData = [
+  ['Electronics and Gadgets', { key: 'LAX', value: 'Los Angeles International Airport' }],
+  ['Medical Supplies', { key: 'JFK', value: 'John F. Kennedy International Airport' }],
+  ['Auto Parts', { key: 'ORD', value: "Chicago O'Hare International Airport" }],
+  ['Fresh Produce', { key: 'LHR', value: 'London Heathrow Airport' }],
+  ['Textiles', { key: 'CDG', value: 'Charles de Gaulle Airport' }],
+  ['Industrial Equipment', { key: 'DXB', value: 'Dubai International Airport' }],
+  ['Pharmaceuticals', { key: 'HND', value: 'Tokyo Haneda Airport' }],
+  ['Consumer Goods', { key: 'PEK', value: 'Beijing Capital International Airport' }],
+  ['Machine Parts', { key: 'SIN', value: 'Singapore Changi Airport' }],
+  ['Food Products', { key: 'AMS', value: 'Amsterdam Airport Schiphol' }],
+];
+
+const airportKVData = [
+  { key: 'LAX', value: 'Los Angeles International Airport' },
+  { key: 'JFK', value: 'John F. Kennedy International Airport' },
+  { key: 'ORD', value: "Chicago O'Hare International Airport" },
+  { key: 'LHR', value: 'London Heathrow Airport' },
+  { key: 'CDG', value: 'Charles de Gaulle Airport' },
+  { key: 'DXB', value: 'Dubai International Airport' },
+  { key: 'HND', value: 'Tokyo Haneda Airport' },
+  { key: 'PEK', value: 'Beijing Capital International Airport' },
+  { key: 'SIN', value: 'Singapore Changi Airport' },
+  { key: 'AMS', value: 'Amsterdam Airport Schiphol' },
+  { key: 'FRA', value: 'Frankfurt Airport' },
+  { key: 'ICN', value: 'Seoul Incheon International Airport' },
+  { key: 'YYZ', value: 'Toronto Pearson International Airport' },
+  { key: 'MAD', value: 'Madrid-Barajas Airport' },
+  { key: 'BKK', value: 'Bangkok Suvarnabhumi Airport' },
+  { key: 'MUC', value: 'Munich International Airport' },
+  { key: 'SYD', value: 'Sydney Kingsford Smith Airport' },
+  { key: 'BCN', value: 'Barcelona-El Prat Airport' },
+  { key: 'KUL', value: 'Kuala Lumpur International Airport' },
+  { key: 'ZRH', value: 'Zurich Airport' },
+];
+
+const hotSettings = ref<GridSettings>({
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  data: shipmentKVData,
+  columns: [
+    {
+      title: 'Shipment',
+    },
+    {
+      type: 'autocomplete',
+      source: airportKVData,
+      title: 'Airport',
+    },
+  ],
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example5">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-types/autocomplete-cell-type/vue/example6.vue
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/vue/example6.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const fruits: string[] = [
+  'Apple',
+  'Apricot',
+  'Avocado',
+  'Banana',
+  'Blueberry',
+  'Cherry',
+  'Grape',
+  'Lemon',
+  'Lime',
+  'Mango',
+  'Orange',
+  'Peach',
+  'Pear',
+  'Pineapple',
+  'Plum',
+  'Raspberry',
+  'Strawberry',
+  'Watermelon',
+];
+
+const hotSettings = ref<GridSettings>({
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  data: [
+    ['Apple', 'Apple'],
+    ['Banana', 'Banana'],
+    ['Cherry', 'Cherry'],
+    ['Mango', 'Mango'],
+    ['Orange', 'Orange'],
+  ],
+  colHeaders: ['Filter: true (default)', 'Filter: false'],
+  columns: [
+    {
+      type: 'autocomplete',
+      source: fruits,
+      strict: false,
+      // filter: true is the default — only matching options are shown
+    },
+    {
+      type: 'autocomplete',
+      source: fruits,
+      strict: false,
+      // don't hide options that don't match the search query
+      filter: false,
+    },
+  ],
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example6">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-types/autocomplete-cell-type/vue/example7.vue
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/vue/example7.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const colors: string[] = [
+  'Black',
+  'Blue',
+  'brown',
+  'cyan',
+  'Gray',
+  'green',
+  'Lime',
+  'Magenta',
+  'Navy',
+  'olive',
+  'orange',
+  'Pink',
+  'Purple',
+  'Red',
+  'silver',
+  'Teal',
+  'White',
+  'Yellow',
+];
+
+const hotSettings = ref<GridSettings>({
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  data: [
+    ['Black', 'Black'],
+    ['Blue', 'Blue'],
+    ['Gray', 'Gray'],
+    ['Red', 'Red'],
+    ['White', 'White'],
+  ],
+  colHeaders: ['Case-insensitive (default)', 'Case-sensitive'],
+  columns: [
+    {
+      type: 'autocomplete',
+      source: colors,
+      strict: false,
+      // filteringCaseSensitive: false is the default — typing "bl" matches "Black" and "blue"
+    },
+    {
+      type: 'autocomplete',
+      source: colors,
+      strict: false,
+      // match case while searching autocomplete options
+      filteringCaseSensitive: true,
+    },
+  ],
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example7">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-types/cell-type/cell-type.md
+++ b/docs/content/guides/cell-types/cell-type/cell-type.md
@@ -74,6 +74,29 @@ settings = {
 
 :::
 
+::: only-for vue
+
+```vue
+<script setup>
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const hotSettings = ref({
+  columns: [{ type: 'password' }],
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <HotTable :settings="hotSettings" />
+</template>
+```
+
+:::
+
 the functions [`editor`](@/api/options.md#editor), [`renderer`](@/api/options.md#renderer), and [`copyable`](@/api/options.md#copyable) are automatically set as follows:
 
 ::: only-for javascript
@@ -112,6 +135,33 @@ settings = {
     },
   ],
 };
+```
+
+:::
+
+::: only-for vue
+
+```vue
+<script setup>
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const hotSettings = ref({
+  columns: [{
+    editor: Handsontable.editors.PasswordEditor,
+    renderer: Handsontable.renderers.PasswordRenderer,
+    copyable: false,
+  }],
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <HotTable :settings="hotSettings" />
+</template>
 ```
 
 :::
@@ -162,6 +212,35 @@ settings = {
     },
   ],
 };
+```
+
+:::
+
+::: only-for vue
+
+```vue
+<script setup>
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const hotSettings = ref({
+  columns: [{
+    editor: false,
+    renderer: Handsontable.renderers.TextRenderer,
+    className: 'my-cell',
+    readOnly: true,
+    myCustomProperty: 'foo',
+  }],
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <HotTable :settings="hotSettings" />
+</template>
 ```
 
 :::
@@ -291,6 +370,29 @@ settings = {
 
 :::
 
+::: only-for vue
+
+```vue
+<script setup>
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const hotSettings = ref({
+  columns: [{ type: 'my.custom' }],
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <HotTable :settings="hotSettings" />
+</template>
+```
+
+:::
+
 ## Precedence
 
 It is possible to define the [`type`](@/api/options.md#type) option together with options such as [`renderer`](@/api/options.md#renderer), [`editor`](@/api/options.md#editor) or [`validator`](@/api/options.md#validator). For example:
@@ -339,6 +441,33 @@ settings = {
 
 ```html
 <hot-table [settings]="settings" />
+```
+
+:::
+
+::: only-for vue
+
+```vue
+<script setup>
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const hotSettings = ref({
+  columns: [{
+    type: 'numeric',
+    // validator function defined elsewhere
+    validator: customValidator,
+  }],
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <HotTable :settings="hotSettings" />
+</template>
 ```
 
 :::
@@ -393,6 +522,33 @@ settings = {
 
 :::
 
+::: only-for vue
+
+```vue
+<script setup>
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const hotSettings = ref({
+  columns: [{
+    renderer: Handsontable.renderers.TextRenderer,
+    editor: Handsontable.editors.TextEditor,
+    validator: customValidator,
+  }],
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <HotTable :settings="hotSettings" />
+</template>
+```
+
+:::
+
 There is one more way you can define the configuration using types:
 
 ::: only-for javascript
@@ -439,6 +595,30 @@ settings = {
 
 ```html
 <hot-table [settings]="settings" />
+```
+
+:::
+
+::: only-for vue
+
+```vue
+<script setup>
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const hotSettings = ref({
+  validator: customValidator,
+  columns: [{ type: 'my.custom' }],
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <HotTable :settings="hotSettings" />
+</template>
 ```
 
 :::
@@ -527,6 +707,42 @@ settings = {
 
 :::
 
+::: only-for vue
+
+```vue
+<script setup>
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+function customValidator(query, callback) {
+  // ...validator logic
+  callback(/* Pass `true` or `false` */);
+}
+
+const hotSettings = ref({
+  columns: [{
+    renderer: Handsontable.renderers.PasswordRenderer,
+    editor: Handsontable.editors.PasswordEditor,
+    validator: undefined,
+  }, {
+    renderer: Handsontable.renderers.TextRenderer,
+    editor: Handsontable.editors.TextEditor,
+    validator: customValidator,
+  }],
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <HotTable :settings="hotSettings" />
+</template>
+```
+
+:::
+
 ## Built-in cell types example
 
 The example below shows some of the built-in cell types, i.e. combinations of cell renderers and editors available in Handsontable. The example also shows the declaration of custom cell renderers, namely `yellowRenderer` and `greenRenderer`.
@@ -559,6 +775,16 @@ The example below shows some of the built-in cell types, i.e. combinations of ce
 
 @[code](@/content/guides/cell-types/cell-type/angular/example1.ts)
 @[code](@/content/guides/cell-types/cell-type/angular/example1.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/cell-types/cell-type/vue/example1.vue)
 
 :::
 
@@ -602,6 +828,16 @@ Please keep in mind that opening a cell with `undefined` and `null` values resul
 
 @[code](@/content/guides/cell-types/cell-type/angular/example2.ts)
 @[code](@/content/guides/cell-types/cell-type/angular/example2.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example2 :vue3
+
+@[code](@/content/guides/cell-types/cell-type/vue/example2.vue)
 
 :::
 

--- a/docs/content/guides/cell-types/cell-type/vue/example1.vue
+++ b/docs/content/guides/cell-types/cell-type/vue/example1.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import { textRenderer } from 'handsontable/renderers/textRenderer';
+import type { BaseRenderer } from 'handsontable/renderers';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const colors = ['yellow', 'red', 'orange', 'green', 'blue', 'gray', 'black', 'white'];
+
+const yellowRenderer: BaseRenderer = (instance, td, ...rest) => {
+  textRenderer(instance, td, ...rest);
+  td.style.backgroundColor = 'yellow';
+};
+
+const greenRenderer: BaseRenderer = (instance, td, ...rest) => {
+  textRenderer(instance, td, ...rest);
+  td.style.backgroundColor = 'green';
+};
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    { id: 1, name: 'Ted', isActive: true, color: 'orange', date: '2015-01-01' },
+    { id: 2, name: 'John', isActive: false, color: 'black', date: null },
+    { id: 3, name: 'Al', isActive: true, color: 'red', date: null },
+    { id: 4, name: 'Ben', isActive: false, color: 'blue', date: null },
+  ],
+  colHeaders: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  columns: [
+    { data: 'id', type: 'text' },
+    // 'text' is default, you don't actually need to declare it
+    { data: 'name', renderer: yellowRenderer },
+    // use default 'text' cell type but overwrite its renderer with yellowRenderer
+    { data: 'isActive', type: 'checkbox' },
+    {
+      data: 'date',
+      type: 'intl-date',
+      locale: 'en-US',
+      dateFormat: { year: 'numeric', month: '2-digit', day: '2-digit' },
+    },
+    { data: 'color', type: 'autocomplete', source: colors },
+  ],
+  cell: [{ row: 1, col: 0, renderer: greenRenderer }],
+  cells(row, col) {
+    if (row === 0 && col === 0) {
+      this.renderer = greenRenderer;
+
+      return { renderer: this.renderer };
+    }
+
+    return {};
+  },
+  height: 'auto',
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-types/cell-type/vue/example2.vue
+++ b/docs/content/guides/cell-types/cell-type/vue/example2.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['empty string', '', '', '', '', ''],
+    ['null', null, null, null, null, null],
+    ['undefined', undefined, undefined, undefined, undefined, undefined],
+    ['non-empty value', 'non-empty text', 13000, true, 'orange', 'password'],
+  ],
+  columnSorting: {
+    sortEmptyCells: true,
+  },
+  columns: [
+    {
+      columnSorting: {
+        indicator: false,
+        headerAction: false,
+        compareFunctionFactory: function compareFunctionFactory() {
+          return function comparator() {
+            return 0; // Don't sort the first visual column.
+          };
+        },
+      },
+      readOnly: true,
+    },
+    {},
+    {
+      type: 'numeric',
+      locale: 'en-US',
+      numericFormat: {
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: 2,
+      },
+    },
+    { type: 'checkbox' },
+    { type: 'dropdown', source: ['yellow', 'red', 'orange'] },
+    { type: 'password' },
+  ],
+  preventOverflow: 'horizontal',
+  colHeaders: [
+    'value<br>underneath',
+    'type:text',
+    'type:numeric',
+    'type:checkbox',
+    'type:dropdown',
+    'type:password',
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+  height: 'auto',
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example2">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-types/checkbox-cell-type/checkbox-cell-type.md
+++ b/docs/content/guides/cell-types/checkbox-cell-type/checkbox-cell-type.md
@@ -71,6 +71,16 @@ This is the default usage scenario where column data has a `true` or `false` val
 
 :::
 
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/cell-types/checkbox-cell-type/vue/example1.vue)
+
+:::
+
+:::
+
 ## Checkbox template
 
 If you want to use values other than `true` and `false`, you have to provide this information using [`checkedTemplate`](@/api/options.md#checkedtemplate) and [`uncheckedTemplate`](@/api/options.md#uncheckedtemplate). Handsontable will then update your data using the appropriate template.
@@ -103,6 +113,16 @@ If you want to use values other than `true` and `false`, you have to provide thi
 
 @[code](@/content/guides/cell-types/checkbox-cell-type/angular/example2.ts)
 @[code](@/content/guides/cell-types/checkbox-cell-type/angular/example2.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example2 :vue3
+
+@[code](@/content/guides/cell-types/checkbox-cell-type/vue/example2.vue)
 
 :::
 
@@ -145,6 +165,16 @@ To add a label to the checkbox, use the [`label`](@/api/options.md#label) option
 
 :::
 
+::: only-for vue
+
+::: example #example3 :vue3
+
+@[code](@/content/guides/cell-types/checkbox-cell-type/vue/example3.vue)
+
+:::
+
+:::
+
 ### Label value as a function
 
 The `value` property of the `label` option can also be a function. The function receives four arguments: `row`, `column`, `prop`, and `value`, where `value` is the current cell value. This lets you generate label text dynamically based on the cell's state.
@@ -177,6 +207,16 @@ The `value` property of the `label` option can also be a function. The function 
 
 @[code](@/content/guides/cell-types/checkbox-cell-type/angular/example4.ts)
 @[code](@/content/guides/cell-types/checkbox-cell-type/angular/example4.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example4 :vue3
+
+@[code](@/content/guides/cell-types/checkbox-cell-type/vue/example4.vue)
 
 :::
 

--- a/docs/content/guides/cell-types/checkbox-cell-type/vue/example1.vue
+++ b/docs/content/guides/cell-types/checkbox-cell-type/vue/example1.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    {
+      car: 'Mercedes A 160',
+      year: 2017,
+      available: true,
+      comesInBlack: 'yes',
+    },
+    {
+      car: 'Citroen C4 Coupe',
+      year: 2018,
+      available: false,
+      comesInBlack: 'yes',
+    },
+    {
+      car: 'Audi A4 Avant',
+      year: 2019,
+      available: true,
+      comesInBlack: 'no',
+    },
+    {
+      car: 'Opel Astra',
+      year: 2020,
+      available: false,
+      comesInBlack: 'yes',
+    },
+    {
+      car: 'BMW 320i Coupe',
+      year: 2021,
+      available: false,
+      comesInBlack: 'no',
+    },
+  ],
+  colHeaders: ['Car model', 'Year of manufacture', 'Available'],
+  height: 'auto',
+  columns: [
+    {
+      data: 'car',
+    },
+    {
+      data: 'year',
+      type: 'numeric',
+    },
+    {
+      data: 'available',
+      type: 'checkbox',
+    },
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-types/checkbox-cell-type/vue/example2.vue
+++ b/docs/content/guides/cell-types/checkbox-cell-type/vue/example2.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    {
+      car: 'Mercedes A 160',
+      year: 2017,
+      available: true,
+      comesInBlack: 'yes',
+    },
+    {
+      car: 'Citroen C4 Coupe',
+      year: 2018,
+      available: false,
+      comesInBlack: 'yes',
+    },
+    {
+      car: 'Audi A4 Avant',
+      year: 2019,
+      available: true,
+      comesInBlack: 'no',
+    },
+    {
+      car: 'Opel Astra',
+      year: 2020,
+      available: false,
+      comesInBlack: 'yes',
+    },
+    {
+      car: 'BMW 320i Coupe',
+      year: 2021,
+      available: false,
+      comesInBlack: 'no',
+    },
+  ],
+  colHeaders: ['Car model', 'Year of manufacture', 'Comes in black'],
+  height: 'auto',
+  columns: [
+    {
+      data: 'car',
+    },
+    {
+      data: 'year',
+      type: 'numeric',
+    },
+    {
+      data: 'comesInBlack',
+      type: 'checkbox',
+      checkedTemplate: 'yes',
+      uncheckedTemplate: 'no',
+    },
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example2">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-types/checkbox-cell-type/vue/example3.vue
+++ b/docs/content/guides/cell-types/checkbox-cell-type/vue/example3.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    {
+      car: 'Mercedes A 160',
+      year: 2017,
+      available: true,
+      comesInBlack: 'yes',
+    },
+    {
+      car: 'Citroen C4 Coupe',
+      year: 2018,
+      available: false,
+      comesInBlack: 'yes',
+    },
+    {
+      car: 'Audi A4 Avant',
+      year: 2019,
+      available: true,
+      comesInBlack: 'no',
+    },
+    {
+      car: 'Opel Astra',
+      year: 2020,
+      available: false,
+      comesInBlack: 'yes',
+    },
+    {
+      car: 'BMW 320i Coupe',
+      year: 2021,
+      available: false,
+      comesInBlack: 'no',
+    },
+  ],
+  colHeaders: ['Car model', 'Accepted', 'Comes in black'],
+  height: 'auto',
+  columns: [
+    {
+      data: 'car',
+    },
+    {
+      data: 'available',
+      type: 'checkbox',
+      label: {
+        position: 'after',
+        property: 'car', // Read value from row object
+      },
+    },
+    {
+      data: 'comesInBlack',
+      type: 'checkbox',
+      checkedTemplate: 'yes',
+      uncheckedTemplate: 'no',
+      label: {
+        position: 'before',
+        value: 'In black? ',
+      },
+    },
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example3">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-types/checkbox-cell-type/vue/example4.vue
+++ b/docs/content/guides/cell-types/checkbox-cell-type/vue/example4.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    { car: 'Mercedes A 160', year: 2017, comesInBlack: 'yes' },
+    { car: 'Citroen C4 Coupe', year: 2018, comesInBlack: 'yes' },
+    { car: 'Audi A4 Avant', year: 2019, comesInBlack: 'no' },
+    { car: 'Opel Astra', year: 2020, comesInBlack: 'yes' },
+    { car: 'BMW 320i Coupe', year: 2021, comesInBlack: 'no' },
+  ],
+  colHeaders: ['Car model', 'Year', 'Comes in black'],
+  height: 'auto',
+  columns: [
+    {
+      data: 'car',
+    },
+    {
+      data: 'year',
+    },
+    {
+      data: 'comesInBlack',
+      type: 'checkbox',
+      checkedTemplate: 'yes',
+      uncheckedTemplate: 'no',
+      label: {
+        position: 'after',
+        value(row: number, column: number, prop: string | number, value: string) {
+          if (value === 'yes') {
+            return 'In black';
+          } else {
+            return 'Not in black';
+          }
+        },
+      },
+    },
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example4">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-types/date-cell-type/date-cell-type.md
+++ b/docs/content/guides/cell-types/date-cell-type/date-cell-type.md
@@ -63,6 +63,16 @@ In the following demo, multiple columns use the date cell type with different fo
 :::
 :::
 
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/cell-types/date-cell-type/vue/example1.vue)
+
+:::
+
+:::
+
 ## Use the date cell type
 
 Use the **object-style** configuration by setting the [`type`](@/api/options.md#type) option to `'intl-date'` and [`dateFormat`](@/api/options.md#dateformat) to an object (recommended). The locale is controlled via the [`locale`](@/api/options.md#locale) option.
@@ -176,6 +186,47 @@ settings3 = {
 
 :::
 
+::: only-for vue
+
+```js
+// set the date cell type for the entire grid (Intl, recommended)
+const hotSettings = ref({
+  type: 'intl-date',
+  locale: 'en-US',
+  dateFormat: {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit'
+  }
+});
+
+// set the date cell type for a single column
+const hotSettings = ref({
+  columns: [
+    {
+      type: 'intl-date',
+      locale: 'en-US',
+      dateFormat: { dateStyle: 'short' }
+    }
+  ]
+});
+
+// set the date cell type for a single cell
+const hotSettings = ref({
+  cell: [
+    {
+      row: 0,
+      col: 2,
+      type: 'intl-date',
+      locale: 'en-US',
+      dateFormat: { dateStyle: 'medium' }
+    }
+  ]
+});
+```
+
+:::
+
 For `intl-date` cells, source data **must** be in **ISO 8601 date format** (`YYYY-MM-DD`) for dates to work correctly. The `dateFormat` object only affects how dates are displayed; sorting and filtering rely on the underlying ISO value.
 
 ## Format dates
@@ -256,6 +307,31 @@ settings = {
     }
   ]
 };
+```
+
+:::
+
+::: only-for vue
+
+```js
+const hotSettings = ref({
+  columns: [
+    {
+      type: 'intl-date',
+      locale: 'en-US',
+      dateFormat: {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit'
+      }
+    },
+    {
+      type: 'intl-date',
+      locale: 'de-DE',
+      dateFormat: { dateStyle: 'long' }
+    }
+  ]
+});
 ```
 
 :::

--- a/docs/content/guides/cell-types/date-cell-type/vue/example1.vue
+++ b/docs/content/guides/cell-types/date-cell-type/vue/example1.vue
@@ -1,0 +1,177 @@
+<script setup lang="ts">
+import { ref, onMounted, onBeforeUnmount } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const localeOptions = [
+  { value: 'ar-AR', label: 'Arabic (Global)' },
+  { value: 'cs-CZ', label: 'Czech (Czechia)' },
+  { value: 'de-CH', label: 'German (Switzerland)' },
+  { value: 'de-DE', label: 'German (Germany)' },
+  { value: 'en-US', label: 'English (United States)' },
+  { value: 'es-MX', label: 'Spanish (Mexico)' },
+  { value: 'fa-IR', label: 'Persian (Iran)' },
+  { value: 'fr-FR', label: 'French (France)' },
+  { value: 'hr-HR', label: 'Croatian (Croatia)' },
+  { value: 'it-IT', label: 'Italian (Italy)' },
+  { value: 'ja-JP', label: 'Japanese (Japan)' },
+  { value: 'ko-KR', label: 'Korean (Korea)' },
+  { value: 'lv-LV', label: 'Latvian (Latvia)' },
+  { value: 'nb-NO', label: 'Norwegian Bokmal (Norway)' },
+  { value: 'nl-NL', label: 'Dutch (Netherlands)' },
+  { value: 'pl-PL', label: 'Polish (Poland)' },
+  { value: 'pt-BR', label: 'Portuguese (Brazil)' },
+  { value: 'ru-RU', label: 'Russian (Russia)' },
+  { value: 'sr-SP', label: 'Serbian Latin (Serbia)' },
+  { value: 'zh-CN', label: 'Chinese (Simplified, China)' },
+  { value: 'zh-TW', label: 'Chinese (Traditional, Taiwan)' },
+];
+
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const dropdownRef = ref<HTMLDivElement | null>(null);
+const isOpen = ref(false);
+const locale = ref('en-US');
+
+const selectedLabel = () => localeOptions.find((o) => o.value === locale.value)?.label;
+
+const handleSelect = (value: string) => {
+  locale.value = value;
+  isOpen.value = false;
+  hotRef.value?.hotInstance?.updateSettings({ locale: value } as GridSettings);
+};
+
+const handleOutsideClick = (e: MouseEvent) => {
+  if (dropdownRef.value && !dropdownRef.value.contains(e.target as Node)) {
+    isOpen.value = false;
+  }
+};
+
+const handleEscape = (e: KeyboardEvent) => {
+  if (e.key === 'Escape') {
+    isOpen.value = false;
+  }
+};
+
+onMounted(() => {
+  document.addEventListener('click', handleOutsideClick);
+  document.addEventListener('keydown', handleEscape);
+});
+
+onBeforeUnmount(() => {
+  document.removeEventListener('click', handleOutsideClick);
+  document.removeEventListener('keydown', handleEscape);
+});
+
+const data = [
+  {
+    car: 'Mercedes A 160',
+    product_date: '2002-06-15',
+    payment_date: '2002-05-20',
+    registration_date: '2002-07-01',
+  },
+  {
+    car: 'Citroën C4 Coupe',
+    product_date: '2007-03-22',
+    payment_date: '2007-02-28',
+    registration_date: '2007-04-10',
+  },
+  {
+    car: 'Audi A4 Avant',
+    product_date: '2011-09-08',
+    payment_date: '2011-08-15',
+    registration_date: '2011-09-20',
+  },
+  {
+    car: 'Opel Astra',
+    product_date: '2012-01-30',
+    payment_date: '2012-01-10',
+    registration_date: '2012-02-14',
+  },
+  {
+    car: 'BMW 320i Coupe',
+    product_date: '2004-11-12',
+    payment_date: '2004-10-20',
+    registration_date: '2004-12-01',
+  },
+];
+
+const hotSettings = ref<GridSettings>({
+  data,
+  colHeaders: ['Car', 'Product date', 'Payment date', 'Registration date'],
+  locale: 'en-US',
+  columns: [
+    {
+      type: 'text',
+      data: 'car',
+    },
+    {
+      type: 'intl-date',
+      data: 'product_date',
+      dateFormat: { dateStyle: 'short' },
+    },
+    {
+      type: 'intl-date',
+      data: 'payment_date',
+      dateFormat: {
+        month: 'long',
+        day: 'numeric',
+        year: 'numeric',
+      },
+    },
+    {
+      type: 'intl-date',
+      data: 'registration_date',
+      dateFormat: {
+        weekday: 'long',
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      },
+    },
+  ],
+  columnSorting: true,
+  filters: true,
+  dropdownMenu: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <div class="example-controls-container">
+      <div class="controls">
+        <div class="theme-dropdown" ref="dropdownRef">
+          <button
+            class="theme-dropdown-trigger"
+            type="button"
+            aria-haspopup="listbox"
+            :aria-expanded="isOpen"
+            @click="isOpen = !isOpen"
+          >
+            <span>{{ selectedLabel() }}</span>
+            <svg class="theme-dropdown-chevron" aria-hidden="true" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6l6 -6"/></svg>
+          </button>
+          <ul v-if="isOpen" class="theme-dropdown-menu" role="listbox">
+            <li
+              v-for="opt in localeOptions"
+              :key="opt.value"
+              role="option"
+              :aria-selected="locale === opt.value"
+              @click="handleSelect(opt.value)"
+            >
+              {{ opt.label }}
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <HotTable ref="hotRef" :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-types/dropdown-cell-type/dropdown-cell-type.md
+++ b/docs/content/guides/cell-types/dropdown-cell-type/dropdown-cell-type.md
@@ -55,6 +55,12 @@ Internally, cell `{ type: 'dropdown' }` is equivalent to cell `{ type:'autocompl
 
 :::
 
+::: only-for vue
+
+Internally, cell `{ type: 'dropdown' }` is equivalent to cell `{ type:'autocomplete', strict: true, filter: false }`. Therefore you can think of `dropdown` as a searchable `<select>`.
+
+:::
+
 ::: only-for javascript
 
 ::: example #example1 .docs-height-small --js 1 --ts 2
@@ -83,6 +89,16 @@ Internally, cell `{ type: 'dropdown' }` is equivalent to cell `{ type:'autocompl
 
 @[code](@/content/guides/cell-types/dropdown-cell-type/angular/example1.ts)
 @[code](@/content/guides/cell-types/dropdown-cell-type/angular/example1.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example1 .docs-height-small :vue3
+
+@[code](@/content/guides/cell-types/dropdown-cell-type/vue/example1.vue)
 
 :::
 
@@ -140,6 +156,16 @@ You can provide the `source` option as an array of values that will be used as t
 
 :::
 
+::: only-for vue
+
+::: example #example2 .docs-height-small :vue3
+
+@[code](@/content/guides/cell-types/dropdown-cell-type/vue/example2.vue)
+
+:::
+
+:::
+
 ### Array of objects
 
 You can provide the `source` option as an array of objects with `key` and `value` properties. The `value` property will be used as the dropdown option, while the entire object will be used as the value of the cell.
@@ -183,6 +209,16 @@ You can provide the `source` option as an array of objects with `key` and `value
 
 @[code](@/content/guides/cell-types/dropdown-cell-type/angular/example3.html)
 
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example3 .docs-height-small :vue3
+
+@[code](@/content/guides/cell-types/dropdown-cell-type/vue/example3.vue)
 
 :::
 

--- a/docs/content/guides/cell-types/dropdown-cell-type/vue/example1.vue
+++ b/docs/content/guides/cell-types/dropdown-cell-type/vue/example1.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  height: 'auto',
+  data: [
+    ['Tesla', 2017, 'black', 'black'],
+    ['Nissan', 2018, 'blue', 'blue'],
+    ['Chrysler', 2019, 'yellow', 'black'],
+    ['Volvo', 2020, 'white', 'gray'],
+  ],
+  colHeaders: ['Car', 'Year', 'Chassis color', 'Bumper color'],
+  columns: [
+    {},
+    { type: 'numeric' },
+    {
+      type: 'dropdown',
+      source: ['yellow', 'red', 'orange', 'green', 'blue', 'gray', 'black', 'white'],
+    },
+    {
+      type: 'dropdown',
+      source: ['yellow', 'red', 'orange', 'green', 'blue', 'gray', 'black', 'white'],
+    },
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-types/dropdown-cell-type/vue/example2.vue
+++ b/docs/content/guides/cell-types/dropdown-cell-type/vue/example2.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const shipmentKVData = [
+  ['Electronics and Gadgets', 'Los Angeles International Airport'],
+  ['Medical Supplies', 'John F. Kennedy International Airport'],
+  ['Auto Parts', "Chicago O'Hare International Airport"],
+  ['Fresh Produce', 'London Heathrow Airport'],
+  ['Textiles', 'Charles de Gaulle Airport'],
+  ['Industrial Equipment', 'Dubai International Airport'],
+  ['Pharmaceuticals', 'Tokyo Haneda Airport'],
+  ['Consumer Goods', 'Beijing Capital International Airport'],
+  ['Machine Parts', 'Singapore Changi Airport'],
+  ['Food Products', 'Amsterdam Airport Schiphol'],
+];
+
+const airportKVData = [
+  'Los Angeles International Airport',
+  'John F. Kennedy International Airport',
+  "Chicago O'Hare International Airport",
+  'London Heathrow Airport',
+  'Charles de Gaulle Airport',
+  'Dubai International Airport',
+  'Tokyo Haneda Airport',
+  'Beijing Capital International Airport',
+  'Singapore Changi Airport',
+  'Amsterdam Airport Schiphol',
+  'Frankfurt Airport',
+  'Seoul Incheon International Airport',
+  'Toronto Pearson International Airport',
+  'Madrid-Barajas Airport',
+  'Bangkok Suvarnabhumi Airport',
+  'Munich International Airport',
+  'Sydney Kingsford Smith Airport',
+  'Barcelona-El Prat Airport',
+  'Kuala Lumpur International Airport',
+  'Zurich Airport',
+];
+
+const hotSettings = ref<GridSettings>({
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+  data: shipmentKVData,
+  columns: [
+    {
+      title: 'Shipment',
+    },
+    {
+      type: 'dropdown',
+      source: airportKVData,
+      title: 'Airport',
+    },
+  ],
+});
+</script>
+
+<template>
+  <div id="example2">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-types/dropdown-cell-type/vue/example3.vue
+++ b/docs/content/guides/cell-types/dropdown-cell-type/vue/example3.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const shipmentKVData = [
+  ['Electronics and Gadgets', { key: 'LAX', value: 'Los Angeles International Airport' }],
+  ['Medical Supplies', { key: 'JFK', value: 'John F. Kennedy International Airport' }],
+  ['Auto Parts', { key: 'ORD', value: "Chicago O'Hare International Airport" }],
+  ['Fresh Produce', { key: 'LHR', value: 'London Heathrow Airport' }],
+  ['Textiles', { key: 'CDG', value: 'Charles de Gaulle Airport' }],
+  ['Industrial Equipment', { key: 'DXB', value: 'Dubai International Airport' }],
+  ['Pharmaceuticals', { key: 'HND', value: 'Tokyo Haneda Airport' }],
+  ['Consumer Goods', { key: 'PEK', value: 'Beijing Capital International Airport' }],
+  ['Machine Parts', { key: 'SIN', value: 'Singapore Changi Airport' }],
+  ['Food Products', { key: 'AMS', value: 'Amsterdam Airport Schiphol' }],
+];
+
+const airportKVData = [
+  { key: 'LAX', value: 'Los Angeles International Airport' },
+  { key: 'JFK', value: 'John F. Kennedy International Airport' },
+  { key: 'ORD', value: "Chicago O'Hare International Airport" },
+  { key: 'LHR', value: 'London Heathrow Airport' },
+  { key: 'CDG', value: 'Charles de Gaulle Airport' },
+  { key: 'DXB', value: 'Dubai International Airport' },
+  { key: 'HND', value: 'Tokyo Haneda Airport' },
+  { key: 'PEK', value: 'Beijing Capital International Airport' },
+  { key: 'SIN', value: 'Singapore Changi Airport' },
+  { key: 'AMS', value: 'Amsterdam Airport Schiphol' },
+  { key: 'FRA', value: 'Frankfurt Airport' },
+  { key: 'ICN', value: 'Seoul Incheon International Airport' },
+  { key: 'YYZ', value: 'Toronto Pearson International Airport' },
+  { key: 'MAD', value: 'Madrid-Barajas Airport' },
+  { key: 'BKK', value: 'Bangkok Suvarnabhumi Airport' },
+  { key: 'MUC', value: 'Munich International Airport' },
+  { key: 'SYD', value: 'Sydney Kingsford Smith Airport' },
+  { key: 'BCN', value: 'Barcelona-El Prat Airport' },
+  { key: 'KUL', value: 'Kuala Lumpur International Airport' },
+  { key: 'ZRH', value: 'Zurich Airport' },
+];
+
+const hotSettings = ref<GridSettings>({
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+  data: shipmentKVData,
+  columns: [
+    {
+      title: 'Shipment',
+    },
+    {
+      type: 'dropdown',
+      source: airportKVData,
+      title: 'Airport',
+    },
+  ],
+});
+</script>
+
+<template>
+  <div id="example3">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-types/handsontable-cell-type/handsontable-cell-type.md
+++ b/docs/content/guides/cell-types/handsontable-cell-type/handsontable-cell-type.md
@@ -69,6 +69,16 @@ While HOT-in-HOT is opened, the text field above the HOT-in-HOT remains focused 
 
 :::
 
+::: only-for vue
+
+::: example #example1 .docs-height-small :vue3
+
+@[code](@/content/guides/cell-types/handsontable-cell-type/vue/example1.vue)
+
+:::
+
+:::
+
 ## Keyboard shortcuts
 
 | Key | Action |

--- a/docs/content/guides/cell-types/handsontable-cell-type/vue/example1.vue
+++ b/docs/content/guides/cell-types/handsontable-cell-type/vue/example1.vue
@@ -1,0 +1,72 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const colorData = [['yellow'], ['red'], ['orange'], ['green'], ['blue'], ['gray'], ['black'], ['white']];
+
+const manufacturerData = [
+  { name: 'BMW', country: 'Germany', owner: 'Bayerische Motoren Werke AG' },
+  { name: 'Chrysler', country: 'USA', owner: 'Chrysler Group LLC' },
+  { name: 'Nissan', country: 'Japan', owner: 'Nissan Motor Company Ltd' },
+  { name: 'Suzuki', country: 'Japan', owner: 'Suzuki Motor Corporation' },
+  { name: 'Toyota', country: 'Japan', owner: 'Toyota Motor Corporation' },
+  { name: 'Volvo', country: 'Sweden', owner: 'Zhejiang Geely Holding Group' },
+];
+
+const hotSettings = ref<GridSettings>({
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  data: [
+    ['Tesla', 2017, 'black', 'black'],
+    ['Nissan', 2018, 'blue', 'blue'],
+    ['Chrysler', 2019, 'yellow', 'black'],
+    ['Volvo', 2020, 'white', 'gray'],
+  ],
+  colHeaders: ['Car', 'Year', 'Chassis color', 'Bumper color'],
+  columns: [
+    {
+      type: 'handsontable',
+      handsontable: {
+        colHeaders: ['Marque', 'Country', 'Parent company'],
+        autoColumnSize: true,
+        data: manufacturerData,
+        getValue() {
+          const selection = this.getSelectedLast();
+
+          // Get the manufacturer name of the clicked row and ignore header
+          // coordinates (negative values)
+          return this.getSourceDataAtRow(Math.max(selection[0], 0)).name;
+        },
+      },
+    },
+    { type: 'numeric' },
+    {
+      type: 'handsontable',
+      handsontable: {
+        colHeaders: false,
+        data: colorData,
+      },
+    },
+    {
+      type: 'handsontable',
+      handsontable: {
+        colHeaders: false,
+        data: colorData,
+      },
+    },
+  ],
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-types/multiselect-cell-type/multiselect-cell-type.md
+++ b/docs/content/guides/cell-types/multiselect-cell-type/multiselect-cell-type.md
@@ -80,6 +80,16 @@ You can provide the `source` option as an array of values that will be used as t
 :::
 :::
 
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/cell-types/multiselect-cell-type/vue/example1.vue)
+
+:::
+
+:::
+
 ### Array of objects
 
 You can provide the `source` option as an array of objects with `key` and `value` properties. The `value` property will be used as the MultiSelect's option label, while the entire object will be used as the value saved to the cell's source data.
@@ -113,6 +123,16 @@ You can provide the `source` option as an array of objects with `key` and `value
 @[code](@/content/guides/cell-types/multiselect-cell-type/angular/example2.html)
 
 :::
+:::
+
+::: only-for vue
+
+::: example #example2 :vue3
+
+@[code](@/content/guides/cell-types/multiselect-cell-type/vue/example2.vue)
+
+:::
+
 :::
 
 ## Keyboard navigation
@@ -173,6 +193,16 @@ The demo below showcases some the options in an interactive example.
 @[code](@/content/guides/cell-types/multiselect-cell-type/angular/example3.html)
 
 :::
+:::
+
+::: only-for vue
+
+::: example #example3 :vue3
+
+@[code](@/content/guides/cell-types/multiselect-cell-type/vue/example3.vue)
+
+:::
+
 :::
 
 #### API methods

--- a/docs/content/guides/cell-types/multiselect-cell-type/vue/example1.vue
+++ b/docs/content/guides/cell-types/multiselect-cell-type/vue/example1.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const shipmentCategories: string[] = [
+  'Electronics and Gadgets',
+  'Medical Supplies',
+  'Auto Parts',
+  'Fresh Produce',
+  'Textiles',
+  'Industrial Equipment',
+  'Pharmaceuticals',
+  'Consumer Goods',
+  'Machine Parts',
+  'Food Products',
+];
+
+const data: (string | string[])[][] = [
+  ['Los Angeles International Airport', ['Electronics and Gadgets', 'Medical Supplies']],
+  ["Chicago O'Hare International Airport", ['Auto Parts', 'Fresh Produce']],
+  ['Charles de Gaulle Airport', ['Textiles', 'Industrial Equipment']],
+  ['Tokyo Haneda Airport', ['Pharmaceuticals', 'Consumer Goods']],
+  ['Singapore Changi Airport', ['Machine Parts', 'Food Products']],
+  ['Luton Airport', ['Electronics and Gadgets', 'Pharmaceuticals']],
+  ['Frankfurt Airport', ['Industrial Equipment', 'Auto Parts', 'Consumer Goods']],
+  ['Sydney Kingsford Smith Airport', ['Fresh Produce', 'Food Products']],
+  ['Toronto Pearson International Airport', ['Medical Supplies', 'Textiles']],
+  ['Hong Kong International Airport', ['Machine Parts', 'Electronics and Gadgets', 'Industrial Equipment']],
+  ['Heathrow Airport', ['Textiles', 'Consumer Goods']],
+];
+
+const hotSettings = ref<GridSettings>({
+  data,
+  columns: [
+    {
+      title: 'Airport',
+    },
+    {
+      type: 'multiselect',
+      source: shipmentCategories,
+      title: 'Shipment',
+    },
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+  height: 'auto',
+  stretchH: 'last',
+  width: '100%',
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-types/multiselect-cell-type/vue/example2.vue
+++ b/docs/content/guides/cell-types/multiselect-cell-type/vue/example2.vue
@@ -1,0 +1,135 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+interface ShipmentCategory {
+  key: string;
+  value: string;
+}
+
+const shipmentCategories: ShipmentCategory[] = [
+  { key: 'electronics', value: 'Electronics and Gadgets' },
+  { key: 'medical', value: 'Medical Supplies' },
+  { key: 'auto-parts', value: 'Auto Parts' },
+  { key: 'fresh-produce', value: 'Fresh Produce' },
+  { key: 'textiles', value: 'Textiles' },
+  { key: 'industrial', value: 'Industrial Equipment' },
+  { key: 'pharmaceuticals', value: 'Pharmaceuticals' },
+  { key: 'consumer', value: 'Consumer Goods' },
+  { key: 'machine-parts', value: 'Machine Parts' },
+  { key: 'food', value: 'Food Products' },
+];
+
+const data: (string | ShipmentCategory[])[][] = [
+  [
+    'Los Angeles International Airport',
+    [
+      { key: 'electronics', value: 'Electronics and Gadgets' },
+      { key: 'medical', value: 'Medical Supplies' },
+    ],
+  ],
+  [
+    "Chicago O'Hare International Airport",
+    [
+      { key: 'auto-parts', value: 'Auto Parts' },
+      { key: 'fresh-produce', value: 'Fresh Produce' },
+    ],
+  ],
+  [
+    'Charles de Gaulle Airport',
+    [
+      { key: 'textiles', value: 'Textiles' },
+      { key: 'industrial', value: 'Industrial Equipment' },
+    ],
+  ],
+  [
+    'Tokyo Haneda Airport',
+    [
+      { key: 'pharmaceuticals', value: 'Pharmaceuticals' },
+      { key: 'consumer', value: 'Consumer Goods' },
+    ],
+  ],
+  [
+    'Singapore Changi Airport',
+    [
+      { key: 'machine-parts', value: 'Machine Parts' },
+      { key: 'food', value: 'Food Products' },
+    ],
+  ],
+  [
+    'Luton Airport',
+    [
+      { key: 'electronics', value: 'Electronics and Gadgets' },
+      { key: 'pharmaceuticals', value: 'Pharmaceuticals' },
+    ],
+  ],
+  [
+    'Frankfurt Airport',
+    [
+      { key: 'industrial', value: 'Industrial Equipment' },
+      { key: 'auto-parts', value: 'Auto Parts' },
+      { key: 'consumer', value: 'Consumer Goods' },
+    ],
+  ],
+  [
+    'Sydney Kingsford Smith Airport',
+    [
+      { key: 'fresh-produce', value: 'Fresh Produce' },
+      { key: 'food', value: 'Food Products' },
+    ],
+  ],
+  [
+    'Toronto Pearson International Airport',
+    [
+      { key: 'medical', value: 'Medical Supplies' },
+      { key: 'textiles', value: 'Textiles' },
+    ],
+  ],
+  [
+    'Hong Kong International Airport',
+    [
+      { key: 'machine-parts', value: 'Machine Parts' },
+      { key: 'electronics', value: 'Electronics and Gadgets' },
+      { key: 'industrial', value: 'Industrial Equipment' },
+    ],
+  ],
+  [
+    'Heathrow Airport',
+    [
+      { key: 'textiles', value: 'Textiles' },
+      { key: 'consumer', value: 'Consumer Goods' },
+    ],
+  ],
+];
+
+const hotSettings = ref<GridSettings>({
+  data,
+  columns: [
+    {
+      title: 'Airport',
+    },
+    {
+      type: 'multiselect',
+      source: shipmentCategories,
+      title: 'Shipment',
+    },
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+  height: 'auto',
+  stretchH: 'last',
+  width: '100%',
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example2">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-types/multiselect-cell-type/vue/example3.vue
+++ b/docs/content/guides/cell-types/multiselect-cell-type/vue/example3.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const requiredItems: string[] = ['Passport', 'Tickets', 'Wallet', 'Phone', 'Keys'];
+const optionalExtras: string[] = ['Snacks', 'Book', 'Camera', 'Umbrella', 'First aid kit'];
+const interests: string[] = ['Art', 'History', 'Nature', 'Food', 'Shopping'];
+
+const sortAlphabetically = (entries: (string | object)[]) =>
+  [...entries].sort((a, b) => String(a).localeCompare(String(b)));
+
+const data: string[][][] = [
+  [['Passport', 'Phone'], ['Snacks', 'Book'], ['Nature']],
+  [['Tickets', 'Wallet'], ['Camera'], []],
+  [['Phone', 'Keys'], ['First aid kit', 'Snacks', 'Umbrella'], ['Nature']],
+  [['Wallet', 'Phone'], [], ['Food', 'Shopping']],
+  [['Passport', 'Tickets'], ['Book'], ['Art', 'History']],
+  [['Phone', 'Keys'], ['First aid kit', 'Snacks', 'Umbrella'], ['Nature']],
+  [['Wallet', 'Phone'], [], ['Food', 'Shopping']],
+  [['Passport', 'Tickets'], ['Book'], ['Art', 'History']],
+  [['Phone', 'Keys'], ['First aid kit', 'Snacks', 'Umbrella'], ['Nature']],
+  [['Wallet', 'Phone'], [], ['Food', 'Shopping']],
+  [['Passport', 'Tickets'], ['Book'], ['Art', 'History']],
+  [['Phone', 'Keys'], ['First aid kit', 'Snacks', 'Umbrella'], ['Nature']],
+  [['Wallet', 'Phone'], [], ['Food', 'Shopping']],
+  [['Passport', 'Tickets'], ['Book'], ['Art', 'History']],
+];
+
+const hotSettings = ref<GridSettings>({
+  data,
+  columns: [
+    {
+      type: 'multiselect',
+      source: requiredItems,
+      title: 'Required items',
+      allowEmpty: false,
+    },
+    {
+      type: 'multiselect',
+      source: optionalExtras,
+      title: 'Optional extras',
+      placeholder: 'Select up to 3',
+      maxSelections: 3,
+      visibleRows: 4,
+      searchInput: false,
+    },
+    {
+      type: 'multiselect',
+      source: interests,
+      title: 'Interests',
+      placeholder: 'Select interests',
+      sourceSortFunction: sortAlphabetically,
+      filteringCaseSensitive: true,
+    },
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+  height: 'auto',
+  stretchH: 'last',
+  width: '100%',
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example3">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-types/numeric-cell-type/numeric-cell-type.md
+++ b/docs/content/guides/cell-types/numeric-cell-type/numeric-cell-type.md
@@ -77,6 +77,16 @@ Use the locale selector above the table to see how different locales affect numb
 
 :::
 
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/cell-types/numeric-cell-type/vue/example1.vue)
+
+:::
+
+:::
+
 ## Use the numeric cell type
 
 To use the numeric cell type, set the [`type`](@/api/options.md#type) option to `'numeric'`:
@@ -123,6 +133,21 @@ cell={[{
   col: 0,
   type: 'numeric',
 }]}
+```
+
+:::
+
+::: only-for vue
+
+```html
+<!-- set the numeric cell type for each cell of the entire grid -->
+<HotTable :settings="{ type: 'numeric' }" />
+
+<!-- set the numeric cell type for each cell of a single column -->
+<HotTable :settings="{ columns: [{ type: 'numeric' }] }" />
+
+<!-- set the numeric cell type for a single cell -->
+<HotTable :settings="{ cell: [{ row: 0, col: 0, type: 'numeric' }] }" />
 ```
 
 :::
@@ -224,6 +249,34 @@ columns: [
       minimumFractionDigits: 2
     }
   }]}
+/>
+```
+
+:::
+
+::: only-for vue
+
+```html
+<HotTable
+  :settings="{
+    columns: [{
+      type: 'numeric',
+      locale: 'en-US',
+      numericFormat: {
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: 2
+      }
+    }, {
+      type: 'numeric',
+      locale: 'de-DE',
+      numericFormat: {
+        style: 'currency',
+        currency: 'EUR',
+        minimumFractionDigits: 2
+      }
+    }]
+  }"
 />
 ```
 
@@ -359,6 +412,16 @@ In the following demo, columns **Price in Japan** and **Price in Turkey** use tw
 
 @[code](@/content/guides/cell-types/numeric-cell-type/angular/example3.ts)
 @[code](@/content/guides/cell-types/numeric-cell-type/angular/example3.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example3 :vue3-numbro
+
+@[code](@/content/guides/cell-types/numeric-cell-type/vue/example3.vue)
 
 :::
 

--- a/docs/content/guides/cell-types/numeric-cell-type/vue/example1.vue
+++ b/docs/content/guides/cell-types/numeric-cell-type/vue/example1.vue
@@ -1,0 +1,233 @@
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const localeOptions = [
+  { value: 'ar-AR', label: 'Arabic (Global)' },
+  { value: 'cs-CZ', label: 'Czech (Czechia)' },
+  { value: 'de-CH', label: 'German (Switzerland)' },
+  { value: 'de-DE', label: 'German (Germany)' },
+  { value: 'en-US', label: 'English (United States)' },
+  { value: 'es-MX', label: 'Spanish (Mexico)' },
+  { value: 'fa-IR', label: 'Persian (Iran)' },
+  { value: 'fr-FR', label: 'French (France)' },
+  { value: 'hr-HR', label: 'Croatian (Croatia)' },
+  { value: 'it-IT', label: 'Italian (Italy)' },
+  { value: 'ja-JP', label: 'Japanese (Japan)' },
+  { value: 'ko-KR', label: 'Korean (Korea)' },
+  { value: 'lv-LV', label: 'Latvian (Latvia)' },
+  { value: 'nb-NO', label: 'Norwegian Bokmal (Norway)' },
+  { value: 'nl-NL', label: 'Dutch (Netherlands)' },
+  { value: 'pl-PL', label: 'Polish (Poland)' },
+  { value: 'pt-BR', label: 'Portuguese (Brazil)' },
+  { value: 'ru-RU', label: 'Russian (Russia)' },
+  { value: 'sr-SP', label: 'Serbian Latin (Serbia)' },
+  { value: 'zh-CN', label: 'Chinese (Simplified, China)' },
+  { value: 'zh-TW', label: 'Chinese (Traditional, Taiwan)' },
+];
+
+const hotTableComponent = ref(null);
+const dropdownRef = ref<HTMLDivElement | null>(null);
+const isOpen = ref(false);
+const locale = ref('en-US');
+
+const selectedLabel = () => localeOptions.find((o) => o.value === locale.value)?.label;
+
+const handleSelect = (value: string) => {
+  locale.value = value;
+  isOpen.value = false;
+  hotTableComponent.value?.hotInstance?.updateSettings({ locale: value } as GridSettings);
+};
+
+const handleOutsideClick = (e: MouseEvent) => {
+  if (dropdownRef.value && !dropdownRef.value.contains(e.target as Node)) {
+    isOpen.value = false;
+  }
+};
+
+const handleEscape = (e: KeyboardEvent) => {
+  if (e.key === 'Escape') {
+    isOpen.value = false;
+  }
+};
+
+onMounted(() => {
+  document.addEventListener('click', handleOutsideClick);
+  document.addEventListener('keydown', handleEscape);
+});
+
+onUnmounted(() => {
+  document.removeEventListener('click', handleOutsideClick);
+  document.removeEventListener('keydown', handleEscape);
+});
+
+const data = [
+  {
+    car: 'Mercedes A 160',
+    year: 2017,
+    price_usd: 7000,
+    price_eur: 7000,
+    distance_km: 125000,
+    fuel_liters: 45.5,
+    discount_percent: 0.15,
+    quantity: 1250,
+  },
+  {
+    car: 'Citroen C4 Coupe',
+    year: 2018,
+    price_usd: 8330,
+    price_eur: 8330,
+    distance_km: 98000,
+    fuel_liters: 52.3,
+    discount_percent: 0.08,
+    quantity: 2100,
+  },
+  {
+    car: 'Audi A4 Avant',
+    year: 2019,
+    price_usd: 33900,
+    price_eur: 33900,
+    distance_km: 45000,
+    fuel_liters: 60.0,
+    discount_percent: 0.05,
+    quantity: 850,
+  },
+  {
+    car: 'Opel Astra',
+    year: 2020,
+    price_usd: 5000,
+    price_eur: 5000,
+    distance_km: 156000,
+    fuel_liters: 48.7,
+    discount_percent: 0.12,
+    quantity: 3200,
+  },
+  {
+    car: 'BMW 320i Coupe',
+    year: 2021,
+    price_usd: 30500,
+    price_eur: 30500,
+    distance_km: 32000,
+    fuel_liters: 55.2,
+    discount_percent: 0.03,
+    quantity: 1500,
+  },
+];
+
+const hotSettings = ref<GridSettings>({
+  data,
+  colHeaders: ['Car', 'Year', 'Price (USD)', 'Price (EUR)', 'Distance', 'Fuel', 'Discount', 'Quantity'],
+  locale: 'en-US',
+  columns: [
+    {
+      data: 'car',
+      type: 'text',
+    },
+    {
+      data: 'year',
+      type: 'numeric',
+    },
+    {
+      data: 'price_usd',
+      type: 'numeric',
+      numericFormat: {
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: 2,
+      },
+    },
+    {
+      data: 'price_eur',
+      type: 'numeric',
+      numericFormat: {
+        style: 'currency',
+        currency: 'EUR',
+        minimumFractionDigits: 2,
+      },
+    },
+    {
+      data: 'distance_km',
+      type: 'numeric',
+      numericFormat: {
+        style: 'unit',
+        unit: 'kilometer',
+        useGrouping: true,
+      },
+    },
+    {
+      data: 'fuel_liters',
+      type: 'numeric',
+      numericFormat: {
+        style: 'unit',
+        unit: 'liter',
+        minimumFractionDigits: 1,
+        maximumFractionDigits: 1,
+      },
+    },
+    {
+      data: 'discount_percent',
+      type: 'numeric',
+      numericFormat: {
+        style: 'percent',
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 2,
+      },
+    },
+    {
+      data: 'quantity',
+      type: 'numeric',
+      numericFormat: {
+        style: 'decimal',
+        useGrouping: true,
+        minimumFractionDigits: 0,
+      },
+    },
+  ],
+  columnSorting: true,
+  filters: true,
+  dropdownMenu: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <div class="example-controls-container">
+      <div class="controls">
+        <div class="theme-dropdown" ref="dropdownRef">
+          <button
+            class="theme-dropdown-trigger"
+            type="button"
+            aria-haspopup="listbox"
+            :aria-expanded="isOpen"
+            @click="isOpen = !isOpen"
+          >
+            <span>{{ selectedLabel() }}</span>
+            <svg class="theme-dropdown-chevron" aria-hidden="true" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6l6 -6"/></svg>
+          </button>
+          <ul v-if="isOpen" class="theme-dropdown-menu" role="listbox">
+            <li
+              v-for="opt in localeOptions"
+              :key="opt.value"
+              role="option"
+              :aria-selected="locale === opt.value"
+              @click="handleSelect(opt.value)"
+            >
+              {{ opt.label }}
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <HotTable ref="hotTableComponent" :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-types/numeric-cell-type/vue/example3.vue
+++ b/docs/content/guides/cell-types/numeric-cell-type/vue/example3.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable, HotColumn } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const formatJP = { style: 'decimal', useGrouping: true, minimumFractionDigits: 2, maximumFractionDigits: 2 };
+const formatTR = { style: 'decimal', useGrouping: true, minimumFractionDigits: 2, maximumFractionDigits: 2 };
+
+const hotData = ref([
+  {
+    productName: 'Product A',
+    JP_price: 1450.32,
+    TR_price: 202.14,
+  },
+  {
+    productName: 'Product B',
+    JP_price: 2430.22,
+    TR_price: 338.86,
+  },
+  {
+    productName: 'Product C',
+    JP_price: 3120.1,
+    TR_price: 435.2,
+  },
+]);
+
+const hotSettings = ref<GridSettings>({
+  autoRowSize: false,
+  autoColumnSize: false,
+  columnSorting: true,
+  colHeaders: ['Product name', 'Price in Japan', 'Price in Turkey'],
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example3">
+    <HotTable :data="hotData" :settings="hotSettings">
+      <HotColumn data="productName" type="text" :width="150" />
+      <HotColumn data="JP_price" type="numeric" locale="ja-JP" :numericFormat="formatJP" :width="150" />
+      <HotColumn data="TR_price" type="numeric" locale="tr-TR" :numericFormat="formatTR" :width="150" />
+    </HotTable>
+  </div>
+</template>

--- a/docs/content/guides/cell-types/password-cell-type/password-cell-type.md
+++ b/docs/content/guides/cell-types/password-cell-type/password-cell-type.md
@@ -61,6 +61,16 @@ The password cell type behaves like a text cell, the only difference being that 
 
 :::
 
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/cell-types/password-cell-type/vue/example1.vue)
+
+:::
+
+:::
+
 ## Fixed hash length
 
 By default, every hash has a length equal to the length of its corresponding value. Use option `hashLength` to set a fixed hash length.
@@ -93,6 +103,16 @@ By default, every hash has a length equal to the length of its corresponding val
 
 @[code](@/content/guides/cell-types/password-cell-type/angular/example2.ts)
 @[code](@/content/guides/cell-types/password-cell-type/angular/example2.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example2 :vue3
+
+@[code](@/content/guides/cell-types/password-cell-type/vue/example2.vue)
 
 :::
 
@@ -135,6 +155,16 @@ By default, every hash consists of asterisks `*`. Use the option `hashSymbol` to
 
 :::
 
+::: only-for vue
+
+::: example #example3 :vue3
+
+@[code](@/content/guides/cell-types/password-cell-type/vue/example3.vue)
+
+:::
+
+:::
+
 ## Reveal delay
 
 Use the `hashRevealDelay` option to briefly show each character as you type it. After the delay (in milliseconds) elapses, the character is replaced by the hash symbol. This lets you confirm what you typed without permanently exposing the value.
@@ -169,6 +199,16 @@ When `hashRevealDelay` is set, the editor switches from a native `<input type="p
 
 @[code](@/content/guides/cell-types/password-cell-type/angular/example4.ts)
 @[code](@/content/guides/cell-types/password-cell-type/angular/example4.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example4 :vue3
+
+@[code](@/content/guides/cell-types/password-cell-type/vue/example4.vue)
 
 :::
 

--- a/docs/content/guides/cell-types/password-cell-type/vue/example1.vue
+++ b/docs/content/guides/cell-types/password-cell-type/vue/example1.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    {
+      id: 1,
+      name: { first: 'Chris', last: 'Right' },
+      password: 'plainTextPassword',
+    },
+    { id: 2, name: { first: 'John', last: 'Honest' }, password: 'txt' },
+    { id: 3, name: { first: 'Greg', last: 'Well' }, password: 'longer' },
+  ],
+  colHeaders: ['ID', 'First name', 'Last name', 'Password'],
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  columns: [
+    { data: 'id' },
+    { data: 'name.first' },
+    { data: 'name.last' },
+    { data: 'password', type: 'password' },
+  ],
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-types/password-cell-type/vue/example2.vue
+++ b/docs/content/guides/cell-types/password-cell-type/vue/example2.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    {
+      id: 1,
+      name: { first: 'Chris', last: 'Right' },
+      password: 'plainTextPassword',
+    },
+    { id: 2, name: { first: 'John', last: 'Honest' }, password: 'txt' },
+    { id: 3, name: { first: 'Greg', last: 'Well' }, password: 'longer' },
+  ],
+  colHeaders: ['ID', 'First name', 'Last name', 'Password'],
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  columns: [
+    { data: 'id' },
+    { data: 'name.first' },
+    { data: 'name.last' },
+    { data: 'password', type: 'password', hashLength: 10 },
+  ],
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example2">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-types/password-cell-type/vue/example3.vue
+++ b/docs/content/guides/cell-types/password-cell-type/vue/example3.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    {
+      id: 1,
+      name: { first: 'Chris', last: 'Right' },
+      password: 'plainTextPassword',
+    },
+    { id: 2, name: { first: 'John', last: 'Honest' }, password: 'txt' },
+    { id: 3, name: { first: 'Greg', last: 'Well' }, password: 'longer' },
+  ],
+  colHeaders: ['ID', 'First name', 'Last name', 'Password'],
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  columns: [
+    { data: 'id' },
+    { data: 'name.first' },
+    { data: 'name.last' },
+    { data: 'password', type: 'password', hashSymbol: '&#9632;' },
+  ],
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example3">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-types/password-cell-type/vue/example4.vue
+++ b/docs/content/guides/cell-types/password-cell-type/vue/example4.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    { id: 1, name: { first: 'Chris', last: 'Right' }, password: 'plainTextPassword' },
+    { id: 2, name: { first: 'John', last: 'Honest' }, password: 'txt' },
+    { id: 3, name: { first: 'Greg', last: 'Well' }, password: 'longer' },
+  ],
+  colHeaders: ['ID', 'First name', 'Last name', 'Password'],
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  columns: [
+    { data: 'id' },
+    { data: 'name.first' },
+    { data: 'name.last' },
+    { data: 'password', type: 'password', hashRevealDelay: 1000 },
+  ],
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example4">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-types/select-cell-type/select-cell-type.md
+++ b/docs/content/guides/cell-types/select-cell-type/select-cell-type.md
@@ -65,6 +65,16 @@ The select cell type is a simpler form of the [dropdown](@/guides/cell-types/dro
 
 :::
 
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/cell-types/select-cell-type/vue/example1.vue)
+
+:::
+
+:::
+
 ## Result
 
 After configuring the select cell type, cells render a native HTML `<select>` element when the user activates them. The user picks a value from the list and the selected value is written to the data source.

--- a/docs/content/guides/cell-types/select-cell-type/vue/example1.vue
+++ b/docs/content/guides/cell-types/select-cell-type/vue/example1.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['2017', 'Honda', 10],
+    ['2018', 'Toyota', 20],
+    ['2019', 'Nissan', 30],
+  ],
+  colWidths: [50, 70, 50],
+  colHeaders: true,
+  columns: [
+    {},
+    {
+      type: 'select',
+      selectOptions: ['Kia', 'Nissan', 'Toyota', 'Honda'],
+    },
+    {},
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+  height: 'auto',
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-types/time-cell-type/time-cell-type.md
+++ b/docs/content/guides/cell-types/time-cell-type/time-cell-type.md
@@ -60,6 +60,16 @@ In the following demo, the **Start**, **Break start**, and **End** columns use t
 :::
 :::
 
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/cell-types/time-cell-type/vue/example1.vue)
+
+:::
+
+:::
+
 ## Use the time cell type
 
 Use the **object-style** configuration by setting the [`type`](@/api/options.md#type) option to `'intl-time'` and [`timeFormat`](@/api/options.md#timeformat) to an object (recommended). The locale is controlled via the [`locale`](@/api/options.md#locale) option.
@@ -176,6 +186,60 @@ settings3 = {
 
 :::
 
+::: only-for vue
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+// set the time cell type for the entire grid (Intl, recommended)
+const hotSettings = ref<GridSettings>({
+  type: 'intl-time',
+  locale: 'en-US',
+  timeFormat: {
+    hour: 'numeric',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: true
+  },
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+// set the time cell type for a single column
+const hotSettingsColumn = ref<GridSettings>({
+  columns: [
+    {
+      type: 'intl-time',
+      locale: 'en-US',
+      timeFormat: { timeStyle: 'medium' }
+    }
+  ],
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+// set the time cell type for a single cell
+const hotSettingsCell = ref<GridSettings>({
+  cell: [
+    {
+      row: 0,
+      col: 2,
+      type: 'intl-time',
+      locale: 'en-US',
+      timeFormat: { hour: '2-digit', minute: '2-digit', hour12: true }
+    }
+  ],
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+```
+
+:::
+
 For `intl-time` cells, source data **must** be in **24-hour time format** (`HH:mm`, `HH:mm:ss`, or `HH:mm:ss.SSS`) for times to work correctly. The `timeFormat` object only affects how times are displayed; sorting and filtering rely on the underlying value.
 
 ## Format times
@@ -259,6 +323,46 @@ settings = {
     }
   ]
 };
+```
+
+:::
+
+::: only-for vue
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  columns: [
+    {
+      type: 'intl-time',
+      locale: 'en-US',
+      timeFormat: {
+        hour: 'numeric',
+        minute: '2-digit',
+        second: '2-digit',
+        hour12: true
+      }
+    },
+    {
+      type: 'intl-time',
+      locale: 'de-DE',
+      timeFormat: { timeStyle: 'medium' }
+    }
+  ],
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <HotTable :settings="hotSettings" />
+</template>
 ```
 
 :::

--- a/docs/content/guides/cell-types/time-cell-type/vue/example1.vue
+++ b/docs/content/guides/cell-types/time-cell-type/vue/example1.vue
@@ -1,0 +1,153 @@
+<script setup lang="ts">
+import { ref, onMounted, onBeforeUnmount } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const localeOptions = [
+  { value: 'ar-AR', label: 'Arabic (Global)' },
+  { value: 'cs-CZ', label: 'Czech (Czechia)' },
+  { value: 'de-CH', label: 'German (Switzerland)' },
+  { value: 'de-DE', label: 'German (Germany)' },
+  { value: 'en-US', label: 'English (United States)' },
+  { value: 'es-MX', label: 'Spanish (Mexico)' },
+  { value: 'fa-IR', label: 'Persian (Iran)' },
+  { value: 'fr-FR', label: 'French (France)' },
+  { value: 'hr-HR', label: 'Croatian (Croatia)' },
+  { value: 'it-IT', label: 'Italian (Italy)' },
+  { value: 'ja-JP', label: 'Japanese (Japan)' },
+  { value: 'ko-KR', label: 'Korean (Korea)' },
+  { value: 'lv-LV', label: 'Latvian (Latvia)' },
+  { value: 'nb-NO', label: 'Norwegian Bokmal (Norway)' },
+  { value: 'nl-NL', label: 'Dutch (Netherlands)' },
+  { value: 'pl-PL', label: 'Polish (Poland)' },
+  { value: 'pt-BR', label: 'Portuguese (Brazil)' },
+  { value: 'ru-RU', label: 'Russian (Russia)' },
+  { value: 'sr-SP', label: 'Serbian Latin (Serbia)' },
+  { value: 'zh-CN', label: 'Chinese (Simplified, China)' },
+  { value: 'zh-TW', label: 'Chinese (Traditional, Taiwan)' },
+];
+
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const dropdownRef = ref<HTMLDivElement | null>(null);
+const isOpen = ref(false);
+const locale = ref('en-US');
+
+const selectedLabel = () => localeOptions.find((o) => o.value === locale.value)?.label;
+
+const handleSelect = (value: string) => {
+  locale.value = value;
+  isOpen.value = false;
+  hotRef.value?.hotInstance?.updateSettings({ locale: value } as GridSettings);
+};
+
+const handleOutsideClick = (e: MouseEvent) => {
+  if (dropdownRef.value && !dropdownRef.value.contains(e.target as Node)) {
+    isOpen.value = false;
+  }
+};
+
+const handleEscape = (e: KeyboardEvent) => {
+  if (e.key === 'Escape') {
+    isOpen.value = false;
+  }
+};
+
+onMounted(() => {
+  document.addEventListener('click', handleOutsideClick);
+  document.addEventListener('keydown', handleEscape);
+});
+
+onBeforeUnmount(() => {
+  document.removeEventListener('click', handleOutsideClick);
+  document.removeEventListener('keydown', handleEscape);
+});
+
+const data = [
+  { shift: 'Morning', start: '09:00', breakStart: '12:00', end: '17:00' },
+  { shift: 'Afternoon', start: '13:30', breakStart: '16:00', end: '21:00' },
+  { shift: 'Night', start: '22:00', breakStart: '01:00', end: '06:00' },
+  { shift: 'Split', start: '08:00', breakStart: '12:30', end: '20:00' },
+  { shift: 'Short day', start: '10:00', breakStart: '13:00', end: '15:00' },
+];
+
+const hotSettings = ref<GridSettings>({
+  data,
+  colHeaders: ['Shift', 'Start', 'Break start', 'End'],
+  locale: 'en-US',
+  columns: [
+    {
+      type: 'text',
+      data: 'shift',
+    },
+    {
+      type: 'intl-time',
+      data: 'start',
+      timeFormat: {
+        timeStyle: 'short',
+      },
+    },
+    {
+      type: 'intl-time',
+      data: 'breakStart',
+      timeFormat: {
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+      },
+    },
+    {
+      type: 'intl-time',
+      data: 'end',
+      timeFormat: {
+        hour: 'numeric',
+        hourCycle: 'h12',
+        dayPeriod: 'short',
+      },
+    },
+  ],
+  columnSorting: true,
+  filters: true,
+  dropdownMenu: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <div class="example-controls-container">
+      <div class="controls">
+        <div class="theme-dropdown" ref="dropdownRef">
+          <button
+            class="theme-dropdown-trigger"
+            type="button"
+            aria-haspopup="listbox"
+            :aria-expanded="isOpen"
+            @click="isOpen = !isOpen"
+          >
+            <span>{{ selectedLabel() }}</span>
+            <svg class="theme-dropdown-chevron" aria-hidden="true" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6l6 -6"/></svg>
+          </button>
+          <ul v-if="isOpen" class="theme-dropdown-menu" role="listbox">
+            <li
+              v-for="opt in localeOptions"
+              :key="opt.value"
+              role="option"
+              :aria-selected="locale === opt.value"
+              @click="handleSelect(opt.value)"
+            >
+              {{ opt.label }}
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <HotTable ref="hotRef" :settings="hotSettings" />
+  </div>
+</template>


### PR DESCRIPTION
### Context

The PR adds Vue 3 variants to all 11 cell-type guide pages under `docs/content/guides/cell-types/`. These pages already shipped JavaScript, React, and Angular examples and declared a `vue:` frontmatter block, but rendered no Vue content under `vue-data-grid/`. This continues the Vue-variant series and brings the cell-type guides to full framework parity.

For each page this PR adds:

- One `vue/example<N>.vue` SFC per existing example (29 files total), using `<script setup lang="ts">` with typed `GridSettings`, faithfully matching the data, columns, cell types, and settings of the JS/React siblings.
- `::: only-for vue` example blocks (`:vue3`, and `:vue3-numbro` for the numeric numbro example).
- `::: only-for vue` prose sections mirroring the existing React/Angular prose.

All `.md` edits are pure additions — no existing JS/React/Angular content was modified.

### How has this been tested?

- `cd docs && npm run docs:lint` — passes.
- Ran the docs dev server (`npm run dev`) and loaded the rendered Vue pages in a browser:
  - `vue-data-grid/autocomplete-cell-type` (7 examples), `vue-data-grid/numeric-cell-type` (numbro), and `vue-data-grid/time-cell-type` (custom locale-switcher UI).
  - Every example mounts a working grid (`.ht_master` present, cells populated), the custom UI and shared `--css` slot render, and there are 0 console errors.
- Verified the embedded `hot-example-sb-data` for each Vue example (`framework: "vue"`, `.vue` file, builtin deps) so "Edit on StackBlitz" works.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1743

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime impact on the grid or wrappers; main risk is example or Node-version doc drift if prerequisites text is not fully aligned.
> 
> **Overview**
> Adds **Vue 3** coverage to all **11 cell-type guides** under `docs/content/guides/cell-types/`, so `vue-data-grid/` pages match the existing JS/React/Angular examples.
> 
> For each guide, the PR adds **`vue/example*.vue`** SFCs (`<script setup lang="ts">`, `@handsontable/vue3`, `registerAllModules()`, typed `GridSettings`) and wires them in with new **`::: only-for vue`** blocks (`:vue3` / `:vue3-numbro` where needed). The **cell type** guide also gets Vue prose snippets for `type`, precedence, and custom aliases. Larger demos (numeric/date/time) reuse the **locale dropdown** pattern and call `hotInstance.updateSettings({ locale })`.
> 
> **Docs-only** updates in `.ai/STRUCTURE.md`, `AGENTS.md`, and `docs/AGENTS.md` state the docs site requires **Node 22** (was Node 20). No core or wrapper package code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a49def4f40793ffc7d8ae70ee9a265fdb642d8cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->