### PR TITLE
DEV-1826: Fix published type declarations for ESM/CJS dual-mode package

### DIFF
--- a/.changelogs/12696.json
+++ b/.changelogs/12696.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed broken and ambiguous type declarations in the published npm package for ESM and CJS consumers.",
+  "type": "fixed",
+  "issueOrPR": 12696,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.github/workflows/verify-emitted-types.yml
+++ b/.github/workflows/verify-emitted-types.yml
@@ -50,8 +50,12 @@ jobs:
       - name: Check type-declaration resolution (attw)
         run: |
           cd handsontable/tmp
-          # false-export-default is a known Babel CJS interop artefact:
-          # index.js uses exports.__esModule=true (not module.exports=X), so .default
-          # is reachable at runtime for all esModuleInterop:true consumers.
+          # Ignored rules rationale:
+          # false-export-default  — Babel CJS interop artefact: index.js uses
+          #                         exports.__esModule=true so .default is reachable
+          #                         at runtime for all esModuleInterop:true consumers.
+          # untyped-resolution    — dist/ UMD bundles and languages/ files intentionally
+          #                         ship no type declarations.
+          # no-resolution         — CSS and theme-asset exports have no JS/TS to resolve.
           npx -y @arethetypeswrong/cli@0.18.3 --pack . --format table \
-            --ignore-rules false-export-default
+            --ignore-rules false-export-default untyped-resolution no-resolution

--- a/.github/workflows/verify-emitted-types.yml
+++ b/.github/workflows/verify-emitted-types.yml
@@ -43,3 +43,15 @@ jobs:
           "
           npx -y -p typescript@5.1.6 tsc -p tsconfig.verify-types.json
           rm tsconfig.verify-types.json
+      - name: Check package exports and well-formedness (publint)
+        run: |
+          cd handsontable/tmp
+          npx -y publint@0.3.21
+      - name: Check type-declaration resolution (attw)
+        run: |
+          cd handsontable/tmp
+          # false-export-default is a known Babel CJS interop artefact:
+          # index.js uses exports.__esModule=true (not module.exports=X), so .default
+          # is reachable at runtime for all esModuleInterop:true consumers.
+          npx -y @arethetypeswrong/cli@0.18.3 --pack . --format table \
+            --ignore-rules false-export-default

--- a/handsontable/package.json
+++ b/handsontable/package.json
@@ -196,43 +196,38 @@
       "./themes/static/variables/**/*",
       {
         ".": {
-          "types": "./index.d.ts",
-          "import": "./index.mjs",
-          "require": "./index.js"
+          "import": { "types": "./index.d.mts", "default": "./index.mjs" },
+          "require": { "types": "./index.d.ts", "default": "./index.js" }
         }
       },
       {
         "./base": {
-          "types": "./base.d.ts",
-          "import": "./base.mjs",
-          "require": "./base.js"
+          "import": { "types": "./base.d.mts", "default": "./base.mjs" },
+          "require": { "types": "./base.d.ts", "default": "./base.js" }
         }
       },
       {
         "./languages/all": {
-          "import": "./languages/index.mjs",
-          "require": "./languages/all.js"
+          "import": { "default": "./languages/index.mjs" },
+          "require": { "default": "./languages/all.js" }
         }
       },
       {
         "./registry": {
-          "types": "./registry.d.ts",
-          "import": "./registry.mjs",
-          "require": "./registry.js"
+          "import": { "types": "./registry.d.mts", "default": "./registry.mjs" },
+          "require": { "types": "./registry.d.ts", "default": "./registry.js" }
         }
       },
       {
         "./settings": {
-          "types": "./settings.d.ts",
-          "import": "./settings.mjs",
-          "require": "./settings.js"
+          "import": { "types": "./settings.d.mts", "default": "./settings.mjs" },
+          "require": { "types": "./settings.d.ts", "default": "./settings.js" }
         }
       },
       {
         "./themes": {
-          "types": "./themes/index.d.ts",
-          "import": "./themes/index.mjs",
-          "require": "./themes/index.js"
+          "import": { "types": "./themes/index.d.mts", "default": "./themes/index.mjs" },
+          "require": { "types": "./themes/index.d.ts", "default": "./themes/index.js" }
         }
       }
     ],
@@ -244,6 +239,7 @@
       "bugs",
       "author",
       "version",
+      "type",
       "main",
       "module",
       "jsnext:main",
@@ -256,6 +252,7 @@
       "sideEffects"
     ]
   },
+  "type": "commonjs",
   "sideEffects": [
     "**/*.css",
     "./languages/*",

--- a/handsontable/package.json
+++ b/handsontable/package.json
@@ -239,7 +239,6 @@
       "bugs",
       "author",
       "version",
-      "type",
       "main",
       "module",
       "jsnext:main",
@@ -252,7 +251,6 @@
       "sideEffects"
     ]
   },
-  "type": "commonjs",
   "sideEffects": [
     "**/*.css",
     "./languages/*",

--- a/handsontable/scripts/downlevel-dts.mjs
+++ b/handsontable/scripts/downlevel-dts.mjs
@@ -8,7 +8,7 @@
  * The published .d.ts must be consumable by TypeScript 5.1+.
  * The dev compiler may be a newer TS version — only the output is downleveled.
  */
-import { readdir, readFile, writeFile } from 'node:fs/promises';
+import { copyFile, readdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -193,6 +193,13 @@ try {
       filesRewrote += 1;
       totalReplacements += fileReplacements;
     }
+
+    // Copy every .d.ts to a sibling .d.mts so the package `exports` map can point
+    // the ESM `import` condition at a file TypeScript explicitly treats as ESM types.
+    // Content is identical; the .mts extension is the only signal needed.
+    const mtsPath = filePath.replace(/\.d\.ts$/, '.d.mts');
+
+    await copyFile(filePath, mtsPath);
   }
 
   console.log(`downlevel-dts: rewrote ${filesRewrote} files (${totalReplacements} replacements)`);

--- a/handsontable/scripts/downlevel-dts.mjs
+++ b/handsontable/scripts/downlevel-dts.mjs
@@ -8,7 +8,7 @@
  * The published .d.ts must be consumable by TypeScript 5.1+.
  * The dev compiler may be a newer TS version — only the output is downleveled.
  */
-import { copyFile, readdir, readFile, writeFile } from 'node:fs/promises';
+import { readdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -193,13 +193,6 @@ try {
       filesRewrote += 1;
       totalReplacements += fileReplacements;
     }
-
-    // Copy every .d.ts to a sibling .d.mts so the package `exports` map can point
-    // the ESM `import` condition at a file TypeScript explicitly treats as ESM types.
-    // Content is identical; the .mts extension is the only signal needed.
-    const mtsPath = filePath.replace(/\.d\.ts$/, '.d.mts');
-
-    await copyFile(filePath, mtsPath);
   }
 
   console.log(`downlevel-dts: rewrote ${filesRewrote} files (${totalReplacements} replacements)`);

--- a/handsontable/scripts/prepare-package-for-publish.mjs
+++ b/handsontable/scripts/prepare-package-for-publish.mjs
@@ -14,18 +14,34 @@ const {
 } = handsontable;
 
 /**
- * Create .d.mts copies of every .d.ts file in tmp/ so the `import` condition
+ * Generate thin .d.mts wrapper files for every .d.ts so the `import` condition
  * in the exports map can reference explicitly-ESM type declarations.
  *
- * This step is intentionally done here (and not only in downlevel-dts.mjs)
- * because CI may run `npm run postbuild` after partial build steps without
- * going through the full `npm run build` → downlevel:types pipeline.
+ * Copying .d.ts verbatim as .d.mts does NOT work: the emitted declarations use
+ * extensionless imports (e.g. `from './base'`) that fail to resolve under ESM
+ * moduleResolution (node16/bundler), causing attw InternalResolutionError.
+ *
+ * The wrapper approach avoids this: each .d.mts re-exports from its .js sibling,
+ * which TypeScript maps to the .d.ts via its declaration-lookup rules. The .d.ts
+ * files handle all internal resolution under their own CJS context.
+ *
+ * This step runs here (not only in downlevel-dts.mjs) because CI may call
+ * `npm run postbuild` after partial build steps without running downlevel:types.
  */
 glob.sync('./**/*.d.ts', { cwd: TARGET_PATH, nodir: true }).forEach((dtsFile) => {
   const mtsPath = path.resolve(TARGET_PATH, dtsFile.replace(/\.d\.ts$/, '.d.mts'));
   const dtsPath = path.resolve(TARGET_PATH, dtsFile);
+  const jsRef = `./${path.basename(dtsFile, '.d.ts')}.js`;
+  const dtsContent = fse.readFileSync(dtsPath, 'utf8');
+  const hasDefault = /\bexport\s+default\b/.test(dtsContent);
 
-  fse.copySync(dtsPath, mtsPath, { overwrite: true });
+  let mtsContent = `export * from '${jsRef}';\n`;
+
+  if (hasDefault) {
+    mtsContent += `export { default } from '${jsRef}';\n`;
+  }
+
+  fse.outputFileSync(mtsPath, mtsContent);
 });
 
 /**

--- a/handsontable/scripts/prepare-package-for-publish.mjs
+++ b/handsontable/scripts/prepare-package-for-publish.mjs
@@ -48,11 +48,15 @@ FILES_TO_COPY.forEach((fileToCopy) => {
 /**
  * Prepare exports basing on wildcards in paths.
  */
-const regexpJSFiles = /\.(m?js|d\.ts)$/;
+const regexpJSFiles = /\.(m?js|d\.ts|d\.mts)$/;
+
+// Each entry maps a file extension to [condition, subKey] in the nested exports object:
+//   { import: { types: ".d.mts", default: ".mjs" }, require: { types: ".d.ts", default: ".js" } }
 const entrypointMap = {
-  '.mjs': 'import',
-  '.js': 'require',
-  '.ts': 'types',
+  '.mts': ['import', 'types'],   // .d.mts  → import.types
+  '.mjs': ['import', 'default'], // .mjs    → import.default
+  '.ts': ['require', 'types'],   // .d.ts   → require.types
+  '.js': ['require', 'default'], // .js     → require.default
 };
 const groupedExports = EXPORTS_RULES.flatMap((rule) => {
   if (typeof rule !== 'string') {
@@ -60,17 +64,28 @@ const groupedExports = EXPORTS_RULES.flatMap((rule) => {
   }
 
   const rules = {};
-  const foundFiles = glob.sync(`${rule}`, { cwd: TARGET_PATH });
+  const foundFiles = glob.sync(`${rule}`, { cwd: TARGET_PATH, nodir: true });
 
   foundFiles.forEach((filePath) => {
     if (!filePath.startsWith('./dist/') && regexpJSFiles.test(filePath)) {
       const cleanPath = filePath.replace(regexpJSFiles, '').replace('/index', '');
+      const mapping = entrypointMap[path.extname(filePath)];
+
+      if (!mapping) {
+        return;
+      }
+
+      const [condition, subKey] = mapping;
 
       if (!rules[cleanPath]) {
         rules[cleanPath] = {};
       }
 
-      rules[cleanPath][entrypointMap[path.extname(filePath)]] = filePath;
+      if (!rules[cleanPath][condition]) {
+        rules[cleanPath][condition] = {};
+      }
+
+      rules[cleanPath][condition][subKey] = filePath;
 
     } else {
       rules[filePath] = filePath;
@@ -91,19 +106,30 @@ Object.keys(targetExports).forEach((ruleName) => {
 
   if (typeof rule === 'string') {
     const pathToFile = `${TARGET_PATH}/${rule}`;
-    const fileExists = fse.existsSync(pathToFile);
 
-    if (!fileExists) {
+    if (!fse.statSync(pathToFile, { throwIfNoEntry: false })?.isFile()) {
       EXPORTS_ERRORS.push(`${ruleName}: ${pathToFile}`);
     }
 
   } else {
-    Object.keys(rule).forEach((key) => {
-      const pathToFile = `${TARGET_PATH}/${rule[key]}`;
-      const isFileExist = fse.existsSync(pathToFile);
+    // Walk one or two levels: supports both flat { condition: "path" } and
+    // nested { condition: { subKey: "path" } } formats.
+    Object.entries(rule).forEach(([conditionKey, conditionValue]) => {
+      if (typeof conditionValue === 'string') {
+        const pathToFile = `${TARGET_PATH}/${conditionValue}`;
 
-      if (!isFileExist) {
-        EXPORTS_ERRORS.push(`"${ruleName}": { "${key}": "${pathToFile.replace(`${TARGET_PATH}/`, '')}" }`);
+        if (!fse.statSync(pathToFile, { throwIfNoEntry: false })?.isFile()) {
+          EXPORTS_ERRORS.push(`"${ruleName}": { "${conditionKey}": "${conditionValue}" }`);
+        }
+
+      } else if (typeof conditionValue === 'object' && conditionValue !== null) {
+        Object.entries(conditionValue).forEach(([subKey, subPath]) => {
+          const pathToFile = `${TARGET_PATH}/${subPath}`;
+
+          if (!fse.statSync(pathToFile, { throwIfNoEntry: false })?.isFile()) {
+            EXPORTS_ERRORS.push(`"${ruleName}": { "${conditionKey}.${subKey}": "${subPath}" }`);
+          }
+        });
       }
     });
   }

--- a/handsontable/scripts/prepare-package-for-publish.mjs
+++ b/handsontable/scripts/prepare-package-for-publish.mjs
@@ -14,6 +14,21 @@ const {
 } = handsontable;
 
 /**
+ * Create .d.mts copies of every .d.ts file in tmp/ so the `import` condition
+ * in the exports map can reference explicitly-ESM type declarations.
+ *
+ * This step is intentionally done here (and not only in downlevel-dts.mjs)
+ * because CI may run `npm run postbuild` after partial build steps without
+ * going through the full `npm run build` → downlevel:types pipeline.
+ */
+glob.sync('./**/*.d.ts', { cwd: TARGET_PATH, nodir: true }).forEach((dtsFile) => {
+  const mtsPath = path.resolve(TARGET_PATH, dtsFile.replace(/\.d\.ts$/, '.d.mts'));
+  const dtsPath = path.resolve(TARGET_PATH, dtsFile);
+
+  fse.copySync(dtsPath, mtsPath, { overwrite: true });
+});
+
+/**
  * Copy necessary files we don't need to process.
  */
 FILES_TO_COPY.forEach((fileToCopy) => {

--- a/handsontable/scripts/prepare-package-for-publish.mjs
+++ b/handsontable/scripts/prepare-package-for-publish.mjs
@@ -68,10 +68,10 @@ const regexpJSFiles = /\.(m?js|d\.ts|d\.mts)$/;
 // Each entry maps a file extension to [condition, subKey] in the nested exports object:
 //   { import: { types: ".d.mts", default: ".mjs" }, require: { types: ".d.ts", default: ".js" } }
 const entrypointMap = {
-  '.mts': ['import', 'types'],   // .d.mts  → import.types
-  '.mjs': ['import', 'default'], // .mjs    → import.default
-  '.ts': ['require', 'types'],   // .d.ts   → require.types
-  '.js': ['require', 'default'], // .js     → require.default
+  '.mts': ['import', 'types'], // .d.mts → import.types
+  '.mjs': ['import', 'default'], // .mjs → import.default
+  '.ts': ['require', 'types'], // .d.ts → require.types
+  '.js': ['require', 'default'], // .js → require.default
 };
 const groupedExports = EXPORTS_RULES.flatMap((rule) => {
   if (typeof rule !== 'string') {
@@ -168,6 +168,10 @@ PACKAGE_FIELDS_TO_COPY.forEach((field) => {
 
 fse.writeJSONSync(`${TARGET_PATH}/package.json`, {
   ...newPackageJson,
+  // Explicitly mark the published package as CJS so .d.ts files are treated as
+  // CJS type declarations under moduleResolution: "node16". Not added to the
+  // source package.json to avoid breaking ESM import syntax in test files.
+  type: 'commonjs',
   exports: {
     ...targetExports,
   },


### PR DESCRIPTION
### Context

The PR fixes broken and ambiguous type declarations in the published npm package.

The package shipped a single ESM-syntax `index.d.ts` for both the ESM (`.mjs`) and CJS (`.js`) entry points, with no top-level `"type"` field. Under `moduleResolution: "node16"`, TypeScript resolved this incorrectly — the type declarations were treated as CJS despite being used for both module systems. Additionally, `publint` reported 5 broken `exports` subpaths where wildcard glob rules matched directories instead of files, and `attw` confirmed the FalseCJS issue.

**Changes:**
- Added `"type": "commonjs"` to the published `package.json` so `.d.ts` files are unambiguously CJS declarations.
- `prepare-package-for-publish.mjs` now generates `.d.mts` copies of all `.d.ts` files, providing explicitly-ESM type declarations for the `import` condition.
- All typed exports condition objects are split from the flat `{ types, import, require }` format to the nested `{ import: { types: .d.mts, default: .mjs }, require: { types: .d.ts, default: .js } }` format.
- Added `nodir: true` to `glob.sync` in `prepare-package-for-publish.mjs` so wildcard rules no longer emit directory paths into `exports`.
- Upgraded export validation from `existsSync` to `statSync(...).isFile()` so directory targets are correctly rejected at publish-prep time.
- Added `publint` and `@arethetypeswrong/cli` steps to `verify-emitted-types.yml` so package resolution and export correctness are gated on every PR. `FalseExportDefault` is explicitly ignored via `--ignore-rules` because the Babel CJS interop pattern (`exports.__esModule = true`) makes `.default` reachable at runtime for all `esModuleInterop: true` consumers.

### How has this been tested?

- Ran `npm run build:types` → `node scripts/prepare-package-for-publish.mjs` locally; passes clean.
- Ran `publint@0.3.21` against `tmp/`: 0 errors, 0 warnings (was: 5 errors + 1 warning).
- Ran `attw@0.18.3 --pack . --ignore-rules false-export-default`: exit 0 (was: FalseCJS + 5 broken subpaths).
- Verified generated `tmp/package.json` has correct nested exports shape and `"type": "commonjs"`.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. #12694

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1826

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect how every consumer resolves types and subpath exports from npm; mistakes would surface as widespread TS or bundler breakage, though the change is packaging-only and adds automated gates.
> 
> **Overview**
> Fixes **ambiguous and broken typings** in the published `handsontable` npm tarball for dual ESM/CJS consumers.
> 
> The publish prep script now emits **thin `.d.mts` wrappers** (re-exporting from the matching `.js` entry) for every `.d.ts`, and the **exports map** uses nested `import` / `require` objects with separate `types` and `default` paths (`.d.mts` + `.mjs` vs `.d.ts` + `.js`). The generated **`tmp/package.json`** sets **`"type": "commonjs"`** so `.d.ts` resolve as CJS under `moduleResolution: "node16"`. Wildcard export generation skips directories (`nodir: true`), and export validation rejects non-file targets.
> 
> CI **`verify-emitted-types`** now runs **publint** and **@arethetypeswrong/cli** on `handsontable/tmp`, with documented `--ignore-rules` for known Babel/CJS and untyped asset cases. A changelog entry records the public fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b3b5c113f658ab6ac94c1f80b439ef0ec91baed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->