### PR TITLE
DEV-1746: Add Vue 3 examples for Dialog guides

### DIFF
--- a/docs/content/guides/dialog/dialog/dialog.md
+++ b/docs/content/guides/dialog/dialog/dialog.md
@@ -72,6 +72,16 @@ To enable the Dialog plugin, set the [`dialog`](@/api/options.md#dialog) option 
 
 :::
 
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code collapse={11-32,50-54}](@/content/guides/dialog/dialog/vue/example1.vue)
+
+:::
+
+:::
+
 ## Content types
 
 The dialog supports multiple content types including plain text, HTML strings, and DOM elements.
@@ -106,6 +116,16 @@ The dialog supports multiple content types including plain text, HTML strings, a
 
 @[code](@/content/guides/dialog/dialog/angular/example2.ts)
 @[code](@/content/guides/dialog/dialog/angular/example2.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example2 :vue3
+
+@[code collapse={11-32,55-57}](@/content/guides/dialog/dialog/vue/example2.vue)
 
 :::
 
@@ -146,6 +166,16 @@ The dialog supports multiple content types including plain text, HTML strings, a
 
 :::
 
+::: only-for vue
+
+::: example #example3 :vue3
+
+@[code collapse={11-32,55-67}](@/content/guides/dialog/dialog/vue/example3.vue)
+
+:::
+
+:::
+
 ## Template types
 
 As the `content` option allows you to use plain text, HTML strings, and DOM elements, the `template` option allows you to use predefined dialog templates instead of custom content which can be useful for displaying alerts, confirmations, and other common ready-to-use dialogs.
@@ -178,6 +208,16 @@ The plugin offers two new methods to display predefined dialog templates: [`show
 @[code](@/content/guides/dialog/dialog/angular/example4.html)
 
 :::
+:::
+
+::: only-for vue
+
+::: example #example4 :vue3
+
+@[code collapse={11-32,50-147}](@/content/guides/dialog/dialog/vue/example4.vue)
+
+:::
+
 :::
 
 ## Background variants
@@ -213,6 +253,16 @@ The dialog supports two background variants: `solid` and `semi-transparent`.
 
 @[code](@/content/guides/dialog/dialog/angular/example5.ts)
 @[code](@/content/guides/dialog/dialog/angular/example5.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example5 :vue3
+
+@[code collapse={19-40,95-101}](@/content/guides/dialog/dialog/vue/example5.vue)
 
 :::
 
@@ -255,6 +305,15 @@ The dialog content can have a background color using the `contentBackground` opt
 
 :::
 
+::: only-for vue
+
+::: example #example6 :vue3
+
+@[code collapse={11-32,55-57}](@/content/guides/dialog/dialog/vue/example6.vue)
+
+:::
+
+:::
 
 ## Dialog accessibility
 
@@ -298,6 +357,16 @@ The dialog plugin provides accessibility features through ARIA attributes. You c
 
 :::
 
+::: only-for vue
+
+::: example #example7 :vue3
+
+@[code collapse={11-32,59-61}](@/content/guides/dialog/dialog/vue/example7.vue)
+
+:::
+
+:::
+
 ## Programmatic control
 
 You can control the dialog programmatically using the plugin's methods.
@@ -333,6 +402,16 @@ You can control the dialog programmatically using the plugin's methods.
 
 @[code](@/content/guides/dialog/dialog/angular/example8.ts)
 @[code](@/content/guides/dialog/dialog/angular/example8.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example8 :vue3
+
+@[code collapse={11-32,52-58}](@/content/guides/dialog/dialog/vue/example8.vue)
 
 :::
 

--- a/docs/content/guides/dialog/dialog/vue/example1.vue
+++ b/docs/content/guides/dialog/dialog/vue/example1.vue
@@ -1,0 +1,93 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { HotTable, HotColumn } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+
+const data = [
+  { model: 'Trail Helmet', price: 1298.14, sellDate: '2025-08-31', sellTime: '14:12', inStock: true },
+  { model: 'Windbreaker Jacket', price: 178.9, sellDate: '2025-05-10', sellTime: '22:26', inStock: false },
+  { model: 'Cycling Cap', price: 288.1, sellDate: '2025-09-15', sellTime: '09:37', inStock: true },
+  { model: 'HL Mountain Frame', price: 94.49, sellDate: '2025-01-17', sellTime: '14:19', inStock: false },
+  { model: 'Racing Socks', price: 430.38, sellDate: '2025-05-10', sellTime: '13:42', inStock: true },
+  { model: 'Racing Socks', price: 138.85, sellDate: '2025-09-20', sellTime: '14:48', inStock: true },
+  { model: 'HL Mountain Frame', price: 1909.63, sellDate: '2025-09-05', sellTime: '09:35', inStock: false },
+  { model: 'Carbon Handlebar', price: 1080.7, sellDate: '2025-10-24', sellTime: '22:58', inStock: false },
+  { model: 'Aero Bottle', price: 1571.13, sellDate: '2025-05-24', sellTime: '00:24', inStock: true },
+  { model: 'Windbreaker Jacket', price: 919.09, sellDate: '2025-07-16', sellTime: '19:11', inStock: true },
+  { model: 'HL Road Tire', price: 886.22, sellDate: '2025-09-09', sellTime: '00:42', inStock: false },
+  { model: 'Speed Gloves', price: 635.13, sellDate: '2025-11-17', sellTime: '12:45', inStock: true },
+  { model: 'Trail Helmet', price: 1440.64, sellDate: '2025-01-03', sellTime: '20:16', inStock: false },
+  { model: 'Aero Bottle', price: 944.63, sellDate: '2025-11-15', sellTime: '16:14', inStock: false },
+  { model: 'Windbreaker Jacket', price: 1161.43, sellDate: '2025-06-24', sellTime: '13:19', inStock: false },
+  { model: 'LED Bike Light', price: 1012.5, sellDate: '2025-05-01', sellTime: '17:30', inStock: false },
+  { model: 'Windbreaker Jacket', price: 635.37, sellDate: '2025-05-14', sellTime: '09:05', inStock: true },
+  { model: 'Road Tire Tube', price: 1421.27, sellDate: '2025-01-31', sellTime: '13:33', inStock: true },
+  { model: 'Action Camera', price: 1019.05, sellDate: '2025-12-07', sellTime: '01:26', inStock: false },
+  { model: 'Carbon Handlebar', price: 603.96, sellDate: '2025-09-13', sellTime: '04:10', inStock: false },
+];
+
+const hotSettings = ref<GridSettings>({
+  data,
+  width: '100%',
+  height: 300,
+  stretchH: 'all',
+  contextMenu: true,
+  rowHeaders: true,
+  colHeaders: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  autoRowSize: true,
+  dialog: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+onMounted(() => {
+  hotRef.value?.hotInstance?.getPlugin('dialog').show({
+    content: 'This is a basic dialog with default configuration.',
+    closable: true,
+  });
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable ref="hotRef" :settings="hotSettings">
+      <HotColumn title="Model" type="text" data="model" :width="150" header-class-name="htLeft" />
+      <HotColumn
+        title="Price"
+        type="numeric"
+        data="price"
+        :width="80"
+        locale="en-US"
+        :numeric-format="{ style: 'currency', currency: 'USD', minimumFractionDigits: 2 }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn
+        title="Date"
+        type="intl-date"
+        data="sellDate"
+        :width="131"
+        locale="en-US"
+        :date-format="{ month: 'short', day: 'numeric', year: 'numeric' }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn
+        title="Time"
+        type="intl-time"
+        data="sellTime"
+        :width="90"
+        :time-format="{ hour: '2-digit', minute: '2-digit', hour12: true }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn title="In stock" type="checkbox" data="inStock" class-name="htCenter" header-class-name="htCenter" />
+    </HotTable>
+  </div>
+</template>

--- a/docs/content/guides/dialog/dialog/vue/example2.vue
+++ b/docs/content/guides/dialog/dialog/vue/example2.vue
@@ -1,0 +1,93 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { HotTable, HotColumn } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+
+const data = [
+  { model: 'Trail Helmet', price: 1298.14, sellDate: '2025-08-31', sellTime: '14:12', inStock: true },
+  { model: 'Windbreaker Jacket', price: 178.9, sellDate: '2025-05-10', sellTime: '22:26', inStock: false },
+  { model: 'Cycling Cap', price: 288.1, sellDate: '2025-09-15', sellTime: '09:37', inStock: true },
+  { model: 'HL Mountain Frame', price: 94.49, sellDate: '2025-01-17', sellTime: '14:19', inStock: false },
+  { model: 'Racing Socks', price: 430.38, sellDate: '2025-05-10', sellTime: '13:42', inStock: true },
+  { model: 'Racing Socks', price: 138.85, sellDate: '2025-09-20', sellTime: '14:48', inStock: true },
+  { model: 'HL Mountain Frame', price: 1909.63, sellDate: '2025-09-05', sellTime: '09:35', inStock: false },
+  { model: 'Carbon Handlebar', price: 1080.7, sellDate: '2025-10-24', sellTime: '22:58', inStock: false },
+  { model: 'Aero Bottle', price: 1571.13, sellDate: '2025-05-24', sellTime: '00:24', inStock: true },
+  { model: 'Windbreaker Jacket', price: 919.09, sellDate: '2025-07-16', sellTime: '19:11', inStock: true },
+  { model: 'HL Road Tire', price: 886.22, sellDate: '2025-09-09', sellTime: '00:42', inStock: false },
+  { model: 'Speed Gloves', price: 635.13, sellDate: '2025-11-17', sellTime: '12:45', inStock: true },
+  { model: 'Trail Helmet', price: 1440.64, sellDate: '2025-01-03', sellTime: '20:16', inStock: false },
+  { model: 'Aero Bottle', price: 944.63, sellDate: '2025-11-15', sellTime: '16:14', inStock: false },
+  { model: 'Windbreaker Jacket', price: 1161.43, sellDate: '2025-06-24', sellTime: '13:19', inStock: false },
+  { model: 'LED Bike Light', price: 1012.5, sellDate: '2025-05-01', sellTime: '17:30', inStock: false },
+  { model: 'Windbreaker Jacket', price: 635.37, sellDate: '2025-05-14', sellTime: '09:05', inStock: true },
+  { model: 'Road Tire Tube', price: 1421.27, sellDate: '2025-01-31', sellTime: '13:33', inStock: true },
+  { model: 'Action Camera', price: 1019.05, sellDate: '2025-12-07', sellTime: '01:26', inStock: false },
+  { model: 'Carbon Handlebar', price: 603.96, sellDate: '2025-09-13', sellTime: '04:10', inStock: false },
+];
+
+const hotSettings = ref<GridSettings>({
+  data,
+  width: '100%',
+  height: 300,
+  stretchH: 'all',
+  contextMenu: true,
+  rowHeaders: true,
+  colHeaders: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  autoRowSize: true,
+  dialog: {
+    content: 'This is a simple text message displayed in the dialog.',
+    closable: true,
+  },
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+onMounted(() => {
+  hotRef.value?.hotInstance?.getPlugin('dialog').show();
+});
+</script>
+
+<template>
+  <div id="example2">
+    <HotTable ref="hotRef" :settings="hotSettings">
+      <HotColumn title="Model" type="text" data="model" :width="150" header-class-name="htLeft" />
+      <HotColumn
+        title="Price"
+        type="numeric"
+        data="price"
+        :width="80"
+        locale="en-US"
+        :numeric-format="{ style: 'currency', currency: 'USD', minimumFractionDigits: 2 }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn
+        title="Date"
+        type="intl-date"
+        data="sellDate"
+        :width="131"
+        locale="en-US"
+        :date-format="{ month: 'short', day: 'numeric', year: 'numeric' }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn
+        title="Time"
+        type="intl-time"
+        data="sellTime"
+        :width="90"
+        :time-format="{ hour: '2-digit', minute: '2-digit', hour12: true }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn title="In stock" type="checkbox" data="inStock" class-name="htCenter" header-class-name="htCenter" />
+    </HotTable>
+  </div>
+</template>

--- a/docs/content/guides/dialog/dialog/vue/example3.vue
+++ b/docs/content/guides/dialog/dialog/vue/example3.vue
@@ -1,0 +1,104 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { HotTable, HotColumn } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+
+const data = [
+  { model: 'Trail Helmet', price: 1298.14, sellDate: '2025-08-31', sellTime: '14:12', inStock: true },
+  { model: 'Windbreaker Jacket', price: 178.9, sellDate: '2025-05-10', sellTime: '22:26', inStock: false },
+  { model: 'Cycling Cap', price: 288.1, sellDate: '2025-09-15', sellTime: '09:37', inStock: true },
+  { model: 'HL Mountain Frame', price: 94.49, sellDate: '2025-01-17', sellTime: '14:19', inStock: false },
+  { model: 'Racing Socks', price: 430.38, sellDate: '2025-05-10', sellTime: '13:42', inStock: true },
+  { model: 'Racing Socks', price: 138.85, sellDate: '2025-09-20', sellTime: '14:48', inStock: true },
+  { model: 'HL Mountain Frame', price: 1909.63, sellDate: '2025-09-05', sellTime: '09:35', inStock: false },
+  { model: 'Carbon Handlebar', price: 1080.7, sellDate: '2025-10-24', sellTime: '22:58', inStock: false },
+  { model: 'Aero Bottle', price: 1571.13, sellDate: '2025-05-24', sellTime: '00:24', inStock: true },
+  { model: 'Windbreaker Jacket', price: 919.09, sellDate: '2025-07-16', sellTime: '19:11', inStock: true },
+  { model: 'HL Road Tire', price: 886.22, sellDate: '2025-09-09', sellTime: '00:42', inStock: false },
+  { model: 'Speed Gloves', price: 635.13, sellDate: '2025-11-17', sellTime: '12:45', inStock: true },
+  { model: 'Trail Helmet', price: 1440.64, sellDate: '2025-01-03', sellTime: '20:16', inStock: false },
+  { model: 'Aero Bottle', price: 944.63, sellDate: '2025-11-15', sellTime: '16:14', inStock: false },
+  { model: 'Windbreaker Jacket', price: 1161.43, sellDate: '2025-06-24', sellTime: '13:19', inStock: false },
+  { model: 'LED Bike Light', price: 1012.5, sellDate: '2025-05-01', sellTime: '17:30', inStock: false },
+  { model: 'Windbreaker Jacket', price: 635.37, sellDate: '2025-05-14', sellTime: '09:05', inStock: true },
+  { model: 'Road Tire Tube', price: 1421.27, sellDate: '2025-01-31', sellTime: '13:33', inStock: true },
+  { model: 'Action Camera', price: 1019.05, sellDate: '2025-12-07', sellTime: '01:26', inStock: false },
+  { model: 'Carbon Handlebar', price: 603.96, sellDate: '2025-09-13', sellTime: '04:10', inStock: false },
+];
+
+const hotSettings = ref<GridSettings>({
+  data,
+  width: '100%',
+  height: 300,
+  stretchH: 'all',
+  contextMenu: true,
+  rowHeaders: true,
+  colHeaders: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  autoRowSize: true,
+  dialog: {
+    content:
+      '<p>This dialog contains <strong>HTML</strong> content with formatting.</p><button type="button" class="hot-doc-dialog-html-button" id="example3-button">Hide dialog</button>',
+    closable: true,
+  },
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+onMounted(() => {
+  const hotInstance = hotRef.value?.hotInstance;
+
+  if (!hotInstance) {
+    return;
+  }
+
+  hotInstance.getPlugin('dialog').show();
+
+  document.getElementById('example3-button')?.addEventListener('click', () => {
+    hotInstance.getPlugin('dialog').hide();
+  });
+});
+</script>
+
+<template>
+  <div id="example3">
+    <HotTable ref="hotRef" :settings="hotSettings">
+      <HotColumn title="Model" type="text" data="model" :width="150" header-class-name="htLeft" />
+      <HotColumn
+        title="Price"
+        type="numeric"
+        data="price"
+        :width="80"
+        locale="en-US"
+        :numeric-format="{ style: 'currency', currency: 'USD', minimumFractionDigits: 2 }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn
+        title="Date"
+        type="intl-date"
+        data="sellDate"
+        :width="131"
+        locale="en-US"
+        :date-format="{ month: 'short', day: 'numeric', year: 'numeric' }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn
+        title="Time"
+        type="intl-time"
+        data="sellTime"
+        :width="90"
+        :time-format="{ hour: '2-digit', minute: '2-digit', hour12: true }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn title="In stock" type="checkbox" data="inStock" class-name="htCenter" header-class-name="htCenter" />
+    </HotTable>
+  </div>
+</template>

--- a/docs/content/guides/dialog/dialog/vue/example4.vue
+++ b/docs/content/guides/dialog/dialog/vue/example4.vue
@@ -1,0 +1,192 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable, HotColumn } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+
+const data = [
+  { model: 'Trail Helmet', price: 1298.14, sellDate: '2025-08-31', sellTime: '14:12', inStock: true },
+  { model: 'Windbreaker Jacket', price: 178.9, sellDate: '2025-05-10', sellTime: '22:26', inStock: false },
+  { model: 'Cycling Cap', price: 288.1, sellDate: '2025-09-15', sellTime: '09:37', inStock: true },
+  { model: 'HL Mountain Frame', price: 94.49, sellDate: '2025-01-17', sellTime: '14:19', inStock: false },
+  { model: 'Racing Socks', price: 430.38, sellDate: '2025-05-10', sellTime: '13:42', inStock: true },
+  { model: 'Racing Socks', price: 138.85, sellDate: '2025-09-20', sellTime: '14:48', inStock: true },
+  { model: 'HL Mountain Frame', price: 1909.63, sellDate: '2025-09-05', sellTime: '09:35', inStock: false },
+  { model: 'Carbon Handlebar', price: 1080.7, sellDate: '2025-10-24', sellTime: '22:58', inStock: false },
+  { model: 'Aero Bottle', price: 1571.13, sellDate: '2025-05-24', sellTime: '00:24', inStock: true },
+  { model: 'Windbreaker Jacket', price: 919.09, sellDate: '2025-07-16', sellTime: '19:11', inStock: true },
+  { model: 'HL Road Tire', price: 886.22, sellDate: '2025-09-09', sellTime: '00:42', inStock: false },
+  { model: 'Speed Gloves', price: 635.13, sellDate: '2025-11-17', sellTime: '12:45', inStock: true },
+  { model: 'Trail Helmet', price: 1440.64, sellDate: '2025-01-03', sellTime: '20:16', inStock: false },
+  { model: 'Aero Bottle', price: 944.63, sellDate: '2025-11-15', sellTime: '16:14', inStock: false },
+  { model: 'Windbreaker Jacket', price: 1161.43, sellDate: '2025-06-24', sellTime: '13:19', inStock: false },
+  { model: 'LED Bike Light', price: 1012.5, sellDate: '2025-05-01', sellTime: '17:30', inStock: false },
+  { model: 'Windbreaker Jacket', price: 635.37, sellDate: '2025-05-14', sellTime: '09:05', inStock: true },
+  { model: 'Road Tire Tube', price: 1421.27, sellDate: '2025-01-31', sellTime: '13:33', inStock: true },
+  { model: 'Action Camera', price: 1019.05, sellDate: '2025-12-07', sellTime: '01:26', inStock: false },
+  { model: 'Carbon Handlebar', price: 603.96, sellDate: '2025-09-13', sellTime: '04:10', inStock: false },
+];
+
+const hotSettings = ref<GridSettings>({
+  data,
+  width: '100%',
+  height: 300,
+  stretchH: 'all',
+  contextMenu: true,
+  rowHeaders: true,
+  colHeaders: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  autoRowSize: true,
+  dialog: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+function showAlert(): void {
+  const hotInstance = hotRef.value?.hotInstance;
+
+  if (!hotInstance) {
+    return;
+  }
+
+  const dialogPlugin = hotInstance.getPlugin('dialog');
+
+  dialogPlugin.showAlert(
+    {
+      title: 'Alert',
+      description: 'This is an example of the alert dialog.',
+    },
+    () => {
+      dialogPlugin.hide();
+    }
+  );
+}
+
+function showConfirm(): void {
+  const hotInstance = hotRef.value?.hotInstance;
+
+  if (!hotInstance) {
+    return;
+  }
+
+  const dialogPlugin = hotInstance.getPlugin('dialog');
+
+  dialogPlugin.showConfirm(
+    'Do you want to undo the last action?',
+    () => {
+      hotInstance.getPlugin('undoRedo').undo();
+      dialogPlugin.hide();
+    },
+    () => {
+      dialogPlugin.hide();
+    }
+  );
+}
+
+function showCustomConfirm(): void {
+  const hotInstance = hotRef.value?.hotInstance;
+
+  if (!hotInstance) {
+    return;
+  }
+
+  const dialogPlugin = hotInstance.getPlugin('dialog');
+
+  dialogPlugin.show({
+    template: {
+      type: 'confirm',
+      title: 'Increase the price of the first row by:',
+      buttons: [
+        {
+          text: 'Cancel',
+          type: 'secondary',
+          callback: () => {
+            dialogPlugin.hide();
+          },
+        },
+        {
+          text: '$100',
+          type: 'secondary',
+          callback: () => {
+            dialogPlugin.hide();
+            hotInstance.setDataAtCell(0, 1, (hotInstance.getDataAtCell(0, 1) as number) + 100);
+            hotInstance.selectCell(0, 1);
+          },
+        },
+        {
+          text: '$200',
+          type: 'secondary',
+          callback: () => {
+            dialogPlugin.hide();
+            hotInstance.setDataAtCell(0, 1, (hotInstance.getDataAtCell(0, 1) as number) + 200);
+            hotInstance.selectCell(0, 1);
+          },
+        },
+        {
+          text: '$500',
+          type: 'secondary',
+          callback: () => {
+            dialogPlugin.hide();
+            hotInstance.setDataAtCell(0, 1, (hotInstance.getDataAtCell(0, 1) as number) + 500);
+            hotInstance.selectCell(0, 1);
+          },
+        },
+      ],
+    },
+    background: 'solid',
+    contentBackground: false,
+    closable: true,
+  });
+}
+</script>
+
+<template>
+  <div id="example4">
+    <div class="example-controls-container">
+      <div class="controls">
+        <button type="button" @click="showAlert">Show Alert</button>
+        <button type="button" @click="showConfirm">Show Confirm</button>
+        <button type="button" @click="showCustomConfirm">
+          Show custom Confirm (with solid background)
+        </button>
+      </div>
+    </div>
+    <HotTable ref="hotRef" :settings="hotSettings">
+      <HotColumn title="Model" type="text" data="model" :width="150" header-class-name="htLeft" />
+      <HotColumn
+        title="Price"
+        type="numeric"
+        data="price"
+        :width="80"
+        locale="en-US"
+        :numeric-format="{ style: 'currency', currency: 'USD', minimumFractionDigits: 2 }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn
+        title="Date"
+        type="intl-date"
+        data="sellDate"
+        :width="131"
+        locale="en-US"
+        :date-format="{ month: 'short', day: 'numeric', year: 'numeric' }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn
+        title="Time"
+        type="intl-time"
+        data="sellTime"
+        :width="90"
+        :time-format="{ hour: '2-digit', minute: '2-digit', hour12: true }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn title="In stock" type="checkbox" data="inStock" class-name="htCenter" header-class-name="htCenter" />
+    </HotTable>
+  </div>
+</template>

--- a/docs/content/guides/dialog/dialog/vue/example5.vue
+++ b/docs/content/guides/dialog/dialog/vue/example5.vue
@@ -1,0 +1,179 @@
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue';
+import { HotTable, HotColumn } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const dropdownRef = ref<HTMLDivElement | null>(null);
+const isOpen = ref(false);
+const selected = ref<'solid' | 'semi-transparent'>('solid');
+
+const backgroundOptions = [
+  { value: 'solid' as const, label: 'Solid' },
+  { value: 'semi-transparent' as const, label: 'Semi-transparent' },
+];
+
+const data = [
+  { model: 'Trail Helmet', price: 1298.14, sellDate: '2025-08-31', sellTime: '14:12', inStock: true },
+  { model: 'Windbreaker Jacket', price: 178.9, sellDate: '2025-05-10', sellTime: '22:26', inStock: false },
+  { model: 'Cycling Cap', price: 288.1, sellDate: '2025-09-15', sellTime: '09:37', inStock: true },
+  { model: 'HL Mountain Frame', price: 94.49, sellDate: '2025-01-17', sellTime: '14:19', inStock: false },
+  { model: 'Racing Socks', price: 430.38, sellDate: '2025-05-10', sellTime: '13:42', inStock: true },
+  { model: 'Racing Socks', price: 138.85, sellDate: '2025-09-20', sellTime: '14:48', inStock: true },
+  { model: 'HL Mountain Frame', price: 1909.63, sellDate: '2025-09-05', sellTime: '09:35', inStock: false },
+  { model: 'Carbon Handlebar', price: 1080.7, sellDate: '2025-10-24', sellTime: '22:58', inStock: false },
+  { model: 'Aero Bottle', price: 1571.13, sellDate: '2025-05-24', sellTime: '00:24', inStock: true },
+  { model: 'Windbreaker Jacket', price: 919.09, sellDate: '2025-07-16', sellTime: '19:11', inStock: true },
+  { model: 'HL Road Tire', price: 886.22, sellDate: '2025-09-09', sellTime: '00:42', inStock: false },
+  { model: 'Speed Gloves', price: 635.13, sellDate: '2025-11-17', sellTime: '12:45', inStock: true },
+  { model: 'Trail Helmet', price: 1440.64, sellDate: '2025-01-03', sellTime: '20:16', inStock: false },
+  { model: 'Aero Bottle', price: 944.63, sellDate: '2025-11-15', sellTime: '16:14', inStock: false },
+  { model: 'Windbreaker Jacket', price: 1161.43, sellDate: '2025-06-24', sellTime: '13:19', inStock: false },
+  { model: 'LED Bike Light', price: 1012.5, sellDate: '2025-05-01', sellTime: '17:30', inStock: false },
+  { model: 'Windbreaker Jacket', price: 635.37, sellDate: '2025-05-14', sellTime: '09:05', inStock: true },
+  { model: 'Road Tire Tube', price: 1421.27, sellDate: '2025-01-31', sellTime: '13:33', inStock: true },
+  { model: 'Action Camera', price: 1019.05, sellDate: '2025-12-07', sellTime: '01:26', inStock: false },
+  { model: 'Carbon Handlebar', price: 603.96, sellDate: '2025-09-13', sellTime: '04:10', inStock: false },
+];
+
+const hotSettings = ref<GridSettings>({
+  data,
+  width: '100%',
+  height: 300,
+  stretchH: 'all',
+  contextMenu: true,
+  rowHeaders: true,
+  colHeaders: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  autoRowSize: true,
+  dialog: {
+    content: 'This dialog uses a solid background (default).',
+    background: 'solid',
+    closable: true,
+  },
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+function handleClickOutside(e: MouseEvent): void {
+  if (dropdownRef.value && !dropdownRef.value.contains(e.target as Node)) {
+    isOpen.value = false;
+  }
+}
+
+function handleEscape(e: KeyboardEvent): void {
+  if (e.key === 'Escape') {
+    isOpen.value = false;
+  }
+}
+
+function handleSelect(value: 'solid' | 'semi-transparent'): void {
+  selected.value = value;
+  isOpen.value = false;
+
+  const hotInstance = hotRef.value?.hotInstance;
+
+  if (!hotInstance) {
+    return;
+  }
+
+  const content =
+    value === 'solid'
+      ? 'This dialog uses a solid background (default).'
+      : 'This dialog uses a semi-transparent background.';
+
+  hotInstance.getPlugin('dialog').update({ content, background: value });
+}
+
+onMounted(() => {
+  hotRef.value?.hotInstance?.getPlugin('dialog').show();
+  document.addEventListener('click', handleClickOutside);
+  document.addEventListener('keydown', handleEscape);
+});
+
+onUnmounted(() => {
+  document.removeEventListener('click', handleClickOutside);
+  document.removeEventListener('keydown', handleEscape);
+});
+</script>
+
+<template>
+  <div id="example5">
+    <div class="example-controls-container">
+      <div class="controls">
+        <div ref="dropdownRef" class="theme-dropdown">
+          <button
+            class="theme-dropdown-trigger"
+            type="button"
+            aria-haspopup="listbox"
+            :aria-expanded="isOpen"
+            @click="isOpen = !isOpen"
+          >
+            <span>{{ backgroundOptions.find((o) => o.value === selected)?.label }}</span>
+            <svg
+              class="theme-dropdown-chevron"
+              aria-hidden="true"
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="M6 9l6 6l6 -6" />
+            </svg>
+          </button>
+          <ul v-if="isOpen" class="theme-dropdown-menu" role="listbox">
+            <li
+              v-for="opt in backgroundOptions"
+              :key="opt.value"
+              role="option"
+              :aria-selected="selected === opt.value"
+              @click="handleSelect(opt.value)"
+            >
+              {{ opt.label }}
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <HotTable ref="hotRef" :settings="hotSettings">
+      <HotColumn title="Model" type="text" data="model" :width="150" header-class-name="htLeft" />
+      <HotColumn
+        title="Price"
+        type="numeric"
+        data="price"
+        :width="80"
+        locale="en-US"
+        :numeric-format="{ style: 'currency', currency: 'USD', minimumFractionDigits: 2 }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn
+        title="Date"
+        type="intl-date"
+        data="sellDate"
+        :width="131"
+        locale="en-US"
+        :date-format="{ month: 'short', day: 'numeric', year: 'numeric' }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn
+        title="Time"
+        type="intl-time"
+        data="sellTime"
+        :width="90"
+        :time-format="{ hour: '2-digit', minute: '2-digit', hour12: true }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn title="In stock" type="checkbox" data="inStock" class-name="htCenter" header-class-name="htCenter" />
+    </HotTable>
+  </div>
+</template>

--- a/docs/content/guides/dialog/dialog/vue/example6.vue
+++ b/docs/content/guides/dialog/dialog/vue/example6.vue
@@ -1,0 +1,95 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { HotTable, HotColumn } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+
+const data = [
+  { model: 'Trail Helmet', price: 1298.14, sellDate: '2025-08-31', sellTime: '14:12', inStock: true },
+  { model: 'Windbreaker Jacket', price: 178.9, sellDate: '2025-05-10', sellTime: '22:26', inStock: false },
+  { model: 'Cycling Cap', price: 288.1, sellDate: '2025-09-15', sellTime: '09:37', inStock: true },
+  { model: 'HL Mountain Frame', price: 94.49, sellDate: '2025-01-17', sellTime: '14:19', inStock: false },
+  { model: 'Racing Socks', price: 430.38, sellDate: '2025-05-10', sellTime: '13:42', inStock: true },
+  { model: 'Racing Socks', price: 138.85, sellDate: '2025-09-20', sellTime: '14:48', inStock: true },
+  { model: 'HL Mountain Frame', price: 1909.63, sellDate: '2025-09-05', sellTime: '09:35', inStock: false },
+  { model: 'Carbon Handlebar', price: 1080.7, sellDate: '2025-10-24', sellTime: '22:58', inStock: false },
+  { model: 'Aero Bottle', price: 1571.13, sellDate: '2025-05-24', sellTime: '00:24', inStock: true },
+  { model: 'Windbreaker Jacket', price: 919.09, sellDate: '2025-07-16', sellTime: '19:11', inStock: true },
+  { model: 'HL Road Tire', price: 886.22, sellDate: '2025-09-09', sellTime: '00:42', inStock: false },
+  { model: 'Speed Gloves', price: 635.13, sellDate: '2025-11-17', sellTime: '12:45', inStock: true },
+  { model: 'Trail Helmet', price: 1440.64, sellDate: '2025-01-03', sellTime: '20:16', inStock: false },
+  { model: 'Aero Bottle', price: 944.63, sellDate: '2025-11-15', sellTime: '16:14', inStock: false },
+  { model: 'Windbreaker Jacket', price: 1161.43, sellDate: '2025-06-24', sellTime: '13:19', inStock: false },
+  { model: 'LED Bike Light', price: 1012.5, sellDate: '2025-05-01', sellTime: '17:30', inStock: false },
+  { model: 'Windbreaker Jacket', price: 635.37, sellDate: '2025-05-14', sellTime: '09:05', inStock: true },
+  { model: 'Road Tire Tube', price: 1421.27, sellDate: '2025-01-31', sellTime: '13:33', inStock: true },
+  { model: 'Action Camera', price: 1019.05, sellDate: '2025-12-07', sellTime: '01:26', inStock: false },
+  { model: 'Carbon Handlebar', price: 603.96, sellDate: '2025-09-13', sellTime: '04:10', inStock: false },
+];
+
+const hotSettings = ref<GridSettings>({
+  data,
+  width: '100%',
+  height: 300,
+  stretchH: 'all',
+  contextMenu: true,
+  rowHeaders: true,
+  colHeaders: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  autoRowSize: true,
+  dialog: {
+    content: 'This dialog uses a semi-transparent and content background.',
+    contentBackground: true,
+    background: 'semi-transparent',
+    closable: true,
+  },
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+onMounted(() => {
+  hotRef.value?.hotInstance?.getPlugin('dialog').show();
+});
+</script>
+
+<template>
+  <div id="example6">
+    <HotTable ref="hotRef" :settings="hotSettings">
+      <HotColumn title="Model" type="text" data="model" :width="150" header-class-name="htLeft" />
+      <HotColumn
+        title="Price"
+        type="numeric"
+        data="price"
+        :width="80"
+        locale="en-US"
+        :numeric-format="{ style: 'currency', currency: 'USD', minimumFractionDigits: 2 }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn
+        title="Date"
+        type="intl-date"
+        data="sellDate"
+        :width="131"
+        locale="en-US"
+        :date-format="{ month: 'short', day: 'numeric', year: 'numeric' }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn
+        title="Time"
+        type="intl-time"
+        data="sellTime"
+        :width="90"
+        :time-format="{ hour: '2-digit', minute: '2-digit', hour12: true }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn title="In stock" type="checkbox" data="inStock" class-name="htCenter" header-class-name="htCenter" />
+    </HotTable>
+  </div>
+</template>

--- a/docs/content/guides/dialog/dialog/vue/example7.vue
+++ b/docs/content/guides/dialog/dialog/vue/example7.vue
@@ -1,0 +1,99 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { HotTable, HotColumn } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+
+const data = [
+  { model: 'Trail Helmet', price: 1298.14, sellDate: '2025-08-31', sellTime: '14:12', inStock: true },
+  { model: 'Windbreaker Jacket', price: 178.9, sellDate: '2025-05-10', sellTime: '22:26', inStock: false },
+  { model: 'Cycling Cap', price: 288.1, sellDate: '2025-09-15', sellTime: '09:37', inStock: true },
+  { model: 'HL Mountain Frame', price: 94.49, sellDate: '2025-01-17', sellTime: '14:19', inStock: false },
+  { model: 'Racing Socks', price: 430.38, sellDate: '2025-05-10', sellTime: '13:42', inStock: true },
+  { model: 'Racing Socks', price: 138.85, sellDate: '2025-09-20', sellTime: '14:48', inStock: true },
+  { model: 'HL Mountain Frame', price: 1909.63, sellDate: '2025-09-05', sellTime: '09:35', inStock: false },
+  { model: 'Carbon Handlebar', price: 1080.7, sellDate: '2025-10-24', sellTime: '22:58', inStock: false },
+  { model: 'Aero Bottle', price: 1571.13, sellDate: '2025-05-24', sellTime: '00:24', inStock: true },
+  { model: 'Windbreaker Jacket', price: 919.09, sellDate: '2025-07-16', sellTime: '19:11', inStock: true },
+  { model: 'HL Road Tire', price: 886.22, sellDate: '2025-09-09', sellTime: '00:42', inStock: false },
+  { model: 'Speed Gloves', price: 635.13, sellDate: '2025-11-17', sellTime: '12:45', inStock: true },
+  { model: 'Trail Helmet', price: 1440.64, sellDate: '2025-01-03', sellTime: '20:16', inStock: false },
+  { model: 'Aero Bottle', price: 944.63, sellDate: '2025-11-15', sellTime: '16:14', inStock: false },
+  { model: 'Windbreaker Jacket', price: 1161.43, sellDate: '2025-06-24', sellTime: '13:19', inStock: false },
+  { model: 'LED Bike Light', price: 1012.5, sellDate: '2025-05-01', sellTime: '17:30', inStock: false },
+  { model: 'Windbreaker Jacket', price: 635.37, sellDate: '2025-05-14', sellTime: '09:05', inStock: true },
+  { model: 'Road Tire Tube', price: 1421.27, sellDate: '2025-01-31', sellTime: '13:33', inStock: true },
+  { model: 'Action Camera', price: 1019.05, sellDate: '2025-12-07', sellTime: '01:26', inStock: false },
+  { model: 'Carbon Handlebar', price: 603.96, sellDate: '2025-09-13', sellTime: '04:10', inStock: false },
+];
+
+const hotSettings = ref<GridSettings>({
+  data,
+  width: '100%',
+  height: 300,
+  stretchH: 'all',
+  contextMenu: true,
+  rowHeaders: true,
+  colHeaders: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  autoRowSize: true,
+  dialog: {
+    content: '<h2 id="example6-title">Title</h2><p id="example6-description">Description</p>',
+    a11y: {
+      role: 'alertdialog',
+      ariaLabel: 'Title',
+      ariaLabelledby: 'example6-title',
+      ariaDescribedby: 'example6-description',
+    },
+    closable: true,
+  },
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+onMounted(() => {
+  hotRef.value?.hotInstance?.getPlugin('dialog').show();
+});
+</script>
+
+<template>
+  <div id="example7">
+    <HotTable ref="hotRef" :settings="hotSettings">
+      <HotColumn title="Model" type="text" data="model" :width="150" header-class-name="htLeft" />
+      <HotColumn
+        title="Price"
+        type="numeric"
+        data="price"
+        :width="80"
+        locale="en-US"
+        :numeric-format="{ style: 'currency', currency: 'USD', minimumFractionDigits: 2 }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn
+        title="Date"
+        type="intl-date"
+        data="sellDate"
+        :width="131"
+        locale="en-US"
+        :date-format="{ month: 'short', day: 'numeric', year: 'numeric' }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn
+        title="Time"
+        type="intl-time"
+        data="sellTime"
+        :width="90"
+        :time-format="{ hour: '2-digit', minute: '2-digit', hour12: true }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn title="In stock" type="checkbox" data="inStock" class-name="htCenter" header-class-name="htCenter" />
+    </HotTable>
+  </div>
+</template>

--- a/docs/content/guides/dialog/dialog/vue/example8.vue
+++ b/docs/content/guides/dialog/dialog/vue/example8.vue
@@ -1,0 +1,103 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable, HotColumn } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+
+const data = [
+  { model: 'Trail Helmet', price: 1298.14, sellDate: '2025-08-31', sellTime: '14:12', inStock: true },
+  { model: 'Windbreaker Jacket', price: 178.9, sellDate: '2025-05-10', sellTime: '22:26', inStock: false },
+  { model: 'Cycling Cap', price: 288.1, sellDate: '2025-09-15', sellTime: '09:37', inStock: true },
+  { model: 'HL Mountain Frame', price: 94.49, sellDate: '2025-01-17', sellTime: '14:19', inStock: false },
+  { model: 'Racing Socks', price: 430.38, sellDate: '2025-05-10', sellTime: '13:42', inStock: true },
+  { model: 'Racing Socks', price: 138.85, sellDate: '2025-09-20', sellTime: '14:48', inStock: true },
+  { model: 'HL Mountain Frame', price: 1909.63, sellDate: '2025-09-05', sellTime: '09:35', inStock: false },
+  { model: 'Carbon Handlebar', price: 1080.7, sellDate: '2025-10-24', sellTime: '22:58', inStock: false },
+  { model: 'Aero Bottle', price: 1571.13, sellDate: '2025-05-24', sellTime: '00:24', inStock: true },
+  { model: 'Windbreaker Jacket', price: 919.09, sellDate: '2025-07-16', sellTime: '19:11', inStock: true },
+  { model: 'HL Road Tire', price: 886.22, sellDate: '2025-09-09', sellTime: '00:42', inStock: false },
+  { model: 'Speed Gloves', price: 635.13, sellDate: '2025-11-17', sellTime: '12:45', inStock: true },
+  { model: 'Trail Helmet', price: 1440.64, sellDate: '2025-01-03', sellTime: '20:16', inStock: false },
+  { model: 'Aero Bottle', price: 944.63, sellDate: '2025-11-15', sellTime: '16:14', inStock: false },
+  { model: 'Windbreaker Jacket', price: 1161.43, sellDate: '2025-06-24', sellTime: '13:19', inStock: false },
+  { model: 'LED Bike Light', price: 1012.5, sellDate: '2025-05-01', sellTime: '17:30', inStock: false },
+  { model: 'Windbreaker Jacket', price: 635.37, sellDate: '2025-05-14', sellTime: '09:05', inStock: true },
+  { model: 'Road Tire Tube', price: 1421.27, sellDate: '2025-01-31', sellTime: '13:33', inStock: true },
+  { model: 'Action Camera', price: 1019.05, sellDate: '2025-12-07', sellTime: '01:26', inStock: false },
+  { model: 'Carbon Handlebar', price: 603.96, sellDate: '2025-09-13', sellTime: '04:10', inStock: false },
+];
+
+const hotSettings = ref<GridSettings>({
+  data,
+  width: '100%',
+  height: 300,
+  stretchH: 'all',
+  contextMenu: true,
+  rowHeaders: true,
+  colHeaders: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  autoRowSize: true,
+  dialog: {
+    content: 'This dialog can be controlled programmatically.',
+    closable: true,
+  },
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+function showDialog(): void {
+  hotRef.value?.hotInstance?.getPlugin('dialog').show();
+}
+
+function hideDialog(): void {
+  hotRef.value?.hotInstance?.getPlugin('dialog').hide();
+}
+</script>
+
+<template>
+  <div id="example8">
+    <div class="example-controls-container">
+      <div class="controls">
+        <button type="button" @click="showDialog">Show Dialog</button>
+        <button type="button" @click="hideDialog">Hide Dialog</button>
+      </div>
+    </div>
+    <HotTable ref="hotRef" :settings="hotSettings">
+      <HotColumn title="Model" type="text" data="model" :width="150" header-class-name="htLeft" />
+      <HotColumn
+        title="Price"
+        type="numeric"
+        data="price"
+        :width="80"
+        locale="en-US"
+        :numeric-format="{ style: 'currency', currency: 'USD', minimumFractionDigits: 2 }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn
+        title="Date"
+        type="intl-date"
+        data="sellDate"
+        :width="131"
+        locale="en-US"
+        :date-format="{ month: 'short', day: 'numeric', year: 'numeric' }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn
+        title="Time"
+        type="intl-time"
+        data="sellTime"
+        :width="90"
+        :time-format="{ hour: '2-digit', minute: '2-digit', hour12: true }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn title="In stock" type="checkbox" data="inStock" class-name="htCenter" header-class-name="htCenter" />
+    </HotTable>
+  </div>
+</template>

--- a/docs/content/guides/dialog/loading/loading.md
+++ b/docs/content/guides/dialog/loading/loading.md
@@ -72,6 +72,16 @@ To enable the Loading plugin, set the [`loading`](@/api/options.md#loading) opti
 
 :::
 
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code collapse={11-32,54-56}](@/content/guides/dialog/loading/vue/example1.vue)
+
+:::
+
+:::
+
 ## Custom configuration
 
 The loading dialog supports customization of the icon, title, and description.
@@ -104,6 +114,16 @@ The loading dialog supports customization of the icon, title, and description.
 
 @[code collapse={20-41,44-94}](@/content/guides/dialog/loading/angular/example2.ts)
 @[code](@/content/guides/dialog/loading/angular/example2.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example2 :vue3
+
+@[code collapse={11-32,54-56}](@/content/guides/dialog/loading/vue/example2.vue)
 
 :::
 
@@ -147,6 +167,16 @@ Here are some common scenarios where the loading dialog is useful:
 
 :::
 
+::: only-for vue
+
+::: example #example3 :vue3
+
+@[code collapse={51-62,86-88}](@/content/guides/dialog/loading/vue/example3.vue)
+
+:::
+
+:::
+
 ## Loading with Pagination plugin
 
 The example below demonstrates how to use the Loading plugin with pagination in external container:
@@ -182,6 +212,17 @@ The example below demonstrates how to use the Loading plugin with pagination in 
 
 @[code collapse={55-104,162-191}](@/content/guides/dialog/loading/angular/example4.ts)
 @[code](@/content/guides/dialog/loading/angular/example4.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example4 :vue3 --css 1
+
+@[code](@/content/guides/dialog/loading/react/example4.css)
+@[code collapse={78-107,122-124}](@/content/guides/dialog/loading/vue/example4.vue)
 
 :::
 

--- a/docs/content/guides/dialog/loading/vue/example1.vue
+++ b/docs/content/guides/dialog/loading/vue/example1.vue
@@ -1,0 +1,90 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { HotTable, HotColumn } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+
+const data = [
+  { model: 'Trail Helmet', price: 1298.14, sellDate: '2025-08-31', sellTime: '14:12', inStock: true },
+  { model: 'Windbreaker Jacket', price: 178.9, sellDate: '2025-05-10', sellTime: '22:26', inStock: false },
+  { model: 'Cycling Cap', price: 288.1, sellDate: '2025-09-15', sellTime: '09:37', inStock: true },
+  { model: 'HL Mountain Frame', price: 94.49, sellDate: '2025-01-17', sellTime: '14:19', inStock: false },
+  { model: 'Racing Socks', price: 430.38, sellDate: '2025-05-10', sellTime: '13:42', inStock: true },
+  { model: 'Racing Socks', price: 138.85, sellDate: '2025-09-20', sellTime: '14:48', inStock: true },
+  { model: 'HL Mountain Frame', price: 1909.63, sellDate: '2025-09-05', sellTime: '09:35', inStock: false },
+  { model: 'Carbon Handlebar', price: 1080.7, sellDate: '2025-10-24', sellTime: '22:58', inStock: false },
+  { model: 'Aero Bottle', price: 1571.13, sellDate: '2025-05-24', sellTime: '00:24', inStock: true },
+  { model: 'Windbreaker Jacket', price: 919.09, sellDate: '2025-07-16', sellTime: '19:11', inStock: true },
+  { model: 'HL Road Tire', price: 886.22, sellDate: '2025-09-09', sellTime: '00:42', inStock: false },
+  { model: 'Speed Gloves', price: 635.13, sellDate: '2025-11-17', sellTime: '12:45', inStock: true },
+  { model: 'Trail Helmet', price: 1440.64, sellDate: '2025-01-03', sellTime: '20:16', inStock: false },
+  { model: 'Aero Bottle', price: 944.63, sellDate: '2025-11-15', sellTime: '16:14', inStock: false },
+  { model: 'Windbreaker Jacket', price: 1161.43, sellDate: '2025-06-24', sellTime: '13:19', inStock: false },
+  { model: 'LED Bike Light', price: 1012.5, sellDate: '2025-05-01', sellTime: '17:30', inStock: false },
+  { model: 'Windbreaker Jacket', price: 635.37, sellDate: '2025-05-14', sellTime: '09:05', inStock: true },
+  { model: 'Road Tire Tube', price: 1421.27, sellDate: '2025-01-31', sellTime: '13:33', inStock: true },
+  { model: 'Action Camera', price: 1019.05, sellDate: '2025-12-07', sellTime: '01:26', inStock: false },
+  { model: 'Carbon Handlebar', price: 603.96, sellDate: '2025-09-13', sellTime: '04:10', inStock: false },
+];
+
+const hotSettings = ref<GridSettings>({
+  data,
+  width: '100%',
+  height: 300,
+  stretchH: 'all',
+  contextMenu: true,
+  rowHeaders: true,
+  colHeaders: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  autoRowSize: true,
+  loading: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+onMounted(() => {
+  hotRef.value?.hotInstance?.getPlugin('loading').show();
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable ref="hotRef" :settings="hotSettings">
+      <HotColumn title="Model" type="text" data="model" :width="150" header-class-name="htLeft" />
+      <HotColumn
+        title="Price"
+        type="numeric"
+        data="price"
+        :width="80"
+        locale="en-US"
+        :numeric-format="{ style: 'currency', currency: 'USD', minimumFractionDigits: 2 }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn
+        title="Date"
+        type="intl-date"
+        data="sellDate"
+        :width="130"
+        locale="en-US"
+        :date-format="{ month: 'short', day: 'numeric', year: 'numeric' }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn
+        title="Time"
+        type="intl-time"
+        data="sellTime"
+        :width="90"
+        :time-format="{ hour: '2-digit', minute: '2-digit', hour12: true }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn title="In stock" type="checkbox" data="inStock" class-name="htCenter" header-class-name="htCenter" />
+    </HotTable>
+  </div>
+</template>

--- a/docs/content/guides/dialog/loading/vue/example2.vue
+++ b/docs/content/guides/dialog/loading/vue/example2.vue
@@ -1,0 +1,94 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { HotTable, HotColumn } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+
+const data = [
+  { model: 'Trail Helmet', price: 1298.14, sellDate: '2025-08-31', sellTime: '14:12', inStock: true },
+  { model: 'Windbreaker Jacket', price: 178.9, sellDate: '2025-05-10', sellTime: '22:26', inStock: false },
+  { model: 'Cycling Cap', price: 288.1, sellDate: '2025-09-15', sellTime: '09:37', inStock: true },
+  { model: 'HL Mountain Frame', price: 94.49, sellDate: '2025-01-17', sellTime: '14:19', inStock: false },
+  { model: 'Racing Socks', price: 430.38, sellDate: '2025-05-10', sellTime: '13:42', inStock: true },
+  { model: 'Racing Socks', price: 138.85, sellDate: '2025-09-20', sellTime: '14:48', inStock: true },
+  { model: 'HL Mountain Frame', price: 1909.63, sellDate: '2025-09-05', sellTime: '09:35', inStock: false },
+  { model: 'Carbon Handlebar', price: 1080.7, sellDate: '2025-10-24', sellTime: '22:58', inStock: false },
+  { model: 'Aero Bottle', price: 1571.13, sellDate: '2025-05-24', sellTime: '00:24', inStock: true },
+  { model: 'Windbreaker Jacket', price: 919.09, sellDate: '2025-07-16', sellTime: '19:11', inStock: true },
+  { model: 'HL Road Tire', price: 886.22, sellDate: '2025-09-09', sellTime: '00:42', inStock: false },
+  { model: 'Speed Gloves', price: 635.13, sellDate: '2025-11-17', sellTime: '12:45', inStock: true },
+  { model: 'Trail Helmet', price: 1440.64, sellDate: '2025-01-03', sellTime: '20:16', inStock: false },
+  { model: 'Aero Bottle', price: 944.63, sellDate: '2025-11-15', sellTime: '16:14', inStock: false },
+  { model: 'Windbreaker Jacket', price: 1161.43, sellDate: '2025-06-24', sellTime: '13:19', inStock: false },
+  { model: 'LED Bike Light', price: 1012.5, sellDate: '2025-05-01', sellTime: '17:30', inStock: false },
+  { model: 'Windbreaker Jacket', price: 635.37, sellDate: '2025-05-14', sellTime: '09:05', inStock: true },
+  { model: 'Road Tire Tube', price: 1421.27, sellDate: '2025-01-31', sellTime: '13:33', inStock: true },
+  { model: 'Action Camera', price: 1019.05, sellDate: '2025-12-07', sellTime: '01:26', inStock: false },
+  { model: 'Carbon Handlebar', price: 603.96, sellDate: '2025-09-13', sellTime: '04:10', inStock: false },
+];
+
+const hotSettings = ref<GridSettings>({
+  data,
+  width: '100%',
+  height: 300,
+  stretchH: 'all',
+  contextMenu: true,
+  rowHeaders: true,
+  colHeaders: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  autoRowSize: true,
+  loading: {
+    icon: '<svg class="ht-loading__icon-svg" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16"><path stroke="currentColor" stroke-width="2" d="M15 8a7 7 0 1 1-3.5-6.062"></path></svg>',
+    title: 'Processing Data...',
+    description: 'Please wait while we load your inventory data...',
+  },
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+onMounted(() => {
+  hotRef.value?.hotInstance?.getPlugin('loading').show();
+});
+</script>
+
+<template>
+  <div id="example2">
+    <HotTable ref="hotRef" :settings="hotSettings">
+      <HotColumn title="Model" type="text" data="model" :width="150" header-class-name="htLeft" />
+      <HotColumn
+        title="Price"
+        type="numeric"
+        data="price"
+        :width="80"
+        locale="en-US"
+        :numeric-format="{ style: 'currency', currency: 'USD', minimumFractionDigits: 2 }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn
+        title="Date"
+        type="intl-date"
+        data="sellDate"
+        :width="130"
+        locale="en-US"
+        :date-format="{ month: 'short', day: 'numeric', year: 'numeric' }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn
+        title="Time"
+        type="intl-time"
+        data="sellTime"
+        :width="90"
+        :time-format="{ hour: '2-digit', minute: '2-digit', hour12: true }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn title="In stock" type="checkbox" data="inStock" class-name="htCenter" header-class-name="htCenter" />
+    </HotTable>
+  </div>
+</template>

--- a/docs/content/guides/dialog/loading/vue/example3.vue
+++ b/docs/content/guides/dialog/loading/vue/example3.vue
@@ -1,0 +1,120 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable, HotColumn } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+type InventoryRow = {
+  model: string;
+  price: number;
+  sellDate: string;
+  sellTime: string;
+  inStock: boolean;
+};
+
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const tableData = ref<InventoryRow[]>([]);
+const isLoading = ref(false);
+
+const hotSettings = ref<GridSettings>({
+  data: tableData.value,
+  width: '100%',
+  height: 300,
+  stretchH: 'all',
+  contextMenu: true,
+  rowHeaders: true,
+  colHeaders: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  autoRowSize: true,
+  loading: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+async function loadData(): Promise<void> {
+  const hotInstance = hotRef.value?.hotInstance;
+
+  if (!hotInstance) {
+    return;
+  }
+
+  const loadingPlugin = hotInstance.getPlugin('loading');
+
+  isLoading.value = true;
+  loadingPlugin.show();
+
+  try {
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+
+    const loadedData: InventoryRow[] = [
+      { model: 'Trail Helmet', price: 1298.14, sellDate: '2025-08-31', sellTime: '14:12', inStock: true },
+      { model: 'Windbreaker Jacket', price: 178.9, sellDate: '2025-05-10', sellTime: '22:26', inStock: false },
+      { model: 'Cycling Cap', price: 288.1, sellDate: '2025-09-15', sellTime: '09:37', inStock: true },
+      { model: 'HL Mountain Frame', price: 94.49, sellDate: '2025-01-17', sellTime: '14:19', inStock: false },
+      { model: 'Racing Socks', price: 430.38, sellDate: '2025-05-10', sellTime: '13:42', inStock: true },
+      { model: 'Racing Socks', price: 138.85, sellDate: '2025-09-20', sellTime: '14:48', inStock: true },
+      { model: 'HL Mountain Frame', price: 1909.63, sellDate: '2025-09-05', sellTime: '09:35', inStock: false },
+      { model: 'Carbon Handlebar', price: 1080.7, sellDate: '2025-10-24', sellTime: '22:58', inStock: false },
+      { model: 'Aero Bottle', price: 1571.13, sellDate: '2025-05-24', sellTime: '00:24', inStock: true },
+      { model: 'Windbreaker Jacket', price: 919.09, sellDate: '2025-07-16', sellTime: '19:11', inStock: true },
+    ];
+
+    tableData.value = loadedData;
+    hotInstance.loadData(loadedData);
+    loadingPlugin.hide();
+    isLoading.value = false;
+  } catch {
+    setTimeout(() => {
+      loadingPlugin.hide();
+      isLoading.value = false;
+    }, 2000);
+  }
+}
+</script>
+
+<template>
+  <div id="example3">
+    <div class="example-controls-container">
+      <div class="controls">
+        <button type="button" id="loadData" :disabled="isLoading" @click="loadData">
+          {{ tableData.length > 0 ? 'Reload Data' : 'Load Data' }}
+        </button>
+      </div>
+    </div>
+    <HotTable ref="hotRef" :settings="hotSettings">
+      <HotColumn title="Model" type="text" data="model" :width="150" header-class-name="htLeft" />
+      <HotColumn
+        title="Price"
+        type="numeric"
+        data="price"
+        :width="80"
+        locale="en-US"
+        :numeric-format="{ style: 'currency', currency: 'USD', minimumFractionDigits: 2 }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn
+        title="Date"
+        type="intl-date"
+        data="sellDate"
+        :width="130"
+        locale="en-US"
+        :date-format="{ month: 'short', day: 'numeric', year: 'numeric' }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn
+        title="Time"
+        type="intl-time"
+        data="sellTime"
+        :width="90"
+        :time-format="{ hour: '2-digit', minute: '2-digit', hour12: true }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn title="In stock" type="checkbox" data="inStock" class-name="htCenter" header-class-name="htCenter" />
+    </HotTable>
+  </div>
+</template>

--- a/docs/content/guides/dialog/loading/vue/example4.vue
+++ b/docs/content/guides/dialog/loading/vue/example4.vue
@@ -1,0 +1,174 @@
+<script setup lang="ts">
+import { ref, onMounted, nextTick } from 'vue';
+import { HotTable, HotColumn } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+type InventoryRow = {
+  model: string;
+  price: number;
+  sellDate: string;
+  sellTime: string;
+  inStock: boolean;
+};
+
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const paginationContainerRef = ref<HTMLDivElement | null>(null);
+const tableData = ref<InventoryRow[]>([]);
+const isLoading = ref(false);
+
+const hotSettings = ref<GridSettings>({
+  data: tableData.value,
+  width: '100%',
+  height: 300,
+  stretchH: 'all',
+  contextMenu: true,
+  rowHeaders: true,
+  colHeaders: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  autoRowSize: true,
+  loading: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+onMounted(() => {
+  nextTick(() => {
+    const paginationContainer = paginationContainerRef.value;
+    const hot = hotRef.value?.hotInstance;
+
+    if (!hot || !paginationContainer) {
+      return;
+    }
+
+    hot.updateSettings({
+      pagination: {
+        uiContainer: paginationContainer,
+      },
+    });
+
+    hot.addHook('afterLoadingShow', () => {
+      paginationContainer.classList.add('overlay');
+    });
+
+    hot.addHook('afterLoadingHide', () => {
+      paginationContainer.classList.remove('overlay');
+    });
+  });
+});
+
+async function loadData(): Promise<void> {
+  const hotInstance = hotRef.value?.hotInstance;
+
+  if (!hotInstance) {
+    return;
+  }
+
+  const loadingPlugin = hotInstance.getPlugin('loading');
+
+  isLoading.value = true;
+  loadingPlugin.show();
+
+  try {
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+
+    const loadedData: InventoryRow[] = [
+      { model: 'Trail Helmet', price: 1298.14, sellDate: '2025-08-31', sellTime: '14:12', inStock: true },
+      { model: 'Windbreaker Jacket', price: 178.9, sellDate: '2025-05-10', sellTime: '22:26', inStock: false },
+      { model: 'Cycling Cap', price: 288.1, sellDate: '2025-09-15', sellTime: '09:37', inStock: true },
+      { model: 'HL Mountain Frame', price: 94.49, sellDate: '2025-01-17', sellTime: '14:19', inStock: false },
+      { model: 'Racing Socks', price: 430.38, sellDate: '2025-05-10', sellTime: '13:42', inStock: true },
+      { model: 'Racing Socks', price: 138.85, sellDate: '2025-09-20', sellTime: '14:48', inStock: true },
+      { model: 'HL Mountain Frame', price: 1909.63, sellDate: '2025-09-05', sellTime: '09:35', inStock: false },
+      { model: 'Carbon Handlebar', price: 1080.7, sellDate: '2025-10-24', sellTime: '22:58', inStock: false },
+      { model: 'Aero Bottle', price: 1571.13, sellDate: '2025-05-24', sellTime: '00:24', inStock: true },
+      { model: 'Windbreaker Jacket', price: 919.09, sellDate: '2025-07-16', sellTime: '19:11', inStock: true },
+      { model: 'LED Bike Light', price: 1012.5, sellDate: '2025-05-01', sellTime: '17:30', inStock: false },
+      { model: 'Windbreaker Jacket', price: 635.37, sellDate: '2025-05-14', sellTime: '09:05', inStock: true },
+      { model: 'Road Tire Tube', price: 1421.27, sellDate: '2025-01-31', sellTime: '13:33', inStock: true },
+      { model: 'Action Camera', price: 1019.05, sellDate: '2025-12-07', sellTime: '01:26', inStock: false },
+      { model: 'Carbon Handlebar', price: 603.96, sellDate: '2025-09-13', sellTime: '04:10', inStock: false },
+      { model: 'Aero Bottle', price: 1334.03, sellDate: '2025-01-24', sellTime: '03:29', inStock: false },
+      { model: 'Road Tire Tube', price: 1841.17, sellDate: '2025-05-22', sellTime: '01:45', inStock: false },
+      { model: 'Aero Bottle', price: 1622.05, sellDate: '2025-01-13', sellTime: '08:30', inStock: true },
+      { model: 'Comfort Saddle', price: 1456.24, sellDate: '2025-07-20', sellTime: '03:39', inStock: false },
+      { model: 'Windbreaker Jacket', price: 1736.96, sellDate: '2025-09-25', sellTime: '00:43', inStock: true },
+      { model: 'Fitness Watch', price: 1075.31, sellDate: '2025-11-07', sellTime: '17:47', inStock: true },
+      { model: 'Cycling Cap', price: 726.01, sellDate: '2025-10-28', sellTime: '12:44', inStock: true },
+      { model: 'Road Tire Tube', price: 601.99, sellDate: '2025-09-22', sellTime: '00:26', inStock: true },
+      { model: 'Speed Gloves', price: 1758.26, sellDate: '2025-10-04', sellTime: '04:59', inStock: true },
+      { model: 'Speed Gloves', price: 564.35, sellDate: '2025-07-10', sellTime: '18:21', inStock: true },
+      { model: 'Hydration Pack', price: 954.84, sellDate: '2025-11-02', sellTime: '00:59', inStock: false },
+      { model: 'Cycling Cap', price: 1511.5, sellDate: '2025-02-11', sellTime: '02:38', inStock: false },
+      { model: 'HL Road Tire', price: 269.6, sellDate: '2025-06-18', sellTime: '04:58', inStock: false },
+    ];
+
+    tableData.value = loadedData;
+    hotInstance.loadData(loadedData);
+    loadingPlugin.hide();
+    isLoading.value = false;
+  } catch {
+    setTimeout(() => {
+      loadingPlugin.hide();
+      isLoading.value = false;
+    }, 2000);
+  }
+}
+</script>
+
+<template>
+  <div id="example4">
+    <HotTable ref="hotRef" :settings="hotSettings">
+      <HotColumn title="Model" type="text" data="model" :width="150" header-class-name="htLeft" />
+      <HotColumn
+        title="Price"
+        type="numeric"
+        data="price"
+        :width="80"
+        locale="en-US"
+        :numeric-format="{ style: 'currency', currency: 'USD', minimumFractionDigits: 2 }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn
+        title="Date"
+        type="intl-date"
+        data="sellDate"
+        :width="130"
+        locale="en-US"
+        :date-format="{ month: 'short', day: 'numeric', year: 'numeric' }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn
+        title="Time"
+        type="intl-time"
+        data="sellTime"
+        :width="90"
+        :time-format="{ hour: '2-digit', minute: '2-digit', hour12: true }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn title="In stock" type="checkbox" data="inStock" class-name="htCenter" header-class-name="htCenter" />
+    </HotTable>
+    <div class="example-controls-container example-controls-below-grid">
+      <div class="controls">
+        <button type="button" id="loadData" :disabled="isLoading" @click="loadData">
+          {{ tableData.length > 0 ? 'Reload Data' : 'Load Data' }}
+        </button>
+      </div>
+    </div>
+    <div style="margin-top: 16px">
+      <p style="padding: 0; font-size: var(--sl-text-xs); color: var(--sl-color-gray-3)">
+        This is a demonstration of how to use the Loading plugin with pagination in external container. You need to
+        create pagination overlay manually, after that you can use the <code>afterLoadingShow</code> and
+        <code>afterLoadingHide</code> hooks to show and hide the pagination container overlay.
+      </p>
+    </div>
+    <div style="margin-top: 16px">
+      <div ref="paginationContainerRef" class="example4-pagination" />
+    </div>
+  </div>
+</template>

--- a/docs/content/guides/dialog/notification/notification.md
+++ b/docs/content/guides/dialog/notification/notification.md
@@ -72,6 +72,16 @@ Enable the plugin with [`notification: true`](@/api/options.md#notification), th
 
 :::
 
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/dialog/notification/vue/example1.vue)
+
+:::
+
+:::
+
 ## Toolbar actions (inventory-style)
 
 Use separate buttons for save, error recovery, and warnings. Primary and secondary actions on an error toast can call `hideAll()` before showing follow-up feedback.
@@ -105,6 +115,16 @@ Use separate buttons for save, error recovery, and warnings. Primary and seconda
 
 @[code](@/content/guides/dialog/notification/angular/example2.ts)
 @[code](@/content/guides/dialog/notification/angular/example2.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example2 :vue3
+
+@[code](@/content/guides/dialog/notification/vue/example2.vue)
 
 :::
 

--- a/docs/content/guides/dialog/notification/vue/example1.vue
+++ b/docs/content/guides/dialog/notification/vue/example1.vue
@@ -1,0 +1,91 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+
+const data = [
+  ['Review pricing sheet', 'Draft', 'Apr 12', 'Morgan Lee', 'Medium', 'Finance'],
+  ['Ship partner samples', 'In progress', 'Apr 14', 'Jordan Kim', 'High', 'Sales'],
+  ['Q2 revenue forecast', 'Done', 'Apr 8', 'Avery Chen', 'Low', 'Finance'],
+  ['New client onboarding', 'Blocked', 'Apr 18', 'Riley Patel', 'High', 'Success'],
+  ['Update documentation', 'Draft', 'Apr 20', 'Casey Ruiz', 'Low', 'Engineering'],
+  ['Audit vendor contracts', 'In progress', 'Apr 22', 'Morgan Lee', 'Medium', 'Legal'],
+  ['Refresh brand assets', 'Draft', 'Apr 25', 'Sam Okafor', 'Low', 'Marketing'],
+  ['Fix login timeout bug', 'In progress', 'Apr 16', 'Devon Walsh', 'High', 'Engineering'],
+  ['Prep board deck', 'Done', 'Apr 10', 'Jordan Kim', 'Medium', 'Exec'],
+  ['Migrate legacy CRM rows', 'Blocked', 'Apr 28', 'Alex Rivera', 'High', 'Engineering'],
+  ['Schedule user interviews', 'Draft', 'Apr 19', 'Riley Patel', 'Medium', 'Product'],
+  ['Approve expense policy', 'In progress', 'Apr 21', 'Morgan Lee', 'Low', 'Finance'],
+  ['Localize help center', 'Draft', 'May 2', 'Sam Okafor', 'Medium', 'Marketing'],
+  ['Load test checkout API', 'In progress', 'Apr 17', 'Devon Walsh', 'High', 'Engineering'],
+  ['Quarterly OKR check-in', 'Done', 'Apr 9', 'Avery Chen', 'Low', 'Exec'],
+];
+
+const hotSettings = ref<GridSettings>({
+  data,
+  columns: [
+    { data: 0, type: 'text', width: 200 },
+    { data: 1, type: 'text', width: 105 },
+    { data: 2, type: 'text', width: 72 },
+    { data: 3, type: 'text', width: 120 },
+    { data: 4, type: 'text', width: 80 },
+    { data: 5, type: 'text', width: 100 },
+  ],
+  colHeaders: ['Task', 'Status', 'Due', 'Owner', 'Priority', 'Team'],
+  rowHeaders: true,
+  width: '100%',
+  height: 420,
+  notification: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+onMounted(() => {
+  const hot = hotRef.value?.hotInstance;
+
+  if (!hot) {
+    return;
+  }
+
+  const notification = hot.getPlugin('notification');
+
+  notification.showMessage({
+    title: 'Top start',
+    message: 'Info toast in the top-start corner.',
+    variant: 'info',
+    position: 'top-start',
+    duration: 0,
+  });
+  notification.showMessage({
+    title: 'Top end',
+    message: 'Success toast in the top-end corner.',
+    variant: 'success',
+    position: 'top-end',
+    duration: 0,
+  });
+  notification.showMessage({
+    title: 'Bottom start',
+    message: 'Warning toast in the bottom-start corner.',
+    variant: 'warning',
+    position: 'bottom-start',
+    duration: 0,
+  });
+  notification.showMessage({
+    title: 'Bottom end',
+    message: 'Error toast in the bottom-end corner.',
+    variant: 'error',
+    position: 'bottom-end',
+    duration: 0,
+  });
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable ref="hotRef" :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/dialog/notification/vue/example2.vue
+++ b/docs/content/guides/dialog/notification/vue/example2.vue
@@ -1,0 +1,107 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+
+const data = [
+  ['SKU-001', 'Alkaline AA 4pk', 240, 40, 'A-12'],
+  ['SKU-002', 'USB-C cable 1m', 18, 24, 'B-03'],
+  ['SKU-003', 'Notebook A5 ruled', 0, 30, 'C-01'],
+  ['SKU-004', 'Wireless mouse', 6, 15, 'B-07'],
+  ['SKU-005', 'HDMI cable 2m', 2, 10, 'A-04'],
+  ['SKU-006', 'Desk lamp LED', 45, 12, 'D-02'],
+  ['SKU-007', 'Laptop stand aluminum', 0, 8, 'C-14'],
+  ['SKU-008', 'Mechanical keycap set', 112, 20, 'B-01'],
+];
+
+const hotSettings = ref<GridSettings>({
+  data,
+  columns: [
+    { data: 0, type: 'text', width: 90 },
+    { data: 1, type: 'text', width: 200 },
+    { data: 2, type: 'numeric', width: 100 },
+    { data: 3, type: 'numeric', width: 95 },
+    { data: 4, type: 'text', width: 70 },
+  ],
+  colHeaders: ['SKU', 'Product', 'Qty on hand', 'Reorder at', 'Bin'],
+  rowHeaders: true,
+  width: '100%',
+  height: 280,
+  notification: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+function getPlugin() {
+  return hotRef.value?.hotInstance?.getPlugin('notification');
+}
+
+function onSave(): void {
+  getPlugin()?.showMessage({
+    title: 'Saved',
+    message: 'Inventory updates were written.',
+    variant: 'success',
+    position: 'top-end',
+    duration: 2500,
+  });
+}
+
+function onSyncError(): void {
+  const plugin = getPlugin();
+
+  if (!plugin) {
+    return;
+  }
+
+  plugin.showMessage({
+    title: 'Sync failed',
+    message: 'The service is unavailable. Retry when your connection is stable.',
+    variant: 'error',
+    position: 'bottom-end',
+    duration: 0,
+    actions: [
+      {
+        label: 'Retry',
+        type: 'primary',
+        callback: () => {
+          plugin.hideAll();
+          plugin.showMessage({
+            message: 'Sync completed.',
+            variant: 'success',
+            position: 'bottom-end',
+          });
+        },
+      },
+      { label: 'Dismiss', type: 'secondary', callback: () => plugin.hideAll() },
+    ],
+  });
+}
+
+function onLowStock(): void {
+  getPlugin()?.showMessage({
+    title: 'Review quantities',
+    message:
+      'SKUs below reorder: USB-C cable 1m, Wireless mouse, HDMI cable 2m. Out of stock: Notebook A5 ruled, Laptop stand.',
+    variant: 'warning',
+    position: 'top-start',
+    duration: 6000,
+  });
+}
+</script>
+
+<template>
+  <div id="example2">
+    <div class="example-controls-container">
+      <div class="controls">
+        <button type="button" class="button button--primary" @click="onSave">Save</button>
+        <button type="button" class="button button--primary" @click="onSyncError">Sync error</button>
+        <button type="button" class="button button--primary" @click="onLowStock">Low stock</button>
+      </div>
+    </div>
+    <HotTable ref="hotRef" :settings="hotSettings" />
+  </div>
+</template>


### PR DESCRIPTION
### Context

The Dialog category guides had JavaScript, React, and Angular examples but no Vue 3 variants. Readers on the Vue Data Grid docs could not run live examples for the Dialog, Loading, or Notification plugins.

[skip changelog]

### How has this been tested?

- `npm run build` in `docs/` (Node 20)
- Manual verification of all examples on vue-data-grid for `/dialog`, `/loading`, and `/notification`
- StackBlitz smoke tests for basic and control-bar examples

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s)

DEV-1746

### Affected project(s)

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist

- [x] I have reviewed the guidelines about Contributing to Handsontable and I confirm that my code follows the code style of this project.
- [ ] I have signed the Contributor License Agreement
- [x] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only additions with no runtime or library changes; minor note that Loading example 4 references React CSS by path, which is consistent with shared styles but worth a quick doc build check.
> 
> **Overview**
> Adds **Vue 3** live examples and `::: only-for vue` embeds across the **Dialog**, **Loading**, and **Notification** guides so the Vue Data Grid docs match the other framework variants.
> 
> For **Dialog**, eight new `example1`–`example8.vue` demos cover basic setup, text/HTML content, alert/confirm templates, background and content styling, ARIA options, and show/hide controls via `hotInstance.getPlugin('dialog')` after mount.
> 
> For **Loading**, four Vue examples mirror basic/custom overlays, async load with `loading.show()` / `hide()`, and pagination in an external container with `afterLoadingShow` / `afterLoadingHide` hooks (pagination example reuses the React `example4.css`).
> 
> For **Notification**, two examples show corner variants on mount and toolbar-driven save/sync/low-stock toasts with action buttons.
> 
> Changes are **documentation and examples only**; no Handsontable or `@handsontable/vue3` package code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e8b28809345b37ec93463e90d6b2e39381aa113. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->