### PR TITLE
DEV-1747: Add Vue 3 navigation guide examples

### DIFF
--- a/docs/content/guides/navigation/custom-shortcuts/custom-shortcuts.md
+++ b/docs/content/guides/navigation/custom-shortcuts/custom-shortcuts.md
@@ -57,6 +57,18 @@ For more information, see the [Instance access](@/guides/getting-started/angular
 
 :::
 
+::: only-for vue
+
+::: tip
+
+To use the Handsontable API, use a template ref on `HotTable` and read `hotRef.value.hotInstance`.
+
+For more information, see [Referencing the Handsontable instance in Vue 3](@/guides/integrate-with-vue3/vue3-hot-reference/vue3-hot-reference.md).
+
+:::
+
+:::
+
 <ol class="sl-steps">
 <li>
 
@@ -305,6 +317,22 @@ settings = {
 
 ```html
 <hot-table [settings]="settings" />
+```
+
+:::
+
+::: only-for vue
+
+```js
+const hotSettings = ref({
+  beforeKeyDown(event) {
+    // the `Enter` shortcut won't work
+    if (event.key === 'enter') {
+      return false;
+    }
+  },
+  // ...other settings
+});
 ```
 
 :::

--- a/docs/content/guides/navigation/focus-scopes/focus-scopes.md
+++ b/docs/content/guides/navigation/focus-scopes/focus-scopes.md
@@ -50,6 +50,18 @@ For more information, see the [Instance access](@/guides/getting-started/angular
 :::
 :::
 
+::: only-for vue
+
+::: tip
+
+To use the Handsontable API, use a template ref on `HotTable` and read `hotRef.value.hotInstance`.
+
+For more information, see [Referencing the Handsontable instance in Vue 3](@/guides/integrate-with-vue3/vue3-hot-reference/vue3-hot-reference.md).
+
+:::
+
+:::
+
 <ol class="sl-steps">
 <li>
 
@@ -126,6 +138,17 @@ to the bottom text input and how the internal state changes.
 :::
 :::
 
+::: only-for vue
+
+::: example #example1 :vue3 --css 1
+
+@[code](@/content/guides/navigation/focus-scopes/react/example1.css)
+@[code collapse={17-118,145-147,220-222}](@/content/guides/navigation/focus-scopes/vue/example1.vue)
+
+:::
+
+:::
+
 ### Modal scopes
 
 Modal scopes have a priority over inline scopes. If a modal scope is active, the inline scopes will not be activated. This is useful for dialogs, popups, or any UI that may overlap other inline scopes and need to be activated first.
@@ -173,6 +196,17 @@ appears after the inline scope elements in the DOM.
 @[code](@/content/guides/navigation/focus-scopes/angular/example2.html)
 
 :::
+:::
+
+::: only-for vue
+
+::: example #example2 :vue3 --css 1
+
+@[code](@/content/guides/navigation/focus-scopes/react/example2.css)
+@[code collapse={17-118,145-147,228-236}](@/content/guides/navigation/focus-scopes/vue/example2.vue)
+
+:::
+
 :::
 
 ## Register a focus scope

--- a/docs/content/guides/navigation/focus-scopes/vue/example1.vue
+++ b/docs/content/guides/navigation/focus-scopes/vue/example1.vue
@@ -1,0 +1,229 @@
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue';
+import { HotTable, HotColumn } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+
+const tableData = [
+  { model: 'Trail Helmet', price: 1298.14, sellDate: '2025-08-31', sellTime: '14:12', inStock: true },
+  { model: 'Windbreaker Jacket', price: 178.9, sellDate: '2025-05-10', sellTime: '22:26', inStock: false },
+  { model: 'Cycling Cap', price: 288.1, sellDate: '2025-09-15', sellTime: '09:37', inStock: true },
+  { model: 'HL Mountain Frame', price: 94.49, sellDate: '2025-01-17', sellTime: '14:19', inStock: false },
+  { model: 'Racing Socks', price: 430.38, sellDate: '2025-05-10', sellTime: '13:42', inStock: true },
+  { model: 'Racing Socks', price: 138.85, sellDate: '2025-09-20', sellTime: '14:48', inStock: true },
+  { model: 'HL Mountain Frame', price: 1909.63, sellDate: '2025-09-05', sellTime: '09:35', inStock: false },
+  { model: 'Carbon Handlebar', price: 1080.7, sellDate: '2025-10-24', sellTime: '22:58', inStock: false },
+  { model: 'Aero Bottle', price: 1571.13, sellDate: '2025-05-24', sellTime: '00:24', inStock: true },
+  { model: 'Windbreaker Jacket', price: 919.09, sellDate: '2025-07-16', sellTime: '19:11', inStock: true },
+  { model: 'HL Road Tire', price: 886.22, sellDate: '2025-09-09', sellTime: '00:42', inStock: false },
+  { model: 'Speed Gloves', price: 635.13, sellDate: '2025-11-17', sellTime: '12:45', inStock: true },
+  { model: 'Trail Helmet', price: 1440.64, sellDate: '2025-01-03', sellTime: '20:16', inStock: false },
+  { model: 'Aero Bottle', price: 944.63, sellDate: '2025-11-15', sellTime: '16:14', inStock: false },
+  { model: 'Windbreaker Jacket', price: 1161.43, sellDate: '2025-06-24', sellTime: '13:19', inStock: false },
+  { model: 'LED Bike Light', price: 1012.5, sellDate: '2025-05-01', sellTime: '17:30', inStock: false },
+  { model: 'Windbreaker Jacket', price: 635.37, sellDate: '2025-05-14', sellTime: '09:05', inStock: true },
+  { model: 'Road Tire Tube', price: 1421.27, sellDate: '2025-01-31', sellTime: '13:33', inStock: true },
+  { model: 'Action Camera', price: 1019.05, sellDate: '2025-12-07', sellTime: '01:26', inStock: false },
+  { model: 'Carbon Handlebar', price: 603.96, sellDate: '2025-09-13', sellTime: '04:10', inStock: false },
+  { model: 'Aero Bottle', price: 1334.03, sellDate: '2025-01-24', sellTime: '03:29', inStock: false },
+  { model: 'Road Tire Tube', price: 1841.17, sellDate: '2025-05-22', sellTime: '01:45', inStock: false },
+  { model: 'Aero Bottle', price: 1622.05, sellDate: '2025-01-13', sellTime: '08:30', inStock: true },
+  { model: 'Comfort Saddle', price: 1456.24, sellDate: '2025-07-20', sellTime: '03:39', inStock: false },
+  { model: 'Windbreaker Jacket', price: 1736.96, sellDate: '2025-09-25', sellTime: '00:43', inStock: true },
+  { model: 'Fitness Watch', price: 1075.31, sellDate: '2025-11-07', sellTime: '17:47', inStock: true },
+  { model: 'Cycling Cap', price: 726.01, sellDate: '2025-10-28', sellTime: '12:44', inStock: true },
+  { model: 'Road Tire Tube', price: 601.99, sellDate: '2025-09-22', sellTime: '00:26', inStock: true },
+  { model: 'Speed Gloves', price: 1758.26, sellDate: '2025-10-04', sellTime: '04:59', inStock: true },
+  { model: 'Speed Gloves', price: 564.35, sellDate: '2025-07-10', sellTime: '18:21', inStock: true },
+  { model: 'Hydration Pack', price: 954.84, sellDate: '2025-11-02', sellTime: '00:59', inStock: false },
+  { model: 'Cycling Cap', price: 1511.5, sellDate: '2025-02-11', sellTime: '02:38', inStock: false },
+  { model: 'HL Road Tire', price: 269.6, sellDate: '2025-06-18', sellTime: '04:58', inStock: false },
+  { model: 'Road Tire Tube', price: 435.07, sellDate: '2025-07-22', sellTime: '23:12', inStock: false },
+  { model: 'Fitness Watch', price: 1187.8, sellDate: '2025-08-13', sellTime: '10:19', inStock: true },
+  { model: 'Racing Socks', price: 770.19, sellDate: '2025-02-02', sellTime: '20:37', inStock: true },
+  { model: 'Carbon Handlebar', price: 60.41, sellDate: '2025-12-27', sellTime: '20:30', inStock: true },
+  { model: 'Racing Socks', price: 944.21, sellDate: '2025-05-23', sellTime: '18:43', inStock: false },
+  { model: 'Racing Socks', price: 621.96, sellDate: '2025-12-12', sellTime: '04:59', inStock: false },
+  { model: 'HL Road Tire', price: 774.91, sellDate: '2025-06-02', sellTime: '03:48', inStock: true },
+  { model: 'LED Bike Light', price: 1205.29, sellDate: '2025-04-15', sellTime: '22:08', inStock: false },
+  { model: 'Racing Socks', price: 388.19, sellDate: '2025-05-24', sellTime: '08:36', inStock: true },
+  { model: 'Windbreaker Jacket', price: 267.88, sellDate: '2025-05-25', sellTime: '15:00', inStock: true },
+  { model: 'LED Bike Light', price: 283.72, sellDate: '2025-09-26', sellTime: '02:16', inStock: true },
+  { model: 'Comfort Saddle', price: 1782.91, sellDate: '2025-03-07', sellTime: '09:43', inStock: false },
+  { model: 'Trail Helmet', price: 1943.46, sellDate: '2025-06-05', sellTime: '01:49', inStock: true },
+  { model: 'Speed Gloves', price: 1737.8, sellDate: '2025-09-18', sellTime: '14:21', inStock: true },
+  { model: 'Road Tire Tube', price: 354.89, sellDate: '2025-08-11', sellTime: '02:03', inStock: true },
+  { model: 'Hydration Pack', price: 1490.45, sellDate: '2025-12-04', sellTime: '02:23', inStock: true },
+  { model: 'LED Bike Light', price: 844.48, sellDate: '2025-09-22', sellTime: '02:29', inStock: true },
+  { model: 'Road Tire Tube', price: 1965.77, sellDate: '2025-02-10', sellTime: '23:52', inStock: false },
+  { model: 'Action Camera', price: 522.33, sellDate: '2025-11-11', sellTime: '16:50', inStock: false },
+  { model: 'Comfort Saddle', price: 109.4, sellDate: '2025-05-13', sellTime: '11:41', inStock: true },
+  { model: 'Hydration Pack', price: 1067.76, sellDate: '2025-08-07', sellTime: '05:04', inStock: false },
+  { model: 'Speed Gloves', price: 1738.77, sellDate: '2025-01-28', sellTime: '08:38', inStock: false },
+  { model: 'Aero Bottle', price: 1600.35, sellDate: '2025-01-29', sellTime: '00:36', inStock: false },
+  { model: 'Speed Gloves', price: 524.91, sellDate: '2025-12-15', sellTime: '12:56', inStock: true },
+  { model: 'Windbreaker Jacket', price: 1780.51, sellDate: '2025-09-23', sellTime: '05:02', inStock: false },
+  { model: 'Comfort Saddle', price: 1955.0, sellDate: '2025-09-29', sellTime: '13:03', inStock: false },
+  { model: 'Speed Gloves', price: 957.4, sellDate: '2025-08-06', sellTime: '03:19', inStock: true },
+  { model: 'Fitness Watch', price: 193.72, sellDate: '2025-04-01', sellTime: '19:49', inStock: false },
+  { model: 'Speed Gloves', price: 677.94, sellDate: '2025-10-11', sellTime: '22:25', inStock: false },
+  { model: 'LED Bike Light', price: 1155.9, sellDate: '2025-03-02', sellTime: '11:36', inStock: false },
+  { model: 'LED Bike Light', price: 586.82, sellDate: '2025-11-22', sellTime: '20:29', inStock: false },
+  { model: 'Action Camera', price: 406.41, sellDate: '2025-10-25', sellTime: '11:10', inStock: false },
+  { model: 'Road Tire Tube', price: 595.55, sellDate: '2025-05-24', sellTime: '01:30', inStock: false },
+  { model: 'Racing Socks', price: 1078.63, sellDate: '2025-04-28', sellTime: '02:57', inStock: true },
+  { model: 'Cycling Cap', price: 1781.04, sellDate: '2025-10-07', sellTime: '06:58', inStock: false },
+  { model: 'Trail Helmet', price: 181.8, sellDate: '2025-10-02', sellTime: '20:04', inStock: false },
+  { model: 'HL Mountain Frame', price: 489.39, sellDate: '2025-07-20', sellTime: '10:51', inStock: true },
+  { model: 'HL Road Tire', price: 1964.04, sellDate: '2025-07-10', sellTime: '15:01', inStock: true },
+  { model: 'Action Camera', price: 1321.19, sellDate: '2025-02-02', sellTime: '13:39', inStock: true },
+  { model: 'Trail Helmet', price: 1311.09, sellDate: '2025-12-27', sellTime: '14:45', inStock: false },
+  { model: 'Windbreaker Jacket', price: 1573.57, sellDate: '2025-09-20', sellTime: '20:31', inStock: false },
+  { model: 'Speed Gloves', price: 338.01, sellDate: '2025-10-22', sellTime: '18:56', inStock: false },
+  { model: 'Carbon Handlebar', price: 309.18, sellDate: '2025-11-10', sellTime: '15:20', inStock: true },
+  { model: 'LED Bike Light', price: 1289.0, sellDate: '2025-08-22', sellTime: '15:34', inStock: true },
+  { model: 'Action Camera', price: 1655.66, sellDate: '2025-06-12', sellTime: '15:38', inStock: false },
+  { model: 'Hydration Pack', price: 1126.33, sellDate: '2025-09-15', sellTime: '06:29', inStock: false },
+  { model: 'Racing Socks', price: 157.45, sellDate: '2025-01-26', sellTime: '19:25', inStock: true },
+  { model: 'Aero Bottle', price: 1707.67, sellDate: '2025-02-02', sellTime: '17:34', inStock: true },
+  { model: 'Road Tire Tube', price: 601.95, sellDate: '2025-04-14', sellTime: '08:02', inStock: true },
+  { model: 'HL Road Tire', price: 118.42, sellDate: '2025-02-08', sellTime: '06:08', inStock: false },
+  { model: 'Racing Socks', price: 1721.99, sellDate: '2025-10-13', sellTime: '09:01', inStock: true },
+  { model: 'Action Camera', price: 1620.39, sellDate: '2025-07-18', sellTime: '05:53', inStock: false },
+  { model: 'Trail Helmet', price: 1051.16, sellDate: '2025-01-21', sellTime: '09:44', inStock: true },
+  { model: 'Fitness Watch', price: 1534.64, sellDate: '2025-02-27', sellTime: '09:19', inStock: true },
+  { model: 'Comfort Saddle', price: 984.12, sellDate: '2025-03-16', sellTime: '07:24', inStock: false },
+  { model: 'Comfort Saddle', price: 1316.13, sellDate: '2025-02-11', sellTime: '11:01', inStock: true },
+  { model: 'Carbon Handlebar', price: 774.69, sellDate: '2025-10-17', sellTime: '11:38', inStock: false },
+  { model: 'Road Tire Tube', price: 1887.19, sellDate: '2025-10-19', sellTime: '06:02', inStock: true },
+  { model: 'Cycling Cap', price: 519.44, sellDate: '2025-10-21', sellTime: '03:54', inStock: true },
+  { model: 'Trail Helmet', price: 1149.2, sellDate: '2025-04-24', sellTime: '04:40', inStock: false },
+  { model: 'Carbon Handlebar', price: 915.24, sellDate: '2025-07-10', sellTime: '05:22', inStock: true },
+  { model: 'Comfort Saddle', price: 1625.63, sellDate: '2025-03-31', sellTime: '23:55', inStock: true },
+  { model: 'Racing Socks', price: 143.76, sellDate: '2025-12-02', sellTime: '07:25', inStock: true },
+  { model: 'Cycling Cap', price: 981.24, sellDate: '2025-08-09', sellTime: '19:52', inStock: false },
+  { model: 'Comfort Saddle', price: 779.4, sellDate: '2025-06-12', sellTime: '17:08', inStock: true },
+  { model: 'Carbon Handlebar', price: 1512.24, sellDate: '2025-07-27', sellTime: '07:02', inStock: true },
+  { model: 'Cycling Cap', price: 444.79, sellDate: '2025-09-11', sellTime: '10:05', inStock: false },
+];
+
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const isListening = ref(false);
+const focusScope = ref<string | null>(null);
+const shortcutsContext = ref<string | null>(null);
+
+const hotSettings = ref<GridSettings>({
+  data: tableData,
+  pagination: true,
+  autoRowSize: true,
+  tabNavigation: false,
+  width: '100%',
+  height: 250,
+  stretchH: 'all',
+  contextMenu: true,
+  rowHeaders: true,
+  colHeaders: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+function updateDebugInfo(): void {
+  const hotInstance = hotRef.value?.hotInstance;
+
+  if (hotInstance) {
+    isListening.value = hotInstance.isListening();
+    focusScope.value = hotInstance.getFocusScopeManager().getActiveScopeId();
+    shortcutsContext.value = hotInstance.getShortcutManager().getActiveContextName();
+  }
+}
+
+let debugInterval: ReturnType<typeof setInterval> | undefined;
+
+onMounted(() => {
+  debugInterval = setInterval(updateDebugInfo, 200);
+});
+
+onUnmounted(() => {
+  if (debugInterval) {
+    clearInterval(debugInterval);
+  }
+});
+</script>
+
+<template>
+  <div id="example1" class="example-container">
+    <input
+      class="placeholder-input"
+      type="text"
+      name="focusable-text-input"
+      placeholder="Focusable top text input"
+    >
+
+    <HotTable ref="hotRef" :settings="hotSettings">
+      <HotColumn title="Model" type="text" data="model" :width="150" header-class-name="htLeft" />
+      <HotColumn
+        title="Price"
+        type="numeric"
+        data="price"
+        :width="80"
+        locale="en-US"
+        :numeric-format="{ style: 'currency', currency: 'USD', minimumFractionDigits: 2 }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn
+        title="Date"
+        type="intl-date"
+        data="sellDate"
+        :width="131"
+        locale="en-US"
+        :date-format="{ month: 'short', day: 'numeric', year: 'numeric' }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn
+        title="Time"
+        type="intl-time"
+        data="sellTime"
+        :width="81"
+        :time-format="{ hour: '2-digit', minute: '2-digit', hour12: true }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn title="In stock" type="checkbox" data="inStock" class-name="htCenter" header-class-name="htCenter" />
+    </HotTable>
+
+    <input
+      class="placeholder-input"
+      type="text"
+      name="focusable-text-input"
+      placeholder="Focusable bottom text input"
+    >
+
+    <strong>Debug information:</strong>
+    <table class="debug-table">
+      <colgroup>
+        <col>
+        <col style="width: 200px">
+      </colgroup>
+      <tbody>
+        <tr>
+          <td><code>isListening()</code></td>
+          <td><code class="isListening">{{ String(isListening) }}</code></td>
+        </tr>
+        <tr>
+          <td><code>getFocusScopeManager().getActiveScopeId()</code></td>
+          <td><code class="focusScope">{{ String(focusScope) }}</code></td>
+        </tr>
+        <tr>
+          <td><code>getShortcutManager().getActiveContextName()</code></td>
+          <td><code class="shortcutsContext">{{ String(shortcutsContext) }}</code></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>

--- a/docs/content/guides/navigation/focus-scopes/vue/example2.vue
+++ b/docs/content/guides/navigation/focus-scopes/vue/example2.vue
@@ -1,0 +1,240 @@
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted, nextTick } from 'vue';
+import { HotTable, HotColumn } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+
+const tableData = [
+  { model: 'Trail Helmet', price: 1298.14, sellDate: '2025-08-31', sellTime: '14:12', inStock: true },
+  { model: 'Windbreaker Jacket', price: 178.9, sellDate: '2025-05-10', sellTime: '22:26', inStock: false },
+  { model: 'Cycling Cap', price: 288.1, sellDate: '2025-09-15', sellTime: '09:37', inStock: true },
+  { model: 'HL Mountain Frame', price: 94.49, sellDate: '2025-01-17', sellTime: '14:19', inStock: false },
+  { model: 'Racing Socks', price: 430.38, sellDate: '2025-05-10', sellTime: '13:42', inStock: true },
+  { model: 'Racing Socks', price: 138.85, sellDate: '2025-09-20', sellTime: '14:48', inStock: true },
+  { model: 'HL Mountain Frame', price: 1909.63, sellDate: '2025-09-05', sellTime: '09:35', inStock: false },
+  { model: 'Carbon Handlebar', price: 1080.7, sellDate: '2025-10-24', sellTime: '22:58', inStock: false },
+  { model: 'Aero Bottle', price: 1571.13, sellDate: '2025-05-24', sellTime: '00:24', inStock: true },
+  { model: 'Windbreaker Jacket', price: 919.09, sellDate: '2025-07-16', sellTime: '19:11', inStock: true },
+  { model: 'HL Road Tire', price: 886.22, sellDate: '2025-09-09', sellTime: '00:42', inStock: false },
+  { model: 'Speed Gloves', price: 635.13, sellDate: '2025-11-17', sellTime: '12:45', inStock: true },
+  { model: 'Trail Helmet', price: 1440.64, sellDate: '2025-01-03', sellTime: '20:16', inStock: false },
+  { model: 'Aero Bottle', price: 944.63, sellDate: '2025-11-15', sellTime: '16:14', inStock: false },
+  { model: 'Windbreaker Jacket', price: 1161.43, sellDate: '2025-06-24', sellTime: '13:19', inStock: false },
+  { model: 'LED Bike Light', price: 1012.5, sellDate: '2025-05-01', sellTime: '17:30', inStock: false },
+  { model: 'Windbreaker Jacket', price: 635.37, sellDate: '2025-05-14', sellTime: '09:05', inStock: true },
+  { model: 'Road Tire Tube', price: 1421.27, sellDate: '2025-01-31', sellTime: '13:33', inStock: true },
+  { model: 'Action Camera', price: 1019.05, sellDate: '2025-12-07', sellTime: '01:26', inStock: false },
+  { model: 'Carbon Handlebar', price: 603.96, sellDate: '2025-09-13', sellTime: '04:10', inStock: false },
+  { model: 'Aero Bottle', price: 1334.03, sellDate: '2025-01-24', sellTime: '03:29', inStock: false },
+  { model: 'Road Tire Tube', price: 1841.17, sellDate: '2025-05-22', sellTime: '01:45', inStock: false },
+  { model: 'Aero Bottle', price: 1622.05, sellDate: '2025-01-13', sellTime: '08:30', inStock: true },
+  { model: 'Comfort Saddle', price: 1456.24, sellDate: '2025-07-20', sellTime: '03:39', inStock: false },
+  { model: 'Windbreaker Jacket', price: 1736.96, sellDate: '2025-09-25', sellTime: '00:43', inStock: true },
+  { model: 'Fitness Watch', price: 1075.31, sellDate: '2025-11-07', sellTime: '17:47', inStock: true },
+  { model: 'Cycling Cap', price: 726.01, sellDate: '2025-10-28', sellTime: '12:44', inStock: true },
+  { model: 'Road Tire Tube', price: 601.99, sellDate: '2025-09-22', sellTime: '00:26', inStock: true },
+  { model: 'Speed Gloves', price: 1758.26, sellDate: '2025-10-04', sellTime: '04:59', inStock: true },
+  { model: 'Speed Gloves', price: 564.35, sellDate: '2025-07-10', sellTime: '18:21', inStock: true },
+  { model: 'Hydration Pack', price: 954.84, sellDate: '2025-11-02', sellTime: '00:59', inStock: false },
+  { model: 'Cycling Cap', price: 1511.5, sellDate: '2025-02-11', sellTime: '02:38', inStock: false },
+  { model: 'HL Road Tire', price: 269.6, sellDate: '2025-06-18', sellTime: '04:58', inStock: false },
+  { model: 'Road Tire Tube', price: 435.07, sellDate: '2025-07-22', sellTime: '23:12', inStock: false },
+  { model: 'Fitness Watch', price: 1187.8, sellDate: '2025-08-13', sellTime: '10:19', inStock: true },
+  { model: 'Racing Socks', price: 770.19, sellDate: '2025-02-02', sellTime: '20:37', inStock: true },
+  { model: 'Carbon Handlebar', price: 60.41, sellDate: '2025-12-27', sellTime: '20:30', inStock: true },
+  { model: 'Racing Socks', price: 944.21, sellDate: '2025-05-23', sellTime: '18:43', inStock: false },
+  { model: 'Racing Socks', price: 621.96, sellDate: '2025-12-12', sellTime: '04:59', inStock: false },
+  { model: 'HL Road Tire', price: 774.91, sellDate: '2025-06-02', sellTime: '03:48', inStock: true },
+  { model: 'LED Bike Light', price: 1205.29, sellDate: '2025-04-15', sellTime: '22:08', inStock: false },
+  { model: 'Racing Socks', price: 388.19, sellDate: '2025-05-24', sellTime: '08:36', inStock: true },
+  { model: 'Windbreaker Jacket', price: 267.88, sellDate: '2025-05-25', sellTime: '15:00', inStock: true },
+  { model: 'LED Bike Light', price: 283.72, sellDate: '2025-09-26', sellTime: '02:16', inStock: true },
+  { model: 'Comfort Saddle', price: 1782.91, sellDate: '2025-03-07', sellTime: '09:43', inStock: false },
+  { model: 'Trail Helmet', price: 1943.46, sellDate: '2025-06-05', sellTime: '01:49', inStock: true },
+  { model: 'Speed Gloves', price: 1737.8, sellDate: '2025-09-18', sellTime: '14:21', inStock: true },
+  { model: 'Road Tire Tube', price: 354.89, sellDate: '2025-08-11', sellTime: '02:03', inStock: true },
+  { model: 'Hydration Pack', price: 1490.45, sellDate: '2025-12-04', sellTime: '02:23', inStock: true },
+  { model: 'LED Bike Light', price: 844.48, sellDate: '2025-09-22', sellTime: '02:29', inStock: true },
+  { model: 'Road Tire Tube', price: 1965.77, sellDate: '2025-02-10', sellTime: '23:52', inStock: false },
+  { model: 'Action Camera', price: 522.33, sellDate: '2025-11-11', sellTime: '16:50', inStock: false },
+  { model: 'Comfort Saddle', price: 109.4, sellDate: '2025-05-13', sellTime: '11:41', inStock: true },
+  { model: 'Hydration Pack', price: 1067.76, sellDate: '2025-08-07', sellTime: '05:04', inStock: false },
+  { model: 'Speed Gloves', price: 1738.77, sellDate: '2025-01-28', sellTime: '08:38', inStock: false },
+  { model: 'Aero Bottle', price: 1600.35, sellDate: '2025-01-29', sellTime: '00:36', inStock: false },
+  { model: 'Speed Gloves', price: 524.91, sellDate: '2025-12-15', sellTime: '12:56', inStock: true },
+  { model: 'Windbreaker Jacket', price: 1780.51, sellDate: '2025-09-23', sellTime: '05:02', inStock: false },
+  { model: 'Comfort Saddle', price: 1955.0, sellDate: '2025-09-29', sellTime: '13:03', inStock: false },
+  { model: 'Speed Gloves', price: 957.4, sellDate: '2025-08-06', sellTime: '03:19', inStock: true },
+  { model: 'Fitness Watch', price: 193.72, sellDate: '2025-04-01', sellTime: '19:49', inStock: false },
+  { model: 'Speed Gloves', price: 677.94, sellDate: '2025-10-11', sellTime: '22:25', inStock: false },
+  { model: 'LED Bike Light', price: 1155.9, sellDate: '2025-03-02', sellTime: '11:36', inStock: false },
+  { model: 'LED Bike Light', price: 586.82, sellDate: '2025-11-22', sellTime: '20:29', inStock: false },
+  { model: 'Action Camera', price: 406.41, sellDate: '2025-10-25', sellTime: '11:10', inStock: false },
+  { model: 'Road Tire Tube', price: 595.55, sellDate: '2025-05-24', sellTime: '01:30', inStock: false },
+  { model: 'Racing Socks', price: 1078.63, sellDate: '2025-04-28', sellTime: '02:57', inStock: true },
+  { model: 'Cycling Cap', price: 1781.04, sellDate: '2025-10-07', sellTime: '06:58', inStock: false },
+  { model: 'Trail Helmet', price: 181.8, sellDate: '2025-10-02', sellTime: '20:04', inStock: false },
+  { model: 'HL Mountain Frame', price: 489.39, sellDate: '2025-07-20', sellTime: '10:51', inStock: true },
+  { model: 'HL Road Tire', price: 1964.04, sellDate: '2025-07-10', sellTime: '15:01', inStock: true },
+  { model: 'Action Camera', price: 1321.19, sellDate: '2025-02-02', sellTime: '13:39', inStock: true },
+  { model: 'Trail Helmet', price: 1311.09, sellDate: '2025-12-27', sellTime: '14:45', inStock: false },
+  { model: 'Windbreaker Jacket', price: 1573.57, sellDate: '2025-09-20', sellTime: '20:31', inStock: false },
+  { model: 'Speed Gloves', price: 338.01, sellDate: '2025-10-22', sellTime: '18:56', inStock: false },
+  { model: 'Carbon Handlebar', price: 309.18, sellDate: '2025-11-10', sellTime: '15:20', inStock: true },
+  { model: 'LED Bike Light', price: 1289.0, sellDate: '2025-08-22', sellTime: '15:34', inStock: true },
+  { model: 'Action Camera', price: 1655.66, sellDate: '2025-06-12', sellTime: '15:38', inStock: false },
+  { model: 'Hydration Pack', price: 1126.33, sellDate: '2025-09-15', sellTime: '06:29', inStock: false },
+  { model: 'Racing Socks', price: 157.45, sellDate: '2025-01-26', sellTime: '19:25', inStock: true },
+  { model: 'Aero Bottle', price: 1707.67, sellDate: '2025-02-02', sellTime: '17:34', inStock: true },
+  { model: 'Road Tire Tube', price: 601.95, sellDate: '2025-04-14', sellTime: '08:02', inStock: true },
+  { model: 'HL Road Tire', price: 118.42, sellDate: '2025-02-08', sellTime: '06:08', inStock: false },
+  { model: 'Racing Socks', price: 1721.99, sellDate: '2025-10-13', sellTime: '09:01', inStock: true },
+  { model: 'Action Camera', price: 1620.39, sellDate: '2025-07-18', sellTime: '05:53', inStock: false },
+  { model: 'Trail Helmet', price: 1051.16, sellDate: '2025-01-21', sellTime: '09:44', inStock: true },
+  { model: 'Fitness Watch', price: 1534.64, sellDate: '2025-02-27', sellTime: '09:19', inStock: true },
+  { model: 'Comfort Saddle', price: 984.12, sellDate: '2025-03-16', sellTime: '07:24', inStock: false },
+  { model: 'Comfort Saddle', price: 1316.13, sellDate: '2025-02-11', sellTime: '11:01', inStock: true },
+  { model: 'Carbon Handlebar', price: 774.69, sellDate: '2025-10-17', sellTime: '11:38', inStock: false },
+  { model: 'Road Tire Tube', price: 1887.19, sellDate: '2025-10-19', sellTime: '06:02', inStock: true },
+  { model: 'Cycling Cap', price: 519.44, sellDate: '2025-10-21', sellTime: '03:54', inStock: true },
+  { model: 'Trail Helmet', price: 1149.2, sellDate: '2025-04-24', sellTime: '04:40', inStock: false },
+  { model: 'Carbon Handlebar', price: 915.24, sellDate: '2025-07-10', sellTime: '05:22', inStock: true },
+  { model: 'Comfort Saddle', price: 1625.63, sellDate: '2025-03-31', sellTime: '23:55', inStock: true },
+  { model: 'Racing Socks', price: 143.76, sellDate: '2025-12-02', sellTime: '07:25', inStock: true },
+  { model: 'Cycling Cap', price: 981.24, sellDate: '2025-08-09', sellTime: '19:52', inStock: false },
+  { model: 'Comfort Saddle', price: 779.4, sellDate: '2025-06-12', sellTime: '17:08', inStock: true },
+  { model: 'Carbon Handlebar', price: 1512.24, sellDate: '2025-07-27', sellTime: '07:02', inStock: true },
+  { model: 'Cycling Cap', price: 444.79, sellDate: '2025-09-11', sellTime: '10:05', inStock: false },
+];
+
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const isListening = ref(false);
+const focusScope = ref<string | null>(null);
+const shortcutsContext = ref<string | null>(null);
+
+const hotSettings = ref<GridSettings>({
+  data: tableData,
+  pagination: true,
+  dialog: true,
+  autoRowSize: true,
+  tabNavigation: false,
+  width: '100%',
+  height: 250,
+  stretchH: 'all',
+  contextMenu: true,
+  rowHeaders: true,
+  colHeaders: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+function updateDebugInfo(): void {
+  const hotInstance = hotRef.value?.hotInstance;
+
+  if (hotInstance) {
+    isListening.value = hotInstance.isListening();
+    focusScope.value = hotInstance.getFocusScopeManager().getActiveScopeId();
+    shortcutsContext.value = hotInstance.getShortcutManager().getActiveContextName();
+  }
+}
+
+let debugInterval: ReturnType<typeof setInterval> | undefined;
+
+onMounted(async () => {
+  await nextTick();
+
+  const hotInstance = hotRef.value?.hotInstance;
+
+  hotInstance?.getPlugin('dialog').show({
+    content: 'This is a simple text message displayed in the dialog.',
+    closable: true,
+    background: 'semi-transparent',
+  });
+
+  debugInterval = setInterval(updateDebugInfo, 200);
+});
+
+onUnmounted(() => {
+  if (debugInterval) {
+    clearInterval(debugInterval);
+  }
+});
+</script>
+
+<template>
+  <div id="example2" class="example-container">
+    <input
+      class="placeholder-input"
+      type="text"
+      name="focusable-text-input"
+      placeholder="Focusable top text input"
+    >
+
+    <HotTable ref="hotRef" :settings="hotSettings">
+      <HotColumn title="Model" type="text" data="model" :width="150" header-class-name="htLeft" />
+      <HotColumn
+        title="Price"
+        type="numeric"
+        data="price"
+        :width="80"
+        locale="en-US"
+        :numeric-format="{ style: 'currency', currency: 'USD', minimumFractionDigits: 2 }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn
+        title="Date"
+        type="intl-date"
+        data="sellDate"
+        :width="131"
+        locale="en-US"
+        :date-format="{ month: 'short', day: 'numeric', year: 'numeric' }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn
+        title="Time"
+        type="intl-time"
+        data="sellTime"
+        :width="81"
+        :time-format="{ hour: '2-digit', minute: '2-digit', hour12: true }"
+        class-name="htRight"
+        header-class-name="htRight"
+      />
+      <HotColumn title="In stock" type="checkbox" data="inStock" class-name="htCenter" header-class-name="htCenter" />
+    </HotTable>
+
+    <input
+      class="placeholder-input"
+      type="text"
+      name="focusable-text-input"
+      placeholder="Focusable bottom text input"
+    >
+
+    <strong>Debug information:</strong>
+    <table class="debug-table">
+      <colgroup>
+        <col>
+        <col style="width: 200px">
+      </colgroup>
+      <tbody>
+        <tr>
+          <td><code>isListening()</code></td>
+          <td><code class="isListening">{{ String(isListening) }}</code></td>
+        </tr>
+        <tr>
+          <td><code>getFocusScopeManager().getActiveScopeId()</code></td>
+          <td><code class="focusScope">{{ String(focusScope) }}</code></td>
+        </tr>
+        <tr>
+          <td><code>getShortcutManager().getActiveContextName()</code></td>
+          <td><code class="shortcutsContext">{{ String(shortcutsContext) }}</code></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>

--- a/docs/content/guides/navigation/searching-values/searching-values.md
+++ b/docs/content/guides/navigation/searching-values/searching-values.md
@@ -50,6 +50,18 @@ For more information, see the [Instance access](@/guides/getting-started/angular
 
 :::
 
+::: only-for vue
+
+::: tip
+
+To use the Handsontable API, use a template ref on `HotTable` and read `hotRef.value.hotInstance`.
+
+For more information, see [Referencing the Handsontable instance in Vue 3](@/guides/integrate-with-vue3/vue3-hot-reference/vue3-hot-reference.md).
+
+:::
+
+:::
+
 The [`Search`](@/api/search.md) plugin lets you scan all cells in the grid and get back a list of matches. Enable it by setting the [`search`](@/api/options.md#search) option to `true` or to a configuration object.
 
 Once enabled, the plugin exposes the [`query(queryStr)`](@/api/search.md#query) method. Call it with a search string whenever the user types. By default, the search is case-insensitive and matches partial cell values.
@@ -91,6 +103,16 @@ The example below:
 
 @[code](@/content/guides/navigation/searching-values/angular/example1.ts)
 @[code](@/content/guides/navigation/searching-values/angular/example1.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/navigation/searching-values/vue/example1.vue)
 
 :::
 
@@ -148,6 +170,17 @@ The example below highlights search results with a pink background and red text.
 
 :::
 
+::: only-for vue
+
+::: example #example2 :vue3 --css 1
+
+@[code](@/content/guides/navigation/searching-values/react/example2.css)
+@[code](@/content/guides/navigation/searching-values/vue/example2.vue)
+
+:::
+
+:::
+
 ## Custom query method
 
 You can replace the built-in substring search with a custom query method, using the [`queryMethod`](@/api/options.md#search) option.
@@ -192,6 +225,16 @@ The example below searches only for exact matches. To do this, it:
 
 :::
 
+::: only-for vue
+
+::: example #example3 :vue3
+
+@[code](@/content/guides/navigation/searching-values/vue/example3.vue)
+
+:::
+
+:::
+
 ## Custom callback
 
 You can add a custom callback function, using the [`Search`](@/api/search.md) plugin's [`callback`](@/api/options.md#search) option.
@@ -231,6 +274,16 @@ The example below displays the number of matching search results. To do this, it
 
 @[code](@/content/guides/navigation/searching-values/angular/example4.ts)
 @[code](@/content/guides/navigation/searching-values/angular/example4.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example4 :vue3
+
+@[code](@/content/guides/navigation/searching-values/vue/example4.vue)
 
 :::
 

--- a/docs/content/guides/navigation/searching-values/vue/example1.vue
+++ b/docs/content/guides/navigation/searching-values/vue/example1.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+
+const data = [
+  ['Tesla', 2017, 'black', 'black'],
+  ['Nissan', 2018, 'blue', 'blue'],
+  ['Chrysler', 2019, 'yellow', 'black'],
+  ['Volvo', 2020, 'yellow', 'gray'],
+];
+
+const hotSettings = ref<GridSettings>({
+  data,
+  colHeaders: true,
+  search: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+function onSearchKeyUp(event: KeyboardEvent): void {
+  const target = event.currentTarget as HTMLInputElement;
+  const hot = hotRef.value?.hotInstance;
+  const search = hot?.getPlugin('search');
+  const queryResult = search?.query(target.value);
+
+  console.log(queryResult);
+
+  hot?.render();
+}
+</script>
+
+<template>
+  <div id="example1">
+    <div class="example-controls-container">
+      <div class="controls">
+        <input
+          id="search_field"
+          type="search"
+          placeholder="Search"
+          @keyup="onSearchKeyUp"
+        >
+      </div>
+    </div>
+    <HotTable ref="hotRef" :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/navigation/searching-values/vue/example2.vue
+++ b/docs/content/guides/navigation/searching-values/vue/example2.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+
+const data = [
+  ['Tesla', 2017, 'black', 'black'],
+  ['Nissan', 2018, 'blue', 'blue'],
+  ['Chrysler', 2019, 'yellow', 'black'],
+  ['Volvo', 2020, 'yellow', 'gray'],
+];
+
+const hotSettings = ref<GridSettings>({
+  data,
+  colHeaders: true,
+  search: {
+    searchResultClass: 'my-class',
+  },
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+function onSearchKeyUp(event: KeyboardEvent): void {
+  const target = event.currentTarget as HTMLInputElement;
+  const hot = hotRef.value?.hotInstance;
+  const search = hot?.getPlugin('search');
+  const queryResult = search?.query(target.value);
+
+  console.log(queryResult);
+
+  hot?.render();
+}
+</script>
+
+<template>
+  <div id="example2">
+    <div class="example-controls-container">
+      <div class="controls">
+        <input
+          id="search_field2"
+          type="search"
+          placeholder="Search"
+          @keyup="onSearchKeyUp"
+        >
+      </div>
+    </div>
+    <HotTable ref="hotRef" :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/navigation/searching-values/vue/example3.vue
+++ b/docs/content/guides/navigation/searching-values/vue/example3.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+
+const data = [
+  ['Tesla', 2017, 'black', 'black'],
+  ['Nissan', 2018, 'blue', 'blue'],
+  ['Chrysler', 2019, 'yellow', 'black'],
+  ['Volvo', 2020, 'white', 'gray'],
+];
+
+function onlyExactMatch(
+  queryStr: string | number | null | undefined,
+  value: string | number | null | undefined
+): boolean {
+  return queryStr?.toString() === value?.toString();
+}
+
+const hotSettings = ref<GridSettings>({
+  data,
+  colHeaders: true,
+  search: {
+    queryMethod: onlyExactMatch,
+  },
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+function onSearchKeyUp(event: KeyboardEvent): void {
+  const target = event.currentTarget as HTMLInputElement;
+  const hot = hotRef.value?.hotInstance;
+  const search = hot?.getPlugin('search');
+  const queryResult = search?.query(target.value);
+
+  console.log(queryResult);
+
+  hot?.render();
+}
+</script>
+
+<template>
+  <div id="example3">
+    <div class="example-controls-container">
+      <div class="controls">
+        <input
+          id="search_field3"
+          type="search"
+          placeholder="Search"
+          @keyup="onSearchKeyUp"
+        >
+      </div>
+    </div>
+    <HotTable ref="hotRef" :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/navigation/searching-values/vue/example4.vue
+++ b/docs/content/guides/navigation/searching-values/vue/example4.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+import type Handsontable from 'handsontable/base';
+
+registerAllModules();
+
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const resultCount = ref(0);
+
+const data = [
+  ['Tesla', 2017, 'black', 'black'],
+  ['Nissan', 2018, 'blue', 'blue'],
+  ['Chrysler', 2019, 'yellow', 'black'],
+  ['Volvo', 2020, 'white', 'gray'],
+];
+
+function searchResultCounter(
+  instance: Handsontable,
+  row: number,
+  col: number,
+  _value: string | number | null,
+  testResult: boolean
+): void {
+  instance.getCellMeta(row, col).isSearchResult = testResult;
+
+  if (testResult) {
+    resultCount.value += 1;
+  }
+}
+
+const hotSettings = ref<GridSettings>({
+  data,
+  colHeaders: true,
+  search: {
+    callback: searchResultCounter,
+  },
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+function onSearchKeyUp(event: KeyboardEvent): void {
+  const target = event.currentTarget as HTMLInputElement;
+  const hot = hotRef.value?.hotInstance;
+
+  resultCount.value = 0;
+
+  const search = hot?.getPlugin('search');
+  const queryResult = search?.query(target.value);
+
+  console.log(queryResult);
+
+  hot?.render();
+}
+</script>
+
+<template>
+  <div id="example4">
+    <div class="example-controls-container">
+      <div class="controls">
+        <input
+          id="search_field4"
+          type="search"
+          placeholder="Search"
+          @keyup="onSearchKeyUp"
+        >
+      </div>
+      <output class="console" id="output">
+        {{ resultCount }} results
+      </output>
+    </div>
+    <HotTable ref="hotRef" :settings="hotSettings" />
+  </div>
+</template>


### PR DESCRIPTION
### Context

The PR adds Vue 3 documentation parity for four navigation guides under `docs/content/guides/navigation/`, matching existing React and Angular examples.

- **searching-values**: four runnable Vue SFC examples (`example1`–`example4`)
- **focus-scopes**: two runnable Vue SFC examples with shared CSS from React variants
- **custom-shortcuts**: Vue tip (instance access) and `beforeKeyDown` snippet
- **keyboard-shortcuts**: reference-only page; Vue frontmatter already present, no runnable examples in any framework

[skip changelog]

### How has this been tested?

- Local docs dev server (`pnpm dev` in `docs/`)
- Verified under Vue 3 framework URLs:
  - `/docs/vue-data-grid/searching-values/` — four examples render; search input highlights cells
  - `/docs/vue-data-grid/focus-scopes/` — inline and modal scope demos with debug panel
  - `/docs/vue-data-grid/custom-shortcuts/` — Vue tip and snippet visible
  - `/docs/vue-data-grid/keyboard-shortcuts/` — page loads

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1747

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to documentation and demo SFCs; no library, auth, or production code paths are modified.
> 
> **Overview**
> Adds **Vue 3 parity** for navigation docs under `docs/content/guides/navigation/`, matching existing React and Angular coverage.
> 
> **Searching values** — four new Vue SFC demos (`example1`–`example4`) wired into the guide for basic search, custom result class (reuses React `example2.css`), exact-match `queryMethod`, and a callback that counts results.
> 
> **Focus scopes** — two new Vue demos for inline (pagination) and modal (dialog) focus behavior, including a live debug panel for `isListening()`, active scope, and shortcuts context; examples reuse React focus-scope CSS.
> 
> **Custom shortcuts** — Vue-only tip on reaching the grid via `hotRef.value.hotInstance`, plus a `beforeKeyDown` example in a `ref` settings object.
> 
> No runtime or package changes; docs and example assets only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3afe80ec0f93b1bc83c846fa5a365b096f9e9cf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->