### PR TITLE
DEV-1827: Enforce JSDoc on classes, methods, functions, and fields in core source

### DIFF
--- a/.claude/skills/handsontable-dev/SKILL.md
+++ b/.claude/skills/handsontable-dev/SKILL.md
@@ -182,6 +182,110 @@ ESLint will fail the build if a function gets too branchy. The fix is almost alw
 
 ---
 
+## JSDoc
+
+### When it is required
+
+`jsdoc/require-jsdoc` is set to `error` for `src/**/*.ts` and `scripts/**/*.mjs`. Every **class**, **method**, **function declaration**, and **class field** must have a JSDoc block. Test and type files (`*.unit.ts`, `*.spec.ts`, `*.types.ts`, `*.d.ts`) are exempt.
+
+### Format — always multiline
+
+Never write a single-line block. Even a one-sentence description needs the three-line form so it can be extended later:
+
+```ts
+// ✗ Bad
+/** Returns the active editor instance. */
+
+// ✓ Good
+/**
+ * Returns the active editor instance.
+ */
+```
+
+There must be a blank line before `/**` and after the closing `*/` (i.e., at least one empty line separating the JSDoc block from the previous code and from the next declaration).
+
+### Type annotations and sync with TypeScript
+
+**Always include `{Type}` in `@param` and `@returns` tags** — for every method, public or private. The `docs:api` generator (`jsdoc-to-markdown`) reads `handsontable/tmp/` (compiled JS that preserves JSDoc verbatim), and the type annotations are what appear in the API reference. Without them, type information is absent from the generated docs.
+
+```ts
+// ✓ Good — {Type} present, keeps docs accurate
+/**
+ * Sets the value at the given coordinates.
+ *
+ * @param {number} row - The visual row index.
+ * @param {number} col - The visual column index.
+ * @param {*} value - The value to set.
+ */
+setValue(row: number, col: number, value: unknown): void
+
+// ✗ Bad — no type information in docs
+/**
+ * Sets the value at the given coordinates.
+ *
+ * @param row - The visual row index.
+ * @param col - The visual column index.
+ * @param value - The value to set.
+ */
+setValue(row: number, col: number, value: unknown): void
+```
+
+**Types must stay in sync with the TypeScript signature.** When you change a parameter's TS type, update the JSDoc `{Type}` to match. An outdated type in JSDoc is actively misleading — it appears verbatim in the generated docs.
+
+```ts
+// ✗ Bad — JSDoc says {number} but TS accepts a range object too
+/**
+ * @param {number} colRange - Visual column index.
+ */
+calculateColumnsWidth(colRange: number | { from: number; to: number }): void
+
+// ✓ Good — JSDoc matches the TS signature
+/**
+ * @param {number|object} colRange - Visual column index or a range object with `from`/`to`.
+ */
+calculateColumnsWidth(colRange: number | { from: number; to: number }): void
+```
+
+The TS `[80004]` lint warning ("JSDoc types may be moved to TypeScript types") is **suppressed** in this codebase for `.ts` source files — do not let it discourage you from writing `{Type}` annotations.
+
+### Private `#` fields
+
+Add a description block but omit `@private` — the `#` prefix is the privacy marker:
+
+```ts
+// ✗ Bad
+/**
+ * @private
+ * The plugin's internal state map.
+ */
+#stateMap: Map<number, boolean> = new Map();
+
+// ✓ Good
+/**
+ * Internal state map keyed by visual column index.
+ */
+#stateMap: Map<number, boolean> = new Map();
+```
+
+### Description quality
+
+Descriptions must be substantive — explain what the member does or represents, not just restate its name. American English, active voice, short sentences.
+
+```ts
+// ✗ Bad — circular
+/**
+ * The column widths cache.
+ */
+
+// ✓ Good — tells the reader something new
+/**
+ * Stores calculated column widths keyed by visual column index.
+ * Populated on demand; invalidated when column configuration changes.
+ */
+```
+
+---
+
 ## DOM and data gotchas
 
 - **Merged cells: read meta, not DOM.** Always read `colspan`/`rowspan` from `hot.getCellMeta(row, col)`, never from `td.colSpan` / `td.rowSpan`. The MergeCells plugin sets `cellProperties.colspan` via `afterGetCellMeta` — that value is authoritative. The DOM attribute may be missing when the cell is outside the viewport, and it ignores custom `afterGetCellMeta` overrides.
@@ -248,6 +352,6 @@ The CI `verify-emitted-types` job reports the exact leaked identifier with `TS23
 - [ ] `npm run build` (or `build:types` + `downlevel:types`) run if public types changed
 - [ ] Wired into all relevant index / factory files
 - [ ] Added to `metaSchema.ts` if a new option was introduced
-- [ ] JSDoc on all exported functions and classes
+- [ ] JSDoc on every class, method, function declaration, and class field (multiline format; `{Type}` in every `@param`/`@returns`, in sync with the TS signature; no `@private` on `#` fields)
 - [ ] No breaking change introduced (or the breaking change is explicitly called out)
 - [ ] Changelog entry added (`bin/changelog entry`)

--- a/handsontable/.eslintrc.js
+++ b/handsontable/.eslintrc.js
@@ -117,7 +117,7 @@ module.exports = {
         'scripts/**/*.mjs',
       ],
       excludedFiles: [
-        'src/3rdparty/walkontable/**', // own build/test pipeline — out of scope for now
+        'src/3rdparty/walkontable/test/**', // walkontable test helpers — exempt
         'src/**/__tests__/**',
         'src/**/test/**',
         '*.unit.ts',

--- a/handsontable/.eslintrc.js
+++ b/handsontable/.eslintrc.js
@@ -108,6 +108,34 @@ module.exports = {
         'handsontable/require-await': 'off',
       },
     },
+    // Source files and build scripts must document classes, methods, functions, and fields
+    // so the Typedoc API reference and guides render complete descriptions. Test/type files are
+    // excluded (require-jsdoc is already off for *.unit.js / *.spec.js elsewhere in this config).
+    {
+      files: [
+        'src/**/*.ts',
+        'scripts/**/*.mjs',
+      ],
+      excludedFiles: [
+        'src/3rdparty/walkontable/**', // own build/test pipeline — out of scope for now
+        'src/**/__tests__/**',
+        'src/**/test/**',
+        '*.unit.ts',
+        '*.spec.ts',
+        '*.types.ts',
+        '*.d.ts',
+      ],
+      rules: {
+        'jsdoc/require-jsdoc': ['error', {
+          require: {
+            FunctionDeclaration: true,
+            MethodDefinition: true,
+            ClassDeclaration: true,
+          },
+          contexts: ['PropertyDefinition'], // class fields
+        }],
+      },
+    },
     {
       files: ['scripts/**'],
       rules: {

--- a/handsontable/AGENTS.md
+++ b/handsontable/AGENTS.md
@@ -113,6 +113,8 @@ npm run stylelint --prefix handsontable
 
 Common violations and their fixes (the rules behind them are in Critical Rules above; the full custom-rule catalog with test-file overrides is in `handsontable/.ai/CONVENTIONS.md`, and the rule implementations live in `.config/plugin/eslint/rules/`):
 
+Source `.ts` files (`src/**/*.ts`, excluding walkontable and test/type files) and build scripts (`scripts/**/*.mjs`) now enforce `jsdoc/require-jsdoc` at `error` level for classes, methods, functions, and class fields. Test and type files (`*.unit.ts`, `*.spec.ts`, `*.types.ts`, `*.d.ts`) are exempt.
+
 | Violation | Fix |
 |---|---|
 | `throw new Error('message')` | `import { throwWithCause } from 'helpers/errors'; throwWithCause('message', cause);` |
@@ -122,6 +124,7 @@ Common violations and their fixes (the rules behind them are in Critical Rules a
 | `window.scrollTo(...)` | `this.hot.rootWindow.scrollTo(...)` |
 | `document.querySelector(...)` | `this.hot.rootDocument.querySelector(...)` |
 | `console.warn(...)` | `import { warn } from 'helpers/console'; warn(...);` |
+| Missing JSDoc comment (`jsdoc/require-jsdoc`) on a class/method/field/function | Add a multiline block above it with a blank line before `/**` and after `*/` — `/**` on its own line, then ` * Description.`, then ` */`; no `@private` tag on `#`-fields; no `@param`/`@returns` in `.ts` files |
 
 ## Build
 

--- a/handsontable/scripts/utils/run-step.mjs
+++ b/handsontable/scripts/utils/run-step.mjs
@@ -183,10 +183,26 @@ export function runStep(cmd, opts = {}) {
  * On non-TTY each event is printed as a plain line (no ANSI cursor movement).
  */
 export class ParallelSpinner {
+  /**
+   * Tracks active spinner entries by name, storing the current animation frame index and start timestamp.
+   */
   #active = new Map(); // name → {frame, startMs}
+
+  /**
+   * Holds the interval handle returned by setInterval, or null when the spinner is not running.
+   */
   #timer = null;
+
+  /**
+   * Counts the number of spinner lines currently written to stdout so they can be erased on the next render.
+   */
   #lineCount = 0;
 
+  /**
+   * Registers a new task by name, prints a start indicator on non-TTY, or starts the animation interval on TTY.
+   *
+   * @param {string} name The unique name of the task to start.
+   */
   start(name) {
     this.#active.set(name, { frame: 0, startMs: performance.now() });
 
@@ -204,6 +220,13 @@ export class ParallelSpinner {
     this.#render();
   }
 
+  /**
+   * Marks a task as finished, prints the result line with a pass/fail indicator and elapsed time, then stops the spinner if no tasks remain.
+   *
+   * @param {string} name The unique name of the task that finished.
+   * @param {boolean} ok Whether the task succeeded.
+   * @param {number} elapsed The time in milliseconds the task took to complete.
+   */
   finish(name, ok, elapsed) {
     const mark = ok ? '\x1b[32m✓\x1b[0m' : '\x1b[31m✗\x1b[0m';
 
@@ -225,6 +248,9 @@ export class ParallelSpinner {
     }
   }
 
+  /**
+   * Clears the animation interval and erases any spinner lines still visible on screen.
+   */
   stop() {
     if (this.#timer) {
       clearInterval(this.#timer);
@@ -234,6 +260,9 @@ export class ParallelSpinner {
     this.#clear();
   }
 
+  /**
+   * Erases all spinner lines written since the last render by moving the cursor up and clearing each line.
+   */
   #clear() {
     if (!isTTY || this.#lineCount === 0) {
       return;
@@ -243,6 +272,9 @@ export class ParallelSpinner {
     this.#lineCount = 0;
   }
 
+  /**
+   * Clears previous spinner output and redraws a spinning indicator line for each active task.
+   */
   #render() {
     if (!isTTY || this.#active.size === 0) {
       return;

--- a/handsontable/src/3rdparty/SheetClip/SheetClip.ts
+++ b/handsontable/src/3rdparty/SheetClip/SheetClip.ts
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/require-description-complete-sentence */
 /**
  * SheetClip - Spreadsheet Clipboard Parser.
  * version 0.2

--- a/handsontable/src/3rdparty/walkontable/src/calculator/viewportBase.ts
+++ b/handsontable/src/3rdparty/walkontable/src/calculator/viewportBase.ts
@@ -60,6 +60,11 @@ export class ViewportBaseCalculator {
    */
   calculationResults: Map<string, CalculationTypeLike> = new Map();
 
+  /**
+   * Creates a new ViewportBaseCalculator instance.
+   *
+   * @param {Array<[string, CalculationTypeLike]>} calculationTypes - The calculation types to be performed.
+   */
   constructor(calculationTypes: Array<[string, CalculationTypeLike]>) {
     this.calculationTypes = calculationTypes;
   }

--- a/handsontable/src/3rdparty/walkontable/src/calculator/viewportColumns.ts
+++ b/handsontable/src/3rdparty/walkontable/src/calculator/viewportColumns.ts
@@ -30,16 +30,49 @@ export interface ViewportColumnsCalculatorOptions {
  * @class ViewportColumnsCalculator
  */
 export class ViewportColumnsCalculator extends ViewportBaseCalculator {
+  /**
+   * @type {number}
+   */
   viewportWidth: number = 0;
+  /**
+   * @type {number}
+   */
   scrollOffset: number = 0;
+  /**
+   * @type {number}
+   */
   zeroBasedScrollOffset: number = 0;
+  /**
+   * @type {number}
+   */
   totalColumns: number = 0;
+  /**
+   * @type {number}
+   */
   columnWidth: number = 0;
+  /**
+   * @type {((calc: unknown) => void) | null}
+   */
   overrideFn: ((calc: unknown) => void) | null = null;
+  /**
+   * @type {number}
+   */
   inlineStartOffset: number = 0;
+  /**
+   * @type {number}
+   */
   totalCalculatedWidth: number = 0;
+  /**
+   * @type {boolean}
+   */
   needReverse: boolean = true;
+  /**
+   * @type {PositionCache | null}
+   */
   positionCache: PositionCache | null = null;
+  /**
+   * @type {number}
+   */
   lastProcessedIndex: number = -1;
 
   /**

--- a/handsontable/src/3rdparty/walkontable/src/calculator/viewportRows.ts
+++ b/handsontable/src/3rdparty/walkontable/src/calculator/viewportRows.ts
@@ -30,17 +30,53 @@ export interface ViewportRowsCalculatorOptions {
  * @class ViewportRowsCalculator
  */
 export class ViewportRowsCalculator extends ViewportBaseCalculator {
+  /**
+   * @type {number}
+   */
   viewportHeight: number = 0;
+  /**
+   * @type {number}
+   */
   scrollOffset: number = 0;
+  /**
+   * @type {number}
+   */
   zeroBasedScrollOffset: number = 0;
+  /**
+   * @type {number}
+   */
   totalRows: number = 0;
+  /**
+   * @type {number}
+   */
   rowHeight: number = 0;
+  /**
+   * @type {((calc: unknown) => void) | null}
+   */
   overrideFn: ((calc: unknown) => void) | null = null;
+  /**
+   * @type {number}
+   */
   horizontalScrollbarHeight: number = 0;
+  /**
+   * @type {number}
+   */
   innerViewportHeight: number = 0;
+  /**
+   * @type {number}
+   */
   totalCalculatedHeight: number = 0;
+  /**
+   * @type {boolean}
+   */
   needReverse: boolean = true;
+  /**
+   * @type {PositionCache | null}
+   */
   positionCache: PositionCache | null = null;
+  /**
+   * @type {number}
+   */
   lastProcessedIndex: number = -1;
 
   /**

--- a/handsontable/src/3rdparty/walkontable/src/cell/coords.ts
+++ b/handsontable/src/3rdparty/walkontable/src/cell/coords.ts
@@ -35,6 +35,13 @@ class CellCoords {
    */
   #isRtl: boolean = false;
 
+  /**
+   * Creates a new CellCoords instance.
+   *
+   * @param {number} [row] A visual row index.
+   * @param {number} [column] A visual column index.
+   * @param {boolean} [isRtl=false] A flag which determines if the coordinates run in RTL mode.
+   */
   constructor(row?: number, column?: number, isRtl: boolean = false) {
     this.#isRtl = isRtl;
 

--- a/handsontable/src/3rdparty/walkontable/src/cell/coords.ts
+++ b/handsontable/src/3rdparty/walkontable/src/cell/coords.ts
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/require-description-complete-sentence */
 /**
  * @description
  *

--- a/handsontable/src/3rdparty/walkontable/src/cell/range.ts
+++ b/handsontable/src/3rdparty/walkontable/src/cell/range.ts
@@ -50,6 +50,14 @@ class CellRange {
    */
   #isRtl: boolean = false;
 
+  /**
+   * Creates a new CellRange instance.
+   *
+   * @param {CellCoords} highlight The cell where selection was started.
+   * @param {CellCoords} from The start of the range.
+   * @param {CellCoords} to The end of the range.
+   * @param {boolean} isRtl A flag indicating whether to use right-to-left (RTL) layout.
+   */
   constructor(highlight: CellCoords, from: CellCoords = highlight, to: CellCoords = highlight, isRtl: boolean = false) {
     this.highlight = highlight.clone();
     this.from = from.clone();

--- a/handsontable/src/3rdparty/walkontable/src/cell/range.ts
+++ b/handsontable/src/3rdparty/walkontable/src/cell/range.ts
@@ -2,7 +2,6 @@ import CellCoords from './../cell/coords';
 
 type DirectionType = 'NW-SE' | 'NE-SW' | 'SE-NW' | 'SW-NE';
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
 /**
  * @description
  *

--- a/handsontable/src/3rdparty/walkontable/src/core/_base.ts
+++ b/handsontable/src/3rdparty/walkontable/src/core/_base.ts
@@ -20,12 +20,47 @@ import CellRange from '../cell/range';
  * @class Walkontable
  */
 export default class CoreAbstract {
+  /**
+   * The main table instance.
+   *
+   * @type {Table}
+   */
   declare wtTable: Table;
+  /**
+   * The scroll handler instance.
+   *
+   * @type {Scroll}
+   */
   declare wtScroll: Scroll;
+  /**
+   * The viewport calculator instance.
+   *
+   * @type {Viewport}
+   */
   declare wtViewport: Viewport;
+  /**
+   * The overlays manager instance.
+   *
+   * @type {Overlays}
+   */
   declare wtOverlays: Overlays;
+  /**
+   * The selection manager instance.
+   *
+   * @type {SelectionManager}
+   */
   declare selectionManager: SelectionManager;
+  /**
+   * The event handler instance.
+   *
+   * @type {Event}
+   */
   declare wtEvent: Event;
+  /**
+   * Reference to the source CoreAbstract instance (used for clones).
+   *
+   * @type {CoreAbstract}
+   */
   declare cloneSource: CoreAbstract;
   /**
    * The walkontable instance id.
@@ -34,7 +69,17 @@ export default class CoreAbstract {
    * @type {Readonly<string>}
    */
   guid = `wt_${randomString()}`;
+  /**
+   * Flag indicating whether the current drawing operation was interrupted.
+   *
+   * @type {boolean}
+   */
   drawInterrupted = false;
+  /**
+   * Flag indicating whether the table has been drawn.
+   *
+   * @type {boolean}
+   */
   drawn = false;
 
   /**
@@ -61,6 +106,11 @@ export default class CoreAbstract {
    */
   declare wtSettings: Settings;
 
+  /**
+   * Gets or creates the event manager instance.
+   *
+   * @returns {EventManager} The event manager instance.
+   */
   get eventManager(): EventManager {
     return new EventManager(this);
   }
@@ -80,6 +130,9 @@ export default class CoreAbstract {
     this.wtScroll = new Scroll(this.createScrollDao());
   }
 
+  /**
+   * Finds and stores original table headers, setting up column header rendering callbacks if not already configured.
+   */
   findOriginalHeaders() {
     const originalHeaders: string[] = [];
 

--- a/handsontable/src/3rdparty/walkontable/src/event.ts
+++ b/handsontable/src/3rdparty/walkontable/src/event.ts
@@ -26,14 +26,54 @@ const LONG_PRESS_MOVE_THRESHOLD = 10;
  * @class Event
  */
 class Event {
+  /**
+   * State object tracking momentum scrolling status and timeout.
+   *
+   * @type {{ ongoing?: boolean; _timeout?: ReturnType<typeof setTimeout> }}
+   */
   declare momentumScrolling: { ongoing?: boolean; _timeout?: ReturnType<typeof setTimeout> };
+  /**
+   * Flag indicating whether a touch event is currently being processed.
+   *
+   * @type {boolean}
+   */
   declare touchApplied: boolean;
+  /**
+   * Reference to the last element the mouse was over, or null if none.
+   *
+   * @type {HTMLElement | null}
+   */
   declare lastMouseOver: HTMLElement | null;
 
+  /**
+   * Walkontable settings instance.
+   *
+   * @type {Settings}
+   */
   #wtSettings;
+  /**
+   * DOM bindings for walkontable elements.
+   *
+   * @type {DomBindings}
+   */
   #domBindings;
+  /**
+   * Reference to the walkontable table.
+   *
+   * @type {Table}
+   */
   #wtTable;
+  /**
+   * Selection manager instance.
+   *
+   * @type {SelectionManager}
+   */
   #selectionManager: SelectionManager;
+  /**
+   * Parent Event instance, or null for the root instance.
+   *
+   * @type {Event | null}
+   */
   #parent;
   /**
    * Instance of {@link EventManager}.

--- a/handsontable/src/3rdparty/walkontable/src/facade/core.ts
+++ b/handsontable/src/3rdparty/walkontable/src/facade/core.ts
@@ -11,6 +11,11 @@ import CoreAbstract from '../core/_base';
  * @inheritDoc
  */
 export default class WalkontableFacade {
+  /**
+   * The underlying Walkontable core instance with backward compatibility support.
+   *
+   * @type {CoreAbstract & Record<string, any>}
+   */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   declare _wot: CoreAbstract & Record<string, any>;
 
@@ -25,6 +30,11 @@ export default class WalkontableFacade {
     }
   }
 
+  /**
+   * Initializes the facade from a settings object.
+   *
+   * @param {Record<string, any>} settings - The Walkontable settings configuration.
+   */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   _initFromSettings(settings: Record<string, any>) {
     settings.facade = (instance: CoreAbstract) => {
@@ -37,149 +47,379 @@ export default class WalkontableFacade {
     this._wot = new Walkontable(settings.table, settings) as CoreAbstract & Record<string, any>;
   }
 
+  /**
+   * Gets the unique identifier of the Walkontable instance.
+   *
+   * @returns {*} The unique identifier.
+   */
   get guid() {
     return this._wot.guid;
   }
 
+  /**
+   * Gets the root document used by the Walkontable instance.
+   *
+   * @returns {*} The root document.
+   */
   get rootDocument() {
     return this._wot.domBindings.rootDocument;
   }
 
+  /**
+   * Gets the root window used by the Walkontable instance.
+   *
+   * @returns {*} The root window.
+   */
   get rootWindow() {
     return this._wot.domBindings.rootWindow;
   }
+  /**
+   * Gets the settings manager for the Walkontable instance.
+   *
+   * @returns {*} The settings manager.
+   */
   get wtSettings() {
     return this._wot.wtSettings; // todo create facade
   }
+  /**
+   * Gets the clone source of the Walkontable instance.
+   *
+   * @returns {*} The clone source.
+   */
   get cloneSource() {
     return this._wot.cloneSource; // todo create facade
   }
+  /**
+   * Gets the clone overlay of the Walkontable instance.
+   *
+   * @returns {Overlay} The clone overlay.
+   */
   get cloneOverlay(): Overlay {
     return this._wot.cloneOverlay as Overlay; // todo create facade
   }
+  /**
+   * Gets the selection manager of the Walkontable instance.
+   *
+   * @returns {*} The selection manager.
+   */
   get selectionManager() {
     return this._wot.selectionManager; // todo create facade
   }
+  /**
+   * Gets the viewport manager of the Walkontable instance.
+   *
+   * @returns {*} The viewport manager.
+   */
   get wtViewport() {
     return this._wot.wtViewport; // todo create facade
   }
+  /**
+   * Gets the overlays manager of the Walkontable instance.
+   *
+   * @returns {*} The overlays manager.
+   */
   get wtOverlays() {
     return this._wot.wtOverlays; // todo create facade
   }
+  /**
+   * Gets the table manager of the Walkontable instance.
+   *
+   * @returns {*} The table manager.
+   */
   get wtTable() {
     return this._wot.wtTable; // todo create facade
   }
+  /**
+   * Gets the event manager of the Walkontable instance.
+   *
+   * @returns {*} The event manager.
+   */
   get wtEvent() {
     return this._wot.wtEvent; // todo create facade
   }
+  /**
+   * Gets the scroll manager of the Walkontable instance.
+   *
+   * @returns {*} The scroll manager.
+   */
   get wtScroll() {
     return this._wot.wtScroll; // todo create facade
   }
+  /**
+   * Gets whether the Walkontable instance has been drawn.
+   *
+   * @returns {*} True if drawn, false otherwise.
+   */
   get drawn() {
     return this._wot.drawn;
   }
+  /**
+   * Sets whether the Walkontable instance has been drawn.
+   *
+   * @param {*} value - The drawn state.
+   */
   set drawn(value) {
     this._wot.drawn = value;
   }
+  /**
+   * Gets the name of the active overlay.
+   *
+   * @returns {*} The active overlay name.
+   */
   get activeOverlayName() {
     return this._wot.activeOverlayName;
   }
+  /**
+   * Gets whether drawing has been interrupted.
+   *
+   * @returns {*} True if drawing is interrupted, false otherwise.
+   */
   get drawInterrupted() {
     return this._wot.drawInterrupted;
   }
+  /**
+   * Sets whether drawing has been interrupted.
+   *
+   * @param {*} value - The interrupted state.
+   */
   set drawInterrupted(value) {
     this._wot.drawInterrupted = value;
   }
+  /**
+   * Gets the last element that was moused over.
+   *
+   * @returns {HTMLElement | null} The last moused-over element, or null.
+   */
   get lastMouseOver(): HTMLElement | null {
     return this._wot.lastMouseOver as HTMLElement | null;
   }
+  /**
+   * Sets the last element that was moused over.
+   *
+   * @param {*} value - The element to set.
+   */
   set lastMouseOver(value) {
     this._wot.lastMouseOver = value;
   }
+  /**
+   * Gets the momentum scrolling state.
+   *
+   * @returns {{ ongoing?: boolean; _timeout?: ReturnType<typeof setTimeout> }} The momentum scrolling state.
+   */
   get momentumScrolling(): { ongoing?: boolean; _timeout?: ReturnType<typeof setTimeout> } {
     return this._wot.momentumScrolling as { ongoing?: boolean; _timeout?: ReturnType<typeof setTimeout> };
   }
+  /**
+   * Sets the momentum scrolling state.
+   *
+   * @param {*} value - The momentum scrolling state.
+   */
   set momentumScrolling(value) {
     this._wot.momentumScrolling = value;
   }
+  /**
+   * Gets whether touch input has been applied.
+   *
+   * @returns {boolean} True if touch was applied, false otherwise.
+   */
   get touchApplied(): boolean {
     return this._wot.touchApplied as boolean;
   }
+  /**
+   * Sets whether touch input has been applied.
+   *
+   * @param {*} value - The touch applied state.
+   */
   set touchApplied(value) {
     this._wot.touchApplied = value;
   }
+  /**
+   * Gets the DOM bindings configuration.
+   *
+   * @returns {*} The DOM bindings.
+   */
   get domBindings() {
     return this._wot.domBindings;
   }
+  /**
+   * Gets the list of event listeners.
+   *
+   * @returns {unknown[]} The array of event listeners.
+   */
   get eventListeners(): unknown[] {
     return this._wot.eventListeners as unknown[];
   }
+  /**
+   * Sets the list of event listeners.
+   *
+   * @param {*} value - The event listeners array.
+   */
   set eventListeners(value) {
     this._wot.eventListeners = value;
   }
+  /**
+   * Gets the event manager instance.
+   *
+   * @returns {*} The event manager.
+   */
   get eventManager() {
     return this._wot.eventManager;
   }
+  /**
+   * Creates a new cell coordinates object.
+   *
+   * @param {number} row - The row index.
+   * @param {number} column - The column index.
+   * @returns {*} The new cell coordinates object.
+   */
   createCellCoords(row: number, column: number) {
     return this._wot.createCellCoords(row, column);
   }
 
+  /**
+   * Creates a new cell range.
+   *
+   * @param {CellCoords} highlight - The highlighted cell coordinates.
+   * @param {CellCoords} from - The starting cell coordinates.
+   * @param {CellCoords} to - The ending cell coordinates.
+   * @returns {*} The new cell range.
+   */
   createCellRange(highlight: CellCoords, from: CellCoords, to: CellCoords) {
     return this._wot.createCellRange(highlight, from, to);
   }
 
+  /**
+   * Redraws the table.
+   *
+   * @param {boolean} [fastDraw=false] - Whether to perform a fast draw.
+   * @returns {WalkontableFacade} This instance for method chaining.
+   */
   draw(fastDraw = false) {
     this._wot.draw(fastDraw);
 
     return this;
   }
 
+  /**
+   * Gets the DOM cell element at the specified coordinates.
+   *
+   * @param {CellCoords} coords - The cell coordinates.
+   * @param {boolean} [topmost=false] - Whether to get the topmost element.
+   * @returns {*} The DOM cell element.
+   */
   getCell(coords: CellCoords, topmost = false) {
     return this._wot.getCell(coords, topmost);
   }
 
+  /**
+   * Scrolls the viewport to the specified cell coordinates.
+   *
+   * @param {CellCoords} coords - The cell coordinates to scroll to.
+   * @param {string} horizontalSnap - The horizontal snap setting.
+   * @param {string} verticalSnap - The vertical snap setting.
+   * @returns {*} The result of the scroll operation.
+   */
   scrollViewport(coords: CellCoords, horizontalSnap: string, verticalSnap: string) {
     return this._wot.scrollViewport(coords, horizontalSnap, verticalSnap);
   }
 
+  /**
+   * Scrolls the viewport horizontally.
+   *
+   * @param {number} column - The column index to scroll to.
+   * @param {string} snapping - The snapping setting.
+   * @returns {*} The result of the scroll operation.
+   */
   scrollViewportHorizontally(column: number, snapping: string) {
     return this._wot.scrollViewportHorizontally(column, snapping);
   }
 
+  /**
+   * Scrolls the viewport vertically.
+   *
+   * @param {number} row - The row index to scroll to.
+   * @param {string} snapping - The snapping setting.
+   * @returns {*} The result of the scroll operation.
+   */
   scrollViewportVertically(row: number, snapping: string) {
     return this._wot.scrollViewportVertically(row, snapping);
   }
 
+  /**
+   * Gets the current viewport dimensions.
+   *
+   * @returns {*} The viewport dimensions.
+   */
   getViewport() {
     return this._wot.getViewport();
   }
 
+  /**
+   * Gets the name of the currently active overlay.
+   *
+   * @returns {string} The overlay type name, or 'master' if no clone overlay.
+   */
   getOverlayName() {
     return this._wot.cloneOverlay ? (this._wot.cloneOverlay as Overlay).type : 'master';
   }
 
+  /**
+   * Gets an overlay by its name.
+   *
+   * @param {string} overlayName - The name of the overlay to retrieve.
+   * @returns {Overlay | null} The overlay, or null if not found.
+   */
   getOverlayByName(overlayName: string): Overlay | null {
     return this._wot.getOverlayByName(overlayName) as Overlay | null;
   }
 
+  /**
+   * Exports the current settings as CSS class names on the table element.
+   */
   exportSettingsAsClassNames(): void {
     this._wot.exportSettingsAsClassNames();
   }
 
+  /**
+   * Updates Walkontable settings.
+   *
+   * @param {string | Record<string, unknown>} settings - The setting key or settings object.
+   * @param {unknown} value - The value to set (when settings is a string).
+   * @returns {WalkontableFacade} This instance for method chaining.
+   */
   update(settings: string | Record<string, unknown>, value: unknown) {
     this._wot.wtSettings.update(settings, value);
 
     return this;
   }
 
+  /**
+   * Gets a setting value.
+   *
+   * @param {string} key - The setting key.
+   * @param {unknown} param1 - Optional parameter.
+   * @param {unknown} param2 - Optional parameter.
+   * @param {unknown} param3 - Optional parameter.
+   * @param {unknown} param4 - Optional parameter.
+   * @returns {unknown} The setting value.
+   */
   getSetting(key: string, param1: unknown, param2: unknown, param3: unknown, param4: unknown): unknown {
     return this._wot.wtSettings.getSetting(key, param1, param2, param3, param4) as unknown;
   }
 
+  /**
+   * Checks whether a setting exists.
+   *
+   * @param {string} key - The setting key.
+   * @returns {*} True if the setting exists, false otherwise.
+   */
   hasSetting(key: string) {
     return this._wot.wtSettings.has(key);
   }
 
+  /**
+   * Destroys the Walkontable instance and cleans up resources.
+   */
   destroy() {
     this._wot.destroy();
   }

--- a/handsontable/src/3rdparty/walkontable/src/overlay/_base.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/_base.ts
@@ -35,19 +35,89 @@ export abstract class Overlay {
    */
   wtSettings!: Settings;
 
+  /**
+   * The Walkontable instance.
+   *
+   * @type {WalkontableInstance}
+   */
   declare wot: WalkontableInstance;
+  /**
+   * DOM elements bound to the current instance.
+   *
+   * @type {DomBindings}
+   */
   declare domBindings: DomBindings;
+  /**
+   * Function that returns the proper facade.
+   *
+   * @type {Function}
+   */
   declare facadeGetter: Function;
+  /**
+   * Legacy support for the Walkontable instance.
+   *
+   * @type {WalkontableInstance}
+   */
   declare instance: WalkontableInstance;
+  /**
+   * The overlay type name.
+   *
+   * @type {string}
+   */
   declare type: string;
+  /**
+   * The main table scrollable element.
+   *
+   * @type {HTMLElement | Window}
+   */
   declare mainTableScrollableElement: HTMLElement | Window; // assigned in makeClone() called from constructor
+  /**
+   * The table element.
+   *
+   * @type {HTMLTableElement}
+   */
   declare TABLE: HTMLTableElement;
+  /**
+   * The hider element.
+   *
+   * @type {HTMLElement}
+   */
   declare hider: HTMLElement;
+  /**
+   * The spreader element.
+   *
+   * @type {HTMLElement}
+   */
   declare spreader: HTMLElement;
+  /**
+   * The holder element.
+   *
+   * @type {HTMLElement | Window}
+   */
   declare holder: HTMLElement | Window;
+  /**
+   * The Walkontable root element.
+   *
+   * @type {HTMLElement}
+   */
   declare wtRootElement: HTMLElement;
+  /**
+   * The trimming container.
+   *
+   * @type {HTMLElement | Window}
+   */
   declare trimmingContainer: HTMLElement | Window;
+  /**
+   * Flag indicating if full render is needed.
+   *
+   * @type {boolean}
+   */
   declare needFullRender: boolean;
+  /**
+   * The cloned Walkontable instance.
+   *
+   * @type {WalkontableInstance | null}
+   */
   declare clone: WalkontableInstance | null;
 
   /**

--- a/handsontable/src/3rdparty/walkontable/src/overlay/bottomInlineStartCorner.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/bottomInlineStartCorner.ts
@@ -16,7 +16,13 @@ import {
  * @class BottomInlineStartCornerOverlay
  */
 export class BottomInlineStartCornerOverlay extends Overlay {
+  /**
+   * @type {Overlay}
+   */
   declare bottomOverlay: Overlay;
+  /**
+   * @type {Overlay}
+   */
   declare inlineStartOverlay: Overlay;
 
   /**
@@ -105,26 +111,64 @@ export class BottomInlineStartCornerOverlay extends Overlay {
     return true;
   }
 
+  /**
+   * Sets the scroll position (no-op for corner overlay).
+   * @param {number} _pos The scroll position (unused).
+   * @returns {boolean} Always returns false.
+   */
   setScrollPosition(_pos: number) {
     return false;
   }
+  /**
+   * Gets the scroll position (no-op for corner overlay).
+   * @returns {number} Always returns 0.
+   */
   getScrollPosition() {
     return 0;
   }
+  /**
+   * Gets the table parent offset (no-op for corner overlay).
+   * @returns {number} Always returns 0.
+   */
   getTableParentOffset() {
     return 0;
   }
+  /**
+   * Gets the overlay offset (no-op for corner overlay).
+   * @returns {number} Always returns 0.
+   */
   getOverlayOffset() {
     return 0;
   }
+  /**
+   * Handles scroll events (no-op for corner overlay).
+   */
   onScroll() {}
+  /**
+   * Sums the size of cells between two indexes (no-op for corner overlay).
+   * @param {number} _from The starting cell index (unused).
+   * @param {number} _to The ending cell index (unused).
+   * @returns {number} Always returns 0.
+   */
   sumCellSizes(_from: number, _to: number) {
     return 0;
   }
+  /**
+   * Adjusts the size of overlay elements (intentionally empty).
+   */
   adjustElementsSize() { // intentionally empty
   }
+  /**
+   * Applies changes to the DOM (intentionally empty).
+   */
   applyToDOM() { // intentionally empty
   }
+  /**
+   * Scrolls to a specified cell index (no-op for corner overlay).
+   * @param {number} _sourceIndex The source row or column index (unused).
+   * @param {boolean} _snapToEdge Whether to snap to the edge (unused).
+   * @returns {boolean} Always returns false.
+   */
   scrollTo(_sourceIndex: number, _snapToEdge: boolean) {
     return false;
   }

--- a/handsontable/src/3rdparty/walkontable/src/overlay/topInlineStartCorner.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/topInlineStartCorner.ts
@@ -66,26 +66,64 @@ export class TopInlineStartCornerOverlay extends Overlay {
       && (this.wtSettings.getSetting('shouldRenderInlineStartOverlay') as boolean);
   }
 
+  /**
+   * Prevents scroll position changes for this overlay.
+   * @param {number} _pos The scroll position to set (ignored).
+   * @returns {boolean} Always returns false.
+   */
   setScrollPosition(_pos: number) {
     return false;
   }
+  /**
+   * Gets the scroll position for this overlay.
+   * @returns {number} Always returns 0.
+   */
   getScrollPosition() {
     return 0;
   }
+  /**
+   * Gets the parent table offset for this overlay.
+   * @returns {number} Always returns 0.
+   */
   getTableParentOffset() {
     return 0;
   }
+  /**
+   * Gets the overlay offset for this corner overlay.
+   * @returns {number} Always returns 0.
+   */
   getOverlayOffset() {
     return 0;
   }
+  /**
+   * Handles scroll events (intentionally empty for corner overlay).
+   */
   onScroll() {}
+  /**
+   * Sums cell sizes within a range.
+   * @param {number} _from The starting cell index (ignored).
+   * @param {number} _to The ending cell index (ignored).
+   * @returns {number} Always returns 0.
+   */
   sumCellSizes(_from: number, _to: number) {
     return 0;
   }
+  /**
+   * Adjusts overlay element sizes (intentionally empty for corner overlay).
+   */
   adjustElementsSize() { // intentionally empty
   }
+  /**
+   * Applies changes to the DOM (intentionally empty for corner overlay).
+   */
   applyToDOM() { // intentionally empty
   }
+  /**
+   * Scrolls the overlay to a specified position.
+   * @param {number} _sourceIndex The source index to scroll to (ignored).
+   * @param {boolean} _snapToEdge Whether to snap to edge (ignored).
+   * @returns {boolean} Always returns false.
+   */
   scrollTo(_sourceIndex: number, _snapToEdge: boolean) {
     return false;
   }

--- a/handsontable/src/3rdparty/walkontable/src/renderer/_base.ts
+++ b/handsontable/src/3rdparty/walkontable/src/renderer/_base.ts
@@ -38,6 +38,12 @@ export class BaseRenderer {
    */
   renderedNodes: number = 0;
 
+  /**
+   * Creates a new BaseRenderer instance.
+   *
+   * @param {string | null} nodeType - The node type which the renderer will manage while building the table (eg. 'TD', 'TR', 'TH'), or null.
+   * @param {HTMLElement} rootNode - The root node to which newly created elements will be inserted.
+   */
   constructor(nodeType: string | null, rootNode?: HTMLElement) {
     this.nodesPool = typeof nodeType === 'string' ? new NodesPool(nodeType) : null;
     this.nodeType = nodeType;

--- a/handsontable/src/3rdparty/walkontable/src/renderer/cells.ts
+++ b/handsontable/src/3rdparty/walkontable/src/renderer/cells.ts
@@ -38,6 +38,9 @@ export class CellsRenderer extends BaseRenderer {
    */
   sourceRowIndex = 0;
 
+  /**
+   * Creates a new CellsRenderer instance.
+   */
   constructor() {
     super('TD');
   }

--- a/handsontable/src/3rdparty/walkontable/src/renderer/colGroup.ts
+++ b/handsontable/src/3rdparty/walkontable/src/renderer/colGroup.ts
@@ -26,6 +26,11 @@ export class ColGroupRenderer extends BaseRenderer {
    */
   orderView;
 
+  /**
+   * Creates a new ColGroupRenderer instance.
+   *
+   * @param {HTMLElement} rootNode - The root HTML element (colgroup) for rendering COL elements.
+   */
   constructor(rootNode: HTMLElement) {
     super('COL', rootNode);
 

--- a/handsontable/src/3rdparty/walkontable/src/renderer/columnHeaderRows.ts
+++ b/handsontable/src/3rdparty/walkontable/src/renderer/columnHeaderRows.ts
@@ -27,6 +27,11 @@ export class ColumnHeaderRowsRenderer extends BaseRenderer {
    */
   orderView: OrderView;
 
+  /**
+   * Creates a new ColumnHeaderRowsRenderer instance.
+   *
+   * @param {HTMLElement} rootNode - The root HTML element (THEAD) to manage TR elements within.
+   */
   constructor(rootNode: HTMLElement) {
     super('TR', rootNode);
 

--- a/handsontable/src/3rdparty/walkontable/src/renderer/columnHeaders.ts
+++ b/handsontable/src/3rdparty/walkontable/src/renderer/columnHeaders.ts
@@ -39,6 +39,9 @@ export class ColumnHeadersRenderer extends BaseRenderer {
    */
   sourceRowIndex: number = 0;
 
+  /**
+   * Creates a new ColumnHeadersRenderer instance.
+   */
   constructor() {
     super('TH');
   }

--- a/handsontable/src/3rdparty/walkontable/src/renderer/index.ts
+++ b/handsontable/src/3rdparty/walkontable/src/renderer/index.ts
@@ -28,8 +28,16 @@ interface RendererOptions {
  * @class Renderer
  */
 class Renderer {
+  /**
+   * @type {TableRenderer}
+   */
   declare renderer: TableRenderer;
 
+  /**
+   * Creates a new Renderer instance.
+   *
+   * @param {RendererOptions} options The renderer configuration options.
+   */
   constructor({
     TABLE, THEAD, COLGROUP, TBODY, rowUtils, columnUtils, cellRenderer, stylesHandler
   }: RendererOptions = {}) {

--- a/handsontable/src/3rdparty/walkontable/src/renderer/rowHeaders.ts
+++ b/handsontable/src/3rdparty/walkontable/src/renderer/rowHeaders.ts
@@ -35,6 +35,9 @@ export class RowHeadersRenderer extends BaseRenderer {
    */
   sourceRowIndex = 0;
 
+  /**
+   * Creates a new RowHeadersRenderer instance.
+   */
   constructor() {
     super('TH');
   }

--- a/handsontable/src/3rdparty/walkontable/src/renderer/rows.ts
+++ b/handsontable/src/3rdparty/walkontable/src/renderer/rows.ts
@@ -40,6 +40,11 @@ export class RowsRenderer extends BaseRenderer {
    */
   declare orderView: OrderView;
 
+  /**
+   * Creates a new RowsRenderer instance.
+   *
+   * @param {HTMLElement} rootNode - The root node (TBODY element) for managing TR elements.
+   */
   constructor(rootNode: HTMLElement) {
     super('TR', rootNode);
 

--- a/handsontable/src/3rdparty/walkontable/src/renderer/table.ts
+++ b/handsontable/src/3rdparty/walkontable/src/renderer/table.ts
@@ -180,6 +180,14 @@ export class TableRenderer {
    */
   declare stylesHandler: StylesHandler;
 
+  /**
+   * Creates a new TableRenderer instance.
+   *
+   * @param {HTMLTableElement} rootNode The HTML table element to use as the root node for rendering.
+   * @param {object} options The configuration options.
+   * @param {Function} [options.cellRenderer] The cell renderer function.
+   * @param {StylesHandler} [options.stylesHandler] The styles handler instance.
+   */
   constructor(
     rootNode: HTMLTableElement,
     { cellRenderer, stylesHandler }: { cellRenderer?: Function; stylesHandler?: StylesHandler } = {}) {

--- a/handsontable/src/3rdparty/walkontable/src/selection/border/border.ts
+++ b/handsontable/src/3rdparty/walkontable/src/selection/border/border.ts
@@ -27,25 +27,85 @@ const BORDER_STYLE_HORIZONTAL_SUFFIX = '-horizontal';
  *
  */
 class Border {
+  /**
+   * @type {EventManager}
+   */
   declare eventManager: EventManager;
+  /**
+   * @type {WalkontableInstance}
+   */
   declare instance: WalkontableInstance;
+  /**
+   * @type {WalkontableInstance}
+   */
   declare wot: WalkontableInstance;
+  /**
+   * @type {BorderInstanceSettings}
+   */
   declare settings: BorderInstanceSettings;
+  /**
+   * @type {boolean}
+   */
   declare mouseDown: boolean;
+  /**
+   * @type {HTMLDivElement | null}
+   */
   declare main: HTMLDivElement | null;
+  /**
+   * @type {HTMLElement | null}
+   */
   declare top: HTMLElement | null;
+  /**
+   * @type {HTMLElement | null}
+   */
   declare bottom: HTMLElement | null;
+  /**
+   * @type {HTMLElement | null}
+   */
   declare start: HTMLElement | null;
+  /**
+   * @type {HTMLElement | null}
+   */
   declare end: HTMLElement | null;
+  /**
+   * @type {CSSStyleDeclaration | null}
+   */
   declare topStyle: CSSStyleDeclaration | null;
+  /**
+   * @type {CSSStyleDeclaration | null}
+   */
   declare bottomStyle: CSSStyleDeclaration | null;
+  /**
+   * @type {CSSStyleDeclaration | null}
+   */
   declare startStyle: CSSStyleDeclaration | null;
+  /**
+   * @type {CSSStyleDeclaration | null}
+   */
   declare endStyle: CSSStyleDeclaration | null;
+  /**
+   * @type {CornerDefaultStyle}
+   */
   declare cornerDefaultStyle: CornerDefaultStyle;
+  /**
+   * @type {number}
+   */
   declare cornerCenterPointOffset: number;
+  /**
+   * @type {HTMLElement | null}
+   */
   declare corner: HTMLElement | null;
+  /**
+   * @type {CSSStyleDeclaration | null}
+   */
   declare cornerStyle: CSSStyleDeclaration | null;
+  /**
+   * @type {SelectionHandles}
+   */
   declare selectionHandles: SelectionHandles;
+  /**
+   * @type {boolean}
+   */
   declare disabled: boolean;
 
   // TODO As this is an internal class, should be designed for using {Walkontable}. It uses the facade,

--- a/handsontable/src/3rdparty/walkontable/src/selection/manager.ts
+++ b/handsontable/src/3rdparty/walkontable/src/selection/manager.ts
@@ -70,6 +70,11 @@ export class SelectionManager {
    */
   #selectionBorders = new Map<Selection, Map<WalkontableInstance, Border>>();
 
+  /**
+   * Creates a new SelectionManager instance.
+   *
+   * @param {SelectionsContainer | null} selections The Highlight instance that holds Selection instances.
+   */
   constructor(selections: SelectionsContainer | null) {
     this.#selections = selections;
   }

--- a/handsontable/src/3rdparty/walkontable/src/selection/selection.ts
+++ b/handsontable/src/3rdparty/walkontable/src/selection/selection.ts
@@ -12,14 +12,44 @@ import localHooks from '../../../../mixins/localHooks';
  * @class Selection
  */
 class Selection {
+  /**
+   * @type {Record<string, unknown>}
+   */
   declare settings: Record<string, unknown>;
+  /**
+   * @type {CellRange | null}
+   */
   declare cellRange: CellRange | null;
 
   // Properties/methods added dynamically by mixin(Selection, localHooks)
+  /**
+   * @type {Record<string, Function[]>}
+   */
   declare _localHooks: Record<string, Function[]>;
+  /**
+   * Adds a local hook callback to the hooks registry.
+   * @param {string} key - The hook key identifier.
+   * @param {(...args: unknown[]) => void} callback - The callback function to register.
+   * @returns {this}
+   */
   declare addLocalHook: (key: string, callback: (...args: unknown[]) => void) => this;
+  /**
+   * Removes a local hook callback from the hooks registry.
+   * @param {string} key - The hook key identifier.
+   * @param {Function} callback - The callback function to unregister.
+   * @returns {this}
+   */
   declare removeLocalHook: (key: string, callback: Function) => this;
+  /**
+   * Runs all local hook callbacks registered for the given key.
+   * @param {string} key - The hook key identifier.
+   * @param {...unknown[]} args - Arguments to pass to the hook callbacks.
+   */
   declare runLocalHooks: (key: string, ...args: unknown[]) => void;
+  /**
+   * Clears all local hooks from the registry.
+   * @returns {this}
+   */
   declare clearLocalHooks: () => this;
 
   /**

--- a/handsontable/src/3rdparty/walkontable/src/settings.ts
+++ b/handsontable/src/3rdparty/walkontable/src/settings.ts
@@ -280,6 +280,7 @@ export default class Settings {
    * @returns {*}
    */
   getSetting(key: 'stylesHandler'): StylesHandler;
+  /* eslint-disable jsdoc/require-jsdoc -- TypeScript overload signatures share the JSDoc of the first overload above */
   getSetting(key: 'preventOverflow'): 'horizontal' | 'vertical' | false;
   getSetting(key: 'rtlMode'): boolean;
   getSetting(key: 'isDataViewInstance'): boolean;
@@ -306,6 +307,7 @@ export default class Settings {
 
     return this.settings[key] as unknown;
   }
+  /* eslint-enable jsdoc/require-jsdoc */
 
   /**
    * Get a setting value without any evaluation.
@@ -315,6 +317,7 @@ export default class Settings {
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   getSettingPure<T = any>(key: string): T;
+  // eslint-disable-next-line jsdoc/require-jsdoc -- TypeScript overload implementation; documented in the overload signature above
   getSettingPure(key: string) {
     return this.settings[key];
   }

--- a/handsontable/src/3rdparty/walkontable/src/table.ts
+++ b/handsontable/src/3rdparty/walkontable/src/table.ts
@@ -989,7 +989,6 @@ class Table {
     return Math.abs(row) <= columnHeadersCount;
   }
 
-  /* eslint-disable jsdoc/require-description-complete-sentence */
   /**
    * Check if the given row index is lower than the index of the first row that
    * is currently rendered and return TRUE in that case, or FALSE otherwise.
@@ -1018,7 +1017,6 @@ class Table {
    * @function isRowBeforeRenderedRows
    * @returns {boolean}
    */
-  /* eslint-enable jsdoc/require-description-complete-sentence */
   isRowBeforeRenderedRows(row: number) {
     const first = this.getFirstRenderedRow();
 
@@ -1031,7 +1029,6 @@ class Table {
     return row < first;
   }
 
-  /* eslint-disable jsdoc/require-description-complete-sentence */
   /**
    * Check if the given column index is greater than the index of the last column that
    * is currently rendered and return TRUE in that case, or FALSE otherwise.
@@ -1063,12 +1060,10 @@ class Table {
    * @function isRowAfterRenderedRows
    * @returns {boolean}
    */
-  /* eslint-enable jsdoc/require-description-complete-sentence */
   isRowAfterRenderedRows(row: number) {
     return row > this.getLastRenderedRow();
   }
 
-  /* eslint-disable jsdoc/require-description-complete-sentence */
   /**
    * Check if the given column index is lower than the index of the first column that
    * is currently rendered and return TRUE in that case, or FALSE otherwise.
@@ -1096,7 +1091,6 @@ class Table {
    * @function isColumnBeforeRenderedColumns
    * @returns {boolean}
    */
-  /* eslint-enable jsdoc/require-description-complete-sentence */
   isColumnBeforeRenderedColumns(column: number) {
     const first = this.getFirstRenderedColumn();
 
@@ -1109,7 +1103,6 @@ class Table {
     return column < first;
   }
 
-  /* eslint-disable jsdoc/require-description-complete-sentence */
   /**
    * Check if the given column index is greater than the index of the last column that
    * is currently rendered and return TRUE in that case, or FALSE otherwise.
@@ -1140,7 +1133,6 @@ class Table {
    * @function isColumnAfterRenderedColumns
    * @returns {boolean}
    */
-  /* eslint-enable jsdoc/require-description-complete-sentence */
   isColumnAfterRenderedColumns(column: number) {
     return this.columnFilter && (column > this.getLastRenderedColumn());
   }

--- a/handsontable/src/3rdparty/walkontable/src/table.ts
+++ b/handsontable/src/3rdparty/walkontable/src/table.ts
@@ -48,9 +48,29 @@ class Table {
    * @type {Settings}
    */
   declare wtSettings: Settings;
+  /**
+   * The DOM bindings for the table.
+   *
+   * @type {DomBindings}
+   */
   domBindings;
+  /**
+   * The table body element (TBODY).
+   *
+   * @type {HTMLTableSectionElement | null}
+   */
   TBODY: HTMLTableSectionElement | null = null;
+  /**
+   * The table head element (THEAD).
+   *
+   * @type {HTMLTableSectionElement | null}
+   */
   THEAD: HTMLTableSectionElement | null = null;
+  /**
+   * The column group element (COLGROUP).
+   *
+   * @type {HTMLTableColElement | null}
+   */
   COLGROUP: HTMLTableColElement | null = null;
   /**
    * Indicates if the table has height bigger than 0px.
@@ -71,52 +91,252 @@ class Table {
    * @type {boolean}
    */
   isTableVisible = false;
+  /**
+   * The offset of the table element.
+   *
+   * @type {number | { top: number; left: number }}
+   */
   tableOffset: number | { top: number; left: number } = 0;
+  /**
+   * The offset of the holder element.
+   *
+   * @type {number | { top: number; left: number }}
+   */
   holderOffset: number | { top: number; left: number } = 0;
 
+  /**
+   * The borders holder element.
+   *
+   * @type {HTMLElement}
+   */
   declare bordersHolder?: HTMLElement;
+  /**
+   * Indicates if this instance is of type MasterTable (i.e. it is NOT an overlay).
+   *
+   * @type {boolean}
+   */
   declare isMaster: boolean;
+  /**
+   * The name of the table (overlay name or 'master').
+   *
+   * @type {string}
+   */
   declare name: string;
+  /**
+   * The data access object.
+   *
+   * @type {DataAccessObject}
+   */
   declare dataAccessObject: DataAccessObject;
+  /**
+   * Function which returns the proper facade.
+   *
+   * @type {Function}
+   */
   declare facadeGetter: Function;
+  /**
+   * The Walkontable instance.
+   *
+   * @type {WalkontableInstance}
+   */
   declare instance: WalkontableInstance;
+  /**
+   * The Walkontable instance (legacy alias for instance).
+   *
+   * @type {WalkontableInstance}
+   */
   declare wot: WalkontableInstance;
+  /**
+   * The table element.
+   *
+   * @type {HTMLTableElement}
+   */
   declare TABLE: HTMLTableElement;
+  /**
+   * The spreader element.
+   *
+   * @type {HTMLElement}
+   */
   declare spreader: HTMLElement;
+  /**
+   * The hider element.
+   *
+   * @type {HTMLElement}
+   */
   declare hider: HTMLElement;
+  /**
+   * The holder element.
+   *
+   * @type {HTMLElement}
+   */
   declare holder: HTMLElement;
+  /**
+   * The root element.
+   *
+   * @type {HTMLElement}
+   */
   declare wtRootElement: HTMLElement;
+  /**
+   * The row filter.
+   *
+   * @type {RowFilter | null}
+   */
   declare rowFilter: RowFilter | null;
+  /**
+   * The column filter.
+   *
+   * @type {ColumnFilter | null}
+   */
   declare columnFilter: ColumnFilter | null;
+  /**
+   * Indicates if the header width should be corrected.
+   *
+   * @type {boolean}
+   */
   declare correctHeaderWidth: boolean;
+  /**
+   * The row utilities.
+   *
+   * @type {RowUtils}
+   */
   declare rowUtils: RowUtils;
+  /**
+   * The column utilities.
+   *
+   * @type {ColumnUtils}
+   */
   declare columnUtils: ColumnUtils;
+  /**
+   * The table renderer.
+   *
+   * @type {Renderer}
+   */
   declare tableRenderer: Renderer;
 
   // Methods provided by mixins (calculatedRows, calculatedColumns, stickyRowsTop,
   // stickyRowsBottom, stickyColumnsStart) applied to Table subclasses at runtime.
+  /**
+   * Gets the index of the first rendered row.
+   *
+   * @type {() => number}
+   */
   declare getFirstRenderedRow: () => number;
+  /**
+   * Gets the index of the first visible row.
+   *
+   * @type {() => number}
+   */
   declare getFirstVisibleRow: () => number;
+  /**
+   * Gets the index of the first partially visible row.
+   *
+   * @type {() => number}
+   */
   declare getFirstPartiallyVisibleRow: () => number;
+  /**
+   * Gets the index of the last rendered row.
+   *
+   * @type {() => number}
+   */
   declare getLastRenderedRow: () => number;
+  /**
+   * Gets the index of the last visible row.
+   *
+   * @type {() => number}
+   */
   declare getLastVisibleRow: () => number;
+  /**
+   * Gets the index of the last partially visible row.
+   *
+   * @type {() => number}
+   */
   declare getLastPartiallyVisibleRow: () => number;
+  /**
+   * Gets the count of rendered rows.
+   *
+   * @type {() => number}
+   */
   declare getRenderedRowsCount: () => number;
+  /**
+   * Gets the count of visible rows.
+   *
+   * @type {() => number}
+   */
   declare getVisibleRowsCount: () => number;
+  /**
+   * Gets the count of column headers.
+   *
+   * @type {() => number}
+   */
   declare getColumnHeadersCount: () => number;
+  /**
+   * Gets the index of the first rendered column.
+   *
+   * @type {() => number}
+   */
   declare getFirstRenderedColumn: () => number;
+  /**
+   * Gets the index of the first visible column.
+   *
+   * @type {() => number}
+   */
   declare getFirstVisibleColumn: () => number;
+  /**
+   * Gets the index of the first partially visible column.
+   *
+   * @type {() => number}
+   */
   declare getFirstPartiallyVisibleColumn: () => number;
+  /**
+   * Gets the index of the last rendered column.
+   *
+   * @type {() => number}
+   */
   declare getLastRenderedColumn: () => number;
+  /**
+   * Gets the index of the last visible column.
+   *
+   * @type {() => number}
+   */
   declare getLastVisibleColumn: () => number;
+  /**
+   * Gets the index of the last partially visible column.
+   *
+   * @type {() => number}
+   */
   declare getLastPartiallyVisibleColumn: () => number;
+  /**
+   * Gets the count of rendered columns.
+   *
+   * @type {() => number}
+   */
   declare getRenderedColumnsCount: () => number;
+  /**
+   * Gets the count of visible columns.
+   *
+   * @type {() => number}
+   */
   declare getVisibleColumnsCount: () => number;
+  /**
+   * Gets the count of row headers.
+   *
+   * @type {() => number}
+   */
   declare getRowHeadersCount: () => number;
 
   // Methods defined in subclass MasterTable but called from Table via `this.isMaster` guards.
+  /**
+   * Aligns overlays with the trimming container.
+   *
+   * @returns {void}
+   */
   alignOverlaysWithTrimmingContainer(): void { // intentionally empty
   }
+  /**
+   * Marks oversized column headers.
+   *
+   * @returns {void}
+   */
   markOversizedColumnHeaders(): void { // intentionally empty
   }
 
@@ -1137,30 +1357,68 @@ class Table {
     return this.columnFilter && (column > this.getLastRenderedColumn());
   }
 
+  /**
+   * Checks if the column is after the last visible column.
+   *
+   * @param {number} column The visual column index.
+   * @returns {boolean}
+   */
   isColumnAfterViewport(column: number) {
     return this.columnFilter && (column > this.getLastVisibleColumn());
   }
 
+  /**
+   * Checks if the row is after the last visible row.
+   *
+   * @param {number} row The visual row index.
+   * @returns {boolean}
+   */
   isRowAfterViewport(row: number) {
     return this.rowFilter && (row > this.getLastVisibleRow());
   }
 
+  /**
+   * Checks if the column is before the first visible column.
+   *
+   * @param {number} column The visual column index.
+   * @returns {boolean}
+   */
   isColumnBeforeViewport(column: number) {
     return this.columnFilter && (this.columnFilter!.sourceToRendered(column) < 0 && column >= 0);
   }
 
+  /**
+   * Checks if the last row is fully visible.
+   *
+   * @returns {boolean}
+   */
   isLastRowFullyVisible() {
     return this.getLastVisibleRow() === this.getLastRenderedRow();
   }
 
+  /**
+   * Checks if the last column is fully visible.
+   *
+   * @returns {boolean}
+   */
   isLastColumnFullyVisible() {
     return this.getLastVisibleColumn() === this.getLastRenderedColumn();
   }
 
+  /**
+   * Checks if all rows fit in the viewport.
+   *
+   * @returns {boolean}
+   */
   allRowsInViewport() {
     return this.wtSettings.getSetting('totalRows') === this.getVisibleRowsCount();
   }
 
+  /**
+   * Checks if all columns fit in the viewport.
+   *
+   * @returns {boolean}
+   */
   allColumnsInViewport() {
     return this.wtSettings.getSetting('totalColumns') === this.getVisibleColumnsCount();
   }

--- a/handsontable/src/3rdparty/walkontable/src/table/master.ts
+++ b/handsontable/src/3rdparty/walkontable/src/table/master.ts
@@ -86,6 +86,11 @@ class MasterTable extends Table {
     super(dataAccessObject, facadeGetter, domBindings, wtSettings, 'master');
   }
 
+  /**
+   * Aligns overlays with the trimming container, applying cached measurements when possible
+   * or performing a full measurement of the container. Uses ResizeObservers to detect
+   * container and hider size changes, and validates the table visibility.
+   */
   alignOverlaysWithTrimmingContainer() {
     // The base-class constructor invokes this method before MasterTable's
     // field initializers have run. Accessing a private field in that window
@@ -283,6 +288,10 @@ class MasterTable extends Table {
     this.isTableVisible = isVisible(this.TABLE);
   }
 
+  /**
+   * Marks oversized column headers in the master overlay by iterating through all
+   * rendered columns and marking those that exceed their container dimensions.
+   */
   markOversizedColumnHeaders() {
     const { wtSettings } = this;
     const { wtViewport } = this.dataAccessObject;

--- a/handsontable/src/3rdparty/walkontable/src/utils/nodesPool.ts
+++ b/handsontable/src/3rdparty/walkontable/src/utils/nodesPool.ts
@@ -21,6 +21,11 @@ export class NodesPool {
    * @type {string}
    */
   nodeType;
+  /**
+   * The root document object for creating DOM elements.
+   *
+   * @type {Document}
+   */
   declare rootDocument: Document;
   /**
    * The holder for all created DOM nodes (THs, TDs).
@@ -29,6 +34,11 @@ export class NodesPool {
    */
   pool: Map<number, HTMLElement> = new Map();
 
+  /**
+   * Creates a new NodesPool instance.
+   *
+   * @param {string} nodeType The type of DOM node to generate (e.g. 'TH', 'TD').
+   */
   constructor(nodeType: string) {
     this.nodeType = nodeType.toUpperCase();
   }

--- a/handsontable/src/3rdparty/walkontable/src/utils/orderView/rendererAdapter/differBasedRendererAdapter.ts
+++ b/handsontable/src/3rdparty/walkontable/src/utils/orderView/rendererAdapter/differBasedRendererAdapter.ts
@@ -14,6 +14,9 @@ import {
  * @class {DifferBasedRendererAdapter}
  */
 export class DifferBasedRendererAdapter {
+  /**
+   * @type {OrderView}
+   */
   declare orderView: OrderView;
   /**
    * The list of render commands to execute. The command is an array with the following

--- a/handsontable/src/3rdparty/walkontable/src/utils/orderView/rendererAdapter/directDomRendererAdapter.ts
+++ b/handsontable/src/3rdparty/walkontable/src/utils/orderView/rendererAdapter/directDomRendererAdapter.ts
@@ -7,6 +7,11 @@ import { WORKING_SPACE_TOP, WORKING_SPACE_BOTTOM } from '../constants';
  * @class {DirectDomRendererAdapter}
  */
 export class DirectDomRendererAdapter {
+  /**
+   * The OrderView instance associated with this adapter.
+   *
+   * @type {OrderView}
+   */
   declare orderView: OrderView;
   /**
    * The visual index of currently processed row.

--- a/handsontable/src/3rdparty/walkontable/src/utils/orderView/view.ts
+++ b/handsontable/src/3rdparty/walkontable/src/utils/orderView/view.ts
@@ -55,6 +55,13 @@ export class OrderView {
    */
   rendererAdapter;
 
+  /**
+   * Creates a new OrderView instance.
+   *
+   * @param {HTMLElement} rootNode The root node to manage.
+   * @param {function(number?): HTMLElement} nodesPool Factory for creating new DOM elements.
+   * @param {string} childNodeType The type of child nodes to manage.
+   */
   constructor(rootNode: HTMLElement, nodesPool: (index?: number) => HTMLElement, childNodeType: string) {
     this.rootNode = rootNode;
     this.nodesPool = nodesPool;

--- a/handsontable/src/3rdparty/walkontable/src/utils/orderView/viewDiffer/index.ts
+++ b/handsontable/src/3rdparty/walkontable/src/utils/orderView/viewDiffer/index.ts
@@ -17,8 +17,16 @@ import { ViewOrder } from './viewOrder';
  * @class {ViewDiffer}
  */
 export class ViewDiffer {
+  /**
+   * @type {ViewSizeSet}
+   */
   sizeSet;
 
+  /**
+   * Creates a new ViewDiffer instance.
+   *
+   * @param {ViewSizeSet} sizeSet - The view size configuration to use for generating commands.
+   */
   constructor(sizeSet: ViewSizeSet) {
     this.sizeSet = sizeSet;
   }

--- a/handsontable/src/3rdparty/walkontable/src/utils/orderView/viewDiffer/index.ts
+++ b/handsontable/src/3rdparty/walkontable/src/utils/orderView/viewDiffer/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/require-description-complete-sentence */
 import type { ViewSizeSet } from '../viewSizeSet';
 import {
   WORKING_SPACE_BOTTOM,

--- a/handsontable/src/3rdparty/walkontable/src/utils/orderView/viewDiffer/viewOrder.ts
+++ b/handsontable/src/3rdparty/walkontable/src/utils/orderView/viewDiffer/viewOrder.ts
@@ -5,9 +5,25 @@
  * @class {ViewOrder}
  */
 export class ViewOrder {
+  /**
+   * Array of offset indexes representing the order of rendered elements.
+   *
+   * @type {number[]}
+   */
   order: number[] = [];
+  /**
+   * Set of offset indexes for O(1) membership checks.
+   *
+   * @type {Set<number>}
+   */
   #indexSet = new Set<number>();
 
+  /**
+   * Creates a new ViewOrder instance with offset indexes from viewOffset to viewOffset + viewSize.
+   *
+   * @param {number} viewOffset The starting offset index.
+   * @param {number} viewSize The number of elements in the view.
+   */
   constructor(viewOffset: number, viewSize: number) {
     const order = new Array<number>(viewSize);
     const indexSet = this.#indexSet;

--- a/handsontable/src/3rdparty/walkontable/src/viewport.ts
+++ b/handsontable/src/3rdparty/walkontable/src/viewport.ts
@@ -29,28 +29,97 @@ import { DEFAULT_COLUMN_WIDTH } from './constants';
  * @class Viewport
  */
 class Viewport {
+  /**
+   * @type {DataAccessObject}
+   */
   declare dataAccessObject: DataAccessObject;
+  /**
+   * @type {WalkontableInstance}
+   */
   declare wot: WalkontableInstance;
+  /**
+   * @type {WalkontableInstance}
+   */
   declare instance: WalkontableInstance;
+  /**
+   * @type {DomBindings}
+   */
   declare domBindings: DomBindings;
+  /**
+   * @type {Settings}
+   */
   declare wtSettings: Settings;
+  /**
+   * @type {Table}
+   */
   declare wtTable: Table;
+  /**
+   * @type {Record<number, number | undefined>}
+   */
   declare oversizedRows: Record<number, number | undefined>;
+  /**
+   * @type {Record<number, number | undefined>}
+   */
   declare oversizedColumnHeaders: Record<number, number | undefined>;
+  /**
+   * @type {Record<string, unknown>}
+   */
   declare hasOversizedColumnHeadersMarked: Record<string, unknown>;
+  /**
+   * @type {number}
+   */
   declare clientHeight: number;
+  /**
+   * @type {number}
+   */
   declare columnHeaderHeight: number;
+  /**
+   * @type {number}
+   */
   declare rowHeaderWidth: number;
+  /**
+   * @type {RowsCalculationType | null}
+   */
   declare rowsVisibleCalculator: RowsCalculationType | null;
+  /**
+   * @type {ColumnsCalculationType | null}
+   */
   declare columnsVisibleCalculator: ColumnsCalculationType | null;
+  /**
+   * @type {Map<string, () => CalculationTypeLike>}
+   */
   declare rowsCalculatorTypes: Map<string, () => CalculationTypeLike>;
+  /**
+   * @type {Map<string, () => CalculationTypeLike>}
+   */
   declare columnsCalculatorTypes: Map<string, () => CalculationTypeLike>;
+  /**
+   * @type {EventManager}
+   */
   declare eventManager: EventManager;
+  /**
+   * @type {RowsCalculationType | null}
+   */
   declare rowsRenderCalculator: RowsCalculationType | null;
+  /**
+   * @type {ColumnsCalculationType | null}
+   */
   declare columnsRenderCalculator: ColumnsCalculationType | null;
+  /**
+   * @type {RowsCalculationType | null}
+   */
   declare rowsPartiallyVisibleCalculator: RowsCalculationType | null;
+  /**
+   * @type {ColumnsCalculationType | null}
+   */
   declare columnsPartiallyVisibleCalculator: ColumnsCalculationType | null;
+  /**
+   * @type {PositionCache}
+   */
   declare rowHeightCache: PositionCache;
+  /**
+   * @type {PositionCache}
+   */
   declare columnWidthCache: PositionCache;
 
   /**

--- a/handsontable/src/3rdparty/walkontable/test/helpers/common.js
+++ b/handsontable/src/3rdparty/walkontable/test/helpers/common.js
@@ -23,7 +23,6 @@ afterAll(() => {
   $('.jasmine_html-reporter').show();
 });
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
 /**
  * The function allows you to run the test suites based on different parameters (object configuration, datasets etc).
  *
@@ -53,7 +52,6 @@ export function using(name, parameters, func) {
     });
   });
 }
-/* eslint-enable jsdoc/require-description-complete-sentence */
 
 /**
  * @param {number} [delay=100] The delay in ms after which the Promise is resolved.

--- a/handsontable/src/3rdparty/walkontable/test/helpers/custom-matchers.js
+++ b/handsontable/src/3rdparty/walkontable/test/helpers/custom-matchers.js
@@ -4,7 +4,6 @@ import { normalize, pretty } from './htmlNormalize';
 beforeEach(function() {
   const currentSpec = this;
 
-  /* eslint-disable jsdoc/require-description-complete-sentence */
   /**
    * Extend the matcher factories with the `matchersUtil` argument extended with a configuration provided in the
    * spec as:
@@ -33,7 +32,6 @@ beforeEach(function() {
 
     return matchers;
   }
-  /* eslint-enable jsdoc/require-description-complete-sentence */
 
   const matchers = {
     toBeInArray() {
@@ -109,7 +107,6 @@ beforeEach(function() {
         }
       };
     },
-    /* eslint-disable jsdoc/require-description-complete-sentence */
     /**
      * The matcher checks if the provided selection pattern matches to the rendered cells by checking if
      * the appropriate CSS class name was added.
@@ -161,7 +158,6 @@ beforeEach(function() {
      *
      * @returns {object}
      */
-    /* eslint-enable jsdoc/require-description-complete-sentence */
     toBeMatchToSelectionPattern() {
       return {
         compare(actualPattern) {

--- a/handsontable/src/core/coordsMapper/rangeToRenderableMapper.ts
+++ b/handsontable/src/core/coordsMapper/rangeToRenderableMapper.ts
@@ -35,6 +35,9 @@ export class CellRangeToRenderableMapper {
    */
   #columnIndexMapper;
 
+  /**
+   * Initializes the mapper with the row and column IndexMapper instances used to resolve renderable coordinates.
+   */
   constructor({ rowIndexMapper, columnIndexMapper }: { rowIndexMapper: IndexMapper; columnIndexMapper: IndexMapper }) {
     this.#rowIndexMapper = rowIndexMapper;
     this.#columnIndexMapper = columnIndexMapper;

--- a/handsontable/src/core/coordsMapper/rangeToRenderableMapper.ts
+++ b/handsontable/src/core/coordsMapper/rangeToRenderableMapper.ts
@@ -2,7 +2,6 @@ import type { default as CellRange } from '../../3rdparty/walkontable/src/cell/r
 import type { default as CellCoords } from '../../3rdparty/walkontable/src/cell/coords';
 import type { IndexMapper } from '../../translations';
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
 /**
  * CellRangeToRenderableMapper is a utility responsible for converting CellRange instances
  * defined in visual coordinates (which may include hidden rows/columns) into renderable

--- a/handsontable/src/core/hooks/bucket.ts
+++ b/handsontable/src/core/hooks/bucket.ts
@@ -34,6 +34,9 @@ export class HooksBucket {
    */
   #needsSort: Set<string> = new Set();
 
+  /**
+   * Initializes the bucket and pre-creates empty hook collections for all currently registered hook names.
+   */
   constructor() {
     REGISTERED_HOOKS.forEach(hookName => this.#createHooksCollection(hookName));
   }

--- a/handsontable/src/core/hooks/constants.ts
+++ b/handsontable/src/core/hooks/constants.ts
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/require-description-complete-sentence */
 /**
  * @description
  *
@@ -127,7 +126,6 @@
  */
 
 export const REGISTERED_HOOKS = [
-  /* eslint-disable jsdoc/require-description-complete-sentence */
   /**
    * Fired after resetting a cell's meta. This happens when the {@link Core#updateSettings} method is called.
    *
@@ -3679,7 +3677,6 @@ export const REMOVED_HOOKS = new Map([
   ['hiddenRow', '8.0.0'],
 ]);
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
 /**
  * The list of the hooks which are deprecated. The warning message is printed out in
  * the developer console when the hook is used.
@@ -3699,6 +3696,5 @@ export const REMOVED_HOOKS = new Map([
  *
  * @type {Map<string, string>}
  */
-/* eslint-enable jsdoc/require-description-complete-sentence */
 export const DEPRECATED_HOOKS = new Map<string, string>([
 ]);

--- a/handsontable/src/core/hooks/index.ts
+++ b/handsontable/src/core/hooks/index.ts
@@ -16,7 +16,15 @@ const REMOVED_MESSAGE = toSingleLine`The plugin hook "[hookName]" was removed in
   Please consult release notes https://github.com/handsontable/handsontable/releases/tag/[removedInVersion] to\x20
   learn about the migration path.`;
 
+/**
+ * Manages the global and per-instance hook system for Handsontable.
+ * Acts as the central publish-subscribe bus that decouples core logic, plugins,
+ * and user code through named `before*` / `after*` lifecycle events.
+ */
 export class Hooks {
+  /**
+   * Returns the global singleton instance shared across all Handsontable instances.
+   */
   static getSingleton() {
     return getGlobalSingleton();
   }

--- a/handsontable/src/dataMap/dataSource.ts
+++ b/handsontable/src/dataMap/dataSource.ts
@@ -38,10 +38,22 @@ class DataSource {
    */
   dataType = 'array';
 
+  /**
+   * Translates a visual column index to the corresponding data property key. May be overridden by DataMap when object data is used.
+   */
   colToProp: (column: unknown) => unknown = (_column: unknown) => undefined;
+  /**
+   * Translates a data property key to the corresponding visual column index. May be overridden by DataMap when object data is used.
+   */
   propToCol: (prop: unknown) => unknown = (_prop: unknown) => undefined;
+  /**
+   * Returns the number of columns derived from the data source cache; injected externally when object-based data is used.
+   */
   countCachedColumns?: () => number;
 
+  /**
+   * Initializes the data source with a reference to the Handsontable instance and the raw data array.
+   */
   constructor(hotInstance: HotInstance, dataSource: unknown[][] | object[][] = []) {
     this.hot = hotInstance;
     this.data = dataSource;

--- a/handsontable/src/dataMap/metaManager/index.ts
+++ b/handsontable/src/dataMap/metaManager/index.ts
@@ -34,39 +34,57 @@ import { throwWithCause } from '../../helpers/errors';
  * A more detailed description of the specific layers can be found in the "metaLayers/" modules description.
  */
 export default class MetaManager {
+  /**
+   * The Handsontable instance passed to this manager on construction.
+   */
   declare hot: unknown;
+  /**
+   * The global meta layer that holds default settings shared across the entire grid.
+   */
   declare globalMeta: GlobalMeta;
+  /**
+   * The table meta layer that holds instance-level settings applied to the whole table.
+   */
   declare tableMeta: TableMeta;
+  /**
+   * The column meta layer that holds per-column settings keyed by physical column index.
+   */
   declare columnMeta: ColumnMeta;
+  /**
+   * The cell meta layer that holds per-cell settings keyed by physical row and column index.
+   */
   declare cellMeta: CellMeta;
 
   // Mixin-injected properties/methods (added by `mixin(MetaManager, localHooks)`)
+  /**
+   * Registry of local hook callbacks, keyed by hook name and injected by the `localHooks` mixin.
+   */
   declare _localHooks: Record<string, Function[]>;
+  /**
+   * Registers a callback for the given local hook name; returns this instance for chaining.
+   */
   declare addLocalHook: (key: string, callback: Function) => this;
+  /**
+   * Unregisters a previously added callback from the given local hook name; returns this instance for chaining.
+   */
   declare removeLocalHook: (key: string, callback: Function) => this;
+  /**
+   * Executes all callbacks registered under the given local hook name, passing any extra arguments.
+   */
   declare runLocalHooks: (key: string, ...args: unknown[]) => void;
+  /**
+   * Removes all registered local hook callbacks and returns this instance for chaining.
+   */
   declare clearLocalHooks: () => this;
 
+  /**
+   * Initializes all meta layers, applies custom settings to global meta, and instantiates any meta modifier classes.
+   */
   constructor(hot: unknown, customSettings: Record<string, unknown> = {}, metaMods: unknown[] = []) {
-    /**
-     * @type {Handsontable}
-     */
     this.hot = hot;
-    /**
-     * @type {GlobalMeta}
-     */
     this.globalMeta = new GlobalMeta(hot);
-    /**
-     * @type {TableMeta}
-     */
     this.tableMeta = new TableMeta(this.globalMeta);
-    /**
-     * @type {ColumnMeta}
-     */
     this.columnMeta = new ColumnMeta(this.globalMeta);
-    /**
-     * @type {CellMeta}
-     */
     this.cellMeta = new CellMeta(this.columnMeta);
 
     (metaMods as Array<new (metaManager: MetaManager) => unknown>).forEach(ModifierClass => new ModifierClass(this));

--- a/handsontable/src/dataMap/metaManager/lazyFactoryMap.ts
+++ b/handsontable/src/dataMap/metaManager/lazyFactoryMap.ts
@@ -1,7 +1,6 @@
 import { assert, isNullish } from './utils';
 import { isUnsignedNumber } from '../../helpers/number';
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
 /**
  * @class LazyFactoryMap
  *
@@ -12,10 +11,6 @@ import { isUnsignedNumber } from '../../helpers/number';
  *
  * It's essential to notice that the "key" index under which the item was created
  * is volatile. After altering the grid, the "key" index can change.
- */
-/* eslint-enable jsdoc/require-description-complete-sentence */
-/**
- * Lazy map that creates values on demand using a factory function and supports index-based insertion and removal operations.
  */
 export default class LazyFactoryMap<V = Record<string, unknown>> {
   /**

--- a/handsontable/src/dataMap/metaManager/lazyFactoryMap.ts
+++ b/handsontable/src/dataMap/metaManager/lazyFactoryMap.ts
@@ -14,6 +14,9 @@ import { isUnsignedNumber } from '../../helpers/number';
  * is volatile. After altering the grid, the "key" index can change.
  */
 /* eslint-enable jsdoc/require-description-complete-sentence */
+/**
+ * Lazy map that creates values on demand using a factory function and supports index-based insertion and removal operations.
+ */
 export default class LazyFactoryMap<V = Record<string, unknown>> {
   /**
    * The data factory function.
@@ -42,6 +45,9 @@ export default class LazyFactoryMap<V = Record<string, unknown>> {
    */
   holes = new Set<number>();
 
+  /**
+   * Initializes the map with the given factory function used to create values for new keys on first access.
+   */
   constructor(valueFactory: (key: number) => V) {
     this.valueFactory = valueFactory;
   }

--- a/handsontable/src/dataMap/metaManager/metaLayers/cellMeta.ts
+++ b/handsontable/src/dataMap/metaManager/metaLayers/cellMeta.ts
@@ -5,7 +5,6 @@ import { isDefined } from '../../../helpers/mixed';
 import { isUnsignedNumber } from '../../../helpers/number';
 import type ColumnMeta from './columnMeta';
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
 /**
  * @class CellMeta
  *
@@ -34,7 +33,6 @@ import type ColumnMeta from './columnMeta';
  *                    │ (instance)  │
  *                    +-------------+
  */
-// eslint-disable-next-line jsdoc/require-description-complete-sentence
 export default class CellMeta {
   /**
    * Reference to the ColumnMeta layer. While creating new cell meta objects, all new objects
@@ -124,9 +122,6 @@ export default class CellMeta {
    * @param {number} physicalColumn The physical column index.
    * @param {string} [key] If the key exists its value will be returned, otherwise the whole cell meta object.
    * @returns {object}
-   */
-  /**
-   * Returns the full cell meta object for the given physical row and column.
    */
   getMeta(physicalRow: number, physicalColumn: number): Record<string, unknown>;
   /**

--- a/handsontable/src/dataMap/metaManager/metaLayers/cellMeta.ts
+++ b/handsontable/src/dataMap/metaManager/metaLayers/cellMeta.ts
@@ -34,7 +34,7 @@ import type ColumnMeta from './columnMeta';
  *                    │ (instance)  │
  *                    +-------------+
  */
-/* eslint-enable jsdoc/require-description-complete-sentence */
+// eslint-disable-next-line jsdoc/require-description-complete-sentence
 export default class CellMeta {
   /**
    * Reference to the ColumnMeta layer. While creating new cell meta objects, all new objects
@@ -52,6 +52,9 @@ export default class CellMeta {
    */
   metas = new LazyFactoryMap(() => this._createRow());
 
+  /**
+   * Initializes the cell meta layer with a reference to the ColumnMeta layer used as the prototype source for new cell meta objects.
+   */
   constructor(columnMeta: ColumnMeta) {
     this.columnMeta = columnMeta;
   }
@@ -122,8 +125,17 @@ export default class CellMeta {
    * @param {string} [key] If the key exists its value will be returned, otherwise the whole cell meta object.
    * @returns {object}
    */
+  /**
+   * Returns the full cell meta object for the given physical row and column.
+   */
   getMeta(physicalRow: number, physicalColumn: number): Record<string, unknown>;
+  /**
+   * Returns the value of the specified property key from the cell meta object at the given physical row and column.
+   */
   getMeta(physicalRow: number, physicalColumn: number, key: string): unknown;
+  /**
+   * Returns the cell meta object or a specific property value from it, depending on whether a key is provided.
+   */
   getMeta(physicalRow: number, physicalColumn: number, key?: string): Record<string, unknown> | unknown {
     const cellMeta = this.metas.obtain(physicalRow).obtain(physicalColumn);
 

--- a/handsontable/src/dataMap/metaManager/metaLayers/columnMeta.ts
+++ b/handsontable/src/dataMap/metaManager/metaLayers/columnMeta.ts
@@ -52,6 +52,9 @@ export default class ColumnMeta {
    */
   metas = new LazyFactoryMap(() => this._createMeta());
 
+  /**
+   * Initializes the column meta layer with a reference to the GlobalMeta layer and sets up the lazy map for per-column meta objects.
+   */
   constructor(globalMeta: { getMetaConstructor(): Function }) {
     this.globalMeta = globalMeta;
     this.metas = new LazyFactoryMap(() => this._createMeta());

--- a/handsontable/src/dataMap/metaManager/metaLayers/globalMeta.ts
+++ b/handsontable/src/dataMap/metaManager/metaLayers/globalMeta.ts
@@ -50,6 +50,9 @@ export default class GlobalMeta {
    */
   declare meta: Record<string, unknown>;
 
+  /**
+   * Initializes the global meta layer, populates the meta prototype with schema defaults, and attaches the Handsontable instance reference.
+   */
   constructor(hot: unknown) {
     this.meta = this.metaCtor.prototype as Record<string, unknown>;
 

--- a/handsontable/src/dataMap/metaManager/metaLayers/tableMeta.ts
+++ b/handsontable/src/dataMap/metaManager/metaLayers/tableMeta.ts
@@ -34,6 +34,9 @@ export default class TableMeta {
    */
   declare meta: Record<string, unknown>;
 
+  /**
+   * Initializes the table meta layer by instantiating a new meta object from the GlobalMeta constructor.
+   */
   constructor(globalMeta: { getMetaConstructor(): new (...args: unknown[]) => unknown }) {
     const MetaCtor = globalMeta.getMetaConstructor();
 

--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -2,7 +2,6 @@ import { isEmpty } from '../../helpers/mixed';
 import { isObjectEqual } from '../../helpers/object';
 import type { HotInstance } from '../../core/types';
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
 /**
  * @alias Options
  * @class Options
@@ -121,8 +120,6 @@ import type { HotInstance } from '../../core/types';
  */
 export default (): Record<string, unknown> => {
   return {
-
-    /* eslint-disable jsdoc/require-description-complete-sentence */
 
     /**
      * Information on which of the meta properties were added automatically.
@@ -6868,6 +6865,5 @@ export default (): Record<string, unknown> => {
      */
     parsePastedValue: false,
 
-    /* eslint-enable jsdoc/require-description-complete-sentence */
   };
 };

--- a/handsontable/src/dataMap/metaManager/mods/dynamicCellMeta.ts
+++ b/handsontable/src/dataMap/metaManager/mods/dynamicCellMeta.ts
@@ -29,6 +29,10 @@ type MetaManagerWithHot = MetaManagerInstance & {
   [key: string]: unknown;
 };
 
+/**
+ * Modifier that extends cell meta objects dynamically through Handsontable hooks and the `cells` option,
+ * memoizing results per render cycle to avoid redundant work.
+ */
 export class DynamicCellMetaMod {
   /**
    * @type {MetaManager}
@@ -39,6 +43,9 @@ export class DynamicCellMetaMod {
    */
   metaSyncMemo = new Map();
 
+  /**
+   * Initializes the modifier, registers the `afterGetCellMeta` local hook, and subscribes to `beforeRender` to clear the memo on full renders.
+   */
   constructor(metaManager: MetaManagerWithHot) {
     this.metaManager = metaManager;
 

--- a/handsontable/src/dataMap/metaManager/mods/extendMetaProperties.ts
+++ b/handsontable/src/dataMap/metaManager/mods/extendMetaProperties.ts
@@ -78,6 +78,9 @@ export class ExtendMetaPropertiesMod {
     }],
   ]);
 
+  /**
+   * Initializes the modifier with a reference to the MetaManager and immediately extends the global meta with calculated property values.
+   */
   constructor(metaManager: MetaManagerInstance & {
     hot: { isRtl: () => boolean; [key: string]: unknown };
     globalMeta: { meta: Record<string, unknown>; [key: string]: unknown };

--- a/handsontable/src/editorManager.ts
+++ b/handsontable/src/editorManager.ts
@@ -7,6 +7,10 @@ import { getEditorInstance } from './editors/registry';
 import type { BaseEditor } from './editors/baseEditor';
 import EventManager from './eventManager';
 
+/**
+ * Manages the lifecycle of cell editors — opening, closing, and delegating keyboard events to
+ * the active editor during user interaction with the grid.
+ */
 class EditorManager {
   /**
    * Instance of {@link Handsontable}.

--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.ts
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.ts
@@ -44,6 +44,9 @@ type ChoiceArray = unknown[];
  * @class AutocompleteEditor
  */
 export class AutocompleteEditor extends HandsontableEditor {
+  /**
+   * Returns the unique editor type identifier for the autocomplete editor.
+   */
   static get EDITOR_TYPE() {
     return EDITOR_TYPE;
   }

--- a/handsontable/src/editors/baseEditor/baseEditor.ts
+++ b/handsontable/src/editors/baseEditor/baseEditor.ts
@@ -26,6 +26,9 @@ export const EDITOR_STATE = Object.freeze({
  * @class BaseEditor
  */
 export class BaseEditor {
+  /**
+   * Returns the unique editor type identifier for the base editor.
+   */
   static get EDITOR_TYPE() {
     return EDITOR_TYPE;
   }
@@ -108,9 +111,21 @@ export class BaseEditor {
   declare cellProperties: Record<string, unknown>;
 
   // Mixin-injected methods from hooksRefRegisterer
+  /**
+   * Internal storage map for hook callbacks registered on this editor instance.
+   */
   declare _hooksStorage: Record<string, Function[]>;
+  /**
+   * Registers a hook callback for the given hook name on this editor instance.
+   */
   declare addHook: (...args: unknown[]) => unknown;
+  /**
+   * Removes all hook callbacks registered under the given key on this editor instance.
+   */
   declare removeHooksByKey: (...args: unknown[]) => unknown;
+  /**
+   * Removes all hook callbacks registered on this editor instance.
+   */
   declare clearHooks: (...args: unknown[]) => unknown;
 
   /**

--- a/handsontable/src/editors/baseEditor/baseEditor.ts
+++ b/handsontable/src/editors/baseEditor/baseEditor.ts
@@ -463,7 +463,6 @@ export class BaseEditor {
     return this.state === EDITOR_STATE.WAITING;
   }
 
-  /* eslint-disable jsdoc/require-description-complete-sentence */
   /**
    * Gets the object that provides information about the edited cell size and its position
    * relative to the table viewport.
@@ -607,7 +606,6 @@ export class BaseEditor {
       maxWidth,
     };
   }
-  /* eslint-enable jsdoc/require-description-complete-sentence */
 
   /**
    * Gets className of the edited cell if exist.

--- a/handsontable/src/editors/checkboxEditor/checkboxEditor.ts
+++ b/handsontable/src/editors/checkboxEditor/checkboxEditor.ts
@@ -8,10 +8,16 @@ export const EDITOR_TYPE = 'checkbox';
  * @class CheckboxEditor
  */
 export class CheckboxEditor extends BaseEditor {
+  /**
+   * Returns the unique editor type identifier for the checkbox editor.
+   */
   static get EDITOR_TYPE() {
     return EDITOR_TYPE;
   }
 
+  /**
+   * Handles the mouseup event on the cell TD element to trigger a checkbox click via a double-click interaction.
+   */
   beginEditing(initialValue?: unknown, event?: Event): void {
     // Just some events connected with the checkbox editor are delegated here. Some `keydown` events like `enter` and
     // `space` key presses are handled inside `checkboxRenderer`. Some events come here from `editorManager`. The below
@@ -27,19 +33,40 @@ export class CheckboxEditor extends BaseEditor {
     }
   }
 
+  /**
+   * No-op override — the checkbox editor does not perform a finish step.
+   */
   finishEditing(): void { // intentionally empty
   }
+  /**
+   * No-op override — the checkbox editor requires no DOM initialization.
+   */
   init(): void { // intentionally empty
   }
+  /**
+   * No-op override — the checkbox editor has no visible editing element to open.
+   */
   open(): void { // intentionally empty
   }
+  /**
+   * No-op override — the checkbox editor has no visible editing element to close.
+   */
   close(): void { // intentionally empty
   }
+  /**
+   * Returns undefined because checkbox state is written directly to the cell; no separate value is held.
+   */
   getValue(): unknown {
     return undefined;
   }
+  /**
+   * No-op override — the checkbox editor writes its value directly via DOM events.
+   */
   setValue(): void { // intentionally empty
   }
+  /**
+   * No-op override — the checkbox editor delegates focus to the native checkbox element.
+   */
   focus(): void { // intentionally empty
   }
 }

--- a/handsontable/src/editors/dateEditor/dateEditor.ts
+++ b/handsontable/src/editors/dateEditor/dateEditor.ts
@@ -31,6 +31,9 @@ interface PikadayInstance {
  * @class DateEditor
  */
 export class DateEditor extends TextEditor {
+  /**
+   * Returns the unique editor type identifier for the date editor.
+   */
   static get EDITOR_TYPE() {
     return EDITOR_TYPE;
   }
@@ -52,6 +55,9 @@ export class DateEditor extends TextEditor {
    */
   declare datePickerStyle: CSSStyleDeclaration;
 
+  /**
+   * Verifies that moment.js and Pikaday are available, then initializes the editor and registers lifecycle hooks.
+   */
   init(): void {
     if (typeof moment !== 'function') {
       throwWithCause('You need to include moment.js to your project.');

--- a/handsontable/src/editors/dropdownEditor/dropdownEditor.ts
+++ b/handsontable/src/editors/dropdownEditor/dropdownEditor.ts
@@ -8,6 +8,9 @@ export const EDITOR_TYPE = 'dropdown';
  * @class DropdownEditor
  */
 export class DropdownEditor extends AutocompleteEditor {
+  /**
+   * Returns the unique editor type identifier for the dropdown editor.
+   */
   static get EDITOR_TYPE() {
     return EDITOR_TYPE;
   }

--- a/handsontable/src/editors/handsontableEditor/handsontableEditor.ts
+++ b/handsontable/src/editors/handsontableEditor/handsontableEditor.ts
@@ -16,6 +16,9 @@ export const EDITOR_TYPE = 'handsontable';
  * @class HandsontableEditor
  */
 export class HandsontableEditor extends TextEditor {
+  /**
+   * Returns the unique editor type identifier for the Handsontable editor.
+   */
   static get EDITOR_TYPE() {
     return EDITOR_TYPE;
   }
@@ -40,7 +43,13 @@ export class HandsontableEditor extends TextEditor {
   declare htOptions: Record<string, unknown>;
 
   // Mixin methods from hooksRefRegisterer (applied to BaseEditor at runtime).
+  /**
+   * Registers a hook callback for the given hook name on this editor instance.
+   */
   declare addHook: (...args: unknown[]) => unknown;
+  /**
+   * Removes all hook callbacks registered under the given key on this editor instance.
+   */
   declare removeHooksByKey: (...args: unknown[]) => unknown;
 
   /**

--- a/handsontable/src/editors/intlDateEditor/intlDateEditor.ts
+++ b/handsontable/src/editors/intlDateEditor/intlDateEditor.ts
@@ -11,10 +11,16 @@ export const EDITOR_TYPE = 'intl-date';
  * @class IntlDateEditor
  */
 export class IntlDateEditor extends TextEditor {
+  /**
+   * Returns the unique editor type identifier for the intl-date editor.
+   */
   static get EDITOR_TYPE() {
     return EDITOR_TYPE;
   }
 
+  /**
+   * Initializes the editor and registers an afterSetTheme hook to close on theme changes.
+   */
   init(): void {
     super.init();
 
@@ -25,12 +31,18 @@ export class IntlDateEditor extends TextEditor {
     });
   }
 
+  /**
+   * Creates the editor's textarea element as a native date input.
+   */
   createElements(type?: string): void {
     super.createElements('input');
 
     this.TEXTAREA.setAttribute('type', 'date');
   }
 
+  /**
+   * Sets the editor value, falling back to `defaultDate` when the value is empty, and warns if the value is not a valid ISO date string.
+   */
   setValue(value: unknown): void {
     if (isEmpty(value)) {
       value = this.cellProperties.defaultDate;
@@ -46,10 +58,16 @@ export class IntlDateEditor extends TextEditor {
     super.setValue(value);
   }
 
+  /**
+   * Selects all text in the date input element when the editor receives focus.
+   */
   focus(): void {
     this.TEXTAREA.select();
   }
 
+  /**
+   * Opens the editor and programmatically invokes the native date picker via showPicker().
+   */
   open(): void {
     super.open();
 

--- a/handsontable/src/editors/intlTimeEditor/intlTimeEditor.ts
+++ b/handsontable/src/editors/intlTimeEditor/intlTimeEditor.ts
@@ -10,10 +10,16 @@ export const EDITOR_TYPE = 'intl-time';
  * @class IntlTimeEditor
  */
 export class IntlTimeEditor extends TextEditor {
+  /**
+   * Returns the unique editor type identifier for the intl-time editor.
+   */
   static get EDITOR_TYPE() {
     return EDITOR_TYPE;
   }
 
+  /**
+   * Initializes the editor and registers an afterSetTheme hook to close on theme changes.
+   */
   init(): void {
     super.init();
 
@@ -24,12 +30,18 @@ export class IntlTimeEditor extends TextEditor {
     });
   }
 
+  /**
+   * Creates the editor's textarea element as a native time input.
+   */
   createElements(type?: string): void {
     super.createElements('input');
 
     this.TEXTAREA.setAttribute('type', 'time');
   }
 
+  /**
+   * Sets the editor value and warns if the value does not match the 24-hour time format required by the native time input.
+   */
   setValue(value: unknown): void {
     if (!isValidTime(value)) {
       warn(toSingleLine`IntlTimeEditor: value must be in 24-hour time format ("HH:mm", "HH:mm:ss" or "HH:mm:ss.SSS")\x20
@@ -41,10 +53,16 @@ export class IntlTimeEditor extends TextEditor {
     super.setValue(value);
   }
 
+  /**
+   * Selects all text in the time input element when the editor receives focus.
+   */
   focus(): void {
     this.TEXTAREA.select();
   }
 
+  /**
+   * Opens the editor and programmatically invokes the native time picker via showPicker().
+   */
   open(): void {
     super.open();
 

--- a/handsontable/src/editors/multiSelectEditor/controllers/dropdownController.ts
+++ b/handsontable/src/editors/multiSelectEditor/controllers/dropdownController.ts
@@ -42,15 +42,45 @@ interface DropdownControllerCache {
  * @class DropdownController
  */
 export class DropdownController {
+  /**
+   * The Handsontable instance GUID used to scope checkbox IDs within the dropdown.
+   */
   #instanceId: string | null = null;
+  /**
+   * The host div element that contains the search wrapper, separator, and list.
+   */
   #containerElement: HTMLDivElement | null = null;
+  /**
+   * The `<ul>` element that holds the individual checkbox list items.
+   */
   #dropdownListElement: HTMLUListElement | null = null;
+  /**
+   * The `<input>` element used for filtering dropdown entries.
+   */
   #searchInputElement: HTMLInputElement | null = null;
+  /**
+   * The horizontal rule element separating the search input from the item list.
+   */
   #separatorElement: HTMLElement | null = null;
+  /**
+   * The wrapper div that groups the search icon and search input.
+   */
   #searchInputWrapper: HTMLDivElement | null = null;
+  /**
+   * The controller managing the search input element and its filter events.
+   */
   #inputController: InputController | null = null;
+  /**
+   * The root document derived from the container element's owner document.
+   */
   #rootDocument: Document | null = null;
+  /**
+   * The event manager used to register and remove DOM event listeners on checkbox items.
+   */
   #eventManager = new EventManager(this);
+  /**
+   * Runtime cache storing settings, state flags, and event listener references.
+   */
   #cache: DropdownControllerCache = {
     visibleRowsNumberSetting: null,
     entriesCount: 0,
@@ -61,10 +91,25 @@ export class DropdownController {
     sourceSortFunction: null,
   };
 
+  /**
+   * Internal storage map for local hook callbacks mixed in at runtime.
+   */
   declare _localHooks: Record<string, Function[]>;
+  /**
+   * Registers a local hook callback for the given key on this controller.
+   */
   declare addLocalHook: (key: string, callback: Function) => this;
+  /**
+   * Removes a specific local hook callback for the given key.
+   */
   declare removeLocalHook: (key: string, callback: Function) => this;
+  /**
+   * Runs all local hook callbacks registered under the given key, passing any extra arguments.
+   */
   declare runLocalHooks: (key: string, ...args: unknown[]) => void;
+  /**
+   * Removes all local hook callbacks registered on this controller.
+   */
   declare clearLocalHooks: () => this;
 
   /**
@@ -108,14 +153,23 @@ export class DropdownController {
     });
   }
 
+  /**
+   * Stores the maximum number of visible rows used when constraining the dropdown's rendered height.
+   */
   setVisibleRowsNumberSetting(visibleRowsNumber: number): void {
     this.#cache.visibleRowsNumberSetting = visibleRowsNumber;
   }
 
+  /**
+   * Stores a comparator function applied to the source entries before rendering; pass null to remove sorting.
+   */
   setSourceSortFunction(sourceSortFunction: ((entries: DropdownEntry[]) => DropdownEntry[]) | null): void {
     this.#cache.sourceSortFunction = sourceSortFunction ?? null;
   }
 
+  /**
+   * Shows or hides the search input and separator elements and toggles the input controller's listener.
+   */
   setSearchInputVisibility(searchInput = true): void {
     if (!this.#searchInputWrapper || !this.#separatorElement || !this.#inputController) {
       return;
@@ -216,28 +270,43 @@ export class DropdownController {
     this.#containerElement.scrollTop = 0;
   }
 
+  /**
+   * Returns the pixel width of the dropdown list element, or 0 if the list is not yet mounted.
+   */
   getDropdownWidth(): number {
     return this.#dropdownListElement
       ? getDropdownWidth({ dropdownListElement: this.#dropdownListElement })
       : 0;
   }
 
+  /**
+   * Unchecks all checkboxes in the dropdown list.
+   */
   deselectAllItems(): void {
     if (this.#dropdownListElement) {
       deselectAllItems({ dropdownListElement: this.#dropdownListElement });
     }
   }
 
+  /**
+   * Focuses the first item in the dropdown list if at least one entry exists.
+   */
   focusFirstItem(): void {
     if (this.#cache.entriesCount > 0) {
       this.#focusItem(0);
     }
   }
 
+  /**
+   * Focuses the dropdown item at the given absolute index.
+   */
   focusItem(index: number): void {
     this.#focusItem(index);
   }
 
+  /**
+   * Moves focus to the previous item, or to the search input when already at the first item.
+   */
   focusPreviousItem(): void {
     if (!this.#dropdownListElement) {
       return;
@@ -254,6 +323,9 @@ export class DropdownController {
     this.#focusItem(this.#cache.currentlySelectedItemIndex - 1);
   }
 
+  /**
+   * Moves focus to the next item in the list, stopping at the last entry.
+   */
   focusNextItem(): void {
     if (!this.#dropdownListElement) {
       return;
@@ -268,12 +340,18 @@ export class DropdownController {
     this.#focusItem(this.#cache.currentlySelectedItemIndex + 1);
   }
 
+  /**
+   * Transfers DOM focus to the search input element.
+   */
   focusSearchInput(): void {
     if (this.#searchInputElement) {
       this.#searchInputElement.focus();
     }
   }
 
+  /**
+   * Clears all dropdown items, resets internal cache state, clears the search input value, and resets container styles.
+   */
   reset(): void {
     this.removeAllDropdownItems();
     this.#resetCache();
@@ -290,10 +368,16 @@ export class DropdownController {
     }
   }
 
+  /**
+   * Returns true when the dropdown is currently rendered above the edited cell instead of below.
+   */
   isFlippedVertically(): boolean {
     return this.#cache.flippedVertically;
   }
 
+  /**
+   * Calculates the total pixel height of the dropdown including the item list and search input wrapper.
+   */
   getHeight(maxRowsCalculation = false, outerWidth = false): number {
     if (!this.#rootDocument || !this.#containerElement) {
       return 0;
@@ -307,10 +391,16 @@ export class DropdownController {
     );
   }
 
+  /**
+   * Returns the InputController instance that manages the search input, or null if not yet initialized.
+   */
   getInputController(): InputController | null {
     return this.#inputController;
   }
 
+  /**
+   * Removes all list items from the dropdown, unregisters their event listeners, and clears the checkbox listener cache.
+   */
   removeAllDropdownItems(): void {
     if (!this.#dropdownListElement) {
       return;
@@ -322,6 +412,9 @@ export class DropdownController {
     this.#dropdownListElement.innerHTML = '';
   }
 
+  /**
+   * Disables all unchecked checkboxes in the dropdown and sets the internal disabled flag.
+   */
   disableCheckboxes(): void {
     this.#cache.areCheckboxesDisabled = true;
 
@@ -330,6 +423,9 @@ export class DropdownController {
     }
   }
 
+  /**
+   * Re-enables all checkboxes in the dropdown and clears the internal disabled flag.
+   */
   enableCheckboxes(): void {
     this.#cache.areCheckboxesDisabled = false;
 
@@ -338,6 +434,9 @@ export class DropdownController {
     }
   }
 
+  /**
+   * Updates the focused item index cache and applies the focus highlight to the item at the given position.
+   */
   #focusItem(index: number): void {
     this.#cache.currentlySelectedItemIndex = index;
 
@@ -346,12 +445,18 @@ export class DropdownController {
     }
   }
 
+  /**
+   * Returns true when the dropdown is taller than the space below the cell and there is more space above.
+   */
   #requiresFlippingVertically(availableSpace: { spaceAbove: number; spaceBelow: number; cellHeight: number }): boolean {
     const { spaceAbove, spaceBelow, cellHeight } = availableSpace;
 
     return this.getHeight(true) > spaceBelow && spaceAbove > spaceBelow + cellHeight;
   }
 
+  /**
+   * Applies or removes the absolute positioning that renders the dropdown above the edited cell.
+   */
   #toggleVerticalFlip(availableSpace: { cellHeight: number }): void {
     if (!this.#containerElement) {
       return;
@@ -368,6 +473,9 @@ export class DropdownController {
     }
   }
 
+  /**
+   * Calculates the pixel height of a single dropdown row using CSS custom properties from the container's computed style.
+   */
   #getEntryHeight(): number {
     if (!this.#rootDocument || !this.#containerElement) {
       return 0;
@@ -380,6 +488,9 @@ export class DropdownController {
     );
   }
 
+  /**
+   * Returns the pixel height occupied by the list items, using either the actual rendered count or the full entry count when calculating the maximum.
+   */
   #getListHeight(maxRowsCalculation: boolean): number {
     const maxRenderedItems = this.#cache.entriesCount;
     const actualRenderedItems = maxRowsCalculation
@@ -390,6 +501,9 @@ export class DropdownController {
     return actualRenderedItems * entryHeight;
   }
 
+  /**
+   * Returns the combined pixel height of the search input wrapper and separator, or 0 when the input is hidden.
+   */
   #getSearchInputWrapperHeight(): number {
     if (!this.#inputController?.enabled || !this.#searchInputWrapper ||
         !this.#separatorElement || !this.#rootDocument || !this.#containerElement) {
@@ -404,6 +518,9 @@ export class DropdownController {
     return searchInputWrapperHeight + separatorHeight;
   }
 
+  /**
+   * Creates a list item element for the given entry, marks it as selected if needed, registers events, and appends it to the list.
+   */
   #addDropdownItem({
     rootDocument,
     itemKey,
@@ -440,6 +557,9 @@ export class DropdownController {
     this.#dropdownListElement.appendChild(itemElement);
   }
 
+  /**
+   * Attaches change and click event listeners to the checkbox inside the given list item and stores them for later removal.
+   */
   #registerEvents(itemElement: HTMLLIElement): void {
     const checkbox = getCheckboxElement(itemElement);
 
@@ -484,6 +604,9 @@ export class DropdownController {
     this.#eventManager.addEventListener(itemElement, 'click', itemClickListener);
   }
 
+  /**
+   * Removes the change and click listeners previously registered on the checkbox inside the given list item.
+   */
   #unregisterEvents(itemElement: HTMLLIElement): void {
     const checkbox = getCheckboxElement(itemElement);
 
@@ -499,6 +622,9 @@ export class DropdownController {
     }
   }
 
+  /**
+   * Resets all cached state values to their initial defaults, clearing listeners and counters.
+   */
   #resetCache(): void {
     this.#cache.visibleRowsNumberSetting = null;
     this.#cache.entriesCount = 0;

--- a/handsontable/src/editors/multiSelectEditor/controllers/inputController.ts
+++ b/handsontable/src/editors/multiSelectEditor/controllers/inputController.ts
@@ -14,20 +14,47 @@ export interface InputControllerOptions {
  * @class InputController
  */
 export class InputController {
+  /**
+   * The search input element managed by this controller.
+   */
   input: HTMLInputElement;
+  /**
+   * The event manager used to register and remove DOM event listeners.
+   */
   eventManager: InstanceType<typeof EventManager>;
+  /**
+   * Whether the search input is currently active and listening for input events.
+   */
   enabled: boolean;
 
+  /**
+   * Internal storage map for local hook callbacks registered on this controller.
+   */
   declare _localHooks: Record<string, Function[]>;
+  /**
+   * Registers a local hook callback for the given key on this controller.
+   */
   declare addLocalHook: (key: string, callback: Function) => this;
+  /**
+   * Removes a local hook callback for the given key on this controller.
+   */
   declare removeLocalHook: (key: string, callback: Function) => this;
+  /**
+   * Runs all local hook callbacks registered under the given key.
+   */
   declare runLocalHooks: (key: string, ...args: unknown[]) => void;
+  /**
+   * Removes all local hook callbacks registered on this controller.
+   */
   declare clearLocalHooks: () => this;
 
+  /**
+   * Bound handler for the native input event, used to trigger filtering.
+   */
   private onInput = this._onInput.bind(this);
 
   /**
-   * Creates a new InputController.
+   * Wires the given input element and event manager, and enables the controller immediately.
    */
   constructor({ input, eventManager }: InputControllerOptions) {
     this.input = input;
@@ -36,23 +63,22 @@ export class InputController {
   }
 
   /**
-   * Gets the input element.
+   * Returns the underlying `<input>` element managed by this controller.
    */
   getInputElement(): HTMLInputElement {
     return this.input;
   }
 
   /**
-   * Sets the value of the input.
+   * Writes the given string into the input element's value property without firing a DOM input event.
    */
   setValue(value: string): void {
     this.input.value = value;
   }
 
   /**
-   * Toggles the input.
-   *
-   * @param {boolean} enabled If true, the input will be enabled.
+   * Enables or disables the input controller: passes `true` to start listening for input events,
+   * `false` to stop.
    */
   toggle(enabled: boolean): void {
     this.enabled = enabled;
@@ -67,25 +93,29 @@ export class InputController {
   }
 
   /**
-   * Listens to the input keyup event.
+   * Registers the native `input` event listener on the managed element so that typing triggers `triggerFilter`.
    */
   listen(): void {
     this.eventManager.addEventListener(this.input, 'input', this.onInput as (event: Event) => void);
   }
 
   /**
-   * Unlistens to the input keyup event.
+   * Removes the previously registered `input` event listener from the managed element.
    */
   unlisten(): void {
     this.eventManager.removeEventListener(this.input, 'input', this.onInput as (event: Event) => void);
   }
 
+  /**
+   * Handles the native input event and delegates to the internal filter trigger.
+   */
   private _onInput(): void {
     this.#triggerFilter(this.input.value);
   }
 
   /**
-   * Triggers the filtering.
+   * Runs all `triggerFilter` local hook callbacks with the current input value to initiate
+   * entry filtering in the dropdown.
    */
   #triggerFilter(value: string): void {
     this.runLocalHooks('triggerFilter', value);

--- a/handsontable/src/editors/multiSelectEditor/controllers/selectedItemsController.ts
+++ b/handsontable/src/editors/multiSelectEditor/controllers/selectedItemsController.ts
@@ -8,7 +8,13 @@ import { includesValue } from '../utils/utils';
  * @class SelectedItemsController
  */
 export class SelectedItemsController {
+  /**
+   * The set holding the currently selected item values.
+   */
   selectedItems: Set<unknown>;
+  /**
+   * The maximum number of items that can be selected simultaneously.
+   */
   maxSelectionsCount: number;
 
   /**

--- a/handsontable/src/editors/multiSelectEditor/multiSelectEditor.ts
+++ b/handsontable/src/editors/multiSelectEditor/multiSelectEditor.ts
@@ -20,24 +20,48 @@ const SHORTCUTS_GROUP = 'multiselectEditor';
 const EDITOR_VISIBLE_CLASS_NAME = 'ht_editor_visible';
 
 /**
- * @private
- * @class MultiSelectEditor
+ * Cell editor that lets users pick one or more values from a checkbox dropdown list.
+ * Saves on every check/uncheck rather than on editor close.
  */
 export class MultiSelectEditor extends BaseEditor {
+  /**
+   * Overrides the base flag to keep the editor open after data changes — multiselect saves on each selection.
+   */
   _closeAfterDataChange = false;
 
+  /**
+   * Controller managing the set of currently selected values in the editor.
+   */
   #selectedItems = new SelectedItemsController();
+  /**
+   * The outer wrapper element that positions the dropdown relative to the edited cell.
+   */
   #editorContainer: HTMLDivElement | null = null;
 
+  /**
+   * The container element passed to `DropdownController` that holds the dropdown UI.
+   */
   dropdownContainerElement: HTMLDivElement | null = null;
+  /**
+   * The controller responsible for rendering and managing the dropdown list.
+   */
   dropdownController: DropdownController | null = null;
 
+  /**
+   * The event manager used to register and clean up DOM event listeners.
+   */
   declare eventManager: InstanceType<typeof EventManager>;
 
+  /**
+   * Returns the unique editor type identifier for the multiselect editor.
+   */
   static get EDITOR_TYPE() {
     return EDITOR_TYPE;
   }
 
+  /**
+   * Initializes the editor, creates DOM elements, and binds dropdown and hook events.
+   */
   constructor(hotInstance: HotInstance) {
     super(hotInstance);
 
@@ -47,6 +71,9 @@ export class MultiSelectEditor extends BaseEditor {
     this.bindEvents();
   }
 
+  /**
+   * Creates the outer container, dropdown container, accessibility attributes, and the DropdownController instance.
+   */
   createElements(): void {
     const { rootDocument } = this.hot;
 
@@ -68,6 +95,9 @@ export class MultiSelectEditor extends BaseEditor {
     this.dropdownController = new DropdownController(this.dropdownContainerElement, this.hot.guid);
   }
 
+  /**
+   * Prepares the editor for the given cell, resets the dropdown, syncs the current selection, and applies cell settings.
+   */
   prepare(
     row: number,
     col: number,
@@ -101,10 +131,16 @@ export class MultiSelectEditor extends BaseEditor {
     }
   }
 
+  /**
+   * Delegates to the base finishEditing to complete saving or restoring the cell value.
+   */
   finishEditing(restoreOriginalValue: boolean, ctrlDown: boolean, callback?: Function): void {
     super.finishEditing(restoreOriginalValue, ctrlDown, callback);
   }
 
+  /**
+   * Wires dropdown check/uncheck hooks, scroll hooks, destroy cleanup, and the search filter trigger.
+   */
   bindEvents(): void {
     this.dropdownController!.addLocalHook('afterDropdownItemChecked',
       (selectedKey: string, selectedValue: string) => {
@@ -135,6 +171,9 @@ export class MultiSelectEditor extends BaseEditor {
       'triggerFilter', (value: string) => this.#filterEntries(value));
   }
 
+  /**
+   * Shows the dropdown, positions it next to the edited cell, registers keyboard shortcuts, and focuses the appropriate element.
+   */
   open(event?: Event | null): void {
     const keyCode = event && 'keyCode' in event ? (event as { keyCode: number }).keyCode : 0;
     const keyStr = event && 'key' in event ? (event as { key: string }).key : '';
@@ -162,20 +201,32 @@ export class MultiSelectEditor extends BaseEditor {
 
   }
 
+  /**
+   * Hides the dropdown element, unregisters keyboard shortcuts, and stops the search input listener.
+   */
   close(): void {
     this.#hideEditableElement();
     this.#unregisterShortcuts();
     this.dropdownController!.getInputController()!.unlisten();
   }
 
+  /**
+   * Returns the currently selected values as an array to be written to the cell.
+   */
   getValue(): unknown[] {
     return this.#selectedItems.getItemsArray();
   }
 
+  /**
+   * No-op override — MultiSelectEditor saves data immediately on each check/uncheck event.
+   */
   setValue(): void {
     // Currently not implemented - MultiSelectEditor saves data after every change.
   }
 
+  /**
+   * Repositions the dropdown next to the edited cell; closes the editor if the cell is no longer rendered.
+   */
   refreshDimensions(): void {
     if (!this.getEditedCell()) {
       this.close();
@@ -192,6 +243,9 @@ export class MultiSelectEditor extends BaseEditor {
     addClass(this.#editorContainer!, EDITOR_VISIBLE_CLASS_NAME);
   }
 
+  /**
+   * Focuses the first dropdown item when search input is disabled, or the search input otherwise.
+   */
   focus(): void {
     if (this.#getEditorSetting('searchInput') === false) {
       this.dropdownController!.focusFirstItem();
@@ -200,19 +254,31 @@ export class MultiSelectEditor extends BaseEditor {
     }
   }
 
+  /**
+   * Returns the underlying search input element from the dropdown's input controller.
+   */
   getInputElement(): HTMLInputElement {
     return this.dropdownController!.getInputController()!.getInputElement();
   }
 
+  /**
+   * Closes the editor and resets the dropdown controller state, releasing DOM resources.
+   */
   destroy(): void {
     this.close();
     this.dropdownController!.reset();
   }
 
+  /**
+   * Returns the `source` cell property as an array of dropdown entries, defaulting to an empty array.
+   */
   #getSource(): DropdownEntry[] {
     return (this.cellProperties.source as DropdownEntry[]) ?? [];
   }
 
+  /**
+   * Registers ArrowUp/ArrowDown and Enter/Space shortcuts for keyboard navigation and checkbox toggling.
+   */
   #registerShortcuts(): void {
     const shortcutManager = this.hot.getShortcutManager();
     const editorContext = shortcutManager.getContext('editor');
@@ -263,6 +329,9 @@ export class MultiSelectEditor extends BaseEditor {
     });
   }
 
+  /**
+   * Removes all keyboard shortcuts registered under the multiselect editor's shortcut group.
+   */
   #unregisterShortcuts(): void {
     const shortcutManager = this.hot.getShortcutManager();
     const editorContext = shortcutManager.getContext('editor');
@@ -270,22 +339,37 @@ export class MultiSelectEditor extends BaseEditor {
     editorContext!.removeShortcutsByGroup(SHORTCUTS_GROUP);
   }
 
+  /**
+   * Makes the outer editor container visible by clearing its `display` style.
+   */
   #showEditableElement(): void {
     this.#editorContainer!.style.display = '';
   }
 
+  /**
+   * Hides the outer editor container by setting its `display` style to `'none'`.
+   */
   #hideEditableElement(): void {
     this.#editorContainer!.style.display = 'none';
   }
 
+  /**
+   * Disables all unchecked checkboxes in the dropdown when the maximum selection count is reached.
+   */
   #blockNewSelections(): void {
     this.dropdownController!.disableCheckboxes();
   }
 
+  /**
+   * Re-enables all checkboxes in the dropdown when the selection count drops below the maximum.
+   */
   #unblockNewSelections(): void {
     this.dropdownController!.enableCheckboxes();
   }
 
+  /**
+   * Filters the source entries by the given query string and re-renders the dropdown with matching items.
+   */
   #filterEntries(
     query: string,
     filterSelectedItems: boolean = this.#getEditorSetting<boolean>('filterSelectedItems') ?? true
@@ -310,6 +394,9 @@ export class MultiSelectEditor extends BaseEditor {
     this.dropdownController!.updateDimensions(this.#getAvailableSpace(), true);
   }
 
+  /**
+   * Calculates the available vertical space above and below the edited cell for positioning the dropdown.
+   */
   #getAvailableSpace(): { spaceAbove: number; spaceBelow: number; cellHeight: number } {
     const cellRect = this.getEditedCellRect()!;
     const isVerticallyScrollableByWindow = this.hot.view.isVerticallyScrollableByWindow();
@@ -332,12 +419,18 @@ export class MultiSelectEditor extends BaseEditor {
     };
   }
 
+  /**
+   * Reads the current selected items array and writes it to the cell via saveValue.
+   */
   #saveCurrentSelection(): void {
     const value = this.#selectedItems.getItemsArray();
 
     this.saveValue([[value]]);
   }
 
+  /**
+   * Adds the given key/value pair (or bare value) to the selected items and persists the new selection.
+   */
   #addSelectedValue(selectedKey: string, selectedValue: string): void {
     if (selectedKey) {
       this.#selectedItems.add({ key: selectedKey, value: selectedValue });
@@ -348,6 +441,9 @@ export class MultiSelectEditor extends BaseEditor {
     this.refreshDimensions();
   }
 
+  /**
+   * Removes the given key/value pair (or bare value) from the selected items and persists the new selection.
+   */
   #removeSelectedValue(deselectedKey: string, deselectedValue: string): void {
     if (deselectedKey) {
       this.#selectedItems.remove({ key: deselectedKey, value: deselectedValue });
@@ -358,6 +454,9 @@ export class MultiSelectEditor extends BaseEditor {
     this.refreshDimensions();
   }
 
+  /**
+   * Replaces the internal SelectedItemsController with a new one pre-populated from the given values array.
+   */
   #syncSelectedValues(valuesArray: unknown[]): void {
     if (valuesArray.length > 0) {
       this.#selectedItems = new SelectedItemsController(valuesArray);
@@ -366,10 +465,16 @@ export class MultiSelectEditor extends BaseEditor {
     }
   }
 
+  /**
+   * Reads a typed setting value from the cell properties by the given key.
+   */
   #getEditorSetting<T>(settingKey: string): T {
     return this.cellProperties[settingKey] as T;
   }
 
+  /**
+   * Handles the afterSetSourceDataAtCell hook to re-sync the dropdown when the renderer updates the source data for the edited cell.
+   */
   #onAfterSetSourceDataAtCell(changes: unknown[][], source: string): void {
     if (
       this.isOpened() &&

--- a/handsontable/src/editors/multiSelectEditor/multiSelectEditor.ts
+++ b/handsontable/src/editors/multiSelectEditor/multiSelectEditor.ts
@@ -22,6 +22,9 @@ const EDITOR_VISIBLE_CLASS_NAME = 'ht_editor_visible';
 /**
  * Cell editor that lets users pick one or more values from a checkbox dropdown list.
  * Saves on every check/uncheck rather than on editor close.
+ *
+ * @private
+ * @class MultiSelectEditor
  */
 export class MultiSelectEditor extends BaseEditor {
   /**

--- a/handsontable/src/editors/numericEditor/numericEditor.ts
+++ b/handsontable/src/editors/numericEditor/numericEditor.ts
@@ -7,6 +7,9 @@ export const EDITOR_TYPE = 'numeric';
  * @class NumericEditor
  */
 export class NumericEditor extends TextEditor {
+  /**
+   * Returns the unique editor type identifier for the numeric editor.
+   */
   static get EDITOR_TYPE() {
     return EDITOR_TYPE;
   }

--- a/handsontable/src/editors/registry.ts
+++ b/handsontable/src/editors/registry.ts
@@ -51,9 +51,18 @@ const {
  * Wraps an editor class and lazily creates a single editor instance per Handsontable instance.
  */
 export class RegisteredEditor {
+  /**
+   * The editor constructor wrapped by this registered editor entry.
+   */
   #editorClass: EditorConstructorWithType;
+  /**
+   * Map from Handsontable instance GUID to the lazily created editor instance.
+   */
   #instances: Record<string, unknown> = {};
 
+  /**
+   * Wraps the given editor class and registers an afterDestroy hook to clean up instances.
+   */
   constructor(editorClass: EditorConstructorWithType) {
     this.#editorClass = editorClass;
 

--- a/handsontable/src/editors/selectEditor/selectEditor.ts
+++ b/handsontable/src/editors/selectEditor/selectEditor.ts
@@ -19,6 +19,9 @@ export const EDITOR_TYPE = 'select';
  * @class SelectEditor
  */
 export class SelectEditor extends BaseEditor {
+  /**
+   * Returns the unique editor type identifier for the select editor.
+   */
   static get EDITOR_TYPE() {
     return EDITOR_TYPE;
   }

--- a/handsontable/src/editors/textEditor/textEditor.ts
+++ b/handsontable/src/editors/textEditor/textEditor.ts
@@ -29,6 +29,9 @@ export const EDITOR_TYPE = 'text';
  * @class TextEditor
  */
 export class TextEditor extends BaseEditor {
+  /**
+   * Returns the unique editor type identifier for the text editor.
+   */
   static get EDITOR_TYPE() {
     return EDITOR_TYPE;
   }

--- a/handsontable/src/editors/timeEditor/timeEditor.ts
+++ b/handsontable/src/editors/timeEditor/timeEditor.ts
@@ -7,6 +7,9 @@ export const EDITOR_TYPE = 'time';
  * @class TimeEditor
  */
 export class TimeEditor extends TextEditor {
+  /**
+   * Returns the unique editor type identifier for the time editor.
+   */
   static get EDITOR_TYPE() {
     return EDITOR_TYPE;
   }

--- a/handsontable/src/focusManager/grid.ts
+++ b/handsontable/src/focusManager/grid.ts
@@ -29,6 +29,10 @@ interface ActiveEditorInstance {
   [key: string]: unknown;
 }
 
+/**
+ * Manages browser focus within the grid to ensure correct behavior for keyboard navigation,
+ * screen readers, and IME text composition.
+ */
 export class FocusGridManager {
   /**
    * The Handsontable instance.
@@ -81,10 +85,16 @@ export class FocusGridManager {
    */
   #isSuspended = false;
 
+  /**
+   * Initializes the manager with a reference to the Handsontable instance.
+   */
   constructor(hotInstance: HotInstance) {
     this.#hot = hotInstance;
   }
 
+  /**
+   * Registers hooks to track selection changes and apply focus logic based on the configured focus mode.
+   */
   init() {
     const hotSettings = this.#hot.getSettings();
 

--- a/handsontable/src/helpers/number.ts
+++ b/handsontable/src/helpers/number.ts
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/require-description-complete-sentence */
 /**
  * Checks if the passed value is numeric one. For example these values (passed as string or number)
  * are considered as numeric values:
@@ -44,7 +43,6 @@ export function isNumeric(value: unknown, additionalDelimiters: string[] = []): 
 
   return false;
 }
-/* eslint-enable jsdoc/require-description-complete-sentence */
 
 /**
  * Checks if the passed value is numeric-like value. The helper returns `true` for the same

--- a/handsontable/src/helpers/templateLiteralTag.ts
+++ b/handsontable/src/helpers/templateLiteralTag.ts
@@ -19,7 +19,6 @@ export function toSingleLine(strings: TemplateStringsArray | string[], ...expres
   return result.trim();
 }
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
 /**
  * Creates DOM element from the string. For example:
  * ```
@@ -70,4 +69,3 @@ export function html(strings: TemplateStringsArray, ...values: unknown[]) {
 
   return { fragment, refs };
 }
-/* eslint-enable jsdoc/require-description-complete-sentence */

--- a/handsontable/src/plugins/autoColumnSize/autoColumnSize.ts
+++ b/handsontable/src/plugins/autoColumnSize/autoColumnSize.ts
@@ -160,19 +160,34 @@ const COLUMN_SIZE_MAP_NAME = 'autoColumnSize';
  * :::
  */
 /* eslint-enable jsdoc/require-description-complete-sentence */
+/**
+ * Plugin that automatically calculates and sets column widths based on the widest cell content in each column.
+ */
 export class AutoColumnSize extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify this plugin in Handsontable settings.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority order used to determine the order in which plugins are initialized.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }
 
+  /**
+   * Returns `true` so the plugin updates on every `updateSettings` call, regardless of config object contents.
+   */
   static get SETTING_KEYS(): string[] | boolean {
     return true;
   }
 
+  /**
+   * Returns the default settings applied when the plugin is enabled without explicit configuration.
+   */
   static get DEFAULT_SETTINGS(): { useHeaders: boolean; samplingRatio: number | null; allowSampleDuplicates: boolean } {
     return {
       useHeaders: true,
@@ -181,10 +196,16 @@ export class AutoColumnSize extends BasePlugin {
     };
   }
 
+  /**
+   * Returns the number of columns processed in a single calculation step during asynchronous sizing.
+   */
   static get CALCULATION_STEP() {
     return 50;
   }
 
+  /**
+   * Returns the maximum number of columns whose widths are calculated synchronously before switching to async mode.
+   */
   static get SYNC_CALCULATION_LIMIT() {
     return 50;
   }
@@ -286,6 +307,9 @@ export class AutoColumnSize extends BasePlugin {
    */
   #disposeMapObserver: (() => void) | null = null;
 
+  /**
+   * Initializes the plugin, registers the column widths map, and sets up the column resize hook.
+   */
   constructor(hotInstance: HotInstance) {
     super(hotInstance);
     this.hot.columnIndexMapper.registerMap(COLUMN_SIZE_MAP_NAME, this.columnWidthsMap);
@@ -507,10 +531,8 @@ export class AutoColumnSize extends BasePlugin {
   }
 
   /**
-   * Processes a single column for width calculation.
-   *
-   * @param {number} visualColumn Visual column index.
-   * @param {object} rowsRange Range of rows to process.
+   * Generates content samples for the given column within the row range and adds each sample
+   * to the ghost table so its rendered width can be measured.
    */
   #fillGhostTableWithSamples(visualColumn: number, rowsRange: { from: number, to: number }) {
     const samples = this.samplesGenerator.generateColumnSamples(visualColumn, rowsRange);
@@ -669,7 +691,8 @@ export class AutoColumnSize extends BasePlugin {
   }
 
   /**
-   * On before view render listener.
+   * Recalculates widths for currently visible columns and processes any columns queued by
+   * data or header changes before the next render.
    */
   #onBeforeRender = () => {
     this.calculateVisibleColumnsWidth();
@@ -681,10 +704,8 @@ export class AutoColumnSize extends BasePlugin {
   };
 
   /**
-   * On after load data listener.
-   *
-   * @param {Array} sourceData Source data.
-   * @param {boolean} isFirstLoad `true` if this is the first load.
+   * Triggers a full column width recalculation after new data is loaded, skipping the initial
+   * load since `#onInit` already handles it.
    */
   #onAfterLoadData = (_sourceData: unknown[], isFirstLoad: boolean) => {
     if (!isFirstLoad) {
@@ -693,9 +714,8 @@ export class AutoColumnSize extends BasePlugin {
   };
 
   /**
-   * On before change listener.
-   *
-   * @param {Array} changes An array of modified data.
+   * Queues the visual column indexes affected by the incoming changes so their widths are
+   * recalculated on the next render.
    */
   #onBeforeChange = (changes: unknown[][]) => {
     const changedColumns = changes.reduce<number[]>((acc, [, columnProperty]: unknown[]) => {
@@ -712,12 +732,8 @@ export class AutoColumnSize extends BasePlugin {
   };
 
   /**
-   * On before column resize listener.
-   *
-   * @param {number} size Calculated new column width.
-   * @param {number} column Visual index of the resized column.
-   * @param {boolean} isDblClick  Flag that determines whether there was a double-click.
-   * @returns {number}
+   * Recalculates the column width from content on a double-click and returns it as the new
+   * size; returns the user-dragged size otherwise.
    */
   #onBeforeColumnResize = (size: number, column: number, isDblClick: boolean) => {
     let newSize = size;
@@ -732,7 +748,8 @@ export class AutoColumnSize extends BasePlugin {
   };
 
   /**
-   * On after Handsontable init fill plugin with all necessary values.
+   * Initializes the column header cache and triggers the first full column width recalculation
+   * after Handsontable has finished initializing.
    */
   #onInit = () => {
     this.#cachedColumnHeaders = this.hot.getColHeader() as unknown[];
@@ -741,9 +758,8 @@ export class AutoColumnSize extends BasePlugin {
   };
 
   /**
-   * After formulas values updated listener.
-   *
-   * @param {Array} changes An array of modified data.
+   * Queues visual column indexes whose formula results changed so their widths are recalculated
+   * before the next render. Skips changes belonging to a different sheet.
    */
   #onAfterFormulasValuesUpdate = (changes: unknown[]) => {
     if (!this.#isInitialized) {

--- a/handsontable/src/plugins/autoColumnSize/autoColumnSize.ts
+++ b/handsontable/src/plugins/autoColumnSize/autoColumnSize.ts
@@ -16,7 +16,6 @@ export const PLUGIN_KEY = 'autoColumnSize';
 export const PLUGIN_PRIORITY = 10;
 const COLUMN_SIZE_MAP_NAME = 'autoColumnSize';
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
 /**
  * @plugin AutoColumnSize
  * @class AutoColumnSize
@@ -158,10 +157,6 @@ const COLUMN_SIZE_MAP_NAME = 'autoColumnSize';
  * ```
  *
  * :::
- */
-/* eslint-enable jsdoc/require-description-complete-sentence */
-/**
- * Plugin that automatically calculates and sets column widths based on the widest cell content in each column.
  */
 export class AutoColumnSize extends BasePlugin {
   /**

--- a/handsontable/src/plugins/autoRowSize/autoRowSize.ts
+++ b/handsontable/src/plugins/autoRowSize/autoRowSize.ts
@@ -15,7 +15,6 @@ const ROW_WIDTHS_MAP_NAME = 'autoRowSize';
 const FIRST_COLUMN_NOT_RENDERED_CLASS_NAME = 'htFirstDatasetColumnNotRendered';
 const AUTO_ROW_SIZE_CLASS_NAME = 'htAutoRowSize';
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
 /**
  * @plugin AutoRowSize
  * @class AutoRowSize
@@ -146,10 +145,6 @@ const AUTO_ROW_SIZE_CLASS_NAME = 'htAutoRowSize';
  * }
  * ```
  * :::
- */
-/* eslint-enable jsdoc/require-description-complete-sentence */
-/**
- * Plugin that automatically calculates and sets row heights based on the tallest cell content in each row.
  */
 export class AutoRowSize extends BasePlugin {
   /**

--- a/handsontable/src/plugins/autoRowSize/autoRowSize.ts
+++ b/handsontable/src/plugins/autoRowSize/autoRowSize.ts
@@ -148,19 +148,34 @@ const AUTO_ROW_SIZE_CLASS_NAME = 'htAutoRowSize';
  * :::
  */
 /* eslint-enable jsdoc/require-description-complete-sentence */
+/**
+ * Plugin that automatically calculates and sets row heights based on the tallest cell content in each row.
+ */
 export class AutoRowSize extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify this plugin in Handsontable settings.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority order used to determine the order in which plugins are initialized.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }
 
+  /**
+   * Returns `true` so the plugin updates on every `updateSettings` call, regardless of config object contents.
+   */
   static get SETTING_KEYS(): string[] | boolean {
     return true;
   }
 
+  /**
+   * Returns the default settings applied when the plugin is enabled without explicit configuration.
+   */
   static get DEFAULT_SETTINGS(): { useHeaders: boolean; samplingRatio: number | null; allowSampleDuplicates: boolean } {
     return {
       useHeaders: true,
@@ -169,10 +184,16 @@ export class AutoRowSize extends BasePlugin {
     };
   }
 
+  /**
+   * Returns the number of rows processed in a single calculation step during asynchronous sizing.
+   */
   static get CALCULATION_STEP() {
     return 50;
   }
 
+  /**
+   * Returns the maximum number of rows whose heights are calculated synchronously before switching to async mode.
+   */
   static get SYNC_CALCULATION_LIMIT() {
     return 500;
   }
@@ -267,6 +288,9 @@ export class AutoRowSize extends BasePlugin {
    */
   #isInitialized = false;
 
+  /**
+   * Initializes the plugin, registers the row heights map, and sets up the row resize hook.
+   */
   constructor(hotInstance: HotInstance) {
     super(hotInstance);
     this.hot.rowIndexMapper.registerMap(ROW_WIDTHS_MAP_NAME, this.rowHeightsMap);
@@ -683,14 +707,16 @@ export class AutoRowSize extends BasePlugin {
   }
 
   /**
-   * `beforeViewRender` hook listener.
+   * Toggles the `htFirstDatasetColumnNotRendered` CSS class based on whether the first
+   * physical column is currently in the renderable viewport.
    */
   #onBeforeViewRender = () => {
     this.#toggleFirstDatasetColumnRenderedClassName();
   };
 
   /**
-   * `beforeRender` hook listener.
+   * Recalculates heights for currently visible rows and processes any rows queued by data
+   * changes before the next render.
    */
   #onBeforeRender = () => {
     this.calculateVisibleRowsHeight();
@@ -702,12 +728,8 @@ export class AutoRowSize extends BasePlugin {
   };
 
   /**
-   * On before row resize listener.
-   *
-   * @param {number} size The size of the current row index.
-   * @param {number} row Current row index.
-   * @param {boolean} isDblClick Indicates if the resize was triggered by doubleclick.
-   * @returns {number}
+   * Recalculates the row height from content on a double-click and returns it as the new
+   * size; returns the user-dragged size otherwise.
    */
   #onBeforeRowResize = (size: number, row: number, isDblClick: boolean) => {
     let newSize = size;
@@ -722,10 +744,8 @@ export class AutoRowSize extends BasePlugin {
   };
 
   /**
-   * On after load data listener.
-   *
-   * @param {Array} sourceData Source data.
-   * @param {boolean} isFirstLoad `true` if this is the first load.
+   * Triggers a full row height recalculation after new data is loaded, skipping the initial
+   * load since `#onInit` already handles it.
    */
   #onAfterLoadData = (_sourceData: unknown[], isFirstLoad: boolean) => {
     if (!isFirstLoad) {
@@ -734,9 +754,8 @@ export class AutoRowSize extends BasePlugin {
   };
 
   /**
-   * On before change listener.
-   *
-   * @param {Array} changes 2D array containing information about each of the edited cells.
+   * Queues the visual row indexes affected by the incoming changes so their heights are
+   * recalculated on the next render.
    */
   #onBeforeChange = (changes: unknown[][]) => {
     const changedRows = changes.reduce<number[]>((acc, [row]: unknown[]) => {
@@ -753,7 +772,7 @@ export class AutoRowSize extends BasePlugin {
   };
 
   /**
-   * On after Handsontable init plugin with all necessary values.
+   * Triggers the first full row height recalculation after Handsontable has finished initializing.
    */
   #onInit = () => {
     this.recalculateAllRowsHeight();
@@ -761,9 +780,8 @@ export class AutoRowSize extends BasePlugin {
   };
 
   /**
-   * After formulas values updated listener.
-   *
-   * @param {Array} changes An array of modified data.
+   * Queues visual row indexes whose formula results changed so their heights are recalculated
+   * before the next render. Skips changes belonging to a different sheet.
    */
   #onAfterFormulasValuesUpdate = (changes: unknown[]) => {
     if (!this.#isInitialized) {

--- a/handsontable/src/plugins/autofill/autofill.ts
+++ b/handsontable/src/plugins/autofill/autofill.ts
@@ -34,22 +34,36 @@ const INTERVAL_FOR_ADDING_ROW = 200;
  * @class Autofill
  * @plugin Autofill
  */
-
+/**
+ * Plugin providing drag-down and copy-down fill handle functionality for extending cell values across a selection.
+ */
 export class Autofill extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify this plugin in Handsontable settings.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority order used to determine the order in which plugins are initialized.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }
 
+  /**
+   * Returns the setting keys that trigger a plugin update when changed via `updateSettings`.
+   */
   static get SETTING_KEYS() {
     return [
       SETTING_KEY,
     ];
   }
 
+  /**
+   * Returns the default settings applied when the plugin is enabled without explicit configuration.
+   */
   static get DEFAULT_SETTINGS(): { direction: string | undefined; autoInsertRow: boolean } {
     return {
       direction: undefined,
@@ -57,6 +71,9 @@ export class Autofill extends BasePlugin {
     };
   }
 
+  /**
+   * Returns validator functions for each plugin setting to verify their values are valid before applying them.
+   */
   static get SETTINGS_VALIDATORS() {
     return {
       direction: (value: unknown) =>

--- a/handsontable/src/plugins/autofill/autofill.ts
+++ b/handsontable/src/plugins/autofill/autofill.ts
@@ -20,8 +20,6 @@ const SETTING_KEY = 'fillHandle';
 const INSERT_ROW_ALTER_ACTION_NAME = 'insert_row_below';
 const INTERVAL_FOR_ADDING_ROW = 200;
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
-
 /**
  * This plugin provides "drag-down" and "copy-down" functionalities, both operated using the small square in the right
  * bottom of the cell selection.
@@ -33,9 +31,6 @@ const INTERVAL_FOR_ADDING_ROW = 200;
  *
  * @class Autofill
  * @plugin Autofill
- */
-/**
- * Plugin providing drag-down and copy-down fill handle functionality for extending cell values across a selection.
  */
 export class Autofill extends BasePlugin {
   /**

--- a/handsontable/src/plugins/base/base.ts
+++ b/handsontable/src/plugins/base/base.ts
@@ -35,13 +35,28 @@ let initializedPlugins: string[] | null = null;
  * @property {Core} hot Handsontable instance.
  */
 export class BasePlugin {
+  /**
+   * Reference to the Handsontable instance this plugin belongs to.
+   */
   declare hot: HotInstance;
+  /**
+   * Translation helper object provided by the i18n system, if available.
+   */
   declare t?: Record<string, Function>;
+  /**
+   * Reference to the plugin's own class constructor, used for static property access at runtime.
+   */
   declare ['constructor']: typeof BasePlugin;
 
   // Allow child classes to define isEnabled
+  /**
+   * Returns `true` if the plugin should be active based on current Handsontable settings. Defined by each subclass.
+   */
   isEnabled?(): boolean;
 
+  /**
+   * Returns the plugin key used to identify and look up this plugin in Handsontable settings and the plugin registry.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
@@ -146,6 +161,9 @@ export class BasePlugin {
     this.hot.addHook('beforeInit', () => this.init());
   }
 
+  /**
+   * Initializes the plugin by resolving its name, applying settings, and checking required dependencies.
+   */
   init(): void {
     this.pluginName = this.hot.getPluginName(this);
     this.updatePluginSettings(this.hot.getSettings()[this.constructor.PLUGIN_KEY]);
@@ -405,6 +423,9 @@ export class BasePlugin {
    *                              If 0 or no order index is provided, the callback will be added between the "negative" and "positive" indexes.
    */
   addHook<K extends keyof Events>(name: K, callback: Events[K], orderIndex?: number): void;
+  /**
+   * Registers a hook listener and tracks it so it can be removed automatically when the plugin is disabled.
+   */
   addHook(name: string, callback: HookCallback, orderIndex?: number): void {
     this.#hooks[name] = (this.#hooks[name] || []);
 

--- a/handsontable/src/plugins/bindRowsWithHeaders/bindRowsWithHeaders.ts
+++ b/handsontable/src/plugins/bindRowsWithHeaders/bindRowsWithHeaders.ts
@@ -58,10 +58,16 @@ const bindTypeToMapStrategy = new Map([
  * :::
  */
 export class BindRowsWithHeaders extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify this plugin in Handsontable settings.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority order used to determine the order in which plugins are initialized.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }

--- a/handsontable/src/plugins/bindRowsWithHeaders/maps/looseBindsMap.ts
+++ b/handsontable/src/plugins/bindRowsWithHeaders/maps/looseBindsMap.ts
@@ -8,6 +8,9 @@ import {
  * Map from physical index to another index.
  */
 class LooseBindsMap extends IndexMap {
+  /**
+   * Initializes the loose binds map with an identity function so each row header index initially maps to itself.
+   */
   constructor() {
     super((index: number) => index);
   }

--- a/handsontable/src/plugins/bindRowsWithHeaders/maps/strictBindsMap.ts
+++ b/handsontable/src/plugins/bindRowsWithHeaders/maps/strictBindsMap.ts
@@ -8,6 +8,9 @@ import {
  * Map from physical index to another index.
  */
 class StrictBindsMap extends IndexMap {
+  /**
+   * Initializes the strict binds map with an identity function so each row header index initially maps to itself.
+   */
   constructor() {
     super((index: number) => index);
   }

--- a/handsontable/src/plugins/collapsibleColumns/collapsibleColumns.ts
+++ b/handsontable/src/plugins/collapsibleColumns/collapsibleColumns.ts
@@ -67,8 +67,6 @@ const actionDictionary = new Map([
   }],
 ]);
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
-
 /**
  * @plugin CollapsibleColumns
  * @class CollapsibleColumns

--- a/handsontable/src/plugins/collapsibleColumns/collapsibleColumns.ts
+++ b/handsontable/src/plugins/collapsibleColumns/collapsibleColumns.ts
@@ -170,20 +170,32 @@ const actionDictionary = new Map([
  * :::
  */
 export class CollapsibleColumns extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify this plugin in Handsontable settings.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority order used to determine the order in which plugins are initialized.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }
 
+  /**
+   * Returns the list of plugin dependencies required before this plugin can be initialized.
+   */
   static get PLUGIN_DEPS() {
     return [
       'plugin:NestedHeaders',
     ];
   }
 
+  /**
+   * Returns the setting keys that trigger a plugin update when changed via `updateSettings`.
+   */
   static get SETTING_KEYS() {
     return [
       PLUGIN_KEY,

--- a/handsontable/src/plugins/columnSorting/columnSorting.ts
+++ b/handsontable/src/plugins/columnSorting/columnSorting.ts
@@ -119,10 +119,16 @@ const pluginConflictsState = new WeakMap();
  * ```
  */
 export class ColumnSorting extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify this plugin in Handsontable settings.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority order used to determine the order in which plugins are initialized.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }

--- a/handsontable/src/plugins/columnSorting/columnStatesManager.ts
+++ b/handsontable/src/plugins/columnSorting/columnStatesManager.ts
@@ -57,6 +57,9 @@ export class ColumnStatesManager {
    */
   mapName;
 
+  /**
+   * Initializes the column states manager with the Handsontable instance and registers the sorting states index map under the given map name.
+   */
   constructor(hot: HotInstance, mapName: string) {
     this.hot = hot;
     this.mapName = mapName;

--- a/handsontable/src/plugins/columnSummary/columnSummary.ts
+++ b/handsontable/src/plugins/columnSummary/columnSummary.ts
@@ -142,10 +142,16 @@ export interface SummaryEndpoint {
  * :::
  */
 export class ColumnSummary extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify this plugin in Handsontable settings.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority order used to determine the order in which plugins are initialized.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }
@@ -157,7 +163,13 @@ export class ColumnSummary extends BasePlugin {
    * @type {null|Endpoints}
    */
   endpoints: Endpoints | null = null;
+  /**
+   * Plugin settings provided by the user, or `null` if none were supplied.
+   */
   declare settings: Record<string, unknown> | null;
+  /**
+   * The endpoint configuration object currently being processed during a summary calculation.
+   */
   declare currentEndpoint: unknown;
 
   /**

--- a/handsontable/src/plugins/columnSummary/columnSummary.ts
+++ b/handsontable/src/plugins/columnSummary/columnSummary.ts
@@ -20,8 +20,6 @@ export interface SummaryEndpoint {
   [key: string]: unknown;
 }
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
-
 /**
  * @plugin ColumnSummary
  * @class ColumnSummary

--- a/handsontable/src/plugins/columnSummary/endpoints.ts
+++ b/handsontable/src/plugins/columnSummary/endpoints.ts
@@ -76,6 +76,9 @@ class Endpoints {
    */
   cellsToSetCache: [number, number | undefined, unknown][] = [];
 
+  /**
+   * Initializes the endpoints manager with a reference to the ColumnSummary plugin and the summary endpoint configuration.
+   */
   constructor(plugin: ColumnSummary, settings: EndpointConfig[] | ((...args: unknown[]) => EndpointConfig[])) {
     this.plugin = plugin;
     this.hot = this.plugin.hot;

--- a/handsontable/src/plugins/comments/commentEditor.ts
+++ b/handsontable/src/plugins/comments/commentEditor.ts
@@ -10,20 +10,38 @@ import { EditorResizeObserver } from './editorResizeObserver';
  * @class CommentEditor
  */
 class CommentEditor {
+  /**
+   * Registers a local hook listener scoped to this instance. Provided by the `localHooks` mixin.
+   */
   declare addLocalHook: (key: string, callback: Function) => void;
+  /**
+   * Executes all local hook listeners registered under the given name. Provided by the `localHooks` mixin.
+   */
   declare runLocalHooks: Function;
+  /**
+   * Returns the CSS class name applied to the outer comments container element.
+   */
   static get CLASS_EDITOR_CONTAINER() {
     return 'htCommentsContainer';
   }
 
+  /**
+   * Returns the CSS class name applied to the comment editor element.
+   */
   static get CLASS_EDITOR() {
     return 'htComments';
   }
 
+  /**
+   * Returns the CSS class name applied to the comment textarea input element.
+   */
   static get CLASS_INPUT() {
     return 'htCommentTextArea';
   }
 
+  /**
+   * Returns the CSS class name applied to cells that have comments attached.
+   */
   static get CLASS_CELL() {
     return 'htCommentCell';
   }
@@ -61,6 +79,9 @@ class CommentEditor {
    */
   #resizeObserver = new EditorResizeObserver();
 
+  /**
+   * Initializes the comment editor, builds its DOM structure, and attaches the resize observer.
+   */
   constructor(rootDocument: Document, isRtl: boolean, rootPortalElement: HTMLElement) {
     this.#rootDocument = rootDocument;
     this.#rootPortalElement = rootPortalElement;

--- a/handsontable/src/plugins/comments/comments.ts
+++ b/handsontable/src/plugins/comments/comments.ts
@@ -63,7 +63,6 @@ interface CommentRange {
 const SHORTCUTS_GROUP = PLUGIN_KEY;
 const SHORTCUTS_CONTEXT_NAME = `plugin:${PLUGIN_KEY}`;
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
 /**
  * @plugin Comments
  * @class Comments

--- a/handsontable/src/plugins/comments/comments.ts
+++ b/handsontable/src/plugins/comments/comments.ts
@@ -207,14 +207,23 @@ const SHORTCUTS_CONTEXT_NAME = `plugin:${PLUGIN_KEY}`;
  * :::
  */
 export class Comments extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify this plugin in Handsontable settings.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority order used to determine the order in which plugins are initialized.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }
 
+  /**
+   * Returns the default settings applied when the plugin is enabled without explicit configuration.
+   */
   static get DEFAULT_SETTINGS() {
     return {
       displayDelay: 250,
@@ -809,12 +818,27 @@ export class Comments extends BasePlugin {
    * @param {string} property Cell meta property.
    * @returns {Mixed}
    */
+  /**
+   * @overload
+   */
   getCommentMeta(row: number, column: number, property: typeof META_COMMENT_VALUE): string | undefined;
+  /**
+   * @overload
+   */
   getCommentMeta(row: number, column: number, property: typeof META_READONLY): boolean | undefined;
+  /**
+   * @overload
+   */
   getCommentMeta(
     row: number, column: number, property: typeof META_STYLE
   ): { width: number; height: number } | undefined;
+  /**
+   * @overload
+   */
   getCommentMeta(row: number, column: number, property: string): unknown;
+  /**
+   * Returns the value of a specific meta property from the comment attached to the given cell.
+   */
   getCommentMeta(row: number, column: number, property: string): unknown {
     const cellMeta = this.hot.getCellMeta<{ [META_COMMENT]?: CommentMeta }>(row, column);
     const comment = cellMeta[META_COMMENT];

--- a/handsontable/src/plugins/comments/displaySwitch.ts
+++ b/handsontable/src/plugins/comments/displaySwitch.ts
@@ -19,8 +19,17 @@ class DisplaySwitch {
    * @type {boolean}
    */
   wasLastActionShow = true;
+  /**
+   * Registers a local hook listener scoped to this instance. Provided by the `localHooks` mixin.
+   */
   declare addLocalHook: (key: string, callback: Function) => void;
+  /**
+   * Executes all local hook listeners registered under the given name. Provided by the `localHooks` mixin.
+   */
   declare runLocalHooks: Function;
+  /**
+   * Removes all local hook listeners. Provided by the `localHooks` mixin.
+   */
   declare clearLocalHooks: Function;
   /**
    * Show comment after predefined delay. It keeps reference to immutable `debounce` function.
@@ -35,6 +44,9 @@ class DisplaySwitch {
    */
   hidingTimer: ReturnType<typeof setTimeout> | null = null;
 
+  /**
+   * Initializes the display switch and configures the debounced show delay.
+   */
   constructor(displayDelay: number) {
     this.updateDelay(displayDelay);
   }

--- a/handsontable/src/plugins/comments/editorResizeObserver.ts
+++ b/handsontable/src/plugins/comments/editorResizeObserver.ts
@@ -8,7 +8,13 @@ import localHooks from '../../mixins/localHooks';
  * @class EditorResizeObserver
  */
 export class EditorResizeObserver {
+  /**
+   * Registers a local hook listener scoped to this instance. Provided by the `localHooks` mixin.
+   */
   declare addLocalHook: Function;
+  /**
+   * Executes all local hook listeners registered under the given name. Provided by the `localHooks` mixin.
+   */
   declare runLocalHooks: Function;
   /**
    * The flag that indicates if the initial call should be ignored. It is used to prevent the initial call

--- a/handsontable/src/plugins/contextMenu/commandExecutor.ts
+++ b/handsontable/src/plugins/contextMenu/commandExecutor.ts
@@ -33,6 +33,9 @@ export class CommandExecutor {
    */
   commonCallback: Function | null = null;
 
+  /**
+   * Initializes the command executor with a reference to the Handsontable instance.
+   */
   constructor(hotInstance: HotInstance) {
     this.hot = hotInstance;
   }

--- a/handsontable/src/plugins/contextMenu/contextMenu.ts
+++ b/handsontable/src/plugins/contextMenu/contextMenu.ts
@@ -81,14 +81,23 @@ Hooks.getSingleton().register('afterContextMenuExecute');
  * @plugin ContextMenu
  */
 export class ContextMenu extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify this plugin in Handsontable settings.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority order used to determine the order in which plugins are initialized.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }
 
+  /**
+   * Returns the list of plugin dependencies required before this plugin can be initialized.
+   */
   static get PLUGIN_DEPS() {
     return [
       'plugin:AutoColumnSize',

--- a/handsontable/src/plugins/contextMenu/contextMenu.ts
+++ b/handsontable/src/plugins/contextMenu/contextMenu.ts
@@ -56,7 +56,6 @@ Hooks.getSingleton().register('afterContextMenuShow');
 Hooks.getSingleton().register('afterContextMenuHide');
 Hooks.getSingleton().register('afterContextMenuExecute');
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
 /**
  * @class ContextMenu
  * @description

--- a/handsontable/src/plugins/contextMenu/itemsFactory.ts
+++ b/handsontable/src/plugins/contextMenu/itemsFactory.ts
@@ -27,6 +27,9 @@ export class ItemsFactory {
    */
   declare defaultOrderPattern: string[];
 
+  /**
+   * Initializes the items factory with a Handsontable instance and an optional default ordering pattern for menu items.
+   */
   constructor(hotInstance: HotInstance, orderPattern: string[] | null = null) {
     this.hot = hotInstance;
     this.defaultOrderPattern = orderPattern || [];

--- a/handsontable/src/plugins/contextMenu/menu/cursor.ts
+++ b/handsontable/src/plugins/contextMenu/menu/cursor.ts
@@ -52,9 +52,18 @@ export class Cursor {
    * @type {number}
    */
   cellWidth;
+  /**
+   * Reference to the root window used for reading scroll offsets and dimensions.
+   */
   declare rootWindow: Window;
+  /**
+   * Indicates the source type of the cursor position: either `'literal'` or `'event'`.
+   */
   declare type: string;
 
+  /**
+   * Initializes the cursor position by computing coordinates from either a literal object or a DOM event.
+   */
   constructor(object: CursorSourceLiteral | Event, rootWindow: Window) {
     const windowScrollTop = rootWindow.scrollY;
     const windowScrollLeft = rootWindow.scrollX;

--- a/handsontable/src/plugins/contextMenu/menu/menu.ts
+++ b/handsontable/src/plugins/contextMenu/menu/menu.ts
@@ -132,8 +132,17 @@ export class Menu {
    * @type {boolean}
    */
   origOutsideClickDeselects: GridSettings['outsideClickDeselects'] = undefined;
+  /**
+   * Registers a local hook listener scoped to this instance. Provided by the `localHooks` mixin.
+   */
   declare addLocalHook: (key: string, callback: Function) => object;
+  /**
+   * Executes all local hook listeners registered under the given name. Provided by the `localHooks` mixin.
+   */
   declare runLocalHooks: (key: string, ...args: unknown[]) => void;
+  /**
+   * Removes all local hook listeners and returns this instance. Provided by the `localHooks` mixin.
+   */
   declare clearLocalHooks: () => object;
   /**
    * The controller module that allows modifying the menu item selection positions.

--- a/handsontable/src/plugins/contextMenu/menu/positioner.ts
+++ b/handsontable/src/plugins/contextMenu/menu/positioner.ts
@@ -46,6 +46,9 @@ export class Positioner {
     right: 0,
   };
 
+  /**
+   * Initializes the positioner with a flag indicating whether the menu should be kept within the viewport boundaries.
+   */
   constructor(keepInViewport: boolean) {
     this.#keepInViewport = keepInViewport;
   }

--- a/handsontable/src/plugins/copyPaste/clipboardData.ts
+++ b/handsontable/src/plugins/copyPaste/clipboardData.ts
@@ -2,13 +2,25 @@
  * @private
  */
 export default class ClipboardData {
+  /**
+   * Key-value store mapping MIME type strings to their clipboard content.
+   */
   declare data: Record<string, string>;
+  /**
+   * Initializes the clipboard data store as an empty object.
+   */
   constructor() {
     this.data = {};
   }
+  /**
+   * Stores a value in the clipboard data under the given MIME type key.
+   */
   setData(type: string, value: string) {
     this.data[type] = value;
   }
+  /**
+   * Returns the clipboard data stored under the given MIME type key, or `undefined` if absent.
+   */
   getData(type: string) {
     return this.data[type] || void 0;
   }

--- a/handsontable/src/plugins/copyPaste/copyPaste.ts
+++ b/handsontable/src/plugins/copyPaste/copyPaste.ts
@@ -51,7 +51,6 @@ const META_HEAD = [
 
 const sanitizeDeprecatedMessageShown = new WeakSet();
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
 /**
  * @description
  * Copy, cut, and paste data by using the `CopyPaste` plugin.

--- a/handsontable/src/plugins/copyPaste/copyPaste.ts
+++ b/handsontable/src/plugins/copyPaste/copyPaste.ts
@@ -24,7 +24,9 @@ import {
 } from './copyableRanges';
 import { _dataToHTML, htmlToGridSettings } from '../../utils/parseTable';
 
-/** Internet Explorer-specific window extension with legacy clipboard API. */
+/**
+ * Internet Explorer-specific window extension with legacy clipboard API.
+ */
 interface IEWindow extends Window {
   clipboardData: DataTransfer;
 }
@@ -85,10 +87,16 @@ const sanitizeDeprecatedMessageShown = new WeakSet();
  * @plugin CopyPaste
  */
 export class CopyPaste extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify this plugin in Handsontable settings.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the setting keys that trigger a plugin update when changed via `updateSettings`.
+   */
   static get SETTING_KEYS() {
     return [
       PLUGIN_KEY,
@@ -96,10 +104,16 @@ export class CopyPaste extends BasePlugin {
     ];
   }
 
+  /**
+   * Returns the priority order used to determine the order in which plugins are initialized.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }
 
+  /**
+   * Returns the default settings applied when the plugin is enabled without explicit configuration.
+   */
   static get DEFAULT_SETTINGS() {
     return {
       pasteMode: 'overwrite',

--- a/handsontable/src/plugins/copyPaste/copyableRanges.ts
+++ b/handsontable/src/plugins/copyPaste/copyableRanges.ts
@@ -35,7 +35,6 @@ export class CopyableRangesFactory {
    */
   #countColumnHeaders;
 
-  /* eslint-disable jsdoc/require-description-complete-sentence */
   /**
    * @param {{
    *   countRows: function(): number,
@@ -55,7 +54,6 @@ export class CopyableRangesFactory {
     this.#columnsLimit = columnsLimit;
     this.#countColumnHeaders = countColumnHeaders;
   }
-  /* eslint-enable jsdoc/require-description-complete-sentence */
 
   /**
    * Sets the selection range to be processed.

--- a/handsontable/src/plugins/copyPaste/pasteEvent.ts
+++ b/handsontable/src/plugins/copyPaste/pasteEvent.ts
@@ -4,12 +4,24 @@ import ClipboardData from './clipboardData';
  * @private
  */
 export default class PasteEvent {
+  /**
+   * The simulated clipboard data object attached to this paste event.
+   */
   declare clipboardData: ClipboardData;
+  /**
+   * Initializes the paste event with an empty `ClipboardData` instance.
+   */
   constructor() {
     this.clipboardData = new ClipboardData();
   }
+  /**
+   * No-op implementation of `preventDefault` to satisfy the event interface contract.
+   */
   preventDefault() { // intentionally empty
   }
+  /**
+   * Returns an empty array as a stub for the composed path of this synthetic event.
+   */
   composedPath(): unknown[] {
     return [];
   }

--- a/handsontable/src/plugins/customBorders/customBorders.ts
+++ b/handsontable/src/plugins/customBorders/customBorders.ts
@@ -87,8 +87,6 @@ function isBorderSide(value: string): value is BorderSide {
 
 const SUPPORTED_STYLES = ['dashed', 'dotted', 'solid'];
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
-
 /**
  * @plugin CustomBorders
  * @class CustomBorders

--- a/handsontable/src/plugins/customBorders/customBorders.ts
+++ b/handsontable/src/plugins/customBorders/customBorders.ts
@@ -142,10 +142,16 @@ const SUPPORTED_STYLES = ['dashed', 'dotted', 'solid'];
  * ```
  */
 export class CustomBorders extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify this plugin in Handsontable settings.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority order used to determine the order in which plugins are initialized.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }

--- a/handsontable/src/plugins/dataProvider/dataProvider.ts
+++ b/handsontable/src/plugins/dataProvider/dataProvider.ts
@@ -140,7 +140,9 @@ export interface DataProviderFetchOptions {
   signal: AbortSignal;
 }
 
-/** @deprecated Use DataProviderFetchOptions */
+/**
+ * @deprecated Use DataProviderFetchOptions
+ */
 export type DataProviderOptions = DataProviderFetchOptions;
 
 export interface RowsCreatePayload {
@@ -198,22 +200,37 @@ export {
  * Use [[Options#columnSorting]] for server-driven sort (single column). Query `sort` uses `prop` (column data key).
  */
 export class DataProvider extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify this plugin in Handsontable settings.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority order used to determine the order in which plugins are initialized.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }
 
+  /**
+   * Returns the setting keys that trigger a plugin update when changed via `updateSettings`.
+   */
   static get SETTING_KEYS() {
     return [PLUGIN_KEY];
   }
 
+  /**
+   * Returns the default settings applied when the plugin is enabled without explicit configuration.
+   */
   static get DEFAULT_SETTINGS() {
     return DEFAULT_SETTINGS;
   }
 
+  /**
+   * Returns validator functions for each plugin setting to verify their values are valid before applying them.
+   */
   static get SETTINGS_VALIDATORS() {
     return SETTINGS_VALIDATORS;
   }

--- a/handsontable/src/plugins/dialog/dialog.ts
+++ b/handsontable/src/plugins/dialog/dialog.ts
@@ -11,7 +11,6 @@ export const PLUGIN_PRIORITY = 360;
 const SHORTCUTS_GROUP = PLUGIN_KEY;
 const SHORTCUTS_CONTEXT_NAME = `plugin:${PLUGIN_KEY}`;
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
 /**
  * @plugin Dialog
  * @class Dialog
@@ -160,9 +159,6 @@ const SHORTCUTS_CONTEXT_NAME = `plugin:${PLUGIN_KEY}`;
  * </hot-table>
  * ```
  * :::
- */
-/**
- * Plugin that provides a modal dialog system for displaying custom content and user interactions within Handsontable.
  */
 export class Dialog extends BasePlugin {
   /**

--- a/handsontable/src/plugins/dialog/dialog.ts
+++ b/handsontable/src/plugins/dialog/dialog.ts
@@ -161,16 +161,27 @@ const SHORTCUTS_CONTEXT_NAME = `plugin:${PLUGIN_KEY}`;
  * ```
  * :::
  */
-
+/**
+ * Plugin that provides a modal dialog system for displaying custom content and user interactions within Handsontable.
+ */
 export class Dialog extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify this plugin in Handsontable settings.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority order used to determine the order in which plugins are initialized.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }
 
+  /**
+   * Returns the default settings applied when the plugin is enabled without explicit configuration.
+   */
   static get DEFAULT_SETTINGS() {
     return {
       template: null as object | null,
@@ -189,6 +200,9 @@ export class Dialog extends BasePlugin {
     };
   }
 
+  /**
+   * Returns validator functions for each plugin setting to verify their values are valid before applying them.
+   */
   static get SETTINGS_VALIDATORS() {
     return {
       template: (value: unknown) => isPlainObject(value) &&

--- a/handsontable/src/plugins/dialog/ui.ts
+++ b/handsontable/src/plugins/dialog/ui.ts
@@ -98,6 +98,9 @@ export class DialogUI {
    */
   #sanitizer?: (html: string) => string | undefined;
 
+  /**
+   * Initializes the dialog UI with a root element, RTL layout flag, and an optional HTML sanitizer, then installs the DOM structure.
+   */
   constructor({ rootElement, isRtl, sanitizer }: {
     rootElement: HTMLElement; isRtl: boolean; sanitizer?: (html: string) => string | undefined;
   }) {

--- a/handsontable/src/plugins/dragToScroll/dragToScroll.ts
+++ b/handsontable/src/plugins/dragToScroll/dragToScroll.ts
@@ -19,8 +19,6 @@ interface Boundaries {
   bottom: number;
 }
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
-
 /**
  * @description
  * Plugin used to scroll Handsontable by selecting a cell and dragging outside of the visible viewport.

--- a/handsontable/src/plugins/dragToScroll/dragToScroll.ts
+++ b/handsontable/src/plugins/dragToScroll/dragToScroll.ts
@@ -30,14 +30,23 @@ interface Boundaries {
  * @plugin DragToScroll
  */
 export class DragToScroll extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify this plugin in Handsontable settings.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority order used to determine the order in which plugins are initialized.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }
 
+  /**
+   * Returns the default settings applied when the plugin is enabled without explicit configuration.
+   */
   static get DEFAULT_SETTINGS() {
     return {
       interval: {

--- a/handsontable/src/plugins/dropdownMenu/dropdownMenu.ts
+++ b/handsontable/src/plugins/dropdownMenu/dropdownMenu.ts
@@ -40,7 +40,6 @@ interface DropdownMenuSettings {
   [key: string]: unknown;
 }
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
 /**
  * @plugin DropdownMenu
  * @class DropdownMenu
@@ -103,9 +102,6 @@ interface DropdownMenuSettings {
  * <hot-table [settings]="settings"></hot-table>
  * ```
  * :::
- */
-/**
- * Plugin that adds a dropdown menu to column headers, providing column-specific operations such as sorting and filtering.
  */
 export class DropdownMenu extends BasePlugin {
   /**

--- a/handsontable/src/plugins/dropdownMenu/dropdownMenu.ts
+++ b/handsontable/src/plugins/dropdownMenu/dropdownMenu.ts
@@ -104,16 +104,27 @@ interface DropdownMenuSettings {
  * ```
  * :::
  */
-
+/**
+ * Plugin that adds a dropdown menu to column headers, providing column-specific operations such as sorting and filtering.
+ */
 export class DropdownMenu extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify this plugin in Handsontable settings.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority order used to determine the order in which plugins are initialized.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }
 
+  /**
+   * Returns the list of plugin dependencies required before this plugin can be initialized.
+   */
   static get PLUGIN_DEPS() {
     return [
       'plugin:AutoColumnSize',
@@ -168,6 +179,9 @@ export class DropdownMenu extends BasePlugin {
    */
   #isButtonClicked = false;
 
+  /**
+   * Initializes the plugin and registers the column header hook needed to inject the dropdown button.
+   */
   constructor(hotInstance: HotInstance) {
     super(hotInstance);
 

--- a/handsontable/src/plugins/emptyDataState/emptyDataState.ts
+++ b/handsontable/src/plugins/emptyDataState/emptyDataState.ts
@@ -15,7 +15,9 @@ function isPlainRecord(v: unknown): v is Record<string, unknown> {
   return isObject(v);
 }
 
-/** The possible shapes of the `message` setting value. */
+/**
+ * The possible shapes of the `message` setting value.
+ */
 type MessageSetting =
   | string
   | Record<string, unknown>
@@ -208,22 +210,36 @@ const SHORTCUTS_CONTEXT_NAME = `plugin:${PLUGIN_KEY}`;
  * ```
  * :::
  */
-
+/**
+ * Plugin that renders a customizable overlay when the data source is empty, replacing the standard empty grid display.
+ */
 export class EmptyDataState extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify this plugin in Handsontable settings.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority order used to determine the order in which plugins are initialized.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }
 
+  /**
+   * Returns the default settings applied when the plugin is enabled without explicit configuration.
+   */
   static get DEFAULT_SETTINGS() {
     return {
       message: undefined as string | Record<string, unknown> | undefined,
     };
   }
 
+  /**
+   * Returns validator functions for each plugin setting to verify their values are valid before applying them.
+   */
   static get SETTINGS_VALIDATORS() {
     return {
       message: (value: unknown) => {

--- a/handsontable/src/plugins/emptyDataState/emptyDataState.ts
+++ b/handsontable/src/plugins/emptyDataState/emptyDataState.ts
@@ -210,9 +210,6 @@ const SHORTCUTS_CONTEXT_NAME = `plugin:${PLUGIN_KEY}`;
  * ```
  * :::
  */
-/**
- * Plugin that renders a customizable overlay when the data source is empty, replacing the standard empty grid display.
- */
 export class EmptyDataState extends BasePlugin {
   /**
    * Returns the plugin key used to identify this plugin in Handsontable settings.

--- a/handsontable/src/plugins/emptyDataState/ui.ts
+++ b/handsontable/src/plugins/emptyDataState/ui.ts
@@ -151,6 +151,9 @@ export class EmptyDataStateUI {
    */
   #placeholderElement: HTMLElement | null = null;
 
+  /**
+   * Initializes the empty data state UI with the root element and document, then builds and inserts the DOM structure.
+   */
   constructor({
     rootElement,
     rootDocument,

--- a/handsontable/src/plugins/exportFile/dataProvider.ts
+++ b/handsontable/src/plugins/exportFile/dataProvider.ts
@@ -25,6 +25,9 @@ class DataProvider {
    */
   options: Record<string, unknown> = {};
 
+  /**
+   * Initializes the data provider with a reference to the Handsontable instance used to retrieve data for export.
+   */
   constructor(hotInstance: HotInstance) {
     this.hot = hotInstance;
   }

--- a/handsontable/src/plugins/exportFile/exportFile.ts
+++ b/handsontable/src/plugins/exportFile/exportFile.ts
@@ -16,67 +16,117 @@ export const PLUGIN_KEY = 'exportFile';
  * Options for a single worksheet in a multi-sheet export (XLSX only).
  */
 export interface SheetOptions {
-  /** The Handsontable instance to export data from. */
+  /**
+   * The Handsontable instance to export data from.
+   */
   instance: HotInstance;
-  /** Worksheet name. Defaults to `'Sheet'` when omitted. */
+  /**
+   * Worksheet name. Defaults to `'Sheet'` when omitted.
+   */
   name?: string;
-  /** Include column headers. */
+  /**
+   * Include column headers.
+   */
   colHeaders?: boolean;
   /**
    * @deprecated Use `colHeaders` instead.
    */
   columnHeaders?: boolean;
-  /** Include row headers. */
+  /**
+   * Include row headers.
+   */
   rowHeaders?: boolean;
-  /** Controls how hidden columns are exported. */
+  /**
+   * Controls how hidden columns are exported.
+   */
   exportHiddenColumns?: boolean | 'hide';
-  /** Controls how hidden rows are exported. */
+  /**
+   * Controls how hidden rows are exported.
+   */
   exportHiddenRows?: boolean | 'hide';
-  /** Export cell formulas instead of computed values (XLSX only). */
+  /**
+   * Export cell formulas instead of computed values (XLSX only).
+   */
   exportFormulas?: boolean;
-  /** Cell range to export: `[startRow, startColumn, endRow, endColumn]`. */
+  /**
+   * Cell range to export: `[startRow, startColumn, endRow, endColumn]`.
+   */
   range?: number[];
 }
 
-/** Border style descriptor used in {@link HeaderStyle}. */
+/**
+ * Border style descriptor used in {@link HeaderStyle}.
+ */
 export interface HeaderStyleBorder {
-  /** Border line style (e.g. `'thin'`, `'medium'`, `'thick'`). */
+  /**
+   * Border line style (e.g. `'thin'`, `'medium'`, `'thick'`).
+   */
   style?: string;
-  /** Border color in hex (e.g. `'#000000'`). */
+  /**
+   * Border color in hex (e.g. `'#000000'`).
+   */
   argb?: string;
 }
 
-/** Style applied to header cells in XLSX exports. */
+/**
+ * Style applied to header cells in XLSX exports.
+ */
 export interface HeaderStyle {
-  /** Background fill color in hex (e.g. `'#f2f2f2'`). */
+  /**
+   * Background fill color in hex (e.g. `'#f2f2f2'`).
+   */
   backgroundColor?: string;
-  /** Font color in hex. */
+  /**
+   * Font color in hex.
+   */
   fontColor?: string;
-  /** Border descriptor applied to all sides. */
+  /**
+   * Border descriptor applied to all sides.
+   */
   border?: HeaderStyleBorder;
 }
 
-/** A single conditional formatting rule within a {@link ConditionalFormattingDescriptor}. */
+/**
+ * A single conditional formatting rule within a {@link ConditionalFormattingDescriptor}.
+ */
 export interface ConditionalFormattingRule {
-  /** Rule type (e.g. `'cellIs'`, `'colorScale'`, `'dataBar'`, `'iconSet'`). */
+  /**
+   * Rule type (e.g. `'cellIs'`, `'colorScale'`, `'dataBar'`, `'iconSet'`).
+   */
   type: string;
-  /** Comparison operator for `cellIs` rules (e.g. `'greaterThan'`, `'between'`). */
+  /**
+   * Comparison operator for `cellIs` rules (e.g. `'greaterThan'`, `'between'`).
+   */
   operator?: string;
-  /** Formula values used by the rule. */
+  /**
+   * Formula values used by the rule.
+   */
   formulae?: Array<string | number>;
-  /** ExcelJS format descriptor (color, icon set, etc.) applied when the rule matches. */
+  /**
+   * ExcelJS format descriptor (color, icon set, etc.) applied when the rule matches.
+   */
   format?: Record<string, unknown>;
-  /** Priority of the rule (lower number = higher priority). */
+  /**
+   * Priority of the rule (lower number = higher priority).
+   */
   priority?: number;
 }
 
-/** Descriptor for a conditional formatting region in an XLSX export. */
+/**
+ * Descriptor for a conditional formatting region in an XLSX export.
+ */
 export interface ConditionalFormattingDescriptor {
-  /** Row range `[startRow, endRow]` (visual indexes). Defaults to the full exported range. */
+  /**
+   * Row range `[startRow, endRow]` (visual indexes). Defaults to the full exported range.
+   */
   rows?: [number, number];
-  /** Column range `[startCol, endCol]` (visual indexes). Defaults to the full exported range. */
+  /**
+   * Column range `[startCol, endCol]` (visual indexes). Defaults to the full exported range.
+   */
   cols?: [number, number];
-  /** Conditional formatting rules to apply to the region. */
+  /**
+   * Conditional formatting rules to apply to the region.
+   */
   rules: ConditionalFormattingRule[];
 }
 
@@ -86,57 +136,101 @@ export interface ConditionalFormattingDescriptor {
  * {@link ExportFile#downloadFile}, and {@link ExportFile#downloadFileAsync}.
  */
 export interface ExportOptions {
-  /** MIME type (e.g. `'text/csv'`). Default depends on format. */
+  /**
+   * MIME type (e.g. `'text/csv'`). Default depends on format.
+   */
   mimeType?: string;
-  /** File extension (e.g. `'csv'`). Default depends on format. */
+  /**
+   * File extension (e.g. `'csv'`). Default depends on format.
+   */
   fileExtension?: string;
-  /** File name. Placeholders `[YYYY]`, `[MM]`, `[DD]` are replaced with the current date. */
+  /**
+   * File name. Placeholders `[YYYY]`, `[MM]`, `[DD]` are replaced with the current date.
+   */
   filename?: string;
-  /** Character encoding. Defaults to `'utf-8'`. */
+  /**
+   * Character encoding. Defaults to `'utf-8'`.
+   */
   encoding?: string;
-  /** Include BOM signature. Default depends on format. */
+  /**
+   * Include BOM signature. Default depends on format.
+   */
   bom?: boolean;
-  /** Column delimiter (CSV only). Defaults to `','`. */
+  /**
+   * Column delimiter (CSV only). Defaults to `','`.
+   */
   columnDelimiter?: string;
-  /** Row delimiter (CSV only). Defaults to `'\r\n'`. */
+  /**
+   * Row delimiter (CSV only). Defaults to `'\r\n'`.
+   */
   rowDelimiter?: string;
-  /** Include column headers. */
+  /**
+   * Include column headers.
+   */
   colHeaders?: boolean;
   /**
    * @deprecated Use `colHeaders` instead.
    */
   columnHeaders?: boolean;
-  /** Include row headers. */
+  /**
+   * Include row headers.
+   */
   rowHeaders?: boolean;
-  /** Controls how hidden columns are exported. */
+  /**
+   * Controls how hidden columns are exported.
+   */
   exportHiddenColumns?: boolean | 'hide';
-  /** Controls how hidden rows are exported. */
+  /**
+   * Controls how hidden rows are exported.
+   */
   exportHiddenRows?: boolean | 'hide';
-  /** Export cell formulas instead of computed values (XLSX only). */
+  /**
+   * Export cell formulas instead of computed values (XLSX only).
+   */
   exportFormulas?: boolean;
-  /** Cell range: `[startRow, startColumn, endRow, endColumn]`. */
+  /**
+   * Cell range: `[startRow, startColumn, endRow, endColumn]`.
+   */
   range?: number[];
-  /** Sanitize cell values before export (CSV only). */
+  /**
+   * Sanitize cell values before export (CSV only).
+   */
   sanitizeValues?: boolean | RegExp | ((val: string) => string);
-  /** Apply DEFLATE compression. `true` uses level 6; a number 1–9 sets a specific level (XLSX only). */
+  /**
+   * Apply DEFLATE compression. `true` uses level 6; a number 1–9 sets a specific level (XLSX only).
+   */
   compression?: boolean | number;
-  /** Conditional formatting rules to apply (XLSX only). */
+  /**
+   * Conditional formatting rules to apply (XLSX only).
+   */
   conditionalFormatting?: ConditionalFormattingDescriptor[];
-  /** Multi-sheet configuration. Each entry defines one worksheet (XLSX only). */
+  /**
+   * Multi-sheet configuration. Each entry defines one worksheet (XLSX only).
+   */
   sheets?: SheetOptions[];
-  /** Style for header cells (XLSX only). Pass `null` to disable. */
+  /**
+   * Style for header cells (XLSX only). Pass `null` to disable.
+   */
   headerStyle?: HeaderStyle | null;
-  /** ExcelJS engine instance. Overrides the engine from plugin settings for this call. */
+  /**
+   * ExcelJS engine instance. Overrides the engine from plugin settings for this call.
+   */
   engine?: object;
 }
 
-/** Plugin-level settings for the `exportFile` option in {@link GridSettings}. */
+/**
+ * Plugin-level settings for the `exportFile` option in {@link GridSettings}.
+ */
 export interface ExportFileSettings {
-  /** Map of export engines keyed by format name (e.g. `{ xlsx: ExcelJS }`). */
+  /**
+   * Map of export engines keyed by format name (e.g. `{ xlsx: ExcelJS }`).
+   */
   engines?: Record<string, object>;
 }
 
-/** @deprecated Use {@link ExportFileSettings} instead. */
+/**
+ * @deprecated Use {@link ExportFileSettings} instead.
+ */
 export type Settings = ExportFileSettings;
 export const PLUGIN_PRIORITY = 240;
 
@@ -280,14 +374,23 @@ function getPluginSettings(settings: unknown): ExportFileSettings | undefined {
  * :::
  */
 export class ExportFile extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify this plugin in Handsontable settings.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority order used to determine the order in which plugins are initialized.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }
 
+  /**
+   * Returns the setting keys that trigger a plugin update when changed via `updateSettings`.
+   */
   static get SETTING_KEYS() {
     return [PLUGIN_KEY];
   }

--- a/handsontable/src/plugins/exportFile/types/_base.ts
+++ b/handsontable/src/plugins/exportFile/types/_base.ts
@@ -74,6 +74,9 @@ class BaseType {
    */
   declare options: Record<string, unknown>;
 
+  /**
+   * Initializes the export type with the data provider and merges the given options with the class defaults.
+   */
   constructor(dataProvider: DataProvider, options: Record<string, unknown>) {
     this.dataProvider = dataProvider;
     this.options = this._mergeOptions(options);

--- a/handsontable/src/plugins/exportFile/types/xlsx.ts
+++ b/handsontable/src/plugins/exportFile/types/xlsx.ts
@@ -93,7 +93,9 @@ interface ExcelJsWorkbook {
   };
 }
 
-/** Descriptor for a merge cell, in data-array coordinate space. */
+/**
+ * Descriptor for a merge cell, in data-array coordinate space.
+ */
 interface MergeDescriptor {
   row: number;
   col: number;
@@ -101,7 +103,9 @@ interface MergeDescriptor {
   colspan: number;
 }
 
-/** Descriptor for a ColumnSummary destination, in data-array coordinate space. */
+/**
+ * Descriptor for a ColumnSummary destination, in data-array coordinate space.
+ */
 interface ColumnSummaryDescriptor {
   type: string;
   destRow: number;
@@ -110,14 +114,18 @@ interface ColumnSummaryDescriptor {
   sourceRanges: [number, number][];
 }
 
-/** One entry in the `conditionalFormatting` option array. */
+/**
+ * One entry in the `conditionalFormatting` option array.
+ */
 interface ConditionalFormattingDescriptor {
   rows?: [number, number];
   cols?: [number, number];
   rules: unknown[];
 }
 
-/** An entry in a nested-header layer returned by DataProvider#getNestedColumnHeaders. */
+/**
+ * An entry in a nested-header layer returned by DataProvider#getNestedColumnHeaders.
+ */
 interface NestedHeaderEntry {
   label: string | null;
   colspan: number;
@@ -174,7 +182,9 @@ const PIXELS_TO_POINTS_RATIO = 0.75;
 // when row headers are exported. Chosen to comfortably fit typical row-index numbers.
 const ROW_HEADER_DEFAULT_WIDTH = 5;
 
-/** Typed view of the options object used internally within the Xlsx exporter. */
+/**
+ * Typed view of the options object used internally within the Xlsx exporter.
+ */
 interface XlsxOptions extends Record<string, unknown> {
   exportFormulas?: boolean;
   headerStyle?: { backgroundColor?: string; border?: { style?: string; color?: string } | null } | null;
@@ -194,6 +204,9 @@ class Xlsx extends BaseType {
     return true;
   }
 
+  /**
+   * Returns true to indicate that XLSX data should be treated as binary output.
+   */
   get binary() {
     return true;
   }

--- a/handsontable/src/plugins/filters/component/_base.ts
+++ b/handsontable/src/plugins/filters/component/_base.ts
@@ -47,6 +47,9 @@ export class BaseComponent {
    */
   state;
 
+  /**
+   * Initializes the filter component with a Handsontable instance, assigns the component ID, and optionally registers a column index map for stateful components.
+   */
   constructor(hotInstance: HotInstance, { id, stateless = true }: { id: string; stateless?: boolean }) {
     this.hot = hotInstance;
     this.id = id;

--- a/handsontable/src/plugins/filters/component/actionBar.ts
+++ b/handsontable/src/plugins/filters/component/actionBar.ts
@@ -17,13 +17,22 @@ export class ActionBarComponent extends BaseComponent {
    */
   name = '';
 
+  /**
+   * Returns the identifier string for the OK action button.
+   */
   static get BUTTON_OK() {
     return 'ok';
   }
+  /**
+   * Returns the identifier string for the Cancel action button.
+   */
   static get BUTTON_CANCEL() {
     return 'cancel';
   }
 
+  /**
+   * Initializes the action bar component with OK and Cancel buttons.
+   */
   constructor(hotInstance: HotInstance, options: { id: string; name: string }) {
     super(hotInstance, {
       id: options.id,

--- a/handsontable/src/plugins/filters/component/condition.ts
+++ b/handsontable/src/plugins/filters/component/condition.ts
@@ -40,6 +40,9 @@ export class ConditionComponent extends BaseComponent {
    */
   addSeparator = false;
 
+  /**
+   * Initializes the condition component with the given ID, display name, separator flag, and optional menu container.
+   */
   constructor(hotInstance: HotInstance, options: {
     id: string; name: string | (() => string); addSeparator: boolean; menuContainer?: HTMLElement
   }) {

--- a/handsontable/src/plugins/filters/component/operators.ts
+++ b/handsontable/src/plugins/filters/component/operators.ts
@@ -25,6 +25,9 @@ export class OperatorsComponent extends BaseComponent {
    */
   name = '';
 
+  /**
+   * Initializes the operators component with the given ID and display name, and builds the operators UI element.
+   */
   constructor(hotInstance: HotInstance, options: { id: string; name: string }) {
     super(hotInstance, {
       id: options.id,

--- a/handsontable/src/plugins/filters/component/value.ts
+++ b/handsontable/src/plugins/filters/component/value.ts
@@ -68,6 +68,9 @@ export class ValueComponent extends BaseComponent {
    */
   hiddenWhen: (() => boolean) | undefined;
 
+  /**
+   * Initializes the value component with the given ID, display name, search mode, and optional visibility predicate.
+   */
   constructor(hotInstance: HotInstance, options: {
     id: string; name: string | (() => string); searchMode: unknown; hiddenWhen?: (() => boolean);
   }) {

--- a/handsontable/src/plugins/filters/conditionCollection.ts
+++ b/handsontable/src/plugins/filters/conditionCollection.ts
@@ -1,11 +1,15 @@
 import type { HotInstance } from '../../core/types';
 import type { OperationType, ConditionId, ColumnConditions } from './filters';
 
-/** Internal representation of a condition — extends the public ConditionId with the resolved function. */
+/**
+ * Internal representation of a condition — extends the public ConditionId with the resolved function.
+ */
 interface StoredCondition extends ConditionId {
   func: Function;
 }
-/** Internal column state as stored in filteringStates. */
+/**
+ * Internal column state as stored in filteringStates.
+ */
 interface StoredColumnState {
   operation: OperationType;
   conditions: StoredCondition[];
@@ -48,6 +52,9 @@ class ConditionCollection {
    */
   filteringStates = new IndexToValueMap();
 
+  /**
+   * Initializes the condition collection with the Handsontable instance, optionally registering the filtering states index map on the column index mapper.
+   */
   constructor(hot: HotInstance, isMapRegistrable = true) {
     this.hot = hot;
     this.isMapRegistrable = isMapRegistrable;

--- a/handsontable/src/plugins/filters/conditionUpdateObserver.ts
+++ b/handsontable/src/plugins/filters/conditionUpdateObserver.ts
@@ -62,6 +62,9 @@ class ConditionUpdateObserver {
    */
   latestOrderStack: number[] = [];
 
+  /**
+   * Initializes the observer with the Handsontable instance, a condition collection to watch, and an optional factory for column source data.
+   */
   constructor(
     hot: HotInstance,
     conditionCollection: ConditionCollection,

--- a/handsontable/src/plugins/filters/dataFilter.ts
+++ b/handsontable/src/plugins/filters/dataFilter.ts
@@ -18,6 +18,9 @@ class DataFilter {
    */
   columnDataFactory;
 
+  /**
+   * Initializes the data filter with a condition collection that provides filtering logic and a factory function that supplies column source data.
+   */
   constructor(
     conditionCollection: { getFilteredColumns: () => unknown[]; isMatch: (value: unknown, column: number) => boolean },
     columnDataFactory: (column: number) => unknown[] = () => []

--- a/handsontable/src/plugins/filters/filters.ts
+++ b/handsontable/src/plugins/filters/filters.ts
@@ -556,7 +556,6 @@ export class Filters extends BasePlugin {
       ?.removeShortcutsByGroup(SHORTCUTS_GROUP);
   }
 
-  /* eslint-disable jsdoc/require-description-complete-sentence */
   /**
    * @memberof Filters#
    * @function addCondition
@@ -946,10 +945,6 @@ export class Filters extends BasePlugin {
    * @param {Array} args Condition arguments. The expected format depends on the condition - see the table above for details.
    * @param {string} [operationId=conjunction] `id` of operation which is performed on the column.
    */
-  /* eslint-enable jsdoc/require-description-complete-sentence */
-  /**
-   * Adds a filter condition to the specified column, optionally combining it with other conditions using the given logical operation.
-   */
   addCondition(column: number, name: string, args: unknown[], operationId: string = OPERATION_AND): void {
     if (name === CONDITION_BY_VALUE && this.#isDataProviderActive) {
       return;
@@ -1001,7 +996,6 @@ export class Filters extends BasePlugin {
     this.conditionCollection?.importAllConditions(conditions);
   }
 
-  /* eslint-disable jsdoc/require-description-complete-sentence */
   /**
    * Exports filter conditions for all columns from the plugin.
    * The array represents the filter state for each column. For example:
@@ -1031,7 +1025,6 @@ export class Filters extends BasePlugin {
   exportConditions(): ColumnConditions[] {
     return this.conditionCollection?.exportAllConditions() ?? [];
   }
-  /* eslint-enable jsdoc/require-description-complete-sentence */
 
   /**
    * Filters data based on added filter conditions.

--- a/handsontable/src/plugins/filters/filters.ts
+++ b/handsontable/src/plugins/filters/filters.ts
@@ -158,26 +158,41 @@ const SHORTCUTS_GROUP = PLUGIN_KEY;
  * :::
  */
 export class Filters extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify this plugin in Handsontable settings.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority order used to determine the order in which plugins are initialized.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }
 
+  /**
+   * Returns the default settings applied when the plugin is enabled without explicit configuration.
+   */
   static get DEFAULT_SETTINGS() {
     return {
       searchMode: 'show',
     };
   }
 
+  /**
+   * Returns validator functions for each plugin setting to verify their values are valid before applying them.
+   */
   static get SETTINGS_VALIDATORS() {
     return {
       searchMode: (value: unknown) => typeof value === 'string' && ['show', 'apply'].includes(value),
     };
   }
 
+  /**
+   * Returns the list of plugin dependencies required before this plugin can be initialized.
+   */
   static get PLUGIN_DEPS() {
     return [
       'plugin:DropdownMenu',
@@ -262,6 +277,9 @@ export class Filters extends BasePlugin {
    */
   #isDataProviderActive = false;
 
+  /**
+   * Initializes the plugin and registers the column header hook needed to inject the filter UI.
+   */
   constructor(hotInstance: HotInstance) {
     super(hotInstance);
     // One listener for the enable/disable functionality
@@ -929,6 +947,9 @@ export class Filters extends BasePlugin {
    * @param {string} [operationId=conjunction] `id` of operation which is performed on the column.
    */
   /* eslint-enable jsdoc/require-description-complete-sentence */
+  /**
+   * Adds a filter condition to the specified column, optionally combining it with other conditions using the given logical operation.
+   */
   addCondition(column: number, name: string, args: unknown[], operationId: string = OPERATION_AND): void {
     if (name === CONDITION_BY_VALUE && this.#isDataProviderActive) {
       return;

--- a/handsontable/src/plugins/filters/ui/_base.ts
+++ b/handsontable/src/plugins/filters/ui/_base.ts
@@ -27,6 +27,9 @@ export interface BaseUIOptions {
  * @private
  */
 export class BaseUI {
+  /**
+   * Returns the default configuration options applied to a new UI component instance.
+   */
   static get DEFAULTS(): BaseUIOptions {
     return clone({
       className: '',
@@ -69,6 +72,9 @@ export class BaseUI {
    */
   declare buildState: string | undefined;
 
+  /**
+   * Initializes the UI component with the Handsontable instance and merged configuration options.
+   */
   constructor(hotInstance: HotInstance, options: Record<string, unknown>) {
     this.hot = hotInstance;
     this.options = extend(BaseUI.DEFAULTS, options) as BaseUIOptions;
@@ -247,6 +253,9 @@ export class BaseUI {
   focus() { // intentionally empty
   }
 
+  /**
+   * Destroys the UI component by releasing the event manager, nulling references, and removing the element from the DOM.
+   */
   destroy() {
     this.eventManager?.destroy();
     this.eventManager = null;

--- a/handsontable/src/plugins/filters/ui/input.ts
+++ b/handsontable/src/plugins/filters/ui/input.ts
@@ -9,6 +9,9 @@ import { BaseUI } from './_base';
  * @class InputUI
  */
 export class InputUI extends BaseUI {
+  /**
+   * Returns the default configuration options for the input UI component, including placeholder, type, and tab index.
+   */
   static get DEFAULTS(): BaseUIOptions {
     return clone({
       placeholder: '',
@@ -25,6 +28,9 @@ export class InputUI extends BaseUI {
    */
   #input: HTMLInputElement | null = null;
 
+  /**
+   * Initializes the input UI component and registers event hooks for keyboard interaction.
+   */
   constructor(hotInstance: HotInstance, options: Record<string, unknown>) {
     super(hotInstance, extend(InputUI.DEFAULTS, options) as Record<string, unknown>);
     this.registerHooks();

--- a/handsontable/src/plugins/filters/ui/link.ts
+++ b/handsontable/src/plugins/filters/ui/link.ts
@@ -8,6 +8,9 @@ import { BaseUI } from './_base';
  * @class LinkUI
  */
 export class LinkUI extends BaseUI {
+  /**
+   * Returns the default configuration options for the link UI component, including href, tag name, and tab index.
+   */
   static get DEFAULTS(): BaseUIOptions {
     return clone({
       href: '#',
@@ -24,6 +27,9 @@ export class LinkUI extends BaseUI {
    */
   #link: HTMLAnchorElement | null = null;
 
+  /**
+   * Initializes the link UI component with the Handsontable instance and merged configuration options.
+   */
   constructor(hotInstance: HotInstance, options: Record<string, unknown>) {
     super(hotInstance, extend(LinkUI.DEFAULTS, options) as BaseUIOptions);
   }

--- a/handsontable/src/plugins/filters/ui/multipleSelect.ts
+++ b/handsontable/src/plugins/filters/ui/multipleSelect.ts
@@ -25,6 +25,9 @@ interface SelectItem {
  * @class MultipleSelectUI
  */
 export class MultipleSelectUI extends BaseUI {
+  /**
+   * Returns the default configuration options for the multiple select UI component.
+   */
   static get DEFAULTS(): BaseUIOptions {
     return clone({
       className: 'htUIMultipleSelect',
@@ -38,12 +41,30 @@ export class MultipleSelectUI extends BaseUI {
    * @type {Array}
    */
   #items: SelectItem[] = [];
+  /**
+   * Nested Handsontable instance used to render the list of selectable filter values.
+   */
   #itemsBox: HotInstance | null = null;
+  /**
+   * Current locale string used for sorting and comparing filter values.
+   */
   #locale: string = '';
+  /**
+   * Input component for searching within the list of selectable filter values.
+   */
   #searchInput: InputUI | null = null;
+  /**
+   * Link component for selecting all available filter values at once.
+   */
   #selectAllUI: LinkUI | null = null;
+  /**
+   * Link component for clearing all selected filter values at once.
+   */
   #clearAllUI: LinkUI | null = null;
 
+  /**
+   * Initializes the multiple select UI component, creates child input and link components, and registers event hooks.
+   */
   constructor(hotInstance: HotInstance, options: Record<string, unknown>) {
     super(hotInstance, extend(
       MultipleSelectUI.DEFAULTS as Record<string, unknown>, options

--- a/handsontable/src/plugins/filters/ui/radioInput.ts
+++ b/handsontable/src/plugins/filters/ui/radioInput.ts
@@ -8,6 +8,9 @@ import { BaseUI } from './_base';
  * @class RadioInputUI
  */
 export class RadioInputUI extends BaseUI {
+  /**
+   * Returns the default configuration options for the radio input UI component, including type, tag name, and CSS class.
+   */
   static get DEFAULTS(): BaseUIOptions {
     return clone({
       type: 'radio',
@@ -30,6 +33,9 @@ export class RadioInputUI extends BaseUI {
    */
   #label: HTMLLabelElement | null = null;
 
+  /**
+   * Initializes the radio input UI component with the Handsontable instance and merged configuration options.
+   */
   constructor(hotInstance: HotInstance, options: Record<string, unknown>) {
     super(hotInstance, extend(RadioInputUI.DEFAULTS, options) as Record<string, unknown>);
   }

--- a/handsontable/src/plugins/filters/ui/select.ts
+++ b/handsontable/src/plugins/filters/ui/select.ts
@@ -21,6 +21,9 @@ interface SelectMenuItem {
  * @class SelectUI
  */
 export class SelectUI extends BaseUI {
+  /**
+   * Returns the default configuration options for the select UI component.
+   */
   static get DEFAULTS(): BaseUIOptions {
     return clone({
       className: 'htUISelect',
@@ -34,12 +37,30 @@ export class SelectUI extends BaseUI {
    *
    * @type {Menu}
    */
+  /**
+   * Dropdown menu instance used to display the list of selectable operator options.
+   */
   #menu: Menu | null = null;
+  /**
+   * List of available operator menu items displayed in the dropdown.
+   */
   #items: SelectMenuItem[] = [];
+  /**
+   * UI component that renders the currently selected operator label.
+   */
   #caption: BaseUI | null = null;
+  /**
+   * Reference to the DOM element that displays the currently selected operator caption.
+   */
   #captionElement: HTMLElement | null = null;
+  /**
+   * UI component that wraps the dropdown toggle and menu.
+   */
   #dropdown: BaseUI | null = null;
 
+  /**
+   * Initializes the select UI component and registers event hooks for dropdown interaction.
+   */
   constructor(hotInstance: HotInstance, options: Record<string, unknown>) {
     super(hotInstance, extend(SelectUI.DEFAULTS as Record<string, unknown>, options) as Record<string, unknown>);
     this.registerHooks();

--- a/handsontable/src/plugins/filters/ui/select.ts
+++ b/handsontable/src/plugins/filters/ui/select.ts
@@ -37,9 +37,6 @@ export class SelectUI extends BaseUI {
    *
    * @type {Menu}
    */
-  /**
-   * Dropdown menu instance used to display the list of selectable operator options.
-   */
   #menu: Menu | null = null;
   /**
    * List of available operator menu items displayed in the dropdown.

--- a/handsontable/src/plugins/formulas/formulas.ts
+++ b/handsontable/src/plugins/formulas/formulas.ts
@@ -106,14 +106,23 @@ const isBlockedSource = (source: unknown) =>
  * @class Formulas
  */
 export class Formulas extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify this plugin in Handsontable settings.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority order used to determine the order in which plugins are initialized.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }
 
+  /**
+   * Returns the list of settings keys observed by the plugin for configuration changes.
+   */
   static get SETTING_KEYS() {
     return [
       PLUGIN_KEY,

--- a/handsontable/src/plugins/formulas/indexSyncer/axisSyncer.ts
+++ b/handsontable/src/plugins/formulas/indexSyncer/axisSyncer.ts
@@ -76,6 +76,9 @@ class AxisSyncer {
    */
   #removedIndexes: number[] = [];
 
+  /**
+   * Initializes the axis syncer for the given axis with the corresponding index mapper and parent index syncer references.
+   */
   constructor(axis: string, indexMapper: AxisIndexMapper, indexSyncer: ParentIndexSyncer) {
     this.#axis = axis;
     this.#indexMapper = indexMapper;

--- a/handsontable/src/plugins/formulas/indexSyncer/index.ts
+++ b/handsontable/src/plugins/formulas/indexSyncer/index.ts
@@ -62,6 +62,9 @@ class IndexSyncer {
    */
   #sheetId: number | null = null;
 
+  /**
+   * Initializes the index syncer by creating row and column axis syncers and storing the deferred action callback.
+   */
   constructor(rowIndexMapper: IndexMapper, columnIndexMapper: IndexMapper, postponeAction: Function) {
     this.#rowIndexSyncer = new AxisSyncer('row', rowIndexMapper, this);
     this.#columnIndexSyncer = new AxisSyncer('column', columnIndexMapper, this);

--- a/handsontable/src/plugins/hiddenColumns/hiddenColumns.ts
+++ b/handsontable/src/plugins/hiddenColumns/hiddenColumns.ts
@@ -189,14 +189,23 @@ const SKIP_COLUMN_ON_PASTE_BY_PLUGIN = Symbol('skipColumnOnPasteByHiddenColumns'
  * :::
  */
 export class HiddenColumns extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify this plugin in Handsontable settings.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority order used to determine the order in which plugins are initialized.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }
 
+  /**
+   * Returns the default settings applied when the plugin is enabled without explicit configuration.
+   */
   static get DEFAULT_SETTINGS() {
     return {
       copyPasteEnabled: true,

--- a/handsontable/src/plugins/hiddenColumns/hiddenColumns.ts
+++ b/handsontable/src/plugins/hiddenColumns/hiddenColumns.ts
@@ -18,8 +18,6 @@ export const PLUGIN_PRIORITY = 310;
 
 const SKIP_COLUMN_ON_PASTE_BY_PLUGIN = Symbol('skipColumnOnPasteByHiddenColumns');
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
-
 /**
  * @plugin HiddenColumns
  * @class HiddenColumns

--- a/handsontable/src/plugins/hiddenRows/hiddenRows.ts
+++ b/handsontable/src/plugins/hiddenRows/hiddenRows.ts
@@ -18,8 +18,6 @@ export const PLUGIN_PRIORITY = 320;
 
 const SKIP_ROW_ON_PASTE_BY_PLUGIN = Symbol('skipRowOnPasteByHiddenRows');
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
-
 /**
  * @plugin HiddenRows
  * @class HiddenRows

--- a/handsontable/src/plugins/hiddenRows/hiddenRows.ts
+++ b/handsontable/src/plugins/hiddenRows/hiddenRows.ts
@@ -189,14 +189,23 @@ const SKIP_ROW_ON_PASTE_BY_PLUGIN = Symbol('skipRowOnPasteByHiddenRows');
  * :::
  */
 export class HiddenRows extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify this plugin in Handsontable settings.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority order used to determine the order in which plugins are initialized.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }
 
+  /**
+   * Returns the default settings applied when the plugin is enabled without explicit configuration.
+   */
   static get DEFAULT_SETTINGS() {
     return {
       copyPasteEnabled: true,

--- a/handsontable/src/plugins/loading/loading.ts
+++ b/handsontable/src/plugins/loading/loading.ts
@@ -119,10 +119,6 @@ export { LOADING_CLASS_NAME };
  * ```
  * :::
  */
-
-/**
- * Plugin that displays a loading overlay with a spinner and optional title and description while data is being processed.
- */
 export class Loading extends BasePlugin {
   /**
    * Returns the plugin key used to identify this plugin in Handsontable settings.

--- a/handsontable/src/plugins/loading/loading.ts
+++ b/handsontable/src/plugins/loading/loading.ts
@@ -120,15 +120,27 @@ export { LOADING_CLASS_NAME };
  * :::
  */
 
+/**
+ * Plugin that displays a loading overlay with a spinner and optional title and description while data is being processed.
+ */
 export class Loading extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify this plugin in Handsontable settings.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority order used to determine the order in which plugins are initialized.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }
 
+  /**
+   * Returns the default settings applied when the plugin is enabled without explicit configuration.
+   */
   static get DEFAULT_SETTINGS() {
     return {
       // eslint-disable-next-line max-len
@@ -138,6 +150,9 @@ export class Loading extends BasePlugin {
     };
   }
 
+  /**
+   * Returns an object of validator functions used to type-check each settings property at runtime.
+   */
   static get SETTINGS_VALIDATORS() {
     return {
       icon: (value: unknown) => typeof value === 'string',

--- a/handsontable/src/plugins/manualColumnFreeze/manualColumnFreeze.ts
+++ b/handsontable/src/plugins/manualColumnFreeze/manualColumnFreeze.ts
@@ -28,10 +28,16 @@ export const PLUGIN_PRIORITY = 110;
  * ```
  */
 export class ManualColumnFreeze extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify this plugin in Handsontable settings.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority order used to determine the order in which plugins are initialized.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }

--- a/handsontable/src/plugins/manualColumnFreeze/manualColumnFreeze.ts
+++ b/handsontable/src/plugins/manualColumnFreeze/manualColumnFreeze.ts
@@ -11,8 +11,6 @@ Hooks.getSingleton().register('afterColumnUnfreeze');
 export const PLUGIN_KEY = 'manualColumnFreeze';
 export const PLUGIN_PRIORITY = 110;
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
-
 /**
  * @plugin ManualColumnFreeze
  * @class ManualColumnFreeze

--- a/handsontable/src/plugins/manualColumnMove/manualColumnMove.ts
+++ b/handsontable/src/plugins/manualColumnMove/manualColumnMove.ts
@@ -17,8 +17,6 @@ const CSS_SHOW_UI = 'show-ui';
 const CSS_ON_MOVING = 'on-moving--columns';
 const CSS_AFTER_SELECTION = 'after-selection--columns';
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
-
 /**
  * @plugin ManualColumnMove
  * @class ManualColumnMove

--- a/handsontable/src/plugins/manualColumnMove/manualColumnMove.ts
+++ b/handsontable/src/plugins/manualColumnMove/manualColumnMove.ts
@@ -44,10 +44,16 @@ const CSS_AFTER_SELECTION = 'after-selection--columns';
  * @plugin ManualColumnMove
  */
 export class ManualColumnMove extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify this plugin in Handsontable settings.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority order used to determine the order in which plugins are initialized.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }

--- a/handsontable/src/plugins/manualColumnMove/ui/_base.ts
+++ b/handsontable/src/plugins/manualColumnMove/ui/_base.ts
@@ -39,6 +39,9 @@ class BaseUI {
    */
   declare inlineProperty: 'left' | 'right';
 
+  /**
+   * Initializes the base UI element with the Handsontable instance and sets the inline CSS property name based on the document layout direction.
+   */
   constructor(hotInstance: HotInstance) {
     this.hot = hotInstance;
     this.inlineProperty = hotInstance.isRtl() ? 'right' : 'left';

--- a/handsontable/src/plugins/manualColumnResize/manualColumnResize.ts
+++ b/handsontable/src/plugins/manualColumnResize/manualColumnResize.ts
@@ -36,12 +36,21 @@ const PERSISTENT_STATE_KEY = PLUGIN_KEY;
  * - guide - the helper guide that shows the desired width as a vertical guide.
  */
 export class ManualColumnResize extends BasePlugin {
+  /**
+   * Stores the horizontal pointer position at the start of a column resize drag operation.
+   */
   declare startX: number;
 
+  /**
+   * Returns the plugin key used to identify this plugin in Handsontable settings.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority order used to determine the order in which plugins are initialized.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }
@@ -125,6 +134,9 @@ export class ManualColumnResize extends BasePlugin {
    */
   #config!: unknown[];
 
+  /**
+   * Initializes the plugin and applies CSS classes to the resize handle and guide elements.
+   */
   constructor(hotInstance: HotInstance) {
     super(hotInstance);
 

--- a/handsontable/src/plugins/manualColumnResize/manualColumnResize.ts
+++ b/handsontable/src/plugins/manualColumnResize/manualColumnResize.ts
@@ -22,8 +22,6 @@ export const PLUGIN_KEY = 'manualColumnResize';
 export const PLUGIN_PRIORITY = 130;
 const PERSISTENT_STATE_KEY = PLUGIN_KEY;
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
-
 /**
  * @plugin ManualColumnResize
  * @class ManualColumnResize

--- a/handsontable/src/plugins/manualRowMove/manualRowMove.ts
+++ b/handsontable/src/plugins/manualRowMove/manualRowMove.ts
@@ -42,14 +42,23 @@ const CSS_AFTER_SELECTION = 'after-selection--rows';
  * @plugin ManualRowMove
  */
 export class ManualRowMove extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify this plugin in Handsontable settings.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority order used to determine the order in which plugins are initialized.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }
 
+  /**
+   * Returns the list of settings keys observed by the plugin for configuration changes.
+   */
   static get SETTING_KEYS() {
     return [PLUGIN_KEY];
   }

--- a/handsontable/src/plugins/manualRowMove/manualRowMove.ts
+++ b/handsontable/src/plugins/manualRowMove/manualRowMove.ts
@@ -16,8 +16,6 @@ const CSS_SHOW_UI = 'show-ui';
 const CSS_ON_MOVING = 'on-moving--rows';
 const CSS_AFTER_SELECTION = 'after-selection--rows';
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
-
 /**
  * @plugin ManualRowMove
  * @class ManualRowMove

--- a/handsontable/src/plugins/manualRowMove/ui/_base.ts
+++ b/handsontable/src/plugins/manualRowMove/ui/_base.ts
@@ -28,6 +28,9 @@ class BaseUI {
    */
   state = STATE_INITIALIZED;
 
+  /**
+   * Initializes the base row-move UI element with a reference to the Handsontable instance.
+   */
   constructor(hotInstance: HotInstance) {
     this.hot = hotInstance;
   }

--- a/handsontable/src/plugins/manualRowResize/manualRowResize.ts
+++ b/handsontable/src/plugins/manualRowResize/manualRowResize.ts
@@ -36,10 +36,16 @@ const PERSISTENT_STATE_KEY = PLUGIN_KEY;
  * - guide - the helper guide that shows the desired height as a horizontal guide.
  */
 export class ManualRowResize extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify this plugin in Handsontable settings.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority order used to determine the order in which plugins are initialized.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }
@@ -123,6 +129,9 @@ export class ManualRowResize extends BasePlugin {
    */
   #config!: unknown[];
 
+  /**
+   * Initializes the plugin and applies CSS classes to the resize handle and guide elements.
+   */
   constructor(hotInstance: HotInstance) {
     super(hotInstance);
 

--- a/handsontable/src/plugins/manualRowResize/manualRowResize.ts
+++ b/handsontable/src/plugins/manualRowResize/manualRowResize.ts
@@ -22,8 +22,6 @@ export const PLUGIN_KEY = 'manualRowResize';
 export const PLUGIN_PRIORITY = 30;
 const PERSISTENT_STATE_KEY = PLUGIN_KEY;
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
-
 /**
  * @plugin ManualRowResize
  * @class ManualRowResize

--- a/handsontable/src/plugins/mergeCells/calculations/autofill.ts
+++ b/handsontable/src/plugins/mergeCells/calculations/autofill.ts
@@ -37,6 +37,9 @@ class AutofillCalculations {
    */
   currentFillData: Record<string, unknown> | null = null;
 
+  /**
+   * Initializes the autofill calculations helper with a reference to the MergeCells plugin and its merged cells collection.
+   */
   constructor(plugin: MergeCellsPlugin) {
     this.plugin = plugin;
     this.mergedCellsCollection = this.plugin.mergedCellsCollection;

--- a/handsontable/src/plugins/mergeCells/calculations/selection.ts
+++ b/handsontable/src/plugins/mergeCells/calculations/selection.ts
@@ -17,6 +17,9 @@ interface MergeCellsPluginRef {
   mergedCellsCollection: MergedCellsCollection;
 }
 
+/**
+ * Handles all selection-related calculations for merged cells, such as class name generation and full-selection detection.
+ */
 class SelectionCalculations {
   /**
    * Reference to the Merge Cells plugin.
@@ -37,6 +40,9 @@ class SelectionCalculations {
    */
   fullySelectedMergedCellClassName = 'fullySelectedMergedCell';
 
+  /**
+   * Initializes the selection calculations helper with a reference to the MergeCells plugin instance.
+   */
   constructor(plugin: MergeCellsPluginRef) {
     this.plugin = plugin;
     this.hot = plugin.hot;

--- a/handsontable/src/plugins/mergeCells/cellCoords.ts
+++ b/handsontable/src/plugins/mergeCells/cellCoords.ts
@@ -59,6 +59,9 @@ class MergedCellCoords {
    */
   #cellRange: CellRange | null = null;
 
+  /**
+   * Initializes the merged cell coordinates with its top-left position, span dimensions, and factories for creating cell coordinate and range objects.
+   */
   constructor(
     row: number, column: number, rowspan: number, colspan: number,
     cellCoordsFactory: (row: number, col: number) => CellCoords,

--- a/handsontable/src/plugins/mergeCells/cellsCollection.ts
+++ b/handsontable/src/plugins/mergeCells/cellsCollection.ts
@@ -39,6 +39,9 @@ class MergedCellsCollection {
    */
   declare hot: HotInstance;
 
+  /**
+   * Initializes the cells collection with references to the MergeCells plugin and the Handsontable instance.
+   */
   constructor(mergeCellsPlugin: MergeCells) {
     this.plugin = mergeCellsPlugin;
     this.hot = mergeCellsPlugin.hot;

--- a/handsontable/src/plugins/mergeCells/focusOrder.ts
+++ b/handsontable/src/plugins/mergeCells/focusOrder.ts
@@ -53,6 +53,9 @@ export class FocusOrder {
    */
   #columnIndexMapper!: IndexMapper;
 
+  /**
+   * Initializes the focus order manager with the merged cell getter and row and column index mappers used to navigate focus through merged regions.
+   */
   constructor({ mergedCellsGetter, rowIndexMapper, columnIndexMapper }: {
     mergedCellsGetter: (row: number, column: number) => MergedCellCoords | false,
     rowIndexMapper: IndexMapper, columnIndexMapper: IndexMapper

--- a/handsontable/src/plugins/mergeCells/mergeCells.ts
+++ b/handsontable/src/plugins/mergeCells/mergeCells.ts
@@ -84,14 +84,23 @@ const SHORTCUTS_GROUP = PLUGIN_KEY;
  * :::
  */
 export class MergeCells extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify this plugin in Handsontable settings.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority order used to determine the order in which plugins are initialized.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }
 
+  /**
+   * Returns the default settings applied when the plugin is enabled without explicit configuration.
+   */
   static get DEFAULT_SETTINGS() {
     const cells: { row: number; col: number; rowspan: number; colspan: number }[] = [];
 

--- a/handsontable/src/plugins/mergeCells/mergeCells.ts
+++ b/handsontable/src/plugins/mergeCells/mergeCells.ts
@@ -28,8 +28,6 @@ export const PLUGIN_KEY = 'mergeCells';
 export const PLUGIN_PRIORITY = 150;
 const SHORTCUTS_GROUP = PLUGIN_KEY;
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
-
 /**
  * @plugin MergeCells
  * @class MergeCells

--- a/handsontable/src/plugins/multiColumnSorting/multiColumnSorting.ts
+++ b/handsontable/src/plugins/multiColumnSorting/multiColumnSorting.ts
@@ -70,14 +70,23 @@ registerRootComparator(PLUGIN_KEY, rootComparator);
  * ```
  */
 export class MultiColumnSorting extends ColumnSorting {
+  /**
+   * Returns the plugin key used to identify this plugin in Handsontable settings.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority order used to determine the order in which plugins are initialized.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }
 
+  /**
+   * Returns the list of settings keys observed by the plugin for configuration changes.
+   */
   static get SETTING_KEYS() {
     return [PLUGIN_KEY];
   }

--- a/handsontable/src/plugins/multipleSelectionHandles/multipleSelectionHandles.ts
+++ b/handsontable/src/plugins/multipleSelectionHandles/multipleSelectionHandles.ts
@@ -13,10 +13,16 @@ export const PLUGIN_PRIORITY = 160;
  * @class MultipleSelectionHandles
  */
 export class MultipleSelectionHandles extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify this plugin in Handsontable settings.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority order used to determine the order in which plugins are initialized.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }
@@ -223,6 +229,9 @@ export class MultipleSelectionHandles extends BasePlugin {
     });
   }
 
+  /**
+   * Calculates the new selection range coordinates after dragging a touch handle, accounting for drag direction and handle position.
+   */
   getCurrentRangeCoords(
     selectedRange: CellRange, currentTouch: CellCoords, touchStartDirection: string,
     currentDirection: string, draggedHandle: string

--- a/handsontable/src/plugins/nestedHeaders/__tests__/stateManager/custom-matchers.js
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/stateManager/custom-matchers.js
@@ -72,7 +72,6 @@ beforeEach(() => {
   }
 
   const matchers = {
-    /* eslint-disable jsdoc/require-description-complete-sentence */
     /**
      * The matcher checks if the provided column headers structure pattern matches
      * to the current tree passed to the matcher.
@@ -96,7 +95,6 @@ beforeEach(() => {
      *
      * @returns {object}
      */
-    /* eslint-enable jsdoc/require-description-complete-sentence */
     toBeMatchToHeadersStructure() {
       return {
         compare(tree, actualPattern) {

--- a/handsontable/src/plugins/nestedHeaders/nestedHeaders.ts
+++ b/handsontable/src/plugins/nestedHeaders/nestedHeaders.ts
@@ -20,8 +20,6 @@ import { resolveRowspanNavigationContextRow } from './utils/navigation';
 export const PLUGIN_KEY = 'nestedHeaders';
 export const PLUGIN_PRIORITY = 280;
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
-
 /**
  * @plugin NestedHeaders
  * @class NestedHeaders

--- a/handsontable/src/plugins/nestedHeaders/nestedHeaders.ts
+++ b/handsontable/src/plugins/nestedHeaders/nestedHeaders.ts
@@ -97,52 +97,59 @@ export const PLUGIN_PRIORITY = 280;
  * :::
  */
 export class NestedHeaders extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify this plugin in Handsontable settings.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority order used to determine the order in which plugins are initialized.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }
 
+  /**
+   * Manages the state tree of nested header spans and their visibility.
+   */
   #stateManager = new StateManager();
+  /**
+   * Observer that synchronizes column hiding state with the nested headers visibility.
+   */
   #hidingIndexMapObserver: { unsubscribe: () => void } | null = null;
+  /**
+   * Stores the initial focus coordinates before a column header click initiates a range selection.
+   */
   #focusInitialCoords: { row: number, col: number, clone: () => CellCoords } | null = null;
+  /**
+   * Indicates whether a column selection drag triggered by a nested header click is currently in progress.
+   */
   #isColumnsSelectionInProgress = false;
   /**
    * Keeps the last highlight position made by column selection. The coords are necessary to scroll
    * the viewport to the correct position when the nested header is clicked when the `navigableHeaders`
    * option is disabled.
-   *
-   * @type {CellCoords | null}
    */
   #recentlyHighlightCoords: { row: number | null, col: number | null } | null = null;
   /**
    * Stores the header row level used as context for horizontal navigation when entering
    * and leaving rowspanned headers.
-   *
-   * @type {number|null}
    */
   #rowspanHeaderNavigationContextRow: number | null = null;
   /**
    * Stores the expected next highlight coordinates after keyboard navigation. If the next
    * keyboard move starts from different coordinates, the horizontal navigation context
    * is considered stale and should be reset.
-   *
-   * @type {{row: number, col: number}|null}
    */
   #expectedNextKeyboardHighlightCoords: { row: number; col: number } | null = null;
   /**
    * Determines if the widths map should be updated.
-   *
-   * @type {boolean}
    */
   #updateWidthsMap = false;
   /**
    * Custom helper for getting widths of the nested headers.
-   *
-   * @private
-   * @type {GhostTable}
    */
   // @TODO This should be changed after refactor handsontable/utils/ghostTable.
   ghostTable = new GhostTable({
@@ -152,21 +159,23 @@ export class NestedHeaders extends BasePlugin {
   /**
    * The flag which determines that the nested header settings contains overlapping headers
    * configuration.
-   *
-   * @type {boolean}
    */
   detectedOverlappedHeaders = false;
   /**
    * Determines if the current nested headers state contains headers with `rowspan`.
-   *
-   * @type {boolean}
    */
   #hasRowspanHeaders = false;
 
+  /**
+   * Returns whether the plugin is enabled based on the presence of the `nestedHeaders` settings key.
+   */
   isEnabled(): boolean {
     return !!this.hot.getSettings()[PLUGIN_KEY];
   }
 
+  /**
+   * Enables the plugin by registering all required hooks and initializing the header state.
+   */
   enablePlugin() {
     if (this.enabled) {
       return;
@@ -208,6 +217,9 @@ export class NestedHeaders extends BasePlugin {
     this.updatePlugin();
   }
 
+  /**
+   * Updates the plugin state when Handsontable settings change, rebuilding the header tree and refreshing column widths.
+   */
   updatePlugin() {
     if (!this.hot.view) {
       return;
@@ -275,6 +287,9 @@ export class NestedHeaders extends BasePlugin {
     super.updatePlugin();
   }
 
+  /**
+   * Disables the plugin by removing all registered hooks, clearing header state, and resetting visual indicators.
+   */
   disablePlugin() {
     this.hot.rowIndexMapper
       .removeLocalHook('cacheUpdated', this.#updateFocusHighlightPosition);
@@ -295,18 +310,30 @@ export class NestedHeaders extends BasePlugin {
     super.disablePlugin();
   }
 
+  /**
+   * Returns the internal state manager that tracks the nested header spans and their layout configuration.
+   */
   getStateManager() {
     return this.#stateManager;
   }
 
+  /**
+   * Returns the number of nested header rows currently configured in the plugin.
+   */
   getLayersCount() {
     return this.#stateManager.getLayersCount();
   }
 
+  /**
+   * Returns the header settings node for the specified header level and column index.
+   */
   getHeaderSettings(headerLevel: number, columnIndex: number) {
     return this.#stateManager.getHeaderSettings(headerLevel, columnIndex);
   }
 
+  /**
+   * Removes all colspan and rowspan attributes from the rendered header cells in all overlays.
+   */
   clearColspans() {
     if (!this.hot.view) {
       return;
@@ -361,6 +388,9 @@ export class NestedHeaders extends BasePlugin {
     }
   }
 
+  /**
+   * Creates and returns a header renderer function for the specified header layer level.
+   */
   headerRendererFactory(headerLevel: number) {
     const fixedColumnsStart = this.hot.view._wt.getSetting('fixedColumnsStart') as number;
 
@@ -450,6 +480,9 @@ export class NestedHeaders extends BasePlugin {
     };
   }
 
+  /**
+   * Returns the display value for a nested header cell at the given visual column index and header level.
+   */
   getColumnHeaderValue(visualColumnIndex: number, headerLevel: number) {
     const {
       isHidden,
@@ -464,6 +497,9 @@ export class NestedHeaders extends BasePlugin {
     return this.hot.getColHeader(visualColumnIndex, headerLevel);
   }
 
+  /**
+   * Updates the focus highlight position in the selection model to reflect the current nested header layout.
+   */
   readonly #updateFocusHighlightPosition = () => {
     const selection = this.hot?.getSelectedRangeActive();
 
@@ -669,6 +705,9 @@ export class NestedHeaders extends BasePlugin {
     return mostLeftColumnIndex <= firstVisibleColumn ? mostLeftColumnIndex : mostRightColumnIndex;
   };
 
+  /**
+   * Adjusts the column highlight start index and width to align with the nested header spanning configuration.
+   */
   #onBeforeHighlightingColumnHeader = (
     visualColumn: number, headerLevel: number,
     highlightMeta: { columnCursor: number, selectionType: string, selectionWidth: number }
@@ -703,6 +742,9 @@ export class NestedHeaders extends BasePlugin {
     return visualColumn;
   };
 
+  /**
+   * Enriches copied data with nested column header labels when column headers are included in the copy range.
+   */
   #onBeforeCopy = (
     data: unknown[][],
     copyableRanges: { startRow: number, startCol: number, endRow: number, endCol: number }[],
@@ -763,6 +805,9 @@ export class NestedHeaders extends BasePlugin {
     }
   };
 
+  /**
+   * Initiates a column selection when a nested header cell is clicked, selecting all columns covered by the header span.
+   */
   #onAfterOnCellMouseDown = (event: MouseEvent, coords: CellCoords) => {
     if (coords.row === null || coords.col === null) {
       return;
@@ -810,6 +855,9 @@ export class NestedHeaders extends BasePlugin {
     }
   };
 
+  /**
+   * Extends the column selection range when the pointer moves over a nested header cell during a drag selection.
+   */
   #onBeforeOnCellMouseOver = (
     event: MouseEvent, coords: { row: number, col: number }, TD: HTMLElement,
     controller: { column: boolean, cell: boolean }
@@ -858,10 +906,16 @@ export class NestedHeaders extends BasePlugin {
     this.hot.selection.selectColumns(...columnsToSelect);
   };
 
+  /**
+   * Clears the in-progress column selection flag when the pointer button is released.
+   */
   #onBeforeOnCellMouseUp = () => {
     this.#isColumnsSelectionInProgress = false;
   };
 
+  /**
+   * Adjusts the selection highlight position when navigable headers are enabled and a multi-column header is selected.
+   */
   #onBeforeSelectionHighlightSet = () => {
     const { navigableHeaders } = this.hot.getSettings();
 
@@ -905,6 +959,9 @@ export class NestedHeaders extends BasePlugin {
     }
   };
 
+  /**
+   * Corrects the keyboard navigation delta when traversing across rowspanned nested header cells.
+   */
   #onModifyTransformStart = (delta: { row: number, col: number }) => {
     const activeRange = this.hot.getSelectedRangeActive();
 
@@ -1095,6 +1152,9 @@ export class NestedHeaders extends BasePlugin {
     };
   };
 
+  /**
+   * Expands the column selection range to fully include the header spans at the start and end columns.
+   */
   #onBeforeSelectColumns = (
     from: { row: number, col: number }, to: { row: number, col: number }, highlight: { clone: () => CellCoords }
   ) => {
@@ -1130,6 +1190,9 @@ export class NestedHeaders extends BasePlugin {
     }
   };
 
+  /**
+   * Replaces the default column header renderer array with layer-specific renderers generated by this plugin.
+   */
   #onAfterGetColumnHeaderRenderers = (renderersArray: unknown[]) => {
     if (this.#stateManager.getLayersCount() > 0) {
       renderersArray.length = 0;
@@ -1140,6 +1203,9 @@ export class NestedHeaders extends BasePlugin {
     }
   };
 
+  /**
+   * Extends the viewport start column to include any header spans that begin outside the calculated viewport boundary.
+   */
   #onAfterViewportColumnCalculatorOverride = (calc: { startColumn: number }) => {
     const headerLayersCount = this.#stateManager.getLayersCount();
     let newStartColumn = calc.startColumn;
@@ -1171,10 +1237,6 @@ export class NestedHeaders extends BasePlugin {
    * When `autoColumnSize` is explicitly disabled, the user opts out of auto-sizing
    * columns based on content; the plugin respects user-provided widths and does
    * not override them with the ghost-table-measured header label width.
-   *
-   * @param {number} width Width from hook.
-   * @param {number} column Visual index of an column.
-   * @returns {number}
    */
   #onModifyColWidth = (width: number, column: number) => {
     if (this.hot.getSettings().autoColumnSize === false) {
@@ -1188,8 +1250,6 @@ export class NestedHeaders extends BasePlugin {
 
   /**
    * Equalizes all nested column header layers' heights when rowspans are used.
-   *
-   * @returns {number[]|undefined}
    */
   #onModifyColumnHeaderHeight = (): number[] | undefined => {
     if (!this.#hasRowspanHeaders) {
@@ -1212,13 +1272,12 @@ export class NestedHeaders extends BasePlugin {
    * Listens the `modifyColumnHeaderValue` hook that overwrites the column headers values based on
    * the internal state and settings of the plugin.
    *
-   * @param {string} value The column header value.
-   * @param {number} visualColumnIndex The visual column index.
-   * @param {number} headerLevel The index of header level. The header level accepts positive (0 to N)
-   *                             and negative (-1 to -N) values. For positive values, 0 points to the
-   *                             top most header, and for negative direction, -1 points to the most bottom
-   *                             header (the header closest to the cells).
-   * @returns {string} Returns the column header value to update.
+   * @param value The column header value.
+   * @param visualColumnIndex The visual column index.
+   * @param headerLevel The index of header level. The header level accepts positive (0 to N)
+   *                    and negative (-1 to -N) values. For positive values, 0 points to the
+   *                    top most header, and for negative direction, -1 points to the most bottom
+   *                    header (the header closest to the cells).
    */
   #onModifyColumnHeaderValue = (value: string, visualColumnIndex: number, headerLevel: number): string => {
     const {
@@ -1228,6 +1287,9 @@ export class NestedHeaders extends BasePlugin {
     return label;
   };
 
+  /**
+   * Returns the leftmost DOM cell element within the nested header span at the given row and column when in a header row.
+   */
   #onModifyFocusedElement = (row: number, column: number) => {
     if (row < 0) {
       return this.hot.getCell(row, this.#stateManager.findLeftMostColumnIndex(row, column), true) ?? undefined;
@@ -1267,9 +1329,6 @@ export class NestedHeaders extends BasePlugin {
    * observer only fires on hidden/visible value changes, so a move that does not
    * change which physical columns are hidden would otherwise leave the tree state
    * pointing at stale visual indexes.
-   *
-   * @param {object} payload The `cacheUpdated` payload.
-   * @param {boolean} payload.indexesSequenceChanged True when the column order changed.
    */
   #onColumnIndexMapperCacheUpdated = ({ indexesSequenceChanged }: { indexesSequenceChanged: boolean }) => {
     if (!indexesSequenceChanged) {
@@ -1287,6 +1346,9 @@ export class NestedHeaders extends BasePlugin {
     this.updatePlugin();
   };
 
+  /**
+   * Re-initializes the plugin state after new data is loaded, unless this is the initial data load.
+   */
   #onAfterLoadData = (sourceData: unknown[], initialLoad: boolean) => {
     if (!initialLoad) {
       this.updatePlugin();
@@ -1320,6 +1382,9 @@ export class NestedHeaders extends BasePlugin {
     super.destroy();
   }
 
+  /**
+   * Returns the header tree node data for the given coordinates, or undefined if the coordinates do not point to a header cell.
+   */
   _getHeaderTreeNodeDataByCoords(coords: { row: number, col: number }): HeaderNodeData | null | undefined {
     if (coords.row >= 0 || coords.col < 0) {
       return;

--- a/handsontable/src/plugins/nestedHeaders/stateManager/headersTree.ts
+++ b/handsontable/src/plugins/nestedHeaders/stateManager/headersTree.ts
@@ -29,16 +29,18 @@ export interface HeaderSettings {
 export interface HeaderNodeData extends HeaderSettings {
   headerLevel: number;
   columnIndex: number;
-  /** A cloned subtree stored during collapse, restored on expand. */
+  /**
+   * A cloned subtree stored during collapse, restored on expand.
+   */
   clonedTree?: TreeNode | null;
 }
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
 /**
+ * Builds and manages a tree structure representing the nested headers configuration, mapping visual column indexes to header nodes.
+ *
  * @private
  * @class HeadersTree
  */
-/* eslint-enable jsdoc/require-description-complete-sentence */
 export default class HeadersTree {
   /**
    * The collection of nested headers settings structured into trees.
@@ -62,6 +64,9 @@ export default class HeadersTree {
    */
   readonly #sourceSettings: SourceSettings | null = null;
 
+  /**
+   * Initializes the headers tree with the given source settings used to build the nested header structure.
+   */
   constructor(sourceSettings: SourceSettings) {
     this.#sourceSettings = sourceSettings;
   }

--- a/handsontable/src/plugins/nestedHeaders/stateManager/index.ts
+++ b/handsontable/src/plugins/nestedHeaders/stateManager/index.ts
@@ -157,7 +157,6 @@ export default class StateManager {
     return this.triggerNodeModification(action, -1, columnIndex);
   }
 
-  /* eslint-disable jsdoc/require-description-complete-sentence */
   /**
    * @memberof StateManager#
    * @function rowCoordsToLevel
@@ -166,10 +165,6 @@ export default class StateManager {
    *
    * @param {number} rowIndex A visual row index.
    * @returns {number|null} Returns unsigned number.
-   */
-  /* eslint-enable jsdoc/require-description-complete-sentence */
-  /**
-   * Translates a visual row index into the corresponding header level index, returning null for non-header rows.
    */
   rowCoordsToLevel(rowIndex: number): number | null {
     if (rowIndex >= 0) {
@@ -185,7 +180,6 @@ export default class StateManager {
     return headerLevel;
   }
 
-  /* eslint-disable jsdoc/require-description-complete-sentence */
   /**
    * @memberof StateManager#
    * @function levelToRowCoords
@@ -194,10 +188,6 @@ export default class StateManager {
    *
    * @param {number} headerLevel Header level index.
    * @returns {number} Returns negative number.
-   */
-  /* eslint-enable jsdoc/require-description-complete-sentence */
-  /**
-   * Translates a header level index into the corresponding negative row coordinate used by Handsontable's header system.
    */
   levelToRowCoords(headerLevel: number): number | null {
     if (headerLevel < 0) {

--- a/handsontable/src/plugins/nestedHeaders/stateManager/index.ts
+++ b/handsontable/src/plugins/nestedHeaders/stateManager/index.ts
@@ -168,6 +168,9 @@ export default class StateManager {
    * @returns {number|null} Returns unsigned number.
    */
   /* eslint-enable jsdoc/require-description-complete-sentence */
+  /**
+   * Translates a visual row index into the corresponding header level index, returning null for non-header rows.
+   */
   rowCoordsToLevel(rowIndex: number): number | null {
     if (rowIndex >= 0) {
       return null;
@@ -193,6 +196,9 @@ export default class StateManager {
    * @returns {number} Returns negative number.
    */
   /* eslint-enable jsdoc/require-description-complete-sentence */
+  /**
+   * Translates a header level index into the corresponding negative row coordinate used by Handsontable's header system.
+   */
   levelToRowCoords(headerLevel: number): number | null {
     if (headerLevel < 0) {
       return null;

--- a/handsontable/src/plugins/nestedHeaders/stateManager/matrixGenerator.ts
+++ b/handsontable/src/plugins/nestedHeaders/stateManager/matrixGenerator.ts
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/require-description-complete-sentence */
 import { arrayEach } from '../../../helpers/array';
 import { createDefaultHeaderSettings, createPlaceholderHeaderSettings } from './utils';
 import type TreeNode from '../../../utils/dataStructures/tree';

--- a/handsontable/src/plugins/nestedHeaders/stateManager/settingsNormalizer.ts
+++ b/handsontable/src/plugins/nestedHeaders/stateManager/settingsNormalizer.ts
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/require-description-complete-sentence */
 import { arrayEach, arrayMap } from '../../../helpers/array';
 import { isObject } from '../../../helpers/object';
 import { stringify } from '../../../helpers/mixed';

--- a/handsontable/src/plugins/nestedHeaders/utils/ghostTable.ts
+++ b/handsontable/src/plugins/nestedHeaders/utils/ghostTable.ts
@@ -49,6 +49,9 @@ class GhostTable {
    */
   widthsMap;
 
+  /**
+   * Initializes the ghost table with the Handsontable instance and headers state manager, and registers the widths index map.
+   */
   constructor({ hot, headersStateManager }: { hot: HotInstance; headersStateManager: StateManager }) {
     this.hot = hot;
     this.headersStateManager = headersStateManager;

--- a/handsontable/src/plugins/nestedRows/data/dataManager.ts
+++ b/handsontable/src/plugins/nestedRows/data/dataManager.ts
@@ -803,7 +803,7 @@ class DataManager {
 
   /* eslint-enable jsdoc/require-param */
   /**
-   * Moves a row from one position to another within the nested data structure, updating parent–child relationships accordingly.
+   *
    */
   moveRow(fromIndex: number, toIndex: number, moveToCollapsed: boolean, moveToLastChild: boolean) {
     const moveToLastRow = toIndex === this.hot.countRows();

--- a/handsontable/src/plugins/nestedRows/data/dataManager.ts
+++ b/handsontable/src/plugins/nestedRows/data/dataManager.ts
@@ -66,6 +66,9 @@ class DataManager {
     nodeInfo: new WeakMap<object, NodeInfo>()
   };
 
+  /**
+   * Initializes the data manager with references to the NestedRows plugin and the Handsontable instance.
+   */
   constructor(nestedRowsPlugin: NestedRows, hotInstance: HotInstance) {
     this.hot = hotInstance;
     this.plugin = nestedRowsPlugin;
@@ -799,6 +802,9 @@ class DataManager {
    */
 
   /* eslint-enable jsdoc/require-param */
+  /**
+   * Moves a row from one position to another within the nested data structure, updating parent–child relationships accordingly.
+   */
   moveRow(fromIndex: number, toIndex: number, moveToCollapsed: boolean, moveToLastChild: boolean) {
     const moveToLastRow = toIndex === this.hot.countRows();
     const fromParent = this.getRowParent(fromIndex)!;

--- a/handsontable/src/plugins/nestedRows/nestedRows.ts
+++ b/handsontable/src/plugins/nestedRows/nestedRows.ts
@@ -29,10 +29,16 @@ const WRONG_DATA_TYPE_ERROR = 'The Nested Rows plugin requires an Array of Objec
  * Plugin responsible for displaying and operating on data sources with nested structures.
  */
 export class NestedRows extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify and access this plugin within Handsontable.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority value that determines the plugin's initialization order relative to other plugins.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }

--- a/handsontable/src/plugins/nestedRows/nestedRows.ts
+++ b/handsontable/src/plugins/nestedRows/nestedRows.ts
@@ -14,7 +14,6 @@ export const PLUGIN_KEY = 'nestedRows';
 export const PLUGIN_PRIORITY = 300;
 const SHORTCUTS_GROUP = PLUGIN_KEY;
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
 /**
  * Error message for the wrong data type error.
  */

--- a/handsontable/src/plugins/nestedRows/ui/_base.ts
+++ b/handsontable/src/plugins/nestedRows/ui/_base.ts
@@ -19,6 +19,9 @@ class BaseUI {
    */
   declare plugin: NestedRows;
 
+  /**
+   * Initializes the base UI component with references to the NestedRows plugin instance and the Handsontable instance.
+   */
   constructor(pluginInstance: NestedRows, hotInstance: HotInstance) {
     this.hot = hotInstance;
     this.plugin = pluginInstance;

--- a/handsontable/src/plugins/nestedRows/ui/collapsing.ts
+++ b/handsontable/src/plugins/nestedRows/ui/collapsing.ts
@@ -48,6 +48,9 @@ class CollapsingUI extends BaseUI {
    */
   declare lastCollapsedRows: number[] | undefined;
 
+  /**
+   * Initializes the collapsing UI component and sets up the stash mechanism for preserving collapsed row state across operations.
+   */
   constructor(nestedRowsPlugin: NestedRows, hotInstance: HotInstance) {
     super(nestedRowsPlugin, hotInstance);
 

--- a/handsontable/src/plugins/nestedRows/ui/contextMenu.ts
+++ b/handsontable/src/plugins/nestedRows/ui/contextMenu.ts
@@ -45,6 +45,9 @@ class ContextMenuUI extends BaseUI {
    */
   dataManager = this.plugin.dataManager;
 
+  /**
+   * Map of context menu entry keys to their handler functions that modify the nested row structure.
+   */
   #menuEntries: Record<string, (key: string, selection: ContextMenuSelection[]) => void> = {
     row_above: (key: string, selection: ContextMenuSelection[]) => {
       const lastSelection = selection[selection.length - 1];

--- a/handsontable/src/plugins/nestedRows/ui/headers.ts
+++ b/handsontable/src/plugins/nestedRows/ui/headers.ts
@@ -67,6 +67,9 @@ class HeadersUI extends BaseUI {
     };
   }
 
+  /**
+   * Initializes the headers UI component and sets up the data manager reference used to determine nesting levels for each row header.
+   */
   constructor(nestedRowsPlugin: NestedRows, hotInstance: HotInstance) {
     super(nestedRowsPlugin, hotInstance);
     /**

--- a/handsontable/src/plugins/nestedRows/utils/rowMoveController.ts
+++ b/handsontable/src/plugins/nestedRows/utils/rowMoveController.ts
@@ -72,6 +72,9 @@ export default class RowMoveController {
    */
   movedToCollapsed: boolean = false;
 
+  /**
+   * Initializes the row move controller with references to the NestedRows plugin, the Handsontable instance, the data manager, and the collapsing UI.
+   */
   constructor(plugin: NestedRowsPlugin) {
     this.plugin = plugin;
     this.hot = plugin.hot;

--- a/handsontable/src/plugins/notification/notification.ts
+++ b/handsontable/src/plugins/notification/notification.ts
@@ -102,14 +102,23 @@ const TICK_MS = 200;
  * ```
  */
 export class Notification extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify this plugin in Handsontable settings.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority order used to determine the order in which plugins are initialized.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }
 
+  /**
+   * Returns the default settings applied when the plugin is enabled without explicit configuration.
+   */
   static get DEFAULT_SETTINGS() {
     return {
       stackLimit: 10,
@@ -117,6 +126,9 @@ export class Notification extends BasePlugin {
     };
   }
 
+  /**
+   * Returns an object of validator functions used to type-check each settings property at runtime.
+   */
   static get SETTINGS_VALIDATORS() {
     return {
       stackLimit: (value: unknown) => typeof value === 'number' && value > 0 && Number.isInteger(value),

--- a/handsontable/src/plugins/pagination/pagination.ts
+++ b/handsontable/src/plugins/pagination/pagination.ts
@@ -99,14 +99,23 @@ const AUTO_PAGE_SIZE_WARNING = toSingleLine`The \`auto\` page size setting requi
  * :::
  */
 export class Pagination extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify this plugin in Handsontable settings.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority order used to determine the order in which plugins are initialized.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }
 
+  /**
+   * Returns the default settings applied when the plugin is enabled without explicit configuration.
+   */
   static get DEFAULT_SETTINGS() {
     return {
       pageSize: 10,

--- a/handsontable/src/plugins/pagination/pagination.ts
+++ b/handsontable/src/plugins/pagination/pagination.ts
@@ -24,7 +24,6 @@ const SHORTCUTS_CONTEXT_NAME = `plugin:${PLUGIN_KEY}`;
 const AUTO_PAGE_SIZE_WARNING = toSingleLine`The \`auto\` page size setting requires the \`autoRowSize\`\x20
   plugin to be enabled. Set the \`autoRowSize: true\` in the configuration to ensure correct behavior.`;
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
 /**
  * @plugin Pagination
  * @class Pagination

--- a/handsontable/src/plugins/pagination/ui.ts
+++ b/handsontable/src/plugins/pagination/ui.ts
@@ -53,7 +53,13 @@ interface PaginationRefs {
  * @class PaginationUI
  */
 export class PaginationUI {
+  /**
+   * Triggers registered local hooks with the given hook name and arguments.
+   */
   declare runLocalHooks: (...args: unknown[]) => void;
+  /**
+   * Registers a callback to be executed when the specified local hook fires.
+   */
   declare addLocalHook: (hookName: string, callback: Function) => PaginationUI;
   /**
    * The root element where the pagination UI will be installed.
@@ -105,6 +111,9 @@ export class PaginationUI {
    */
   readonly #a11yAnnouncer: (message: unknown) => void;
 
+  /**
+   * Initializes the pagination UI by creating DOM elements, applying layout settings, and registering event listeners.
+   */
   constructor({
     rootElement,
     uiContainer,

--- a/handsontable/src/plugins/persistentState/persistentState.ts
+++ b/handsontable/src/plugins/persistentState/persistentState.ts
@@ -45,10 +45,16 @@ const deprecationWarningInstances = new WeakSet();
  *
  */
 export class PersistentState extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify and access this plugin within Handsontable.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority value that determines the plugin's initialization order relative to other plugins.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }

--- a/handsontable/src/plugins/persistentState/persistentState.ts
+++ b/handsontable/src/plugins/persistentState/persistentState.ts
@@ -12,8 +12,6 @@ export const PLUGIN_PRIORITY = 0;
 
 const deprecationWarningInstances = new WeakSet();
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
-
 /**
  * @plugin PersistentState
  * @class PersistentState

--- a/handsontable/src/plugins/persistentState/storage.ts
+++ b/handsontable/src/plugins/persistentState/storage.ts
@@ -25,6 +25,9 @@ class Storage {
    */
   savedKeys: string[] = [];
 
+  /**
+   * Initializes the storage with a namespace prefix and a window reference, then loads previously saved keys from localStorage.
+   */
   // eslint-disable-next-line no-restricted-globals
   constructor(prefix: string, rootWindow = window) {
     this.rootWindow = rootWindow;

--- a/handsontable/src/plugins/search/search.ts
+++ b/handsontable/src/plugins/search/search.ts
@@ -43,8 +43,6 @@ interface CellSearchMeta {
   queryMethod?: typeof DEFAULT_QUERY_METHOD;
 }
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
-
 /**
  * @plugin Search
  * @class Search

--- a/handsontable/src/plugins/search/search.ts
+++ b/handsontable/src/plugins/search/search.ts
@@ -35,7 +35,9 @@ const DEFAULT_QUERY_METHOD = function(query: string, value: unknown, cellPropert
     .indexOf(query.toLocaleLowerCase(cellProperties.locale as string | undefined)) !== -1;
 };
 
-/** Per-cell overrides stored in the `search` meta property. */
+/**
+ * Per-cell overrides stored in the `search` meta property.
+ */
 interface CellSearchMeta {
   callback?: typeof DEFAULT_CALLBACK;
   queryMethod?: typeof DEFAULT_QUERY_METHOD;
@@ -75,10 +77,16 @@ interface CellSearchMeta {
  * ```
  */
 export class Search extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify and access this plugin within Handsontable.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority value that determines the plugin's initialization order relative to other plugins.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }

--- a/handsontable/src/plugins/stretchColumns/calculator.ts
+++ b/handsontable/src/plugins/stretchColumns/calculator.ts
@@ -41,6 +41,9 @@ export class StretchCalculator {
    */
   #activeStrategy = 'none';
 
+  /**
+   * Initializes the stretch columns calculator with the Handsontable instance and registers the stretch widths index map.
+   */
   constructor(hotInstance: HotInstance) {
     this.#hot = hotInstance;
     this.#widthsMap = this.#hot.columnIndexMapper

--- a/handsontable/src/plugins/stretchColumns/strategies/_base.ts
+++ b/handsontable/src/plugins/stretchColumns/strategies/_base.ts
@@ -34,6 +34,9 @@ export class StretchStrategy {
    */
   stretchedWidths = new Map<number, number>();
 
+  /**
+   * Initializes the stretch strategy with a function that overrides individual column widths during the stretch calculation.
+   */
   constructor(overwriteColumnWidthFn: (width: number, column: number) => number) {
     this.overwriteColumnWidthFn = overwriteColumnWidthFn;
   }

--- a/handsontable/src/plugins/stretchColumns/stretchColumns.ts
+++ b/handsontable/src/plugins/stretchColumns/stretchColumns.ts
@@ -66,15 +66,27 @@ export const PLUGIN_PRIORITY = 155;
  * :::
  */
 /* eslint-enable jsdoc/require-description-complete-sentence */
+/**
+ * Plugin that stretches columns to fill the available horizontal space using the configured stretching strategy.
+ */
 export class StretchColumns extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify this plugin in Handsontable settings.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority order used to determine the order in which plugins are initialized.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }
 
+  /**
+   * Returns whether the plugin handles its own settings keys without a dedicated key list.
+   */
   static get SETTING_KEYS(): boolean {
     return true;
   }

--- a/handsontable/src/plugins/stretchColumns/stretchColumns.ts
+++ b/handsontable/src/plugins/stretchColumns/stretchColumns.ts
@@ -4,7 +4,6 @@ import { StretchCalculator } from './calculator';
 export const PLUGIN_KEY = 'stretchColumns';
 export const PLUGIN_PRIORITY = 155;
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
 /**
  * @plugin StretchColumns
  * @class StretchColumns
@@ -64,10 +63,6 @@ export const PLUGIN_PRIORITY = 155;
  * <hot-table [settings]="settings"></hot-table>
  * ```
  * :::
- */
-/* eslint-enable jsdoc/require-description-complete-sentence */
-/**
- * Plugin that stretches columns to fill the available horizontal space using the configured stretching strategy.
  */
 export class StretchColumns extends BasePlugin {
   /**

--- a/handsontable/src/plugins/touchScroll/touchScroll.ts
+++ b/handsontable/src/plugins/touchScroll/touchScroll.ts
@@ -12,14 +12,23 @@ export const PLUGIN_PRIORITY = 200;
  * @class TouchScroll
  */
 export class TouchScroll extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify this plugin in Handsontable settings.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority order used to determine the order in which plugins are initialized.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }
 
+  /**
+   * Returns whether the plugin handles its own settings keys without a dedicated key list.
+   */
   static get SETTING_KEYS(): true {
     return true;
   }

--- a/handsontable/src/plugins/trimRows/trimRows.ts
+++ b/handsontable/src/plugins/trimRows/trimRows.ts
@@ -154,14 +154,23 @@ export const PLUGIN_PRIORITY = 330;
  * :::
  */
 export class TrimRows extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify this plugin in Handsontable settings.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority order used to determine the order in which plugins are initialized.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }
 
+  /**
+   * Returns the list of settings keys observed by the plugin for configuration changes.
+   */
   static get SETTING_KEYS() {
     return [PLUGIN_KEY];
   }

--- a/handsontable/src/plugins/trimRows/trimRows.ts
+++ b/handsontable/src/plugins/trimRows/trimRows.ts
@@ -5,8 +5,6 @@ import { arrayEach, arrayReduce } from '../../helpers/array';
 export const PLUGIN_KEY = 'trimRows';
 export const PLUGIN_PRIORITY = 330;
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
-
 /**
  * @plugin TrimRows
  * @class TrimRows

--- a/handsontable/src/plugins/undoRedo/actions/_base.ts
+++ b/handsontable/src/plugins/undoRedo/actions/_base.ts
@@ -12,14 +12,23 @@ export class BaseAction {
    */
   actionType = '';
 
+  /**
+   * Initializes the action with the given action type identifier.
+   */
   constructor(actionType: string) {
     this.actionType = actionType;
   }
 
+  /**
+   * Reverts the action, restoring the previous state. Subclasses must override this method.
+   */
   undo(..._args: unknown[]): void {
     throwWithCause('Not implemented');
   }
 
+  /**
+   * Reapplies the action after it has been undone. Subclasses must override this method.
+   */
   redo(..._args: unknown[]): void {
     throwWithCause('Not implemented');
   }

--- a/handsontable/src/plugins/undoRedo/actions/cellAlignment.ts
+++ b/handsontable/src/plugins/undoRedo/actions/cellAlignment.ts
@@ -28,6 +28,9 @@ export class CellAlignmentAction extends BaseAction {
    */
   alignment;
 
+  /**
+   * Initializes the cell alignment action with the previous state, cell range, alignment axis, and CSS alignment class.
+   */
   constructor({ stateBefore, range, type, alignment }: {
     stateBefore: unknown[], range: CellRange[], type: string, alignment: string
   }) {
@@ -38,6 +41,9 @@ export class CellAlignmentAction extends BaseAction {
     this.alignment = alignment;
   }
 
+  /**
+   * Registers the `beforeCellAlignment` hook listener that records a new CellAlignmentAction whenever alignment changes.
+   */
   static startRegisteringEvents(hot: HotInstance, undoRedoPlugin: unknown) {
     hot.addHook('beforeCellAlignment', (stateBefore: unknown, range: CellRange[], type: string, alignment: unknown) => {
       (undoRedoPlugin as { done: (callback: () => CellAlignmentAction) => void }).done(() => new CellAlignmentAction({

--- a/handsontable/src/plugins/undoRedo/actions/columnMove.ts
+++ b/handsontable/src/plugins/undoRedo/actions/columnMove.ts
@@ -19,12 +19,18 @@ export class ColumnMoveAction extends BaseAction {
    */
   finalColumnIndex;
 
+  /**
+   * Initializes the column move action with the array of moved column indexes and their destination index.
+   */
   constructor({ columns, finalIndex }: { columns: number[], finalIndex: number }) {
     super('col_move');
     this.columns = columns.slice();
     this.finalColumnIndex = finalIndex;
   }
 
+  /**
+   * Registers the `beforeColumnMove` hook listener that records a new ColumnMoveAction whenever columns are moved.
+   */
   static startRegisteringEvents(hot: HotInstance, undoRedoPlugin: unknown) {
     hot.addHook('beforeColumnMove', (columns: unknown, finalIndex: unknown) => {
       if (columns === false) {

--- a/handsontable/src/plugins/undoRedo/actions/columnSort.ts
+++ b/handsontable/src/plugins/undoRedo/actions/columnSort.ts
@@ -19,12 +19,18 @@ export class ColumnSortAction extends BaseAction {
    */
   nextSortState;
 
+  /**
+   * Initializes the column sort action with the previous and next sort state snapshots.
+   */
   constructor({ currentSortState, newSortState }: { currentSortState: unknown, newSortState: unknown }) {
     super('col_sort');
     this.previousSortState = currentSortState;
     this.nextSortState = newSortState;
   }
 
+  /**
+   * Registers the `beforeColumnSort` hook listener that records a new ColumnSortAction whenever sorting changes.
+   */
   static startRegisteringEvents(hot: HotInstance, undoRedoPlugin: unknown) {
     hot.addHook('beforeColumnSort', (currentSortState: unknown, newSortState: unknown, sortPossible: unknown) => {
       if (!sortPossible) {

--- a/handsontable/src/plugins/undoRedo/actions/createColumn.ts
+++ b/handsontable/src/plugins/undoRedo/actions/createColumn.ts
@@ -18,12 +18,18 @@ export class CreateColumnAction extends BaseAction {
    */
   amount;
 
+  /**
+   * Initializes the create column action with the visual insertion index and the number of columns created.
+   */
   constructor({ index, amount }: { index: number, amount: number }) {
     super('insert_col');
     this.index = index;
     this.amount = amount;
   }
 
+  /**
+   * Registers the `afterCreateCol` hook listener that records a new CreateColumnAction after columns are inserted.
+   */
   static startRegisteringEvents(hot: HotInstance, undoRedoPlugin: unknown) {
     hot.addHook('afterCreateCol', (index: number, amount: number, source: string) => {
       (undoRedoPlugin as { done: (...args: unknown[]) => void }).done(

--- a/handsontable/src/plugins/undoRedo/actions/createRow.ts
+++ b/handsontable/src/plugins/undoRedo/actions/createRow.ts
@@ -18,12 +18,18 @@ export class CreateRowAction extends BaseAction {
    */
   amount;
 
+  /**
+   * Initializes the create row action with the visual insertion index and the number of rows created.
+   */
   constructor({ index, amount }: { index: number, amount: number }) {
     super('insert_row');
     this.index = index;
     this.amount = amount;
   }
 
+  /**
+   * Registers the `afterCreateRow` hook listener that records a new CreateRowAction after rows are inserted.
+   */
   static startRegisteringEvents(hot: HotInstance, undoRedoPlugin: unknown) {
     hot.addHook('afterCreateRow', (index: number, amount: number, source: string) => {
       (undoRedoPlugin as { done: (...args: unknown[]) => void }).done(

--- a/handsontable/src/plugins/undoRedo/actions/dataChange.ts
+++ b/handsontable/src/plugins/undoRedo/actions/dataChange.ts
@@ -35,6 +35,9 @@ export class DataChangeAction extends BaseAction {
    */
   declare countRows: number;
 
+  /**
+   * Initializes the data change action with the recorded cell changes, selection state, and grid dimensions at the time of the change.
+   */
   constructor({ changes, selected, countCols, countRows }: {
     changes: unknown[][], selected: unknown[], countCols: number, countRows: number
   }) {
@@ -45,6 +48,9 @@ export class DataChangeAction extends BaseAction {
     this.countRows = countRows;
   }
 
+  /**
+   * Registers the `beforeChange` hook listener that captures effective cell value changes and records them as DataChangeActions.
+   */
   static startRegisteringEvents(hot: HotInstance, undoRedoPlugin: unknown) {
     const plugin = undoRedoPlugin as UndoRedoPluginLike;
 

--- a/handsontable/src/plugins/undoRedo/actions/filters.ts
+++ b/handsontable/src/plugins/undoRedo/actions/filters.ts
@@ -18,6 +18,9 @@ export class FiltersAction extends BaseAction {
    */
   previousConditionsStack;
 
+  /**
+   * Initializes the filters action with the current and previous filter condition stacks.
+   */
   constructor({ conditionsStack, previousConditionsStack }: {
     conditionsStack: unknown, previousConditionsStack: unknown
   }) {
@@ -26,6 +29,9 @@ export class FiltersAction extends BaseAction {
     this.previousConditionsStack = previousConditionsStack;
   }
 
+  /**
+   * Registers the `beforeFilter` hook listener that records a new FiltersAction whenever filter conditions change.
+   */
   static startRegisteringEvents(hot: HotInstance, undoRedoPlugin: unknown) {
     hot.addHook('beforeFilter', (conditionsStack: unknown, previousConditionsStack: unknown) => {
       (undoRedoPlugin as { done: (...args: unknown[]) => void }).done(() => new FiltersAction({

--- a/handsontable/src/plugins/undoRedo/actions/mergeCells.ts
+++ b/handsontable/src/plugins/undoRedo/actions/mergeCells.ts
@@ -14,14 +14,23 @@ export class MergeCellsAction extends BaseAction {
    * @param {CellRange} cellRange The merged cell range.
    */
   cellRange;
+  /**
+   * Stores the cell data captured before the merge, used to restore values when the action is undone.
+   */
   declare data: unknown;
 
+  /**
+   * Initializes the merge cells action with the affected cell range and the original cell data.
+   */
   constructor({ data, cellRange }: { data: unknown, cellRange: CellRange }) {
     super('merge_cells');
     this.cellRange = cellRange;
     this.data = data;
   }
 
+  /**
+   * Registers the hooks needed to capture merge and unmerge events so they can be tracked for undo and redo.
+   */
   static startRegisteringEvents(hot: HotInstance, undoRedoPlugin: unknown) {
     hot.addHook('beforeMergeCells', (cellRange: unknown, auto: unknown) => {
       if (auto) {

--- a/handsontable/src/plugins/undoRedo/actions/removeColumn.ts
+++ b/handsontable/src/plugins/undoRedo/actions/removeColumn.ts
@@ -49,6 +49,9 @@ export class RemoveColumnAction extends BaseAction {
    */
   removedCellMetas;
 
+  /**
+   * Initializes the remove column action with the removed data, column indexes, headers, position sequences, and cell meta backup.
+   */
   constructor({
     index,
     indexes,
@@ -75,6 +78,9 @@ export class RemoveColumnAction extends BaseAction {
     this.removedCellMetas = removedCellMetas;
   }
 
+  /**
+   * Registers the `beforeRemoveCol` hook listener that captures removed column data and records a RemoveColumnAction.
+   */
   static startRegisteringEvents(hot: HotInstance, undoRedoPlugin: unknown) {
     hot.addHook('beforeRemoveCol', (index: number, amount: number, logicColumns: unknown, source: string) => {
       const wrappedAction = () => {

--- a/handsontable/src/plugins/undoRedo/actions/removeRow.ts
+++ b/handsontable/src/plugins/undoRedo/actions/removeRow.ts
@@ -41,6 +41,9 @@ export class RemoveRowAction extends BaseAction {
    */
   removedMergedCells;
 
+  /**
+   * Initializes the remove row action with the removed data, row index sequence, fixed-row counts, cell meta backup, and affected merged cells.
+   */
   constructor({
     index,
     data,
@@ -64,6 +67,9 @@ export class RemoveRowAction extends BaseAction {
     this.removedMergedCells = removedMergedCells;
   }
 
+  /**
+   * Registers the `beforeRemoveRow` hook listener that captures removed row data and records a RemoveRowAction.
+   */
   static startRegisteringEvents(hot: HotInstance, undoRedoPlugin: unknown) {
     hot.addHook('beforeRemoveRow', (index: number, amount: number, logicRows: unknown, source: string) => {
       const wrappedAction = () => {

--- a/handsontable/src/plugins/undoRedo/actions/rowMove.ts
+++ b/handsontable/src/plugins/undoRedo/actions/rowMove.ts
@@ -19,12 +19,18 @@ export class RowMoveAction extends BaseAction {
    */
   finalRowIndex;
 
+  /**
+   * Initializes the row move action with the array of moved row indexes and their destination index.
+   */
   constructor({ rows, finalIndex }: { rows: number[], finalIndex: number }) {
     super('row_move');
     this.rows = rows.slice();
     this.finalRowIndex = finalIndex;
   }
 
+  /**
+   * Registers the `beforeRowMove` hook listener that records a new RowMoveAction whenever rows are moved.
+   */
   static startRegisteringEvents(hot: HotInstance, undoRedoPlugin: unknown) {
     hot.addHook('beforeRowMove', (rows: unknown, finalIndex: unknown) => {
       if (rows === false) {

--- a/handsontable/src/plugins/undoRedo/actions/unmergeCells.ts
+++ b/handsontable/src/plugins/undoRedo/actions/unmergeCells.ts
@@ -15,11 +15,17 @@ export class UnmergeCellsAction extends BaseAction {
    */
   cellRange;
 
+  /**
+   * Initializes the unmerge cells action with the cell range that was unmerged.
+   */
   constructor({ cellRange }: { cellRange: CellRange }) {
     super('unmerge_cells');
     this.cellRange = cellRange;
   }
 
+  /**
+   * Registers the `afterUnmergeCells` hook listener that records a new UnmergeCellsAction after cells are manually unmerged.
+   */
   static startRegisteringEvents(hot: HotInstance, undoRedoPlugin: unknown) {
     hot.addHook('afterUnmergeCells', (cellRange: unknown, auto: unknown) => {
       if (auto) {

--- a/handsontable/src/plugins/undoRedo/undoRedo.ts
+++ b/handsontable/src/plugins/undoRedo/undoRedo.ts
@@ -36,14 +36,23 @@ Hooks.getSingleton().register('afterRedo');
  * @plugin UndoRedo
  */
 export class UndoRedo extends BasePlugin {
+  /**
+   * Returns the plugin key used to identify this plugin in Handsontable settings.
+   */
   static get PLUGIN_KEY() {
     return PLUGIN_KEY;
   }
 
+  /**
+   * Returns the priority order used to determine the order in which plugins are initialized.
+   */
   static get PLUGIN_PRIORITY() {
     return PLUGIN_PRIORITY;
   }
 
+  /**
+   * Returns whether the plugin handles its own settings keys without a dedicated key list.
+   */
   static get SETTING_KEYS(): true {
     return true;
   }
@@ -72,6 +81,9 @@ export class UndoRedo extends BasePlugin {
    */
   ignoreNewActions = false;
 
+  /**
+   * Initializes the plugin and registers all built-in undo/redo action handlers for the given Handsontable instance.
+   */
   constructor(hotInstance: HotInstance) {
     super(hotInstance);
     registerActions(hotInstance, this);

--- a/handsontable/src/plugins/undoRedo/undoRedo.ts
+++ b/handsontable/src/plugins/undoRedo/undoRedo.ts
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/require-description-complete-sentence */
 import type { HotInstance } from '../../core/types';
 import { BasePlugin } from '../base';
 import { Hooks } from '../../core/hooks';

--- a/handsontable/src/selection/highlight/highlight.ts
+++ b/handsontable/src/selection/highlight/highlight.ts
@@ -152,6 +152,9 @@ class Highlight {
    */
   customSelections: VisualSelection[] = [];
 
+  /**
+   * Initializes the highlight manager with configuration options and creates the focus and fill highlight instances.
+   */
   constructor(options: Record<string, unknown>) {
     this.options = options;
     this.focus = createFocusHighlight(options);

--- a/handsontable/src/selection/highlight/visualSelection.ts
+++ b/handsontable/src/selection/highlight/visualSelection.ts
@@ -14,7 +14,14 @@ interface VisualSelectionSettings {
   [key: string]: unknown;
 }
 
+/**
+ * Extends the Walkontable Selection class to operate on visual coordinates, translating them to
+ * renderable indexes when committing the selection to the DOM.
+ */
 class VisualSelection extends Selection {
+  /**
+   * The settings object that includes index mappers and coordinate factory helpers specific to visual selection.
+   */
   declare settings: VisualSelectionSettings;
 
   /**
@@ -24,6 +31,9 @@ class VisualSelection extends Selection {
    */
   visualCellRange: CellRange | null = null;
 
+  /**
+   * Initializes the visual selection with optional settings overrides and an initial visual cell range.
+   */
   constructor(settings: Record<string, unknown>, visualCellRange?: CellRange | null) {
     super(settings, null);
     this.visualCellRange = visualCellRange || null;

--- a/handsontable/src/selection/range.ts
+++ b/handsontable/src/selection/range.ts
@@ -20,6 +20,9 @@ class SelectionRange {
    */
   createCellRange: (...args: CellCoords[]) => CellRange;
 
+  /**
+   * Initializes the collection with a factory function used to create new CellRange instances.
+   */
   constructor(createCellRange: (...args: CellCoords[]) => CellRange) {
     this.createCellRange = createCellRange;
   }
@@ -219,6 +222,9 @@ class SelectionRange {
     return cellRange;
   }
 
+  /**
+   * Returns an iterator over all CellRange entries stored in the collection, enabling use in for-of loops.
+   */
   [Symbol.iterator]() {
     return this.ranges[Symbol.iterator]();
   }

--- a/handsontable/src/selection/selection.ts
+++ b/handsontable/src/selection/selection.ts
@@ -50,9 +50,12 @@ function isFocusPositionObject(value: unknown): value is { row: number; col: num
  */
 class Selection {
   /**
-   * Local hooks mixin properties.
+   * Triggers registered local hook callbacks for the given hook name, passing any additional arguments.
    */
   declare runLocalHooks: (...args: unknown[]) => void;
+  /**
+   * Registers a local hook callback for the given hook name on this instance.
+   */
   declare addLocalHook: (...args: unknown[]) => this;
 
   /**
@@ -146,6 +149,9 @@ class Selection {
    */
   #activeSelectionLayer = 0;
 
+  /**
+   * Initializes the Selection manager with grid settings and table API references, and sets up transformation modules and highlight layers.
+   */
   constructor(settings: SelectionSettings, tableProps: SelectionTableProps) {
     this.settings = settings;
     this.tableProps = tableProps;

--- a/handsontable/src/selection/transformation/_base.ts
+++ b/handsontable/src/selection/transformation/_base.ts
@@ -23,9 +23,12 @@ import localHooks from '../../mixins/localHooks';
  */
 export class BaseTransformation {
   /**
-   * Mixin property declarations for localHooks.
+   * Triggers registered local hook callbacks for the given hook name, passing any additional arguments.
    */
   declare runLocalHooks: (...args: unknown[]) => void;
+  /**
+   * Registers a local hook callback for the given hook name on this transformation instance.
+   */
   declare addLocalHook: (...args: unknown[]) => object;
 
   /**
@@ -54,6 +57,9 @@ export class BaseTransformation {
    */
   declare tableApi: SelectionTableProps;
 
+  /**
+   * Initializes the transformation module with the selection range collection and the table API reference.
+   */
   constructor(range: SelectionRange, tableApi: SelectionTableProps) {
     this.#range = range;
     this.tableApi = tableApi;

--- a/handsontable/src/shortcuts/context.ts
+++ b/handsontable/src/shortcuts/context.ts
@@ -43,7 +43,6 @@ export function isContextObject(objectToCheck: unknown): objectToCheck is Contex
   return isObject(objectToCheck) && (objectToCheck as Record<string, unknown>).__kindOf === __kindOf;
 }
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
 /**
  * The `ShortcutContext` API lets you store and manage [keyboard shortcuts](@/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md) in a given [context](@/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md#keyboard-shortcut-contexts).
  *

--- a/handsontable/src/shortcuts/contexts/constants.ts
+++ b/handsontable/src/shortcuts/contexts/constants.ts
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/require-description-complete-sentence */
 /**
  * Group name for keyboard shortcuts that are active when the cell is selected.
  */

--- a/handsontable/src/shortcuts/keyObserver.ts
+++ b/handsontable/src/shortcuts/keyObserver.ts
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/require-description-complete-sentence */
 
 /**
  * Create a key observer.

--- a/handsontable/src/shortcuts/manager.ts
+++ b/handsontable/src/shortcuts/manager.ts
@@ -8,7 +8,6 @@ import { useRecorder } from './recorder';
 import { getEventKeyCombinations } from './utils';
 import { toSingleLine } from '../helpers/templateLiteralTag';
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
 /**
  * The `ShortcutManager` API lets you store and manage [keyboard shortcut contexts](@/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md#keyboard-shortcut-contexts) ([`ShortcutContext`](@/api/shortcutContext.md)).
  *

--- a/handsontable/src/shortcuts/recorder.ts
+++ b/handsontable/src/shortcuts/recorder.ts
@@ -9,8 +9,6 @@ const modifierKeysObserver = createKeysObserver();
 const modKeyListeners: Array<{event: 'keydown' | 'keyup'; listener: (event: KeyboardEvent) => void}> = [];
 let instanceCounter = 0;
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
-
 /**
  * A key recorder, used for tracking key events.
  *

--- a/handsontable/src/shortcuts/utils.ts
+++ b/handsontable/src/shortcuts/utils.ts
@@ -21,8 +21,6 @@ const mappings = new Map([
   ['down', 'arrowdown'],
 ]);
 
-/* eslint-disable jsdoc/require-description-complete-sentence */
-
 /**
  * Get a single, normalized string from the list of the `KeyboardEvent.key` properties.
  *

--- a/handsontable/src/translations/changesObservable/observable.ts
+++ b/handsontable/src/translations/changesObservable/observable.ts
@@ -52,11 +52,13 @@ export class ChangesObservable {
    */
   #initialIndexValue: unknown = false;
 
+  /**
+   * Initializes the observable with an optional initial index value used as the baseline for generating first-time change events.
+   */
   constructor({ initialIndexValue }: { initialIndexValue?: unknown } = {}) {
     this.#initialIndexValue = initialIndexValue ?? false;
   }
 
-  /* eslint-disable jsdoc/require-description-complete-sentence */
   /**
    * Creates and returns a new instance of the ChangesObserver object. The resource
    * allows subscribing to the index changes that during the code running may change.
@@ -79,7 +81,7 @@ export class ChangesObservable {
    *
    * @returns {ChangesObserver}
    */
-  /* eslint-enable jsdoc/require-description-complete-sentence */
+  // eslint-disable-next-line jsdoc/require-description-complete-sentence
   createObserver() {
     const observer = new ChangesObserver();
 

--- a/handsontable/src/translations/changesObservable/observable.ts
+++ b/handsontable/src/translations/changesObservable/observable.ts
@@ -81,7 +81,6 @@ export class ChangesObservable {
    *
    * @returns {ChangesObserver}
    */
-  // eslint-disable-next-line jsdoc/require-description-complete-sentence
   createObserver() {
     const observer = new ChangesObserver();
 

--- a/handsontable/src/translations/changesObservable/observer.ts
+++ b/handsontable/src/translations/changesObservable/observer.ts
@@ -9,9 +9,21 @@ import localHooks from '../../mixins/localHooks';
  */
 export class ChangesObserver {
   // Mixin-injected properties/methods (added by `mixin(ChangesObserver, localHooks)`)
+  /**
+   * Internal storage map for local hook callbacks, keyed by hook name.
+   */
   declare _localHooks: Record<string, Function[]>;
+  /**
+   * Registers a callback function for the given local hook name.
+   */
   declare addLocalHook: (key: string, callback: Function) => this;
+  /**
+   * Triggers all callbacks registered under the given local hook name.
+   */
   declare runLocalHooks: (key: string, ...args: unknown[]) => void;
+  /**
+   * Removes all locally registered hook callbacks from this observer instance.
+   */
   declare clearLocalHooks: () => this;
 
   /**

--- a/handsontable/src/translations/indexMapper.ts
+++ b/handsontable/src/translations/indexMapper.ts
@@ -47,9 +47,21 @@ const deprecationWarns = new Set();
  */
 export class IndexMapper {
   // Mixin-injected properties/methods (added by `mixin(IndexMapper, localHooks)`)
+  /**
+   * Internal storage map for local hook callbacks, keyed by hook name.
+   */
   declare _localHooks: Record<string, Function[]>;
+  /**
+   * Registers a callback function for the given local hook name on this index mapper.
+   */
   declare addLocalHook: (key: string, callback: Function) => this;
+  /**
+   * Removes a previously registered callback function for the given local hook name.
+   */
   declare removeLocalHook: (key: string, callback: Function) => this;
+  /**
+   * Triggers all callbacks registered under the given local hook name, passing any additional arguments.
+   */
   declare runLocalHooks: (key: string, ...args: unknown[]) => void;
 
   /**
@@ -187,6 +199,9 @@ export class IndexMapper {
    */
   readonly #dirtyObservedMaps = new Set<IndexMap>();
 
+  /**
+   * Initializes the IndexMapper by wiring change listeners on the indexes sequence, trimming, and hiding map collections to keep caches up to date.
+   */
   constructor() {
     this.indexesSequence.addLocalHook('change', () => {
       this.indexesSequenceChanged = true;

--- a/handsontable/src/translations/mapCollections/aggregatedCollection.ts
+++ b/handsontable/src/translations/mapCollections/aggregatedCollection.ts
@@ -8,6 +8,9 @@ import { isDefined } from '../../helpers/mixed';
  */
 export class AggregatedCollection extends MapCollection {
   // Mixin-injected properties/methods (added by `mixin(MapCollection, localHooks)`)
+  /**
+   * Registers a callback function for the given local hook name on this aggregated collection.
+   */
   declare addLocalHook: (key: string, callback: Function) => this;
 
   /**
@@ -25,6 +28,9 @@ export class AggregatedCollection extends MapCollection {
    */
   fallbackValue;
 
+  /**
+   * Initializes the aggregated collection with a function that combines per-index values and a fallback value for indexes with no data.
+   */
   constructor(aggregationFunction: (valuesForIndex: unknown[]) => unknown, fallbackValue: unknown) {
     super();
     this.aggregationFunction = aggregationFunction;

--- a/handsontable/src/translations/mapCollections/mapCollection.ts
+++ b/handsontable/src/translations/mapCollections/mapCollection.ts
@@ -11,8 +11,17 @@ let registeredMaps = 0;
  */
 export class MapCollection {
   // Mixin-injected properties/methods (added by `mixin(MapCollection, localHooks)`)
+  /**
+   * Internal storage map for local hook callbacks, keyed by hook name.
+   */
   declare _localHooks: Record<string, Function[]>;
+  /**
+   * Registers a callback function for the given local hook name on this collection.
+   */
   declare addLocalHook: (key: string, callback: Function) => this;
+  /**
+   * Triggers all callbacks registered under the given local hook name across this collection.
+   */
   declare runLocalHooks: (key: string, ...args: unknown[]) => void;
 
   /**

--- a/handsontable/src/translations/maps/hidingMap.ts
+++ b/handsontable/src/translations/maps/hidingMap.ts
@@ -8,6 +8,9 @@ import { arrayReduce } from '../../helpers/array';
  * @class HidingMap
  */
 export class HidingMap extends PhysicalIndexToValueMap {
+  /**
+   * Initializes the hiding map with an optional default value, defaulting to `false` (not hidden).
+   */
   constructor(initValueOrFn = false) {
     super(initValueOrFn);
   }

--- a/handsontable/src/translations/maps/indexMap.ts
+++ b/handsontable/src/translations/maps/indexMap.ts
@@ -25,10 +25,22 @@ export class IndexMap {
   initValueOrFn;
 
   // Mixin declarations for localHooks (signature must match mixin for subclass assignability)
+  /**
+   * Triggers all callbacks registered under the given local hook name, returning any results.
+   */
   declare runLocalHooks: (key: string, ...args: unknown[]) => unknown;
+  /**
+   * Registers a callback function for the given local hook name on this map instance.
+   */
   declare addLocalHook: (key: string, callback: Function) => unknown;
+  /**
+   * Removes all locally registered hook callbacks from this map instance.
+   */
   declare clearLocalHooks: () => void;
 
+  /**
+   * Initializes the index map with an optional default value or factory function applied to each index.
+   */
   constructor(initValueOrFn: unknown = null) {
     this.initValueOrFn = initValueOrFn;
   }

--- a/handsontable/src/translations/maps/indexesSequence.ts
+++ b/handsontable/src/translations/maps/indexesSequence.ts
@@ -10,6 +10,9 @@ import { getDecreasedIndexes, getIncreasedIndexes } from './utils';
  * @class IndexesSequence
  */
 export class IndexesSequence extends IndexMap {
+  /**
+   * Initializes the sequence map with an identity function so each index maps to its own physical value.
+   */
   constructor() {
     // Not handling custom init function or init value.
     super((index: number) => index);

--- a/handsontable/src/translations/maps/trimmingMap.ts
+++ b/handsontable/src/translations/maps/trimmingMap.ts
@@ -8,6 +8,9 @@ import { arrayReduce } from '../../helpers/array';
  * @class TrimmingMap
  */
 export class TrimmingMap extends PhysicalIndexToValueMap {
+  /**
+   * Initializes the trimming map with an optional default value, defaulting to `false` (not trimmed).
+   */
   constructor(initValueOrFn = false) {
     super(initValueOrFn);
   }

--- a/handsontable/src/utils/autoResize.ts
+++ b/handsontable/src/utils/autoResize.ts
@@ -1,11 +1,9 @@
-/* eslint-disable jsdoc/require-description-complete-sentence */
 /**
  * autoResize - resizes a DOM element to the width and height of another DOM element
  *
  * Copyright 2014, Marcin Warpechowski
  * Licensed under the MIT license
  */
-/* eslint-enable jsdoc/require-description-complete-sentence */
 /**
  * Attaches an event listener to the given element.
  *

--- a/handsontable/src/utils/dataStructures/linkedList.ts
+++ b/handsontable/src/utils/dataStructures/linkedList.ts
@@ -32,6 +32,9 @@ class NodeStructure {
    */
   prev: NodeStructure | null = null;
 
+  /**
+   * Initializes the node with the given data value.
+   */
   constructor(data: unknown) {
     this.data = data;
   }
@@ -44,7 +47,13 @@ class NodeStructure {
  * @util
  */
 class LinkedList {
+  /**
+   * The first node in the list, or null when the list is empty.
+   */
   first: NodeStructure | null = null;
+  /**
+   * The last node in the list, or null when the list is empty.
+   */
   last: NodeStructure | null = null;
 
   /**

--- a/handsontable/src/utils/dataStructures/queue.ts
+++ b/handsontable/src/utils/dataStructures/queue.ts
@@ -3,7 +3,13 @@
  * @util
  */
 class Queue {
+  /**
+   * The ordered collection of items held in the queue, where index 0 is the front.
+   */
   declare items: unknown[];
+  /**
+   * Initializes the queue with an optional pre-populated array of items.
+   */
   constructor(initial: unknown[] = []) {
     /**
      * Items collection.

--- a/handsontable/src/utils/dataStructures/stack.ts
+++ b/handsontable/src/utils/dataStructures/stack.ts
@@ -3,7 +3,13 @@
  * @util
  */
 class Stack {
+  /**
+   * The ordered collection of items held in the stack, where the last element is the top.
+   */
   declare items: unknown[];
+  /**
+   * Initializes the stack with an optional pre-populated array of items.
+   */
   constructor(initial: unknown[] = []) {
     /**
      * Items collection.

--- a/handsontable/src/utils/dataStructures/tree.ts
+++ b/handsontable/src/utils/dataStructures/tree.ts
@@ -121,6 +121,9 @@ export default class TreeNode {
    */
   childs: TreeNode[] = [];
 
+  /**
+   * Initializes the tree node with the provided data object.
+   */
   constructor(data: Record<string, unknown>) {
     this.data = data;
   }
@@ -135,7 +138,6 @@ export default class TreeNode {
     this.childs.push(node);
   }
 
-  /* eslint-disable jsdoc/require-description-complete-sentence */
   /**
    * @memberof TreeNode#
    * @function cloneTree
@@ -157,7 +159,7 @@ export default class TreeNode {
    * @param {TreeNode} [nodeTree=this] A TreeNode to clone.
    * @returns {TreeNode}
    */
-  /* eslint-enable jsdoc/require-description-complete-sentence */
+  // eslint-disable-next-line jsdoc/require-description-complete-sentence
   cloneTree(nodeTree: TreeNode = this) {
     const clonedNode = new TreeNode({
       ...nodeTree.data,

--- a/handsontable/src/utils/dataStructures/tree.ts
+++ b/handsontable/src/utils/dataStructures/tree.ts
@@ -159,7 +159,6 @@ export default class TreeNode {
    * @param {TreeNode} [nodeTree=this] A TreeNode to clone.
    * @returns {TreeNode}
    */
-  // eslint-disable-next-line jsdoc/require-description-complete-sentence
   cloneTree(nodeTree: TreeNode = this) {
     const clonedNode = new TreeNode({
       ...nodeTree.data,

--- a/handsontable/src/utils/ghostTable.ts
+++ b/handsontable/src/utils/ghostTable.ts
@@ -99,6 +99,9 @@ class GhostTable {
    */
   table: GhostTableStruct | null = null;
 
+  /**
+   * Initializes the ghost table utility with a reference to the Handsontable instance used for DOM context.
+   */
   constructor(hotInstance: HotInstance | object) {
     this.hot = hotInstance as HotInstance;
   }

--- a/handsontable/src/utils/interval.ts
+++ b/handsontable/src/utils/interval.ts
@@ -4,6 +4,9 @@ import { requestAnimationFrame, cancelAnimationFrame } from './../helpers/featur
  * @class Interval
  */
 class Interval {
+  /**
+   * Creates and returns a new Interval instance for the given function and delay in milliseconds.
+   */
   static create(func: Function, delay: number) {
     return new Interval(func, delay);
   }
@@ -46,6 +49,9 @@ class Interval {
    */
   readonly #callback;
 
+  /**
+   * Initializes the interval with a callback function and a delay in milliseconds, binding the internal RAF callback.
+   */
   constructor(func: Function, delay: number) {
     this.#func = func;
     this.delay = parseDelay(delay);

--- a/handsontable/src/utils/samplesGenerator.ts
+++ b/handsontable/src/utils/samplesGenerator.ts
@@ -54,6 +54,9 @@ class SamplesGenerator {
    */
   includeHidden = false;
 
+  /**
+   * Initializes the samples generator with the data factory function used to retrieve cell values during sampling.
+   */
   constructor(dataFactory: DataFactory) {
     this.dataFactory = dataFactory;
   }

--- a/handsontable/src/utils/stylesHandler.ts
+++ b/handsontable/src/utils/stylesHandler.ts
@@ -186,6 +186,9 @@ export class StylesHandler {
     return this.#themeName;
   }
 
+  /**
+   * Injects the core Handsontable stylesheet into the document head, skipping injection if it is already present.
+   */
   #injectCoreStyles() {
     if (!this.#hot || !this.#rootDocument || !this.#rootDocument.head) {
       return;

--- a/handsontable/test/helpers/custom-matchers.js
+++ b/handsontable/test/helpers/custom-matchers.js
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/require-description-complete-sentence */
 import { generateASCIITable } from './asciiTable';
 import { normalize, pretty } from './htmlNormalize';
 // http://stackoverflow.com/questions/986937/how-can-i-get-the-browsers-scrollbar-sizes

--- a/handsontable/test/helpers/focusNavigator.js
+++ b/handsontable/test/helpers/focusNavigator.js
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/require-description-complete-sentence */
 /**
  * The module emulates the browser's focus traversal algorithm.
  */

--- a/handsontable/test/helpers/jasmine-helpers.js
+++ b/handsontable/test/helpers/jasmine-helpers.js
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/require-description-complete-sentence */
 /**
  * The function allows to run the test suites based on different parameters (object configuration, datasets etc).
  *


### PR DESCRIPTION
### Context

The PR extends `jsdoc/require-jsdoc` to require JSDoc on classes, methods, function declarations, and class fields in `src/**/*.ts` and `scripts/**/*.mjs`. Before this change the rule used default options, which only covered top-level `FunctionDeclaration` — leaving all class members and fields undocumented. This caused the Typedoc API reference to render with empty descriptions.

522 existing violations across 162 files are documented in this PR. Each declaration now carries a concise description in American English, active voice. Walkontable (`src/3rdparty/walkontable/**`) and test/type files (`*.unit.ts`, `*.spec.ts`, `*.types.ts`, `*.d.ts`) remain exempt.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1827

### How has this been tested?

- `npm run eslint --prefix handsontable` exits 0
- Negative test: removing a JSDoc block from a method in `src/editors/dateEditor/dateEditor.ts` produces `Missing JSDoc comment (jsdoc/require-jsdoc)`; restoring it clears the error
- Test files exempt: `npx eslint src/plugins/base/__tests__/base.unit.ts` exits 0
- `npx eslint "scripts/**/*.mjs"` exits 0

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1827

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and lint-only enforcement with no runtime behavior changes; large touch surface increases merge conflict risk but not functional risk.
> 
> **Overview**
> Turns on **`jsdoc/require-jsdoc` at error** for `src/**/*.ts` and `scripts/**/*.mjs`, requiring multiline JSDoc on **classes, methods, function declarations, and class fields** (via `PropertyDefinition`). Test and type paths stay exempt (`*.unit.ts`, `*.spec.ts`, `*.types.ts`, `*.d.ts`, `__tests__`, etc.).
> 
> The bulk of the diff **adds the missing blocks** across core, Walkontable, plugins, editors, dataMap, and build scripts so ESLint passes—constructors, private `#` fields, static getters like `PLUGIN_KEY` / `EDITOR_TYPE`, and mixin-injected members. Several files drop `jsdoc/require-description-complete-sentence` disables now that descriptions are written inline; Walkontable `settings.ts` uses targeted eslint disables for TS overload signatures.
> 
> **Contributor docs** expand: `.claude/skills/handsontable-dev/SKILL.md` adds a full JSDoc section (multiline format, **`{Type}` on every `@param`/`@returns`**, sync with TS signatures, `#` field rules); `AGENTS.md` documents the new lint rule and checklist item; note that AGENTS’ fix table currently says to omit `@param`/`@returns` in `.ts`, which **conflicts** with the skill’s Typedoc-oriented guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a708e912d21a17bd6a409af11ced5841572e726c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->