### PR TITLE
DEV-1748: Add Vue 3 variants to internationalization guides

### DIFF
--- a/docs/content/guides/internationalization/language/language.md
+++ b/docs/content/guides/internationalization/language/language.md
@@ -182,6 +182,36 @@ export class Component {
 
 :::
 
+::: only-for vue
+
+<ol class="sl-steps">
+<li>
+
+**ES modules (ESM)**
+
+```js
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import { registerLanguageDictionary, deDE } from 'handsontable/i18n';
+
+registerAllModules();
+registerLanguageDictionary(deDE);
+
+const hotSettings = ref({
+  language: deDE.languageCode,
+});
+```
+
+```html
+<HotTable :settings="hotSettings" />
+```
+
+</li>
+</ol>
+
+:::
+
 ### Demo
 
 To see the translated context menu, right-click on a cell.
@@ -216,6 +246,16 @@ Language files were loaded after loading Handsontable.
 
 @[code](@/content/guides/internationalization/language/angular/example1.ts)
 @[code](@/content/guides/internationalization/language/angular/example1.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example1 :vue3-languages
+
+@[code](@/content/guides/internationalization/language/vue/example1.vue)
 
 :::
 

--- a/docs/content/guides/internationalization/language/vue/example1.vue
+++ b/docs/content/guides/internationalization/language/vue/example1.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import { registerLanguageDictionary, deDE } from 'handsontable/i18n';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+registerLanguageDictionary(deDE);
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['Lorem', 'ipsum', 'dolor', 'sit', '12/1/2015', 23],
+    ['adipiscing', 'elit', 'Ut', 'imperdiet', '5/12/2015', 6],
+    ['Pellentesque', 'vulputate', 'leo', 'semper', '10/23/2015', 26],
+    ['diam', 'et', 'malesuada', 'libero', '12/1/2014', 98],
+    ['orci', 'et', 'dignissim', 'hendrerit', '12/1/2016', 8.5],
+  ],
+  contextMenu: true,
+  height: 'auto',
+  language: deDE.languageCode,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/internationalization/layout-direction/layout-direction.md
+++ b/docs/content/guides/internationalization/layout-direction/layout-direction.md
@@ -87,6 +87,16 @@ To try out Handsontable's RTL support, check out the demo below:
 
 :::
 
+::: only-for vue
+
+::: example #example1 :vue3-languages
+
+@[code](@/content/guides/internationalization/layout-direction/vue/example1.vue)
+
+:::
+
+:::
+
 ### Elements affected by layout direction
 
 Setting a different layout direction affects the behavior of the following areas of Handsontable:
@@ -157,6 +167,16 @@ In the example below, the RTL layout direction is inherited from a `dir` attribu
 
 :::
 
+::: only-for vue
+
+::: example #example2 :vue3
+
+@[code](@/content/guides/internationalization/layout-direction/vue/example2.vue)
+
+:::
+
+:::
+
 ### Set the layout direction to RTL
 
 You can render Handsontable from the right to the left, regardless of your HTML document's `dir` attribute.
@@ -192,6 +212,16 @@ and set it to `'rtl'`:
 
 @[code](@/content/guides/internationalization/layout-direction/angular/example3.ts)
 @[code](@/content/guides/internationalization/layout-direction/angular/example3.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example3 :vue3
+
+@[code](@/content/guides/internationalization/layout-direction/vue/example3.vue)
 
 :::
 
@@ -237,6 +267,16 @@ and set it to `'ltr'`:
 
 :::
 
+::: only-for vue
+
+::: example #example4 :vue3
+
+@[code](@/content/guides/internationalization/layout-direction/vue/example4.vue)
+
+:::
+
+:::
+
 ## Set the horizontal text alignment
 
 You can apply different horizontal [text alignment](@/guides/cell-features/text-alignment/text-alignment.md) settings, overwriting the horizontal text alignment resulting from your grid's layout direction.
@@ -271,6 +311,16 @@ In the example below, some columns are explicitly aligned to the left, center, o
 
 @[code](@/content/guides/internationalization/layout-direction/angular/example5.ts)
 @[code](@/content/guides/internationalization/layout-direction/angular/example5.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example5 :vue3
+
+@[code](@/content/guides/internationalization/layout-direction/vue/example5.vue)
 
 :::
 

--- a/docs/content/guides/internationalization/layout-direction/vue/example1.vue
+++ b/docs/content/guides/internationalization/layout-direction/vue/example1.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import { registerLanguageDictionary, arAR } from 'handsontable/i18n';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+registerLanguageDictionary(arAR);
+
+function generateArabicData(): (string | number | boolean)[][] {
+  const randomName = () => ['عمر', 'علي', 'عبد الله', 'معتصم'][Math.floor(Math.random() * 4)];
+  const randomCountry = () => ['تركيا', 'مصر', 'لبنان', 'العراق'][Math.floor(Math.random() * 4)];
+  const randomDate = () => new Date(Math.floor(Math.random() * Date.now())).toLocaleDateString();
+  const randomBool = () => Math.random() > 0.5;
+  const randomNumber = (a = 0, b = 1000) => a + Math.floor(Math.random() * b);
+  const randomPhrase = () => `${randomCountry()} ${randomName()} ${randomNumber()}`;
+
+  return Array.from({ length: 10 }, () => [
+    randomBool(),
+    randomName(),
+    randomCountry(),
+    randomPhrase(),
+    randomDate(),
+    randomPhrase(),
+    randomBool(),
+    randomNumber(0, 200).toString(),
+    randomNumber(0, 10),
+    randomNumber(0, 5),
+  ]);
+}
+
+const hotSettings = ref<GridSettings>({
+  data: generateArabicData(),
+  colHeaders: true,
+  rowHeaders: true,
+  height: 'auto',
+  layoutDirection: 'rtl',
+  language: 'ar-AR',
+  dropdownMenu: true,
+  filters: true,
+  contextMenu: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/internationalization/layout-direction/vue/example2.vue
+++ b/docs/content/guides/internationalization/layout-direction/vue/example2.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['', 'Tesla', 'Volvo', 'Toyota', 'Ford'],
+    ['2019', 10, 11, 12, 13],
+    ['2020', 20, 11, 14, 13],
+    ['2021', 30, 15, 12, 13],
+  ],
+  colHeaders: true,
+  rowHeaders: true,
+  height: 'auto',
+  layoutDirection: 'inherit',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <section dir="rtl">
+    <div id="example2">
+      <HotTable :settings="hotSettings" />
+    </div>
+  </section>
+</template>

--- a/docs/content/guides/internationalization/layout-direction/vue/example3.vue
+++ b/docs/content/guides/internationalization/layout-direction/vue/example3.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['', 'Tesla', 'Volvo', 'Toyota', 'Ford'],
+    ['2019', 10, 11, 12, 13],
+    ['2020', 20, 11, 14, 13],
+    ['2021', 30, 15, 12, 13],
+  ],
+  colHeaders: true,
+  rowHeaders: true,
+  height: 'auto',
+  layoutDirection: 'rtl',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example3">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/internationalization/layout-direction/vue/example4.vue
+++ b/docs/content/guides/internationalization/layout-direction/vue/example4.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['', 'Tesla', 'Volvo', 'Toyota', 'Ford'],
+    ['2019', 10, 11, 12, 13],
+    ['2020', 20, 11, 14, 13],
+    ['2021', 30, 15, 12, 13],
+  ],
+  colHeaders: true,
+  rowHeaders: true,
+  height: 'auto',
+  layoutDirection: 'ltr',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example4">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/internationalization/layout-direction/vue/example5.vue
+++ b/docs/content/guides/internationalization/layout-direction/vue/example5.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['', 'Tesla', 'Volvo', 'Toyota', 'Ford'],
+    ['2019', 10, 11, 12, 13],
+    ['2020', 20, 11, 14, 13],
+    ['2021', 30, 15, 12, 13],
+  ],
+  colHeaders: true,
+  rowHeaders: true,
+  height: 'auto',
+  layoutDirection: 'rtl',
+  columns: [
+    {},
+    { className: 'htLeft' },
+    { className: 'htCenter' },
+    { className: 'htRight' },
+    {},
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example5">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/internationalization/locale/locale.md
+++ b/docs/content/guides/internationalization/locale/locale.md
@@ -87,6 +87,21 @@ settings = {
 
 :::
 
+::: only-for vue
+
+```js
+const hotSettings = ref({
+  // set the entire grid's locale to Polish
+  locale: 'pl-PL',
+});
+```
+
+```html
+<HotTable :settings="hotSettings" />
+```
+
+:::
+
 You can set the [`locale`](@/api/options.md#locale) option to any valid and canonicalized Unicode BCP 47 locale tag.
 
 ## Set a column's locale
@@ -159,6 +174,33 @@ settings = {
 
 ```html
 <hot-table [settings]="settings" />
+```
+
+:::
+
+::: only-for vue
+
+```js
+const hotSettings = ref({
+  columns: [
+    {
+      // set the first column's locale to Polish
+      locale: 'pl-PL',
+    },
+    {
+      // set the second column's locale to German
+      locale: 'de-DE',
+    },
+    {
+      // set the third column's locale to Japanese
+      locale: 'ja-JP',
+    },
+  ],
+});
+```
+
+```html
+<HotTable :settings="hotSettings" />
 ```
 
 :::


### PR DESCRIPTION
### Context

The PR adds Vue 3 documentation variants for the four Internationalization guides (DEV-1748).

- **Language** and **Layout direction**: runnable Vue SFC examples and `::: only-for vue` embeds aligned with JavaScript, React, and Angular (`:vue3-languages` where other frameworks use language presets).
- **Locale**: Vue code snippets only (grid and column `locale`), matching other frameworks — no embedded demo on any framework.
- **IME support**: shared prose and video only — no Vue-only example (parity with other frameworks).

ClickUp: https://app.clickup.com/t/9015210959/DEV-1748

[skip changelog]

### How has this been tested?

- `pnpm dev` in `docs/` — verified `/vue-data-grid/language/`, `/layout-direction/`, `/locale/`, and `/ime-support/` return 200.
- `npm run build` in `docs/` — completed successfully (1178 pages).

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1748

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and example SFCs only; no product code, auth, or data handling changes.
> 
> **Overview**
> Adds **Vue 3** coverage to the internationalization docs so they match JavaScript, React, and Angular.
> 
> The **Language** guide gets a Vue-only ESM setup snippet (`registerAllModules`, `registerLanguageDictionary`, `HotTable` with `ref` settings) and a live demo wired with `:vue3-languages`. The **Layout direction** guide adds five Vue SFC examples (RTL Arabic demo, inherited `dir`, explicit RTL/LTR, and column alignment) embedded at each existing example slot. The **Locale** guide only adds Vue snippets for grid- and column-level `locale`—no new runnable demo, consistent with other frameworks.
> 
> Changes are limited to `docs/content/guides/internationalization/`; runtime packages are untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4964ec9414a3a3ff1d5e3c6bb0838e17a686607e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->