### PR TITLE
DEV-1744: Add Vue 3 variants to cell functions guides

### DIFF
--- a/docs/content/guides/cell-functions/cell-editor/cell-editor.md
+++ b/docs/content/guides/cell-functions/cell-editor/cell-editor.md
@@ -263,6 +263,16 @@ Override only the methods you need. The `PasswordEditor` below extends `TextEdit
 
 :::
 
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/cell-functions/cell-editor/vue/example1.vue)
+
+:::
+
+:::
+
 ### Building an editor from scratch
 
 Extend `BaseEditor` directly for full control. The `SelectEditor` below renders a `<select>` dropdown. It also overrides keyboard behavior so <kbd>**Arrow Up**</kbd> / <kbd>**Arrow Down**</kbd> cycle through options rather than closing the editor.
@@ -294,6 +304,16 @@ To use a class-based editor from scratch in React, pass the editor class as the 
 ::: only-for angular
 
 To use a class-based editor from scratch in Angular, pass the editor class as the `editor` property in a column configuration object. See the [class-based editors](#class-based-editors) section for an example.
+
+:::
+
+::: only-for vue
+
+::: example #example2 :vue3
+
+@[code](@/content/guides/cell-functions/cell-editor/vue/example2.vue)
+
+:::
 
 :::
 
@@ -354,6 +374,14 @@ settings = { columns: [{ editor: 'myEditor' }] };
 
 ```html
 <hot-table [settings]="settings" />
+```
+
+:::
+
+::: only-for vue
+
+```html
+<HotTable :settings="{ columns: [{ editor: 'myEditor' }] }" />
 ```
 
 :::

--- a/docs/content/guides/cell-functions/cell-editor/vue/example1.vue
+++ b/docs/content/guides/cell-functions/cell-editor/vue/example1.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import { TextEditor } from 'handsontable/editors/textEditor';
+import type Handsontable from 'handsontable/base';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+class PasswordEditor extends TextEditor {
+  override createElements(): void {
+    super.createElements();
+    this.TEXTAREA = this.hot.rootDocument.createElement('input') as HTMLInputElement;
+    this.TEXTAREA.setAttribute('type', 'password');
+    this.TEXTAREA.setAttribute('data-hot-input', 'true');
+    this.textareaStyle = this.TEXTAREA.style;
+    this.textareaStyle.width = '0';
+    this.textareaStyle.height = '0';
+    this.TEXTAREA_PARENT.innerText = '';
+    this.TEXTAREA_PARENT.appendChild(this.TEXTAREA);
+  }
+}
+
+function maskedRenderer(
+  _instance: Handsontable.Core,
+  td: HTMLTableCellElement,
+  _row: number,
+  _col: number,
+  _prop: string | number,
+  value: Handsontable.CellValue
+): HTMLTableCellElement {
+  td.innerText = value ? '●●●●●●●●' : '—';
+  td.style.letterSpacing = value ? '2px' : 'normal';
+
+  return td;
+}
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['Alice Chen', 'alice@example.com', 'Admin', 'Wh1stl3!2024'],
+    ['Bob Garcia', 'bob@example.com', 'Editor', 'P@ssw0rd42'],
+    ['Carol Smith', 'carol@example.com', 'Viewer', 'Tr0ub4dor&3'],
+    ['Dave Kim', 'dave@example.com', 'Editor', 'c0rrectH0rs3'],
+    ['Eve Johnson', 'eve@example.com', 'Admin', 'Sup3rS3cr3t!'],
+  ],
+  colHeaders: ['Name', 'Email', 'Role', 'Password'],
+  columns: [
+    { type: 'text' },
+    { type: 'text' },
+    { type: 'text' },
+    { editor: PasswordEditor as typeof TextEditor, renderer: maskedRenderer },
+  ],
+  colWidths: [130, 190, 70, 130],
+  rowHeaders: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-functions/cell-editor/vue/example2.vue
+++ b/docs/content/guides/cell-functions/cell-editor/vue/example2.vue
@@ -1,0 +1,188 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import { BaseEditor } from 'handsontable/editors/baseEditor';
+import { stopImmediatePropagation } from 'handsontable/helpers/dom/event';
+import type Handsontable from 'handsontable/base';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+class SelectEditor extends BaseEditor {
+  declare select: HTMLSelectElement;
+
+  init(): void {
+    this.select = this.hot.rootDocument.createElement('SELECT') as HTMLSelectElement;
+    this.select.setAttribute('data-hot-input', 'true');
+    this.select.classList.add('htSelectEditor');
+    this.select.style.display = 'none';
+    this.hot.rootElement.appendChild(this.select);
+  }
+
+  override prepare(
+    row: number,
+    col: number,
+    prop: number | string,
+    td: HTMLTableCellElement,
+    originalValue: Handsontable.CellValue,
+    cellProperties: object
+  ): void {
+    super.prepare(row, col, prop, td, originalValue, cellProperties);
+
+    const rawOptions = (this.cellProperties as any).selectOptions ?? []; // eslint-disable-line @typescript-eslint/no-explicit-any
+    const options: Record<string, string> = Array.isArray(rawOptions)
+      ? Object.fromEntries(rawOptions.map((v: string) => [v, v]))
+      : rawOptions;
+
+    this.select.innerText = '';
+    Object.keys(options).forEach((key) => {
+      const option = this.hot.rootDocument.createElement('OPTION') as HTMLOptionElement;
+
+      option.value = key;
+      option.innerText = options[key];
+      this.select.appendChild(option);
+    });
+  }
+
+  getValue(): string {
+    return this.select.value;
+  }
+
+  setValue(value: string): void {
+    this.select.value = value;
+  }
+
+  open(): void {
+    const { top, start, width, height } = this.getEditedCellRect();
+    const s = this.select.style;
+
+    s.height = `${height}px`;
+    s.minWidth = `${width}px`;
+    s.top = `${top}px`;
+    (s as any)[this.hot.isRtl() ? 'right' : 'left'] = `${start}px`; // eslint-disable-line @typescript-eslint/no-explicit-any
+    s.margin = '0px';
+    s.display = '';
+
+    this.addHook('beforeKeyDown', (event: KeyboardEvent) => {
+      const { selectedIndex, length } = this.select;
+
+      if (event.keyCode === 38 && selectedIndex > 0) {
+        (this.select[selectedIndex - 1] as HTMLOptionElement).selected = true;
+        stopImmediatePropagation(event);
+        event.preventDefault();
+      } else if (event.keyCode === 40 && selectedIndex < length - 1) {
+        (this.select[selectedIndex + 1] as HTMLOptionElement).selected = true;
+        stopImmediatePropagation(event);
+        event.preventDefault();
+      }
+    });
+  }
+
+  close(): void {
+    this.select.style.display = 'none';
+    this.clearHooks();
+  }
+
+  focus(): void {
+    this.select.focus();
+  }
+}
+
+const PRIORITY_COLORS: Record<string, string> = {
+  Low: '#22c55e',
+  Medium: '#f59e0b',
+  High: '#ef4444',
+  Critical: '#7c3aed',
+};
+
+const STATUS_COLORS: Record<string, string> = {
+  'To Do': '#6b7280',
+  'In Progress': '#3b82f6',
+  Review: '#f59e0b',
+  Done: '#22c55e',
+};
+
+function badgeRenderer(colorMap: Record<string, string>) {
+  return (
+    instance: Handsontable.Core,
+    td: HTMLTableCellElement,
+    _row: number,
+    _col: number,
+    _prop: string | number,
+    value: string
+  ): HTMLTableCellElement => {
+    td.innerText = '';
+
+    if (value) {
+      const badge = instance.rootDocument.createElement('span');
+
+      badge.className = 'htSelectBadge';
+      badge.style.background = colorMap[value] ?? '#6b7280';
+      badge.innerText = value;
+      td.appendChild(badge);
+    }
+
+    return td;
+  };
+}
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['Migrate database schema', 'High', 'In Progress'],
+    ['Update API documentation', 'Medium', 'To Do'],
+    ['Fix authentication bug', 'Critical', 'Review'],
+    ['Add dark mode support', 'Low', 'Done'],
+    ['Improve test coverage', 'Medium', 'In Progress'],
+    ['Deploy to staging server', 'High', 'To Do'],
+    ['Refactor billing module', 'Medium', 'Done'],
+  ],
+  colHeaders: ['Task', 'Priority', 'Status'],
+  columns: [
+    { type: 'text' },
+    {
+      editor: SelectEditor as typeof BaseEditor,
+      renderer: badgeRenderer(PRIORITY_COLORS),
+      selectOptions: ['Low', 'Medium', 'High', 'Critical'],
+    } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+    {
+      editor: SelectEditor as typeof BaseEditor,
+      renderer: badgeRenderer(STATUS_COLORS),
+      selectOptions: ['To Do', 'In Progress', 'Review', 'Done'],
+    } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+  ],
+  colWidths: [220, 110, 130],
+  rowHeaders: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example2">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>
+
+<style>
+.htSelectEditor {
+  /* Enables dimension changes for <select> in WebKit browsers */
+  -webkit-appearance: menulist-button !important;
+  position: absolute;
+  width: auto;
+  z-index: 300;
+}
+
+.htSelectBadge {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 600;
+  color: #fff;
+  letter-spacing: 0.3px;
+  white-space: nowrap;
+}
+</style>

--- a/docs/content/guides/cell-functions/cell-function/cell-function.md
+++ b/docs/content/guides/cell-functions/cell-function/cell-function.md
@@ -151,6 +151,23 @@ settings: GridSettings = {
 
 :::
 
+::: only-for vue
+
+```html
+<HotTable :settings="{
+  type: 'text',
+  columns: [
+    { type: 'numeric' },
+    { type: 'text' },
+  ],
+  cell: [
+    { row: 0, col: 0, type: 'checkbox' },
+  ],
+}" />
+```
+
+:::
+
 
 ## Mixing renderer, editor, and validator
 
@@ -190,6 +207,16 @@ The example below shows a product inventory table. Each column uses a different 
 
 @[code](@/content/guides/cell-functions/cell-function/angular/example1.ts)
 @[code](@/content/guides/cell-functions/cell-function/angular/example1.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/cell-functions/cell-function/vue/example1.vue)
 
 :::
 
@@ -241,6 +268,33 @@ const renderer = cellProperties.renderer;   // renderer function
 const editor = cellProperties.editor;       // editor class
 const validator = cellProperties.validator; // validator function or RegExp
 const type = cellProperties.type;           // cell type string
+```
+
+:::
+
+::: only-for vue
+
+```html
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+
+onMounted(() => {
+  const hot = hotRef.value?.hotInstance;
+  const cellProperties = hot?.getCellMeta(0, 0);
+
+  cellProperties?.renderer;   // renderer function
+  cellProperties?.editor;     // editor class
+  cellProperties?.validator;  // validator function or RegExp
+  cellProperties?.type;       // cell type string
+});
+</script>
+
+<template>
+  <HotTable ref="hotRef" />
+</template>
 ```
 
 :::
@@ -328,6 +382,33 @@ export class AppComponent implements AfterViewInit {
     const type = cellProperties.type;           // 'numeric'
   }
 }
+```
+
+:::
+
+::: only-for vue
+
+```html
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+
+onMounted(() => {
+  const hot = hotRef.value?.hotInstance;
+  const cellProperties = hot?.getCellMeta(0, 0);
+
+  cellProperties?.renderer;   // numericRenderer function
+  cellProperties?.editor;     // NumericEditor class
+  cellProperties?.validator;  // numericValidator function
+  cellProperties?.type;       // 'numeric'
+});
+</script>
+
+<template>
+  <HotTable ref="hotRef" :settings="{ columns: [{ type: 'numeric' }] }" />
+</template>
 ```
 
 :::

--- a/docs/content/guides/cell-functions/cell-function/vue/example1.vue
+++ b/docs/content/guides/cell-functions/cell-function/vue/example1.vue
@@ -1,0 +1,134 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+import type Handsontable from 'handsontable/base';
+
+registerAllModules();
+
+// Custom renderer: visualizes stock level as a progress bar with a numeric label.
+// Demonstrates using a renderer independently from the editor and validator.
+function stockRenderer(
+  hotInstance: Handsontable.Core,
+  td: HTMLTableCellElement,
+  _row: number,
+  _col: number,
+  _prop: string | number,
+  value: unknown
+): HTMLTableCellElement {
+  const num = parseInt(value as string, 10);
+  const valid = !isNaN(num) && num >= 0;
+  const pct = valid ? Math.min(100, (num / 1000) * 100) : 0;
+  const color = pct > 60 ? '#22c55e' : pct > 20 ? '#f59e0b' : '#ef4444';
+
+  td.innerText = '';
+
+  const wrapper = hotInstance.rootDocument.createElement('div');
+
+  wrapper.className = 'htStockBar';
+
+  const track = hotInstance.rootDocument.createElement('div');
+
+  track.className = 'htStockBarTrack';
+
+  const fill = hotInstance.rootDocument.createElement('div');
+
+  fill.className = 'htStockBarFill';
+  fill.style.width = `${pct}%`;
+  fill.style.background = color;
+
+  const label = hotInstance.rootDocument.createElement('span');
+
+  label.className = 'htStockBarLabel';
+  label.innerText = valid ? `${num}` : '—';
+  track.appendChild(fill);
+  wrapper.appendChild(track);
+  wrapper.appendChild(label);
+  td.appendChild(wrapper);
+
+  return td;
+}
+
+// Custom validator: accepts integers in the range 0–1000.
+// Demonstrates using a validator independently from the renderer and editor.
+function stockValidator(value: unknown, callback: (valid: boolean) => void): void {
+  const num = Number(value);
+
+  callback(Number.isInteger(num) && num >= 0 && num <= 1000);
+}
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['Apple', 1.2, 820],
+    ['Banana', 0.5, 280],
+    ['Cherry', 3.0, 45],
+    ['Mango', 2.5, 960],
+    ['Pear', 0.8, 170],
+    ['Blueberry', 4.5, 15],
+  ],
+  colHeaders: ['Product', 'Price', 'Stock'],
+  columns: [
+    // Built-in type bundles renderer + editor + no validator
+    { type: 'text' },
+    // Built-in type bundles renderer + editor + validator with custom format
+    {
+      type: 'numeric',
+      locale: 'en-US',
+      numericFormat: { style: 'currency', currency: 'USD', minimumFractionDigits: 2 },
+    },
+    // Mixed: custom renderer, built-in numeric editor, custom validator
+    {
+      renderer: stockRenderer,
+      editor: 'numeric',
+      validator: stockValidator,
+      allowInvalid: false,
+    },
+  ],
+  colWidths: [120, 90, 200],
+  rowHeaders: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>
+
+<style>
+.htStockBar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 4px;
+  height: 100%;
+  box-sizing: border-box;
+}
+
+.htStockBarTrack {
+  flex: 1;
+  height: 8px;
+  background: var(--ht-background-secondary-color);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.htStockBarFill {
+  height: 100%;
+  border-radius: 4px;
+  min-width: 2px;
+}
+
+.htStockBarLabel {
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  min-width: 28px;
+  text-align: right;
+  white-space: nowrap;
+}
+</style>

--- a/docs/content/guides/cell-functions/cell-renderer/cell-renderer.md
+++ b/docs/content/guides/cell-functions/cell-renderer/cell-renderer.md
@@ -72,6 +72,14 @@ settings = {
 
 :::
 
+::: only-for vue
+
+```html
+<HotTable :settings="{ columns: [{ renderer: 'numeric' }] }" />
+```
+
+:::
+
 ::: only-for react
 
 ## Declare a custom renderer as a component
@@ -176,6 +184,32 @@ The following example implements `@handsontable/angular-wrapper` with a custom r
 
 @[code](@/content/guides/cell-functions/cell-renderer/angular/example4.ts)
 @[code](@/content/guides/cell-functions/cell-renderer/angular/example4.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+## Declare a custom renderer as a component
+
+Handsontable's Vue wrapper lets you create custom cell renderers using Vue components.
+
+To use a Vue component as a renderer, define the component with `defineComponent`, then write a renderer function that mounts it into the cell `td` element with Vue's `render` and `h` helpers. Mounting with `render(h(Component, props), td)` reuses the same component instance across re-renders -- Vue patches the existing tree instead of remounting it. To pass static props alongside the cell data, merge them into the second argument of `h()`.
+
+::: tip
+
+Handsontable's [`autoRowSize`](@/api/options.md#autorowsize) and [`autoColumnSize`](@/api/options.md#autocolumnsize) options require calculating the widths/heights of some of the cells before rendering them into the table. For this reason, it's not currently possible to use them alongside component-based renderers, as they're created after the table's initialization.
+
+Be sure to turn those options off in your Handsontable configuration, as keeping them enabled may cause unexpected results. Please note that [`autoColumnSize`](@/api/options.md#autocolumnsize) is enabled by default.
+
+:::
+
+If your component needs access to a Vue application context -- for example, global components, plugins, or `provide` / `inject` -- create a dedicated app per cell with `createApp(Component, props).mount(td)` instead of `render()`. Track the returned app instances so you can call `app.unmount()` when the grid is destroyed.
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/cell-functions/cell-renderer/vue/example1.vue)
 
 :::
 
@@ -316,6 +350,14 @@ settings = {
 
 :::
 
+::: only-for vue
+
+```html
+<HotTable :settings="{ columns: [{ renderer: 'my.custom' }] }" />
+```
+
+:::
+
 ## Render custom HTML in cells
 
 This example shows how to use custom cell renderers to display HTML content in a cell. This is a very powerful feature. Just remember to escape any HTML code that could be used for XSS attacks. In the below configuration:
@@ -356,6 +398,16 @@ This example shows how to use custom cell renderers to display HTML content in a
 :::
 :::
 
+::: only-for vue
+
+::: example #example4 :vue3
+
+@[code](@/content/guides/cell-functions/cell-renderer/vue/example4.vue)
+
+:::
+
+:::
+
 ## Render custom HTML in header
 
 You can also put HTML into row and column headers. If you need to attach events to DOM elements like the checkbox below, just remember to identify the element by class name, not by id. This is because row and column headers are duplicated in the DOM tree and id attribute must be unique.
@@ -390,6 +442,16 @@ You can also put HTML into row and column headers. If you need to attach events 
 @[code](@/content/guides/cell-functions/cell-renderer/angular/example6.html)
 
 :::
+:::
+
+::: only-for vue
+
+::: example #example5 :vue3
+
+@[code](@/content/guides/cell-functions/cell-renderer/vue/example5.vue)
+
+:::
+
 :::
 
 ## Add event listeners in cell renderer function
@@ -543,6 +605,21 @@ settings = {
 
 :::
 
+::: only-for vue
+
+```html
+<HotTable :settings="{
+  columns: [{
+    data: 'price',
+    valueFormatter(value) {
+      return value ? `$${value.toFixed(2)}` : '';
+    }
+  }]
+}" />
+```
+
+:::
+
 #### Key differences
 
 | Aspect | `valueFormatter` | `renderer` |
@@ -609,6 +686,24 @@ settings = {
     }
   ]
 };
+```
+
+:::
+
+::: only-for vue
+
+```html
+<HotTable :settings="{
+  columns: [{
+    data: 'amount',
+    valueFormatter(value) {
+      return `$${value.toFixed(2)}`;
+    },
+    renderer(hotInstance, td, row, col, prop, value, cellProperties) {
+      td.innerHTML = `<div class='amount-cell'><span class='currency'>${value}</span></div>`;
+    }
+  }]
+}" />
 ```
 
 :::

--- a/docs/content/guides/cell-functions/cell-renderer/vue/example1.vue
+++ b/docs/content/guides/cell-functions/cell-renderer/vue/example1.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { ref, h, render, defineComponent } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+import type { BaseRenderer } from 'handsontable/renderers';
+
+registerAllModules();
+
+// A small Vue component used as a cell renderer.
+const CellDisplay = defineComponent({
+  props: {
+    row: { type: Number, required: true },
+    col: { type: Number, required: true },
+    value: { type: String, default: '' },
+  },
+  render() {
+    return h('span', [
+      h('i', { style: 'color:#a9a9a9' }, `Row: ${this.row}, column: ${this.col},`),
+      ' value: ',
+      h('strong', this.value),
+    ]);
+  },
+});
+
+const componentRenderer: BaseRenderer = (instance, td, row, col, _prop, value) => {
+  render(h(CellDisplay, { row, col, value: String(value) }), td);
+
+  return td;
+};
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['Mercedes A 160', 'Q1 2024', '7 200'],
+    ['Citroen C4 Coupe', 'Q2 2024', '8 330'],
+    ['Audi A4 Avant', 'Q3 2024', '33 900'],
+    ['Opel Astra', 'Q4 2024', '5 000'],
+    ['BMW 320i Coupe', 'Q1 2025', '30 500'],
+  ],
+  colHeaders: ['Model', 'Quarter', 'Price (EUR)'],
+  columns: [
+    { renderer: componentRenderer },
+    { renderer: componentRenderer },
+    { renderer: componentRenderer },
+  ],
+  colWidths: 250,
+  autoRowSize: false,
+  autoColumnSize: false,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-functions/cell-renderer/vue/example4.vue
+++ b/docs/content/guides/cell-functions/cell-renderer/vue/example4.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+import type { BaseRenderer } from 'handsontable/renderers';
+
+registerAllModules();
+
+interface Book {
+  title: string;
+  description: string;
+  comments: string;
+  cover: string;
+}
+
+const data: Book[] = [
+  {
+    title:
+      '<a href="https://www.amazon.com/Professional-JavaScript-Developers-Nicholas-Zakas/dp/1118026691">Professional JavaScript for Web Developers</a>',
+    description:
+      'This <a href="https://bit.ly/sM1bDf">book</a> provides a developer-level introduction along with more advanced and useful features of <b>JavaScript</b>.',
+    comments: 'I would rate it &#x2605;&#x2605;&#x2605;&#x2605;&#x2606;',
+    cover: '/docs/img/examples/professional-javascript-developers-nicholas-zakas.jpg',
+  },
+  {
+    title: '<a href="https://shop.oreilly.com/product/9780596517748.do">JavaScript: The Good Parts</a>',
+    description:
+      'This book provides a developer-level introduction along with <b>more advanced</b> and useful features of JavaScript.',
+    comments: 'This is the book about JavaScript',
+    cover: '/docs/img/examples/javascript-the-good-parts.jpg',
+  },
+  {
+    title: '<a href="https://shop.oreilly.com/product/9780596805531.do">JavaScript: The Definitive Guide</a>',
+    description:
+      '<em>JavaScript: The Definitive Guide</em> provides a thorough description of the core <b>JavaScript</b> language and both the legacy and standard DOMs implemented in web browsers.',
+    comments:
+      'I\'ve never actually read it, but the <a href="https://shop.oreilly.com/product/9780596805531.do">comments</a> are highly <strong>positive</strong>.',
+    cover: '/docs/img/examples/javascript-the-definitive-guide.jpg',
+  },
+];
+
+const safeHtmlRenderer: BaseRenderer = (_instance, td, _row, _col, _prop, value) => {
+  // WARNING: Be sure you only allow certain HTML tags to avoid XSS threats.
+  // Sanitize the "value" before passing it to the innerHTML property.
+  td.innerHTML = value as string;
+};
+
+const coverRenderer: BaseRenderer = (_instance, td, _row, _col, _prop, value) => {
+  const img = document.createElement('img');
+
+  img.src = value as string;
+
+  img.addEventListener('mousedown', (event) => {
+    event.preventDefault();
+  });
+
+  td.innerText = '';
+  td.appendChild(img);
+
+  return td;
+};
+
+const hotSettings = ref<GridSettings>({
+  data,
+  colWidths: [200, 200, 200, 80],
+  colHeaders: ['Title', 'Description', 'Comments', 'Cover'],
+  height: 'auto',
+  columns: [
+    { data: 'title', renderer: 'html' },
+    { data: 'description', renderer: 'html' },
+    { data: 'comments', renderer: safeHtmlRenderer },
+    { data: 'cover', renderer: coverRenderer },
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example4">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-functions/cell-renderer/vue/example5.vue
+++ b/docs/content/guides/cell-functions/cell-renderer/vue/example5.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+import type { BaseRenderer } from 'handsontable/renderers';
+import { textRenderer } from 'handsontable/renderers/textRenderer';
+
+registerAllModules();
+
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const isChecked = ref(false);
+
+const customRenderer: BaseRenderer = (instance, td, row, col, prop, value, cellProperties) => {
+  textRenderer(instance, td, row, col, prop, value, cellProperties);
+
+  if (isChecked.value) {
+    td.style.backgroundColor = 'yellow';
+  } else {
+    td.style.backgroundColor = 'rgba(255,255,255,0.1)';
+  }
+};
+
+const hotSettings = ref<GridSettings>({
+  height: 'auto',
+  columns: [{}, { renderer: customRenderer }],
+  colHeaders(col: number) {
+    return col === 0
+      ? '<b>Bold</b> and <em>Beautiful</em>'
+      : `Some <input type="checkbox" class="checker" ${isChecked.value ? 'checked="checked"' : ''}> checkbox`;
+  },
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+function onContainerMousedown(event: MouseEvent) {
+  const target = event.target as HTMLElement;
+
+  if (target.nodeName === 'INPUT' && target.className === 'checker') {
+    event.stopPropagation();
+  }
+}
+
+function onContainerMouseup(event: MouseEvent) {
+  const target = event.target as HTMLElement;
+
+  if (target.nodeName === 'INPUT' && target.className === 'checker') {
+    isChecked.value = !(target as HTMLInputElement).checked;
+    hotRef.value?.hotInstance?.render();
+  }
+}
+</script>
+
+<template>
+  <div id="example5">
+    <div id="exampleContainer5" @mousedown="onContainerMousedown" @mouseup="onContainerMouseup">
+      <HotTable ref="hotRef" :settings="hotSettings" />
+    </div>
+  </div>
+</template>

--- a/docs/content/guides/cell-functions/cell-validator/cell-validator.md
+++ b/docs/content/guides/cell-functions/cell-validator/cell-validator.md
@@ -130,6 +130,14 @@ const hot = new Handsontable(container, {
 
 :::
 
+::: only-for vue
+
+```html
+<HotTable :settings="{ columns: [{ validator: 'my.custom' }] }" />
+```
+
+:::
+
 ## Full featured example
 
 Use the validator method to easily validate synchronous or asynchronous changes to a cell. If you need more control, [`beforeValidate`](@/api/hooks.md#beforevalidate) and [`afterValidate`](@/api/hooks.md#aftervalidate) hooks are available. In the below example, `email_validator_fn` is an async validator that resolves after 1000 ms.
@@ -160,6 +168,14 @@ invalidCellClassName="myInvalidClass"
 
 ```ts
 invalidCellClassName: 'myInvalidClass'
+```
+
+:::
+
+::: only-for vue
+
+```html
+<HotTable :settings="{ invalidCellClassName: 'myInvalidClass' }" />
 ```
 
 :::
@@ -202,6 +218,20 @@ columns: [
 
 :::
 
+::: only-for vue
+
+```html
+<HotTable :settings="{
+  columns: [
+    { data: 'firstName', invalidCellClassName: 'myInvalidClass' },
+    { data: 'lastName', invalidCellClassName: 'myInvalidSecondClass' },
+    { data: 'address' }
+  ]
+}" />
+```
+
+:::
+
 Callback console log:
 
 ::: only-for javascript
@@ -233,6 +263,16 @@ Callback console log:
 
 @[code collapse={33-98}](@/content/guides/cell-functions/cell-validator/angular/example1.ts)
 @[code](@/content/guides/cell-functions/cell-validator/angular/example1.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/cell-functions/cell-validator/vue/example1.vue)
 
 :::
 

--- a/docs/content/guides/cell-functions/cell-validator/vue/example1.vue
+++ b/docs/content/guides/cell-functions/cell-validator/vue/example1.vue
@@ -1,0 +1,102 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+interface RowData {
+  id: number;
+  name: { first: string; last: string };
+  ip: string;
+  email: string;
+}
+
+const ipValidatorRegexp =
+  /^(?:\b(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b|null)$/;
+
+const emailValidator = (value: string, callback: (valid: boolean) => void) => {
+  setTimeout(() => {
+    if (/.+@.+/.test(value)) {
+      callback(true);
+    } else {
+      callback(false);
+    }
+  }, 1000);
+};
+
+const output = ref('Here you will see the log');
+
+const data: RowData[] = [
+  { id: 1, name: { first: 'Joe', last: 'Fabiano' }, ip: '0.0.0.1', email: 'Joe.Fabiano@ex.com' },
+  { id: 2, name: { first: 'Fred', last: 'Wecler' }, ip: '0.0.0.1', email: 'Fred.Wecler@ex.com' },
+  { id: 3, name: { first: 'Steve', last: 'Wilson' }, ip: '0.0.0.1', email: 'Steve.Wilson@ex.com' },
+  { id: 4, name: { first: 'Maria', last: 'Fernandez' }, ip: '0.0.0.1', email: 'M.Fernandez@ex.com' },
+  { id: 5, name: { first: 'Pierre', last: 'Barbault' }, ip: '0.0.0.1', email: 'Pierre.Barbault@ex.com' },
+  { id: 6, name: { first: 'Nancy', last: 'Moore' }, ip: '0.0.0.1', email: 'Nancy.Moore@ex.com' },
+  { id: 7, name: { first: 'Barbara', last: 'MacDonald' }, ip: '0.0.0.1', email: 'B.MacDonald@ex.com' },
+  { id: 8, name: { first: 'Wilma', last: 'Williams' }, ip: '0.0.0.1', email: 'Wilma.Williams@ex.com' },
+  { id: 9, name: { first: 'Sasha', last: 'Silver' }, ip: '0.0.0.1', email: 'Sasha.Silver@ex.com' },
+  { id: 10, name: { first: 'Don', last: 'Pérignon' }, ip: '0.0.0.1', email: 'Don.Pérignon@ex.com' },
+  { id: 11, name: { first: 'Aaron', last: 'Kinley' }, ip: '0.0.0.1', email: 'Aaron.Kinley@ex.com' },
+];
+
+const hotSettings = ref<GridSettings>({
+  data,
+  beforeChange(changes) {
+    for (let i = changes.length - 1; i >= 0; i--) {
+      const currChange = changes[i];
+
+      if (!currChange) {
+        continue;
+      }
+
+      // gently don't accept the word "foo" (remove the change at index i)
+      if (currChange[3] === 'foo') {
+        changes.splice(i, 1);
+      }
+      // if any of pasted cells contains the word "nuke", reject the whole paste
+      else if (currChange[3] === 'nuke') {
+        return false;
+      }
+      // capitalise first letter in column 1 and 2
+      else if (currChange[1] === 'name.first' || currChange[1] === 'name.last') {
+        const newValue = currChange[3];
+
+        if (newValue !== null && typeof newValue === 'string') {
+          currChange[3] = newValue.charAt(0).toUpperCase() + newValue.slice(1);
+        }
+      }
+    }
+
+    return true;
+  },
+  afterChange(changes, source) {
+    if (source !== 'loadData') {
+      output.value = JSON.stringify(changes);
+    }
+  },
+  colHeaders: ['ID', 'First name', 'Last name', 'IP', 'E-mail'],
+  height: 'auto',
+  licenseKey: 'non-commercial-and-evaluation',
+  columns: [
+    { data: 'id', type: 'numeric' },
+    { data: 'name.first' },
+    { data: 'name.last' },
+    { data: 'ip', validator: ipValidatorRegexp, allowInvalid: true },
+    { data: 'email', validator: emailValidator },
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+});
+</script>
+
+<template>
+  <div id="example1">
+    <div class="example-controls-container">
+      <output class="console" id="output">{{ output }}</output>
+    </div>
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-functions/custom-cells/custom-cells.md
+++ b/docs/content/guides/cell-functions/custom-cells/custom-cells.md
@@ -895,6 +895,54 @@ This information is also applicable in Angular when you need lower-level control
 
 :::
 
+::: only-for vue
+
+## Vue
+
+The Vue 3 wrapper does not provide a component-based editor API equivalent to React's `EditorComponent` or Angular's `HotCellEditorAdvancedComponent`. Instead, you use Handsontable's standard renderer functions and editor classes directly — the same primitives that work in vanilla JavaScript — but you can also mount Vue components into cells using Vue's `render` function.
+
+### Custom renderers
+
+A **renderer function** receives the cell's `td` element and fills it with whatever markup you need. You pass it directly to the `renderer` option on a column.
+
+#### Function renderer
+
+The simplest approach: write a plain function, manipulate the `td` element, and return it.
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/cell-functions/custom-cells/vue/example1.vue)
+
+:::
+
+#### Vue component renderer
+
+For richer cell content, use Vue's `h` and `render` helpers to mount a Vue component into the `td` element on every render call.
+
+::: example #example2 :vue3
+
+@[code](@/content/guides/cell-functions/custom-cells/vue/example2.vue)
+
+:::
+
+### Custom editors
+
+Create a custom editor by extending one of Handsontable's built-in editor classes (for example, `TextEditor`) and overriding the methods you need to change. Pass the class to the `editor` option on a column.
+
+::: example #example3 :vue3
+
+@[code](@/content/guides/cell-functions/custom-cells/vue/example3.vue)
+
+:::
+
+::: tip
+
+The sections below describe the framework-agnostic `rendererFactory` and `editorFactory` helpers. You can use both helpers in Vue 3 projects — pass the result to the `renderer` or `editor` column option the same way you would pass a renderer function or editor class.
+
+:::
+
+:::
+
 
 ## Renderers
 

--- a/docs/content/guides/cell-functions/custom-cells/vue/example1.vue
+++ b/docs/content/guides/cell-functions/custom-cells/vue/example1.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+function imageRenderer(
+  _instance: unknown,
+  td: HTMLTableCellElement,
+  _row: number,
+  _col: number,
+  _prop: string | number,
+  value: unknown
+): HTMLTableCellElement {
+  const src = String(value ?? '');
+  const img = document.createElement('img');
+
+  img.src = src;
+  img.addEventListener('mousedown', (event) => {
+    event.preventDefault();
+  });
+
+  td.innerText = '';
+  td.appendChild(img);
+
+  return td;
+}
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['Professional JavaScript for Web Developers',
+      '/docs/img/examples/professional-javascript-developers-nicholas-zakas.jpg'],
+    ['JavaScript: The Good Parts',
+      '/docs/img/examples/javascript-the-good-parts.jpg'],
+  ],
+  columns: [
+    {},
+    {
+      renderer: imageRenderer,
+    },
+  ],
+  colHeaders: true,
+  rowHeights: 55,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-functions/custom-cells/vue/example2.vue
+++ b/docs/content/guides/cell-functions/custom-cells/vue/example2.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import { ref, h, render } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+type ImageCellProps = { src: string };
+
+const ImageCell = (props: ImageCellProps) =>
+  h('img', {
+    src: props.src,
+    onMousedown: (event: MouseEvent) => event.preventDefault(),
+  });
+
+function imageComponentRenderer(
+  _instance: unknown,
+  td: HTMLTableCellElement,
+  _row: number,
+  _col: number,
+  _prop: string | number,
+  value: unknown
+): HTMLTableCellElement {
+  const vnode = h(ImageCell, { src: String(value ?? '') });
+
+  render(vnode, td);
+
+  return td;
+}
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['Professional JavaScript for Web Developers',
+      '/docs/img/examples/professional-javascript-developers-nicholas-zakas.jpg'],
+    ['JavaScript: The Good Parts',
+      '/docs/img/examples/javascript-the-good-parts.jpg'],
+  ],
+  columns: [
+    {},
+    {
+      renderer: imageComponentRenderer,
+    },
+  ],
+  colHeaders: true,
+  rowHeights: 55,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example2">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-functions/custom-cells/vue/example3.vue
+++ b/docs/content/guides/cell-functions/custom-cells/vue/example3.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { TextEditor } from 'handsontable/editors/textEditor';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+class CustomEditor extends TextEditor {
+  createElements(): void {
+    super.createElements();
+
+    this.TEXTAREA = document.createElement('input') as HTMLInputElement & HTMLTextAreaElement;
+    this.TEXTAREA.setAttribute('placeholder', 'Type a book title...');
+    this.TEXTAREA.setAttribute('data-hot-input', 'true');
+    this.textareaStyle = this.TEXTAREA.style;
+    this.TEXTAREA_PARENT.innerText = '';
+    this.TEXTAREA_PARENT.appendChild(this.TEXTAREA);
+  }
+}
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['Professional JavaScript for Web Developers', 'Nicholas Zakas', 2009],
+    ['JavaScript: The Good Parts', 'Douglas Crockford', 2008],
+    ['You Don\'t Know JS', 'Kyle Simpson', 2014],
+    ['Eloquent JavaScript', 'Marijn Haverbeke', 2018],
+    ['JavaScript Patterns', 'Stoyan Stefanov', 2010],
+  ],
+  columns: [
+    { editor: CustomEditor },
+    {},
+    { type: 'numeric' },
+  ],
+  colHeaders: ['Title', 'Author', 'Year'],
+  colWidths: [220, 180, 60],
+  autoWrapRow: true,
+  autoWrapCol: true,
+  height: 'auto',
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example3">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>


### PR DESCRIPTION
### Context

The PR adds Vue 3 variants to the five Cell functions guide pages: `cell-editor`, `cell-function`, `cell-renderer`, `cell-validator`, and `custom-cells`. This continues the framework-parity effort so Vue users get working examples and guidance under `vue-data-grid/`, matching the existing JavaScript, React, and Angular variants.

Each page gains `::: only-for vue` sections that mirror the JavaScript variant block-for-block, plus `vue/example*.vue` Single-File Components written with `<script setup lang="ts">` and the Composition API.

The Vue 3 wrapper has no React/Angular-style high-level component-cell API, so the Vue examples use Handsontable's standard renderer functions and editor classes. The `cell-renderer` and `custom-cells` pages also demonstrate a custom renderer implemented as a Vue component via `render(h(Component), td)`. Conceptual guidance from the `integrate-with-vue3` custom-renderer/custom-editor tutorial pages (which are slated for removal) is migrated into `cell-renderer` so it is not lost: component-instance reuse, passing static props, and using `createApp(Component, props).mount(td)` with `app.unmount()` when a component needs Vue application context.

`[skip changelog]` — docs-only change that adds Vue variants to existing pages (no new pages).

### How has this been tested?

- Ran the docs site (`npm run start` in `docs/`) and verified all five pages render the Vue variant at `/docs/vue-data-grid/<page>/` with working grids and **0 console errors**.
- Confirmed the Vue-component renderer mounts into cells (`cell-renderer` and `custom-cells`), the masked/select editors render (`cell-editor`), and the image renderer produces `<img>` cells (`custom-cells`).
- Verified every `@[code]` reference resolves to a created `.vue` file, every `::: example #exampleN :vue3` id matches its SFC root-div id, and all `:::` directive blocks are balanced.
- Confirmed no links point at the soon-to-be-removed `vue3-custom-renderer-example` / `vue3-custom-editor-example` pages.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1744

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

(Documentation only — `docs/`.)

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1744

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only additions under docs/ with no changes to Handsontable packages or application logic.
> 
> **Overview**
> Adds **Vue 3** parity to the five Cell functions guides (`cell-editor`, `cell-function`, `cell-renderer`, `cell-validator`, `custom-cells`) with `::: only-for vue` blocks and new `vue/example*.vue` demos using `<script setup>`, `HotTable`, and standard Handsontable renderer/editor APIs.
> 
> **cell-editor** and **cell-function** wire live examples (password/masked editor, `SelectEditor`, mixed renderer/validator grid) plus inline `HotTable` snippets for registration and `getCellMeta`. **cell-renderer** and **custom-cells** document mounting Vue components into cells via `h`/`render` (and `createApp` when app context is needed), with examples for HTML headers, safe HTML, and image cells. **cell-validator** adds a full async/sync validation demo. Docs-only; no runtime package changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef9826ef816def48db8bf965b9e4001f978cb752. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->