### PR TITLE
DEV-1751: Add Vue 3 variants to optimization guides

### DIFF
--- a/docs/content/guides/optimization/batch-operations/batch-operations.md
+++ b/docs/content/guides/optimization/batch-operations/batch-operations.md
@@ -85,6 +85,18 @@ For more information, see the [Instance access](@/guides/getting-started/angular
 
 :::
 
+::: only-for vue
+
+::: tip
+
+To use the Handsontable API, you'll need access to the Handsontable instance. Use a template ref on the `HotTable` component and read its `hotInstance` property.
+
+For more information, see the [Referencing the Handsontable instance in Vue 3](@/guides/integrate-with-vue3/vue3-hot-reference/vue3-hot-reference.md) page.
+
+:::
+
+:::
+
 ```js
 // call the batch method on an instance
 hot.batch(() => {
@@ -245,6 +257,16 @@ The following examples show how much the [`batch()`](@/api/core.md#batch) method
 
 @[code](@/content/guides/optimization/batch-operations/angular/example1.ts)
 @[code](@/content/guides/optimization/batch-operations/angular/example1.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/optimization/batch-operations/vue/example1.vue)
 
 :::
 

--- a/docs/content/guides/optimization/batch-operations/vue/example1.vue
+++ b/docs/content/guides/optimization/batch-operations/vue/example1.vue
@@ -1,0 +1,108 @@
+<script setup lang="ts">
+import { ref, useTemplateRef } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
+const counter = ref(0);
+const output = ref('');
+
+const dataInit: GridSettings['data'] = [
+  [1, 'Gary Nash', 'Speckled trousers', 'S', 1, 'yes'],
+  [2, 'Gloria Brown', '100% Stainless sweater', 'M', 2, 'no'],
+  [3, 'Ronald Carver', 'Sunny T-shirt', 'S', 1, 'no'],
+  [4, 'Samuel Watkins', 'Floppy socks', 'S', 3, 'no'],
+  [5, 'Stephanie Huddart', 'Bushy-bush cap', 'XXL', 1, 'no'],
+  [6, 'Madeline McGillivray', 'Long skirt', 'L', 1, 'no'],
+  [7, 'Jai Moor', 'Happy dress', 'XS', 1, 'no'],
+  [8, 'Ben Lower', 'Speckled trousers', 'M', 1, 'no'],
+  [9, 'Ali Tunbridge', 'Speckled trousers', 'M', 2, 'no'],
+  [10, 'Archie Galvin', 'Regular shades', 'uni', 10, 'no'],
+];
+
+const data2 = [[11, 'Gavin Elle', 'Floppy socks', 'XS', 3, 'yes']];
+const data3 = [
+  [12, 'Gary Erre', 'Happy dress', 'M', 1, 'no'],
+  [13, 'Anna Moon', 'Unicorn shades', 'uni', 200, 'no'],
+  [14, 'Elise Eli', 'Regular shades', 'uni', 1, 'no'],
+];
+
+const hotSettings = ref<GridSettings>({
+  data: dataInit,
+  width: 'auto',
+  height: 'auto',
+  colHeaders: ['ID', 'Customer name', 'Product name', 'Size', 'qty', 'Return'],
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+function logOutput(msg: string) {
+  counter.value += 1;
+  output.value = `[${counter.value}] ${msg}\n${output.value}`;
+}
+
+function alterTable() {
+  const hot = hotRef.value?.hotInstance;
+
+  hot?.alter('insert_row_above', 10, 10);
+  hot?.alter('insert_col_start', 6, 1);
+  hot?.populateFromArray(10, 0, data2);
+  hot?.populateFromArray(11, 0, data3);
+  hot?.setCellMeta(2, 2, 'className', 'green-bg');
+  hot?.setCellMeta(4, 2, 'className', 'green-bg');
+  hot?.setCellMeta(5, 2, 'className', 'green-bg');
+  hot?.setCellMeta(6, 2, 'className', 'green-bg');
+  hot?.setCellMeta(8, 2, 'className', 'green-bg');
+  hot?.setCellMeta(9, 2, 'className', 'green-bg');
+  hot?.setCellMeta(10, 2, 'className', 'green-bg');
+  hot?.alter('remove_col', 6, 1);
+  hot?.alter('remove_row', 10, 10);
+  hot?.setCellMeta(0, 5, 'className', 'red-bg');
+  hot?.setCellMeta(10, 5, 'className', 'red-bg');
+  hot?.render();
+}
+
+function buttonWithoutClick() {
+  const t1 = performance.now();
+
+  alterTable();
+
+  const t2 = performance.now();
+
+  logOutput(`Time without batch ${(t2 - t1).toFixed(2)}ms`);
+}
+
+function buttonWithClick() {
+  const hot = hotRef.value?.hotInstance;
+  const t1 = performance.now();
+
+  hot?.batch(alterTable);
+
+  const t2 = performance.now();
+
+  logOutput(`Time with batch ${(t2 - t1).toFixed(2)}ms`);
+}
+</script>
+
+<template>
+  <div id="example1">
+    <div class="example-controls-container">
+      <div class="controls">
+        <button id="buttonWithout" class="button button--primary" @click="buttonWithoutClick">
+          Run without batch method
+        </button>
+        <button id="buttonWith" class="button button--primary" @click="buttonWithClick">
+          Run with batch method
+        </button>
+      </div>
+      <output class="console" id="output">
+        {{ output || 'Here you will see the log' }}
+      </output>
+    </div>
+    <HotTable ref="hotRef" :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/optimization/bundle-size/bundle-size.md
+++ b/docs/content/guides/optimization/bundle-size/bundle-size.md
@@ -90,6 +90,27 @@ export class ExampleComponent {
 
 :::
 
+::: only-for vue
+
+```js
+import Handsontable from 'handsontable/base';
+import { HotTable } from '@handsontable/vue3';
+import { registerPlugin, ContextMenu } from 'handsontable/plugins';
+
+registerPlugin(ContextMenu);
+
+const hotSettings = ref({
+  contextMenu: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+```
+
+```html
+<HotTable :settings="hotSettings" />
+```
+
+:::
+
 ## Optimize Moment.js
 
 By default, [Moment.js](https://momentjs.com/) (Handsontable's dependency) comes with all possible locales, which increases the bundle size.
@@ -188,6 +209,34 @@ export class ExampleComponent {
     type: "date",
   };
 }
+```
+
+:::
+
+::: only-for vue
+
+```js
+import Handsontable from 'handsontable/base';
+import { HotTable } from '@handsontable/vue3';
+import { registerCellType, DateCellType } from 'handsontable/cellTypes';
+
+// explicitly import Moment.js
+import moment from 'moment';
+// explicitly import a Moment.js locale of your choice
+import 'moment/locale/ja';
+
+// register the Moment.js locale of your choice
+moment.locale('ja');
+registerCellType(DateCellType);
+
+const hotSettings = ref({
+  type: 'date',
+  licenseKey: 'non-commercial-and-evaluation',
+});
+```
+
+```html
+<HotTable :settings="hotSettings" />
 ```
 
 :::

--- a/docs/content/guides/optimization/performance/performance.md
+++ b/docs/content/guides/optimization/performance/performance.md
@@ -72,6 +72,22 @@ settings = {
 
 :::
 
+::: only-for vue
+
+```js
+const hotSettings = ref({
+  colWidths: [50, 150, 45],
+  rowHeights: [40, 40, 40, 40],
+  licenseKey: 'non-commercial-and-evaluation',
+});
+```
+
+```html
+<HotTable :settings="hotSettings" />
+```
+
+:::
+
 When taking this approach, make sure that the contents of your cells fit in your row and column sizes, or let the user change [column widths](@/guides/columns/column-width/column-width.md#adjust-the-column-width-manually) and [row heights](@/guides/rows/row-height/row-height.md#adjust-row-heights-manually) manually.
 
 Read more:
@@ -130,6 +146,16 @@ For more information, see the [Instance methods](@/guides/getting-started/react-
 To use the Handsontable API, you'll need access to the Handsontable instance. You can do that by utilizing a reference to the `HotTable` component, and reading its `hotInstance` property.
 
 For more information, see the [Instance access](@/guides/getting-started/angular-hot-instance/angular-hot-instance.md) page.
+
+:::
+:::
+
+::: only-for vue
+::: tip
+
+To use the Handsontable API, you'll need access to the Handsontable instance. Use a template ref on the `HotTable` component and read its `hotInstance` property.
+
+For more information, see the [Referencing the Handsontable instance in Vue 3](@/guides/integrate-with-vue3/vue3-hot-reference/vue3-hot-reference.md) page.
 
 :::
 :::


### PR DESCRIPTION
[skip changelog]

### Context

Add Vue 3 framework variants to the three optimization guides (batch-operations, performance, bundle-size), mirroring existing React/Angular content.

ClickUp: DEV-1751

### How has this been tested?

Manual verification on the docs dev server (`pnpm dev` in `docs/`):

- http://localhost:4321/docs/vue-data-grid/batch-operations/ — Vue tip, live demo, batch timing buttons, StackBlitz button
- http://localhost:4321/docs/vue-data-grid/performance/ — Vue col-width snippet and suspend-rendering tip
- http://localhost:4321/docs/vue-data-grid/bundle-size/ — Vue modules and Moment.js snippets

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

DEV-1751

### Affected project(s):

- [ ] handsontable
- [ ] @handsontable/react-wrapper
- [ ] @handsontable/angular-wrapper
- [ ] @handsontable/vue3
- [x] Documentation

### Checklist

- [x] My code follows the code style of this project.
- [x] I have signed the CLA (not required for internal team members).
- [x] My change requires a change to the documentation and I have updated it accordingly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes with no runtime or API impact; risk is limited to example accuracy and doc build wiring.
> 
> **Overview**
> Adds **Vue 3**-specific content to the optimization guides so they match the existing React and Angular coverage.
> 
> On **batch operations**, Vue readers get a tip for reaching `hotInstance` via a template ref (linked to the Vue 3 instance guide), plus a new **live `:vue3` demo** (`example1.vue`) that compares timed runs with and without `hot.batch()`.
> 
> On **performance**, Vue gets a `hotSettings` / `<HotTable :settings>` snippet for fixed `colWidths` and `rowHeights`, and the same instance-access tip before the suspend-rendering `batch()` example.
> 
> On **bundle size**, Vue gets snippets for selective plugin registration with `handsontable/base` and `@handsontable/vue3`, and for trimming Moment.js locales when using the date cell type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f9ac5979fbf54bcf6c5c81141befdca2d8fdfc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->