### PR TITLE
DEV-1752: Add Vue 3 variants to tools and building guides

### DIFF
--- a/docs/content/guides/tools-and-building/custom-builds/custom-builds.md
+++ b/docs/content/guides/tools-and-building/custom-builds/custom-builds.md
@@ -250,8 +250,6 @@ From the `/wrappers/angular-wrapper` directory, You can also run individual Angu
 
 :::
 
-::: only-for javascript
-
 ### Build the Vue package
 
 To build the Vue package:
@@ -293,8 +291,6 @@ From the `/wrappers/vue3` directory, you can also run individual Vue `build` tas
   - Creates the minified bundles:
     - `/wrappers/vue3/dist/vue-handsontable.min.js`
     - `/wrappers/vue3/dist/vue-handsontable.min.js.map`
-
-:::
 
 :::
 

--- a/docs/content/guides/tools-and-building/custom-plugins/custom-plugins.md
+++ b/docs/content/guides/tools-and-building/custom-plugins/custom-plugins.md
@@ -42,6 +42,12 @@ You can create a custom plugin in JavaScript, and then reference it from within 
 
 :::
 
+::: only-for vue
+
+You can create a custom plugin in JavaScript, and then reference it from within your Vue app.
+
+:::
+
 ### 1. Prerequisites
 
 Import the following:
@@ -350,6 +356,33 @@ settings = {
 
 :::
 
+::: only-for vue
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import type { GridSettings } from 'handsontable/settings';
+
+const settings = ref<GridSettings>({
+  // Pass `true` to enable the plugin with default options.
+  customPlugin: true,
+  // You can also enable the plugin by passing an object with options.
+  customPlugin: {
+    msg: 'user-defined message',
+  },
+  // You can also initialize the plugin without enabling it at the beginning.
+  customPlugin: false,
+});
+</script>
+
+<template>
+  <HotTable :settings="settings" />
+</template>
+```
+
+:::
+
 ### 5. Get a reference to the plugin's instance
 
 To use the plugin's API, call the [`getPlugin`](@/api/core.md#getplugin) method to get a reference to the plugin's instance.
@@ -419,6 +452,38 @@ export class ExampleComponent implements AfterViewInit {
     this.hotTable?.hotInstance?.getPlugin(CustomPlugin.PLUGIN_KEY);
   }
 }
+```
+
+:::
+
+::: only-for vue
+
+::: tip
+
+To use the Handsontable API, create a reference to the `HotTable` component, and read its `hotInstance` property.
+
+For more information, see the [Instance methods](@/guides/integrate-with-vue3/vue3-hot-reference/vue3-hot-reference.md) page.
+
+:::
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { CustomPlugin } from './customPlugin';
+
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+
+function usePlugin() {
+  const pluginInstance = hotRef.value?.hotInstance?.getPlugin(CustomPlugin.PLUGIN_KEY);
+
+  pluginInstance?.externalMethodExample();
+}
+</script>
+
+<template>
+  <HotTable ref="hotRef" :settings="settings" />
+</template>
 ```
 
 :::

--- a/docs/content/guides/tools-and-building/modules/modules.md
+++ b/docs/content/guides/tools-and-building/modules/modules.md
@@ -79,6 +79,12 @@ To get the base JavaScript module, import Handsontable from `handsontable/base` 
 
 :::
 
+::: only-for vue
+
+To get the base JavaScript module, import Handsontable from `handsontable/base` (not from `handsontable`, which would give you the full distribution package):
+
+:::
+
 ```js
 import Handsontable from 'handsontable/base';
 ```
@@ -286,6 +292,36 @@ export class ExampleComponent {
 
 :::
 
+::: only-for vue
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import type { GridSettings } from 'handsontable/settings';
+import {
+  registerCellType,
+  NumericCellType,
+} from 'handsontable/cellTypes';
+
+registerCellType(NumericCellType);
+
+const hotSettings = ref<GridSettings>({
+  columns: [
+    {
+      type: 'numeric',
+    },
+  ],
+});
+</script>
+
+<template>
+  <HotTable :settings="hotSettings" />
+</template>
+```
+
+:::
+
 Or, you can import the `numeric` cell type's renderer, editor, and validator individually (the effect is the same as above):
 
 ::: only-for javascript
@@ -400,6 +436,50 @@ export class ExampleComponent {
     ],
   };
 }
+```
+
+:::
+
+::: only-for vue
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import type { GridSettings } from 'handsontable/settings';
+import {
+  registerRenderer,
+  numericRenderer,
+} from 'handsontable/renderers';
+import {
+  registerEditor,
+  NumericEditor,
+} from 'handsontable/editors';
+import {
+  registerValidator,
+  numericValidator,
+} from 'handsontable/validators';
+
+registerRenderer(numericRenderer);
+registerEditor(NumericEditor);
+registerValidator(numericValidator);
+
+const hotSettings = ref<GridSettings>({
+  columns: [
+    {
+      renderer: 'numeric',
+      editor: 'numeric',
+      validator: 'numeric',
+      dataType: 'number',
+      type: 'numeric',
+    },
+  ],
+});
+</script>
+
+<template>
+  <HotTable :settings="hotSettings" />
+</template>
 ```
 
 :::

--- a/docs/content/guides/tools-and-building/typescript-types/typescript-types.md
+++ b/docs/content/guides/tools-and-building/typescript-types/typescript-types.md
@@ -330,9 +330,9 @@ const settings: GridSettings = {
 };
 ```
 
-### Type the HOT instance in a React ref
-
 ::: only-for react
+
+### Type the HOT instance in a React ref
 
 ```tsx
 import { useRef } from 'react';
@@ -358,9 +358,9 @@ export function Grid() {
 
 :::
 
-### Type the HOT instance in Angular
-
 ::: only-for angular
+
+### Type the HOT instance in Angular
 
 ```typescript
 import { Component, ViewChild } from '@angular/core';
@@ -381,6 +381,33 @@ export class GridComponent {
   };
 }
 ```
+
+:::
+
+::: only-for vue
+
+### Type the HOT instance in a Vue ref
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import type { GridSettings } from 'handsontable';
+
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+
+const settings: GridSettings = {
+  data: myData,
+  licenseKey: 'non-commercial-and-evaluation',
+};
+</script>
+
+<template>
+  <HotTable ref="hotRef" :settings="settings" />
+</template>
+```
+
+The ref is typed as the `HotTable` component; read the `HotInstance` through `hotRef.value?.hotInstance`.
 
 :::
 


### PR DESCRIPTION
### Context

The PR adds Vue 3 variants to the **Tools and building** guide pages, so the `vue-data-grid/` version of each page shows Vue-specific content instead of falling back to framework-agnostic prose. This is part of the Vue 3 docs-porting sprint, which brings Vue to parity with the React and Angular docs variants.

Scope: the 5 in-scope pages under `docs/content/guides/tools-and-building/` — `modules`, `typescript-types`, `custom-plugins`, `custom-builds`, `testing`. (`packages` is `onlyFor: ['javascript']` in the sidebar and is out of scope.)

None of these pages contain runnable `::: example` embeds — every framework block is a prose code-fence snippet inside a `::: only-for` block. So this PR adds mirrored prose `::: only-for vue` blocks only; it creates no `.vue` SFC files and no StackBlitz embeds.

Per-page changes:

- **`modules.md`** — adds 3 `::: only-for vue` blocks mirroring the 3 React blocks (base-module import, numeric cell-type import, renderer/editor/validator import).
- **`typescript-types.md`** — adds a Vue `::: only-for vue` block under "Type the HOT instance in a Vue ref", using `ref<InstanceType<typeof HotTable> | null>(null)`.
- **`custom-plugins.md`** — adds 3 `::: only-for vue` blocks. Plugin options live inside the `:settings` ref (mirroring Angular), not as `<HotTable>` props. The instance-access tip links to `vue3-hot-reference`.
- **`custom-builds.md`** — removes the `::: only-for javascript` wrapper around "Build the Vue package" so it renders on all framework variants, matching the already-unwrapped React/Angular build sections.
- **`testing.md`** — no change (framework-agnostic core-testing content with no React/Angular blocks to mirror).

No existing frontmatter `id` values were changed.

### How has this been tested?

- `npm run docs:lint` — passes (exit 0).
- Cold-started the docs dev server (`npm run start`, astro dev on `:4321`) and fetched each Vue variant (all HTTP 200):
  - `/docs/vue-data-grid/modules/` — 3 Vue blocks render; both code snippets show `<HotTable :settings>`.
  - `/docs/vue-data-grid/typescript-types/` — the "Type the HOT instance in a Vue ref" block renders.
  - `/docs/vue-data-grid/custom-plugins/` — 3 Vue blocks render; instance tip links to `vue3-hot-reference`.
  - `/docs/vue-data-grid/custom-builds/` — "Build the Vue package" now renders on the js/react/angular/vue variants.
  - `/docs/vue-data-grid/testing/` — renders unchanged.
- Parity check: per edited page, `only-for vue` count equals `only-for react` count (modules 3, custom-plugins 3, typescript-types 1).

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1752

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

(Documentation only — `docs/` content.)

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1752

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only prose and code-fence examples; no changes to Handsontable packages, auth, or application behavior.
> 
> **Overview**
> Adds **Vue 3** parity to the **Tools and building** docs under `vue-data-grid/`, mirroring existing React/Angular `::: only-for` snippets (no runtime or library code).
> 
> **`modules.md`** — three new Vue blocks: base import intro, full `NumericCellType` example, and split renderer/editor/validator registration, all using `@handsontable/vue3` with `:settings` on `HotTable`.
> 
> **`custom-plugins.md`** — Vue intro plus examples for enabling plugins via a `GridSettings` ref, and accessing `getPlugin` through `hotRef` → `hotInstance` (with a tip linking to `vue3-hot-reference`).
> 
> **`typescript-types.md`** — Vue section for typing the grid ref as `InstanceType<typeof HotTable>` and reading `HotInstance` from `hotInstance`; React/Angular “type the HOT instance” headings are moved inside their framework blocks only.
> 
> **`custom-builds.md`** — removes the `::: only-for javascript` wrapper around **Build the Vue package** so that section appears on every framework variant, consistent with React/Angular build instructions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4016a3b82342424d208f7baa0b95c5b29e39478. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->