### PR TITLE
SU-589: Wire PUBLIC_CHAT_API_URL into docs-staging build

### DIFF
--- a/.github/workflows/docs-staging.yml
+++ b/.github/workflows/docs-staging.yml
@@ -169,6 +169,7 @@ jobs:
           # RC release branches build in production mode to mimic the final
           # production deployment (GTM/HotJar injected, dev badge hidden).
           BUILD_MODE: ${{ steps.release-info.outputs.is_release == 'true' && 'production' || '' }}
+          PUBLIC_CHAT_API_URL: ${{ secrets.PUBLIC_CHAT_API_URL }}
 
       - name: Build and deploy the preview to Netlify
         run: |


### PR DESCRIPTION
### Context

The PR fixes the docs-staging deployment so the `dev.handsontable.com/docs` widget calls the dev backend instead of production.

`PUBLIC_CHAT_API_URL` is set as a GitHub Actions repository secret. The intent: when the docs site builds on `develop`, the widget bundle should be baked with the dev proxy URL so that `dev.handsontable.com/docs` calls the dev backend instead of production.

`docs/astro.config.mjs:834-835` already reads it correctly:

```js
'import.meta.env.PUBLIC_CHAT_API_URL': JSON.stringify(
  process.env.PUBLIC_CHAT_API_URL || 'https://hot-docs-assistant.netlify.app'
)
```

But the `Build docs (for staging preview)` step in `.github/workflows/docs-staging.yml` never references the secret. GitHub Actions secrets are not auto-injected — they must be explicitly mapped into the step's `env:` block. So `process.env.PUBLIC_CHAT_API_URL` evaluates to `undefined` at build time and the fallback (prod URL) gets baked into the widget.

This PR adds one line to the staging workflow's `env:` block. `docs-production.yml` is intentionally left untouched so production deploys keep falling through to the hardcoded fallback URL.

[skip changelog]

### How has this been tested?

Workflow/config change. Verification happens after merge:

- Confirm the `docs-staging.yml` workflow run on `develop` completes successfully.
- Open `dev.handsontable.com/docs` in a browser with DevTools → Network.
- Send a message through the docs assistant widget.
- Inspect the `/api/chat` request URL — host must be `dev--hot-docs-assistant.netlify.app`.
- Cross-check production: `/api/chat` still goes to `hot-docs-assistant.netlify.app`.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. SU-589

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/SU-589

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single workflow env mapping for staging only; no application logic changes and production deploy path is untouched.
> 
> **Overview**
> **Staging docs builds** now pass the repository secret `PUBLIC_CHAT_API_URL` into the **Build docs (for staging preview)** step so the Astro/Vite `define` in `astro.config.mjs` can bake the **dev** docs-assistant backend into the widget instead of always using the production fallback.
> 
> Without this explicit `env:` mapping, `process.env.PUBLIC_CHAT_API_URL` was unset in CI and `dev.handsontable.com/docs` chat traffic pointed at production. **Production** docs workflow behavior is unchanged (still uses the hardcoded fallback when the env var is absent).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dda84e05ce3c866e25aeec8461070142432d07a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->