### PR TITLE
DEV-1753: Add Vue 3 variants to styling and theming guides

### DIFF
--- a/docs/content/guides/styling/legacy-style/legacy-style.md
+++ b/docs/content/guides/styling/legacy-style/legacy-style.md
@@ -94,6 +94,29 @@ export class AppComponent {
 
 :::
 
+::: only-for vue
+
+```ts
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import { classicTheme } from 'handsontable/themes';
+
+registerAllModules();
+
+const hotSettings = ref({
+  theme: classicTheme,
+  // ... other options
+  licenseKey: 'non-commercial-and-evaluation',
+});
+```
+
+```html
+<HotTable :settings="hotSettings" />
+```
+
+:::
+
 ### Option 2: Using CSS files with theme as string
 
 Alternatively, you can use CSS files and pass the theme name as a string to the `theme` option.
@@ -145,6 +168,22 @@ const hot = new Handsontable(container, {
   theme: 'ht-theme-classic'
 }">
 </hot-table>
+```
+
+:::
+
+::: only-for vue
+
+```ts
+const hotSettings = ref({
+  theme: 'ht-theme-classic',
+  // ... other options
+  licenseKey: 'non-commercial-and-evaluation',
+});
+```
+
+```html
+<HotTable :settings="hotSettings" />
 ```
 
 :::

--- a/docs/content/guides/styling/theme-customization/theme-customization.md
+++ b/docs/content/guides/styling/theme-customization/theme-customization.md
@@ -126,6 +126,34 @@ myTheme.setDensityType('default');
 
 :::
 
+::: only-for vue
+
+```ts
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import { mainTheme, registerTheme } from 'handsontable/themes';
+
+registerAllModules();
+
+const myTheme = registerTheme(mainTheme);
+
+myTheme.setColorScheme('light');
+myTheme.setDensityType('default');
+
+const hotSettings = ref({
+  theme: myTheme,
+  // other options
+  licenseKey: 'non-commercial-and-evaluation',
+});
+```
+
+```html
+<HotTable :settings="hotSettings" />
+```
+
+:::
+
 ### Configure theme parameters
 
 Use the `params()` method to update theme parameters dynamically:
@@ -177,6 +205,16 @@ The following example demonstrates using the Theme API to register a theme with 
 
 :::
 
+::: only-for vue
+
+::: example #example2 .disable-auto-theme :vue3
+
+@[code](@/content/guides/styling/theme-customization/vue/example2.vue)
+
+:::
+
+:::
+
 ## Option 2: Figma Theme Generator
 
 The Figma Theme Generator allows designers and developers to work together seamlessly by exporting design tokens directly from Figma into a CSS theme file.
@@ -223,6 +261,16 @@ Here's an example for `.ht-theme-main`:
 ::: example #example1 :angular --ts 1 --html 2
 @[code](@/content/guides/styling/theme-customization/angular/example1.ts)
 @[code](@/content/guides/styling/theme-customization/angular/example1.html)
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example1 .disable-auto-theme :vue3
+
+@[code](@/content/guides/styling/theme-customization/vue/example1.vue)
+
 :::
 
 :::

--- a/docs/content/guides/styling/theme-customization/vue/example1.vue
+++ b/docs/content/guides/styling/theme-customization/vue/example1.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import 'handsontable/styles/ht-theme-main.css';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotSettings = computed<GridSettings>(() => ({
+  theme: 'ht-theme-main',
+  data: [
+    ['John Doe', 'johndoe@example.com', 'New York', 32, 'Engineer'],
+    ['Jane Smith', 'janesmith@example.com', 'Los Angeles', 29, 'Designer'],
+    ['Sam Wilson', 'samwilson@example.com', 'Chicago', 41, 'Manager'],
+    ['Emily Johnson', 'emilyj@example.com', 'San Francisco', 35, 'Developer'],
+    ['Michael Brown', 'mbrown@example.com', 'Boston', 38, 'Analyst'],
+  ],
+  colHeaders: ['Name', 'Email', 'City', 'Age', 'Position'],
+  columns: [
+    { data: 0, type: 'text' },
+    { data: 1, type: 'text' },
+    { data: 2, type: 'text' },
+    { data: 3, type: 'numeric' },
+    { data: 4, type: 'text' },
+  ],
+  rowHeaders: true,
+  width: '100%',
+  height: 'auto',
+  licenseKey: 'non-commercial-and-evaluation',
+}));
+</script>
+
+<template>
+  <div id="example1" class="disable-auto-theme override-theme">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>
+
+<style>
+.ht-theme-main {
+  --ht-accent-color: #2c78d4;
+  --ht-foreground-color: #1a2533;
+  --ht-background-color: #f8f9fa;
+  --ht-row-header-odd-background-color: #f8f9fa;
+  --ht-row-header-even-background-color: #e9ecef;
+  --ht-row-cell-odd-background-color: #f8f9fa;
+  --ht-row-cell-even-background-color: #e9ecef;
+  --ht-cell-horizontal-border-color: #cbd5e0;
+  --ht-cell-vertical-border-color: #cbd5e0;
+  --ht-wrapper-border-color: #a0aec0;
+}
+</style>

--- a/docs/content/guides/styling/theme-customization/vue/example2.vue
+++ b/docs/content/guides/styling/theme-customization/vue/example2.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import { horizonTheme, registerTheme, getTheme } from 'handsontable/themes';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+registerTheme(horizonTheme);
+
+getTheme('horizon')?.params({
+  colors: {
+    primary: {
+      500: '#9333ea',
+    },
+  },
+  tokens: {
+    fontSize: '16px',
+    iconSize: 'sizing.size_5',
+    accentColor: ['colors.primary.500', 'colors.primary.600'],
+  },
+});
+
+const hotSettings = computed<GridSettings>(() => ({
+  theme: getTheme('horizon')?.setColorScheme('light').setDensityType('default'),
+  data: [
+    ['John Doe', 'johndoe@example.com', 'New York', 32, 'Engineer'],
+    ['Jane Smith', 'janesmith@example.com', 'Los Angeles', 29, 'Designer'],
+    ['Sam Wilson', 'samwilson@example.com', 'Chicago', 41, 'Manager'],
+    ['Emily Johnson', 'emilyj@example.com', 'San Francisco', 35, 'Developer'],
+    ['Michael Brown', 'mbrown@example.com', 'Boston', 38, 'Analyst'],
+  ],
+  colHeaders: ['Name', 'Email', 'City', 'Age', 'Position'],
+  columns: [
+    { data: 0, type: 'text' },
+    { data: 1, type: 'text' },
+    { data: 2, type: 'text' },
+    { data: 3, type: 'numeric' },
+    { data: 4, type: 'text' },
+  ],
+  rowHeaders: true,
+  dropdownMenu: true,
+  width: '100%',
+  height: 'auto',
+  licenseKey: 'non-commercial-and-evaluation',
+}));
+</script>
+
+<template>
+  <div id="example2" class="disable-auto-theme">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/styling/themes/themes.md
+++ b/docs/content/guides/styling/themes/themes.md
@@ -91,6 +91,17 @@ If you want to use the `main` theme without any modifications, you don't need to
 
 :::
 
+::: only-for vue
+
+::: example #exampleTheme .disable-auto-theme :vue3 --css 1
+
+@[code collapse={14-116,221-233}](@/content/guides/styling/themes/vue/exampleTheme.vue)
+@[code](@/content/guides/styling/themes/react/exampleTheme.css)
+
+:::
+
+:::
+
 ## Light and dark modes
 
 Each theme comes with three modes:
@@ -161,6 +172,29 @@ export class AppComponent {
     // ... other options
   };
 }
+```
+
+:::
+
+::: only-for vue
+
+```ts
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import { mainTheme } from 'handsontable/themes';
+
+registerAllModules();
+
+const hotSettings = ref({
+  theme: mainTheme,
+  // ... other options
+  licenseKey: 'non-commercial-and-evaluation',
+});
+```
+
+```html
+<HotTable :settings="hotSettings" />
 ```
 
 :::
@@ -266,6 +300,30 @@ export class AppComponent {
 
 :::
 
+::: only-for vue
+
+```ts
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { mainTheme, registerTheme } from 'handsontable/themes';
+
+const theme = registerTheme(mainTheme)
+  .setColorScheme('auto')
+  .setDensityType('comfortable');
+
+const hotSettings = ref({
+  theme: theme,
+  // ... other options
+  licenseKey: 'non-commercial-and-evaluation',
+});
+```
+
+```html
+<HotTable :settings="hotSettings" />
+```
+
+:::
+
 ### Option 2: Using CSS files
 
 Alternatively, you can load theme CSS files and pass the theme name as a string to the `theme` option.
@@ -340,6 +398,22 @@ const hot = new Handsontable(container, {
   theme: 'ht-theme-main'
 }">
 </hot-table>
+```
+
+:::
+
+::: only-for vue
+
+```ts
+const hotSettings = ref({
+  theme: 'ht-theme-main',
+  // ... other options
+  licenseKey: 'non-commercial-and-evaluation',
+});
+```
+
+```html
+<HotTable :settings="hotSettings" />
 ```
 
 :::

--- a/docs/content/guides/styling/themes/vue/exampleTheme.vue
+++ b/docs/content/guides/styling/themes/vue/exampleTheme.vue
@@ -1,0 +1,293 @@
+<script setup lang="ts">
+import { ref, computed, watch, nextTick, useTemplateRef } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import { mainTheme, horizonTheme, classicTheme, registerTheme, getTheme } from 'handsontable/themes';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+registerTheme(mainTheme);
+registerTheme(horizonTheme);
+registerTheme(classicTheme);
+
+const data: (string | number | boolean)[][] = [
+  [false, 'Tagcat', 'United Kingdom', 'Classic Vest', '2025-10-11', '01-2331942', true, '172', 2, 2],
+  [true, 'Zoomzone', 'Indonesia', 'Cycling Cap', '2025-05-03', '88-2768633', true, '188', 6, 2],
+  [true, 'Meeveo', 'United States', 'Full-Finger Gloves', '2025-03-27', '51-6775945', true, '162', 1, 3],
+  [false, 'Buzzdog', 'Philippines', 'HL Mountain Frame', '2025-08-29', '44-4028109', true, '133', 7, 1],
+  [true, 'Katz', 'India', 'Half-Finger Gloves', '2025-10-02', '08-2758492', true, '87', 1, 3],
+  [false, 'Jaxbean', 'China', 'HL Road Frame', '2025-09-28', '84-3557705', false, '26', 8, 1],
+  [false, 'Wikido', 'Brazil', 'HL Touring Frame', '2025-06-24', '20-9397637', false, '110', 4, 1],
+  [false, 'Browsedrive', 'United States', 'LL Mountain Frame', '2025-03-13', '36-0079556', true, '50', 4, 4],
+  [false, 'Twinder', 'United Kingdom', 'LL Road Frame', '2025-04-06', '41-1489542', false, '160', 6, 1],
+  [false, 'Jetwire', 'China', 'LL Touring Frame', '2025-02-01', '37-1531629', true, '30', 8, 5],
+  [false, 'Chatterpoint', 'China', 'Long-Sleeve Logo Jersey', '2025-07-14', '25-5083429', true, '39', 7, 2],
+  [false, 'Twinder', 'Egypt', "Men's Bib-Shorts", '2025-08-31', '04-4281278', false, '96', 6, 1],
+  [false, 'Midel', 'United States', "Men's Sports Shorts", '2025-06-27', '55-1711908', true, '108', 10, 3],
+  [false, 'Yodo', 'India', 'ML Mountain Frame', '2025-03-16', '58-8360815', false, '46', 1, 1],
+  [false, 'Camido', 'Russia', 'ML Mountain Frame-W', '2025-09-13', '10-3786104', true, '97', 8, 3],
+  [false, 'Eire', 'Thailand', 'ML Road Frame', '2025-04-10', '45-1186054', true, '161', 1, 4],
+  [false, 'Vinte', 'United Kingdom', 'ML Road Frame-W', '2025-01-22', '62-6202742', true, '58', 4, 3],
+  [false, 'Twitterlist', 'China', 'Mountain Bike Socks', '2025-11-09', '88-9646223', true, '92', 8, 3],
+  [false, 'Eidel', 'Bangladesh', 'Mountain-100', '2025-09-19', '45-5588112', true, '5', 6, 5],
+  [false, 'Trunyx', 'Nigeria', 'Mountain-200', '2025-03-09', '66-6271819', true, '158', 4, 1],
+  [false, 'Katz', 'Turkey', 'Mountain-300', '2025-03-05', '38-9245023', false, '121', 5, 4],
+  [false, 'Kaymbo', 'United States', 'Mountain-400-W', '2025-12-24', '44-5916927', false, '61', 5, 4],
+  [false, 'Ozu', 'Pakistan', 'Mountain-500', '2025-06-13', '31-5449914', true, '155', 2, 2],
+  [false, 'Rhynyx', 'India', 'Racing Socks', '2025-12-05', '19-9413869', true, '162', 2, 4],
+  [false, 'Flashset', 'Iran', 'Road-150', '2025-12-14', '25-9807605', false, '46', 7, 1],
+  [false, 'Yata', 'Congo (Kinshasa)', 'Road-250', '2025-06-12', '74-4291983', true, '47', 4, 4],
+  [false, 'Brainlounge', 'Vietnam', 'Road-350-W', '2025-03-10', '83-0980643', true, '104', 2, 3],
+  [false, 'Babblestorm', 'United States', 'Road-450', '2025-10-10', '19-2878430', true, '101', 6, 4],
+  [false, 'Youspan', 'Brazil', 'Road-550-W', '2025-12-16', '19-1838230', true, '150', 10, 3],
+  [false, 'Nlounge', 'China', 'Road-650', '2025-10-31', '32-2267938', true, '42', 4, 2],
+  [false, 'Twinte', 'India', 'Road-750', '2025-08-17', '79-2821972', true, '144', 9, 3],
+  [false, 'Oyonder', 'United Kingdom', 'Short-Sleeve Classic Jersey', '2025-12-04', '46-6597557', true, '195', 4, 1],
+  [false, 'Gigabox', 'Pakistan', 'Sport-100', '2025-02-03', '15-1793960', true, '199', 4, 4],
+  [false, 'Livetube', 'France', 'Touring-1000', '2025-05-16', '86-0811003', true, '110', 4, 5],
+  [false, 'Voomm', 'United Kingdom', 'Touring-2000', '2025-07-15', '95-3068680', true, '51', 4, 4],
+  [false, 'Voonyx', 'China', 'Touring-3000', '2025-11-27', '35-3085360', false, '69', 2, 5],
+  [false, 'Zoombeat', 'United States', "Women's Mountain Shorts", '2025-11-03', '56-8673088', false, '53', 2, 3],
+  [false, 'Roomm', 'China', "Women's Tights", '2025-03-16', '76-0085918', true, '168', 1, 1],
+  [false, 'Leenti', 'China', 'Mountain-400', '2025-05-16', '03-0893276', false, '58', 1, 4],
+  [false, 'Jetpulse', 'United States', 'Road-550', '2025-02-08', '79-9013306', true, '152', 9, 3],
+  [false, 'Katz', 'Peru', 'Road-350', '2025-02-15', '55-7799920', true, '66', 4, 2],
+  [false, 'Cogidoo', 'India', 'LL Mountain Front Wheel', '2025-06-04', '07-0881122', false, '112', 9, 2],
+  [false, 'Divavu', 'Colombia', 'Touring Rear Wheel', '2025-02-24', '58-6157387', true, '50', 10, 4],
+  [false, 'Mydeo', 'China', 'Touring Front Wheel', '2025-12-07', '12-2810010', false, '31', 3, 5],
+  [false, 'Browsebug', 'Japan', 'ML Mountain Front Wheel', '2025-01-14', '64-9249984', true, '132', 5, 5],
+  [false, 'Layo', 'China', 'HL Mountain Front Wheel', '2025-04-24', '45-0739652', true, '45', 1, 5],
+  [false, 'Snaptags', 'United Kingdom', 'LL Touring Handlebars', '2025-08-06', '09-5712761', true, '197', 4, 2],
+  [false, 'Cogilith', 'China', 'HL Touring Handlebars', '2025-05-31', '01-7345008', true, '190', 4, 3],
+  [false, 'Reallinks', 'United Kingdom', 'LL Road Front Wheel', '2025-05-14', '62-1065350', true, '184', 3, 4],
+  [false, 'Quaxo', 'United States', 'ML Road Front Wheel', '2025-03-23', '44-7241323', true, '169', 3, 4],
+  [false, 'Devify', 'China', 'HL Road Front Wheel', '2025-12-12', '52-0295699', false, '152', 4, 4],
+  [false, 'Youopia', 'Angola', 'LL Mountain Handlebars', '2025-04-01', '52-2650922', false, '182', 6, 4],
+  [false, 'Ainyx', 'China', 'Touring Pedal', '2025-02-27', '48-3618525', true, '141', 6, 1],
+  [false, 'Browsetype', 'Malaysia', 'ML Mountain Handlebars', '2025-04-28', '51-8893923', true, '169', 7, 1],
+  [false, 'Muxo', 'China', 'HL Mountain Handlebars', '2025-08-22', '68-5911361', false, '39', 7, 1],
+  [false, 'Bubbletube', 'China', 'LL Road Handlebars', '2025-10-04', '41-5880042', true, '71', 8, 3],
+  [false, 'Fadeo', 'Vietnam', 'ML Road Handlebars', '2025-04-23', '90-5913983', true, '148', 10, 3],
+  [false, 'Yadel', 'United Kingdom', 'HL Road Handlebars', '2025-04-18', '92-0960699', true, '116', 8, 1],
+  [false, 'Blognation', 'China', 'LL Headset', '2025-01-10', '06-9493898', true, '96', 10, 1],
+  [false, 'Devpoint', 'China', 'ML Headset', '2025-12-25', '69-5878565', true, '35', 4, 2],
+  [false, 'Aibox', 'United Kingdom', 'HL Headset', '2025-03-18', '13-1133017', true, '16', 8, 2],
+  [false, 'Brightdog', 'China', 'LL Mountain Pedal', '2025-09-11', '39-6530433', true, '194', 2, 5],
+  [false, 'Gabcube', 'Nigeria', 'ML Mountain Pedal', '2025-04-22', '96-6860388', true, '24', 1, 3],
+  [false, 'Muxo', 'China', 'HL Mountain Pedal', '2025-06-05', '30-0356137', true, '170', 4, 4],
+  [false, 'Tambee', 'China', 'ML Touring Seat/Saddle', '2025-02-22', '93-9058255', true, '184', 9, 5],
+  [false, 'Cogilith', 'India', 'LL Touring Seat/Saddle', '2025-04-06', '82-9268909', false, '153', 10, 4],
+  [false, 'Dynabox', 'Hong Kong', 'HL Touring Seat/Saddle', '2025-01-10', '20-6913815', false, '88', 10, 1],
+  [false, 'Shuffledrive', 'Sudan', 'LL Road Pedal', '2025-09-16', '08-8238817', true, '57', 9, 2],
+  [false, 'Fivechat', 'China', 'ML Road Pedal', '2025-08-26', '44-7370350', false, '62', 4, 1],
+  [false, 'Meembee', 'United States', 'HL Road Pedal', '2025-12-27', '01-3525949', true, '123', 2, 4],
+  [false, 'Dynazzy', 'United Kingdom', 'LL Mountain Seat/Saddle 1', '2025-12-15', '04-2414623', true, '77', 10, 5],
+  [false, 'Eare', 'China', 'ML Mountain Seat/Saddle 1', '2025-04-04', '15-1917509', false, '199', 9, 4],
+  [false, 'Yozio', 'China', 'HL Mountain Seat/Saddle 1', '2025-03-15', '06-2526845', true, '149', 8, 2],
+  [false, 'Quinu', "Xi'an", '425-777-7829', '2025-02-22', '83-1713558', false, '191', 9, 5],
+  [false, 'Jazzy', 'United Kingdom', 'ML Road Seat/Saddle 1', '2025-08-07', '00-8892524', true, '150', 10, 2],
+  [false, 'Thoughtsphere', 'China', 'HL Road Seat/Saddle 1', '2025-11-28', '39-5538991', true, '130', 7, 3],
+  [false, 'Leenti', 'China', 'ML Road Rear Wheel', '2025-12-29', '06-9002973', true, '179', 1, 2],
+  [false, 'Quaxo', 'United Kingdom', 'HL Road Rear Wheel', '2025-09-06', '73-6104901', true, '98', 5, 3],
+  [false, 'Tanoodle', 'Chile', 'LL Mountain Seat/Saddle 2', '2025-05-24', '68-7384479', true, '175', 2, 3],
+  [false, 'Feednation', 'China', 'ML Mountain Seat/Saddle 2', '2025-11-21', '26-7757763', true, '11', 1, 3],
+  [false, 'Kayveo', 'China', 'HL Mountain Seat/Saddle 2', '2025-06-21', '07-4873562', false, '184', 7, 4],
+  [false, 'Meevee', 'Saudi Arabia', 'LL Road Seat/Saddle 1', '2025-11-16', '46-5819554', false, '27', 9, 3],
+  [false, 'Twitterworks', 'China', 'ML Road Seat/Saddle 2', '2025-04-19', '01-2666826', true, '186', 3, 2],
+  [false, 'Wikizz', 'Tanzania', 'HL Road Seat/Saddle 2', '2025-03-08', '54-7090503', true, '20', 3, 3],
+  [false, 'Yoveo', 'United States', 'LL Mountain Tire', '2025-10-14', '78-7658520', false, '153', 2, 1],
+  [false, 'Yakidoo', 'China', 'ML Mountain Tire', '2025-10-12', '23-9926318', true, '161', 8, 5],
+  [false, 'Oyope', 'China', 'HL Mountain Tire', '2025-09-20', '20-0179517', true, '98', 10, 5],
+  [false, 'Skipstorm', 'United States', 'LL Road Tire', '2025-10-01', '02-9543343', true, '30', 7, 3],
+  [false, 'Minyx', 'United States', 'ML Road Tire', '2025-07-07', '98-3938169', true, '73', 10, 2],
+  [false, 'Miboo', 'China', 'HL Road Tire', '2025-07-25', '68-5197934', true, '158', 9, 1],
+  [false, 'Realfire', 'United States', 'Touring Tire', '2025-08-27', '39-8260460', true, '122', 5, 2],
+  [false, 'Shufflester', 'China', 'Mountain Tire Tube', '2025-06-08', '45-9776170', true, '33', 2, 4],
+  [false, 'Ntag', 'China', 'Road Tire Tube', '2025-12-06', '45-0858451', true, '107', 6, 2],
+  [false, 'Jabberbean', 'United States', 'Touring Tire Tube', '2025-04-26', '15-4247305', true, '15', 1, 2],
+  [false, 'Thoughtblab', 'China', 'LL Bottom Bracket', '2025-05-21', '15-8534931', true, '168', 5, 2],
+  [false, 'Jabbertype', 'China', 'Classic Vest', '2025-07-25', '23-1251557', true, '135', 4, 2],
+  [false, 'Buzzshare', 'United Kingdom', 'Cycling Cap', '2025-07-07', '86-5920601', true, '11', 1, 4],
+  [false, 'Roodel', 'United States', 'Full-Finger Gloves', '2025-01-13', '48-1055459', true, '41', 6, 4],
+  [false, 'Zoovu', 'China', 'Half-Finger Gloves', '2025-06-03', '12-7842022', true, '144', 6, 1],
+  [false, 'Photofeed', 'China', 'HL Mountain Frame', '2025-07-14', '94-5088099', true, '106', 1, 4],
+];
+
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
+
+const currentTheme = document.documentElement.getAttribute('data-theme') === 'dark'
+  ? 'horizon-dark'
+  : 'horizon-light';
+
+const themeName = ref(currentTheme);
+const menuOpen = ref(false);
+const dotColors = ref({ fg: '', bg: '', accent: '' });
+
+const themeOptions = [
+  { value: 'main-light', label: 'Main Light' },
+  { value: 'main-dark', label: 'Main Dark' },
+  { value: 'horizon-light', label: 'Horizon Light' },
+  { value: 'horizon-dark', label: 'Horizon Dark' },
+  { value: 'classic-light', label: 'Classic Light' },
+  { value: 'classic-dark', label: 'Classic Dark' },
+];
+
+const currentOption = computed(
+  () => themeOptions.find((o) => o.value === themeName.value) ?? themeOptions[0],
+);
+
+function resolveTheme(name: string) {
+  const [theme, scheme] = name.split('-');
+
+  return getTheme(theme)?.setColorScheme(scheme || 'auto');
+}
+
+const hotSettings = computed<GridSettings>(() => ({
+  theme: resolveTheme(themeName.value),
+  data,
+  height: 450,
+  colWidths: [180, 220, 140, 120, 120, 120, 140],
+  colHeaders: ['Company Name', 'Name', 'Sell date', 'In stock', 'Quantity', 'Order ID', 'Country'],
+  contextMenu: [
+    'cut',
+    'copy',
+    '---------',
+    'row_above',
+    'row_below',
+    'remove_row',
+    '---------',
+    'alignment',
+    'make_read_only',
+    'clear_column',
+  ],
+  columns: [
+    { data: 1, type: 'text', headerClassName: 'htLeft' },
+    { data: 3, type: 'text', headerClassName: 'htLeft' },
+    {
+      data: 4,
+      type: 'intl-date',
+      allowInvalid: false,
+      locale: 'en-GB',
+      dateFormat: { day: '2-digit', month: '2-digit', year: 'numeric' },
+      headerClassName: 'htLeft',
+    },
+    { data: 6, type: 'checkbox', className: 'htCenter', headerClassName: 'htLeft' },
+    { data: 7, type: 'numeric', headerClassName: 'htLeft' },
+    { data: 5, type: 'text', headerClassName: 'htLeft' },
+    { data: 2, type: 'text', headerClassName: 'htLeft' },
+  ],
+  dropdownMenu: true,
+  hiddenColumns: { indicators: true },
+  multiColumnSorting: true,
+  filters: true,
+  rowHeaders: true,
+  manualRowMove: true,
+  headerClassName: 'htLeft',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  manualRowResize: true,
+  manualColumnResize: true,
+  navigableHeaders: true,
+  licenseKey: 'non-commercial-and-evaluation',
+}));
+
+function updateDotColors() {
+  const gridEl = hotRef.value?.hotInstance?.rootElement;
+
+  if (!gridEl) {
+    return;
+  }
+
+  const helper = document.createElement('div');
+
+  helper.style.cssText = 'position:absolute;visibility:hidden;pointer-events:none;';
+  gridEl.appendChild(helper);
+
+  const resolve = (varName: string) => {
+    helper.style.color = 'var(' + varName + ')';
+
+    return getComputedStyle(helper).color;
+  };
+
+  dotColors.value = {
+    fg: resolve('--ht-foreground-color'),
+    bg: resolve('--ht-background-color'),
+    accent: resolve('--ht-accent-color'),
+  };
+
+  gridEl.removeChild(helper);
+}
+
+watch(themeName, async () => {
+  const [, colorScheme] = themeName.value.split('-');
+  const container = document.getElementById('exampleTheme');
+
+  if (container) {
+    container.dataset.colorScheme = colorScheme || 'auto';
+  }
+
+  await nextTick();
+  updateDotColors();
+}, { immediate: true });
+
+function selectTheme(value: string) {
+  themeName.value = value;
+  menuOpen.value = false;
+}
+
+function toggleMenu() {
+  menuOpen.value = !menuOpen.value;
+}
+</script>
+
+<template>
+  <div id="exampleTheme" class="disable-auto-theme">
+    <div class="example-controls-container">
+      <div class="controls">
+        <div class="theme-dropdown" @click.stop>
+          <button
+            class="theme-dropdown-trigger"
+            type="button"
+            aria-haspopup="listbox"
+            :aria-expanded="menuOpen"
+            @click="toggleMenu"
+          >
+            <span class="theme-dropdown-colors">
+              <span class="color" :style="{ background: dotColors.fg }" />
+              <span class="color" :style="{ background: dotColors.bg }" />
+              <span class="color" :style="{ background: dotColors.accent }" />
+            </span>
+            <span class="theme-dropdown-label">{{ currentOption.label }}</span>
+            <svg
+              class="theme-dropdown-chevron"
+              aria-hidden="true"
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="M6 9l6 6l6 -6" />
+            </svg>
+          </button>
+          <ul v-if="menuOpen" class="theme-dropdown-menu" role="listbox">
+            <li
+              v-for="opt in themeOptions"
+              :key="opt.value"
+              role="option"
+              :aria-selected="opt.value === themeName"
+              @click="selectTheme(opt.value)"
+            >
+              {{ opt.label }}
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <HotTable :key="themeName" ref="hotRef" :settings="hotSettings" />
+  </div>
+</template>


### PR DESCRIPTION
### Context

Add Vue 3 variants to the styling and theming documentation guides so they match the existing React and Angular coverage.

Pages updated:
- Themes (`/themes`) — theme switcher embed + code snippets
- Theme Customization (`/theme-customization`) — two runnable examples + register-theme snippet
- Legacy Style (`/legacy-style`) — migration code snippets
- Design System — no changes (shared content only)

[skip changelog]

### How has this been tested?

Manual verification on the docs dev server (`cd docs && pnpm dev`):

- http://localhost:4321/docs/vue-data-grid/themes/ — theme dropdown demo renders; theme modes switch
- http://localhost:4321/docs/vue-data-grid/theme-customization/ — both `#example1` and `#example2` render
- http://localhost:4321/docs/vue-data-grid/legacy-style/ — Vue snippets visible
- http://localhost:4321/docs/vue-data-grid/handsontable-design-system/ — page loads

StackBlitz buttons present for all three SFC examples (themes: 1, theme-customization: 2).

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1753

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 4090708758ccd74465be7ec88e2f04a326443387. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->