### PR TITLE
DEV-1831, DEV-1832: Unify Vue docs examples on TypeScript and useTemplateRef

### DIFF
--- a/.claude/skills/creating-docs-examples/SKILL.md
+++ b/.claude/skills/creating-docs-examples/SKILL.md
@@ -180,8 +180,33 @@ const hotSettings = ref<GridSettings>({
 - The root `<div>` in `<template>` must use an `id` that matches the example container in the guide (`#example1` in `::: example #example1 :vue3`).
 - Prefer a single `:settings` object for grid options. Use individual props only when the guide text highlights a specific prop.
 - Put Handsontable hooks (`afterChange`, `beforeDataProviderFetch`, etc.) inside the settings object, not as Vue event listeners on `<HotTable>`.
-- Use `ref()` from `vue` for reactive state that the template or handlers update. Use a plain `const` for `hotSettings` when reactive deep updates would trigger unwanted `updateSettings()` calls (for example, when only a status label changes beside the grid).
-- Access the underlying instance with a template ref when needed: `const hotRef = ref(null)` and `<HotTable ref="hotRef" :settings="hotSettings" />`, then `hotRef.value?.hotInstance`.
+- Use `ref()` from `vue` for reactive state that the template or handlers update (`hotSettings`, toggles, selected values). Use a plain `const` for `hotSettings` when reactive deep updates would trigger unwanted `updateSettings()` calls (for example, when only a status label changes beside the grid).
+- Always use `useTemplateRef('refName')` for template refs bound via `ref="..."` in `<template>`. Never use `ref()` for template refs.
+- HotTable instance access:
+
+```vue
+import { useTemplateRef } from 'vue';
+
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
+```
+
+```vue
+<HotTable ref="hotRef" :settings="hotSettings" />
+```
+
+Access: `hotRef.value?.hotInstance`.
+
+- DOM element refs:
+
+```vue
+const dropdownRef = useTemplateRef<HTMLDivElement>('dropdownRef');
+```
+
+```vue
+<div ref="dropdownRef" class="theme-dropdown">...</div>
+```
+
+Access: `dropdownRef.value`. The string passed to `useTemplateRef(...)` must match the template `ref` attribute exactly.
 - For `HotColumn`, nest it inside `<HotTable>` in `<template>` and pass column options via `:settings` on each `HotColumn`.
 - Optional `<style scoped>` is allowed for example-only UI (buttons, status text). Example-runner CSS from the guide's `--css` slot still applies globally.
 

--- a/docs/content/guides/accessories-and-menus/empty-data-state/vue/example2.vue
+++ b/docs/content/guides/accessories-and-menus/empty-data-state/vue/example2.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 
 const hotSettings = ref<GridSettings>({
   data: [],

--- a/docs/content/guides/accessories-and-menus/empty-data-state/vue/example3.vue
+++ b/docs/content/guides/accessories-and-menus/empty-data-state/vue/example3.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 
 const hotSettings = ref<GridSettings>({
   data: [],

--- a/docs/content/guides/accessories-and-menus/export-to-csv/vue/example1.vue
+++ b/docs/content/guides/accessories-and-menus/export-to-csv/vue/example1.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 
 const gridData = [
   ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1'],

--- a/docs/content/guides/accessories-and-menus/export-to-csv/vue/example2.vue
+++ b/docs/content/guides/accessories-and-menus/export-to-csv/vue/example2.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 
 const gridData = [
   ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1'],

--- a/docs/content/guides/accessories-and-menus/export-to-csv/vue/example3.vue
+++ b/docs/content/guides/accessories-and-menus/export-to-csv/vue/example3.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 
 const gridData = [
   ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1'],

--- a/docs/content/guides/accessories-and-menus/export-to-csv/vue/example4.vue
+++ b/docs/content/guides/accessories-and-menus/export-to-csv/vue/example4.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 
 const hotSettings = ref<GridSettings>({
   data: [

--- a/docs/content/guides/accessories-and-menus/export-to-excel/vue/example1.vue
+++ b/docs/content/guides/accessories-and-menus/export-to-excel/vue/example1.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import ExcelJS from 'exceljs';
@@ -7,7 +7,7 @@ import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 
 const hotData = [
   ['Alice Martin', 'North', 142000, true, 'Exceeded Q1 target by 18%.'],

--- a/docs/content/guides/accessories-and-menus/export-to-excel/vue/example2.vue
+++ b/docs/content/guides/accessories-and-menus/export-to-excel/vue/example2.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import ExcelJS from 'exceljs';
@@ -7,8 +7,8 @@ import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotQ1Ref = ref<InstanceType<typeof HotTable> | null>(null);
-const hotQ2Ref = ref<InstanceType<typeof HotTable> | null>(null);
+const hotQ1Ref = useTemplateRef<InstanceType<typeof HotTable>>('hotQ1Ref');
+const hotQ2Ref = useTemplateRef<InstanceType<typeof HotTable>>('hotQ2Ref');
 
 const q1Data = [
   ['Alice Martin', 'North', 142000, true],

--- a/docs/content/guides/cell-features/clipboard/vue/example3.vue
+++ b/docs/content/guides/cell-features/clipboard/vue/example3.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotTableRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotTableRef = useTemplateRef<InstanceType<typeof HotTable>>('hotTableRef');
 
 const hotSettings = ref<GridSettings>({
   data: [

--- a/docs/content/guides/cell-features/conditional-formatting/vue/example1.vue
+++ b/docs/content/guides/cell-features/conditional-formatting/vue/example1.vue
@@ -6,7 +6,7 @@ import type { BaseRenderer } from 'handsontable/renderers';
 import { textRenderer } from 'handsontable/renderers/textRenderer';
 import type { GridSettings } from 'handsontable/settings';
 import type Handsontable from 'handsontable/base';
-import { ref } from 'vue';
+import { ref, useTemplateRef } from 'vue';
 
 registerAllModules();
 
@@ -44,7 +44,7 @@ const negativeValueRenderer: BaseRenderer = (instance, td, row, col, prop, value
 
 registerRenderer('negativeValueRenderer', negativeValueRenderer);
 
-const hotTableRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotTableRef = useTemplateRef<InstanceType<typeof HotTable>>('hotTableRef');
 
 const hotSettings: GridSettings = {
   data,

--- a/docs/content/guides/cell-features/selection/vue/example1.vue
+++ b/docs/content/guides/cell-features/selection/vue/example1.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref } from 'vue';
+import { computed, onMounted, onUnmounted, ref, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
@@ -12,7 +12,7 @@ const options = [
   { value: 'multiple', label: 'Multiple ranges selection' },
 ] as const;
 
-const dropdownRef = ref<HTMLDivElement | null>(null);
+const dropdownRef = useTemplateRef<HTMLDivElement>('dropdownRef');
 const isOpen = ref(false);
 const selected = ref<'single' | 'range' | 'multiple'>('multiple');
 

--- a/docs/content/guides/cell-features/selection/vue/example2.vue
+++ b/docs/content/guides/cell-features/selection/vue/example2.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type Handsontable from 'handsontable/base';
@@ -7,7 +7,7 @@ import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotTableRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotTableRef = useTemplateRef<InstanceType<typeof HotTable>>('hotTableRef');
 const output = ref('');
 
 const hotSettings = ref<GridSettings>({

--- a/docs/content/guides/cell-features/selection/vue/example3.vue
+++ b/docs/content/guides/cell-features/selection/vue/example3.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotTableRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotTableRef = useTemplateRef<InstanceType<typeof HotTable>>('hotTableRef');
 
 const hotSettings = ref<GridSettings>({
   data: [

--- a/docs/content/guides/cell-features/selection/vue/example5.vue
+++ b/docs/content/guides/cell-features/selection/vue/example5.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotTableRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotTableRef = useTemplateRef<InstanceType<typeof HotTable>>('hotTableRef');
 
 const hotSettings = ref<GridSettings>({
   data: [

--- a/docs/content/guides/cell-functions/cell-function/cell-function.md
+++ b/docs/content/guides/cell-functions/cell-function/cell-function.md
@@ -276,10 +276,10 @@ const type = cellProperties.type;           // cell type string
 
 ```html
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { onMounted, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 
 onMounted(() => {
   const hot = hotRef.value?.hotInstance;
@@ -390,10 +390,10 @@ export class AppComponent implements AfterViewInit {
 
 ```html
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { onMounted, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 
 onMounted(() => {
   const hot = hotRef.value?.hotInstance;

--- a/docs/content/guides/cell-functions/cell-renderer/vue/example5.vue
+++ b/docs/content/guides/cell-functions/cell-renderer/vue/example5.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
@@ -8,7 +8,7 @@ import { textRenderer } from 'handsontable/renderers/textRenderer';
 
 registerAllModules();
 
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 const isChecked = ref(false);
 
 const customRenderer: BaseRenderer = (instance, td, row, col, prop, value, cellProperties) => {

--- a/docs/content/guides/cell-types/date-cell-type/vue/example1.vue
+++ b/docs/content/guides/cell-types/date-cell-type/vue/example1.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, onBeforeUnmount } from 'vue';
+import { ref, onMounted, onBeforeUnmount, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
@@ -31,8 +31,8 @@ const localeOptions = [
   { value: 'zh-TW', label: 'Chinese (Traditional, Taiwan)' },
 ];
 
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
-const dropdownRef = ref<HTMLDivElement | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
+const dropdownRef = useTemplateRef<HTMLDivElement>('dropdownRef');
 const isOpen = ref(false);
 const locale = ref('en-US');
 

--- a/docs/content/guides/cell-types/numeric-cell-type/vue/example1.vue
+++ b/docs/content/guides/cell-types/numeric-cell-type/vue/example1.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted } from 'vue';
+import { ref, onMounted, onUnmounted, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
@@ -31,8 +31,8 @@ const localeOptions = [
   { value: 'zh-TW', label: 'Chinese (Traditional, Taiwan)' },
 ];
 
-const hotTableComponent = ref(null);
-const dropdownRef = ref<HTMLDivElement | null>(null);
+const hotTableComponent = useTemplateRef<InstanceType<typeof HotTable>>('hotTableComponent');
+const dropdownRef = useTemplateRef<HTMLDivElement>('dropdownRef');
 const isOpen = ref(false);
 const locale = ref('en-US');
 

--- a/docs/content/guides/cell-types/time-cell-type/vue/example1.vue
+++ b/docs/content/guides/cell-types/time-cell-type/vue/example1.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, onBeforeUnmount } from 'vue';
+import { ref, onMounted, onBeforeUnmount, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
@@ -31,8 +31,8 @@ const localeOptions = [
   { value: 'zh-TW', label: 'Chinese (Traditional, Taiwan)' },
 ];
 
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
-const dropdownRef = ref<HTMLDivElement | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
+const dropdownRef = useTemplateRef<HTMLDivElement>('dropdownRef');
 const isOpen = ref(false);
 const locale = ref('en-US');
 

--- a/docs/content/guides/columns/column-filter/column-filter.md
+++ b/docs/content/guides/columns/column-filter/column-filter.md
@@ -867,7 +867,7 @@ this.hotTable.hotInstance!.updateSettings({
 ::: only-for vue
 
 ```js
-const hotTableRef = ref(null);
+const hotTableRef = useTemplateRef<InstanceType<typeof HotTable>>('hotTableRef');
 
 hotTableRef.value.hotInstance.updateSettings({
   // enable filtering
@@ -987,7 +987,7 @@ this.hotTable.hotInstance!.updateSettings({
 ::: only-for vue
 
 ```js
-const hotTableRef = ref(null);
+const hotTableRef = useTemplateRef<InstanceType<typeof HotTable>>('hotTableRef');
 
 hotTableRef.value.hotInstance.updateSettings({
   // enable filtering for all columns

--- a/docs/content/guides/columns/column-filter/vue/exampleExcludeRowsFromFiltering.vue
+++ b/docs/content/guides/columns/column-filter/vue/exampleExcludeRowsFromFiltering.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 // you need a template ref to call Handsontable's instance methods
-import { ref } from 'vue';
+import { ref, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
@@ -8,7 +8,7 @@ import type { GridSettings } from 'handsontable/settings';
 // register Handsontable's modules
 registerAllModules();
 
-const hotTableRef = ref<any>(null);
+const hotTableRef = useTemplateRef<InstanceType<typeof HotTable>>('hotTableRef');
 
 const exclude = () => {
   const hotInstance = hotTableRef.value?.hotInstance;

--- a/docs/content/guides/columns/column-filter/vue/exampleFilterOnInitialization.vue
+++ b/docs/content/guides/columns/column-filter/vue/exampleFilterOnInitialization.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 // you need a template ref to call Handsontable's instance methods
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
@@ -8,7 +8,7 @@ import type { GridSettings } from 'handsontable/settings';
 // register Handsontable's modules
 registerAllModules();
 
-const hotTableRef = ref<any>(null);
+const hotTableRef = useTemplateRef<InstanceType<typeof HotTable>>('hotTableRef');
 
 onMounted(() => {
   const handsontableInstance = hotTableRef.value?.hotInstance;

--- a/docs/content/guides/columns/column-filter/vue/exampleFilterThroughAPI1.vue
+++ b/docs/content/guides/columns/column-filter/vue/exampleFilterThroughAPI1.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
@@ -7,7 +7,7 @@ import type { GridSettings } from 'handsontable/settings';
 // register Handsontable's modules
 registerAllModules();
 
-const hotTableRef = ref<any>(null);
+const hotTableRef = useTemplateRef<InstanceType<typeof HotTable>>('hotTableRef');
 
 const filterBelow200 = () => {
   // get the `Filters` plugin, so you can use its API

--- a/docs/content/guides/columns/column-filter/vue/exampleQuickFilter.vue
+++ b/docs/content/guides/columns/column-filter/vue/exampleQuickFilter.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted, computed } from 'vue';
+import { ref, onMounted, onUnmounted, computed, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
@@ -16,8 +16,8 @@ const columnOptions = [
   { value: '5', label: 'In stock' },
 ];
 
-const hotTableRef = ref<any>(null);
-const dropdownRef = ref<HTMLDivElement | null>(null);
+const hotTableRef = useTemplateRef<InstanceType<typeof HotTable>>('hotTableRef');
+const dropdownRef = useTemplateRef<HTMLDivElement>('dropdownRef');
 const selectedColumn = ref('0');
 const open = ref(false);
 

--- a/docs/content/guides/dialog/dialog/vue/example1.vue
+++ b/docs/content/guides/dialog/dialog/vue/example1.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, useTemplateRef } from 'vue';
 import { HotTable, HotColumn } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 
 const data = [
   { model: 'Trail Helmet', price: 1298.14, sellDate: '2025-08-31', sellTime: '14:12', inStock: true },

--- a/docs/content/guides/dialog/dialog/vue/example2.vue
+++ b/docs/content/guides/dialog/dialog/vue/example2.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, useTemplateRef } from 'vue';
 import { HotTable, HotColumn } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 
 const data = [
   { model: 'Trail Helmet', price: 1298.14, sellDate: '2025-08-31', sellTime: '14:12', inStock: true },

--- a/docs/content/guides/dialog/dialog/vue/example3.vue
+++ b/docs/content/guides/dialog/dialog/vue/example3.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, useTemplateRef } from 'vue';
 import { HotTable, HotColumn } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 
 const data = [
   { model: 'Trail Helmet', price: 1298.14, sellDate: '2025-08-31', sellTime: '14:12', inStock: true },

--- a/docs/content/guides/dialog/dialog/vue/example4.vue
+++ b/docs/content/guides/dialog/dialog/vue/example4.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, useTemplateRef } from 'vue';
 import { HotTable, HotColumn } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 
 const data = [
   { model: 'Trail Helmet', price: 1298.14, sellDate: '2025-08-31', sellTime: '14:12', inStock: true },

--- a/docs/content/guides/dialog/dialog/vue/example5.vue
+++ b/docs/content/guides/dialog/dialog/vue/example5.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted } from 'vue';
+import { ref, onMounted, onUnmounted, useTemplateRef } from 'vue';
 import { HotTable, HotColumn } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
-const dropdownRef = ref<HTMLDivElement | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
+const dropdownRef = useTemplateRef<HTMLDivElement>('dropdownRef');
 const isOpen = ref(false);
 const selected = ref<'solid' | 'semi-transparent'>('solid');
 

--- a/docs/content/guides/dialog/dialog/vue/example6.vue
+++ b/docs/content/guides/dialog/dialog/vue/example6.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, useTemplateRef } from 'vue';
 import { HotTable, HotColumn } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 
 const data = [
   { model: 'Trail Helmet', price: 1298.14, sellDate: '2025-08-31', sellTime: '14:12', inStock: true },

--- a/docs/content/guides/dialog/dialog/vue/example7.vue
+++ b/docs/content/guides/dialog/dialog/vue/example7.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, useTemplateRef } from 'vue';
 import { HotTable, HotColumn } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 
 const data = [
   { model: 'Trail Helmet', price: 1298.14, sellDate: '2025-08-31', sellTime: '14:12', inStock: true },

--- a/docs/content/guides/dialog/dialog/vue/example8.vue
+++ b/docs/content/guides/dialog/dialog/vue/example8.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, useTemplateRef } from 'vue';
 import { HotTable, HotColumn } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 
 const data = [
   { model: 'Trail Helmet', price: 1298.14, sellDate: '2025-08-31', sellTime: '14:12', inStock: true },

--- a/docs/content/guides/dialog/loading/vue/example1.vue
+++ b/docs/content/guides/dialog/loading/vue/example1.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, useTemplateRef } from 'vue';
 import { HotTable, HotColumn } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 
 const data = [
   { model: 'Trail Helmet', price: 1298.14, sellDate: '2025-08-31', sellTime: '14:12', inStock: true },

--- a/docs/content/guides/dialog/loading/vue/example2.vue
+++ b/docs/content/guides/dialog/loading/vue/example2.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, useTemplateRef } from 'vue';
 import { HotTable, HotColumn } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 
 const data = [
   { model: 'Trail Helmet', price: 1298.14, sellDate: '2025-08-31', sellTime: '14:12', inStock: true },

--- a/docs/content/guides/dialog/loading/vue/example3.vue
+++ b/docs/content/guides/dialog/loading/vue/example3.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, useTemplateRef } from 'vue';
 import { HotTable, HotColumn } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
@@ -14,7 +14,7 @@ type InventoryRow = {
   inStock: boolean;
 };
 
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 const tableData = ref<InventoryRow[]>([]);
 const isLoading = ref(false);
 

--- a/docs/content/guides/dialog/loading/vue/example4.vue
+++ b/docs/content/guides/dialog/loading/vue/example4.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, nextTick } from 'vue';
+import { ref, onMounted, nextTick, useTemplateRef } from 'vue';
 import { HotTable, HotColumn } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
@@ -14,8 +14,8 @@ type InventoryRow = {
   inStock: boolean;
 };
 
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
-const paginationContainerRef = ref<HTMLDivElement | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
+const paginationContainerRef = useTemplateRef<HTMLDivElement>('paginationContainerRef');
 const tableData = ref<InventoryRow[]>([]);
 const isLoading = ref(false);
 

--- a/docs/content/guides/dialog/notification/vue/example1.vue
+++ b/docs/content/guides/dialog/notification/vue/example1.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 
 const data = [
   ['Review pricing sheet', 'Draft', 'Apr 12', 'Morgan Lee', 'Medium', 'Finance'],

--- a/docs/content/guides/dialog/notification/vue/example2.vue
+++ b/docs/content/guides/dialog/notification/vue/example2.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 
 const data = [
   ['SKU-001', 'Alkaline AA 4pk', 240, 40, 'A-12'],

--- a/docs/content/guides/getting-started/binding-to-data/vue/example1.vue
+++ b/docs/content/guides/getting-started/binding-to-data/vue/example1.vue
@@ -1,11 +1,12 @@
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotSettings = ref({
+const hotSettings = ref<GridSettings>({
   data: [
     ['', 'Tesla', 'Nissan', 'Toyota', 'Honda', 'Mazda', 'Ford'],
     ['2017', 10, 11, 12, 13, 15, 16],

--- a/docs/content/guides/getting-started/binding-to-data/vue/example10.vue
+++ b/docs/content/guides/getting-started/binding-to-data/vue/example10.vue
@@ -1,13 +1,14 @@
-<script setup>
+<script setup lang="ts">
 import { ref, onMounted } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotRef = ref(null);
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
 
-const hotSettings = ref({
+const hotSettings = ref<GridSettings>({
   data: [
     ['', 'Tesla', 'Nissan', 'Toyota', 'Honda', 'Mazda', 'Ford'],
     ['2017', 10, 11, 12, 13, 15, 16],

--- a/docs/content/guides/getting-started/binding-to-data/vue/example10.vue
+++ b/docs/content/guides/getting-started/binding-to-data/vue/example10.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 
 const hotSettings = ref<GridSettings>({
   data: [

--- a/docs/content/guides/getting-started/binding-to-data/vue/example11.vue
+++ b/docs/content/guides/getting-started/binding-to-data/vue/example11.vue
@@ -1,7 +1,8 @@
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
@@ -14,7 +15,7 @@ const data = [
   ['2021', 10, 11, 12, 13, 15, 16],
 ];
 
-const hotSettings = ref({
+const hotSettings = ref<GridSettings>({
   data: structuredClone(data),
   height: 'auto',
   autoWrapRow: true,

--- a/docs/content/guides/getting-started/binding-to-data/vue/example2.vue
+++ b/docs/content/guides/getting-started/binding-to-data/vue/example2.vue
@@ -1,11 +1,12 @@
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotSettings = ref({
+const hotSettings = ref<GridSettings>({
   data: [
     ['', 'Tesla', 'Nissan', 'Toyota', 'Honda', 'Mazda', 'Ford'],
     ['2017', 10, 11, 12, 13, 15, 16],

--- a/docs/content/guides/getting-started/binding-to-data/vue/example3.vue
+++ b/docs/content/guides/getting-started/binding-to-data/vue/example3.vue
@@ -1,11 +1,12 @@
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotSettings = ref({
+const hotSettings = ref<GridSettings>({
   data: [
     { id: 1, name: 'Ted Right', address: '' },
     { id: 2, name: 'Frank Honest', address: '' },

--- a/docs/content/guides/getting-started/binding-to-data/vue/example4.vue
+++ b/docs/content/guides/getting-started/binding-to-data/vue/example4.vue
@@ -1,11 +1,12 @@
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotSettings = ref({
+const hotSettings = ref<GridSettings>({
   data: [
     { id: 1, name: { first: 'Ted', last: 'Right' }, address: '' },
     { id: 2, address: '' },

--- a/docs/content/guides/getting-started/binding-to-data/vue/example5.vue
+++ b/docs/content/guides/getting-started/binding-to-data/vue/example5.vue
@@ -1,11 +1,12 @@
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotSettings = ref({
+const hotSettings = ref<GridSettings>({
   data: [
     { id: 1, name: { first: 'Ted', last: 'Right' }, address: '' },
     { id: 2, address: '' },

--- a/docs/content/guides/getting-started/binding-to-data/vue/example6.vue
+++ b/docs/content/guides/getting-started/binding-to-data/vue/example6.vue
@@ -1,11 +1,12 @@
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotSettings = ref({
+const hotSettings = ref<GridSettings>({
   data: [],
   dataSchema: {
     id: null,

--- a/docs/content/guides/getting-started/binding-to-data/vue/example7.vue
+++ b/docs/content/guides/getting-started/binding-to-data/vue/example7.vue
@@ -1,11 +1,14 @@
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-function model(opts) {
+type ModelOpts = Record<string, unknown>;
+
+function model(opts: ModelOpts) {
   const _pub = {
     id: undefined,
     name: undefined,
@@ -20,7 +23,7 @@ function model(opts) {
     }
   }
 
-  _pub.attr = function(attr, val) {
+  _pub.attr = function(attr: string, val?: unknown) {
     if (typeof val === 'undefined') {
       window.console && console.log('GET the', attr, 'value of', _pub);
       return _priv[attr];
@@ -33,11 +36,11 @@ function model(opts) {
   return _pub;
 }
 
-function property(attr) {
-  return (row, value) => row.attr(attr, value);
+function property(attr: string) {
+  return (row: ReturnType<typeof model>, value: unknown) => row.attr(attr, value);
 }
 
-const hotSettings = ref({
+const hotSettings = ref<GridSettings>({
   data: [
     model({ id: 1, name: 'Ted Right', address: '' }),
     model({ id: 2, name: 'Frank Honest', address: '' }),

--- a/docs/content/guides/getting-started/binding-to-data/vue/example9.vue
+++ b/docs/content/guides/getting-started/binding-to-data/vue/example9.vue
@@ -1,11 +1,12 @@
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotSettings = ref({
+const hotSettings = ref<GridSettings>({
   autoWrapRow: true,
   autoWrapCol: true,
   height: 'auto',

--- a/docs/content/guides/getting-started/configuration-options/vue/example1.vue
+++ b/docs/content/guides/getting-started/configuration-options/vue/example1.vue
@@ -1,11 +1,12 @@
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotSettings = ref({
+const hotSettings = ref<GridSettings>({
   data: [
     ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1', 'J1'],
     ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2', 'H2', 'I2', 'J2'],

--- a/docs/content/guides/getting-started/configuration-options/vue/example2.vue
+++ b/docs/content/guides/getting-started/configuration-options/vue/example2.vue
@@ -1,11 +1,12 @@
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotSettings = ref({
+const hotSettings = ref<GridSettings>({
   data: [
     ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1', 'J1'],
     ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2', 'H2', 'I2', 'J2'],

--- a/docs/content/guides/getting-started/configuration-options/vue/example3.vue
+++ b/docs/content/guides/getting-started/configuration-options/vue/example3.vue
@@ -1,11 +1,12 @@
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotSettings = ref({
+const hotSettings = ref<GridSettings>({
   data: [
     ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1', 'J1'],
     ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2', 'H2', 'I2', 'J2'],

--- a/docs/content/guides/getting-started/configuration-options/vue/example4.vue
+++ b/docs/content/guides/getting-started/configuration-options/vue/example4.vue
@@ -1,11 +1,12 @@
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotSettings = ref({
+const hotSettings = ref<GridSettings>({
   data: [
     ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1', 'J1'],
     ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2', 'H2', 'I2', 'J2'],

--- a/docs/content/guides/getting-started/configuration-options/vue/example6.vue
+++ b/docs/content/guides/getting-started/configuration-options/vue/example6.vue
@@ -1,11 +1,12 @@
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotSettings = ref({
+const hotSettings = ref<GridSettings>({
   data: [
     ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1', 'J1'],
     ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2', 'H2', 'I2', 'J2'],

--- a/docs/content/guides/getting-started/demo/vue/example3.vue
+++ b/docs/content/guides/getting-started/demo/vue/example3.vue
@@ -1,13 +1,21 @@
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
+import type { CellProperties, GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
 const SELECTED_CLASS = 'selected';
 
-function addClassesToRows(TD, row, column, _prop, _value, cellProperties) {
+function addClassesToRows(
+  TD: HTMLTableCellElement,
+  row: number,
+  column: number,
+  _prop: string | number,
+  _value: unknown,
+  cellProperties: CellProperties,
+) {
   if (column !== 0) {
     return;
   }
@@ -127,7 +135,7 @@ const data = [
   [false, 'Photofeed', 'China', 'HL Mountain Frame', '2025-07-14', '94-5088099', true, '106', 1, 4],
 ];
 
-const hotSettings = ref({
+const hotSettings = ref<GridSettings>({
   data,
   height: 450,
   width: '100%',

--- a/docs/content/guides/getting-started/events-and-hooks/vue/example2.vue
+++ b/docs/content/guides/getting-started/events-and-hooks/vue/example2.vue
@@ -1,13 +1,15 @@
-<script setup>
+<script setup lang="ts">
 import { ref, onMounted } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import { stopImmediatePropagation } from 'handsontable/helpers/dom/event';
+import type { GridSettings } from 'handsontable/settings';
+import type { CellChange } from 'handsontable/common';
 
 registerAllModules();
 
-const hotRef = ref(null);
-let lastChange = null;
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+let lastChange: CellChange[] | null = null;
 
 onMounted(() => {
   const hot = hotRef.value?.hotInstance;
@@ -36,7 +38,7 @@ onMounted(() => {
   });
 });
 
-const hotSettings = ref({
+const hotSettings = ref<GridSettings>({
   data: [
     ['Tesla', 2017, 'black', 'black'],
     ['Nissan', 2018, 'blue', 'blue'],
@@ -47,7 +49,7 @@ const hotSettings = ref({
   rowHeaders: true,
   height: 'auto',
   minSpareRows: 1,
-  beforeChange(changes, source) {
+  beforeChange(changes) {
     lastChange = changes;
   },
   autoWrapRow: true,

--- a/docs/content/guides/getting-started/events-and-hooks/vue/example2.vue
+++ b/docs/content/guides/getting-started/events-and-hooks/vue/example2.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import { stopImmediatePropagation } from 'handsontable/helpers/dom/event';
@@ -8,7 +8,7 @@ import type { CellChange } from 'handsontable/common';
 
 registerAllModules();
 
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 let lastChange: CellChange[] | null = null;
 
 onMounted(() => {

--- a/docs/content/guides/getting-started/events-and-hooks/vue/example3.vue
+++ b/docs/content/guides/getting-started/events-and-hooks/vue/example3.vue
@@ -1,11 +1,12 @@
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotSettings = ref({
+const hotSettings = ref<GridSettings>({
   data: [
     ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1', 'J1', 'K1', 'L1'],
     ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2', 'H2', 'I2', 'J2', 'K2', 'L2'],
@@ -26,20 +27,28 @@ const hotSettings = ref({
   licenseKey: 'non-commercial-and-evaluation',
 });
 
-function onFixedRowsChange(event) {
-  hotSettings.value = { ...hotSettings.value, fixedRowsTop: event.target.checked ? 2 : 0 };
+function onFixedRowsChange(event: Event) {
+  const checked = (event.target as HTMLInputElement).checked;
+
+  hotSettings.value = { ...hotSettings.value, fixedRowsTop: checked ? 2 : 0 };
 }
 
-function onFixedColumnsChange(event) {
-  hotSettings.value = { ...hotSettings.value, fixedColumnsStart: event.target.checked ? 2 : 0 };
+function onFixedColumnsChange(event: Event) {
+  const checked = (event.target as HTMLInputElement).checked;
+
+  hotSettings.value = { ...hotSettings.value, fixedColumnsStart: checked ? 2 : 0 };
 }
 
-function onRowHeadersChange(event) {
-  hotSettings.value = { ...hotSettings.value, rowHeaders: event.target.checked };
+function onRowHeadersChange(event: Event) {
+  const checked = (event.target as HTMLInputElement).checked;
+
+  hotSettings.value = { ...hotSettings.value, rowHeaders: checked };
 }
 
-function onColHeadersChange(event) {
-  hotSettings.value = { ...hotSettings.value, colHeaders: event.target.checked };
+function onColHeadersChange(event: Event) {
+  const checked = (event.target as HTMLInputElement).checked;
+
+  hotSettings.value = { ...hotSettings.value, colHeaders: checked };
 }
 </script>
 

--- a/docs/content/guides/getting-started/grid-size/vue/example.vue
+++ b/docs/content/guides/getting-started/grid-size/vue/example.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
@@ -15,7 +15,7 @@ const data = new Array(100)
   );
 
 const isContainerExpanded = ref(false);
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 
 function triggerBtnClickCallback() {
   isContainerExpanded.value = !isContainerExpanded.value;

--- a/docs/content/guides/getting-started/grid-size/vue/example.vue
+++ b/docs/content/guides/getting-started/grid-size/vue/example.vue
@@ -1,7 +1,8 @@
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
@@ -14,17 +15,21 @@ const data = new Array(100)
   );
 
 const isContainerExpanded = ref(false);
-const hotRef = ref(null);
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
 
 function triggerBtnClickCallback() {
   isContainerExpanded.value = !isContainerExpanded.value;
   const parent = document.getElementById('exampleParent');
 
+  if (!parent) {
+    return;
+  }
+
   parent.style.height = isContainerExpanded.value ? '410px' : '157px';
   hotRef.value?.hotInstance?.refreshDimensions();
 }
 
-const hotSettings = ref({
+const hotSettings = ref<GridSettings>({
   data,
   rowHeaders: true,
   colHeaders: true,

--- a/docs/content/guides/getting-started/installation/vue/example1.vue
+++ b/docs/content/guides/getting-started/installation/vue/example1.vue
@@ -1,11 +1,12 @@
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotSettings = ref({
+const hotSettings = ref<GridSettings>({
   data: [
     ['', 'Tesla', 'Volvo', 'Toyota', 'Ford'],
     ['2019', 10, 11, 12, 13],

--- a/docs/content/guides/getting-started/saving-data/vue/example1.vue
+++ b/docs/content/guides/getting-started/saving-data/vue/example1.vue
@@ -1,17 +1,21 @@
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+import type { CellChange, ChangeSource } from 'handsontable/common';
 
 registerAllModules();
 
-const hotRef = ref(null);
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
 const output = ref('Click "Load" to load data from server');
 const isAutosave = ref(false);
 
-function autosaveClickCallback(event) {
-  isAutosave.value = event.target.checked;
-  output.value = event.target.checked
+function autosaveClickCallback(event: Event) {
+  const checked = (event.target as HTMLInputElement).checked;
+
+  isAutosave.value = checked;
+  output.value = checked
     ? 'Changes will be autosaved'
     : 'Changes will not be autosaved';
 }
@@ -20,7 +24,7 @@ function loadClickCallback() {
   const hot = hotRef.value?.hotInstance;
 
   fetch('/docs/scripts/json/load.json').then((response) => {
-    response.json().then((data) => {
+    response.json().then((data: { data: unknown[][] }) => {
       hot?.loadData(data.data);
       output.value = 'Data loaded';
     });
@@ -41,7 +45,7 @@ function saveClickCallback() {
   });
 }
 
-function afterChange(change, source) {
+function afterChange(change: CellChange[] | null, source: ChangeSource) {
   if (source === 'loadData') {
     return;
   }
@@ -61,7 +65,7 @@ function afterChange(change, source) {
   });
 }
 
-const hotSettings = ref({
+const hotSettings = ref<GridSettings>({
   startRows: 8,
   startCols: 6,
   rowHeaders: true,

--- a/docs/content/guides/getting-started/saving-data/vue/example1.vue
+++ b/docs/content/guides/getting-started/saving-data/vue/example1.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
@@ -7,7 +7,7 @@ import type { CellChange, ChangeSource } from 'handsontable/common';
 
 registerAllModules();
 
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 const output = ref('Click "Load" to load data from server');
 const isAutosave = ref(false);
 

--- a/docs/content/guides/getting-started/server-side-data/vue/example1.vue
+++ b/docs/content/guides/getting-started/server-side-data/vue/example1.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
@@ -460,7 +460,7 @@ function createInventoryDemoServer() {
 }
 
 const server = createInventoryDemoServer();
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 const status = ref('Initializing…');
 
 // hotSettings is a plain const (not reactive) to prevent updateSettings being triggered

--- a/docs/content/guides/getting-started/server-side-data/vue/example1.vue
+++ b/docs/content/guides/getting-started/server-side-data/vue/example1.vue
@@ -1,12 +1,32 @@
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+import type {
+  DataProviderQueryParameters,
+  DataProviderFetchOptions,
+  DataProviderBeforeFetchParameters,
+  RowUpdatePayload,
+} from 'handsontable/plugins/dataProvider';
 
 registerAllModules();
 
+type DemoRow = {
+  id: number;
+  product: string;
+  sku: string;
+  category: string;
+  unitPrice: number;
+  inStock: number;
+};
+
+type FilterCondition = { name?: string; args?: unknown[] };
+
+type DataProviderFilterColumn = NonNullable<DataProviderQueryParameters['filters']>[number];
+
 const LATENCY_MS = 450;
-const SEED_CATALOG = [
+const SEED_CATALOG: readonly DemoRow[] = [
   {
     id: 1,
     product: 'Wireless ergonomic keyboard',
@@ -233,7 +253,7 @@ const SEED_CATALOG = [
   },
 ];
 
-function delay(ms, signal) {
+function delay(ms: number, signal: AbortSignal) {
   return new Promise((resolve, reject) => {
     if (signal.aborted) {
       reject(new DOMException('Aborted', 'AbortError'));
@@ -254,7 +274,7 @@ function delay(ms, signal) {
   });
 }
 
-function asLowerString(cell) {
+function asLowerString(cell: unknown) {
   if (cell === null || cell === undefined) {
     return '';
   }
@@ -262,7 +282,7 @@ function asLowerString(cell) {
   return String(cell).toLowerCase();
 }
 
-function matchesCondition(cell, cond) {
+function matchesCondition(cell: unknown, cond: FilterCondition) {
   const args = Array.isArray(cond.args) ? cond.args : [];
   const name = cond.name;
 
@@ -304,7 +324,7 @@ function matchesCondition(cell, cond) {
   }
 }
 
-function rowMatchesFilterColumn(row, colFilter) {
+function rowMatchesFilterColumn(row: DemoRow, colFilter: DataProviderFilterColumn) {
   const value = row[colFilter.prop];
   const conditions = colFilter.conditions ?? [];
   const op = colFilter.operation ?? 'conjunction';
@@ -326,7 +346,7 @@ function rowMatchesFilterColumn(row, colFilter) {
   return parts.every((fn) => fn());
 }
 
-function applyQueryFilters(rows, filters) {
+function applyQueryFilters(rows: DemoRow[], filters: DataProviderQueryParameters['filters']) {
   if (!filters || filters.length === 0) {
     return rows;
   }
@@ -349,7 +369,7 @@ function createInventoryDemoServer() {
     setFailNextFetch() {
       failNextFetch = true;
     },
-    fetchRows(queryParameters, { signal }) {
+    fetchRows(queryParameters: DataProviderQueryParameters, { signal }: DataProviderFetchOptions) {
       const { page, pageSize, sort, filters } = queryParameters;
       let rows = [...store.rows];
 
@@ -391,8 +411,12 @@ function createInventoryDemoServer() {
         };
       });
     },
-    async onRowsCreate({ rowsAmount, position, referenceRowId }) {
-      const newRows = [];
+    async onRowsCreate({ rowsAmount, position, referenceRowId }: {
+      rowsAmount: number;
+      position: 'above' | 'below';
+      referenceRowId?: number | string;
+    }) {
+      const newRows: DemoRow[] = [];
 
       for (let i = 0; i < rowsAmount; i += 1) {
         store.nextId += 1;
@@ -418,7 +442,7 @@ function createInventoryDemoServer() {
 
       store.rows.splice(insertAt, 0, ...newRows);
     },
-    async onRowsUpdate(rows) {
+    async onRowsUpdate(rows: RowUpdatePayload[]) {
       rows.forEach(({ id, changes }) => {
         const row = store.rows.find((r) => r.id === id);
 
@@ -427,7 +451,7 @@ function createInventoryDemoServer() {
         }
       });
     },
-    async onRowsRemove(rowIds) {
+    async onRowsRemove(rowIds: Array<number | string>) {
       const idSet = new Set(rowIds);
 
       store.rows = store.rows.filter((r) => !idSet.has(r.id));
@@ -436,12 +460,12 @@ function createInventoryDemoServer() {
 }
 
 const server = createInventoryDemoServer();
-const hotRef = ref(null);
+const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
 const status = ref('Initializing…');
 
 // hotSettings is a plain const (not reactive) to prevent updateSettings being triggered
 // when status changes — avoids re-fetching data on every status text update.
-const hotSettings = {
+const hotSettings: GridSettings = {
   dataProvider: {
     rowId: 'id',
     fetchRows: (queryParameters, options) => server.fetchRows(queryParameters, options),
@@ -468,13 +492,13 @@ const hotSettings = {
   contextMenu: true,
   emptyDataState: true,
   notification: true,
-  beforeDataProviderFetch(params) {
+  beforeDataProviderFetch(params: DataProviderBeforeFetchParameters) {
     status.value = params.skipLoading ? 'Updating after sort or edit…' : 'Loading data…';
   },
   afterDataProviderFetch() {
     status.value = `Ready (simulated ${LATENCY_MS}ms request).`;
   },
-  afterDataProviderFetchError(error) {
+  afterDataProviderFetchError(error: Error) {
     status.value = `Could not load data: ${error.message}`;
   },
 };

--- a/docs/content/guides/integrate-with-vue3/vue3-custom-context-menu-example/vue/example1.vue
+++ b/docs/content/guides/integrate-with-vue3/vue3-custom-context-menu-example/vue/example1.vue
@@ -1,12 +1,13 @@
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { ContextMenu } from 'handsontable/plugins/contextMenu';
 import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotSettings = ref({
+const hotSettings = ref<GridSettings>({
   data: [
     ['A1', 'B1', 'C1', 'D1', 'E1'],
     ['A2', 'B2', 'C2', 'D2', 'E2'],

--- a/docs/content/guides/integrate-with-vue3/vue3-custom-editor-example/vue/example1.vue
+++ b/docs/content/guides/integrate-with-vue3/vue3-custom-editor-example/vue/example1.vue
@@ -1,8 +1,9 @@
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { TextEditor } from 'handsontable/editors/textEditor';
 import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
@@ -19,7 +20,7 @@ class CustomEditor extends TextEditor {
   }
 }
 
-const hotSettings = ref({
+const hotSettings = ref<GridSettings>({
   startRows: 5,
   columns: [
     {

--- a/docs/content/guides/integrate-with-vue3/vue3-custom-id-class-style/vue/example1.vue
+++ b/docs/content/guides/integrate-with-vue3/vue3-custom-id-class-style/vue/example1.vue
@@ -1,11 +1,12 @@
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotSettings = ref({
+const hotSettings = ref<GridSettings>({
   startRows: 5,
   startCols: 5,
   colHeaders: true,

--- a/docs/content/guides/integrate-with-vue3/vue3-custom-renderer-example/vue/example1.vue
+++ b/docs/content/guides/integrate-with-vue3/vue3-custom-renderer-example/vue/example1.vue
@@ -1,11 +1,28 @@
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+import type { BaseRenderer } from 'handsontable/renderers';
 
 registerAllModules();
 
-const hotSettings = ref({
+const imageRenderer: BaseRenderer = (_instance, td, _row, _col, _prop, value) => {
+  const img = document.createElement('img');
+
+  img.src = String(value);
+
+  img.addEventListener('mousedown', (event) => {
+    event.preventDefault();
+  });
+
+  td.innerText = '';
+  td.appendChild(img);
+
+  return td;
+};
+
+const hotSettings = ref<GridSettings>({
   data: [
     ['A1', '/docs/img/examples/professional-javascript-developers-nicholas-zakas.jpg'],
     ['A2', '/docs/img/examples/javascript-the-good-parts.jpg']
@@ -13,20 +30,7 @@ const hotSettings = ref({
   columns: [
     {},
     {
-      renderer(instance, td, row, col, prop, value) {
-        const img = document.createElement('img');
-
-        img.src = value;
-
-        img.addEventListener('mousedown', (event) => {
-          event.preventDefault();
-        });
-
-        td.innerText = '';
-        td.appendChild(img);
-
-        return td;
-      }
+      renderer: imageRenderer
     }
   ],
   colHeaders: true,

--- a/docs/content/guides/integrate-with-vue3/vue3-custom-renderer-example/vue/example2.vue
+++ b/docs/content/guides/integrate-with-vue3/vue3-custom-renderer-example/vue/example2.vue
@@ -1,7 +1,9 @@
-<script setup>
+<script setup lang="ts">
 import { ref, h, render, defineComponent } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+import type { BaseRenderer } from 'handsontable/renderers';
 
 registerAllModules();
 
@@ -12,20 +14,20 @@ const ImageCell = defineComponent({
   render() {
     return h('img', {
       src: this.src,
-      onMousedown: (event) => event.preventDefault(),
+      onMousedown: (event: MouseEvent) => event.preventDefault(),
     });
   },
 });
 
-function imageComponentRenderer(instance, td, row, col, prop, value) {
-  const vnode = h(ImageCell, { src: value });
+const imageComponentRenderer: BaseRenderer = (_instance, td, _row, _col, _prop, value) => {
+  const vnode = h(ImageCell, { src: String(value) });
 
   render(vnode, td);
 
   return td;
-}
+};
 
-const hotSettings = ref({
+const hotSettings = ref<GridSettings>({
   data: [
     ['Professional JavaScript for Web Developers',
       '/docs/img/examples/professional-javascript-developers-nicholas-zakas.jpg'],

--- a/docs/content/guides/integrate-with-vue3/vue3-formulas-example/vue/example1.vue
+++ b/docs/content/guides/integrate-with-vue3/vue3-formulas-example/vue/example1.vue
@@ -1,8 +1,9 @@
-<script setup>
+<script setup lang="ts">
 import { ref, markRaw } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import { HyperFormula } from 'hyperformula';
+import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
@@ -12,7 +13,7 @@ const hfRaw = markRaw(
   })
 );
 
-const hotSettings = ref({
+const hotSettings = ref<GridSettings>({
   data: [
     ['4', '=IF(A1>4, "TRUE", "FALSE")', 'C1'],
     ['2', 'B2', '=A1+A2'],

--- a/docs/content/guides/integrate-with-vue3/vue3-hot-column/vue/example1.vue
+++ b/docs/content/guides/integrate-with-vue3/vue3-hot-column/vue/example1.vue
@@ -1,11 +1,12 @@
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue';
 import { HotTable, HotColumn } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotSettings = ref({
+const hotSettings = ref<GridSettings>({
   data: [
     ['A1', 'B1'],
     ['A2', 'B2'],
@@ -23,7 +24,7 @@ const hotSettings = ref({
   autoWrapCol: true,
   licenseKey: 'non-commercial-and-evaluation',
 });
-const secondColumnSettings = ref({
+const secondColumnSettings = ref<GridSettings>({
   title: 'Second column header',
 });
 </script>

--- a/docs/content/guides/integrate-with-vue3/vue3-hot-column/vue/example2.vue
+++ b/docs/content/guides/integrate-with-vue3/vue3-hot-column/vue/example2.vue
@@ -1,19 +1,26 @@
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue';
 import { HotTable, HotColumn } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotData = ref([
+type ProductRow = {
+  id: number;
+  name: string;
+  payment: { price: number; currency: string };
+};
+
+const hotData = ref<ProductRow[]>([
   { id: 1, name: 'Table tennis racket', payment: { price: 13, currency: 'PLN' } },
   { id: 2, name: 'Outdoor game ball', payment: { price: 14, currency: 'USD' } },
   { id: 3, name: 'Mountain bike', payment: { price: 300, currency: 'USD' } }
 ]);
-const secondColumnSettings = ref({
+const secondColumnSettings = ref<GridSettings>({
   title: 'Second column header'
 });
-const settings = ref({
+const settings = ref<GridSettings>({
   height: 'auto',
   autoWrapRow: true,
   autoWrapCol: true,

--- a/docs/content/guides/integrate-with-vue3/vue3-hot-column/vue/example3.vue
+++ b/docs/content/guides/integrate-with-vue3/vue3-hot-column/vue/example3.vue
@@ -1,8 +1,9 @@
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue';
 import { HotTable, HotColumn } from '@handsontable/vue3';
 import { TextEditor } from 'handsontable/editors/textEditor';
 import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
@@ -20,14 +21,14 @@ class CustomEditor extends TextEditor {
 }
 
 const customEditor = CustomEditor;
-const hotData = ref([
+const hotData = ref<string[][]>([
   ['A1', 'B1'],
   ['A2', 'B2'],
   ['A3', 'B3'],
   ['A4', 'B4'],
   ['A5', 'B5'],
 ]);
-const settings = ref({
+const settings = ref<GridSettings>({
   height: 'auto',
   autoWrapRow: true,
   autoWrapCol: true,

--- a/docs/content/guides/integrate-with-vue3/vue3-hot-reference/vue/example1.vue
+++ b/docs/content/guides/integrate-with-vue3/vue3-hot-reference/vue/example1.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotTableComponent = ref<InstanceType<typeof HotTable> | null>(null);
+const hotTableComponent = useTemplateRef<InstanceType<typeof HotTable>>('hotTableComponent');
 const hotSettings = ref<GridSettings>({
   data: [
     ['A1', 'B1', 'C1', 'D1'],

--- a/docs/content/guides/integrate-with-vue3/vue3-hot-reference/vue/example1.vue
+++ b/docs/content/guides/integrate-with-vue3/vue3-hot-reference/vue/example1.vue
@@ -1,12 +1,13 @@
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotTableComponent = ref(null);
-const hotSettings = ref({
+const hotTableComponent = ref<InstanceType<typeof HotTable> | null>(null);
+const hotSettings = ref<GridSettings>({
   data: [
     ['A1', 'B1', 'C1', 'D1'],
     ['A2', 'B2', 'C2', 'D2'],
@@ -21,7 +22,7 @@ const hotSettings = ref({
 });
 
 function swapHotData() {
-  hotTableComponent.value.hotInstance.loadData([['new', 'data']]);
+  hotTableComponent.value?.hotInstance?.loadData([['new', 'data']]);
 }
 </script>
 

--- a/docs/content/guides/integrate-with-vue3/vue3-language-change-example/vue/example1.vue
+++ b/docs/content/guides/integrate-with-vue3/vue3-language-change-example/vue/example1.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, onBeforeUnmount } from 'vue';
+import { ref, onMounted, onBeforeUnmount, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import {
   registerLanguageDictionary,
@@ -68,7 +68,7 @@ const hotSettings = ref<GridSettings>({
 const language = ref('en-US');
 const isOpen = ref(false);
 const languages = ref<string[]>([]);
-const dropdown = ref<HTMLElement | null>(null);
+const dropdown = useTemplateRef<HTMLElement>('dropdown');
 
 function toggleDropdown() {
   isOpen.value = !isOpen.value;

--- a/docs/content/guides/integrate-with-vue3/vue3-language-change-example/vue/example1.vue
+++ b/docs/content/guides/integrate-with-vue3/vue3-language-change-example/vue/example1.vue
@@ -1,4 +1,4 @@
-<script setup>
+<script setup lang="ts">
 import { ref, onMounted, onBeforeUnmount } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import {
@@ -25,6 +25,7 @@ import {
   zhTW
 } from 'handsontable/i18n';
 import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
 
 registerLanguageDictionary(arAR);
 registerLanguageDictionary(csCZ);
@@ -48,7 +49,7 @@ registerLanguageDictionary(zhTW);
 
 registerAllModules();
 
-const hotSettings = ref({
+const hotSettings = ref<GridSettings>({
   data: [
     ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1', 'J1'],
     ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2', 'H2', 'I2', 'J2'],
@@ -66,25 +67,25 @@ const hotSettings = ref({
 });
 const language = ref('en-US');
 const isOpen = ref(false);
-const languages = ref([]);
-const dropdown = ref(null);
+const languages = ref<string[]>([]);
+const dropdown = ref<HTMLElement | null>(null);
 
 function toggleDropdown() {
   isOpen.value = !isOpen.value;
 }
 
-function selectLanguage(lang) {
+function selectLanguage(lang: string) {
   language.value = lang;
   isOpen.value = false;
 }
 
-function handleClickOutside(e) {
-  if (dropdown.value && !dropdown.value.contains(e.target)) {
+function handleClickOutside(e: MouseEvent) {
+  if (dropdown.value && !dropdown.value.contains(e.target as Node)) {
     isOpen.value = false;
   }
 }
 
-function handleEscape(e) {
+function handleEscape(e: KeyboardEvent) {
   if (e.key === 'Escape') {
     isOpen.value = false;
   }

--- a/docs/content/guides/integrate-with-vue3/vue3-setting-up-a-language/vue/example1.vue
+++ b/docs/content/guides/integrate-with-vue3/vue3-setting-up-a-language/vue/example1.vue
@@ -1,14 +1,21 @@
-<script setup>
+<script setup lang="ts">
 import { HotTable, HotColumn } from '@handsontable/vue3';
 import numbro from 'numbro';
 import jaJP from 'numbro/languages/ja-JP';
 import trTR from 'numbro/languages/tr-TR';
 import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
 numbro.registerLanguage(jaJP);
 numbro.registerLanguage(trTR);
+
+type ProductRow = {
+  productName: string;
+  JP_price: number;
+  TR_price: number;
+};
 
 const formatJP = {
   pattern: '0,0.00 $',
@@ -18,7 +25,7 @@ const formatTR = {
   pattern: '0,0.00 $',
   culture: 'tr-TR',
 };
-const hotData = [
+const hotData: ProductRow[] = [
   {
     productName: 'Product A',
     JP_price: 1.32,
@@ -35,7 +42,7 @@ const hotData = [
     TR_price: 678.1,
   },
 ];
-const settings = {
+const settings: GridSettings = {
   height: 'auto',
   autoWrapRow: true,
   autoWrapCol: true,

--- a/docs/content/guides/integrate-with-vue3/vue3-simple-example/vue/example1.vue
+++ b/docs/content/guides/integrate-with-vue3/vue3-simple-example/vue/example1.vue
@@ -1,11 +1,12 @@
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotSettings = ref({
+const hotSettings = ref<GridSettings>({
   data: [
     ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1', 'I1', 'J1'],
     ['A2', 'B2', 'C2', 'D2', 'E2', 'F2', 'G2', 'H2', 'I2', 'J2'],

--- a/docs/content/guides/integrate-with-vue3/vue3-vuex-example/vue/example1.vue
+++ b/docs/content/guides/integrate-with-vue3/vue3-vuex-example/vue/example1.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, useTemplateRef } from 'vue';
 import { createStore } from 'vuex';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
@@ -37,7 +37,7 @@ const store = createStore<VuexState>({
   }
 });
 
-const wrapper = ref<InstanceType<typeof HotTable> | null>(null);
+const wrapper = useTemplateRef<InstanceType<typeof HotTable>>('wrapper');
 const hotSettings = ref<GridSettings>({
   data: [
     ['A1', 'B1', 'C1', 'D1'],

--- a/docs/content/guides/integrate-with-vue3/vue3-vuex-example/vue/example1.vue
+++ b/docs/content/guides/integrate-with-vue3/vue3-vuex-example/vue/example1.vue
@@ -1,12 +1,22 @@
-<script setup>
+<script setup lang="ts">
 import { ref, onMounted } from 'vue';
 import { createStore } from 'vuex';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const store = createStore({
+type VuexState = {
+  hotData: string[][] | null;
+  hotSettings: {
+    readOnly: boolean;
+    autoWrapRow: boolean;
+    autoWrapCol: boolean;
+  };
+};
+
+const store = createStore<VuexState>({
   state() {
     return {
       hotData: null,
@@ -18,17 +28,17 @@ const store = createStore({
     };
   },
   mutations: {
-    updateData(state, hotData) {
+    updateData(state, hotData: string[][]) {
       state.hotData = hotData;
     },
-    updateSettings(state, updateObj) {
+    updateSettings(state, updateObj: { prop: keyof VuexState['hotSettings']; value: boolean }) {
       state.hotSettings[updateObj.prop] = updateObj.value;
     }
   }
 });
 
-const wrapper = ref(null);
-const hotSettings = ref({
+const wrapper = ref<InstanceType<typeof HotTable> | null>(null);
+const hotSettings = ref<GridSettings>({
   data: [
     ['A1', 'B1', 'C1', 'D1'],
     ['A2', 'B2', 'C2', 'D2'],
@@ -42,20 +52,27 @@ const hotSettings = ref({
   autoWrapRow: true,
   autoWrapCol: true,
   afterChange: () => {
-    if (wrapper.value) {
-      store.commit('updateData', wrapper.value.hotInstance.getSourceData());
+    if (wrapper.value?.hotInstance) {
+      store.commit('updateData', wrapper.value.hotInstance.getSourceData() as string[][]);
     }
   },
   licenseKey: 'non-commercial-and-evaluation'
 });
 
-function toggleReadOnly(event) {
-  hotSettings.value.readOnly = event.target.checked;
-  store.commit('updateSettings', { prop: 'readOnly', value: hotSettings.value.readOnly });
+function toggleReadOnly(event: Event) {
+  const checked = (event.target as HTMLInputElement).checked;
+
+  hotSettings.value.readOnly = checked;
+  store.commit('updateSettings', { prop: 'readOnly', value: checked });
 }
 
 function updateVuexPreview() {
   const previewTable = document.querySelector('#vuex-preview pre');
+
+  if (!previewTable) {
+    return;
+  }
+
   let newInnerHtml = '<div>';
 
   for (const [key, value] of Object.entries(store.state)) {
@@ -78,8 +95,8 @@ function updateVuexPreview() {
     } else if (key === 'hotSettings') {
       newInnerHtml += '<strong>hotSettings:</strong> <ul>';
 
-      for (const settingsKey of Object.keys(value)) {
-        newInnerHtml += `<li>${settingsKey}: ${store.state.hotSettings[settingsKey]}</li>`;
+      for (const settingsKey of Object.keys(value as VuexState['hotSettings'])) {
+        newInnerHtml += `<li>${settingsKey}: ${store.state.hotSettings[settingsKey as keyof VuexState['hotSettings']]}</li>`;
       }
 
       newInnerHtml += '</ul>';
@@ -94,7 +111,7 @@ function updateVuexPreview() {
 
 onMounted(() => {
   store.subscribe(() => updateVuexPreview());
-  store.commit('updateData', wrapper.value.hotInstance.getSourceData());
+  store.commit('updateData', wrapper.value?.hotInstance?.getSourceData() as string[][]);
 });
 </script>
 

--- a/docs/content/guides/navigation/focus-scopes/vue/example1.vue
+++ b/docs/content/guides/navigation/focus-scopes/vue/example1.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted } from 'vue';
+import { ref, onMounted, onUnmounted, useTemplateRef } from 'vue';
 import { HotTable, HotColumn } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
@@ -110,7 +110,7 @@ const tableData = [
   { model: 'Cycling Cap', price: 444.79, sellDate: '2025-09-11', sellTime: '10:05', inStock: false },
 ];
 
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 const isListening = ref(false);
 const focusScope = ref<string | null>(null);
 const shortcutsContext = ref<string | null>(null);

--- a/docs/content/guides/navigation/focus-scopes/vue/example2.vue
+++ b/docs/content/guides/navigation/focus-scopes/vue/example2.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted, nextTick } from 'vue';
+import { ref, onMounted, onUnmounted, nextTick, useTemplateRef } from 'vue';
 import { HotTable, HotColumn } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
@@ -110,7 +110,7 @@ const tableData = [
   { model: 'Cycling Cap', price: 444.79, sellDate: '2025-09-11', sellTime: '10:05', inStock: false },
 ];
 
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 const isListening = ref(false);
 const focusScope = ref<string | null>(null);
 const shortcutsContext = ref<string | null>(null);

--- a/docs/content/guides/navigation/searching-values/vue/example1.vue
+++ b/docs/content/guides/navigation/searching-values/vue/example1.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 
 const data = [
   ['Tesla', 2017, 'black', 'black'],

--- a/docs/content/guides/navigation/searching-values/vue/example2.vue
+++ b/docs/content/guides/navigation/searching-values/vue/example2.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 
 const data = [
   ['Tesla', 2017, 'black', 'black'],

--- a/docs/content/guides/navigation/searching-values/vue/example3.vue
+++ b/docs/content/guides/navigation/searching-values/vue/example3.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 
 const data = [
   ['Tesla', 2017, 'black', 'black'],

--- a/docs/content/guides/navigation/searching-values/vue/example4.vue
+++ b/docs/content/guides/navigation/searching-values/vue/example4.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
@@ -7,7 +7,7 @@ import type Handsontable from 'handsontable/base';
 
 registerAllModules();
 
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 const resultCount = ref(0);
 
 const data = [

--- a/docs/content/guides/rows/row-prepopulating/vue/example3.vue
+++ b/docs/content/guides/rows/row-prepopulating/vue/example3.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import { type BaseRenderer } from 'handsontable/renderers';
@@ -10,7 +10,7 @@ import type { GridSettings } from 'handsontable/settings';
 // Register all Handsontable's modules.
 registerAllModules();
 
-const hotRef = ref<InstanceType<typeof HotTable> | null>(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 
 const templateValues: string[] = ['one', 'two', 'three'];
 const data: (string | number)[][] = [

--- a/docs/content/guides/rows/rows-pagination/vue/example3.vue
+++ b/docs/content/guides/rows/rows-pagination/vue/example3.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
@@ -109,7 +109,7 @@ const data = [
   { model: 'Cycling Cap', price: 444.79, sellDate: '2025-09-11', sellTime: '10:05', inStock: false },
 ];
 
-const hotRef = ref(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 
 const paginationState = ref({
   currentPage: 1,

--- a/docs/content/guides/rows/rows-pagination/vue/example4.vue
+++ b/docs/content/guides/rows/rows-pagination/vue/example4.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
@@ -109,7 +109,7 @@ const data = [
   { model: 'Cycling Cap', price: 444.79, sellDate: '2025-09-11', sellTime: '10:05', inStock: false },
 ];
 
-const customContainerRef = ref<HTMLElement | null>(null);
+const customContainerRef = useTemplateRef<HTMLElement>('customContainerRef');
 
 const hotSettings = ref<GridSettings>({
   data,

--- a/docs/content/guides/rows/rows-pagination/vue/example5.vue
+++ b/docs/content/guides/rows/rows-pagination/vue/example5.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
@@ -109,7 +109,7 @@ const data = [
   { model: 'Cycling Cap', price: 444.79, sellDate: '2025-09-11', sellTime: '10:05', inStock: false },
 ];
 
-const hotRef = ref(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 
 const hotSettings = ref<GridSettings>({
   data,

--- a/docs/content/guides/rows/rows-sorting/vue/exampleSortByAPI.vue
+++ b/docs/content/guides/rows/rows-sorting/vue/exampleSortByAPI.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotRef = ref(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 
 const hotSettings = ref<GridSettings>({
   data: [

--- a/docs/content/guides/rows/rows-sorting/vue/exampleSortByAPIMultipleColumns.vue
+++ b/docs/content/guides/rows/rows-sorting/vue/exampleSortByAPIMultipleColumns.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-const hotRef = ref(null);
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 
 const hotSettings = ref<GridSettings>({
   data: [


### PR DESCRIPTION
[skip changelog]

### Context

The PR unifies Vue 3 documentation examples on two conventions that were applied inconsistently across the docs site:

1. **DEV-1831 — TypeScript SFCs:** Migrates the remaining Vue doc examples to `<script setup lang="ts">`, with `GridSettings` typing and consistent imports from `@handsontable/vue3` and `handsontable/registry`.
2. **DEV-1832 — `useTemplateRef`:** Replaces `ref()` with `useTemplateRef()` for all template refs (HotTable component refs and DOM element refs such as dropdown containers). Updates inline Vue snippets in guide markdown and documents the convention in `creating-docs-examples`.

Together, these changes align Vue examples with Vue 3.5 best practices and the project's docs authoring standards.

### How has this been tested?

- Verified all 27 affected guide pages on the local docs dev server (`pnpm dev` in `docs/`).
- Confirmed migrated examples render without console errors and without stuck loading shimmers.
- Spot-checked interactive template-ref behavior (e.g. `vue3-hot-reference` "Load new data" button, dual-grid export-to-excel example, DOM refs in rows-pagination).
- Ran `npm run docs:test:plugins --prefix docs` (22/22 passed).

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1832
2. DEV-1831

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

Documentation site only (`docs/`).

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1832

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example code only; no product library or runtime API changes. Large touch surface but mechanical ref/typing updates with manual QA noted in the PR.
> 
> **Overview**
> This PR standardizes **Vue 3 documentation examples** under two conventions: **TypeScript SFCs** and **`useTemplateRef` for template refs**.
> 
> **`useTemplateRef` (DEV-1832):** Across guide `vue/example*.vue` files, `HotTable` refs and DOM refs (dropdowns, pagination containers, etc.) move from `ref<...>(null)` to `useTemplateRef<...>('matchingName')`, with optional chaining kept for `hotInstance` access. Inline Vue snippets in guides such as `cell-function.md` and `column-filter.md` are updated the same way. **`creating-docs-examples/SKILL.md`** now requires `useTemplateRef` for any `ref="..."` binding and documents patterns for grid and DOM refs.
> 
> **TypeScript (DEV-1831):** Remaining examples gain `<script setup lang="ts">`, `GridSettings` (and related types where needed), and stricter typing for handlers and demo data—especially in getting-started, integrate-with-vue3, and server-side data examples—without changing runtime grid behavior.
> 
> Scope is **`docs/` only**; the `@handsontable/vue3` package is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6da6d7ec630a1e17443a84520d2ca5528fc7f8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->