### PR TITLE
DEV-1755: Add Vue instance reference getting-started page

### DIFF
--- a/docs/content/guides/accessories-and-menus/export-to-excel/export-to-excel.md
+++ b/docs/content/guides/accessories-and-menus/export-to-excel/export-to-excel.md
@@ -160,7 +160,7 @@ For more information, see the [Instance methods](@/guides/getting-started/react-
 
 To use the Handsontable API, you need access to the Handsontable instance. Use a template ref on the `HotTable` component and read its `hotInstance` property.
 
-For more information, see the [Referencing the Handsontable instance in Vue 3](@/guides/integrate-with-vue3/vue3-hot-reference/vue3-hot-reference.md) page.
+For more information, see the [Referencing the Handsontable instance in Vue 3](@/guides/getting-started/vue3-hot-reference/vue3-hot-reference.md) page.
 
 :::
 

--- a/docs/content/guides/columns/column-hiding/column-hiding.md
+++ b/docs/content/guides/columns/column-hiding/column-hiding.md
@@ -377,7 +377,7 @@ For more information, see the [Instance methods](@/guides/getting-started/react-
 To use the Handsontable API, you'll need access to the Handsontable instance. You can do that by
 utilizing a reference to the `HotTable` component, and reading its `hotInstance` property.
 
-For more information, see the [Referencing the Handsontable instance](@/guides/integrate-with-vue3/vue3-hot-reference/vue3-hot-reference.md) page.
+For more information, see the [Referencing the Handsontable instance](@/guides/getting-started/vue3-hot-reference/vue3-hot-reference.md) page.
 
 :::
 

--- a/docs/content/guides/getting-started/grid-size/grid-size.md
+++ b/docs/content/guides/getting-started/grid-size/grid-size.md
@@ -421,7 +421,7 @@ For more information, see the [Instance access](@/guides/getting-started/angular
 
 To use the Handsontable API, you'll need access to the Handsontable instance. Use a template ref on the `HotTable` component and read its `hotInstance` property.
 
-For more information, see the [Referencing the Handsontable instance in Vue 3](@/guides/integrate-with-vue3/vue3-hot-reference/vue3-hot-reference.md) page.
+For more information, see the [Referencing the Handsontable instance in Vue 3](@/guides/getting-started/vue3-hot-reference/vue3-hot-reference.md) page.
 
 :::
 

--- a/docs/content/guides/getting-started/vue3-hot-reference/vue/example1.vue
+++ b/docs/content/guides/getting-started/vue3-hot-reference/vue/example1.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import { useTemplateRef } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotTableRef = useTemplateRef<InstanceType<typeof HotTable>>('hotTableRef');
+
+const hotSettings = {
+  data: [
+    ['A1', 'B1', 'C1', 'D1'],
+    ['A2', 'B2', 'C2', 'D2'],
+    ['A3', 'B3', 'C3', 'D3'],
+    ['A4', 'B4', 'C4', 'D4'],
+  ],
+  colHeaders: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+};
+
+const selectCell = () => {
+  // The Handsontable instance is stored under the `hotInstance` property of the wrapper component.
+  hotTableRef.value?.hotInstance?.selectCell(1, 1);
+}
+</script>
+
+<template>
+  <div id="example1">
+    <div class="example-controls-container">
+      <div class="controls">
+        <button @click="selectCell">Select cell B2</button>
+      </div>
+    </div>
+    <HotTable ref="hotTableRef" :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/getting-started/vue3-hot-reference/vue3-hot-reference.md
+++ b/docs/content/guides/getting-started/vue3-hot-reference/vue3-hot-reference.md
@@ -1,0 +1,82 @@
+---
+type: how-to
+id: v8r3km2q
+title: Instance reference
+metaTitle: Instance reference - JavaScript Data Grid | Handsontable
+description: Reference a Handsontable instance from within a Vue 3 component, to programmatically perform actions such as selecting cells.
+permalink: /vue-instance-reference
+canonicalUrl: /vue-instance-reference
+tags:
+  - referring
+  - referencing
+  - ref
+  - instance
+vue:
+  metaTitle: Instance reference - Vue Data Grid | Handsontable
+searchCategory: Guides
+onlyFor: vue
+category: Getting started
+---
+Use `useTemplateRef` and the `hotInstance` property to get a reference to the Handsontable instance from a Vue 3 component, then call any API method on it.
+
+[[toc]]
+
+## Use Handsontable's API
+
+You can programmatically change the internal state of Handsontable beyond what's possible with props. To do that, call API methods of the relevant Handsontable instance associated with your instance of the [`HotTable`](@/guides/getting-started/installation/installation.md#use-the-hottable-component) component.
+
+In `<script setup>`, create a template reference with [`useTemplateRef`](https://vuejs.org/api/composition-api-helpers.html#usetemplateref) and give the `HotTable` component a `ref` attribute whose value matches the reference key. After the component mounts, the Handsontable instance is available under the `hotInstance` property of that reference.
+
+[Find out which Vue 3 versions are supported](@/guides/getting-started/installation/installation.md#supported-versions-of-vue)
+
+```vue
+<script setup lang="ts">
+import { useTemplateRef } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+
+const hotTableRef = useTemplateRef<InstanceType<typeof HotTable>>('hotTableRef');
+
+const selectCell = () => {
+  hotTableRef.value?.hotInstance?.selectCell(1, 1);
+};
+</script>
+
+<template>
+  <HotTable ref="hotTableRef" :settings="hotSettings" />
+</template>
+```
+
+The string passed to `useTemplateRef()` must match the `ref` attribute on `HotTable`. Access the grid through `hotTableRef.value?.hotInstance`.
+
+The following live example selects cell B2 when you click the button.
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/getting-started/vue3-hot-reference/vue/example1.vue)
+
+:::
+
+## Vue versions before 3.5
+
+`useTemplateRef` requires Vue 3.5 or newer. On earlier versions, use the `ref` function instead. Declare a `ref` initialized to `null`, then give the `HotTable` component a `ref` attribute whose value matches the variable name.
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+
+const hotTableRef = ref<InstanceType<typeof HotTable> | null>(null);
+
+const selectCell = () => {
+  hotTableRef.value?.hotInstance?.selectCell(1, 1);
+}
+</script>
+
+<template>
+  <HotTable ref="hotTableRef" :settings="hotSettings" />
+</template>
+```
+
+## Result
+
+Your Vue 3 component now holds a reference to the Handsontable instance. You can call any Handsontable API method on that instance -- such as `selectCell()` or `getPlugin()` -- from event handlers or lifecycle hooks.

--- a/docs/content/guides/integrate-with-vue3/vue3-vuex-example/vue3-vuex-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-vuex-example/vue3-vuex-example.md
@@ -41,6 +41,6 @@ The following example implements the `@handsontable/vue3` component with a [`rea
 
 ## Next steps
 
-- [Referencing the Handsontable instance in Vue 3](@/guides/integrate-with-vue3/vue3-hot-reference/vue3-hot-reference.md) -- access the Handsontable API directly from your component.
+- [Referencing the Handsontable instance in Vue 3](@/guides/getting-started/vue3-hot-reference/vue3-hot-reference.md) -- access the Handsontable API directly from your component.
 - [HotColumn component in Vue 3](@/guides/integrate-with-vue3/vue3-hot-column/vue3-hot-column.md) -- configure columns declaratively alongside your store.
 - [Formulas integration in Vue 3](@/guides/integrate-with-vue3/vue3-formulas-example/vue3-formulas-example.md) -- combine Vuex-managed data with formula calculations.

--- a/docs/content/guides/navigation/custom-shortcuts/custom-shortcuts.md
+++ b/docs/content/guides/navigation/custom-shortcuts/custom-shortcuts.md
@@ -63,7 +63,7 @@ For more information, see the [Instance access](@/guides/getting-started/angular
 
 To use the Handsontable API, use a template ref on `HotTable` and read `hotRef.value.hotInstance`.
 
-For more information, see [Referencing the Handsontable instance in Vue 3](@/guides/integrate-with-vue3/vue3-hot-reference/vue3-hot-reference.md).
+For more information, see [Referencing the Handsontable instance in Vue 3](@/guides/getting-started/vue3-hot-reference/vue3-hot-reference.md).
 
 :::
 

--- a/docs/content/guides/navigation/focus-scopes/focus-scopes.md
+++ b/docs/content/guides/navigation/focus-scopes/focus-scopes.md
@@ -56,7 +56,7 @@ For more information, see the [Instance access](@/guides/getting-started/angular
 
 To use the Handsontable API, use a template ref on `HotTable` and read `hotRef.value.hotInstance`.
 
-For more information, see [Referencing the Handsontable instance in Vue 3](@/guides/integrate-with-vue3/vue3-hot-reference/vue3-hot-reference.md).
+For more information, see [Referencing the Handsontable instance in Vue 3](@/guides/getting-started/vue3-hot-reference/vue3-hot-reference.md).
 
 :::
 

--- a/docs/content/guides/navigation/searching-values/searching-values.md
+++ b/docs/content/guides/navigation/searching-values/searching-values.md
@@ -56,7 +56,7 @@ For more information, see the [Instance access](@/guides/getting-started/angular
 
 To use the Handsontable API, use a template ref on `HotTable` and read `hotRef.value.hotInstance`.
 
-For more information, see [Referencing the Handsontable instance in Vue 3](@/guides/integrate-with-vue3/vue3-hot-reference/vue3-hot-reference.md).
+For more information, see [Referencing the Handsontable instance in Vue 3](@/guides/getting-started/vue3-hot-reference/vue3-hot-reference.md).
 
 :::
 

--- a/docs/content/guides/sidebar.js
+++ b/docs/content/guides/sidebar.js
@@ -6,6 +6,7 @@ const gettingStartedItems = [
   { path: 'guides/getting-started/grid-size/grid-size' },
   { path: 'guides/getting-started/react-methods/react-methods', onlyFor: ['react'] },
   { path: 'guides/getting-started/angular-hot-instance/angular-hot-instance', onlyFor: ['angular'] },
+  { path: 'guides/getting-started/vue3-hot-reference/vue3-hot-reference', onlyFor: ['vue'] },
   { path: 'guides/getting-started/license-key/license-key' },
   { path: 'guides/getting-started/react-redux/react-redux', onlyFor: ['react'] },
 ];

--- a/docs/content/guides/upgrade-and-migration/migrating-from-11.1-to-12.0/migrating-from-11.1-to-12.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-11.1-to-12.0/migrating-from-11.1-to-12.0.md
@@ -97,8 +97,8 @@ To replace [`data`](@/api/options.md#data) and reset the states, call the [`load
 Read more on referencing the Handsontable instance:
 - [Referencing the Handsontable instance in Angular](@/angular/guides/getting-started/angular-hot-instance/angular-hot-instance.md)
 - [Referencing the Handsontable instance in React](@/react/guides/getting-started/react-methods/react-methods.md)
-- [Referencing the Handsontable instance in Vue](@/guides/integrate-with-vue3/vue3-hot-reference/vue3-hot-reference.md)
-- [Referencing the Handsontable instance in Vue 3](@/guides/integrate-with-vue3/vue3-hot-reference/vue3-hot-reference.md)
+- [Referencing the Handsontable instance in Vue](@/guides/getting-started/vue3-hot-reference/vue3-hot-reference.md)
+- [Referencing the Handsontable instance in Vue 3](@/guides/getting-started/vue3-hot-reference/vue3-hot-reference.md)
 
 :::
 


### PR DESCRIPTION
### Context

The PR adds a dedicated Vue-only "Instance reference" page to the Getting started section, documenting how to access the Handsontable instance from a Vue 3 component. It is part of the Vue-as-first-class-framework effort and mirrors the existing React (`react-methods`, "Instance methods") and Angular (`angular-hot-instance`, "Instance access") getting-started pages.

The content is relocated and rewritten from `integrate-with-vue3/vue3-hot-reference`. The page leads with the modern `useTemplateRef` pattern (Vue 3.5+) and documents the `ref` approach only as a legacy fallback for Vue 3.2–3.4, consistent with the TypeScript + `useTemplateRef` convention unified in #12710.

New page:
- `content/guides/getting-started/vue3-hot-reference/vue3-hot-reference.md` — `onlyFor: vue`, permalink `/vue-instance-reference`, renders at `/vue-data-grid/vue-instance-reference/`.
- `content/guides/getting-started/vue3-hot-reference/vue/example1.vue` — TypeScript SFC using `useTemplateRef<InstanceType<typeof HotTable>>(...)` and `hotInstance.selectCell()`.

Registered in the Vue sidebar (`sidebar.js`, `onlyFor: ['vue']`) and repointed 9 inbound links (8 files) from the old page to the new one.

Scope note: the old `integrate-with-vue3/vue3-hot-reference` page and URL redirects are intentionally left in place — their removal is owned by other task. The Vue sidebar therefore shows both entries until DEV-1758 lands (expected, not a bug).

Follow-up: Vue has no visual-regression coverage in `visualDocs.spec.ts` (no `vuePaths` array / `vue` test case). Tracked separately.
### How has this been tested?

Verified against the local docs dev server (`npm run dev`, Node 22):

- Page renders at `/vue-data-grid/vue-instance-reference/` (HTTP 200), title "Instance reference".
- Appears in the **Vue** sidebar under Getting started; **absent** from the JavaScript, React, and Angular sidebars (0 references on each).
- Example renders the `useTemplateRef` + `lang="ts"` source, the "Select cell B2" button, and a working "Edit on StackBlitz" payload (`"framework":"vue"`).
- Each repointed inbound link resolves to the new page (e.g. `vue-data-grid/grid-size` → `vue-instance-reference`, HTTP 200).

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1755

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

This is a documentation-only change. `[skip changelog]`

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1755

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only: new guide, sidebar entry, and link updates with no runtime or package changes.
> 
> **Overview**
> Adds a Vue-only **Getting started** guide **Instance reference** at `guides/getting-started/vue3-hot-reference`, aligned with React/Angular instance-access pages. Content is rewritten to lead with **`useTemplateRef`** and `hotInstance` (Vue 3.5+), with **`ref`** documented only for Vue 3.2–3.4, plus a new TypeScript live example (`example1.vue`).
> 
> The Vue sidebar lists the page under Getting started (`onlyFor: ['vue']`). Cross-guide tips and migration links now point at the new path instead of `integrate-with-vue3/vue3-hot-reference`. The legacy integrate-with-Vue page and its sidebar entry are unchanged in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ae18104bb43a7928006d2e1a4589c7ea2bada1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->