### PR TITLE
fix(angular-wrapper): update peerDependencies lower bound from Angular v16 to v19 (DEV-1834)

### DIFF
--- a/wrappers/angular-wrapper/README.md
+++ b/wrappers/angular-wrapper/README.md
@@ -6,7 +6,7 @@
     <img width="360" alt="Logo of Handsontable data grid" src="https://github.com/handsontable/handsontable/blob/develop/resources/handsontable-logo-black.svg?raw=true"/>
   </picture>
   <br><br>
-  <h3>The official <img src="https://raw.githubusercontent.com/handsontable/handsontable/develop/resources/icons/angular-icon.svg" width="16" height="16"> Angular 16+ wrapper for Handsontable.
+  <h3>The official <img src="https://raw.githubusercontent.com/handsontable/handsontable/develop/resources/icons/angular-icon.svg" width="16" height="16"> Angular 19+ wrapper for Handsontable.
     <br>
     <a href="https://handsontable.com/docs/angular-data-grid" target="_blank">JavaScript Data Grid</a> with a spreadsheet-like look and feel.</h3>
 

--- a/wrappers/angular-wrapper/package.json
+++ b/wrappers/angular-wrapper/package.json
@@ -54,7 +54,7 @@
     "release": "npm run test && npm run publish-package"
   },
   "peerDependencies": {
-    "@angular/core": ">=16.0.0 <22.0.0",
+    "@angular/core": ">=19.0.0 <22.0.0",
     "handsontable": "^17.0.0",
     "rxjs": "^7.0.0"
   },


### PR DESCRIPTION
## Summary

- Updates `peerDependencies` in `wrappers/angular-wrapper/package.json` so the published package contract reflects the minimum supported Angular version (19), matching the already-upgraded `devDependencies`.

Fixes DEV-1834. Follow-up to DEV-1184.

## Changes

- `wrappers/angular-wrapper/package.json`: `@angular/core` peer range changed from `>=16.0.0 <22.0.0` to `>=19.0.0 <22.0.0`

## Test plan

- [ ] `pnpm --filter @handsontable/angular-wrapper run test` passes (95 tests)
- [ ] Confirm no Angular 16/17/18 consumer is broken in the peer range

https://claude.ai/code/session_01HASt2h7Smt3ceMmGUWy6vY

---
_Generated by [Claude Code](https://claude.ai/code/session_01HASt2h7Smt3ceMmGUWy6vY)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Drops official support for Angular 16–18 in the peer range, so consumers on those versions may see install warnings or unsupported combinations despite no runtime code changes.
> 
> **Overview**
> Aligns the **published Angular support contract** with the wrapper’s existing Angular 19 toolchain by raising the minimum `@angular/core` peer range from **16** to **19** (upper bound unchanged at `<22.0.0`).
> 
> The **README** headline is updated from “Angular 16+” to **“Angular 19+”** so install docs match what npm will enforce for consumers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32b1128fe06bdb606dce6eab45dd57efc7d7e8ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[skip changelog]