### PR TITLE
docs(angular-wrapper): update ng-packagr version reference from 16 to 19 in AGENTS.md (DEV-1835)

### DIFF
--- a/wrappers/angular-wrapper/AGENTS.md
+++ b/wrappers/angular-wrapper/AGENTS.md
@@ -24,7 +24,7 @@
 
 ## Build & Test
 
-- Build: ng-packagr 16
+- Build: ng-packagr 19
 - Test: `npm run test --prefix wrappers/angular-wrapper` (Jest + jest-preset-angular)
 - Gotcha: Tests use `NODE_OPTIONS=--openssl-legacy-provider`
 


### PR DESCRIPTION
## Summary

- Fixes an outdated version reference in `wrappers/angular-wrapper/AGENTS.md` — the build tool is now ng-packagr **19**, not 16.

Fixes DEV-1835. Follow-up to DEV-1184.

## Changes

- `wrappers/angular-wrapper/AGENTS.md`: `ng-packagr 16` → `ng-packagr 19`

## Test plan

- [ ] Review that AGENTS.md accurately reflects the current toolchain

https://claude.ai/code/session_01HASt2h7Smt3ceMmGUWy6vY

---
_Generated by [Claude Code](https://claude.ai/code/session_01HASt2h7Smt3ceMmGUWy6vY)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line documentation change with no runtime, build, or security impact.
> 
> **Overview**
> Updates **`wrappers/angular-wrapper/AGENTS.md`** so the **Build & Test** section documents **ng-packagr 19** instead of the outdated **16**, aligning agent/contributor guidance with the wrapper’s current toolchain (e.g. `ng-packagr` ^19 in `package.json`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e8fd13114e984458c1c7beb25f489e93085d2fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[skip changelog]