### PR TITLE
chore(angular-wrapper): add changelog entry for Angular v16→v19 dependency upgrade (DEV-1836)

### DIFF
--- a/.changelogs/1836.json
+++ b/.changelogs/1836.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Updated Angular peer dependency minimum version to 19 in `@handsontable/angular-wrapper`",
+  "type": "changed",
+  "issueOrPR": 1836,
+  "breaking": true,
+  "framework": "angular"
+}


### PR DESCRIPTION
## Summary

- Adds the missing `.changelogs/1836.json` entry for the Angular 16→19 dependency upgrade in `@handsontable/angular-wrapper` (originally done in DEV-1184 but without a changelog).

Fixes DEV-1836. Follow-up to DEV-1184.

## Changes

- `.changelogs/1836.json`: new `changed` entry, `breaking: true`, scoped to `framework: angular`

## Test plan

- [ ] Verify `.changelogs/1836.json` is valid JSON and matches the schema used by other entries

https://claude.ai/code/session_01HASt2h7Smt3ceMmGUWy6vY

---
_Generated by [Claude Code](https://claude.ai/code/session_01HASt2h7Smt3ceMmGUWy6vY)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog addition with no runtime or dependency changes in this PR.
> 
> **Overview**
> Adds the missing changelog record for **DEV-1836**, documenting that `@handsontable/angular-wrapper` now requires **Angular 19** as the minimum peer dependency (work originally shipped under DEV-1184).
> 
> The new `.changelogs/1836.json` entry is typed as `changed`, marked **`breaking: true`**, and scoped to `framework: angular`, matching the schema used by other changelog files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cdc2ea97201ec999a180b65ce0ab2bda1bcf25a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->