### PR TITLE
DEV-1754: Add Vue-only HotColumn page to Getting Started

### DIFF
--- a/docs/content/guides/getting-started/vue3-hot-column/vue/example1.vue
+++ b/docs/content/guides/getting-started/vue3-hot-column/vue/example1.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable, HotColumn } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['A1', 'B1'],
+    ['A2', 'B2'],
+    ['A3', 'B3'],
+    ['A4', 'B4'],
+    ['A5', 'B5'],
+    ['A6', 'B6'],
+    ['A7', 'B7'],
+    ['A8', 'B8'],
+    ['A9', 'B9'],
+    ['A10', 'B10'],
+  ],
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+const secondColumnSettings = ref<GridSettings>({
+  title: 'Second column header',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings">
+      <HotColumn title="First column header" />
+      <HotColumn :settings="secondColumnSettings" read-only="true" />
+    </HotTable>
+  </div>
+</template>

--- a/docs/content/guides/getting-started/vue3-hot-column/vue/example2.vue
+++ b/docs/content/guides/getting-started/vue3-hot-column/vue/example2.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable, HotColumn } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+type ProductRow = {
+  id: number;
+  name: string;
+  payment: { price: number; currency: string };
+};
+
+const hotData = ref<ProductRow[]>([
+  { id: 1, name: 'Table tennis racket', payment: { price: 13, currency: 'PLN' } },
+  { id: 2, name: 'Outdoor game ball', payment: { price: 14, currency: 'USD' } },
+  { id: 3, name: 'Mountain bike', payment: { price: 300, currency: 'USD' } }
+]);
+const secondColumnSettings = ref<GridSettings>({
+  title: 'Second column header'
+});
+const settings = ref<GridSettings>({
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation'
+});
+</script>
+
+<template>
+  <div id="example2">
+    <HotTable :data="hotData" :settings="settings">
+      <HotColumn title="ID" data="id" />
+      <HotColumn :settings="secondColumnSettings" read-only="true" data="name" />
+      <HotColumn title="Price" data="payment.price" />
+      <HotColumn title="Currency" data="payment.currency" />
+    </HotTable>
+  </div>
+</template>

--- a/docs/content/guides/getting-started/vue3-hot-column/vue/example3.vue
+++ b/docs/content/guides/getting-started/vue3-hot-column/vue/example3.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable, HotColumn } from '@handsontable/vue3';
+import { TextEditor } from 'handsontable/editors/textEditor';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+class CustomEditor extends TextEditor {
+  createElements() {
+    super.createElements();
+
+    this.TEXTAREA = document.createElement('input');
+    this.TEXTAREA.setAttribute('placeholder', 'Custom placeholder');
+    this.TEXTAREA.setAttribute('data-hot-input', true);
+    this.textareaStyle = this.TEXTAREA.style;
+    this.TEXTAREA_PARENT.innerText = '';
+    this.TEXTAREA_PARENT.appendChild(this.TEXTAREA);
+  }
+}
+
+const customEditor = CustomEditor;
+const hotData = ref<string[][]>([
+  ['A1', 'B1'],
+  ['A2', 'B2'],
+  ['A3', 'B3'],
+  ['A4', 'B4'],
+  ['A5', 'B5'],
+]);
+const settings = ref<GridSettings>({
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example3">
+    <HotTable :data="hotData" :settings="settings">
+      <HotColumn title="Column A" :editor="customEditor" />
+      <HotColumn title="Column B" :read-only="true" />
+    </HotTable>
+  </div>
+</template>

--- a/docs/content/guides/getting-started/vue3-hot-column/vue3-hot-column.md
+++ b/docs/content/guides/getting-started/vue3-hot-column/vue3-hot-column.md
@@ -1,0 +1,53 @@
+---
+type: how-to
+id: h7xv9mwq
+title: Using the HotColumn component in Vue 3
+metaTitle: HotColumn component - JavaScript Data Grid | Handsontable
+description: Configure the Vue 3 data grid's columns, using the props of the "HotColumn" component. Define a custom cell editor or a custom cell renderer.
+permalink: /vue-hot-column
+canonicalUrl: /vue-hot-column
+vue:
+  metaTitle: HotColumn component - Vue Data Grid | Handsontable
+searchCategory: Guides
+onlyFor: vue
+category: Getting started
+---
+HotColumn is a Vue 3 component that lets you define column settings declaratively as child components of HotTable.
+
+[[toc]]
+
+[Find out which Vue 3 versions are supported](@/guides/integrate-with-vue3/vue3-installation/vue3-installation.md#vue-3-version-support)
+
+## Declare column settings
+
+To declare column-specific settings, pass the settings as `<HotColumn/>` properties, either separately or wrapped as a `settings` property, exactly as you would for `<HotTable/>`.
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/integrate-with-vue3/vue3-hot-column/vue/example1.vue)
+
+:::
+
+## Array of objects
+
+To work with an array of objects for the `<HotColumn/>` component, you need to provide precise information about the data structure for the columns. To do this, refer to the data for a column in properties as `data`.
+
+::: example #example2 :vue3
+
+@[code](@/content/guides/integrate-with-vue3/vue3-hot-column/vue/example2.vue)
+
+:::
+
+## Declare a custom editor as a component
+
+You can declare a custom editor by creating a class that extends `TextEditor` and passing it to a `<HotColumn/>` via the `editor` prop. The editor's input element uses a `placeholder` attribute to display a hint when the cell value is empty.
+
+::: example #example3 :vue3
+
+@[code](@/content/guides/integrate-with-vue3/vue3-hot-column/vue/example3.vue)
+
+:::
+
+## Result
+
+Using `HotColumn` child components, each column reads its settings declaratively from Vue props rather than from a flat `columns` array, keeping your template in sync with your column configuration.

--- a/docs/content/guides/getting-started/vue3-hot-column/vue3-hot-column.md
+++ b/docs/content/guides/getting-started/vue3-hot-column/vue3-hot-column.md
@@ -16,7 +16,7 @@ HotColumn is a Vue 3 component that lets you define column settings declarativel
 
 [[toc]]
 
-[Find out which Vue 3 versions are supported](@/guides/integrate-with-vue3/vue3-installation/vue3-installation.md#vue-3-version-support)
+[Find out which Vue 3 versions are supported](@/guides/getting-started/installation/installation.md#supported-versions-of-vue)
 
 ## Declare column settings
 
@@ -24,7 +24,7 @@ To declare column-specific settings, pass the settings as `<HotColumn/>` propert
 
 ::: example #example1 :vue3
 
-@[code](@/content/guides/integrate-with-vue3/vue3-hot-column/vue/example1.vue)
+@[code](@/content/guides/getting-started/vue3-hot-column/vue/example1.vue)
 
 :::
 
@@ -34,7 +34,7 @@ To work with an array of objects for the `<HotColumn/>` component, you need to p
 
 ::: example #example2 :vue3
 
-@[code](@/content/guides/integrate-with-vue3/vue3-hot-column/vue/example2.vue)
+@[code](@/content/guides/getting-started/vue3-hot-column/vue/example2.vue)
 
 :::
 
@@ -44,7 +44,7 @@ You can declare a custom editor by creating a class that extends `TextEditor` an
 
 ::: example #example3 :vue3
 
-@[code](@/content/guides/integrate-with-vue3/vue3-hot-column/vue/example3.vue)
+@[code](@/content/guides/getting-started/vue3-hot-column/vue/example3.vue)
 
 :::
 

--- a/docs/content/guides/integrate-with-vue3/vue3-custom-editor-example/vue3-custom-editor-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-custom-editor-example/vue3-custom-editor-example.md
@@ -99,5 +99,5 @@ The following example implements the `@handsontable/vue3` component with a custo
 ## Next steps
 
 - [Cell editor](@/guides/cell-functions/cell-editor/cell-editor.md) -- read the full editor API documentation.
-- [HotColumn component in Vue 3](@/guides/integrate-with-vue3/vue3-hot-column/vue3-hot-column.md) -- declare editors per column using HotColumn.
+- [HotColumn component in Vue 3](@/guides/getting-started/vue3-hot-column/vue3-hot-column.md) -- declare editors per column using HotColumn.
 - [Custom renderer in Vue 3](@/guides/integrate-with-vue3/vue3-custom-renderer-example/vue3-custom-renderer-example.md) -- complement your editor with a custom renderer.

--- a/docs/content/guides/integrate-with-vue3/vue3-custom-renderer-example/vue3-custom-renderer-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-custom-renderer-example/vue3-custom-renderer-example.md
@@ -114,5 +114,5 @@ If your component needs access to a Vue application context -- for example, glob
 ## Next steps
 
 - [Cell renderer](@/guides/cell-functions/cell-renderer/cell-renderer.md) -- explore the full renderer API.
-- [HotColumn component in Vue 3](@/guides/integrate-with-vue3/vue3-hot-column/vue3-hot-column.md) -- assign renderers per column declaratively.
+- [HotColumn component in Vue 3](@/guides/getting-started/vue3-hot-column/vue3-hot-column.md) -- assign renderers per column declaratively.
 - [Custom editor in Vue 3](@/guides/integrate-with-vue3/vue3-custom-editor-example/vue3-custom-editor-example.md) -- pair your renderer with a custom editor.

--- a/docs/content/guides/integrate-with-vue3/vue3-formulas-example/vue3-formulas-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-formulas-example/vue3-formulas-example.md
@@ -107,4 +107,4 @@ This keeps the engine untouched and ensures it behaves exactly as intended.
 
 - [Formula calculation](@/guides/formulas/formula-calculation/formula-calculation.md) -- learn the full Formulas plugin API.
 - [Modules in Vue 3](@/guides/integrate-with-vue3/vue3-modules/vue3-modules.md) -- reduce bundle size by importing only required modules.
-- [HotColumn component in Vue 3](@/guides/integrate-with-vue3/vue3-hot-column/vue3-hot-column.md) -- configure columns declaratively.
+- [HotColumn component in Vue 3](@/guides/getting-started/vue3-hot-column/vue3-hot-column.md) -- configure columns declaratively.

--- a/docs/content/guides/integrate-with-vue3/vue3-simple-example/vue3-simple-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-simple-example/vue3-simple-example.md
@@ -43,6 +43,6 @@ In this example, a `div` element of `id="example1"` where the `@handsontable/vue
 
 ## Next steps
 
-- [HotColumn component in Vue 3](@/guides/integrate-with-vue3/vue3-hot-column/vue3-hot-column.md) -- define column settings declaratively with HotColumn.
+- [HotColumn component in Vue 3](@/guides/getting-started/vue3-hot-column/vue3-hot-column.md) -- define column settings declaratively with HotColumn.
 - [Custom renderer in Vue 3](@/guides/integrate-with-vue3/vue3-custom-renderer-example/vue3-custom-renderer-example.md) -- customize how cell content is displayed.
 - [Language change in Vue 3](@/guides/integrate-with-vue3/vue3-language-change-example/vue3-language-change-example.md) -- switch the grid UI language at runtime.

--- a/docs/content/guides/integrate-with-vue3/vue3-vuex-example/vue3-vuex-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-vuex-example/vue3-vuex-example.md
@@ -42,5 +42,5 @@ The following example implements the `@handsontable/vue3` component with a [`rea
 ## Next steps
 
 - [Referencing the Handsontable instance in Vue 3](@/guides/getting-started/vue3-hot-reference/vue3-hot-reference.md) -- access the Handsontable API directly from your component.
-- [HotColumn component in Vue 3](@/guides/integrate-with-vue3/vue3-hot-column/vue3-hot-column.md) -- configure columns declaratively alongside your store.
+- [HotColumn component in Vue 3](@/guides/getting-started/vue3-hot-column/vue3-hot-column.md) -- configure columns declaratively alongside your store.
 - [Formulas integration in Vue 3](@/guides/integrate-with-vue3/vue3-formulas-example/vue3-formulas-example.md) -- combine Vuex-managed data with formula calculations.

--- a/docs/content/guides/sidebar.js
+++ b/docs/content/guides/sidebar.js
@@ -7,6 +7,7 @@ const gettingStartedItems = [
   { path: 'guides/getting-started/react-methods/react-methods', onlyFor: ['react'] },
   { path: 'guides/getting-started/angular-hot-instance/angular-hot-instance', onlyFor: ['angular'] },
   { path: 'guides/getting-started/vue3-hot-reference/vue3-hot-reference', onlyFor: ['vue'] },
+  { path: 'guides/getting-started/vue3-hot-column/vue3-hot-column', onlyFor: ['vue'] },
   { path: 'guides/getting-started/vue3-nuxt/vue3-nuxt', onlyFor: ['vue'] },
   { path: 'guides/getting-started/license-key/license-key' },
   { path: 'guides/getting-started/react-redux/react-redux', onlyFor: ['react'] },


### PR DESCRIPTION
### Context

The PR adds a dedicated Vue-only page for the `HotColumn` component under `Getting started/`, analogous to the existing `react-methods` (React-only) and `angular-hot-instance` (Angular-only) pages. The content is migrated from `integrate-with-vue3/vue3-hot-column/` — the old page is left in place pending a separate cleanup task. Five inbound links from Vue-specific guide pages are repointed to the new location. Vue SFC examples are copied to live next to the new page.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1754

### How has this been tested?

- `npm run docs:lint` — 0 errors
- Cold-started docs dev server; verified HTTP 200 at `/vue-data-grid/vue-hot-column/`
- Confirmed page appears in Vue sidebar under Getting started; absent from JS, React, Angular sidebars
- Verified all three `<HotColumn>` examples render; StackBlitz payload contains `"framework":"vue"`
- Verified repointed links resolve to the new page (not 404)
- Verified version-support link resolves to `installation.md#supported-versions-of-vue`

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1754

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

Documentation site only (`docs/`).

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes with no runtime or library code; duplicate HotColumn URLs may exist until the old page is removed.
> 
> **Overview**
> Adds a **Vue-only Getting started** guide for **`HotColumn`** at `guides/getting-started/vue3-hot-column/`, with three live `:vue3` examples (column props/`settings`, object `data` paths, custom `TextEditor`).
> 
> Registers the page in **`sidebar.js`** under Getting started (`onlyFor: ['vue']`), and repoints **Next steps** links in five Vue integration tutorials from `integrate-with-vue3/vue3-hot-column` to the new path. The original integrate-with-vue3 HotColumn page and sidebar entry are **unchanged** in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c01354a21173b11c12cb1504ac50b87efbed9e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->