### PR TITLE
DEV-1756: Add Vue-only Vuex state management page to Getting Started

### DIFF
--- a/docs/content/guides/getting-started/vue3-vuex/vue/example1.vue
+++ b/docs/content/guides/getting-started/vue3-vuex/vue/example1.vue
@@ -1,0 +1,186 @@
+<script setup lang="ts">
+import { ref, onMounted, useTemplateRef } from 'vue';
+import { createStore } from 'vuex';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+type VuexState = {
+  hotData: string[][] | null;
+  hotSettings: {
+    readOnly: boolean;
+    autoWrapRow: boolean;
+    autoWrapCol: boolean;
+  };
+};
+
+const store = createStore<VuexState>({
+  state() {
+    return {
+      hotData: null,
+      hotSettings: {
+        readOnly: false,
+        autoWrapRow: true,
+        autoWrapCol: true,
+      }
+    };
+  },
+  mutations: {
+    updateData(state, hotData: string[][]) {
+      state.hotData = hotData;
+    },
+    updateSettings(state, updateObj: { prop: keyof VuexState['hotSettings']; value: boolean }) {
+      state.hotSettings[updateObj.prop] = updateObj.value;
+    }
+  }
+});
+
+const wrapper = useTemplateRef<InstanceType<typeof HotTable>>('wrapper');
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['A1', 'B1', 'C1', 'D1'],
+    ['A2', 'B2', 'C2', 'D2'],
+    ['A3', 'B3', 'C3', 'D3'],
+    ['A4', 'B4', 'C4', 'D4'],
+  ],
+  colHeaders: true,
+  rowHeaders: true,
+  readOnly: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  afterChange: () => {
+    if (wrapper.value?.hotInstance) {
+      store.commit('updateData', wrapper.value.hotInstance.getSourceData() as string[][]);
+    }
+  },
+  licenseKey: 'non-commercial-and-evaluation'
+});
+
+function toggleReadOnly(event: Event) {
+  const checked = (event.target as HTMLInputElement).checked;
+
+  hotSettings.value.readOnly = checked;
+  store.commit('updateSettings', { prop: 'readOnly', value: checked });
+}
+
+function updateVuexPreview() {
+  const previewTable = document.querySelector('#vuex-preview pre');
+
+  if (!previewTable) {
+    return;
+  }
+
+  let newInnerHtml = '<div>';
+
+  for (const [key, value] of Object.entries(store.state)) {
+    newInnerHtml += '<div><div class="table-container">';
+
+    if (key === 'hotData' && Array.isArray(value)) {
+      newInnerHtml += '<strong>hotData:</strong> <br><table><tbody>';
+
+      for (const row of value) {
+        newInnerHtml += '<tr>';
+
+        for (const cell of row) {
+          newInnerHtml += `<td>${cell}</td>`;
+        }
+
+        newInnerHtml += '</tr>';
+      }
+      newInnerHtml += '</tbody></table>';
+
+    } else if (key === 'hotSettings') {
+      newInnerHtml += '<strong>hotSettings:</strong> <ul>';
+
+      for (const settingsKey of Object.keys(value as VuexState['hotSettings'])) {
+        newInnerHtml += `<li>${settingsKey}: ${store.state.hotSettings[settingsKey as keyof VuexState['hotSettings']]}</li>`;
+      }
+
+      newInnerHtml += '</ul>';
+    }
+
+    newInnerHtml += '</div></div>';
+  }
+  newInnerHtml += '</div>';
+
+  previewTable.innerHTML = newInnerHtml;
+}
+
+onMounted(() => {
+  store.subscribe(() => updateVuexPreview());
+  store.commit('updateData', wrapper.value?.hotInstance?.getSourceData() as string[][]);
+});
+</script>
+
+<template>
+  <div id="example1">
+    <div class="example-controls-container">
+      <div class="controls">
+        <label><input v-on:click="toggleReadOnly" checked id="readOnlyCheck" type="checkbox" /> Toggle <code>readOnly</code> for the entire table</label>
+      </div>
+    </div>
+    <HotTable ref="wrapper" :settings="hotSettings" />
+    <div id="vuex-preview">
+      <strong>Vuex store dump:</strong>
+      <pre></pre>
+    </div>
+  </div>
+</template>
+
+<style>
+#vuex-preview {
+  margin-top: 0.75rem;
+}
+
+#vuex-preview strong {
+  display: block;
+  margin-bottom: 0.375rem;
+  color: var(--sl-color-gray-2, #555555);
+  font-family: var(--sl-font, Inter, system-ui, -apple-system, sans-serif);
+  font-size: var(--sl-text-xs, 0.75rem);
+}
+
+#vuex-preview pre {
+  height: 168px;
+  padding: 0.5rem 0.75rem;
+  overflow-y: auto;
+  font-size: var(--sl-text-xs, 0.75rem);
+  font-family: var(--sl-font-mono, ui-monospace, monospace);
+  line-height: 1.6;
+  border: 1px solid var(--sl-color-gray-5, #e0e0e0);
+  background: var(--sl-color-gray-7, #f5f5f5);
+  color: var(--sl-color-gray-2, #555555);
+  margin: 0;
+  border-radius: 0;
+}
+
+#vuex-preview pre .table-container {
+  margin-bottom: 0.375rem;
+}
+
+#vuex-preview pre table {
+  border-collapse: collapse;
+  margin: 0.25rem 0;
+  font-size: var(--sl-text-xs, 0.75rem);
+}
+
+#vuex-preview pre td {
+  padding: 0.125rem 0.5rem 0.125rem 0;
+  color: var(--sl-color-gray-2, #555555);
+  border: none;
+}
+
+#vuex-preview pre ul {
+  margin: 0.125rem 0 0;
+  padding-left: 1.25rem;
+  list-style: disc;
+}
+
+#vuex-preview pre li {
+  padding: 0.0625rem 0;
+  color: var(--sl-color-gray-2, #555555);
+}
+</style>

--- a/docs/content/guides/getting-started/vue3-vuex/vue3-vuex.md
+++ b/docs/content/guides/getting-started/vue3-vuex/vue3-vuex.md
@@ -1,0 +1,57 @@
+---
+type: tutorial
+id: m4v9kp2z
+title: Vuex state management
+metaTitle: Vuex state management - Vue Data Grid | Handsontable
+description: Use the Vuex state management pattern to maintain the data and configuration options of your Vue 3 data grid.
+permalink: /vue-vuex
+canonicalUrl: /vue-vuex
+tags:
+  - vuex
+  - state management
+vue:
+  metaTitle: Vuex state management - Vue Data Grid | Handsontable
+searchCategory: Guides
+onlyFor: vue
+category: Getting started
+---
+
+In this tutorial, you will connect a Handsontable grid to a Vuex store. You will learn to commit mutations on cell changes and sync grid data with shared application state.
+
+[[toc]]
+
+## Before you begin
+
+- Install [Vuex 4](https://vuex.vuejs.org/) in your Vue 3 project: `npm install vuex@next`.
+- Understand how Handsontable handles data: see [Binding to data](@/guides/getting-started/binding-to-data/binding-to-data.md#understand-binding-as-a-reference).
+
+## Integrate with Vuex
+
+::: tip
+
+Before using any state management library, make sure you know how Handsontable handles data: see the [Binding to data](@/guides/getting-started/binding-to-data/binding-to-data.md#understand-binding-as-a-reference) page.
+
+:::
+
+The following example implements the `@handsontable/vue3` component with a [`readOnly`](@/api/options.md#readonly) toggle switch and the Vuex state manager. Editing a cell commits a mutation to the store, and a live store dump displays the current state below the grid.
+
+[Find out which Vue 3 versions are supported](@/guides/integrate-with-vue3/vue3-installation/vue3-installation.md#vue-3-version-support)
+
+::: example #example1 :vue3-vuex
+
+@[code](@/content/guides/getting-started/vue3-vuex/vue/example1.vue)
+
+:::
+
+## What you learned
+
+- How to create a typed Vuex store with `createStore<VuexState>` and define mutations for grid data and settings.
+- How to use the `afterChange` hook to commit a Vuex mutation whenever the user edits a cell.
+- How to toggle a Handsontable option (`readOnly`) by dispatching a store mutation from a UI control.
+- How to subscribe to store changes with `store.subscribe()` to reactively update a live state dump.
+
+## Next steps
+
+- [Pinia state management](@/guides/getting-started/vue3-pinia/vue3-pinia.md) -- use Pinia as a lighter, Vue 3-native alternative to Vuex for managing grid state.
+- [Referencing the Handsontable instance in Vue 3](@/guides/getting-started/vue3-hot-reference/vue3-hot-reference.md) -- access the Handsontable API directly from your component.
+- [HotColumn component in Vue 3](@/guides/getting-started/vue3-hot-column/vue3-hot-column.md) -- configure columns declaratively alongside your store.

--- a/docs/content/guides/sidebar.js
+++ b/docs/content/guides/sidebar.js
@@ -8,6 +8,7 @@ const gettingStartedItems = [
   { path: 'guides/getting-started/angular-hot-instance/angular-hot-instance', onlyFor: ['angular'] },
   { path: 'guides/getting-started/license-key/license-key' },
   { path: 'guides/getting-started/react-redux/react-redux', onlyFor: ['react'] },
+  { path: 'guides/getting-started/vue3-vuex/vue3-vuex', onlyFor: ['vue'] },
 ];
 
 const stylingItems = [


### PR DESCRIPTION
### Context

The PR adds a Vue-only "Vuex state management" page to the Getting Started section of the docs site, analogous to the existing `react-redux` page for React. The new page is visible only in the Vue sidebar (`onlyFor: vue` in both frontmatter and `sidebar.js`) and renders under the `/vue-data-grid/vue-vuex/` prefix. The Vue SFC example has been copied to its new canonical location at `getting-started/vue3-vuex/vue/`. The old page under "Integrate with Vue 3" is left untouched — cleanup is a separate task.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1756

### How has this been tested?

- Dev server smoke test: page returns HTTP 200 at `/vue-data-grid/vue-vuex/`
- Sidebar visibility verified: `vue-vuex` link appears in Vue sidebar, absent from React, Angular, and JavaScript sidebars
- Permalink uniqueness confirmed: `grep -rn "permalink: /vue-vuex"` returns only the new file

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1756

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

Documentation site only (`docs/`).

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or library code impact.
> 
> **Overview**
> Adds a **Vue-only Getting started** guide for wiring `@handsontable/vue3` to **Vuex 4**, mirroring the existing React Redux page. The tutorial at permalink `/vue-vuex` covers typed `createStore`, `afterChange` commits, a `readOnly` toggle, and a live store dump via `store.subscribe()`.
> 
> A new interactive example lives at `getting-started/vue3-vuex/vue/example1.vue`. **Getting started** navigation in `sidebar.js` gains `vue3-vuex` with `onlyFor: ['vue']`, so the link shows only on the Vue docs variant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c11252a4b324bcbf687ad6cb063963cd3bad4f3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->