### PR TITLE
DEV-1757: Add Vue-only custom ID, class, and style page to Getting Started

### DIFF
--- a/docs/content/guides/getting-started/vue3-custom-id-class-style/vue/example1.vue
+++ b/docs/content/guides/getting-started/vue3-custom-id-class-style/vue/example1.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  startRows: 5,
+  startCols: 5,
+  colHeaders: true,
+  stretchH: 'all',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation'
+});
+const id = ref('my-custom-id');
+const className = ref('my-custom-classname');
+const style = ref('height: 142px; overflow: hidden; border: 1px solid red;');
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :id="id" :class="className" :style="style" :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/getting-started/vue3-custom-id-class-style/vue3-custom-id-class-style.md
+++ b/docs/content/guides/getting-started/vue3-custom-id-class-style/vue3-custom-id-class-style.md
@@ -1,0 +1,37 @@
+---
+type: how-to
+id: n5t2hq7r
+title: Custom ID, class, and style
+metaTitle: Custom ID, class, and style - Javascript Data Grid | Handsontable
+description: Pass a custom ID, class, and style to the HotTable component, to further customize your Vue 3 data grid.
+permalink: /vue-custom-id-class-style
+canonicalUrl: /vue-custom-id-class-style
+vue:
+  metaTitle: Custom ID, class, and style - Vue Data Grid | Handsontable
+searchCategory: Guides
+onlyFor: vue
+category: Getting started
+---
+
+Pass `id`, `className`, and `style` props to the HotTable component to control its HTML attributes and appearance.
+
+[[toc]]
+
+## Overview
+
+Custom `id`, `class`, `style`, and other attributes can be passed into the `hot-table` wrapper element.
+Each of them will be applied to the root Handsontable element, allowing further customization of the table.
+
+[Find out which Vue 3 versions are supported](@/guides/getting-started/installation/installation.md#supported-versions-of-vue)
+
+## Example
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/getting-started/vue3-custom-id-class-style/vue/example1.vue)
+
+:::
+
+## Result
+
+The rendered `HotTable` element has the custom `id`, `class`, and `style` attributes applied directly to its root DOM element, making it straightforward to target with CSS or JavaScript selectors.

--- a/docs/content/guides/sidebar.js
+++ b/docs/content/guides/sidebar.js
@@ -8,6 +8,7 @@ const gettingStartedItems = [
   { path: 'guides/getting-started/angular-hot-instance/angular-hot-instance', onlyFor: ['angular'] },
   { path: 'guides/getting-started/license-key/license-key' },
   { path: 'guides/getting-started/react-redux/react-redux', onlyFor: ['react'] },
+  { path: 'guides/getting-started/vue3-custom-id-class-style/vue3-custom-id-class-style', onlyFor: ['vue'] },
 ];
 
 const stylingItems = [


### PR DESCRIPTION
### Context

The PR adds a standalone Vue-only docs page for "Custom ID, class, and style" to the Getting started section, migrating this topic out of the legacy `integrate-with-vue3/` folder into the unified structure used by the React and Angular framework-specific pages.

The topic -- passing `id`, `class`, and `style` attributes to the `<HotTable>` wrapper element -- exists only in Vue and has no equivalent in React or Angular, so a standalone `onlyFor: vue` page under `getting-started/` is the correct placement. The existing old page and its sidebar entry are left untouched (cleanup is a separate task).

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1757

[skip changelog]

### How has this been tested?

- Verified on the docs dev server: page renders at `/vue-data-grid/vue-custom-id-class-style`, example shows grid with custom `id`, `class`, and red border applied.
- Confirmed page appears in the Vue sidebar only (not in JS/React/Angular sidebars).
- Confirmed "Edit on StackBlitz" opens with `"framework":"vue"`.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1757

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and navigation only; no runtime or library code changes.
> 
> **Overview**
> Adds a **Vue-only** Getting started guide for passing custom **`id`**, **`class`**, and **`style`** to `<HotTable>`, aligned with other framework-specific pages under `getting-started/`.
> 
> The new page (`/vue-custom-id-class-style`) includes overview copy, a live **Vue 3** example (`example1.vue`) that binds those props to the grid root, and a short “Result” section. **Getting started** navigation in `sidebar.js` gains an `onlyFor: ['vue']` entry; the legacy `integrate-with-vue3/` page is unchanged in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9592a07855d547949d8ebb52fabea0c1b14563cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->