### PR TITLE
DEV-1762: Add Vue-only Pinia state management page to Getting Started

### DIFF
--- a/docs/content/guides/getting-started/vue3-pinia/vue/example1.vue
+++ b/docs/content/guides/getting-started/vue3-pinia/vue/example1.vue
@@ -85,7 +85,7 @@ watch(
 watch(
   () => store.employees,
   (val) => {
-    hotSettings.value = { ...hotSettings.value, data: val.map(e => Object.values(e)) };
+    wrapper.value?.hotInstance?.loadData(val.map(e => Object.values(e)));
   },
   { deep: true }
 );

--- a/docs/content/guides/getting-started/vue3-pinia/vue/example1.vue
+++ b/docs/content/guides/getting-started/vue3-pinia/vue/example1.vue
@@ -1,0 +1,153 @@
+<script setup lang="ts">
+import { ref, watch, onMounted, useTemplateRef } from 'vue';
+import { defineStore, createPinia, setActivePinia } from 'pinia';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+// Activate Pinia without a Vue app instance (required in the docs example runner).
+setActivePinia(createPinia());
+
+type Employee = {
+  name: string;
+  department: string;
+  title: string;
+  salary: number;
+  startDate: string;
+};
+
+const useEmployeeStore = defineStore('employees', {
+  state: () => ({
+    readOnly: false,
+    employees: [
+      { name: 'Ana García',    department: 'Engineering',  title: 'Senior Engineer',   salary: 95000, startDate: '2021-03-14' },
+      { name: 'James Okafor', department: 'Marketing',    title: 'Product Manager',   salary: 87000, startDate: '2019-07-22' },
+      { name: 'Li Wei',       department: 'Engineering',  title: 'Frontend Engineer', salary: 82000, startDate: '2022-01-10' },
+      { name: 'Sara Novak',   department: 'Design',       title: 'UX Designer',       salary: 78000, startDate: '2020-11-05' },
+      { name: 'Tom Eriksson', department: 'Sales',        title: 'Account Executive', salary: 74000, startDate: '2023-04-18' },
+    ] as Employee[],
+  }),
+  actions: {
+    toggleReadOnly() {
+      this.readOnly = !this.readOnly;
+    },
+    updateEmployee(row: number, col: number, value: string | number) {
+      const keys = Object.keys(this.employees[0]) as (keyof Employee)[];
+      const key = keys[col];
+
+      if (key && this.employees[row]) {
+        (this.employees[row] as Record<string, string | number>)[key] = value;
+      }
+    },
+    resetData() {
+      this.employees = [
+        { name: 'Ana García',    department: 'Engineering',  title: 'Senior Engineer',   salary: 95000, startDate: '2021-03-14' },
+        { name: 'James Okafor', department: 'Marketing',    title: 'Product Manager',   salary: 87000, startDate: '2019-07-22' },
+        { name: 'Li Wei',       department: 'Engineering',  title: 'Frontend Engineer', salary: 82000, startDate: '2022-01-10' },
+        { name: 'Sara Novak',   department: 'Design',       title: 'UX Designer',       salary: 78000, startDate: '2020-11-05' },
+        { name: 'Tom Eriksson', department: 'Sales',        title: 'Account Executive', salary: 74000, startDate: '2023-04-18' },
+      ];
+    },
+  },
+});
+
+const store = useEmployeeStore();
+const wrapper = useTemplateRef<InstanceType<typeof HotTable>>('wrapper');
+
+const hotSettings = ref<GridSettings>({
+  data: store.employees.map(e => Object.values(e)),
+  colHeaders: ['Name', 'Department', 'Title', 'Salary', 'Start Date'],
+  rowHeaders: true,
+  height: 'auto',
+  readOnly: store.readOnly,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  afterChange(changes) {
+    if (!changes) return;
+
+    for (const [row, col, , newValue] of changes) {
+      store.updateEmployee(row as number, col as number, newValue as string | number);
+    }
+  },
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+// Store → grid: watch for store mutations and update the grid.
+watch(
+  () => store.readOnly,
+  (val) => {
+    hotSettings.value = { ...hotSettings.value, readOnly: val };
+  }
+);
+
+watch(
+  () => store.employees,
+  (val) => {
+    hotSettings.value = { ...hotSettings.value, data: val.map(e => Object.values(e)) };
+  },
+  { deep: true }
+);
+
+function updateStorePreview() {
+  const pre = document.querySelector('#pinia-preview pre');
+
+  if (!pre) return;
+
+  pre.textContent = JSON.stringify({ readOnly: store.readOnly, employees: store.employees }, null, 2);
+}
+
+onMounted(() => {
+  store.$subscribe(() => updateStorePreview());
+  updateStorePreview();
+});
+</script>
+
+<template>
+  <div id="example1">
+    <div class="example-controls-container">
+      <div class="controls">
+        <button v-on:click="store.toggleReadOnly()">
+          Toggle <code>readOnly</code> (currently: {{ store.readOnly }})
+        </button>
+        <button v-on:click="store.resetData()" style="margin-left: 0.5rem">
+          Reset data
+        </button>
+      </div>
+    </div>
+    <HotTable ref="wrapper" :settings="hotSettings" />
+    <div id="pinia-preview">
+      <strong>Pinia store dump:</strong>
+      <pre></pre>
+    </div>
+  </div>
+</template>
+
+<style>
+#pinia-preview {
+  margin-top: 0.75rem;
+}
+
+#pinia-preview strong {
+  display: block;
+  margin-bottom: 0.375rem;
+  color: var(--sl-color-gray-2, #555555);
+  font-family: var(--sl-font, Inter, system-ui, -apple-system, sans-serif);
+  font-size: var(--sl-text-xs, 0.75rem);
+}
+
+#pinia-preview pre {
+  height: 168px;
+  padding: 0.5rem 0.75rem;
+  overflow-y: auto;
+  font-size: var(--sl-text-xs, 0.75rem);
+  font-family: var(--sl-font-mono, ui-monospace, monospace);
+  line-height: 1.6;
+  border: 1px solid var(--sl-color-gray-5, #e0e0e0);
+  background: var(--sl-color-gray-7, #f5f5f5);
+  color: var(--sl-color-gray-2, #555555);
+  margin: 0;
+  border-radius: 0;
+}
+</style>

--- a/docs/content/guides/getting-started/vue3-pinia/vue3-pinia.md
+++ b/docs/content/guides/getting-started/vue3-pinia/vue3-pinia.md
@@ -1,0 +1,59 @@
+---
+type: how-to
+id: c0y2nwis
+title: Pinia in Vue 3
+metaTitle: Pinia in Vue 3 - Vue 3 Data Grid | Handsontable
+description: Use the Pinia store to maintain the data and configuration options of your Vue 3 data grid.
+permalink: /vue-pinia
+canonicalUrl: /vue-pinia
+vue:
+  metaTitle: Pinia in Vue 3 - Vue Data Grid | Handsontable
+searchCategory: Guides
+onlyFor: vue
+category: Getting started
+---
+
+Use [Pinia](https://pinia.vuejs.org/) -- the officially recommended state-management library for Vue 3 -- to manage your Handsontable data and settings.
+
+[[toc]]
+
+## Prerequisites
+
+- The `@handsontable/vue3` package installed. See [Installing Handsontable](@/guides/getting-started/installation/installation.md).
+- The `pinia` package installed: `npm install pinia`.
+
+## Steps
+
+### 1. Define a Pinia store
+
+Create a store with `defineStore`. The example below defines state that holds the grid data and a `readOnly` flag, plus actions to mutate both.
+
+### 2. Activate Pinia
+
+Because the docs example runner does not call `app.use(pinia)`, activate Pinia at module scope with `setActivePinia(createPinia())` before calling `useStore()`.
+
+### 3. Connect the store to `<HotTable>`
+
+Bind the store state to your `gridSettings` ref and use the `afterChange` hook to write cell edits back to the store.
+
+### 4. React to store changes from the grid
+
+Use Vue's `watch` to observe store state and update the grid when the store changes outside of a direct cell edit -- for example, when a button dispatches an action.
+
+## Example
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/getting-started/vue3-pinia/vue/example1.vue)
+
+:::
+
+## Result
+
+The grid reflects the Pinia store state at all times. Cell edits update the store, and store mutations (for example, toggling `readOnly` or resetting data) are immediately reflected in the grid.
+
+## Related
+
+- [Pinia documentation](https://pinia.vuejs.org/)
+- [Vuex in Vue 3](@/guides/getting-started/vue3-vuex/vue3-vuex.md) -- an alternative state management approach using Vuex 4.
+- [Instance access in Vue 3](@/guides/getting-started/vue3-hot-reference/vue3-hot-reference.md) -- access the Handsontable API directly from your component.

--- a/docs/content/guides/integrate-with-vue3/vue3-vuex-example/vue3-vuex-example.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-vuex-example/vue3-vuex-example.md
@@ -44,3 +44,9 @@ The following example implements the `@handsontable/vue3` component with a [`rea
 - [Referencing the Handsontable instance in Vue 3](@/guides/getting-started/vue3-hot-reference/vue3-hot-reference.md) -- access the Handsontable API directly from your component.
 - [HotColumn component in Vue 3](@/guides/integrate-with-vue3/vue3-hot-column/vue3-hot-column.md) -- configure columns declaratively alongside your store.
 - [Formulas integration in Vue 3](@/guides/integrate-with-vue3/vue3-formulas-example/vue3-formulas-example.md) -- combine Vuex-managed data with formula calculations.
+
+:::: only-for vue
+
+See also [Pinia in Vue 3](@/guides/getting-started/vue3-pinia/vue3-pinia.md) -- the officially recommended state-management library for Vue 3.
+
+::::

--- a/docs/content/guides/sidebar.js
+++ b/docs/content/guides/sidebar.js
@@ -10,6 +10,7 @@ const gettingStartedItems = [
   { path: 'guides/getting-started/license-key/license-key' },
   { path: 'guides/getting-started/react-redux/react-redux', onlyFor: ['react'] },
   { path: 'guides/getting-started/vue3-vuex/vue3-vuex', onlyFor: ['vue'] },
+  { path: 'guides/getting-started/vue3-pinia/vue3-pinia', onlyFor: ['vue'] },
 ];
 
 const stylingItems = [

--- a/docs/package.json
+++ b/docs/package.json
@@ -54,6 +54,7 @@
     "starlight-page-actions": "^0.5.0",
     "starlight-theme-rapide": "^0.5.2",
     "unist-util-visit": "^5.0.0",
+    "pinia": "^2.3.1",
     "vuex": "^4.1.0",
     "xlsx": "^0.18.5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,6 +217,9 @@ importers:
       papaparse:
         specifier: ^5.5.3
         version: 5.5.3
+      pinia:
+        specifier: ^2.3.1
+        version: 2.3.1(typescript@5.8.3)(vue@3.5.35(typescript@5.8.3))
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -9695,6 +9698,15 @@ packages:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
 
+  pinia@2.3.1:
+    resolution: {integrity: sha512-khUlZSwt9xXCaTbbxFYBKDc/bWAGWJjOgvxETwkTN7KRm66EeT1ZdZj6i2ceh9sP2Pzqsbc704r2yngBrxBVug==}
+    peerDependencies:
+      typescript: '>=4.4.4'
+      vue: ^2.7.0 || ^3.5.11
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
@@ -11849,6 +11861,17 @@ packages:
   void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
+
+  vue-demi@0.14.10:
+    resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
+    engines: {node: '>=12'}
+    hasBin: true
+    peerDependencies:
+      '@vue/composition-api': ^1.0.0-rc.1
+      vue: ^3.0.0-0 || ^2.6.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
 
   vue-eslint-parser@8.3.0:
     resolution: {integrity: sha512-dzHGG3+sYwSf6zFBa0Gi9ZDshD7+ad14DGOdTLjruRVgZXe2J+DcZ9iUhyR48z5g1PqRa20yt3Njna/veLJL/g==}
@@ -23455,6 +23478,16 @@ snapshots:
 
   pify@4.0.1: {}
 
+  pinia@2.3.1(typescript@5.8.3)(vue@3.5.35(typescript@5.8.3)):
+    dependencies:
+      '@vue/devtools-api': 6.6.4
+      vue: 3.5.35(typescript@5.8.3)
+      vue-demi: 0.14.10(vue@3.5.35(typescript@5.8.3))
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+
   pirates@4.0.7: {}
 
   piscina@4.8.0:
@@ -25856,6 +25889,10 @@ snapshots:
       vite: 7.3.5(@types/node@20.19.41)(jiti@1.21.7)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)
 
   void-elements@3.1.0: {}
+
+  vue-demi@0.14.10(vue@3.5.35(typescript@5.8.3)):
+    dependencies:
+      vue: 3.5.35(typescript@5.8.3)
 
   vue-eslint-parser@8.3.0(eslint@8.57.1):
     dependencies:


### PR DESCRIPTION
### Context

The PR adds a new Vue-only "Pinia in Vue 3" page to the Getting Started section. Pinia is the officially recommended state-management library for Vue 3, but the docs had no guide for it -- only the older Vuex page. The new page covers: defining a Pinia store, connecting it to a `<HotTable>` component, and reacting to store changes in the grid (both grid→store via `afterChange` and store→grid via `watch`).

The page:
- Lives at `docs/content/guides/getting-started/vue3-pinia/` with `onlyFor: vue` -- analogous to `react-redux` and `angular-hot-instance`.
- Is hidden from JS/React/Angular sidebars via `onlyFor: ['vue']` in `sidebar.js`.
- Ships a single TypeScript SFC (`<script setup lang="ts">`) using `useTemplateRef` and domain-realistic HR data.
- Uses `setActivePinia(createPinia())` at module scope so the example runner renders correctly without `app.use(pinia)`.
- Cross-links to the Vuex page (with a `:::: only-for vue` guard on the Vuex side).

`pinia ^2.3.1` added to `docs/package.json` so the dev-server live example resolves the import and StackBlitz pins a real version.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1762

### How has this been tested?

- Dev server (Node 22, `npm run dev`): HTTP 200 at `/vue-data-grid/vue-pinia/`, grid renders, store↔grid reactivity works.
- Page present in Vue sidebar; absent from JS/React/Angular sidebars (confirmed via HTML inspection).
- StackBlitz payload: `"framework":"vue"` and `"pinia"` in deps (confirmed via page source).
- `npm run docs:lint` passes.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1762

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and docs-site dependencies only; no changes to Handsontable or framework packages.
> 
> **Overview**
> Adds a **Vue-only Getting Started guide** for using **Pinia** with Handsontable, parallel to the existing Vuex page.
> 
> The new **`vue3-pinia`** doc walks through defining a store, activating Pinia in the docs example runner via `setActivePinia`, wiring **`afterChange`** for grid→store updates, and **`watch`** for store→grid sync. It ships a live **`example1.vue`** demo (HR employee grid, `readOnly` toggle, reset, store JSON preview).
> 
> **Navigation and deps:** the page is registered in **`sidebar.js`** with `onlyFor: ['vue']`, and **`pinia ^2.3.1`** is added to **`docs/package.json`** (lockfile updated) so dev/StackBlitz examples resolve Pinia.
> 
> **Cross-links:** the Vuex integration tutorial’s “Next steps” gains a Vue-only blurb pointing readers to the new Pinia guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 976f12000c90e5584ccb16aaf971432920b3b94c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->