### PR TITLE
DEV-1763: Add Vue-only Nuxt.js integration guide

### DIFF
--- a/docs/content/guides/getting-started/vue3-nuxt/vue3-nuxt.md
+++ b/docs/content/guides/getting-started/vue3-nuxt/vue3-nuxt.md
@@ -1,0 +1,181 @@
+---
+type: how-to
+id: n5br7y1k
+title: Use Handsontable in Nuxt
+metaTitle: Use Handsontable in Nuxt - JavaScript Data Grid | Handsontable
+description: Set up Handsontable in a Nuxt 3 application using the ClientOnly component or the .client.vue suffix to avoid SSR errors.
+permalink: /vue-nuxt
+canonicalUrl: /vue-nuxt
+tags:
+  - nuxt
+  - ssr
+  - client-only
+vue:
+  metaTitle: Use Handsontable in Nuxt - Vue 3 Data Grid | Handsontable
+searchCategory: Guides
+onlyFor: vue
+category: Getting started
+---
+
+Handsontable relies on browser APIs that are not available during server-side rendering. This page explains how to integrate Handsontable into a Nuxt 3 application without SSR errors.
+
+[[toc]]
+
+## Why Handsontable needs client-side rendering
+
+Nuxt 3 renders Vue components on the server before sending HTML to the browser. That server environment has no DOM -- no `window`, no `document`, no `HTMLElement`. Handsontable's initialization code and the underlying Walkontable rendering engine access these browser globals.
+
+When Nuxt runs a component that imports or initializes Handsontable on the server, you get errors like:
+
+```
+ReferenceError: window is not defined
+```
+
+The fix is to keep all Handsontable code out of the server rendering path.
+
+## Prerequisites
+
+- Nuxt 3 project set up and running.
+- Handsontable and the Vue 3 wrapper installed:
+
+  ```bash
+  npm install handsontable @handsontable/vue3
+  ```
+
+## Using `<ClientOnly>`
+
+Nuxt's built-in `<ClientOnly>` component prevents its children from rendering on the server. Wrap your `<HotTable>` in it:
+
+```vue
+<template>
+  <ClientOnly>
+    <HotTable :settings="gridSettings" />
+    <template #fallback>
+      <p>Loading the data grid...</p>
+    </template>
+  </ClientOnly>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const gridSettings = ref<GridSettings>({
+  data: [
+    ['Mercedes', 'Germany', 2000, 2023],
+    ['BMW', 'Germany', 1998, 2024],
+    ['Toyota', 'Japan', 2001, 2023],
+    ['Honda', 'Japan', 1999, 2022],
+    ['Ford', 'USA', 1997, 2024],
+  ],
+  colHeaders: ['Brand', 'Country', 'Since', 'Until'],
+  rowHeaders: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+```
+
+The `#fallback` slot renders on the server in place of the grid. Use it to show a placeholder or skeleton so the page has visible content before the browser takes over.
+
+::: tip
+
+`<ClientOnly>` prevents **rendering** on the server but the `import` statements still execute on the server. If you see a `window is not defined` error at import time rather than render time, use the `.client.vue` approach described below.
+
+:::
+
+## Using the `.client.vue` suffix
+
+Nuxt treats any component file ending in `.client.vue` as a client-only component -- it is excluded from the server bundle entirely, including its imports. This is the most robust option when a package accesses browser APIs at module load time.
+
+Create a wrapper component named with the `.client.vue` suffix:
+
+```
+components/
+└── HandsonGrid.client.vue
+```
+
+```vue
+<!-- components/HandsonGrid.client.vue -->
+<template>
+  <HotTable :settings="props.settings" />
+</template>
+
+<script setup lang="ts">
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const props = defineProps<{
+  settings: GridSettings;
+}>();
+</script>
+```
+
+Use it in your page without any additional wrapper:
+
+```vue
+<template>
+  <HandsonGrid :settings="gridSettings" />
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import type { GridSettings } from 'handsontable/settings';
+
+const gridSettings = ref<GridSettings>({
+  data: [
+    ['Mercedes', 'Germany', 2000, 2023],
+    ['BMW', 'Germany', 1998, 2024],
+    ['Toyota', 'Japan', 2001, 2023],
+    ['Honda', 'Japan', 1999, 2022],
+    ['Ford', 'USA', 1997, 2024],
+  ],
+  colHeaders: ['Brand', 'Country', 'Since', 'Until'],
+  rowHeaders: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+```
+
+::: tip
+
+The `.client.vue` convention only works with Nuxt auto-imports and `#components` imports. If you import the component using its full file path (for example, `import HandsonGrid from '~/components/HandsonGrid.client.vue'`), Nuxt does not apply the client-only behavior.
+
+:::
+
+## `nuxt.config.ts` notes
+
+For most Nuxt 3 projects (which use Vite by default), no extra configuration is needed. `<ClientOnly>` or `.client.vue` is sufficient.
+
+In rare cases -- for example, when using a Nuxt plugin that imports Handsontable in a server-side context -- you can add the packages to `build.transpile` as a fallback:
+
+```typescript
+// nuxt.config.ts
+export default defineNuxtConfig({
+  build: {
+    transpile: ['handsontable', '@handsontable/vue3'],
+  },
+});
+```
+
+Start with `<ClientOnly>` or `.client.vue` before reaching for this option.
+
+## Result
+
+Handsontable renders in the browser. The SSR pass shows the `#fallback` content (with `<ClientOnly>`) or nothing (with `.client.vue`), and the grid initializes once the Vue component mounts on the client.
+
+<div class="boxes-list gray">
+
+- [Working example with Nuxt](https://handsontable.com/codesandbox-vm?example-dir=nuxt&handsontable-version={{$currentVersion}})
+
+</div>
+
+## Related
+
+- [Vue 3 installation](@/guides/getting-started/installation/installation.md)

--- a/docs/content/guides/integrate-with-vue3/vue3-installation/vue3-installation.md
+++ b/docs/content/guides/integrate-with-vue3/vue3-installation/vue3-installation.md
@@ -87,6 +87,14 @@ You can reduce the size of your bundle by importing and registering only the
 
 :::
 
+## Next steps
+
+::: only-for vue
+
+- If you use Nuxt 3, read [Use Handsontable in Nuxt](@/guides/getting-started/vue3-nuxt/vue3-nuxt.md) to handle SSR.
+
+:::
+
 ## Related API reference
 
 **Configuration options**

--- a/docs/content/guides/sidebar.js
+++ b/docs/content/guides/sidebar.js
@@ -7,6 +7,7 @@ const gettingStartedItems = [
   { path: 'guides/getting-started/react-methods/react-methods', onlyFor: ['react'] },
   { path: 'guides/getting-started/angular-hot-instance/angular-hot-instance', onlyFor: ['angular'] },
   { path: 'guides/getting-started/vue3-hot-reference/vue3-hot-reference', onlyFor: ['vue'] },
+  { path: 'guides/getting-started/vue3-nuxt/vue3-nuxt', onlyFor: ['vue'] },
   { path: 'guides/getting-started/license-key/license-key' },
   { path: 'guides/getting-started/react-redux/react-redux', onlyFor: ['react'] },
   { path: 'guides/getting-started/vue3-vuex/vue3-vuex', onlyFor: ['vue'] },


### PR DESCRIPTION
### Context

The PR adds a new Vue-only "getting started" page covering how to use Handsontable in a Nuxt 3 application (`docs/content/guides/getting-started/vue3-nuxt/vue3-nuxt.md`).

Handsontable uses browser APIs (`window`, `document`) that are unavailable during SSR. Nuxt developers hit `ReferenceError: window is not defined` immediately on first install, with no guidance in the current docs. This page fills that gap.

**Coverage:**
- Why Handsontable requires client-side rendering in Nuxt (SSR environment has no DOM)
- `<ClientOnly>` wrapper with `#fallback` slot (primary approach)
- `.client.vue` suffix convention (more robust alternative — prevents server-side import, not just render)
- `nuxt.config.ts` `build.transpile` note (rarely needed in Vite-based Nuxt 3, documented as a last resort)

**Intentional omission:** The page uses code snippets only — no live `::: example` embeds and no "Edit on StackBlitz" button. The docs example runner and StackBlitz scaffold both build a plain Vite + Vue 3 project (`public/example-tabs.js`), not Nuxt. `<ClientOnly>` is a Nuxt-only component and would not resolve in that environment, so a runnable Nuxt demo is not feasible in this infrastructure.

**Correction from the ClickUp task spec:** The task mentioned `defineAsyncComponent` with `ssr: false` as an alternative. That API does not exist in Vue or Nuxt — it is a Next.js pattern (`dynamic(..., { ssr: false })`). The page documents the correct Nuxt mechanism: the `.client.vue` file suffix.

Also adds a cross-link from `vue3-installation.md` under a "Next steps" section (`::: only-for vue`).

### How has this been tested?

- Docs dev server started fresh (`npx astro dev --port 4329`)
- HTTP 200 confirmed at `/docs/vue-data-grid/vue-nuxt/`
- Page present in Vue sidebar; 0 references in JS, React, and Angular sidebars
- Slug `/vue-nuxt` verified unique (`grep -rn "permalink: /vue-nuxt" content/`)

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1763

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1763

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or library code impact.
> 
> **Overview**
> Adds a **Vue-only** getting started guide for **Nuxt 3** (`/vue-nuxt`) that explains why Handsontable breaks SSR and how to avoid `window is not defined`.
> 
> The new page documents **`<ClientOnly>`** (with a `#fallback` placeholder), **`.client.vue`** wrappers when imports run on the server, and optional **`build.transpile`** in `nuxt.config.ts` as a last resort. It uses snippets only (no live Nuxt example embed).
> 
> **Vue 3 installation** gains a **Next steps** section linking to the Nuxt guide, and the guide is listed in **`sidebar.js`** under Getting started with `onlyFor: ['vue']`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54709bb6a3f58c29d1f972093b0756e030318f37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->