### PR TITLE
DEV-1837: Modernize tsconfig.json and fix noImplicitThis errors

### DIFF
--- a/.changelogs/12722.json
+++ b/.changelogs/12722.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Improved TypeScript type annotations in built-in renderers and internal Core methods for strict-mode compatibility.",
+  "type": "changed",
+  "issueOrPR": 12722,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -103,6 +103,23 @@ const foreignHotInstances = new Map();
 const deprecationWarns = new Set();
 
 /**
+ * Internal Core properties not exposed in HotInstance but accessed by constructor-assigned
+ * function expressions. These are implementation details of the Core constructor that
+ * cannot be part of the public HotInstance interface.
+ *
+ * @private
+ */
+interface CoreInternals {
+  renderSuspendedCounter: number;
+  executionSuspendedCounter: number;
+  isExecutionSuspended(): boolean;
+  timeouts: ReturnType<typeof setTimeout>[];
+  microtasks: Array<{ cancelled: boolean }>;
+  _validateCells(callback?: (valid: boolean) => void, rows?: number[], columns?: number[]): void;
+  selectAll(includeRowHeaders?: boolean, includeColumnHeaders?: boolean, options?: Record<string, unknown>): void;
+}
+
+/**
  * Handsontable constructor.
  *
  * @core
@@ -1589,7 +1606,7 @@ export default function Core(
         this.validatorsInQueue = this.validatorsInQueue - 1 < 0 ? 0 : this.validatorsInQueue - 1;
         this.checkIfQueueIsEmpty();
       },
-      onQueueEmpty() { },
+      onQueueEmpty(_valid: boolean) { },
       checkIfQueueIsEmpty() {
         if (this.validatorsInQueue === 0 && resolved === false) {
           resolved = true;
@@ -2417,7 +2434,7 @@ export default function Core(
    * @since 8.3.0
    * @returns {boolean}
    */
-  this.isRenderSuspended = function() {
+  this.isRenderSuspended = function(this: HotInstance & CoreInternals) {
     return this.renderSuspendedCounter > 0;
   };
 
@@ -2455,7 +2472,7 @@ export default function Core(
    * hot.resumeRender(); // It re-renders the table internally
    * ```
    */
-  this.suspendRender = function() {
+  this.suspendRender = function(this: HotInstance & CoreInternals) {
     this.renderSuspendedCounter += 1;
   };
 
@@ -2489,7 +2506,7 @@ export default function Core(
    * hot.resumeRender(); // It re-renders the table internally
    * ```
    */
-  this.resumeRender = function() {
+  this.resumeRender = function(this: HotInstance & CoreInternals) {
     const nextValue = this.renderSuspendedCounter - 1;
 
     this.renderSuspendedCounter = Math.max(nextValue, 0);
@@ -2565,7 +2582,7 @@ export default function Core(
    * @since 8.3.0
    * @returns {boolean}
    */
-  this.isExecutionSuspended = function() {
+  this.isExecutionSuspended = function(this: HotInstance & CoreInternals) {
     return this.executionSuspendedCounter > 0;
   };
 
@@ -2591,7 +2608,7 @@ export default function Core(
    * hot.resumeExecution(); // It updates the cache internally
    * ```
    */
-  this.suspendExecution = function() {
+  this.suspendExecution = function(this: HotInstance & CoreInternals) {
     this.executionSuspendedCounter += 1;
     this.columnIndexMapper.suspendOperations();
     this.rowIndexMapper.suspendOperations();
@@ -2623,7 +2640,7 @@ export default function Core(
    * hot.resumeExecution(); // It updates the cache internally
    * ```
    */
-  this.resumeExecution = function(forceFlushChanges = false) {
+  this.resumeExecution = function(this: HotInstance & CoreInternals, forceFlushChanges = false) {
     const nextValue = this.executionSuspendedCounter - 1;
 
     this.executionSuspendedCounter = Math.max(nextValue, 0);
@@ -3406,7 +3423,7 @@ export default function Core(
    * @memberof Core#
    * @function clear
    */
-  this.clear = function() {
+  this.clear = function(this: HotInstance & CoreInternals) {
     this.selectAll();
     this.emptySelectedCells();
     this.deselectCell();
@@ -4032,7 +4049,8 @@ export default function Core(
    * @param {number} [deleteAmount=0] The number of items to be removed. If set to 0, no cell meta objects will be removed.
    * @param {...object} [cellMetaRows] The new cell meta row objects to be added to the cell meta collection.
    */
-  this.spliceCellsMeta = function(visualIndex: number, deleteAmount = 0, ...cellMetaRows: object[]) {
+  this.spliceCellsMeta = function(
+    this: HotInstance & CoreInternals, visualIndex: number, deleteAmount = 0, ...cellMetaRows: object[]) {
     if (cellMetaRows.length > 0 && !Array.isArray(cellMetaRows[0])) {
       throwWithCause('The 3rd argument (cellMetaRows) has to be passed as an array of cell meta objects array.');
     }
@@ -4046,7 +4064,9 @@ export default function Core(
         metaManager.createRow(instance.toPhysicalRow(visualIndex));
 
         arrayEach(cellMetaRow as unknown[],
-          (cellMeta, columnIndex) => this.setCellMetaObject(visualIndex, columnIndex, cellMeta));
+          (cellMeta, columnIndex) => {
+            this.setCellMetaObject(visualIndex, columnIndex, cellMeta as Record<string, unknown>);
+          });
       });
     }
 
@@ -4300,7 +4320,7 @@ export default function Core(
    * })
    * ```
    */
-  this.validateCells = function(callback?: (valid: boolean) => void) {
+  this.validateCells = function(this: HotInstance & CoreInternals, callback?: (valid: boolean) => void) {
     this._validateCells(callback);
   };
 
@@ -4323,7 +4343,7 @@ export default function Core(
    * })
    * ```
    */
-  this.validateRows = function(rows: number[], callback?: (valid: boolean) => void) {
+  this.validateRows = function(this: HotInstance & CoreInternals, rows: number[], callback?: (valid: boolean) => void) {
     if (!Array.isArray(rows)) {
       throwWithCause('validateRows parameter `rows` must be an array');
     }
@@ -4349,7 +4369,8 @@ export default function Core(
    * })
    * ```
    */
-  this.validateColumns = function(columns: number[], callback?: (valid: boolean) => void) {
+  this.validateColumns = function(
+    this: HotInstance & CoreInternals, columns: number[], callback?: (valid: boolean) => void) {
     if (!Array.isArray(columns)) {
       throwWithCause('validateColumns parameter `columns` must be an array');
     }
@@ -5919,7 +5940,7 @@ export default function Core(
    * @returns {number} The timeout handle (usable with `clearTimeout`).
    * @private
    */
-  this._registerTimeout = function(handle: Function | number, delay = 0) {
+  this._registerTimeout = function(this: HotInstance & CoreInternals, handle: Function | number, delay = 0) {
     let handleFunc = handle;
 
     if (typeof handleFunc === 'function') {
@@ -5936,7 +5957,7 @@ export default function Core(
    *
    * @private
    */
-  this._clearTimeouts = function() {
+  this._clearTimeouts = function(this: HotInstance & CoreInternals) {
     arrayEach(this.timeouts, (handler: ReturnType<typeof setTimeout>) => {
       clearTimeout(handler);
     });
@@ -5950,7 +5971,7 @@ export default function Core(
    * @param {Function} callback Function to be delayed in execution.
    * @private
    */
-  this._registerMicrotask = function(callback: Function) {
+  this._registerMicrotask = function(this: HotInstance & CoreInternals, callback: Function) {
     const entry = { cancelled: false };
 
     this.microtasks.push(entry);
@@ -5966,7 +5987,7 @@ export default function Core(
    *
    * @private
    */
-  this._clearMicrotasks = function() {
+  this._clearMicrotasks = function(this: HotInstance & CoreInternals) {
     arrayEach(this.microtasks, (entry: { cancelled: boolean }) => {
       entry.cancelled = true;
     });

--- a/handsontable/src/eventManager.ts
+++ b/handsontable/src/eventManager.ts
@@ -63,7 +63,7 @@ class EventManager {
      * @private
      * @param {Event} event The event object.
      */
-    function callbackProxy(event: Event) {
+    function callbackProxy(this: EventTarget, event: Event) {
       callbackRef.call(this, extendEvent(event));
     }
 

--- a/handsontable/src/helpers/function.ts
+++ b/handsontable/src/helpers/function.ts
@@ -29,7 +29,7 @@ export function throttle(func: (...args: unknown[]) => unknown, wait: number = 2
    * @param {...*} args The list of arguments passed during the function invocation.
    * @returns {object}
    */
-  function _throttle(...args: unknown[]) {
+  function _throttle(this: unknown, ...args: unknown[]) {
     const stamp = Date.now();
     let needCall = false;
 
@@ -86,7 +86,7 @@ export function throttleAfterHits(
    * @param {*} args The list of arguments passed during the function invocation.
    * @returns {*}
    */
-  function _throttleAfterHits(...args: unknown[]) {
+  function _throttleAfterHits(this: unknown, ...args: unknown[]) {
     if (remainHits) {
       remainHits -= 1;
 
@@ -118,7 +118,7 @@ export function debounce(
    * @param {*} args The list of arguments passed during the function invocation.
    * @returns {*}
    */
-  function _debounce(...args: unknown[]) {
+  function _debounce(this: unknown, ...args: unknown[]) {
     if (lastTimer) {
       clearTimeout(lastTimer);
     }
@@ -155,7 +155,7 @@ export function debounce(
 export function pipe(...functions: Array<(...args: unknown[]) => unknown>): (...args: unknown[]) => unknown {
   const [firstFunc, ...restFunc] = functions;
 
-  return function _pipe(...args) {
+  return function _pipe(this: unknown, ...args: unknown[]) {
     return arrayReduce(
       restFunc, (acc, fn) => (fn as (...args: unknown[]) => unknown)(acc), firstFunc.apply(this, args));
   };
@@ -169,7 +169,7 @@ export function pipe(...functions: Array<(...args: unknown[]) => unknown>): (...
  * @returns {Function}
  */
 export function partial(func: (...args: unknown[]) => unknown, ...params: unknown[]): (...args: unknown[]) => unknown {
-  return function _partial(...restParams) {
+  return function _partial(this: unknown, ...restParams: unknown[]) {
     return func.apply(this, params.concat(restParams));
   };
 }
@@ -204,7 +204,7 @@ export function curry(func: (...args: unknown[]) => unknown): (...args: unknown[
    * @returns {Function}
    */
   function given(argsSoFar: unknown[]) {
-    return function _curry(...params: unknown[]) {
+    return function _curry(this: unknown, ...params: unknown[]) {
       const passedArgsSoFar = argsSoFar.concat(params);
       let result;
 
@@ -251,7 +251,7 @@ export function curryRight(func: (...args: unknown[]) => unknown): (...args: unk
    * @returns {Function}
    */
   function given(argsSoFar: unknown[]) {
-    return function _curry(...params: unknown[]) {
+    return function _curry(this: unknown, ...params: unknown[]) {
       const passedArgsSoFar = argsSoFar.concat(params.reverse());
       let result;
 

--- a/handsontable/src/plugins/exportFile/contextMenuItem/exportItem.ts
+++ b/handsontable/src/plugins/exportFile/contextMenuItem/exportItem.ts
@@ -4,6 +4,7 @@ import {
   CONTEXTMENU_ITEMS_EXPORT_FILE_CSV,
   CONTEXTMENU_ITEMS_EXPORT_FILE_XLSX,
 } from '../../../i18n/constants';
+import type { HotInstance } from '../../../core/types';
 import type { ExportFile } from '../exportFile';
 import { PLUGIN_KEY } from '../exportFile';
 import { getExportOptions } from './utils';
@@ -22,30 +23,30 @@ import { getExportOptions } from './utils';
 export default function exportItem(exportFilePlugin: ExportFile): object {
   return {
     key: 'export_file',
-    name(): string {
+    name(this: HotInstance): string {
       return this.getTranslatedPhrase(CONTEXTMENU_ITEMS_EXPORT) as string;
     },
-    hidden() {
+    hidden(this: HotInstance) {
       return this.getSettings()[PLUGIN_KEY] === undefined;
     },
     submenu: {
       items: [
         {
           key: 'export_file:csv',
-          name(): string {
+          name(this: HotInstance): string {
             return this.getTranslatedPhrase(CONTEXTMENU_ITEMS_EXPORT_FILE_CSV) as string;
           },
-          callback() {
+          callback(this: HotInstance) {
             exportFilePlugin.downloadFile('csv', getExportOptions(this) as Record<string, unknown>);
           },
           disabled: false,
         },
         {
           key: 'export_file:xlsx',
-          name(): string {
+          name(this: HotInstance): string {
             return this.getTranslatedPhrase(CONTEXTMENU_ITEMS_EXPORT_FILE_XLSX) as string;
           },
-          callback() {
+          callback(this: HotInstance) {
             exportFilePlugin.downloadFileAsync(
               'xlsx', getExportOptions(this) as Record<string, unknown>
             ).catch((err) => {

--- a/handsontable/src/plugins/exportFile/contextMenuItem/exportItem.ts
+++ b/handsontable/src/plugins/exportFile/contextMenuItem/exportItem.ts
@@ -24,7 +24,7 @@ export default function exportItem(exportFilePlugin: ExportFile): object {
   return {
     key: 'export_file',
     name(this: HotInstance): string {
-      return this.getTranslatedPhrase(CONTEXTMENU_ITEMS_EXPORT) as string;
+      return this.getTranslatedPhrase(CONTEXTMENU_ITEMS_EXPORT);
     },
     hidden(this: HotInstance) {
       return this.getSettings()[PLUGIN_KEY] === undefined;
@@ -34,7 +34,7 @@ export default function exportItem(exportFilePlugin: ExportFile): object {
         {
           key: 'export_file:csv',
           name(this: HotInstance): string {
-            return this.getTranslatedPhrase(CONTEXTMENU_ITEMS_EXPORT_FILE_CSV) as string;
+            return this.getTranslatedPhrase(CONTEXTMENU_ITEMS_EXPORT_FILE_CSV);
           },
           callback(this: HotInstance) {
             exportFilePlugin.downloadFile('csv', getExportOptions(this) as Record<string, unknown>);
@@ -44,7 +44,7 @@ export default function exportItem(exportFilePlugin: ExportFile): object {
         {
           key: 'export_file:xlsx',
           name(this: HotInstance): string {
-            return this.getTranslatedPhrase(CONTEXTMENU_ITEMS_EXPORT_FILE_XLSX) as string;
+            return this.getTranslatedPhrase(CONTEXTMENU_ITEMS_EXPORT_FILE_XLSX);
           },
           callback(this: HotInstance) {
             exportFilePlugin.downloadFileAsync(

--- a/handsontable/src/plugins/nestedRows/ui/contextMenu.ts
+++ b/handsontable/src/plugins/nestedRows/ui/contextMenu.ts
@@ -1,6 +1,7 @@
 import { rangeEach } from '../../../helpers/number';
 import { arrayEach } from '../../../helpers/array';
 import * as C from '../../../i18n/constants';
+import type { HotInstance } from '../../../core/types';
 import BaseUI from './_base';
 
 /**
@@ -73,7 +74,7 @@ class ContextMenuUI extends BaseUI {
     const newEntries = [
       {
         key: 'add_child',
-        name(): string {
+        name(this: HotInstance): string {
           return String(this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_NESTED_ROWS_INSERT_CHILD));
         },
         callback: () => {
@@ -92,7 +93,7 @@ class ContextMenuUI extends BaseUI {
       },
       {
         key: 'detach_from_parent',
-        name(): string {
+        name(this: HotInstance): string {
           return String(this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_NESTED_ROWS_DETACH_CHILD));
         },
         callback: () => {

--- a/handsontable/src/renderers/autocompleteRenderer/autocompleteRenderer.ts
+++ b/handsontable/src/renderers/autocompleteRenderer/autocompleteRenderer.ts
@@ -20,6 +20,7 @@ export const RENDERER_TYPE: 'autocomplete' = 'autocomplete';
  * @param {object} cellProperties The cell meta object (see {@link Core#getCellMeta}).
  */
 export function autocompleteRenderer(
+  this: unknown,
   hotInstance: HotInstance, TD: HTMLTableCellElement, row: number, col: number,
   prop: string | number, value: unknown, cellProperties: Record<string, unknown>): void {
   const { rootDocument } = hotInstance;
@@ -35,7 +36,8 @@ export function autocompleteRenderer(
 
   ARROW.appendChild(rootDocument.createTextNode(String.fromCharCode(9660)));
 
-  rendererFunc.apply(this, [hotInstance, TD, row, col, prop, value, cellProperties]);
+  (rendererFunc as (this: unknown, ...args: unknown[]) => void)
+    .apply(this, [hotInstance, TD, row, col, prop, value, cellProperties]);
 
   if (!TD.firstChild) { // http://jsperf.com/empty-node-if-needed
     // otherwise empty fields appear borderless in demo/renderers.html (IE)

--- a/handsontable/src/renderers/dateRenderer/dateRenderer.ts
+++ b/handsontable/src/renderers/dateRenderer/dateRenderer.ts
@@ -16,6 +16,7 @@ export const RENDERER_TYPE: 'date' = 'date';
  * @param {object} cellProperties The cell meta object (see {@link Core#getCellMeta}).
  */
 export function dateRenderer(
+  this: unknown,
   hotInstance: HotInstance, TD: HTMLTableCellElement, row: number, col: number,
   prop: string | number, value: unknown, cellProperties: Record<string, unknown>): void {
   autocompleteRenderer.apply(this, [hotInstance, TD, row, col, prop, value, cellProperties]);

--- a/handsontable/src/renderers/dropdownRenderer/dropdownRenderer.ts
+++ b/handsontable/src/renderers/dropdownRenderer/dropdownRenderer.ts
@@ -16,6 +16,7 @@ export const RENDERER_TYPE: 'dropdown' = 'dropdown';
  * @param {object} cellProperties The cell meta object (see {@link Core#getCellMeta}).
  */
 export function dropdownRenderer(
+  this: unknown,
   hotInstance: HotInstance, TD: HTMLTableCellElement, row: number, col: number,
   prop: string | number, value: unknown, cellProperties: Record<string, unknown>): void {
   autocompleteRenderer.apply(this, [hotInstance, TD, row, col, prop, value, cellProperties]);

--- a/handsontable/src/renderers/handsontableRenderer/handsontableRenderer.ts
+++ b/handsontable/src/renderers/handsontableRenderer/handsontableRenderer.ts
@@ -16,6 +16,7 @@ export const RENDERER_TYPE: 'handsontable' = 'handsontable';
  * @param {object} cellProperties The cell meta object (see {@link Core#getCellMeta}).
  */
 export function handsontableRenderer(
+  this: unknown,
   hotInstance: HotInstance, TD: HTMLTableCellElement, row: number, col: number,
   prop: string | number, value: unknown, cellProperties: Record<string, unknown>): void {
   autocompleteRenderer.apply(this, [hotInstance, TD, row, col, prop, value, cellProperties]);

--- a/handsontable/src/renderers/htmlRenderer/htmlRenderer.ts
+++ b/handsontable/src/renderers/htmlRenderer/htmlRenderer.ts
@@ -13,6 +13,7 @@ export const RENDERER_TYPE: 'html' = 'html';
  * @param {*} value The rendered value.
  */
 export function htmlRenderer(
+  this: unknown,
   hotInstance: HotInstance, TD: HTMLTableCellElement, row: number, col: number,
   prop: string | number, value: unknown): void {
   fastInnerHTML(TD, value === null || value === undefined ? '' : value as string, false);

--- a/handsontable/src/renderers/numericRenderer/numericRenderer.ts
+++ b/handsontable/src/renderers/numericRenderer/numericRenderer.ts
@@ -39,6 +39,7 @@ export function valueFormatter(value: unknown, cellProperties: Record<string, un
  * @param {object} cellProperties The cell meta object (see {@link Core#getCellMeta}).
  */
 export function numericRenderer(
+  this: unknown,
   hotInstance: HotInstance, TD: HTMLTableCellElement, row: number, col: number,
   prop: string | number, value: unknown, cellProperties: Record<string, unknown>): void {
   const isNumbroFormat = isNumbroScheme(cellProperties);

--- a/handsontable/src/renderers/selectRenderer/selectRenderer.ts
+++ b/handsontable/src/renderers/selectRenderer/selectRenderer.ts
@@ -14,6 +14,7 @@ export const RENDERER_TYPE: 'select' = 'select';
  * @param {object} cellProperties The cell meta object (see {@link Core#getCellMeta}).
  */
 export function selectRenderer(
+  this: unknown,
   hotInstance: HotInstance, TD: HTMLTableCellElement, row: number, col: number,
   prop: string | number, value: unknown, cellProperties: Record<string, unknown>): void {
   textRenderer.apply(this, [hotInstance, TD, row, col, prop, value, cellProperties]);

--- a/handsontable/src/renderers/textRenderer/textRenderer.ts
+++ b/handsontable/src/renderers/textRenderer/textRenderer.ts
@@ -17,6 +17,7 @@ export const RENDERER_TYPE: 'text' = 'text';
  * @param {object} cellProperties The cell meta object (see {@link Core#getCellMeta}).
  */
 export function textRenderer(
+  this: unknown,
   hotInstance: HotInstance, TD: HTMLTableCellElement, row: number, col: number,
   prop: string | number, value: unknown, cellProperties: Record<string, unknown>): void {
   let escaped = value;

--- a/handsontable/src/renderers/timeRenderer/timeRenderer.ts
+++ b/handsontable/src/renderers/timeRenderer/timeRenderer.ts
@@ -16,6 +16,7 @@ export const RENDERER_TYPE: 'time' = 'time';
  * @param {object} cellProperties The cell meta object (see {@link Core#getCellMeta}).
  */
 export function timeRenderer(
+  this: unknown,
   hotInstance: HotInstance, TD: HTMLTableCellElement, row: number, col: number,
   prop: string | number, value: unknown, cellProperties: Record<string, unknown>): void {
   textRenderer.apply(this, [hotInstance, TD, row, col, prop, value, cellProperties]);

--- a/handsontable/tsconfig.json
+++ b/handsontable/tsconfig.json
@@ -1,25 +1,22 @@
 {
   "compilerOptions": {
-    "target": "es2015",
-    "module": "es2015",
-    "lib": ["es2015", "es2016", "es2017", "es2020", "esnext", "dom", "dom.iterable"],
+    "target": "es2020",
+    "module": "esnext",
+    "lib": ["esnext", "dom", "dom.iterable"],
     "allowJs": false,
     "checkJs": false,
     "noEmit": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "strict": true,
     "noImplicitAny": true,
-    "noImplicitThis": false,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": false,
-    "ignoreDeprecations": "6.0",
-    "baseUrl": ".",
+    "forceConsistentCasingInFileNames": true,
     "paths": {
-      "handsontable/*": ["src/*"]
+      "handsontable/*": ["./src/*"]
     }
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
### Context

The PR modernizes `handsontable/tsconfig.json` to align with the 2026/TS 6 baseline and fixes all `noImplicitThis` errors exposed by the updated configuration.

**`tsconfig.json` changes:**
- `target`: `es2015` → `es2020` (matches browser targets: Chrome ≥ 110, Firefox ≥ 110, Safari ≥ 14.1; no runtime impact — Babel/SWC own transpilation)
- `module`: `es2015` → `esnext`
- `lib`: collapsed to `["esnext", "dom", "dom.iterable"]`
- `moduleResolution`: `node` → `bundler` (correct for Rspack/Babel projects, no extension required on imports)
- `forceConsistentCasingInFileNames`: `false` → `true`
- Removed `noImplicitThis: false` — enables strict `this` checking
- Removed `ignoreDeprecations: "6.0"` — no longer needed
- Removed `baseUrl: "."` — paths use `"./src/*"` relative references instead

**`noImplicitThis` fixes:**

Removing `noImplicitThis: false` revealed untyped `this` in ~15 locations across:
- **`core.ts`** — Constructor-assigned function expressions access private instance state (`renderSuspendedCounter`, `executionSuspendedCounter`, `timeouts`, `microtasks`, etc.) not declared in the public `HotInstance` interface. A new `CoreInternals` interface is introduced for these private properties; all 15 function expressions use `this: HotInstance & CoreInternals` instead of the temporary `this: any`.
- **Renderers** (`textRenderer`, `htmlRenderer`, `autocompleteRenderer`, `dateRenderer`, `dropdownRenderer`, `handsontableRenderer`, `numericRenderer`, `selectRenderer`, `timeRenderer`) — annotated with `this: unknown` to preserve the existing `.apply(this, [...])` delegation chain without breaking changes.
- **`eventManager.ts`** — `callbackProxy` annotated with `this: EventTarget`.
- **`helpers/function.ts`** — Inner wrapper functions annotated with `this: unknown`.
- **Context menu items** (`exportItem.ts`, `nestedRows/ui/contextMenu.ts`) — Method shorthands annotated with `this: HotInstance`.

All changes are non-breaking: renderer `this` forwarding behavior is preserved, and the `build:types` pipeline (`tsc` + `downlevel-dts` + `test/types`) passes cleanly.

### How has this been tested?

- `npm run test:types --prefix handsontable` — passes (tsc + downlevel-dts + test/types)
- `npm run eslint --prefix handsontable -- src/core.ts src/renderers/autocompleteRenderer/autocompleteRenderer.ts` — no errors

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1837

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1837

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compile-time-only annotations and tsconfig alignment; renderer `this` forwarding and public APIs are intentionally unchanged.
> 
> **Overview**
> **Modernizes** `handsontable/tsconfig.json` for stricter TypeScript (e.g. `target`/`module` updates, `moduleResolution: "bundler"`, `forceConsistentCasingInFileNames: true`) and **drops** `noImplicitThis: false`, so implicit-`this` issues must be fixed across the codebase.
> 
> **Adds** a private `CoreInternals` interface and types constructor-bound Core methods as `this: HotInstance & CoreInternals` (render/execution suspend, timeouts/microtasks, validation, `clear`, `spliceCellsMeta`, etc.). **Annotates** built-in renderers with `this: unknown` to keep `.apply(this, …)` delegation; **types** context-menu shorthands with `this: HotInstance`; **fixes** `eventManager` proxy and `helpers/function` wrappers similarly. **Includes** a non-breaking changelog entry for improved strict-mode typings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddd54a2753301f4eda56687ca1a86ff41c6fe418. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->