### PR TITLE
DEV-1842: Remove deprecated #exposeAPIToCore from UndoRedo plugin

### DIFF
--- a/.changelogs/12728.json
+++ b/.changelogs/12728.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Removed the deprecated Core-level undo/redo methods (`hot.undo()`, `hot.redo()`, `hot.clearUndo()`, `hot.isUndoAvailable()`, `hot.isRedoAvailable()`, `hot.undoRedo`). Use `hot.getPlugin('undoRedo')` instead.",
+  "type": "removed",
+  "issueOrPR": 12728,
+  "breaking": true,
+  "framework": "none"
+}

--- a/docs/content/guides/accessories-and-menus/undo-redo/undo-redo.md
+++ b/docs/content/guides/accessories-and-menus/undo-redo/undo-redo.md
@@ -121,18 +121,6 @@ Here's the list of all unsupported features:
 
 </div>
 
-**Core methods**
-
-<div class="boxes-list">
-
-- [clearUndo()](@/api/core.md#clearundo)
-- [isRedoAvailable()](@/api/core.md#isredoavailable)
-- [isUndoAvailable()](@/api/core.md#isundoavailable)
-- [redo()](@/api/core.md#redo)
-- [undo()](@/api/core.md#undo)
-
-</div>
-
 **Hooks**
 
 <div class="boxes-list">

--- a/handsontable/src/__tests__/core/methods.types.ts
+++ b/handsontable/src/__tests__/core/methods.types.ts
@@ -57,7 +57,6 @@ hot.batch(() => {});
 (hot.batchRender(() => 'string') as string).toUpperCase();
 (hot.batchRender(() => 12345) as number).toFixed();
 (hot as any).clear();
-hot.clearUndo?.();
 hot.colToProp(123) === 'foo';
 hot.countCols() === 123;
 (hot as any).countEmptyCols(true) === 123;

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -5672,14 +5672,6 @@ export default function Core(
    * @returns {string}
    */
   this.getPluginName = function(plugin: Record<string, unknown>) {
-    // Workaround for the UndoRedo plugin which, currently doesn't follow the plugin architecture.
-    if (plugin === instance.undoRedo) {
-      const undoRedoWithCtor = instance.undoRedo as
-        Record<string, unknown> & { constructor: Record<string, unknown> };
-
-      return undoRedoWithCtor.constructor.PLUGIN_KEY as string;
-    }
-
     return pluginsRegistry.getId(plugin) as string;
   };
 

--- a/handsontable/src/core/types.ts
+++ b/handsontable/src/core/types.ts
@@ -218,14 +218,6 @@ export interface HotInstance {
     to?: { row: number | null; col: number | null } | CellCoords
   ): CellRange;
 
-  // Undo/Redo
-  undo?(): void;
-  redo?(): void;
-  clearUndo?(): void;
-  isUndoAvailable?(): boolean;
-  isRedoAvailable?(): boolean;
-  undoRedo?: object;
-
   // Plugins
   getPlugin<K extends keyof PluginTypeMap>(pluginName: K): PluginTypeMap[K];
   getPlugin(pluginName: string): BasePlugin;

--- a/handsontable/src/plugins/undoRedo/undoRedo.ts
+++ b/handsontable/src/plugins/undoRedo/undoRedo.ts
@@ -2,12 +2,9 @@ import type { HotInstance } from '../../core/types';
 import { BasePlugin } from '../base';
 import { Hooks } from '../../core/hooks';
 import { deepClone } from '../../helpers/object';
-import { warn } from '../../helpers/console';
-import { toSingleLine } from '../../helpers/templateLiteralTag';
 import { registerActions } from './actions';
 
 const SHORTCUTS_GROUP = 'undoRedo';
-const deprecationWarns = new Set<unknown>();
 
 export interface UndoRedoAction {
   actionType: string;
@@ -333,84 +330,6 @@ export class UndoRedo extends BasePlugin {
       this.clear();
     }
   };
-
-  /**
-   * Expose the plugin API to the Core. It is for backward compatibility and it should be removed in the future.
-   */
-  #exposeAPIToCore() {
-    const deprecatedWarn = (methodName: unknown) => {
-      if (!deprecationWarns.has(methodName)) {
-        warn(toSingleLine`The "${methodName}" method is deprecated and it will be removed\x20
-          from the Core API in the future. Please use the method from the UndoRedo plugin\x20
-          (e.g. \`hotInstance.getPlugin("undoRedo").${methodName}()\`).`);
-
-        deprecationWarns.add(methodName);
-      }
-    };
-
-    /**
-     * @alias undo
-     * @deprecated This method is deprecated and it will be removed from the Core API in the future. Please use the method from the [`UndoRedo`](@/api/undoRedo.md#undo-2) plugin.
-     * @memberof! Core#
-     */
-    this.hot.undo = () => {
-      deprecatedWarn('undo');
-      this.undo();
-    };
-    /**
-     * @alias redo
-     * @deprecated This method is deprecated and it will be removed from the Core API in the future. Please use the method from the [`UndoRedo`](@/api/undoRedo.md#redo) plugin.
-     * @memberof! Core#
-     */
-    this.hot.redo = () => {
-      deprecatedWarn('redo');
-      this.redo();
-    };
-    /**
-     * @alias isUndoAvailable
-     * @deprecated This method is deprecated and it will be removed from the Core API in the future. Please use the method from the [`UndoRedo`](@/api/undoRedo.md#isundoavailable) plugin.
-     * @memberof! Core#
-     * @returns {boolean}
-     */
-    this.hot.isUndoAvailable = () => {
-      deprecatedWarn('isUndoAvailable');
-
-      return this.isUndoAvailable();
-    };
-    /**
-     * @alias isRedoAvailable
-     * @deprecated This method is deprecated and it will be removed from the Core API in the future. Please use the method from the [`UndoRedo`](@/api/undoRedo.md#isredoavailable) plugin.
-     * @memberof! Core#
-     * @returns {boolean}
-     */
-    this.hot.isRedoAvailable = () => {
-      deprecatedWarn('isRedoAvailable');
-
-      return this.isRedoAvailable();
-    };
-    /**
-     * @alias clearUndo
-     * @deprecated This method is deprecated and it will be removed from the Core API in the future. Please use the method from the [`UndoRedo`](@/api/undoRedo.md#clear) plugin.
-     * @memberof! Core#
-     */
-    this.hot.clearUndo = () => {
-      deprecatedWarn('clear');
-      this.clear();
-    };
-    this.hot.undoRedo = this;
-  }
-
-  /**
-   * Removes the plugin API from the Core. It is for backward compatibility and it should be removed in the future.
-   */
-  #removeAPIFromCore() {
-    delete this.hot.undo;
-    delete this.hot.redo;
-    delete this.hot.isUndoAvailable;
-    delete this.hot.isRedoAvailable;
-    delete this.hot.clearUndo;
-    delete this.hot.undoRedo;
-  }
 
   /**
    * Destroys the plugin instance.


### PR DESCRIPTION
### Context

The PR removes the deprecated `#exposeAPIToCore()` and `#removeAPIFromCore()` private methods from the `UndoRedo` plugin, along with all the stale Core-level API surface they were meant to manage.

**Key finding:** these methods were *never called*. They were introduced during the TypeScript conversion (commit `18e73ccca1`) but the call site was never committed. As a result, `hot.undo()`, `hot.redo()`, `hot.clearUndo()`, `hot.isUndoAvailable()`, `hot.isRedoAvailable()`, and `hot.undoRedo` have been `undefined` at runtime since the TS migration — calling them would throw "is not a function". The deprecation warning never fired either.

The change aligns the public TypeScript API surface with reality and removes a dead `instance.undoRedo` workaround branch in `getPluginName` (which also had a latent crash: `getPluginName(undefined)` → `undefined.constructor.PLUGIN_KEY`).

**This is a breaking change** targeting the 18.0 release: the optional `undo?`, `redo?`, `clearUndo?`, `isUndoAvailable?`, `isRedoAvailable?`, and `undoRedo?` members are removed from `HotInstance`. Runtime behavior is unchanged (they were already `undefined`), but TypeScript consumers referencing these members will now get a compile error.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1842

### How has this been tested?

- ESLint passes: `node scripts/run.mjs lint:eslint` — clean
- Type declarations rebuilt via `npm run build:types` — `tmp/core/types.d.ts` no longer contains the removed members
- `npm run test:types` (via `tsc -p test/types`) — verifies the type surface via `src/**/*.types.ts`

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1842

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking TypeScript surface for undo/redo on Core; runtime was already without those methods, but migrations must switch to the plugin API.
> 
> **Overview**
> **Breaking change for 18.0:** Core-level undo/redo members are dropped from the public API. `HotInstance` no longer declares `undo`, `redo`, `clearUndo`, `isUndoAvailable`, `isRedoAvailable`, or `undoRedo`; callers should use `hot.getPlugin('undoRedo')` instead.
> 
> Implementation cleanup removes the unused UndoRedo `#exposeAPIToCore` / `#removeAPIFromCore` shims (and related deprecation warnings) plus the special-case in `getPluginName` for `instance.undoRedo`. The undo/redo guide’s “Core methods” list is removed, and a changelog entry documents the removal.
> 
> Runtime behavior is intended to stay the same—the Core shortcuts were not wired up after the TS migration—while TypeScript projects that still reference those Core members will fail to compile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8565b5ce6920daf2fd719861e4e8a96cd62ab563. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->