### PR TITLE
DEV-1843: Revert HotTableModule version to 0.0.0-VERSION placeholder

### DIFF
--- a/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.module.ts
+++ b/wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.module.ts
@@ -6,5 +6,5 @@ import { HotTableComponent } from './hot-table.component';
   exports: [HotTableComponent],
 })
 export class HotTableModule {
-  static readonly version = '17.1.0';
+  static readonly version = '0.0.0-VERSION';
 }


### PR DESCRIPTION
### Context

The PR reverts `HotTableModule.version` from a hardcoded release value (`'17.1.0'`) back to the `'0.0.0-VERSION'` placeholder. This placeholder is required by the autogenerated release pipeline — the build system replaces it with the actual version at release time. Without it, the version string in the Angular wrapper would be stale after each release.

### How has this been tested?

- Manual inspection: confirmed the placeholder value is correct per the release automation scripts
- `npm run test --prefix wrappers/angular-wrapper` passes

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1843

### Affected project(s):

- [ ] `handsontable`
- [x] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1843

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single static version string change with no runtime behavior impact beyond correct release-time versioning.
> 
> **Overview**
> Restores `HotTableModule.version` in the Angular wrapper from the hardcoded `'17.1.0'` back to the **`'0.0.0-VERSION'`** release placeholder so `pre-build.js` / `post-build.js` can inject the real package version during builds instead of shipping a stale string in source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe8145a8c5d75a1279c23f22ee986141c0d9496f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->