### PR TITLE
DEV-1820: Remove vestigial VuePress id fields from framework frontmatter

### DIFF
--- a/docs/content/guides/accessibility/accessibility-conformance-report/accessibility-conformance-report.md
+++ b/docs/content/guides/accessibility/accessibility-conformance-report/accessibility-conformance-report.md
@@ -1,6 +1,5 @@
 ---
 type: reference
-id: r7vpat01
 title: Accessibility conformance report (VPAT)
 metaTitle: Accessibility conformance report (VPAT) - JavaScript Data Grid | Handsontable
 description: Review Handsontable's Voluntary Product Accessibility Template (VPAT) report, covering WCAG 2.2 Level A and AA conformance.
@@ -15,13 +14,10 @@ tags:
   - conformance
   - section 508
 react:
-  id: r7vpat02
   metaTitle: Accessibility conformance report (VPAT) - React Data Grid | Handsontable
 angular:
-  id: r7vpat03
   metaTitle: Accessibility conformance report (VPAT) - Angular Data Grid | Handsontable
 vue:
-  id: vvtwmknl
   metaTitle: Accessibility conformance report (VPAT) - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Accessibility

--- a/docs/content/guides/accessibility/accessibility/accessibility.md
+++ b/docs/content/guides/accessibility/accessibility/accessibility.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: o4qhm1bg
 title: Accessibility
 metaTitle: Accessibility - JavaScript Data Grid | Handsontable
 description: Learn about Handsontable's accessibility features.
@@ -19,13 +18,10 @@ tags:
   - compliance
   - vpat
 react:
-  id: x82phf34
   metaTitle: Accessibility - React Data Grid | Handsontable
 angular:
-  id: 99l3uae8
   metaTitle: Accessibility - Angular Data Grid | Handsontable
 vue:
-  id: br13tylp
   metaTitle: Accessibility - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Accessibility

--- a/docs/content/guides/accessories-and-menus/context-menu/context-menu.md
+++ b/docs/content/guides/accessories-and-menus/context-menu/context-menu.md
@@ -1,6 +1,5 @@
 ---
 type: reference
-id: 3hrrxxln
 title: Context menu
 metaTitle: Context menu - JavaScript Data Grid | Handsontable
 description: Quickly access contextual actions such as removing rows, inserting columns or copying data, by opening the context menu.
@@ -12,13 +11,10 @@ tags:
   - pop-up menu
   - right-click menu
 react:
-  id: r2x6mh6h
   metaTitle: Context menu - React Data Grid | Handsontable
 angular:
-  id: 3xspgb3u
   metaTitle: Context menu - Angular Data Grid | Handsontable
 vue:
-  id: qgm3koe6
   metaTitle: Context menu - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Accessories and menus

--- a/docs/content/guides/accessories-and-menus/drag-to-scroll/drag-to-scroll.md
+++ b/docs/content/guides/accessories-and-menus/drag-to-scroll/drag-to-scroll.md
@@ -1,6 +1,5 @@
 ---
 type: reference
-id: k3mw9bpx
 title: Drag to scroll
 metaTitle: Drag to scroll - JavaScript Data Grid | Handsontable
 description: Scroll the grid automatically by dragging a cell selection or fill handle outside the visible viewport.
@@ -13,13 +12,10 @@ tags:
   - selection scroll
   - fill handle scroll
 react:
-  id: j8nt5qra
   metaTitle: Drag to scroll - React Data Grid | Handsontable
 angular:
-  id: h2vz7cfs
   metaTitle: Drag to scroll - Angular Data Grid | Handsontable
 vue:
-  id: axdawq9z
   metaTitle: Drag to scroll - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Accessories and menus

--- a/docs/content/guides/accessories-and-menus/empty-data-state/empty-data-state.md
+++ b/docs/content/guides/accessories-and-menus/empty-data-state/empty-data-state.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: 7b3d9f2e
 title: Empty Data State
 metaTitle: Empty Data State - JavaScript Data Grid | Handsontable
 description: Display empty data state overlays and provide user feedback when your data grid has no data to display using the Empty Data State plugin.
@@ -14,13 +13,10 @@ tags:
   - user feedback
   - overlay
 react:
-  id: c8e4a1b5
   metaTitle: Empty Data State - React Data Grid | Handsontable
 angular:
-  id: 9f2e8c4a
   metaTitle: Empty Data State - Angular Data Grid | Handsontable
 vue:
-  id: qx83am9a
   metaTitle: Empty Data State - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Accessories and Menus

--- a/docs/content/guides/accessories-and-menus/export-to-csv/export-to-csv.md
+++ b/docs/content/guides/accessories-and-menus/export-to-csv/export-to-csv.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: 51aacis1
 title: Export to CSV
 metaTitle: Export to CSV - JavaScript Data Grid | Handsontable
 description: Export your grid's raw data to the CSV format, as a downloadable file, a blob, or a string. Customize your export using Handsontable's configuration options.
@@ -10,13 +9,10 @@ tags:
   - export to file
   - save file
 react:
-  id: sfxo3g54
   metaTitle: Export to CSV - React Data Grid | Handsontable
 angular:
-  id: hwhzgoir
   metaTitle: Export to CSV - Angular Data Grid | Handsontable
 vue:
-  id: z1ogjdj0
   metaTitle: Export to CSV - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Accessories and menus

--- a/docs/content/guides/accessories-and-menus/export-to-excel/export-to-excel.md
+++ b/docs/content/guides/accessories-and-menus/export-to-excel/export-to-excel.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: b4qs2km7
 title: Export to Excel
 metaTitle: Export to Excel - JavaScript Data Grid | Handsontable
 description: Export your grid data to an Excel (.xlsx) file, preserving cell types, styling, formulas, merged cells, and more. Requires ExcelJS as a peer dependency.
@@ -12,13 +11,10 @@ tags:
   - xlsx
   - excel
 react:
-  id: lf2p8nx3
   metaTitle: Export to Excel - React Data Grid | Handsontable
 angular:
-  id: wm5j9ry1
   metaTitle: Export to Excel - Angular Data Grid | Handsontable
 vue:
-  id: 2a0aqf2z
   metaTitle: Export to Excel - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Accessories and menus

--- a/docs/content/guides/accessories-and-menus/icon-pack/icon-pack.md
+++ b/docs/content/guides/accessories-and-menus/icon-pack/icon-pack.md
@@ -1,6 +1,5 @@
 ---
 type: reference
-id: zu0ja2qo
 title: Icon pack
 metaTitle: Icon pack - JavaScript Data Grid | Handsontable
 description: Create toolbars, menu bars, and context menus with our set of icons, designed specifically for tables, spreadsheets, and data-rich components.
@@ -10,13 +9,10 @@ tags:
   - spreadsheet icons
   - toolbar icons
 react:
-  id: 24wgu6o9
   metaTitle: Icon pack - React Data Grid | Handsontable
 angular:
-  id: 5qu8t28e
   metaTitle: Icon pack - Angular Data Grid | Handsontable
 vue:
-  id: x2vg8kb0
   metaTitle: Icon pack - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Accessories and menus

--- a/docs/content/guides/accessories-and-menus/undo-redo/undo-redo.md
+++ b/docs/content/guides/accessories-and-menus/undo-redo/undo-redo.md
@@ -1,6 +1,5 @@
 ---
 type: reference
-id: glh01i6q
 title: Undo and redo
 metaTitle: Undo and redo - JavaScript Data Grid | Handsontable
 description: Revert and restore your changes, using the undo and redo features.
@@ -15,13 +14,10 @@ tags:
   - erase last change
   - roll back changes
 react:
-  id: me8uxp3w
   metaTitle: Undo and redo - React Data Grid | Handsontable
 angular:
-  id: o21k5bjr
   metaTitle: Undo and redo - Angular Data Grid | Handsontable
 vue:
-  id: lf37v5ul
   metaTitle: Undo and redo - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Accessories and menus

--- a/docs/content/guides/cell-features/autofill-values/autofill-values.md
+++ b/docs/content/guides/cell-features/autofill-values/autofill-values.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: if13we5c
 title: Autofill values
 metaTitle: Autofill values - JavaScript Data Grid | Handsontable
 description: Copy a cell's value into multiple other cells, using the "fill handle" UI element. Configure the direction of copying, and more, through Handsontable's API.
@@ -15,13 +14,10 @@ tags:
   - auto-fill
   - auto fill
 react:
-  id: m4x3zpiw
   metaTitle: Autofill values - React Data Grid | Handsontable
 angular:
-  id: 8tftfxgq
   metaTitle: Autofill values - Angular Data Grid | Handsontable
 vue:
-  id: mhnmzkay
   metaTitle: Autofill values - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features

--- a/docs/content/guides/cell-features/clipboard/clipboard.md
+++ b/docs/content/guides/cell-features/clipboard/clipboard.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: 2vbt7ev0
 title: Clipboard
 metaTitle: Clipboard - JavaScript Data Grid | Handsontable
 description: Copy data from selected cells to the clipboard, using the "Ctrl/Cmd + C" shortcut or the context menu. Control the clipboard with Handsontable's API.
@@ -11,13 +10,10 @@ tags:
   - cut
   - paste
 react:
-  id: mlctr1ri
   metaTitle: Clipboard - React Data Grid | Handsontable
 angular:
-  id: q473yaal
   metaTitle: Clipboard - Angular Data Grid | Handsontable
 vue:
-  id: hiuseqwy
   metaTitle: Clipboard - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features

--- a/docs/content/guides/cell-features/comments/comments.md
+++ b/docs/content/guides/cell-features/comments/comments.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: deqvum60
 title: Comments
 metaTitle: Comments - JavaScript Data Grid | Handsontable
 description: Add a comment (a note) to a cell, using the context menu, just like in Excel. Edit and delete comments. Make comments read-only.
@@ -9,13 +8,10 @@ canonicalUrl: /comments
 tags:
   - notes
 react:
-  id: lxw2632u
   metaTitle: Comments - React Data Grid | Handsontable
 angular:
-  id: o4jcn137
   metaTitle: Comments - Angular Data Grid | Handsontable
 vue:
-  id: 5vq1pcjg
   metaTitle: Comments - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features

--- a/docs/content/guides/cell-features/conditional-formatting/conditional-formatting.md
+++ b/docs/content/guides/cell-features/conditional-formatting/conditional-formatting.md
@@ -1,19 +1,15 @@
 ---
 type: reference
-id: 4ca0c70r
 title: Conditional formatting
 metaTitle: Conditional formatting - JavaScript Data Grid | Handsontable
 description: Format specified cells, based on dynamic conditions.
 permalink: /conditional-formatting
 canonicalUrl: /conditional-formatting
 react:
-  id: eyatgywe
   metaTitle: Conditional formatting - React Data Grid | Handsontable
 angular:
-  id: uz3qc620
   metaTitle: Conditional formatting - Angular Data Grid | Handsontable
 vue:
-  id: 6w0okh8i
   metaTitle: Conditional formatting - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features

--- a/docs/content/guides/cell-features/disabled-cells/disabled-cells.md
+++ b/docs/content/guides/cell-features/disabled-cells/disabled-cells.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: k41dcpud
 title: Disabled cells
 metaTitle: Disabled cells - JavaScript Data Grid | Handsontable
 description: Make specified cells read-only to protect them from unwanted changes but still allow navigation and copying of data.
@@ -13,13 +12,10 @@ tags:
   - noneditable
   - locked
 react:
-  id: zhv7fs29
   metaTitle: Disabled cells - React Data Grid | Handsontable
 angular:
-  id: 2epog9e1
   metaTitle: Disabled cells - Angular Data Grid | Handsontable
 vue:
-  id: jn1egqb7
   metaTitle: Disabled cells - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features

--- a/docs/content/guides/cell-features/formatting-cells/formatting-cells.md
+++ b/docs/content/guides/cell-features/formatting-cells/formatting-cells.md
@@ -1,19 +1,15 @@
 ---
 type: how-to
-id: epmvqw9m
 title: Formatting cells
 metaTitle: Formatting cells - JavaScript Data Grid | Handsontable
 description: Change the appearance of cells, using custom CSS classes, inline styles, or custom cell borders.
 permalink: /formatting-cells
 canonicalUrl: /formatting-cells
 react:
-  id: qywqgovy
   metaTitle: Formatting cells - React Data Grid | Handsontable
 angular:
-  id: 0eswjne7
   metaTitle: Formatting cells - Angular Data Grid | Handsontable
 vue:
-  id: dqqkqp0d
   metaTitle: Formatting cells - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features

--- a/docs/content/guides/cell-features/merge-cells/merge-cells.md
+++ b/docs/content/guides/cell-features/merge-cells/merge-cells.md
@@ -1,19 +1,15 @@
 ---
 type: how-to
-id: k5920uow
 title: Merge cells
 metaTitle: Merge cells - JavaScript Data Grid | Handsontable
 description: Merge adjacent cells, using the "Ctrl + M" shortcut or the context menu. Control merged cells, using Handsontable's API.
 permalink: /merge-cells
 canonicalUrl: /merge-cells
 react:
-  id: ulndkavi
   metaTitle: Merge cells - React Data Grid | Handsontable
 angular:
-  id: pbcdsao1
   metaTitle: Merge cells - Angular Data Grid | Handsontable
 vue:
-  id: lo9jkbbq
   metaTitle: Merge cells - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features

--- a/docs/content/guides/cell-features/selection/selection.md
+++ b/docs/content/guides/cell-features/selection/selection.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: a52om5wr
 title: Selection
 metaTitle: Selection - JavaScript Data Grid | Handsontable
 description: Select a single cell, a range of adjacent cells, or multiple non-adjacent ranges of cells.
@@ -10,13 +9,10 @@ tags:
   - selecting ranges
   - cell selection
 react:
-  id: k88lznt8
   metaTitle: Selection - React Data Grid | Handsontable
 angular:
-  id: 8l4fmyur
   metaTitle: Selection - Angular Data Grid | Handsontable
 vue:
-  id: tnavl8bq
   metaTitle: Selection - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features

--- a/docs/content/guides/cell-features/text-alignment/text-alignment.md
+++ b/docs/content/guides/cell-features/text-alignment/text-alignment.md
@@ -1,19 +1,15 @@
 ---
 type: how-to
-id: chduupye
 title: Text alignment
 metaTitle: Text alignment - JavaScript Data Grid | Handsontable
 description: "Align values within cells: horizontally (to the right, left, center, or by justifying them), and vertically (to the top, middle, or bottom of the cell)."
 permalink: /text-alignment
 canonicalUrl: /text-alignment
 react:
-  id: 959g5cbf
   metaTitle: Text alignment - React Data Grid | Handsontable
 angular:
-  id: h6sbjq1g
   metaTitle: Text alignment - Angular Data Grid | Handsontable
 vue:
-  id: bqfjy5q5
   metaTitle: Text alignment - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features

--- a/docs/content/guides/cell-functions/cell-editor/cell-editor.md
+++ b/docs/content/guides/cell-functions/cell-editor/cell-editor.md
@@ -1,19 +1,15 @@
 ---
 type: how-to
-id: u00oul7m
 title: Cell editor
 metaTitle: Cell editor - JavaScript Data Grid | Handsontable
 description: Create a custom cell editor function, to have full control over how editing works in the cells of your data grid.
 permalink: /cell-editor
 canonicalUrl: /cell-editor
 react:
-  id: 6i8ttta0
   metaTitle: Cell editor - React Data Grid | Handsontable
 angular:
-  id: 7qb4y4u4
   metaTitle: Cell editor - Angular Data Grid | Handsontable
 vue:
-  id: qwv2hoqe
   metaTitle: Cell editor - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell functions

--- a/docs/content/guides/cell-functions/cell-function/cell-function.md
+++ b/docs/content/guides/cell-functions/cell-function/cell-function.md
@@ -1,19 +1,15 @@
 ---
 type: explanation
-id: neoo8dhv
 title: Cell functions
 metaTitle: Cell functions - JavaScript Data Grid | Handsontable
 description: Render, edit, and validate the contents of your cells, using Handsontable's cell functions. Quickly set up your cells, using cell types.
 permalink: /cell-function
 canonicalUrl: /cell-function
 react:
-  id: i2sqtwh6
   metaTitle: Cell functions - React Data Grid | Handsontable
 angular:
-  id: 377lnttu
   metaTitle: Cell functions - Angular Data Grid | Handsontable
 vue:
-  id: bc7idv59
   metaTitle: Cell functions - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell functions

--- a/docs/content/guides/cell-functions/cell-renderer/cell-renderer.md
+++ b/docs/content/guides/cell-functions/cell-renderer/cell-renderer.md
@@ -1,19 +1,15 @@
 ---
 type: how-to
-id: ohjf69hj
 title: Cell renderer
 metaTitle: Cell renderer - JavaScript Data Grid | Handsontable
 description: Create a custom cell renderer function, to have full control over how a cell looks.
 permalink: /cell-renderer
 canonicalUrl: /cell-renderer
 react:
-  id: 2ej30mcg
   metaTitle: Cell renderer - React Data Grid | Handsontable
 angular:
-  id: 36rymylj
   metaTitle: Cell renderer - Angular Data Grid | Handsontable
 vue:
-  id: hsxnm2ev
   metaTitle: Cell renderer - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell functions

--- a/docs/content/guides/cell-functions/cell-validator/cell-validator.md
+++ b/docs/content/guides/cell-functions/cell-validator/cell-validator.md
@@ -1,19 +1,15 @@
 ---
 type: how-to
-id: h840od8r
 title: Cell validator
 metaTitle: Cell validator - JavaScript Data Grid | Handsontable
 description: Validate data added or changed by the user, with predefined or custom rules. Validation helps you make sure that the data matches the expected format.
 permalink: /cell-validator
 canonicalUrl: /cell-validator
 react:
-  id: fvou30a5
   metaTitle: Cell validator - React Data Grid | Handsontable
 angular:
-  id: ut7amcaz
   metaTitle: Cell validator - Angular Data Grid | Handsontable
 vue:
-  id: bcog8al2
   metaTitle: Cell validator - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell functions

--- a/docs/content/guides/cell-functions/custom-cells/custom-cells.md
+++ b/docs/content/guides/cell-functions/custom-cells/custom-cells.md
@@ -1,19 +1,15 @@
 ---
 type: explanation
-id: c2670b72
 title: Custom Cells
 metaTitle: Simplified Custom Cell Definitions - JavaScript Data Grid | Handsontable
 description: Validate data added or changed by the user, with predefined or custom rules. Validation helps you make sure that the data matches the expected format.
 permalink: /custom-cells
 canonicalUrl: /custom-cells
 react:
-  id: 6b3e971b
   metaTitle: Custom Cell Definitions - React Data Grid | Handsontable
 angular:
-  id: 29d3662c
   metaTitle: Custom Cell Definitions - Angular Data Grid | Handsontable
 vue:
-  id: q319vaao
   metaTitle: Custom Cell Definitions - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell functions

--- a/docs/content/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: cjib1mhw
 title: Autocomplete cell type
 metaTitle: Autocomplete cell type - JavaScript Data Grid | Handsontable
 description: Collect user input with a list of choices, by using the autocomplete cell type.
@@ -12,13 +11,10 @@ tags:
   - autocomplete
   - key value
 react:
-  id: vnnvp396
   metaTitle: Autocomplete cell type - React Data Grid | Handsontable
 angular:
-  id: md3vhixm
   metaTitle: Autocomplete cell type - Angular Data Grid | Handsontable
 vue:
-  id: 1w3x57l3
   metaTitle: Autocomplete cell type - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types

--- a/docs/content/guides/cell-types/cell-type/cell-type.md
+++ b/docs/content/guides/cell-types/cell-type/cell-type.md
@@ -1,19 +1,15 @@
 ---
 type: explanation
-id: de2hxgso
 title: Cell type
 metaTitle: Cell type - JavaScript Data Grid | Handsontable
 description: Use Handsontable's built-in cell types such as autocomplete, date, time, and more, for consistent UI across cell renderer, editor, and validator.
 permalink: /cell-type
 canonicalUrl: /cell-type
 react:
-  id: m60w87tn
   metaTitle: Cell type - React Data Grid | Handsontable
 angular:
-  id: aho23taw
   metaTitle: Cell type - Angular Data Grid | Handsontable
 vue:
-  id: 8y6p0z00
   metaTitle: Cell type - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types

--- a/docs/content/guides/cell-types/checkbox-cell-type/checkbox-cell-type.md
+++ b/docs/content/guides/cell-types/checkbox-cell-type/checkbox-cell-type.md
@@ -1,19 +1,15 @@
 ---
 type: how-to
-id: p8sggqin
 title: Checkbox cell type
 metaTitle: Checkbox cell type - JavaScript Data Grid | Handsontable
 description: Create interactive elements that can be checked or unchecked, by using the checkbox cell type.
 permalink: /checkbox-cell-type
 canonicalUrl: /checkbox-cell-type
 react:
-  id: tfr1gisf
   metaTitle: Checkbox cell type - React Data Grid | Handsontable
 angular:
-  id: 4cn9mp6z
   metaTitle: Checkbox cell type - Angular Data Grid | Handsontable
 vue:
-  id: 2a1x3jgu
   metaTitle: Checkbox cell type - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types

--- a/docs/content/guides/cell-types/date-cell-type/date-cell-type.md
+++ b/docs/content/guides/cell-types/date-cell-type/date-cell-type.md
@@ -1,19 +1,15 @@
 ---
 type: how-to
-id: p25m5sco
 title: Date cell type
 metaTitle: Date cell type - JavaScript Data Grid | Handsontable
 description: Display, format, sort, and filter dates correctly by using the date cell type.
 permalink: /date-cell-type
 canonicalUrl: /date-cell-type
 react:
-  id: u7t2rn0n
   metaTitle: Date cell type - React Data Grid | Handsontable
 angular:
-  id: 9vvupwbx
   metaTitle: Date cell type - Angular Data Grid | Handsontable
 vue:
-  id: 0t5rmi6v
   metaTitle: Date cell type - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types

--- a/docs/content/guides/cell-types/dropdown-cell-type/dropdown-cell-type.md
+++ b/docs/content/guides/cell-types/dropdown-cell-type/dropdown-cell-type.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: oi78d8nv
 title: Dropdown cell type
 metaTitle: Dropdown cell type - JavaScript Data Grid | Handsontable
 description: Collect user input with a searchable list of choices, by using the dropdown cell type.
@@ -12,13 +11,10 @@ tags:
   - autocomplete
   - key value
 react:
-  id: 5i86kjqu
   metaTitle: Dropdown cell type - React Data Grid | Handsontable
 angular:
-  id: yatyane1
   metaTitle: Dropdown cell type - Angular Data Grid | Handsontable
 vue:
-  id: k3c8d136
   metaTitle: Dropdown cell type - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types

--- a/docs/content/guides/cell-types/handsontable-cell-type/handsontable-cell-type.md
+++ b/docs/content/guides/cell-types/handsontable-cell-type/handsontable-cell-type.md
@@ -1,19 +1,15 @@
 ---
 type: how-to
-id: kdie9yhz
 title: Handsontable cell type
 metaTitle: Handsontable cell type - JavaScript Data Grid | Handsontable
 description: Add a spreadsheet editor in a popup, by using the Handsontable cell type.
 permalink: /handsontable-cell-type
 canonicalUrl: /handsontable-cell-type
 react:
-  id: fcxtj167
   metaTitle: Handsontable cell type - React Data Grid | Handsontable
 angular:
-  id: cewiknc8
   metaTitle: Handsontable cell type - Angular Data Grid | Handsontable
 vue:
-  id: wd9yzry6
   metaTitle: Handsontable cell type - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types

--- a/docs/content/guides/cell-types/multiselect-cell-type/multiselect-cell-type.md
+++ b/docs/content/guides/cell-types/multiselect-cell-type/multiselect-cell-type.md
@@ -1,19 +1,15 @@
 ---
 type: how-to
-id: cjih3fhw
 title: MultiSelect cell type
 metaTitle: MultiSelect cell type - JavaScript Data Grid | Handsontable
 description: Collect user input with a list of multiple-selection entries, by using the MultiSelect cell type.
 permalink: /multiselect-cell-type
 canonicalUrl: /multiselect-cell-type
 react:
-  id: vnhtf396
   metaTitle: MultiSelect cell type - React Data Grid | Handsontable
 angular:
-  id: mdg4dixm
   metaTitle: MultiSelect cell type - Angular Data Grid | Handsontable
 vue:
-  id: 6zrsi767
   metaTitle: MultiSelect cell type - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types

--- a/docs/content/guides/cell-types/numeric-cell-type/numeric-cell-type.md
+++ b/docs/content/guides/cell-types/numeric-cell-type/numeric-cell-type.md
@@ -1,19 +1,15 @@
 ---
 type: how-to
-id: l5a447bl
 title: Numeric cell type
 metaTitle: Numeric cell type - JavaScript Data Grid | Handsontable
 description: Display, format, sort, and filter numbers correctly by using the numeric cell type.
 permalink: /numeric-cell-type
 canonicalUrl: /numeric-cell-type
 react:
-  id: e6zmmawj
   metaTitle: Numeric cell type - React Data Grid | Handsontable
 angular:
-  id: odhu846f
   metaTitle: Numeric cell type - Angular Data Grid | Handsontable
 vue:
-  id: 31btf76b
   metaTitle: Numeric cell type - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types

--- a/docs/content/guides/cell-types/password-cell-type/password-cell-type.md
+++ b/docs/content/guides/cell-types/password-cell-type/password-cell-type.md
@@ -1,19 +1,15 @@
 ---
 type: how-to
-id: a7a5mkrw
 title: Password cell type
 metaTitle: Password cell type - JavaScript Data Grid | Handsontable
 description: Use the password cell type to mask confidential values by rendering entered characters as symbols.
 permalink: /password-cell-type
 canonicalUrl: /password-cell-type
 react:
-  id: gydne13d
   metaTitle: Password cell type - React Data Grid | Handsontable
 angular:
-  id: 2x5025ww
   metaTitle: Password cell type - Angular Data Grid | Handsontable
 vue:
-  id: lfsxgjsp
   metaTitle: Password cell type - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types

--- a/docs/content/guides/cell-types/select-cell-type/select-cell-type.md
+++ b/docs/content/guides/cell-types/select-cell-type/select-cell-type.md
@@ -1,19 +1,15 @@
 ---
 type: how-to
-id: pqe1xozj
 title: Select cell type
 metaTitle: Select cell type - JavaScript Data Grid | Handsontable
 description: Use the select cell type to collect user input with an HTML <select> element that creates a multi-item dropdown list.
 permalink: /select-cell-type
 canonicalUrl: /select-cell-type
 react:
-  id: xmdreeu3
   metaTitle: Select cell type - React Data Grid | Handsontable
 angular:
-  id: dtzqxytv
   metaTitle: Select cell type - Angular Data Grid | Handsontable
 vue:
-  id: phqvirxa
   metaTitle: Select cell type - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types

--- a/docs/content/guides/cell-types/time-cell-type/time-cell-type.md
+++ b/docs/content/guides/cell-types/time-cell-type/time-cell-type.md
@@ -1,19 +1,15 @@
 ---
 type: how-to
-id: q63yhvq5
 title: Time cell type
 metaTitle: Time cell type - JavaScript Data Grid | Handsontable
 description: Display, format, sort, and filter time values correctly by using the time cell type. Use Intl.DateTimeFormat (recommended) or the legacy moment.js-based configuration.
 permalink: /time-cell-type
 canonicalUrl: /time-cell-type
 react:
-  id: 34n5nwja
   metaTitle: Time cell type - React Data Grid | Handsontable
 angular:
-  id: fu9fqphw
   metaTitle: Time cell type - Angular Data Grid | Handsontable
 vue:
-  id: bxoffcid
   metaTitle: Time cell type - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types

--- a/docs/content/guides/columns/column-filter/column-filter.md
+++ b/docs/content/guides/columns/column-filter/column-filter.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: 3xxlonuv
 title: Column filter
 metaTitle: Column filter - JavaScript Data Grid | Handsontable
 description: Filter your data by values or by a set of conditions.
@@ -20,13 +19,10 @@ tags:
   - advanced filter
   - dropdown
 react:
-  id: vz7ct2bv
   metaTitle: Column filter - React Data Grid | Handsontable
 angular:
-  id: woyi876m
   metaTitle: Column filter - Angular Data Grid | Handsontable
 vue:
-  id: mv5nc30h
   metaTitle: Column filter - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Columns

--- a/docs/content/guides/columns/column-freezing/column-freezing.md
+++ b/docs/content/guides/columns/column-freezing/column-freezing.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: 2anhuqf7
 title: Column freezing
 metaTitle: Column freezing - JavaScript Data Grid | Handsontable
 description: Lock (freeze) the position of specified columns, keeping them visible while scrolling to another area of the grid.
@@ -12,13 +11,10 @@ tags:
   - pinning columns
   - fixedColumns
 react:
-  id: otumcpty
   metaTitle: Column freezing - React Data Grid | Handsontable
 angular:
-  id: i85vqeao
   metaTitle: Column freezing - Angular Data Grid | Handsontable
 vue:
-  id: yfngr43j
   metaTitle: Column freezing - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Columns

--- a/docs/content/guides/columns/column-groups/column-groups.md
+++ b/docs/content/guides/columns/column-groups/column-groups.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: k4mb003v
 title: Column groups
 metaTitle: Column groups - JavaScript Data Grid | Handsontable
 description: Group your columns, using multiple levels of nested column headers, to better reflect the structure of your data.
@@ -13,13 +12,10 @@ tags:
   - colspan
   - rowspan
 react:
-  id: 2ei1omu0
   metaTitle: Column groups - React Data Grid | Handsontable
 angular:
-  id: 2k8cam98
   metaTitle: Column groups - Angular Data Grid | Handsontable
 vue:
-  id: ogbyqaox
   metaTitle: Column groups - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Columns

--- a/docs/content/guides/columns/column-header/column-header.md
+++ b/docs/content/guides/columns/column-header/column-header.md
@@ -1,19 +1,15 @@
 ---
 type: how-to
-id: qiasr3y1
 title: Column headers
 metaTitle: Column headers - JavaScript Data Grid | Handsontable
 description: Use default column headers (A, B, C), or set them to custom values provided by an array or a function.
 permalink: /column-header
 canonicalUrl: /column-header
 react:
-  id: 5e0tnexi
   metaTitle: Column headers - React Data Grid | Handsontable
 angular:
-  id: owl7h4t1
   metaTitle: Column headers - Angular Data Grid | Handsontable
 vue:
-  id: j4ac3057
   metaTitle: Column headers - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Columns

--- a/docs/content/guides/columns/column-hiding/column-hiding.md
+++ b/docs/content/guides/columns/column-hiding/column-hiding.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: 6elqkmhr
 title: Column hiding
 metaTitle: Column hiding - JavaScript Data Grid | Handsontable
 description:
@@ -9,13 +8,10 @@ description:
 permalink: /column-hiding
 canonicalUrl: /column-hiding
 react:
-  id: u1aw329h
   metaTitle: Column hiding - React Data Grid | Handsontable
 angular:
-  id: 69k5r1oh
   metaTitle: Column hiding - Angular Data Grid | Handsontable
 vue:
-  id: hwodm9tg
   metaTitle: Column hiding - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Columns

--- a/docs/content/guides/columns/column-menu/column-menu.md
+++ b/docs/content/guides/columns/column-menu/column-menu.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: 25b7vhfs
 title: Column menu
 metaTitle: Column menu - JavaScript Data Grid | Handsontable
 description: Display a configurable dropdown menu, triggered by clicking on a button in a column header.
@@ -9,13 +8,10 @@ canonicalUrl: /column-menu
 tags:
   - dropdown menu
 react:
-  id: uc7w8gu1
   metaTitle: Column menu - React Data Grid | Handsontable
 angular:
-  id: zclxcsij
   metaTitle: Column menu - Angular Data Grid | Handsontable
 vue:
-  id: km8rip58
   metaTitle: Column menu - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Columns

--- a/docs/content/guides/columns/column-moving/column-moving.md
+++ b/docs/content/guides/columns/column-moving/column-moving.md
@@ -1,19 +1,15 @@
 ---
 type: how-to
-id: aq1vywt4
 title: Column moving
 metaTitle: Column moving - JavaScript Data Grid | Handsontable
 description: Change the order of columns, either manually (dragging them to another location), or programmatically (using Handsontable's API methods).
 permalink: /column-moving
 canonicalUrl: /column-moving
 react:
-  id: zhlikwwh
   metaTitle: Column moving - React Data Grid | Handsontable
 angular:
-  id: fsfvsoi3
   metaTitle: Column moving - Angular Data Grid | Handsontable
 vue:
-  id: 79rgvlew
   metaTitle: Column moving - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Columns

--- a/docs/content/guides/columns/column-summary/column-summary.md
+++ b/docs/content/guides/columns/column-summary/column-summary.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: xndxqkoc
 title: Column summary
 metaTitle: Column summary - JavaScript Data Grid | Handsontable
 description: Calculate sum, min, max, count, average or custom aggregates of individual columns' data, using Handsontable's aggregate functions.
@@ -15,13 +14,10 @@ tags:
   - destinationColumn
   - reversedRowCoords
 react:
-  id: r3x4l0gp
   metaTitle: Column summary - React Data Grid | Handsontable
 angular:
-  id: 1rptt5bu
   metaTitle: Column summary - Angular Data Grid | Handsontable
 vue:
-  id: hqbq312j
   metaTitle: Column summary - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Columns

--- a/docs/content/guides/columns/column-virtualization/column-virtualization.md
+++ b/docs/content/guides/columns/column-virtualization/column-virtualization.md
@@ -1,6 +1,5 @@
 ---
 type: explanation
-id: xv8sf6at
 title: Column virtualization
 metaTitle: Column virtualization - JavaScript Data Grid | Handsontable
 description: Render hundreds of columns without freezing the browser, using column virtualization.
@@ -11,13 +10,10 @@ tags:
   - render all columns
   - offset
 react:
-  id: 24n21dwi
   metaTitle: Column virtualization - React Data Grid | Handsontable
 angular:
-  id: qhqjtdsr
   metaTitle: Column virtualization - Angular Data Grid | Handsontable
 vue:
-  id: y0yzk8sd
   metaTitle: Column virtualization - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Columns

--- a/docs/content/guides/columns/column-width/column-width.md
+++ b/docs/content/guides/columns/column-width/column-width.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: bpcuomaq
 title: Column widths
 metaTitle: Column widths - JavaScript Data Grid | Handsontable
 description: Configure column widths, using an array or a function. Let your users manually change column widths using Handsontable's interface.
@@ -16,13 +15,10 @@ tags:
   - column dimensions
   - manual resize
 react:
-  id: gr6w8qsy
   metaTitle: Column widths - React Data Grid | Handsontable
 angular:
-  id: eourt93b
   metaTitle: Column widths - Angular Data Grid | Handsontable
 vue:
-  id: tp1u20zm
   metaTitle: Column widths - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Columns

--- a/docs/content/guides/columns/react-hot-column/react-hot-column.md
+++ b/docs/content/guides/columns/react-hot-column/react-hot-column.md
@@ -1,6 +1,5 @@
 ---
 type: reference
-id: h5waqmlx
 title: Column component
 metaTitle: Column component - React Data Grid | Handsontable
 description: Configure the React data grid's columns, using the props of the "HotColumn" component. Pass your component as a custom cell editor or a custom cell renderer.

--- a/docs/content/guides/dialog/dialog/dialog.md
+++ b/docs/content/guides/dialog/dialog/dialog.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: 1xi1xek4
 title: Dialog
 metaTitle: Dialog - JavaScript Data Grid | Handsontable
 description: Display modal dialogs, alerts, loading indicators, and notifications to enhance user interaction and provide feedback in your data grid application.
@@ -14,13 +13,10 @@ tags:
   - confirm
   - prompt
 react:
-  id: 55z3zjaz
   metaTitle: Dialog - React Data Grid | Handsontable
 angular:
-  id: vq1llzfz
   metaTitle: Dialog - Angular Data Grid | Handsontable
 vue:
-  id: r8xzqxzt
   metaTitle: Dialog - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Dialog

--- a/docs/content/guides/dialog/loading/loading.md
+++ b/docs/content/guides/dialog/loading/loading.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: 2yi2yfl5
 title: Loading
 metaTitle: Loading - JavaScript Data Grid | Handsontable
 description: Display loading indicators and progress feedback in your data grid application using the Loading plugin.
@@ -14,13 +13,10 @@ tags:
   - spinner
   - indicator
 react:
-  id: 66z4zjaz
   metaTitle: Loading - React Data Grid | Handsontable
 angular:
-  id: wq2llzfz
   metaTitle: Loading - Angular Data Grid | Handsontable
 vue:
-  id: odrgfc3c
   metaTitle: Loading - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Dialog

--- a/docs/content/guides/dialog/notification/notification.md
+++ b/docs/content/guides/dialog/notification/notification.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: 3zi3znot
 title: Notification
 metaTitle: Notification - JavaScript Data Grid | Handsontable
 description: Show non-blocking toast notifications anchored to the grid with the Notification plugin.
@@ -12,13 +11,10 @@ tags:
   - dialog
   - accessibility
 react:
-  id: 77z5zjaz
   metaTitle: Notification - React Data Grid | Handsontable
 angular:
-  id: xr3llzfz
   metaTitle: Notification - Angular Data Grid | Handsontable
 vue:
-  id: i9f864ry
   metaTitle: Notification - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Dialog

--- a/docs/content/guides/formulas/formula-calculation/formula-calculation.md
+++ b/docs/content/guides/formulas/formula-calculation/formula-calculation.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: g7i1xok4
 title: Formula calculation
 metaTitle: Formula calculation - JavaScript Data Grid | Handsontable
 description: Perform calculations on cells' values, using a powerful calculation engine that handles nearly 400 functions, custom functions, named expressions, and more.
@@ -17,13 +16,10 @@ tags:
   - function
   - hyperformula
 react:
-  id: 05z3cjez
   metaTitle: Formula calculation - React Data Grid | Handsontable
 angular:
-  id: hqzll0fz
   metaTitle: Formula calculation - Angular Data Grid | Handsontable
 vue:
-  id: 57yg2rca
   metaTitle: Formula calculation - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Formulas

--- a/docs/content/guides/getting-started/angular-hot-instance/angular-hot-instance.md
+++ b/docs/content/guides/getting-started/angular-hot-instance/angular-hot-instance.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: o4wgil5k
 title: Instance access
 metaTitle: Instance access - Javascript Data Grid | Handsontable
 description: Reference a Handsontable instance from within a Angular component, to programmatically perform actions.

--- a/docs/content/guides/getting-started/binding-to-data/binding-to-data.md
+++ b/docs/content/guides/getting-started/binding-to-data/binding-to-data.md
@@ -1,6 +1,5 @@
 ---
 type: tutorial
-id: 66g0jo36
 title: Binding to data
 metaTitle: Binding to data - JavaScript Data Grid | Handsontable
 description: Use Handsontable's configuration options or API methods to fill your data grid with various data structures, including an array of arrays or an array of objects.
@@ -11,13 +10,10 @@ tags:
   - data connect
   - data sources
 react:
-  id: umdq9b9j
   metaTitle: Binding to data - React Data Grid | Handsontable
 angular:
-  id: xnqn2zg9
   metaTitle: Binding to data - Angular Data Grid | Handsontable
 vue:
-  id: lahmb9og
   metaTitle: Binding to data - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Getting started

--- a/docs/content/guides/getting-started/configuration-options/configuration-options.md
+++ b/docs/content/guides/getting-started/configuration-options/configuration-options.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: p7oq0ph7
 title: Configuration options
 metaTitle: Configuration options - JavaScript Data Grid | Handsontable
 description: Configure the data grid down to each column, row, and cell, using various built-in options that control Handsontable's behavior and user interface.
@@ -11,13 +10,10 @@ tags:
   - config
   - options
 react:
-  id: gmpbmisy
   metaTitle: Configuration options - React Data Grid | Handsontable
 angular:
-  id: 16bofyho
   metaTitle: Configuration options - Angular Data Grid | Handsontable
 vue:
-  id: 4xi8scx0
   metaTitle: Configuration options - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Getting started

--- a/docs/content/guides/getting-started/demo/demo.md
+++ b/docs/content/guides/getting-started/demo/demo.md
@@ -1,6 +1,5 @@
 ---
 type: tutorial
-id: jnwpo47i
 title: Demo
 metaTitle: Demo - JavaScript Data Grid | Handsontable
 description: Play around with a demo of Handsontable, in your favorite framework.
@@ -10,15 +9,12 @@ tags:
   - demo
   - hello world
 react:
-  id: ccqbm8hn
   metaTitle: Demo - React Data Grid | Handsontable
   description: Play around with a demo of Handsontable in React.
 angular:
-  id: i2n378hh
   metaTitle: Demo - Angular Data Grid | Handsontable
   description: Play around with a demo of Handsontable in Angular.
 vue:
-  id: c104k1nn
   metaTitle: Demo - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Getting started

--- a/docs/content/guides/getting-started/events-and-hooks/events-and-hooks.md
+++ b/docs/content/guides/getting-started/events-and-hooks/events-and-hooks.md
@@ -1,6 +1,5 @@
 ---
 type: explanation
-id: own6evdy
 title: Events and hooks
 metaTitle: Events and hooks - JavaScript Data Grid | Handsontable
 description: Run your code before or after specific data grid actions, using Handsontable's API hooks (callbacks). For example, control what happens with the user's input.
@@ -17,13 +16,10 @@ tags:
 - events
 - hooks
 react:
-  id: d966se98
   metaTitle: Events and hooks - React Data Grid | Handsontable
 angular:
-  id: iifvbgu0
   metaTitle: Events and hooks - Angular Data Grid | Handsontable
 vue:
-  id: nmvkusp7
   metaTitle: Events and hooks - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Data management

--- a/docs/content/guides/getting-started/grid-size/grid-size.md
+++ b/docs/content/guides/getting-started/grid-size/grid-size.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: svu0391b
 title: Grid size
 metaTitle: Grid size - JavaScript Data Grid | Handsontable
 description: Set the width and height of the grid, using either absolute values or values relative to the parent container.
@@ -12,13 +11,10 @@ tags:
   - height
   - dimensions
 react:
-  id: cifepxzs
   metaTitle: Grid size - React Data Grid | Handsontable
 angular:
-  id: w6lvb55f
   metaTitle: Grid size - Angular Data Grid | Handsontable
 vue:
-  id: ej8mo5um
   metaTitle: Grid size - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Getting started

--- a/docs/content/guides/getting-started/installation/installation.md
+++ b/docs/content/guides/getting-started/installation/installation.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: rqtn1ajf
 title: Installation
 metaTitle: Installation - JavaScript Data Grid | Handsontable
 description: Install Handsontable through your preferred package manager, or import Handsontable's assets directly from a CDN.
@@ -9,13 +8,10 @@ canonicalUrl: /installation
 tags:
   - quick start
 react:
-  id: zqk2jjw3
   metaTitle: Installation - React Data Grid | Handsontable
 angular:
-  id: y52wtu7t
   metaTitle: Installation - Angular Data Grid | Handsontable
 vue:
-  id: gflge7lk
   metaTitle: Installation - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Getting started

--- a/docs/content/guides/getting-started/introduction/introduction.md
+++ b/docs/content/guides/getting-started/introduction/introduction.md
@@ -1,19 +1,15 @@
 ---
 type: explanation
-id: rgajvjfa
 title: Introduction
 metaTitle: JavaScript Data Grid - Documentation | Handsontable
 description: An overview of Handsontable's developer documentation. Handsontable is a client-side, spreadsheet-like data grid for editing data in web applications.
 permalink: /
 canonicalUrl: /
 react:
-  id: fexwrrj2
   metaTitle: React Data Grid - Documentation | Handsontable
 angular:
-  id: igd8lqh8
   metaTitle: Angular Data Grid - Documentation | Handsontable
 vue:
-  id: xpwj6wcn
   metaTitle: Vue Data Grid - Documentation | Handsontable
 searchCategory: Guides
 category: Getting started

--- a/docs/content/guides/getting-started/license-key/license-key.md
+++ b/docs/content/guides/getting-started/license-key/license-key.md
@@ -1,19 +1,15 @@
 ---
 type: how-to
-id: zbx8ayzw
 title: License key
 metaTitle: License key - JavaScript Data Grid | Handsontable
 description: Activate Handsontable, passing your license key in the configuration object. Use a special key for non-commercial and evaluation purposes.
 permalink: /license-key
 canonicalUrl: /license-key
 react:
-  id: vyfski60
   metaTitle: License key - React Data Grid | Handsontable
 angular:
-  id: bcvwr25r
   metaTitle: License key - Angular Data Grid | Handsontable
 vue:
-  id: 7pgm711u
   metaTitle: License key - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Getting started

--- a/docs/content/guides/getting-started/react-methods/react-methods.md
+++ b/docs/content/guides/getting-started/react-methods/react-methods.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: dceorl8m
 title: Instance methods
 metaTitle: Instance methods - JavaScript Data Grid | Handsontable
 description: Reference a Handsontable instance from within a React component, to programmatically perform actions such as selecting cells.
@@ -15,10 +14,8 @@ tags:
 react:
   metaTitle: Instance methods - React Data Grid | Handsontable
 angular:
-  id: 7a8puryp
   metaTitle: Instance methods - Angular Data Grid | Handsontable
 vue:
-  id: dzj81kmk
   metaTitle: Instance methods - Vue Data Grid | Handsontable
 searchCategory: Guides
 onlyFor: react

--- a/docs/content/guides/getting-started/react-redux/react-redux.md
+++ b/docs/content/guides/getting-started/react-redux/react-redux.md
@@ -1,6 +1,5 @@
 ---
 type: tutorial
-id: kbk0pm8t
 title: Integration with Redux
 metaTitle: Integration with Redux - JavaScript Data Grid | Handsontable
 description: Maintain the data and configuration options of your grid by using the Redux state container.

--- a/docs/content/guides/getting-started/saving-data/saving-data.md
+++ b/docs/content/guides/getting-started/saving-data/saving-data.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: 7js3d370
 title: Saving data
 metaTitle: Saving data - JavaScript Data Grid | Handsontable
 description: Saving data after each change to the data set, using Handsontable's API hooks. Preserve the table's state by saving data to the local storage.
@@ -11,13 +10,10 @@ tags:
   - server
   - ajax
 react:
-  id: rib1rhmf
   metaTitle: Saving data - React Data Grid | Handsontable
 angular:
-  id: uny2nvqk
   metaTitle: Saving data - Angular Data Grid | Handsontable
 vue:
-  id: qnevlxum
   metaTitle: Saving data - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Getting started

--- a/docs/content/guides/getting-started/server-side-data/server-side-data-configuration.md
+++ b/docs/content/guides/getting-started/server-side-data/server-side-data-configuration.md
@@ -1,6 +1,5 @@
 ---
 type: reference
-id: h7j4k8l2
 title: Server-side configuration
 metaTitle: Server-side configuration - JavaScript Data Grid | Handsontable
 description: Handsontable dataProvider configuration—required keys, pagination and pageSize, query parameters for fetchRows, column sorting, and server-side filters.
@@ -11,13 +10,10 @@ tags:
   - server-side
   - pagination
 react:
-  id: t6w2p9m4
   metaTitle: Server-side configuration - React Data Grid | Handsontable
 angular:
-  id: u7x3q0n5
   metaTitle: Server-side configuration - Angular Data Grid | Handsontable
 vue:
-  id: fqk72s67
   metaTitle: Server-side configuration - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Server-side data

--- a/docs/content/guides/getting-started/server-side-data/server-side-data-crud.md
+++ b/docs/content/guides/getting-started/server-side-data/server-side-data-crud.md
@@ -1,6 +1,5 @@
 ---
 type: reference
-id: p9q3r6s1
 title: Server-side CRUD
 metaTitle: Server-side CRUD - JavaScript Data Grid | Handsontable
 description: Handsontable dataProvider create, update, and remove—onRowsCreate, onRowsUpdate, onRowsRemove, mutation hooks, optimistic UI, validators, and programmatic CRUD.
@@ -11,13 +10,10 @@ tags:
   - server-side
   - CRUD
 react:
-  id: v8y4r0p6
   metaTitle: Server-side CRUD - React Data Grid | Handsontable
 angular:
-  id: w9z5s1q7
   metaTitle: Server-side CRUD - Angular Data Grid | Handsontable
 vue:
-  id: aryloxoj
   metaTitle: Server-side CRUD - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Server-side data

--- a/docs/content/guides/getting-started/server-side-data/server-side-data-fetching.md
+++ b/docs/content/guides/getting-started/server-side-data/server-side-data-fetching.md
@@ -1,6 +1,5 @@
 ---
 type: reference
-id: t2u5v8w3
 title: Server-side fetching and examples
 metaTitle: Server-side fetching and examples - JavaScript Data Grid | Handsontable
 description: Handsontable DataProvider fetch hooks, loading UI with emptyDataState, plugin methods fetchData and getQueryParameters, REST and GraphQL sample servers, and CodeSandbox projects.
@@ -12,13 +11,10 @@ tags:
   - REST
   - GraphQL
 react:
-  id: x0a6t2r8
   metaTitle: Server-side fetching and examples - React Data Grid | Handsontable
 angular:
-  id: y1b7u3s9
   metaTitle: Server-side fetching and examples - Angular Data Grid | Handsontable
 vue:
-  id: 5wb5dzit
   metaTitle: Server-side fetching and examples - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Server-side data

--- a/docs/content/guides/getting-started/server-side-data/server-side-data-migration.md
+++ b/docs/content/guides/getting-started/server-side-data/server-side-data-migration.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: k3m9n2p1
 title: Migrate to server-side data
 metaTitle: Migrate to server-side data - JavaScript Data Grid | Handsontable
 description: Move from a full in-memory data array and afterChange saves to Handsontable dataProvider—stable row ids, fetchRows, CRUD callbacks, pagination, and filters.
@@ -11,13 +10,10 @@ tags:
   - server-side
   - migration
 react:
-  id: r4n8m2k7
   metaTitle: Migrate to server-side data - React Data Grid | Handsontable
 angular:
-  id: s5p9n3l8
   metaTitle: Migrate to server-side data - Angular Data Grid | Handsontable
 vue:
-  id: 0c1h1cah
   metaTitle: Migrate to server-side data - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Server-side data

--- a/docs/content/guides/getting-started/server-side-data/server-side-data.md
+++ b/docs/content/guides/getting-started/server-side-data/server-side-data.md
@@ -1,6 +1,5 @@
 ---
 type: tutorial
-id: xm9k2p7q
 title: Server-side data
 metaTitle: Server-side data - JavaScript Data Grid | Handsontable
 description: Load paged data with Handsontable DataProvider—fetchRows, CRUD callbacks, migration from client-side arrays, pagination, sorting, filters, REST and GraphQL examples, and a JavaScript monorepo project with two Node servers.
@@ -12,13 +11,10 @@ tags:
   - pagination
   - REST
 react:
-  id: ym8j3n4r
   metaTitle: Server-side data - React Data Grid | Handsontable
 angular:
-  id: zn7h5m6s
   metaTitle: Server-side data - Angular Data Grid | Handsontable
 vue:
-  id: 8ct2kiul
   metaTitle: Server-side data - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Getting started

--- a/docs/content/guides/getting-started/vue3-custom-id-class-style/vue3-custom-id-class-style.md
+++ b/docs/content/guides/getting-started/vue3-custom-id-class-style/vue3-custom-id-class-style.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: n5t2hq7r
 title: Custom ID, class, and style
 metaTitle: Custom ID, class, and style - Javascript Data Grid | Handsontable
 description: Pass a custom ID, class, and style to the HotTable component, to further customize your Vue 3 data grid.

--- a/docs/content/guides/getting-started/vue3-hot-column/vue3-hot-column.md
+++ b/docs/content/guides/getting-started/vue3-hot-column/vue3-hot-column.md
@@ -1,7 +1,6 @@
 ---
 type: how-to
-id: h7xv9mwq
-title: Using the HotColumn component in Vue 3
+title: HotColumn component
 metaTitle: HotColumn component - JavaScript Data Grid | Handsontable
 description: Configure the Vue 3 data grid's columns, using the props of the "HotColumn" component. Define a custom cell editor or a custom cell renderer.
 permalink: /vue-hot-column

--- a/docs/content/guides/getting-started/vue3-hot-reference/vue3-hot-reference.md
+++ b/docs/content/guides/getting-started/vue3-hot-reference/vue3-hot-reference.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: v8r3km2q
 title: Instance reference
 metaTitle: Instance reference - JavaScript Data Grid | Handsontable
 description: Reference a Handsontable instance from within a Vue 3 component, to programmatically perform actions such as selecting cells.

--- a/docs/content/guides/getting-started/vue3-nuxt/vue3-nuxt.md
+++ b/docs/content/guides/getting-started/vue3-nuxt/vue3-nuxt.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: n5br7y1k
 title: Use Handsontable in Nuxt
 metaTitle: Use Handsontable in Nuxt - JavaScript Data Grid | Handsontable
 description: Set up Handsontable in a Nuxt 3 application using the ClientOnly component or the .client.vue suffix to avoid SSR errors.

--- a/docs/content/guides/getting-started/vue3-pinia/vue3-pinia.md
+++ b/docs/content/guides/getting-started/vue3-pinia/vue3-pinia.md
@@ -1,8 +1,7 @@
 ---
 type: how-to
-id: c0y2nwis
-title: Pinia in Vue 3
-metaTitle: Pinia in Vue 3 - Vue 3 Data Grid | Handsontable
+title: Pinia state management
+metaTitle: Pinia state management - Vue 3 Data Grid | Handsontable
 description: Use the Pinia store to maintain the data and configuration options of your Vue 3 data grid.
 permalink: /vue-pinia
 canonicalUrl: /vue-pinia

--- a/docs/content/guides/getting-started/vue3-vuex/vue3-vuex.md
+++ b/docs/content/guides/getting-started/vue3-vuex/vue3-vuex.md
@@ -1,6 +1,5 @@
 ---
 type: tutorial
-id: m4v9kp2z
 title: Vuex state management
 metaTitle: Vuex state management - Vue Data Grid | Handsontable
 description: Use the Vuex state management pattern to maintain the data and configuration options of your Vue 3 data grid.

--- a/docs/content/guides/internationalization/ime-support/ime-support.md
+++ b/docs/content/guides/internationalization/ime-support/ime-support.md
@@ -1,6 +1,5 @@
 ---
 type: explanation
-id: bhst4cl4
 title: IME support
 metaTitle: IME support - JavaScript Data Grid | Handsontable
 description: Convert keystrokes to characters not available on the keyboard, using the Input Method Editor. This feature is always enabled and available for cell editors.
@@ -13,13 +12,10 @@ tags:
   - chinese
   - latin
 react:
-  id: 8pqhhu5r
   metaTitle: IME support - React Data Grid | Handsontable
 angular:
-  id: 7u4izjbt
   metaTitle: IME support - Angular Data Grid | Handsontable
 vue:
-  id: 0m1fmtge
   metaTitle: IME support - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Internationalization

--- a/docs/content/guides/internationalization/language/language.md
+++ b/docs/content/guides/internationalization/language/language.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: 1g89qnhe
 title: Language
 metaTitle: Language - JavaScript Data Grid | Handsontable
 description: Set Handsontable's UI language to one of the built-in translations, or create your own language set using our templates.
@@ -13,13 +12,10 @@ tags:
   - L10n
   - i18n
 react:
-  id: qz0qgi9f
   metaTitle: Language - React Data Grid | Handsontable
 angular:
-  id: eujz2e6s
   metaTitle: Language - Angular Data Grid | Handsontable
 vue:
-  id: np656che
   metaTitle: Language - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Internationalization

--- a/docs/content/guides/internationalization/layout-direction/layout-direction.md
+++ b/docs/content/guides/internationalization/layout-direction/layout-direction.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: gcdt3pns
 title: Layout direction
 metaTitle: Layout direction - JavaScript Data Grid | Handsontable
 description: Set the layout direction for right-to-left languages. Automatically inherit your HTML file's "dir" property, or set the layout direction manually.
@@ -18,13 +17,10 @@ tags:
   - L10n
   - i18n
 react:
-  id: g4mu790t
   metaTitle: Layout direction - React Data Grid | Handsontable
 angular:
-  id: orgwjmih
   metaTitle: Layout direction - Angular Data Grid | Handsontable
 vue:
-  id: ubzdplj2
   metaTitle: Layout direction - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Internationalization

--- a/docs/content/guides/internationalization/locale/locale.md
+++ b/docs/content/guides/internationalization/locale/locale.md
@@ -1,6 +1,5 @@
 ---
 type: reference
-id: 97k6p9p7
 title: Locale
 metaTitle: Locale - JavaScript Data Grid | Handsontable
 description: Configure Handsontable's locale settings, to properly handle locale-related data and actions such as filtering, searching, or sorting.
@@ -12,13 +11,10 @@ tags:
   - L10n
   - i18n
 react:
-  id: 1ueuuazs
   metaTitle: Locale - React Data Grid | Handsontable
 angular:
-  id: arpg1wyq
   metaTitle: Locale - Angular Data Grid | Handsontable
 vue:
-  id: rt5nxjxz
   metaTitle: Locale - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Internationalization

--- a/docs/content/guides/navigation/custom-shortcuts/custom-shortcuts.md
+++ b/docs/content/guides/navigation/custom-shortcuts/custom-shortcuts.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: g7139vli
 title: Custom shortcuts
 metaTitle: Custom shortcuts - JavaScript Data Grid | Handsontable
 description: Customize Handsontable's keyboard shortcuts.
@@ -18,13 +17,10 @@ tags:
   - custom shortcuts
   - shortcut keys
 react:
-  id: d5ay8gj1
   metaTitle: Custom shortcuts - React Data Grid | Handsontable
 angular:
-  id: lqk5kuws
   metaTitle: Custom shortcuts - Angular Data Grid | Handsontable
 vue:
-  id: 8i6v370n
   metaTitle: Custom shortcuts - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Navigation

--- a/docs/content/guides/navigation/focus-scopes/focus-scopes.md
+++ b/docs/content/guides/navigation/focus-scopes/focus-scopes.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: cdahp04c
 title: Focus scopes
 metaTitle: Focus scopes - JavaScript Data Grid | Handsontable
 description: Manage focus boundaries and keyboard shortcuts contexts with focus scopes.
@@ -15,13 +14,10 @@ tags:
   - shortcuts context
   - tab navigation
 react:
-  id: lx9qi7uu
   metaTitle: Focus scopes - React Data Grid | Handsontable
 angular:
-  id: xat52y9g
   metaTitle: Focus scopes - Angular Data Grid | Handsontable
 vue:
-  id: 42scu64a
   metaTitle: Focus scopes - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Navigation

--- a/docs/content/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md
+++ b/docs/content/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md
@@ -1,6 +1,5 @@
 ---
 type: reference
-id: 5w6juytv
 title: Keyboard shortcuts
 metaTitle: Keyboard shortcuts - JavaScript Data Grid | Handsontable
 description: Access all Handsontable features using just your keyboard. Use shortcuts you know from Google Sheets or Microsoft Excel.
@@ -17,13 +16,10 @@ tags:
   - commands
   - shortcut keys
 react:
-  id: ddjw4zt88
   metaTitle: Keyboard shortcuts - React Data Grid | Handsontable
 angular:
-  id: v7sq2x22
   metaTitle: Keyboard shortcuts - Angular Data Grid | Handsontable
 vue:
-  id: h8l2k0pm
   metaTitle: Keyboard shortcuts - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Navigation

--- a/docs/content/guides/navigation/searching-values/searching-values.md
+++ b/docs/content/guides/navigation/searching-values/searching-values.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: ct5f32ig
 title: Searching values
 metaTitle: Searching values - JavaScript Data Grid | Handsontable
 description: Search data across Handsontable, using built-in API methods and implementing your own search UI.
@@ -11,13 +10,10 @@ tags:
   - highlight values
   - search values
 react:
-  id: 48lhnrbd
   metaTitle: Searching values - React Data Grid | Handsontable
 angular:
-  id: q7wwbzzr
   metaTitle: Searching values - Angular Data Grid | Handsontable
 vue:
-  id: bzxlya7r
   metaTitle: Searching values - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Navigation

--- a/docs/content/guides/optimization/batch-operations/batch-operations.md
+++ b/docs/content/guides/optimization/batch-operations/batch-operations.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: kgegbmgz
 title: Batch operations
 metaTitle: Batch operations - JavaScript Data Grid | Handsontable
 description: Batch CRUD operations, to avoid unnecessary rendering cycles and boost your grid's performance.
@@ -11,13 +10,10 @@ tags:
   - batching
   - performance
 react:
-  id: 3xqdvk3u
   metaTitle: Batch operations - React Data Grid | Handsontable
 angular:
-  id: tnvv2pjr
   metaTitle: Batch operations - Angular Data Grid | Handsontable
 vue:
-  id: 2h71fwls
   metaTitle: Batch operations - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Optimization

--- a/docs/content/guides/optimization/bundle-size/bundle-size.md
+++ b/docs/content/guides/optimization/bundle-size/bundle-size.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: vjcvrdeh
 title: Bundle size
 metaTitle: Bundle size - JavaScript Data Grid | Handsontable
 description: Reduce the size of your JavaScript bundle by getting rid of redundant Handsontable modules and Moment.js locales.
@@ -9,13 +8,10 @@ canonicalUrl: /bundle-size
 tags:
   - size
 react:
-  id: c8onyes4
   metaTitle: Bundle size - React Data Grid | Handsontable
 angular:
-  id: qdq3dmts
   metaTitle: Bundle size - Angular Data Grid | Handsontable
 vue:
-  id: 3hb79ptx
   metaTitle: Bundle size - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Optimization

--- a/docs/content/guides/optimization/performance/performance.md
+++ b/docs/content/guides/optimization/performance/performance.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: w6bvsin5
 title: Performance
 metaTitle: Performance - JavaScript Data Grid | Handsontable
 description: Boost your grid's performance by setting a constant column size, suspending rendering, deciding how many rows and columns are pre-rendered, and more.
@@ -9,13 +8,10 @@ canonicalUrl: /performance
 tags:
   - speed
 react:
-  id: gbdbrlc8
   metaTitle: Performance - React Data Grid | Handsontable
 angular:
-  id: 34wyxzpj
   metaTitle: Performance - Angular Data Grid | Handsontable
 vue:
-  id: 983rpyud
   metaTitle: Performance - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Optimization

--- a/docs/content/guides/rows/row-freezing/row-freezing.md
+++ b/docs/content/guides/rows/row-freezing/row-freezing.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: jgrtvjxx
 title: Row freezing
 metaTitle: Row freezing - JavaScript Data Grid | Handsontable
 description: Lock (freeze) the position of specified rows, keeping them visible while scrolling to another area of the grid. This feature is sometimes called "pinned rows".
@@ -11,13 +10,10 @@ tags:
   - pinning rows
   - fixedRows
 react:
-  id: y5wx1mrk
   metaTitle: Row freezing - React Data Grid | Handsontable
 angular:
-  id: mskor25j
   metaTitle: Row freezing - Angular Data Grid | Handsontable
 vue:
-  id: 42j169m6
   metaTitle: Row freezing - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Rows

--- a/docs/content/guides/rows/row-header/row-header.md
+++ b/docs/content/guides/rows/row-header/row-header.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: j1zswn3i
 title: Row headers
 metaTitle: Row headers - JavaScript Data Grid | Handsontable
 description: Use default row headers (1, 2, 3), or set them to custom values provided by an array or a function.
@@ -11,13 +10,10 @@ tags:
   - bind rows with headers
   - row id
 react:
-  id: prlcpqk8
   metaTitle: Row headers - React Data Grid | Handsontable
 angular:
-  id: jtqk0t2p
   metaTitle: Row headers - Angular Data Grid | Handsontable
 vue:
-  id: 27seavlh
   metaTitle: Row headers - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Rows

--- a/docs/content/guides/rows/row-height/row-height.md
+++ b/docs/content/guides/rows/row-height/row-height.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: fehmrn1j
 title: Row heights
 metaTitle: Row heights - JavaScript Data Grid | Handsontable
 description: Configure row heights, using a number, an array or a function. Let your users manually change row heights using Handsontable's interface.
@@ -18,13 +17,10 @@ tags:
   - row dimensions
   - manual resize
 react:
-  id: 87ulwfs2
   metaTitle: Row heights - React Data Grid | Handsontable
 angular:
-  id: h42skmvo
   metaTitle: Row heights - Angular Data Grid | Handsontable
 vue:
-  id: xj52ap5s
   metaTitle: Row heights - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Rows

--- a/docs/content/guides/rows/row-hiding/row-hiding.md
+++ b/docs/content/guides/rows/row-hiding/row-hiding.md
@@ -1,19 +1,15 @@
 ---
 type: how-to
-id: 37786931
 title: Row hiding
 metaTitle: Row hiding - JavaScript Data Grid | Handsontable
 description: Hide individual rows to avoid rendering them as DOM elements. It helps you reduce screen clutter and improve the grid's performance.
 permalink: /row-hiding
 canonicalUrl: /row-hiding
 react:
-  id: al1djb6l
   metaTitle: Row hiding - React Data Grid | Handsontable
 angular:
-  id: 2dxb42jh
   metaTitle: Row hiding - Angular Data Grid | Handsontable
 vue:
-  id: e9gf8ukv
   metaTitle: Row hiding - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Rows

--- a/docs/content/guides/rows/row-moving/row-moving.md
+++ b/docs/content/guides/rows/row-moving/row-moving.md
@@ -1,19 +1,15 @@
 ---
 type: how-to
-id: d2in9k81
 title: Row moving
 metaTitle: Row moving - JavaScript Data Grid | Handsontable
 description: Change the order of rows, either manually (dragging them to another location), or programmatically (using Handsontable's API methods).
 permalink: /row-moving
 canonicalUrl: /row-moving
 react:
-  id: g5mksyu1
   metaTitle: Row moving - React Data Grid | Handsontable
 angular:
-  id: ntz1a9ns
   metaTitle: Row moving - Angular Data Grid | Handsontable
 vue:
-  id: hhbbqpe7
   metaTitle: Row moving - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Rows

--- a/docs/content/guides/rows/row-parent-child/row-parent-child.md
+++ b/docs/content/guides/rows/row-parent-child/row-parent-child.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: ivtc0o9b
 title: Row parent-child
 metaTitle: Row parent-child - JavaScript Data Grid | Handsontable
 description:
@@ -16,13 +15,10 @@ tags:
   - grouping rows
   - master detail
 react:
-  id: vo8uukt2
   metaTitle: Row parent-child - React Data Grid | Handsontable
 angular:
-  id: ojdl5nkd
   metaTitle: Row parent-child - Angular Data Grid | Handsontable
 vue:
-  id: 9ww894yr
   metaTitle: Row parent-child - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Rows

--- a/docs/content/guides/rows/row-prepopulating/row-prepopulating.md
+++ b/docs/content/guides/rows/row-prepopulating/row-prepopulating.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: 42px61id
 title: Row pre-populating
 metaTitle: Row pre-populating - JavaScript Data Grid | Handsontable
 description: Pre-populate spare rows with default values using minSpareRows, custom placeholder renderers, or auto-filling template values.
@@ -12,13 +11,10 @@ tags:
   - bottom rows
   - placeholder
 react:
-  id: kmqhr00y
   metaTitle: Row pre-populating - React Data Grid | Handsontable
 angular:
-  id: me99ozqr
   metaTitle: Row pre-populating - Angular Data Grid | Handsontable
 vue:
-  id: 8y54l1cw
   metaTitle: Row pre-populating - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Rows

--- a/docs/content/guides/rows/row-trimming/row-trimming.md
+++ b/docs/content/guides/rows/row-trimming/row-trimming.md
@@ -1,19 +1,15 @@
 ---
 type: how-to
-id: 4q2wi29j
 title: Row trimming
 metaTitle: Row trimming - JavaScript Data Grid | Handsontable
 description: Hide individual rows from your interface and exclude them from the rendering process and DataMap. This feature is similar, but not the same, as "hiding rows".
 permalink: /row-trimming
 canonicalUrl: /row-trimming
 react:
-  id: fkcjw0q1
   metaTitle: Row trimming - React Data Grid | Handsontable
 angular:
-  id: fhh1b0n6
   metaTitle: Row trimming - Angular Data Grid | Handsontable
 vue:
-  id: 0dah88rc
   metaTitle: Row trimming - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Rows

--- a/docs/content/guides/rows/row-virtualization/row-virtualization.md
+++ b/docs/content/guides/rows/row-virtualization/row-virtualization.md
@@ -1,6 +1,5 @@
 ---
 type: explanation
-id: vasj6t6t
 title: Row virtualization
 metaTitle: Row virtualization - JavaScript Data Grid | Handsontable
 description: Render thousands of rows without freezing the browser, using row virtualization.
@@ -11,13 +10,10 @@ tags:
   - render all rows
   - offset
 react:
-  id: kjsl63sh
   metaTitle: Row virtualization - React Data Grid | Handsontable
 angular:
-  id: 2imqjvmp
   metaTitle: Row virtualization - Angular Data Grid | Handsontable
 vue:
-  id: 0d3wrjhf
   metaTitle: Row virtualization - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Rows

--- a/docs/content/guides/rows/rows-pagination/rows-pagination.md
+++ b/docs/content/guides/rows/rows-pagination/rows-pagination.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: 85u4f81b
 title: Rows pagination
 metaTitle: Rows pagination - JavaScript Data Grid | Handsontable
 description: The pagination component splits the data into a range of pages, allowing users to easily navigate through large data sets.
@@ -20,13 +19,10 @@ tags:
   - range of pages
   - chunks
 react:
-  id: 5inhebcn
   metaTitle: Row pagination - React Data Grid | Handsontable
 angular:
-  id: lt6sgwts
   metaTitle: Row pagination - Angular Data Grid | Handsontable
 vue:
-  id: 57pnumth
   metaTitle: Row pagination - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Rows

--- a/docs/content/guides/rows/rows-sorting/rows-sorting.md
+++ b/docs/content/guides/rows/rows-sorting/rows-sorting.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: 6o0zftmc
 title: Rows sorting
 metaTitle: Rows sorting - JavaScript Data Grid | Handsontable
 description: Sort rows alphabetically or numerically, in ascending, descending or a custom order, by one or multiple columns.
@@ -26,13 +25,10 @@ tags:
   - sort rows
   - sort columns
 react:
-  id: h4jfevxj
   metaTitle: Rows sorting - React Data Grid | Handsontable
 angular:
-  id: kzkj37v5
   metaTitle: Rows sorting - Angular Data Grid | Handsontable
 vue:
-  id: d43129gx
   metaTitle: Rows sorting - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Rows

--- a/docs/content/guides/security/security/security.md
+++ b/docs/content/guides/security/security/security.md
@@ -1,19 +1,15 @@
 ---
 type: explanation
-id: nb36sme6
 title: Security
 metaTitle: Security - JavaScript Data Grid | Handsontable
 description: Learn about the security measures we take to make sure you can safely implement Handsontable in your client-side application.
 permalink: /security
 canonicalUrl: /security
 react:
-  id: h8zg4ign
   metaTitle: Security - React Data Grid | Handsontable
 angular:
-  id: 25m4fmia
   metaTitle: Security - Angular Data Grid | Handsontable
 vue:
-  id: jwm6n1b7
   metaTitle: Security - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Security

--- a/docs/content/guides/styling/design-system/design-system.md
+++ b/docs/content/guides/styling/design-system/design-system.md
@@ -1,6 +1,5 @@
 ---
 type: explanation
-id: xfus5qpz
 title: Design System
 metaTitle: Design System / UI Kit - JavaScript Data Grid | Handsontable
 description: Design, prototype, and customize spreadsheet-like components with the Design System for Figma.
@@ -18,13 +17,10 @@ tags:
   - local variables
   - tokens
 react:
-  id: 0mz9id0l
   metaTitle: Design System / UI Kit - React Data Grid | Handsontable
 angular:
-  id: vru7jook
   metaTitle: Design System / UI Kit - Angular Data Grid | Handsontable
 vue:
-  id: ehyr1ulk
   metaTitle: Design System / UI Kit - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Styling

--- a/docs/content/guides/styling/legacy-style/legacy-style.md
+++ b/docs/content/guides/styling/legacy-style/legacy-style.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: yfus6qpz
 title: Legacy Style
 metaTitle: Legacy Style - JavaScript Data Grid | Handsontable
 description: The legacy stylesheet was removed in Handsontable 17.0.0. Learn how to migrate to the Classic theme using the Theme API or CSS imports.
@@ -14,13 +13,10 @@ tags:
   - classic theme
   - legacy
 react:
-  id: jn3po47i
   metaTitle: Legacy Style - React Data Grid | Handsontable
 angular:
-  id: 1sco7djp
   metaTitle: Legacy Style - Angular Data Grid | Handsontable
 vue:
-  id: 6xwhqf4v
   metaTitle: Legacy Style - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Styling

--- a/docs/content/guides/styling/theme-customization/theme-customization.md
+++ b/docs/content/guides/styling/theme-customization/theme-customization.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: x2u15qpx
 title: Theme Customization
 metaTitle: Theme Customization - JavaScript Data Grid | Handsontable
 description: Customize Handsontable's appearance using the Theme API, Figma Theme Generator, CSS variables, or the visual Theme Builder.
@@ -18,13 +17,10 @@ tags:
   - local variables
   - tokens
 react:
-  id: 0m19ic0d
   metaTitle: Theme Customization - React Data Grid | Handsontable
 angular:
-  id: xau2jfok
   metaTitle: Theme Customization - Angular Data Grid | Handsontable
 vue:
-  id: 2t881imb
   metaTitle: Theme Customization - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Styling

--- a/docs/content/guides/styling/themes/themes.md
+++ b/docs/content/guides/styling/themes/themes.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: jn1po47i
 title: Themes
 metaTitle: Themes - JavaScript Data Grid | Handsontable
 description: Apply themes using the Theme API or CSS files. Built-in themes include main, horizon, and classic with automatic light and dark modes.
@@ -23,13 +22,10 @@ tags:
   - visual tokens
   - design system
 react:
-  id: jn2po47i
   metaTitle: Themes - React Data Grid | Handsontable
 angular:
-  id: 1sco6djp
   metaTitle: Themes - Angular Data Grid | Handsontable
 vue:
-  id: ioop937e
   metaTitle: Themes - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Styling

--- a/docs/content/guides/technical-specification/documentation-license/documentation-license.md
+++ b/docs/content/guides/technical-specification/documentation-license/documentation-license.md
@@ -1,19 +1,15 @@
 ---
 type: reference
-id: hpr42b2a
 title: Documentation license
 metaTitle: Documentation license - JavaScript Data Grid | Handsontable
 description: Learn about the licensing terms of Handsontable's documentation.
 permalink: /documentation-license
 canonicalUrl: /documentation-license
 react:
-  id: u3lvnmzh
   metaTitle: Documentation license - React Data Grid | Handsontable
 angular:
-  id: g9ytiw67
   metaTitle: Documentation license - Angular Data Grid | Handsontable
 vue:
-  id: cr13gd09
   metaTitle: Documentation license - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Technical specification

--- a/docs/content/guides/technical-specification/software-license/software-license.md
+++ b/docs/content/guides/technical-specification/software-license/software-license.md
@@ -1,19 +1,15 @@
 ---
 type: reference
-id: jgk5hkn4
 title: Software license
 metaTitle: Software license - JavaScript Data Grid | Handsontable
 description: Learn about the licensing terms of the Handsontable data grid.
 permalink: /software-license
 canonicalUrl: /software-license
 react:
-  id: ea206i3o
   metaTitle: Software license - React Data Grid | Handsontable
 angular:
-  id: fe9wliki
   metaTitle: Software license - Angular Data Grid | Handsontable
 vue:
-  id: l0bvmbpl
   metaTitle: Software license - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Technical specification

--- a/docs/content/guides/technical-specification/supported-browsers/supported-browsers.md
+++ b/docs/content/guides/technical-specification/supported-browsers/supported-browsers.md
@@ -1,6 +1,5 @@
 ---
 type: reference
-id: zzjh2u93
 title: Supported browsers
 metaTitle: Supported browsers - JavaScript Data Grid | Handsontable
 description: Handsontable supports the most popular desktop and mobile browsers, such as Chrome, Safari, Firefox, Edge, Opera, Samsung Internet, and others.
@@ -9,13 +8,10 @@ canonicalUrl: /supported-browsers
 tags:
   - compatibility
 react:
-  id: 1e7f39og
   metaTitle: Supported browsers - React Data Grid | Handsontable
 angular:
-  id: a7fpjwud
   metaTitle: Supported browsers - Angular Data Grid | Handsontable
 vue:
-  id: 6kn7722c
   metaTitle: Supported browsers - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Technical specification

--- a/docs/content/guides/technical-specification/third-party-licenses/third-party-licenses.md
+++ b/docs/content/guides/technical-specification/third-party-licenses/third-party-licenses.md
@@ -1,19 +1,15 @@
 ---
 type: reference
-id: rck7asx7
 title: Third-party licenses
 metaTitle: Third-party licenses - JavaScript Data Grid | Handsontable
 description: Learn about the licensing terms of Handsontable's software dependencies.
 permalink: /third-party-licenses
 canonicalUrl: /third-party-licenses
 react:
-  id: 5rt8dyg9
   metaTitle: Third-party licenses - React Data Grid | Handsontable
 angular:
-  id: kc0urkyj
   metaTitle: Third-party licenses - Angular Data Grid | Handsontable
 vue:
-  id: ztyi7ggq
   metaTitle: Third-party licenses - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Technical specification

--- a/docs/content/guides/tools-and-building/custom-builds/custom-builds.md
+++ b/docs/content/guides/tools-and-building/custom-builds/custom-builds.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: 7a5vawwl
 title: Custom builds
 metaTitle: Custom builds - JavaScript Data Grid | Handsontable
 description: Handsontable's building process transforms the source files located in the code repository into dedicated packages.
@@ -11,13 +10,10 @@ tags:
   - bundling
   - contributing
 react:
-  id: pcflnieu
   metaTitle: Custom builds - React Data Grid | Handsontable
 angular:
-  id: 098p9wiw
   metaTitle: Custom builds - Angular Data Grid | Handsontable
 vue:
-  id: kg9fj032
   metaTitle: Custom builds - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Tools and building

--- a/docs/content/guides/tools-and-building/custom-plugins/custom-plugins.md
+++ b/docs/content/guides/tools-and-building/custom-plugins/custom-plugins.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: 39o3uw0q
 title: Custom plugins
 metaTitle: Custom plugins - JavaScript Data Grid | Handsontable
 description: Extend Handsontable's functionality by writing your custom plugin. Use the BasePlugin for a quick start.
@@ -11,13 +10,10 @@ tags:
   - skeleton
   - extend
 react:
-  id: y66k6b2h
   metaTitle: Custom plugins - React Data Grid | Handsontable
 angular:
-  id: ompl9j5i
   metaTitle: Custom plugins - Angular Data Grid | Handsontable
 vue:
-  id: 8w2zb1ze
   metaTitle: Custom plugins - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Tools and building

--- a/docs/content/guides/tools-and-building/modules/modules.md
+++ b/docs/content/guides/tools-and-building/modules/modules.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: ffimaicc
 title: Modules
 metaTitle: Modules - JavaScript Data Grid | Handsontable
 description: Reduce the size of your JavaScript bundle, by importing only the modules that you need. The base module is mandatory, all other modules are optional.
@@ -9,13 +8,10 @@ canonicalUrl: /modules
 tags:
   - tree shaking
 react:
-  id: weudz1vh
   metaTitle: Modules - React Data Grid | Handsontable
 angular:
-  id: 9i62e6cn
   metaTitle: Modules - Angular Data Grid | Handsontable
 vue:
-  id: xvedd0on
   metaTitle: Modules - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Tools and building

--- a/docs/content/guides/tools-and-building/packages/packages.md
+++ b/docs/content/guides/tools-and-building/packages/packages.md
@@ -1,6 +1,5 @@
 ---
 type: reference
-id: xt5zuczu
 title: Packages
 metaTitle: Packages - JavaScript Data Grid | Handsontable
 description: Instantly add Handsontable to your web app, using pre-built UMD packages of JavaScript and CSS.

--- a/docs/content/guides/tools-and-building/testing/testing.md
+++ b/docs/content/guides/tools-and-building/testing/testing.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: 6fv7kuj6
 title: Testing
 metaTitle: Testing - JavaScript Data Grid | Handsontable
 description: Run one or multiple tests, using Handsontable's ready-made commands for Jasmine and Puppeteer.
@@ -14,13 +13,10 @@ tags:
   - puppeteer
   - spec
 react:
-  id: y3wp74jh
   metaTitle: Testing - React Data Grid | Handsontable
 angular:
-  id: zggveqea
   metaTitle: Testing - Angular Data Grid | Handsontable
 vue:
-  id: kx1qz7jh
   metaTitle: Testing - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Tools and building

--- a/docs/content/guides/tools-and-building/typescript-types/typescript-types.md
+++ b/docs/content/guides/tools-and-building/typescript-types/typescript-types.md
@@ -1,6 +1,5 @@
 ---
 type: reference
-id: t9kx3mwp
 title: TypeScript types
 metaTitle: TypeScript types - JavaScript Data Grid | Handsontable
 description: A complete reference of the TypeScript types and interfaces that Handsontable exports, with usage examples for settings, hook callbacks, custom renderers, and editors.
@@ -12,13 +11,10 @@ tags:
   - interfaces
   - type safety
 react:
-  id: r2bq7nyc
   metaTitle: TypeScript types - React Data Grid | Handsontable
 angular:
-  id: a5vj6hsz
   metaTitle: TypeScript types - Angular Data Grid | Handsontable
 vue:
-  id: v8j6vpbp
   metaTitle: TypeScript types - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Tools and building

--- a/docs/content/guides/upgrade-and-migration/changelog-10/changelog-10.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-10/changelog-10.md
@@ -1,19 +1,15 @@
 ---
 type: reference
-id: 6x1ythps
 title: Changelog 10.0
 metaTitle: Changelog 10.0 - JavaScript Data Grid | Handsontable
 description: See the full history of changes made to Handsontable 10.0 in each minor and patch release.
 permalink: /changelog-10
 canonicalUrl: /changelog-10
 react:
-  id: 5mrcneib
   metaTitle: Changelog 10.0 - React Data Grid | Handsontable
 angular:
-  id: jizop4f1
   metaTitle: Changelog 10.0 - Angular Data Grid | Handsontable
 vue:
-  id: 3ycojv99
   metaTitle: Changelog 10.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration

--- a/docs/content/guides/upgrade-and-migration/changelog-11/changelog-11.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-11/changelog-11.md
@@ -1,19 +1,15 @@
 ---
 type: reference
-id: kk7fprli
 title: Changelog 11.0
 metaTitle: Changelog 11.0 - JavaScript Data Grid | Handsontable
 description: See the full history of changes made to Handsontable 11.0 in each minor and patch release.
 permalink: /changelog-11
 canonicalUrl: /changelog-11
 react:
-  id: ny8fq2bb
   metaTitle: Changelog 11.0 - React Data Grid | Handsontable
 angular:
-  id: 9fzgv1of
   metaTitle: Changelog 11.0 - Angular Data Grid | Handsontable
 vue:
-  id: aitghfh1
   metaTitle: Changelog 11.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration

--- a/docs/content/guides/upgrade-and-migration/changelog-12/changelog-12.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-12/changelog-12.md
@@ -1,19 +1,15 @@
 ---
 type: reference
-id: t93bqrh5
 title: Changelog 12.0
 metaTitle: Changelog 12.0 - JavaScript Data Grid | Handsontable
 description: See the full history of changes made to Handsontable 12.0 in each minor and patch release.
 permalink: /changelog-12
 canonicalUrl: /changelog-12
 react:
-  id: v49fpp8y
   metaTitle: Changelog 12.0 - React Data Grid | Handsontable
 angular:
-  id: w26ga6t8
   metaTitle: Changelog 12.0 - Angular Data Grid | Handsontable
 vue:
-  id: c2zp1wav
   metaTitle: Changelog 12.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration

--- a/docs/content/guides/upgrade-and-migration/changelog-13/changelog-13.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-13/changelog-13.md
@@ -1,19 +1,15 @@
 ---
 type: reference
-id: e195f568
 title: Changelog 13.0
 metaTitle: Changelog 13.0 - JavaScript Data Grid | Handsontable
 description: See the full history of changes made to Handsontable 13.0 in each minor and patch release.
 permalink: /changelog-13
 canonicalUrl: /changelog-13
 react:
-  id: 6j5r5hmi
   metaTitle: Changelog 13.0 - React Data Grid | Handsontable
 angular:
-  id: yf3kyziz
   metaTitle: Changelog 13.0 - Angular Data Grid | Handsontable
 vue:
-  id: wltmh28p
   metaTitle: Changelog 13.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration

--- a/docs/content/guides/upgrade-and-migration/changelog-14/changelog-14.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-14/changelog-14.md
@@ -1,19 +1,15 @@
 ---
 type: reference
-id: 5wvnjbho
 title: Changelog 14.0
 metaTitle: Changelog 14.0 - JavaScript Data Grid | Handsontable
 description: See the full history of changes made to Handsontable 14.0 in each minor and patch release.
 permalink: /changelog-14
 canonicalUrl: /changelog-14
 react:
-  id: dhkjk1de
   metaTitle: Changelog 14.0 - React Data Grid | Handsontable
 angular:
-  id: d5haqby0
   metaTitle: Changelog 14.0 - Angular Data Grid | Handsontable
 vue:
-  id: st0v0t8a
   metaTitle: Changelog 14.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration

--- a/docs/content/guides/upgrade-and-migration/changelog-15/changelog-15.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-15/changelog-15.md
@@ -1,19 +1,15 @@
 ---
 type: reference
-id: yhyglrda
 title: Changelog 15.0
 metaTitle: Changelog 15.0 - JavaScript Data Grid | Handsontable
 description: See the full history of changes made to Handsontable 15.0 in each minor and patch release.
 permalink: /changelog-15
 canonicalUrl: /changelog-15
 react:
-  id: ehmp2gq9
   metaTitle: Changelog 15.0 - React Data Grid | Handsontable
 angular:
-  id: m8s84zjg
   metaTitle: Changelog 15.0 - Angular Data Grid | Handsontable
 vue:
-  id: 6tqfgd15
   metaTitle: Changelog 15.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration

--- a/docs/content/guides/upgrade-and-migration/changelog-16/changelog-16.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-16/changelog-16.md
@@ -1,19 +1,15 @@
 ---
 type: reference
-id: znsspzmg
 title: Changelog 16.0
 metaTitle: Changelog 16.0 - JavaScript Data Grid | Handsontable
 description: See the full history of changes made to Handsontable 16.0 in each minor and patch release.
 permalink: /changelog-16
 canonicalUrl: /changelog-16
 react:
-  id: jdezk1ny
   metaTitle: Changelog 16.0 - React Data Grid | Handsontable
 angular:
-  id: hjp86je4
   metaTitle: Changelog 16.0 - Angular Data Grid | Handsontable
 vue:
-  id: szp3hgw3
   metaTitle: Changelog 16.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration

--- a/docs/content/guides/upgrade-and-migration/changelog-17/changelog-17.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-17/changelog-17.md
@@ -1,19 +1,15 @@
 ---
 type: reference
-id: l59xqo44
 title: Changelog 17.0
 metaTitle: Changelog 17.0 - JavaScript Data Grid | Handsontable
 description: See the full history of changes made to Handsontable 17.0 in each minor and patch release.
 permalink: /changelog-17
 canonicalUrl: /changelog-17
 react:
-  id: tgfvndey
   metaTitle: Changelog 17.0 - React Data Grid | Handsontable
 angular:
-  id: wyn633o3
   metaTitle: Changelog 17.0 - Angular Data Grid | Handsontable
 vue:
-  id: ubusl9gr
   metaTitle: Changelog 17.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration

--- a/docs/content/guides/upgrade-and-migration/changelog-7/changelog-7.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-7/changelog-7.md
@@ -1,19 +1,15 @@
 ---
 type: reference
-id: 5t9ao5jq
 title: Older versions
 metaTitle: Older versions - JavaScript Data Grid | Handsontable
 description: See the full history of changes made to older versions of Handsontable.
 permalink: /changelog-older
 canonicalUrl: /changelog-older
 react:
-  id: dhzkd73r
   metaTitle: Older versions - React Data Grid | Handsontable
 angular:
-  id: fqniwvjh
   metaTitle: Older versions - Angular Data Grid | Handsontable
 vue:
-  id: v80zhxm8
   metaTitle: Older versions - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration

--- a/docs/content/guides/upgrade-and-migration/changelog-8/changelog-8.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-8/changelog-8.md
@@ -1,19 +1,15 @@
 ---
 type: reference
-id: umu0w734
 title: Changelog 8.0
 metaTitle: Changelog 8.0 - JavaScript Data Grid | Handsontable
 description: See the full history of changes made to Handsontable 8.0 in each minor and patch release.
 permalink: /changelog-8
 canonicalUrl: /changelog-8
 react:
-  id: 9at7xeg2
   metaTitle: Changelog 8.0 - React Data Grid | Handsontable
 angular:
-  id: m4tjxvhx
   metaTitle: Changelog 8.0 - Angular Data Grid | Handsontable
 vue:
-  id: ck0vyddl
   metaTitle: Changelog 8.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration

--- a/docs/content/guides/upgrade-and-migration/changelog-9/changelog-9.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-9/changelog-9.md
@@ -1,19 +1,15 @@
 ---
 type: reference
-id: flrcarvt
 title: Changelog 9.0
 metaTitle: Changelog 9.0 - JavaScript Data Grid | Handsontable
 description: See the full history of changes made to Handsontable 9.0 in each minor and patch release.
 permalink: /changelog-9
 canonicalUrl: /changelog-9
 react:
-  id: lz2if8hm
   metaTitle: Changelog 9.0 - React Data Grid | Handsontable
 angular:
-  id: 0q8lci2y
   metaTitle: Changelog 9.0 - Angular Data Grid | Handsontable
 vue:
-  id: wxwai6xr
   metaTitle: Changelog 9.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration

--- a/docs/content/guides/upgrade-and-migration/changelog/changelog.md
+++ b/docs/content/guides/upgrade-and-migration/changelog/changelog.md
@@ -1,6 +1,5 @@
 ---
 type: reference
-id: nbp8i3mk
 title: Changelog
 metaTitle: Changelog - JavaScript Data Grid | Handsontable
 description:
@@ -14,13 +13,10 @@ tags:
   - upgrade
   - breaking change
 react:
-  id: 7y9fco03
   metaTitle: Changelog - React Data Grid | Handsontable
 angular:
-  id: um6ros3a
   metaTitle: Changelog - Angular Data Grid | Handsontable
 vue:
-  id: a5q6rij8
   metaTitle: Changelog - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration

--- a/docs/content/guides/upgrade-and-migration/deprecation-policy/deprecation-policy.md
+++ b/docs/content/guides/upgrade-and-migration/deprecation-policy/deprecation-policy.md
@@ -1,19 +1,15 @@
 ---
 type: explanation
-id: 4f25a767
 title: Deprecation policy
 metaTitle: Deprecation policy - JavaScript Data Grid | Handsontable
 description: Handsontable ensures that if API is marked deprecated, we commit to a grace period (at least 3 months) during which the deprecated feature still works.
 permalink: /deprecation-policy
 canonicalUrl: /deprecation-policy
 react:
-  id: 16cb9e4b
   metaTitle: Deprecation policy - React Data Grid | Handsontable
 angular:
-  id: d5ac977b
   metaTitle: Deprecation policy - Angular Data Grid | Handsontable
 vue:
-  id: yqn3hlb4
   metaTitle: Deprecation policy - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration

--- a/docs/content/guides/upgrade-and-migration/long-term-support/long-term-support.md
+++ b/docs/content/guides/upgrade-and-migration/long-term-support/long-term-support.md
@@ -1,19 +1,15 @@
 ---
 type: explanation
-id: 4055bdfa
 title: Long Term Support (LTS)
 metaTitle: Long Term Support (LTS) - JavaScript Data Grid | Handsontable
 description: LTS (Long-Term Support) versions are Handsontable releases that are maintained for an extended period. 
 permalink: /long-term-support
 canonicalUrl: /long-term-support
 react:
-  id: cff9afef
   metaTitle: Long Term Support (LTS) - React Data Grid | Handsontable
 angular:
-  id: 0dc19b1b
   metaTitle: Long Term Support (LTS) - Angular Data Grid | Handsontable
 vue:
-  id: tydr1bbr
   metaTitle: Long Term Support (LTS) - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration

--- a/docs/content/guides/upgrade-and-migration/migrating-from-10.0-to-11.0/migrating-from-10.0-to-11.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-10.0-to-11.0/migrating-from-10.0-to-11.0.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: m946ghwr
 title: Migrating from 10.0 to 11.0
 metaTitle: Migrate from 10.0 to 11.0 - JavaScript Data Grid | Handsontable
 description: Migrate from Handsontable 10.0 to Handsontable 11.0, released on November 17, 2021.
@@ -8,13 +7,10 @@ permalink: /migration-from-10.0-to-11.0
 canonicalUrl: /migration-from-10.0-to-11.0
 pageClass: migration-guide
 react:
-  id: sney23fh
   metaTitle: Migrate from 10.0 to 11.0 - React Data Grid | Handsontable
 angular:
-  id: 1fc8toqq
   metaTitle: Migrate from 10.0 to 11.0 - Angular Data Grid | Handsontable
 vue:
-  id: cvsqifxl
   metaTitle: Migrate from 10.0 to 11.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration

--- a/docs/content/guides/upgrade-and-migration/migrating-from-11.1-to-12.0/migrating-from-11.1-to-12.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-11.1-to-12.0/migrating-from-11.1-to-12.0.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: tpa768pc
 title: Migrating from 11.1 to 12.0
 metaTitle: Migrate from 11.1 to 12.0 - JavaScript Data Grid | Handsontable
 description: Migrate from Handsontable 11.1 to Handsontable 12.0, released on April 28, 2022.
@@ -8,13 +7,10 @@ permalink: /migration-from-11.1-to-12.0
 canonicalUrl: /migration-from-11.1-to-12.0
 pageClass: migration-guide
 react:
-  id: ncj9bstu
   metaTitle: Migrate from 11.1 to 12.0 - React Data Grid | Handsontable
 angular:
-  id: e9gbxrvk
   metaTitle: Migrate from 11.1 to 12.0 - Angular Data Grid | Handsontable
 vue:
-  id: cxu9kcv7
   metaTitle: Migrate from 11.1 to 12.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration

--- a/docs/content/guides/upgrade-and-migration/migrating-from-12.4-to-13.0/migrating-from-12.4-to-13.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-12.4-to-13.0/migrating-from-12.4-to-13.0.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: fgjqkigc
 title: Migrating from 12.4 to 13.0
 metaTitle: Migrate from 12.4 to 13.0 - JavaScript Data Grid | Handsontable
 description: Migrate from Handsontable 12.4 to Handsontable 13.0, released on June 22, 2023.
@@ -8,13 +7,10 @@ permalink: /migration-from-12.4-to-13.0
 canonicalUrl: /migration-from-12.4-to-13.0
 pageClass: migration-guide
 react:
-  id: tvum3ibg
   metaTitle: Migrate from 12.4 to 13.0 - React Data Grid | Handsontable
 angular:
-  id: kgutwhxo
   metaTitle: Migrate from 12.4 to 13.0 - Angular Data Grid | Handsontable
 vue:
-  id: i1ljbb3p
   metaTitle: Migrate from 12.4 to 13.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration

--- a/docs/content/guides/upgrade-and-migration/migrating-from-13.1-to-14.0/migrating-from-13.1-to-14.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-13.1-to-14.0/migrating-from-13.1-to-14.0.md
@@ -14,7 +14,6 @@ angular:
   id: rxlauyd8-13.1-to-14.0-react
   metaTitle: Migrate from 13.1 to 14.0 - Angular Data Grid | Handsontable
 vue:
-  id: 40f19qus
   metaTitle: Migrate from 13.1 to 14.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration

--- a/docs/content/guides/upgrade-and-migration/migrating-from-14.6-to-15.0/migrating-from-14.6-to-15.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-14.6-to-15.0/migrating-from-14.6-to-15.0.md
@@ -14,7 +14,6 @@ angular:
   id: 7kr2r20j-14.6-to-15.0-react
   metaTitle: Migrate from 14.6 to 15.0 - Angular Data Grid | Handsontable
 vue:
-  id: d0lcx03j
   metaTitle: Migrate from 14.6 to 15.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration

--- a/docs/content/guides/upgrade-and-migration/migrating-from-15.3-to-16.0/migrating-from-15.3-to-16.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-15.3-to-16.0/migrating-from-15.3-to-16.0.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: 1k7arh9z
 title: Migrating from 15.3 to 16.0
 metaTitle: Migrating from 15.3 to 16.0 - JavaScript Data Grid | Handsontable
 description: Migrate from Handsontable 15.3 to Handsontable 16.0, released on July 9, 2025.
@@ -8,13 +7,10 @@ permalink: /migration-from-15.3-to-16.0
 canonicalUrl: /migration-from-15.3-to-16.0
 pageClass: migration-guide
 react:
-  id: 4k7wrh9z
   metaTitle: Migrate from 15.3 to 16.0 - React Data Grid | Handsontable
 angular:
-  id: 9v65a4pd
   metaTitle: Migrate from 15.3 to 16.0 - Angular Data Grid | Handsontable
 vue:
-  id: qe6ypgg9
   metaTitle: Migrate from 15.3 to 16.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration

--- a/docs/content/guides/upgrade-and-migration/migrating-from-16.0-to-16.1/migrating-from-16.0-to-16.1.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-16.0-to-16.1/migrating-from-16.0-to-16.1.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: sf7vrh9z
 title: Migrating from 16.0 to 16.1
 metaTitle: Migrating from 16.0 to 16.1 - JavaScript Data Grid | Handsontable
 description: Migrate from Handsontable 16.0 to Handsontable 16.1, released on September 15, 2025.
@@ -8,13 +7,10 @@ permalink: /migration-from-16.0-to-16.1
 canonicalUrl: /migration-from-16.0-to-16.1
 pageClass: migration-guide
 react:
-  id: 1k2grh9z
   metaTitle: Migrate from 16.0 to 16.1 - React Data Grid | Handsontable
 angular:
-  id: bv25a4sd
   metaTitle: Migrate from 16.0 to 16.1 - Angular Data Grid | Handsontable
 vue:
-  id: d7wjzk8v
   metaTitle: Migrate from 16.0 to 16.1 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration

--- a/docs/content/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: 9w5zs3t2
 title: Migrating from 16.2 to 17.0
 metaTitle: Migrating from 16.2 to 17.0 - JavaScript Data Grid | Handsontable
 description: Migrate from Handsontable 16.2 to Handsontable 17.0, released on released on March 09, 2025.
@@ -8,13 +7,10 @@ permalink: /migration-from-16.2-to-17.0
 canonicalUrl: /migration-from-16.2-to-17.0
 pageClass: migration-guide
 react:
-  id: xc52w3t2
   metaTitle: Migrate from 16.2 to 17.0 - React Data Grid | Handsontable
 angular:
-  id: 9r25a4sd
   metaTitle: Migrate from 16.2 to 17.0 - Angular Data Grid | Handsontable
 vue:
-  id: pv0dplqt
   metaTitle: Migrate from 16.2 to 17.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration

--- a/docs/content/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: m4hz9xy1
 title: Migrating from 17.1 to 18.0
 metaTitle: Migrating from 17.1 to 18.0 - JavaScript Data Grid | Handsontable
 description: Migrate from Handsontable 17.1 to Handsontable 18.0 -- update TypeScript imports from the removed handsontable/common subpath.
@@ -8,13 +7,10 @@ permalink: /migration-from-17.1-to-18.0
 canonicalUrl: /migration-from-17.1-to-18.0
 pageClass: migration-guide
 react:
-  id: p8qn2wr5
   metaTitle: Migrate from 17.1 to 18.0 - React Data Grid | Handsontable
 angular:
-  id: k3jb6ts0
   metaTitle: Migrate from 17.1 to 18.0 - Angular Data Grid | Handsontable
 vue:
-  id: 205js05l
   metaTitle: Migrate from 17.1 to 18.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration

--- a/docs/content/guides/upgrade-and-migration/migrating-from-7.4-to-8.0/migrating-from-7.4-to-8.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-7.4-to-8.0/migrating-from-7.4-to-8.0.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: g7ligsfi
 title: Migrate from 7.4 to 8.0
 metaTitle: Migrate from 7.4 to 8.0 - JavaScript Data Grid | Handsontable
 description: Migrate from Handsontable 7.4 to Handsontable 8.0, released on August 5, 2020.
@@ -8,13 +7,10 @@ permalink: /migration-from-7.4-to-8.0
 canonicalUrl: /migration-from-7.4-to-8.0
 pageClass: migration-guide
 react:
-  id: ivkac4xa
   metaTitle: Migrate from 7.4 to 8.0 - React Data Grid | Handsontable
 angular:
-  id: wo49dhyu
   metaTitle: Migrate from 7.4 to 8.0 - Angular Data Grid | Handsontable
 vue:
-  id: 0nffktzd
   metaTitle: Migrate from 7.4 to 8.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration

--- a/docs/content/guides/upgrade-and-migration/migrating-from-8.4-to-9.0/migrating-from-8.4-to-9.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-8.4-to-9.0/migrating-from-8.4-to-9.0.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: 3cqz2dy9
 title: Migrating from 8.4 to 9.0
 metaTitle: Migrate from 8.4 to 9.0 - JavaScript Data Grid | Handsontable
 description: Migrate from Handsontable 8.4 to Handsontable 9.0, released on June 1, 2021.
@@ -8,13 +7,10 @@ permalink: /migration-from-8.4-to-9.0
 canonicalUrl: /migration-from-8.4-to-9.0
 pageClass: migration-guide
 react:
-  id: yns5r79k
   metaTitle: Migrate from 8.4 to 9.0 - React Data Grid | Handsontable
 angular:
-  id: tulale8x
   metaTitle: Migrate from 8.4 to 9.0 - Angular Data Grid | Handsontable
 vue:
-  id: cdw8pqqn
   metaTitle: Migrate from 8.4 to 9.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration

--- a/docs/content/guides/upgrade-and-migration/migrating-from-9.0-to-10.0/migrating-from-9.0-to-10.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-9.0-to-10.0/migrating-from-9.0-to-10.0.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: 5l7bspro
 title: Migrating from 9.0 to 10.0
 metaTitle: Migrate from 9.0 to 10.0 - JavaScript Data Grid | Handsontable
 description: Migrate from Handsontable 9.0 to Handsontable 10.0, released on September 29, 2021.
@@ -8,13 +7,10 @@ permalink: /migration-from-9.0-to-10.0
 canonicalUrl: /migration-from-9.0-to-10.0
 pageClass: migration-guide
 react:
-  id: oh5ffbjc
   metaTitle: Migrate from 9.0 to 10.0 - React Data Grid | Handsontable
 angular:
-  id: a1bu3jwp
   metaTitle: Migrate from 9.0 to 10.0 - Angular Data Grid | Handsontable
 vue:
-  id: k9w710b0
   metaTitle: Migrate from 9.0 to 10.0 - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration

--- a/docs/content/guides/upgrade-and-migration/versioning-policy/versioning-policy.md
+++ b/docs/content/guides/upgrade-and-migration/versioning-policy/versioning-policy.md
@@ -1,19 +1,15 @@
 ---
 type: explanation
-id: fwrhn9ys
 title: Versioning policy
 metaTitle: Versioning policy - JavaScript Data Grid | Handsontable
 description: Handsontable follows the principles of Semantic Versioning (SemVer). Each version is numbered in the X.Y.Z (Major.Minor.Patch) format.
 permalink: /versioning-policy
 canonicalUrl: /versioning-policy
 react:
-  id: avrihx7w
   metaTitle: Versioning policy - React Data Grid | Handsontable
 angular:
-  id: 1q96vyfn
   metaTitle: Versioning policy - Angular Data Grid | Handsontable
 vue:
-  id: x4d3c7e7
   metaTitle: Versioning policy - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration


### PR DESCRIPTION
### Context

The PR removes vestigial `id:` fields from all docs page frontmatter. These fields were VuePress page identifiers carried over during the migration to Astro/Starlight. Investigation confirmed they are not consumed anywhere in the current codebase -- `src/content.config.ts` defines `react`/`vue`/`angular` blocks as `z.record(z.string(), z.unknown())` and no code reads those nested fields for routing, SEO, or rendering. The top-level `id:` field is labeled "VuePress unique page ID" in the schema comment.

Removes 507 lines across 136 files. `metaTitle` fields inside framework blocks are intentionally preserved (deferred to Phase 3).

[skip changelog]

### How has this been tested?

- `grep -rn '^id: [[:alnum:]]*$' content/guides --include='*.md'` -- zero matches after cleanup
- `grep -rn '^  id: [[:alnum:]]*$' content/guides --include='*.md'` -- zero matches after cleanup
- Spot-checked representative files to confirm `metaTitle`, `vue:`, `react:`, `angular:` blocks are intact

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1820

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1820

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only frontmatter deletion with no runtime or schema-breaking changes; optional `id` remains in the content schema for compatibility.
> 
> **Overview**
> Removes legacy **VuePress `id` fields** from guide frontmatter across the docs tree (~136 pages). Top-level `id:` entries and nested `id:` under `react` / `angular` / `vue` are dropped; **framework `metaTitle` values and other frontmatter are unchanged**.
> 
> A few Vue-only pages get **title/metaTitle wording tweaks** (e.g. HotColumn and Pinia guides). No guide body content or API behavior is modified—this is dead metadata cleanup after the Astro/Starlight migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1c7dd6ca66dcadbadef44aa13dd79219c8557d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->