### PR TITLE
DEV-1725: Fix Vue 3 documentation consistency gaps

### DIFF
--- a/docs/content/guides/accessibility/accessibility/accessibility.md
+++ b/docs/content/guides/accessibility/accessibility/accessibility.md
@@ -165,7 +165,7 @@ Check out the interactive demo below to see how various Handsontable settings im
 
 ::: example #example2 :vue3 --css 1
 
-@[code](@/content/guides/accessibility/accessibility/react/example2.css)
+@[code](@/content/guides/accessibility/accessibility/vue/example2.css)
 @[code](@/content/guides/accessibility/accessibility/vue/example2.vue)
 
 :::

--- a/docs/content/guides/accessibility/accessibility/vue/example2.css
+++ b/docs/content/guides/accessibility/accessibility/vue/example2.css
@@ -1,0 +1,75 @@
+.checkbox-container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin: 0 -1rem 0 !important;
+  padding: 0 1rem 0.75rem;
+  border-bottom: 1px solid var(--sl-color-gray-5, #e0e0e0);
+}
+
+.checkbox-container > div {
+  display: flex;
+}
+
+.checkbox-container > div > label {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.external-link {
+  margin-left: 0.5rem;
+  position: relative;
+  top: 2px;
+  color: var(--sl-color-text, #333333);
+}
+
+.external-link:hover {
+  color: var(--sl-color-accent, #1A42E8);
+}
+
+.placeholder-input {
+  max-width: 20rem;
+  padding: 0.4rem 0.625rem;
+  font-size: var(--sl-text-sm, 0.875rem);
+  line-height: 1.25rem;
+  color: var(--sl-color-text, #333333);
+  background: none;
+  border: 1px solid var(--sl-color-gray-5, #e0e0e0);
+  border-radius: 0;
+  outline: none;
+}
+
+.placeholder-input::placeholder {
+  color: var(--sl-color-gray-3, #777777);
+}
+
+.placeholder-input:focus {
+  border-color: var(--sl-color-accent, #1A42E8);
+}
+
+.option-label {
+  color: var(--sl-color-text, #333333);
+  font-size: var(--sl-text-sm, 0.875rem);
+}
+
+/*
+  We want the focus to be around input and label, in order to achieve this,
+  we remove focus from the input and add it to the label (wrapper in this case)
+  we then use the :focus-within pseudo class plus native focus styles
+  https://css-tricks.com/copy-the-browsers-native-focus-styles/
+*/
+.option-label:focus-within {
+  outline: 5px auto Highlight;
+  outline: 5px auto -webkit-focus-ring-color;
+}
+
+.option-label > input:focus {
+  outline: none;
+}
+
+.example-container {
+  gap: 1rem;
+  display: flex;
+  flex-direction: column;
+}

--- a/docs/content/guides/accessories-and-menus/export-to-csv/export-to-csv.md
+++ b/docs/content/guides/accessories-and-menus/export-to-csv/export-to-csv.md
@@ -205,6 +205,18 @@ For more information, see the [Instance methods](@/guides/getting-started/react-
 
 :::
 
+:::: only-for vue
+
+::: tip
+
+To use the Handsontable API, you'll need access to the Handsontable instance. You can do that by utilizing a reference to the `HotTable` component, and reading its `hotInstance` property.
+
+For more information, see the [Instance methods](@/guides/getting-started/vue3-hot-reference/vue3-hot-reference.md) page.
+
+:::
+
+::::
+
 The plugin exposes the following methods to export data.
 
 - [`downloadFile(format, options)`](@/api/exportFile.md#downloadfile) - generates a downloadable file directly in the browser. Synchronous; supports text-based formats only (e.g. CSV). For XLSX, use [`downloadFileAsync`](@/api/exportFile.md#downloadfileasync).

--- a/docs/content/guides/dialog/loading/loading.md
+++ b/docs/content/guides/dialog/loading/loading.md
@@ -221,7 +221,7 @@ The example below demonstrates how to use the Loading plugin with pagination in 
 
 ::: example #example4 :vue3 --css 1
 
-@[code](@/content/guides/dialog/loading/react/example4.css)
+@[code](@/content/guides/dialog/loading/vue/example4.css)
 @[code collapse={78-107,122-124}](@/content/guides/dialog/loading/vue/example4.vue)
 
 :::

--- a/docs/content/guides/dialog/loading/vue/example4.css
+++ b/docs/content/guides/dialog/loading/vue/example4.css
@@ -1,0 +1,14 @@
+.example4-pagination {
+  position: relative;
+}
+
+.example4-pagination.overlay .ht-pagination::before {
+  content: "";
+  display: block;
+  width: 100%;
+  height: 100%;
+  background-color: var(--ht-dialog-semi-transparent-background-color);
+  position: absolute;
+  inset: 0;
+  z-index: 1000;
+}

--- a/docs/content/guides/getting-started/configuration-options/configuration-options.md
+++ b/docs/content/guides/getting-started/configuration-options/configuration-options.md
@@ -1240,9 +1240,6 @@ In the example below, some cells are read-only, and some cells are editable:
 
 :::
 
-
-
-
 ::: only-for react
 
 ## Non-Idempotent Options
@@ -1302,7 +1299,7 @@ Use [`initialState`](@/api/options.md#initialstate) to apply these options only 
 
 ::: only-for vue
 
-::: example #example6 :vue --js 1
+::: example #example6 :vue3
 
 @[code](@/content/guides/getting-started/configuration-options/vue/example6.vue)
 

--- a/docs/content/guides/getting-started/vue3-hot-column/vue/example4.vue
+++ b/docs/content/guides/getting-started/vue3-hot-column/vue/example4.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable, HotColumn } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+import type { BaseRenderer } from 'handsontable/renderers';
+
+registerAllModules();
+
+const scoreRenderer: BaseRenderer = (_instance, td, _row, _col, _prop, value) => {
+  const score = Number(value);
+
+  td.innerHTML = String(value ?? '');
+  td.style.color = score >= 80 ? '#2d7d46' : score < 50 ? '#c0392b' : '';
+  td.style.fontWeight = score >= 80 ? 'bold' : '';
+
+  return td;
+};
+
+const hotData = ref([
+  ['Ana García', 92],
+  ['James Okafor', 45],
+  ['Li Wei', 73],
+  ['Sara Müller', 88],
+  ['Tom Nakamura', 31],
+]);
+
+const settings = ref<GridSettings>({
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example4">
+    <HotTable :data="hotData" :settings="settings">
+      <HotColumn title="Employee" :read-only="true" />
+      <HotColumn title="Score" type="numeric" :renderer="scoreRenderer" />
+    </HotTable>
+  </div>
+</template>

--- a/docs/content/guides/getting-started/vue3-hot-column/vue3-hot-column.md
+++ b/docs/content/guides/getting-started/vue3-hot-column/vue3-hot-column.md
@@ -48,6 +48,16 @@ You can declare a custom editor by creating a class that extends `TextEditor` an
 
 :::
 
+## Declare a custom renderer
+
+You can declare a custom renderer by creating a function that matches the [`BaseRenderer`](@/api/renderers.md) signature and passing it to a `<HotColumn/>` via the `renderer` prop. The renderer receives the cell's `td` element and the cell value, and must return the modified `td`.
+
+::: example #example4 :vue3
+
+@[code](@/content/guides/getting-started/vue3-hot-column/vue/example4.vue)
+
+:::
+
 ## Result
 
 Using `HotColumn` child components, each column reads its settings declaratively from Vue props rather than from a flat `columns` array, keeping your template in sync with your column configuration.

--- a/docs/content/guides/navigation/focus-scopes/focus-scopes.md
+++ b/docs/content/guides/navigation/focus-scopes/focus-scopes.md
@@ -142,7 +142,7 @@ to the bottom text input and how the internal state changes.
 
 ::: example #example1 :vue3 --css 1
 
-@[code](@/content/guides/navigation/focus-scopes/react/example1.css)
+@[code](@/content/guides/navigation/focus-scopes/vue/example1.css)
 @[code collapse={17-118,145-147,220-222}](@/content/guides/navigation/focus-scopes/vue/example1.vue)
 
 :::
@@ -202,7 +202,7 @@ appears after the inline scope elements in the DOM.
 
 ::: example #example2 :vue3 --css 1
 
-@[code](@/content/guides/navigation/focus-scopes/react/example2.css)
+@[code](@/content/guides/navigation/focus-scopes/vue/example2.css)
 @[code collapse={17-118,145-147,228-236}](@/content/guides/navigation/focus-scopes/vue/example2.vue)
 
 :::

--- a/docs/content/guides/navigation/focus-scopes/vue/example1.css
+++ b/docs/content/guides/navigation/focus-scopes/vue/example1.css
@@ -1,0 +1,25 @@
+.placeholder-input {
+  max-width: 20rem;
+  padding: 0.4rem 0.625rem;
+  font-size: var(--sl-text-sm, 0.875rem);
+  line-height: 1.25rem;
+  color: var(--sl-color-text, #333333);
+  background: none;
+  border: 1px solid var(--sl-color-gray-5, #e0e0e0);
+  border-radius: 0;
+  outline: none;
+}
+
+.placeholder-input::placeholder {
+  color: var(--sl-color-gray-3, #777777);
+}
+
+.placeholder-input:focus {
+  border-color: var(--sl-color-accent, #1A42E8);
+}
+
+.example-container {
+  gap: 1rem;
+  display: flex;
+  flex-direction: column;
+}

--- a/docs/content/guides/navigation/focus-scopes/vue/example2.css
+++ b/docs/content/guides/navigation/focus-scopes/vue/example2.css
@@ -1,0 +1,25 @@
+.placeholder-input {
+  max-width: 20rem;
+  padding: 0.4rem 0.625rem;
+  font-size: var(--sl-text-sm, 0.875rem);
+  line-height: 1.25rem;
+  color: var(--sl-color-text, #333333);
+  background: none;
+  border: 1px solid var(--sl-color-gray-5, #e0e0e0);
+  border-radius: 0;
+  outline: none;
+}
+
+.placeholder-input::placeholder {
+  color: var(--sl-color-gray-3, #777777);
+}
+
+.placeholder-input:focus {
+  border-color: var(--sl-color-accent, #1A42E8);
+}
+
+.example-container {
+  gap: 1rem;
+  display: flex;
+  flex-direction: column;
+}

--- a/docs/content/guides/navigation/searching-values/searching-values.md
+++ b/docs/content/guides/navigation/searching-values/searching-values.md
@@ -174,7 +174,7 @@ The example below highlights search results with a pink background and red text.
 
 ::: example #example2 :vue3 --css 1
 
-@[code](@/content/guides/navigation/searching-values/react/example2.css)
+@[code](@/content/guides/navigation/searching-values/vue/example2.css)
 @[code](@/content/guides/navigation/searching-values/vue/example2.vue)
 
 :::

--- a/docs/content/guides/navigation/searching-values/vue/example2.css
+++ b/docs/content/guides/navigation/searching-values/vue/example2.css
@@ -1,0 +1,4 @@
+.ht-theme-main .handsontable .my-class {
+  background: pink;
+  color: red;
+}

--- a/docs/content/guides/rows/row-hiding/row-hiding.md
+++ b/docs/content/guides/rows/row-hiding/row-hiding.md
@@ -360,6 +360,18 @@ ngAfterViewInit() {
 
 :::
 
+:::: only-for vue
+
+::: tip
+
+To use the Handsontable API, you'll need access to the Handsontable instance. You can do that by utilizing a reference to the `HotTable` component, and reading its `hotInstance` property.
+
+For more information, see the [Instance methods](@/guides/getting-started/vue3-hot-reference/vue3-hot-reference.md) page.
+
+:::
+
+::::
+
 ### Access the `HiddenRows` plugin instance
 
 To access the [`HiddenRows`](@/api/hiddenRows.md) plugin instance, use the [`getPlugin()`](@/api/core.md#getplugin) method:

--- a/docs/content/guides/rows/row-parent-child/row-parent-child.md
+++ b/docs/content/guides/rows/row-parent-child/row-parent-child.md
@@ -70,6 +70,16 @@ const configurationOptions: GridSettings = {
 
 :::
 
+::: only-for vue
+
+```ts
+const hotSettings = {
+  nestedRows: true,
+};
+```
+
+:::
+
 Note that using all the functionalities provided by the plugin requires enabling the row headers and the Handsontable context menu. To do this set
 [`rowHeaders`](@/api/options.md#rowheaders) and [`contextMenu`](@/api/options.md#contextmenu) to `true`. The _collapse_ / _expand_ buttons are located in the
 row headers, and the row modification options _add row_, _insert child_, etc., are in the Context Menu.

--- a/docs/content/guides/rows/row-trimming/row-trimming.md
+++ b/docs/content/guides/rows/row-trimming/row-trimming.md
@@ -62,6 +62,15 @@ trimRows: true,
 
 :::
 
+::: only-for vue
+
+```ts
+// enable the `TrimRows` plugin
+trimRows: true,
+```
+
+:::
+
 To both enable row trimming and trim selected rows at Handsontable's initialization, set the [`trimRows`](@/api/options.md#trimrows) option to an array of physical row indexes.
 
 ::: only-for javascript
@@ -88,6 +97,16 @@ trimRows: [5, 10, 15],
 :::
 
 ::: only-for angular
+
+```ts
+// enable the `TrimRows` plugin
+// at Handsontable's initialization, trim rows 5, 10, and 15
+trimRows: [5, 10, 15],
+```
+
+:::
+
+::: only-for vue
 
 ```ts
 // enable the `TrimRows` plugin
@@ -179,6 +198,18 @@ ngAfterViewInit() {
   // ...
 }
 ```
+
+:::
+
+::: only-for vue
+
+::: tip
+
+To use the Handsontable API, you'll need access to the Handsontable instance. You can do that by utilizing a reference to the `HotTable` component, and reading its `hotInstance` property.
+
+For more information, see the [Instance methods](@/guides/getting-started/vue3-hot-reference/vue3-hot-reference.md) page.
+
+:::
 
 :::
 

--- a/docs/content/guides/rows/rows-pagination/rows-pagination.md
+++ b/docs/content/guides/rows/rows-pagination/rows-pagination.md
@@ -352,6 +352,27 @@ const configurationOptions = {
 ```
 :::
 
+::: only-for vue
+
+```ts
+const hotSettings = {
+  beforePageChange() {
+    // add your code here
+    return false; // to block page change
+  },
+  afterPageChange() {
+    // add your code here
+  },
+  beforePageSizeChange() {
+    // add your code here
+    return false; // to block page size change
+  },
+  // ...
+};
+```
+
+:::
+
 ## Localize pagination
 
 Translate default pagination labels - such as "Page size:", "Page" and more - using the global translations mechanism. The pagination introduces the following keys to the language dictionary that you can use to translate the pagination UI:

--- a/docs/content/guides/rows/rows-sorting/rows-sorting.md
+++ b/docs/content/guides/rows/rows-sorting/rows-sorting.md
@@ -273,6 +273,33 @@ const configurationOptions: GridSettings = {
 
 :::
 
+::: only-for vue
+
+```ts
+const hotSettings = {
+  columnSorting: {
+    // enable click-to-sort on column headers (default: true)
+    headerAction: true,
+    // place empty cells at the end (default: false)
+    sortEmptyCells: false,
+    // show sort-order arrow in the column header (default: true)
+    indicator: true,
+    // sort column 1 descending at initialization
+    initialConfig: {
+      column: 1,
+      sortOrder: 'desc',
+    },
+    compareFunctionFactory(sortOrder, columnMeta) {
+      return function(value, nextValue) {
+        // return -1, 0, or 1
+      };
+    },
+  },
+};
+```
+
+:::
+
 You can also override `columnSorting` options per column, using the `columns` configuration:
 
 ::: only-for javascript
@@ -333,6 +360,26 @@ const configurationOptions: GridSettings = {
 
 ```html
 <hot-table [settings]="configurationOptions"></hot-table>
+```
+
+:::
+
+::: only-for vue
+
+```ts
+const hotSettings = {
+  columnSorting: true,
+  columns: [
+    {
+      columnSorting: {
+        // no sort icon for the first column
+        indicator: false,
+        // disable click-to-sort for the first column
+        headerAction: false,
+      },
+    },
+  ],
+};
 ```
 
 :::
@@ -451,6 +498,21 @@ const configurationOptions: GridSettings = {
 
 :::
 
+::: only-for vue
+
+```ts
+const hotSettings = {
+  columnSorting: {
+    initialConfig: {
+      column: 0,
+      sortOrder: 'asc',
+    },
+  },
+};
+```
+
+:::
+
 To set an initial sort order across multiple columns, use the [`MultiColumnSorting`](@/api/multiColumnSorting.md) plugin with an array value for `initialConfig`. See [Set an initial multi-column sort order](#set-an-initial-multi-column-sort-order).
 
 ## Add a custom comparator
@@ -524,6 +586,24 @@ const configurationOptions: GridSettings = {
 
 :::
 
+::: only-for vue
+
+```ts
+const hotSettings = {
+  columnSorting: {
+    compareFunctionFactory: function(sortOrder, columnMeta) {
+      return function(value, nextValue) {
+        if (value < nextValue) return -1;
+        if (value > nextValue) return 1;
+        return 0;
+      };
+    },
+  },
+};
+```
+
+:::
+
 ## Use sorting hooks
 
 Run code before or after sorting using the following [Handsontable hooks](@/guides/getting-started/events-and-hooks/events-and-hooks.md):
@@ -583,6 +663,22 @@ const configurationOptions: GridSettings = {
 
 ```html
 <hot-table [settings]="configurationOptions"></hot-table>
+```
+
+:::
+
+::: only-for vue
+
+```ts
+const hotSettings = {
+  beforeColumnSort(currentSortConfig, destinationSortConfigs) {
+    // add your code here
+    return false; // return false to block front-end sorting
+  },
+  afterColumnSort(currentSortConfig, sortedSortConfigs) {
+    // add your code here
+  },
+};
 ```
 
 :::

--- a/docs/content/guides/styling/themes/themes.md
+++ b/docs/content/guides/styling/themes/themes.md
@@ -95,8 +95,8 @@ If you want to use the `main` theme without any modifications, you don't need to
 
 ::: example #exampleTheme .disable-auto-theme :vue3 --css 1
 
+@[code](@/content/guides/styling/themes/vue/exampleTheme.css)
 @[code collapse={14-116,221-233}](@/content/guides/styling/themes/vue/exampleTheme.vue)
-@[code](@/content/guides/styling/themes/react/exampleTheme.css)
 
 :::
 

--- a/docs/content/guides/styling/themes/vue/exampleTheme.css
+++ b/docs/content/guides/styling/themes/vue/exampleTheme.css
@@ -1,0 +1,106 @@
+/* Theme dropdown */
+.theme-dropdown {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.theme-dropdown-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: none;
+  border: 1px solid var(--sl-color-gray-5, #e0e0e0);
+  color: var(--sl-color-gray-2, #555555);
+  cursor: pointer;
+  font-size: var(--sl-text-sm, 0.875rem);
+  font-weight: 500;
+  padding: 0.4rem 0.625rem;
+  transition: color 0.15s, background-color 0.15s;
+  white-space: nowrap;
+  border-radius: 0;
+}
+
+.theme-dropdown-trigger:hover {
+  color: var(--sl-color-white, #333333);
+  background: var(--sl-color-gray-7, var(--sl-color-gray-6, #eeeeee));
+}
+
+.theme-dropdown-chevron {
+  flex-shrink: 0;
+  margin-inline-start: 0.15rem;
+  transition: transform 0.15s;
+}
+
+.theme-dropdown-trigger[aria-expanded='true'] .theme-dropdown-chevron {
+  transform: rotate(180deg);
+}
+
+.theme-dropdown-menu {
+  background: var(--sl-color-bg-nav, #ffffff);
+  border: 1px solid var(--sl-color-gray-5, #e0e0e0);
+  border-radius: 0;
+  box-shadow: none;
+  inset-inline-start: 0;
+  list-style: none;
+  margin: 0;
+  min-width: 100%;
+  overflow-y: auto;
+  padding: 0;
+  position: absolute;
+  top: 100%;
+  z-index: 100;
+}
+
+.theme-dropdown-menu[hidden] {
+  display: none !important;
+}
+
+.theme-dropdown-menu li {
+  align-items: center;
+  color: var(--sl-color-text, #333333);
+  display: flex;
+  font-size: var(--sl-text-sm, 0.875rem);
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  border-bottom: 1px solid var(--sl-color-gray-5, #e0e0e0);
+  transition: background 0.1s, color 0.1s;
+  white-space: nowrap;
+  list-style: none;
+  margin: 0;
+}
+
+.theme-dropdown-menu li .theme-dropdown-colors {
+  display: none;
+}
+
+.theme-dropdown-menu li:last-child {
+  border-bottom: none;
+}
+
+.theme-dropdown-menu li:hover,
+.theme-dropdown-menu li:focus-visible {
+  background: var(--sl-color-gray-6, #eeeeee);
+  color: var(--sl-color-white, #333333);
+  outline: none;
+}
+
+.theme-dropdown-menu li[aria-selected='true'] {
+  color: var(--sl-color-white, #333333);
+  box-shadow: inset 0 0 0 1px var(--sl-color-accent, #1A42E8);
+}
+
+/* Color dots */
+.theme-dropdown-colors {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+}
+
+.theme-dropdown-colors .color {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: 1px solid var(--sl-color-gray-4, #bbbbbb);
+}


### PR DESCRIPTION
### Context

The PR fixes consistency gaps found during a pre-launch verification of the Vue 3 documentation added in DEV-1725. Thirteen pages had one or more of the following issues:

- Missing `::: only-for vue` blocks in sections that had JavaScript, React, and Angular variants (rows-sorting ×5, row-trimming ×3, rows-pagination, row-parent-child, row-hiding, configuration-options, export-to-csv).
- Vue example blocks referencing `react/*.css` files instead of `vue/*.css` files (accessibility, focus-scopes ×2, searching-values, dialog/loading, themes). Created matching `vue/*.css` files and updated the references.
- The `vue3-hot-column` page described "a custom cell editor **or** renderer" but only showed an editor example. Added `example4.vue` with a `BaseRenderer` passed via `<HotColumn :renderer>`.
- The `configuration-options.md` page had an existing Vue block using the legacy `:vue` preset; updated it to `:vue3`.

[skip changelog]

### How has this been tested?

- All changes are documentation-only (markdown + `.vue` example file).
- Manual review: each added Vue block was cross-checked against the existing React/Angular equivalent in the same section.
- No unit or E2E tests are affected.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1725

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1725

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown and doc example assets only; no changes to `@handsontable/vue3` or core grid behavior.
> 
> **Overview**
> Aligns **Vue 3** guide pages with the other framework variants by filling gaps found in pre-launch review.
> 
> **Example assets:** Vue live examples that incorrectly pulled **`react/*.css`** now use dedicated **`vue/*.css`** files (accessibility, focus-scopes, searching-values, loading/pagination overlay, themes).
> 
> **Missing Vue snippets:** Adds **`::: only-for vue`** blocks on row guides (sorting, trimming, pagination, parent-child, hiding), **export-to-csv**, and API tips that point to **`vue3-hot-reference`**—mirroring existing JS/React/Angular sections.
> 
> **HotColumn docs:** New **`example4.vue`** and section on passing a **`BaseRenderer`** via **`<HotColumn :renderer>`** (page previously showed only a custom editor).
> 
> **Preset:** **`configuration-options`** example6 switches from legacy **`:vue`** to **`:vue3`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d592d4dbda9ea2cf0ae35506dc35cdcad179e7e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->