### PR TITLE
Fix `isCtrlPressed()` for Handsontable instances hosted in different iframe documents (#12707)

### DIFF
--- a/.changelogs/12707.json
+++ b/.changelogs/12707.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed `ShortcutManager.isCtrlPressed()` returning `false` for Handsontable instances created after the first one in a different document (e.g. another iframe), which caused `Ctrl/Cmd+click` additive selection to silently break in those instances.",
+  "type": "fixed",
+  "issueOrPR": 12707,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/shortcuts/__tests__/manager.unit.ts
+++ b/handsontable/src/shortcuts/__tests__/manager.unit.ts
@@ -33,6 +33,109 @@ describe('Shortcut Manager', () => {
     });
   });
 
+  describe('modifier-key tracking across multiple instances and documents', () => {
+    it('should track Ctrl keydown for the first manager (regression baseline)', () => {
+      const manager = createTestManager();
+
+      document.documentElement.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Control', bubbles: true })
+      );
+
+      expect(manager.isCtrlPressed()).toBe(true);
+
+      manager.releasePressedKeys();
+      manager.destroy();
+    });
+
+    it('should track Ctrl keydown for a second manager that lives in a different document (e.g. an iframe)',
+      () => {
+        // Manager A on the main document.
+        const managerA = createTestManager();
+
+        // Manager B on a separate document, simulating a Handsontable instance hosted in an iframe.
+        const otherDocument = document.implementation.createHTMLDocument('iframe');
+        // `parent: {}` keeps `getParentWindow()` happy without simulating a real frame chain
+        // (it returns `null` because `frameElement` is not an `HTMLIFrameElement`).
+        const otherWindow = { document: otherDocument, parent: {} } as unknown as Window;
+        const managerB = createTestManager({ ownerWindow: otherWindow });
+
+        // Ctrl is pressed inside the "iframe" document only.
+        otherDocument.documentElement.dispatchEvent(
+          new KeyboardEvent('keydown', { key: 'Control', bubbles: true })
+        );
+
+        // Both managers share the module-level observer, so both must report Ctrl pressed.
+        // Before the fix, only the FIRST manager attached the modifier-key listeners on its
+        // own document chain, so this event was never observed and `isCtrlPressed()` was
+        // always `false` for the second manager.
+        expect(managerB.isCtrlPressed()).toBe(true);
+        expect(managerA.isCtrlPressed()).toBe(true);
+
+        otherDocument.documentElement.dispatchEvent(
+          new KeyboardEvent('keyup', { key: 'Control', bubbles: true })
+        );
+
+        expect(managerB.isCtrlPressed()).toBe(false);
+        expect(managerA.isCtrlPressed()).toBe(false);
+
+        managerA.destroy();
+        managerB.destroy();
+      });
+
+    it('should keep tracking Ctrl on the main document after a manager from a different document is destroyed',
+      () => {
+        const managerA = createTestManager();
+
+        const otherDocument = document.implementation.createHTMLDocument('iframe');
+        const otherWindow = { document: otherDocument, parent: {} } as unknown as Window;
+        const managerB = createTestManager({ ownerWindow: otherWindow });
+
+        managerB.destroy();
+
+        document.documentElement.dispatchEvent(
+          new KeyboardEvent('keydown', { key: 'Control', bubbles: true })
+        );
+
+        expect(managerA.isCtrlPressed()).toBe(true);
+
+        managerA.releasePressedKeys();
+        managerA.destroy();
+      });
+
+    it('should detach modifier-key listeners from a document once its last manager is destroyed',
+      () => {
+        const otherDocument = document.implementation.createHTMLDocument('iframe');
+        const otherWindow = { document: otherDocument, parent: {} } as unknown as Window;
+
+        // Two managers attached to the same auxiliary document — refcount must hit 0 only after both go away.
+        const managerB1 = createTestManager({ ownerWindow: otherWindow });
+        const managerB2 = createTestManager({ ownerWindow: otherWindow });
+
+        managerB1.destroy();
+
+        otherDocument.documentElement.dispatchEvent(
+          new KeyboardEvent('keydown', { key: 'Control', bubbles: true })
+        );
+
+        expect(managerB2.isCtrlPressed()).toBe(true);
+
+        managerB2.releasePressedKeys();
+        managerB2.destroy();
+
+        // After the last manager for this document is gone, dispatching a Ctrl keydown there
+        // must not affect any future manager's pressed-keys state.
+        otherDocument.documentElement.dispatchEvent(
+          new KeyboardEvent('keydown', { key: 'Control', bubbles: true })
+        );
+
+        const managerC = createTestManager();
+
+        expect(managerC.isCtrlPressed()).toBe(false);
+
+        managerC.destroy();
+      });
+  });
+
   describe('global scope shortcuts when the table shortcut pipeline is blocked', () => {
     it('should run shortcuts on global contexts when handleEvent returns false', () => {
       const spy = jasmine.createSpy('globalF6');

--- a/handsontable/src/shortcuts/__tests__/shortcutManager.spec.js
+++ b/handsontable/src/shortcuts/__tests__/shortcutManager.spec.js
@@ -744,4 +744,46 @@ describe('shortcutManager', () => {
       expect(gridContext.scope).toBe('global');
     });
   });
+
+  // Regression: https://github.com/handsontable/handsontable/issues/12707
+  describe('modifier-key tracking across multiple instances and documents', () => {
+    it('should report Ctrl as pressed for a second instance hosted in an iframe document', async() => {
+      const $iframe = $('<iframe width="500px" height="300px"/>').appendTo(spec().$container);
+      const iframeDoc = $iframe[0].contentDocument;
+
+      iframeDoc.open('text/html', 'replace');
+      iframeDoc.write(`
+        <!doctype html>
+        <head>
+          ${getE2eThemeStylesheetLinkTagsHtml()}
+        </head>
+      `);
+      iframeDoc.close();
+
+      handsontable();
+
+      const $iframeContainer = $('<div/>').appendTo(iframeDoc.body);
+
+      $iframeContainer.handsontable({});
+
+      const iframeShortcutManager = $iframeContainer.handsontable('getInstance').getShortcutManager();
+
+      expect(iframeShortcutManager.isCtrlPressed()).toBeFalse();
+
+      iframeDoc.documentElement.dispatchEvent(
+        new iframeDoc.defaultView.KeyboardEvent('keydown', { key: 'Control', bubbles: true })
+      );
+
+      expect(iframeShortcutManager.isCtrlPressed()).toBeTrue();
+
+      iframeDoc.documentElement.dispatchEvent(
+        new iframeDoc.defaultView.KeyboardEvent('keyup', { key: 'Control', bubbles: true })
+      );
+
+      expect(iframeShortcutManager.isCtrlPressed()).toBeFalse();
+
+      $iframeContainer.handsontable('destroy');
+      $iframe.remove();
+    });
+  });
 });

--- a/handsontable/src/shortcuts/recorder.ts
+++ b/handsontable/src/shortcuts/recorder.ts
@@ -6,8 +6,87 @@ import { isMacOS } from '../helpers/browser';
 import { isFunction } from '../helpers/function';
 
 const modifierKeysObserver = createKeysObserver();
-const modKeyListeners: Array<{event: 'keydown' | 'keyup'; listener: (event: KeyboardEvent) => void}> = [];
-let instanceCounter = 0;
+/**
+ * Tracks how many active recorder instances reference each document.
+ *
+ * The modifier-key listeners (`keydown` / `keyup`) feeding `modifierKeysObserver`
+ * must be attached exactly once per document, regardless of how many
+ * Handsontable instances live in that document, and regardless of which
+ * instance was created first. Using `Map<Document, number>` lets every new
+ * `useRecorder` call ensure its document has the listeners installed
+ * (cross-iframe safe), and lets the last unmounting instance remove them.
+ */
+const modKeyDocumentRefCounts = new Map<Document, number>();
+
+/**
+ * Module-level `keydown` listener that updates `modifierKeysObserver`.
+ * Hoisted out of `useRecorder` so the same function reference can be safely
+ * added/removed once per document.
+ *
+ * @param {KeyboardEvent} event The event object.
+ */
+function onkeydownForModKeys(event: KeyboardEvent) {
+  if (typeof event.key === 'string') {
+    const pressedKey = normalizeEventKey(event);
+
+    if (isModifierKey(pressedKey)) {
+      modifierKeysObserver.press(pressedKey);
+    }
+  }
+}
+
+/**
+ * Module-level `keyup` listener that updates `modifierKeysObserver`.
+ * Hoisted out of `useRecorder` so the same function reference can be safely
+ * added/removed once per document.
+ *
+ * @param {KeyboardEvent} event The event object.
+ */
+function onkeyupForModKeys(event: KeyboardEvent) {
+  if (typeof event.key === 'string') {
+    const pressedKey = normalizeEventKey(event);
+
+    if (isModifierKey(pressedKey)) {
+      modifierKeysObserver.release(pressedKey);
+    }
+  }
+}
+
+/**
+ * Ensures the modifier-key listeners are attached to the given document
+ * exactly once across every recorder instance using that document.
+ *
+ * @param {Document} doc The document to install the listeners on.
+ */
+function attachModKeyListeners(doc: Document) {
+  const refCount = modKeyDocumentRefCounts.get(doc) ?? 0;
+
+  if (refCount === 0) {
+    doc.documentElement.addEventListener('keydown', onkeydownForModKeys);
+    doc.documentElement.addEventListener('keyup', onkeyupForModKeys);
+  }
+
+  modKeyDocumentRefCounts.set(doc, refCount + 1);
+}
+
+/**
+ * Removes the modifier-key listeners from the given document when the last
+ * recorder instance using that document unmounts.
+ *
+ * @param {Document} doc The document to clean up.
+ */
+function detachModKeyListeners(doc: Document) {
+  const refCount = modKeyDocumentRefCounts.get(doc) ?? 0;
+
+  if (refCount <= 1) {
+    doc.documentElement.removeEventListener('keydown', onkeydownForModKeys);
+    doc.documentElement.removeEventListener('keyup', onkeyupForModKeys);
+    modKeyDocumentRefCounts.delete(doc);
+
+  } else {
+    modKeyDocumentRefCounts.set(doc, refCount - 1);
+  }
+}
 
 /**
  * A key recorder, used for tracking key events.
@@ -110,38 +189,6 @@ export function useRecorder(
   };
 
   /**
-   * `KeyboardEvent`'s callback function for observing the pressed state of the mod keys.
-   *
-   * @private
-   * @param {KeyboardEvent} event The event object
-   */
-  const onkeydownForModKeys = (event: KeyboardEvent) => {
-    if (typeof event.key === 'string') {
-      const pressedKey = normalizeEventKey(event);
-
-      if (isModifierKey(pressedKey)) {
-        modifierKeysObserver.press(pressedKey);
-      }
-    }
-  };
-
-  /**
-   * `KeyboardEvent`'s callback function for observing the pressed state of the mod keys.
-   *
-   * @private
-   * @param {KeyboardEvent} event The event object
-   */
-  const onkeyupForModKeys = (event: KeyboardEvent) => {
-    if (typeof event.key === 'string') {
-      const pressedKey = normalizeEventKey(event);
-
-      if (isModifierKey(pressedKey)) {
-        modifierKeysObserver.release(pressedKey);
-      }
-    }
-  };
-
-  /**
    * `FocusEvent`'s callback function
    *
    * @private
@@ -156,16 +203,8 @@ export function useRecorder(
   const mount = () => {
     let eventTarget: Window | null = ownerWindow;
 
-    instanceCounter += 1;
-
     while (eventTarget) {
-      if (instanceCounter === 1) {
-        eventTarget.document.documentElement.addEventListener('keydown', onkeydownForModKeys);
-        modKeyListeners.push({ event: 'keydown', listener: onkeydownForModKeys });
-
-        eventTarget.document.documentElement.addEventListener('keyup', onkeyupForModKeys);
-        modKeyListeners.push({ event: 'keyup', listener: onkeyupForModKeys });
-      }
+      attachModKeyListeners(eventTarget.document);
 
       eventTarget.document.documentElement.addEventListener('keydown', onkeydown);
       eventTarget.document.documentElement.addEventListener('blur', onblur);
@@ -180,22 +219,8 @@ export function useRecorder(
   const unmount = () => {
     let eventTarget: Window | null = ownerWindow;
 
-    instanceCounter -= 1;
-
     while (eventTarget) {
-      if (instanceCounter === 0) {
-        for (let i = 0; i < modKeyListeners.length; i++) {
-          const { event: eventType, listener } = modKeyListeners[i];
-
-          if (eventType === 'keydown') {
-            eventTarget.document.documentElement.removeEventListener('keydown', listener);
-          } else {
-            eventTarget.document.documentElement.removeEventListener('keyup', listener);
-          }
-        }
-
-        modKeyListeners.length = 0;
-      }
+      detachModKeyListeners(eventTarget.document);
 
       eventTarget.document.documentElement.removeEventListener('keydown', onkeydown);
       eventTarget.document.documentElement.removeEventListener('blur', onblur);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Context

Fixes [#12707](https://github.com/handsontable/handsontable/issues/12707).

The `ShortcutManager`'s modifier-key observer is module-level (shared across every Handsontable instance in a JS realm), but the keyboard listeners that feed it were attached only on the **first** instance's window chain (`instanceCounter === 1` guard in `recorder.ts`). Every subsequent instance shared the same observer but never installed its own `keydown` / `keyup` modifier listeners on its document.

Concretely: if a second Handsontable lives in a different iframe, that iframe's document never has the modifier-key listeners attached, so:

- `event.ctrlKey === true` (Ctrl really is held), but
- `hot.getShortcutManager().isCtrlPressed() === false`.

Because `setRangeStart()` decides whether a click is additive from `isCtrlPressed()` (not from `MouseEvent.ctrlKey`), `Ctrl/Cmd+click` silently degraded from "extend selection" to "replace selection" for any grid past the first one in a separate document.

### Root cause and fix

In `handsontable/src/shortcuts/recorder.ts`:

- Replace the shared `instanceCounter` + `modKeyListeners` array with a `Map<Document, number>` refcount keyed by document.
- Hoist `onkeydownForModKeys` / `onkeyupForModKeys` to module scope so the same function references are added and removed deterministically per document.
- On `mount()`, walk the window chain and call `attachModKeyListeners(document)` for each document. The first reference to a given document installs the listeners; subsequent references just bump the refcount.
- On `unmount()`, walk the same chain and call `detachModKeyListeners(document)`. Only the last reference removes the listeners.

This makes the modifier-key tracking correct regardless of:
- creation order of the instances,
- which iframe they live in,
- whether multiple instances share the same document, and
- the order in which they're destroyed.

The mouse-event side (`setRangeStart`) is unchanged — once `isCtrlPressed()` returns the right value, additive selection works again.

### How has this been tested?

Both **unit tests** (Jest, jsdom) and **E2E tests** (Jasmine, Puppeteer) are added.

`handsontable/src/shortcuts/__tests__/manager.unit.ts` — four new tests under `modifier-key tracking across multiple instances and documents`:

1. Baseline: Ctrl is tracked for the first manager.
2. **Regression for #12707**: a second manager hosted in a separate document (simulated iframe) reports `isCtrlPressed() === true` after a Ctrl `keydown` is dispatched on that document. Without the fix, this assertion fails.
3. Listeners on the main document keep working after a manager attached to a different document is destroyed.
4. Refcount semantics: when two managers share a document, listeners are removed only after both unmount.

`handsontable/src/shortcuts/__tests__/shortcutManager.spec.js` — adds an E2E test that creates a real iframe, mounts a Handsontable inside it after another grid has already been created, and asserts that the iframe-hosted instance's `getShortcutManager().isCtrlPressed()` reacts to `keydown` / `keyup` of `Control` dispatched inside the iframe document.

```
✓ should track Ctrl keydown for the first manager (regression baseline)
✓ should track Ctrl keydown for a second manager that lives in a different document (e.g. an iframe)
✓ should keep tracking Ctrl on the main document after a manager from a different document is destroyed
✓ should detach modifier-key listeners from a document once its last manager is destroyed
```

(Full unit suite for `shortcuts/`: 58/58 passing. `npm run test:types`: passing.)

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s)

1. https://github.com/handsontable/handsontable/issues/12707

### Affected project(s)

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf4b430d-7aac-4418-aaab-b343685ed8b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf4b430d-7aac-4418-aaab-b343685ed8b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

