### PR TITLE
DEV-1767: Update demo packages to Handsontable 17.1.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,9 +82,11 @@ jobs:
               - *hot-shared
               - './handsontable/test/e2e/**'
               - './handsontable/test/scripts/**'
+              - './examples/next/visual-tests/**'
             build-handsontable-es-cjs:
               - *hot-shared
               - 'wrappers/**'
+              - './examples/next/visual-tests/**'
             test-handsontable-unit:
               - *hot-shared
               - './handsontable/test/unit/**'

--- a/examples/next/docs/angular-wrapper/package-lock.json
+++ b/examples/next/docs/angular-wrapper/package-lock.json
@@ -10146,9 +10146,9 @@
       "license": "MIT"
     },
     "node_modules/handsontable": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/handsontable/-/handsontable-17.0.1.tgz",
-      "integrity": "sha512-N7d/Vv341sGsKq/afsR+Y1EcSD1YCAwpLN245VnmprTGaFtDSBsiu12EsjNPD/1VCvZvN5PLH8Ojsq/TzqhLZQ==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/handsontable/-/handsontable-17.1.0.tgz",
+      "integrity": "sha512-3afpoGQT04i11IYge4gZNHp4Io3RFoLi+vVk4yTc2oHGjuBJBhjVVlTnOcYM8N9Ay1ikjSh4T3ZiwFVYEsgJrA==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@handsontable/pikaday": "^1.0.0",

--- a/examples/next/docs/js/package-lock.json
+++ b/examples/next/docs/js/package-lock.json
@@ -1969,9 +1969,9 @@
       }
     },
     "node_modules/handsontable": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/handsontable/-/handsontable-17.0.1.tgz",
-      "integrity": "sha512-N7d/Vv341sGsKq/afsR+Y1EcSD1YCAwpLN245VnmprTGaFtDSBsiu12EsjNPD/1VCvZvN5PLH8Ojsq/TzqhLZQ==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/handsontable/-/handsontable-17.1.0.tgz",
+      "integrity": "sha512-3afpoGQT04i11IYge4gZNHp4Io3RFoLi+vVk4yTc2oHGjuBJBhjVVlTnOcYM8N9Ay1ikjSh4T3ZiwFVYEsgJrA==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@handsontable/pikaday": "^1.0.0",

--- a/examples/next/docs/react-wrapper/package-lock.json
+++ b/examples/next/docs/react-wrapper/package-lock.json
@@ -10626,9 +10626,9 @@
       "license": "MIT"
     },
     "node_modules/handsontable": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/handsontable/-/handsontable-17.0.1.tgz",
-      "integrity": "sha512-N7d/Vv341sGsKq/afsR+Y1EcSD1YCAwpLN245VnmprTGaFtDSBsiu12EsjNPD/1VCvZvN5PLH8Ojsq/TzqhLZQ==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/handsontable/-/handsontable-17.1.0.tgz",
+      "integrity": "sha512-3afpoGQT04i11IYge4gZNHp4Io3RFoLi+vVk4yTc2oHGjuBJBhjVVlTnOcYM8N9Ay1ikjSh4T3ZiwFVYEsgJrA==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@handsontable/pikaday": "^1.0.0",

--- a/examples/next/docs/ts/package-lock.json
+++ b/examples/next/docs/ts/package-lock.json
@@ -738,9 +738,9 @@
       }
     },
     "node_modules/handsontable": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/handsontable/-/handsontable-17.0.1.tgz",
-      "integrity": "sha512-N7d/Vv341sGsKq/afsR+Y1EcSD1YCAwpLN245VnmprTGaFtDSBsiu12EsjNPD/1VCvZvN5PLH8Ojsq/TzqhLZQ==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/handsontable/-/handsontable-17.1.0.tgz",
+      "integrity": "sha512-3afpoGQT04i11IYge4gZNHp4Io3RFoLi+vVk4yTc2oHGjuBJBhjVVlTnOcYM8N9Ay1ikjSh4T3ZiwFVYEsgJrA==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@handsontable/pikaday": "^1.0.0",

--- a/examples/next/docs/vue3/package-lock.json
+++ b/examples/next/docs/vue3/package-lock.json
@@ -2688,9 +2688,9 @@
       }
     },
     "node_modules/handsontable": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/handsontable/-/handsontable-17.0.1.tgz",
-      "integrity": "sha512-N7d/Vv341sGsKq/afsR+Y1EcSD1YCAwpLN245VnmprTGaFtDSBsiu12EsjNPD/1VCvZvN5PLH8Ojsq/TzqhLZQ==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/handsontable/-/handsontable-17.1.0.tgz",
+      "integrity": "sha512-3afpoGQT04i11IYge4gZNHp4Io3RFoLi+vVk4yTc2oHGjuBJBhjVVlTnOcYM8N9Ay1ikjSh4T3ZiwFVYEsgJrA==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@handsontable/pikaday": "^1.0.0",

--- a/examples/next/visual-tests/angular-wrapper/package-lock.json
+++ b/examples/next/visual-tests/angular-wrapper/package-lock.json
@@ -10079,9 +10079,9 @@
       "license": "MIT"
     },
     "node_modules/handsontable": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/handsontable/-/handsontable-17.0.1.tgz",
-      "integrity": "sha512-N7d/Vv341sGsKq/afsR+Y1EcSD1YCAwpLN245VnmprTGaFtDSBsiu12EsjNPD/1VCvZvN5PLH8Ojsq/TzqhLZQ==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/handsontable/-/handsontable-17.1.0.tgz",
+      "integrity": "sha512-3afpoGQT04i11IYge4gZNHp4Io3RFoLi+vVk4yTc2oHGjuBJBhjVVlTnOcYM8N9Ay1ikjSh4T3ZiwFVYEsgJrA==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@handsontable/pikaday": "^1.0.0",

--- a/examples/next/visual-tests/js/package-lock.json
+++ b/examples/next/visual-tests/js/package-lock.json
@@ -2115,9 +2115,9 @@
       "license": "ISC"
     },
     "node_modules/handsontable": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/handsontable/-/handsontable-17.0.1.tgz",
-      "integrity": "sha512-N7d/Vv341sGsKq/afsR+Y1EcSD1YCAwpLN245VnmprTGaFtDSBsiu12EsjNPD/1VCvZvN5PLH8Ojsq/TzqhLZQ==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/handsontable/-/handsontable-17.1.0.tgz",
+      "integrity": "sha512-3afpoGQT04i11IYge4gZNHp4Io3RFoLi+vVk4yTc2oHGjuBJBhjVVlTnOcYM8N9Ay1ikjSh4T3ZiwFVYEsgJrA==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@handsontable/pikaday": "^1.0.0",

--- a/examples/next/visual-tests/react-wrapper/package-lock.json
+++ b/examples/next/visual-tests/react-wrapper/package-lock.json
@@ -9349,9 +9349,9 @@
       "license": "MIT"
     },
     "node_modules/handsontable": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/handsontable/-/handsontable-17.0.1.tgz",
-      "integrity": "sha512-N7d/Vv341sGsKq/afsR+Y1EcSD1YCAwpLN245VnmprTGaFtDSBsiu12EsjNPD/1VCvZvN5PLH8Ojsq/TzqhLZQ==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/handsontable/-/handsontable-17.1.0.tgz",
+      "integrity": "sha512-3afpoGQT04i11IYge4gZNHp4Io3RFoLi+vVk4yTc2oHGjuBJBhjVVlTnOcYM8N9Ay1ikjSh4T3ZiwFVYEsgJrA==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@handsontable/pikaday": "^1.0.0",

--- a/examples/next/visual-tests/vue3/package-lock.json
+++ b/examples/next/visual-tests/vue3/package-lock.json
@@ -2877,9 +2877,9 @@
       "license": "ISC"
     },
     "node_modules/handsontable": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/handsontable/-/handsontable-17.0.1.tgz",
-      "integrity": "sha512-N7d/Vv341sGsKq/afsR+Y1EcSD1YCAwpLN245VnmprTGaFtDSBsiu12EsjNPD/1VCvZvN5PLH8Ojsq/TzqhLZQ==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/handsontable/-/handsontable-17.1.0.tgz",
+      "integrity": "sha512-3afpoGQT04i11IYge4gZNHp4Io3RFoLi+vVk4yTc2oHGjuBJBhjVVlTnOcYM8N9Ay1ikjSh4T3ZiwFVYEsgJrA==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@handsontable/pikaday": "^1.0.0",


### PR DESCRIPTION
### Context

The PR updates `package-lock.json` files for all 9 demo packages in `examples/next/` so they resolve `handsontable` to `17.1.0` (previously locked to `17.0.1`). All packages declare `"handsontable": "latest"` in `package.json` -- running `npm update handsontable` in each workspace resolves the new latest version and rewrites the lock file.

Packages updated:
- `examples/next/visual-tests/js/`
- `examples/next/visual-tests/react-wrapper/`
- `examples/next/visual-tests/vue3/`
- `examples/next/visual-tests/angular-wrapper/`
- `examples/next/docs/js/`
- `examples/next/docs/ts/`
- `examples/next/docs/react-wrapper/`
- `examples/next/docs/vue3/`
- `examples/next/docs/angular-wrapper/`

Also fixes `.github/workflows/test.yml`: adds `./examples/next/visual-tests/**` to the `build-handsontable-umd` and `build-handsontable-es-cjs` path filters so that the build jobs run (and produce the required artifacts) whenever visual-test example files change.

### How has this been tested?

- Verified each lock file resolves `"version": "17.1.0"` under `node_modules/handsontable`
- Ran `npm run build` for all 5 framework variants (JS, TS, React, Vue 3, Angular) -- all built successfully
- Started dev servers for all 5 framework variants and confirmed grids render correctly in browser

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1767

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1767

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile and CI path-filter updates only; no changes to the core `handsontable` package or runtime logic.
> 
> **Overview**
> Bumps the locked **`handsontable`** dependency from **17.0.1** to **17.1.0** in nine `examples/next` workspace `package-lock.json` files (docs and visual-tests for JS, TS, React, Vue 3, and Angular). Demo `package.json` files still use `"handsontable": "latest"`; only the lockfile resolution changes.
> 
> Updates **`.github/workflows/test.yml`** so changes under **`./examples/next/visual-tests/**`** also trigger **`build-handsontable-umd`** and **`build-handsontable-es-cjs`**, ensuring those build jobs (and their artifacts) run when visual-test example locks or related files change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cb14b5197b108cc8c700998a8f0e3ea06d8611b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->