### PR TITLE
ci: opt fossa-scan job into Node.js 24 to fix deprecation warning

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -62,6 +62,8 @@ jobs:
   fossa-scan:
       name: FOSSA Scan
       runs-on: ubuntu-latest
+      env:
+        FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       steps:
         - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # https://github.com/actions/checkout/releases/tag/v6.0.2
         - uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # https://github.com/fossas/fossa-action/releases/tag/v1.9.0


### PR DESCRIPTION
## Summary

- `fossas/fossa-action` v1.9.0 is the latest release but still targets Node.js 20, which GitHub Actions is deprecating (forced migration June 16, 2026; removal September 16, 2026)
- Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` env var to the `fossa-scan` job to opt into Node.js 24 now, silencing the deprecation warning
- No action version bump is needed — this is the recommended workaround until FOSSA publishes a Node.js 24-native release

## Test plan

- [ ] Verify the `FOSSA Scan` job passes in CI after this change
- [ ] Confirm no deprecation warning about Node.js 20 appears in the job logs

[skip changelog]

https://claude.ai/code/session_018XzEUhTqCKZWV6k9TiJEhR

---
_Generated by [Claude Code](https://claude.ai/code/session_018XzEUhTqCKZWV6k9TiJEhR)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow env change with no application, auth, or data-handling impact.
> 
> **Overview**
> Sets **`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true`** on the **`fossa-scan`** job in **Code Quality** so `fossas/fossa-action` (still on Node 20) runs on Node 24 ahead of GitHub’s deprecation timeline, without bumping the action version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2af5338b4335e874402202caa4da74e851a424d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->