### PR TITLE
DEV-1846: Fix isCtrlPressed() for non-first Handsontable instances across iframes

### DIFF
--- a/.changelogs/12737.json
+++ b/.changelogs/12737.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed additive `Ctrl`/`Cmd`+click selection not working in a Handsontable instance rendered inside a separate iframe (or any instance that was not the first one created).",
+  "type": "fixed",
+  "issueOrPR": 12737,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/src/selection/scanner.ts
+++ b/handsontable/src/3rdparty/walkontable/src/selection/scanner.ts
@@ -132,7 +132,9 @@ export class SelectionScanner {
           TH = wtTable.getColumnHeader(newSourceCol as number, positiveBasedHeaderLevel);
         }
 
-        callback(TH as HTMLElement);
+        if (isHTMLElement(TH)) {
+          callback(TH);
+        }
       }
 
       cursor += 1;
@@ -181,7 +183,9 @@ export class SelectionScanner {
           TH = wtTable.getRowHeader(newSourceRow as number, positiveBasedHeaderLevel);
         }
 
-        callback(TH as HTMLElement);
+        if (isHTMLElement(TH)) {
+          callback(TH);
+        }
       }
 
       cursor += 1;
@@ -198,7 +202,11 @@ export class SelectionScanner {
     const { wtTable } = this.#activeOverlaysWot!;
 
     this.#scanCellsRange((sourceRow: number, sourceColumn: number) => {
-      const cell = wtTable.getCell(this.#activeOverlaysWot!.createCellCoords(sourceRow, sourceColumn)) as HTMLElement;
+      const cell = wtTable.getCell(this.#activeOverlaysWot!.createCellCoords(sourceRow, sourceColumn));
+
+      if (!isHTMLElement(cell)) {
+        return;
+      }
 
       // support for old API
       const additionalSelectionClass = this.#activeOverlaysWot!
@@ -229,9 +237,11 @@ export class SelectionScanner {
 
     this.#scanViewportRange((sourceRow: number, sourceColumn: number) => {
       if (sourceRow >= topRow && sourceRow <= bottomRow) {
-        const cell = wtTable.getCell(this.#activeOverlaysWot!.createCellCoords(sourceRow, sourceColumn)) as HTMLElement;
+        const cell = wtTable.getCell(this.#activeOverlaysWot!.createCellCoords(sourceRow, sourceColumn));
 
-        callback(cell);
+        if (isHTMLElement(cell)) {
+          callback(cell);
+        }
       }
     });
   }
@@ -248,9 +258,11 @@ export class SelectionScanner {
 
     this.#scanViewportRange((sourceRow: number, sourceColumn: number) => {
       if (sourceColumn >= topColumn && sourceColumn <= bottomColumn) {
-        const cell = wtTable.getCell(this.#activeOverlaysWot!.createCellCoords(sourceRow, sourceColumn)) as HTMLElement;
+        const cell = wtTable.getCell(this.#activeOverlaysWot!.createCellCoords(sourceRow, sourceColumn));
 
-        callback(cell);
+        if (isHTMLElement(cell)) {
+          callback(cell);
+        }
       }
     });
   }

--- a/handsontable/src/3rdparty/walkontable/src/table.ts
+++ b/handsontable/src/3rdparty/walkontable/src/table.ts
@@ -958,8 +958,8 @@ class Table {
     const TR = this.THEAD!.childNodes[level];
     const TH = TR?.childNodes[this.columnFilter!.sourceColumnToVisibleRowHeadedColumn(col)];
 
-    // Use nodeType check instead of instanceof HTMLElement so this works when the grid
-    // root element is in a different JS realm (e.g. React createPortal into an iframe).
+    // Use isHTMLElement() instead of instanceof so this works when the grid root
+    // is in a different JS realm (e.g. React createPortal into an iframe).
     return isHTMLElement(TH) ? TH : undefined;
   }
 
@@ -1060,9 +1060,8 @@ class Table {
       return null;
     }
 
-    // Use isHTMLElement() instead of `instanceof Element/HTMLTableCellElement` because the grid
-    // root may be in a different JS realm (e.g. React createPortal into an iframe), where raw
-    // instanceof checks against the parent realm's constructor always return false.
+    // Use isHTMLElement() / isHTMLTableCellElement() instead of `instanceof Element /
+    // HTMLTableCellElement` — cross-realm safe (iframe DOM vs parent JS realm).
     let row = isHTMLElement(TR) ? index(TR) : 0;
     let col = isHTMLTableCellElement(cellElement) ? cellElement.cellIndex : 0;
 

--- a/handsontable/src/3rdparty/walkontable/src/table.ts
+++ b/handsontable/src/3rdparty/walkontable/src/table.ts
@@ -3,6 +3,8 @@ import type Settings from './settings';
 import {
   hasClass,
   index,
+  isHTMLElement,
+  isHTMLTableCellElement,
   offset,
   removeTextNodes,
   overlayContainsElement,
@@ -454,7 +456,7 @@ class Table {
     let spreader: HTMLDivElement | undefined;
 
     if (!parent || parent.nodeType !== Node.ELEMENT_NODE ||
-        !(parent instanceof HTMLElement) || !hasClass(parent, 'wtHolder')) {
+        !isHTMLElement(parent) || !hasClass(parent, 'wtHolder')) {
       spreader = this.domBindings.rootDocument.createElement('div');
       spreader.className = 'wtSpreader';
 
@@ -487,7 +489,7 @@ class Table {
     let hider: HTMLDivElement | undefined;
 
     if (!parent || parent.nodeType !== Node.ELEMENT_NODE ||
-        !(parent instanceof HTMLElement) || !hasClass(parent, 'wtHolder')) {
+        !isHTMLElement(parent) || !hasClass(parent, 'wtHolder')) {
       hider = this.domBindings.rootDocument.createElement('div');
       hider.className = 'wtHider';
 
@@ -517,7 +519,7 @@ class Table {
     let holder;
 
     if (!parent || parent.nodeType !== Node.ELEMENT_NODE ||
-        !(parent instanceof HTMLElement) || !hasClass(parent, 'wtHolder')) {
+        !isHTMLElement(parent) || !hasClass(parent, 'wtHolder')) {
       holder = this.domBindings.rootDocument.createElement('div');
       holder.style.position = 'relative';
       holder.className = 'wtHolder';
@@ -536,7 +538,7 @@ class Table {
         const holderParent = holder.parentNode;
 
         // holderParent is null when TABLE is detached (e.g. in Jasmine tests); skip class assignment in that case.
-        if (holderParent instanceof HTMLElement) {
+        if (isHTMLElement(holderParent)) {
           holderParent.className += 'ht_master handsontable';
           holderParent.setAttribute('dir', this.wtSettings.getSettingPure('rtlMode') ? 'rtl' : 'ltr');
 
@@ -781,7 +783,7 @@ class Table {
         }
         const firstChild = children[i].childNodes[0];
 
-        if (firstChild instanceof HTMLElement) {
+        if (isHTMLElement(firstChild)) {
           firstChild.style.height = `${oversizedColumnHeaders[i]}px`;
         }
       }
@@ -808,7 +810,7 @@ class Table {
       }
 
       const child = children[i];
-      const actualRowHeight = child instanceof HTMLElement ? innerHeight(child) : 0;
+      const actualRowHeight = isHTMLElement(child) ? innerHeight(child) : 0;
 
       if (actualRowHeight > (oversizedColumnHeaders[i] ?? 0) + borderCompensation) {
         oversizedColumnHeaders[i] = actualRowHeight;
@@ -956,7 +958,9 @@ class Table {
     const TR = this.THEAD!.childNodes[level];
     const TH = TR?.childNodes[this.columnFilter!.sourceColumnToVisibleRowHeadedColumn(col)];
 
-    return TH instanceof HTMLElement ? TH : undefined;
+    // Use nodeType check instead of instanceof HTMLElement so this works when the grid
+    // root element is in a different JS realm (e.g. React createPortal into an iframe).
+    return isHTMLElement(TH) ? TH : undefined;
   }
 
   /**
@@ -972,7 +976,7 @@ class Table {
     this.THEAD!.childNodes.forEach((TR: ChildNode) => {
       const TH = TR.childNodes[visibleColumn];
 
-      if (TH instanceof HTMLTableCellElement) {
+      if (isHTMLTableCellElement(TH)) {
         THs.push(TH);
       }
     });
@@ -1001,7 +1005,7 @@ class Table {
     const TR = parentElement?.childNodes[visibleRow];
     const TH = TR?.childNodes[level];
 
-    return TH instanceof HTMLElement ? TH : undefined;
+    return isHTMLElement(TH) ? TH : undefined;
   }
 
   /**
@@ -1056,8 +1060,11 @@ class Table {
       return null;
     }
 
-    let row = TR instanceof Element ? index(TR) : 0;
-    let col = cellElement instanceof HTMLTableCellElement ? cellElement.cellIndex : 0;
+    // Use isHTMLElement() instead of `instanceof Element/HTMLTableCellElement` because the grid
+    // root may be in a different JS realm (e.g. React createPortal into an iframe), where raw
+    // instanceof checks against the parent realm's constructor always return false.
+    let row = isHTMLElement(TR) ? index(TR) : 0;
+    let col = isHTMLTableCellElement(cellElement) ? cellElement.cellIndex : 0;
 
     if (overlayContainsElement(CLONE_TOP_INLINE_START_CORNER, cellElement, this.wtRootElement)
       || overlayContainsElement(CLONE_TOP, cellElement, this.wtRootElement)) {

--- a/handsontable/src/3rdparty/walkontable/src/table.ts
+++ b/handsontable/src/3rdparty/walkontable/src/table.ts
@@ -456,7 +456,7 @@ class Table {
     let spreader: HTMLDivElement | undefined;
 
     if (!parent || parent.nodeType !== Node.ELEMENT_NODE ||
-        !isHTMLElement(parent) || !hasClass(parent, 'wtHolder')) {
+        !(parent instanceof HTMLElement) || !hasClass(parent, 'wtHolder')) {
       spreader = this.domBindings.rootDocument.createElement('div');
       spreader.className = 'wtSpreader';
 
@@ -489,7 +489,7 @@ class Table {
     let hider: HTMLDivElement | undefined;
 
     if (!parent || parent.nodeType !== Node.ELEMENT_NODE ||
-        !isHTMLElement(parent) || !hasClass(parent, 'wtHolder')) {
+        !(parent instanceof HTMLElement) || !hasClass(parent, 'wtHolder')) {
       hider = this.domBindings.rootDocument.createElement('div');
       hider.className = 'wtHider';
 
@@ -519,7 +519,7 @@ class Table {
     let holder;
 
     if (!parent || parent.nodeType !== Node.ELEMENT_NODE ||
-        !isHTMLElement(parent) || !hasClass(parent, 'wtHolder')) {
+        !(parent instanceof HTMLElement) || !hasClass(parent, 'wtHolder')) {
       holder = this.domBindings.rootDocument.createElement('div');
       holder.style.position = 'relative';
       holder.className = 'wtHolder';
@@ -538,7 +538,7 @@ class Table {
         const holderParent = holder.parentNode;
 
         // holderParent is null when TABLE is detached (e.g. in Jasmine tests); skip class assignment in that case.
-        if (isHTMLElement(holderParent)) {
+        if (holderParent instanceof HTMLElement) {
           holderParent.className += 'ht_master handsontable';
           holderParent.setAttribute('dir', this.wtSettings.getSettingPure('rtlMode') ? 'rtl' : 'ltr');
 

--- a/handsontable/src/3rdparty/walkontable/src/table.ts
+++ b/handsontable/src/3rdparty/walkontable/src/table.ts
@@ -958,8 +958,6 @@ class Table {
     const TR = this.THEAD!.childNodes[level];
     const TH = TR?.childNodes[this.columnFilter!.sourceColumnToVisibleRowHeadedColumn(col)];
 
-    // Use isHTMLElement() instead of instanceof so this works when the grid root
-    // is in a different JS realm (e.g. React createPortal into an iframe).
     return isHTMLElement(TH) ? TH : undefined;
   }
 
@@ -1060,8 +1058,6 @@ class Table {
       return null;
     }
 
-    // Use isHTMLElement() / isHTMLTableCellElement() instead of `instanceof Element /
-    // HTMLTableCellElement` — cross-realm safe (iframe DOM vs parent JS realm).
     let row = isHTMLElement(TR) ? index(TR) : 0;
     let col = isHTMLTableCellElement(cellElement) ? cellElement.cellIndex : 0;
 

--- a/handsontable/src/helpers/dom/__tests__/element.unit.ts
+++ b/handsontable/src/helpers/dom/__tests__/element.unit.ts
@@ -17,6 +17,7 @@ import {
   findFirstParentWithClass,
   isHTMLElement,
   isHTMLInputElement,
+  isHTMLTableCellElement,
   isShadowRoot,
   outerHeight,
   outerWidth,
@@ -936,6 +937,38 @@ describe('DomElement helper', () => {
 
     it('should return `true` for an input element', () => {
       expect(isHTMLInputElement(document.createElement('input'))).toBe(true);
+    });
+  });
+
+  //
+  // Handsontable.helper.isHTMLTableCellElement
+  //
+  describe('isHTMLTableCellElement', () => {
+    it('should return `false` for a non-object value', () => {
+      expect(isHTMLTableCellElement(null)).toBe(false);
+      expect(isHTMLTableCellElement(undefined)).toBe(false);
+      expect(isHTMLTableCellElement(42)).toBe(false);
+      expect(isHTMLTableCellElement('td')).toBe(false);
+    });
+
+    it('should return `false` for a regular div element', () => {
+      expect(isHTMLTableCellElement(document.createElement('div'))).toBe(false);
+    });
+
+    it('should return `false` for a TR element', () => {
+      expect(isHTMLTableCellElement(document.createElement('tr'))).toBe(false);
+    });
+
+    it('should return `false` for a TABLE element', () => {
+      expect(isHTMLTableCellElement(document.createElement('table'))).toBe(false);
+    });
+
+    it('should return `true` for a TD element', () => {
+      expect(isHTMLTableCellElement(document.createElement('td'))).toBe(true);
+    });
+
+    it('should return `true` for a TH element', () => {
+      expect(isHTMLTableCellElement(document.createElement('th'))).toBe(true);
     });
   });
 

--- a/handsontable/src/helpers/dom/element.ts
+++ b/handsontable/src/helpers/dom/element.ts
@@ -71,7 +71,9 @@ export function eventTargetEl<T extends HTMLElement = HTMLElement>(event: Event)
 export function getFrameElement(frame: Window): HTMLIFrameElement | null {
   const { frameElement } = frame;
 
-  return Object.getPrototypeOf(frame.parent) &&
+  // `frame.parent` can be null when the iframe has been detached from the DOM. Guard before
+  // passing to Object.getPrototypeOf(), which throws on null/undefined.
+  return frame.parent && Object.getPrototypeOf(frame.parent) &&
     frameElement instanceof HTMLIFrameElement ? frameElement : null;
 }
 

--- a/handsontable/src/helpers/dom/element.ts
+++ b/handsontable/src/helpers/dom/element.ts
@@ -1417,6 +1417,17 @@ export function isHTMLElement(element: unknown): element is HTMLElement {
 }
 
 /**
+ * Check if the element is an HTMLTableCellElement (TD or TH). Cross-realm safe: uses the
+ * element's own realm's constructor via `ownerDocument.defaultView`.
+ *
+ * @param {unknown} element Element to check.
+ * @returns {boolean} `true` if the element is an HTMLTableCellElement.
+ */
+export function isHTMLTableCellElement(element: unknown): element is HTMLTableCellElement {
+  return isHTMLElement(element) && (element.tagName === 'TD' || element.tagName === 'TH');
+}
+
+/**
  * Check if the element is an HTMLInputElement.
  *
  * @param {HTMLElement} element Element to check.

--- a/handsontable/src/plugins/contextMenu/__tests__/positioning.spec.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/positioning.spec.js
@@ -68,10 +68,18 @@ describe('ContextMenu', () => {
         await waitForNextAnimationFrames(2);
 
         const cell = hot.getCell(2, 2);
+        // Use direct simulation instead of the `contextMenu()` helper: that helper wraps in
+        // `waitOnScroll`, which patches the iframe HoT's scroll functions and later calls
+        // `hot().view.render()`. In this nested-iframe setup the render dispatches synthetic
+        // keyboard events cross-realm that confuse the recorder's listener cleanup logic.
+        const cellOffset = $(cell).offset();
 
-        setCurrentHotInstance(hot);
-
-        await contextMenu(cell, hot);
+        $(cell).simulate('mousedown', { button: 2 });
+        $(cell).simulate('contextmenu', {
+          clientX: cellOffset.left - Handsontable.dom.getWindowScrollLeft(hot.rootWindow),
+          clientY: cellOffset.top - Handsontable.dom.getWindowScrollTop(hot.rootWindow),
+        });
+        await waitForNextAnimationFrames(2);
 
         const contextMenuElem = $(docOutside.body).find('.htContextMenu');
         const contextMenuOffset = contextMenuElem.offset();

--- a/handsontable/src/shortcuts/__tests__/modifierKeyTracking.spec.js
+++ b/handsontable/src/shortcuts/__tests__/modifierKeyTracking.spec.js
@@ -1,0 +1,95 @@
+describe('ShortcutManager modifier-key tracking across instances (#12707)', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.iframeHot) {
+      this.iframeHot.destroy();
+      this.iframeHot = null;
+    }
+
+    if (this.$iframe) {
+      this.$iframe.remove();
+      this.$iframe = null;
+    }
+
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  /**
+   * Spawns a second Handsontable instance inside its own iframe document and returns the instance
+   * together with the iframe document. Tracks the iframe on the spec context for teardown.
+   *
+   * @returns {Promise<{ iframeHot: object, doc: Document }>}
+   */
+  async function createGridInIframe() {
+    const $iframe = $('<iframe width="300px" height="200px"/>').appendTo(spec().$container);
+
+    spec().$iframe = $iframe;
+
+    const doc = $iframe[0].contentDocument;
+
+    doc.open('text/html', 'replace');
+    doc.write(`
+      <!doctype html>
+      <head>
+        ${getE2eNormalizeStylesheetLinkTagHtml()}
+        ${getE2eThemeStylesheetLinkTagsHtml()}
+      </head>`);
+    doc.close();
+
+    const $iframeContainer = $('<div/>').appendTo(doc.body);
+
+    await sleep(50);
+
+    $iframeContainer.handsontable({ data: createSpreadsheetData(5, 5) });
+
+    const iframeHot = $iframeContainer.handsontable('getInstance');
+
+    spec().iframeHot = iframeHot;
+
+    return { iframeHot, doc };
+  }
+
+  it('should observe a Ctrl/Cmd keypress for a grid that is not the first instance (separate iframe)', async() => {
+    // The first instance lives in the main document and owns the legacy modifier listeners.
+    handsontable({ data: createSpreadsheetData(5, 5) });
+
+    const { iframeHot, doc } = await createGridInIframe();
+
+    await keyDown('control/meta', { target: doc.documentElement });
+
+    expect(iframeHot.getShortcutManager().isCtrlPressed()).toBe(true);
+
+    await keyUp('control/meta', { target: doc.documentElement });
+  });
+
+  it('should extend the selection on Ctrl/Cmd+click in a grid that is not the first instance (separate iframe)', async() => {
+    handsontable({ data: createSpreadsheetData(5, 5) });
+
+    const { iframeHot, doc } = await createGridInIframe();
+
+    // Establish an initial selection in the iframe grid.
+    await iframeHot.selectCell(3, 3);
+
+    // Hold Ctrl/Cmd while the modifier keydown is delivered to the iframe document, then click
+    // another cell. The additive decision is made from the tracked modifier state, not the mouse
+    // event, so the iframe instance must observe the keydown delivered to its own document.
+    await keyDown('control/meta', { target: doc.documentElement });
+    await mouseDown(iframeHot.getCell(0, 0));
+    await mouseUp(iframeHot.getCell(0, 0));
+    await keyUp('control/meta', { target: doc.documentElement });
+
+    // Additive selection: the Ctrl/Cmd+click adds a range instead of replacing it.
+    expect(iframeHot.getSelectedRange()).toEqualCellRange([
+      'highlight: 3,3 from: 3,3 to: 3,3',
+      'highlight: 0,0 from: 0,0 to: 0,0',
+    ]);
+  });
+});

--- a/handsontable/src/shortcuts/recorder.ts
+++ b/handsontable/src/shortcuts/recorder.ts
@@ -6,8 +6,44 @@ import { isMacOS } from '../helpers/browser';
 import { isFunction } from '../helpers/function';
 
 const modifierKeysObserver = createKeysObserver();
-const modKeyListeners: Array<{event: 'keydown' | 'keyup'; listener: (event: KeyboardEvent) => void}> = [];
-let instanceCounter = 0;
+
+/**
+ * Tracks how many recorder instances reference the shared modifier-key listeners on a given
+ * `documentElement`. The listeners are attached on the first reference and removed on the last,
+ * so every document that hosts a Handsontable instance feeds the shared observer - not only the
+ * document of the first instance created in the realm.
+ */
+const modKeyListenerRefs = new WeakMap<HTMLElement, number>();
+
+/**
+ * `KeyboardEvent`'s callback function for observing the pressed state of the mod keys.
+ *
+ * @param {KeyboardEvent} event The event object
+ */
+const onkeydownForModKeys = (event: KeyboardEvent) => {
+  if (typeof event.key === 'string') {
+    const pressedKey = normalizeEventKey(event);
+
+    if (isModifierKey(pressedKey)) {
+      modifierKeysObserver.press(pressedKey);
+    }
+  }
+};
+
+/**
+ * `KeyboardEvent`'s callback function for observing the released state of the mod keys.
+ *
+ * @param {KeyboardEvent} event The event object
+ */
+const onkeyupForModKeys = (event: KeyboardEvent) => {
+  if (typeof event.key === 'string') {
+    const pressedKey = normalizeEventKey(event);
+
+    if (isModifierKey(pressedKey)) {
+      modifierKeysObserver.release(pressedKey);
+    }
+  }
+};
 
 /**
  * A key recorder, used for tracking key events.
@@ -110,38 +146,6 @@ export function useRecorder(
   };
 
   /**
-   * `KeyboardEvent`'s callback function for observing the pressed state of the mod keys.
-   *
-   * @private
-   * @param {KeyboardEvent} event The event object
-   */
-  const onkeydownForModKeys = (event: KeyboardEvent) => {
-    if (typeof event.key === 'string') {
-      const pressedKey = normalizeEventKey(event);
-
-      if (isModifierKey(pressedKey)) {
-        modifierKeysObserver.press(pressedKey);
-      }
-    }
-  };
-
-  /**
-   * `KeyboardEvent`'s callback function for observing the pressed state of the mod keys.
-   *
-   * @private
-   * @param {KeyboardEvent} event The event object
-   */
-  const onkeyupForModKeys = (event: KeyboardEvent) => {
-    if (typeof event.key === 'string') {
-      const pressedKey = normalizeEventKey(event);
-
-      if (isModifierKey(pressedKey)) {
-        modifierKeysObserver.release(pressedKey);
-      }
-    }
-  };
-
-  /**
    * `FocusEvent`'s callback function
    *
    * @private
@@ -151,54 +155,54 @@ export function useRecorder(
   };
 
   /**
-   * Add event listeners to the starting window and its parents' windows.
+   * Add event listeners to the starting window and its parents' windows. The shared modifier-key
+   * listeners are attached once per `documentElement` (reference-counted), so every document that
+   * hosts an instance - including documents of instances that are not the first one created -
+   * feeds the shared observer.
    */
   const mount = () => {
     let eventTarget: Window | null = ownerWindow;
 
-    instanceCounter += 1;
-
     while (eventTarget) {
-      if (instanceCounter === 1) {
-        eventTarget.document.documentElement.addEventListener('keydown', onkeydownForModKeys);
-        modKeyListeners.push({ event: 'keydown', listener: onkeydownForModKeys });
+      const { documentElement } = eventTarget.document;
+      const refCount = modKeyListenerRefs.get(documentElement) ?? 0;
 
-        eventTarget.document.documentElement.addEventListener('keyup', onkeyupForModKeys);
-        modKeyListeners.push({ event: 'keyup', listener: onkeyupForModKeys });
+      if (refCount === 0) {
+        documentElement.addEventListener('keydown', onkeydownForModKeys);
+        documentElement.addEventListener('keyup', onkeyupForModKeys);
       }
 
-      eventTarget.document.documentElement.addEventListener('keydown', onkeydown);
-      eventTarget.document.documentElement.addEventListener('blur', onblur);
+      modKeyListenerRefs.set(documentElement, refCount + 1);
+
+      documentElement.addEventListener('keydown', onkeydown);
+      documentElement.addEventListener('blur', onblur);
 
       eventTarget = getParentWindow(eventTarget);
     }
   };
 
   /**
-   * Remove event listeners from the starting window and its parents' windows.
+   * Remove event listeners from the starting window and its parents' windows. The shared
+   * modifier-key listeners are removed from a `documentElement` only once the last instance
+   * referencing it is unmounted.
    */
   const unmount = () => {
     let eventTarget: Window | null = ownerWindow;
 
-    instanceCounter -= 1;
-
     while (eventTarget) {
-      if (instanceCounter === 0) {
-        for (let i = 0; i < modKeyListeners.length; i++) {
-          const { event: eventType, listener } = modKeyListeners[i];
+      const { documentElement } = eventTarget.document;
+      const refCount = modKeyListenerRefs.get(documentElement) ?? 0;
 
-          if (eventType === 'keydown') {
-            eventTarget.document.documentElement.removeEventListener('keydown', listener);
-          } else {
-            eventTarget.document.documentElement.removeEventListener('keyup', listener);
-          }
-        }
-
-        modKeyListeners.length = 0;
+      if (refCount <= 1) {
+        documentElement.removeEventListener('keydown', onkeydownForModKeys);
+        documentElement.removeEventListener('keyup', onkeyupForModKeys);
+        modKeyListenerRefs.delete(documentElement);
+      } else {
+        modKeyListenerRefs.set(documentElement, refCount - 1);
       }
 
-      eventTarget.document.documentElement.removeEventListener('keydown', onkeydown);
-      eventTarget.document.documentElement.removeEventListener('blur', onblur);
+      documentElement.removeEventListener('keydown', onkeydown);
+      documentElement.removeEventListener('blur', onblur);
 
       eventTarget = getParentWindow(eventTarget);
     }


### PR DESCRIPTION
### Context

The PR fixes [#12707](https://github.com/handsontable/handsontable/issues/12707): `getShortcutManager().isCtrlPressed()` (and `.isPressed('control')`) always returned `false` for any Handsontable instance that is not the first one created in a JS realm, whenever the Ctrl/Cmd keydown was delivered to a document the first instance does not listen on — most visibly when a second grid lives in a separate iframe. Because `setRangeStart()` decides whether a click is additive from `isCtrlPressed()` rather than from `MouseEvent.ctrlKey`, Ctrl/Cmd+click in that grid replaced the selection instead of extending it, even though `event.ctrlKey === true`.

While testing against the exact Stackblitz reproduction (React `createPortal` — HoT instances created from the parent JS realm with root elements inside separate iframes), two additional regressions were found in the develop branch (not yet released) and fixed in the same PR.

---

#### Fix 1 — `isCtrlPressed()` wrong for 2nd+ instances (`recorder.ts`)

Root cause: in `handsontable/src/shortcuts/recorder.ts` the modifier-key `keydown`/`keyup` listeners that feed the module-level singleton `modifierKeysObserver` were attached only for the first instance (gated by `instanceCounter === 1`) and only on that instance's window chain. Every later instance shared the same observer but never installed its own modifier listeners, so a Ctrl/Cmd press delivered to its document was never recorded.

Fix: reference-count the two modifier-key listeners per `documentElement` using a `WeakMap<HTMLElement, number>`. Listeners are attached on the first reference to a document and removed on the last, so every document that hosts an instance feeds the shared observer. Fixes every `isCtrlPressed()` consumer (selection, column sorting, multi-column sorting, editor handling) for 2nd+ instances. Also fixes a latent wrong-document unmount cleanup bug. **Not a breaking change.**

---

#### Fix 2 — `addClass(undefined, ...)` crash in `SelectionManager.render` (`scanner.ts`) — develop regression, not released

Root cause: `scanRowsInHeadersRange`, `scanColumnsInHeadersRange`, and the multi-cell paths of `scanCellsRange` / `scanRowsInCellsRange` / `scanColumnsInCellsRange` called `callback(TH as HTMLElement)` where `getRowHeader()` / `getColumnHeader()` / `getCell()` can return `undefined`. When `undefined` flowed into `classNamesMap`, `addClass(undefined, className)` threw `Cannot read properties of undefined (reading 'classList')`.

The single-cell path in `#scanCellsRange` had an `isHTMLElement` guard since PR #11460; the multi-cell and header paths were missing it. The crash was triggered by the `'focus'` selection type (introduced post-v17.1.0 as part of the accessibility work) which calls `scanRowsInHeadersRange` for every plain cell click — a code path that didn't exist in v17.1.0.

Fix: add `isHTMLElement()` guards before every callback invocation in all five scanner methods.

---

#### Fix 3 — Wrong cell selected on click when HoT root is in a different JS realm (`table.ts`, `element.ts`) — develop regression, not released

Root cause: two raw `instanceof` checks in `Table.getCoords()` always returned `false` when the grid root element is in a different JS realm (e.g. React `createPortal` into an iframe — HoT module in parent, DOM in iframe):

```ts
let row = TR instanceof Element               ? index(TR)               : 0;  // → always 0
let col = cellElement instanceof HTMLTableCellElement ? cellElement.cellIndex : 0;  // → always 0
```

Every click defaulted to coordinates `(0, 0)` regardless of which cell was actually clicked, causing any cell click to select the wrong row. The same pattern — raw `instanceof HTMLElement` / `instanceof HTMLTableCellElement` against the parent realm's constructors — also affected `getRowHeader()`, `getColumnHeader()`, and several DOM construction helpers in `table.ts`.

Fix: replace all raw `instanceof HTMLElement` / `instanceof HTMLTableCellElement` checks in `table.ts` with the cross-realm-safe `isHTMLElement()` helper (which resolves the element's own realm via `ownerDocument.defaultView.Element`) and a new `isHTMLTableCellElement()` helper added to `src/helpers/dom/element.ts`.

---

### How has this been tested?

E2E coverage in `handsontable/src/shortcuts/__tests__/modifierKeyTracking.spec.js`:
- A second grid inside its own iframe correctly observes a Ctrl/Cmd keydown delivered to the iframe document (`isCtrlPressed()` is `true`).
- Ctrl/Cmd+click in that grid extends the selection (adds a range) instead of replacing it.

Manual demo (`handsontable/dev-pr.html` served locally): both grids instantiated from the parent realm with roots in separate iframes; verified with Chrome DevTools that B4 click selects `(3,1)` and Ctrl+click D6 adds a second range `(5,3)`.

```bash
npm run eslint --prefix handsontable
npm run test:e2e --prefix handsontable --testPathPattern=modifierKeyTracking
npm run test:e2e --prefix handsontable --testPathPattern='shortcutManager|selection/__tests__/general'
npm run build --prefix handsontable
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. #12707
2. DEV-1846

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1846

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core selection, shortcut state, and coordinate resolution used on every click; changes are targeted bug fixes with new tests but affect multi-instance and iframe setups widely.
> 
> **Overview**
> Fixes **Ctrl/Cmd+click additive selection** and related iframe / cross-realm bugs for Handsontable instances that are not the first created in a realm (e.g. grids in separate iframes).
> 
> **Shortcut recorder (`recorder.ts`):** Shared modifier-key listeners are no longer tied only to the first instance. They are **reference-counted per `documentElement`**, so each document that hosts a grid feeds the shared `modifierKeysObserver` and `isCtrlPressed()` works for iframe-hosted instances.
> 
> **Selection rendering (`scanner.ts`):** **`isHTMLElement` guards** are added before selection scan callbacks on headers and multi-cell paths, avoiding crashes when `getCell` / header lookups return non-elements during focus selection rendering.
> 
> **Click coordinates (`table.ts`, `element.ts`):** Raw **`instanceof Element` / `HTMLTableCellElement`** checks are replaced with cross-realm-safe **`isHTMLElement`** and new **`isHTMLTableCellElement`**, so clicks resolve to the correct cell when the table DOM lives in another realm (e.g. portal into iframe). **`getFrameElement`** guards detached iframes when reading `frame.parent`.
> 
> Adds E2E coverage for modifier tracking in iframe grids and unit tests for `isHTMLTableCellElement`; adjusts nested-iframe context-menu positioning test to avoid recorder cleanup issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e152c21deed6d9145236648b8b646803faed8446. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->