### PR TITLE
fix(docs): fix 3 bugs in React recipe examples (DEV-1847, DEV-1848, DEV-1849)

### DIFF
--- a/docs/content/recipes/accessibility/keyboard-shortcuts/react/example1.tsx
+++ b/docs/content/recipes/accessibility/keyboard-shortcuts/react/example1.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState, useEffect } from 'react';
 import { HotTable } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
+import type Handsontable from 'handsontable/base';
 
 registerAllModules();
 

--- a/docs/content/recipes/cell-types/feedback/react/example1.tsx
+++ b/docs/content/recipes/cell-types/feedback/react/example1.tsx
@@ -1,7 +1,6 @@
 import { HotTable, HotColumn } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
 import { CellProperties } from 'handsontable/settings';
-import { BaseEditor } from 'handsontable/editors/baseEditor';
 import { editorFactory } from 'handsontable/editors';
 import { registerCellType } from 'handsontable/cellTypes';
 import './example1.css';
@@ -82,7 +81,7 @@ const feedbackCellDefinition: Pick<CellProperties, 'renderer' | 'validator' | 'e
   }),
 };
 
-registerCellType('feedback', feedbackCellDefinition as BaseEditor);
+registerCellType('feedback', feedbackCellDefinition);
 
 const ExampleComponent = () => {
   return (

--- a/docs/content/recipes/cell-types/moment-date/javascript/example1.js
+++ b/docs/content/recipes/cell-types/moment-date/javascript/example1.js
@@ -138,7 +138,7 @@ const correctFormat = (value, dateFormat) => {
 };
 
 const cellDateTypeDefinition = {
-  renderer: getRenderer('autocomplete'),
+  renderer: getRenderer('text'),
   validator(value, callback) {
     let valid = true;
 

--- a/docs/content/recipes/cell-types/moment-date/react/example1.jsx
+++ b/docs/content/recipes/cell-types/moment-date/react/example1.jsx
@@ -30,7 +30,7 @@ const correctFormat = (value, dateFormat) => {
 };
 
 const cellDateTypeDefinition = {
-  renderer: getRenderer('autocomplete'),
+  renderer: getRenderer('text'),
   validator(value, callback) {
     let valid = true;
 

--- a/docs/content/recipes/cell-types/moment-date/react/example1.tsx
+++ b/docs/content/recipes/cell-types/moment-date/react/example1.tsx
@@ -37,7 +37,7 @@ const correctFormat = (value: string, dateFormat: string): string => {
 };
 
 const cellDateTypeDefinition = {
-  renderer: getRenderer('autocomplete'),
+  renderer: getRenderer('text'),
   validator(this: any, value: string, callback: (valid: boolean) => void) {
     let valid = true;
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Fixes 3 bugs found during a React recipes documentation audit.

- **DEV-1847** — `keyboard-shortcuts` TSX: add missing `import type Handsontable from 'handsontable/base'`. The `useRef` generic used `Handsontable` as a type without importing it, causing a TypeScript compile error for any user copying the snippet.
- **DEV-1848** — `feedback` TSX: remove incorrect `as BaseEditor` cast in `registerCellType('feedback', feedbackCellDefinition as BaseEditor)`. The second argument is a cell-type definition object (`Pick<CellProperties, ...>`), not a `BaseEditor` instance. The JSX variant had no cast and was already correct.
- **DEV-1849** — `moment-date` JSX + TSX: change `getRenderer('autocomplete')` → `getRenderer('text')`. The `autocomplete` renderer adds a dropdown arrow to every date cell, which is visually wrong. The analogous `moment-time` recipe already uses `getRenderer('text')`.

## Files changed

| File | Change |
|---|---|
| `docs/content/recipes/accessibility/keyboard-shortcuts/react/example1.tsx` | Add `import type Handsontable from 'handsontable/base'` |
| `docs/content/recipes/cell-types/feedback/react/example1.tsx` | Remove `as BaseEditor` cast; remove unused `BaseEditor` import |
| `docs/content/recipes/cell-types/moment-date/react/example1.jsx` | `getRenderer('autocomplete')` → `getRenderer('text')` |
| `docs/content/recipes/cell-types/moment-date/react/example1.tsx` | `getRenderer('autocomplete')` → `getRenderer('text')` |

## Test plan

- [ ] **DEV-1847**: Copy the TypeScript tab from the keyboard-shortcuts recipe. Run `tsc --noEmit`. Expect no errors on the `useRef` line.
- [ ] **DEV-1848**: Copy the TypeScript tab from the feedback recipe. Run `tsc --noEmit`. Expect no errors or unsafe casts.
- [ ] **DEV-1849**: Open the moment-date recipe. Observe the date column cells. Expect plain text rendering with no dropdown arrow (▼). Compare with moment-time — both should look identical.

[skip changelog]
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NfoR6vKA1c4xyTRwfTyhUb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to example snippets; no runtime library or production code paths.
> 
> **Overview**
> Fixes three copy-paste issues in React (and one JS) **Handsontable recipe** examples from a docs audit.
> 
> The **keyboard-shortcuts** TypeScript sample now imports `Handsontable` as a type so `useRef<{ hotInstance: Handsontable | null }>` compiles when users copy the snippet. The **feedback** TypeScript sample drops the wrong `as BaseEditor` on `registerCellType` and the unused `BaseEditor` import—the argument is a cell-type definition, not an editor class. **moment-date** examples (JS, JSX, TSX) switch the custom cell renderer from `getRenderer('autocomplete')` to `getRenderer('text')` so date cells render as plain text without a dropdown arrow, matching **moment-time**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2983c83de51d5c69ef30751665674e764d8f7598. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->