### PR TITLE
DEV-1851: Fix double border on row/col headers when HoT is initialized inside an iframe

### DIFF
--- a/handsontable/src/3rdparty/walkontable/src/table.ts
+++ b/handsontable/src/3rdparty/walkontable/src/table.ts
@@ -11,6 +11,7 @@ import {
   outerWidth,
   innerHeight,
   isVisible,
+  isHTMLElement,
   setAttribute,
 } from '../../../helpers/dom/element';
 import { isFunction } from '../../../helpers/function';
@@ -454,7 +455,7 @@ class Table {
     let spreader: HTMLDivElement | undefined;
 
     if (!parent || parent.nodeType !== Node.ELEMENT_NODE ||
-        !(parent instanceof HTMLElement) || !hasClass(parent, 'wtHolder')) {
+        !isHTMLElement(parent) || !hasClass(parent, 'wtHolder')) {
       spreader = this.domBindings.rootDocument.createElement('div');
       spreader.className = 'wtSpreader';
 
@@ -487,7 +488,7 @@ class Table {
     let hider: HTMLDivElement | undefined;
 
     if (!parent || parent.nodeType !== Node.ELEMENT_NODE ||
-        !(parent instanceof HTMLElement) || !hasClass(parent, 'wtHolder')) {
+        !isHTMLElement(parent) || !hasClass(parent, 'wtHolder')) {
       hider = this.domBindings.rootDocument.createElement('div');
       hider.className = 'wtHider';
 
@@ -517,7 +518,7 @@ class Table {
     let holder;
 
     if (!parent || parent.nodeType !== Node.ELEMENT_NODE ||
-        !(parent instanceof HTMLElement) || !hasClass(parent, 'wtHolder')) {
+        !isHTMLElement(parent) || !hasClass(parent, 'wtHolder')) {
       holder = this.domBindings.rootDocument.createElement('div');
       holder.style.position = 'relative';
       holder.className = 'wtHolder';
@@ -536,7 +537,10 @@ class Table {
         const holderParent = holder.parentNode;
 
         // holderParent is null when TABLE is detached (e.g. in Jasmine tests); skip class assignment in that case.
-        if (holderParent instanceof HTMLElement) {
+        // isHTMLElement() is used instead of `instanceof HTMLElement` because the latter fails in
+        // cross-frame contexts (e.g. when HoT is mounted inside an <iframe> via React portals):
+        // the iframe's HTMLElement constructor !== the parent frame's HTMLElement.
+        if (isHTMLElement(holderParent)) {
           holderParent.className += 'ht_master handsontable';
           holderParent.setAttribute('dir', this.wtSettings.getSettingPure('rtlMode') ? 'rtl' : 'ltr');
 

--- a/handsontable/src/3rdparty/walkontable/test/spec/table/createHolder.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/table/createHolder.spec.js
@@ -46,12 +46,12 @@ describe('WalkontableTable', () => {
 
       let iframe = null;
 
-      beforeEach(function() {
+      beforeEach(() => {
         iframe = document.createElement('iframe');
         document.body.appendChild(iframe);
       });
 
-      afterEach(function() {
+      afterEach(() => {
         // Destroy before removing the iframe so destroy() still has valid DOM refs.
         spec().wotInstance.destroy();
 

--- a/handsontable/src/3rdparty/walkontable/test/spec/table/createHolder.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/table/createHolder.spec.js
@@ -1,0 +1,91 @@
+describe('WalkontableTable', () => {
+  const debug = false;
+
+  beforeEach(function() {
+    this.$wrapper = $('<div></div>').addClass('handsontable').css({ overflow: 'hidden' });
+    this.$wrapper.width(200).height(200);
+    this.$container = $('<div></div>');
+    this.$table = $('<table></table>').addClass('htCore');
+    this.$wrapper.append(this.$container);
+    this.$container.append(this.$table);
+    this.$wrapper.appendTo('body');
+    createDataArray(5, 4);
+  });
+
+  afterEach(function() {
+    if (!debug) {
+      $('.wtHolder').remove();
+    }
+
+    this.$wrapper.remove();
+    this.wotInstance.destroy();
+  });
+
+  describe('createHolder()', () => {
+    it('should assign "ht_master handsontable" classes to the master overlay ' +
+       'when the table element is attached to the current document', async() => {
+      const wt = walkontable({
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
+      });
+
+      await wt.draw();
+
+      expect(spec().$wrapper.find('.ht_master').length).toBe(1);
+      expect(spec().$wrapper.find('.ht_master.handsontable').length).toBe(1);
+    });
+
+    describe('cross-frame rendering', () => {
+      // The Handsontable JS bundle runs in the parent window's context, so
+      // `HTMLElement` refers to the parent frame's constructor. When HoT is
+      // mounted inside an <iframe> (e.g. via React portals), the table element
+      // is owned by the iframe's document.  `element instanceof HTMLElement`
+      // returns false for those elements, so the fix uses `isHTMLElement()`,
+      // which checks `element instanceof element.ownerDocument.defaultView.Element`.
+
+      let iframe = null;
+
+      beforeEach(function() {
+        iframe = document.createElement('iframe');
+        document.body.appendChild(iframe);
+      });
+
+      afterEach(function() {
+        // Destroy before removing the iframe so destroy() still has valid DOM refs.
+        spec().wotInstance.destroy();
+
+        iframe.remove();
+        iframe = null;
+
+        // Prevent the outer afterEach from calling destroy() a second time.
+        spec().wotInstance = { destroy: () => {} };
+      });
+
+      it('should assign "ht_master handsontable" classes to the master overlay ' +
+         'when Walkontable is initialized with a table element owned by a cross-frame document', async() => {
+        const iframeDoc = iframe.contentDocument;
+        const container = iframeDoc.createElement('div');
+        const table = iframeDoc.createElement('table');
+
+        table.className = 'htCore';
+        container.appendChild(table);
+        iframeDoc.body.appendChild(container);
+
+        const wt = walkontable({
+          data: getData,
+          totalRows: getTotalRows,
+          totalColumns: getTotalColumns,
+        }, table);
+
+        await wt.draw();
+
+        const masterOverlay = iframeDoc.querySelector('.ht_master');
+
+        expect(masterOverlay).not.toBe(null);
+        expect(masterOverlay.classList.contains('ht_master')).toBe(true);
+        expect(masterOverlay.classList.contains('handsontable')).toBe(true);
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Context

The PR fixes a double border on row and column headers when Handsontable is initialized inside an `<iframe>` (e.g. via React portals).

**Root cause:** `createHolder()` in `table.ts` guards the master overlay class assignment with `instanceof HTMLElement`. In a cross-frame context the Handsontable bundle runs in the parent window, so `HTMLElement` is the parent frame's constructor. Elements owned by the iframe document are instances of the iframe's `HTMLElement` — not the parent's — so `instanceof` returns `false`. The master overlay div gets an empty `className`; CSS selectors targeting `.ht_master` never match; `visibility: hidden` is never applied to the master `thead`/`tbody th`; those elements overlap the visible clone-overlay headers — double border.

**Regression introduced by:** `18e73ccca1 TypeScript initial conversion (#12011)` — the TS type guard was added for type safety but broke cross-frame usage. The original JS code called `holder.parentNode.className +=` unconditionally.

**Fix:** Replace both `instanceof HTMLElement` calls in `createHolder()` with the existing `isHTMLElement()` helper (`helpers/dom/element.ts`), which checks `element instanceof element.ownerDocument.defaultView.Element` — frame-safe by design.

[skip changelog]

### How has this been tested?

- Manual repro page mirroring `IframeGrid.tsx` (two iframes, stylesheet clone + portal pattern, both `handsontable.css` and `ht-theme-main.css` active, no `themeName`)
- Before fix: master overlay has empty `className`, double border visible at 4× zoom
- After fix: master overlay has `ht_master handsontable`, `visibility: hidden` applies correctly, matches CDN v17.1.0 baseline

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1851

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1851

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted DOM guard change in Walkontable table construction with new regression tests; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **double row/column header borders** when Handsontable runs inside an **iframe** (e.g. React portals) by making Walkontable’s DOM wrapper setup **frame-safe**.
> 
> In `table.ts`, **`createSpreader`**, **`createHider`**, and **`createHolder`** now use **`isHTMLElement()`** instead of **`instanceof HTMLElement`** when checking parent nodes. That restores applying **`ht_master handsontable`** on the master overlay root so CSS can hide the master header cells and they don’t stack on clone overlays.
> 
> Adds **`createHolder.spec.js`** with same-document and cross-frame iframe coverage for those classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 812361bca129ff8d483d6a54373a03cf5b2469ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->