### PR TITLE
DEV-1852: Fix duplicate isHTMLElement import in walkontable table.ts

### DIFF
--- a/.changelogs/12740.json
+++ b/.changelogs/12740.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed a TypeScript duplicate identifier error for `isHTMLElement` in the Walkontable table module.",
+  "type": "fixed",
+  "issueOrPR": 12740,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/12740.json
+++ b/.changelogs/12740.json
@@ -1,8 +1,0 @@
-{
-  "issuesOrigin": "public",
-  "title": "Fixed a TypeScript duplicate identifier error for `isHTMLElement` in the Walkontable table module.",
-  "type": "fixed",
-  "issueOrPR": 12740,
-  "breaking": false,
-  "framework": "none"
-}

--- a/handsontable/src/3rdparty/walkontable/src/table.ts
+++ b/handsontable/src/3rdparty/walkontable/src/table.ts
@@ -13,7 +13,6 @@ import {
   outerWidth,
   innerHeight,
   isVisible,
-  isHTMLElement,
   setAttribute,
 } from '../../../helpers/dom/element';
 import { isFunction } from '../../../helpers/function';


### PR DESCRIPTION
[skip changelog]

### Context

The PR fixes a duplicate identifier TypeScript error in `src/3rdparty/walkontable/src/table.ts`. The symbol `isHTMLElement` was imported twice from `../../../helpers/dom/element` (lines 6 and 16), causing `TS2300: Duplicate identifier 'isHTMLElement'`. The second import was removed.

This is a regression introduced but not yet released — no changelog entry required.

### How has this been tested?

- TypeScript compilation passes after the fix
- No logic changes — import deduplication only

```bash
npm run test:types --prefix handsontable
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1852

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1852

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-only change with no logic or behavior changes.
> 
> **Overview**
> Removes a **duplicate** `isHTMLElement` import in `walkontable/src/table.ts` so TypeScript no longer reports `TS2300: Duplicate identifier 'isHTMLElement'`.
> 
> The symbol stays on the existing import from `helpers/dom/element`; runtime behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 661d1ef070096c53c732789228a9b6ea5403d3b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->