### PR TITLE
DEV-1854: Fix row misalignment with wrapped headers and fixed columns (#12632)

### DIFF
--- a/.changelogs/12741.json
+++ b/.changelogs/12741.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed rows in frozen columns becoming misaligned with the rest of the grid when column headers wrap onto multiple lines.",
+  "type": "fixed",
+  "issueOrPR": 12741,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/src/overlay/inlineStart.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/inlineStart.ts
@@ -185,7 +185,15 @@ export class InlineStartOverlay extends Overlay {
       let height = wtViewport.getWorkspaceHeight();
 
       if (wtViewport.hasHorizontalScroll()) {
-        height -= getScrollbarWidth(rootDocument);
+        // Match the master holder's actual inner height instead of subtracting a rounded scrollbar
+        // width. `clientHeight` natively accounts for the horizontal scrollbar at the browser's
+        // sub-pixel accuracy; under fractional browser zoom a rounded `getScrollbarWidth()` diverges
+        // from the real scrollbar size, giving the frozen overlay a different vertical scroll range
+        // than the master. That mismatch clamps the overlay's scrollTop ~1px short at the bottom and
+        // shifts the frozen rows out of alignment (#12632).
+        const masterClientHeight = wtTable.holder.clientHeight;
+
+        height = masterClientHeight > 0 ? masterClientHeight : height - getScrollbarWidth(rootDocument);
       }
 
       height = Math.min(height, wtTable.wtRootElement.scrollHeight);

--- a/handsontable/src/3rdparty/walkontable/src/table.ts
+++ b/handsontable/src/3rdparty/walkontable/src/table.ts
@@ -601,6 +601,11 @@ class Table {
     if (runFastDraw) {
       if (this.isMaster) {
         wtOverlays.refresh(true);
+        // Fast (scroll) draws skip the full-render header-height pass below, so the master/top
+        // header heights can drift against the frozen overlays during scrolling (a tall wrapped
+        // frozen header that the master never renders). Re-sync here. The method is a cheap no-op
+        // unless the grid has frozen columns with column headers, so non-frozen grids are unaffected.
+        this.syncOversizedColumnHeadersWithFrozenOverlays();
       }
     } else {
       if (this.isMaster) {
@@ -665,6 +670,7 @@ class Table {
           }
 
           wtOverlays.refresh(false);
+          this.syncOversizedColumnHeadersWithFrozenOverlays();
           wtOverlays.applyToDOM();
 
           this.wtSettings.getSetting('onDraw', true);
@@ -813,6 +819,77 @@ class Table {
       if (actualRowHeight > (oversizedColumnHeaders[i] ?? 0) + borderCompensation) {
         oversizedColumnHeaders[i] = actualRowHeight;
       }
+    }
+  }
+
+  /**
+   * Frozen column headers (e.g., with `white-space: normal`) are rendered only in the frozen
+   * overlays, never in the master table's THEAD. When such a header is taller than the headers
+   * of the scrollable columns, the master and top overlay THEADs render shorter than the corner
+   * and inline-start overlays, so the frozen overlay body rows sit shifted against the master.
+   * The gap can be sub-pixel: under browser zoom the frozen header content is a fraction of a
+   * pixel taller than the applied height, and that fraction accumulates into a visible 1px shift.
+   *
+   * This method runs after the frozen overlays have rendered. It reads the corner overlay's
+   * content-driven THEAD row heights with sub-pixel precision and forces the matching master and
+   * top overlay header cells to the same height so every overlay THEAD ends up the same height
+   * and the body rows stay pixel-aligned.
+   *
+   * It deliberately does NOT write to `wtViewport.oversizedColumnHeaders`. That cache is applied
+   * back to the corner overlay on the next render; growing it here would inflate the corner cell,
+   * which would then be re-measured taller, ratcheting the height up every render. Reading the
+   * corner's natural (content-driven) height and only adjusting the master/top side keeps the
+   * synchronization stable and lets the header shrink again when the content allows.
+   */
+  syncOversizedColumnHeadersWithFrozenOverlays(): void {
+    const { wtOverlays } = this.dataAccessObject;
+    // Cheapest possible bail-out first: with no frozen columns the corner overlay is not cloned,
+    // so the overwhelmingly common (non-frozen) grids pay only a couple of property reads per draw.
+    const cornerClone = wtOverlays.topInlineStartCornerOverlay?.clone;
+
+    if (!cornerClone?.wtTable?.THEAD) {
+      return;
+    }
+
+    const columnHeaders = this.wtSettings.getSetting<unknown[]>('columnHeaders');
+
+    if (!columnHeaders.length) {
+      return;
+    }
+
+    const cornerChildren = cornerClone.wtTable.THEAD.childNodes;
+    const topClone = wtOverlays.topOverlay?.clone;
+    const targetTheads = [this.THEAD, topClone?.wtTable?.THEAD];
+    // Sub-pixel tolerance to avoid rewriting heights on floating-point jitter while still
+    // catching the fractional gaps (e.g. ~0.33px at 75% zoom) that read as a 1px shift.
+    const epsilon = 0.1;
+
+    for (let i = 0, len = columnHeaders.length; i < len; i++) {
+      const cornerChild = cornerChildren[i];
+
+      if (!(cornerChild instanceof HTMLElement)) {
+        continue;
+      }
+
+      const cornerRowHeight = cornerChild.getBoundingClientRect().height;
+
+      targetTheads.forEach((thead) => {
+        const targetRow = thead?.childNodes[i];
+
+        if (!(targetRow instanceof HTMLElement) || targetRow.childNodes.length === 0) {
+          return;
+        }
+
+        const firstChild = targetRow.childNodes[0];
+
+        if (!(firstChild instanceof HTMLElement)) {
+          return;
+        }
+
+        if (Math.abs(targetRow.getBoundingClientRect().height - cornerRowHeight) > epsilon) {
+          firstChild.style.height = `${cornerRowHeight}px`;
+        }
+      });
     }
   }
 

--- a/handsontable/src/__tests__/colHeader.spec.js
+++ b/handsontable/src/__tests__/colHeader.spec.js
@@ -470,6 +470,68 @@ describe('ColHeader', () => {
     expect(Math.abs(inlineStartThead.offsetHeight - masterThead.offsetHeight)).toBeLessThanOrEqual(1);
   });
 
+  it('should keep all overlay THEAD heights in sync when a wrapped header in the frozen region is taller than the scrollable headers, under fractional zoom (#12632)', async() => {
+    // This bug only manifests at a non-integer devicePixelRatio (browser zoom != 100%), where the
+    // tall wrapped frozen header overflows the applied header height by a sub-pixel amount that the
+    // master THEAD (which never renders the frozen header) does not pick up. `setDeviceScaleFactor`
+    // is exposed only by the Puppeteer harness.
+    if (typeof setDeviceScaleFactor === 'undefined') {
+      pending('setDeviceScaleFactor is only available in the Puppeteer harness');
+
+      return;
+    }
+
+    const style = document.createElement('style');
+
+    style.textContent = '.wrapHeader { white-space: normal !important; }';
+    document.head.appendChild(style);
+
+    spec().$container.css('width', '400px');
+
+    try {
+      await setDeviceScaleFactor(0.9);
+
+      handsontable({
+        data: createSpreadsheetData(100, 50),
+        colWidths: 100,
+        fixedColumnsStart: 2,
+        rowHeaders: false,
+        // The long, wrapping header sits inside the frozen region (column 1). It is never rendered
+        // in the master THEAD, only in the frozen overlays, so the master/top THEADs must be synced
+        // to the frozen overlays' (taller) height for the body rows to stay aligned.
+        colHeaders: ['A', 'This is a very long header that wraps onto multiple lines', 'C', 'D'],
+        columnHeaderHeight: 23,
+        height: 320,
+        headerClassName: 'wrapHeader',
+      });
+
+      await sleep(100);
+
+      const theadHeight = sel => spec().$container.find(`${sel} thead`)[0].getBoundingClientRect().height;
+
+      // The frozen header is taller than the configured columnHeaderHeight.
+      expect(theadHeight('.ht_master')).toBeGreaterThan(23);
+
+      // Scroll horizontally to the far right, then vertically to the last row. The master/top THEADs
+      // now render only short scrollable headers, while the frozen overlays still show the tall
+      // wrapped header. Before the fix the overlay THEADs diverged by ~1px (more under zoom),
+      // shifting the frozen rows out of alignment.
+      await scrollViewportTo({ col: countCols() - 1 });
+      await sleep(50);
+      await scrollViewportTo({ row: countRows() - 1, verticalSnap: 'bottom' });
+      await sleep(100);
+
+      const masterHeight = theadHeight('.ht_master');
+
+      expect(Math.abs(theadHeight('.ht_clone_top_inline_start_corner') - masterHeight)).toBeLessThan(0.5);
+      expect(Math.abs(theadHeight('.ht_clone_inline_start') - masterHeight)).toBeLessThan(0.5);
+      expect(Math.abs(theadHeight('.ht_clone_top') - masterHeight)).toBeLessThan(0.5);
+    } finally {
+      await setDeviceScaleFactor(1);
+      style.remove();
+    }
+  });
+
   it('should allow defining custom column header height using the columnHeaderHeight config option', async() => {
     handsontable({
       startCols: 3,

--- a/handsontable/src/__tests__/colHeader.spec.js
+++ b/handsontable/src/__tests__/colHeader.spec.js
@@ -471,16 +471,6 @@ describe('ColHeader', () => {
   });
 
   it('should keep all overlay THEAD heights in sync when a wrapped header in the frozen region is taller than the scrollable headers, under fractional zoom (#12632)', async() => {
-    // This bug only manifests at a non-integer devicePixelRatio (browser zoom != 100%), where the
-    // tall wrapped frozen header overflows the applied header height by a sub-pixel amount that the
-    // master THEAD (which never renders the frozen header) does not pick up. `setDeviceScaleFactor`
-    // is exposed only by the Puppeteer harness.
-    if (typeof setDeviceScaleFactor === 'undefined') {
-      pending('setDeviceScaleFactor is only available in the Puppeteer harness');
-
-      return;
-    }
-
     const style = document.createElement('style');
 
     style.textContent = '.wrapHeader { white-space: normal !important; }';
@@ -488,48 +478,49 @@ describe('ColHeader', () => {
 
     spec().$container.css('width', '400px');
 
-    try {
-      await setDeviceScaleFactor(0.9);
+    // This bug only manifests at a non-integer devicePixelRatio (browser zoom != 100%), where the
+    // tall wrapped frozen header overflows the applied header height by a sub-pixel amount that the
+    // master THEAD (which never renders the frozen header) does not pick up. The global `afterEach`
+    // restores the default device pixel ratio after this spec.
+    await setDeviceScaleFactor(0.9);
 
-      handsontable({
-        data: createSpreadsheetData(100, 50),
-        colWidths: 100,
-        fixedColumnsStart: 2,
-        rowHeaders: false,
-        // The long, wrapping header sits inside the frozen region (column 1). It is never rendered
-        // in the master THEAD, only in the frozen overlays, so the master/top THEADs must be synced
-        // to the frozen overlays' (taller) height for the body rows to stay aligned.
-        colHeaders: ['A', 'This is a very long header that wraps onto multiple lines', 'C', 'D'],
-        columnHeaderHeight: 23,
-        height: 320,
-        headerClassName: 'wrapHeader',
-      });
+    handsontable({
+      data: createSpreadsheetData(100, 50),
+      colWidths: 100,
+      fixedColumnsStart: 2,
+      rowHeaders: false,
+      // The long, wrapping header sits inside the frozen region (column 1). It is never rendered
+      // in the master THEAD, only in the frozen overlays, so the master/top THEADs must be synced
+      // to the frozen overlays' (taller) height for the body rows to stay aligned.
+      colHeaders: ['A', 'This is a very long header that wraps onto multiple lines', 'C', 'D'],
+      columnHeaderHeight: 23,
+      height: 320,
+      headerClassName: 'wrapHeader',
+    });
 
-      await sleep(100);
+    await sleep(100);
 
-      const theadHeight = sel => spec().$container.find(`${sel} thead`)[0].getBoundingClientRect().height;
+    const theadHeight = sel => spec().$container.find(`${sel} thead`)[0].getBoundingClientRect().height;
 
-      // The frozen header is taller than the configured columnHeaderHeight.
-      expect(theadHeight('.ht_master')).toBeGreaterThan(23);
+    // The frozen header is taller than the configured columnHeaderHeight.
+    expect(theadHeight('.ht_master')).toBeGreaterThan(23);
 
-      // Scroll horizontally to the far right, then vertically to the last row. The master/top THEADs
-      // now render only short scrollable headers, while the frozen overlays still show the tall
-      // wrapped header. Before the fix the overlay THEADs diverged by ~1px (more under zoom),
-      // shifting the frozen rows out of alignment.
-      await scrollViewportTo({ col: countCols() - 1 });
-      await sleep(50);
-      await scrollViewportTo({ row: countRows() - 1, verticalSnap: 'bottom' });
-      await sleep(100);
+    // Scroll horizontally to the far right, then vertically to the last row. The master/top THEADs
+    // now render only short scrollable headers, while the frozen overlays still show the tall
+    // wrapped header. Before the fix the overlay THEADs diverged by ~1px (more under zoom),
+    // shifting the frozen rows out of alignment.
+    await scrollViewportTo({ col: countCols() - 1 });
+    await sleep(50);
+    await scrollViewportTo({ row: countRows() - 1, verticalSnap: 'bottom' });
+    await sleep(100);
 
-      const masterHeight = theadHeight('.ht_master');
+    const masterHeight = theadHeight('.ht_master');
 
-      expect(Math.abs(theadHeight('.ht_clone_top_inline_start_corner') - masterHeight)).toBeLessThan(0.5);
-      expect(Math.abs(theadHeight('.ht_clone_inline_start') - masterHeight)).toBeLessThan(0.5);
-      expect(Math.abs(theadHeight('.ht_clone_top') - masterHeight)).toBeLessThan(0.5);
-    } finally {
-      await setDeviceScaleFactor(1);
-      style.remove();
-    }
+    expect(Math.abs(theadHeight('.ht_clone_top_inline_start_corner') - masterHeight)).toBeLessThan(0.5);
+    expect(Math.abs(theadHeight('.ht_clone_inline_start') - masterHeight)).toBeLessThan(0.5);
+    expect(Math.abs(theadHeight('.ht_clone_top') - masterHeight)).toBeLessThan(0.5);
+
+    style.remove();
   });
 
   it('should allow defining custom column header height using the columnHeaderHeight config option', async() => {

--- a/handsontable/test/helpers/common.js
+++ b/handsontable/test/helpers/common.js
@@ -17,9 +17,19 @@ beforeEach(function() {
   }
 });
 
-afterEach(() => {
+afterEach(async() => {
   if (!DEBUG) {
     specContext.spec = null;
+  }
+
+  // Restore the default device pixel ratio if a spec changed it via `setDeviceScaleFactor`
+  // (exposed only by the Puppeteer e2e harness), so a fractional DPR cannot leak into the next
+  // spec and break viewport-dependent tests. The `devicePixelRatio !== 1` guard keeps this a
+  // no-op (a single property read) for the vast majority of specs that never touch the DPR.
+  if (!process.env.JEST_WORKER_ID
+      && typeof window.setDeviceScaleFactor === 'function'
+      && window.devicePixelRatio !== 1) {
+    await window.setDeviceScaleFactor(1);
   }
 });
 

--- a/handsontable/test/scripts/run-puppeteer.mjs
+++ b/handsontable/test/scripts/run-puppeteer.mjs
@@ -227,22 +227,20 @@ await page.exposeFunction('getEventListeners', async(selector) => {
 });
 
 // Overrides the device scale factor (emulates a non-100% browser zoom / fractional DPR) for the
-// current page via CDP. Pass 1 (or a falsy value) to clear the override. Used by tests that must
+// current page. Pass 1 (or a falsy value) to restore the default. Used by tests that must
 // reproduce sub-pixel rendering bugs which only manifest when devicePixelRatio is not an integer.
+//
+// This goes through `page.setViewport` rather than a raw `Emulation.setDeviceMetricsOverride` /
+// `clearDeviceMetricsOverride` pair on purpose: the CDP "clear" call would also drop Puppeteer's
+// own viewport override (the width/height set at launch), reverting the window to the browser
+// default size and breaking later specs that rely on the window as the scrollable element.
+// `page.setViewport` keeps the current dimensions and only changes the scale factor.
 await page.exposeFunction('setDeviceScaleFactor', async(scaleFactor) => {
-  if (!scaleFactor || scaleFactor === 1) {
-    await cdpClient.send('Emulation.clearDeviceMetricsOverride');
+  const viewport = page.viewport() ?? { width: 1280, height: 720 };
 
-    return;
-  }
-
-  const { width, height } = page.viewport() ?? { width: 1280, height: 720 };
-
-  await cdpClient.send('Emulation.setDeviceMetricsOverride', {
-    width,
-    height,
-    deviceScaleFactor: scaleFactor,
-    mobile: false,
+  await page.setViewport({
+    ...viewport,
+    deviceScaleFactor: scaleFactor || 1,
   });
 });
 

--- a/handsontable/test/scripts/run-puppeteer.mjs
+++ b/handsontable/test/scripts/run-puppeteer.mjs
@@ -226,6 +226,26 @@ await page.exposeFunction('getEventListeners', async(selector) => {
   });
 });
 
+// Overrides the device scale factor (emulates a non-100% browser zoom / fractional DPR) for the
+// current page via CDP. Pass 1 (or a falsy value) to clear the override. Used by tests that must
+// reproduce sub-pixel rendering bugs which only manifest when devicePixelRatio is not an integer.
+await page.exposeFunction('setDeviceScaleFactor', async(scaleFactor) => {
+  if (!scaleFactor || scaleFactor === 1) {
+    await cdpClient.send('Emulation.clearDeviceMetricsOverride');
+
+    return;
+  }
+
+  const { width, height } = page.viewport() ?? { width: 1280, height: 720 };
+
+  await cdpClient.send('Emulation.setDeviceMetricsOverride', {
+    width,
+    height,
+    deviceScaleFactor: scaleFactor,
+    mobile: false,
+  });
+});
+
 page.on('pageerror', async(msg) => {
   /* eslint-disable no-console */
   console.log(msg);


### PR DESCRIPTION
### Context

The PR fixes row misalignment that appears when column headers wrap (`white-space: normal`) and the grid has fixed (frozen) columns — reported in [#12632](https://github.com/handsontable/handsontable/issues/12632).

A tall wrapped header that lives in the frozen region is rendered **only** in the frozen overlays (corner / inline-start), never in the master table's THEAD. As a result the master and top THEADs render shorter than the frozen overlays, and the frozen body rows shift out of alignment with the master by ~1px. The offset is amplified under browser zoom (fractional `devicePixelRatio`), matching the "gets even bigger when zooming" symptom in the report.

Two independent root causes were addressed:

1. **Header height desync.** `oversizedColumnHeaders` is measured from the master THEAD, which never contains the frozen header, so the master/top THEADs were never synced to the (taller) frozen overlays. A new `syncOversizedColumnHeadersWithFrozenOverlays()` reads the corner overlay's content-driven THEAD row height with sub-pixel precision and forces the master/top header cells to match. It runs after the frozen overlays render **and** on fast (scroll) draws, because the desync also occurs during scrolling. It deliberately does not write back to the shared `oversizedColumnHeaders` cache (that would ratchet the corner cell taller every frame). It bails out cheapest-first (no corner clone → return), so non-frozen grids pay ~0 per draw.

2. **Bottom-anchor scroll-clamp geometry.** `overlay/inlineStart.ts` subtracted a rounded `getScrollbarWidth()` from the frozen overlay's holder height. Under fractional zoom that rounded value diverged from the real scrollbar size, giving the frozen overlay a different vertical scroll range than the master and clamping its `scrollTop` ~1px short at the bottom. It now matches the master holder's actual `clientHeight`, removing the zoom-amplified offset.

A constant 1px body-row offset can still remain at the absolute last row with the default row calculator — this is the pre-existing, documented row-calculator limitation (`overlays.ts`, the `hiderHeightComp` compensation) and is absent when `autoRowSize` is enabled. It is out of scope for this fix.

### How has this been tested?

- New fractional-DPR E2E regression test in `handsontable/src/__tests__/colHeader.spec.js`, using a new `setDeviceScaleFactor()` helper exposed by the Puppeteer harness (`test/scripts/run-puppeteer.mjs`). Verified it **fails without the fix** (`Expected 1 to be less than 0.5`) and passes with it.
- Manual verification with Chrome DevTools at real 75% / 90% browser zoom and emulated fractional DPR: all overlay THEADs stay the same height (`theadDelta = 0`) at every scroll position; the horizontal-scroll misalignment is eliminated; `autoRowSize: true` is pixel-perfect including the bottom row.
- Regression suites, all green:
  - `npm run test:walkontable --prefix handsontable` (685 specs)
  - `npm run test:e2e --prefix handsontable -- --testPathPattern='colHeader|autoRowSize'` (101 specs)
  - `npm run test:e2e --prefix handsontable -- --testPathPattern='fixedColumns|manualColumnFreeze|viewportScroll|Scroll'` (363 specs)
  - `npm run eslint`, `npm run stylelint`, `npm run test:types` — clean.
- Performance: the per-fast-draw sync is ~0.0003 ms for non-frozen grids (early-out) and 0.004–0.064 ms for frozen-column grids (≤0.4% of a 60fps frame budget).

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. #12632
2. DEV-1854

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/86ca70896

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Walkontable overlay sizing and per-draw header sync on frozen-column grids; early-outs limit cost elsewhere, but scroll/render timing regressions are possible.
> 
> **Overview**
> Fixes **frozen-column body rows drifting ~1px** from the master grid when column headers wrap and `fixedColumnsStart` is set ([#12632](https://github.com/handsontable/handsontable/issues/12632)).
> 
> **Header sync:** Adds `syncOversizedColumnHeadersWithFrozenOverlays()` on the master table draw path (full and fast scroll draws). It measures the corner overlay’s wrapped frozen-header THEAD height and aligns master/top overlay header cells to match, without updating `oversizedColumnHeaders` (avoids height ratcheting).
> 
> **Scroll geometry:** In `inlineStart.ts`, the frozen overlay holder height now uses the master holder’s `clientHeight` when a horizontal scrollbar is present instead of subtracting rounded `getScrollbarWidth()`, so vertical scroll range matches the master under fractional zoom.
> 
> **Tests:** E2E regression with `setDeviceScaleFactor` in Puppeteer, DPR cleanup in `afterEach`, and changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6c6fcd3a8d8c586399b9aa42a5f657b80da4b5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->