### PR TITLE
docs: fix missing Vue left menu in Recipes section

### DIFF
--- a/docs/content/recipes/sidebar.js
+++ b/docs/content/recipes/sidebar.js
@@ -1,6 +1,6 @@
 const realTimeItems = [
   { path: 'real-time/websocket-updates/websocket-updates', title: 'Real-time updates via WebSocket', onlyFor: ['javascript', 'react', 'angular'] },
-  { path: 'real-time/chartjs-sync/chartjs-sync', title: 'Sync rows to Chart.js', onlyFor: ['javascript', 'react', 'angular'] },
+  { path: 'real-time/chartjs-sync/chartjs-sync', title: 'Sync rows to Chart.js', onlyFor: ['javascript', 'react', 'angular', 'vue'] },
 ];
 
 const columnManagementItems = [
@@ -9,19 +9,19 @@ const columnManagementItems = [
 ];
 
 const contextMenuItems = [
-  { path: 'context-menu/custom-context-menu/custom-context-menu', title: 'Custom context menu actions', onlyFor: ['javascript', 'react', 'angular'] },
-  { path: 'context-menu/row-operations/row-operations', title: 'Programmatic row operations', onlyFor: ['javascript', 'react', 'angular'] },
+  { path: 'context-menu/custom-context-menu/custom-context-menu', title: 'Custom context menu actions', onlyFor: ['javascript', 'react', 'angular', 'vue'] },
+  { path: 'context-menu/row-operations/row-operations', title: 'Programmatic row operations', onlyFor: ['javascript', 'react', 'angular', 'vue'] },
 ];
 
 const dataManagementItems = [
   { path: 'data-management/load-data-rest-api/load-data-rest-api', title: 'Load data from a REST API', onlyFor: ['javascript', 'react', 'angular'] },
-  { path: 'data-management/load-data-graphql/load-data-graphql', title: 'Load data from a GraphQL API', onlyFor: ['javascript', 'react', 'angular'] },
+  { path: 'data-management/load-data-graphql/load-data-graphql', title: 'Load data from a GraphQL API', onlyFor: ['javascript', 'react', 'angular', 'vue'] },
   { path: 'data-management/sync-two-grids/sync-two-grids', title: 'Sync two grids', onlyFor: ['javascript', 'angular', 'react'] },
-  { path: 'data-management/undo-redo-custom-ui/undo-redo-custom-ui', title: 'Undo / redo with a custom UI', onlyFor: ['javascript', 'angular', 'react'] },
-  { path: 'data-management/auto-save-backend/auto-save-backend', title: 'Auto-save changes to a backend', onlyFor: ['javascript', 'angular', 'react'] },
-  { path: 'data-management/server-side-django/server-side-django', title: 'Server-side data with Django', onlyFor: ['javascript', 'angular', 'react'] },
-  { path: 'data-management/server-side-expressjs/server-side-expressjs', title: 'Server-side data with Express.js', onlyFor: ['javascript', 'angular', 'react'] },
-  { path: 'data-management/server-side-laravel/server-side-laravel', title: 'Server-side data with Laravel', onlyFor: ['javascript', 'angular', 'react'] },
+  { path: 'data-management/undo-redo-custom-ui/undo-redo-custom-ui', title: 'Undo / redo with a custom UI', onlyFor: ['javascript', 'angular', 'react', 'vue'] },
+  { path: 'data-management/auto-save-backend/auto-save-backend', title: 'Auto-save changes to a backend', onlyFor: ['javascript', 'angular', 'react', 'vue'] },
+  { path: 'data-management/server-side-django/server-side-django', title: 'Server-side data with Django', onlyFor: ['javascript', 'angular', 'react', 'vue'] },
+  { path: 'data-management/server-side-expressjs/server-side-expressjs', title: 'Server-side data with Express.js', onlyFor: ['javascript', 'angular', 'react', 'vue'] },
+  { path: 'data-management/server-side-laravel/server-side-laravel', title: 'Server-side data with Laravel', onlyFor: ['javascript', 'angular', 'react', 'vue'] },
   { path: 'data-management/server-side-nestjs/server-side-nestjs', title: 'Server-side data with NestJS', onlyFor: ['javascript', 'angular', 'react'] },
   { path: 'data-management/server-side-rails/server-side-rails', title: 'Server-side data with Ruby on Rails', onlyFor: ['javascript', 'angular', 'react'] },
   { path: 'data-management/server-side-spring/server-side-spring', title: 'Server-side data with Spring Boot', onlyFor: ['javascript', 'angular', 'react'] },
@@ -29,16 +29,16 @@ const dataManagementItems = [
 ];
 
 const cellTypesItems = [
-  // JavaScript + Angular (shared multi-framework pages)
-  { path: 'cell-types/color-picker/color-picker', title: 'Color picker', onlyFor: ['javascript', 'angular'] },
-  { path: 'cell-types/feedback/feedback', title: 'Feedback', onlyFor: ['javascript', 'angular'] },
-  { path: 'cell-types/rating/rating', title: 'Star Rating', onlyFor: ['javascript', 'angular'] },
-  // JavaScript only
-  { path: 'cell-types/flatpickr/flatpickr', title: 'Flatpickr', onlyFor: ['javascript'] },
-  { path: 'cell-types/moment-date/moment-date', title: 'Moment.js-based date', onlyFor: ['javascript'] },
-  { path: 'cell-types/moment-time/moment-time', title: 'Moment.js-based time', onlyFor: ['javascript'] },
-  { path: 'cell-types/numbro/numbro', title: 'Numbro', onlyFor: ['javascript'] },
-  { path: 'cell-types/pikaday/pikaday', title: 'Pikaday', onlyFor: ['javascript'] },
+  // JavaScript + Angular + Vue (shared multi-framework pages)
+  { path: 'cell-types/color-picker/color-picker', title: 'Color picker', onlyFor: ['javascript', 'angular', 'vue'] },
+  { path: 'cell-types/feedback/feedback', title: 'Feedback', onlyFor: ['javascript', 'angular', 'vue'] },
+  { path: 'cell-types/rating/rating', title: 'Star Rating', onlyFor: ['javascript', 'angular', 'vue'] },
+  // JavaScript + Vue only
+  { path: 'cell-types/flatpickr/flatpickr', title: 'Flatpickr', onlyFor: ['javascript', 'vue'] },
+  { path: 'cell-types/moment-date/moment-date', title: 'Moment.js-based date', onlyFor: ['javascript', 'vue'] },
+  { path: 'cell-types/moment-time/moment-time', title: 'Moment.js-based time', onlyFor: ['javascript', 'vue'] },
+  { path: 'cell-types/numbro/numbro', title: 'Numbro', onlyFor: ['javascript', 'vue'] },
+  { path: 'cell-types/pikaday/pikaday', title: 'Pikaday', onlyFor: ['javascript', 'vue'] },
   // React only
   { path: 'cell-types/feedback-react/feedback-react', title: 'Feedback', onlyFor: ['react'] },
   { path: 'cell-types/colorful-picker/colorful-picker', title: 'Colorful Picker', onlyFor: ['react'] },
@@ -48,7 +48,7 @@ const cellTypesItems = [
 ];
 
 const performanceItems = [
-  { path: 'performance/lazy-loading/lazy-loading', title: 'Lazy loading with pagination', onlyFor: ['javascript', 'react', 'angular'] },
+  { path: 'performance/lazy-loading/lazy-loading', title: 'Lazy loading with pagination', onlyFor: ['javascript', 'react', 'angular', 'vue'] },
   { path: 'performance/persist-column-layout/persist-column-layout', title: 'Persist column layout', onlyFor: ['javascript', 'angular', 'react'] },
 ];
 
@@ -56,17 +56,17 @@ const renderingStylingItems = [
   {
     path: 'rendering-styling/frozen-summary-row/frozen-summary-row',
     title: 'Frozen summary row',
-    onlyFor: ['javascript', 'angular', 'react'],
+    onlyFor: ['javascript', 'angular', 'react', 'vue'],
   },
   {
     path: 'rendering-styling/sparkline-cell-renderer/sparkline-cell-renderer',
     title: 'Sparkline cell renderer',
-    onlyFor: ['javascript', 'angular', 'react'],
+    onlyFor: ['javascript', 'angular', 'react', 'vue'],
   },
   {
     path: 'rendering-styling/conditional-row-coloring/conditional-row-coloring',
     title: 'Conditional row coloring',
-    onlyFor: ['javascript', 'angular', 'react'],
+    onlyFor: ['javascript', 'angular', 'react', 'vue'],
   },
 ];
 
@@ -74,7 +74,7 @@ const importExportItems = [
   {
     path: 'import-export/export-to-pdf/export-to-pdf',
     title: 'Export to PDF',
-    onlyFor: ['javascript', 'angular', 'react'],
+    onlyFor: ['javascript', 'angular', 'react', 'vue'],
   },
   { path: 'import-export/import-csv-excel/import-csv-excel', title: 'Import from CSV or Excel', onlyFor: ['javascript', 'angular', 'react'] },
 ];
@@ -100,12 +100,12 @@ const editingValidationItems = [
   {
     path: 'editing-validation/dependent-dropdowns/dependent-dropdowns',
     title: 'Dependent dropdowns',
-    onlyFor: ['javascript', 'angular', 'react'],
+    onlyFor: ['javascript', 'angular', 'react', 'vue'],
   },
   {
     path: 'editing-validation/row-validation-error-summary/row-validation-error-summary',
     title: 'Row validation with error summary',
-    onlyFor: ['javascript', 'angular', 'react'],
+    onlyFor: ['javascript', 'angular', 'react', 'vue'],
   },
 ];
 
@@ -118,43 +118,43 @@ module.exports = {
   sidebar: [
     'introduction',
     { title: 'Accessibility & UX', path: 'accessibility', children: accessibilityItems, collapsable: false, onlyFor: ['javascript', 'react', 'angular'] },
-    { title: 'Real-time & Integrations', path: 'real-time', children: realTimeItems, collapsable: false, onlyFor: ['javascript', 'react', 'angular'] },
+    { title: 'Real-time & Integrations', path: 'real-time', children: realTimeItems, collapsable: false, onlyFor: ['javascript', 'react', 'angular', 'vue'] },
     { title: 'Column Management', path: 'column-management', children: columnManagementItems, collapsable: false, onlyFor: ['javascript', 'angular', 'react'] },
-    { title: 'Data Management', path: 'data-management', children: dataManagementItems, collapsable: false, onlyFor: ['javascript', 'angular', 'react'] },
-    { title: 'Cell Types', path: 'cell-types', children: cellTypesItems, collapsable: false, onlyFor: ['react', 'javascript', 'angular'] },
-    { title: 'Context Menu', path: 'context-menu', children: contextMenuItems, collapsable: false, onlyFor: ['javascript', 'react', 'angular'] },
+    { title: 'Data Management', path: 'data-management', children: dataManagementItems, collapsable: false, onlyFor: ['javascript', 'angular', 'react', 'vue'] },
+    { title: 'Cell Types', path: 'cell-types', children: cellTypesItems, collapsable: false, onlyFor: ['react', 'javascript', 'angular', 'vue'] },
+    { title: 'Context Menu', path: 'context-menu', children: contextMenuItems, collapsable: false, onlyFor: ['javascript', 'react', 'angular', 'vue'] },
     {
       title: 'Editing and Validation',
       path: 'editing-validation',
       children: editingValidationItems,
       collapsable: false,
-      onlyFor: ['javascript', 'angular', 'react'],
+      onlyFor: ['javascript', 'angular', 'react', 'vue'],
     },
     {
       title: 'Import and Export',
       path: 'import-export',
       children: importExportItems,
       collapsable: false,
-      onlyFor: ['javascript', 'angular', 'react'],
+      onlyFor: ['javascript', 'angular', 'react', 'vue'],
     },
     {
       title: 'Filtering and Search',
       path: 'filtering-and-search',
       children: [
         ...filteringAndSearchItems,
-        { path: 'filtering-search/multi-column-filter-panel/multi-column-filter-panel', title: 'Multi-column filter panel', onlyFor: ['javascript', 'angular', 'react'] },
+        { path: 'filtering-search/multi-column-filter-panel/multi-column-filter-panel', title: 'Multi-column filter panel', onlyFor: ['javascript', 'angular', 'react', 'vue'] },
       ],
       collapsable: false,
-      onlyFor: ['javascript', 'angular', 'react'],
+      onlyFor: ['javascript', 'angular', 'react', 'vue'],
     },
     {
       title: 'Rendering and styling',
       path: 'rendering-styling',
       children: renderingStylingItems,
       collapsable: false,
-      onlyFor: ['javascript', 'angular', 'react'],
+      onlyFor: ['javascript', 'angular', 'react', 'vue'],
     },
-    { title: 'Performance', path: 'performance', children: performanceItems, collapsable: false, onlyFor: ['javascript', 'react', 'angular'] },
+    { title: 'Performance', path: 'performance', children: performanceItems, collapsable: false, onlyFor: ['javascript', 'react', 'angular', 'vue'] },
     { title: 'Themes', path: 'themes', children: themesItems, collapsable: false, onlyFor: ['react', 'javascript', 'angular'] },
   ],
 };


### PR DESCRIPTION
## Summary

Fixes DEV-1855 / https://app.clickup.com/t/86ca70exc

- Vue users saw a completely empty left-navigation menu when visiting any Recipes page (e.g. `/docs/vue-data-grid/recipes/filtering-and-search/`)
- Root cause: every `onlyFor` array in `docs/content/recipes/sidebar.js` listed only `['javascript', 'react', 'angular']` — `'vue'` was absent everywhere
- Fix: added `'vue'` to `onlyFor` for all sections and individual items that already have `::: only-for javascript vue` content blocks in their recipe pages; sections/items with no Vue content (accessibility, column management, themes, React-only and Angular-only items) remain unchanged

## Sections now visible for Vue

| Section | Vue items |
|---|---|
| Real-time & Integrations | Sync rows to Chart.js |
| Data Management | Load from GraphQL, Undo/redo, Auto-save, Django, Express.js, Laravel |
| Cell Types | Color picker, Feedback, Star Rating, Flatpickr, Moment.js date/time, Numbro, Pikaday |
| Context Menu | Custom context menu actions, Programmatic row operations |
| Editing and Validation | Dependent dropdowns, Row validation with error summary |
| Import and Export | Export to PDF |
| Filtering and Search | Multi-column filter panel |
| Rendering and Styling | Frozen summary row, Sparkline cell renderer, Conditional row coloring |
| Performance | Lazy loading with pagination |

## Sections unchanged (no Vue content exists)

- Accessibility & UX
- Column Management
- Themes

## Test plan

- [ ] Open `/docs/vue-data-grid/recipes/` — confirm left menu now shows multiple sections
- [ ] Open `/docs/vue-data-grid/recipes/filtering-and-search/` — confirm "Multi-column filter panel" appears in the left menu but "Global Search" and "Highlight search matches" do not
- [ ] Verify JS, React, Angular recipe menus are unaffected

[skip changelog]

https://claude.ai/code/session_012F7XaHn4uEg4mT9AsJzmQM

---
_Generated by [Claude Code](https://claude.ai/code/session_012F7XaHn4uEg4mT9AsJzmQM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only sidebar visibility metadata; no runtime or API behavior changes.
> 
> **Overview**
> Fixes an empty Recipes left nav for Vue docs by adding **`vue`** to **`onlyFor`** in `docs/content/recipes/sidebar.js` wherever recipe pages already include Vue content (via `::: only-for` blocks).
> 
> **Section-level** visibility now includes Vue for Real-time & Integrations, Data Management, Cell Types, Context Menu, Editing and Validation, Import and Export, Filtering and Search, Rendering and styling, and Performance. **Individual items** gain `vue` only when applicable—for example Chart.js sync, GraphQL/undo-redo/auto-save/server-side Django–Express–Laravel recipes, shared and JS+Vue cell types, context menu recipes, lazy loading, PDF export, multi-column filter panel, and several styling recipes.
> 
> Sections and links **without** Vue content stay unchanged (Accessibility & UX, Column Management, Themes, React-only/Angular-only cell types, and items like REST API load or persist column layout).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62c37666fd0089177e9fdb8430237f753013b085. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->