### PR TITLE
DEV-1732: Add Vue 3 to docs site navigation on prod-docs/17.1

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -734,15 +734,18 @@ export default defineConfig({
       ],
 
       sidebar: [
-        { label: 'JavaScript', collapsed: true, items: allSidebars.javascript },
-        { label: 'React', collapsed: true, items: allSidebars.react },
-        { label: 'Angular', collapsed: true, items: allSidebars.angular },
-        { label: 'JavaScript Recipes', collapsed: true, items: allSidebars.javascriptRecipes },
-        { label: 'React Recipes', collapsed: true, items: allSidebars.reactRecipes },
-        { label: 'Angular Recipes', collapsed: true, items: allSidebars.angularRecipes },
+        { label: 'JavaScript',           collapsed: true, items: allSidebars.javascript },
+        { label: 'React',                collapsed: true, items: allSidebars.react },
+        { label: 'Angular',              collapsed: true, items: allSidebars.angular },
+        { label: 'Vue 3',                collapsed: true, items: allSidebars.vue },
+        { label: 'JavaScript Recipes',   collapsed: true, items: allSidebars.javascriptRecipes },
+        { label: 'React Recipes',        collapsed: true, items: allSidebars.reactRecipes },
+        { label: 'Angular Recipes',      collapsed: true, items: allSidebars.angularRecipes },
+        { label: 'Vue 3 Recipes',        collapsed: true, items: allSidebars.vueRecipes },
         { label: 'JavaScript Changelog', collapsed: true, items: allSidebars.javascriptChangelog },
-        { label: 'React Changelog', collapsed: true, items: allSidebars.reactChangelog },
-        { label: 'Angular Changelog', collapsed: true, items: allSidebars.angularChangelog },
+        { label: 'React Changelog',      collapsed: true, items: allSidebars.reactChangelog },
+        { label: 'Angular Changelog',    collapsed: true, items: allSidebars.angularChangelog },
+        { label: 'Vue 3 Changelog',      collapsed: true, items: allSidebars.vueChangelog },
       ],
 
       components: {

--- a/docs/src/components/FrameworkSwitcher.astro
+++ b/docs/src/components/FrameworkSwitcher.astro
@@ -16,12 +16,15 @@ const currentPrefix = pathname.includes('/react-data-grid/')
   ? 'react-data-grid'
   : pathname.includes('/angular-data-grid/')
     ? 'angular-data-grid'
-    : 'javascript-data-grid';
+    : pathname.includes('/vue-data-grid/')
+      ? 'vue-data-grid'
+      : 'javascript-data-grid';
 
 const frameworks = [
   { id: 'javascript-data-grid', label: 'JS', fullName: 'JavaScript', icon: 'i-javascript' },
   { id: 'react-data-grid', label: 'React', fullName: 'React', icon: 'i-react' },
   { id: 'angular-data-grid', label: 'Angular', fullName: 'Angular', icon: 'i-angular' },
+  { id: 'vue-data-grid', label: 'Vue', fullName: 'Vue 3', icon: 'i-vue' },
 ];
 
 const current = frameworks.find((f) => f.id === currentPrefix)!;
@@ -142,5 +145,10 @@ const items = frameworks.map((fw) => ({
   .i-angular {
     -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='1' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath stroke='none' d='M0 0h24v24H0z' fill='none'/%3E%3Cpath d='M5.428 17.245l6.076 3.471a1 1 0 0 0 .992 0l6.076 -3.471a1 1 0 0 0 .495 -.734l1.323 -9.704a1 1 0 0 0 -.658 -1.078l-7.4 -2.612a1 1 0 0 0 -.665 0l-7.399 2.613a1 1 0 0 0 -.658 1.078l1.323 9.704a1 1 0 0 0 .495 .734l0 -.001'/%3E%3Cpath d='M9 15l3 -8l3 8'/%3E%3Cpath d='M10 13h4'/%3E%3C/svg%3E");
     mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='1' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath stroke='none' d='M0 0h24v24H0z' fill='none'/%3E%3Cpath d='M5.428 17.245l6.076 3.471a1 1 0 0 0 .992 0l6.076 -3.471a1 1 0 0 0 .495 -.734l1.323 -9.704a1 1 0 0 0 -.658 -1.078l-7.4 -2.612a1 1 0 0 0 -.665 0l-7.399 2.613a1 1 0 0 0 -.658 1.078l1.323 9.704a1 1 0 0 0 .495 .734l0 -.001'/%3E%3Cpath d='M9 15l3 -8l3 8'/%3E%3Cpath d='M10 13h4'/%3E%3C/svg%3E");
+  }
+
+  .i-vue {
+    -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='1' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath stroke='none' d='M0 0h24v24H0z' fill='none'/%3E%3Cpath d='M16.5 4l-4.5 8l-4.5 -8'/%3E%3Cpath d='M3 4l9 16l9 -16'/%3E%3C/svg%3E");
+    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='1' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath stroke='none' d='M0 0h24v24H0z' fill='none'/%3E%3Cpath d='M16.5 4l-4.5 8l-4.5 -8'/%3E%3Cpath d='M3 4l9 16l9 -16'/%3E%3C/svg%3E");
   }
 </style>

--- a/docs/src/components/Header.astro
+++ b/docs/src/components/Header.astro
@@ -30,7 +30,9 @@ const currentPrefix = pathname.includes('/react-data-grid/')
   ? 'react-data-grid'
   : pathname.includes('/angular-data-grid/')
     ? 'angular-data-grid'
-    : 'javascript-data-grid';
+    : pathname.includes('/vue-data-grid/')
+      ? 'vue-data-grid'
+      : 'javascript-data-grid';
 
 const guidesUrl = `/docs/${currentPrefix}/`;
 const recipesUrl = `/docs/${currentPrefix}/recipes/`;
@@ -50,6 +52,7 @@ const frameworks = [
   { id: 'javascript-data-grid', label: 'JavaScript' },
   { id: 'react-data-grid', label: 'React' },
   { id: 'angular-data-grid', label: 'Angular' },
+  { id: 'vue-data-grid', label: 'Vue' },
 ];
 ---
 

--- a/docs/src/components/PageTitle.astro
+++ b/docs/src/components/PageTitle.astro
@@ -65,6 +65,7 @@ const FRAMEWORK_LABELS: Record<string, string> = {
   'javascript-data-grid': 'JavaScript Data Grid',
   'react-data-grid':      'React Data Grid',
   'angular-data-grid':    'Angular Data Grid',
+  'vue-data-grid':        'Vue Data Grid',
 };
 
 // ── Current page data ─────────────────────────────────────────────────────────
@@ -76,7 +77,9 @@ const prefix = pathname.includes('/react-data-grid/')
   ? 'react-data-grid'
   : pathname.includes('/angular-data-grid/')
     ? 'angular-data-grid'
-    : 'javascript-data-grid';
+    : pathname.includes('/vue-data-grid/')
+      ? 'vue-data-grid'
+      : 'javascript-data-grid';
 
 const frameworkLabel = FRAMEWORK_LABELS[prefix];
 const homeLabel      = hotVersion ? `${hotVersion} ${frameworkLabel}` : frameworkLabel;

--- a/docs/src/components/Sidebar.astro
+++ b/docs/src/components/Sidebar.astro
@@ -47,24 +47,29 @@ const prefix = pathname.includes('/react-data-grid/')
   ? 'react-data-grid'
   : pathname.includes('/angular-data-grid/')
     ? 'angular-data-grid'
-    : 'javascript-data-grid';
+    : pathname.includes('/vue-data-grid/')
+      ? 'vue-data-grid'
+      : 'javascript-data-grid';
 
 const GUIDE_LABELS: Record<string, string> = {
   'javascript-data-grid': 'JavaScript',
   'react-data-grid': 'React',
   'angular-data-grid': 'Angular',
+  'vue-data-grid': 'Vue 3',
 };
 
 const RECIPE_LABELS: Record<string, string> = {
   'javascript-data-grid': 'JavaScript Recipes',
   'react-data-grid': 'React Recipes',
   'angular-data-grid': 'Angular Recipes',
+  'vue-data-grid': 'Vue 3 Recipes',
 };
 
 const CHANGELOG_LABELS: Record<string, string> = {
   'javascript-data-grid': 'JavaScript Changelog',
   'react-data-grid': 'React Changelog',
   'angular-data-grid': 'Angular Changelog',
+  'vue-data-grid': 'Vue 3 Changelog',
 };
 
 const isRecipePage = pathname.includes('/recipes/');

--- a/docs/src/sidebar.mjs
+++ b/docs/src/sidebar.mjs
@@ -26,6 +26,7 @@ const FRAMEWORK_PREFIXES = {
   javascript: 'javascript-data-grid',
   react: 'react-data-grid',
   angular: 'angular-data-grid',
+  vue: 'vue-data-grid',
 };
 
 // ---------------------------------------------------------------------------
@@ -371,8 +372,9 @@ export function buildSidebar(framework = 'javascript', prefix = 'javascript-data
 /**
  * Builds sidebar configs for all supported frameworks, including recipes.
  *
- * @returns {{ javascript: Array, react: Array, angular: Array,
- *             javascriptRecipes: Array, reactRecipes: Array, angularRecipes: Array }}
+ * @returns {{ javascript: Array, react: Array, angular: Array, vue: Array,
+ *             javascriptRecipes: Array, reactRecipes: Array, angularRecipes: Array, vueRecipes: Array,
+ *             javascriptChangelog: Array, reactChangelog: Array, angularChangelog: Array, vueChangelog: Array }}
  */
 export function buildAllSidebars() {
   const result = {};


### PR DESCRIPTION
### Context

The PR fixes the missing **Vue tab in the documentation top-bar framework switcher** on production.

The recent docs sync (#12646) brought all Vue 3 **content** to `prod-docs/17.1` (166 Vue example files, plus the Vue guide pages), because those commits carried the `documentation` label. However, the Vue **navigation infrastructure** — the top-bar switcher, sidebar, header, and breadcrumb — was added in #12672, which was labeled `Docs: Tools`, not `documentation`. The content-only sync filters by the `documentation` label, so #12672 was skipped.

The result: production has every Vue page, but no Vue tab to reach them. The switcher still hardcodes only JS / React / Angular. The development build (up to date with `develop`) shows the Vue tab because it has #12672.

This PR cherry-picks #12672 (`8c4e9a408`) onto `prod-docs/17.1` to restore parity. It adds the `vue-data-grid` entry to `FrameworkSwitcher.astro` and wires Vue into the sidebar, header, and breadcrumb. The cherry-pick applied with no conflicts.

### How has this been tested?

- Confirmed `docs/src/components/FrameworkSwitcher.astro` now includes the `vue-data-grid` framework entry and `/vue-data-grid/` path detection.
- Verified the cherry-pick of `8c4e9a408` applied cleanly (6 files, no conflicts).
- Verified production already has the Vue content the new tab links to (166 Vue example files on `prod-docs/17.1`).

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1732
2. DEV-1733
3. DEV-1734
4. DEV-1735
5. Original PR: #12672

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`
- [x] `handsontable-documentation`

### Checklist:

- [x] I have reviewed the guidelines about Contributing to Handsontable and I confirm that my code follows the code style of this project.
- [x] I have signed the Contributor License Agreement
- [ ] My change requires a change to the documentation.

[skip changelog] — docs-site infrastructure cherry-pick; no source-code change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-site navigation and sidebar wiring only; no runtime product or auth changes.
> 
> **Overview**
> Restores **Vue 3** in the production docs navigation so users can reach `/vue-data-grid/` pages that already exist but were unreachable from the UI.
> 
> `sidebar.mjs` adds the `vue` → `vue-data-grid` prefix so `buildAllSidebars()` emits Vue guides, recipes, and changelog trees; **astro.config.mjs** registers those as **Vue 3**, **Vue 3 Recipes**, and **Vue 3 Changelog** sidebar groups. **FrameworkSwitcher**, **Header**, **PageTitle**, and **Sidebar** all recognize `/vue-data-grid/` for prefix detection, framework-specific labels, and cross-framework link rewriting (including mobile framework picks in the header). The switcher also adds a Vue tab with an `.i-vue` icon mask.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f08898ffcedb7044d37ea2811ddaa3588c792d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->