### PR TITLE
fix(docs): open docs assistant on first Ask AI click

### DIFF
--- a/docs/src/components/DocsAssistant/DocsAssistantWidget.tsx
+++ b/docs/src/components/DocsAssistant/DocsAssistantWidget.tsx
@@ -67,6 +67,11 @@ export function DocsAssistantWidget() {
   useEffect(() => {
     const onToggle = () => setOpen((v) => !v);
     window.addEventListener('docs-assistant:toggle', onToggle);
+    // Tell the bootstrap the toggle listener is now attached. The widget is
+    // mounted lazily on the first button click, and the bootstrap waits for
+    // this signal before dispatching that first toggle — otherwise the click
+    // would be lost to the mount/listener race and the panel would not open.
+    window.dispatchEvent(new Event('docs-assistant:ready'));
     return () => window.removeEventListener('docs-assistant:toggle', onToggle);
   }, []);
 

--- a/docs/src/scripts/docs-assistant-bootstrap.ts
+++ b/docs/src/scripts/docs-assistant-bootstrap.ts
@@ -10,9 +10,35 @@
 import type { Root } from 'react-dom/client';
 
 const CONTAINER_ID = 'docs-assistant-root';
+const READY_EVENT = 'docs-assistant:ready';
+
+// Safety cap so a failed mount never leaves the trigger button permanently
+// unresponsive while waiting for the ready signal.
+const READY_TIMEOUT = 3000;
 
 let root: Root | null = null;
 let mountInFlight: Promise<void> | null = null;
+
+/**
+ * Resolves once the freshly mounted widget has attached its
+ * `docs-assistant:toggle` listener (it dispatches `docs-assistant:ready`
+ * from the same effect). Registering the listener before `root.render()`
+ * guarantees the signal cannot be missed. A timeout keeps the trigger
+ * button responsive even if the widget never reaches that effect.
+ */
+function waitForWidgetReady(): Promise<void> {
+  return new Promise<void>((resolve) => {
+    let timer = 0;
+    const done = () => {
+      window.clearTimeout(timer);
+      window.removeEventListener(READY_EVENT, done);
+      resolve();
+    };
+
+    window.addEventListener(READY_EVENT, done, { once: true });
+    timer = window.setTimeout(done, READY_TIMEOUT);
+  });
+}
 
 async function ensureMounted(): Promise<void> {
   if (typeof document === 'undefined') return;
@@ -45,8 +71,17 @@ async function ensureMounted(): Promise<void> {
     ]);
 
     if (!root) {
+      // Start listening for the ready signal *before* render so the widget's
+      // mount effect cannot fire it before we subscribe. Without this, the
+      // first `docs-assistant:toggle` dispatched by Header.astro right after
+      // this promise resolves would arrive before the widget's toggle
+      // listener exists, and the first click would be silently dropped.
+      const ready = waitForWidgetReady();
+
       root = createRoot(container);
       root.render(createElement(DocsAssistantWidget));
+
+      await ready;
     }
   })()
     .catch((err) => {

--- a/docs/tests/docsAssistant.spec.ts
+++ b/docs/tests/docsAssistant.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Regression test for the "Ask AI" docs assistant trigger.
+ *
+ * The widget mounts lazily on the first click of the header "Ask AI" button.
+ * A mount/listener race previously dropped that first click, so the panel
+ * never opened until a second click. The bootstrap now waits for the widget
+ * to signal `docs-assistant:ready` before dispatching the first toggle, so a
+ * single click must open the panel.
+ *
+ * See docs/src/scripts/docs-assistant-bootstrap.ts and
+ * docs/src/components/DocsAssistant/DocsAssistantWidget.tsx.
+ */
+
+test.beforeEach(async ({ page, baseURL }) => {
+  const url = new URL(baseURL?.toString() || '');
+
+  await page.context().addCookies([
+    {
+      name: 'CookieConsent',
+      value: '-2',
+      domain: url.hostname,
+      path: '/',
+      expires: -1,
+      httpOnly: false,
+      secure: false,
+      sameSite: 'Lax',
+    },
+    {
+      name: '70d6d6e3-3a3e-4392-a095-5fe2a6b8bd70',
+      value: process.env.PASS_COOKIE ?? '',
+      domain: 'dev.handsontable.com',
+      path: '/',
+      expires: -1,
+      httpOnly: false,
+      secure: false,
+      sameSite: 'Lax',
+    },
+  ]);
+});
+
+test('opens the docs assistant on the first "Ask AI" click', async ({ page, baseURL }) => {
+  await page.goto(`${baseURL}/javascript-data-grid/`);
+  await expect(page.getByText('Page not found (404)')).toHaveCount(0);
+  await page.waitForLoadState('domcontentloaded');
+
+  const panel = page.locator('.da-panel');
+  const askAiBtn = page.locator('#header-assistant-btn');
+
+  await expect(askAiBtn).toBeVisible();
+
+  // A single click must open the panel (the regression: it took two clicks
+  // because the first toggle raced the widget's listener registration).
+  await askAiBtn.click();
+
+  await expect(panel).toHaveAttribute('data-open', 'true');
+  await expect(panel).toBeVisible();
+
+  // Clicking again closes it, confirming the toggle wiring is intact.
+  await askAiBtn.click();
+  await expect(panel).toHaveAttribute('data-open', 'false');
+});


### PR DESCRIPTION
### Context

The PR fixes a regression where the docs assistant panel does not open on the first click of the **Ask AI** button. It opens only on the second click. This reproduces on both production docs and `develop`.

Root cause — a mount/listener race introduced when the widget became lazy-mounted:

- The widget registers its `docs-assistant:toggle` listener inside a React `useEffect`, which runs *after* `root.render()` resolves.
- `docs-assistant-bootstrap.ts` resolved the mount promise as soon as `root.render()` was called, and `Header.astro` dispatched the first `docs-assistant:toggle` in the `.then()` right after.
- That first toggle fired before the widget's listener existed, so it was dropped. The panel stayed closed until a second click (by which point the listener was attached).

Fix:

- The widget dispatches a `docs-assistant:ready` event once its toggle listener is attached.
- The bootstrap subscribes to `docs-assistant:ready` *before* calling `root.render()` and waits for it (with a 3s safety timeout) before resolving the mount. The first click now reliably opens the panel.

### How has this been tested?

- Added `docs/tests/docsAssistant.spec.ts` (Playwright): loads a docs page, clicks `#header-assistant-btn` once, and asserts `.da-panel[data-open="true"]`; a second click closes it. Run with `BASE_URL=... npm run docs:visual-test docsAssistant.spec.ts` against a running docs server.
- Manual: open any docs page, click **Ask AI** once — the panel slides in.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. Follow-up to #12743 (Vue navigation sync to `prod-docs/17.1`)

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`
- [x] `handsontable-documentation`

### Checklist:

- [x] I have reviewed the guidelines about Contributing to Handsontable and I confirm that my code follows the code style of this project.
- [x] I have signed the Contributor License Agreement
- [ ] My change requires a change to the documentation.

Note: the same fix should also land on `develop` so the next docs sync does not reintroduce the regression on production.

[skip changelog] — docs-site bug fix; no library source change.