### PR TITLE
DEV-1850 - Angular wrapper,  tests, and configuration changes for Ang…

### DIFF
--- a/.changelogs/12752.json
+++ b/.changelogs/12752.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Added support for installing Angular 16 through 22, without the --force flag",
+  "type": "changed",
+  "issueOrPR": 12752,
+  "breaking": false,
+  "framework": "angular"
+}

--- a/wrappers/angular-wrapper/README.md
+++ b/wrappers/angular-wrapper/README.md
@@ -6,7 +6,7 @@
     <img width="360" alt="Logo of Handsontable data grid" src="https://github.com/handsontable/handsontable/blob/develop/resources/handsontable-logo-black.svg?raw=true"/>
   </picture>
   <br><br>
-  <h3>The official <img src="https://raw.githubusercontent.com/handsontable/handsontable/develop/resources/icons/angular-icon.svg" width="16" height="16"> Angular 19+ wrapper for Handsontable.
+  <h3>The official <img src="https://raw.githubusercontent.com/handsontable/handsontable/develop/resources/icons/angular-icon.svg" width="16" height="16"> Angular 16+ wrapper for Handsontable.
     <br>
     <a href="https://handsontable.com/docs/angular-data-grid" target="_blank">JavaScript Data Grid</a> with a spreadsheet-like look and feel.</h3>
 

--- a/wrappers/angular-wrapper/package.json
+++ b/wrappers/angular-wrapper/package.json
@@ -54,7 +54,7 @@
     "release": "npm run test && npm run publish-package"
   },
   "peerDependencies": {
-    "@angular/core": ">=19.0.0 <22.0.0",
+    "@angular/core": ">=16.0.0 <23.0.0",
     "handsontable": "^17.0.0",
     "rxjs": "^7.0.0"
   },


### PR DESCRIPTION
### Context
Added support for installing Angular 16 through 22, without the --force flag

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [x] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1850

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Peer-range and documentation updates only; no runtime or API changes appear in the diff.
> 
> **Overview**
> **Widens official Angular support** for `@handsontable/angular-wrapper` so npm can resolve the package on **Angular 16–22** without `npm install --force`.
> 
> The `@angular/core` **peer dependency** moves from `>=19.0.0 <22.0.0` to **`>=16.0.0 <23.0.0`**. The wrapper **README** headline is updated from “Angular 19+” to **“Angular 16+”**. A **changelog** entry records the change as non-breaking for the Angular framework.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a80ed737507e59b8e9279f88c179dd9e044c3dc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->