### PR TITLE
DEV-1857: Allow native middle-click autoscroll over the grid

### DIFF
--- a/.changelogs/12754.json
+++ b/.changelogs/12754.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed the middle mouse button (scroll wheel) not starting the browser's native autoscroll when clicked over the grid on Windows and Linux.",
+  "type": "fixed",
+  "issueOrPR": 12754,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/__tests__/tableView/onCellMouseDown.spec.js
+++ b/handsontable/src/__tests__/tableView/onCellMouseDown.spec.js
@@ -33,5 +33,42 @@ describe('tableView', () => {
         expect(afterOnCellMouseDown.calls.argsFor(0)[2]).toBe(corner);
       });
     });
+
+    describe('native middle-button autoscroll (#2722)', () => {
+      const dispatchMouseDown = (target, button) => {
+        const event = new MouseEvent('mousedown', {
+          button,
+          buttons: button === 1 ? 4 : 1,
+          bubbles: true,
+          cancelable: true,
+        });
+
+        target.dispatchEvent(event);
+
+        return event.defaultPrevented;
+      };
+
+      it('should not prevent the default action of a middle-button mousedown so the browser can start autoscroll', async() => {
+        handsontable({
+          data: createSpreadsheetData(5, 5),
+        });
+
+        const cell = getCell(1, 1);
+
+        // button 1 = middle (scroll wheel) — the default action must survive
+        expect(dispatchMouseDown(cell, 1)).toBe(false);
+      });
+
+      it('should still prevent the default action of a left-button mousedown (text selection guard)', async() => {
+        handsontable({
+          data: createSpreadsheetData(5, 5),
+        });
+
+        const cell = getCell(1, 1);
+
+        // button 0 = left — default is prevented to suppress native text selection while dragging
+        expect(dispatchMouseDown(cell, 0)).toBe(true);
+      });
+    });
   });
 });

--- a/handsontable/src/helpers/dom/__tests__/event.unit.js
+++ b/handsontable/src/helpers/dom/__tests__/event.unit.js
@@ -1,0 +1,25 @@
+import { isLeftClick, isMiddleClick, isRightClick } from '../event';
+
+describe('DOM event helpers', () => {
+  describe('isMiddleClick', () => {
+    it('should return `true` when the middle mouse button (button 1) is pressed', () => {
+      expect(isMiddleClick({ button: 1 })).toBe(true);
+    });
+
+    it('should return `false` for the left mouse button (button 0)', () => {
+      expect(isMiddleClick({ button: 0 })).toBe(false);
+    });
+
+    it('should return `false` for the right mouse button (button 2)', () => {
+      expect(isMiddleClick({ button: 2 })).toBe(false);
+    });
+
+    it('should not overlap with `isLeftClick` and `isRightClick`', () => {
+      const middleClick = { button: 1 };
+
+      expect(isMiddleClick(middleClick)).toBe(true);
+      expect(isLeftClick(middleClick)).toBe(false);
+      expect(isRightClick(middleClick)).toBe(false);
+    });
+  });
+});

--- a/handsontable/src/helpers/dom/event.ts
+++ b/handsontable/src/helpers/dom/event.ts
@@ -41,6 +41,16 @@ export function isLeftClick(event: Event): boolean {
 }
 
 /**
+ * Check if provided event was triggered by clicking the middle mouse button (the scroll wheel).
+ *
+ * @param {Event} event The mouse event object.
+ * @returns {boolean}
+ */
+export function isMiddleClick(event: Event): boolean {
+  return (event as MouseEvent).button === 1;
+}
+
+/**
  * Check if the provided event is a touch event.
  *
  * @param {Event} event The event object.

--- a/handsontable/src/tableView.ts
+++ b/handsontable/src/tableView.ts
@@ -21,7 +21,7 @@ import {
   getParentWindow,
 } from './helpers/dom/element';
 import EventManager from './eventManager';
-import { isImmediatePropagationStopped, isRightClick, isLeftClick } from './helpers/dom/event';
+import { isImmediatePropagationStopped, isRightClick, isLeftClick, isMiddleClick } from './helpers/dom/event';
 import Walkontable from './3rdparty/walkontable/src';
 import { handleMouseEvent } from './selection/mouseEventHandler';
 import { isRootInstance } from './utils/rootInstance';
@@ -336,6 +336,13 @@ class TableView {
     this.eventManager.addEventListener(rootElement, 'mousedown', (event) => {
       // Ignore synthetic mousedown events from Android touch interactions.
       if (this.#isSyntheticMouseEvent(event)) {
+        return;
+      }
+
+      // Leave the middle mouse button (the scroll wheel) untouched so the browser can start its
+      // native autoscroll. Calling `preventDefault()` on a middle-button mousedown cancels that
+      // panning behavior, which is available on Windows and Linux (https://github.com/handsontable/handsontable/issues/2722).
+      if (isMiddleClick(event)) {
         return;
       }
 


### PR DESCRIPTION
### Context

The PR fixes the browser's native middle mouse button (scroll wheel) autoscroll not starting when the cursor is over the grid. On Windows and Linux, a middle-button click over a scrollable element shows the panning cursor and lets the user scroll by moving the mouse. This works over the browser viewport and plain scroll containers, but not over Handsontable.

Root cause: in `src/tableView.ts`, the `rootElement` `mousedown` listener calls `event.preventDefault()` whenever text selection isn't allowed (the default for grid cells). It did so for every mouse button, including the middle button (button 1). Canceling the mousedown default action suppresses the browser's native autoscroll. Middle-click never starts a grid selection (`mouseEventHandler` gates selection to the left/right buttons), so the `preventDefault` was the only thing blocking autoscroll.

Fix: exclude only the middle button from the `preventDefault` path via a new `isMiddleClick()` helper and an early return in the `mousedown` handler. Left- and right-button behavior is unchanged, so there is no breaking change.

Verification note: macOS has no native middle-click autoscroll, so local verification proves the code-level blocker (`preventDefault`) is gone but cannot confirm the Windows panning cursor returns — that needs confirmation on a real Windows machine. The fix is expected to also resolve the reported Firefox case (same mechanism), unverified.

### How has this been tested?

- Unit (`isMiddleClick` helper):
  - `npm run test:unit --prefix handsontable --testPathPattern=helpers/dom/__tests__/event.unit`
- E2E regression (middle button must not prevent default; left button still does):
  - `npm run test:e2e --prefix handsontable --testPathPattern=tableView/onCellMouseDown`
  - Red-green verified: reverting the guard fails the middle-button spec; restoring it passes.
- No regression on the edited handler path — 142 specs, 0 failures:
  - `npm run test:e2e --prefix handsontable --testPathPattern='__tests__/tableView|settings/fragmentSelection|settings/outsideClickDeselects|selection/__tests__/general'`
- Manual proxy (Chrome on macOS): a middle-button `mousedown` over the grid reports `defaultPrevented === false` after the fix (was `true`), matching a plain `overflow:auto` control; left/right stay `true`.
- `npm run eslint --prefix handsontable` clean; `npm run build --prefix handsontable` succeeds.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1857
2. #2722

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/86ca7f99r

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to one mousedown branch; left/right selection and text-selection guards are unchanged and covered by new tests.
> 
> **Overview**
> Restores **native middle-click autoscroll** over the grid on Windows/Linux by no longer calling `preventDefault()` on middle-button `mousedown` in `tableView`.
> 
> Adds **`isMiddleClick()`** (button 1) alongside the existing left/right helpers, and **returns early** from the root `mousedown` handler when the middle button is used so the browser can start panning. Left-click still prevents default to block native text selection while dragging.
> 
> Coverage includes unit tests for `isMiddleClick`, e2e checks that middle `mousedown` is not default-prevented while left still is, and a changelog entry for #2722.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cbb4a0c84868483c56121d13d8d733795797595. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->