### PR TITLE
DEV-1858: Fix Page Up/Down not scrolling master viewport when selection enters frozen rows overlay

### DIFF
--- a/.changelogs/12755.json
+++ b/.changelogs/12755.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed Page Up and Page Down not scrolling the master viewport to align with the frozen rows overlay.",
+  "type": "fixed",
+  "issueOrPR": 12755,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/selection/__tests__/keyboardShortcuts/pageDown.spec.js
+++ b/handsontable/src/selection/__tests__/keyboardShortcuts/pageDown.spec.js
@@ -197,6 +197,44 @@ describe('Selection navigation', () => {
       expect(getSelectedRange()).toEqualCellRange(['highlight: -3,3 from: -3,3 to: -3,3']);
     });
 
+    it('should scroll the master viewport to the bottom when Page Down moves the selection into a bottom fixed row', async() => {
+      const fixedRowsBottom = 2;
+      const totalRows = 50;
+
+      handsontable({
+        width: 300,
+        height: containerHeightForRows(10),
+        rowHeaders: true,
+        colHeaders: true,
+        startRows: totalRows,
+        startCols: 5,
+        fixedRowsBottom,
+      });
+
+      await waitForNextAnimationFrames(1);
+
+      // Use the actual page size so the math works across all themes
+      const pageSize = hot().countVisibleRows();
+      // After 2 x Page Down: startRow → totalRows-fixedRowsBottom-1 → (clamped to last frozen row)
+      const startRow = totalRows - fixedRowsBottom - 1 - pageSize - 1;
+
+      await selectCell(startRow, 2);
+      await waitForNextAnimationFrames(2);
+
+      // First Page Down: moves by pageSize (still non-frozen), viewport scrolls down
+      await keyDownUp('pagedown');
+      await waitForNextAnimationFrames(2);
+
+      // Second Page Down: moves beyond totalRows, clamped to last row (in bottom frozen overlay)
+      await keyDownUp('pagedown');
+      await waitForNextAnimationFrames(2);
+
+      // Selection must be inside the frozen area
+      expect(getSelectedRange()[0].highlight.row).toBeGreaterThanOrEqual(totalRows - fixedRowsBottom);
+      // Master viewport must be scrolled to the bottom so frozen rows are aligned
+      expect(tableView().getLastFullyVisibleRow()).toBe(totalRows - fixedRowsBottom - 1);
+    });
+
     it('should move the cell selection down for oversized row', async() => {
       handsontable({
         width: 180,

--- a/handsontable/src/selection/__tests__/keyboardShortcuts/pageUp.spec.js
+++ b/handsontable/src/selection/__tests__/keyboardShortcuts/pageUp.spec.js
@@ -248,6 +248,113 @@ describe('Selection navigation', () => {
       expect(tableView().getFirstFullyVisibleRow()).toBe(0);
     });
 
+    it('should scroll the master viewport to the top when Page Up moves the selection into a top fixed row', async() => {
+      const fixedRowsTop = 2;
+      const totalRows = 50;
+
+      handsontable({
+        width: 300,
+        height: containerHeightForRows(10),
+        rowHeaders: true,
+        colHeaders: true,
+        startRows: totalRows,
+        startCols: 5,
+        fixedRowsTop,
+      });
+
+      await waitForNextAnimationFrames(1);
+
+      // Use the actual page size so the math works across all themes
+      const pageSize = hot().countVisibleRows();
+      // After 2 x Page Up: startRow → fixedRowsTop+1 → 0 (in frozen area)
+      const startRow = pageSize + fixedRowsTop + 1;
+
+      await selectCell(startRow, 2);
+      await waitForNextAnimationFrames(2);
+
+      // First Page Up: moves to fixedRowsTop+1 (still non-frozen), viewport scrolls up
+      await keyDownUp('pageup');
+      await waitForNextAnimationFrames(2);
+
+      // Second Page Up: moves to row 0 which is in the top frozen overlay
+      await keyDownUp('pageup');
+      await waitForNextAnimationFrames(2);
+
+      // Selection must be inside the frozen area
+      expect(getSelectedRange()[0].highlight.row).toBeLessThan(fixedRowsTop);
+      // Master viewport must be scrolled back to top so frozen rows are aligned
+      expect(tableView().getFirstFullyVisibleRow()).toBe(fixedRowsTop);
+    });
+
+    it('should scroll the master viewport to the top when Page Up moves the selection to a column header with top fixed rows', async() => {
+      const fixedRowsTop = 2;
+
+      handsontable({
+        width: 300,
+        height: containerHeightForRows(10),
+        rowHeaders: true,
+        colHeaders: true,
+        startRows: 50,
+        startCols: 5,
+        fixedRowsTop,
+        navigableHeaders: true,
+        afterGetColumnHeaderRenderers(headerRenderers) {
+          headerRenderers.push(columnHeader.bind(this));
+        },
+      });
+
+      await waitForNextAnimationFrames(1);
+
+      // countColHeaders() = 2 (default + 1 extra); rowsStep = -(pageSize + 2).
+      // From startRow = pageSize + fixedRowsTop the jump overshoots past row 0, so the
+      // command clamps to the topmost column header (-2) in a single Page Up.
+      const pageSize = hot().countVisibleRows();
+      const startRow = pageSize + fixedRowsTop;
+
+      await selectCell(startRow, 2);
+      await waitForNextAnimationFrames(2);
+
+      await keyDownUp('pageup');
+      await waitForNextAnimationFrames(2);
+
+      // Selection should be at the topmost column header (row < 0)
+      expect(getSelectedRange()[0].highlight.row).toBeLessThan(0);
+      // Master viewport must be scrolled to top even with fixedRowsTop set
+      expect(tableView().getFirstFullyVisibleRow()).toBe(fixedRowsTop);
+    });
+
+    it('should scroll the master viewport to the top when Page Up moves the selection into a top fixed row with both top and bottom fixed rows', async() => {
+      const fixedRowsTop = 2;
+      const fixedRowsBottom = 2;
+
+      handsontable({
+        width: 300,
+        height: containerHeightForRows(10),
+        rowHeaders: true,
+        colHeaders: true,
+        startRows: 50,
+        startCols: 5,
+        fixedRowsTop,
+        fixedRowsBottom,
+      });
+
+      await waitForNextAnimationFrames(1);
+
+      const pageSize = hot().countVisibleRows();
+      const startRow = pageSize + fixedRowsTop + 1;
+
+      await selectCell(startRow, 2);
+      await waitForNextAnimationFrames(2);
+
+      await keyDownUp('pageup');
+      await waitForNextAnimationFrames(2);
+      await keyDownUp('pageup');
+      await waitForNextAnimationFrames(2);
+
+      expect(getSelectedRange()[0].highlight.row).toBeLessThan(fixedRowsTop);
+      expect(tableView().getFirstFullyVisibleRow()).toBe(fixedRowsTop);
+    });
+
     it('should move the cell selection up for oversized row', async() => {
       handsontable({
         width: 180,

--- a/handsontable/src/shortcuts/contexts/commands/moveCellSelection/downByViewportHeight.ts
+++ b/handsontable/src/shortcuts/contexts/commands/moveCellSelection/downByViewportHeight.ts
@@ -25,8 +25,17 @@ export const command = {
     selection.transformStart(rowsStep, 0);
     selection.markEndSource();
 
-    if ((hot.getSelectedRangeActive()?.highlight.row ?? 0) < 0) {
+    // When selection lands in the bottom frozen rows area, the normal scroll strategy
+    // is blocked by the Walkontable frozen-row guard. Explicitly scroll the master
+    // viewport to the bottom so the frozen rows overlay stays aligned.
+    const fixedRowsBottom = hot.getSettings().fixedRowsBottom ?? 0;
+    const totalRows = hot.countRows();
+    const currentRow = hot.getSelectedRangeActive()?.highlight.row ?? 0;
+
+    if (currentRow < 0) {
       hot.scrollViewportTo({ row: 0 });
+    } else if (fixedRowsBottom > 0 && currentRow >= totalRows - fixedRowsBottom) {
+      hot.scrollViewportTo({ row: totalRows - fixedRowsBottom - 1, verticalSnap: 'bottom' });
     }
   },
 };

--- a/handsontable/src/shortcuts/contexts/commands/moveCellSelection/upByViewportHeight.ts
+++ b/handsontable/src/shortcuts/contexts/commands/moveCellSelection/upByViewportHeight.ts
@@ -25,8 +25,14 @@ export const command = {
     selection.transformStart(rowsStep, 0);
     selection.markEndSource();
 
-    if ((hot.getSelectedRangeActive()?.highlight.row ?? 0) < 0) {
-      hot.scrollViewportTo({ row: 0 });
+    // When selection lands in the top frozen rows area (including column headers when
+    // navigableHeaders is enabled), the normal scroll strategy is blocked by the
+    // Walkontable frozen-row guard. Explicitly scroll the master viewport to top.
+    const fixedRowsTop = hot.getSettings().fixedRowsTop ?? 0;
+    const currentRow = hot.getSelectedRangeActive()?.highlight.row ?? 0;
+
+    if (currentRow < fixedRowsTop) {
+      hot.scrollViewportTo({ row: fixedRowsTop, verticalSnap: 'top' });
     }
   },
 };


### PR DESCRIPTION
### Context

The PR fixes a viewport misalignment that occurs when `fixedRowsTop` or `fixedRowsBottom` is set and the user presses Page Up or Page Down until the selection moves into the frozen rows overlay. After such a navigation, the master viewport remains at its previous scroll position instead of snapping to the boundary of the frozen area, causing the row headers to appear misaligned.

**Root cause:** `Walkontable/scroll.ts → scrollViewportVertically()` has a guard that returns early (no scroll) when auto-snapping to a row inside a frozen overlay. This is intentional for mouse clicks on frozen cells, but it also silently suppresses the scroll when Page Up/Down moves the keyboard selection into those rows. The same guard blocked the existing `row < 0` branch (column-header navigation with `navigableHeaders: true` + `fixedRowsTop > 0`).

**Fix:** In `upByViewportHeight.ts`, after `transformStart`, check whether the resulting highlight row is `< fixedRowsTop`. If so, call `scrollViewportTo({ row: fixedRowsTop, verticalSnap: 'top' })` with an explicit snap direction to bypass the guard and force the master viewport to position 0. The condition subsumes the old `row < 0` case (column-header navigation), fixing the latent `navigableHeaders + fixedRowsTop` bug at the same time. Symmetric fix in `downByViewportHeight.ts` for `fixedRowsBottom`.

Fixes: https://github.com/handsontable/handsontable/issues/2755

### Before
<img width="710" height="366" alt="Kapture 2026-06-11 at 10 30 34" src="https://github.com/user-attachments/assets/e70d2ea4-24f0-4e47-bff6-d275d519bb44" />

### After
<img width="710" height="366" alt="Kapture 2026-06-11 at 10 31 13" src="https://github.com/user-attachments/assets/934f8bae-c533-4467-a40e-5016ed90ada6" />

### How has this been tested?

New E2E tests added to `pageUp.spec.js` and `pageDown.spec.js`:
- Page Up with `fixedRowsTop: 2` — verifies `getFirstFullyVisibleRow() === fixedRowsTop` after selection enters frozen area
- Page Down with `fixedRowsBottom: 2` — verifies `getLastFullyVisibleRow() === totalRows - fixedRowsBottom - 1`
- `navigableHeaders: true` + `fixedRowsTop: 2` — verifies column-header selection also triggers the scroll
- Combined `fixedRowsTop: 2` + `fixedRowsBottom: 2` — verifies both overlays do not interfere

All tests were written red-first (failing without the fix) and verified green across all three themes (main, classic, horizon).

```bash
npm run test:e2e --prefix handsontable --testPathPattern="pageUp|pageDown"
npm run test:e2e --prefix handsontable --testPathPattern="pageUp|pageDown" --theme=classic
npm run test:e2e --prefix handsontable --testPathPattern="pageUp|pageDown" --theme=horizon
```

No unit tests for shortcut command callbacks exist in the project; scroll behavior requires real Walkontable rendering and is best covered by E2E.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1858
2. Fixes https://github.com/handsontable/handsontable/issues/2755

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1858

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized keyboard shortcut scroll logic with targeted E2E coverage; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **Page Up / Page Down** misalignment when keyboard selection moves into **top or bottom frozen rows** (`fixedRowsTop` / `fixedRowsBottom`): the master viewport now snaps so row headers line up with the frozen overlay.
> 
> After `transformStart`, **`upByViewportHeight`** calls `scrollViewportTo({ row: fixedRowsTop, verticalSnap: 'top' })` when the highlight is above the frozen band (replacing the narrower `row < 0` scroll), which also covers **column headers** with `navigableHeaders` and `fixedRowsTop`. **`downByViewportHeight`** keeps the header case and adds a **bottom frozen** snap via `scrollViewportTo` with `verticalSnap: 'bottom'`.
> 
> **E2E tests** in `pageUp.spec.js` and `pageDown.spec.js` assert viewport position for top/bottom frozen rows, navigable headers, and combined fixed top+bottom. A **changelog** entry records the public fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60c9103f0e3829ca107564691abeed137109f014. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->