### PR TITLE
DEV-1859: Fix mobile menu buttons broken by missing astro:page-load fallback

### DIFF
--- a/docs/src/components/Header.astro
+++ b/docs/src/components/Header.astro
@@ -558,10 +558,15 @@ const frameworks = [
   // hydrated before initMobileNav() moves DOM nodes out of their server-rendered
   // positions via document.body.appendChild(). Moving nodes on astro:after-swap
   // races with Preact hydration and causes "NotFoundError: insertBefore" failures
-  // (Sentry HANDSONTABLE-DOCS-1BT). astro:page-load fires on both the initial
-  // load and every subsequent view-transition navigation, so no separate
-  // DOMContentLoaded / direct call is needed.
+  // (Sentry HANDSONTABLE-DOCS-1BT).
+  // Without <ClientRouter /> (View Transitions), astro:page-load never fires — not
+  // even on the initial page load. The window.load fallback covers that case:
+  // setTimeout(0) defers past any same-tick astro:page-load dispatch (ClientRouter
+  // fires it on window.load too) so we never call initMobileNav() twice.
   document.addEventListener('astro:page-load', initMobileNav);
+  window.addEventListener('load', () => setTimeout(() => {
+    if (document.getElementById('mobile-nav-overlay')?.parentElement !== document.body) initMobileNav();
+  }, 0), { once: true });
 </script>
 
 <style>

--- a/docs/src/components/__tests__/header-mobile-nav.test.mjs
+++ b/docs/src/components/__tests__/header-mobile-nav.test.mjs
@@ -16,8 +16,10 @@ test('mobile nav initializes only via astro:page-load, with no separate direct c
     mobileNavLifecycleBlock,
     /document\.addEventListener\('astro:page-load', initMobileNav\);/
   );
-  // No separate DOMContentLoaded fallback or direct initMobileNav() call — astro:page-load
-  // fires on the initial load too, so a separate bootstrap path is not needed.
+  // No DOMContentLoaded fallback or standalone initMobileNav() call — the window.load
+  // fallback is allowed for pages without <ClientRouter /> (View Transitions), but it
+  // must be guarded so it never calls initMobileNav() on its own line (to keep the
+  // no-direct-call intent and avoid accidental Preact race regressions).
   assert.doesNotMatch(
     mobileNavLifecycleBlock,
     /document\.addEventListener\('DOMContentLoaded'/
@@ -25,7 +27,7 @@ test('mobile nav initializes only via astro:page-load, with no separate direct c
   assert.doesNotMatch(
     mobileNavLifecycleBlock,
     /^\s*initMobileNav\(\);/m,
-    'initMobileNav() must not be called directly (only via the astro:page-load listener)'
+    'initMobileNav() must not be a standalone call on its own line (guard it inline)'
   );
 });
 


### PR DESCRIPTION
### Context

The PR fixes all mobile menu buttons (burger menu, sidebar toggle, AI assistant, Table of Contents toggle) being completely non-functional on the docs site. Only the theme toggle worked because it is a Starlight built-in web component that doesn't depend on our custom `initMobileNav()` script.

**Root cause:** Commit `26e6f7c83` (PR https://github.com/handsontable/handsontable/pull/12656) changed the mobile nav initialization to rely solely on `document.addEventListener('astro:page-load', initMobileNav)`. However, `astro:page-load` is dispatched only by Astro's View Transitions router (`<ClientRouter />`), which is not used in this project. Without it, the event never fires — not even on the initial page load — so `initMobileNav()` was never called and no click listeners were ever attached to the buttons.

**Fix:** A `window.load` fallback is added alongside the existing `astro:page-load` listener. `setTimeout(0)` defers the fallback past any same-tick `astro:page-load` dispatch (ClientRouter also fires it on `window.load`) so we never call `initMobileNav()` twice if `<ClientRouter />` is ever introduced. A DOM-state guard (`overlay.parentElement !== document.body`) provides a second safety net.

### How has this been tested?

- Verified manually in the browser at mobile viewport (390 px): burger menu opens/closes, sidebar panel opens, ToC panel opens, AI assistant button dispatches the toggle event.
- All 3 existing unit tests pass:

```
node --test docs/src/components/__tests__/header-mobile-nav.test.mjs
# tests 3 / pass 3 / fail 0
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. [DEV-1859](https://app.clickup.com/t/86ca7ggfv)

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to docs header mobile-nav bootstrap timing; guarded to avoid double init and Preact hydration races.
> 
> **Overview**
> Restores **docs mobile navigation** (burger menu, sidebar toggle, ToC, AI assistant) when the site does not use Astro View Transitions (`<ClientRouter />`), because `astro:page-load` never runs in that setup and `initMobileNav()` was never invoked.
> 
> **`Header.astro`** keeps the existing `astro:page-load` listener and adds a one-time **`window.load`** fallback: `setTimeout(0)` avoids double init if View Transitions are added later, and init runs only when `#mobile-nav-overlay` is not yet under `document.body`. Comments document the ClientRouter vs non-ClientRouter behavior and the prior Preact hydration race.
> 
> **`header-mobile-nav.test.mjs`** updates lifecycle assertions to allow this guarded `window.load` path while still forbidding `DOMContentLoaded` and standalone `initMobileNav()` lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4190601db5d9c0ebe516a303d665e690dc09fa3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->