### PR TITLE
DEV-1860: Fix Argos date-format diffs in wrapper visual tests (sync date column with js baseline)

### DIFF
--- a/.claude/skills/pr-creation/SKILL.md
+++ b/.claude/skills/pr-creation/SKILL.md
@@ -86,17 +86,20 @@ git push -u origin <branch-name>
 
 **Always write the PR body to a temp file and use `--body-file`.** Never use `--body "$(cat <<'EOF'...EOF)"` — backticks inside a heredoc passed through shell command substitution are stored as literal `\`` characters in GitHub, breaking all inline code formatting in the PR description.
 
+**Use a unique, task-scoped temp filename — not a fixed `/tmp/pr-body.md`.** The Write tool refuses to overwrite a file it has not read in the current session, so a stale `/tmp/pr-body.md` left over from an earlier session makes the write fail with "Error writing file." Name the file after the branch's task/issue ID so it is both unique per PR and easy to trace: `/tmp/pr-body-DEV-1860.md`, `/tmp/pr-body-issue-11832.md`. If that path somehow already exists, append a short unique suffix (e.g. `/tmp/pr-body-DEV-1860-2.md`).
+
 The correct workflow:
 
-1. Write the body to `/tmp/pr-body.md` using the Write tool (no shell escaping needed).
-2. Pass it with `--body-file /tmp/pr-body.md`.
+1. Write the body to `/tmp/pr-body-<task-id>.md` using the Write tool (no shell escaping needed).
+2. Pass it with `--body-file /tmp/pr-body-<task-id>.md`.
 
 ```bash
 # Step 1: write body to file first (use the Write tool, not shell echo/cat)
+#         e.g. /tmp/pr-body-DEV-1860.md
 # Step 2: create the PR
 gh pr create --draft --base develop \
   --title "DEV-xxx: Short description" \
-  --body-file /tmp/pr-body.md
+  --body-file /tmp/pr-body-DEV-xxx.md
 ```
 
 The body file template (write this with the Write tool, backticks and all, no escaping):
@@ -144,7 +147,7 @@ ClickUp task: https://app.clickup.com/t/9015210959/DEV-xxx
 
 ## 5a. Updating an Existing PR's Body
 
-When asked to update, fix, or re-fill a PR description, use the same temp-file approach: write the body to `/tmp/pr-body.md` with the Write tool, then `gh pr edit <number> --body-file /tmp/pr-body.md`. Keep the full template structure — do not replace it with a shorter summary. Never use `--body "$(cat <<'EOF'...EOF)"` — backticks are not shell-escaped in the Write tool output and will be stored as literal `\`` on GitHub.
+When asked to update, fix, or re-fill a PR description, use the same temp-file approach with a unique, task-scoped filename: write the body to `/tmp/pr-body-<task-id>.md` (e.g. `/tmp/pr-body-DEV-1860.md`) with the Write tool, then `gh pr edit <number> --body-file /tmp/pr-body-<task-id>.md`. A fixed `/tmp/pr-body.md` fails when a stale copy from an earlier session exists, because the Write tool will not overwrite a file it has not read this session. Keep the full template structure — do not replace it with a shorter summary. Never use `--body "$(cat <<'EOF'...EOF)"` — backticks are not shell-escaped in the Write tool output and will be stored as literal `\`` on GitHub.
 
 ## 6. Changelog Entry (after PR is created)
 

--- a/examples/next/visual-tests/angular-wrapper/demo/src/data-grid/data-grid.component.ts
+++ b/examples/next/visual-tests/angular-wrapper/demo/src/data-grid/data-grid.component.ts
@@ -48,7 +48,7 @@ export class DataGridComponent {
     columns: [
       { data: '1' },
       { data: '3' },
-      { data: '4', type: 'date', allowInvalid: false },
+      { data: '4', type: 'date', allowInvalid: false, dateFormat: { dateStyle: 'short' }, locale: 'en-US' },
       { data: '6', type: 'checkbox', className: 'htCenter', headerClassName: 'htCenter' },
       { data: '7', type: 'numeric', headerClassName: 'htRight' },
       { 

--- a/examples/next/visual-tests/react-wrapper/demo/src/DataGrid.tsx
+++ b/examples/next/visual-tests/react-wrapper/demo/src/DataGrid.tsx
@@ -53,7 +53,7 @@ const DataGrid = () => {
     >
       <HotColumn data={1} />
       <HotColumn data={3} />
-      <HotColumn data={4} type="date" allowInvalid={false} />
+      <HotColumn data={4} type="date" allowInvalid={false} dateFormat={{ dateStyle: "short" }} locale="en-US" />
       <HotColumn data={6} type="checkbox" className="htCenter" headerClassName="htCenter" />
       <HotColumn data={7} type="numeric" headerClassName="htRight" />
       <HotColumn data={8} editor={false} className="htMiddle" renderer={ProgressBarRenderer} readOnly={true} />

--- a/examples/next/visual-tests/vue3/demo/src/components/DataGrid.vue
+++ b/examples/next/visual-tests/vue3/demo/src/components/DataGrid.vue
@@ -60,7 +60,9 @@ export default {
           {
             data: 4,
             type: "date",
-            allowInvalid: false
+            allowInvalid: false,
+            dateFormat: { dateStyle: "short" },
+            locale: "en-US"
           },
           {
             data: 6,

--- a/visual-tests/AGENTS.md
+++ b/visual-tests/AGENTS.md
@@ -35,6 +35,20 @@ test(__filename, async({ tablePage }) => {
 - Organization: `tests/js-only/`, `tests/multi-frameworks/`, `tests/cross-browser/`
 - Examples for testing live in `examples/next/docs/`
 
+## Golden snapshots: js-copied baselines (critical gotcha)
+
+The reference (golden) baseline and PR builds are generated **differently**, and this asymmetry is a recurring source of false-positive Argos diffs.
+
+- **Reference branch (`develop`)** — `scripts/run-tests.mjs` renders **only the `js` framework** (`getFrameworkList()` returns `[REFERENCE_FRAMEWORK]` when `isReferenceBranch()`), then **copies** the js `multi-frameworks` screenshots into the `react-wrapper` / `vue3` / `angular-wrapper` baselines. The wrapper screenshots in the golden set are therefore **identical to the js render** — the wrappers are never actually rendered on `develop`.
+- **Pull requests (non-reference branches)** — every framework (`js` + all wrappers) is rendered for real from its own visual-test example, and each is compared against the copied js baseline.
+
+**Implication:** the harness assumes every framework renders each multi-framework demo **pixel-identically to js**. When that assumption breaks, the affected wrapper snapshots diverge from the copied js baseline on **every** PR — a constant, content-independent diff — while `develop` builds can never detect it (they only ever re-copy js).
+
+**Rule:** any change to a `js` visual-test demo that affects rendering (cell-type config, `dateFormat`, `locale`, formatting, data) **must be mirrored in all three wrapper demos**, or every future PR inherits a phantom diff. The wrapper demos must produce the same DOM/output as js.
+
+- Visual-test examples live under **`examples/next/visual-tests/<framework>/demo/`** (js, react-wrapper, vue3, angular-wrapper) — distinct from the docs examples in `examples/next/docs/`.
+- Example regression (DEV-1860): PRO-986 migrated the **js** date column to `dateFormat: { dateStyle: 'short' }` + `locale: 'en-US'` (native `Intl`) but left the wrapper demos with bare `type: 'date'`, so the wrappers rendered the default `Intl` format (`10/11/2020`) instead of the baseline's `10/11/20` → a constant 255-snapshot diff on every PR until the wrapper demos were synced. Pinning the browser `locale` in `playwright.config.ts` does **not** fix this class of bug — the gap is the demo config, not the runtime locale.
+
 ## Helpers
 
 - `src/helpers.ts`: screenshotPath, DOM selectors, platform detection

--- a/visual-tests/playwright-cross-browser.config.ts
+++ b/visual-tests/playwright-cross-browser.config.ts
@@ -36,6 +36,15 @@ const config: PlaywrightTestConfig = {
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: 'http://localhost:8082',
 
+    /**
+     * Pin the browser locale and timezone so date/time rendering is deterministic.
+     * Date cells format values with `Intl.DateTimeFormat` and the native `<input type="date">`
+     * editor renders in the browser locale; without pinning, the resolved locale/timezone varies
+     * between CI runners and the same snapshot flaps between formats (e.g. MM/DD/YYYY vs DD/MM/YYYY).
+     */
+    locale: 'en-US',
+    timezoneId: 'UTC',
+
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',

--- a/visual-tests/playwright.config.ts
+++ b/visual-tests/playwright.config.ts
@@ -37,6 +37,15 @@ const config: PlaywrightTestConfig = {
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: 'http://localhost:8082',
 
+    /**
+     * Pin the browser locale and timezone so date/time rendering is deterministic.
+     * Date cells format values with `Intl.DateTimeFormat` and the native `<input type="date">`
+     * editor renders in the browser locale; without pinning, the resolved locale/timezone varies
+     * between CI runners and the same snapshot flaps between formats (e.g. MM/DD/YYYY vs DD/MM/YYYY).
+     */
+    locale: 'en-US',
+    timezoneId: 'UTC',
+
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',


### PR DESCRIPTION
### Context

The PR fixes the persistent Argos visual-test failures (a constant **255 changed** snapshots) that appeared on every PR branched off `develop` after #12689 (PRO-986).

**Root cause.** The visual-test harness only renders the `js` framework on the reference branch (`develop`) and *copies* those screenshots into the `react`/`vue3`/`angular` baselines (`visual-tests/scripts/run-tests.mjs`), on the assumption that every framework renders the multi-framework demos identically. PRO-986 migrated the **js** demo's date column to the native `Intl` API — `dateFormat: { dateStyle: 'short' }` + `locale: 'en-US'` — but **left the wrapper demos untouched**. With no `dateFormat`/`locale`, the wrapper date column fell back to the default `Intl` format (`10/11/2020`) instead of the js baseline's short format (`10/11/20`), so every wrapper snapshot containing a date diverged from the copied js baseline. The diff was constant (content-independent) and showed up on react/vue3/angular — confirmed by pre-PRO-986 PRs passing clean while every post-PRO-986 PR shows the same 255.

**Fix.** Add the same `dateFormat: { dateStyle: 'short' }` and `locale: 'en-US'` to the date column in all three wrapper visual-test demos so they render identically to the js baseline, restoring the harness's copy-from-js assumption. No RTL branch is needed — there are no multi-framework RTL specs and the wrapper demos don't render Arabic.

**Also includes:**

1. **Hardening:** `locale: 'en-US'` + `timezoneId: 'UTC'` pinned in `visual-tests/playwright.config.ts` and `playwright-cross-browser.config.ts`, so `Intl` date formatting and the native `<input type="date">` editor don't vary with the CI runner's environment. This is defensive — not the fix for the 255 diffs.
2. A small `pr-creation` skill fix (`.claude/skills/pr-creation/SKILL.md`): the PR body is written to a unique, task-scoped temp file (e.g. `/tmp/pr-body-DEV-1860.md`) instead of a fixed `/tmp/pr-body.md`, which fails when a stale copy from an earlier session exists.

### How has this been tested?

- `npx eslint` on the changed `visual-tests/` config files — clean.
- Verified the wrapper demos previously had no `dateFormat`/`locale` on the date column, while the js `default` demo (the baseline source) sets both; the fix makes them match.
- Final validation is the Argos build on this PR: the wrapper date snapshots should now match the js baseline (255 → 0 for the date-driven diffs).

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1860
2. Surfaced by #12754; regression from #12689

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog] — changes are limited to the visual-test demos/harness config and the internal `pr-creation` skill; no package source code is affected.

ClickUp task: https://app.clickup.com/t/86ca7h7xk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to visual-test demos, Playwright config, and internal docs/skills; no library runtime behavior is modified.
> 
> **Overview**
> Fixes persistent Argos wrapper visual-test failures (constant ~255 snapshot diffs) by aligning **react**, **vue3**, and **angular** multi-framework `DataGrid` demos with the **js** baseline: the date column now uses `dateFormat: { dateStyle: 'short' }` and `locale: 'en-US'`, matching PRO-986’s js demo after wrapper configs were left on bare `type: 'date'`.
> 
> **Playwright** configs (`playwright.config.ts`, `playwright-cross-browser.config.ts`) pin `locale: 'en-US'` and `timezoneId: 'UTC'` for more stable `Intl` / native date input rendering across CI environments.
> 
> **Docs/tooling:** `visual-tests/AGENTS.md` documents the js-copied golden baseline asymmetry and the rule to mirror js rendering changes in all wrapper demos; `pr-creation` skill now uses task-scoped PR body temp files instead of a fixed `/tmp/pr-body.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 921ffe50b7767393911e471f2da7b42d9b20e346. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->