### PR TITLE
Cherry pick to prod: Fix mobile menu buttons broken by missing astro:page-load

### DIFF
--- a/docs/src/components/Header.astro
+++ b/docs/src/components/Header.astro
@@ -535,10 +535,15 @@ const frameworks = [
   // hydrated before initMobileNav() moves DOM nodes out of their server-rendered
   // positions via document.body.appendChild(). Moving nodes on astro:after-swap
   // races with Preact hydration and causes "NotFoundError: insertBefore" failures
-  // (Sentry HANDSONTABLE-DOCS-1BT). astro:page-load fires on both the initial
-  // load and every subsequent view-transition navigation, so no separate
-  // DOMContentLoaded / direct call is needed.
+  // (Sentry HANDSONTABLE-DOCS-1BT).
+  // Without <ClientRouter /> (View Transitions), astro:page-load never fires — not
+  // even on the initial page load. The window.load fallback covers that case:
+  // setTimeout(0) defers past any same-tick astro:page-load dispatch (ClientRouter
+  // fires it on window.load too) so we never call initMobileNav() twice.
   document.addEventListener('astro:page-load', initMobileNav);
+  window.addEventListener('load', () => setTimeout(() => {
+    if (document.getElementById('mobile-nav-overlay')?.parentElement !== document.body) initMobileNav();
+  }, 0), { once: true });
 </script>
 
 <style>

--- a/docs/src/components/__tests__/header-mobile-nav.test.mjs
+++ b/docs/src/components/__tests__/header-mobile-nav.test.mjs
@@ -16,8 +16,10 @@ test('mobile nav initializes only via astro:page-load, with no separate direct c
     mobileNavLifecycleBlock,
     /document\.addEventListener\('astro:page-load', initMobileNav\);/
   );
-  // No separate DOMContentLoaded fallback or direct initMobileNav() call — astro:page-load
-  // fires on the initial load too, so a separate bootstrap path is not needed.
+  // No DOMContentLoaded fallback or standalone initMobileNav() call — the window.load
+  // fallback is allowed for pages without <ClientRouter /> (View Transitions), but it
+  // must be guarded so it never calls initMobileNav() on its own line (to keep the
+  // no-direct-call intent and avoid accidental Preact race regressions).
   assert.doesNotMatch(
     mobileNavLifecycleBlock,
     /document\.addEventListener\('DOMContentLoaded'/
@@ -25,7 +27,7 @@ test('mobile nav initializes only via astro:page-load, with no separate direct c
   assert.doesNotMatch(
     mobileNavLifecycleBlock,
     /^\s*initMobileNav\(\);/m,
-    'initMobileNav() must not be called directly (only via the astro:page-load listener)'
+    'initMobileNav() must not be a standalone call on its own line (guard it inline)'
   );
 });
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Cherry picks https://github.com/handsontable/handsontable/pull/12756 to the 17.1 docs

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Manual tests

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only header lifecycle change with an explicit guard against double initialization; no auth, data, or API surface changes.
> 
> **Overview**
> **Fixes broken mobile menu controls on docs pages that do not use View Transitions (`<ClientRouter />`).** On those pages, `astro:page-load` never runs (including first paint), so `initMobileNav()` was never called and hamburger/sidebar/ToC wiring stayed dead.
> 
> `Header.astro` keeps the existing `astro:page-load` → `initMobileNav()` path for ClientRouter navigations, and adds a **one-shot `window.load` fallback** deferred with `setTimeout(0)`. The fallback only runs `initMobileNav()` when `#mobile-nav-overlay` is still not under `document.body`, so ClientRouter pages that already initialized on the same tick do not double-run (avoiding Preact hydration races / Sentry `HANDSONTABLE-DOCS-1BT`).
> 
> `header-mobile-nav.test.mjs` is updated to document and enforce this contract: still no `DOMContentLoaded` or standalone `initMobileNav();` on its own line, while allowing the guarded inline call inside the load handler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c7bd8460f10c7ecb5496e5dad9e9c961f4601d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->