### PR TITLE
DEV-1862: Fix Vue invalid styling in mobile framework selector

### DIFF
--- a/docs/src/styles/mobile/nav-overlay.css
+++ b/docs/src/styles/mobile/nav-overlay.css
@@ -81,9 +81,15 @@
 
 .mobile-nav-frameworks {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(2, 1fr);
   border-top: 1px solid var(--sl-color-gray-5);
   gap: 0;
+}
+
+@media (min-width: 28rem) {
+  .mobile-nav-frameworks {
+    grid-template-columns: repeat(4, 1fr);
+  }
 }
 
 .mobile-nav-fw {
@@ -102,8 +108,20 @@
   white-space: nowrap;
 }
 
-.mobile-nav-fw:last-child {
+/* 2-column layout: even items are in the right column */
+.mobile-nav-fw:nth-child(2n) {
   border-right: 0;
+}
+
+/* 4-column layout: restore right border for item 2, only last item has none */
+@media (min-width: 28rem) {
+  .mobile-nav-fw:nth-child(2n) {
+    border-right: 1px solid var(--sl-color-gray-5);
+  }
+
+  .mobile-nav-fw:last-child {
+    border-right: 0;
+  }
 }
 
 .mobile-nav-fw:hover {


### PR DESCRIPTION
### Context

The PR fixes the mobile framework selector in the docs site navigation overlay. The grid was set to `repeat(3, 1fr)` — 3 columns for 4 frameworks — so Vue wrapped alone onto a second row, making it look like a broken or missing option.

The fix introduces a responsive grid:
- **< 28rem (448 px)** — `repeat(2, 1fr)` — 2x2 layout for small phones
- **>= 28rem** — `repeat(4, 1fr)` — all four frameworks in one row for larger screens

Right-border logic is updated to match each layout: even items lose their right border in the 2-column case; only the last item does in the 4-column case.

### How has this been tested?

- Manually inspected the overlay at small (375 px) and larger (480 px+) viewport widths using browser dev tools.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1862

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1862

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-site mobile navigation CSS only; no runtime, auth, or data handling impact.
> 
> **Overview**
> Fixes the **mobile docs nav** framework picker so all four options (including Vue) read as a deliberate grid instead of one item stranded on a second row.
> 
> The `.mobile-nav-frameworks` grid switches from a fixed **3 columns** to **2 columns** by default and **4 columns** from **28rem** up, giving a 2×2 layout on narrow phones and a single row on wider viewports. **Right-border** rules are aligned with each layout: even cells drop the right border in the 2-column case; from 28rem only the last cell does.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f158ff301654d3e264ee257e66c6d5cf5eedf524. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->