### PR TITLE
Restore missing cherry-picks dropped by prod-docs/17.1 sync

### DIFF
--- a/docs/content/recipes/themes/ant-design/ant-design.md
+++ b/docs/content/recipes/themes/ant-design/ant-design.md
@@ -29,22 +29,22 @@ type: how-to
 
 In this tutorial, you will integrate Handsontable into a React app that uses Ant Design and align the grid with your design system tokens through the Theme API. You will learn how to map Ant Design tokens to Handsontable theme parameters so the grid matches your existing styles.
 
-<iframe src="https://codesandbox.io/p/devbox/github/handsontable/examples/tree/master/examples/ant-design?view=preview"
+<iframe src="https://codesandbox.io/embed/n3c25x?view=preview&module=%2Fsrc%2FApp.tsx"
   style="width:100%; height: 500px; border:0; border-radius: 4px; overflow:hidden;"
-  title="Handsontable with Ant Design recipe"
+  title="Handsontable with AntDesign"
   allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
 ></iframe>
 
-[**Open in CodeSandbox**](https://codesandbox.io/p/devbox/github/handsontable/examples/tree/master/examples/ant-design)
+[**Open in CodeSandbox**](https://codesandbox.io/p/sandbox/handsontable-with-antdesign-n3c25x)
 [**View source on GitHub**](https://github.com/handsontable/examples/tree/master/examples/ant-design)
 
 ## Overview
 
 This recipe uses the official [handsontable/examples Ant Design demo](https://github.com/handsontable/examples/tree/master/examples/ant-design) as the live reference implementation. It shows how to integrate Handsontable into a React app that uses [Ant Design](https://ant.design/) by registering a custom theme and mapping Handsontable theme colors and tokens to Ant Design table-like styles.
 
-**Difficulty:** Beginner  
-**Time:** ~15 minutes  
+**Difficulty:** Beginner
+**Time:** ~15 minutes
 **Stack:** React, Ant Design, Handsontable, `@handsontable/react-wrapper`
 
 ## What You'll Get

--- a/docs/content/recipes/themes/fluent-ui/fluent-ui.md
+++ b/docs/content/recipes/themes/fluent-ui/fluent-ui.md
@@ -24,21 +24,21 @@ type: how-to
 
 In this tutorial, you will integrate Handsontable into a React app with Fluent UI so your grid follows Fluent colors, typography, and spacing. You will learn how to map Fluent UI tokens to Handsontable theme parameters through the Theme API.
 
-<iframe src="https://stackblitz.com/edit/vitejs-vite-3jyuy1rk?embed=1&file=src%2FApp.jsx&view=preview"
-     style="width:100%; height: 500px; border:0; border-radius: 4px; overflow:hidden;"
-     title="Handsontable with Fluent UI recipe"
-     allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
-     sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
-   ></iframe>
+<iframe src="https://codesandbox.io/embed/2y26vw?view=preview&module=%2Fsrc%2FApp.tsx"
+  style="width:100%; height: 500px; border:0; border-radius: 4px; overflow:hidden;"
+  title="Handsontable with Fluent UI"
+  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+></iframe>
 
-[**Open in stackblitz**](https://stackblitz.com/edit/vitejs-vite-3jyuy1rk?file=src%2FApp.jsx&file=src%2FApp.jsx)
+[**Open in CodeSandbox**](https://codesandbox.io/p/sandbox/2y26vw)
 
 ## Overview
 
 This recipe shows how to integrate Handsontable into a React app that uses [Fluent UI](https://react.fluentui.dev/) by registering a custom theme with Theme API colors and tokens. The grid follows your Fluent design language.
 
-**Difficulty:** Beginner  
-**Time:** ~15 minutes  
+**Difficulty:** Beginner
+**Time:** ~15 minutes
 **Stack:** React, Fluent UI, Handsontable, `@handsontable/react-wrapper`
 
 ## What You'll Get

--- a/docs/src/components/Header.astro
+++ b/docs/src/components/Header.astro
@@ -30,7 +30,9 @@ const currentPrefix = pathname.includes('/react-data-grid/')
   ? 'react-data-grid'
   : pathname.includes('/angular-data-grid/')
     ? 'angular-data-grid'
-    : 'javascript-data-grid';
+    : pathname.includes('/vue-data-grid/')
+      ? 'vue-data-grid'
+      : 'javascript-data-grid';
 
 const guidesUrl = `/docs/${currentPrefix}/`;
 const recipesUrl = `/docs/${currentPrefix}/recipes/`;
@@ -51,6 +53,7 @@ const frameworks = [
   { id: 'javascript-data-grid', label: 'JavaScript' },
   { id: 'react-data-grid', label: 'React' },
   { id: 'angular-data-grid', label: 'Angular' },
+  { id: 'vue-data-grid', label: 'Vue' },
 ];
 ---
 

--- a/docs/src/components/Header.astro
+++ b/docs/src/components/Header.astro
@@ -315,6 +315,26 @@ const frameworks = [
       document.querySelector<HTMLButtonElement>('sl-doc-search .DocSearch-Button')?.click();
     }, { signal });
 
+    // --- Docs assistant: ensure React is mounted, then toggle (iOS needs touchend too) ---
+    const bindAssistantBtn = (btn: HTMLButtonElement | null) => {
+      if (!btn) return;
+      let lastTap = 0;
+      const onAssistantTap = (e: Event) => {
+        e.preventDefault();
+        const now = Date.now();
+        if (now - lastTap < 400) return;
+        lastTap = now;
+        const ensure = window.docsAssistantEnsureMounted?.() ?? Promise.resolve();
+        void ensure.then(() => {
+          window.dispatchEvent(new CustomEvent('docs-assistant:toggle'));
+        });
+      };
+      btn.addEventListener('click', onAssistantTap, { signal });
+      btn.addEventListener('touchend', onAssistantTap, { signal });
+    };
+    bindAssistantBtn(document.getElementById('header-assistant-btn') as HTMLButtonElement | null);
+    bindAssistantBtn(document.getElementById('mobile-assistant-btn') as HTMLButtonElement | null);
+
     let overlayOpen = false;
     let tocOpen = false;
     let overlayTrapCleanup: (() => void) | null = null;

--- a/docs/src/scripts/docs-assistant-bootstrap.ts
+++ b/docs/src/scripts/docs-assistant-bootstrap.ts
@@ -105,6 +105,7 @@ async function ensureMounted(): Promise<void> {
   return mountInFlight;
 }
 
+
 declare global {
   interface Window {
     docsAssistantEnsureMounted?: () => Promise<void>;

--- a/docs/src/styles/mobile/nav-overlay.css
+++ b/docs/src/styles/mobile/nav-overlay.css
@@ -81,9 +81,15 @@
 
 .mobile-nav-frameworks {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(2, 1fr);
   border-top: 1px solid var(--sl-color-gray-5);
   gap: 0;
+}
+
+@media (min-width: 28rem) {
+  .mobile-nav-frameworks {
+    grid-template-columns: repeat(4, 1fr);
+  }
 }
 
 .mobile-nav-fw {
@@ -102,8 +108,20 @@
   white-space: nowrap;
 }
 
-.mobile-nav-fw:last-child {
+/* 2-column layout: even items are in the right column */
+.mobile-nav-fw:nth-child(2n) {
   border-right: 0;
+}
+
+/* 4-column layout: restore right border for item 2, only last item has none */
+@media (min-width: 28rem) {
+  .mobile-nav-fw:nth-child(2n) {
+    border-right: 1px solid var(--sl-color-gray-5);
+  }
+
+  .mobile-nav-fw:last-child {
+    border-right: 0;
+  }
 }
 
 .mobile-nav-fw:hover {


### PR DESCRIPTION
### Context

The PR backports four fixes to `prod-docs/17.1` that address regressions caused by incomplete cherry-picks and a bad conflict resolution in the sync commit `2b07faeef`.

**1. DEV-1732–1735 — Vue missing from mobile framework selector (`e2ea595f8`)**
The original DEV-1732/1733/1734/1735 cherry-pick added Vue to the desktop `FrameworkSwitcher` but the mobile nav overlay in `Header.astro` was not updated: `currentPrefix` had no `/vue-data-grid/` branch (so Vue pages fell back to `javascript-data-grid`), and the `frameworks` array rendered only JS/React/Angular. Vue was visible on desktop but absent on mobile.

**2. DEV-1709/1710 — Ask AI button broken (`651e973b4`)**
`bindAssistantBtn` — the function that wires click/touchend listeners on both Ask AI buttons and dispatches `docs-assistant:toggle` — was introduced by the DEV-1709/1710 cherry-pick (`578b1e644`). The sync commit `2b07faeef` accidentally removed it during conflict resolution. No subsequent cherry-pick restored it, so the Ask AI button was a dead element on `prod-docs/17.1`. The fix cherry-picks `e26e290275` from develop with HEAD-wins conflict resolution for the `docs-assistant-bootstrap.ts` chunk-reload logic and `variables.css` accent colours, both of which were updated in later commits already present on this branch.

**3. DEV-1862 — Vue option missing styling in mobile nav overlay (`2e1199469`)**
A small CSS fix for the Vue framework button in the mobile nav overlay.

**4. DEV-1702 — Ant Design and Fluent UI CodeSandbox URLs broken (`a91542deb`)**
The DEV-1702 fix (`9e75a3b3bb`) updated the embedded CodeSandbox URL for the Ant Design recipe and switched the Fluent UI example from StackBlitz to CodeSandbox. It was applied before the sync commit `2b07faeef`, which then overwrote those files and reverted the fix. Cherry-picked again from develop to restore both URL changes.

### How has this been tested?

- Verified `bindAssistantBtn` is present in `Header.astro` after cherry-pick
- Confirmed no conflict markers remain in any file
- Manual testing of the Ask AI button, Vue framework selector on mobile, and Ant Design/Fluent UI recipe embeds recommended before merging

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. DEV-1732, DEV-1733, DEV-1734, DEV-1735
2. DEV-1709, DEV-1710
3. DEV-1862
4. DEV-1702

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-site-only changes (header JS, assistant bootstrap hook, recipe iframes, mobile CSS) with no product API or auth impact; main risk is regressions in mobile nav or assistant toggle behavior.
> 
> **Overview**
> Restores docs UX fixes that were lost during a `prod-docs/17.1` sync: **Ask AI** works again, **Vue** appears correctly in mobile framework navigation, recipe embeds load, and the mobile framework grid lays out cleanly with four options.
> 
> **Ask AI:** `Header.astro` re-adds `bindAssistantBtn` for desktop and mobile buttons so taps call `window.docsAssistantEnsureMounted()` then dispatch `docs-assistant:toggle` (with debouncing and `touchend` for iOS). `docs-assistant-bootstrap.ts` exposes `docsAssistantEnsureMounted` on `window` for that flow.
> 
> **Vue on mobile:** `currentPrefix` recognizes `/vue-data-grid/`, and the mobile overlay `frameworks` list includes Vue so links and active state match desktop.
> 
> **Recipes:** Ant Design and Fluent UI pages switch broken embeds to working CodeSandbox URLs (Fluent moves off StackBlitz); minor metadata line formatting only.
> 
> **Mobile nav CSS:** Framework selector uses a 2-column grid on narrow viewports and 4 columns from `28rem`, with border rules updated so a fourth Vue pill styles correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a91542deb52fb33e4065d506335637f1919840fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->