### PR TITLE
DEV-1864: Fix SonarCloud BLOCKER and HIGH severity issues

### DIFF
--- a/.changelogs/12761.json
+++ b/.changelogs/12761.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed multiple code quality issues reported by SonarCloud static analysis.",
+  "type": "fixed",
+  "issueOrPR": 12761,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/src/core/_base.ts
+++ b/handsontable/src/3rdparty/walkontable/src/core/_base.ts
@@ -376,7 +376,7 @@ export default class CoreAbstract {
    * @returns {ScrollDao}
    */
   createScrollDao() {
-    const wot = this; // NOSONAR
+    const wot = this;
 
     return {
       get drawn() {
@@ -427,7 +427,7 @@ export default class CoreAbstract {
    * @returns {Record<string, unknown>}
    */
   getTableDao(): Record<string, unknown> {
-    const wot = this; // NOSONAR
+    const wot = this;
 
     return {
       get wot() {

--- a/handsontable/src/3rdparty/walkontable/src/core/_base.ts
+++ b/handsontable/src/3rdparty/walkontable/src/core/_base.ts
@@ -376,7 +376,7 @@ export default class CoreAbstract {
    * @returns {ScrollDao}
    */
   createScrollDao() {
-    const wot = this;
+    const wot = this; // NOSONAR
 
     return {
       get drawn() {
@@ -427,7 +427,7 @@ export default class CoreAbstract {
    * @returns {Record<string, unknown>}
    */
   getTableDao(): Record<string, unknown> {
-    const wot = this;
+    const wot = this; // NOSONAR
 
     return {
       get wot() {

--- a/handsontable/src/3rdparty/walkontable/src/core/core.ts
+++ b/handsontable/src/3rdparty/walkontable/src/core/core.ts
@@ -99,39 +99,37 @@ export default class Walkontable extends CoreAbstract {
    * @returns {Record<string, unknown>}
    */
   getViewportDao(): Record<string, unknown> {
-    const wot = this;
-
-    return {
+    return ((instance: this) => ({
       get wot() {
-        return wot;
+        return instance;
       },
       get topOverlayTrimmingContainer() {
-        return wot.wtOverlays.topOverlay.trimmingContainer;
+        return instance.wtOverlays.topOverlay.trimmingContainer;
       },
       get inlineStartOverlayTrimmingContainer() {
-        return wot.wtOverlays.inlineStartOverlay.trimmingContainer;
+        return instance.wtOverlays.inlineStartOverlay.trimmingContainer;
       },
       get topScrollPosition() {
-        return wot.wtOverlays.topOverlay.getScrollPosition();
+        return instance.wtOverlays.topOverlay.getScrollPosition();
       },
       get topParentOffset() {
-        return wot.wtOverlays.topOverlay.getTableParentOffset();
+        return instance.wtOverlays.topOverlay.getTableParentOffset();
       },
       get inlineStartScrollPosition() {
-        return wot.wtOverlays.inlineStartOverlay.getScrollPosition();
+        return instance.wtOverlays.inlineStartOverlay.getScrollPosition();
       },
       get inlineStartParentOffset() {
-        return wot.wtOverlays.inlineStartOverlay.getTableParentOffset();
+        return instance.wtOverlays.inlineStartOverlay.getTableParentOffset();
       },
       get topOverlay() {
-        return wot.wtOverlays.topOverlay; // TODO refactoring: move outside dao, use IOC
+        return instance.wtOverlays.topOverlay; // TODO refactoring: move outside dao, use IOC
       },
       get inlineStartOverlay() {
-        return wot.wtOverlays.inlineStartOverlay; // TODO refactoring: move outside dao, use IOC
+        return instance.wtOverlays.inlineStartOverlay; // TODO refactoring: move outside dao, use IOC
       },
       get bottomOverlay() {
-        return wot.wtOverlays.bottomOverlay; // TODO refactoring: move outside dao, use IOC
+        return instance.wtOverlays.bottomOverlay; // TODO refactoring: move outside dao, use IOC
       }
-    };
+    }))(this);
   }
 }

--- a/handsontable/src/3rdparty/walkontable/src/selection/border/border.ts
+++ b/handsontable/src/3rdparty/walkontable/src/selection/border/border.ts
@@ -198,7 +198,6 @@ class Border {
     event.preventDefault();
     stopImmediatePropagation(event);
 
-    const _this = this;
     const documentBody = this.wot.rootDocument.body;
     const bounds = parentElement.getBoundingClientRect();
 
@@ -227,12 +226,12 @@ class Border {
     /**
      * @param {Event} handlerEvent The mouse event object.
      */
-    function handler(handlerEvent: MouseEvent) {
+    const handler = (handlerEvent: MouseEvent) => {
       if (isOutside(handlerEvent)) {
-        _this.eventManager.removeEventListener(documentBody, 'mousemove', handler as (event: Event) => void);
+        this.eventManager.removeEventListener(documentBody, 'mousemove', handler as (event: Event) => void);
         parentElement.style.display = 'block';
       }
-    }
+    };
 
     this.eventManager.addEventListener(documentBody, 'mousemove', handler);
   }

--- a/handsontable/src/3rdparty/walkontable/src/stickyScrollStrategy.ts
+++ b/handsontable/src/3rdparty/walkontable/src/stickyScrollStrategy.ts
@@ -312,45 +312,50 @@ export class StickyScrollStrategy {
       return;
     }
 
-    if (overlays.inlineStartOverlay.needFullRender && overlays.inlineStartOverlay.clone) {
-      const cloneSpreader = overlays.inlineStartOverlay.clone.wtTable.spreader;
+    this.#applyCloneSpreaderStyles(overlays.inlineStartOverlay, position, isSticky, stickyTop, null, isRtl);
+    this.#applyCloneSpreaderStyles(overlays.topOverlay, position, isSticky, null, stickyLeft, isRtl);
+    this.#applyCloneSpreaderStyles(overlays.bottomOverlay, position, isSticky, null, stickyLeft, isRtl);
+  }
 
-      cloneSpreader.style.position = position;
+  /**
+   * Applies position styles to a single overlay clone spreader when its overlay is fully rendered.
+   *
+   * @param {Overlay} overlay The overlay whose clone spreader to update.
+   * @param {'sticky'|'relative'} position The CSS position value.
+   * @param {boolean} isSticky Whether sticky mode is active.
+   * @param {number|null} stickyTop The vertical sticky offset, or null to skip.
+   * @param {number|null} stickyLeft The horizontal sticky offset, or null to skip.
+   * @param {boolean} isRtl Whether RTL mode is active.
+   */
+  #applyCloneSpreaderStyles(
+    overlay: Overlay,
+    position: 'sticky' | 'relative',
+    isSticky: boolean,
+    stickyTop: number | null,
+    stickyLeft: number | null,
+    isRtl: boolean
+  ): void {
+    if (!overlay.needFullRender || !overlay.clone) {
+      return;
+    }
 
-      if (isSticky) {
+    const cloneSpreader = overlay.clone.wtTable.spreader;
+    const leftProp = isRtl ? 'right' : 'left';
+
+    cloneSpreader.style.position = position;
+
+    if (isSticky) {
+      if (stickyTop !== null) {
         cloneSpreader.style.top = `${stickyTop}px`;
-
-      } else {
-        this.#clearSpreaderInsetStyles(cloneSpreader);
       }
-    }
 
-    if (overlays.topOverlay.needFullRender && overlays.topOverlay.clone) {
-      const cloneSpreader = overlays.topOverlay.clone.wtTable.spreader;
-
-      cloneSpreader.style.position = position;
-
-      if (isSticky) {
+      if (stickyLeft !== null) {
         cloneSpreader.style[leftProp] = `${stickyLeft}px`;
         cloneSpreader.style[isRtl ? 'left' : 'right'] = '';
-
-      } else {
-        this.#clearSpreaderInsetStyles(cloneSpreader);
       }
-    }
 
-    if (overlays.bottomOverlay.needFullRender && overlays.bottomOverlay.clone) {
-      const cloneSpreader = overlays.bottomOverlay.clone.wtTable.spreader;
-
-      cloneSpreader.style.position = position;
-
-      if (isSticky) {
-        cloneSpreader.style[leftProp] = `${stickyLeft}px`;
-        cloneSpreader.style[isRtl ? 'left' : 'right'] = '';
-
-      } else {
-        this.#clearSpreaderInsetStyles(cloneSpreader);
-      }
+    } else {
+      this.#clearSpreaderInsetStyles(cloneSpreader);
     }
   }
 

--- a/handsontable/src/3rdparty/walkontable/src/table.ts
+++ b/handsontable/src/3rdparty/walkontable/src/table.ts
@@ -462,7 +462,7 @@ class Table {
 
       if (parent) {
         // if TABLE is detached (e.g. in Jasmine test), it has no parentNode so we cannot attach holder to it
-        parent.insertBefore(spreader, table);
+        table.before(spreader);
       }
       spreader.appendChild(table);
     }
@@ -495,7 +495,7 @@ class Table {
 
       if (parent) {
         // if TABLE is detached (e.g. in Jasmine test), it has no parentNode so we cannot attach holder to it
-        parent.insertBefore(hider, spreader);
+        spreader.before(hider);
       }
       hider.appendChild(spreader);
     }
@@ -532,7 +532,7 @@ class Table {
 
       if (parent) {
         // if TABLE is detached (e.g. in Jasmine test), it has no parentNode so we cannot attach holder to it
-        parent.insertBefore(holder, hider);
+        hider.before(holder);
       }
       if (this.isMaster) {
         const holderParent = holder.parentNode;
@@ -1642,7 +1642,9 @@ class Table {
   /**
    * Destroys the table instance. Overridden by MasterTable to release DOM resources.
    */
-  destroy() {}
+  destroy() {
+    // Intentionally empty
+  }
 }
 
 export default Table;

--- a/handsontable/src/3rdparty/walkontable/src/utils/orderView/rendererAdapter/directDomRendererAdapter.ts
+++ b/handsontable/src/3rdparty/walkontable/src/utils/orderView/rendererAdapter/directDomRendererAdapter.ts
@@ -109,7 +109,7 @@ export class DirectDomRendererAdapter {
     if (node.tagName !== this.orderView.childNodeType) {
       const newNode = this.orderView.nodesPool();
 
-      rootNode.replaceChild(newNode, node);
+      node.replaceWith(newNode);
       node = newNode;
     }
 

--- a/handsontable/src/cellTypes/numericType/accessors/valueSetter.ts
+++ b/handsontable/src/cellTypes/numericType/accessors/valueSetter.ts
@@ -56,15 +56,12 @@ function getCellDecimalSeparator(cellMeta: CellProperties) {
  * Defines what value is set to a numeric-typed cell.
  *
  * @param {*} newValue The value to be set.
- * @param {number} row The row index.
- * @param {number} column The column index.
+ * @param {number} _row The row index.
+ * @param {number} _column The column index.
  * @param {object} cellMeta The cell meta object.
  * @returns {*} The new value to be set.
  */
-export function valueSetter(newValue: unknown, row: number, column: number, cellMeta: CellProperties): unknown {
-  void row;
-  void column;
-
+export function valueSetter(newValue: unknown, _row: number, _column: number, cellMeta: CellProperties): unknown {
   if (typeof newValue !== 'string') {
     return newValue;
   }

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -86,6 +86,49 @@ import DataMap from './dataMap/dataMap';
 let activeGuid: string | null = null;
 
 /**
+ * Normalizes an array of `[index, amount]` pairs by merging overlapping or adjacent groups
+ * into the smallest set of non-overlapping groups, sorted in ascending order.
+ *
+ * @param {number[][]} indexes Array of `[index, amount]` pairs to normalize.
+ * @returns {number[][]} Normalized array of `[index, amount]` pairs.
+ */
+function normalizeIndexesGroup(indexes: number[][]): number[][] {
+  if (indexes.length === 0) {
+    return [];
+  }
+
+  const sortedIndexes = [...indexes];
+
+  // Sort the indexes in ascending order.
+  sortedIndexes.sort(([indexA], [indexB]) => {
+    if (indexA === indexB) {
+      return 0;
+    }
+
+    return indexA > indexB ? 1 : -1;
+  });
+
+  // Normalize the {index, amount} groups into bigger groups.
+  const normalizedIndexes = arrayReduce(sortedIndexes, (acc: number[][], [groupIndex, groupAmount]: number[]) => {
+    const previousItem = acc[acc.length - 1];
+    const [prevIndex, prevAmount] = previousItem;
+    const prevLastIndex = prevIndex + prevAmount;
+
+    if (groupIndex <= prevLastIndex) {
+      const amountToAdd = Math.max(groupAmount - (prevLastIndex - groupIndex), 0);
+
+      previousItem[1] += amountToAdd;
+    } else {
+      acc.push([groupIndex, groupAmount]);
+    }
+
+    return acc;
+  }, [sortedIndexes[0]]);
+
+  return normalizedIndexes;
+}
+
+/**
  * Keeps the collection of the all Handsontable instances created on the same page. The
  * list is then used to trigger the "afterUnlisten" hook when the "listen()" method was
  * called on another instance.
@@ -756,45 +799,45 @@ export default function Core(
   });
 
   this.selection
-    .addLocalHook('beforeHighlightSet', () => void instance.runHooks('beforeSelectionHighlightSet'))
+    .addLocalHook('beforeHighlightSet', () => instance.runHooks('beforeSelectionHighlightSet'))
     .addLocalHook('beforeSetRangeStart',
-      (...args: unknown[]) => void instance.runHooks('beforeSetRangeStart', ...args))
+      (...args: unknown[]) => instance.runHooks('beforeSetRangeStart', ...args))
     .addLocalHook('beforeSetRangeStartOnly',
-      (...args: unknown[]) => void instance.runHooks('beforeSetRangeStartOnly', ...args))
+      (...args: unknown[]) => instance.runHooks('beforeSetRangeStartOnly', ...args))
     .addLocalHook('beforeSetRangeEnd',
-      (...args: unknown[]) => void instance.runHooks('beforeSetRangeEnd', ...args))
+      (...args: unknown[]) => instance.runHooks('beforeSetRangeEnd', ...args))
     .addLocalHook('beforeSelectColumns',
-      (...args: unknown[]) => void instance.runHooks('beforeSelectColumns', ...args))
+      (...args: unknown[]) => instance.runHooks('beforeSelectColumns', ...args))
     .addLocalHook('afterSelectColumns',
-      (...args: unknown[]) => void instance.runHooks('afterSelectColumns', ...args))
+      (...args: unknown[]) => instance.runHooks('afterSelectColumns', ...args))
     .addLocalHook('beforeSelectRows',
-      (...args: unknown[]) => void instance.runHooks('beforeSelectRows', ...args))
+      (...args: unknown[]) => instance.runHooks('beforeSelectRows', ...args))
     .addLocalHook('afterSelectRows',
-      (...args: unknown[]) => void instance.runHooks('afterSelectRows', ...args))
+      (...args: unknown[]) => instance.runHooks('afterSelectRows', ...args))
     .addLocalHook('beforeSelectAll',
-      (...args: unknown[]) => void instance.runHooks('beforeSelectAll', ...args))
+      (...args: unknown[]) => instance.runHooks('beforeSelectAll', ...args))
     .addLocalHook('afterSelectAll',
-      (...args: unknown[]) => void instance.runHooks('afterSelectAll', ...args))
+      (...args: unknown[]) => instance.runHooks('afterSelectAll', ...args))
     .addLocalHook('beforeModifyTransformStart',
-      (...args: unknown[]) => void instance.runHooks('modifyTransformStart', ...args))
+      (...args: unknown[]) => instance.runHooks('modifyTransformStart', ...args))
     .addLocalHook('afterModifyTransformStart',
-      (...args: unknown[]) => void instance.runHooks('afterModifyTransformStart', ...args))
+      (...args: unknown[]) => instance.runHooks('afterModifyTransformStart', ...args))
     .addLocalHook('beforeModifyTransformFocus',
-      (...args: unknown[]) => void instance.runHooks('modifyTransformFocus', ...args))
+      (...args: unknown[]) => instance.runHooks('modifyTransformFocus', ...args))
     .addLocalHook('afterModifyTransformFocus',
-      (...args: unknown[]) => void instance.runHooks('afterModifyTransformFocus', ...args))
+      (...args: unknown[]) => instance.runHooks('afterModifyTransformFocus', ...args))
     .addLocalHook('beforeModifyTransformEnd',
-      (...args: unknown[]) => void instance.runHooks('modifyTransformEnd', ...args))
+      (...args: unknown[]) => instance.runHooks('modifyTransformEnd', ...args))
     .addLocalHook('afterModifyTransformEnd',
-      (...args: unknown[]) => void instance.runHooks('afterModifyTransformEnd', ...args))
+      (...args: unknown[]) => instance.runHooks('afterModifyTransformEnd', ...args))
     .addLocalHook('beforeRowWrap',
-      (...args: unknown[]) => void instance.runHooks('beforeRowWrap', ...args))
+      (...args: unknown[]) => instance.runHooks('beforeRowWrap', ...args))
     .addLocalHook('beforeColumnWrap',
-      (...args: unknown[]) => void instance.runHooks('beforeColumnWrap', ...args))
+      (...args: unknown[]) => instance.runHooks('beforeColumnWrap', ...args))
     .addLocalHook('insertRowRequire',
-      (totalRows: number) => void instance.alter('insert_row_above', totalRows, 1, 'auto'))
+      (totalRows: number) => instance.alter('insert_row_above', totalRows, 1, 'auto'))
     .addLocalHook('insertColRequire',
-      (totalCols: number) => void instance.alter('insert_col_start', totalCols, 1, 'auto'));
+      (totalCols: number) => instance.alter('insert_col_start', totalCols, 1, 'auto'));
 
   grid = {
     /**
@@ -818,42 +861,6 @@ export default function Core(
       if (skipAlter === false) {
         return;
       }
-
-      const normalizeIndexesGroup = (indexes: number[][]) => {
-        if (indexes.length === 0) {
-          return [];
-        }
-
-        const sortedIndexes = [...indexes];
-
-        // Sort the indexes in ascending order.
-        sortedIndexes.sort(([indexA], [indexB]) => {
-          if (indexA === indexB) {
-            return 0;
-          }
-
-          return indexA > indexB ? 1 : -1;
-        });
-
-        // Normalize the {index, amount} groups into bigger groups.
-        const normalizedIndexes = arrayReduce(sortedIndexes, (acc: number[][], [groupIndex, groupAmount]: number[]) => {
-          const previousItem = acc[acc.length - 1];
-          const [prevIndex, prevAmount] = previousItem;
-          const prevLastIndex = prevIndex + prevAmount;
-
-          if (groupIndex <= prevLastIndex) {
-            const amountToAdd = Math.max(groupAmount - (prevLastIndex - groupIndex), 0);
-
-            previousItem[1] += amountToAdd;
-          } else {
-            acc.push([groupIndex, groupAmount]);
-          }
-
-          return acc;
-        }, [sortedIndexes[0]]);
-
-        return normalizedIndexes;
-      };
 
       /* eslint-disable no-case-declarations */
       switch (action) {
@@ -2412,13 +2419,15 @@ export default function Core(
         return;
       }
 
-      rangeEach(fromRow, toRow, (row) => {
+      const collectEmptyCellChanges = (row: number) => {
         rangeEach(fromColumn, toColumn, (column) => {
           if (!this.getCellMeta(row, column).readOnly) {
             changes.push([row, column, null]);
           }
         });
-      });
+      };
+
+      rangeEach(fromRow, toRow, collectEmptyCellChanges);
     });
 
     if (changes.length > 0) {
@@ -3284,7 +3293,7 @@ export default function Core(
       const initialStyle = instance.rootElement.getAttribute('style');
 
       if (initialStyle) {
-        instance.rootElement.setAttribute('data-initialstyle', instance.rootElement.getAttribute('style') ?? '');
+        instance.rootElement.dataset.initialstyle = instance.rootElement.getAttribute('style') ?? '';
       }
     }
 
@@ -3299,7 +3308,7 @@ export default function Core(
 
       if (height === null) {
 
-        const initialStyle = instance.rootElement.getAttribute('data-initialstyle');
+        const initialStyle = instance.rootElement.dataset.initialstyle;
 
         if (initialStyle && (initialStyle.indexOf('height') > -1 || initialStyle.indexOf('overflow') > -1)) {
           instance.rootElement.setAttribute('style', initialStyle);
@@ -5243,6 +5252,33 @@ export default function Core(
   };
 
   /**
+   * Resolves renderable row and column indexes for scrolling, accounting for hidden indexes.
+   *
+   * @param {number|undefined} row Visual row index.
+   * @param {number|undefined} col Visual column index.
+   * @returns {{renderableRow: number|undefined, renderableColumn: number|undefined}|false} Resolved
+   *   renderable indexes, or `false` when scrolling target is not reachable.
+   */
+  const resolveRenderableScrollTarget = (row: number | undefined, col: number | undefined) => {
+    const isValidRowGrid = row !== undefined && Number.isInteger(row) && row >= 0;
+    const isValidColumnGrid = col !== undefined && Number.isInteger(col) && col >= 0;
+
+    const visualRowToScroll = isValidRowGrid ? getIndexToScroll(instance.rowIndexMapper, row!) : undefined;
+    const visualColumnToScroll = isValidColumnGrid ? getIndexToScroll(instance.columnIndexMapper, col!) : undefined;
+
+    if (visualRowToScroll === null || visualColumnToScroll === null) {
+      return false;
+    }
+
+    const renderableRow = isValidRowGrid ?
+      (instance.rowIndexMapper.getRenderableFromVisualIndex(visualRowToScroll!) ?? undefined) : row;
+    const renderableColumn = isValidColumnGrid ?
+      (instance.columnIndexMapper.getRenderableFromVisualIndex(visualColumnToScroll!) ?? undefined) : col;
+
+    return { renderableRow, renderableColumn };
+  };
+
+  /**
    * Scroll viewport to coordinates specified by the `row` and/or `col` object properties.
    *
    * ```js
@@ -5315,21 +5351,14 @@ export default function Core(
     }
 
     if (considerHiddenIndexes === undefined || considerHiddenIndexes) {
-      const isValidRowGrid = row !== undefined && Number.isInteger(row) && row >= 0;
-      const isValidColumnGrid = col !== undefined && Number.isInteger(col) && col >= 0;
+      const resolved = resolveRenderableScrollTarget(row, col);
 
-      const visualRowToScroll = isValidRowGrid ? getIndexToScroll(this.rowIndexMapper, row!) : undefined;
-      const visualColumnToScroll = isValidColumnGrid ? getIndexToScroll(this.columnIndexMapper, col!) : undefined;
-
-      if (visualRowToScroll === null || visualColumnToScroll === null) {
+      if (resolved === false) {
         return false;
       }
 
-      renderableRow = isValidRowGrid ?
-        (instance.rowIndexMapper.getRenderableFromVisualIndex(visualRowToScroll!) ?? undefined) : row;
-
-      renderableColumn = isValidColumnGrid ?
-        (instance.columnIndexMapper.getRenderableFromVisualIndex(visualColumnToScroll!) ?? undefined) : col;
+      renderableRow = resolved.renderableRow;
+      renderableColumn = resolved.renderableColumn;
     }
 
     const isRowInteger = Number.isInteger(renderableRow);

--- a/handsontable/src/core/hooks/index.ts
+++ b/handsontable/src/core/hooks/index.ts
@@ -210,61 +210,56 @@ export class Hooks {
     context: Record<string, unknown>, key: string,
     p1?: unknown, p2?: unknown, p3?: unknown, p4?: unknown, p5?: unknown, p6?: unknown
   ) {
-    {
-      const globalHandlers = this.getBucket().getHooks(key);
-      const length = globalHandlers ? globalHandlers.length : 0;
-      let index = 0;
+    p1 = this.#runHandlers(this.getBucket().getHooks(key), context, key, null, p1, p2, p3, p4, p5, p6);
+    p1 = this.#runHandlers(this.getBucket(context).getHooks(key), context, key, context, p1, p2, p3, p4, p5, p6);
 
-      if (length) {
-        // Do not optimize this loop with arrayEach or arrow function! If you do You'll decrease perf because of GC.
-        while (index < length) {
-          if (!globalHandlers[index] || globalHandlers[index].skip) {
-            index += 1;
-            /* eslint-disable no-continue */
-            continue;
-          }
+    return p1;
+  }
 
-          const res = fastCall(globalHandlers[index].callback, context, p1, p2, p3, p4, p5, p6);
+  /**
+   * Runs all callbacks from a single handler list (global or local), threading the return value through p1.
+   *
+   * @param {Array|null} handlers The list of hook entries to iterate.
+   * @param {object} context Handsontable instance used as `this` for each callback.
+   * @param {string} key Hook/Event name.
+   * @param {object|null} removeContext Context passed to `remove` — null for global handlers.
+   * @param {*} p1 First argument (threaded through callbacks).
+   * @param {*} p2 Second argument.
+   * @param {*} p3 Third argument.
+   * @param {*} p4 Fourth argument.
+   * @param {*} p5 Fifth argument.
+   * @param {*} p6 Sixth argument.
+   * @returns {*} Updated p1 value after running all callbacks.
+   */
+  #runHandlers(
+    handlers: ReturnType<HooksBucket['getHooks']>,
+    context: Record<string, unknown>,
+    key: string,
+    removeContext: Record<string, unknown> | null,
+    p1: unknown, p2: unknown, p3: unknown, p4: unknown, p5: unknown, p6: unknown
+  ) {
+    const length = handlers ? handlers.length : 0;
+    let index = 0;
 
-          if (res !== undefined) {
-            // eslint-disable-next-line no-param-reassign
-            p1 = res;
-          }
-          if (globalHandlers[index] && globalHandlers[index].runOnce) {
-            this.remove(key, globalHandlers[index].callback);
-          }
-
+    if (length) {
+      // Do not optimize this loop with arrayEach or arrow function! If you do You'll decrease perf because of GC.
+      while (index < length) {
+        if (!handlers[index] || handlers[index].skip) {
           index += 1;
+          /* eslint-disable no-continue */
+          continue;
         }
-      }
-    }
-    {
-      const localHandlers = this.getBucket(context).getHooks(key);
-      const length = localHandlers ? localHandlers.length : 0;
-      let index = 0;
 
-      if (length) {
-        // Do not optimize this loop with arrayEach or arrow function! If you do You'll decrease perf because of GC.
-        while (index < length) {
-          if (!localHandlers[index] || localHandlers[index].skip) {
-            index += 1;
-            /* eslint-disable no-continue */
-            continue;
-          }
+        const res = fastCall(handlers[index].callback, context, p1, p2, p3, p4, p5, p6);
 
-          const res = fastCall(localHandlers[index].callback, context, p1, p2, p3, p4, p5, p6);
-
-          if (res !== undefined) {
-            // eslint-disable-next-line no-param-reassign
-            p1 = res;
-          }
-
-          if (localHandlers[index] && localHandlers[index].runOnce) {
-            this.remove(key, localHandlers[index].callback, context);
-          }
-
-          index += 1;
+        if (res !== undefined) {
+          p1 = res;
         }
+        if (handlers[index] && handlers[index].runOnce) {
+          this.remove(key, handlers[index].callback, removeContext);
+        }
+
+        index += 1;
       }
     }
 

--- a/handsontable/src/dataMap/dataMap.ts
+++ b/handsontable/src/dataMap/dataMap.ts
@@ -162,46 +162,57 @@ class DataMap {
     }
 
     const columns = this.tableMeta.columns;
-    let i;
 
     this.colToPropCache = [];
     this.propToColCache = new Map();
 
     if (columns) {
-      let columnsLen = 0;
-      let filteredIndex = 0;
-      const isColumnsFn = typeof columns === 'function';
-
-      if (isColumnsFn) {
-        const schemaLen = deepObjectSize(schema);
-
-        columnsLen = schemaLen > 0 ? schemaLen : this.countFirstRowKeys();
-
-      } else {
-        const maxCols = this.tableMeta.maxCols;
-
-        columnsLen = Math.min(maxCols ?? Infinity, columns.length);
-      }
-
-      for (i = 0; i < columnsLen; i++) {
-        const column = typeof columns === 'function'
-          ? (columns as (index: number) => Record<string, unknown>)(i) : columns[i];
-
-        if (isObject(column)) {
-          if (typeof column.data !== 'undefined') {
-            const index = isColumnsFn ? filteredIndex : i;
-            const columnData = column.data as string | number;
-
-            this.colToPropCache[index] = columnData;
-            this.propToColCache!.set(columnData, index);
-          }
-
-          filteredIndex += 1;
-        }
-      }
-
+      this.#buildColumnCache(columns, schema);
     } else {
       this.recursiveDuckColumns(schema);
+    }
+  }
+
+  /**
+   * Builds the column property cache from the `columns` setting.
+   *
+   * @param {Function|Array} columns The columns setting value.
+   * @param {unknown} schema The current data schema.
+   */
+  #buildColumnCache(
+    columns: ((column: number) => Record<string, unknown>) | Record<string, unknown>[],
+    schema: unknown
+  ) {
+    let columnsLen = 0;
+    let filteredIndex = 0;
+    const isColumnsFn = typeof columns === 'function';
+
+    if (isColumnsFn) {
+      const schemaLen = deepObjectSize(schema);
+
+      columnsLen = schemaLen > 0 ? schemaLen : this.countFirstRowKeys();
+
+    } else {
+      const maxCols = this.tableMeta.maxCols;
+
+      columnsLen = Math.min(maxCols ?? Infinity, columns.length);
+    }
+
+    for (let i = 0; i < columnsLen; i++) {
+      const column = isColumnsFn
+        ? (columns as (index: number) => Record<string, unknown>)(i) : columns[i];
+
+      if (isObject(column)) {
+        if (typeof column.data !== 'undefined') {
+          const index = isColumnsFn ? filteredIndex : i;
+          const columnData = column.data as string | number;
+
+          this.colToPropCache[index] = columnData;
+          this.propToColCache!.set(columnData, index);
+        }
+
+        filteredIndex += 1;
+      }
     }
   }
 
@@ -479,28 +490,11 @@ class DataMap {
     for (
       let col = firstNewPhysicalColumnIndex;
       numberOfCreatedCols < amount && numberOfVisualCols + numberOfCreatedCols < (maxCols ?? Infinity);
-      col++
+      col++, numberOfCreatedCols++
     ) {
-      if (typeof visualColumnIndex !== 'number' || visualColumnIndex >= numberOfVisualCols + numberOfCreatedCols) {
-        if (numberOfSourceRows > 0) {
-          for (let row = 0; row < numberOfSourceRows; row += 1) {
-            if (typeof dataSource[row] === 'undefined') {
-              dataSource[row] = [];
-            }
-
-            (dataSource[row] as unknown[]).push(null);
-          }
-        } else {
-          dataSource.push([null]);
-        }
-
-      } else {
-        for (let row = 0; row < numberOfSourceRows; row++) {
-          (dataSource[row] as unknown[]).splice(col, 0, null);
-        }
-      }
-
-      numberOfCreatedCols += 1;
+      this.#insertColumnIntoDataSource(
+        dataSource, col, visualColumnIndex, numberOfVisualCols + numberOfCreatedCols, numberOfSourceRows
+      );
     }
 
     if (numberOfCreatedCols > 0) {
@@ -528,6 +522,42 @@ class DataMap {
       delta: numberOfCreatedCols,
       startPhysicalIndex: firstNewPhysicalColumnIndex,
     };
+  }
+
+  /**
+   * Inserts a single null column into the data source at the given physical column index.
+   *
+   * @param {Array} dataSource The data source array.
+   * @param {number} col The physical column index at which to splice.
+   * @param {number|undefined} visualColumnIndex The visual column index being inserted.
+   * @param {number} currentVisualColCount The current visual column count including already-created columns.
+   * @param {number} numberOfSourceRows The number of source rows.
+   */
+  #insertColumnIntoDataSource(
+    dataSource: (Record<string, unknown> | unknown[])[],
+    col: number,
+    visualColumnIndex: number | undefined,
+    currentVisualColCount: number,
+    numberOfSourceRows: number
+  ) {
+    if (typeof visualColumnIndex !== 'number' || visualColumnIndex >= currentVisualColCount) {
+      if (numberOfSourceRows > 0) {
+        for (let row = 0; row < numberOfSourceRows; row += 1) {
+          if (typeof dataSource[row] === 'undefined') {
+            dataSource[row] = [];
+          }
+
+          (dataSource[row] as unknown[]).push(null);
+        }
+      } else {
+        dataSource.push([null]);
+      }
+
+    } else {
+      for (let row = 0; row < numberOfSourceRows; row++) {
+        (dataSource[row] as unknown[]).splice(col, 0, null);
+      }
+    }
   }
 
   /**
@@ -621,26 +651,7 @@ class DataMap {
       }
     }
 
-    if (isTableUniform) {
-      for (let r = 0, rlen = this.hot!.countSourceRows(); r < rlen; r++) {
-        (data[r] as unknown[]).splice(removedPhysicalIndexes[0], amount);
-
-        if (r === 0) {
-          this.metaManager!.removeColumn(removedPhysicalIndexes[0], amount);
-        }
-      }
-
-    } else {
-      for (let r = 0, rlen = this.hot!.countSourceRows(); r < rlen; r++) {
-        for (let c = 0; c < removedColumnsCount; c++) {
-          (data[r] as unknown[]).splice(descendingPhysicalColumns[c], 1);
-
-          if (r === 0) {
-            this.metaManager!.removeColumn(descendingPhysicalColumns[c], 1);
-          }
-        }
-      }
-    }
+    this.#spliceRemovedColumns(data, isTableUniform, removedPhysicalIndexes, descendingPhysicalColumns, amount);
 
     if (columnIndex < this.hot!.countCols()) {
       this.hot!.columnIndexMapper.removeIndexes(removedPhysicalIndexes);
@@ -654,6 +665,47 @@ class DataMap {
     this.refreshDuckSchema();
 
     return true;
+  }
+
+  /**
+   * Splices the removed physical columns from each row in the data source,
+   * updating the meta manager for the first row.
+   *
+   * @param {Array} data The data source array.
+   * @param {boolean} isTableUniform Whether the removed columns form a contiguous range.
+   * @param {number[]} removedPhysicalIndexes Physical indexes of removed columns in ascending order.
+   * @param {number[]} descendingPhysicalColumns Physical indexes of removed columns in descending order.
+   * @param {number} amount The number of columns to remove.
+   */
+  #spliceRemovedColumns(
+    data: (Record<string, unknown> | unknown[])[],
+    isTableUniform: boolean,
+    removedPhysicalIndexes: number[],
+    descendingPhysicalColumns: number[],
+    amount: number
+  ) {
+    if (isTableUniform) {
+      for (let r = 0, rlen = this.hot!.countSourceRows(); r < rlen; r++) {
+        (data[r] as unknown[]).splice(removedPhysicalIndexes[0], amount);
+
+        if (r === 0) {
+          this.metaManager!.removeColumn(removedPhysicalIndexes[0], amount);
+        }
+      }
+
+    } else {
+      const removedColumnsCount = descendingPhysicalColumns.length;
+
+      for (let r = 0, rlen = this.hot!.countSourceRows(); r < rlen; r++) {
+        for (let c = 0; c < removedColumnsCount; c++) {
+          (data[r] as unknown[]).splice(descendingPhysicalColumns[c], 1);
+
+          if (r === 0) {
+            this.metaManager!.removeColumn(descendingPhysicalColumns[c], 1);
+          }
+        }
+      }
+    }
   }
 
   /**

--- a/handsontable/src/dataMap/metaManager/mods/extendMetaProperties.ts
+++ b/handsontable/src/dataMap/metaManager/mods/extendMetaProperties.ts
@@ -126,18 +126,19 @@ export class ExtendMetaPropertiesMod {
   installPropWatcher(propName: string, origProp: string,
                      onChange: (this: unknown, changedPropName: string,
                                 value: unknown, isInitialChange: boolean) => void) {
-    const self = this;
+    const { usageTracker } = this;
+    const boundOnChange = onChange.bind(this);
 
     Object.defineProperty(this.metaManager.globalMeta.meta, propName as string, {
       get(): unknown {
         return this[origProp as string];
       },
       set(value: unknown) {
-        const isInitialChange = !self.usageTracker.has(propName);
+        const isInitialChange = !usageTracker.has(propName);
 
-        self.usageTracker.add(propName);
+        usageTracker.add(propName);
 
-        onChange.call(self, propName, value, isInitialChange);
+        boundOnChange(propName, value, isInitialChange);
 
         this[origProp as string] = value;
       },

--- a/handsontable/src/dataMap/metaManager/utils.ts
+++ b/handsontable/src/dataMap/metaManager/utils.ts
@@ -41,7 +41,7 @@ export function extendByMetaType(
 
   if (metaObject._automaticallyAssignedMetaProps) {
     objectEach(settings, (_value: unknown, key: string) => {
-      void (metaObject._automaticallyAssignedMetaProps as Set<string>).delete(key);
+      (metaObject._automaticallyAssignedMetaProps as Set<string>).delete(key);
     });
   }
 

--- a/handsontable/src/dataMap/replaceData.ts
+++ b/handsontable/src/dataMap/replaceData.ts
@@ -25,7 +25,6 @@ interface ReplaceDataConfig {
 /**
  * Builds the initial empty dataset rows when `data` is `null`.
  *
- * @private
  * @param {HotInstance} hotInstance The Handsontable instance.
  * @param {DataMap} newDataMap The newly created DataMap instance.
  * @param {object} tableMeta The current table settings.

--- a/handsontable/src/dataMap/replaceData.ts
+++ b/handsontable/src/dataMap/replaceData.ts
@@ -23,6 +23,46 @@ interface ReplaceDataConfig {
 }
 
 /**
+ * Builds the initial empty dataset rows when `data` is `null`.
+ *
+ * @private
+ * @param {HotInstance} hotInstance The Handsontable instance.
+ * @param {DataMap} newDataMap The newly created DataMap instance.
+ * @param {object} tableMeta The current table settings.
+ * @returns {unknown[]} The generated data array.
+ */
+function buildNullData(
+  hotInstance: HotInstance,
+  newDataMap: DataMap,
+  tableMeta: ReturnType<HotInstance['getSettings']>
+): unknown[] {
+  const dataSchema = newDataMap.getSchema();
+  const data: unknown[] = [];
+
+  for (let r = 0, rlen = tableMeta.startRows as number; r < rlen; r++) {
+    let row;
+
+    if ((hotInstance.dataType === 'object' || hotInstance.dataType === 'function') && tableMeta.dataSchema) {
+      row = deepClone(dataSchema);
+
+    } else if (hotInstance.dataType === 'array') {
+      row = deepClone((dataSchema as unknown[])[0]);
+
+    } else {
+      row = [];
+
+      for (let c = 0, clen = tableMeta.startCols as number; c < clen; c++) {
+        row.push(null);
+      }
+    }
+
+    data.push(row);
+  }
+
+  return data;
+}
+
+/**
  * Loads new data to Handsontable.
  *
  * @private
@@ -89,33 +129,8 @@ function replaceData(
     }
 
   } else if (data === null) {
-    const dataSchema = newDataMap.getSchema();
-
     // eslint-disable-next-line no-param-reassign
-    data = [];
-    let row;
-    let r = 0;
-    let rlen = 0;
-
-    for (r = 0, rlen = tableMeta.startRows as number; r < rlen; r++) {
-      if ((hotInstance.dataType === 'object' || hotInstance.dataType === 'function') && tableMeta.dataSchema) {
-        row = deepClone(dataSchema);
-        (data as unknown[]).push(row);
-
-      } else if (hotInstance.dataType === 'array') {
-        row = deepClone((dataSchema as unknown[])[0]);
-        (data as unknown[]).push(row);
-
-      } else {
-        row = [];
-
-        for (let c = 0, clen = tableMeta.startCols as number; c < clen; c++) {
-          row.push(null);
-        }
-
-        (data as unknown[]).push(row);
-      }
-    }
+    data = buildNullData(hotInstance, newDataMap, tableMeta);
 
   } else {
     throwWithCause(`${internalSource} only accepts array of objects or array of arrays (${typeof data} given)`);

--- a/handsontable/src/editors/baseEditor/baseEditor.ts
+++ b/handsontable/src/editors/baseEditor/baseEditor.ts
@@ -550,38 +550,10 @@ export class BaseEditor {
     const horizontalScrollPosition = Math.abs(wtOverlays.inlineStartOverlay?.getScrollPosition() ?? 0);
     const verticalScrollPosition = wtOverlays.topOverlay?.getScrollPosition() ?? 0;
     const scrollbarWidth = getScrollbarWidth(this.hot.rootDocument);
-    let cellTopOffset = TD.offsetTop;
-
-    if (['inline_start', 'master'].includes(overlayName)) {
-      cellTopOffset += firstRowOffset - verticalScrollPosition;
-    }
-
-    if (['bottom', 'bottom_inline_start_corner'].includes(overlayName) && wtOverlays.bottomOverlay?.clone) {
-      const {
-        wtViewport: bottomWtViewport,
-        wtTable: bottomWtTable,
-      } = wtOverlays.bottomOverlay!.clone!;
-
-      cellTopOffset += bottomWtViewport.getWorkspaceHeight() - bottomWtTable.getHeight() - scrollbarWidth;
-    }
-
-    let cellStartOffset = TD.offsetLeft;
-
-    if (this.hot.isRtl()) {
-      if (cellStartOffset >= 0) {
-        cellStartOffset = overlayTable.getWidth() - TD.offsetLeft;
-      } else {
-        // The `offsetLeft` returns negative values when the parent offset element has position relative
-        // (it happens when on the cell the selection is applied - the `area` CSS class).
-        // When it happens the `offsetLeft` value is calculated from the right edge of the parent element.
-        cellStartOffset = Math.abs(cellStartOffset);
-      }
-
-      cellStartOffset += firstColumnOffset - horizontalScrollPosition - cellWidth;
-
-    } else if (['top', 'master', 'bottom'].includes(overlayName)) {
-      cellStartOffset += firstColumnOffset - horizontalScrollPosition;
-    }
+    const cellTopOffset = this.#calcCellTopOffset(TD, overlayName, firstRowOffset,
+      verticalScrollPosition, scrollbarWidth);
+    const cellStartOffset = this.#calcCellStartOffset(TD, overlayName, overlayTable, cellWidth,
+      firstColumnOffset, horizontalScrollPosition);
 
     const cellComputedStyle = rootWindow.getComputedStyle(TD);
     const borderPhysicalWidthProp = this.hot.isRtl() ? 'borderRightWidth' : 'borderLeftWidth';
@@ -606,6 +578,75 @@ export class BaseEditor {
       width,
       maxWidth,
     };
+  }
+
+  /**
+   * Calculates the top offset of the edited cell within the overlay's coordinate space.
+   *
+   * @param {HTMLTableCellElement} TD The edited cell element.
+   * @param {string} overlayName The name of the overlay containing the cell.
+   * @param {number} firstRowOffset The start position of the rows render calculator.
+   * @param {number} verticalScrollPosition The current vertical scroll position.
+   * @param {number} scrollbarWidth The scrollbar width in pixels.
+   * @returns {number}
+   */
+  #calcCellTopOffset(
+    TD: HTMLTableCellElement, overlayName: string,
+    firstRowOffset: number, verticalScrollPosition: number, scrollbarWidth: number
+  ): number {
+    let cellTopOffset = TD.offsetTop;
+    const { wtOverlays } = this.hot.view._wt;
+
+    if (['inline_start', 'master'].includes(overlayName)) {
+      cellTopOffset += firstRowOffset - verticalScrollPosition;
+    }
+
+    if (['bottom', 'bottom_inline_start_corner'].includes(overlayName) && wtOverlays.bottomOverlay?.clone) {
+      const {
+        wtViewport: bottomWtViewport,
+        wtTable: bottomWtTable,
+      } = wtOverlays.bottomOverlay!.clone!;
+
+      cellTopOffset += bottomWtViewport.getWorkspaceHeight() - bottomWtTable.getHeight() - scrollbarWidth;
+    }
+
+    return cellTopOffset;
+  }
+
+  /**
+   * Calculates the inline-start offset of the edited cell within the overlay's coordinate space.
+   *
+   * @param {HTMLTableCellElement} TD The edited cell element.
+   * @param {string} overlayName The name of the overlay containing the cell.
+   * @param {object} overlayTable The Walkontable table instance for the overlay.
+   * @param {number} cellWidth The width of the edited cell.
+   * @param {number} firstColumnOffset The start position of the columns render calculator.
+   * @param {number} horizontalScrollPosition The current horizontal scroll position.
+   * @returns {number}
+   */
+  #calcCellStartOffset(
+    TD: HTMLTableCellElement, overlayName: string, overlayTable: { getWidth(): number },
+    cellWidth: number, firstColumnOffset: number, horizontalScrollPosition: number
+  ): number {
+    let cellStartOffset = TD.offsetLeft;
+
+    if (this.hot.isRtl()) {
+      if (cellStartOffset >= 0) {
+        cellStartOffset = overlayTable.getWidth() - TD.offsetLeft;
+      } else {
+        // The `offsetLeft` returns negative values when the parent offset element has position relative
+        // (it happens when on the cell the selection is applied - the `area` CSS class).
+        // When it happens the `offsetLeft` value is calculated from the right edge of the parent element.
+        cellStartOffset = Math.abs(cellStartOffset);
+      }
+
+      cellStartOffset += firstColumnOffset - horizontalScrollPosition - cellWidth;
+
+    } else if (['top', 'master', 'bottom'].includes(overlayName)) {
+      cellStartOffset += firstColumnOffset - horizontalScrollPosition;
+    }
+
+    return cellStartOffset;
   }
 
   /**

--- a/handsontable/src/editors/handsontableEditor/handsontableEditor.ts
+++ b/handsontable/src/editors/handsontableEditor/handsontableEditor.ts
@@ -140,7 +140,8 @@ export class HandsontableEditor extends TextEditor {
     td: HTMLTableCellElement, value: unknown, cellProperties: CellProperties): void {
     super.prepare(row, col, prop, td, value, cellProperties);
 
-    const parent = this;
+    const { hot } = this;
+    const setValue = this.setValue.bind(this);
     const options: Record<string, unknown> = {
       startRows: 0,
       startCols: 0,
@@ -165,9 +166,9 @@ export class HandsontableEditor extends TextEditor {
 
         // if the value is undefined then it means we don't want to set the value
         if (sourceValue !== undefined) {
-          parent.setValue(sourceValue);
+          setValue(sourceValue);
         }
-        parent.hot.destroyEditor();
+        hot.destroyEditor();
       },
       preventWheel: true,
       layoutDirection: this.hot.isRtl() ? 'rtl' : 'ltr',

--- a/handsontable/src/editors/passwordEditor/passwordEditor.ts
+++ b/handsontable/src/editors/passwordEditor/passwordEditor.ts
@@ -74,7 +74,7 @@ export class PasswordEditor extends TextEditor {
 
     this.TEXTAREA = this.hot.rootDocument.createElement('input');
     this.TEXTAREA.setAttribute('type', 'password');
-    this.TEXTAREA.setAttribute('data-hot-input', ''); // Makes the element recognizable by Hot as its own component's element.
+    this.TEXTAREA.dataset.hotInput = ''; // Makes the element recognizable by Hot as its own component's element.
     this.TEXTAREA.className = 'handsontableInput';
     this.textareaStyle = this.TEXTAREA.style;
     this.textareaStyle.width = '0';

--- a/handsontable/src/editors/selectEditor/selectEditor.ts
+++ b/handsontable/src/editors/selectEditor/selectEditor.ts
@@ -42,7 +42,7 @@ export class SelectEditor extends BaseEditor {
   init(): void {
     this.selectWrapper = this.hot.rootDocument.createElement('div');
     this.select = this.hot.rootDocument.createElement('select');
-    this.select.setAttribute('data-hot-input', 'true');
+    this.select.dataset.hotInput = 'true';
     this.selectWrapper.style.display = 'none';
 
     const ARROW = this.hot.rootDocument.createElement('DIV');

--- a/handsontable/src/helpers/browser.ts
+++ b/handsontable/src/helpers/browser.ts
@@ -50,14 +50,14 @@ const platforms: Record<string, TesterResult> = {
 export function setBrowserMeta({ userAgent = navigator.userAgent, vendor = navigator.vendor }: {
   userAgent?: string; vendor?: string;
 } = {}): void {
-  objectEach(browsers, ({ test }) => void test(userAgent, vendor));
+  objectEach(browsers, ({ test }) => test(userAgent, vendor));
 }
 
 /**
  *
  */
 export function setPlatformMeta({ platform = navigator.platform }: { platform?: string } = {}): void {
-  objectEach(platforms, ({ test }) => void test(platform));
+  objectEach(platforms, ({ test }) => test(platform));
 }
 
 if (isCSR()) {

--- a/handsontable/src/helpers/dom/element.ts
+++ b/handsontable/src/helpers/dom/element.ts
@@ -1289,7 +1289,7 @@ export function isInput(element: HTMLElement): boolean {
  * @returns {boolean}
  */
 export function isOutsideInput(element: HTMLElement): boolean {
-  return isInput(element) && element.hasAttribute('data-hot-input') === false;
+  return isInput(element) && ('hotInput' in element.dataset) === false;
 }
 
 /**

--- a/handsontable/src/helpers/mixed.ts
+++ b/handsontable/src/helpers/mixed.ts
@@ -69,7 +69,7 @@ export function isRegExp(variable: unknown): boolean {
   return Object.prototype.toString.call(variable) === '[object RegExp]';
 }
 
-/* eslint-disable */
+/* eslint-disable dot-notation, no-useless-escape, max-len, no-bitwise, computed-property-spacing, jsdoc/require-jsdoc, no-restricted-globals, no-console, prefer-const, no-unused-expressions, no-plusplus, space-infix-ops, comma-spacing, no-nested-ternary */
 const _m = '\x6C\x65\x6E\x67\x74\x68';
 const _hd = (v: string) => parseInt(v, 16);
 const _pi = (v: string) => parseInt(v, 10);

--- a/handsontable/src/helpers/object.ts
+++ b/handsontable/src/helpers/object.ts
@@ -165,6 +165,55 @@ export function clone(object: object): object {
 }
 
 /**
+ * Clones the initial value, performing a deep clone for objects and arrays.
+ *
+ * @param {unknown} newValue The value to clone.
+ * @returns {unknown}
+ */
+function mixinInitValue(newValue: unknown): unknown {
+  let result = newValue;
+
+  if (Array.isArray(result) || isObject(result)) {
+    result = deepClone(result);
+  }
+
+  return result;
+}
+
+/**
+ * Creates a getter function for a mixin property.
+ *
+ * @param {string} property The property name.
+ * @param {unknown} initialValue The initial value for the property.
+ * @returns {Function}
+ */
+function mixinGetter(property: string, initialValue: unknown): (this: Record<string, unknown>) => unknown {
+  const propertyName = `_${property}`;
+
+  return function(this: Record<string, unknown>) {
+    if (this[propertyName] === undefined) {
+      this[propertyName] = mixinInitValue(initialValue);
+    }
+
+    return this[propertyName];
+  };
+}
+
+/**
+ * Creates a setter function for a mixin property.
+ *
+ * @param {string} property The property name.
+ * @returns {Function}
+ */
+function mixinSetter(property: string): (this: Record<string, unknown>, newValue: unknown) => void {
+  const propertyName = `_${property}`;
+
+  return function(this: Record<string, unknown>, newValue: unknown) {
+    this[propertyName] = newValue;
+  };
+}
+
+/**
  * Extend the Base object (usually prototype) of the functionality the `mixins` objects.
  *
  * @param {object} Base Base object which will be extended.
@@ -186,38 +235,9 @@ export function mixin(Base: Function, ...mixins: object[]): object {
         Base.prototype[key] = value;
 
       } else {
-        const getter = function _getter(property: string, initialValue: unknown) {
-          const propertyName = `_${property}`;
-
-          const initValue = (newValue: unknown) => {
-            let result = newValue;
-
-            if (Array.isArray(result) || isObject(result)) {
-              result = deepClone(result);
-            }
-
-            return result;
-          };
-
-          return function(this: Record<string, unknown>) {
-            if (this[propertyName] === undefined) {
-              this[propertyName] = initValue(initialValue);
-            }
-
-            return this[propertyName];
-          };
-        };
-        const setter = function _setter(property: string) {
-          const propertyName = `_${property}`;
-
-          return function(this: Record<string, unknown>, newValue: unknown) {
-            this[propertyName] = newValue;
-          };
-        };
-
         Object.defineProperty(Base.prototype, key, {
-          get: getter(key, value),
-          set: setter(key),
+          get: mixinGetter(key, value),
+          set: mixinSetter(key),
           configurable: true,
         });
       }

--- a/handsontable/src/helpers/templateLiteralTag.ts
+++ b/handsontable/src/helpers/templateLiteralTag.ts
@@ -58,9 +58,9 @@ export function html(strings: TemplateStringsArray, ...values: unknown[]) {
   const refs: Record<string, HTMLElement> = {};
 
   fragment.querySelectorAll('[data-ref]').forEach((element: Element) => {
-    const name = element.getAttribute('data-ref');
+    const name = (element as HTMLElement).dataset.ref ?? null;
 
-    element.removeAttribute('data-ref');
+    delete (element as HTMLElement).dataset.ref;
 
     if (name !== null) {
       refs[name] = element as HTMLElement;

--- a/handsontable/src/helpers/wrappers/jquery.ts
+++ b/handsontable/src/helpers/wrappers/jquery.ts
@@ -4,7 +4,7 @@ import { throwWithCause } from '../../helpers/errors';
  * @param {Core} Handsontable The Handsontable instance.
  */
 export default function jQueryWrapper(Handsontable: Record<string, unknown>) {
-  // eslint-disable-next-line
+  // eslint-disable-next-line no-restricted-globals
   const jQuery = typeof window === 'undefined' ? false : (window as Window & { jQuery?: Function }).jQuery;
 
   if (!jQuery) {

--- a/handsontable/src/plugins/autoColumnSize/autoColumnSize.ts
+++ b/handsontable/src/plugins/autoColumnSize/autoColumnSize.ts
@@ -577,7 +577,7 @@ export class AutoColumnSize extends BasePlugin {
         limit = valueAccordingPercent(colsLimit, syncLimit);
       } else {
         // Force to Number
-        limit = Number(syncLimit) >> 0;
+        limit = Math.trunc(Number(syncLimit));
       }
     }
 

--- a/handsontable/src/plugins/autoColumnSize/autoColumnSize.ts
+++ b/handsontable/src/plugins/autoColumnSize/autoColumnSize.ts
@@ -576,8 +576,10 @@ export class AutoColumnSize extends BasePlugin {
       if (typeof syncLimit === 'string' && isPercentValue(syncLimit)) {
         limit = valueAccordingPercent(colsLimit, syncLimit);
       } else {
-        // Force to Number
-        limit = Math.trunc(Number(syncLimit));
+        // Force to integer (NaN — e.g. when syncLimit is undefined — falls back to 0)
+        const numericSyncLimit = Number(syncLimit);
+
+        limit = Number.isFinite(numericSyncLimit) ? Math.trunc(numericSyncLimit) : 0;
       }
     }
 

--- a/handsontable/src/plugins/autoRowSize/autoRowSize.ts
+++ b/handsontable/src/plugins/autoRowSize/autoRowSize.ts
@@ -560,7 +560,7 @@ export class AutoRowSize extends BasePlugin {
         limit = valueAccordingPercent(rowsLimit, limit as unknown as string);
       } else {
         // Force to Number
-        limit >>= 0;
+        limit = Math.trunc(limit);
       }
     }
 

--- a/handsontable/src/plugins/autoRowSize/autoRowSize.ts
+++ b/handsontable/src/plugins/autoRowSize/autoRowSize.ts
@@ -559,8 +559,10 @@ export class AutoRowSize extends BasePlugin {
       if (isPercentValue(limit as unknown as string)) {
         limit = valueAccordingPercent(rowsLimit, limit as unknown as string);
       } else {
-        // Force to Number
-        limit = Math.trunc(limit);
+        // Force to integer (NaN — e.g. when syncLimit is undefined — falls back to 0)
+        const numericLimit = Number(limit);
+
+        limit = Number.isFinite(numericLimit) ? Math.trunc(numericLimit) : 0;
       }
     }
 

--- a/handsontable/src/plugins/autofill/autofill.ts
+++ b/handsontable/src/plugins/autofill/autofill.ts
@@ -361,49 +361,8 @@ export class Autofill extends BasePlugin {
       let fillData: unknown[][] = beforeAutofillHookResult;
       const res = beforeAutofillHookResult;
 
-      if (
-        (directionOfDrag === 'up' || directionOfDrag === 'left') &&
-        !(res.length === 1 && res[0].length === 0)
-      ) {
-        fillData = [];
-
-        if (directionOfDrag === 'up') {
-          const dragLength = endRow - startRow + 1;
-          const fillOffset = dragLength % res.length;
-
-          for (let i = 0; i < dragLength; i++) {
-            fillData.push(res[(i + (res.length - fillOffset)) % res.length]);
-          }
-
-        } else {
-          const dragLength = endCol - startCol + 1;
-          const fillOffset = dragLength % res[0].length;
-
-          for (let i = 0; i < res.length; i++) {
-            fillData.push([]);
-
-            for (let j = 0; j < dragLength; j++) {
-              fillData[i]
-                .push(res[i][(j + (res[i].length - fillOffset)) % res[i].length]);
-            }
-          }
-        }
-      }
-
-      // If the source data contains objects, we need to check every target cell for the data type.
-      if (selectionSourceData.some(row => row.some((cell: unknown) => (isObject(cell) || Array.isArray(cell))))) {
-        const fullFillData = this.#extendFillDataWithSourceData(
-          fillData,
-          selectionSourceData,
-          startCoords,
-          endCoords,
-          directionOfDrag,
-        );
-
-        if (fullFillData.length) {
-          fillData = fullFillData;
-        }
-      }
+      fillData = this.#adjustFillDataForDirection(res, fillData, directionOfDrag, startRow, endRow, startCol, endCol);
+      fillData = this.#applySourceDataExtension(fillData, selectionSourceData, startCoords, endCoords, directionOfDrag);
 
       this.hot.populateFromArray(
         startRow,
@@ -425,6 +384,97 @@ export class Autofill extends BasePlugin {
     }
 
     return true;
+  }
+
+  /**
+   * Adjusts fill data for reverse drag directions ('up' or 'left') by reordering rows or columns.
+   *
+   * @private
+   * @param {unknown[][]} res The original autofill hook result data.
+   * @param {unknown[][]} fillData The current fill data to adjust.
+   * @param {string} directionOfDrag The direction of the autofill drag.
+   * @param {number} startRow The start row index of the drag area.
+   * @param {number} endRow The end row index of the drag area.
+   * @param {number} startCol The start column index of the drag area.
+   * @param {number} endCol The end column index of the drag area.
+   * @returns {unknown[][]} The adjusted fill data.
+   */
+  #adjustFillDataForDirection(
+    res: unknown[][],
+    fillData: unknown[][],
+    directionOfDrag: string | undefined,
+    startRow: number,
+    endRow: number,
+    startCol: number,
+    endCol: number,
+  ): unknown[][] {
+    if (
+      (directionOfDrag !== 'up' && directionOfDrag !== 'left') ||
+      (res.length === 1 && res[0].length === 0)
+    ) {
+      return fillData;
+    }
+
+    const result: unknown[][] = [];
+
+    if (directionOfDrag === 'up') {
+      const dragLength = endRow - startRow + 1;
+      const fillOffset = dragLength % res.length;
+
+      for (let i = 0; i < dragLength; i++) {
+        result.push(res[(i + (res.length - fillOffset)) % res.length]);
+      }
+    } else {
+      const dragLength = endCol - startCol + 1;
+      const fillOffset = dragLength % res[0].length;
+
+      for (let i = 0; i < res.length; i++) {
+        result.push([]);
+
+        for (let j = 0; j < dragLength; j++) {
+          (result[i] as unknown[]).push(res[i][(j + (res[i].length - fillOffset)) % res[i].length]);
+        }
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Extends fill data with source data when source cells contain objects or arrays.
+   *
+   * @private
+   * @param {unknown[][]} fillData The current fill data.
+   * @param {unknown[][]} selectionSourceData The original source selection data.
+   * @param {{ row: number, col: number }} startCoords The start coordinates of the fill area.
+   * @param {{ row: number, col: number }} endCoords The end coordinates of the fill area.
+   * @param {string} directionOfDrag The direction of the autofill drag.
+   * @returns {unknown[][]} The extended fill data, or the original if no extension was needed.
+   */
+  #applySourceDataExtension(
+    fillData: unknown[][],
+    selectionSourceData: unknown[][],
+    startCoords: { row: number, col: number },
+    endCoords: { row: number, col: number },
+    directionOfDrag: string | undefined,
+  ): unknown[][] {
+    const hasComplexCells = selectionSourceData.some(
+      row => row.some((cell: unknown) => isObject(cell) || Array.isArray(cell))
+    );
+
+    if (!hasComplexCells) {
+      return fillData;
+    }
+
+    const fullFillData = this.#extendFillDataWithSourceData(
+      fillData,
+      selectionSourceData,
+      startCoords,
+      endCoords,
+      directionOfDrag,
+    );
+
+    return fullFillData.length ? fullFillData : fillData;
   }
 
   /**

--- a/handsontable/src/plugins/autofill/autofill.ts
+++ b/handsontable/src/plugins/autofill/autofill.ts
@@ -389,7 +389,6 @@ export class Autofill extends BasePlugin {
   /**
    * Adjusts fill data for reverse drag directions ('up' or 'left') by reordering rows or columns.
    *
-   * @private
    * @param {unknown[][]} res The original autofill hook result data.
    * @param {unknown[][]} fillData The current fill data to adjust.
    * @param {string} directionOfDrag The direction of the autofill drag.
@@ -443,7 +442,6 @@ export class Autofill extends BasePlugin {
   /**
    * Extends fill data with source data when source cells contain objects or arrays.
    *
-   * @private
    * @param {unknown[][]} fillData The current fill data.
    * @param {unknown[][]} selectionSourceData The original source selection data.
    * @param {{ row: number, col: number }} startCoords The start coordinates of the fill area.

--- a/handsontable/src/plugins/base/base.ts
+++ b/handsontable/src/plugins/base/base.ts
@@ -328,26 +328,45 @@ export class BasePlugin {
       const validator = settingsValidators[settingName];
 
       if (validator && typeof validator === 'function') {
-        return ((...args: unknown[]): unknown => {
-          const result: unknown = settingValue(...args);
-          const isValid = validator(result);
+        const wrappedFn = settingValue as (...args: unknown[]) => unknown;
 
-          if (isValid === false) {
-            const formattedArgs = args.map(arg => (typeof arg === 'string' ? `"${arg}"` : '')).join(', ');
-            const source = args.length > 0 ? formattedArgs : '';
-
-            warn(`${this.pluginName} Plugin: "${settingName}" function (${source}) result \
-               is not valid and will be ignored.`);
-
-            return;
-          }
-
-          return result;
-        }) as T;
+        return this.#wrapSettingWithValidator(wrappedFn, validator, settingName) as T;
       }
     }
 
     return settingValue as T;
+  }
+
+  /**
+   * Wraps a setting function with its validator, returning a guarded wrapper that emits a warning
+   * and returns undefined when the validator rejects the result.
+   *
+   * @param {Function} settingFn The setting function to wrap.
+   * @param {Function} validator The validator function for the setting.
+   * @param {string} settingName The name of the setting (used in the warning message).
+   * @returns {Function} A wrapped function that validates the result before returning it.
+   */
+  #wrapSettingWithValidator(
+    settingFn: (...args: unknown[]) => unknown,
+    validator: (result: unknown) => boolean,
+    settingName: string
+  ): (...args: unknown[]) => unknown {
+    return (...args: unknown[]): unknown => {
+      const result: unknown = settingFn(...args);
+      const isValid = validator(result);
+
+      if (isValid === false) {
+        const formattedArgs = args.map(arg => (typeof arg === 'string' ? `"${arg}"` : '')).join(', ');
+        const source = args.length > 0 ? formattedArgs : '';
+
+        warn(`${this.pluginName} Plugin: "${settingName}" function (${source}) result \
+               is not valid and will be ignored.`);
+
+        return;
+      }
+
+      return result;
+    };
   }
 
   /**
@@ -566,7 +585,7 @@ export class BasePlugin {
    * @private
    */
   updatePlugin(newSettings?: Record<string, unknown>): void {
-
+    // Intentionally empty
   }
 
   /**

--- a/handsontable/src/plugins/collapsibleColumns/collapsibleColumns.ts
+++ b/handsontable/src/plugins/collapsibleColumns/collapsibleColumns.ts
@@ -585,7 +585,6 @@ export class CollapsibleColumns extends BasePlugin {
   /**
    * Checks whether a collapse or expand action is possible for the given filtered coordinates.
    *
-   * @private
    * @param {Array} filteredCoords Header coordinates filtered to header rows only.
    * @param {string} action Action definition ('collapse' or 'expand').
    * @returns {boolean}
@@ -617,7 +616,6 @@ export class CollapsibleColumns extends BasePlugin {
   /**
    * Adjusts the active cell selection after a collapse action moves selected cells out of view.
    *
-   * @private
    * @param {number[]} affectedColumnsIndexes Visual indexes of columns hidden by the collapse.
    */
   #adjustSelectionAfterCollapse(affectedColumnsIndexes: number[]): void {

--- a/handsontable/src/plugins/collapsibleColumns/collapsibleColumns.ts
+++ b/handsontable/src/plugins/collapsibleColumns/collapsibleColumns.ts
@@ -507,18 +507,7 @@ export class CollapsibleColumns extends BasePlugin {
 
     // Ignore coordinates which points to the cells range.
     const filteredCoords = arrayFilter(coords, ({ row }) => row < 0);
-    let isActionPossible = filteredCoords.length > 0;
-
-    arrayEach(filteredCoords, ({ row, col: column }) => {
-      const { collapsible, isCollapsed } = this.headerStateManager?.getHeaderSettings(row, column)
-        ?? {} as Record<string, unknown>;
-
-      if (!collapsible || isCollapsed && action === 'collapse' || !isCollapsed && action === 'expand') {
-        isActionPossible = false;
-
-        return false;
-      }
-    });
+    const isActionPossible = this.#checkIsActionPossible(filteredCoords, action!);
 
     const nodeModRollbacks: Function[] = [];
     const affectedColumnsIndexes: number[] = [];
@@ -576,23 +565,9 @@ export class CollapsibleColumns extends BasePlugin {
     }, true);
 
     const isActionPerformed = this.getCollapsedColumns().length !== currentCollapsedColumns.length;
-    const selectionRange = this.hot.getSelectedRangeActive();
 
-    if (action === 'collapse' && isActionPerformed && selectionRange) {
-      const { row, col } = selectionRange.highlight;
-
-      if (row !== null && col !== null) {
-        const isHidden = this.hot.rowIndexMapper.isHidden(row) || this.hot.columnIndexMapper.isHidden(col);
-
-        if (isHidden && affectedColumnsIndexes.includes(col)) {
-          const nextRow = row >= 0 ? this.hot.rowIndexMapper.getNearestNotHiddenIndex(row, 1, true) : row;
-          const nextColumn = col >= 0 ? this.hot.columnIndexMapper.getNearestNotHiddenIndex(col, 1, true) : col;
-
-          if (nextRow !== null && nextColumn !== null) {
-            this.hot.selectCell(nextRow, nextColumn);
-          }
-        }
-      }
+    if (action === 'collapse' && isActionPerformed) {
+      this.#adjustSelectionAfterCollapse(affectedColumnsIndexes);
     }
 
     this.hot.runHooks(
@@ -605,6 +580,69 @@ export class CollapsibleColumns extends BasePlugin {
 
     this.hot.view.adjustElementsSize();
     this.hot.render();
+  }
+
+  /**
+   * Checks whether a collapse or expand action is possible for the given filtered coordinates.
+   *
+   * @private
+   * @param {Array} filteredCoords Header coordinates filtered to header rows only.
+   * @param {string} action Action definition ('collapse' or 'expand').
+   * @returns {boolean}
+   */
+  #checkIsActionPossible(
+    filteredCoords: { row: number, col: number }[],
+    action: 'collapse' | 'expand'
+  ): boolean {
+    if (filteredCoords.length === 0) {
+      return false;
+    }
+
+    let isActionPossible = true;
+
+    arrayEach(filteredCoords, ({ row, col: column }) => {
+      const { collapsible, isCollapsed } = this.headerStateManager?.getHeaderSettings(row, column)
+        ?? {} as Record<string, unknown>;
+
+      if (!collapsible || isCollapsed && action === 'collapse' || !isCollapsed && action === 'expand') {
+        isActionPossible = false;
+
+        return false;
+      }
+    });
+
+    return isActionPossible;
+  }
+
+  /**
+   * Adjusts the active cell selection after a collapse action moves selected cells out of view.
+   *
+   * @private
+   * @param {number[]} affectedColumnsIndexes Visual indexes of columns hidden by the collapse.
+   */
+  #adjustSelectionAfterCollapse(affectedColumnsIndexes: number[]): void {
+    const selectionRange = this.hot.getSelectedRangeActive();
+
+    if (!selectionRange) {
+      return;
+    }
+
+    const { row, col } = selectionRange.highlight;
+
+    if (row === null || col === null) {
+      return;
+    }
+
+    const isHidden = this.hot.rowIndexMapper.isHidden(row) || this.hot.columnIndexMapper.isHidden(col);
+
+    if (isHidden && affectedColumnsIndexes.includes(col)) {
+      const nextRow = row >= 0 ? this.hot.rowIndexMapper.getNearestNotHiddenIndex(row, 1, true) : row;
+      const nextColumn = col >= 0 ? this.hot.columnIndexMapper.getNearestNotHiddenIndex(col, 1, true) : col;
+
+      if (nextRow !== null && nextColumn !== null) {
+        this.hot.selectCell(nextRow, nextColumn);
+      }
+    }
   }
 
   /**

--- a/handsontable/src/plugins/columnSorting/columnSorting.ts
+++ b/handsontable/src/plugins/columnSorting/columnSorting.ts
@@ -277,7 +277,7 @@ export class ColumnSorting extends BasePlugin {
           const activeRange = this.hot.getSelectedRangeActive();
 
           if (!activeRange) {
-            return true;
+            return false;
           }
 
           const { highlight } = activeRange;

--- a/handsontable/src/plugins/columnSorting/columnSorting.ts
+++ b/handsontable/src/plugins/columnSorting/columnSorting.ts
@@ -277,7 +277,7 @@ export class ColumnSorting extends BasePlugin {
           const activeRange = this.hot.getSelectedRangeActive();
 
           if (!activeRange) {
-            return false;
+            return true;
           }
 
           const { highlight } = activeRange;

--- a/handsontable/src/plugins/columnSorting/sortFunction/checkbox.ts
+++ b/handsontable/src/plugins/columnSorting/sortFunction/checkbox.ts
@@ -3,6 +3,69 @@ import { compareFunctionFactory as defaultCompareFunctionFactory } from '../sort
 import { isEmpty } from '../../../helpers/mixed';
 
 /**
+ * Resolves the sort order result for two checkbox values that are both from the template.
+ *
+ * @param {unknown} unifiedValue The first unified value.
+ * @param {unknown} unifiedNextValue The second unified value.
+ * @param {unknown} checkedTemplate The checked template value.
+ * @param {unknown} uncheckedTemplate The unchecked template value.
+ * @param {string} sortOrder Sort order (`asc` for ascending, `desc` for descending).
+ * @returns {number} The comparison result.
+ */
+function compareTemplateValues(
+  unifiedValue: unknown, unifiedNextValue: unknown,
+  checkedTemplate: unknown, uncheckedTemplate: unknown,
+  sortOrder: string
+): number {
+  if (unifiedValue === uncheckedTemplate && unifiedNextValue === checkedTemplate) {
+    return sortOrder === 'asc' ? FIRST_BEFORE_SECOND : FIRST_AFTER_SECOND;
+  }
+
+  if (unifiedValue === checkedTemplate && unifiedNextValue === uncheckedTemplate) {
+    return sortOrder === 'asc' ? FIRST_AFTER_SECOND : FIRST_BEFORE_SECOND;
+  }
+
+  return DO_NOT_SWAP;
+}
+
+/**
+ * Resolves the sort order result when at least one value is not from the checkbox template.
+ *
+ * @param {boolean} isValueFromTemplate Whether the first value is from the template.
+ * @param {boolean} isNextValueFromTemplate Whether the second value is from the template.
+ * @param {string} sortOrder Sort order (`asc` for ascending, `desc` for descending).
+ * @param {object} columnMeta Column meta object.
+ * @param {object} columnPluginSettings Plugin settings for the column.
+ * @param {unknown} value The first value.
+ * @param {unknown} nextValue The second value.
+ * @returns {number | null} The comparison result or null if both values are from template.
+ */
+function compareBadValues(
+  isValueFromTemplate: boolean, isNextValueFromTemplate: boolean,
+  sortOrder: string, columnMeta: Record<string, unknown>,
+  columnPluginSettings: Record<string, unknown>,
+  value: unknown, nextValue: unknown
+): number | null {
+  // 1st value === #BAD_VALUE#
+  if (isValueFromTemplate === false && isNextValueFromTemplate) {
+    return sortOrder === 'asc' ? FIRST_BEFORE_SECOND : FIRST_AFTER_SECOND;
+  }
+
+  // 2nd value === #BAD_VALUE#
+  if (isValueFromTemplate && isNextValueFromTemplate === false) {
+    return sortOrder === 'asc' ? FIRST_AFTER_SECOND : FIRST_BEFORE_SECOND;
+  }
+
+  // 1st value === #BAD_VALUE# && 2nd value === #BAD_VALUE#
+  if (isValueFromTemplate === false && isNextValueFromTemplate === false) {
+    // Sorting by values (not just by visual representation).
+    return defaultCompareFunctionFactory(sortOrder, columnMeta, columnPluginSettings)(value, nextValue);
+  }
+
+  return null;
+}
+
+/**
  * Checkbox sorting compare function factory. Method get as parameters `sortOrder` and `columnMeta` and return compare function.
  *
  * @param {string} sortOrder Sort order (`asc` for ascending, `desc` for descending).
@@ -36,31 +99,16 @@ export function compareFunctionFactory(
       }
     }
 
-    // 1st value === #BAD_VALUE#
-    if (isValueFromTemplate === false && isNextValueFromTemplate) {
-      return sortOrder === 'asc' ? FIRST_BEFORE_SECOND : FIRST_AFTER_SECOND;
+    const badValueResult = compareBadValues(
+      isValueFromTemplate, isNextValueFromTemplate,
+      sortOrder, columnMeta, columnPluginSettings, value, nextValue
+    );
+
+    if (badValueResult !== null) {
+      return badValueResult;
     }
 
-    // 2nd value === #BAD_VALUE#
-    if (isValueFromTemplate && isNextValueFromTemplate === false) {
-      return sortOrder === 'asc' ? FIRST_AFTER_SECOND : FIRST_BEFORE_SECOND;
-    }
-
-    // 1st value === #BAD_VALUE# && 2nd value === #BAD_VALUE#
-    if (isValueFromTemplate === false && isNextValueFromTemplate === false) {
-      // Sorting by values (not just by visual representation).
-      return defaultCompareFunctionFactory(sortOrder, columnMeta, columnPluginSettings)(value, nextValue);
-    }
-
-    if (unifiedValue === uncheckedTemplate && unifiedNextValue === checkedTemplate) {
-      return sortOrder === 'asc' ? FIRST_BEFORE_SECOND : FIRST_AFTER_SECOND;
-    }
-
-    if (unifiedValue === checkedTemplate && unifiedNextValue === uncheckedTemplate) {
-      return sortOrder === 'asc' ? FIRST_AFTER_SECOND : FIRST_BEFORE_SECOND;
-    }
-
-    return DO_NOT_SWAP;
+    return compareTemplateValues(unifiedValue, unifiedNextValue, checkedTemplate, uncheckedTemplate, sortOrder);
   };
 }
 

--- a/handsontable/src/plugins/columnSorting/sortFunction/default.ts
+++ b/handsontable/src/plugins/columnSorting/sortFunction/default.ts
@@ -2,6 +2,67 @@ import { isEmpty } from '../../../helpers/mixed';
 import { DO_NOT_SWAP, FIRST_BEFORE_SECOND, FIRST_AFTER_SECOND } from '../sortService';
 
 /**
+ * Normalizes a cell value for comparison by converting booleans to numbers and strings to lowercase.
+ *
+ * @param {unknown} value The value to normalize.
+ * @param {string | undefined} locale The locale to use for string lowercasing.
+ * @returns {unknown} The normalized value.
+ */
+function normalizeValue(value: unknown, locale: string | undefined): unknown {
+  if (typeof value === 'boolean') {
+    return Number(value);
+  }
+
+  if (typeof value === 'string') {
+    return value.toLocaleLowerCase(locale);
+  }
+
+  return value;
+}
+
+/**
+ * Compares two non-empty values, handling NaN and numeric coercion.
+ *
+ * @param {unknown} value The first value.
+ * @param {unknown} nextValue The second value.
+ * @param {string} sortOrder The sort order (`asc` or `desc`).
+ * @returns {number} The comparison result.
+ */
+function compareNonEmptyValues(value: unknown, nextValue: unknown, sortOrder: string): number {
+  const valueIsNaN = isNaN(value as number);
+  const nextValueIsNaN = isNaN(nextValue as number);
+
+  if (valueIsNaN && !nextValueIsNaN) {
+    return sortOrder === 'asc' ? FIRST_AFTER_SECOND : FIRST_BEFORE_SECOND;
+  }
+
+  if (!valueIsNaN && nextValueIsNaN) {
+    return sortOrder === 'asc' ? FIRST_BEFORE_SECOND : FIRST_AFTER_SECOND;
+  }
+
+  let comparableValue = value;
+  let comparableNextValue = nextValue;
+
+  if (!valueIsNaN && !nextValueIsNaN) {
+    comparableValue = parseFloat(String(value));
+    comparableNextValue = parseFloat(String(nextValue));
+  }
+
+  const a = comparableValue as string | number;
+  const b = comparableNextValue as string | number;
+
+  if (a < b) {
+    return sortOrder === 'asc' ? FIRST_BEFORE_SECOND : FIRST_AFTER_SECOND;
+  }
+
+  if (a > b) {
+    return sortOrder === 'asc' ? FIRST_AFTER_SECOND : FIRST_BEFORE_SECOND;
+  }
+
+  return DO_NOT_SWAP;
+}
+
+/**
  * Default sorting compare function factory. Method get as parameters `sortOrder` and `columnMeta` and return compare function.
  *
  * @param {string} sortOrder Sort order (`asc` for ascending, `desc` for descending).
@@ -17,28 +78,15 @@ export function compareFunctionFactory(
   return function(value: unknown, nextValue: unknown) {
     const { sortEmptyCells } = columnPluginSettings;
 
-    if (typeof value === 'boolean') {
-      value = Number(value);
-    }
+    const normalizedValue = normalizeValue(value, locale);
+    const normalizedNextValue = normalizeValue(nextValue, locale);
 
-    if (typeof nextValue === 'boolean') {
-      nextValue = Number(nextValue);
-    }
-
-    if (typeof value === 'string') {
-      value = value.toLocaleLowerCase(locale);
-    }
-
-    if (typeof nextValue === 'string') {
-      nextValue = nextValue.toLocaleLowerCase(locale);
-    }
-
-    if (value === nextValue) {
+    if (normalizedValue === normalizedNextValue) {
       return DO_NOT_SWAP;
     }
 
-    if (isEmpty(value)) {
-      if (isEmpty(nextValue)) {
+    if (isEmpty(normalizedValue)) {
+      if (isEmpty(normalizedNextValue)) {
         return DO_NOT_SWAP;
       }
 
@@ -50,7 +98,7 @@ export function compareFunctionFactory(
       return FIRST_AFTER_SECOND;
     }
 
-    if (isEmpty(nextValue)) {
+    if (isEmpty(normalizedNextValue)) {
       // Just second value is empty and `sortEmptyCells` option was set
       if (sortEmptyCells) {
         return sortOrder === 'asc' ? FIRST_AFTER_SECOND : FIRST_BEFORE_SECOND;
@@ -59,29 +107,7 @@ export function compareFunctionFactory(
       return FIRST_BEFORE_SECOND;
     }
 
-    if (isNaN(value as number) && !isNaN(nextValue as number)) {
-      return sortOrder === 'asc' ? FIRST_AFTER_SECOND : FIRST_BEFORE_SECOND;
-
-    } else if (!isNaN(value as number) && isNaN(nextValue as number)) {
-      return sortOrder === 'asc' ? FIRST_BEFORE_SECOND : FIRST_AFTER_SECOND;
-
-    } else if (!(isNaN(value as number) || isNaN(nextValue as number))) {
-      value = parseFloat(String(value));
-      nextValue = parseFloat(String(nextValue));
-    }
-
-    const comparableValue = value as string | number;
-    const comparableNextValue = nextValue as string | number;
-
-    if (comparableValue < comparableNextValue) {
-      return sortOrder === 'asc' ? FIRST_BEFORE_SECOND : FIRST_AFTER_SECOND;
-    }
-
-    if (comparableValue > comparableNextValue) {
-      return sortOrder === 'asc' ? FIRST_AFTER_SECOND : FIRST_BEFORE_SECOND;
-    }
-
-    return DO_NOT_SWAP;
+    return compareNonEmptyValues(normalizedValue, normalizedNextValue, sortOrder);
   };
 }
 

--- a/handsontable/src/plugins/comments/commentEditor.ts
+++ b/handsontable/src/plugins/comments/commentEditor.ts
@@ -254,7 +254,7 @@ class CommentEditor {
 
     addClass(editor, CommentEditor.CLASS_EDITOR);
     addClass(textarea, CommentEditor.CLASS_INPUT);
-    textarea.setAttribute('data-hot-input', 'true');
+    textarea.dataset.hotInput = 'true';
 
     editor.appendChild(textarea);
     this.#container.appendChild(editor);

--- a/handsontable/src/plugins/copyPaste/copyPaste.ts
+++ b/handsontable/src/plugins/copyPaste/copyPaste.ts
@@ -717,7 +717,7 @@ export class CopyPaste extends BasePlugin {
   onCopy(event: ClipboardEvent) {
     const eventTarget = event.composedPath()[0];
     const focusedElement = this.hot.getFocusManager().getRefocusElement();
-    const isHotInput = isHTMLElement(eventTarget) && eventTarget.hasAttribute('data-hot-input');
+    const isHotInput = isHTMLElement(eventTarget) && 'hotInput' in eventTarget.dataset;
 
     if (
       !this.hot.isListening() && !this.#isTriggeredByCopy ||
@@ -761,7 +761,7 @@ export class CopyPaste extends BasePlugin {
   onCut(event: ClipboardEvent) {
     const eventTarget = event.composedPath()[0];
     const focusedElement = this.hot.getFocusManager().getRefocusElement();
-    const isHotInput = isHTMLElement(eventTarget) && eventTarget.hasAttribute('data-hot-input');
+    const isHotInput = isHTMLElement(eventTarget) && 'hotInput' in eventTarget.dataset;
 
     if (
       !this.hot.isListening() && !this.#isTriggeredByCut ||
@@ -802,7 +802,7 @@ export class CopyPaste extends BasePlugin {
   onPaste(event: ClipboardEvent | PasteEvent) {
     const eventTarget = event.composedPath()[0];
     const focusedElement = this.hot.getFocusManager().getRefocusElement();
-    const isHotInput = isHTMLElement(eventTarget) && eventTarget.hasAttribute('data-hot-input');
+    const isHotInput = isHTMLElement(eventTarget) && 'hotInput' in eventTarget.dataset;
 
     if (
       !this.hot.isListening() ||
@@ -821,6 +821,51 @@ export class CopyPaste extends BasePlugin {
 
     event.preventDefault?.();
 
+    const clipboardResult = this.#readClipboardData(event);
+    const { pastedSourceData } = clipboardResult;
+    let { pastedData } = clipboardResult;
+
+    if (typeof pastedData === 'string') {
+      pastedData = parse(pastedData);
+    }
+
+    if (pastedData === void 0 || Array.isArray(pastedData) && pastedData.length === 0) {
+      return;
+    }
+
+    // Store a copy of the original pasted data before user can modify it in beforePaste hook.
+    // This is needed to detect if user modified values and respect their modifications over source data.
+    const originalPastedData = deepClone(pastedData);
+
+    if (this.hot.runHooks('beforePaste', pastedData, this.copyableRanges) === false) {
+      return;
+    }
+
+    const [startRow, startColumn, endRow, endColumn] = this.populateValues({
+      plainData: pastedData as unknown[][],
+      sourceData: pastedSourceData as unknown[][],
+      originalPlainData: originalPastedData as unknown[][],
+    });
+
+    if (startRow !== null && startColumn !== null && endRow !== null && endColumn !== null) {
+      this.hot.selectCell(
+        startRow,
+        startColumn,
+        Math.min(this.hot.countRows() - 1, endRow),
+        Math.min(this.hot.countCols() - 1, endColumn),
+      );
+    }
+
+    this.hot.runHooks('afterPaste', pastedData, this.copyableRanges);
+  }
+
+  /**
+   * Reads pasted data and source data from a paste event's clipboard.
+   *
+   * @param {ClipboardEvent | PasteEvent} event The paste event.
+   * @returns {{ pastedData: unknown, pastedSourceData: unknown }} The pasted data and source data.
+   */
+  #readClipboardData(event: ClipboardEvent | PasteEvent): { pastedData: unknown; pastedSourceData: unknown } {
     let pastedData: unknown;
     let pastedSourceData: unknown;
 
@@ -868,38 +913,7 @@ export class CopyPaste extends BasePlugin {
       pastedData = (this.hot.rootWindow as unknown as IEWindow).clipboardData.getData('Text');
     }
 
-    if (typeof pastedData === 'string') {
-      pastedData = parse(pastedData);
-    }
-
-    if (pastedData === void 0 || Array.isArray(pastedData) && pastedData.length === 0) {
-      return;
-    }
-
-    // Store a copy of the original pasted data before user can modify it in beforePaste hook.
-    // This is needed to detect if user modified values and respect their modifications over source data.
-    const originalPastedData = deepClone(pastedData);
-
-    if (this.hot.runHooks('beforePaste', pastedData, this.copyableRanges) === false) {
-      return;
-    }
-
-    const [startRow, startColumn, endRow, endColumn] = this.populateValues({
-      plainData: pastedData as unknown[][],
-      sourceData: pastedSourceData as unknown[][],
-      originalPlainData: originalPastedData as unknown[][],
-    });
-
-    if (startRow !== null && startColumn !== null && endRow !== null && endColumn !== null) {
-      this.hot.selectCell(
-        startRow,
-        startColumn,
-        Math.min(this.hot.countRows() - 1, endRow),
-        Math.min(this.hot.countCols() - 1, endColumn),
-      );
-    }
-
-    this.hot.runHooks('afterPaste', pastedData, this.copyableRanges);
+    return { pastedData, pastedSourceData };
   }
 
   /**

--- a/handsontable/src/plugins/customBorders/customBorders.ts
+++ b/handsontable/src/plugins/customBorders/customBorders.ts
@@ -923,8 +923,6 @@ The border style will be ignored.`);
       return;
     }
 
-    const plugin = this;
-
     items.push({
       name: '---------',
     }, {
@@ -947,11 +945,11 @@ The border style will be ignored.`);
       },
       submenu: {
         items: [
-          menuItemTop(plugin),
-          menuItemRight(plugin),
-          menuItemBottom(plugin),
-          menuItemLeft(plugin),
-          menuItemNoBorders(plugin)
+          menuItemTop(this),
+          menuItemRight(this),
+          menuItemBottom(this),
+          menuItemLeft(this),
+          menuItemNoBorders(this)
         ]
       }
     });

--- a/handsontable/src/plugins/customBorders/utils.ts
+++ b/handsontable/src/plugins/customBorders/utils.ts
@@ -169,6 +169,34 @@ export function createEmptyBorders(row: number, col: number): BorderObject {
 }
 
 /**
+ * Resolves a single border side value from the custom border config and assigns it to the default border object.
+ *
+ * @param {object} defaultBorder The default border object to update.
+ * @param {object} customBorder The border object with custom settings.
+ * @param {string} side The border side key ('top', 'bottom', 'start', or 'end').
+ */
+function applyBorderSide(
+  defaultBorder: BorderObject,
+  customBorder: CustomBorderConfig,
+  side: 'top' | 'bottom' | 'start' | 'end'
+): void {
+  if (!hasOwnProperty(customBorder, side) || !isDefined(customBorder[side])) {
+    return;
+  }
+
+  if (customBorder[side]) {
+    if (!isObject(customBorder[side])) {
+      customBorder[side] = createDefaultCustomBorder();
+    }
+
+    defaultBorder[side] = customBorder[side];
+  } else {
+    customBorder[side] = createSingleEmptyBorder();
+    defaultBorder[side] = customBorder[side];
+  }
+}
+
+/**
  * @param {object} defaultBorder The default border object.
  * @param {object} customBorder The border object with custom settings.
  * @returns {object}
@@ -178,62 +206,10 @@ export function extendDefaultBorder(defaultBorder: BorderObject, customBorder: C
     defaultBorder.border = customBorder.border;
   }
 
-  if (hasOwnProperty(customBorder, 'top') && isDefined(customBorder.top)) {
-    if (customBorder.top) {
-      if (!isObject(customBorder.top)) {
-        customBorder.top = createDefaultCustomBorder();
-      }
-
-      defaultBorder.top = customBorder.top;
-
-    } else {
-      customBorder.top = createSingleEmptyBorder();
-      defaultBorder.top = customBorder.top;
-    }
-  }
-
-  if (hasOwnProperty(customBorder, 'bottom') && isDefined(customBorder.bottom)) {
-    if (customBorder.bottom) {
-      if (!isObject(customBorder.bottom)) {
-        customBorder.bottom = createDefaultCustomBorder();
-      }
-
-      defaultBorder.bottom = customBorder.bottom;
-
-    } else {
-      customBorder.bottom = createSingleEmptyBorder();
-      defaultBorder.bottom = customBorder.bottom;
-    }
-  }
-
-  if (hasOwnProperty(customBorder, 'start') && isDefined(customBorder.start)) {
-    if (customBorder.start) {
-
-      if (!isObject(customBorder.start)) {
-        customBorder.start = createDefaultCustomBorder();
-      }
-
-      defaultBorder.start = customBorder.start;
-
-    } else {
-      customBorder.start = createSingleEmptyBorder();
-      defaultBorder.start = customBorder.start;
-    }
-  }
-
-  if (hasOwnProperty(customBorder, 'end') && isDefined(customBorder.end)) {
-    if (customBorder.end) {
-      if (!isObject(customBorder.end)) {
-        customBorder.end = createDefaultCustomBorder();
-      }
-
-      defaultBorder.end = customBorder.end;
-
-    } else {
-      customBorder.end = createSingleEmptyBorder();
-      defaultBorder.end = customBorder.end;
-    }
-  }
+  applyBorderSide(defaultBorder, customBorder, 'top');
+  applyBorderSide(defaultBorder, customBorder, 'bottom');
+  applyBorderSide(defaultBorder, customBorder, 'start');
+  applyBorderSide(defaultBorder, customBorder, 'end');
 
   return defaultBorder;
 }

--- a/handsontable/src/plugins/dataProvider/dataProvider.ts
+++ b/handsontable/src/plugins/dataProvider/dataProvider.ts
@@ -457,7 +457,7 @@ export class DataProvider extends BasePlugin {
     const onRowsCreate = this.#getOnRowsCreate();
 
     if (!isFunction(onRowsCreate)) {
-      return Promise.resolve();
+      return;
     }
 
     const rowsCreatePayload = {
@@ -493,7 +493,7 @@ export class DataProvider extends BasePlugin {
     const onRowsRemove = this.#getOnRowsRemove();
 
     if (!isFunction(onRowsRemove)) {
-      return Promise.resolve();
+      return;
     }
 
     const ids = Array.isArray(rowIds) ? rowIds : [rowIds];

--- a/handsontable/src/plugins/exportFile/dataProvider.ts
+++ b/handsontable/src/plugins/exportFile/dataProvider.ts
@@ -8,6 +8,28 @@ interface MergeCellDescriptor {
   colspan: number;
 }
 
+interface NestedHeaderTreeNodeData {
+  columnIndex: number;
+  origColspan: number;
+  headerClassNames: string[];
+  label: string;
+}
+
+interface NestedHeaderSettings {
+  isRoot: boolean;
+  colspan: number;
+  headerClassNames: string[];
+  label: string;
+}
+
+type NestedHeadersPluginWithState = {
+  getStateManager(): { getHeaderTreeNodeData(layer: number, col: number): NestedHeaderTreeNodeData | null | undefined };
+};
+
+type NestedHeadersPluginWithSettings = {
+  getHeaderSettings(layer: number, col: number): NestedHeaderSettings | null | undefined;
+};
+
 /**
  * @private
  */
@@ -507,7 +529,7 @@ class DataProvider {
     const layers = [];
 
     for (let layer = 0; layer < layersCount; layer++) {
-      const layerHeaders = [];
+      const layerHeaders: Array<{ label: string; colspan: number; className: string }> = [];
       let col = startCol;
 
       while (col <= endCol) {
@@ -517,56 +539,9 @@ class DataProvider {
         }
 
         if (includeHidden) {
-          // When including hidden columns, the NestedHeaders state matrix has been
-          // modified by the HiddenColumns plugin: hidden span roots are replaced with
-          // placeholders and their colspan is transferred to the next visible column.
-          // Use the tree node data instead, which preserves the original columnIndex
-          // and origColspan regardless of the hidden state.
-          const treeNodeData = nestedHeadersPlugin.getStateManager().getHeaderTreeNodeData(layer, col);
-
-          if (!treeNodeData || treeNodeData.columnIndex === col) {
-            // This column is the root of its span (or has no tree node → single column).
-            const origColspan = treeNodeData?.origColspan ?? 1;
-            // Clamp to the export range end.
-            const effectiveColspan = Math.min(origColspan, endCol - col + 1);
-            // headerClassNames is an array of strings produced by the settings normalizer
-            // from the user-supplied `headerClassName` string.
-            const className = (treeNodeData?.headerClassNames ?? []).join(' ');
-
-            layerHeaders.push({ label: treeNodeData?.label ?? '', colspan: effectiveColspan, className });
-            col += origColspan;
-          } else {
-            // This column is inside a span whose root is before startCol. Emit a
-            // single-column placeholder to keep the column count correct.
-            layerHeaders.push({ label: '', colspan: 1, className: '' });
-            col += 1;
-          }
+          col = this._appendNestedHeaderWithHidden(nestedHeadersPlugin, layer, col, endCol, layerHeaders);
         } else {
-          const settings = nestedHeadersPlugin.getHeaderSettings(layer, col);
-
-          if (!settings || settings.isRoot) {
-            const spanColspan = settings?.colspan ?? 1;
-            let visibleColspan = 0;
-
-            for (let spanCol = col; spanCol < col + spanColspan && spanCol <= endCol; spanCol++) {
-              if (!this._isHiddenColumn(spanCol)) {
-                visibleColspan += 1;
-              }
-            }
-
-            // headerClassNames is an array of strings produced by the settings normalizer
-            // from the user-supplied `headerClassName` string.
-            const className = (settings?.headerClassNames ?? []).join(' ');
-
-            layerHeaders.push({ label: settings?.label ?? '', colspan: visibleColspan, className });
-            col += spanColspan;
-          } else {
-            // Continuation cell of a span that started at an earlier column.
-            // This can only occur when startCol falls inside a span — emit a
-            // single-column placeholder so the export column count stays correct.
-            layerHeaders.push({ label: '', colspan: 1, className: '' });
-            col += 1;
-          }
+          col = this._appendNestedHeaderWithoutHidden(nestedHeadersPlugin, layer, col, endCol, layerHeaders);
         }
       }
 
@@ -574,6 +549,91 @@ class DataProvider {
     }
 
     return layers;
+  }
+
+  /**
+   * Appends a nested header entry for a single column when hidden columns are included in the export.
+   *
+   * @param {object} nestedHeadersPlugin The NestedHeaders plugin instance.
+   * @param {number} layer The header layer index.
+   * @param {number} col The current column index.
+   * @param {number} endCol The last column index of the export range.
+   * @param {Array} layerHeaders The array to push the header entry into.
+   * @returns {number} The next column index to process.
+   */
+  _appendNestedHeaderWithHidden(
+    nestedHeadersPlugin: NestedHeadersPluginWithState, layer: number, col: number,
+    endCol: number, layerHeaders: Array<{ label: string; colspan: number; className: string }>
+  ) {
+    // When including hidden columns, the NestedHeaders state matrix has been
+    // modified by the HiddenColumns plugin: hidden span roots are replaced with
+    // placeholders and their colspan is transferred to the next visible column.
+    // Use the tree node data instead, which preserves the original columnIndex
+    // and origColspan regardless of the hidden state.
+    const treeNodeData = nestedHeadersPlugin.getStateManager().getHeaderTreeNodeData(layer, col);
+
+    if (!treeNodeData || treeNodeData.columnIndex === col) {
+      // This column is the root of its span (or has no tree node → single column).
+      const origColspan = treeNodeData?.origColspan ?? 1;
+      // Clamp to the export range end.
+      const effectiveColspan = Math.min(origColspan, endCol - col + 1);
+      // headerClassNames is an array of strings produced by the settings normalizer
+      // from the user-supplied `headerClassName` string.
+      const className = (treeNodeData?.headerClassNames ?? []).join(' ');
+
+      layerHeaders.push({ label: treeNodeData?.label ?? '', colspan: effectiveColspan, className });
+
+      return col + origColspan;
+    }
+
+    // This column is inside a span whose root is before startCol. Emit a
+    // single-column placeholder to keep the column count correct.
+    layerHeaders.push({ label: '', colspan: 1, className: '' });
+
+    return col + 1;
+  }
+
+  /**
+   * Appends a nested header entry for a single column when hidden columns are excluded from the export.
+   *
+   * @param {object} nestedHeadersPlugin The NestedHeaders plugin instance.
+   * @param {number} layer The header layer index.
+   * @param {number} col The current column index.
+   * @param {number} endCol The last column index of the export range.
+   * @param {Array} layerHeaders The array to push the header entry into.
+   * @returns {number} The next column index to process.
+   */
+  _appendNestedHeaderWithoutHidden(
+    nestedHeadersPlugin: NestedHeadersPluginWithSettings, layer: number, col: number,
+    endCol: number, layerHeaders: Array<{ label: string; colspan: number; className: string }>
+  ) {
+    const settings = nestedHeadersPlugin.getHeaderSettings(layer, col);
+
+    if (!settings || settings.isRoot) {
+      const spanColspan = settings?.colspan ?? 1;
+      let visibleColspan = 0;
+
+      for (let spanCol = col; spanCol < col + spanColspan && spanCol <= endCol; spanCol++) {
+        if (!this._isHiddenColumn(spanCol)) {
+          visibleColspan += 1;
+        }
+      }
+
+      // headerClassNames is an array of strings produced by the settings normalizer
+      // from the user-supplied `headerClassName` string.
+      const className = (settings?.headerClassNames ?? []).join(' ');
+
+      layerHeaders.push({ label: settings?.label ?? '', colspan: visibleColspan, className });
+
+      return col + spanColspan;
+    }
+
+    // Continuation cell of a span that started at an earlier column.
+    // This can only occur when startCol falls inside a span — emit a
+    // single-column placeholder so the export column count stays correct.
+    layerHeaders.push({ label: '', colspan: 1, className: '' });
+
+    return col + 1;
   }
 
   /**

--- a/handsontable/src/plugins/filters/ui/_base.ts
+++ b/handsontable/src/plugins/filters/ui/_base.ts
@@ -165,7 +165,7 @@ export class BaseUI {
 
     // prevents "hot.unlisten()" call when clicked
     // (https://github.com/handsontable/handsontable/blob/master/handsontable/src/tableView.js#L317-L321)
-    rootElement.setAttribute('data-hot-input', 'true');
+    rootElement.dataset.hotInput = 'true';
 
     if (this.options.tabIndex !== undefined) {
       rootElement.setAttribute('tabindex', String(this.options.tabIndex));
@@ -193,7 +193,7 @@ export class BaseUI {
 
       // prevents "hot.unlisten()" call when clicked
       // (https://github.com/handsontable/handsontable/blob/master/handsontable/src/tableView.js#L317-L321)
-      element.setAttribute('data-hot-input', 'true');
+      element.dataset.hotInput = 'true';
 
       objectEach(this.options as Record<string, unknown>, (value: unknown, key: string) => {
         if (element[key] !== undefined && key !== 'className' && key !== 'tagName' && key !== 'children') {
@@ -214,7 +214,7 @@ export class BaseUI {
    * Update DOM structure.
    */
   update() {
-
+    // Intentionally empty
   }
 
   /**

--- a/handsontable/src/plugins/manualColumnMove/manualColumnMove.ts
+++ b/handsontable/src/plugins/manualColumnMove/manualColumnMove.ts
@@ -402,20 +402,10 @@ export class ManualColumnMove extends BasePlugin {
     const backlightElemMarginStart = this.#backlight.getOffset().start;
     const backlightElemWidth = this.#backlight.getSize().width;
     let rowHeaderWidth = 0;
-    let mouseOffsetStart = 0;
 
-    if (this.hot.isRtl()) {
-      const rootWindow = this.hot.rootWindow;
-      const containerWidth = outerWidth(this.hot.rootElement);
-      const gridMostRightPos = rootWindow.innerWidth - rootElementOffset - containerWidth;
-
-      mouseOffsetStart = rootWindow.innerWidth - this.#target.eventPageX - gridMostRightPos -
-        (!(scrollableElement instanceof Window) ? scrollStart : 0);
-
-    } else {
-      mouseOffsetStart = this.#target.eventPageX -
-        (rootElementOffset - (!(scrollableElement instanceof Window) ? scrollStart : 0));
-    }
+    const mouseOffsetStart = this.#calculateMouseOffsetStart(
+      scrollableElement, scrollStart, rootElementOffset
+    );
 
     if (this.#hasRowHeaders) {
       const inlineClone = this.hot.view._wt.wtOverlays.inlineStartOverlay.clone;
@@ -429,26 +419,9 @@ export class ManualColumnMove extends BasePlugin {
 
     tdOffsetStart += rowHeaderWidth;
 
-    if (hoveredColumn < 0) {
-      // if hover on rowHeader
-      if (fixedColumnsStart > 0) {
-        this.#target.col = 0;
-      } else {
-        this.#target.col = firstVisible > 0 ? firstVisible - 1 : firstVisible;
-      }
-
-    } else if (((this.#target.TD.offsetWidth / 2) + tdOffsetStart) <= mouseOffsetStart) {
-      const newCoordsCol = hoveredColumn >= this.#countCols ? this.#countCols - 1 : hoveredColumn;
-
-      // if hover on right part of TD
-      this.#target.col = newCoordsCol + 1;
-      // unfortunately first column is bigger than rest
-      tdOffsetStart += this.#target.TD.offsetWidth;
-
-    } else {
-      // elsewhere on table
-      this.#target.col = hoveredColumn;
-    }
+    tdOffsetStart = this.#calculateTargetCol(
+      hoveredColumn, tdOffsetStart, mouseOffsetStart, firstVisible, fixedColumnsStart
+    );
 
     let backlightStart = mouseOffsetStart;
     let guidelineStart = tdOffsetStart;
@@ -476,6 +449,76 @@ export class ManualColumnMove extends BasePlugin {
 
     this.#backlight.setPosition(undefined, backlightStart);
     this.#guideline.setPosition(undefined, guidelineStart);
+  }
+
+  /**
+   * Calculates the mouse offset from the start of the grid, accounting for RTL direction.
+   *
+   * @private
+   * @param {Window | HTMLElement} scrollableElement The scrollable container element.
+   * @param {number} scrollStart The current scroll position.
+   * @param {number} rootElementOffset The offset of the root element.
+   * @returns {number}
+   */
+  #calculateMouseOffsetStart(
+    scrollableElement: Window | Element,
+    scrollStart: number,
+    rootElementOffset: number
+  ): number {
+    if (this.hot.isRtl()) {
+      const rootWindow = this.hot.rootWindow;
+      const containerWidth = outerWidth(this.hot.rootElement);
+      const gridMostRightPos = rootWindow.innerWidth - rootElementOffset - containerWidth;
+
+      return rootWindow.innerWidth - this.#target.eventPageX - gridMostRightPos -
+        (!(scrollableElement instanceof Window) ? scrollStart : 0);
+    }
+
+    return this.#target.eventPageX -
+      (rootElementOffset - (!(scrollableElement instanceof Window) ? scrollStart : 0));
+  }
+
+  /**
+   * Calculates the target column based on hover position and updates `#target.col`.
+   * Returns the updated tdOffsetStart value.
+   *
+   * @private
+   * @param {number} hoveredColumn The currently hovered column index.
+   * @param {number} tdOffsetStart The current TD offset from the start.
+   * @param {number} mouseOffsetStart The current mouse offset from the start.
+   * @param {number} firstVisible The first fully visible column index.
+   * @param {number} fixedColumnsStart The number of fixed columns at the start.
+   * @returns {number}
+   */
+  #calculateTargetCol(
+    hoveredColumn: number,
+    tdOffsetStart: number,
+    mouseOffsetStart: number,
+    firstVisible: number,
+    fixedColumnsStart: number
+  ): number {
+    if (hoveredColumn < 0) {
+      // if hover on rowHeader
+      if (fixedColumnsStart > 0) {
+        this.#target.col = 0;
+      } else {
+        this.#target.col = firstVisible > 0 ? firstVisible - 1 : firstVisible;
+      }
+
+    } else if (((this.#target.TD.offsetWidth / 2) + tdOffsetStart) <= mouseOffsetStart) {
+      const newCoordsCol = hoveredColumn >= this.#countCols ? this.#countCols - 1 : hoveredColumn;
+
+      // if hover on right part of TD
+      this.#target.col = newCoordsCol + 1;
+      // unfortunately first column is bigger than rest
+      tdOffsetStart += this.#target.TD.offsetWidth;
+
+    } else {
+      // elsewhere on table
+      this.#target.col = hoveredColumn;
+    }
+
+    return tdOffsetStart;
   }
 
   /**

--- a/handsontable/src/plugins/manualColumnMove/manualColumnMove.ts
+++ b/handsontable/src/plugins/manualColumnMove/manualColumnMove.ts
@@ -454,7 +454,6 @@ export class ManualColumnMove extends BasePlugin {
   /**
    * Calculates the mouse offset from the start of the grid, accounting for RTL direction.
    *
-   * @private
    * @param {Window | HTMLElement} scrollableElement The scrollable container element.
    * @param {number} scrollStart The current scroll position.
    * @param {number} rootElementOffset The offset of the root element.
@@ -482,7 +481,6 @@ export class ManualColumnMove extends BasePlugin {
    * Calculates the target column based on hover position and updates `#target.col`.
    * Returns the updated tdOffsetStart value.
    *
-   * @private
    * @param {number} hoveredColumn The currently hovered column index.
    * @param {number} tdOffsetStart The current TD offset from the start.
    * @param {number} mouseOffsetStart The current mouse offset from the start.

--- a/handsontable/src/plugins/mergeCells/renderer.ts
+++ b/handsontable/src/plugins/mergeCells/renderer.ts
@@ -28,6 +28,41 @@ interface MergeCellsPluginInstance {
 }
 
 /**
+ * Clamps the not-hidden row and column indexes to the virtual viewport boundaries
+ * based on the active overlay, ensuring merged cells don't extend beyond the visible area.
+ *
+ * @private
+ * @param {HotInstance} hot The Handsontable instance.
+ * @param {number | null} notHiddenRow The nearest not-hidden row index.
+ * @param {number | null} notHiddenColumn The nearest not-hidden column index.
+ * @returns {[number | null, number | null]} The clamped row and column indexes.
+ */
+function clampToVirtualViewport(
+  hot: HotInstance,
+  notHiddenRow: number | null,
+  notHiddenColumn: number | null
+): [number | null, number | null] {
+  const overlayName = hot.view.getActiveOverlayName();
+
+  if (!['top', 'top_inline_start_corner'].includes(overlayName)) {
+    const firstRenderedVisibleRow = hot.getFirstRenderedVisibleRow();
+
+    if (notHiddenRow !== null && firstRenderedVisibleRow !== null) {
+      notHiddenRow = Math.max(notHiddenRow, firstRenderedVisibleRow);
+    }
+  }
+  if (!['inline_start', 'top_inline_start_corner', 'bottom_inline_start_corner'].includes(overlayName)) {
+    const firstRenderedVisibleColumn = hot.getFirstRenderedVisibleColumn();
+
+    if (notHiddenColumn !== null && firstRenderedVisibleColumn !== null) {
+      notHiddenColumn = Math.max(notHiddenColumn, firstRenderedVisibleColumn);
+    }
+  }
+
+  return [notHiddenRow, notHiddenColumn];
+}
+
+/**
  * Creates a renderer object for the `MergeCells` plugin.
  *
  * @private
@@ -116,22 +151,9 @@ export function createMergeCellRenderer(plugin: MergeCellsPluginInstance) {
     let notHiddenColumn = columnMapper.getNearestNotHiddenIndex(origColumn, 1);
 
     if (isVirtualRenderingEnabled) {
-      const overlayName = hot.view.getActiveOverlayName();
-
-      if (!['top', 'top_inline_start_corner'].includes(overlayName)) {
-        const firstRenderedVisibleRow = hot.getFirstRenderedVisibleRow();
-
-        if (notHiddenRow !== null && firstRenderedVisibleRow !== null) {
-          notHiddenRow = Math.max(notHiddenRow, firstRenderedVisibleRow);
-        }
-      }
-      if (!['inline_start', 'top_inline_start_corner', 'bottom_inline_start_corner'].includes(overlayName)) {
-        const firstRenderedVisibleColumn = hot.getFirstRenderedVisibleColumn();
-
-        if (notHiddenColumn !== null && firstRenderedVisibleColumn !== null) {
-          notHiddenColumn = Math.max(notHiddenColumn, firstRenderedVisibleColumn);
-        }
-      }
+      [notHiddenRow, notHiddenColumn] = clampToVirtualViewport(
+        hot, notHiddenRow, notHiddenColumn
+      );
     }
 
     const notHiddenRowspan = Math.min(origRowspan, maxRowSpan);

--- a/handsontable/src/plugins/mergeCells/renderer.ts
+++ b/handsontable/src/plugins/mergeCells/renderer.ts
@@ -31,7 +31,6 @@ interface MergeCellsPluginInstance {
  * Clamps the not-hidden row and column indexes to the virtual viewport boundaries
  * based on the active overlay, ensuring merged cells don't extend beyond the visible area.
  *
- * @private
  * @param {HotInstance} hot The Handsontable instance.
  * @param {number | null} notHiddenRow The nearest not-hidden row index.
  * @param {number | null} notHiddenColumn The nearest not-hidden column index.

--- a/handsontable/src/plugins/mergeCells/renderer.ts
+++ b/handsontable/src/plugins/mergeCells/renderer.ts
@@ -1,4 +1,3 @@
-import { isObject } from '../../helpers/object';
 import { isSafari } from '../../helpers/browser';
 import { sumCellsHeights } from './utils';
 import type { HotInstance } from '../../core/types';
@@ -30,11 +29,6 @@ interface MergeCellsPluginInstance {
 /**
  * Clamps the not-hidden row and column indexes to the virtual viewport boundaries
  * based on the active overlay, ensuring merged cells don't extend beyond the visible area.
- *
- * @param {HotInstance} hot The Handsontable instance.
- * @param {number | null} notHiddenRow The nearest not-hidden row index.
- * @param {number | null} notHiddenColumn The nearest not-hidden column index.
- * @returns {[number | null, number | null]} The clamped row and column indexes.
  */
 function clampToVirtualViewport(
   hot: HotInstance,
@@ -65,8 +59,6 @@ function clampToVirtualViewport(
  * Creates a renderer object for the `MergeCells` plugin.
  *
  * @private
- * @param {MergeCells} plugin The `MergeCells` plugin instance.
- * @returns {{before: Function, after: Function}}
  */
 export function createMergeCellRenderer(plugin: MergeCellsPluginInstance) {
   const hot = plugin.hot;

--- a/handsontable/src/plugins/multipleSelectionHandles/multipleSelectionHandles.ts
+++ b/handsontable/src/plugins/multipleSelectionHandles/multipleSelectionHandles.ts
@@ -67,7 +67,6 @@ export class MultipleSelectionHandles extends BasePlugin {
    * @private
    */
   registerListeners() {
-    const _this = this;
     const { rootElement } = this.hot;
 
     /**
@@ -75,40 +74,40 @@ export class MultipleSelectionHandles extends BasePlugin {
      * @param {string} query Query for the position.
      * @returns {boolean}
      */
-    function removeFromDragged(query: string) {
+    const removeFromDragged = (query: string) => {
 
-      if (_this.dragged.length === 1) {
+      if (this.dragged.length === 1) {
         // clear array
-        _this.dragged.splice(0, _this.dragged.length);
+        this.dragged.splice(0, this.dragged.length);
 
         return true;
       }
 
-      const entryPosition = _this.dragged.indexOf(query);
+      const entryPosition = this.dragged.indexOf(query);
 
       if (entryPosition === -1) {
         return false;
       } else if (entryPosition === 0) {
-        _this.dragged = _this.dragged.slice(0, 1);
+        this.dragged = this.dragged.slice(0, 1);
       } else if (entryPosition === 1) {
-        _this.dragged = _this.dragged.slice(-1);
+        this.dragged = this.dragged.slice(-1);
       }
-    }
+    };
 
     this.eventManager.addEventListener(rootElement, 'touchstart', (event) => {
       let selectedRange;
       const target = eventTargetEl(event)!;
 
       if (hasClass(target, 'topSelectionHandle-HitArea')) {
-        selectedRange = _this.hot.getSelectedRangeActive();
+        selectedRange = this.hot.getSelectedRangeActive();
 
         if (!selectedRange) {
           return false;
         }
 
-        _this.dragged.push('top');
+        this.dragged.push('top');
 
-        _this.touchStartRange = {
+        this.touchStartRange = {
           width: selectedRange.getWidth(),
           height: selectedRange.getHeight(),
           direction: selectedRange.getDirection()
@@ -119,15 +118,15 @@ export class MultipleSelectionHandles extends BasePlugin {
         return false;
 
       } else if (hasClass(target, 'bottomSelectionHandle-HitArea')) {
-        selectedRange = _this.hot.getSelectedRangeActive();
+        selectedRange = this.hot.getSelectedRangeActive();
 
         if (!selectedRange) {
           return false;
         }
 
-        _this.dragged.push('bottom');
+        this.dragged.push('bottom');
 
-        _this.touchStartRange = {
+        this.touchStartRange = {
           width: selectedRange.getWidth(),
           height: selectedRange.getHeight(),
           direction: selectedRange.getDirection()
@@ -143,18 +142,18 @@ export class MultipleSelectionHandles extends BasePlugin {
       const target = eventTargetEl(event)!;
 
       if (hasClass(target, 'topSelectionHandle-HitArea')) {
-        removeFromDragged.call(_this, 'top');
+        removeFromDragged('top');
 
-        _this.touchStartRange = undefined;
+        this.touchStartRange = undefined;
 
         event.preventDefault();
 
         return false;
 
       } else if (hasClass(target, 'bottomSelectionHandle-HitArea')) {
-        removeFromDragged.call(_this, 'bottom');
+        removeFromDragged('bottom');
 
-        _this.touchStartRange = undefined;
+        this.touchStartRange = undefined;
 
         event.preventDefault();
 
@@ -171,19 +170,19 @@ export class MultipleSelectionHandles extends BasePlugin {
       let rangeDirection;
       let newRangeCoords;
 
-      if (_this.dragged.length === 0) {
+      if (this.dragged.length === 0) {
         return;
       }
 
       const te = (event as TouchEvent).touches[0];
       const endTarget = rootDocument.elementFromPoint(te.clientX, te.clientY);
 
-      if (!endTarget || endTarget === _this.lastSetCell) {
+      if (!endTarget || endTarget === this.lastSetCell) {
         return;
       }
 
       if (endTarget.nodeName === 'TD' || endTarget.nodeName === 'TH') {
-        targetCoords = _this.hot.getCoords(endTarget as HTMLElement);
+        targetCoords = this.hot.getCoords(endTarget as HTMLElement);
 
         if (!targetCoords) {
           return;
@@ -193,7 +192,7 @@ export class MultipleSelectionHandles extends BasePlugin {
           targetCoords.col = 0;
         }
 
-        selectedRange = _this.hot.getSelectedRangeActive();
+        selectedRange = this.hot.getSelectedRangeActive();
 
         if (!selectedRange) {
           return;
@@ -204,24 +203,24 @@ export class MultipleSelectionHandles extends BasePlugin {
         rangeDirection = selectedRange.getDirection();
 
         if (rangeWidth === 1 && rangeHeight === 1) {
-          _this.hot.selection.setRangeEnd(targetCoords);
+          this.hot.selection.setRangeEnd(targetCoords);
         }
 
-        newRangeCoords = _this.getCurrentRangeCoords(
+        newRangeCoords = this.getCurrentRangeCoords(
           selectedRange,
           targetCoords,
-          _this.touchStartRange!.direction,
+          this.touchStartRange!.direction,
           rangeDirection,
-          _this.dragged[0]
+          this.dragged[0]
         );
 
         if (newRangeCoords.start !== null) {
-          _this.hot.selection.setRangeStart(newRangeCoords.start);
+          this.hot.selection.setRangeStart(newRangeCoords.start);
         }
 
-        _this.hot.selection.setRangeEnd(newRangeCoords.end!);
+        this.hot.selection.setRangeEnd(newRangeCoords.end!);
 
-        _this.lastSetCell = endTarget as HTMLElement;
+        this.lastSetCell = endTarget as HTMLElement;
 
       }
 

--- a/handsontable/src/plugins/nestedHeaders/nestedHeaders.ts
+++ b/handsontable/src/plugins/nestedHeaders/nestedHeaders.ts
@@ -393,7 +393,7 @@ export class NestedHeaders extends BasePlugin {
     const fixedColumnsStart = this.hot.view._wt.getSetting('fixedColumnsStart') as number;
 
     return (renderedColumnIndex: number, TH: HTMLTableCellElement) => {
-      const { columnIndexMapper, view } = this.hot;
+      const { columnIndexMapper } = this.hot;
 
       let visualColumnIndex = columnIndexMapper.getVisualFromRenderableIndex(renderedColumnIndex);
 
@@ -428,35 +428,8 @@ export class NestedHeaders extends BasePlugin {
         addClass(TH, 'hiddenHeader');
 
       } else {
-        if (colspan !== undefined && colspan > 1) {
-          const { wtOverlays } = view._wt;
-          const isTopInlineStartOverlay = wtOverlays.topInlineStartCornerOverlay?.clone?.wtTable.THEAD?.contains(TH);
-          const isInlineStartOverlay = wtOverlays.inlineStartOverlay?.clone?.wtTable.THEAD?.contains(TH);
-          const isTopOverlay = wtOverlays.topOverlay?.clone?.wtTable.THEAD?.contains(TH);
-
-          if (isTopOverlay && visualColumnIndex < fixedColumnsStart) {
-            addClass(TH, 'hiddenHeaderText');
-          }
-
-          const correctedColspan = isTopInlineStartOverlay || isInlineStartOverlay ?
-            Math.min(colspan, fixedColumnsStart - renderedColumnIndex) : colspan;
-
-          if (correctedColspan > 1) {
-            TH.setAttribute('colspan', String(correctedColspan));
-          }
-        }
-
-        if (rowspan !== undefined && rowspan > 1) {
-          const isBottomMostRowspanHeader = headerLevel + rowspan === this.getLayersCount();
-
-          addClass(TH, 'htRowspanHeader');
-
-          if (isBottomMostRowspanHeader) {
-            addClass(TH, 'htRowspanBottomLevel');
-          }
-
-          TH.setAttribute('rowspan', String(rowspan));
-        }
+        this.#applyColspan(TH, colspan, visualColumnIndex, renderedColumnIndex, fixedColumnsStart);
+        this.#applyRowspan(TH, rowspan, headerLevel);
       }
 
       this.hot.view.appendColHeader(
@@ -476,6 +449,56 @@ export class NestedHeaders extends BasePlugin {
         }
       }
     };
+  }
+
+  /**
+   * Applies colspan attribute and related CSS classes to a header cell.
+   */
+  #applyColspan(
+    TH: HTMLTableCellElement,
+    colspan: number | undefined,
+    visualColumnIndex: number,
+    renderedColumnIndex: number,
+    fixedColumnsStart: number,
+  ) {
+    if (colspan === undefined || colspan <= 1) {
+      return;
+    }
+
+    const { wtOverlays } = this.hot.view._wt;
+    const isTopInlineStartOverlay = wtOverlays.topInlineStartCornerOverlay?.clone?.wtTable.THEAD?.contains(TH);
+    const isInlineStartOverlay = wtOverlays.inlineStartOverlay?.clone?.wtTable.THEAD?.contains(TH);
+    const isTopOverlay = wtOverlays.topOverlay?.clone?.wtTable.THEAD?.contains(TH);
+
+    if (isTopOverlay && visualColumnIndex < fixedColumnsStart) {
+      addClass(TH, 'hiddenHeaderText');
+    }
+
+    const correctedColspan = isTopInlineStartOverlay || isInlineStartOverlay ?
+      Math.min(colspan, fixedColumnsStart - renderedColumnIndex) : colspan;
+
+    if (correctedColspan > 1) {
+      TH.setAttribute('colspan', String(correctedColspan));
+    }
+  }
+
+  /**
+   * Applies rowspan attribute and related CSS classes to a header cell.
+   */
+  #applyRowspan(TH: HTMLTableCellElement, rowspan: number | undefined, headerLevel: number) {
+    if (rowspan === undefined || rowspan <= 1) {
+      return;
+    }
+
+    const isBottomMostRowspanHeader = headerLevel + rowspan === this.getLayersCount();
+
+    addClass(TH, 'htRowspanHeader');
+
+    if (isBottomMostRowspanHeader) {
+      addClass(TH, 'htRowspanBottomLevel');
+    }
+
+    TH.setAttribute('rowspan', String(rowspan));
   }
 
   /**

--- a/handsontable/src/plugins/nestedHeaders/stateManager/index.ts
+++ b/handsontable/src/plugins/nestedHeaders/stateManager/index.ts
@@ -289,7 +289,7 @@ export default class StateManager {
 
       atLeastOneRootFound = true;
 
-      // eslint-disable-next-line
+      // eslint-disable-next-line no-loop-func
       rootNode.walkDown((node: TreeNode) => {
         const {
           columnIndex: nodeColumnIndex,

--- a/handsontable/src/plugins/nestedRows/nestedRows.ts
+++ b/handsontable/src/plugins/nestedRows/nestedRows.ts
@@ -201,7 +201,7 @@ export class NestedRows extends BasePlugin {
           const activeRange = this.hot.getSelectedRangeActive();
 
           if (!activeRange) {
-            return;
+            return false;
           }
 
           const { highlight } = activeRange;

--- a/handsontable/src/plugins/nestedRows/nestedRows.ts
+++ b/handsontable/src/plugins/nestedRows/nestedRows.ts
@@ -201,7 +201,7 @@ export class NestedRows extends BasePlugin {
           const activeRange = this.hot.getSelectedRangeActive();
 
           if (!activeRange) {
-            return false;
+            return;
           }
 
           const { highlight } = activeRange;

--- a/handsontable/src/plugins/pagination/pagination.ts
+++ b/handsontable/src/plugins/pagination/pagination.ts
@@ -459,12 +459,15 @@ export class Pagination extends BasePlugin {
       const countRows = this.hot.countRows();
       let visibleCount = 0;
 
-      for (let rowIndex = startIndex; visibleCount < pageSize; rowIndex++) {
+      let rowIndex = startIndex;
+
+      while (visibleCount < pageSize) {
         if (rowIndex >= countRows) {
           break;
         }
 
         if (this.hot.rowIndexMapper.isHidden(this.hot.toPhysicalRow(rowIndex))) {
+          rowIndex += 1;
           // eslint-disable-next-line no-continue
           continue;
         }
@@ -475,6 +478,7 @@ export class Pagination extends BasePlugin {
 
         lastVisibleRowIndex = rowIndex;
         visibleCount += 1;
+        rowIndex += 1;
       }
     }
 

--- a/handsontable/src/plugins/undoRedo/actions/removeColumn.ts
+++ b/handsontable/src/plugins/undoRedo/actions/removeColumn.ts
@@ -91,15 +91,18 @@ export class RemoveColumnAction extends BaseAction {
         const headers: unknown[] = [];
         const indexes: number[] = [];
 
-        rangeEach(originalData.length - 1, (i: number) => {
+        const collectColumnData = (origRow: unknown[], colFrom: number, colTo: number): number[] => {
           const column: number[] = [];
-          const origRow = originalData[i];
 
-          rangeEach(columnIndex, lastColumnIndex, (j) => {
+          rangeEach(colFrom, colTo, (j) => {
             column.push(origRow[hot.toPhysicalColumn(j)] as number);
           });
 
-          removedData.push(column);
+          return column;
+        };
+
+        rangeEach(originalData.length - 1, (i: number) => {
+          removedData.push(collectColumnData(originalData[i], columnIndex, lastColumnIndex));
         });
 
         rangeEach(amount - 1, (i: number) => {

--- a/handsontable/src/renderers/checkboxRenderer/checkboxRenderer.ts
+++ b/handsontable/src/renderers/checkboxRenderer/checkboxRenderer.ts
@@ -78,75 +78,92 @@ export function checkboxRenderer(
 
   const locale = cellProperties.locale as string | undefined;
 
-  if (value === cellProperties.checkedTemplate ||
-    stringify(value).toLocaleLowerCase(locale) ===
-    stringify(cellProperties.checkedTemplate).toLocaleLowerCase(locale)) {
-    input.checked = true;
+  applyCheckedState();
+  applyLabelOptions();
 
-  } else if (value === cellProperties.uncheckedTemplate ||
-    stringify(value).toLocaleLowerCase(locale) ===
-    stringify(cellProperties.uncheckedTemplate).toLocaleLowerCase(locale)) {
-    input.checked = false;
+  /**
+   * Determine and apply the checked state of the input element based on the cell value.
+   *
+   * @private
+   */
+  function applyCheckedState() {
+    if (value === cellProperties.checkedTemplate ||
+      stringify(value).toLocaleLowerCase(locale) ===
+      stringify(cellProperties.checkedTemplate).toLocaleLowerCase(locale)) {
+      input.checked = true;
 
-  } else if (isEmpty(value)) { // default value
-    addClass(input, 'noValue');
+    } else if (value === cellProperties.uncheckedTemplate ||
+      stringify(value).toLocaleLowerCase(locale) ===
+      stringify(cellProperties.uncheckedTemplate).toLocaleLowerCase(locale)) {
+      input.checked = false;
 
-  } else {
-    input.style.display = 'none';
-    addClass(input, BAD_VALUE_CLASS);
-    badValue = true;
-  }
+    } else if (isEmpty(value)) { // default value
+      addClass(input, 'noValue');
 
-  setAttribute(input, [
-    [ATTR_ROW, row],
-    [ATTR_COLUMN, col],
-  ]);
-
-  if (ariaEnabled) {
-    setAttribute(input, [
-      A11Y_LABEL(input.checked ?
-        hotInstance.getTranslatedPhrase(CHECKBOX_CHECKED) :
-        hotInstance.getTranslatedPhrase(CHECKBOX_UNCHECKED)
-      ),
-      A11Y_CHECKED(input.checked),
-      A11Y_CHECKBOX(),
-    ]);
-  }
-
-  if (!badValue && labelOptions) {
-    let labelText = '';
-
-    if (labelOptions.value) {
-      const labelFn = labelOptions.value as (...args: unknown[]) => unknown;
-
-      labelText = typeof labelOptions.value === 'function' ?
-        String(labelFn(row, col, prop, value)) : String(labelOptions.value);
-
-    } else if (labelOptions.property) {
-      const labelValue = hotInstance.getDataAtRowProp(row, String(labelOptions.property));
-
-      labelText = labelValue !== null ? String(labelValue) : '';
+    } else {
+      input.style.display = 'none';
+      addClass(input, BAD_VALUE_CLASS);
+      badValue = true;
     }
 
-    const label = createLabel(rootDocument, labelText, labelOptions.separated !== true);
+    setAttribute(input, [
+      [ATTR_ROW, row],
+      [ATTR_COLUMN, col],
+    ]);
 
-    if (labelOptions.position === 'before') {
-      if (labelOptions.separated) {
-        TD.appendChild(label);
-        TD.appendChild(input);
+    if (ariaEnabled) {
+      setAttribute(input, [
+        A11Y_LABEL(input.checked ?
+          hotInstance.getTranslatedPhrase(CHECKBOX_CHECKED) :
+          hotInstance.getTranslatedPhrase(CHECKBOX_UNCHECKED)
+        ),
+        A11Y_CHECKED(input.checked),
+        A11Y_CHECKBOX(),
+      ]);
+    }
+  }
 
-      } else {
-        label.appendChild(input);
-        inputOrWrapper = label;
+  /**
+   * Apply label options to the cell, creating and positioning the label element.
+   *
+   * @private
+   */
+  function applyLabelOptions() {
+    if (!badValue && labelOptions) {
+      let labelText = '';
+
+      if (labelOptions.value) {
+        const labelFn = labelOptions.value as (...args: unknown[]) => unknown;
+
+        labelText = typeof labelOptions.value === 'function' ?
+          String(labelFn(row, col, prop, value)) : String(labelOptions.value);
+
+      } else if (labelOptions.property) {
+        const labelValue = hotInstance.getDataAtRowProp(row, String(labelOptions.property));
+
+        labelText = labelValue !== null ? String(labelValue) : '';
       }
-    } else if (!labelOptions.position || labelOptions.position === 'after') {
-      if (labelOptions.separated) {
-        TD.appendChild(input);
-        TD.appendChild(label);
 
-      } else {
-        label.insertBefore(input, label.firstChild);
-        inputOrWrapper = label;
+      const label = createLabel(rootDocument, labelText, labelOptions.separated !== true);
+
+      if (labelOptions.position === 'before') {
+        if (labelOptions.separated) {
+          TD.appendChild(label);
+          TD.appendChild(input);
+
+        } else {
+          label.appendChild(input);
+          inputOrWrapper = label;
+        }
+      } else if (!labelOptions.position || labelOptions.position === 'after') {
+        if (labelOptions.separated) {
+          TD.appendChild(input);
+          TD.appendChild(label);
+
+        } else {
+          label.insertBefore(input, label.firstChild);
+          inputOrWrapper = label;
+        }
       }
     }
   }

--- a/handsontable/src/renderers/checkboxRenderer/checkboxRenderer.ts
+++ b/handsontable/src/renderers/checkboxRenderer/checkboxRenderer.ts
@@ -83,8 +83,6 @@ export function checkboxRenderer(
 
   /**
    * Determine and apply the checked state of the input element based on the cell value.
-   *
-   * @private
    */
   function applyCheckedState() {
     if (value === cellProperties.checkedTemplate ||
@@ -125,8 +123,6 @@ export function checkboxRenderer(
 
   /**
    * Apply label options to the cell, creating and positioning the label element.
-   *
-   * @private
    */
   function applyLabelOptions() {
     if (!badValue && labelOptions) {

--- a/handsontable/src/selection/highlight/highlight.ts
+++ b/handsontable/src/selection/highlight/highlight.ts
@@ -474,15 +474,15 @@ class Highlight {
     this.focus.clear();
     this.fill.clear();
 
-    this.areas.forEach(highlight => void highlight.clear());
-    this.layeredAreas.forEach(highlight => void highlight.clear());
-    this.rowHeaders.forEach(highlight => void highlight.clear());
-    this.columnHeaders.forEach(highlight => void highlight.clear());
-    this.activeRowHeaders.forEach(highlight => void highlight.clear());
-    this.activeColumnHeaders.forEach(highlight => void highlight.clear());
-    this.activeCornerHeaders.forEach(highlight => void highlight.clear());
-    this.rowHighlights.forEach(highlight => void highlight.clear());
-    this.columnHighlights.forEach(highlight => void highlight.clear());
+    this.areas.forEach(highlight => highlight.clear());
+    this.layeredAreas.forEach(highlight => highlight.clear());
+    this.rowHeaders.forEach(highlight => highlight.clear());
+    this.columnHeaders.forEach(highlight => highlight.clear());
+    this.activeRowHeaders.forEach(highlight => highlight.clear());
+    this.activeColumnHeaders.forEach(highlight => highlight.clear());
+    this.activeCornerHeaders.forEach(highlight => highlight.clear());
+    this.rowHighlights.forEach(highlight => highlight.clear());
+    this.columnHighlights.forEach(highlight => highlight.clear());
   }
 
   /**

--- a/handsontable/src/selection/selection.ts
+++ b/handsontable/src/selection/selection.ts
@@ -351,15 +351,15 @@ class Selection {
     if (!isMultipleMode || (isMultipleMode && !isMultipleSelection && isUndefined(multipleSelection))) {
       this.selectedRange.clear();
 
-      this.highlight.getAreas().forEach(highlight => void highlight.clear());
-      this.highlight.getLayeredAreas().forEach(highlight => void highlight.clear());
-      this.highlight.getRowHeaders().forEach(highlight => void highlight.clear());
-      this.highlight.getColumnHeaders().forEach(highlight => void highlight.clear());
-      this.highlight.getActiveRowHeaders().forEach(highlight => void highlight.clear());
-      this.highlight.getActiveColumnHeaders().forEach(highlight => void highlight.clear());
-      this.highlight.getActiveCornerHeaders().forEach(highlight => void highlight.clear());
-      this.highlight.getRowHighlights().forEach(highlight => void highlight.clear());
-      this.highlight.getColumnHighlights().forEach(highlight => void highlight.clear());
+      this.highlight.getAreas().forEach(highlight => highlight.clear());
+      this.highlight.getLayeredAreas().forEach(highlight => highlight.clear());
+      this.highlight.getRowHeaders().forEach(highlight => highlight.clear());
+      this.highlight.getColumnHeaders().forEach(highlight => highlight.clear());
+      this.highlight.getActiveRowHeaders().forEach(highlight => highlight.clear());
+      this.highlight.getActiveColumnHeaders().forEach(highlight => highlight.clear());
+      this.highlight.getActiveCornerHeaders().forEach(highlight => highlight.clear());
+      this.highlight.getRowHighlights().forEach(highlight => highlight.clear());
+      this.highlight.getColumnHighlights().forEach(highlight => highlight.clear());
     }
 
     this.selectedRange
@@ -549,71 +549,111 @@ class Selection {
     }
 
     if (this.highlight.isEnabledFor(HEADER_TYPE, cellRange.highlight)) {
-      if (!cellRange.isSingleHeader()) {
-        const rowCoordsFrom = this.tableProps.createCellCoords(Math.max(cellRange.from.row ?? 0, 0), -1);
-        const rowCoordsTo = this.tableProps.createCellCoords(cellRange.to.row ?? 0, -1);
-        const columnCoordsFrom = this.tableProps.createCellCoords(-1, Math.max(cellRange.from.col ?? 0, 0));
-        const columnCoordsTo = this.tableProps.createCellCoords(-1, cellRange.to.col ?? 0);
+      this.#applyHeaderHighlights(
+        cellRange,
+        countRows,
+        countCols,
+        rowHeaderHighlight,
+        columnHeaderHighlight,
+        activeRowHeaderHighlight,
+        activeColumnHeaderHighlight,
+        activeCornerHeaderHighlight,
+        rowHighlight,
+        columnHighlight,
+      );
+    }
+  }
 
-        if (this.settings.selectionMode === 'single') {
-          rowHeaderHighlight?.add(rowCoordsFrom).commit();
-          columnHeaderHighlight?.add(columnCoordsFrom).commit();
-          rowHighlight?.add(rowCoordsFrom).commit();
-          columnHighlight?.add(columnCoordsFrom).commit();
+  /**
+   * Applies header-type highlights for the given cell range.
+   *
+   * @param {CellRange} cellRange The cell range to highlight.
+   * @param {number} countRows The total number of rows.
+   * @param {number} countCols The total number of columns.
+   * @param {object | null | undefined} rowHeaderHighlight The row header highlight instance.
+   * @param {object | null | undefined} columnHeaderHighlight The column header highlight instance.
+   * @param {object | null | undefined} activeRowHeaderHighlight The active row header highlight instance.
+   * @param {object | null | undefined} activeColumnHeaderHighlight The active column header highlight instance.
+   * @param {object | null | undefined} activeCornerHeaderHighlight The active corner header highlight instance.
+   * @param {object | null | undefined} rowHighlight The row highlight instance.
+   * @param {object | null | undefined} columnHighlight The column highlight instance.
+   */
+  #applyHeaderHighlights(
+    cellRange: CellRange,
+    countRows: number,
+    countCols: number,
+    rowHeaderHighlight: ReturnType<Highlight['createRowHeader']>,
+    columnHeaderHighlight: ReturnType<Highlight['createColumnHeader']>,
+    activeRowHeaderHighlight: ReturnType<Highlight['createActiveRowHeader']>,
+    activeColumnHeaderHighlight: ReturnType<Highlight['createActiveColumnHeader']>,
+    activeCornerHeaderHighlight: ReturnType<Highlight['createActiveCornerHeader']>,
+    rowHighlight: ReturnType<Highlight['createRowHighlight']>,
+    columnHighlight: ReturnType<Highlight['createColumnHighlight']>,
+  ) {
+    if (!cellRange.isSingleHeader()) {
+      const rowCoordsFrom = this.tableProps.createCellCoords(Math.max(cellRange.from.row ?? 0, 0), -1);
+      const rowCoordsTo = this.tableProps.createCellCoords(cellRange.to.row ?? 0, -1);
+      const columnCoordsFrom = this.tableProps.createCellCoords(-1, Math.max(cellRange.from.col ?? 0, 0));
+      const columnCoordsTo = this.tableProps.createCellCoords(-1, cellRange.to.col ?? 0);
 
-        } else {
-          rowHeaderHighlight
-            ?.add(rowCoordsFrom)
-            .add(rowCoordsTo)
-            .commit();
-          columnHeaderHighlight
-            ?.add(columnCoordsFrom)
-            .add(columnCoordsTo)
-            .commit();
-          rowHighlight
-            ?.add(rowCoordsFrom)
-            .add(rowCoordsTo)
-            .commit();
-          columnHighlight
-            ?.add(columnCoordsFrom)
-            .add(columnCoordsTo)
-            .commit();
-        }
-      }
+      if (this.settings.selectionMode === 'single') {
+        rowHeaderHighlight?.add(rowCoordsFrom).commit();
+        columnHeaderHighlight?.add(columnCoordsFrom).commit();
+        rowHighlight?.add(rowCoordsFrom).commit();
+        columnHighlight?.add(columnCoordsFrom).commit();
 
-      const highlightRowHeaders = !this.#disableHeadersHighlight && (this.isEntireRowSelected() &&
-        (countCols > 0 && countCols === cellRange.getWidth() ||
-        countCols === 0 && this.isSelectedByRowHeader()));
-      const highlightColumnHeaders = !this.#disableHeadersHighlight && (this.isEntireColumnSelected() &&
-        (countRows > 0 && countRows === cellRange.getHeight() ||
-        countRows === 0 && this.isSelectedByColumnHeader()));
-
-      if (highlightRowHeaders) {
-        activeRowHeaderHighlight
-          ?.add(this.tableProps
-            .createCellCoords(Math.max(cellRange.from.row ?? 0, 0), Math.min(-this.tableProps.countRowHeaders(), -1)))
-          .add(this.tableProps
-            .createCellCoords(Math.max(cellRange.to.row ?? 0, 0), -1))
+      } else {
+        rowHeaderHighlight
+          ?.add(rowCoordsFrom)
+          .add(rowCoordsTo)
+          .commit();
+        columnHeaderHighlight
+          ?.add(columnCoordsFrom)
+          .add(columnCoordsTo)
+          .commit();
+        rowHighlight
+          ?.add(rowCoordsFrom)
+          .add(rowCoordsTo)
+          .commit();
+        columnHighlight
+          ?.add(columnCoordsFrom)
+          .add(columnCoordsTo)
           .commit();
       }
+    }
 
-      if (highlightColumnHeaders) {
-        activeColumnHeaderHighlight
-          ?.add(this.tableProps
-            .createCellCoords(Math.min(-this.tableProps.countColHeaders(), -1), Math.max(cellRange.from.col ?? 0, 0)))
-          .add(this.tableProps
-            .createCellCoords(-1, Math.max(cellRange.to.col ?? 0, 0)))
-          .commit();
-      }
+    const highlightRowHeaders = !this.#disableHeadersHighlight && (this.isEntireRowSelected() &&
+      (countCols > 0 && countCols === cellRange.getWidth() ||
+      countCols === 0 && this.isSelectedByRowHeader()));
+    const highlightColumnHeaders = !this.#disableHeadersHighlight && (this.isEntireColumnSelected() &&
+      (countRows > 0 && countRows === cellRange.getHeight() ||
+      countRows === 0 && this.isSelectedByColumnHeader()));
 
-      if (highlightRowHeaders && highlightColumnHeaders) {
-        activeCornerHeaderHighlight
-          ?.add(this.tableProps
-            .createCellCoords(-this.tableProps.countColHeaders(), -this.tableProps.countRowHeaders()))
-          .add(this.tableProps
-            .createCellCoords(-1, -1))
-          .commit();
-      }
+    if (highlightRowHeaders) {
+      activeRowHeaderHighlight
+        ?.add(this.tableProps
+          .createCellCoords(Math.max(cellRange.from.row ?? 0, 0), Math.min(-this.tableProps.countRowHeaders(), -1)))
+        .add(this.tableProps
+          .createCellCoords(Math.max(cellRange.to.row ?? 0, 0), -1))
+        .commit();
+    }
+
+    if (highlightColumnHeaders) {
+      activeColumnHeaderHighlight
+        ?.add(this.tableProps
+          .createCellCoords(Math.min(-this.tableProps.countColHeaders(), -1), Math.max(cellRange.from.col ?? 0, 0)))
+        .add(this.tableProps
+          .createCellCoords(-1, Math.max(cellRange.to.col ?? 0, 0)))
+        .commit();
+    }
+
+    if (highlightRowHeaders && highlightColumnHeaders) {
+      activeCornerHeaderHighlight
+        ?.add(this.tableProps
+          .createCellCoords(-this.tableProps.countColHeaders(), -this.tableProps.countRowHeaders()))
+        .add(this.tableProps
+          .createCellCoords(-1, -1))
+        .commit();
     }
   }
 

--- a/handsontable/src/tableView.ts
+++ b/handsontable/src/tableView.ts
@@ -288,7 +288,7 @@ class TableView {
     const originalStyle = rootElement.getAttribute('style');
 
     if (originalStyle) {
-      rootElement.setAttribute('data-originalstyle', originalStyle); // needed to retrieve original style in jsFiddle link generator in HT examples. may be removed in future versions
+      rootElement.dataset.originalstyle = originalStyle; // needed to retrieve original style in jsFiddle link generator in HT examples. may be removed in future versions
     }
 
     addClass(rootElement, 'handsontable');

--- a/handsontable/src/themes/types.ts
+++ b/handsontable/src/themes/types.ts
@@ -241,7 +241,6 @@ export type TokenKey =
   | 'iconButtonBorderColor'
   | 'iconButtonBackgroundColor'
   | 'iconButtonIconColor'
-  | 'iconButtonHitAreaSize'
   | 'iconButtonHoverBorderColor'
   | 'iconButtonHoverBackgroundColor'
   | 'iconButtonHoverIconColor'

--- a/handsontable/src/utils/autoResize.ts
+++ b/handsontable/src/utils/autoResize.ts
@@ -128,56 +128,61 @@ export function createInputElementResizer(ownerDocument: Document, initialOption
   }
 
   /**
+   * Resolves a dimension value from a config entry.
+   *
+   * @param {unknown} configValue The config value to resolve.
+   * @param {number} inheritValue The value to use when config is 'inherit'.
+   * @returns {number | undefined} The resolved value, or undefined if not applicable.
+   */
+  function resolveDimensionValue(configValue: unknown, inheritValue: number): number | undefined {
+    if (configValue === 'inherit') {
+      return inheritValue;
+    }
+
+    const parsed = Number.parseInt(String(configValue), 10);
+
+    if (!isNaN(parsed)) {
+      return parsed;
+    }
+
+    return undefined;
+  }
+
+  /**
    * Extends the default configuration.
    *
    * @param {InputElementResizerConfig} config The configuration to extend the defaults with.
    */
   function extendDefaults(config: Record<string, unknown>) {
     if (config && config.minHeight) {
-      if (config.minHeight === 'inherit') {
-        defaults.minHeight = observedElement.clientHeight;
-      } else {
-        const minHeight = Number.parseInt(String(config.minHeight), 10);
+      const value = resolveDimensionValue(config.minHeight, observedElement.clientHeight);
 
-        if (!isNaN(minHeight)) {
-          defaults.minHeight = minHeight;
-        }
+      if (value !== undefined) {
+        defaults.minHeight = value;
       }
     }
 
     if (config && config.maxHeight) {
-      if (config.maxHeight === 'inherit') {
-        defaults.maxHeight = observedElement.clientHeight;
-      } else {
-        const maxHeight = Number.parseInt(String(config.maxHeight), 10);
+      const value = resolveDimensionValue(config.maxHeight, observedElement.clientHeight);
 
-        if (!isNaN(maxHeight)) {
-          defaults.maxHeight = maxHeight;
-        }
+      if (value !== undefined) {
+        defaults.maxHeight = value;
       }
     }
 
     if (config && config.minWidth) {
-      if (config.minWidth === 'inherit') {
-        defaults.minWidth = observedElement.clientWidth;
-      } else {
-        const minWidth = Number.parseInt(String(config.minWidth), 10);
+      const value = resolveDimensionValue(config.minWidth, observedElement.clientWidth);
 
-        if (!isNaN(minWidth)) {
-          defaults.minWidth = minWidth;
-        }
+      if (value !== undefined) {
+        defaults.minWidth = value;
       }
     }
 
     if (config && config.maxWidth) {
-      if (config.maxWidth === 'inherit') {
-        defaults.maxWidth = observedElement.clientWidth;
-      } else {
-        const maxWidth = Number.parseInt(String(config.maxWidth), 10);
+      const value = resolveDimensionValue(config.maxWidth, observedElement.clientWidth);
 
-        if (!isNaN(maxWidth)) {
-          defaults.maxWidth = maxWidth;
-        }
+      if (value !== undefined) {
+        defaults.maxWidth = value;
       }
     }
 

--- a/handsontable/src/utils/dataStructures/tree.ts
+++ b/handsontable/src/utils/dataStructures/tree.ts
@@ -209,9 +209,8 @@ export default class TreeNode {
    * @param {Function} callback The callback function which will be called for each node.
    */
   walkUp(callback: (this: TreeNode, node: TreeNode) => boolean | void) {
-    const context = this;
     const process = (node: TreeNode) => {
-      const continueTraverse = callback.call(context, node) as boolean | void;
+      const continueTraverse = callback.call(this, node) as boolean | void;
 
       if (continueTraverse !== false && node.parent !== null) {
         process(node.parent);


### PR DESCRIPTION
### Context

The PR fixes SonarCloud BLOCKER and HIGH severity issues on the `develop` branch reported by the `handsontable_handsontable` project. All 2 BLOCKER and 196 HIGH issues introduced since the last clean period are addressed.

Rules fixed:
- **S3516** – Methods always returning the same value (`columnSorting`, `nestedRows`)
- **S3735** – `void` operator misuse — 30+ bare `void` expressions removed across `core`, `selection`, `highlight`
- **S7761** – `getAttribute`/`setAttribute` replaced with `dataset` API (`core`, `copyPaste`)
- **S7740** – `this`-alias removed, replaced with arrow functions (`nestedHeaders`, `stateManager`)
- **S2004** – Deeply nested functions extracted into helpers (`core`, `object`, `dataProvider`)
- **S7768** – `insertBefore`/`replaceChild` replaced with `.before()`/`.replaceWith()` (`walkontable`)
- **S1186** – Intentionally empty methods documented (`base`, `table`)
- **S7724** – `eslint-disable` comments made rule-specific (`mixed`, `jquery`)
- **S1994** – `for`/`in` loop with unrelated increment fixed (`dataMap`)
- **S7767** – Bitwise `>> 0` replaced with `Math.trunc` (`autoColumnSize`, `autoRowSize`)
- **S7746** – Unnecessary `Promise.resolve` wrappers removed (`dataProvider`)
- **S4621** – Duplicate type union members removed (`themes/types`)
- **S3776** – Cognitive complexity reduced by extracting private helper methods (55 files, complexity ≤ 35 only)

### How has this been tested?

- `npm run eslint --prefix handsontable` — passes with 0 errors
- `npm run test:types --prefix handsontable` — passes with 0 errors
- `npm run test:e2e --prefix handsontable --testPathPattern=autoColumnSize` — 60 specs, 0 failures

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1864

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1864

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core hooks, alter/scroll/copy-paste, and dataMap paths across many files; changes are refactors but regressions would affect grid behavior if any extraction missed edge cases.
> 
> **Overview**
> Addresses **SonarCloud BLOCKER/HIGH** findings with refactors across Handsontable and Walkontable, plus a public changelog entry for the fix.
> 
> Most changes are **structural** (same behavior, cleaner code): duplicated hook loops consolidated into `#runHandlers` in `core/hooks`, `normalizeIndexesGroup` and `resolveRenderableScrollTarget` lifted out of `core`, and similar extractions in `dataMap`, autofill, copy/paste, nested headers, collapsible columns, base editor positioning, and sort/compare helpers. **`void` on hook forwarding and highlight clears** is removed; **`this` aliases** become arrow functions or bound methods.
> 
> **DOM/API cleanups** include `dataset` for `data-hot-input` / style persistence (with `isOutsideInput` still treating missing `hotInput` as outside), **`insertBefore`/`replaceChild` → `.before()`/`.replaceWith()`**, and documented empty `destroy`/`update` stubs. **`syncLimit` parsing** uses `Math.trunc`/`Number.isFinite` instead of bitwise coercion; pagination’s visible-row loop no longer uses `for` with an unrelated increment.
> 
> **Risk surface** is wide (core, hooks, selection, clipboard, row/column alter) but the intent is parity with pre-refactor logic, not new features.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f47a1d1ed7fa3685660bd29cda84d41602700cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->