### PR TITLE
DEV-1863: Add cached locale-aware localeLowerCase helper (closes #3428)

### DIFF
--- a/.changelogs/12762.json
+++ b/.changelogs/12762.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Improved the performance of locale-aware text comparisons (search, filtering, sorting, autocomplete, and checkbox rendering) on large datasets.",
+  "type": "fixed",
+  "issueOrPR": 12762,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.claude/skills/handsontable-dev/SKILL.md
+++ b/.claude/skills/handsontable-dev/SKILL.md
@@ -355,3 +355,4 @@ The CI `verify-emitted-types` job reports the exact leaked identifier with `TS23
 - [ ] JSDoc on every class, method, function declaration, and class field (multiline format; `{Type}` in every `@param`/`@returns`, in sync with the TS signature; no `@private` on `#` fields)
 - [ ] No breaking change introduced (or the breaking change is explicitly called out)
 - [ ] Changelog entry added (`bin/changelog entry`)
+- **Locale-aware lowercasing:** use `localeLowerCase(value, locale)` from `helpers/string`, never native `toLocaleLowerCase(locale)` (ICU-slow, throws on bad tags). Enforced by `no-restricted-syntax`.

--- a/.claude/skills/i18n-translations/SKILL.md
+++ b/.claude/skills/i18n-translations/SKILL.md
@@ -59,3 +59,7 @@ The editor system handles IME composition events (`compositionstart`, `compositi
 | `src/i18n/constants.ts` | All language constant definitions |
 | `src/i18n/languages/` | Per-locale dictionary files (20+ locales) |
 | `src/i18n/languages/index.ts` | Barrel export for language modules |
+
+## Locale-aware string casing
+
+For case-insensitive comparison or lowercasing of cell data, use `localeLowerCase(value, locale)` from `src/helpers/string.ts` — never `String.prototype.toLocaleLowerCase` directly. The helper is locale-correct (Turkish/Azeri/Lithuanian keep their special casing) but takes the fast `toLowerCase()` path for all other locales, and it never throws on an invalid `locale` tag. This rule is enforced by ESLint (`no-restricted-syntax`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,6 +185,7 @@ Follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format. Changel
 
 ## Monorepo gotchas
 
+- Direct `toLocaleLowerCase`/`toLocaleUpperCase` calls are forbidden in core source — use `localeLowerCase()` from `handsontable/src/helpers/string.ts`. Enforced by `no-restricted-syntax` in `handsontable/.eslintrc.js`.
 - The core build outputs ES/CJS modules to `handsontable/tmp/` for wrappers, UMD/minified bundles to `handsontable/dist/`, and CSS to `handsontable/styles/`. Wrapper packages reference the `tmp/` build via workspace linking.
 - Two Handsontable builds exist: `handsontable.js` (base, external deps) and `handsontable.full.js` (includes HyperFormula). When testing build-time behavior, ensure both variants work.
 - The Angular wrapper tests use `NODE_OPTIONS=--openssl-legacy-provider`; this is wired into the `test` script.

--- a/handsontable/.ai/CONVENTIONS.md
+++ b/handsontable/.ai/CONVENTIONS.md
@@ -287,6 +287,16 @@ Use `?.` only when a value is genuinely optional by design. Do not use as a blan
 - Use `requestAnimationFrame` for batching scroll events
 - Target 60fps with 100k+ row datasets
 
+### Locale-aware lowercasing (dogfooding rule)
+
+**Never call `String.prototype.toLocaleLowerCase` or `toLocaleUpperCase` directly.** Always use `localeLowerCase(value, locale)` from `src/helpers/string.ts`.
+
+Passing an explicit locale argument to the native method forces V8's ICU path and is ~45× slower than `toLowerCase()`, even though the result is byte-identical for every locale except Turkish, Azeri, and Lithuanian (the only locales that tailor lowercasing — on the dotted/dotless-I family). The helper probes each locale once (cached) and takes the fast path otherwise. It also never throws on an invalid or empty locale tag.
+
+The only sanctioned direct calls are inside `localeLowerCase` itself, marked with `// eslint-disable-next-line no-restricted-syntax`. The `no-restricted-syntax` ESLint rule enforces this everywhere else (test files excepted).
+
+**Cache safety:** the helper caches only the immutable locale → "does it tailor?" classification, keyed by the locale string. Call sites read the locale live, so changing a cell's or column's `locale` after `updateSettings` just passes a different string — there is no stale cached locale or cached lowercased value. Do not add per-instance locale caches or memoize lowercased values.
+
 ## CSS Conventions
 
 - CSS and JavaScript are strictly separated -- never mix CSS into JavaScript files

--- a/handsontable/.eslintrc.js
+++ b/handsontable/.eslintrc.js
@@ -24,6 +24,10 @@ module.exports = {
       'ForInStatement',
       'LabeledStatement',
       'WithStatement',
+      {
+        selector: "CallExpression[callee.property.name='toLocaleLowerCase'], CallExpression[callee.property.name='toLocaleUpperCase']",
+        message: 'Do not call String.prototype.toLocaleLowerCase/toLocaleUpperCase directly. Use localeLowerCase() from helpers/string — it avoids the slow Intl path for non-tailoring locales and is locale-correct. See handsontable/.ai/CONVENTIONS.md.',
+      },
     ],
     'handsontable/restricted-module-imports': [
       'error',

--- a/handsontable/AGENTS.md
+++ b/handsontable/AGENTS.md
@@ -17,6 +17,7 @@ This is the core data grid package. **TypeScript** - source files in `src/` are 
 - DRY: reuse existing helpers and mixins; if code repeats, extract a generic helper rather than duplicating
 - Method ordering: public methods first, then private listeners
 - In text and comments, always write `Handsontable`, never `HOT` (a `hot` variable holding an instance is fine)
+- Never call `String.prototype.toLocaleLowerCase`/`toLocaleUpperCase` directly — use `localeLowerCase()` from `helpers/string` (faster, locale-correct, crash-safe). Enforced by `no-restricted-syntax`. See `.ai/CONVENTIONS.md`.
 
 ## Plugin Lifecycle
 
@@ -68,6 +69,7 @@ Gotcha: Filters `conditionCollection` uses physical indexes, `getDataAtCol()` us
 - **Two builds to test**: `handsontable.js` (base, no HyperFormula) and `handsontable.full.js` (includes HyperFormula). Test both when changing build-time behavior.
 - **Validator corrections via `setDataAtCell`**: If a validator calls `setDataAtCell` to write a corrected value (e.g. `correctFormat`), the source string **must end with `'Validator'`** (e.g. `'myCustomValidator'`). Without this suffix, the correction is silently overwritten when the same batch contains columns with async validators (async autocomplete `source`). See `src/core.ts` `validateChanges()` and the `handsontable-validator-dev` skill.
 - **Newer-than-TS-5.1 lib types in emitted `.d.ts`**: Published types must be consumable by TS 5.1 (Angular 16's max). If your code causes `tsc` to emit `ArrayIterator`, `WeakKey`, `IteratorObject`, or similar lib types added after TS 5.1, the `verify-emitted-types` CI job will fail. Two ways to fix: add an explicit annotation at the source (`IterableIterator<T>`, `WeakMap<object, any>`), or extend `scripts/downlevel-dts.mjs` with a new replacement row. The source file is still compiled by the modern dev TS — only the published `.d.ts` is downleveled.
+- **`toLocaleLowerCase(locale)` is a performance trap**: an explicit locale arg forces the ICU path (~45× slower) and throws on invalid tags. Use `localeLowerCase(value, locale)` from `helpers/string`. Only Turkish/Azeri/Lithuanian actually tailor lowercasing; the helper detects that and otherwise uses the fast `toLowerCase()`.
 
 ## Key File Locations
 

--- a/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
+++ b/handsontable/src/editors/autocompleteEditor/__tests__/autocompleteEditor.spec.js
@@ -4157,4 +4157,28 @@ describe('AutocompleteEditor', () => {
       expect(document.activeElement).toBe(getActiveEditor().TEXTAREA);
     });
   });
+
+  it('should filter choices case-insensitively under an invalid column locale', async() => {
+    handsontable({
+      columns: [{
+        editor: 'autocomplete',
+        source: ['Apple', 'Apricot', 'Banana'],
+        locale: 'en_US', // invalid tag — current code throws while filtering
+        filter: true,
+      }],
+    });
+
+    await selectCell(0, 0);
+    await keyDownUp('enter'); // open the editor
+
+    const editor = getActiveEditor();
+
+    editor.TEXTAREA.value = 'ap';
+    await keyDownUp('p', {}, editor.TEXTAREA); // trigger the query/filter pass
+    await waitForNextAnimationFrames(2); // allow the async filter render
+
+    // 'ap' matches 'Apple' and 'Apricot' case-insensitively. If filtering threw on the
+    // invalid locale, the inner list would not populate with exactly these two rows.
+    expect(editor.htEditor.countRows()).toBe(2);
+  });
 });

--- a/handsontable/src/editors/autocompleteEditor/autocompleteEditor.ts
+++ b/handsontable/src/editors/autocompleteEditor/autocompleteEditor.ts
@@ -14,7 +14,7 @@ import {
   setCaretPosition,
 } from '../../helpers/dom/element';
 import { isDefined, stringify } from '../../helpers/mixed';
-import { stripTags } from '../../helpers/string';
+import { stripTags, localeLowerCase } from '../../helpers/string';
 import { KEY_CODES, isPrintableChar } from '../../helpers/unicode';
 import { textRenderer } from '../../renderers/textRenderer';
 import {
@@ -182,7 +182,7 @@ export class AutocompleteEditor extends HandsontableEditor {
           TD.innerHTML = cellValue;
         } else if (cellValue && query && query.length > 0) {
           const indexOfMatch = filteringCaseSensitive === true ?
-            cellValue.indexOf(query) : cellValue.toLocaleLowerCase(locale).indexOf(query.toLocaleLowerCase(locale));
+            cellValue.indexOf(query) : localeLowerCase(cellValue, locale).indexOf(localeLowerCase(query, locale));
 
           if (indexOfMatch !== -1) {
             const match = cellValue.slice(indexOfMatch, indexOfMatch + query.length);
@@ -335,14 +335,14 @@ export class AutocompleteEditor extends HandsontableEditor {
     const filteredChoiceIndexes: number[] = [];
     const locale = this.cellProperties.locale as string | undefined;
     const filteringCaseSensitive = this.cellProperties.filteringCaseSensitive as boolean | undefined;
-    const valueToMatch = filteringCaseSensitive ? comparableValue : String(comparableValue).toLocaleLowerCase(locale);
+    const valueToMatch = filteringCaseSensitive ? comparableValue : localeLowerCase(String(comparableValue), locale);
 
     for (let i = 0; i < choices.length; i++) {
       const currentItem =
         this.#isKeyValueObject(choices[i]) ?
           stripTags(stringify((choices[i] as Record<string, unknown>).value)) :
           stripTags(stringify(choices[i]));
-      const itemToMatch = filteringCaseSensitive ? currentItem : currentItem.toLocaleLowerCase(locale);
+      const itemToMatch = filteringCaseSensitive ? currentItem : localeLowerCase(currentItem, locale);
 
       if (itemToMatch.indexOf(String(valueToMatch)) !== -1) {
         filteredChoiceIndexes.push(i);

--- a/handsontable/src/helpers/__tests__/string.unit.ts
+++ b/handsontable/src/helpers/__tests__/string.unit.ts
@@ -5,6 +5,7 @@ import {
   stripTags,
   isJSON,
   toHyphen,
+  localeLowerCase,
 } from 'handsontable/helpers/string';
 
 describe('String helper', () => {
@@ -146,6 +147,44 @@ describe('String helper', () => {
     it('should handle strings that are already hyphenated', () => {
       expect(toHyphen('already-hyphenated')).toBe('already-hyphenated');
       expect(toHyphen('my-component')).toBe('my-component');
+    });
+  });
+
+  //
+  // Handsontable.helper.localeLowerCase
+  //
+  describe('localeLowerCase', () => {
+    it('lowercases using the default Unicode mapping for the default and undefined locale', () => {
+      expect(localeLowerCase('ABC')).toBe('abc');
+      expect(localeLowerCase('ABC', 'en-US')).toBe('abc');
+      expect(localeLowerCase('İ', 'en-US')).toBe('İ'.toLowerCase());
+    });
+
+    it('returns output identical to native toLocaleLowerCase for non-tailoring locales', () => {
+      const samples = ['Apple', 'ÄÖÜ', 'STRASSE', 'ОЗЕРО', 'ΟΔΌΣ'];
+      const locales = ['en-US', 'de-DE', 'fr-FR', 'el-GR', 'ru-RU', undefined];
+
+      locales.forEach((locale) => {
+        samples.forEach((sample) => {
+          expect(localeLowerCase(sample, locale)).toBe(sample.toLocaleLowerCase(locale));
+        });
+      });
+    });
+
+    it('preserves Turkish and Azeri locale-aware lowercasing', () => {
+      expect(localeLowerCase('I', 'tr-TR')).toBe('ı');
+      expect(localeLowerCase('İ', 'tr-TR')).toBe('i');
+      expect(localeLowerCase('I', 'az-AZ')).toBe('ı');
+    });
+
+    it('preserves Lithuanian locale-aware lowercasing', () => {
+      expect(localeLowerCase('Ì', 'lt-LT')).toBe('Ì'.toLocaleLowerCase('lt-LT'));
+    });
+
+    it('does not throw on invalid or empty locale tags (falls back to the default mapping)', () => {
+      expect(localeLowerCase('I', '')).toBe('i');
+      expect(localeLowerCase('I', 'en_US')).toBe('i');
+      expect(localeLowerCase('ABC', 'not a locale!!')).toBe('abc');
     });
   });
 });

--- a/handsontable/src/helpers/string.ts
+++ b/handsontable/src/helpers/string.ts
@@ -154,21 +154,35 @@ export function toHyphen(str: string): string {
 }
 
 /**
- * Characters whose lowercase mapping is tailored only by the Turkish, Azeri, and
- * Lithuanian locales. Used to detect at runtime — without a hardcoded locale list —
- * whether a locale changes the result of lowercasing.
+ * Most languages use the same uppercase-to-lowercase rules as plain English — for
+ * example, `'A'` always becomes `'a'`, `'Ö'` always becomes `'ö'`. Only three locales
+ * diverge: Turkish and Azeri treat dotted `'İ'` and dotless `'I'` as separate letters
+ * (so `'I'` lowercases to `'ı'`, not `'i'`), and Lithuanian inserts an extra dot when
+ * lowercasing `'Ì'`, `'Í'`, and `'Ĩ'`. These five characters are therefore the only
+ * ones in Unicode where locale matters for lowercasing, which makes them a reliable
+ * probe: if a locale changes how they lowercase, it needs special handling; every other
+ * locale can use the much faster `toLowerCase()`.
  */
 const LOCALE_LOWERCASE_PROBE = 'IİÌÍĨ';
 const LOCALE_LOWERCASE_PROBE_DEFAULT = LOCALE_LOWERCASE_PROBE.toLowerCase();
 const localeLowerCaseTailoringCache = new Map<string | undefined, boolean>();
 
 /**
- * Checks whether a locale changes the result of lowercasing compared with the
- * language-neutral Unicode mapping. The answer is immutable for a given JavaScript
- * engine, so it is cached per locale. Invalid or empty locale tags resolve to `false`.
+ * Returns `true` when the given locale changes how letters are lowercased compared
+ * with the standard rules. This is only true for Turkish, Azeri, and Lithuanian.
  *
- * @param {string} [locale] A BCP 47 locale tag, or `undefined` for the host default.
- * @returns {boolean} `true` when the locale tailors lowercasing (Turkish, Azeri, Lithuanian).
+ * The result is cached the first time a locale is seen because the answer never
+ * changes — it is a fixed property of the JavaScript engine, not of the data. Calling
+ * `updateSettings({ locale: 'tr-TR' })` does not invalidate the cache; it simply means
+ * the next call passes `'tr-TR'` as the locale string, which is already cached.
+ *
+ * An invalid or empty locale tag (e.g. `''` or `'en_US'` with an underscore) is treated
+ * as "does not change lowercasing" so the function never throws.
+ *
+ * @param {string} [locale] A BCP 47 locale tag such as `'tr-TR'`, or `undefined` to use
+ *   the host default.
+ * @returns {boolean} `true` for Turkish (`tr`), Azeri (`az`), and Lithuanian (`lt`);
+ *   `false` for everything else.
  */
 function localeAffectsLowerCase(locale?: string): boolean {
   const cached = localeLowerCaseTailoringCache.get(locale);
@@ -192,13 +206,21 @@ function localeAffectsLowerCase(locale?: string): boolean {
 }
 
 /**
- * Lowercases a string, honoring the locale only when the locale actually changes the
- * result (Turkish, Azeri, Lithuanian). For every other locale it uses the fast,
- * language-neutral `toLowerCase`, which is byte-identical to `toLocaleLowerCase` for
- * those locales but avoids the expensive Intl path. Invalid locale tags never throw.
+ * Lowercases a string in a locale-aware and performant way.
+ *
+ * The built-in `toLocaleLowerCase(locale)` is correct but slow — passing an explicit
+ * locale forces the JavaScript engine to use its full international library on every
+ * call, even for languages like German or French where the result would be exactly the
+ * same as plain `toLowerCase()`. This function checks first whether the given locale
+ * actually changes anything, and falls back to the faster `toLowerCase()` when it does
+ * not. The check result is cached, so the overhead is paid only once per locale.
+ *
+ * Invalid or empty locale tags (such as `''` or `'en_US'` with an underscore instead
+ * of a hyphen) are handled gracefully instead of throwing an error.
  *
  * @param {string} value The string to lowercase.
- * @param {string} [locale] A BCP 47 locale tag, or `undefined` for the host default.
+ * @param {string} [locale] A BCP 47 locale tag such as `'tr-TR'` or `'en-US'`,
+ *   or `undefined` to use the host default.
  * @returns {string} The lowercased string.
  */
 export function localeLowerCase(value: string, locale?: string): string {

--- a/handsontable/src/helpers/string.ts
+++ b/handsontable/src/helpers/string.ts
@@ -152,3 +152,56 @@ export function toHyphen(str: string): string {
 
   return str.replace(/([A-Z])/g, '-$1').replaceAll('_', '-').toLowerCase();
 }
+
+/**
+ * Characters whose lowercase mapping is tailored only by the Turkish, Azeri, and
+ * Lithuanian locales. Used to detect at runtime — without a hardcoded locale list —
+ * whether a locale changes the result of lowercasing.
+ */
+const LOCALE_LOWERCASE_PROBE = 'IİÌÍĨ';
+const LOCALE_LOWERCASE_PROBE_DEFAULT = LOCALE_LOWERCASE_PROBE.toLowerCase();
+const localeLowerCaseTailoringCache = new Map<string | undefined, boolean>();
+
+/**
+ * Checks whether a locale changes the result of lowercasing compared with the
+ * language-neutral Unicode mapping. The answer is immutable for a given JavaScript
+ * engine, so it is cached per locale. Invalid or empty locale tags resolve to `false`.
+ *
+ * @param {string} [locale] A BCP 47 locale tag, or `undefined` for the host default.
+ * @returns {boolean} `true` when the locale tailors lowercasing (Turkish, Azeri, Lithuanian).
+ */
+function localeAffectsLowerCase(locale?: string): boolean {
+  const cached = localeLowerCaseTailoringCache.get(locale);
+
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  let affects: boolean;
+
+  try {
+    // eslint-disable-next-line no-restricted-syntax
+    affects = LOCALE_LOWERCASE_PROBE.toLocaleLowerCase(locale) !== LOCALE_LOWERCASE_PROBE_DEFAULT;
+  } catch {
+    affects = false;
+  }
+
+  localeLowerCaseTailoringCache.set(locale, affects);
+
+  return affects;
+}
+
+/**
+ * Lowercases a string, honoring the locale only when the locale actually changes the
+ * result (Turkish, Azeri, Lithuanian). For every other locale it uses the fast,
+ * language-neutral `toLowerCase`, which is byte-identical to `toLocaleLowerCase` for
+ * those locales but avoids the expensive Intl path. Invalid locale tags never throw.
+ *
+ * @param {string} value The string to lowercase.
+ * @param {string} [locale] A BCP 47 locale tag, or `undefined` for the host default.
+ * @returns {string} The lowercased string.
+ */
+export function localeLowerCase(value: string, locale?: string): string {
+  // eslint-disable-next-line no-restricted-syntax
+  return localeAffectsLowerCase(locale) ? value.toLocaleLowerCase(locale) : value.toLowerCase();
+}

--- a/handsontable/src/plugins/columnSorting/__tests__/sortFunction/default.unit.ts
+++ b/handsontable/src/plugins/columnSorting/__tests__/sortFunction/default.unit.ts
@@ -37,3 +37,16 @@ it('defaultSort comparing function shouldn\'t change order when comparing empty 
   expect(defaultSort('asc', {}, {})(undefined, null)).toBe(0);
   expect(defaultSort('desc', {}, {})(undefined, null)).toBe(0);
 });
+
+it('should not throw when the column locale is an invalid BCP 47 tag', () => {
+  const compare = defaultSort('asc', { locale: 'en_US' }, {});
+
+  expect(() => compare('Beta', 'alpha')).not.toThrow();
+});
+
+it('should sort case-insensitively and identically to the default Unicode mapping', () => {
+  const compare = defaultSort('asc', { locale: 'en-US' }, {});
+
+  expect(compare('apple', 'Apple')).toBe(0);
+  expect(compare('Apple', 'banana')).toBeLessThan(0);
+});

--- a/handsontable/src/plugins/columnSorting/sortFunction/default.ts
+++ b/handsontable/src/plugins/columnSorting/sortFunction/default.ts
@@ -1,5 +1,6 @@
 import { isEmpty } from '../../../helpers/mixed';
 import { DO_NOT_SWAP, FIRST_BEFORE_SECOND, FIRST_AFTER_SECOND } from '../sortService';
+import { localeLowerCase } from '../../../helpers/string';
 
 /**
  * Default sorting compare function factory. Method get as parameters `sortOrder` and `columnMeta` and return compare function.
@@ -26,11 +27,11 @@ export function compareFunctionFactory(
     }
 
     if (typeof value === 'string') {
-      value = value.toLocaleLowerCase(locale);
+      value = localeLowerCase(value, locale);
     }
 
     if (typeof nextValue === 'string') {
-      nextValue = nextValue.toLocaleLowerCase(locale);
+      nextValue = localeLowerCase(nextValue, locale);
     }
 
     if (value === nextValue) {

--- a/handsontable/src/plugins/filters/__tests__/condition/beginsWith.unit.ts
+++ b/handsontable/src/plugins/filters/__tests__/condition/beginsWith.unit.ts
@@ -55,4 +55,10 @@ describe('Filters condition (`begins_with`)', () => {
     expect(condition(data('İNANÇ'), ['inan'])).toBe(true);
     expect(condition(data('İNANÇ'), ['inanç'])).toBe(true);
   });
+
+  it('should not throw when the cell locale is an invalid BCP 47 tag', () => {
+    const data = dateRowFactory({ locale: 'en_US' });
+
+    expect(() => condition(data('ABC'), ['abc'])).not.toThrow();
+  });
 });

--- a/handsontable/src/plugins/filters/__tests__/condition/contains.unit.ts
+++ b/handsontable/src/plugins/filters/__tests__/condition/contains.unit.ts
@@ -52,4 +52,10 @@ describe('Filters condition (`contains`)', () => {
     expect(condition(data('İNANÇ'), ['ç'])).toBe(true);
     expect(condition(data('İNANÇ'), ['inanç'])).toBe(true);
   });
+
+  it('should not throw when the cell locale is an invalid BCP 47 tag', () => {
+    const data = dateRowFactory({ locale: 'en_US' });
+
+    expect(() => condition(data('ABC'), ['abc'])).not.toThrow();
+  });
 });

--- a/handsontable/src/plugins/filters/__tests__/condition/endsWith.unit.ts
+++ b/handsontable/src/plugins/filters/__tests__/condition/endsWith.unit.ts
@@ -56,4 +56,10 @@ describe('Filters condition (`ends_with`)', () => {
     expect(condition(data('İNANÇ'), ['nanç'])).toBe(true);
     expect(condition(data('İNANÇ'), ['inanç'])).toBe(true);
   });
+
+  it('should not throw when the cell locale is an invalid BCP 47 tag', () => {
+    const data = dateRowFactory({ locale: 'en_US' });
+
+    expect(() => condition(data('ABC'), ['abc'])).not.toThrow();
+  });
 });

--- a/handsontable/src/plugins/filters/__tests__/condition/equal.unit.ts
+++ b/handsontable/src/plugins/filters/__tests__/condition/equal.unit.ts
@@ -46,4 +46,10 @@ describe('Filters condition (`eq`)', () => {
     expect(condition(data('İnanç'), ['inanç'])).toBe(true);
     expect(condition(data('İNANÇ'), ['inanç'])).toBe(true);
   });
+
+  it('should not throw when the cell locale is an invalid BCP 47 tag', () => {
+    const data = dateRowFactory({ locale: 'en_US' });
+
+    expect(() => condition(data('ABC'), ['abc'])).not.toThrow();
+  });
 });

--- a/handsontable/src/plugins/filters/condition/beginsWith.ts
+++ b/handsontable/src/plugins/filters/condition/beginsWith.ts
@@ -1,5 +1,6 @@
 import * as C from '../../../i18n/constants';
 import { stringify } from '../../../helpers/mixed';
+import { localeLowerCase } from '../../../helpers/string';
 import { registerCondition } from '../conditionRegisterer';
 
 export const CONDITION_NAME = 'begins_with';
@@ -22,7 +23,7 @@ type DataRow = {
  * @returns {boolean}
  */
 export function condition(dataRow: DataRow, [value]: unknown[]) {
-  return stringify(dataRow.value).toLocaleLowerCase(dataRow.meta.locale).startsWith(stringify(value));
+  return localeLowerCase(stringify(dataRow.value), dataRow.meta.locale).startsWith(stringify(value));
 }
 
 registerCondition(CONDITION_NAME, condition, {

--- a/handsontable/src/plugins/filters/condition/contains.ts
+++ b/handsontable/src/plugins/filters/condition/contains.ts
@@ -1,5 +1,6 @@
 import * as C from '../../../i18n/constants';
 import { stringify } from '../../../helpers/mixed';
+import { localeLowerCase } from '../../../helpers/string';
 import { registerCondition } from '../conditionRegisterer';
 
 export const CONDITION_NAME = 'contains';
@@ -22,7 +23,7 @@ type DataRow = {
  * @returns {boolean}
  */
 export function condition(dataRow: DataRow, [value]: unknown[]) {
-  return stringify(dataRow.value).toLocaleLowerCase(dataRow.meta.locale).indexOf(stringify(value)) >= 0;
+  return localeLowerCase(stringify(dataRow.value), dataRow.meta.locale).indexOf(stringify(value)) >= 0;
 }
 
 registerCondition(CONDITION_NAME, condition, {

--- a/handsontable/src/plugins/filters/condition/endsWith.ts
+++ b/handsontable/src/plugins/filters/condition/endsWith.ts
@@ -1,5 +1,6 @@
 import * as C from '../../../i18n/constants';
 import { stringify } from '../../../helpers/mixed';
+import { localeLowerCase } from '../../../helpers/string';
 import { registerCondition } from '../conditionRegisterer';
 
 export const CONDITION_NAME = 'ends_with';
@@ -22,7 +23,7 @@ type DataRow = {
  * @returns {boolean}
  */
 export function condition(dataRow: DataRow, [value]: unknown[]) {
-  return stringify(dataRow.value).toLocaleLowerCase(dataRow.meta.locale).endsWith(stringify(value));
+  return localeLowerCase(stringify(dataRow.value), dataRow.meta.locale).endsWith(stringify(value));
 }
 
 registerCondition(CONDITION_NAME, condition, {

--- a/handsontable/src/plugins/filters/condition/equal.ts
+++ b/handsontable/src/plugins/filters/condition/equal.ts
@@ -1,5 +1,6 @@
 import * as C from '../../../i18n/constants';
 import { stringify } from '../../../helpers/mixed';
+import { localeLowerCase } from '../../../helpers/string';
 import { registerCondition } from '../conditionRegisterer';
 
 export const CONDITION_NAME = 'eq';
@@ -22,7 +23,7 @@ type DataRow = {
  * @returns {boolean}
  */
 export function condition(dataRow: DataRow, [value]: unknown[]) {
-  return stringify(dataRow.value).toLocaleLowerCase(dataRow.meta.locale) === stringify(value);
+  return localeLowerCase(stringify(dataRow.value), dataRow.meta.locale) === stringify(value);
 }
 
 registerCondition(CONDITION_NAME, condition, {

--- a/handsontable/src/plugins/filters/conditionCollection.ts
+++ b/handsontable/src/plugins/filters/conditionCollection.ts
@@ -17,6 +17,7 @@ interface StoredColumnState {
 import { mixin } from '../../helpers/object';
 import { throwWithCause } from '../../helpers/errors';
 import { toSingleLine } from '../../helpers/templateLiteralTag';
+import { localeLowerCase } from '../../helpers/string';
 import localHooks from '../../mixins/localHooks';
 import { getCondition } from './conditionRegisterer';
 import { OPERATION_ID as OPERATION_AND } from './logicalOperations/conjunction';
@@ -123,9 +124,9 @@ class ConditionCollection {
   addCondition(
     column: number, conditionDefinition: Record<string, unknown>, operation = OPERATION_AND, position?: number
   ) {
-    const localeForColumn = this.hot.getCellMeta(0, column).locale;
+    const localeForColumn = this.hot.getCellMeta(0, column).locale as string | undefined;
     const args = (conditionDefinition.args as unknown[])
-      .map((v: unknown) => (typeof v === 'string' ? v.toLocaleLowerCase(localeForColumn as string) : v));
+      .map((v: unknown) => (typeof v === 'string' ? localeLowerCase(v, localeForColumn) : v));
     const name = (conditionDefinition.name || (conditionDefinition.command as Record<string, unknown>).key) as string;
 
     this.runLocalHooks('beforeAdd', column);

--- a/handsontable/src/plugins/filters/ui/multipleSelect.ts
+++ b/handsontable/src/plugins/filters/ui/multipleSelect.ts
@@ -5,6 +5,7 @@ import { isKey } from '../../../helpers/unicode';
 import { dataRowToChangesArray } from '../../../helpers/data';
 import * as C from '../../../i18n/constants';
 import { stopImmediatePropagation } from '../../../helpers/dom/event';
+import { localeLowerCase } from '../../../helpers/string';
 import type { BaseUIOptions } from './_base';
 import { BaseUI } from './_base';
 import { InputUI } from './input';
@@ -357,7 +358,7 @@ export class MultipleSelectUI extends BaseUI {
    */
   #onInput(event: Event) {
     const trimmed = eventTargetEl<HTMLInputElement>(event)!.value.trim();
-    const value = trimmed.toLocaleLowerCase(this.getLocale());
+    const value = localeLowerCase(trimmed, this.getLocale());
 
     if ((this.options as Record<string, unknown>).searchMode === 'apply') {
       const hiddenRows = this.#itemsBox?.getPlugin('hiddenRows');
@@ -368,7 +369,7 @@ export class MultipleSelectUI extends BaseUI {
       }
 
       this.#items.forEach((item, index) => {
-        item.checked = `${item.value}`.toLocaleLowerCase(this.getLocale()).indexOf(value) >= 0;
+        item.checked = localeLowerCase(`${item.value}`, this.getLocale()).indexOf(value) >= 0;
 
         if (!item.checked) {
           rowsToHide.push(index);
@@ -387,7 +388,7 @@ export class MultipleSelectUI extends BaseUI {
         filteredItems = [...this.#items];
       } else {
         filteredItems = this.#items
-          .filter(item => (`${item.value}`).toLocaleLowerCase(this.getLocale()).indexOf(value) >= 0);
+          .filter(item => localeLowerCase(`${item.value}`, this.getLocale()).indexOf(value) >= 0);
       }
 
       this.#itemsBox?.loadData(filteredItems);

--- a/handsontable/src/plugins/search/__tests__/search.spec.js
+++ b/handsontable/src/plugins/search/__tests__/search.spec.js
@@ -599,4 +599,34 @@ describe('Search plugin', () => {
       expect(cellClassName).toBe('cell');
     });
   });
+
+  it('should not throw and should return matches when a column locale is an invalid BCP 47 tag', async() => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      columns: [{ locale: 'en_US' }, {}, {}, {}, {}], // 'en_US' (underscore) is an invalid tag
+      search: true,
+    });
+
+    const search = getPlugin('search');
+    let result;
+
+    expect(() => {
+      result = search.query('a');
+    }).not.toThrow();
+    expect(Array.isArray(result)).toBe(true);
+  });
+
+  it('should perform locale-aware search for Turkish text', async() => {
+    handsontable({
+      data: [['IST'], ['İST'], ['iyi']],
+      columns: [{ locale: 'tr-TR' }],
+      search: true,
+    });
+
+    const search = getPlugin('search');
+    // Under tr-TR, 'i' lowercases İ→i but I→ı, so 'i' matches 'İST' and 'iyi', not 'IST'.
+    const matches = search.query('i').map(r => r.row).sort();
+
+    expect(matches).toEqual([1, 2]);
+  });
 });

--- a/handsontable/src/plugins/search/search.ts
+++ b/handsontable/src/plugins/search/search.ts
@@ -3,6 +3,7 @@ import { BasePlugin } from '../base';
 import { isObject } from '../../helpers/object';
 import { rangeEach } from '../../helpers/number';
 import { isUndefined } from '../../helpers/mixed';
+import { localeLowerCase } from '../../helpers/string';
 
 /**
  * Local type-guard narrowing `unknown` to `Record<string, unknown>`.
@@ -31,8 +32,9 @@ const DEFAULT_QUERY_METHOD = function(query: string, value: unknown, cellPropert
     return false;
   }
 
-  return String(value).toLocaleLowerCase(cellProperties.locale as string | undefined)
-    .indexOf(query.toLocaleLowerCase(cellProperties.locale as string | undefined)) !== -1;
+  const locale = cellProperties.locale as string | undefined;
+
+  return localeLowerCase(String(value), locale).indexOf(localeLowerCase(query, locale)) !== -1;
 };
 
 /**

--- a/handsontable/src/renderers/checkboxRenderer/__tests__/checkboxRenderer.spec.js
+++ b/handsontable/src/renderers/checkboxRenderer/__tests__/checkboxRenderer.spec.js
@@ -672,4 +672,20 @@ describe('CheckboxRenderer', () => {
 
     Handsontable.renderers.registerRenderer('base', originalBaseRenderer);
   });
+
+  it('should match the checked template case-insensitively under an invalid column locale', async() => {
+    handsontable({
+      data: [['yes']],
+      columns: [{
+        type: 'checkbox',
+        checkedTemplate: 'Yes', // differs in case from the value, so the lowercase path runs
+        uncheckedTemplate: 'No',
+        locale: 'en_US', // invalid tag — current code throws during render
+      }],
+    });
+
+    // current code: RangeError from 'yes'.toLocaleLowerCase('en_US') while rendering.
+    // after migration: the cell renders as a checked checkbox.
+    expect(getCell(0, 0).querySelector('input').checked).toBe(true);
+  });
 });

--- a/handsontable/src/renderers/checkboxRenderer/checkboxRenderer.ts
+++ b/handsontable/src/renderers/checkboxRenderer/checkboxRenderer.ts
@@ -3,6 +3,7 @@ import type { CellProperties } from '../../settings';
 import EventManager from '../../eventManager';
 import { empty, addClass, eventTargetEl, setAttribute, isHTMLElement } from '../../helpers/dom/element';
 import { isEmpty, stringify } from '../../helpers/mixed';
+import { localeLowerCase } from '../../helpers/string';
 import { EDITOR_EDIT_GROUP as SHORTCUTS_GROUP_EDITOR } from '../../shortcuts/contexts';
 import { Hooks } from '../../core/hooks';
 import { A11Y_CHECKBOX, A11Y_CHECKED, A11Y_LABEL } from '../../helpers/a11y';
@@ -79,13 +80,13 @@ export function checkboxRenderer(
   const locale = cellProperties.locale as string | undefined;
 
   if (value === cellProperties.checkedTemplate ||
-    stringify(value).toLocaleLowerCase(locale) ===
-    stringify(cellProperties.checkedTemplate).toLocaleLowerCase(locale)) {
+    localeLowerCase(stringify(value), locale) ===
+    localeLowerCase(stringify(cellProperties.checkedTemplate), locale)) {
     input.checked = true;
 
   } else if (value === cellProperties.uncheckedTemplate ||
-    stringify(value).toLocaleLowerCase(locale) ===
-    stringify(cellProperties.uncheckedTemplate).toLocaleLowerCase(locale)) {
+    localeLowerCase(stringify(value), locale) ===
+    localeLowerCase(stringify(cellProperties.uncheckedTemplate), locale)) {
     input.checked = false;
 
   } else if (isEmpty(value)) { // default value


### PR DESCRIPTION
### Context

The PR fixes a long-standing performance regression (issue #3428) where passing any explicit locale argument to `String.prototype.toLocaleLowerCase` forces V8's ICU path, making it ~45× slower than `toLowerCase()` — even for locales like `en-US`, `de-DE`, or `el-GR` that produce byte-identical results.

It also fixes a latent crash: invalid or empty locale tags (e.g. `'en_US'` with an underscore, `''`) cause `toLocaleLowerCase` to throw a `RangeError`. Several call sites in the codebase were already exposed (e.g. `multipleSelect` initialises `#locale = ''`).

**Solution:** A single `localeLowerCase(value, locale)` helper in `src/helpers/string.ts`. It probes once per distinct locale whether that locale actually tailors lowercasing (only Turkish, Azeri, Lithuanian differ — on the dotted/dotless-I family), caches the result, and uses `toLowerCase()` for every other locale. All six subsystems are migrated to the helper. A dogfooding ESLint rule (`no-restricted-syntax`) then forbids direct native calls.

**Measured wins — v17.1.0 CDN vs patched build, Chrome, median of 5–7 runs:**

| Subsystem | v17 (before) | Patched (after) | Speedup |
|---|---|---|---|
| Search `query()` — 5k rows, `en-US` | 65.6 ms | 18.9 ms | **3.5×** |
| Column sorting — 50k rows, `en-US` | 1,731.4 ms | 194.1 ms | **8.9×** |
| Filters `contains` — 20k rows, `en-US` | 32.3 ms | 13.2 ms | **2.5×** |
| Autocomplete filter — 10k choices, `en-US` | 10.9 ms | 0.5 ms | **21.8×** |
| CheckboxRenderer — 10k cells, `en-US` | 21.2 ms | 21.2 ms | **1.0×** (DOM-bound) |

Checkbox rendering time is unchanged — the lowercasing is a negligible fraction of the DOM work for that subsystem. All other subsystems show clear improvement.

> Note: absolute timings vary by machine. The ratios are what matter — they reflect the ICU path being bypassed for `en-US` and other non-tailoring locales.

ClickUp task: https://app.clickup.com/t/86ca7q21d

### How has this been tested?

New unit tests (TDD red→green):
```
npm run test:unit --prefix handsontable -- --testPathPattern=helpers/__tests__/string.unit
npm run test:unit --prefix handsontable -- --testPathPattern=columnSorting/__tests__/sortFunction/default.unit
npm run test:unit --prefix handsontable -- --testPathPattern=filters/__tests__/condition
```

New E2E tests + full regression suites:
```
npm run build --prefix handsontable
npm run test:e2e --prefix handsontable -- --testPathPattern=search/__tests__/search
npm run test:e2e --prefix handsontable -- --testPathPattern=columnSorting/__tests__/columnSorting
npm run test:e2e --prefix handsontable -- --testPathPattern=filters/__tests__
npm run test:e2e --prefix handsontable -- --testPathPattern=autocompleteEditor/__tests__
npm run test:e2e --prefix handsontable -- --testPathPattern=checkboxRenderer/__tests__
```

Full suite results: 2,742 unit tests pass, all targeted E2E suites pass (34, 119, 246, 138, 81 specs respectively, 0 failures).

ESLint clean: `npm run eslint --prefix handsontable`

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1863
2. Fixes #3428

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1863

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared string comparison logic used by search, filters, sorting, and editors on large datasets; behavior must stay locale-correct for tr/az/lt while changing performance and error handling for bad locale tags.
> 
> **Overview**
> Introduces **`localeLowerCase(value, locale)`** in `helpers/string.ts` to replace direct `toLocaleLowerCase(locale)` across hot paths. The helper caches whether a locale actually tailors lowercasing (Turkish, Azeri, Lithuanian) and uses fast `toLowerCase()` otherwise, avoiding V8’s ICU path and **not throwing** on invalid tags like `en_US` or `''`.
> 
> **Call sites migrated** to the helper include search default `queryMethod`, column sorting, filter conditions (`begins_with`, `contains`, `ends_with`, `eq`), `conditionCollection` argument normalization, filters multiple-select search, autocomplete filtering/highlighting, and checkbox template matching.
> 
> An ESLint **`no-restricted-syntax`** rule blocks new direct `toLocaleLowerCase`/`toLocaleUpperCase` calls in core source (tests exempt). Agent docs and a changelog entry document the convention. Unit and E2E tests cover invalid locales, Turkish-aware search, and autocomplete filtering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf377f29a14da7e93b8ea4a34b7ba116b5f19b46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->