### PR TITLE
DEV-1865 - Add typed handsontable ColumnSettings property

### DIFF
--- a/.changelogs/12763.json
+++ b/.changelogs/12763.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "public",
-  "title": "Added a typed `handsontable` property to grid and column settings.",
+  "title": "Added typing for the `handsontable` cell type configuration and the `getValue` setting.",
   "type": "changed",
   "issueOrPR": 12763,
   "breaking": false,

--- a/.changelogs/12763.json
+++ b/.changelogs/12763.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Add typed handsontable ColumnSettings property.",
+  "type": "changed",
+  "issueOrPR": 12763,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/12763.json
+++ b/.changelogs/12763.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "public",
-  "title": "Add typed handsontable ColumnSettings property.",
+  "title": "Added a typed `handsontable` property to grid and column settings.",
   "type": "changed",
   "issueOrPR": 12763,
   "breaking": false,

--- a/handsontable/src/__tests__/core/settings.types.ts
+++ b/handsontable/src/__tests__/core/settings.types.ts
@@ -120,6 +120,13 @@ const allSettings: Required<Handsontable.GridSettings> = {
   },
   fragmentSelection: oneOf(true, 'cell'),
   headerClassName: 'htCenter test',
+  handsontable: {
+    data: [[]],
+    colHeaders: true,
+    getValue: oneOf('name', function(this: Handsontable) {
+      return this.getDataAtCell(0, 0);
+    }),
+  },
   hashLength: 8,
   hashRevealDelay: 1000,
   hashSymbol: '#',
@@ -784,3 +791,20 @@ const _rendererCellProps: Handsontable.CellProperties = cellProperties;
 
 // Assert that a CellProperties value is assignable as the validator `this` context type
 const _validatorCellProps: CellProperties = cellProperties;
+
+// === `handsontable` cell-type setting typing ===
+// The nested-grid config is exposed on both grid settings (global) and column settings (per-column),
+// and `getValue` accepts either a source property name or a function bound to the nested instance.
+const _hotGlobal: Handsontable.GridSettings = {
+  handsontable: { data: [[]], getValue: 'name' },
+};
+const _hotColumn: Handsontable.ColumnSettings = {
+  handsontable: { data: [[]], getValue: 'name' },
+};
+const _hotColumnGetValueFn: Handsontable.ColumnSettings = {
+  handsontable: {
+    getValue(this: Handsontable) {
+      return this.getDataAtCell(0, 0);
+    },
+  },
+};

--- a/handsontable/src/__tests__/core/settings.types.ts
+++ b/handsontable/src/__tests__/core/settings.types.ts
@@ -120,12 +120,13 @@ const allSettings: Required<Handsontable.GridSettings> = {
   },
   fragmentSelection: oneOf(true, 'cell'),
   headerClassName: 'htCenter test',
+  getValue: oneOf('name', function(this: Handsontable) {
+    return this.getDataAtCell(0, 0);
+  }),
   handsontable: {
     data: [[]],
     colHeaders: true,
-    getValue: oneOf('name', function(this: Handsontable) {
-      return this.getDataAtCell(0, 0);
-    }),
+    getValue: 'name',
   },
   hashLength: 8,
   hashRevealDelay: 1000,
@@ -793,8 +794,19 @@ const _rendererCellProps: Handsontable.CellProperties = cellProperties;
 const _validatorCellProps: CellProperties = cellProperties;
 
 // === `handsontable` cell-type setting typing ===
-// The nested-grid config is exposed on both grid settings (global) and column settings (per-column),
-// and `getValue` accepts either a source property name or a function bound to the nested instance.
+// `getValue` is a regular top-level grid setting (read by `Core#getValue`), usable both at the
+// instance level and inside the nested `handsontable` config of the `handsontable` cell type. Its
+// function form binds `this` to the instance.
+
+// `getValue` also works as a top-level grid setting (read by `Core#getValue`), not only nested.
+const _hotTopLevelGetValueString: Handsontable.GridSettings = { getValue: 'name' };
+const _hotTopLevelGetValueFn: Handsontable.GridSettings = {
+  getValue() {
+    return this.getDataAtCell(0, 0);
+  },
+};
+
+// Nested `handsontable` config (global and per-column), with both `getValue` forms.
 const _hotGlobal: Handsontable.GridSettings = {
   handsontable: { data: [[]], getValue: 'name' },
 };
@@ -804,10 +816,15 @@ const _hotColumn: Handsontable.ColumnSettings = {
 const _hotColumnGetValueFn: Handsontable.ColumnSettings = {
   handsontable: {
     // Relies on the *contextual* `this` (no explicit annotation) on purpose: this fails to compile
-    // if the direct `handsontable` re-declaration on `ColumnSettings` is removed, because the
-    // `Omit<GridSettings, 'data'>` + index-signature combination would widen `this` to `{}`.
+    // if a `[key: string]: unknown` index signature is re-added to `ColumnSettings`, because the
+    // value-type mismatch with the `[key: string]: any` inherited from `GridSettings` widens `this`
+    // to `{}`. Keeps the no-index-signature decision in `settings.ts` honest.
     getValue() {
       return this.getDataAtCell(0, 0);
     },
   },
 };
+
+// Custom plugin/meta keys still allowed via the `[key: string]: any` signature inherited from `GridSettings`.
+const _columnArbitraryKeys: Handsontable.ColumnSettings = { someCustomPluginKey: 123 };
+const _cellMetaArbitraryKeys: Handsontable.CellMeta = { someCustomMetaKey: true };

--- a/handsontable/src/__tests__/core/settings.types.ts
+++ b/handsontable/src/__tests__/core/settings.types.ts
@@ -803,7 +803,10 @@ const _hotColumn: Handsontable.ColumnSettings = {
 };
 const _hotColumnGetValueFn: Handsontable.ColumnSettings = {
   handsontable: {
-    getValue(this: Handsontable) {
+    // Relies on the *contextual* `this` (no explicit annotation) on purpose: this fails to compile
+    // if the direct `handsontable` re-declaration on `ColumnSettings` is removed, because the
+    // `Omit<GridSettings, 'data'>` + index-signature combination would widen `this` to `{}`.
+    getValue() {
       return this.getDataAtCell(0, 0);
     },
   },

--- a/handsontable/src/core/settings.ts
+++ b/handsontable/src/core/settings.ts
@@ -69,6 +69,15 @@ export interface GridSettings {
   cells?: (row: number, column: number, prop: string | number) => object;
   source?: unknown[] | ((query: string, callback: (items: unknown[]) => void) => void);
   type?: string;
+  /**
+   * Configuration of the nested grid used by the `handsontable` cell type. It accepts the same
+   * grid settings as the outer table, plus an optional `getValue` that controls which value is
+   * pulled back into the edited cell. It can be a property name of the focused row, or a function
+   * whose `this` is bound to the nested Handsontable instance (matching `Core#getValue`).
+   */
+  handsontable?: GridSettings & {
+    getValue?: string | ((this: HotInstance) => CellValue);
+  };
 
   // Editing
   allowEmpty?: boolean;

--- a/handsontable/src/core/settings.ts
+++ b/handsontable/src/core/settings.ts
@@ -70,9 +70,15 @@ export interface GridSettings {
   source?: unknown[] | ((query: string, callback: (items: unknown[]) => void) => void);
   type?: string;
   /**
-   * Configuration of the nested grid used by the `handsontable` cell type — see {@link HandsontableCellTypeSettings}.
+   * Configuration of the nested grid used by the `handsontable` cell type.
    */
-  handsontable?: HandsontableCellTypeSettings;
+  handsontable?: GridSettings;
+  /**
+   * Controls which value `Core#getValue` returns for the focused cell — a row property name, or a
+   * function whose `this` is bound to the instance. Used by the `handsontable` cell type to pull a
+   * value from the nested grid back into the edited cell.
+   */
+  getValue?: string | ((this: HotInstance) => CellValue);
 
   // Editing
   allowEmpty?: boolean;
@@ -551,16 +557,6 @@ export interface GridSettings {
   // Allow additional plugin-specific keys
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
-}
-
-/**
- * Configuration of the nested grid used by the `handsontable` cell type. It accepts the same
- * grid settings as the outer table, plus an optional `getValue` that controls which value is
- * pulled back into the edited cell. It can be a property name of the focused row, or a function
- * whose `this` is bound to the nested Handsontable instance (matching `Core#getValue`).
- */
-export interface HandsontableCellTypeSettings extends GridSettings {
-  getValue?: string | ((this: HotInstance) => CellValue);
 }
 
 /**

--- a/handsontable/src/core/settings.ts
+++ b/handsontable/src/core/settings.ts
@@ -70,14 +70,9 @@ export interface GridSettings {
   source?: unknown[] | ((query: string, callback: (items: unknown[]) => void) => void);
   type?: string;
   /**
-   * Configuration of the nested grid used by the `handsontable` cell type. It accepts the same
-   * grid settings as the outer table, plus an optional `getValue` that controls which value is
-   * pulled back into the edited cell. It can be a property name of the focused row, or a function
-   * whose `this` is bound to the nested Handsontable instance (matching `Core#getValue`).
+   * Configuration of the nested grid used by the `handsontable` cell type — see {@link HandsontableCellTypeSettings}.
    */
-  handsontable?: GridSettings & {
-    getValue?: string | ((this: HotInstance) => CellValue);
-  };
+  handsontable?: HandsontableCellTypeSettings;
 
   // Editing
   allowEmpty?: boolean;
@@ -556,6 +551,16 @@ export interface GridSettings {
   // Allow additional plugin-specific keys
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
+}
+
+/**
+ * Configuration of the nested grid used by the `handsontable` cell type. It accepts the same
+ * grid settings as the outer table, plus an optional `getValue` that controls which value is
+ * pulled back into the edited cell. It can be a property name of the focused row, or a function
+ * whose `this` is bound to the nested Handsontable instance (matching `Core#getValue`).
+ */
+export interface HandsontableCellTypeSettings extends GridSettings {
+  getValue?: string | ((this: HotInstance) => CellValue);
 }
 
 /**

--- a/handsontable/src/settings.ts
+++ b/handsontable/src/settings.ts
@@ -51,7 +51,7 @@ export type ChangeSource = 'auto' | 'edit' | 'loadData' | 'updateData' | 'popula
   'CopyPaste.paste' | 'CopyPaste.cut' | 'UndoRedo.redo' | 'UndoRedo.undo' | 'ColumnSummary.set' |
   'ColumnSummary.reset' | 'DataProvider.revert';
 
-export type { GridSettings } from './core/settings';
+export type { GridSettings, HandsontableCellTypeSettings } from './core/settings';
 /**
  * Column settings inherit grid settings but overload the meaning of `data` to be specific to each column.
  */

--- a/handsontable/src/settings.ts
+++ b/handsontable/src/settings.ts
@@ -51,27 +51,18 @@ export type ChangeSource = 'auto' | 'edit' | 'loadData' | 'updateData' | 'popula
   'CopyPaste.paste' | 'CopyPaste.cut' | 'UndoRedo.redo' | 'UndoRedo.undo' | 'ColumnSummary.set' |
   'ColumnSummary.reset' | 'DataProvider.revert';
 
-export type { GridSettings, HandsontableCellTypeSettings } from './core/settings';
+export type { GridSettings } from './core/settings';
 /**
  * Column settings inherit grid settings but overload the meaning of `data` to be specific to each column.
  */
 export interface ColumnSettings extends Omit<GridSettings, 'data'> {
   data?: string | number | ColumnDataGetterSetterFunction;
-  /**
-   * Configuration of the nested grid used by the `handsontable` cell type — see {@link GridSettings.handsontable}.
-   *
-   * Re-declared here (identical to the inherited definition) on purpose. `ColumnSettings` combines
-   * the `[key: string]: unknown` index signature below with the `Omit<GridSettings, 'data'>` mapped
-   * type it extends; that combination makes TypeScript widen the *inherited* `handsontable` to the
-   * index signature when contextually typing an object literal, which drops the `this` binding on
-   * `getValue`. A direct property declaration takes precedence over the index signature and keeps
-   * the precise type intact.
-   */
-  handsontable?: GridSettings['handsontable'];
-  /**
-   * Column and cell meta data is extensible, developers can add any properties they want.
-   */
-  [key: string]: unknown;
+
+  // NOTE: do not add a `[key: string]: unknown` index signature here. Column and cell meta is already
+  // extensible with arbitrary keys through the `[key: string]: any` signature inherited from
+  // `GridSettings`. A second index signature with a different value type (`unknown` vs the inherited
+  // `any`) makes TypeScript drop the `this` binding on nested `handsontable.getValue` — contextual
+  // typing widens `this` to `{}`. The `_hotColumnGetValueFn` type test guards against re-adding it.
 }
 
 /**

--- a/handsontable/src/settings.ts
+++ b/handsontable/src/settings.ts
@@ -58,14 +58,16 @@ export type { GridSettings } from './core/settings';
 export interface ColumnSettings extends Omit<GridSettings, 'data'> {
   data?: string | number | ColumnDataGetterSetterFunction;
   /**
-   * Configuration of the nested grid used by the `handsontable` cell type. It accepts the same
-   * grid settings as the outer table, plus an optional `getValue` that controls which value is
-   * pulled back into the edited cell. It can be a property name of the focused row, or a function
-   * whose `this` is bound to the nested Handsontable instance (matching `Core#getValue`).
+   * Configuration of the nested grid used by the `handsontable` cell type — see {@link GridSettings.handsontable}.
+   *
+   * Re-declared here (identical to the inherited definition) on purpose. `ColumnSettings` combines
+   * the `[key: string]: unknown` index signature below with the `Omit<GridSettings, 'data'>` mapped
+   * type it extends; that combination makes TypeScript widen the *inherited* `handsontable` to the
+   * index signature when contextually typing an object literal, which drops the `this` binding on
+   * `getValue`. A direct property declaration takes precedence over the index signature and keeps
+   * the precise type intact.
    */
-  handsontable?: GridSettings & {
-    getValue?: string | ((this: Handsontable) => CellValue);
-  };
+  handsontable?: GridSettings['handsontable'];
   /**
    * Column and cell meta data is extensible, developers can add any properties they want.
    */

--- a/handsontable/src/settings.ts
+++ b/handsontable/src/settings.ts
@@ -58,6 +58,15 @@ export type { GridSettings } from './core/settings';
 export interface ColumnSettings extends Omit<GridSettings, 'data'> {
   data?: string | number | ColumnDataGetterSetterFunction;
   /**
+   * Configuration of the nested grid used by the `handsontable` cell type. It accepts the same
+   * grid settings as the outer table, plus an optional `getValue` that controls which value is
+   * pulled back into the edited cell. It can be a property name of the focused row, or a function
+   * whose `this` is bound to the nested Handsontable instance (matching `Core#getValue`).
+   */
+  handsontable?: GridSettings & {
+    getValue?: string | ((this: Handsontable) => CellValue);
+  };
+  /**
    * Column and cell meta data is extensible, developers can add any properties they want.
    */
   [key: string]: unknown;


### PR DESCRIPTION
### Context
  The handsontable cell-type configuration is now an explicitly typed property on GridSettings, so it can be set both globally and per-column (previously it was only on ColumnSettings, which made global usage a
  TypeScript error). getValue is now a typed top-level grid setting too — read by Core#getValue, it accepts a row-property name or a function whose this is bound to the instance — so it type-checks both at the
  instance level and inside the nested handsontable config. The redundant [key: string]: unknown index signature on ColumnSettings was removed: it duplicated the [key: string]: any already inherited from
  GridSettings, and that value-type mismatch was what made TypeScript drop the this binding on getValue; arbitrary custom keys still work via the inherited signature. This is a types-only change with no runtime impact.

### How has this been tested?
handsontable npm run test:types
npm run build --prefix handsontable
npm run typecheck --prefix docs/angular-type-check


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1766


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Declaration-only TypeScript and test changes with no runtime or behavioral impact.
> 
> **Overview**
> Adds explicit TypeScript support for the **`handsontable` cell type** nested-grid config on both **`GridSettings`** (table-wide) and **`ColumnSettings`** (per column), via a new **`HandsontableCellTypeSettings`** type that mirrors grid options plus optional **`getValue`** (property name or function with **`this`** bound to the nested instance).
> 
> **`ColumnSettings`** re-declares **`handsontable`** so contextual typing keeps **`getValue`**’s **`this`** instead of widening through the **`[key: string]: unknown`** index signature. Compile-time coverage is added in **`settings.types.ts`**; a changelog entry documents the change. **No runtime behavior changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 634eb45871e7e2542334e4ca7157a1d9dd068bb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->