### PR TITLE
DEV-1861: Fix Handsontable with shadcn/ui docs example

### DIFF
--- a/docs/content/recipes/themes/custom-theme/custom-theme.md
+++ b/docs/content/recipes/themes/custom-theme/custom-theme.md
@@ -31,9 +31,13 @@ category: Themes
 
 This tutorial shows you how to integrate Handsontable into a Next.js app that uses shadcn/ui, registering a custom theme that maps shadcn CSS variables and Lucide icons to the Handsontable Theme API.
 
-<iframe src="https://4y8dv9-3000.csb.app/" title="Handsontable with shadcn/ui demo" width="100%" height="500" frameborder="0" allowfullscreen style="border-radius: 8px; min-height: 500px;"></iframe>
+<iframe src="https://codesandbox.io/p/devbox/5kjc5d?embed=1&file=%2Fcomponents%2FDataGrid.tsx"
+     style="width:100%; height: 500px; border:0; border-radius: 4px; overflow:hidden;"
+     title="Handsontable with shadcn"
+     sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+   ></iframe>
 
-[**Open in CodeSandbox**](https://codesandbox.io/p/devbox/github/handsontable/examples/tree/master/examples/next-shadcn.js)
+[**Open in CodeSandbox**](https://codesandbox.io/p/devbox/5kjc5d)
 
 ## Overview
 


### PR DESCRIPTION
### Context

The PR fixes the broken "Handsontable with shadcn/ui" demo on the custom-theme recipe page. The old CodeSandbox embed and "Open in CodeSandbox" link pointed at a dead sandbox, so the example failed to load. This swaps in working CodeSandbox URLs for both the iframe embed and the link.

### How has this been tested?

- Manual: verified the new CodeSandbox embed loads the Handsontable + shadcn/ui demo and the "Open in CodeSandbox" link resolves.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1861

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1861

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only URL and iframe markup changes with no runtime or library impact.
> 
> **Overview**
> Fixes the broken **Handsontable with shadcn/ui** live demo on the custom-theme recipe page by pointing the embedded iframe and **Open in CodeSandbox** link at a working sandbox (`5kjc5d`) instead of the dead URLs.
> 
> The iframe now uses the CodeSandbox devbox embed URL (with `embed=1` and a default file focus on `DataGrid.tsx`), updated inline styling, a clearer `title`, and an explicit `sandbox` attribute for the embed permissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcab10025de34129433bd25cbd0bfe6bd4d3445d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->