### PR TITLE
DEV-1866: Fix Remix example not working on the Introduction page

### DIFF
--- a/wrappers/react-wrapper/package.json
+++ b/wrappers/react-wrapper/package.json
@@ -5,6 +5,7 @@
   "author": "Handsoncode <hello@handsoncode.net> (https://handsoncode.net)",
   "homepage": "https://handsontable.com",
   "license": "SEE LICENSE IN LICENSE.txt",
+  "sideEffects": false,
   "main": "./commonjs/react-handsontable.js",
   "module": "./es/react-handsontable.mjs",
   "jsdelivr": "./dist/react-handsontable.min.js",


### PR DESCRIPTION
## Summary

The Remix (and all other) CodeSandbox example links on the Introduction page work on PR previews but break after merging to `develop`.

### Root cause

The dev docs compute a snapshot version for non-production builds:

```
0.0.0-next-{shortSHA}-{YYYYMMDD}   e.g. 0.0.0-next-42968b5-20260611
```

The render-ms service resolves this by extracting the SHA and fetching the package from pkg.pr.new (`https://pkg.pr.new/handsontable@{sha}`).

Previously, `pkg-pr-new publish` only ran on `pull_request` events. So:
- ✅ PR preview — packages are published with the PR number; SHA is also registered on pkg.pr.new
- ❌ After merge to `develop` — no publish runs; the merged commit's SHA is unknown to pkg.pr.new; render-ms can't resolve the version → CodeSandbox links fail for **all** examples on dev docs

### Fix (this PR)

1. **Add `push: branches: [develop]` trigger** to `pkg-pr-new.yml` with the same paths filter. The build + publish steps now also run on every merge to `develop`, registering each commit's SHA with pkg.pr.new. The PR comment steps are guarded with `if: github.event_name == 'pull_request'` so they don't fire on develop pushes.

2. **Add `"sideEffects": false`** to `@handsontable/react-wrapper/package.json`. This is a genuine SSR bundler improvement: Vite (used by Remix, Nuxt, Astro) can now safely tree-shake the wrapper during SSR without treating every import as a side effect.

## ClickUp

https://app.clickup.com/t/86ca83xv2 (DEV-1866)

## Test plan

- [ ] Merge this PR to `develop` and confirm the `pkg-pr-new.yml` workflow runs on the push event and publishes packages
- [ ] Check `https://dev.handsontable.com/docs/javascript-data-grid/` — Remix (and all SSR) example links open in CodeSandbox without errors
- [ ] Confirm existing PR-preview behavior is unchanged (PR comment still posts, links still use PR number)

[skip changelog]