### PR TITLE
DEV-1263: Make docs example initial render wait for autoRowSize sampling

### DIFF
--- a/docs/src/scripts/example-runner.ts
+++ b/docs/src/scripts/example-runner.ts
@@ -74,12 +74,21 @@ function getInstances(el: Element): any[] {
 }
 
 /**
- * Refreshes the dimensions of a Handsontable instance once autoRowSize stops sampling.
+ * Re-renders a Handsontable instance once autoRowSize stops sampling.
  *
- * autoRowSize samples row heights across several requestAnimationFrame cycles, and refreshing
+ * Examples sit in a flex layout where the grid fills its container (`.ht-wrapper { height: 100% }`)
+ * while the container is sized by the grid's content. At first render — before the layout and CSS
+ * settle — this resolves to a height of 0, and nothing breaks the deadlock on its own. A forced
+ * render() applies the configured pixel height to the holder, which breaks the collapse.
+ *
+ * render() (not refreshDimensions()) is required here: refreshDimensions() only re-renders when the
+ * container box reports a size change, so in the collapsed 0-height state it no-ops and the grid
+ * stays broken.
+ *
+ * autoRowSize samples row heights across several requestAnimationFrame cycles, and rendering
  * mid-sampling computes 0 visible rows. So wait frame by frame until it reports completion
- * (capped, so a stuck flag can't hang), then call refreshDimensions(), which re-reads the
- * container box and re-renders only when the size actually changed.
+ * (capped, so a stuck flag can't hang), then render. Using requestAnimationFrame means a grid
+ * loaded in a background tab refreshes as soon as the tab becomes visible, before any interaction.
  */
 function refreshWhenSettled(hot: any): void {
   let frames = 0;
@@ -97,7 +106,7 @@ function refreshWhenSettled(hot: any): void {
     }
 
     try {
-      hot.refreshDimensions();
+      hot.render();
     } catch (err) {
       console.warn('[hot-example] renderInstances failed:', err);
     }

--- a/docs/src/scripts/example-runner.ts
+++ b/docs/src/scripts/example-runner.ts
@@ -63,55 +63,79 @@ function markLoaded(el: Element): void {
   el.querySelector('.hot-example-preview')?.classList.remove('hot-example-preview--loading');
 }
 
-/** Frame budget guarding the autoRowSize wait loop (~1s at 60fps) against a stuck inProgress flag. */
+/** Frame budget guarding each RAF wait loop (~1s at 60fps) against a never-met condition. */
 const MAX_SETTLE_FRAMES = 60;
+
+/** Returns the live, non-destroyed Handsontable instances mounted inside an example element. */
+function getInstances(el: Element): any[] {
+  return [...el.querySelectorAll<HTMLElement>('.ht-root-wrapper')]
+    .map(wrapper => (wrapper as any).__hotInstance)
+    .filter(hot => hot && !hot.isDestroyed);
+}
+
+/**
+ * Refreshes the dimensions of a Handsontable instance once autoRowSize stops sampling.
+ *
+ * autoRowSize samples row heights across several requestAnimationFrame cycles, and refreshing
+ * mid-sampling computes 0 visible rows. So wait frame by frame until it reports completion
+ * (capped, so a stuck flag can't hang), then call refreshDimensions(), which re-reads the
+ * container box and re-renders only when the size actually changed.
+ */
+function refreshWhenSettled(hot: any): void {
+  let frames = 0;
+
+  const tick = (): void => {
+    if (hot.isDestroyed) return;
+
+    const autoRowSize = hot.getPlugin?.('autoRowSize');
+
+    if (autoRowSize?.isEnabled?.() && autoRowSize.inProgress && frames < MAX_SETTLE_FRAMES) {
+      frames += 1;
+      requestAnimationFrame(tick);
+
+      return;
+    }
+
+    try {
+      hot.refreshDimensions();
+    } catch (err) {
+      console.warn('[hot-example] renderInstances failed:', err);
+    }
+  };
+
+  requestAnimationFrame(tick);
+}
 
 /**
  * Refreshes the dimensions of every Handsontable instance inside an example element.
  *
  * Examples mount inside a zero-size loading shimmer, so the grid initializes with stale
  * (often zero) dimensions. Once markLoaded() reveals the real container we must re-read its
- * size. A fixed setTimeout(100) before render() used to do this, but it was a race:
- * autoRowSize samples row heights across several requestAnimationFrame cycles, and on slow
- * machines sampling outlasts 100ms. A render() fired mid-sampling computes 0 visible rows and
- * leaves the grid in the broken initial state (default row-number headers instead of the
- * configured empty ones).
+ * size. A fixed setTimeout(100) before render() used to do this, but it was a race against
+ * autoRowSize sampling: on slow machines the render fired mid-sampling, computed 0 rows, and
+ * left the grid in the broken initial state (default row-number headers instead of empty ones).
  *
- * Instead, wait frame by frame until autoRowSize reports it has finished sampling, then call
- * refreshDimensions(), which re-reads the container box and re-renders only when the size
- * actually changed.
+ * React, Vue, and Angular mount their components asynchronously, so the instances may not be in
+ * the DOM yet when this runs. Poll for them first (the old fixed delay masked this by deferring
+ * the whole query), then schedule a settle-aware refresh for each.
  */
 function renderInstances(el: Element): void {
-  el.querySelectorAll<HTMLElement>('.ht-root-wrapper').forEach((wrapper) => {
-    const hot = (wrapper as any).__hotInstance;
+  let frames = 0;
 
-    if (!hot) return;
+  const waitForInstances = (): void => {
+    const instances = getInstances(el);
 
-    let frames = 0;
+    if (instances.length === 0 && frames < MAX_SETTLE_FRAMES) {
+      frames += 1;
+      requestAnimationFrame(waitForInstances);
 
-    const refreshWhenSettled = (): void => {
-      if (hot.isDestroyed) return;
+      return;
+    }
 
-      const autoRowSize = hot.getPlugin?.('autoRowSize');
+    instances.forEach(refreshWhenSettled);
+  };
 
-      // autoRowSize samples row heights over several RAF cycles; refreshing mid-sampling
-      // produces 0 rows. Wait until it reports completion (capped, so a stuck flag can't hang).
-      if (autoRowSize?.isEnabled?.() && autoRowSize.inProgress && frames < MAX_SETTLE_FRAMES) {
-        frames += 1;
-        requestAnimationFrame(refreshWhenSettled);
-
-        return;
-      }
-
-      try {
-        hot.refreshDimensions();
-      } catch (err) {
-        console.warn('[hot-example] renderInstances failed:', err);
-      }
-    };
-
-    requestAnimationFrame(refreshWhenSettled);
-  });
+  requestAnimationFrame(waitForInstances);
 }
 
 // ── Main runner ───────────────────────────────────────────────────────────

--- a/docs/src/scripts/example-runner.ts
+++ b/docs/src/scripts/example-runner.ts
@@ -74,16 +74,44 @@ function getInstances(el: Element): any[] {
 }
 
 /**
- * Re-renders a Handsontable instance once autoRowSize stops sampling.
+ * Forces a full overlay resync, mirroring what a user scroll does.
+ *
+ * The inline-start (row header) overlay is a separate clone element whose height is sized from the
+ * holder's height. When the grid first renders into a collapsed (0-height) container, that clone
+ * height is computed as 0, so its row numbers are clipped even though the inner table renders
+ * correctly. A plain render() does not recompute the clone height — but scrolling does. Nudging the
+ * holder's scroll position by a pixel and back triggers the same resync without moving the visible
+ * position. (Verified live: this is what turns the empty row-header column back into 1, 2, 3…)
+ */
+function resyncOverlays(hot: any): void {
+  const holder = hot?.view?._wt?.wtTable?.holder;
+
+  if (!holder) return;
+
+  const { scrollTop, scrollLeft } = holder;
+
+  holder.scrollTop = scrollTop + 1;
+  holder.scrollLeft = scrollLeft + 1;
+  holder.dispatchEvent(new Event('scroll'));
+  holder.scrollTop = scrollTop;
+  holder.scrollLeft = scrollLeft;
+  holder.dispatchEvent(new Event('scroll'));
+}
+
+/**
+ * Re-renders a Handsontable instance once autoRowSize stops sampling, then re-syncs its overlays.
  *
  * Examples sit in a flex layout where the grid fills its container (`.ht-wrapper { height: 100% }`)
  * while the container is sized by the grid's content. At first render — before the layout and CSS
- * settle — this resolves to a height of 0, and nothing breaks the deadlock on its own. A forced
- * render() applies the configured pixel height to the holder, which breaks the collapse.
+ * settle — this resolves to a height of 0, and nothing breaks the deadlock on its own.
  *
- * render() (not refreshDimensions()) is required here: refreshDimensions() only re-renders when the
- * container box reports a size change, so in the collapsed 0-height state it no-ops and the grid
- * stays broken.
+ * The fix is two passes:
+ *   1. render() applies the configured pixel height to the holder, which breaks the 0-height
+ *      collapse so the container reflows to its real size.
+ *   2. On the next frame — after the container has reflowed — resyncOverlays() nudges the scroll to
+ *      re-size the overlay clones against the now-correct holder height. Without this the
+ *      inline-start (row header) overlay keeps the 0 height it computed against the collapsed
+ *      viewport, so the row numbers stay clipped until the user scrolls.
  *
  * autoRowSize samples row heights across several requestAnimationFrame cycles, and rendering
  * mid-sampling computes 0 visible rows. So wait frame by frame until it reports completion
@@ -107,6 +135,11 @@ function refreshWhenSettled(hot: any): void {
 
     try {
       hot.render();
+
+      requestAnimationFrame(() => {
+        if (hot.isDestroyed) return;
+        resyncOverlays(hot);
+      });
     } catch (err) {
       console.warn('[hot-example] renderInstances failed:', err);
     }

--- a/docs/src/scripts/example-runner.ts
+++ b/docs/src/scripts/example-runner.ts
@@ -63,27 +63,55 @@ function markLoaded(el: Element): void {
   el.querySelector('.hot-example-preview')?.classList.remove('hot-example-preview--loading');
 }
 
+/** Frame budget guarding the autoRowSize wait loop (~1s at 60fps) against a stuck inProgress flag. */
+const MAX_SETTLE_FRAMES = 60;
+
 /**
- * Calls render() on every Handsontable instance inside an example element.
+ * Refreshes the dimensions of every Handsontable instance inside an example element.
  *
- * The delay is intentional: autoRowSize sampling runs over several RAF cycles
- * immediately after mount. Calling render() mid-sampling produces 0 rows because
- * the plugin temporarily resets holder dimensions. 100ms lets sampling complete
- * before the forced re-render.
+ * Examples mount inside a zero-size loading shimmer, so the grid initializes with stale
+ * (often zero) dimensions. Once markLoaded() reveals the real container we must re-read its
+ * size. A fixed setTimeout(100) before render() used to do this, but it was a race:
+ * autoRowSize samples row heights across several requestAnimationFrame cycles, and on slow
+ * machines sampling outlasts 100ms. A render() fired mid-sampling computes 0 visible rows and
+ * leaves the grid in the broken initial state (default row-number headers instead of the
+ * configured empty ones).
+ *
+ * Instead, wait frame by frame until autoRowSize reports it has finished sampling, then call
+ * refreshDimensions(), which re-reads the container box and re-renders only when the size
+ * actually changed.
  */
 function renderInstances(el: Element): void {
-  setTimeout(() => {
-    try {
-      el.querySelectorAll<HTMLElement>('.ht-root-wrapper').forEach((wrapper) => {
-        const hot = (wrapper as any).__hotInstance;
+  el.querySelectorAll<HTMLElement>('.ht-root-wrapper').forEach((wrapper) => {
+    const hot = (wrapper as any).__hotInstance;
 
-        if (!hot || hot.isDestroyed) return;
-        hot.render();
-      });
-    } catch (err) {
-      console.warn('[hot-example] renderInstances failed:', err);
-    }
-  }, 100);
+    if (!hot) return;
+
+    let frames = 0;
+
+    const refreshWhenSettled = (): void => {
+      if (hot.isDestroyed) return;
+
+      const autoRowSize = hot.getPlugin?.('autoRowSize');
+
+      // autoRowSize samples row heights over several RAF cycles; refreshing mid-sampling
+      // produces 0 rows. Wait until it reports completion (capped, so a stuck flag can't hang).
+      if (autoRowSize?.isEnabled?.() && autoRowSize.inProgress && frames < MAX_SETTLE_FRAMES) {
+        frames += 1;
+        requestAnimationFrame(refreshWhenSettled);
+
+        return;
+      }
+
+      try {
+        hot.refreshDimensions();
+      } catch (err) {
+        console.warn('[hot-example] renderInstances failed:', err);
+      }
+    };
+
+    requestAnimationFrame(refreshWhenSettled);
+  });
 }
 
 // ── Main runner ───────────────────────────────────────────────────────────

--- a/docs/tests/exampleInitialRender.spec.ts
+++ b/docs/tests/exampleInitialRender.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Regression test for DEV-1263.
+ *
+ * On initial page load, docs examples mount inside a zero-size loading shimmer.
+ * Once the shimmer is removed the grid must re-read its dimensions and render.
+ * The example-runner previously forced this render after a fixed setTimeout(100),
+ * which raced against autoRowSize height sampling (several requestAnimationFrame
+ * cycles). When the forced render fired mid-sampling the grid computed 0 rows and
+ * stayed visually broken until the user scrolled or clicked.
+ *
+ * These tests assert that every framework's demo grid renders its data on initial
+ * load WITHOUT any interaction. CPU throttling is applied to widen the timing
+ * window so the old race reliably surfaces; the assertions never click or scroll,
+ * so a stuck-broken grid cannot "self-heal" before the check.
+ */
+
+// The first data row of the getting-started demo (shared across all frameworks).
+const FIRST_CELL_TEXT = 'Tagcat';
+
+const demoPages = [
+  { prefix: 'js', path: '/javascript-data-grid/demo' },
+  { prefix: 'react', path: '/react-data-grid/demo' },
+  { prefix: 'angular', path: '/angular-data-grid/demo' },
+  { prefix: 'vue', path: '/vue-data-grid/demo' },
+];
+
+test.beforeEach(async({ page, baseURL }) => {
+  const url = new URL(baseURL?.toString() || '');
+  const extractedDomain = url.hostname;
+
+  await page.context().addCookies([
+    {
+      name: 'CookieConsent',
+      value: '-2',
+      domain: extractedDomain,
+      path: '/',
+      expires: -1,
+      httpOnly: false,
+      secure: false,
+      sameSite: 'Lax',
+    },
+    {
+      name: '70d6d6e3-3a3e-4392-a095-5fe2a6b8bd70',
+      value: process.env.PASS_COOKIE ? process.env.PASS_COOKIE : '',
+      domain: 'dev.handsontable.com',
+      path: '/',
+      expires: -1,
+      httpOnly: false,
+      secure: false,
+      sameSite: 'Lax',
+    },
+  ]);
+});
+
+demoPages.forEach(({ prefix, path }) => {
+  test(`${prefix} demo renders data on initial load without interaction`, async({ page, baseURL }) => {
+    // Throttle the CPU so autoRowSize sampling outlasts the legacy 100ms timer,
+    // reproducing the conditions under which the initial render previously broke.
+    const client = await page.context().newCDPSession(page);
+
+    await client.send('Emulation.setCPUThrottlingRate', { rate: 6 });
+
+    await page.goto(`${baseURL}${path}`);
+    await expect(page.getByText('Page not found (404)')).toHaveCount(0);
+    await expect(page.getByText('Password protected site')).toHaveCount(0);
+
+    // The master table holds the rendered data cells. A broken initial render
+    // produces 0 data rows, so the first cell never receives its value.
+    const firstDataCell = page
+      .locator('.ht_master .htCore tbody tr')
+      .first()
+      .locator('td')
+      .first();
+
+    // No click or scroll happens before this assertion: it passes only if the
+    // grid settled into a correct render on its own.
+    await expect(firstDataCell).toHaveText(FIRST_CELL_TEXT);
+
+    // Guard against a partially-collapsed render: several data rows must exist.
+    const renderedRows = page.locator('.ht_master .htCore tbody tr');
+
+    expect(await renderedRows.count()).toBeGreaterThan(5);
+  });
+});


### PR DESCRIPTION
### Context

The PR fixes the recurrence of DEV-1263: on initial load of the docs demo pages, the grid renders in a broken state (row-header column shows index numbers, data not laid out) and only corrects itself after the user scrolls or clicks. It affects every framework demo (JS, React, Angular, Vue).

The original fix (#12513) added a forced `render()` in `docs/src/scripts/example-runner.ts`, scheduled with a fixed `setTimeout(fn, 100)`. Examples mount inside a zero-size loading shimmer, so the grid initializes with stale dimensions and must re-render once the shimmer is removed. But `autoRowSize` samples row heights across several `requestAnimationFrame` cycles after mount, and during sampling the viewport is transiently disturbed. On a slow or loaded machine (CI, cold CPU, large example) sampling outlasts the 100ms timer, so the forced render fires mid-sampling, computes 0 visible rows, and the grid stays broken until a user interaction triggers a fresh render. That is the recurrence reported on production docs.

This change removes the timing bet:

- It waits frame by frame until `autoRowSize.inProgress` is `false` (capped at ~60 frames so a stuck flag cannot hang), so the refresh is correct regardless of how long sampling takes.
- It calls `hot.refreshDimensions()` instead of `hot.render()`. `refreshDimensions()` is the purpose-built API (the same one the `ResizeObserver` path uses): it re-reads the container box after the shimmer is removed and re-renders only when the size changed.

Because all four frameworks funnel through the same `renderInstances()` helper, the fix is framework-agnostic.

### How has this been tested?

- Added `docs/tests/exampleInitialRender.spec.ts`: a Playwright spec that, for each framework demo page, throttles the CPU (6×) to widen the timing window, loads the page, and asserts the grid renders its data on initial load **without any interaction** (first data cell shows `Tagcat`, and more than 5 data rows are rendered). The assertions never click or scroll, so a stuck-broken grid cannot self-heal before the check. Run with:
  - `BASE_URL=<docs-url> npx playwright test exampleInitialRender.spec.ts` (from `docs/`)
- Existing `docs/tests/visualDocs.spec.ts` continues to cover the demo pages as a screenshot net.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1263

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`
- [x] `handsontable-documentation`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog] — docs tooling and test only; no package source code changed.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1263

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scope is docs example bootstrapping and a new Playwright spec only; no Handsontable package runtime changes.
> 
> **Overview**
> Fixes **DEV-1263** where docs demo grids could stay broken on first paint (missing/wrong data, clipped row headers) until scroll or click, especially when **autoRowSize** sampling outlasted a hardcoded delay.
> 
> In **`example-runner.ts`**, the old **`setTimeout(100)` + `hot.render()`** path is replaced with **`requestAnimationFrame`** loops capped at **`MAX_SETTLE_FRAMES`**: **`renderInstances`** waits for Handsontable instances to appear (async framework mounts), then **`refreshWhenSettled`** waits until **autoRowSize** is not **`inProgress`** before calling **`hot.render()`**. A follow-up frame runs **`resyncOverlays`**, which nudges the holder scroll and dispatches scroll events so overlay clones (row headers) pick up the real height after the 0-height loading shimmer.
> 
> Adds **`docs/tests/exampleInitialRender.spec.ts`**: Playwright checks JS/React/Angular/Vue demo pages under **6× CPU throttling** assert the first data cell shows **`Tagcat`** and more than five rows **without** user interaction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5634983438df177354a068025bf12edf7c805d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->