### PR TITLE
fix: Fixed width of the Vue demo example

### DIFF
--- a/docs/content/guides/getting-started/events-and-hooks/react/example3.css
+++ b/docs/content/guides/getting-started/events-and-hooks/react/example3.css
@@ -1,3 +1,3 @@
-#example3 {
+.example-3-max-width {
   max-width: 440px;
 }

--- a/docs/content/guides/getting-started/events-and-hooks/react/example3.jsx
+++ b/docs/content/guides/getting-started/events-and-hooks/react/example3.jsx
@@ -68,7 +68,7 @@ const ExampleComponent = () => {
         </div>
       </div>
 
-      <HotTable id="hot" {...settings} />
+      <HotTable className="example-3-max-width" id="hot" {...settings} />
     </div>
   );
 };

--- a/docs/content/guides/getting-started/events-and-hooks/react/example3.tsx
+++ b/docs/content/guides/getting-started/events-and-hooks/react/example3.tsx
@@ -68,7 +68,7 @@ const ExampleComponent = () => {
         </div>
       </div>
 
-      <HotTable id="hot" {...settings} />
+      <HotTable className="example-3-max-width" id="hot" {...settings} />
     </div>
   );
 };

--- a/docs/content/guides/getting-started/events-and-hooks/vue/example3.vue
+++ b/docs/content/guides/getting-started/events-and-hooks/vue/example3.vue
@@ -53,7 +53,7 @@ function onColHeadersChange(event: Event) {
 </script>
 
 <template>
-  <div id="example3">
+  <div id="example3" class="example-3-max-width">
     <div class="example-controls-container">
       <div class="controls">
         <label>
@@ -82,7 +82,7 @@ function onColHeadersChange(event: Event) {
 </template>
 
 <style>
-#example3 {
+.example-3-max-width {
   max-width: 440px;
 }
 </style>


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
On the builded documentation, styles from the other examples overlaped with one another. In this case, css from the react hook example caused the vue demo to have limited width, as both shared same ID (`#example3`)

Task: https://app.clickup.com/t/9015210959/DEV-1870

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Tested on the builded version of the docs.
* Vue demo has width 100%
* React hook demo has limited width

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation demo styling only; no runtime library, auth, or data-path changes.
> 
> **Overview**
> Fixes **built docs** layout where the React **events-and-hooks** example’s `#example3 { max-width: 440px }` rule was also hitting the Vue demo’s `#example3` wrapper, so the Vue table looked incorrectly narrow.
> 
> The max-width constraint is moved to a shared **`.example-3-max-width`** class: React applies it on `HotTable` in `example3.jsx` / `example3.tsx` (with `example3.css` updated), and Vue adds the class on its root while switching the scoped style from `#example3` to the class. Vue keeps `id="example3"` for the docs example anchor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 576413d40183fc09bf587761109f811a5834a3a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->