### PR TITLE
DEV-1764: Fix missing sitemap-index.xml in nginx redirects config

### DIFF
--- a/docs/cloudflare/_worker.js
+++ b/docs/cloudflare/_worker.js
@@ -7,6 +7,7 @@
  *
  * Redirect priority order (first match wins):
  *   1. /docs/next/:splat                   → /docs/:splat
+ *  1a. /docs/sitemap.xml                   → /docs/sitemap-index.xml
  *   2. / → /docs
  *  2a. /0.8.0/*                            → /docs/javascript-data-grid/changelog
  *  2b. /docs/redirect?pageId=*             → /docs/javascript-data-grid/changelog
@@ -703,6 +704,12 @@ export default {
       const dest = `/docs${splat}${url.search}`;
 
       return redirect301(abs(dest, url));
+    }
+
+    // -- 1a. /docs/sitemap.xml → /docs/sitemap-index.xml ---------------------
+    // Redirect the legacy single-file sitemap URL to Astro's sitemap index.
+    if (path === '/docs/sitemap.xml') {
+      return redirect301(abs('/docs/sitemap-index.xml', url));
     }
 
     // -- 2. Root / → /docs ---------------------------------------------------

--- a/docs/docker/redirects.conf
+++ b/docs/docker/redirects.conf
@@ -198,6 +198,9 @@ rewrite ^/docs/((\d+\.\d+|next)/)?demo-formula-support/?$ /docs/$1$framework/for
 rewrite ^/docs/((\d+\.\d+|next)/)?demo-using-callbacks/?$ /docs/$1$framework/events-and-hooks/ permanent;
 rewrite ^/docs/((\d+\.\d+|next)/)?demo-react-simple-examples/?$ /docs/$1$framework/react-simple-example/ permanent;
 
+# Redirect legacy single-file sitemap URL to Astro's sitemap index
+rewrite ^/docs/sitemap\.xml$ /docs/sitemap-index.xml permanent;
+
 # Redirect all urls without framework prefix e.g. from /docs/[path] to /docs/javascript-data-grid/[path].
 # Except those that already contain a name in the path:
 #  * /javascript-data-grid/
@@ -211,12 +214,12 @@ rewrite ^/docs/((\d+\.\d+|next)/)?demo-react-simple-examples/?$ /docs/$1$framewo
 #  * /scripts/
 #  * /img/
 #  * /404.html
-#  * /sitemap.xml
+#  * /sitemap*.xml (sitemap-index.xml, sitemap-0.xml, etc.)
 #  * /securitum-certificate.pdf
 #  * /seqred-certificate.pdf
 #  * /testarmy-certificate.pdf
 #  * /testarmy-certificate-2024.pdf
 #  * /testarmy-certificate-2025.pdf
 
-rewrite ^/docs/((?:\d+\.\d+|next)/)(?!(?:javascript|react|angular)-data-grid|redirect|assets/|data/|handsontable|@handsontable/|img/|scripts/|404\.html|sitemap\.xml|securitum-certificate\.pdf|seqred-certificate\.pdf|testarmy-certificate\.pdf|testarmy-certificate-2024\.pdf|testarmy-certificate-2025\.pdf)(.+)$ /docs/$1$framework/$2 permanent;
-rewrite ^/docs/(?!\d+\.\d+|next\/)(?!(?:javascript|react|angular)-data-grid|redirect|assets/|data/|handsontable/|@handsontable/|img/|scripts/|404\.html|sitemap\.xml|securitum-certificate\.pdf|seqred-certificate\.pdf|testarmy-certificate\.pdf|testarmy-certificate-2024\.pdf|testarmy-certificate-2025\.pdf)(.+)$ /docs/$framework/$1 permanent;
+rewrite ^/docs/((?:\d+\.\d+|next)/)(?!(?:javascript|react|angular)-data-grid|redirect|assets/|data/|handsontable|@handsontable/|img/|scripts/|404\.html|sitemap[^/]*\.xml|securitum-certificate\.pdf|seqred-certificate\.pdf|testarmy-certificate\.pdf|testarmy-certificate-2024\.pdf|testarmy-certificate-2025\.pdf)(.+)$ /docs/$1$framework/$2 permanent;
+rewrite ^/docs/(?!\d+\.\d+|next\/)(?!(?:javascript|react|angular)-data-grid|redirect|assets/|data/|handsontable/|@handsontable/|img/|scripts/|404\.html|sitemap[^/]*\.xml|securitum-certificate\.pdf|seqred-certificate\.pdf|testarmy-certificate\.pdf|testarmy-certificate-2024\.pdf|testarmy-certificate-2025\.pdf)(.+)$ /docs/$framework/$1 permanent;

--- a/docs/netlify/_redirects
+++ b/docs/netlify/_redirects
@@ -1,5 +1,8 @@
 / /docs
 
+# Redirect legacy single-file sitemap URL to Astro's sitemap index
+/docs/sitemap.xml /docs/sitemap-index.xml 301
+
 /docs/:version/redirect pageId=:pageId /docs/javascript-data-grid/changelog 301
 /docs/redirect pageId=:pageId /docs/javascript-data-grid/changelog 301
 


### PR DESCRIPTION
### Context

The PR fixes missing `sitemap-index.xml` (and `sitemap-0.xml`) on the production docs site.

`@astrojs/sitemap` generates `sitemap-index.xml` + `sitemap-0.xml` during the build — both files land correctly in `dist/`. However, two nginx rewrite rules in `docker/redirects.conf` redirect any unrecognised `/docs/<path>` to a framework-prefixed URL (e.g. `/docs/javascript-data-grid/<path>`). Those rules had a negative-lookahead exclusion list that included only `sitemap\.xml` — a leftover from the VuePress era that generated a single `sitemap.xml`. Neither Astro output filename matched, so requests to `/docs/sitemap-index.xml` were rewritten to a non-existent path and returned 404.

The Netlify deployment had no equivalent interception issue (edge functions only match explicit page slugs), but `/docs/sitemap.xml` would still 404 there with no static file and no redirect.

Changes:

**`docker/redirects.conf`** (Docker/nginx deployment):
- Broadened the exclusion pattern from `sitemap\.xml` to `sitemap[^/]*\.xml` in both rewrite rules to cover all Astro-generated sitemap files.
- Added an explicit `301` redirect from `/docs/sitemap.xml` → `/docs/sitemap-index.xml` for crawlers still using the old single-file URL.
- Updated the comment block to reflect the current file naming.

**`netlify/_redirects`** (Netlify deployment):
- Added `301` redirect from `/docs/sitemap.xml` → `/docs/sitemap-index.xml` for parity with the nginx fix.

### How has this been tested?

* Netlify:
  * `https://dev-handsontable-docs-dev-1764-fix-si.netlify.app/docs/sitemap.xml` redirects to `https://dev-handsontable-docs-dev-1764-fix-si.netlify.app/docs/sitemap-index.xml`
  * `https://dev-handsontable-docs-dev-1764-fix-si.netlify.app/docs/sitemap-index.xml` works
  * `https://dev-handsontable-docs-dev-1764-fix-si.netlify.app/docs/sitemap-0.xml` works
* Cloudflare:
  * `https://pr-12774.handsontable-docs-staging.pages.dev/docs/sitemap.xml` redirects to `https://pr-12774.handsontable-docs-staging.pages.dev/docs/sitemap-index.xml`
  * `https://pr-12774.handsontable-docs-staging.pages.dev/docs/sitemap-index.xml` works
  * `https://pr-12774.handsontable-docs-staging.pages.dev/docs/sitemap-0.xml` works

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1764

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1764


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Redirect-only changes for static sitemap URLs; no application logic or auth/data paths affected.
> 
> **Overview**
> Fixes **404s for Astro-generated sitemaps** (`sitemap-index.xml`, `sitemap-0.xml`) on production docs by aligning redirect rules with `@astrojs/sitemap` output instead of the old single `sitemap.xml` URL.
> 
> In **`docker/redirects.conf`**, the catch-all rules that prefix `/docs/<path>` with a framework slug now **exclude all sitemap XML files** (`sitemap[^/]*\.xml` instead of only `sitemap\.xml`), so those paths are no longer rewritten to bogus framework URLs. A **301** from `/docs/sitemap.xml` → `/docs/sitemap-index.xml` preserves crawlers still using the legacy URL.
> 
> **`netlify/_redirects`** and **`cloudflare/_worker.js`** add the same **legacy sitemap → sitemap-index** redirect so behavior matches nginx and Cloudflare Pages (where the worker replaces `_redirects`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33622df8123b4dd7c939e836ed6654f77434a7d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->