### PR TITLE
DEV-1875: Add visibleWhen option for collapsible nested headers (#10243)

### DIFF
--- a/.changelogs/12776.json
+++ b/.changelogs/12776.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Added the `visibleWhen` nested-header option (`'collapsed'`, `'expanded'`, `'always'`) that lets you choose which columns of a collapsible group stay visible when the group is collapsed or expanded.",
+  "type": "added",
+  "issueOrPR": 12776,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.claude/skills/handsontable-e2e-testing/SKILL.md
+++ b/.claude/skills/handsontable-e2e-testing/SKILL.md
@@ -154,6 +154,25 @@ Under the hood it spawns the regular Rspack dump in `--watch` mode and reopens t
 
 A generic `test/E2ERunner.html` (no run ID) is always regenerated alongside the per-run variant for developer manual testing in a browser. Specs that inject iframes with relative CSS paths (e.g. `afterRefreshDimensions`, `Selection`) rely on the runner living in `test/`, which is why the per-run HTML stays there too.
 
+## Debugging (capturing values from the browser)
+
+E2E specs run inside a headless browser, so a plain `console.log` is NOT printed to your terminal. The Puppeteer runner (`test/scripts/run-puppeteer.mjs`) forwards **only** page console messages whose text starts with `DEBUG`, printing them as `[BROWSER] <text>`:
+
+```js
+it('should ...', async() => {
+  handsontable({ /* ... */ });
+
+  // Prefix with DEBUG so the runner forwards it to your terminal.
+  console.log(`DEBUG state ${JSON.stringify({ labels: getColHeaders(), count: countCols() })}`);
+});
+```
+
+Then filter the run output: `npm run test:e2e --prefix handsontable --testPathPattern=<regex> 2>&1 | grep DEBUG`.
+
+Notes:
+- `JSON.stringify` **omits keys whose value is `undefined`** - a missing key in the output usually means the value was `undefined`, not that the line is stale. Use `String(value)` when you need to distinguish `undefined`/`false`/`null`.
+- For a quick yes/no check you can also just `expect(actual).toEqual('SENTINEL')` and read the "Expected ... to equal" diff - assertion failures always reach the terminal.
+
 ## Test location
 
 All E2E tests live under `src/` alongside the code they test. **The spec filename must match the method, hook, or setting name exactly** (e.g., `getSourceData.spec.js`, `afterChange.spec.js`, `height.spec.js`).

--- a/.github/workflows/docs-angular-typecheck.yml
+++ b/.github/workflows/docs-angular-typecheck.yml
@@ -48,6 +48,11 @@ jobs:
         run: npm run build --prefix wrappers/angular-wrapper
 
       - name: Run type check
+        # Gate on the build that was just checked out and built (the current branch - feature,
+        # develop, etc.), not on the last published `handsontable@latest`. Examples ship with the
+        # code in the same repo state, so one that uses an API added on this branch must not be
+        # failed for it; real type errors on the current build still fail the run.
         run: npm run typecheck --prefix docs/angular-type-check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SKIP_LATEST: '1'

--- a/docs/angular-type-check/README.md
+++ b/docs/angular-type-check/README.md
@@ -39,6 +39,7 @@ Pass `--no-strict` (or set `STRICT=0`) to fall back to the **lenient** dual-vers
 
 ### Useful flags / env
 
+- `--skip-latest` / `SKIP_LATEST=1` — gate on the **current branch build only** (`../../handsontable/tmp`) and skip the `handsontable@latest` comparison entirely. This is what CI uses (`.github/workflows/docs-angular-typecheck.yml`): the workflow checks out and builds the branch under test (a feature branch, `develop`, etc.), so the examples are validated against that build — not the last published release. An example that uses an API added on this branch is therefore not failed for it, while real type errors on the current build still fail. The `handsontable@latest` dual-version classification stays available for local/manual runs (omit the flag) and for `--report`.
 - `--no-strict` / `STRICT=0` — disable strict mode and use the lenient dual-version rule above (version-specific errors become warnings + a neutral PR check instead of failing).
 - `node check.mjs --report` — skips the pass/fail gate and instead classifies every example as **PUBLIC** (type-checks against `handsontable@latest`), **DEV-ONLY** (passes on the local build, fails on latest), or **BROKEN** (fails on both). Always exits `0`.
 - `REFRESH_LATEST=1` — forces a fresh `handsontable@latest` install instead of reusing the cached one in `.latest/` (see "Dual-version checking" below).

--- a/docs/angular-type-check/check.mjs
+++ b/docs/angular-type-check/check.mjs
@@ -38,6 +38,14 @@ const latestDir = path.resolve(__dirname, '.latest');
 // warnings.
 const strict = !process.argv.includes('--no-strict') && process.env.STRICT !== '0';
 
+// Current-build-only mode: type-check the examples against the local build only (the branch under
+// test - whatever the CI checked out and built: a feature branch, develop, etc.), and skip the
+// `handsontable@latest` comparison entirely. This is the right gate for CI: examples ship with the
+// code in the same repo state, so an example that uses an API added on this branch (not yet in the
+// published release) must NOT be failed for it. Real type errors on the current build still fail.
+// Enable with `--skip-latest` or `SKIP_LATEST=1` (the CI workflow sets it).
+const skipLatest = process.argv.includes('--skip-latest') || process.env.SKIP_LATEST === '1';
+
 fs.rmSync(tmpDir, { recursive: true, force: true });
 fs.mkdirSync(tmpDir, { recursive: true });
 
@@ -285,21 +293,34 @@ if (process.argv.includes('--report')) {
 console.log('\n[1/2] Type-checking against local build (../../handsontable/tmp) ...');
 const local = runCheck({ label: 'local', htDir: '../../handsontable/tmp' });
 
-console.log(local.ok
-  ? 'Local build type-checks cleanly; verifying against handsontable@latest to catch latest-only breakages ...'
-  : 'Local build reported errors; verifying against handsontable@latest to classify them ...');
-
-// 2) Always run latest too — even when local is clean — so issues can be
+// 2) Optionally run latest too — even when local is clean — so issues can be
 //    classified as LOCAL-ONLY, LATEST-ONLY, or BOTH. Skipping latest on a clean
 //    local run would hide a "DEV-ONLY" example (type-checks on the dev build but
 //    is broken on the published version): it should surface as a neutral check,
-//    not a silent green.
-const { htPath, version } = ensureLatestHandsontable();
-console.log(`\n[2/2] Type-checking against handsontable@latest (${version}) ...`);
-const latest = runCheck({ label: 'latest', htDir: path.relative(__dirname, htPath).split(path.sep).join('/') });
+//    not a silent green. In `--skip-latest` mode the run gates on the current
+//    branch build only and the published-release comparison is not performed.
+let version = 'skipped';
+let latest = { ok: true, output: '' };
+
+if (skipLatest) {
+  console.log('\n[2/2] Skipping the handsontable@latest comparison (--skip-latest) — '
+    + 'gating on the current branch build only.');
+} else {
+  console.log(local.ok
+    ? 'Local build type-checks cleanly; verifying against handsontable@latest to catch latest-only breakages ...'
+    : 'Local build reported errors; verifying against handsontable@latest to classify them ...');
+
+  const { htPath, version: latestVersion } = ensureLatestHandsontable();
+
+  version = latestVersion;
+  console.log(`\n[2/2] Type-checking against handsontable@latest (${version}) ...`);
+  latest = runCheck({ label: 'latest', htDir: path.relative(__dirname, htPath).split(path.sep).join('/') });
+}
 
 const localErrors = parseErrors(local.output);
-const latestErrors = parseErrors(latest.output);
+// With latest skipped there is no second version, so every local error is treated as a
+// current-build error (it lands in `localOnly` below and fails the run in strict mode).
+const latestErrors = skipLatest ? new Map() : parseErrors(latest.output);
 
 // Guard: if ngc exited non-zero but we couldn't extract a single `error TS…`
 // line from its output, the failure is in a form the parser doesn't understand

--- a/docs/content/guides/columns/column-groups/angular/example3.html
+++ b/docs/content/guides/columns/column-groups/angular/example3.html
@@ -1,0 +1,3 @@
+<div>
+    <app-example3></app-example3>
+</div>

--- a/docs/content/guides/columns/column-groups/angular/example3.ts
+++ b/docs/content/guides/columns/column-groups/angular/example3.ts
@@ -1,0 +1,66 @@
+/* file: app.component.ts */
+import { Component } from '@angular/core';
+import { GridSettings, HotTableModule} from '@handsontable/angular-wrapper';
+
+@Component({
+  selector: 'app-example3',
+  template: `
+    <hot-table
+      [settings]="hotSettings!" [data]="hotData">
+    </hot-table>
+  `,
+  standalone: true,
+  imports: [HotTableModule],
+})
+export class AppComponent {
+
+  readonly hotData = [
+    ['North America', 4200, 3800, 4500, 12500],
+    ['Europe', 3100, 2900, 3300, 9300],
+    ['Asia Pacific', 2600, 2400, 2800, 7800],
+    ['Latin America', 1500, 1700, 1600, 4800],
+    ['Middle East', 1200, 1300, 1450, 3950],
+  ];
+
+  readonly hotSettings: GridSettings = {
+    colHeaders: true,
+    rowHeaders: true,
+    colWidths: 90,
+    height: 'auto',
+    nestedHeaders: [
+      ['Region', { label: 'Q1 2025', colspan: 4 }],
+      [
+        'Region',
+        { label: 'Jan', visibleWhen: 'expanded' },
+        { label: 'Feb', visibleWhen: 'expanded' },
+        { label: 'Mar', visibleWhen: 'expanded' },
+        { label: 'Total', visibleWhen: 'collapsed' },
+      ],
+    ],
+    collapsibleColumns: true,
+    autoWrapRow: true,
+    autoWrapCol: true,
+  };
+}
+/* end-file */
+
+
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+/* end-file */

--- a/docs/content/guides/columns/column-groups/column-groups.md
+++ b/docs/content/guides/columns/column-groups/column-groups.md
@@ -285,21 +285,50 @@ By default, collapsing a group leaves its first column visible. To choose which 
 - `'expanded'` - the column is visible only while its group is expanded (hidden while collapsed).
 - `'always'` - the column is visible in both states. This is the default when `visibleWhen` is omitted.
 
-In the example below, collapsing the **Q1 2025** group keeps only the **Total** column visible, and the per-month columns return when you expand it:
+In the example below, collapse the **Q1 2025** group: the per-month columns (`'expanded'`) hide and the **Total** column (`'collapsed'`) appears. Expanding the group reverses it.
 
-```js
-nestedHeaders: [
-  ['Region', { label: 'Q1 2025', colspan: 4 }],
-  [
-    'Region',
-    { label: 'Jan', visibleWhen: 'expanded' },
-    { label: 'Feb', visibleWhen: 'expanded' },
-    { label: 'Mar', visibleWhen: 'expanded' },
-    { label: 'Total', visibleWhen: 'collapsed' },
-  ],
-],
-collapsibleColumns: true,
-```
+::: only-for javascript
+
+::: example #example3 --js 1 --ts 2
+
+@[code](@/content/guides/columns/column-groups/javascript/example3.js)
+@[code](@/content/guides/columns/column-groups/javascript/example3.ts)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #example3 :react --js 1 --ts 2
+
+@[code](@/content/guides/columns/column-groups/react/example3.jsx)
+@[code](@/content/guides/columns/column-groups/react/example3.tsx)
+
+:::
+
+:::
+
+::: only-for angular
+
+::: example #example3 :angular --ts 1 --html 2
+
+@[code](@/content/guides/columns/column-groups/angular/example3.ts)
+@[code](@/content/guides/columns/column-groups/angular/example3.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example3 :vue3
+
+@[code](@/content/guides/columns/column-groups/vue/example3.vue)
+
+:::
+
+:::
 
 A header without any `visibleWhen` markers keeps the default behavior - collapsing leaves its first column visible. The `visibleWhen` property applies only to headers within a [`collapsible`](@/api/options.md#collapsiblecolumns) group.
 

--- a/docs/content/guides/columns/column-groups/column-groups.md
+++ b/docs/content/guides/columns/column-groups/column-groups.md
@@ -283,9 +283,11 @@ By default, collapsing a group leaves its first column visible. To choose which 
 
 - `'collapsed'` - the column is visible only while its group is collapsed (hidden while expanded).
 - `'expanded'` - the column is visible only while its group is expanded (hidden while collapsed).
-- `'always'` - the column is visible in both states. This is the default when `visibleWhen` is omitted.
+- `'always'` - the column is visible in both states.
 
-In the example below, collapse the **Q1 2025** group: the per-month columns (`'expanded'`) hide and the **Total** column (`'collapsed'`) appears. Expanding the group reverses it.
+Once a group uses `visibleWhen` on any of its headers, the headers you leave unmarked default to `'expanded'` - they are hidden when the group collapses. So you only mark the column(s) you want to keep: tag one with `'always'` (stays in both states) or `'collapsed'` (a summary column that appears only on collapse). At least one column of a group always stays visible, so its collapse button is never lost.
+
+In the example below, collapse the **Q1 2025** group: the per-month columns (marked `'expanded'`) hide and the **Total** column (`'collapsed'`) appears. Expanding the group reverses it.
 
 ::: only-for javascript
 
@@ -330,7 +332,7 @@ In the example below, collapse the **Q1 2025** group: the per-month columns (`'e
 
 :::
 
-A header without any `visibleWhen` markers keeps the default behavior - collapsing leaves its first column visible. The `visibleWhen` property applies only to headers within a [`collapsible`](@/api/options.md#collapsiblecolumns) group.
+A group whose headers use no `visibleWhen` markers keeps the default behavior - collapsing leaves its first column visible. The `visibleWhen` property applies only to headers within a [`collapsible`](@/api/options.md#collapsiblecolumns) group.
 
 ## Known limitations
 

--- a/docs/content/guides/columns/column-groups/column-groups.md
+++ b/docs/content/guides/columns/column-groups/column-groups.md
@@ -277,6 +277,32 @@ collapsibleColumns: [
 
 :::
 
+### Choose which columns stay visible when collapsed
+
+By default, collapsing a group leaves its first column visible. To choose which columns stay visible in each state, add the `visibleWhen` property to a header in the `nestedHeaders` configuration. It accepts three values:
+
+- `'collapsed'` - the column is visible only while its group is collapsed (hidden while expanded).
+- `'expanded'` - the column is visible only while its group is expanded (hidden while collapsed).
+- `'always'` - the column is visible in both states. This is the default when `visibleWhen` is omitted.
+
+In the example below, collapsing the **Q1 2025** group keeps only the **Total** column visible, and the per-month columns return when you expand it:
+
+```js
+nestedHeaders: [
+  ['Region', { label: 'Q1 2025', colspan: 4 }],
+  [
+    'Region',
+    { label: 'Jan', visibleWhen: 'expanded' },
+    { label: 'Feb', visibleWhen: 'expanded' },
+    { label: 'Mar', visibleWhen: 'expanded' },
+    { label: 'Total', visibleWhen: 'collapsed' },
+  ],
+],
+collapsibleColumns: true,
+```
+
+A header without any `visibleWhen` markers keeps the default behavior - collapsing leaves its first column visible. The `visibleWhen` property applies only to headers within a [`collapsible`](@/api/options.md#collapsiblecolumns) group.
+
 ## Known limitations
 
 - A column header can span up to 1000 columns, as the [HTML table specification](https://html.spec.whatwg.org/multipage/tables.html#dom-tdth-colspan) sets the

--- a/docs/content/guides/columns/column-groups/javascript/example3.js
+++ b/docs/content/guides/columns/column-groups/javascript/example3.js
@@ -1,0 +1,32 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+// register Handsontable's modules
+registerAllModules();
+const container = document.querySelector('#example3');
+new Handsontable(container, {
+    data: [
+        ['North America', 4200, 3800, 4500, 12500],
+        ['Europe', 3100, 2900, 3300, 9300],
+        ['Asia Pacific', 2600, 2400, 2800, 7800],
+        ['Latin America', 1500, 1700, 1600, 4800],
+        ['Middle East', 1200, 1300, 1450, 3950],
+    ],
+    colHeaders: true,
+    rowHeaders: true,
+    colWidths: 90,
+    height: 'auto',
+    nestedHeaders: [
+        ['Region', { label: 'Q1 2025', colspan: 4 }],
+        [
+            'Region',
+            { label: 'Jan', visibleWhen: 'expanded' },
+            { label: 'Feb', visibleWhen: 'expanded' },
+            { label: 'Mar', visibleWhen: 'expanded' },
+            { label: 'Total', visibleWhen: 'collapsed' },
+        ],
+    ],
+    collapsibleColumns: true,
+    autoWrapRow: true,
+    autoWrapCol: true,
+    licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/columns/column-groups/javascript/example3.ts
+++ b/docs/content/guides/columns/column-groups/javascript/example3.ts
@@ -1,0 +1,35 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const container = document.querySelector('#example3')!;
+
+new Handsontable(container, {
+  data: [
+    ['North America', 4200, 3800, 4500, 12500],
+    ['Europe', 3100, 2900, 3300, 9300],
+    ['Asia Pacific', 2600, 2400, 2800, 7800],
+    ['Latin America', 1500, 1700, 1600, 4800],
+    ['Middle East', 1200, 1300, 1450, 3950],
+  ],
+  colHeaders: true,
+  rowHeaders: true,
+  colWidths: 90,
+  height: 'auto',
+  nestedHeaders: [
+    ['Region', { label: 'Q1 2025', colspan: 4 }],
+    [
+      'Region',
+      { label: 'Jan', visibleWhen: 'expanded' },
+      { label: 'Feb', visibleWhen: 'expanded' },
+      { label: 'Mar', visibleWhen: 'expanded' },
+      { label: 'Total', visibleWhen: 'collapsed' },
+    ],
+  ],
+  collapsibleColumns: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/columns/column-groups/react/example3.jsx
+++ b/docs/content/guides/columns/column-groups/react/example3.jsx
@@ -1,0 +1,39 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={[
+        ['North America', 4200, 3800, 4500, 12500],
+        ['Europe', 3100, 2900, 3300, 9300],
+        ['Asia Pacific', 2600, 2400, 2800, 7800],
+        ['Latin America', 1500, 1700, 1600, 4800],
+        ['Middle East', 1200, 1300, 1450, 3950],
+      ]}
+      colHeaders={true}
+      rowHeaders={true}
+      colWidths={90}
+      height="auto"
+      nestedHeaders={[
+        ['Region', { label: 'Q1 2025', colspan: 4 }],
+        [
+          'Region',
+          { label: 'Jan', visibleWhen: 'expanded' },
+          { label: 'Feb', visibleWhen: 'expanded' },
+          { label: 'Mar', visibleWhen: 'expanded' },
+          { label: 'Total', visibleWhen: 'collapsed' },
+        ],
+      ]}
+      collapsibleColumns={true}
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/columns/column-groups/react/example3.tsx
+++ b/docs/content/guides/columns/column-groups/react/example3.tsx
@@ -1,0 +1,39 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={[
+        ['North America', 4200, 3800, 4500, 12500],
+        ['Europe', 3100, 2900, 3300, 9300],
+        ['Asia Pacific', 2600, 2400, 2800, 7800],
+        ['Latin America', 1500, 1700, 1600, 4800],
+        ['Middle East', 1200, 1300, 1450, 3950],
+      ]}
+      colHeaders={true}
+      rowHeaders={true}
+      colWidths={90}
+      height="auto"
+      nestedHeaders={[
+        ['Region', { label: 'Q1 2025', colspan: 4 }],
+        [
+          'Region',
+          { label: 'Jan', visibleWhen: 'expanded' },
+          { label: 'Feb', visibleWhen: 'expanded' },
+          { label: 'Mar', visibleWhen: 'expanded' },
+          { label: 'Total', visibleWhen: 'collapsed' },
+        ],
+      ]}
+      collapsibleColumns={true}
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/columns/column-groups/vue/example3.vue
+++ b/docs/content/guides/columns/column-groups/vue/example3.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['North America', 4200, 3800, 4500, 12500],
+    ['Europe', 3100, 2900, 3300, 9300],
+    ['Asia Pacific', 2600, 2400, 2800, 7800],
+    ['Latin America', 1500, 1700, 1600, 4800],
+    ['Middle East', 1200, 1300, 1450, 3950],
+  ],
+  colHeaders: true,
+  rowHeaders: true,
+  colWidths: 90,
+  height: 'auto',
+  nestedHeaders: [
+    ['Region', { label: 'Q1 2025', colspan: 4 }],
+    [
+      'Region',
+      { label: 'Jan', visibleWhen: 'expanded' },
+      { label: 'Feb', visibleWhen: 'expanded' },
+      { label: 'Mar', visibleWhen: 'expanded' },
+      { label: 'Total', visibleWhen: 'collapsed' },
+    ],
+  ],
+  collapsibleColumns: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example3">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/handsontable/src/__tests__/core/settings.types.ts
+++ b/handsontable/src/__tests__/core/settings.types.ts
@@ -168,7 +168,16 @@ const allSettings: Required<Handsontable.GridSettings> = {
   minSpareRows: 123,
   navigableHeaders: true,
   multiColumnSorting: true,
-  nestedHeaders: [],
+  nestedHeaders: [
+    ['Region', { label: 'Q1 2025', colspan: 4, collapsible: true }],
+    [
+      'Region',
+      { label: 'Jan', visibleWhen: 'expanded' },
+      { label: 'Feb', visibleWhen: 'expanded' },
+      { label: 'Total', visibleWhen: 'collapsed' },
+      { label: 'Note', visibleWhen: 'always', headerClassName: 'htRight', rowspan: 1 },
+    ],
+  ],
   nestedRows: true,
   noWordWrapClassName: 'foo',
   numericFormat: numericIntlFormatOptions,

--- a/handsontable/src/__tests__/core/settings.types.ts
+++ b/handsontable/src/__tests__/core/settings.types.ts
@@ -169,7 +169,7 @@ const allSettings: Required<Handsontable.GridSettings> = {
   navigableHeaders: true,
   multiColumnSorting: true,
   nestedHeaders: [
-    ['Region', { label: 'Q1 2025', colspan: 4, collapsible: true }],
+    ['Region', { label: 'Q1 2025', colspan: 4 }],
     [
       'Region',
       { label: 'Jan', visibleWhen: 'expanded' },

--- a/handsontable/src/core/settings.ts
+++ b/handsontable/src/core/settings.ts
@@ -12,6 +12,7 @@ import type { ColumnConditions } from '../plugins/filters';
 import type { PredefinedMenuItemKey, MenuItemConfig, ContextMenu } from '../plugins/contextMenu';
 import type { DropdownMenu } from '../plugins/dropdownMenu';
 import type { ColumnSortingConfig } from '../plugins/columnSorting';
+import type { NestedHeader } from '../plugins/nestedHeaders';
 import type { UndoRedoAction } from '../plugins/undoRedo';
 import type {
   DataProviderBeforeFetchParameters,
@@ -170,7 +171,7 @@ export interface GridSettings {
   manualRowMove?: boolean | number[];
   manualRowResize?: boolean | number[];
   mergeCells?: boolean | object | object[];
-  nestedHeaders?: unknown[][];
+  nestedHeaders?: NestedHeader[][];
   nestedRows?: boolean;
   pagination?: boolean | object;
   search?: boolean | object;

--- a/handsontable/src/core/settings.ts
+++ b/handsontable/src/core/settings.ts
@@ -150,7 +150,7 @@ export interface GridSettings {
   autoColumnSize?: boolean | object;
   autoRowSize?: boolean | object;
   bindRowsWithHeaders?: boolean | string;
-  collapsibleColumns?: boolean | object[];
+  collapsibleColumns?: boolean | { row: number; col: number; collapsible?: boolean; [key: string]: unknown }[];
   columnSummary?: object[] | (() => object[]);
   comments?: boolean | object | object[];
   contextMenu?: boolean | object | string[];

--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -4211,12 +4211,12 @@ export default (): Record<string, unknown> => {
      * | `colspan`         | `number`  | The number of data columns the header spans (an integer greater than `1`). Groups the columns it covers.                                                                                                                                                                                             |
      * | `rowspan`         | `number`  | The number of header rows the header spans (an integer greater than `1`).                                                                                                                                                                                                                            |
      * | `headerClassName` | `string`  | One or more space-separated CSS class names added to the header element (for example, `'htRight'`).                                                                                                                                                                                                  |
-     * | `visibleWhen`     | `string`  | For a header inside a collapsible group, sets in which collapse state the header (and its columns) stays visible: `'collapsed'` (visible only while the group is collapsed), `'expanded'` (visible only while the group is expanded), or `'always'` (visible in both states - the default when omitted). |
+     * | `visibleWhen`     | `string`  | For a header inside a collapsible group, sets in which collapse state the header (and its columns) stays visible: `'collapsed'` (visible only while the group is collapsed), `'expanded'` (visible only while the group is expanded), or `'always'` (visible in both states). When omitted, a header in such a group defaults to `'expanded'` - it is hidden when the group collapses. At least one column of a group always stays visible. |
      *
      * ::: tip
      * A header group is made collapsible through the [`collapsibleColumns`](#collapsibleColumns) option, not through
-     * `nestedHeaders`. Once a group is collapsible, the `visibleWhen` property lets you choose which of its columns
-     * stay visible when it is collapsed or expanded.
+     * `nestedHeaders`. Once a group is collapsible, mark the column(s) you want to keep visible when it collapses
+     * with `visibleWhen: 'always'` (or `'collapsed'`); the remaining columns are hidden on collapse by default.
      * :::
      *
      * ::: tip
@@ -4243,16 +4243,11 @@ export default (): Record<string, unknown> => {
      *   ['H', 'I', 'J', 'K', 'L', 'M', 'N', 'R', 'S', 'T']
      * ],
      *
-     * // choose which column stays visible when a collapsible group is collapsed
+     * // choose which columns stay visible when a collapsible group is collapsed:
+     * // unmarked headers (Jan, Feb, Mar) are hidden on collapse; `Total` appears only when collapsed
      * nestedHeaders: [
      *   ['Region', {label: 'Q1 2025', colspan: 4}],
-     *   [
-     *     'Region',
-     *     {label: 'Jan', visibleWhen: 'expanded'},
-     *     {label: 'Feb', visibleWhen: 'expanded'},
-     *     {label: 'Mar', visibleWhen: 'expanded'},
-     *     {label: 'Total', visibleWhen: 'collapsed'}
-     *   ]
+     *   ['Region', 'Jan', 'Feb', 'Mar', {label: 'Total', visibleWhen: 'collapsed'}]
      * ],
      * collapsibleColumns: true,
      * ```

--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -4193,14 +4193,31 @@ export default (): Record<string, unknown> => {
      * | `true`            | - Enable the [`NestedHeaders`](@/api/nestedHeaders.md) plugin<br>- Don't configure any nested headers                                 |
      * | Array of arrays   | - Enable the [`NestedHeaders`](@/api/nestedHeaders.md) plugin<br>- Configure headers that are nested on Handsontable's initialization |
      *
-     * If you set the `nestedHeaders` option to an array of arrays, each array configures one set of nested headers.
+     * If you set the `nestedHeaders` option to an array of arrays, each array configures one row of
+     * nested headers (top row first). Within a row, headers are listed left to right.
      *
      * Each array element configures one header, and can be one of the following:
      *
-     * | Array element | Description                                                                                  |
-     * | ------------- | -------------------------------------------------------------------------------------------- |
-     * | A string      | The header's label                                                                           |
-     * | An object     | Properties:<br>`label` (string): the header's label<br>`colspan` (integer): number of data columns the header spans<br>`rowspan` (integer): number of header rows the header spans<br>`headerClassName` (string): optional space-separated CSS class names |
+     * | Array element | Description                                               |
+     * | ------------- | --------------------------------------------------------- |
+     * | A string      | The header's label                                        |
+     * | An object     | A header configuration object (see the properties below) |
+     *
+     * A header configuration object accepts the following properties:
+     *
+     * | Property          | Type      | Description                                                                                                                                                                                                                                                                                          |
+     * | ----------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+     * | `label`           | `string`  | The header's label.                                                                                                                                                                                                                                                                                  |
+     * | `colspan`         | `number`  | The number of data columns the header spans (an integer greater than `1`). Groups the columns it covers.                                                                                                                                                                                             |
+     * | `rowspan`         | `number`  | The number of header rows the header spans (an integer greater than `1`).                                                                                                                                                                                                                            |
+     * | `headerClassName` | `string`  | One or more space-separated CSS class names added to the header element (for example, `'htRight'`).                                                                                                                                                                                                  |
+     * | `visibleWhen`     | `string`  | For a header inside a collapsible group, sets in which collapse state the header (and its columns) stays visible: `'collapsed'` (visible only while the group is collapsed), `'expanded'` (visible only while the group is expanded), or `'always'` (visible in both states - the default when omitted). |
+     *
+     * ::: tip
+     * A header group is made collapsible through the [`collapsibleColumns`](#collapsibleColumns) option, not through
+     * `nestedHeaders`. Once a group is collapsible, the `visibleWhen` property lets you choose which of its columns
+     * stay visible when it is collapsed or expanded.
+     * :::
      *
      * ::: tip
      * When `nestedHeaders` is configured, the `label` defined in the [`columns`](#columns) option for the same
@@ -4210,6 +4227,7 @@ export default (): Record<string, unknown> => {
      * Read more:
      * - [Plugins: `NestedHeaders`](@/api/nestedHeaders.md)
      * - [Column groups: Nested headers](@/guides/columns/column-groups/column-groups.md#nested-headers)
+     * - [Column groups: Choose which columns stay visible when collapsed](@/guides/columns/column-groups/column-groups.md#choose-which-columns-stay-visible-when-collapsed)
      *
      * @memberof Options#
      * @type {boolean|Array[]}
@@ -4218,11 +4236,25 @@ export default (): Record<string, unknown> => {
      *
      * @example
      * ```js
+     * // group headers with `label` and `colspan`
      * nestedHeaders: [
      *   ['A', {label: 'B', colspan: 8}, 'C'],
      *   ['D', {label: 'E', colspan: 4}, {label: 'F', colspan: 4}, 'G'],
      *   ['H', 'I', 'J', 'K', 'L', 'M', 'N', 'R', 'S', 'T']
      * ],
+     *
+     * // choose which column stays visible when a collapsible group is collapsed
+     * nestedHeaders: [
+     *   ['Region', {label: 'Q1 2025', colspan: 4}],
+     *   [
+     *     'Region',
+     *     {label: 'Jan', visibleWhen: 'expanded'},
+     *     {label: 'Feb', visibleWhen: 'expanded'},
+     *     {label: 'Mar', visibleWhen: 'expanded'},
+     *     {label: 'Total', visibleWhen: 'collapsed'}
+     *   ]
+     * ],
+     * collapsibleColumns: true,
      * ```
      */
     nestedHeaders: undefined,

--- a/handsontable/src/plugins/collapsibleColumns/__tests__/visibleWhen.spec.js
+++ b/handsontable/src/plugins/collapsibleColumns/__tests__/visibleWhen.spec.js
@@ -1,4 +1,4 @@
-describe('CollapsibleColumns', () => {
+describe('CollapsibleColumns visibleWhen option', () => {
   const id = 'testContainer';
 
   beforeEach(function() {
@@ -12,287 +12,370 @@ describe('CollapsibleColumns', () => {
     }
   });
 
-  describe('visibleWhen (issue #10243)', () => {
-    // The label of every header in the bottom (cell-adjacent) header row that is actually rendered.
-    function bottomHeaderLabels() {
-      const thead = spec().$container.find('.ht_clone_top thead')[0];
-      const rows = thead.querySelectorAll('tr');
-      const lastRow = rows[rows.length - 1];
+  // The label of every header in the bottom (cell-adjacent) header row that is actually rendered.
+  function bottomHeaderLabels() {
+    const thead = spec().$container.find('.ht_clone_top thead')[0];
+    const rows = thead.querySelectorAll('tr');
+    const lastRow = rows[rows.length - 1];
 
-      return Array.from(lastRow.querySelectorAll('th'))
-        .map((th) => {
-          const colHeader = th.querySelector('.colHeader');
+    return Array.from(lastRow.querySelectorAll('th'))
+      .map((th) => {
+        const colHeader = th.querySelector('.colHeader');
 
-          return colHeader ? colHeader.textContent.trim() : '';
-        })
-        .filter(label => label !== '');
-    }
+        return colHeader ? colHeader.textContent.trim() : '';
+      })
+      .filter(label => label !== '');
+  }
 
-    // Number of columns that are not hidden by any source (collapse, visibleWhen, HiddenColumns).
-    function visibleColumnsCount() {
-      let count = 0;
+  // Number of columns that are not hidden by any source (collapse, visibleWhen, HiddenColumns).
+  function visibleColumnsCount() {
+    let count = 0;
 
-      for (let column = 0; column < countCols(); column++) {
-        if (!columnIndexMapper().isHidden(hot().toPhysicalColumn(column))) {
-          count += 1;
-        }
+    for (let column = 0; column < countCols(); column++) {
+      if (!columnIndexMapper().isHidden(hot().toPhysicalColumn(column))) {
+        count += 1;
       }
-
-      return count;
     }
 
-    function collapseGroupB() {
-      getPlugin('collapsibleColumns').collapseSection({ row: -2, col: 1 });
-    }
+    return count;
+  }
 
-    function expandGroupB() {
-      getPlugin('collapsibleColumns').expandSection({ row: -2, col: 1 });
-    }
+  function collapseGroupB() {
+    getPlugin('collapsibleColumns').collapseSection({ row: -2, col: 1 });
+  }
 
-    function hasCollapsedIndicator() {
-      return spec().$container.find('.ht_clone_top thead .collapsibleIndicator.collapsed').length > 0;
-    }
+  function expandGroupB() {
+    getPlugin('collapsibleColumns').expandSection({ row: -2, col: 1 });
+  }
 
-    it('should hide a `visibleWhen: "collapsed"` column while the group is expanded', async() => {
-      handsontable({
-        data: createSpreadsheetData(3, 6),
-        colHeaders: true,
-        rowHeaders: true,
-        nestedHeaders: [
-          ['A', { label: 'Group B', colspan: 4 }, 'C'],
-          ['A',
-            { label: 'B1', visibleWhen: 'expanded' },
-            { label: 'B2', visibleWhen: 'expanded' },
-            { label: 'B3', visibleWhen: 'expanded' },
-            { label: 'Total', visibleWhen: 'collapsed' },
-            'C'],
-        ],
-        collapsibleColumns: true,
-      });
+  function hasCollapsedIndicator() {
+    return spec().$container.find('.ht_clone_top thead .collapsibleIndicator.collapsed').length > 0;
+  }
 
-      // The group starts expanded, so the collapsed-only "Total" column is hidden.
-      expect(bottomHeaderLabels()).toEqual(['A', 'B1', 'B2', 'B3', 'C']);
-      expect(visibleColumnsCount()).toBe(5);
+  it('should hide a `visibleWhen: "collapsed"` column while the group is expanded', async() => {
+    handsontable({
+      data: createSpreadsheetData(3, 6),
+      colHeaders: true,
+      rowHeaders: true,
+      nestedHeaders: [
+        ['A', { label: 'Group B', colspan: 4 }, 'C'],
+        ['A',
+          { label: 'B1', visibleWhen: 'expanded' },
+          { label: 'B2', visibleWhen: 'expanded' },
+          { label: 'B3', visibleWhen: 'expanded' },
+          { label: 'Total', visibleWhen: 'collapsed' },
+          'C'],
+      ],
+      collapsibleColumns: true,
     });
 
-    it('should show only the columns visible when collapsed (the chosen column), then restore on expand', async() => {
-      handsontable({
-        data: createSpreadsheetData(3, 6),
-        colHeaders: true,
-        rowHeaders: true,
-        nestedHeaders: [
-          ['A', { label: 'Group B', colspan: 4 }, 'C'],
-          ['A',
-            { label: 'B1', visibleWhen: 'expanded' },
-            { label: 'B2', visibleWhen: 'expanded' },
-            { label: 'B3', visibleWhen: 'always' }, // the chosen column to keep when collapsed
-            { label: 'B4', visibleWhen: 'expanded' },
-            'C'],
-        ],
-        collapsibleColumns: true,
-      });
+    // The group starts expanded, so the collapsed-only "Total" column is hidden.
+    expect(bottomHeaderLabels()).toEqual(['A', 'B1', 'B2', 'B3', 'C']);
+    expect(visibleColumnsCount()).toBe(5);
+  });
 
-      expect(bottomHeaderLabels()).toEqual(['A', 'B1', 'B2', 'B3', 'B4', 'C']);
-      expect(visibleColumnsCount()).toBe(6);
+  it('should show only the columns visible when collapsed (the chosen column), then restore on expand', async() => {
+    handsontable({
+      data: createSpreadsheetData(3, 6),
+      colHeaders: true,
+      rowHeaders: true,
+      nestedHeaders: [
+        ['A', { label: 'Group B', colspan: 4 }, 'C'],
+        ['A',
+          { label: 'B1', visibleWhen: 'expanded' },
+          { label: 'B2', visibleWhen: 'expanded' },
+          { label: 'B3', visibleWhen: 'always' }, // the chosen column to keep when collapsed
+          { label: 'B4', visibleWhen: 'expanded' },
+          'C'],
+      ],
+      collapsibleColumns: true,
+    });
 
+    expect(bottomHeaderLabels()).toEqual(['A', 'B1', 'B2', 'B3', 'B4', 'C']);
+    expect(visibleColumnsCount()).toBe(6);
+
+    collapseGroupB();
+    await render();
+
+    // Only the chosen `always` column (B3) stays visible under Group B.
+    expect(bottomHeaderLabels()).toEqual(['A', 'B3', 'C']);
+    expect(visibleColumnsCount()).toBe(3);
+    expect(hasCollapsedIndicator()).toBe(true);
+
+    expandGroupB();
+    await render();
+
+    expect(bottomHeaderLabels()).toEqual(['A', 'B1', 'B2', 'B3', 'B4', 'C']);
+    expect(visibleColumnsCount()).toBe(6);
+  });
+
+  it('should show a `visibleWhen: "collapsed"` summary column only while collapsed', async() => {
+    handsontable({
+      data: createSpreadsheetData(3, 6),
+      colHeaders: true,
+      rowHeaders: true,
+      nestedHeaders: [
+        ['A', { label: 'Group B', colspan: 4 }, 'C'],
+        ['A',
+          { label: 'B1', visibleWhen: 'expanded' },
+          { label: 'B2', visibleWhen: 'expanded' },
+          { label: 'B3', visibleWhen: 'expanded' },
+          { label: 'Total', visibleWhen: 'collapsed' },
+          'C'],
+      ],
+      collapsibleColumns: true,
+    });
+
+    expect(bottomHeaderLabels()).toEqual(['A', 'B1', 'B2', 'B3', 'C']);
+
+    collapseGroupB();
+    await render();
+
+    // The expanded-only columns collapse away and the summary column appears.
+    expect(bottomHeaderLabels()).toEqual(['A', 'Total', 'C']);
+    expect(visibleColumnsCount()).toBe(3);
+
+    expandGroupB();
+    await render();
+
+    expect(bottomHeaderLabels()).toEqual(['A', 'B1', 'B2', 'B3', 'C']);
+  });
+
+  it('should stay stable across repeated collapse/expand cycles', async() => {
+    handsontable({
+      data: createSpreadsheetData(3, 6),
+      colHeaders: true,
+      rowHeaders: true,
+      nestedHeaders: [
+        ['A', { label: 'Group B', colspan: 4 }, 'C'],
+        ['A',
+          { label: 'B1', visibleWhen: 'expanded' },
+          { label: 'B2', visibleWhen: 'expanded' },
+          { label: 'B3', visibleWhen: 'always' },
+          { label: 'B4', visibleWhen: 'expanded' },
+          'C'],
+      ],
+      collapsibleColumns: true,
+    });
+
+    for (let cycle = 0; cycle < 3; cycle++) {
       collapseGroupB();
-      await render();
+      await render(); // eslint-disable-line no-await-in-loop
 
-      // Only the chosen `always` column (B3) stays visible under Group B.
       expect(bottomHeaderLabels()).toEqual(['A', 'B3', 'C']);
-      expect(visibleColumnsCount()).toBe(3);
-      expect(hasCollapsedIndicator()).toBe(true);
 
       expandGroupB();
-      await render();
+      await render(); // eslint-disable-line no-await-in-loop
 
       expect(bottomHeaderLabels()).toEqual(['A', 'B1', 'B2', 'B3', 'B4', 'C']);
-      expect(visibleColumnsCount()).toBe(6);
+    }
+  });
+
+  it('should treat an invalid `visibleWhen` value as "always"', async() => {
+    handsontable({
+      data: createSpreadsheetData(3, 6),
+      colHeaders: true,
+      rowHeaders: true,
+      nestedHeaders: [
+        ['A', { label: 'Group B', colspan: 4 }, 'C'],
+        ['A',
+          { label: 'B1', visibleWhen: 'expanded' },
+          { label: 'B2', visibleWhen: 'nonsense' }, // invalid -> always visible
+          { label: 'B3', visibleWhen: 'expanded' },
+          { label: 'B4', visibleWhen: 'expanded' },
+          'C'],
+      ],
+      collapsibleColumns: true,
     });
 
-    it('should show a `visibleWhen: "collapsed"` summary column only while collapsed', async() => {
-      handsontable({
-        data: createSpreadsheetData(3, 6),
-        colHeaders: true,
-        rowHeaders: true,
-        nestedHeaders: [
-          ['A', { label: 'Group B', colspan: 4 }, 'C'],
-          ['A',
-            { label: 'B1', visibleWhen: 'expanded' },
-            { label: 'B2', visibleWhen: 'expanded' },
-            { label: 'B3', visibleWhen: 'expanded' },
-            { label: 'Total', visibleWhen: 'collapsed' },
-            'C'],
-        ],
-        collapsibleColumns: true,
-      });
+    collapseGroupB();
+    await render();
 
-      expect(bottomHeaderLabels()).toEqual(['A', 'B1', 'B2', 'B3', 'C']);
+    // B2 falls back to `always`, so it survives the collapse.
+    expect(bottomHeaderLabels()).toEqual(['A', 'B2', 'C']);
+  });
 
-      collapseGroupB();
-      await render();
-
-      // The expanded-only columns collapse away and the summary column appears.
-      expect(bottomHeaderLabels()).toEqual(['A', 'Total', 'C']);
-      expect(visibleColumnsCount()).toBe(3);
-
-      expandGroupB();
-      await render();
-
-      expect(bottomHeaderLabels()).toEqual(['A', 'B1', 'B2', 'B3', 'C']);
+  it('should keep the legacy first-child collapse for a group without any `visibleWhen` markers', async() => {
+    handsontable({
+      data: createSpreadsheetData(3, 6),
+      colHeaders: true,
+      rowHeaders: true,
+      nestedHeaders: [
+        ['A', { label: 'Group B', colspan: 4 }, 'C'],
+        ['A', 'B1', 'B2', 'B3', 'B4', 'C'],
+      ],
+      collapsibleColumns: true,
     });
 
-    it('should stay stable across repeated collapse/expand cycles', async() => {
-      handsontable({
-        data: createSpreadsheetData(3, 6),
-        colHeaders: true,
-        rowHeaders: true,
-        nestedHeaders: [
-          ['A', { label: 'Group B', colspan: 4 }, 'C'],
-          ['A',
-            { label: 'B1', visibleWhen: 'expanded' },
-            { label: 'B2', visibleWhen: 'expanded' },
-            { label: 'B3', visibleWhen: 'always' },
-            { label: 'B4', visibleWhen: 'expanded' },
-            'C'],
-        ],
-        collapsibleColumns: true,
-      });
+    collapseGroupB();
+    await render();
 
-      for (let cycle = 0; cycle < 3; cycle++) {
-        collapseGroupB();
-        await render(); // eslint-disable-line no-await-in-loop
+    // No markers -> the first child (B1) stays, exactly as before this feature.
+    expect(bottomHeaderLabels()).toEqual(['A', 'B1', 'C']);
+  });
 
-        expect(bottomHeaderLabels()).toEqual(['A', 'B3', 'C']);
-
-        expandGroupB();
-        await render(); // eslint-disable-line no-await-in-loop
-
-        expect(bottomHeaderLabels()).toEqual(['A', 'B1', 'B2', 'B3', 'B4', 'C']);
-      }
+  it('should union the `visibleWhen` hidden set with HiddenColumns', async() => {
+    handsontable({
+      data: createSpreadsheetData(3, 6),
+      colHeaders: true,
+      rowHeaders: true,
+      nestedHeaders: [
+        ['A', { label: 'Group B', colspan: 4 }, 'C'],
+        ['A',
+          { label: 'B1', visibleWhen: 'expanded' },
+          { label: 'B2', visibleWhen: 'always' },
+          { label: 'B3', visibleWhen: 'always' },
+          { label: 'B4', visibleWhen: 'expanded' },
+          'C'],
+      ],
+      collapsibleColumns: true,
+      hiddenColumns: { columns: [2] }, // hide B2 externally
     });
 
-    it('should treat an invalid `visibleWhen` value as "always"', async() => {
-      handsontable({
-        data: createSpreadsheetData(3, 6),
-        colHeaders: true,
-        rowHeaders: true,
-        nestedHeaders: [
-          ['A', { label: 'Group B', colspan: 4 }, 'C'],
-          ['A',
-            { label: 'B1', visibleWhen: 'expanded' },
-            { label: 'B2', visibleWhen: 'nonsense' }, // invalid -> always visible
-            { label: 'B3', visibleWhen: 'expanded' },
-            { label: 'B4', visibleWhen: 'expanded' },
-            'C'],
-        ],
-        collapsibleColumns: true,
-      });
+    collapseGroupB();
+    await render();
 
-      collapseGroupB();
-      await render();
+    // B1/B4 hidden by collapse, B2 hidden by HiddenColumns, only B3 remains.
+    expect(bottomHeaderLabels()).toEqual(['A', 'B3', 'C']);
+  });
 
-      // B2 falls back to `always`, so it survives the collapse.
-      expect(bottomHeaderLabels()).toEqual(['A', 'B2', 'C']);
+  it('should preserve a declarative collapse when columns are inserted nearby', async() => {
+    handsontable({
+      data: createSpreadsheetData(3, 6),
+      colHeaders: true,
+      rowHeaders: true,
+      nestedHeaders: [
+        ['A', { label: 'Group B', colspan: 4 }, 'C'],
+        ['A',
+          { label: 'B1', visibleWhen: 'expanded' },
+          { label: 'B2', visibleWhen: 'expanded' },
+          { label: 'B3', visibleWhen: 'always' },
+          { label: 'B4', visibleWhen: 'expanded' },
+          'C'],
+      ],
+      collapsibleColumns: true,
     });
 
-    it('should keep the legacy first-child collapse for a group without any `visibleWhen` markers', async() => {
-      handsontable({
-        data: createSpreadsheetData(3, 6),
-        colHeaders: true,
-        rowHeaders: true,
-        nestedHeaders: [
-          ['A', { label: 'Group B', colspan: 4 }, 'C'],
-          ['A', 'B1', 'B2', 'B3', 'B4', 'C'],
-        ],
-        collapsibleColumns: true,
-      });
+    collapseGroupB();
+    await render();
+    expect(bottomHeaderLabels()).toEqual(['A', 'B3', 'C']);
 
-      collapseGroupB();
-      await render();
+    // Insert a column to the left of the group; the declarative collapse must survive the rebuild.
+    await alter('insert_col_start', 0, 1);
 
-      // No markers -> the first child (B1) stays, exactly as before this feature.
-      expect(bottomHeaderLabels()).toEqual(['A', 'B1', 'C']);
+    expect(getPlugin('nestedHeaders').getStateManager().getHeaderTreeNodeData(-2, 2).isCollapsed).toBe(true);
+    expect(bottomHeaderLabels()).toEqual(['A', 'B3', 'C']);
+  });
+
+  it('should preserve a declarative collapse across an unrelated updateSettings call', async() => {
+    handsontable({
+      data: createSpreadsheetData(3, 6),
+      colHeaders: true,
+      rowHeaders: true,
+      nestedHeaders: [
+        ['A', { label: 'Group B', colspan: 4 }, 'C'],
+        ['A',
+          { label: 'B1', visibleWhen: 'expanded' },
+          { label: 'B2', visibleWhen: 'expanded' },
+          { label: 'B3', visibleWhen: 'always' },
+          { label: 'B4', visibleWhen: 'expanded' },
+          'C'],
+      ],
+      collapsibleColumns: true,
     });
 
-    it('should union the `visibleWhen` hidden set with HiddenColumns', async() => {
-      handsontable({
-        data: createSpreadsheetData(3, 6),
-        colHeaders: true,
-        rowHeaders: true,
-        nestedHeaders: [
-          ['A', { label: 'Group B', colspan: 4 }, 'C'],
-          ['A',
-            { label: 'B1', visibleWhen: 'expanded' },
-            { label: 'B2', visibleWhen: 'always' },
-            { label: 'B3', visibleWhen: 'always' },
-            { label: 'B4', visibleWhen: 'expanded' },
-            'C'],
-        ],
-        collapsibleColumns: true,
-        hiddenColumns: { columns: [2] }, // hide B2 externally
-      });
+    collapseGroupB();
+    await render();
+    expect(bottomHeaderLabels()).toEqual(['A', 'B3', 'C']);
 
-      collapseGroupB();
-      await render();
+    await updateSettings({ collapsibleColumns: true });
 
-      // B1/B4 hidden by collapse, B2 hidden by HiddenColumns, only B3 remains.
-      expect(bottomHeaderLabels()).toEqual(['A', 'B3', 'C']);
+    // The collapse (driven by the persisted `isCollapsed`) survives the settings rebuild.
+    expect(bottomHeaderLabels()).toEqual(['A', 'B3', 'C']);
+  });
+
+  it('should apply `visibleWhen` markers introduced by updateSettings', async() => {
+    handsontable({
+      data: createSpreadsheetData(3, 6),
+      colHeaders: true,
+      rowHeaders: true,
+      nestedHeaders: [
+        ['A', { label: 'Group B', colspan: 4 }, 'C'],
+        ['A', 'B1', 'B2', 'B3', 'B4', 'C'],
+      ],
+      collapsibleColumns: true,
     });
 
-    it('should preserve a declarative collapse when columns are inserted nearby', async() => {
-      handsontable({
-        data: createSpreadsheetData(3, 6),
-        colHeaders: true,
-        rowHeaders: true,
-        nestedHeaders: [
-          ['A', { label: 'Group B', colspan: 4 }, 'C'],
-          ['A',
-            { label: 'B1', visibleWhen: 'expanded' },
-            { label: 'B2', visibleWhen: 'expanded' },
-            { label: 'B3', visibleWhen: 'always' },
-            { label: 'B4', visibleWhen: 'expanded' },
-            'C'],
-        ],
-        collapsibleColumns: true,
-      });
+    // Without markers the legacy first-child rule applies.
+    collapseGroupB();
+    await render();
+    expect(bottomHeaderLabels()).toEqual(['A', 'B1', 'C']);
 
-      collapseGroupB();
-      await render();
-      expect(bottomHeaderLabels()).toEqual(['A', 'B3', 'C']);
+    expandGroupB();
+    await render();
 
-      // Insert a column to the left of the group; the declarative collapse must survive the rebuild.
-      await alter('insert_col_start', 0, 1);
-
-      expect(getPlugin('nestedHeaders').getStateManager().getHeaderTreeNodeData(-2, 2).isCollapsed).toBe(true);
-      expect(bottomHeaderLabels()).toEqual(['A', 'B3', 'C']);
+    // Add `visibleWhen` markers at runtime.
+    await updateSettings({
+      nestedHeaders: [
+        ['A', { label: 'Group B', colspan: 4 }, 'C'],
+        ['A',
+          { label: 'B1', visibleWhen: 'expanded' },
+          { label: 'B2', visibleWhen: 'expanded' },
+          { label: 'B3', visibleWhen: 'always' },
+          { label: 'B4', visibleWhen: 'expanded' },
+          'C'],
+      ],
     });
 
-    it('should preserve a declarative collapse across updateSettings', async() => {
-      handsontable({
-        data: createSpreadsheetData(3, 6),
-        colHeaders: true,
-        rowHeaders: true,
-        nestedHeaders: [
-          ['A', { label: 'Group B', colspan: 4 }, 'C'],
-          ['A',
-            { label: 'B1', visibleWhen: 'expanded' },
-            { label: 'B2', visibleWhen: 'expanded' },
-            { label: 'B3', visibleWhen: 'always' },
-            { label: 'B4', visibleWhen: 'expanded' },
-            'C'],
-        ],
-        collapsibleColumns: true,
-      });
+    collapseGroupB();
+    await render();
 
-      collapseGroupB();
-      await render();
-      expect(bottomHeaderLabels()).toEqual(['A', 'B3', 'C']);
+    // Now the declarative rule keeps the chosen column (B3) instead of the first child.
+    expect(bottomHeaderLabels()).toEqual(['A', 'B3', 'C']);
+  });
 
-      await updateSettings({ collapsibleColumns: true });
-
-      // The collapse (driven by the persisted `isCollapsed`) survives the settings rebuild.
-      expect(bottomHeaderLabels()).toEqual(['A', 'B3', 'C']);
+  it('should react to changed `visibleWhen` markers set by updateSettings', async() => {
+    handsontable({
+      data: createSpreadsheetData(3, 6),
+      colHeaders: true,
+      rowHeaders: true,
+      nestedHeaders: [
+        ['A', { label: 'Group B', colspan: 4 }, 'C'],
+        ['A',
+          { label: 'B1', visibleWhen: 'expanded' },
+          { label: 'B2', visibleWhen: 'expanded' },
+          { label: 'B3', visibleWhen: 'always' },
+          { label: 'B4', visibleWhen: 'expanded' },
+          'C'],
+      ],
+      collapsibleColumns: true,
     });
+
+    collapseGroupB();
+    await render();
+    expect(bottomHeaderLabels()).toEqual(['A', 'B3', 'C']);
+
+    // Move the chosen column from B3 to B2 via updateSettings. Replacing `nestedHeaders` rebuilds
+    // the header structure from scratch, so the group reopens; collapsing again applies the new
+    // markers.
+    await updateSettings({
+      nestedHeaders: [
+        ['A', { label: 'Group B', colspan: 4 }, 'C'],
+        ['A',
+          { label: 'B1', visibleWhen: 'expanded' },
+          { label: 'B2', visibleWhen: 'always' },
+          { label: 'B3', visibleWhen: 'expanded' },
+          { label: 'B4', visibleWhen: 'expanded' },
+          'C'],
+      ],
+    });
+
+    expect(bottomHeaderLabels()).toEqual(['A', 'B1', 'B2', 'B3', 'B4', 'C']);
+
+    collapseGroupB();
+    await render();
+
+    // Now the collapse keeps B2 (the new `always` column) instead of B3.
+    expect(bottomHeaderLabels()).toEqual(['A', 'B2', 'C']);
   });
 });

--- a/handsontable/src/plugins/collapsibleColumns/__tests__/visibleWhen.spec.js
+++ b/handsontable/src/plugins/collapsibleColumns/__tests__/visibleWhen.spec.js
@@ -1,0 +1,298 @@
+describe('CollapsibleColumns', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  describe('visibleWhen (issue #10243)', () => {
+    // The label of every header in the bottom (cell-adjacent) header row that is actually rendered.
+    function bottomHeaderLabels() {
+      const thead = spec().$container.find('.ht_clone_top thead')[0];
+      const rows = thead.querySelectorAll('tr');
+      const lastRow = rows[rows.length - 1];
+
+      return Array.from(lastRow.querySelectorAll('th'))
+        .map((th) => {
+          const colHeader = th.querySelector('.colHeader');
+
+          return colHeader ? colHeader.textContent.trim() : '';
+        })
+        .filter(label => label !== '');
+    }
+
+    // Number of columns that are not hidden by any source (collapse, visibleWhen, HiddenColumns).
+    function visibleColumnsCount() {
+      let count = 0;
+
+      for (let column = 0; column < countCols(); column++) {
+        if (!columnIndexMapper().isHidden(hot().toPhysicalColumn(column))) {
+          count += 1;
+        }
+      }
+
+      return count;
+    }
+
+    function collapseGroupB() {
+      getPlugin('collapsibleColumns').collapseSection({ row: -2, col: 1 });
+    }
+
+    function expandGroupB() {
+      getPlugin('collapsibleColumns').expandSection({ row: -2, col: 1 });
+    }
+
+    function hasCollapsedIndicator() {
+      return spec().$container.find('.ht_clone_top thead .collapsibleIndicator.collapsed').length > 0;
+    }
+
+    it('should hide a `visibleWhen: "collapsed"` column while the group is expanded', async() => {
+      handsontable({
+        data: createSpreadsheetData(3, 6),
+        colHeaders: true,
+        rowHeaders: true,
+        nestedHeaders: [
+          ['A', { label: 'Group B', colspan: 4 }, 'C'],
+          ['A',
+            { label: 'B1', visibleWhen: 'expanded' },
+            { label: 'B2', visibleWhen: 'expanded' },
+            { label: 'B3', visibleWhen: 'expanded' },
+            { label: 'Total', visibleWhen: 'collapsed' },
+            'C'],
+        ],
+        collapsibleColumns: true,
+      });
+
+      // The group starts expanded, so the collapsed-only "Total" column is hidden.
+      expect(bottomHeaderLabels()).toEqual(['A', 'B1', 'B2', 'B3', 'C']);
+      expect(visibleColumnsCount()).toBe(5);
+    });
+
+    it('should show only the columns visible when collapsed (the chosen column), then restore on expand', async() => {
+      handsontable({
+        data: createSpreadsheetData(3, 6),
+        colHeaders: true,
+        rowHeaders: true,
+        nestedHeaders: [
+          ['A', { label: 'Group B', colspan: 4 }, 'C'],
+          ['A',
+            { label: 'B1', visibleWhen: 'expanded' },
+            { label: 'B2', visibleWhen: 'expanded' },
+            { label: 'B3', visibleWhen: 'always' }, // the chosen column to keep when collapsed
+            { label: 'B4', visibleWhen: 'expanded' },
+            'C'],
+        ],
+        collapsibleColumns: true,
+      });
+
+      expect(bottomHeaderLabels()).toEqual(['A', 'B1', 'B2', 'B3', 'B4', 'C']);
+      expect(visibleColumnsCount()).toBe(6);
+
+      collapseGroupB();
+      await render();
+
+      // Only the chosen `always` column (B3) stays visible under Group B.
+      expect(bottomHeaderLabels()).toEqual(['A', 'B3', 'C']);
+      expect(visibleColumnsCount()).toBe(3);
+      expect(hasCollapsedIndicator()).toBe(true);
+
+      expandGroupB();
+      await render();
+
+      expect(bottomHeaderLabels()).toEqual(['A', 'B1', 'B2', 'B3', 'B4', 'C']);
+      expect(visibleColumnsCount()).toBe(6);
+    });
+
+    it('should show a `visibleWhen: "collapsed"` summary column only while collapsed', async() => {
+      handsontable({
+        data: createSpreadsheetData(3, 6),
+        colHeaders: true,
+        rowHeaders: true,
+        nestedHeaders: [
+          ['A', { label: 'Group B', colspan: 4 }, 'C'],
+          ['A',
+            { label: 'B1', visibleWhen: 'expanded' },
+            { label: 'B2', visibleWhen: 'expanded' },
+            { label: 'B3', visibleWhen: 'expanded' },
+            { label: 'Total', visibleWhen: 'collapsed' },
+            'C'],
+        ],
+        collapsibleColumns: true,
+      });
+
+      expect(bottomHeaderLabels()).toEqual(['A', 'B1', 'B2', 'B3', 'C']);
+
+      collapseGroupB();
+      await render();
+
+      // The expanded-only columns collapse away and the summary column appears.
+      expect(bottomHeaderLabels()).toEqual(['A', 'Total', 'C']);
+      expect(visibleColumnsCount()).toBe(3);
+
+      expandGroupB();
+      await render();
+
+      expect(bottomHeaderLabels()).toEqual(['A', 'B1', 'B2', 'B3', 'C']);
+    });
+
+    it('should stay stable across repeated collapse/expand cycles', async() => {
+      handsontable({
+        data: createSpreadsheetData(3, 6),
+        colHeaders: true,
+        rowHeaders: true,
+        nestedHeaders: [
+          ['A', { label: 'Group B', colspan: 4 }, 'C'],
+          ['A',
+            { label: 'B1', visibleWhen: 'expanded' },
+            { label: 'B2', visibleWhen: 'expanded' },
+            { label: 'B3', visibleWhen: 'always' },
+            { label: 'B4', visibleWhen: 'expanded' },
+            'C'],
+        ],
+        collapsibleColumns: true,
+      });
+
+      for (let cycle = 0; cycle < 3; cycle++) {
+        collapseGroupB();
+        await render(); // eslint-disable-line no-await-in-loop
+
+        expect(bottomHeaderLabels()).toEqual(['A', 'B3', 'C']);
+
+        expandGroupB();
+        await render(); // eslint-disable-line no-await-in-loop
+
+        expect(bottomHeaderLabels()).toEqual(['A', 'B1', 'B2', 'B3', 'B4', 'C']);
+      }
+    });
+
+    it('should treat an invalid `visibleWhen` value as "always"', async() => {
+      handsontable({
+        data: createSpreadsheetData(3, 6),
+        colHeaders: true,
+        rowHeaders: true,
+        nestedHeaders: [
+          ['A', { label: 'Group B', colspan: 4 }, 'C'],
+          ['A',
+            { label: 'B1', visibleWhen: 'expanded' },
+            { label: 'B2', visibleWhen: 'nonsense' }, // invalid -> always visible
+            { label: 'B3', visibleWhen: 'expanded' },
+            { label: 'B4', visibleWhen: 'expanded' },
+            'C'],
+        ],
+        collapsibleColumns: true,
+      });
+
+      collapseGroupB();
+      await render();
+
+      // B2 falls back to `always`, so it survives the collapse.
+      expect(bottomHeaderLabels()).toEqual(['A', 'B2', 'C']);
+    });
+
+    it('should keep the legacy first-child collapse for a group without any `visibleWhen` markers', async() => {
+      handsontable({
+        data: createSpreadsheetData(3, 6),
+        colHeaders: true,
+        rowHeaders: true,
+        nestedHeaders: [
+          ['A', { label: 'Group B', colspan: 4 }, 'C'],
+          ['A', 'B1', 'B2', 'B3', 'B4', 'C'],
+        ],
+        collapsibleColumns: true,
+      });
+
+      collapseGroupB();
+      await render();
+
+      // No markers -> the first child (B1) stays, exactly as before this feature.
+      expect(bottomHeaderLabels()).toEqual(['A', 'B1', 'C']);
+    });
+
+    it('should union the `visibleWhen` hidden set with HiddenColumns', async() => {
+      handsontable({
+        data: createSpreadsheetData(3, 6),
+        colHeaders: true,
+        rowHeaders: true,
+        nestedHeaders: [
+          ['A', { label: 'Group B', colspan: 4 }, 'C'],
+          ['A',
+            { label: 'B1', visibleWhen: 'expanded' },
+            { label: 'B2', visibleWhen: 'always' },
+            { label: 'B3', visibleWhen: 'always' },
+            { label: 'B4', visibleWhen: 'expanded' },
+            'C'],
+        ],
+        collapsibleColumns: true,
+        hiddenColumns: { columns: [2] }, // hide B2 externally
+      });
+
+      collapseGroupB();
+      await render();
+
+      // B1/B4 hidden by collapse, B2 hidden by HiddenColumns, only B3 remains.
+      expect(bottomHeaderLabels()).toEqual(['A', 'B3', 'C']);
+    });
+
+    it('should preserve a declarative collapse when columns are inserted nearby', async() => {
+      handsontable({
+        data: createSpreadsheetData(3, 6),
+        colHeaders: true,
+        rowHeaders: true,
+        nestedHeaders: [
+          ['A', { label: 'Group B', colspan: 4 }, 'C'],
+          ['A',
+            { label: 'B1', visibleWhen: 'expanded' },
+            { label: 'B2', visibleWhen: 'expanded' },
+            { label: 'B3', visibleWhen: 'always' },
+            { label: 'B4', visibleWhen: 'expanded' },
+            'C'],
+        ],
+        collapsibleColumns: true,
+      });
+
+      collapseGroupB();
+      await render();
+      expect(bottomHeaderLabels()).toEqual(['A', 'B3', 'C']);
+
+      // Insert a column to the left of the group; the declarative collapse must survive the rebuild.
+      await alter('insert_col_start', 0, 1);
+
+      expect(getPlugin('nestedHeaders').getStateManager().getHeaderTreeNodeData(-2, 2).isCollapsed).toBe(true);
+      expect(bottomHeaderLabels()).toEqual(['A', 'B3', 'C']);
+    });
+
+    it('should preserve a declarative collapse across updateSettings', async() => {
+      handsontable({
+        data: createSpreadsheetData(3, 6),
+        colHeaders: true,
+        rowHeaders: true,
+        nestedHeaders: [
+          ['A', { label: 'Group B', colspan: 4 }, 'C'],
+          ['A',
+            { label: 'B1', visibleWhen: 'expanded' },
+            { label: 'B2', visibleWhen: 'expanded' },
+            { label: 'B3', visibleWhen: 'always' },
+            { label: 'B4', visibleWhen: 'expanded' },
+            'C'],
+        ],
+        collapsibleColumns: true,
+      });
+
+      collapseGroupB();
+      await render();
+      expect(bottomHeaderLabels()).toEqual(['A', 'B3', 'C']);
+
+      await updateSettings({ collapsibleColumns: true });
+
+      // The collapse (driven by the persisted `isCollapsed`) survives the settings rebuild.
+      expect(bottomHeaderLabels()).toEqual(['A', 'B3', 'C']);
+    });
+  });
+});

--- a/handsontable/src/plugins/collapsibleColumns/__tests__/visibleWhen.spec.js
+++ b/handsontable/src/plugins/collapsibleColumns/__tests__/visibleWhen.spec.js
@@ -171,7 +171,60 @@ describe('CollapsibleColumns visibleWhen option', () => {
     }
   });
 
-  it('should treat an invalid `visibleWhen` value as "always"', async() => {
+  it('should treat an invalid `visibleWhen` value as unset (hidden on collapse, the default)', async() => {
+    handsontable({
+      data: createSpreadsheetData(3, 6),
+      colHeaders: true,
+      rowHeaders: true,
+      nestedHeaders: [
+        ['A', { label: 'Group B', colspan: 4 }, 'C'],
+        ['A',
+          { label: 'B1', visibleWhen: 'always' },
+          { label: 'B2', visibleWhen: 'nonsense' }, // invalid -> unset -> default 'expanded'
+          'B3',
+          { label: 'B4', visibleWhen: 'expanded' },
+          'C'],
+      ],
+      collapsibleColumns: true,
+    });
+
+    collapseGroupB();
+    await render();
+
+    // B2's invalid value is ignored (treated as the default 'expanded'), so it hides on collapse
+    // like the unset B3 and the explicit B4; only the `always` column (B1) stays.
+    expect(bottomHeaderLabels()).toEqual(['A', 'B1', 'C']);
+  });
+
+  it('should hide unmarked siblings on collapse and keep the single `always` column', async() => {
+    handsontable({
+      data: createSpreadsheetData(3, 6),
+      colHeaders: true,
+      rowHeaders: true,
+      nestedHeaders: [
+        ['A', { label: 'Group B', colspan: 4 }, 'C'],
+        // Only B3 is marked; B1, B2, B4 are unmarked and default to 'expanded' (hidden on collapse).
+        ['A', 'B1', 'B2', { label: 'B3', visibleWhen: 'always' }, 'B4', 'C'],
+      ],
+      collapsibleColumns: true,
+    });
+
+    expect(bottomHeaderLabels()).toEqual(['A', 'B1', 'B2', 'B3', 'B4', 'C']);
+
+    collapseGroupB();
+    await render();
+
+    // A single `always` marker is enough: the unmarked siblings collapse away, leaving only B3.
+    expect(bottomHeaderLabels()).toEqual(['A', 'B3', 'C']);
+    expect(hasCollapsedIndicator()).toBe(true);
+
+    expandGroupB();
+    await render();
+
+    expect(bottomHeaderLabels()).toEqual(['A', 'B1', 'B2', 'B3', 'B4', 'C']);
+  });
+
+  it('should keep the first column (and its collapse button) visible when every column would hide', async() => {
     handsontable({
       data: createSpreadsheetData(3, 6),
       colHeaders: true,
@@ -180,7 +233,7 @@ describe('CollapsibleColumns visibleWhen option', () => {
         ['A', { label: 'Group B', colspan: 4 }, 'C'],
         ['A',
           { label: 'B1', visibleWhen: 'expanded' },
-          { label: 'B2', visibleWhen: 'nonsense' }, // invalid -> always visible
+          { label: 'B2', visibleWhen: 'expanded' },
           { label: 'B3', visibleWhen: 'expanded' },
           { label: 'B4', visibleWhen: 'expanded' },
           'C'],
@@ -191,8 +244,16 @@ describe('CollapsibleColumns visibleWhen option', () => {
     collapseGroupB();
     await render();
 
-    // B2 falls back to `always`, so it survives the collapse.
-    expect(bottomHeaderLabels()).toEqual(['A', 'B2', 'C']);
+    // Every child is `expanded` (hidden on collapse); the guard keeps the first one so the group
+    // never blanks out and stays expandable.
+    expect(bottomHeaderLabels()).toEqual(['A', 'B1', 'C']);
+    expect(hasCollapsedIndicator()).toBe(true);
+
+    // The kept indicator can still expand the group back.
+    expandGroupB();
+    await render();
+
+    expect(bottomHeaderLabels()).toEqual(['A', 'B1', 'B2', 'B3', 'B4', 'C']);
   });
 
   it('should keep the legacy first-child collapse for a group without any `visibleWhen` markers', async() => {

--- a/handsontable/src/plugins/collapsibleColumns/__tests__/visibleWhen.spec.js
+++ b/handsontable/src/plugins/collapsibleColumns/__tests__/visibleWhen.spec.js
@@ -439,4 +439,69 @@ describe('CollapsibleColumns visibleWhen option', () => {
     // Now the collapse keeps B2 (the new `always` column) instead of B3.
     expect(bottomHeaderLabels()).toEqual(['A', 'B2', 'C']);
   });
+
+  it('should move the selection off a `visibleWhen: "collapsed"` column when the group expands', async() => {
+    handsontable({
+      data: createSpreadsheetData(3, 6),
+      colHeaders: true,
+      rowHeaders: true,
+      nestedHeaders: [
+        ['A', { label: 'Group B', colspan: 4 }, 'C'],
+        ['A',
+          { label: 'B1', visibleWhen: 'expanded' },
+          { label: 'B2', visibleWhen: 'expanded' },
+          { label: 'B3', visibleWhen: 'expanded' },
+          { label: 'Total', visibleWhen: 'collapsed' },
+          'C'],
+      ],
+      collapsibleColumns: true,
+    });
+
+    collapseGroupB();
+    await render();
+    expect(bottomHeaderLabels()).toEqual(['A', 'Total', 'C']);
+
+    // Select a cell under the summary "Total" column (visual column 4) - visible only while collapsed.
+    await selectCell(0, 4);
+    expect(getSelectedLast()).toEqual([0, 4, 0, 4]);
+
+    expandGroupB();
+    await render();
+
+    // Expanding hides "Total" again; the selection must not linger on the now-hidden column - it
+    // moves to the nearest visible column to the right (C, visual column 5).
+    expect(columnIndexMapper().isHidden(hot().toPhysicalColumn(4))).toBe(true);
+    expect(getSelectedLast()).toEqual([0, 5, 0, 5]);
+  });
+
+  it('should resolve a non-anchor in-span column to its owning group (collapse and expand)', async() => {
+    handsontable({
+      data: createSpreadsheetData(3, 6),
+      colHeaders: true,
+      rowHeaders: true,
+      nestedHeaders: [
+        ['A', { label: 'Group B', colspan: 4 }, 'C'],
+        ['A',
+          { label: 'B1', visibleWhen: 'expanded' },
+          { label: 'B2', visibleWhen: 'expanded' },
+          { label: 'B3', visibleWhen: 'expanded' },
+          { label: 'Total', visibleWhen: 'collapsed' },
+          'C'],
+      ],
+      collapsibleColumns: true,
+    });
+
+    // Collapsing through a non-anchor in-span column (B3, visual column 3) collapses the whole group.
+    getPlugin('collapsibleColumns').collapseSection({ row: -2, col: 3 });
+    await render();
+    expect(bottomHeaderLabels()).toEqual(['A', 'Total', 'C']);
+    expect(hasCollapsedIndicator()).toBe(true);
+
+    // While collapsed the group's anchor (B1, column 1) is hidden, so the indicator renders on the
+    // visible representative ("Total", column 4). Expanding through that non-anchor column restores
+    // the group - this mirrors clicking the relocated indicator.
+    getPlugin('collapsibleColumns').expandSection({ row: -2, col: 4 });
+    await render();
+    expect(bottomHeaderLabels()).toEqual(['A', 'B1', 'B2', 'B3', 'C']);
+  });
 });

--- a/handsontable/src/plugins/collapsibleColumns/collapsibleColumns.ts
+++ b/handsontable/src/plugins/collapsibleColumns/collapsibleColumns.ts
@@ -1,6 +1,6 @@
 import { BasePlugin } from '../base';
 import type { HidingMap } from '../../translations';
-import { arrayEach, arrayFilter, arrayUnique } from '../../helpers/array';
+import { arrayEach, arrayFilter, arrayMap, arrayUnique } from '../../helpers/array';
 import { rangeEach } from '../../helpers/number';
 import { warn } from '../../helpers/console';
 import {
@@ -37,6 +37,7 @@ interface HeaderStateManager {
   triggerNodeModification(action: string, row: number, column: number): {
     colspanCompensation: number; affectedColumns: number[]; rollbackModification: Function;
   };
+  getVisibleWhenHiddenColumns(): number[];
 }
 
 /**
@@ -52,6 +53,10 @@ export const PLUGIN_KEY = 'collapsibleColumns';
 export const PLUGIN_PRIORITY = 290;
 const SETTING_KEYS = ['nestedHeaders'];
 const COLLAPSIBLE_ELEMENT_CLASS = 'collapsibleIndicator';
+// Name of the hiding map that holds columns hidden by the per-child `visibleWhen` rules (issue
+// #10243). Kept separate from the main collapsed-columns map so `getCollapsedColumns()` and the
+// collapse hooks never report a column that is merely hidden in the expanded state.
+const VISIBLE_WHEN_MAP_NAME = 'collapsibleColumns.visibleWhen';
 const SHORTCUTS_GROUP = PLUGIN_KEY;
 
 const actionDictionary = new Map([
@@ -222,6 +227,14 @@ export class CollapsibleColumns extends BasePlugin {
    * @type {HidingMap|null}
    */
   #collapsedColumnsMap: HidingMap | null = null;
+  /**
+   * Map of columns hidden by the per-child `visibleWhen` rules (issue #10243), kept separate from
+   * `#collapsedColumnsMap`.
+   *
+   * @private
+   * @type {HidingMap|null}
+   */
+  #visibleWhenMap: HidingMap | null = null;
 
   /**
    * Checks if the plugin is enabled in the handsontable settings. This method is executed in {@link Hooks#beforeInit}
@@ -251,6 +264,8 @@ export class CollapsibleColumns extends BasePlugin {
       this.#collapsedColumnsMap = this.hot.columnIndexMapper
         .createAndRegisterIndexMap(this.pluginName, 'hiding') as HidingMap;
     }
+    this.#visibleWhenMap = this.hot.columnIndexMapper
+      .createAndRegisterIndexMap(VISIBLE_WHEN_MAP_NAME, 'hiding') as HidingMap;
     this.nestedHeadersPlugin = this.hot.getPlugin('nestedHeaders') as unknown as NestedHeadersPlugin;
     this.headerStateManager = this.nestedHeadersPlugin.getStateManager();
 
@@ -258,6 +273,11 @@ export class CollapsibleColumns extends BasePlugin {
     this.addHook('afterLoadData', this.#onAfterLoadData);
     this.addHook('afterGetColHeader', this.#onAfterGetColHeader);
     this.addHook('beforeOnCellMouseDown', this.#onBeforeOnCellMouseDown);
+    // NestedHeaders (priority 280) rebuilds the header tree on column insert/remove before this
+    // plugin (priority 290) runs, so refreshing here re-derives the `visibleWhen` hidden set against
+    // the freshly rebuilt tree (with `isCollapsed` already restored).
+    this.addHook('afterCreateCol', this.#onAfterColumnStructureChange);
+    this.addHook('afterRemoveCol', this.#onAfterColumnStructureChange);
 
     this.registerShortcuts();
     super.enablePlugin();
@@ -297,6 +317,10 @@ export class CollapsibleColumns extends BasePlugin {
       }
     }
 
+    // Apply the per-child `visibleWhen` rules once the `collapsible` flags are in place - on the
+    // initial render this hides every `visibleWhen: 'collapsed'` column (all groups start expanded).
+    this.#refreshVisibleWhenColumns();
+
     super.updatePlugin();
   }
 
@@ -307,7 +331,9 @@ export class CollapsibleColumns extends BasePlugin {
     if (this.pluginName) {
       this.hot.columnIndexMapper.unregisterMap(this.pluginName);
     }
+    this.hot.columnIndexMapper.unregisterMap(VISIBLE_WHEN_MAP_NAME);
     this.#collapsedColumnsMap = null;
+    this.#visibleWhenMap = null;
     this.nestedHeadersPlugin = null;
 
     this.unregisterShortcuts();
@@ -511,6 +537,11 @@ export class CollapsibleColumns extends BasePlugin {
 
     const nodeModRollbacks: Function[] = [];
     const affectedColumnsIndexes: number[] = [];
+    // Snapshot the declarative `visibleWhen` hidden set (issue #10243) before the nodes are toggled.
+    // triggerNodeModification flips `isCollapsed` for declarative groups, so re-deriving afterwards
+    // tells us which columns the toggle hid/showed - used for selection adjustment and the
+    // action-performed check.
+    const visibleWhenHiddenBefore = this.headerStateManager?.getVisibleWhenHiddenColumns() ?? [];
 
     if (isActionPossible) {
       arrayEach(filteredCoords, ({ row, col: column }) => {
@@ -521,13 +552,17 @@ export class CollapsibleColumns extends BasePlugin {
           colspanCompensation: 0, affectedColumns: [], rollbackModification: () => {}
         };
 
+        // Always keep the rollback - a declarative group toggles `isCollapsed` without reporting
+        // affected columns, so its rollback must still run if the before-hook vetoes the action.
+        // No-op modifications return an empty rollback, so this stays safe.
+        nodeModRollbacks.push(rollbackModification);
+
         // Gate on whether any columns were affected, not on the colspan delta. A collapse can own
         // columns without changing the colspan - when the columns it claims are already hidden by
         // another source (e.g. HiddenColumns) the colspan is unchanged, but the collapse must still
         // record those columns so the group stays collapsed if that external hide is later removed.
         if (affectedColumns.length > 0) {
           affectedColumnsIndexes.push(...affectedColumns);
-          nodeModRollbacks.push(rollbackModification);
         }
       });
     }
@@ -567,10 +602,27 @@ export class CollapsibleColumns extends BasePlugin {
       });
     }, true);
 
-    const isActionPerformed = this.getCollapsedColumns().length !== currentCollapsedColumns.length;
+    // Determine whether the declarative `visibleWhen` hidden set changed (its inputs - the
+    // `isCollapsed` flags - were just toggled). Only refresh the map when it actually changed, so a
+    // plain legacy collapse does not trigger an extra cache update that would disturb the selection
+    // adjustment below.
+    const visibleWhenHiddenAfter = this.headerStateManager?.getVisibleWhenHiddenColumns() ?? [];
+    const visibleWhenHiddenBeforeSet = new Set(visibleWhenHiddenBefore);
+    const newlyHiddenByVisibleWhen = arrayFilter(
+      visibleWhenHiddenAfter, column => !visibleWhenHiddenBeforeSet.has(column)
+    );
+    const isVisibleWhenChanged = newlyHiddenByVisibleWhen.length > 0 ||
+      visibleWhenHiddenAfter.length !== visibleWhenHiddenBefore.length;
+
+    if (isVisibleWhenChanged) {
+      this.#refreshVisibleWhenColumns();
+    }
+
+    const isActionPerformed = this.getCollapsedColumns().length !== currentCollapsedColumns.length ||
+      isVisibleWhenChanged;
 
     if (action === 'collapse' && isActionPerformed) {
-      this.#adjustSelectionAfterCollapse(affectedColumnsIndexes);
+      this.#adjustSelectionAfterCollapse([...affectedColumnsIndexes, ...newlyHiddenByVisibleWhen]);
     }
 
     this.hot.runHooks(
@@ -603,7 +655,11 @@ export class CollapsibleColumns extends BasePlugin {
     let isActionPossible = true;
 
     arrayEach(filteredCoords, ({ row, col: column }) => {
-      const { collapsible, isCollapsed } = this.headerStateManager?.getHeaderSettings(row, column)
+      // Read the tree node, not the generated matrix: a declarative group (issue #10243) can hide its
+      // own anchor column when collapsed, in which case the matrix cell at the anchor is a hidden
+      // placeholder with no collapse state. The tree node always carries the authoritative
+      // `collapsible`/`isCollapsed` regardless of which columns are hidden.
+      const { collapsible, isCollapsed } = this.headerStateManager?.getHeaderTreeNodeData(row, column)
         ?? {} as Record<string, unknown>;
 
       if (!collapsible || isCollapsed && action === 'collapse' || !isCollapsed && action === 'expand') {
@@ -655,6 +711,47 @@ export class CollapsibleColumns extends BasePlugin {
   getCollapsedColumns(): number[] {
     return this.#collapsedColumnsMap?.getHiddenIndexes() ?? [];
   }
+
+  /**
+   * Re-derives the set of columns hidden by the per-child `visibleWhen` rules (issue #10243) from the
+   * current header tree (markers + each group's `isCollapsed` state) and writes it into the dedicated
+   * `#visibleWhenMap`. Pure recompute - safe to call after any collapse/expand toggle, settings
+   * update, or column insert/remove.
+   *
+   * @private
+   */
+  #refreshVisibleWhenColumns(): void {
+    if (!this.#visibleWhenMap || !this.headerStateManager) {
+      return;
+    }
+
+    const visibleWhenMap = this.#visibleWhenMap;
+    const physicalColumnsToHide = new Set(
+      arrayMap(
+        this.headerStateManager.getVisibleWhenHiddenColumns(),
+        visualColumn => this.hot.toPhysicalColumn(visualColumn)
+      )
+    );
+
+    this.hot.batchExecution(() => {
+      visibleWhenMap.clear();
+
+      physicalColumnsToHide.forEach((physicalColumn) => {
+        visibleWhenMap.setValueAtIndex(physicalColumn, true);
+      });
+    }, true);
+  }
+
+  /**
+   * Re-derives the `visibleWhen` hidden set after NestedHeaders rebuilds the header tree on column
+   * insertion or removal. The tree (with `isCollapsed` restored) is the source of truth, so a full
+   * refresh keeps the hidden set correct without tracking shifted indexes manually.
+   *
+   * @private
+   */
+  #onAfterColumnStructureChange = () => {
+    this.#refreshVisibleWhenColumns();
+  };
 
   /**
    * Adds the indicator to the headers.
@@ -768,6 +865,7 @@ export class CollapsibleColumns extends BasePlugin {
    */
   destroy(): void {
     this.#collapsedColumnsMap = null;
+    this.#visibleWhenMap = null;
 
     super.destroy();
   }

--- a/handsontable/src/plugins/collapsibleColumns/collapsibleColumns.ts
+++ b/handsontable/src/plugins/collapsibleColumns/collapsibleColumns.ts
@@ -1,6 +1,6 @@
 import { BasePlugin } from '../base';
 import type { HidingMap } from '../../translations';
-import { arrayEach, arrayFilter, arrayMap, arrayUnique } from '../../helpers/array';
+import { arrayEach, arrayFilter, arrayMap, arrayUnique, getDifferenceOfArrays } from '../../helpers/array';
 import { rangeEach } from '../../helpers/number';
 import { warn } from '../../helpers/console';
 import {
@@ -242,7 +242,12 @@ export class CollapsibleColumns extends BasePlugin {
     this.addHook('beforeOnCellMouseDown', this.#onBeforeOnCellMouseDown);
     // NestedHeaders (priority 280) rebuilds the header tree on column insert/remove before this
     // plugin (priority 290) runs, so refreshing here re-derives the `visibleWhen` hidden set against
-    // the freshly rebuilt tree (with `isCollapsed` already restored).
+    // the freshly rebuilt tree (with `isCollapsed` already restored). There is intentionally no
+    // `afterColumnMove` refresh: a `manualColumnMove` does not rebuild the tree (its `columnIndex`
+    // values are structural), and the collapsed-columns map already strands its entries on a move the
+    // same way - so collapsed groups (legacy and `visibleWhen` alike) do not survive `manualColumnMove`.
+    // That is a pre-existing collapsible-columns limitation; refreshing only `visibleWhen` here would
+    // diverge from legacy collapse without fixing it.
     this.addHook('afterCreateCol', this.#onAfterColumnStructureChange);
     this.addHook('afterRemoveCol', this.#onAfterColumnStructureChange);
 
@@ -422,7 +427,8 @@ export class CollapsibleColumns extends BasePlugin {
   }
 
   /**
-   * Expands section at the provided coords.
+   * Expands section at the provided coords. `coords.col` may be any column the group's header spans,
+   * not only its first (anchor) column - it resolves to the owning collapsible group.
    *
    * @param {object} coords Contains coordinates information. (`coords.row`, `coords.col`).
    */
@@ -431,7 +437,8 @@ export class CollapsibleColumns extends BasePlugin {
   }
 
   /**
-   * Collapses section at the provided coords.
+   * Collapses section at the provided coords. `coords.col` may be any column the group's header spans,
+   * not only its first (anchor) column - it resolves to the owning collapsible group.
    *
    * @param {object} coords Contains coordinates information. (`coords.row`, `coords.col`).
    */
@@ -537,6 +544,11 @@ export class CollapsibleColumns extends BasePlugin {
     const currentCollapsedColumns = this.getCollapsedColumns();
     let destinationCollapsedColumns: number[] = [];
 
+    // The collapse hooks report the collapsed-columns map only. A declarative `visibleWhen` group
+    // hides its columns through the separate `#visibleWhenMap` (so `getCollapsedColumns()` stays a
+    // faithful record of legacy collapses), so for such a group `destinationCollapsedColumns` equals
+    // `currentCollapsedColumns` even though columns were hidden - the `successfullyCollapsed` flag,
+    // not the array delta, tells a consumer whether the toggle did anything.
     if (action === 'collapse') {
       destinationCollapsedColumns = arrayUnique([...currentCollapsedColumns, ...affectedColumnsIndexes]);
 
@@ -569,27 +581,34 @@ export class CollapsibleColumns extends BasePlugin {
       });
     }, true);
 
-    // Determine whether the declarative `visibleWhen` hidden set changed (its inputs - the
-    // `isCollapsed` flags - were just toggled). Only refresh the map when it actually changed, so a
-    // plain legacy collapse does not trigger an extra cache update that would disturb the selection
-    // adjustment below.
+    // The declarative `visibleWhen` hidden set is a pure function of the `isCollapsed` flags that the
+    // node modification just toggled, so re-derive it and diff against the snapshot taken before the
+    // toggle. `newlyHiddenByVisibleWhen` are the columns this toggle hid through `visibleWhen` - on a
+    // collapse the group's own columns, on an expand the `visibleWhen: 'collapsed'` summary columns
+    // that are only visible while collapsed. Only refresh when it changed, so a plain legacy collapse
+    // does not trigger an extra cache update that would disturb the selection adjustment below.
     const visibleWhenHiddenAfter = this.headerStateManager?.getVisibleWhenHiddenColumns() ?? [];
-    const visibleWhenHiddenBeforeSet = new Set(visibleWhenHiddenBefore);
-    const newlyHiddenByVisibleWhen = arrayFilter(
-      visibleWhenHiddenAfter, column => !visibleWhenHiddenBeforeSet.has(column)
-    );
+    const newlyHiddenByVisibleWhen = getDifferenceOfArrays(visibleWhenHiddenAfter, visibleWhenHiddenBefore);
     const isVisibleWhenChanged = newlyHiddenByVisibleWhen.length > 0 ||
       visibleWhenHiddenAfter.length !== visibleWhenHiddenBefore.length;
 
     if (isVisibleWhenChanged) {
-      this.#refreshVisibleWhenColumns();
+      // Pass the already-computed set so the refresh does not walk the header tree a third time.
+      this.#refreshVisibleWhenColumns(visibleWhenHiddenAfter);
     }
 
     const isActionPerformed = this.getCollapsedColumns().length !== currentCollapsedColumns.length ||
       isVisibleWhenChanged;
 
-    if (action === 'collapse' && isActionPerformed) {
-      this.#adjustSelectionAfterCollapse([...affectedColumnsIndexes, ...newlyHiddenByVisibleWhen]);
+    // Move the selection off any column this toggle hid - a collapse hides the group's columns plus
+    // any `visibleWhen` columns, while an expand hides the `visibleWhen: 'collapsed'` columns that are
+    // only visible while collapsed.
+    const newlyHiddenColumns = action === 'collapse'
+      ? arrayUnique([...affectedColumnsIndexes, ...newlyHiddenByVisibleWhen])
+      : newlyHiddenByVisibleWhen;
+
+    if (isActionPerformed && newlyHiddenColumns.length > 0) {
+      this.#adjustSelectionAfterHide(newlyHiddenColumns);
     }
 
     this.hot.runHooks(
@@ -640,11 +659,13 @@ export class CollapsibleColumns extends BasePlugin {
   }
 
   /**
-   * Adjusts the active cell selection after a collapse action moves selected cells out of view.
+   * Moves the active cell selection off any column a collapse or expand action just hid, so the
+   * highlight never lingers on a now-hidden column (for example a `visibleWhen: 'collapsed'` summary
+   * column that is hidden again when its group expands).
    *
-   * @param {number[]} affectedColumnsIndexes Visual indexes of columns hidden by the collapse.
+   * @param {number[]} hiddenColumnsIndexes Visual indexes of columns this action hid.
    */
-  #adjustSelectionAfterCollapse(affectedColumnsIndexes: number[]): void {
+  #adjustSelectionAfterHide(hiddenColumnsIndexes: number[]): void {
     const selectionRange = this.hot.getSelectedRangeActive();
 
     if (!selectionRange) {
@@ -659,7 +680,7 @@ export class CollapsibleColumns extends BasePlugin {
 
     const isHidden = this.hot.rowIndexMapper.isHidden(row) || this.hot.columnIndexMapper.isHidden(col);
 
-    if (isHidden && affectedColumnsIndexes.includes(col)) {
+    if (isHidden && hiddenColumnsIndexes.includes(col)) {
       const nextRow = row >= 0 ? this.hot.rowIndexMapper.getNearestNotHiddenIndex(row, 1, true) : row;
       const nextColumn = col >= 0 ? this.hot.columnIndexMapper.getNearestNotHiddenIndex(col, 1, true) : col;
 
@@ -683,25 +704,32 @@ export class CollapsibleColumns extends BasePlugin {
    * Re-derives the set of columns hidden by the per-child `visibleWhen` rules (issue #10243) from the
    * current header tree (markers + each group's `isCollapsed` state) and writes it into the dedicated
    * `#visibleWhenMap`. Pure recompute - safe to call after any collapse/expand toggle, settings
-   * update, or column insert/remove.
+   * update, or column insert/remove. The hidden set is passed in by the toggle path (which has just
+   * computed it) and re-derived for the settings/structure-change paths. The map is rewritten only
+   * when the hidden set actually changed, so a legacy collapsible setup - which never produces a
+   * `visibleWhen` hidden set - does not pay an index-cache rebuild on every update.
    */
-  #refreshVisibleWhenColumns(): void {
-    if (!this.#visibleWhenMap || !this.headerStateManager) {
+  #refreshVisibleWhenColumns(
+    visualColumnsToHide = this.headerStateManager?.getVisibleWhenHiddenColumns() ?? []
+  ): void {
+    if (!this.#visibleWhenMap) {
       return;
     }
 
     const visibleWhenMap = this.#visibleWhenMap;
-    const physicalColumnsToHide = new Set(
-      arrayMap(
-        this.headerStateManager.getVisibleWhenHiddenColumns(),
-        visualColumn => this.hot.toPhysicalColumn(visualColumn)
-      )
-    );
+    const nextHiddenColumns = arrayMap(visualColumnsToHide, visualColumn => this.hot.toPhysicalColumn(visualColumn));
+    const currentHiddenColumns = visibleWhenMap.getHiddenIndexes();
+    const isUnchanged = nextHiddenColumns.length === currentHiddenColumns.length &&
+      getDifferenceOfArrays(nextHiddenColumns, currentHiddenColumns).length === 0;
+
+    if (isUnchanged) {
+      return;
+    }
 
     this.hot.batchExecution(() => {
       visibleWhenMap.clear();
 
-      physicalColumnsToHide.forEach((physicalColumn) => {
+      arrayEach(nextHiddenColumns, (physicalColumn) => {
         visibleWhenMap.setValueAtIndex(physicalColumn, true);
       });
     }, true);

--- a/handsontable/src/plugins/collapsibleColumns/collapsibleColumns.ts
+++ b/handsontable/src/plugins/collapsibleColumns/collapsibleColumns.ts
@@ -19,35 +19,8 @@ import {
   A11Y_EXPANDED,
   A11Y_HIDDEN
 } from '../../helpers/a11y';
-
-/**
- * Interface for NestedHeaders plugin StateManager.
- */
-interface HeaderStateManager {
-  getHeaderTreeNodeData(row: number, col: number): {
-    collapsible: boolean; isCollapsed: boolean; columnIndex: number; headerLevel: number;
-  } | undefined;
-  getHeaderSettings(headerLevel: number, column: number): {
-    collapsible: boolean; origColspan: number; isCollapsed: boolean;
-  } | undefined;
-  mapState(callback: (headerSettings: Record<string, unknown>) => Record<string, unknown>): void;
-  mergeStateWith(settings: unknown[]): void;
-  mapNodes(callback: (headerSettings: Record<string, unknown>) => unknown): unknown[];
-  levelToRowCoords(headerLevel: unknown): number;
-  triggerNodeModification(action: string, row: number, column: number): {
-    colspanCompensation: number; affectedColumns: number[]; rollbackModification: Function;
-  };
-  getVisibleWhenHiddenColumns(): number[];
-}
-
-/**
- * Interface for the NestedHeaders plugin instance.
- */
-interface NestedHeadersPlugin {
-  getStateManager(): HeaderStateManager;
-  detectedOverlappedHeaders: boolean;
-  [key: string]: unknown;
-}
+import type { NestedHeaders } from '../nestedHeaders/nestedHeaders';
+import type StateManager from '../nestedHeaders/stateManager';
 
 export const PLUGIN_KEY = 'collapsibleColumns';
 export const PLUGIN_PRIORITY = 290;
@@ -212,27 +185,21 @@ export class CollapsibleColumns extends BasePlugin {
    * @private
    * @type {NestedHeaders}
    */
-  nestedHeadersPlugin: NestedHeadersPlugin | null = null;
+  nestedHeadersPlugin: NestedHeaders | null = null;
   /**
    * The NestedHeaders plugin StateManager instance.
    *
    * @private
    * @type {StateManager}
    */
-  headerStateManager: HeaderStateManager | null = null;
+  headerStateManager: StateManager | null = null;
   /**
    * Map of collapsed columns by the plugin.
-   *
-   * @private
-   * @type {HidingMap|null}
    */
   #collapsedColumnsMap: HidingMap | null = null;
   /**
    * Map of columns hidden by the per-child `visibleWhen` rules (issue #10243), kept separate from
    * `#collapsedColumnsMap`.
-   *
-   * @private
-   * @type {HidingMap|null}
    */
   #visibleWhenMap: HidingMap | null = null;
 
@@ -262,11 +229,11 @@ export class CollapsibleColumns extends BasePlugin {
 
     if (this.pluginName) {
       this.#collapsedColumnsMap = this.hot.columnIndexMapper
-        .createAndRegisterIndexMap(this.pluginName, 'hiding') as HidingMap;
+        .createAndRegisterIndexMap(this.pluginName, 'hiding');
     }
     this.#visibleWhenMap = this.hot.columnIndexMapper
-      .createAndRegisterIndexMap(VISIBLE_WHEN_MAP_NAME, 'hiding') as HidingMap;
-    this.nestedHeadersPlugin = this.hot.getPlugin('nestedHeaders') as unknown as NestedHeadersPlugin;
+      .createAndRegisterIndexMap(VISIBLE_WHEN_MAP_NAME, 'hiding');
+    this.nestedHeadersPlugin = this.hot.getPlugin('nestedHeaders');
     this.headerStateManager = this.nestedHeadersPlugin.getStateManager();
 
     this.addHook('init', this.#onInit);
@@ -490,7 +457,7 @@ export class CollapsibleColumns extends BasePlugin {
       if (collapsible === true && Number(origColspan) > 1
           && (isCollapsed && action === 'expand' || !isCollapsed && action === 'collapse')) {
         return {
-          row: this.headerStateManager?.levelToRowCoords(headerLevel) ?? 0,
+          row: this.headerStateManager?.levelToRowCoords(Number(headerLevel)) ?? 0,
           col: columnIndex,
         };
       }
@@ -717,8 +684,6 @@ export class CollapsibleColumns extends BasePlugin {
    * current header tree (markers + each group's `isCollapsed` state) and writes it into the dedicated
    * `#visibleWhenMap`. Pure recompute - safe to call after any collapse/expand toggle, settings
    * update, or column insert/remove.
-   *
-   * @private
    */
   #refreshVisibleWhenColumns(): void {
     if (!this.#visibleWhenMap || !this.headerStateManager) {
@@ -746,8 +711,6 @@ export class CollapsibleColumns extends BasePlugin {
    * Re-derives the `visibleWhen` hidden set after NestedHeaders rebuilds the header tree on column
    * insertion or removal. The tree (with `isCollapsed` restored) is the source of truth, so a full
    * refresh keeps the hidden set correct without tracking shifted indexes manually.
-   *
-   * @private
    */
   #onAfterColumnStructureChange = () => {
     this.#refreshVisibleWhenColumns();

--- a/handsontable/src/plugins/nestedHeaders/__tests__/helpers/index.js
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/helpers/index.js
@@ -122,7 +122,6 @@ export function createColspanSettings(overwriteProps = {}) {
     isPlaceholder: false,
     isRowspanPlaceholder: false,
     headerClassNames: [],
-    visibleWhen: 'always',
     ...overwriteProps,
   };
 }

--- a/handsontable/src/plugins/nestedHeaders/__tests__/helpers/index.js
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/helpers/index.js
@@ -122,6 +122,7 @@ export function createColspanSettings(overwriteProps = {}) {
     isPlaceholder: false,
     isRowspanPlaceholder: false,
     headerClassNames: [],
+    visibleWhen: 'always',
     ...overwriteProps,
   };
 }

--- a/handsontable/src/plugins/nestedHeaders/__tests__/stateManager/index.unit.ts
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/stateManager/index.unit.ts
@@ -963,5 +963,36 @@ describe('StateManager', () => {
       // No `visibleWhen` markers -> the legacy first-child collapse path owns visibility, not this one.
       expect(state.getVisibleWhenHiddenColumns()).toEqual([]);
     });
+
+    it('should hide unset siblings (default "expanded") and keep an explicit "always" column on collapse', () => {
+      const state = buildCollapsibleState([
+        ['A', { label: 'Group B', colspan: 4 }, 'C'],
+        ['A', 'B1', 'B2', { label: 'B3', visibleWhen: 'always' }, 'B4', 'C'],
+      ]);
+
+      // A single explicit marker makes the group declarative; unmarked siblings default to 'expanded'.
+      state.triggerNodeModification('collapse', 0, 1);
+
+      // B1, B2, B4 (unset -> 'expanded' -> columns 1, 2, 4) hide; B3 ('always') stays.
+      expect(state.getVisibleWhenHiddenColumns().slice().sort((a, b) => a - b)).toEqual([1, 2, 4]);
+    });
+
+    it('should keep the first column visible when every column would be hidden on collapse', () => {
+      const state = buildCollapsibleState([
+        ['A', { label: 'Group B', colspan: 4 }, 'C'],
+        ['A',
+          { label: 'B1', visibleWhen: 'expanded' },
+          { label: 'B2', visibleWhen: 'expanded' },
+          { label: 'B3', visibleWhen: 'expanded' },
+          { label: 'B4', visibleWhen: 'expanded' },
+          'C'],
+      ]);
+
+      state.triggerNodeModification('collapse', 0, 1);
+
+      // All four are 'expanded' (hidden on collapse); the guard keeps the first (B1), hiding only 2, 3, 4
+      // so the group's collapse indicator is never lost.
+      expect(state.getVisibleWhenHiddenColumns().slice().sort((a, b) => a - b)).toEqual([2, 3, 4]);
+    });
   });
 });

--- a/handsontable/src/plugins/nestedHeaders/__tests__/stateManager/index.unit.ts
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/stateManager/index.unit.ts
@@ -900,4 +900,68 @@ describe('StateManager', () => {
       expect(state.getColumnsCount()).toBe(0);
     });
   });
+
+  describe('getVisibleWhenHiddenColumns (issue #10243)', () => {
+    /**
+     * Builds a StateManager with the given nested headers and marks every multi-column header as
+     * collapsible (mirrors what the CollapsibleColumns plugin does on update).
+     *
+     * @param {Array[]} nestedHeaders The nested headers settings.
+     * @returns {StateManager}
+     */
+    function buildCollapsibleState(nestedHeaders) {
+      const state = new StateManager();
+
+      state.setState(nestedHeaders);
+      state.mapState(headerSettings => ({ collapsible: Number(headerSettings.origColspan) > 1 }));
+
+      return state;
+    }
+
+    it('should hide a "collapsed"-only column while the group is expanded', () => {
+      const state = buildCollapsibleState([
+        ['A', { label: 'Group B', colspan: 4 }, 'C'],
+        ['A',
+          { label: 'B1', visibleWhen: 'expanded' },
+          { label: 'B2', visibleWhen: 'expanded' },
+          { label: 'B3', visibleWhen: 'expanded' },
+          { label: 'Total', visibleWhen: 'collapsed' },
+          'C'],
+      ]);
+
+      // Group expanded by default: only the collapsed-only "Total" column (index 4) is hidden.
+      expect(state.getVisibleWhenHiddenColumns()).toEqual([4]);
+    });
+
+    it('should hide the "expanded" children and keep the chosen column once collapsed', () => {
+      const state = buildCollapsibleState([
+        ['A', { label: 'Group B', colspan: 4 }, 'C'],
+        ['A',
+          { label: 'B1', visibleWhen: 'expanded' },
+          { label: 'B2', visibleWhen: 'expanded' },
+          { label: 'B3', visibleWhen: 'always' },
+          { label: 'B4', visibleWhen: 'expanded' },
+          'C'],
+      ]);
+
+      expect(state.getVisibleWhenHiddenColumns()).toEqual([]);
+
+      state.triggerNodeModification('collapse', 0, 1);
+
+      // Once collapsed, the "expanded" children (B1, B2, B4 -> columns 1, 2, 4) hide; B3 stays.
+      expect(state.getVisibleWhenHiddenColumns().slice().sort((a, b) => a - b)).toEqual([1, 2, 4]);
+    });
+
+    it('should return an empty list for a legacy group without any markers', () => {
+      const state = buildCollapsibleState([
+        ['A', { label: 'Group B', colspan: 4 }, 'C'],
+        ['A', 'B1', 'B2', 'B3', 'B4', 'C'],
+      ]);
+
+      state.triggerNodeModification('collapse', 0, 1);
+
+      // No `visibleWhen` markers -> the legacy first-child collapse path owns visibility, not this one.
+      expect(state.getVisibleWhenHiddenColumns()).toEqual([]);
+    });
+  });
 });

--- a/handsontable/src/plugins/nestedHeaders/__tests__/stateManager/settingsNormalizer.unit.ts
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/stateManager/settingsNormalizer.unit.ts
@@ -306,4 +306,36 @@ describe('normalizeSettings', () => {
       ],
     ]);
   });
+
+  describe('visibleWhen (issue #10243)', () => {
+    it('should default to "always" when not provided', () => {
+      const [[cell]] = normalizeSettings([['A1']]);
+
+      expect(cell.visibleWhen).toBe('always');
+    });
+
+    it('should carry a valid "collapsed" / "expanded" / "always" value', () => {
+      const [row] = normalizeSettings([[
+        { label: 'A', visibleWhen: 'collapsed' },
+        { label: 'B', visibleWhen: 'expanded' },
+        { label: 'C', visibleWhen: 'always' },
+      ]]);
+
+      expect(row[0].visibleWhen).toBe('collapsed');
+      expect(row[1].visibleWhen).toBe('expanded');
+      expect(row[2].visibleWhen).toBe('always');
+    });
+
+    it('should fall back to "always" for an invalid or non-string value', () => {
+      const [row] = normalizeSettings([[
+        { label: 'A', visibleWhen: 'nonsense' },
+        { label: 'B', visibleWhen: 123 },
+        { label: 'C', visibleWhen: null },
+      ]]);
+
+      expect(row[0].visibleWhen).toBe('always');
+      expect(row[1].visibleWhen).toBe('always');
+      expect(row[2].visibleWhen).toBe('always');
+    });
+  });
 });

--- a/handsontable/src/plugins/nestedHeaders/__tests__/stateManager/settingsNormalizer.unit.ts
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/stateManager/settingsNormalizer.unit.ts
@@ -308,10 +308,10 @@ describe('normalizeSettings', () => {
   });
 
   describe('visibleWhen (issue #10243)', () => {
-    it('should default to "always" when not provided', () => {
+    it('should be left unset (undefined) when not provided', () => {
       const [[cell]] = normalizeSettings([['A1']]);
 
-      expect(cell.visibleWhen).toBe('always');
+      expect(cell.visibleWhen).toBeUndefined();
     });
 
     it('should carry a valid "collapsed" / "expanded" / "always" value', () => {
@@ -326,16 +326,16 @@ describe('normalizeSettings', () => {
       expect(row[2].visibleWhen).toBe('always');
     });
 
-    it('should fall back to "always" for an invalid or non-string value', () => {
+    it('should leave an invalid or non-string value unset (treated as the default)', () => {
       const [row] = normalizeSettings([[
         { label: 'A', visibleWhen: 'nonsense' },
         { label: 'B', visibleWhen: 123 },
         { label: 'C', visibleWhen: null },
       ]]);
 
-      expect(row[0].visibleWhen).toBe('always');
-      expect(row[1].visibleWhen).toBe('always');
-      expect(row[2].visibleWhen).toBe('always');
+      expect(row[0].visibleWhen).toBeUndefined();
+      expect(row[1].visibleWhen).toBeUndefined();
+      expect(row[2].visibleWhen).toBeUndefined();
     });
   });
 });

--- a/handsontable/src/plugins/nestedHeaders/__tests__/stateManager/settingsNormalizer.unit.ts
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/stateManager/settingsNormalizer.unit.ts
@@ -337,5 +337,20 @@ describe('normalizeSettings', () => {
       expect(row[1].visibleWhen).toBeUndefined();
       expect(row[2].visibleWhen).toBeUndefined();
     });
+
+    it('should keep the marker on an empty-label header even when a rowspan covers its slot', () => {
+      // The empty-label header carries a `visibleWhen` marker, so it is a real header rather than a
+      // rowspan empty-slot placeholder - the marker must survive normalization and reach the tree.
+      const normalized = normalizeSettings([
+        [{ label: 'A1', rowspan: 2 }, 'B1'],
+        [{ label: '', visibleWhen: 'collapsed' }, 'B2'],
+      ]);
+      const markers = normalized
+        .flat()
+        .filter(cell => cell.visibleWhen !== undefined);
+
+      expect(markers.length).toBe(1);
+      expect(markers[0].visibleWhen).toBe('collapsed');
+    });
   });
 });

--- a/handsontable/src/plugins/nestedHeaders/index.ts
+++ b/handsontable/src/plugins/nestedHeaders/index.ts
@@ -3,3 +3,4 @@ export {
   PLUGIN_PRIORITY,
   NestedHeaders,
 } from './nestedHeaders';
+export type { NestedHeader, NestedHeaderSettings } from './nestedHeaders';

--- a/handsontable/src/plugins/nestedHeaders/nestedHeaders.ts
+++ b/handsontable/src/plugins/nestedHeaders/nestedHeaders.ts
@@ -40,9 +40,10 @@ export interface NestedHeaderSettings {
    */
   headerClassName?: string;
   /**
-   * In which collapse state the header (and its columns) stays visible:
-   * `'collapsed'` (only while collapsed), `'expanded'` (only while expanded), or `'always'` (both,
-   * the default). Applies within a collapsible group - see the `CollapsibleColumns` plugin.
+   * For a header inside a collapsible group, sets in which collapse state it (and its columns) stays
+   * visible: `'collapsed'` (only while collapsed), `'expanded'` (only while expanded), or `'always'`
+   * (both states). When omitted, the header defaults to `'expanded'` - hidden when the group collapses.
+   * See the `CollapsibleColumns` plugin.
    */
   visibleWhen?: HeaderVisibility;
   [key: string]: unknown;

--- a/handsontable/src/plugins/nestedHeaders/nestedHeaders.ts
+++ b/handsontable/src/plugins/nestedHeaders/nestedHeaders.ts
@@ -14,9 +14,48 @@ import { BasePlugin } from '../base';
 import StateManager from './stateManager';
 import { createColumnVisibilityAdapter } from './stateManager/columnVisibility';
 import type { HeaderNodeData } from './stateManager/headersTree';
+import type { HeaderVisibility } from './stateManager/utils';
 import type CellCoords from '../../3rdparty/walkontable/src/cell/coords';
 import GhostTable from './utils/ghostTable';
 import { resolveRowspanNavigationContextRow } from './utils/navigation';
+
+/**
+ * A single configured nested header. Declares the header label and how it spans and behaves.
+ */
+export interface NestedHeaderSettings {
+  /**
+   * The header label.
+   */
+  label?: string;
+  /**
+   * The number of columns the header spans.
+   */
+  colspan?: number;
+  /**
+   * The number of header rows the header spans.
+   */
+  rowspan?: number;
+  /**
+   * CSS class name(s) added to the header element.
+   */
+  headerClassName?: string;
+  /**
+   * Whether the header can be collapsed/expanded by the `CollapsibleColumns` plugin.
+   */
+  collapsible?: boolean;
+  /**
+   * In which collapse state the header (and its columns) stays visible:
+   * `'collapsed'` (only while collapsed), `'expanded'` (only while expanded), or `'always'` (both,
+   * the default). See `CollapsibleColumns`.
+   */
+  visibleWhen?: HeaderVisibility;
+  [key: string]: unknown;
+}
+
+/**
+ * A single cell in the `nestedHeaders` configuration: a plain label or a configured header object.
+ */
+export type NestedHeader = string | number | NestedHeaderSettings;
 
 export const PLUGIN_KEY = 'nestedHeaders';
 export const PLUGIN_PRIORITY = 280;

--- a/handsontable/src/plugins/nestedHeaders/nestedHeaders.ts
+++ b/handsontable/src/plugins/nestedHeaders/nestedHeaders.ts
@@ -40,13 +40,9 @@ export interface NestedHeaderSettings {
    */
   headerClassName?: string;
   /**
-   * Whether the header can be collapsed/expanded by the `CollapsibleColumns` plugin.
-   */
-  collapsible?: boolean;
-  /**
    * In which collapse state the header (and its columns) stays visible:
    * `'collapsed'` (only while collapsed), `'expanded'` (only while expanded), or `'always'` (both,
-   * the default). See `CollapsibleColumns`.
+   * the default). Applies within a collapsible group - see the `CollapsibleColumns` plugin.
    */
   visibleWhen?: HeaderVisibility;
   [key: string]: unknown;

--- a/handsontable/src/plugins/nestedHeaders/stateManager/headersTree.ts
+++ b/handsontable/src/plugins/nestedHeaders/stateManager/headersTree.ts
@@ -1,6 +1,7 @@
 import { arrayEach } from '../../../helpers/array';
 import TreeNode from '../../../utils/dataStructures/tree';
 import { createDefaultHeaderSettings } from './utils';
+import type { HeaderVisibility } from './utils';
 import type SourceSettings from './sourceSettings';
 
 /**
@@ -20,6 +21,10 @@ export interface HeaderSettings {
   isPlaceholder: boolean;
   isRowspanPlaceholder?: boolean;
   headerClassNames: string[];
+  /**
+   * Declares in which collapse state this header (and its columns) stays visible.
+   */
+  visibleWhen: HeaderVisibility;
   [key: string]: unknown;
 }
 

--- a/handsontable/src/plugins/nestedHeaders/stateManager/headersTree.ts
+++ b/handsontable/src/plugins/nestedHeaders/stateManager/headersTree.ts
@@ -22,9 +22,10 @@ export interface HeaderSettings {
   isRowspanPlaceholder?: boolean;
   headerClassNames: string[];
   /**
-   * Declares in which collapse state this header (and its columns) stays visible.
+   * Explicit per-header collapse-visibility marker. Unset means the header follows the default
+   * ('expanded' - hidden when its group collapses) within a group that uses `visibleWhen`.
    */
-  visibleWhen: HeaderVisibility;
+  visibleWhen?: HeaderVisibility;
   [key: string]: unknown;
 }
 

--- a/handsontable/src/plugins/nestedHeaders/stateManager/index.ts
+++ b/handsontable/src/plugins/nestedHeaders/stateManager/index.ts
@@ -551,6 +551,54 @@ export default class StateManager {
   }
 
   /**
+   * Computes the visual column indexes that should be hidden purely by the `visibleWhen` rules of
+   * declarative collapsible groups (issue #10243), given each group's current `isCollapsed` state.
+   *
+   * A group is "declarative" when at least one of its direct children declares an explicit
+   * `visibleWhen` ('collapsed' or 'expanded'); legacy groups (no markers) are left to the regular
+   * first-visible-child collapse path and are skipped here. Only `collapsible` groups are considered -
+   * a group that cannot be collapsed keeps all its columns. The result is a pure function of the tree
+   * shape, the markers, and the `isCollapsed` flags, so it stays correct across tree rebuilds.
+   *
+   * @returns {number[]} Visual column indexes to hide.
+   */
+  getVisibleWhenHiddenColumns(): number[] {
+    const columnsToHide: number[] = [];
+
+    this.#headersTree.getRoots().forEach((rootNode) => {
+      rootNode.walkDown((node) => {
+        const childNodes = node.childs;
+
+        if (node.data.collapsible !== true || childNodes.length === 0) {
+          return;
+        }
+
+        const isDeclarative = childNodes.some(({ data }) => data.visibleWhen !== 'always');
+
+        if (!isDeclarative) {
+          return;
+        }
+
+        const isGroupCollapsed = node.data.isCollapsed === true;
+
+        childNodes.forEach((childNode) => {
+          const { visibleWhen, columnIndex, origColspan } = childNode.data;
+          const hideChild = (visibleWhen === 'expanded' && isGroupCollapsed) ||
+            (visibleWhen === 'collapsed' && !isGroupCollapsed);
+
+          if (hideChild) {
+            for (let i = 0; i < origColspan; i++) {
+              columnsToHide.push(columnIndex + i);
+            }
+          }
+        });
+      });
+    });
+
+    return columnsToHide;
+  }
+
+  /**
    * Clears the column state manager to the initial state.
    */
   clear() {

--- a/handsontable/src/plugins/nestedHeaders/stateManager/index.ts
+++ b/handsontable/src/plugins/nestedHeaders/stateManager/index.ts
@@ -4,6 +4,7 @@ import type { HeaderNodeData } from './headersTree';
 import HeadersTree from './headersTree';
 import { triggerNodeModification } from './nodeModifiers';
 import type { NodeModificationResult } from './nodeModifiers';
+import { isDeclarativeGroup } from './nodeModifiers/utils/tree';
 import { generateMatrix } from './matrixGenerator';
 import { syncVisibilityOnTree } from './syncVisibility';
 import type { ColumnVisibility } from './columnVisibility';
@@ -577,9 +578,10 @@ export default class StateManager {
           return;
         }
 
-        const isDeclarative = childNodes.some(({ data }) => data.visibleWhen !== undefined);
-
-        if (!isDeclarative) {
+        // Only declarative groups (at least one explicit `visibleWhen` marker) are handled here;
+        // legacy groups keep the first-visible-child collapse path. The predicate lives in one place
+        // so this computation and the collapse/expand modifiers agree on what "declarative" means.
+        if (!isDeclarativeGroup(node)) {
           return;
         }
 
@@ -592,9 +594,13 @@ export default class StateManager {
             (visibility === 'collapsed' && !isGroupCollapsed);
         });
 
-        // Never hide every column of the group - the group header carries the collapse indicator, so
-        // keep the first child visible when a (mis)configuration would otherwise blank the whole group
-        // and leave no way to expand it back.
+        // Never hide every column of the group through `visibleWhen` - the collapse indicator renders
+        // on the group's first visible column, so keep the first child visible when a (mis)configuration
+        // would otherwise blank the whole group and leave no way to expand it back. Known limitation:
+        // if that kept column is independently hidden by another source (HiddenColumns or trimming) the
+        // indicator can still be lost. Reading the external hidden state here is avoided on purpose -
+        // this set feeds the hiding map that syncVisibility consumes, so a node's `isHidden` flag
+        // already carries this set's own previous effect and cannot be trusted as an external-only signal.
         if (childrenToHide.length === childNodes.length) {
           childrenToHide.shift();
         }

--- a/handsontable/src/plugins/nestedHeaders/stateManager/index.ts
+++ b/handsontable/src/plugins/nestedHeaders/stateManager/index.ts
@@ -3,6 +3,7 @@ import SourceSettings from './sourceSettings';
 import type { HeaderNodeData } from './headersTree';
 import HeadersTree from './headersTree';
 import { triggerNodeModification } from './nodeModifiers';
+import type { NodeModificationResult } from './nodeModifiers';
 import { generateMatrix } from './matrixGenerator';
 import { syncVisibilityOnTree } from './syncVisibility';
 import type { ColumnVisibility } from './columnVisibility';
@@ -239,7 +240,7 @@ export default class StateManager {
    */
   triggerNodeModification(
     action: string, headerLevel: number, columnIndex: number
-  ): { rollbackModification: Function, affectedColumns: unknown[], colspanCompensation: number } | undefined {
+  ): NodeModificationResult | undefined {
     if (headerLevel < 0) {
       headerLevel = this.rowCoordsToLevel(headerLevel) ?? 0;
     }
@@ -265,7 +266,7 @@ export default class StateManager {
    */
   triggerColumnModification(
     action: string, columnIndex: number
-  ): { rollbackModification: Function, affectedColumns: unknown[], colspanCompensation: number } | undefined {
+  ): NodeModificationResult | undefined {
     return this.triggerNodeModification(action, -1, columnIndex);
   }
 

--- a/handsontable/src/plugins/nestedHeaders/stateManager/index.ts
+++ b/handsontable/src/plugins/nestedHeaders/stateManager/index.ts
@@ -556,10 +556,13 @@ export default class StateManager {
    * declarative collapsible groups (issue #10243), given each group's current `isCollapsed` state.
    *
    * A group is "declarative" when at least one of its direct children declares an explicit
-   * `visibleWhen` ('collapsed' or 'expanded'); legacy groups (no markers) are left to the regular
-   * first-visible-child collapse path and are skipped here. Only `collapsible` groups are considered -
-   * a group that cannot be collapsed keeps all its columns. The result is a pure function of the tree
-   * shape, the markers, and the `isCollapsed` flags, so it stays correct across tree rebuilds.
+   * `visibleWhen` ('collapsed', 'expanded', or 'always'); legacy groups (no markers) are left to the
+   * regular first-visible-child collapse path and are skipped here. Within a declarative group a child
+   * with no marker defaults to `'expanded'` - it is hidden when the group collapses, matching the
+   * default collapse behavior; `'always'` is the explicit opt-in for staying visible in both states.
+   * Only `collapsible` groups are considered. At least one column per group always stays visible so the
+   * group's collapse indicator survives. The result is a pure function of the tree shape, the markers,
+   * and the `isCollapsed` flags, so it stays correct across tree rebuilds.
    *
    * @returns {number[]} Visual column indexes to hide.
    */
@@ -574,23 +577,31 @@ export default class StateManager {
           return;
         }
 
-        const isDeclarative = childNodes.some(({ data }) => data.visibleWhen !== 'always');
+        const isDeclarative = childNodes.some(({ data }) => data.visibleWhen !== undefined);
 
         if (!isDeclarative) {
           return;
         }
 
         const isGroupCollapsed = node.data.isCollapsed === true;
+        const childrenToHide = childNodes.filter((childNode) => {
+          // An unset child defaults to 'expanded' (hidden on collapse).
+          const visibility = childNode.data.visibleWhen ?? 'expanded';
 
-        childNodes.forEach((childNode) => {
-          const { visibleWhen, columnIndex, origColspan } = childNode.data;
-          const hideChild = (visibleWhen === 'expanded' && isGroupCollapsed) ||
-            (visibleWhen === 'collapsed' && !isGroupCollapsed);
+          return (visibility === 'expanded' && isGroupCollapsed) ||
+            (visibility === 'collapsed' && !isGroupCollapsed);
+        });
 
-          if (hideChild) {
-            for (let i = 0; i < origColspan; i++) {
-              columnsToHide.push(columnIndex + i);
-            }
+        // Never hide every column of the group - the group header carries the collapse indicator, so
+        // keep the first child visible when a (mis)configuration would otherwise blank the whole group
+        // and leave no way to expand it back.
+        if (childrenToHide.length === childNodes.length) {
+          childrenToHide.shift();
+        }
+
+        childrenToHide.forEach(({ data: { columnIndex, origColspan } }) => {
+          for (let i = 0; i < origColspan; i++) {
+            columnsToHide.push(columnIndex + i);
           }
         });
       });

--- a/handsontable/src/plugins/nestedHeaders/stateManager/nodeModifiers/collapse.ts
+++ b/handsontable/src/plugins/nestedHeaders/stateManager/nodeModifiers/collapse.ts
@@ -8,6 +8,7 @@ import {
 } from './utils/tree';
 import type TreeNode from '../../../../utils/dataStructures/tree';
 import type { HeaderNodeData } from '../headersTree';
+import type { NodeModificationResult } from './index';
 
 /**
  * Collapsing a node is a process where the processing node is collapsed
@@ -18,7 +19,7 @@ import type { HeaderNodeData } from '../headersTree';
  */
 export function collapseNode(
   nodeToProcess: TreeNode<HeaderNodeData>
-): { rollbackModification: Function, affectedColumns: unknown[], colspanCompensation: number } {
+): NodeModificationResult {
   const { data: nodeData, childs: nodeChilds } = nodeToProcess;
 
   if (nodeData.isCollapsed || nodeData.isHidden || nodeData.origColspan <= 1) {
@@ -50,7 +51,7 @@ export function collapseNode(
     return collapseNode(nodeChilds[0]);
   }
 
-  const affectedColumns = new Set();
+  const affectedColumns = new Set<number>();
   let colspanCompensation = 0;
 
   if (nodeChilds.length > 0) {

--- a/handsontable/src/plugins/nestedHeaders/stateManager/nodeModifiers/collapse.ts
+++ b/handsontable/src/plugins/nestedHeaders/stateManager/nodeModifiers/collapse.ts
@@ -2,6 +2,7 @@ import { arrayEach } from '../../../../helpers/array';
 import { expandNode } from './expand';
 import {
   getFirstChildProperty,
+  isDeclarativeGroup,
   isNodeReflectsFirstChildColspan,
   traverseExposedColumnIndexes,
 } from './utils/tree';
@@ -23,6 +24,21 @@ export function collapseNode(
   if (nodeData.isCollapsed || nodeData.isHidden || nodeData.origColspan <= 1) {
     return {
       rollbackModification: () => {},
+      affectedColumns: [],
+      colspanCompensation: 0,
+    };
+  }
+
+  // Declarative groups (issue #10243) only flip `isCollapsed` here. Which columns hide is derived
+  // from the children's `visibleWhen` markers + this flag by StateManager#getVisibleWhenHiddenColumns
+  // and applied through the CollapsibleColumns hiding map, so no first-child claiming or colspan
+  // compensation is done. Keeping `isCollapsed` as the only persisted state lets the collapse survive
+  // tree rebuilds via the snapshot/reapply path.
+  if (isDeclarativeGroup(nodeToProcess)) {
+    nodeData.isCollapsed = true;
+
+    return {
+      rollbackModification: () => expandNode(nodeToProcess),
       affectedColumns: [],
       colspanCompensation: 0,
     };

--- a/handsontable/src/plugins/nestedHeaders/stateManager/nodeModifiers/expand.ts
+++ b/handsontable/src/plugins/nestedHeaders/stateManager/nodeModifiers/expand.ts
@@ -2,6 +2,7 @@ import { arrayEach } from '../../../../helpers/array';
 import { collapseNode } from './collapse';
 import {
   getFirstChildProperty,
+  isDeclarativeGroup,
   isNodeReflectsFirstChildColspan,
   traverseExposedColumnIndexes,
 } from './utils/tree';
@@ -23,6 +24,19 @@ export function expandNode(
   if (!nodeData.isCollapsed || nodeData.isHidden || nodeData.origColspan <= 1) {
     return {
       rollbackModification: () => {},
+      affectedColumns: [],
+      colspanCompensation: 0,
+    };
+  }
+
+  // Declarative groups (issue #10243) only flip `isCollapsed` back; the columns to show/hide are
+  // re-derived from the `visibleWhen` markers and applied through the CollapsibleColumns hiding map.
+  // Mirrors the declarative branch in collapseNode.
+  if (isDeclarativeGroup(nodeToProcess)) {
+    nodeData.isCollapsed = false;
+
+    return {
+      rollbackModification: () => collapseNode(nodeToProcess),
       affectedColumns: [],
       colspanCompensation: 0,
     };

--- a/handsontable/src/plugins/nestedHeaders/stateManager/nodeModifiers/expand.ts
+++ b/handsontable/src/plugins/nestedHeaders/stateManager/nodeModifiers/expand.ts
@@ -8,6 +8,7 @@ import {
 } from './utils/tree';
 import type TreeNode from '../../../../utils/dataStructures/tree';
 import type { HeaderNodeData } from '../headersTree';
+import type { NodeModificationResult } from './index';
 
 /**
  * Expanding a node is a process where the processing node is expanded to
@@ -18,7 +19,7 @@ import type { HeaderNodeData } from '../headersTree';
  */
 export function expandNode(
   nodeToProcess: TreeNode<HeaderNodeData>
-): { rollbackModification: Function, affectedColumns: unknown[], colspanCompensation: number } {
+): NodeModificationResult {
   const { data: nodeData, childs: nodeChilds } = nodeToProcess;
 
   if (!nodeData.isCollapsed || nodeData.isHidden || nodeData.origColspan <= 1) {
@@ -54,7 +55,7 @@ export function expandNode(
   // cloned tree. Mirrors the "first visible child" selection done in collapseNode, so children
   // hidden by an external source (or by their own collapse) are left untouched.
   const childsToRestore = nodeChilds.filter(({ data }) => data.clonedTree);
-  const affectedColumns = new Set();
+  const affectedColumns = new Set<number>();
   let colspanCompensation = 0;
 
   if (childsToRestore.length > 0) {

--- a/handsontable/src/plugins/nestedHeaders/stateManager/nodeModifiers/index.ts
+++ b/handsontable/src/plugins/nestedHeaders/stateManager/nodeModifiers/index.ts
@@ -8,6 +8,16 @@ import { collapseNode } from './collapse';
 import { expandNode } from './expand';
 import type TreeNode from '../../../../utils/dataStructures/tree';
 
+/**
+ * The result of a collapse/expand node modification: the visual column indexes the action
+ * hid/showed, by how much the colspan changed, and a rollback that reverses the modification.
+ */
+export interface NodeModificationResult {
+  rollbackModification: Function;
+  affectedColumns: number[];
+  colspanCompensation: number;
+}
+
 const availableModifiers = new Map<string, Function>([
   ['collapse', collapseNode],
   ['expand', expandNode],
@@ -25,13 +35,12 @@ export function triggerNodeModification(
   actionName: string,
   nodeToProcess: TreeNode,
   gridColumnIndex: number
-): { rollbackModification: Function, affectedColumns: unknown[], colspanCompensation: number } | void {
+): NodeModificationResult | void {
   const modifier = availableModifiers.get(actionName);
 
   if (!modifier) {
     throwWithCause(`The node modifier action ("${actionName}") does not exist.`);
   }
 
-  return modifier(nodeToProcess, gridColumnIndex) as
-    { rollbackModification: Function, affectedColumns: unknown[], colspanCompensation: number } | void;
+  return modifier(nodeToProcess, gridColumnIndex) as NodeModificationResult | void;
 }

--- a/handsontable/src/plugins/nestedHeaders/stateManager/nodeModifiers/utils/tree.ts
+++ b/handsontable/src/plugins/nestedHeaders/stateManager/nodeModifiers/utils/tree.ts
@@ -49,6 +49,21 @@ export function traverseExposedColumnIndexes(node: TreeNode<HeaderNodeData>, cal
 }
 
 /**
+ * Checks whether a node is a "declarative" collapsible group - one whose collapse visibility is
+ * driven by per-child `visibleWhen` markers (issue #10243) rather than the legacy first-visible-child
+ * rule. A group is declarative when at least one of its direct children declares an explicit
+ * `visibleWhen` ('collapsed' or 'expanded'). Declarative groups skip the first-child column claiming
+ * in collapse/expand - their hidden set is derived separately from the markers and `isCollapsed`.
+ *
+ * @param {TreeNode} node A tree node to check.
+ * @returns {boolean}
+ */
+export function isDeclarativeGroup(node: TreeNode<HeaderNodeData>): boolean {
+  return node.childs.length > 0 &&
+    node.childs.some(({ data }) => data.visibleWhen !== undefined && data.visibleWhen !== 'always');
+}
+
+/**
  * A tree helper for retrieving a data from the first child.
  *
  * @param {TreeNode} node A tree node to check.

--- a/handsontable/src/plugins/nestedHeaders/stateManager/nodeModifiers/utils/tree.ts
+++ b/handsontable/src/plugins/nestedHeaders/stateManager/nodeModifiers/utils/tree.ts
@@ -52,15 +52,16 @@ export function traverseExposedColumnIndexes(node: TreeNode<HeaderNodeData>, cal
  * Checks whether a node is a "declarative" collapsible group - one whose collapse visibility is
  * driven by per-child `visibleWhen` markers (issue #10243) rather than the legacy first-visible-child
  * rule. A group is declarative when at least one of its direct children declares an explicit
- * `visibleWhen` ('collapsed' or 'expanded'). Declarative groups skip the first-child column claiming
- * in collapse/expand - their hidden set is derived separately from the markers and `isCollapsed`.
+ * `visibleWhen` ('collapsed', 'expanded', or 'always'). Declarative groups skip the first-child column
+ * claiming in collapse/expand - their hidden set is derived separately from the markers and
+ * `isCollapsed`.
  *
  * @param {TreeNode} node A tree node to check.
  * @returns {boolean}
  */
 export function isDeclarativeGroup(node: TreeNode<HeaderNodeData>): boolean {
   return node.childs.length > 0 &&
-    node.childs.some(({ data }) => data.visibleWhen !== undefined && data.visibleWhen !== 'always');
+    node.childs.some(({ data }) => data.visibleWhen !== undefined);
 }
 
 /**

--- a/handsontable/src/plugins/nestedHeaders/stateManager/settingsNormalizer.ts
+++ b/handsontable/src/plugins/nestedHeaders/stateManager/settingsNormalizer.ts
@@ -3,6 +3,8 @@ import { isObject } from '../../../helpers/object';
 import { stringify } from '../../../helpers/mixed';
 import { createDefaultHeaderSettings, createPlaceholderHeaderSettings } from './utils';
 
+import type { HeaderVisibility } from './utils';
+
 interface NormalizedHeaderSettings {
   label: string;
   colspan: number;
@@ -14,7 +16,10 @@ interface NormalizedHeaderSettings {
   isRoot: boolean;
   isPlaceholder: boolean;
   headerClassNames: string[];
+  visibleWhen: HeaderVisibility;
 }
+
+const VISIBLE_WHEN_VALUES = ['collapsed', 'expanded', 'always'];
 
 /**
  * A function that normalizes user-defined settings into one predictable
@@ -107,6 +112,7 @@ export function normalizeSettings(sourceSettings: unknown[][], columnsLimit = In
         colspan,
         rowspan,
         headerClassName,
+        visibleWhen,
       } = sourceHeaderSettings as Record<string, unknown>;
 
       headerSettings.label = stringify(label);
@@ -123,6 +129,11 @@ export function normalizeSettings(sourceSettings: unknown[][], columnsLimit = In
 
       if (typeof headerClassName === 'string') {
         headerSettings.headerClassNames = [...headerClassName.split(' ')];
+      }
+
+      // Unknown/invalid values fall back to the default 'always' so a typo never hides a column.
+      if (typeof visibleWhen === 'string' && VISIBLE_WHEN_VALUES.includes(visibleWhen)) {
+        headerSettings.visibleWhen = visibleWhen as HeaderVisibility;
       }
 
     } else {

--- a/handsontable/src/plugins/nestedHeaders/stateManager/settingsNormalizer.ts
+++ b/handsontable/src/plugins/nestedHeaders/stateManager/settingsNormalizer.ts
@@ -89,12 +89,14 @@ export function normalizeSettings(sourceSettings: unknown[][], columnsLimit = In
       colspan,
       rowspan,
       headerClassName,
+      visibleWhen,
     } = sourceHeaderSettings as Record<string, unknown>;
 
     return stringify(label) === '' &&
       (colspan === undefined || colspan === 1) &&
       (rowspan === undefined || rowspan === 1) &&
-      headerClassName === undefined;
+      headerClassName === undefined &&
+      visibleWhen === undefined;
   };
 
   /**
@@ -131,7 +133,9 @@ export function normalizeSettings(sourceSettings: unknown[][], columnsLimit = In
         headerSettings.headerClassNames = [...headerClassName.split(' ')];
       }
 
-      // Unknown/invalid values fall back to the default 'always' so a typo never hides a column.
+      // Only a recognized value is carried through. An unset or invalid value (e.g. a typo) is left
+      // undefined, which the collapse computation treats as the default 'expanded' - the column is
+      // visible while the group is expanded and hidden when it collapses.
       if (typeof visibleWhen === 'string' && VISIBLE_WHEN_VALUES.includes(visibleWhen)) {
         headerSettings.visibleWhen = visibleWhen as HeaderVisibility;
       }

--- a/handsontable/src/plugins/nestedHeaders/stateManager/settingsNormalizer.ts
+++ b/handsontable/src/plugins/nestedHeaders/stateManager/settingsNormalizer.ts
@@ -16,7 +16,7 @@ interface NormalizedHeaderSettings {
   isRoot: boolean;
   isPlaceholder: boolean;
   headerClassNames: string[];
-  visibleWhen: HeaderVisibility;
+  visibleWhen?: HeaderVisibility;
 }
 
 const VISIBLE_WHEN_VALUES = ['collapsed', 'expanded', 'always'];

--- a/handsontable/src/plugins/nestedHeaders/stateManager/utils.ts
+++ b/handsontable/src/plugins/nestedHeaders/stateManager/utils.ts
@@ -23,10 +23,13 @@
  */
 
 /**
- * Determines in which collapse state a header (and its columns) stays visible:
+ * Explicitly sets in which collapse state a header (and its columns) stays visible:
  * - `'collapsed'` - visible only while the parent group is collapsed (hidden while expanded);
  * - `'expanded'` - visible only while the parent group is expanded (hidden while collapsed);
- * - `'always'` - visible in both states (the default).
+ * - `'always'` - visible in both states.
+ *
+ * When left unset (within a group that uses any of these markers), the header defaults to
+ * `'expanded'` - it is hidden when the group collapses, matching the default collapse behavior.
  */
 export type HeaderVisibility = 'collapsed' | 'expanded' | 'always';
 
@@ -50,7 +53,7 @@ export function createDefaultHeaderSettings({
   isPlaceholder = false,
   isRowspanPlaceholder = false,
   headerClassNames = [],
-  visibleWhen = 'always' as HeaderVisibility
+  visibleWhen
 }: {
   label?: string;
   colspan?: number;

--- a/handsontable/src/plugins/nestedHeaders/stateManager/utils.ts
+++ b/handsontable/src/plugins/nestedHeaders/stateManager/utils.ts
@@ -23,6 +23,14 @@
  */
 
 /**
+ * Determines in which collapse state a header (and its columns) stays visible:
+ * - `'collapsed'` - visible only while the parent group is collapsed (hidden while expanded);
+ * - `'expanded'` - visible only while the parent group is expanded (hidden while collapsed);
+ * - `'always'` - visible in both states (the default).
+ */
+export type HeaderVisibility = 'collapsed' | 'expanded' | 'always';
+
+/**
  * Creates the header settings object with default values.
  *
  * @param {DefaultHeaderSettings} initialValues The initial values for the header settings object.
@@ -41,7 +49,8 @@ export function createDefaultHeaderSettings({
   isRoot = false,
   isPlaceholder = false,
   isRowspanPlaceholder = false,
-  headerClassNames = []
+  headerClassNames = [],
+  visibleWhen = 'always' as HeaderVisibility
 }: {
   label?: string;
   colspan?: number;
@@ -56,6 +65,7 @@ export function createDefaultHeaderSettings({
   isPlaceholder?: boolean;
   isRowspanPlaceholder?: boolean;
   headerClassNames?: string[];
+  visibleWhen?: HeaderVisibility;
 } = {}) {
   return {
     label,
@@ -71,6 +81,7 @@ export function createDefaultHeaderSettings({
     isPlaceholder,
     isRowspanPlaceholder,
     headerClassNames,
+    visibleWhen,
   };
 }
 

--- a/handsontable/src/translations/indexMapper.ts
+++ b/handsontable/src/translations/indexMapper.ts
@@ -8,6 +8,8 @@ import {
   TrimmingMap,
 } from './maps';
 import type { IndexMap } from './maps/indexMap';
+import type { LinkedPhysicalIndexToValueMap } from './maps/linkedPhysicalIndexToValueMap';
+import type { PhysicalIndexToValueMap } from './maps/physicalIndexToValueMap';
 import {
   AggregatedCollection,
   MapCollection,
@@ -270,16 +272,29 @@ export class IndexMapper {
   }
 
   /**
-   * Creates and registers a new `IndexMap` for a specified `IndexMapper` instance.
+   * Creates and registers a new `IndexMap` for a specified `IndexMapper` instance. For a known
+   * `mapType` literal the return type narrows to the concrete map class ('hiding' -> `HidingMap`,
+   * 'trimming' -> `TrimmingMap`, etc.); any other string falls back to the base `IndexMap`.
    *
    * @param {string} indexName A unique index name.
    * @param {string} mapType The index map type (e.g., "hiding", "trimming", "physicalIndexToValue").
    * @param {*} [initValueOrFn] The initial value for the index map.
    * @returns {IndexMap}
    */
-  createAndRegisterIndexMap(indexName: string, mapType: string, initValueOrFn?: unknown) {
+  createAndRegisterIndexMap(indexName: string, mapType: 'hiding', initValueOrFn?: unknown): HidingMap;
+  /* eslint-disable jsdoc/require-jsdoc -- these overloads + the implementation share the JSDoc above */
+  createAndRegisterIndexMap(indexName: string, mapType: 'trimming', initValueOrFn?: unknown): TrimmingMap;
+  createAndRegisterIndexMap(
+    indexName: string, mapType: 'physicalIndexToValue', initValueOrFn?: unknown
+  ): PhysicalIndexToValueMap;
+  createAndRegisterIndexMap(
+    indexName: string, mapType: 'linkedPhysicalIndexToValue', initValueOrFn?: unknown
+  ): LinkedPhysicalIndexToValueMap;
+  createAndRegisterIndexMap(indexName: string, mapType: string, initValueOrFn?: unknown): IndexMap;
+  createAndRegisterIndexMap(indexName: string, mapType: string, initValueOrFn?: unknown): IndexMap {
     return this.registerMap(indexName, createIndexMap(mapType, initValueOrFn));
   }
+  /* eslint-enable jsdoc/require-jsdoc */
 
   /**
    * Register map which provide some index mappings. Type of map determining to which collection it will be added.


### PR DESCRIPTION
### Context

The PR adds a `visibleWhen` option to nested headers so you can choose which columns of a collapsible group stay visible when the group is collapsed or expanded - the public request in [#10243](https://github.com/handsontable/handsontable/issues/10243). Until now, collapsing a group always left only its first column visible, with no way to pick a different one.

Each header in the `nestedHeaders` configuration can declare `visibleWhen`:

- `'collapsed'` - visible only while the group is collapsed (a summary column that appears on collapse)
- `'expanded'` - visible only while the group is expanded
- `'always'` - visible in both states

Within a group that uses `visibleWhen`, an unmarked header defaults to `'expanded'` (hidden when the group collapses), matching the default collapse behavior. So the common "keep one column when collapsed" case needs a single marker:

```js
nestedHeaders: [
  ['Region', { label: 'Q1 2025', colspan: 4 }],
  ['Region', 'Jan', 'Feb', 'Mar', { label: 'Total', visibleWhen: 'collapsed' }],
],
collapsibleColumns: true,
// collapsing the "Q1 2025" group hides Jan/Feb/Mar and reveals "Total"; expanding reverses it
```

A group without any `visibleWhen` markers keeps the existing first-child collapse, so the change is backward compatible. At least one column of a group always stays visible, so its collapse indicator is never lost.

How it works:

- `visibleWhen` is carried through normalization into the header tree node data.
- `StateManager#getVisibleWhenHiddenColumns` derives the hidden set purely from the markers and each group's `isCollapsed` flag (an unmarked header resolves to `'expanded'`), so it stays correct across tree rebuilds (column insert/remove, `updateSettings`).
- The `collapse`/`expand` node modifiers detect a declarative group and only toggle `isCollapsed`; the column hiding is applied by `CollapsibleColumns` through a dedicated `#visibleWhenMap`, kept separate from the collapsed-columns map so `getCollapsedColumns()` stays honest.
- `#checkIsActionPossible` reads the tree node instead of the generated matrix, because a declarative collapse can hide the group's anchor column.

Also in this PR:

- `nestedHeaders` is now strictly typed (`NestedHeader` / `NestedHeaderSettings`), and the `nestedHeaders` option docs in `metaSchema.ts` list every header-object property (`label`, `colspan`, `rowspan`, `headerClassName`, `visibleWhen`).
- Plugin and index-map types are inferred rather than cast - typed `getPlugin('nestedHeaders')` via `PluginTypeMap`, overloaded `IndexMapper#createAndRegisterIndexMap` (so `'hiding'` infers `HidingMap`), and a shared `NodeModificationResult` type - removing the hand-written StateManager interface and the `as` casts.
- The Angular docs type-check (`docs/angular-type-check`) now gates on the current branch build (the branch CI checked out and built), not on `handsontable@latest`, so an example that uses an API added on this branch is no longer failed for it; real type errors on the current build still fail.

This branch is stacked on `feature/DEV-294_NestedHeaders-Collapsible-Hidden-Columns` (which it depends on), so the PR targets that branch rather than `develop`. Retarget to `develop` once DEV-294 merges.

### How has this been tested?

- New E2E suite `npm run test:e2e --prefix handsontable --testPathPattern=collapsibleColumns/__tests__/visibleWhen`: choose the visible column, collapsed-only summary column, multi-cycle stability, invalid value treated as the default, a single `'always'` marker collapsing the rest away, the guard keeping the first column (and a working indicator) when every column would hide, union with `HiddenColumns`, preservation across `insert_col`, and three `updateSettings` scenarios.
- Regression: full `collapsibleColumns/__tests__/` + `nestedHeaders/__tests__/` E2E green - **271 specs, 0 failures**.
- Unit `npm run test:unit --prefix handsontable --testPathPattern=nestedHeaders/__tests__/stateManager`: `getVisibleWhenHiddenColumns` per state + unmarked default + guard + legacy fallback, and `settingsNormalizer` parsing (unset/invalid -> undefined) - **127 specs**. Plus `translations/__tests__/indexMapper` (103) for the index-map overloads.
- Types: `npm run test:types --prefix handsontable` (strict `nestedHeaders` typing + `settings.types.ts` fixture).
- Lint: `eslint` + `stylelint` clean on all changed files.
- Manual: verified the native collapse/expand indicator in a browser against the published next build via jsDelivr.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1875
2. #10243

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/86ca92v4t

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches collapsible column visibility and selection in core plugins; behavior is heavily tested but changes default paths when `visibleWhen` is used.
> 
> **Overview**
> Adds **`visibleWhen`** on nested header objects (`'collapsed'`, `'expanded'`, `'always'`) so collapsible groups can control which child columns stay visible when expanded vs collapsed, instead of always keeping the first column.
> 
> **CollapsibleColumns** applies visibility through a separate hiding map from legacy collapse, refreshes it on toggle/settings/column structure changes, adjusts selection when summary columns hide, and resolves collapse/expand from any column in the group. **NestedHeaders** normalizes the option, derives hidden columns via `getVisibleWhenHiddenColumns`, and uses a declarative collapse path that only toggles `isCollapsed`.
> 
> Also ships docs/examples (example3), changelog, strict **`nestedHeaders`** typing, Angular docs CI **`SKIP_LATEST`**, and E2E debugging notes in the testing skill.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f2ca411d515a0a2b44fc401b0717c1033146107. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->