### PR TITLE
fix(docs): pin Vite to v5 and add CSS support for Vue StackBlitz examples

### DIFF
--- a/docs/public/example-tabs.js
+++ b/docs/public/example-tabs.js
@@ -660,13 +660,21 @@ document.addEventListener('DOMContentLoaded', function () {
     var jsFile = findFile(userFiles, '.vue') || 'App.vue';
     var appCode = userFiles[jsFile] || '';
 
+    var cssFile = findFile(userFiles, '.css');
+    var cssImportedByName = cssFile && new RegExp('import\\s+[\'"]\\./?' + cssFile.replace('.', '\\.') + '[\'"]').test(appCode);
+    var cssDestName = cssImportedByName ? cssFile : 'styles.css';
+
     var deps = Object.assign(
       {
         handsontable:         hotVersion,
         '@handsontable/vue3': hotVersion,
         vue:                  '3.x',
-        vite:                 'latest',
-        '@vitejs/plugin-vue': 'latest',
+        // Pin Vite to v5 to avoid Vite 8/rolldown aggressively tree-shaking filter condition
+        // registration side effects due to sideEffects:false in the handsontable package.json.
+        // Once handsontable's package.json sideEffects is updated to include condition files,
+        // this can be changed back to 'latest'.
+        vite:                 '^5.4.0',
+        '@vitejs/plugin-vue': '^5.0.0',
       },
       extraDeps,
     );
@@ -688,10 +696,11 @@ document.addEventListener('DOMContentLoaded', function () {
 
     var main = [
       'import { createApp } from "vue";',
+      (cssFile && !cssImportedByName) ? 'import "./' + cssDestName + '";' : null,
       'import App from "./App.vue";',
       '',
       'createApp(App).mount("#' + exampleId + '");',
-    ].join('\n');
+    ].filter(Boolean).join('\n');
 
     var cdnCssUrl = 'https://unpkg.com/handsontable@' + hotVersion + '/dist/handsontable.full.min.css';
 
@@ -717,13 +726,19 @@ document.addEventListener('DOMContentLoaded', function () {
 
     var html = indexPartsV.join('\n');
 
-    return {
-      'package.json': pkg,
+    var projectFiles = {
+      'package.json':  pkg,
       'vite.config.js': viteConfig,
-      'index.html':  html,
-      'src/main.js': main,
-      'src/App.vue': appCode,
+      'index.html':    html,
+      'src/main.js':   main,
+      'src/App.vue':   appCode,
     };
+
+    if (cssFile) {
+      projectFiles['src/' + cssDestName] = userFiles[cssFile];
+    }
+
+    return projectFiles;
   }
 
   // ── Angular project ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Pins `vite` to `'^5.4.0'` in `buildVueProject()` — Vite 8 (rolldown) tree-shakes Handsontable's filter-condition side-effect registrations due to `sideEffects:false` in `handsontable/package.json`, causing Vue StackBlitz examples to silently fail. JS and React projects already had this pin; Vue was missed.
- Pins `@vitejs/plugin-vue` to `'^5.0.0'` (compatible with Vite 5.x).
- Adds companion `.css` file support to `buildVueProject()`, matching the existing behaviour of `buildReactProject()` and `buildAngularProject()`.

Fixes: DEV-1878

## Test plan

- [ ] Open any Vue example on https://dev.handsontable.com/docs/vue-data-grid/vue-hot-column/ and click "Edit on StackBlitz"
- [ ] Verify the StackBlitz project opens and the grid renders correctly
- [ ] Verify React and JS StackBlitz examples are unaffected

[skip changelog]

https://claude.ai/code/session_01CQSK6Bf4uzbLcgFaBNcp8g

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQSK6Bf4uzbLcgFaBNcp8g)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only StackBlitz scaffolding in `example-tabs.js`; no runtime product or auth/data paths change.
> 
> **Overview**
> Aligns **Vue** “Edit on StackBlitz” project generation in `buildVueProject()` with JS/React so examples open and run reliably.
> 
> **Vite pinning:** Replaces `vite` / `@vitejs/plugin-vue` `latest` with `^5.4.0` and `^5.0.0` so Vite 8 (rolldown) does not tree-shake Handsontable filter-condition side effects (`sideEffects: false` in the package). Vue was the only framework builder still on `latest`.
> 
> **CSS companions:** When an example includes a `.css` file, the builder now copies it into `src/`, chooses `styles.css` vs the original filename based on whether `App.vue` already imports it, and adds a `main.js` import when needed—same pattern as `buildReactProject()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd31e4f2ab19f29c9175f695305815952eaf6388. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->