### PR TITLE
DEV-1820: Remove vestigial VuePress id fields missed in 2 migration guides

### DIFF
--- a/docs/content/guides/upgrade-and-migration/migrating-from-13.1-to-14.0/migrating-from-13.1-to-14.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-13.1-to-14.0/migrating-from-13.1-to-14.0.md
@@ -8,10 +8,8 @@ permalink: /migration-from-13.1-to-14.0
 canonicalUrl: /migration-from-13.1-to-14.0
 pageClass: migration-guide
 react:
-  id: migrating-13.1-to-14.0-react
   metaTitle: Migrate from 13.1 to 14.0 - React Data Grid | Handsontable
 angular:
-  id: rxlauyd8-13.1-to-14.0-react
   metaTitle: Migrate from 13.1 to 14.0 - Angular Data Grid | Handsontable
 vue:
   metaTitle: Migrate from 13.1 to 14.0 - Vue Data Grid | Handsontable

--- a/docs/content/guides/upgrade-and-migration/migrating-from-14.6-to-15.0/migrating-from-14.6-to-15.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-14.6-to-15.0/migrating-from-14.6-to-15.0.md
@@ -8,10 +8,8 @@ permalink: /migration-from-14.6-to-15.0
 canonicalUrl: /migration-from-14.6-to-15.0
 pageClass: migration-guide
 react:
-  id: migrating-14.6-to-15.0-react
   metaTitle: Migrate from 14.6 to 15.0 - React Data Grid | Handsontable
 angular:
-  id: 7kr2r20j-14.6-to-15.0-react
   metaTitle: Migrate from 14.6 to 15.0 - Angular Data Grid | Handsontable
 vue:
   metaTitle: Migrate from 14.6 to 15.0 - Vue Data Grid | Handsontable


### PR DESCRIPTION
### Context

Follow-up to #12730 (DEV-1820). The original PR cleaned up vestigial VuePress `id:` fields from 136 files but missed two migration guide files that still had `id:` fields inside `react:` and `angular:` frontmatter blocks.

**Files fixed:**
- `docs/content/guides/upgrade-and-migration/migrating-from-13.1-to-14.0/migrating-from-13.1-to-14.0.md`
- `docs/content/guides/upgrade-and-migration/migrating-from-14.6-to-15.0/migrating-from-14.6-to-15.0.md`

Removes 4 `id:` lines total. `metaTitle` fields are preserved.

### How has this been tested?

```
grep -rn '^  id: [[:alnum:]]*$' docs/content/guides --include='*.md'
```
→ zero matches in the affected files after cleanup.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1820

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1820

[skip changelog]

---
_Generated by [Claude Code](https://claude.ai/code/session_01QTLy7fLXMrwEj4DCe71np4)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only frontmatter edits with no runtime or API impact.
> 
> **Overview**
> Completes the DEV-1820 docs cleanup by removing leftover **VuePress `id:` entries** nested under `react:` and `angular:` in two migration guides (`migrating-from-13.1-to-14.0` and `migrating-from-14.6-to-15.0`).
> 
> Each file loses two indented `id:` lines; **page-level `id:` and all `metaTitle` values are unchanged**, matching the pattern applied across the rest of the guides in the earlier migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37e69614e4267bd76ed9fe4826ff3779b99644eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->