### PR TITLE
DEV-312 - `Filter_by_value` does not show in the dropdown m…

### DIFF
--- a/.changelogs/12781.json
+++ b/.changelogs/12781.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed filter menu components being wrongly hidden when dropdownMenu starts with a '---------' separator.",
+  "type": "fixed",
+  "issueOrPR": 12781,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/contextMenu/menu/menu.ts
+++ b/handsontable/src/plugins/contextMenu/menu/menu.ts
@@ -281,6 +281,22 @@ export class Menu {
   }
 
   /**
+   * Returns the position (row index) of the menu item identified by the provided `key` within the
+   * currently rendered menu. Before rendering, `filterSeparators()` and the hidden-item filter run
+   * over `menuItems`, so the rendered list can differ from the raw `menuItems` collection - callers
+   * that need an index matching the rendered rows must use this method instead of reading
+   * `menuItems` directly. Falls back to `menuItems` when the menu has not been rendered yet.
+   *
+   * @param {string} key The menu item key to look up.
+   * @returns {number} The item row index, or `-1` when the item is not found.
+   */
+  getItemPositionByKey(key: string): number {
+    const items = (this.hotMenu?.getSourceData() ?? this.menuItems ?? []) as unknown as { key?: string }[];
+
+    return items.findIndex(item => item.key === key);
+  }
+
+  /**
    * Returns the source data at the provided row index typed as `T`.
    *
    * @param {number} row Row index.

--- a/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
@@ -1997,6 +1997,34 @@ describe('Filters UI', () => {
     expect(onErrorSpy).not.toHaveBeenCalled();
   });
 
+  it('should render all filter components when the dropdownMenu starts with a separator', async() => {
+    // A leading separator is stripped from the rendered menu by `filterSeparators()`, but it stays
+    // in `menu.menuItems`. Previously the component row indexes were read from that unfiltered
+    // collection, so they were off by one and the `hiddenRows` plugin hid the wrong rows - the
+    // "filter by value" list (and others) disappeared, leaving only the operators visible.
+    handsontable({
+      data: getDataForFilters(),
+      columns: getColumnsForFilters(),
+      dropdownMenu: [
+        '---------',
+        'filter_by_condition',
+        '---------',
+        'filter_operators',
+        'filter_by_value',
+        'filter_action_bar',
+      ],
+      filters: true,
+      width: 500,
+      height: 300,
+    });
+
+    await dropdownMenu(0);
+
+    expect(conditionSelectRootElements().first.offsetParent).not.toBe(null);
+    expect(byValueBoxRootElement().offsetParent).not.toBe(null);
+    expect(getFilterDropdownMenuOKButton().offsetParent).not.toBe(null);
+  });
+
   it('should adjust the dropdown height to the currently displayed content', async() => {
     handsontable({
       data: getDataForFilters(),

--- a/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
@@ -2025,6 +2025,32 @@ describe('Filters UI', () => {
     expect(getFilterDropdownMenuOKButton().offsetParent).not.toBe(null);
   });
 
+  it('should render all filter components when the dropdownMenu starts with multiple separators', async() => {
+    // `filterSeparators()` collapses several leading separators at once, so the rendered list can be
+    // shifted by more than one row - a naive "+1" offset would not be enough. The position must be
+    // resolved against the rendered rows regardless of how many separators were stripped.
+    handsontable({
+      data: getDataForFilters(),
+      columns: getColumnsForFilters(),
+      dropdownMenu: [
+        '---------',
+        '---------',
+        'filter_by_condition',
+        'filter_by_value',
+        'filter_action_bar',
+      ],
+      filters: true,
+      width: 500,
+      height: 300,
+    });
+
+    await dropdownMenu(0);
+
+    expect(conditionSelectRootElements().first.offsetParent).not.toBe(null);
+    expect(byValueBoxRootElement().offsetParent).not.toBe(null);
+    expect(getFilterDropdownMenuOKButton().offsetParent).not.toBe(null);
+  });
+
   it('should adjust the dropdown height to the currently displayed content', async() => {
     handsontable({
       data: getDataForFilters(),

--- a/handsontable/src/plugins/filters/filters.ts
+++ b/handsontable/src/plugins/filters/filters.ts
@@ -1529,38 +1529,15 @@ export class Filters extends BasePlugin {
    * @returns {Array}
    */
   getIndexesOfComponents(...components: BaseComponent[]) {
-    const indexes: number[] = [];
-
-    if (!this.dropdownMenuPlugin) {
-      return indexes;
-    }
-
-    const menu = this.dropdownMenuPlugin.menu;
+    const menu = this.dropdownMenuPlugin?.menu;
 
     if (!menu) {
-      return indexes;
+      return [];
     }
 
-    // The visibility of components is toggled through the `hiddenRows` plugin of the rendered
-    // menu (`hotMenu`), so the indexes have to match the rows that are actually rendered. The
-    // `menuItems` collection still holds the raw, unfiltered items (e.g. leading/trailing/duplicated
-    // separators that `filterSeparators()` strips before rendering), so reading indexes from it
-    // would be off whenever such a separator precedes a component. Prefer the rendered source data,
-    // and fall back to `menuItems` only when the menu has not been rendered yet.
-    const renderedItems = (menu.hotMenu?.getSourceData() as unknown as { key: string }[] | null) ?? menu.menuItems;
-
-    arrayEach(components, (component) => {
-      const comp = (component as unknown) as { getMenuItemDescriptor(): { key: string } };
-
-      arrayEach(renderedItems ?? [], (item, index) => {
-        if ((item as { key: string }).key === comp.getMenuItemDescriptor().key) {
-
-          indexes.push(index);
-        }
-      });
-    });
-
-    return indexes;
+    return components
+      .map(component => menu.getItemPositionByKey(String(component.getMenuItemDescriptor().key)))
+      .filter(index => index !== -1);
   }
 
   /**

--- a/handsontable/src/plugins/filters/filters.ts
+++ b/handsontable/src/plugins/filters/filters.ts
@@ -1541,10 +1541,18 @@ export class Filters extends BasePlugin {
       return indexes;
     }
 
+    // The visibility of components is toggled through the `hiddenRows` plugin of the rendered
+    // menu (`hotMenu`), so the indexes have to match the rows that are actually rendered. The
+    // `menuItems` collection still holds the raw, unfiltered items (e.g. leading/trailing/duplicated
+    // separators that `filterSeparators()` strips before rendering), so reading indexes from it
+    // would be off whenever such a separator precedes a component. Prefer the rendered source data,
+    // and fall back to `menuItems` only when the menu has not been rendered yet.
+    const renderedItems = (menu.hotMenu?.getSourceData() as unknown as { key: string }[] | null) ?? menu.menuItems;
+
     arrayEach(components, (component) => {
       const comp = (component as unknown) as { getMenuItemDescriptor(): { key: string } };
 
-      arrayEach(menu.menuItems ?? [], (item, index) => {
+      arrayEach(renderedItems ?? [], (item, index) => {
         if ((item as { key: string }).key === comp.getMenuItemDescriptor().key) {
 
           indexes.push(index);


### PR DESCRIPTION
### Context

Fixed the incorrect hiding of filter menu components (filter_by_value, etc.) when dropdownMenu starts with a '---------' separator — component indexes are now computed based on the actually rendered menu rows, rather than the raw list with uncleaned separators.


### How has this been tested?
npm run test:e2e -- --testPathPattern=filtersUI

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. #9222
2. DEV-312
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-312

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted bug fix in dropdown menu index resolution and filter UI visibility, with regression tests and no API changes.
> 
> **Overview**
> Fixes **filter_by_value** and related dropdown pieces disappearing when **`dropdownMenu`** is customized with **leading `---------` separators**. Rendered rows are built after **`filterSeparators()`** (and hidden-item filtering), but the Filters plugin still mapped component keys to row indexes on the **raw `menuItems` list**, so **`hiddenRows`** targeted the wrong rows.
> 
> Adds **`Menu.getItemPositionByKey()`**, which resolves indexes from the **rendered** menu source data (with a pre-render fallback). **`Filters.getIndexesOfComponents()`** now uses that API instead of scanning **`menuItems`**. New **filters UI e2e** cases cover one and multiple leading separators; changelog entry included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3af8e6c5582d0ff2cdcdc01cc80476b89b7a2e2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->