### PR TITLE
DEV-1879: Fix nested header colspan label jump on horizontal scroll (#4628)

### DIFF
--- a/.changelogs/12783.json
+++ b/.changelogs/12783.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed a nested header bug where a wide column group's label jumped while scrolling horizontally.",
+  "type": "fixed",
+  "issueOrPR": 12783,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/nestedHeaders/__tests__/generalFunctionality.spec.js
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/generalFunctionality.spec.js
@@ -612,6 +612,57 @@ describe('NestedHeaders', () => {
       });
     });
 
+    it('should keep a wide colspan header fully rendered (constant width) while scrolling through it (#4628)', async() => {
+      // A colspan group much wider than the viewport. While scrolling through it, the viewport
+      // calculator override must expand the rendered range to both group edges so the colspan
+      // `<th>` keeps a constant width - otherwise its width changes in column-sized steps and the
+      // center-aligned label visibly jumps.
+      handsontable({
+        data: createSpreadsheetData(5, 100),
+        colHeaders: true,
+        nestedHeaders: [
+          [{ label: 'A', colspan: 4 }, { label: 'WIDE', colspan: 80 }, { label: 'B', colspan: 16 }],
+          Array.from({ length: 100 }, (_, i) => `col${i}`),
+        ],
+        colWidths: 50,
+        autoColumnSize: false,
+        width: 300,
+        height: 200,
+      });
+
+      // The 'WIDE' group spans visual columns 4..83.
+      const groupStart = 4;
+      const groupEnd = 83;
+      const getWideHeader = () => getTopClone().find('thead tr:first th').toArray()
+        .find(th => (th.querySelector('.colHeader')?.innerText ?? '') === 'WIDE') ?? null;
+      const firstRenderedVisual = () => columnIndexMapper()
+        .getVisualFromRenderableIndex(hot().view._wt.wtTable.getFirstRenderedColumn());
+      const lastRenderedVisual = () => columnIndexMapper()
+        .getVisualFromRenderableIndex(hot().view._wt.wtTable.getLastRenderedColumn());
+
+      // Scroll so the group straddles the right edge of the viewport.
+      await scrollViewportTo({ col: 10, horizontalSnap: 'start' });
+
+      // The render range must cover the whole group (both edges), not stop at the viewport.
+      expect(firstRenderedVisual()).toBeLessThanOrEqual(groupStart);
+      expect(lastRenderedVisual()).toBeGreaterThanOrEqual(groupEnd);
+
+      const wideWidth = getWideHeader().offsetWidth;
+
+      // Scrolling further into the group must not change the header's width (no "jump").
+      await scrollViewportTo({ col: 14, horizontalSnap: 'start' });
+
+      expect(firstRenderedVisual()).toBeLessThanOrEqual(groupStart);
+      expect(lastRenderedVisual()).toBeGreaterThanOrEqual(groupEnd);
+      expect(getWideHeader().offsetWidth).toBe(wideWidth);
+
+      await scrollViewportTo({ col: 30, horizontalSnap: 'start' });
+
+      expect(firstRenderedVisual()).toBeLessThanOrEqual(groupStart);
+      expect(lastRenderedVisual()).toBeGreaterThanOrEqual(groupEnd);
+      expect(getWideHeader().offsetWidth).toBe(wideWidth);
+    });
+
     it('should correctly point cell coords for nested corners', async() => {
       const afterOnCellMouseDown = jasmine.createSpy('onAfterOnCellMouseDown');
 

--- a/handsontable/src/plugins/nestedHeaders/nestedHeaders.ts
+++ b/handsontable/src/plugins/nestedHeaders/nestedHeaders.ts
@@ -1326,8 +1326,11 @@ export class NestedHeaders extends BasePlugin {
       const renderedEndColumn = nearestColumn === null ?
         null : columnIndexMapper.getRenderableFromVisualIndex(nearestColumn);
 
-      if (isNumeric(renderedEndColumn) && renderedEndColumn !== null && renderedEndColumn > calc.endColumn) {
+      // The top header layer holds the widest spans, so the first layer that expands the
+      // boundary already yields the largest extent - no deeper layer can exceed it.
+      if (renderedEndColumn !== null && renderedEndColumn > calc.endColumn) {
         calc.endColumn = renderedEndColumn;
+        break;
       }
     }
   }

--- a/handsontable/src/plugins/nestedHeaders/nestedHeaders.ts
+++ b/handsontable/src/plugins/nestedHeaders/nestedHeaders.ts
@@ -1266,9 +1266,23 @@ export class NestedHeaders extends BasePlugin {
   };
 
   /**
-   * Extends the viewport start column to include any header spans that begin outside the calculated viewport boundary.
+   * Extends the viewport's rendered column range so that every nested header group intersecting
+   * the viewport is rendered in full. A wide colspan straddling a viewport edge would otherwise
+   * render only partially, so its `<th>` width changes as columns enter or leave the render range
+   * while scrolling - which makes the center-aligned header label jump. Expanding both the start
+   * and the end boundary to the group's edges keeps each colspan `<th>` at a constant width while
+   * the group is visible (issue #4628).
    */
-  #onAfterViewportColumnCalculatorOverride = (calc: { startColumn: number }) => {
+  #onAfterViewportColumnCalculatorOverride = (calc: { startColumn: number, endColumn: number }) => {
+    this.#extendViewportStartColumn(calc);
+    this.#extendViewportEndColumn(calc);
+  };
+
+  /**
+   * Extends the viewport start column to include any header spans that begin before the calculated
+   * viewport start boundary.
+   */
+  #extendViewportStartColumn(calc: { startColumn: number }) {
     const headerLayersCount = this.#stateManager.getLayersCount();
     let newStartColumn = calc.startColumn;
     let nonRenderable = !!headerLayersCount;
@@ -1291,7 +1305,32 @@ export class NestedHeaders extends BasePlugin {
       nonRenderable ?
         (this.#stateManager.getHeaderTreeNodeData(0, newStartColumn)?.columnIndex ?? newStartColumn) :
         newStartColumn;
-  };
+  }
+
+  /**
+   * Extends the viewport end column to include any header spans that end after the calculated
+   * viewport end boundary, keeping a colspan header that straddles the right edge fully rendered.
+   */
+  #extendViewportEndColumn(calc: { endColumn: number }) {
+    const columnIndexMapper = this.hot.columnIndexMapper;
+    const headerLayersCount = this.#stateManager.getLayersCount();
+    const visualEndColumn = columnIndexMapper.getVisualFromRenderableIndex(calc.endColumn);
+
+    if (visualEndColumn === null) {
+      return;
+    }
+
+    for (let headerLayer = 0; headerLayer < headerLayersCount; headerLayer++) {
+      const endColumn = this.#stateManager.findRightMostColumnIndex(headerLayer, visualEndColumn);
+      const nearestColumn = columnIndexMapper.getNearestNotHiddenIndex(endColumn, -1);
+      const renderedEndColumn = nearestColumn === null ?
+        null : columnIndexMapper.getRenderableFromVisualIndex(nearestColumn);
+
+      if (isNumeric(renderedEndColumn) && renderedEndColumn !== null && renderedEndColumn > calc.endColumn) {
+        calc.endColumn = renderedEndColumn;
+      }
+    }
+  }
 
   /**
    * `modifyColWidth` hook callback - returns width from cache, when is greater than incoming from hook.


### PR DESCRIPTION
### Context

The PR fixes [#4628](https://github.com/handsontable/handsontable/issues/4628) — with `nestedHeaders` and many columns (a colspan group wider than the viewport), the center-aligned group-header label visibly jumps while scrolling horizontally through the group. Reproduced on `17.1.0` and `develop`.

Root cause: the nested-headers `afterViewportColumnCalculatorOverride` handler pinned only the **start** edge of a straddling colspan group (`#extendViewportStartColumn`); the **end** edge was left to the default viewport calculation. As you scroll, columns enter/leave the rendered range in virtualization-sized steps, so the colspan `<th>` width grows/shrinks in steps, and `text-align: center` shifts the label by ~half the width delta each step.

Fix: add the symmetric `#extendViewportEndColumn`, mirroring how `mergeCells` expands both viewport edges. Now a group's full column range is rendered whenever any part of it intersects the viewport, so each colspan `<th>` keeps a constant width while the group is visible — eliminating the jump.

Trade-off (product-confirmed): the label is centered over the now-constant full-group width, so when scrolled deep inside a very wide group the label can sit off-screen. Keeping it always visible would need a follow-up JS-reposition pass — `position: sticky` is unusable here because the header `<th>`'s `overflow: hidden` is the scrollport, so it never scrolls relative to the label.

Cost is bounded by the largest group's column count (not a full `renderAllColumns`), consistent with the existing start-edge behavior.

Note on unit tests: this change is a viewport-calculator/DOM-render-range hook that is not meaningfully testable in jsdom (the start-edge counterpart is E2E-only too). The pure logic it relies on (`findRightMostColumnIndex`) already has unit coverage; the new behavior is covered by an E2E regression test whose negative control was verified (disabling the new code makes the test fail exactly: `lastRenderedVisual` 16/20/36 instead of ≥83, and the header width changes 850→650→1650).

### How has this been tested?

- Added an E2E regression test in `nestedHeaders/__tests__/generalFunctionality.spec.js` asserting the rendered range covers the full group and the colspan `<th>` width stays constant across scroll positions.
- Negative control: temporarily disabled `#extendViewportEndColumn`, rebuilt — the new test fails as predicted; re-enabled — passes.
- `npm run test:e2e --prefix handsontable -- --testPathPattern=nestedHeaders` → 183 specs, 0 failures.
- `npm run test:e2e --prefix handsontable -- --testPathPattern=collapsibleColumns` → 115 specs, 0 failures.
- `npx eslint` on the changed files → clean.
- Manual: Chrome DevTools harness on the issue's exact config (156 cols, `hiddenColumns`, `collapsibleColumns`, `collapseAll`, narrow viewport) — colspan width constant, 0 label jumps (was 5× ~50px).

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. #4628
2. DEV-1879

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/86ca9hqur

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches column viewport virtualization for nested headers, which can widen the rendered range (bounded by largest group width) and affect scroll performance on very wide colspan groups.
> 
> **Overview**
> Fixes **nested header labels jumping** during horizontal scroll when a colspan group is wider than the viewport (#4628). Previously only the **start** of straddling header groups was pulled into the rendered column range; the **end** still followed default virtualization, so colspan `<th>` width changed in steps and center-aligned text shifted.
> 
> The `afterViewportColumnCalculatorOverride` handler now expands **both** `startColumn` and `endColumn` so any intersecting nested group is rendered in full (start logic moved to `#extendViewportStartColumn`, new `#extendViewportEndColumn` via `findRightMostColumnIndex`). An E2E regression test asserts full-group render coverage and stable header width while scrolling; changelog entry added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7ae2ba0c6d84c0567358ba12cdd8d09ae200be7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->