### PR TITLE
DEV-1909: Fix docs querySelectorAll :is() crash on older browsers

### DIFF
--- a/docs/src/components/Head.astro
+++ b/docs/src/components/Head.astro
@@ -87,7 +87,12 @@ import Default from '@astrojs/starlight/components/Head.astro';
   // The preprocessor emits them as standalone elements (wrapped in <p> by Astro),
   // so we scan each heading for consecutive action-element paragraphs and
   // move them into a flex container for side-by-side layout.
-  document.querySelectorAll<HTMLElement>('.sl-markdown-content :is(h2, h3, h4)').forEach((heading) => {
+  // Use an expanded selector list instead of `:is(h2, h3, h4)`. The `:is()` pseudo-class
+  // throws a SyntaxError DOMException inside querySelectorAll on browsers that don't support
+  // it (e.g. older Chrome/Edge and some headless crawlers), which crashes the rest of this
+  // script. The expanded form is behavior-identical and parses in every browser.
+  const headingSelector = '.sl-markdown-content h2, .sl-markdown-content h3, .sl-markdown-content h4';
+  document.querySelectorAll<HTMLElement>(headingSelector).forEach((heading) => {
     const actions: HTMLElement[] = [];
     const parasToRemove: HTMLElement[] = [];
 

--- a/docs/src/components/__tests__/head-heading-actions.test.mjs
+++ b/docs/src/components/__tests__/head-heading-actions.test.mjs
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const headPath = fileURLToPath(new URL('../Head.astro', import.meta.url));
+const headSource = readFileSync(headPath, 'utf8');
+
+// The script that groups .source-code-link / .ask-about-api-btn elements under their
+// preceding heading queries the headings with querySelectorAll. Using the `:is()`
+// pseudo-class there throws a SyntaxError DOMException on browsers/crawlers that don't
+// support it (Sentry HANDSONTABLE-DOCS-1HP / 1HN), crashing the rest of the script.
+const headingActionsBlock = headSource.slice(
+  headSource.indexOf('.api-member-actions container inside their preceding heading.'),
+  headSource.indexOf('docs-assistant:ask')
+);
+
+test('heading-actions grouping does not use :is() inside querySelectorAll', () => {
+  // Regression guard for HANDSONTABLE-DOCS-1HP / 1HN: :is() in a querySelectorAll argument
+  // throws SyntaxError in browsers without :is() support.
+  assert.doesNotMatch(
+    headingActionsBlock,
+    /querySelectorAll[\s\S]*?:is\(/,
+    'querySelectorAll must not use the :is() pseudo-class (unsupported in older browsers)'
+  );
+});
+
+test('heading-actions grouping selects h2, h3, h4 via an expanded selector list', () => {
+  assert.match(
+    headingActionsBlock,
+    /\.sl-markdown-content h2,\s*\.sl-markdown-content h3,\s*\.sl-markdown-content h4/
+  );
+});


### PR DESCRIPTION
### Context

The PR fixes a `SyntaxError` reported in Sentry (`HANDSONTABLE-DOCS-1HP`, `HANDSONTABLE-DOCS-1HN`).

`docs/src/components/Head.astro` runs a client script that groups the `.source-code-link` / `.ask-about-api-btn` action buttons under their preceding heading. It selected the headings with:

```js
document.querySelectorAll('.sl-markdown-content :is(h2, h3, h4)')
```

The `:is()` pseudo-class throws a `SyntaxError` `DOMException` inside `querySelectorAll` on browsers and crawlers that don't support it (older Chrome/Edge, some headless bots). The thrown error aborts the rest of that inline script.

This is the same class of problem as the `:has()` selector in the Starlight Table of Contents, which is already guarded higher up in `Head.astro`. Here the selector can be rewritten without `:is()` entirely, so the fix preserves full behavior in every browser rather than only degrading gracefully:

```js
'.sl-markdown-content h2, .sl-markdown-content h3, .sl-markdown-content h4'
```

### How has this been tested?

- Added `docs/src/components/__tests__/head-heading-actions.test.mjs` — asserts the heading-actions script no longer uses `:is()` inside `querySelectorAll` and selects `h2/h3/h4` via the expanded selector list.
- `npm --prefix docs run docs:test:plugins` — 51 tests pass (49 existing + 2 new).

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1909
2. Sentry: HANDSONTABLE-DOCS-1HP, HANDSONTABLE-DOCS-1HN

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`
- [x] `handsontable-documentation`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog] — docs-site client-script fix, no library source change.

ClickUp task: https://app.clickup.com/t/86ca9jxqn (DEV-1909)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-site inline script only; behavior-preserving selector change with no auth, data, or library API impact.
> 
> **Overview**
> Fixes a client-side crash on docs pages where the heading-actions script in `Head.astro` used `:is(h2, h3, h4)` inside `querySelectorAll`. Unsupported browsers throw `SyntaxError`, which aborted the rest of that script (including grouping API action buttons and wiring ask-about-api clicks).
> 
> The selector is rewritten to an equivalent comma-separated list (`.sl-markdown-content h2, h3, h4` with the parent prefix on each), matching the approach already documented for `:has()` issues elsewhere in the same file.
> 
> Adds `head-heading-actions.test.mjs` as a source-level regression guard so `querySelectorAll` in that block cannot reintroduce `:is()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bd88a8d744b7829b124ab34d494638e941684be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->