### PR TITLE
DEV-1909: [prod cherry-pick] Fix docs querySelectorAll :is() crash on older browsers

### DIFF
--- a/docs/src/components/Head.astro
+++ b/docs/src/components/Head.astro
@@ -87,7 +87,12 @@ import Default from '@astrojs/starlight/components/Head.astro';
   // The preprocessor emits them as standalone elements (wrapped in <p> by Astro),
   // so we scan each heading for consecutive action-element paragraphs and
   // move them into a flex container for side-by-side layout.
-  document.querySelectorAll<HTMLElement>('.sl-markdown-content :is(h2, h3, h4)').forEach((heading) => {
+  // Use an expanded selector list instead of `:is(h2, h3, h4)`. The `:is()` pseudo-class
+  // throws a SyntaxError DOMException inside querySelectorAll on browsers that don't support
+  // it (e.g. older Chrome/Edge and some headless crawlers), which crashes the rest of this
+  // script. The expanded form is behavior-identical and parses in every browser.
+  const headingSelector = '.sl-markdown-content h2, .sl-markdown-content h3, .sl-markdown-content h4';
+  document.querySelectorAll<HTMLElement>(headingSelector).forEach((heading) => {
     const actions: HTMLElement[] = [];
     const parasToRemove: HTMLElement[] = [];
 

--- a/docs/src/components/__tests__/head-heading-actions.test.mjs
+++ b/docs/src/components/__tests__/head-heading-actions.test.mjs
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const headPath = fileURLToPath(new URL('../Head.astro', import.meta.url));
+const headSource = readFileSync(headPath, 'utf8');
+
+// The script that groups .source-code-link / .ask-about-api-btn elements under their
+// preceding heading queries the headings with querySelectorAll. Using the `:is()`
+// pseudo-class there throws a SyntaxError DOMException on browsers/crawlers that don't
+// support it (Sentry HANDSONTABLE-DOCS-1HP / 1HN), crashing the rest of the script.
+const headingActionsBlock = headSource.slice(
+  headSource.indexOf('.api-member-actions container inside their preceding heading.'),
+  headSource.indexOf('docs-assistant:ask')
+);
+
+test('heading-actions grouping does not use :is() inside querySelectorAll', () => {
+  // Regression guard for HANDSONTABLE-DOCS-1HP / 1HN: :is() in a querySelectorAll argument
+  // throws SyntaxError in browsers without :is() support.
+  assert.doesNotMatch(
+    headingActionsBlock,
+    /querySelectorAll[\s\S]*?:is\(/,
+    'querySelectorAll must not use the :is() pseudo-class (unsupported in older browsers)'
+  );
+});
+
+test('heading-actions grouping selects h2, h3, h4 via an expanded selector list', () => {
+  assert.match(
+    headingActionsBlock,
+    /\.sl-markdown-content h2,\s*\.sl-markdown-content h3,\s*\.sl-markdown-content h4/
+  );
+});


### PR DESCRIPTION
### Context

The PR cherry-picks the docs `querySelectorAll(':is()')` crash fix into the production docs branch `prod-docs/17.1`, so the fix reaches handsontable.com/docs without waiting for the next develop→prod sync.

This is a cherry-pick of #12784 (develop, DEV-1909). It fixes Sentry `HANDSONTABLE-DOCS-1HP` and `HANDSONTABLE-DOCS-1HN`.

`docs/src/components/Head.astro` selected headings with `querySelectorAll('.sl-markdown-content :is(h2, h3, h4)')`. The `:is()` pseudo-class throws a `SyntaxError` `DOMException` inside `querySelectorAll` on browsers/crawlers that don't support it (older Chrome/Edge, some headless bots), aborting the rest of that inline script. The selector is rewritten to a behavior-identical expanded list that parses in every browser.

Note: the related `:has()` Table-of-Contents SyntaxError (`HANDSONTABLE-DOCS-1GA`) is already guarded in `prod-docs/17.1`, so it is not part of this cherry-pick (already resolved in Sentry).

### How has this been tested?

- `node --test docs/src/components/__tests__/head-heading-actions.test.mjs` — passes (cherry-picked alongside the fix).
- `npm --prefix docs run docs:test:plugins` — full docs node test suite passes.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1909
2. Cherry-pick of #12784
3. Sentry: HANDSONTABLE-DOCS-1HP, HANDSONTABLE-DOCS-1HN

### Affected project(s):

- [x] `handsontable-documentation`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog] — docs-site client-script fix, cherry-pick to prod branch.

ClickUp task: https://app.clickup.com/t/86ca9jxqn (DEV-1909)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-site inline script selector change with identical DOM behavior; covered by new node tests and no auth or data handling impact.
> 
> **Overview**
> Fixes a client-side crash on older browsers and headless crawlers where **`querySelectorAll` with `:is(h2, h3, h4)`** threw a `SyntaxError` and stopped the rest of the heading-actions script in **`Head.astro`**.
> 
> The selector is replaced with an equivalent expanded list (`.sl-markdown-content h2, h3, h4`) so API member action buttons still group under headings without relying on `:is()` support.
> 
> Adds **`head-heading-actions.test.mjs`** to assert the script block never uses `:is()` inside `querySelectorAll` and uses the expanded selector (regression guard for Sentry HANDSONTABLE-DOCS-1HP / 1HN).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16f6992b3f3222c2139741dca9907fc5fd6ab52a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->