### PR TITLE
DEV-1071: Fix column-filter beforeFilter demo crash on empty conditions stack

### DIFF
--- a/docs/content/guides/columns/column-filter/angular/example10.ts
+++ b/docs/content/guides/columns/column-filter/angular/example10.ts
@@ -113,12 +113,18 @@ export class AppComponent {
     beforeFilter(conditionsStack: { column: number; conditions: unknown[]; operation: string }[]) {
       // gather information about the filters
       console.log(`The amount of filters: ${conditionsStack.length}`);
-      console.log(`The last changed column index: ${conditionsStack[0].column}`);
-      console.log(
-        `The amount of filters added to this column: ${conditionsStack[0].conditions.length}`
-      );
-      // the list of filter conditions
-      console.log(conditionsStack[0].conditions);
+
+      // when the filters are cleared, the conditions stack is empty
+      const [lastChanged] = conditionsStack;
+
+      if (lastChanged) {
+        console.log(`The last changed column index: ${lastChanged.column}`);
+        console.log(
+          `The amount of filters added to this column: ${lastChanged.conditions.length}`
+        );
+        // the list of filter conditions
+        console.log(lastChanged.conditions);
+      }
 
       // return `false` to disable filtering on the client side
       return false;

--- a/docs/content/guides/columns/column-filter/javascript/exampleServerSideFilter.js
+++ b/docs/content/guides/columns/column-filter/javascript/exampleServerSideFilter.js
@@ -104,10 +104,16 @@ new Handsontable(container, {
   beforeFilter(conditionsStack) {
     // gather information about the filters
     console.log(`The amount of filters: ${conditionsStack.length}`);
-    console.log(`The last changed column index: ${conditionsStack[0].column}`);
-    console.log(`The amount of filters added to this column: ${conditionsStack[0].conditions.length}`);
-    // the list of filter conditions
-    console.log(conditionsStack[0].conditions);
+
+    // when the filters are cleared, the conditions stack is empty
+    const [lastChanged] = conditionsStack;
+
+    if (lastChanged) {
+      console.log(`The last changed column index: ${lastChanged.column}`);
+      console.log(`The amount of filters added to this column: ${lastChanged.conditions.length}`);
+      // the list of filter conditions
+      console.log(lastChanged.conditions);
+    }
 
     // return `false` to disable filtering on the client side
     return false;

--- a/docs/content/guides/columns/column-filter/javascript/exampleServerSideFilter.ts
+++ b/docs/content/guides/columns/column-filter/javascript/exampleServerSideFilter.ts
@@ -104,10 +104,16 @@ new Handsontable(container, {
   beforeFilter(conditionsStack) {
     // gather information about the filters
     console.log(`The amount of filters: ${conditionsStack.length}`);
-    console.log(`The last changed column index: ${conditionsStack[0]!.column}`);
-    console.log(`The amount of filters added to this column: ${conditionsStack[0]!.conditions.length}`);
-    // the list of filter conditions
-    console.log(conditionsStack[0]!.conditions);
+
+    // when the filters are cleared, the conditions stack is empty
+    const [lastChanged] = conditionsStack;
+
+    if (lastChanged) {
+      console.log(`The last changed column index: ${lastChanged.column}`);
+      console.log(`The amount of filters added to this column: ${lastChanged.conditions.length}`);
+      // the list of filter conditions
+      console.log(lastChanged.conditions);
+    }
 
     // return `false` to disable filtering on the client side
     return false;

--- a/docs/content/guides/columns/column-filter/react/exampleServerSideFilter.jsx
+++ b/docs/content/guides/columns/column-filter/react/exampleServerSideFilter.jsx
@@ -104,10 +104,16 @@ const ExampleComponent = () => {
       beforeFilter={function (conditionsStack) {
         // gather information about the filters
         console.log(`The amount of filters: ${conditionsStack.length}`);
-        console.log(`The last changed column index: ${conditionsStack[0].column}`);
-        console.log(`The amount of filters added to this column: ${conditionsStack[0].conditions.length}`);
-        // the list of filter conditions
-        console.log(conditionsStack[0].conditions);
+
+        // when the filters are cleared, the conditions stack is empty
+        const [lastChanged] = conditionsStack;
+
+        if (lastChanged) {
+          console.log(`The last changed column index: ${lastChanged.column}`);
+          console.log(`The amount of filters added to this column: ${lastChanged.conditions.length}`);
+          // the list of filter conditions
+          console.log(lastChanged.conditions);
+        }
 
         // return `false` to disable filtering on the client side
         return false;

--- a/docs/content/guides/columns/column-filter/react/exampleServerSideFilter.tsx
+++ b/docs/content/guides/columns/column-filter/react/exampleServerSideFilter.tsx
@@ -104,10 +104,16 @@ const ExampleComponent = () => {
       beforeFilter={function (conditionsStack) {
         // gather information about the filters
         console.log(`The amount of filters: ${conditionsStack.length}`);
-        console.log(`The last changed column index: ${conditionsStack[0].column}`);
-        console.log(`The amount of filters added to this column: ${conditionsStack[0].conditions.length}`);
-        // the list of filter conditions
-        console.log(conditionsStack[0].conditions);
+
+        // when the filters are cleared, the conditions stack is empty
+        const [lastChanged] = conditionsStack;
+
+        if (lastChanged) {
+          console.log(`The last changed column index: ${lastChanged.column}`);
+          console.log(`The amount of filters added to this column: ${lastChanged.conditions.length}`);
+          // the list of filter conditions
+          console.log(lastChanged.conditions);
+        }
 
         // return `false` to disable filtering on the client side
         return false;

--- a/docs/content/guides/columns/column-filter/vue/exampleServerSideFilter.vue
+++ b/docs/content/guides/columns/column-filter/vue/exampleServerSideFilter.vue
@@ -105,10 +105,16 @@ const hotSettings = ref<GridSettings>({
   beforeFilter(conditionsStack) {
     // gather information about the filters
     console.log(`The amount of filters: ${conditionsStack.length}`);
-    console.log(`The last changed column index: ${conditionsStack[0].column}`);
-    console.log(`The amount of filters added to this column: ${conditionsStack[0].conditions.length}`);
-    // the list of filter conditions
-    console.log(conditionsStack[0].conditions);
+
+    // when the filters are cleared, the conditions stack is empty
+    const [lastChanged] = conditionsStack;
+
+    if (lastChanged) {
+      console.log(`The last changed column index: ${lastChanged.column}`);
+      console.log(`The amount of filters added to this column: ${lastChanged.conditions.length}`);
+      // the list of filter conditions
+      console.log(lastChanged.conditions);
+    }
 
     // return `false` to disable filtering on the client side
     return false;


### PR DESCRIPTION
### Context

The PR fixes a `TypeError` reported in Sentry (`HANDSONTABLE-DOCS-1H5`): _"Cannot read properties of undefined (reading 'column')"_ thrown from the column-filter guide's `beforeFilter` demo on `/docs/*/column-filter/`.

The example's `beforeFilter` hook logged information about the first filter entry:

```js
console.log(`The last changed column index: ${conditionsStack[0].column}`);
```

`beforeFilter` also fires when filters are **cleared**, in which case `conditionsStack` is empty and `conditionsStack[0]` is `undefined`, so the access throws.

The fix destructures the first entry and guards it before logging — type-safe regardless of `noUncheckedIndexedAccess`, and the demo no longer throws when filters are cleared. Applied to all framework variants (JS, TS, React, Angular, Vue) of the example.

### How has this been tested?

- Manually: open the column-filter "server-side" demo, add a filter (logs as before), then clear it — no console error (previously threw).
- The docs Playwright console-error suite (`recipeConsoleErrors.spec.ts`) covers example pages for uncaught errors.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1071
2. Sentry: HANDSONTABLE-DOCS-1H5

### Affected project(s):

- [x] `handsontable-documentation`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog] — docs example fix, no library source change.

ClickUp task: https://app.clickup.com/t/86c955u3m (DEV-1071)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only example fixes with no production library or API changes.
> 
> **Overview**
> Fixes a **TypeError** in the column-filter **server-side filtering** doc demos when users **clear filters**: `beforeFilter` runs with an **empty** `conditionsStack`, and the examples previously read `conditionsStack[0].column` unconditionally.
> 
> The demos now take the first entry via destructuring and only log column/condition details when that entry exists, with a short comment that the stack is empty after a clear. The same change is applied across **Angular, JavaScript, TypeScript, React, and Vue** variants of the example. No Handsontable library behavior changes—documentation examples only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74a3114d44dc693586b43a31fc365132d582f862. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->