### PR TITLE
DEV-1917: Fix RC examples install for Angular 22 (align TypeScript version)

### DIFF
--- a/examples/next/docs/angular-wrapper/basic-example/package.json
+++ b/examples/next/docs/angular-wrapper/basic-example/package.json
@@ -45,7 +45,7 @@
     "jasmine-console-reporter": "3.1.0",
     "puppeteer": "^24.2.1",
     "ts-node": "8.3.0",
-    "typescript": "~5.9.0"
+    "typescript": "~6.0.0"
   },
   "license": "SEE LICENSE IN LICENSE.txt"
 }

--- a/examples/next/docs/angular-wrapper/basic-example/tsconfig.json
+++ b/examples/next/docs/angular-wrapper/basic-example/tsconfig.json
@@ -12,7 +12,6 @@
     "allowSyntheticDefaultImports": true,
     "sourceMap": true,
     "declaration": false,
-    "downlevelIteration": true,
     "experimentalDecorators": true,
     "moduleResolution": "bundler",
     "importHelpers": true,

--- a/examples/next/docs/angular-wrapper/data-provider/package.json
+++ b/examples/next/docs/angular-wrapper/data-provider/package.json
@@ -50,7 +50,7 @@
     "jasmine-console-reporter": "3.1.0",
     "puppeteer": "^24.2.1",
     "ts-node": "8.3.0",
-    "typescript": "~5.9.0"
+    "typescript": "~6.0.0"
   },
   "license": "SEE LICENSE IN LICENSE.txt"
 }

--- a/examples/next/docs/angular-wrapper/data-provider/tsconfig.json
+++ b/examples/next/docs/angular-wrapper/data-provider/tsconfig.json
@@ -12,7 +12,6 @@
     "allowSyntheticDefaultImports": true,
     "sourceMap": true,
     "declaration": false,
-    "downlevelIteration": true,
     "experimentalDecorators": true,
     "moduleResolution": "bundler",
     "importHelpers": true,

--- a/examples/next/docs/angular-wrapper/demo/package.json
+++ b/examples/next/docs/angular-wrapper/demo/package.json
@@ -46,7 +46,7 @@
     "jasmine-console-reporter": "3.1.0",
     "puppeteer": "^24.2.1",
     "ts-node": "8.3.0",
-    "typescript": "~5.8.0"
+    "typescript": "~6.0.0"
   },
   "license": "SEE LICENSE IN LICENSE.txt"
 }

--- a/examples/next/docs/angular-wrapper/demo/tsconfig.json
+++ b/examples/next/docs/angular-wrapper/demo/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "baseUrl": "./",
     "outDir": "./dist/out-tsc",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
@@ -9,7 +8,6 @@
     "noFallthroughCasesInSwitch": true,
     "sourceMap": true,
     "declaration": false,
-    "downlevelIteration": true,
     "experimentalDecorators": true,
     "moduleResolution": "bundler",
     "importHelpers": true,

--- a/examples/next/visual-tests/angular-wrapper/basic-example/angular.json
+++ b/examples/next/visual-tests/angular-wrapper/basic-example/angular.json
@@ -34,7 +34,7 @@
             "assets": [
               {
                 "glob": "*.css",
-                "input": "../node_modules/handsontable/styles/",
+                "input": "node_modules/handsontable/styles/",
                 "output": "/assets/handsontable/styles/"
               }
             ],

--- a/examples/next/visual-tests/angular-wrapper/basic-example/package.json
+++ b/examples/next/visual-tests/angular-wrapper/basic-example/package.json
@@ -45,7 +45,7 @@
     "jasmine-console-reporter": "3.1.0",
     "puppeteer": "^24.2.1",
     "ts-node": "8.3.0",
-    "typescript": "~5.9.0"
+    "typescript": "~6.0.0"
   },
   "license": "SEE LICENSE IN LICENSE.txt"
 }

--- a/examples/next/visual-tests/angular-wrapper/basic-example/tsconfig.json
+++ b/examples/next/visual-tests/angular-wrapper/basic-example/tsconfig.json
@@ -12,7 +12,6 @@
     "allowSyntheticDefaultImports": true,
     "sourceMap": true,
     "declaration": false,
-    "downlevelIteration": true,
     "experimentalDecorators": true,
     "moduleResolution": "bundler",
     "importHelpers": true,

--- a/examples/next/visual-tests/angular-wrapper/demo/angular.json
+++ b/examples/next/visual-tests/angular-wrapper/demo/angular.json
@@ -38,12 +38,12 @@
               "src/assets",
               {
                 "glob": "*.css",
-                "input": "../node_modules/handsontable/dist/",
+                "input": "node_modules/handsontable/dist/",
                 "output": "/assets/handsontable/dist/"
               },
               {
                 "glob": "*.css",
-                "input": "../node_modules/handsontable/styles/",
+                "input": "node_modules/handsontable/styles/",
                 "output": "/assets/handsontable/styles/"
               }
             ]

--- a/examples/next/visual-tests/angular-wrapper/demo/package.json
+++ b/examples/next/visual-tests/angular-wrapper/demo/package.json
@@ -48,7 +48,7 @@
     "jasmine-console-reporter": "3.1.0",
     "puppeteer": "^24.2.1",
     "ts-node": "8.3.0",
-    "typescript": "~5.7.0"
+    "typescript": "~6.0.0"
   },
   "license": "SEE LICENSE IN LICENSE.txt"
 }

--- a/examples/next/visual-tests/angular-wrapper/demo/tsconfig.json
+++ b/examples/next/visual-tests/angular-wrapper/demo/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "baseUrl": "./",
     "outDir": "./dist/out-tsc",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
@@ -9,7 +8,6 @@
     "noFallthroughCasesInSwitch": true,
     "sourceMap": true,
     "declaration": false,
-    "downlevelIteration": true,
     "experimentalDecorators": true,
     "moduleResolution": "bundler",
     "importHelpers": true,

--- a/examples/scripts/install-subpackages.mjs
+++ b/examples/scripts/install-subpackages.mjs
@@ -2,6 +2,7 @@
  * Run the npm install command for the examples monorepo and all of the framework mini-monorepos.
  */
 import execa from 'execa';
+import fs from 'fs-extra';
 import thisPackageJson from '../package.json' with { type: 'json' };
 import glob from 'glob';
 import yargs from 'yargs';
@@ -29,6 +30,61 @@ if (!argv.skipClean) {
   await spawnProcess(`node ./scripts/clean-subpackages.mjs ${version}`);
 }
 
+// The Angular package that pins the supported TypeScript range through its peer dependency.
+const ANGULAR_BUILDER_PACKAGE = '@angular-devkit/build-angular';
+
+// Checks whether a framework example directory holds an Angular example.
+const isAngularExample = frameworkUrl => /angular/.test(frameworkUrl);
+
+// Each Angular major supports a narrow TypeScript range, declared by the
+// `@angular-devkit/build-angular` peer dependency (e.g. Angular 22 -> `typescript >=6.0 <6.1`,
+// Angular 21 -> `>=5.9 <6.0`). The examples track the `latest` Angular, so the matching
+// TypeScript version moves over time. Resolve it from the builder peer instead of hard-coding it.
+const resolveAngularTypescriptRange = async (builderSpec) => {
+  const { stdout } = await execa('npm', [
+    'view', `${ANGULAR_BUILDER_PACKAGE}@${builderSpec}`, 'peerDependencies.typescript'
+  ]);
+  // `npm view` lists one range per matching version (ascending); the last line is the newest.
+  const newestRange = stdout.trim().split('\n').pop().trim();
+  const lowerBound = newestRange.match(/>=?\s*(\d+)\.(\d+)/);
+
+  return lowerBound ? `~${lowerBound[1]}.${lowerBound[2]}.0` : null;
+};
+
+// Aligns the `typescript` devDependency of every Angular example in `frameworkUrl` with the
+// TypeScript range required by the Angular version that will be installed. Without this, a new
+// Angular major (which bumps its required TypeScript) fails `npm install` with an `ERESOLVE`
+// peer conflict against the example's pinned TypeScript.
+const alignTypescriptWithAngular = async (frameworkUrl) => {
+  const examplePackageJsonPaths = glob.sync(`${frameworkUrl}/*/package.json`, {
+    ignore: '**/node_modules/**'
+  });
+
+  for (const packageJsonPath of examplePackageJsonPaths) {
+    const packageJson = fs.readJsonSync(packageJsonPath);
+    const { devDependencies } = packageJson;
+    const builderSpec = devDependencies?.[ANGULAR_BUILDER_PACKAGE];
+
+    if (!builderSpec || !devDependencies?.typescript) {
+      continue;
+    }
+
+    const typescriptRange = await resolveAngularTypescriptRange(builderSpec);
+
+    if (typescriptRange && devDependencies.typescript !== typescriptRange) {
+      const previousRange = devDependencies.typescript;
+
+      devDependencies.typescript = typescriptRange;
+      fs.writeJsonSync(packageJsonPath, packageJson, { spaces: 2 });
+
+      console.log(
+        `Aligned TypeScript ${previousRange} -> ${typescriptRange} in ${packageJsonPath} ` +
+        `(for Angular builder "${builderSpec}").`
+      );
+    }
+  }
+};
+
 // Run `npm i` for all the examples in the versioned directory.
 for (const frameworkPackage of thisPackageJson.internal.framework_dirs) {
   const frameworkUrls = glob.sync(`${frameworkPackage}`);
@@ -37,7 +93,19 @@ for (const frameworkPackage of thisPackageJson.internal.framework_dirs) {
     if ((version && frameworkUrl.startsWith(version))) {
       console.log(`\nRunning npm install for ${frameworkUrl}:\n`);
 
-      await spawnProcess('npm install --no-audit', {
+      const installArgs = ['npm install --no-audit'];
+
+      if (isAngularExample(frameworkUrl)) {
+        await alignTypescriptWithAngular(frameworkUrl);
+
+        // The published `@handsontable/angular-wrapper` peer range can lag a brand-new Angular
+        // major; the matching wrapper is built from source and symlinked into the example in the
+        // `link-packages` step below. `--legacy-peer-deps` lets the example resolve the `latest`
+        // Angular during install, after which the locally built wrapper takes over.
+        installArgs.push('--legacy-peer-deps');
+      }
+
+      await spawnProcess(installArgs.join(' '), {
         cwd: frameworkUrl
       });
     }


### PR DESCRIPTION
### Context

The PR fixes the failing **"Build first RC"** job, which errored at the **Install next package for examples** step ([failed run](https://github.com/handsontable/handsontable/actions/runs/27604022621/job/81611518285)).

Angular 22 was released and became `latest`. Its build tooling (`@angular-devkit/build-angular@22`) requires TypeScript `>=6.0 <6.1`, but the Angular examples pinned TypeScript to `~5.9`/`~5.8`/`~5.7`, so `npm install` failed with a hard `ERESOLVE` peer conflict and the RC job aborted.

The examples stay on the `latest` Angular line. Instead of pinning Angular down, the install script now selects the TypeScript version that matches the Angular version being installed, so future Angular majors keep working without further edits.

**Changes**

- `examples/scripts/install-subpackages.mjs` — for Angular example directories, derive the required TypeScript range from the `@angular-devkit/build-angular` peer dependency (e.g. `>=6.0 <6.1` → `~6.0.0`) and align each example's `typescript` devDependency before install. Angular examples are installed with `--legacy-peer-deps`: the published `@handsontable/angular-wrapper` peer range can lag a brand-new Angular major, and the freshly built wrapper is symlinked into the example by the `link-packages` step afterward.
- 5 × `tsconfig.json` — remove `downlevelIteration` (all; no-op at `target: ES2022`) and `baseUrl` (demos). TypeScript 6.0 reports these as errors (`TS5101`).
- 2 × `angular.json` (visual-tests) — change asset input `../node_modules/...` to `node_modules/...`. Angular 22's builder rejects asset paths outside the workspace root.
- 5 × `package.json` — bump `typescript` to `~6.0.0` so the committed state is coherent with Angular 22; the install script re-aligns it automatically on future Angular majors.

### How has this been tested?

Validated through the real RC example chain on Node 22.22.3 (all green):

```bash
node examples/scripts/code-examples.mjs install next   # exit 0 — TS aligned to ~6.0.0, no ERESOLVE
node examples/scripts/code-examples.mjs build next     # exit 0 — all 23 example dirs (js/ts/react/vue/angular)
node examples/scripts/code-examples.mjs test next      # exit 0 — all smoke tests pass
```

All 5 Angular examples (docs: basic-example, data-provider, demo; visual-tests: basic-example, demo) install, build, and pass their smoke test (renders Handsontable) on Angular 22 + TypeScript 6.0.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1917

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

(Affects `handsontable-examples-internal` build tooling only — no shipped package source changed.)

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog] — internal examples build tooling and example configuration only; no shipped package source changed.

ClickUp task: https://app.clickup.com/t/86ca9m8x9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to internal examples install tooling and Angular example configs; no shipped Handsontable package source is modified.
> 
> **Overview**
> Fixes the **Build first RC** examples install failure when **Angular 22** (`latest`) requires **TypeScript 6** while Angular examples still pinned **~5.7–5.9**.
> 
> **`install-subpackages.mjs`** now treats Angular example dirs specially: before `npm install`, it reads `@angular-devkit/build-angular`’s `peerDependencies.typescript` (e.g. `>=6.0 <6.1` → `~6.0.0`), rewrites each example’s `typescript` devDependency when needed, and runs install with **`--legacy-peer-deps`** so `latest` Angular can install while the published `@handsontable/angular-wrapper` peer range may still lag (local wrapper is linked afterward).
> 
> Committed example config is updated for **Angular 22 / TS 6**: five `package.json` files bump **`typescript` to `~6.0.0`**; **`tsconfig.json`** drops **`downlevelIteration`** (and demo **`baseUrl`**) to satisfy **TS5101** under TypeScript 6; visual-test **`angular.json`** asset inputs change from **`../node_modules/...`** to **`node_modules/...`** because Angular 22’s builder rejects paths outside the workspace root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b6adfb9746074701e7fce2f4ea1652c264d115d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->