### PR TITLE
DEV-1786: Show framework labels and fix HTML entities in Algolia search results

### DIFF
--- a/docs/.eslintrc.js
+++ b/docs/.eslintrc.js
@@ -27,6 +27,7 @@ module.exports = {
     '**/components/VersionComparison/**/*.ts',
     '**/content/config.ts',
     '**/content.config.ts',
+    '**/src/config/docsearch.ts',
   ],
   rules: {
     'no-restricted-globals': 'off',

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -784,9 +784,7 @@ export default defineConfig({
         ...(isProduction
           ? [
               starlightDocSearch({
-                appId: 'MMN6OTJMGX',
-                apiKey: 'c2430302c91e0162df988d4b383c9d8b',
-                indexName: 'handsontable',
+                clientOptionsModule: './src/config/docsearch.ts',
               }),
             ]
           : []),

--- a/docs/src/config/docsearch.ts
+++ b/docs/src/config/docsearch.ts
@@ -1,0 +1,53 @@
+import type { DocSearchClientOptions } from '@astrojs/starlight-docsearch';
+
+export default {
+  appId: 'MMN6OTJMGX',
+  apiKey: 'c2430302c91e0162df988d4b383c9d8b',
+  indexName: 'handsontable',
+  transformItems(items: any[]) {
+    return items.map((item) => {
+      const url: string = item.url ?? '';
+      const framework = url.includes('/react-data-grid/')
+        ? 'React'
+        : url.includes('/angular-data-grid/')
+          ? 'Angular'
+          : url.includes('/vue-data-grid/')
+            ? 'Vue'
+            : 'JavaScript';
+
+      const suffix = ` · ${framework}`;
+      const lvl1 = item.hierarchy?.lvl1;
+      const snippetLvl1 = item._snippetResult?.hierarchy?.lvl1;
+
+      return {
+        ...item,
+        // DocSearch reads hierarchy.lvl1 as the raw fallback
+        hierarchy: {
+          ...item.hierarchy,
+          lvl1: lvl1 ? `${lvl1}${suffix}` : framework,
+        },
+        // DocSearch renders _snippetResult.hierarchy.lvl1.value first (it sends
+        // attributesToSnippet: ["hierarchy.lvl1:N", ...] in every search query),
+        // so we must update this field too or the suffix never appears.
+        _snippetResult: item._snippetResult
+          ? {
+              ...item._snippetResult,
+              hierarchy: item._snippetResult.hierarchy
+                ? {
+                    ...item._snippetResult.hierarchy,
+                    lvl1: snippetLvl1
+                      ? {
+                          ...snippetLvl1,
+                          value: snippetLvl1.value
+                            ? `${snippetLvl1.value}${suffix}`
+                            : framework,
+                        }
+                      : undefined,
+                  }
+                : undefined,
+            }
+          : undefined,
+      };
+    });
+  },
+} satisfies DocSearchClientOptions;

--- a/docs/src/config/docsearch.ts
+++ b/docs/src/config/docsearch.ts
@@ -1,5 +1,20 @@
 import type { DocSearchClientOptions } from '@astrojs/starlight-docsearch';
 
+// The Algolia crawler stores hierarchy.lvl0 as raw HTML text, so ampersands
+// and other special characters arrive encoded (e.g. "Data &amp; tools").
+// DocSearch renders lvl0 as plain React children (not dangerouslySetInnerHTML),
+// so the browser never decodes the entities — we must do it here.
+const HTML_ENTITIES: Record<string, string> = {
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&#039;': "'",
+  '&apos;': "'",
+};
+const decodeHtml = (str: string | null | undefined): string | null | undefined =>
+  str ? str.replace(/&(?:amp|lt|gt|quot|#039|apos);/g, (e) => HTML_ENTITIES[e] ?? e) : str;
+
 export default {
   appId: 'MMN6OTJMGX',
   apiKey: 'c2430302c91e0162df988d4b383c9d8b',
@@ -19,13 +34,32 @@ export default {
       const lvl1 = item.hierarchy?.lvl1;
       const snippetLvl1 = item._snippetResult?.hierarchy?.lvl1;
 
+      const highlightLvl0 = item._highlightResult?.hierarchy?.lvl0;
+
       return {
         ...item,
-        // DocSearch reads hierarchy.lvl1 as the raw fallback
         hierarchy: {
           ...item.hierarchy,
+          // lvl0 is the section header — decode entities (fallback path).
+          lvl0: decodeHtml(item.hierarchy?.lvl0),
+          // lvl1 is the breadcrumb; append the framework label.
           lvl1: lvl1 ? `${lvl1}${suffix}` : framework,
         },
+        // The section title is built from _highlightResult.hierarchy.lvl0.value
+        // (see the go() function in @docsearch/js), so we must decode there too.
+        _highlightResult: item._highlightResult
+          ? {
+              ...item._highlightResult,
+              hierarchy: item._highlightResult.hierarchy
+                ? {
+                    ...item._highlightResult.hierarchy,
+                    lvl0: highlightLvl0
+                      ? { ...highlightLvl0, value: decodeHtml(highlightLvl0.value) }
+                      : undefined,
+                  }
+                : undefined,
+            }
+          : undefined,
         // DocSearch renders _snippetResult.hierarchy.lvl1.value first (it sends
         // attributesToSnippet: ["hierarchy.lvl1:N", ...] in every search query),
         // so we must update this field too or the suffix never appears.


### PR DESCRIPTION
### Context

The PR improves Algolia DocSearch results in the Handsontable docs. Two issues are fixed:

1. **Framework label in search results** (DEV-1786) — when the same API method or guide page appears under multiple framework variants (JavaScript, React, Angular, Vue), results looked identical. Each result now shows a framework label in the breadcrumb (e.g. "Hooks · React"), so users know where they'll land before clicking.

2. **HTML entities in section headers** (DEV-1784) — section headers like `"Data & tools"` were rendered as `"Data &amp; tools"` because the Algolia crawler stores `hierarchy.lvl0` as raw HTML text, and DocSearch renders it as plain React children (not `dangerouslySetInnerHTML`). Both `_highlightResult.hierarchy.lvl0.value` and the `hierarchy.lvl0` fallback are now decoded.

The changes move the DocSearch configuration from inline options in `astro.config.mjs` to a `clientOptionsModule` file (`src/config/docsearch.ts`), which is required to pass function-based options like `transformItems`.

### How has this been tested?

A local production build was made (`BUILD_MODE=production`) to enable Algolia search, since search is disabled on staging and cannot be tested there. The changes can be fully verified only on the production environment or a release candidate environment.

- Searched for an API hook (e.g. `afterAutofill`) — results now show "Hooks · JavaScript", "Hooks · React", "Hooks · Angular", "Hooks · Vue" as breadcrumbs instead of four identical "Hooks" lines.
- Searched for a term in the "Data & tools" section — section header now renders as "Data & tools" instead of "Data &amp; tools".

#### Before
<img width="611" height="371" alt="before" src="https://github.com/user-attachments/assets/87556f1b-0ac8-46f0-9713-8527507943b6" />



#### After
<img width="600" height="373" alt="after" src="https://github.com/user-attachments/assets/5459a1a0-6764-4070-8d17-c03856e5a20e" />



### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. https://app.clickup.com/t/9015210959/DEV-1786
2. https://app.clickup.com/t/9015210959/DEV-1784

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only search display logic in production; no auth, data, or core grid behavior changes.
> 
> **Overview**
> Production Algolia DocSearch is wired through **`clientOptionsModule`** (`src/config/docsearch.ts`) instead of inline credentials in `astro.config.mjs`, so **`transformItems`** can run on each result.
> 
> Search hits now **decode HTML entities** in section headers (`hierarchy.lvl0` and `_highlightResult.hierarchy.lvl0`) so titles like “Data & tools” no longer show as `&amp;`.
> 
> Duplicate-looking results across framework doc trees get a **framework suffix** on the breadcrumb (`lvl1` and `_snippetResult.hierarchy.lvl1`), inferred from the result URL (`react-data-grid`, `angular-data-grid`, `vue-data-grid`, or JavaScript).
> 
> ESLint **ignores** `src/config/docsearch.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9de943c1dd78ce3d92655f21092264823dac8c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->