### PR TITLE
DEV-1914: Guard countRowHeaders/countColHeaders against an undefined view

### DIFF
--- a/.changelogs/12790.json
+++ b/.changelogs/12790.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed an error thrown by `countRowHeaders()` and `countColHeaders()` when they were called while the table view was unavailable (during initialization or after the instance was destroyed).",
+  "type": "fixed",
+  "issueOrPR": 12790,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/__tests__/core/countRowHeaders.spec.js
+++ b/handsontable/src/__tests__/core/countRowHeaders.spec.js
@@ -30,6 +30,28 @@ describe('Core.countRowHeaders', () => {
     expect(countRowHeaders()).toBe(0);
   });
 
+  it('should not throw and return 0 when the table view is unavailable (e.g. during teardown)', async() => {
+    const hot = handsontable({
+      data: createSpreadsheetData(5, 5),
+      rowHeaders: true,
+      colHeaders: true,
+    });
+
+    // During init/teardown `view` can be undefined; a shortcut `runOnlyIf` guard
+    // calling these methods then must not throw (regression: HANDSONTABLE-DOCS-1JX).
+    const { view } = hot;
+
+    hot.view = undefined;
+
+    expect(() => hot.countRowHeaders()).not.toThrow();
+    expect(hot.countRowHeaders()).toBe(0);
+    expect(() => hot.countColHeaders()).not.toThrow();
+    expect(hot.countColHeaders()).toBe(0);
+
+    // restore the view so the instance can tear down cleanly in afterEach
+    hot.view = view;
+  });
+
   it('should count custom row headers', async() => {
     handsontable({
       data: createSpreadsheetData(10, 10),

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -4955,7 +4955,9 @@ export default function Core(
    * @returns {number} Number of row headers.
    */
   this.countRowHeaders = function(): number {
-    return (instance.view as TableView).getRowHeadersCount();
+    const view = instance.view as TableView | undefined;
+
+    return view ? view.getRowHeadersCount() : 0;
   };
 
   /**
@@ -4967,7 +4969,9 @@ export default function Core(
    * @returns {number} Number of column headers.
    */
   this.countColHeaders = function(): number {
-    return (instance.view as TableView).getColumnHeadersCount();
+    const view = instance.view as TableView | undefined;
+
+    return view ? view.getColumnHeadersCount() : 0;
   };
 
   /**


### PR DESCRIPTION
### Context

The PR fixes a `TypeError` reported in Sentry (`HANDSONTABLE-DOCS-1JX`): _"Cannot read properties of undefined (reading 'getRowHeadersCount')"_.

`Core#countRowHeaders()` / `Core#countColHeaders()` call `instance.view.getRowHeadersCount()` / `getColumnHeadersCount()` without guarding `view`. A keyboard-shortcut `runOnlyIf` predicate (the focus-navigation context checks `countRowHeaders() > 0 || countColHeaders() > 0`) can fire on a `focusin` while `instance.view` is `undefined` — during the brief init window or after teardown — so the access throws.

The fix returns `0` when the view is not available, which is the correct count when nothing is rendered.

### How has this been tested?

- Added an E2E regression test in `src/__tests__/core/countRowHeaders.spec.js` that nulls `view` (restoring it before teardown so the memory-leak guard stays green) and asserts both methods return `0` without throwing.
- `npm run test:e2e --prefix handsontable -- --testPathPattern=countRowHeaders` → 9 specs, 0 failures.

> Note: `npm run build:types` currently fails on develop with a **pre-existing, unrelated** error at `core.ts:~6058` (`_registerTimeout` `Timeout` vs `number`, an `@types/node`/lib resolution issue) — reproduced with this change stashed. The JS bundles build and the E2E suite passes.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1914
2. Sentry: HANDSONTABLE-DOCS-1JX

### Affected project(s):

- [x] `handsontable`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/86ca9kkvd (DEV-1914)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive guard in Core API methods with a regression test; no auth, data, or breaking behavior changes.
> 
> **Overview**
> Fixes a **TypeError** when `countRowHeaders()` or `countColHeaders()` run while `instance.view` is missing (early init or after teardown). Shortcut `runOnlyIf` checks and selection helpers can call these on `focusin` in that window.
> 
> **`Core#countRowHeaders`** and **`Core#countColHeaders`** now read `view` safely and return **`0`** when it is unavailable instead of calling `getRowHeadersCount()` / `getColumnHeadersCount()` on `undefined`.
> 
> Adds an E2E regression in `countRowHeaders.spec.js` and a changelog entry for the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6daa18defae6368f93505486823a539b55ebbfae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->