### PR TITLE
DEV-1912: Filter expected server-side recipe HTTP errors out of Sentry

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -706,6 +706,38 @@ export default defineConfig({
           content: '/* HOT base styles loaded via handsontable-import.css */',
         },
         // ── All-environment 3rd-party scripts ──────────────────────────────
+        // Sentry: filter out expected demo errors before the Loader Script auto-inits.
+        // The server-side data recipes (/recipes/data-management/server-side-*) run their
+        // examples live, but the docs site has no `/api/products` backend, so the example
+        // `fetchRows()` correctly throws `HTTP <status>` (e.g. 404). That is expected here
+        // (not a product bug), so drop those events instead of reporting them.
+        // `window.sentryOnLoad` is the Loader Script's documented custom-config hook — the
+        // DSN and any dashboard-enabled integrations (Performance/Replay) are applied
+        // automatically, so adding `beforeSend` does not disturb the rest of the setup.
+        {
+          tag: 'script',
+          content: `window.sentryOnLoad = function () {
+  Sentry.init({
+    beforeSend: function (event) {
+      try {
+        var values = (event.exception && event.exception.values) || [];
+        var isDemoHttpError = values.some(function (value) {
+          return value && typeof value.value === 'string' && /^HTTP \\d{3}$/.test(value.value);
+        });
+        var url = (event.request && event.request.url) || '';
+
+        if (isDemoHttpError && url.indexOf('/recipes/data-management/server-side') !== -1) {
+          return null;
+        }
+      } catch (e) {
+        // never let the filter break error reporting
+      }
+
+      return event;
+    },
+  });
+};`,
+        },
         // Sentry error monitoring
         {
           tag: 'script',


### PR DESCRIPTION
### Context

The PR silences two Sentry issues (`HANDSONTABLE-DOCS-1FN`, `HANDSONTABLE-DOCS-1JN`): _"Error: HTTP 404"_ from the server-side data recipes.

The recipe examples (`/docs/*/recipes/data-management/server-side-*`) run live on the docs site, but the docs site has no `/api/products` backend. The example `fetchRows()` does `if (!res.ok) throw new Error(\`HTTP ${res.status}\`)` — which is the **correct** pattern for the real-world integration these recipes document. So the example code is intentionally left unchanged; the 404 is expected on the docs site, not a product defect.

Instead of swallowing the error in ~35 example files (which would teach bad error handling), this adds a `beforeSend` filter to the docs Sentry setup that drops `HTTP <status>` events originating from the server-side recipe pages. The filter is scoped tightly (message matches `/^HTTP \d{3}$/` **and** the page URL contains `/recipes/data-management/server-side`) so it never hides unrelated HTTP errors, and it is wrapped in try/catch so it can never break error reporting.

Sentry here uses the CDN **Loader Script**, whose documented custom-configuration hook is `window.sentryOnLoad`; the DSN and any dashboard-enabled integrations (Performance/Replay) are applied automatically, so adding `beforeSend` does not disturb the rest of the setup. The hook is injected immediately before the loader `<script>`.

### How has this been tested?

- `node --check docs/astro.config.mjs` passes.
- Manually: load a server-side recipe page → the `HTTP 404` from `fetchRows` no longer produces a Sentry event; other errors are unaffected.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1912, DEV-1913
2. Sentry: HANDSONTABLE-DOCS-1FN, HANDSONTABLE-DOCS-1JN

### Affected project(s):

- [x] `handsontable-documentation`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog] — docs-site Sentry configuration, no library source change.

ClickUp tasks: https://app.clickup.com/t/86ca9kkt9 (DEV-1912), https://app.clickup.com/t/86ca9kku1 (DEV-1913)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only Sentry configuration with a narrowly scoped drop rule; other errors and URLs should still report normally.
> 
> **Overview**
> Adds a **Sentry `beforeSend` hook** on the docs site so expected demo failures on server-side data recipe pages are not reported.
> 
> A new inline script sets `window.sentryOnLoad` (the CDN Loader Script hook) and calls `Sentry.init` with a filter that drops events when the exception message matches `HTTP <3-digit status>` **and** the request URL includes `/recipes/data-management/server-side`. The filter is wrapped in try/catch so reporting cannot break. The script is injected **immediately before** the existing Sentry loader `<script>`; recipe example code is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bcb0d4765a35586ff1adad89d961afe7a9ad65f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->