### PR TITLE
DEV-1919: Fix nested headers ignoring stopImmediatePropagation on drag-selection

### DIFF
--- a/.changelogs/12794.json
+++ b/.changelogs/12794.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed nested column headers ignoring `stopImmediatePropagation()` called in the `beforeOnCellMouseOver` hook, so a header drag-selection can now be blocked the same way as for regular column headers.",
+  "type": "fixed",
+  "issueOrPR": 12794,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -4,7 +4,8 @@
       "type": "http",
       "url": "https://mcp.clickup.com/mcp",
       "headers": {
-        "Authorization": "Bearer ${CLICKUP_API_TOKEN}"
+        "Authorization": "Bearer ${CLICKUP_API_TOKEN}",
+        "x-workspace-id": "9015210959"
       }
     },
     "github": {

--- a/handsontable/src/plugins/nestedHeaders/__tests__/selection.spec.js
+++ b/handsontable/src/plugins/nestedHeaders/__tests__/selection.spec.js
@@ -1572,4 +1572,80 @@ describe('NestedHeaders', () => {
       expect(getSelectedRange()).toEqualCellRange(['highlight: 2,4 from: -1,2 to: 2,4']);
     });
   });
+
+  describe('blocking the selection through the mouse event hooks (#6026)', () => {
+    it('should not initiate a column selection when `beforeOnCellMouseDown` stops the event on a nested header', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 10),
+        colHeaders: true,
+        rowHeaders: true,
+        nestedHeaders: [
+          ['N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W']
+        ],
+        beforeOnCellMouseDown(event, coords) {
+          if (coords.row < 0) {
+            event.stopImmediatePropagation();
+          }
+        },
+      });
+
+      getTopClone().find('thead tr:eq(0) th:eq(2)') // "O"
+        .simulate('mousedown')
+        .simulate('mouseup');
+
+      expect(getSelected()).toBeUndefined();
+    });
+
+    it('should not modify the selection while dragging over nested headers when both `beforeOnCellMouseDown` ' +
+       'and `beforeOnCellMouseOver` stop the event', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 10),
+        colHeaders: true,
+        rowHeaders: true,
+        nestedHeaders: [
+          ['N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W']
+        ],
+        beforeOnCellMouseDown(event, coords) {
+          if (coords.row < 0) {
+            event.stopImmediatePropagation();
+          }
+        },
+        beforeOnCellMouseOver(event, coords) {
+          if (coords.row < 0) {
+            event.stopImmediatePropagation();
+          }
+        },
+      });
+
+      await selectCell(2, 4);
+
+      // Drag across the column headers, which both hooks block.
+      getTopClone().find('thead tr:eq(0) th:eq(1)').simulate('mousedown'); // "N"
+      getTopClone().find('thead tr:eq(0) th:eq(2)').simulate('mouseover'); // "O"
+      getTopClone().find('thead tr:eq(0) th:eq(3)').simulate('mouseover'); // "P"
+      getTopClone().find('thead tr:eq(0) th:eq(3)').simulate('mouseup');
+
+      // The selection stays where it was - the header drag is fully blocked, matching the behavior
+      // of regular (non-nested) column headers.
+      expect(getSelected()).toEqual([[2, 4, 2, 4]]);
+    });
+
+    it('should still allow drag-selecting columns over nested headers when the event is not blocked', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 10),
+        colHeaders: true,
+        rowHeaders: true,
+        nestedHeaders: [
+          ['N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W']
+        ],
+      });
+
+      getTopClone().find('thead tr:eq(0) th:eq(1)').simulate('mousedown'); // "N"
+      getTopClone().find('thead tr:eq(0) th:eq(2)').simulate('mouseover'); // "O"
+      getTopClone().find('thead tr:eq(0) th:eq(3)').simulate('mouseover'); // "P"
+      getTopClone().find('thead tr:eq(0) th:eq(3)').simulate('mouseup');
+
+      expect(getSelected()).toEqual([[-1, 0, countRows() - 1, 2]]);
+    });
+  });
 });

--- a/handsontable/src/plugins/nestedHeaders/nestedHeaders.ts
+++ b/handsontable/src/plugins/nestedHeaders/nestedHeaders.ts
@@ -180,6 +180,13 @@ export class NestedHeaders extends BasePlugin {
    */
   #isColumnsSelectionInProgress = false;
   /**
+   * Holds the columns to be selected when the pointer moves over a nested header during a drag. The selection
+   * is applied in the `afterOnCellMouseOver` hook so that it stays gated by `stopImmediatePropagation` called
+   * in a `beforeOnCellMouseOver` listener - mirroring how the mouse-down path applies its selection in
+   * `afterOnCellMouseDown`. Reset on every `beforeOnCellMouseOver` to avoid applying a stale range.
+   */
+  #columnsToSelectOnMouseOver: [number, number, number] | null = null;
+  /**
    * Keeps the last highlight position made by column selection. The coords are necessary to scroll
    * the viewport to the correct position when the nested header is clicked when the `navigableHeaders`
    * option is disabled.
@@ -247,6 +254,7 @@ export class NestedHeaders extends BasePlugin {
     this.addHook('beforeOnCellMouseDown', this.#onBeforeOnCellMouseDown);
     this.addHook('afterOnCellMouseDown', this.#onAfterOnCellMouseDown);
     this.addHook('beforeOnCellMouseOver', this.#onBeforeOnCellMouseOver);
+    this.addHook('afterOnCellMouseOver', this.#onAfterOnCellMouseOver);
     this.addHook('beforeOnCellMouseUp', this.#onBeforeOnCellMouseUp);
     this.addHook('beforeSelectionHighlightSet', this.#onBeforeSelectionHighlightSet);
     this.addHook('modifyTransformStart', this.#onModifyTransformStart);
@@ -918,12 +926,17 @@ export class NestedHeaders extends BasePlugin {
   };
 
   /**
-   * Extends the column selection range when the pointer moves over a nested header cell during a drag selection.
+   * Computes the column selection range when the pointer moves over a nested header cell during a drag
+   * selection and stores it for the `afterOnCellMouseOver` hook to apply. Blocks the core's default
+   * selection handling through the `controller` so the range is driven solely by this plugin. The actual
+   * selection is deferred to `afterOnCellMouseOver` so it stays cancellable through `stopImmediatePropagation`.
    */
   #onBeforeOnCellMouseOver = (
     event: MouseEvent, coords: { row: number, col: number }, TD: HTMLElement,
     controller: { column: boolean, cell: boolean }
   ) => {
+    this.#columnsToSelectOnMouseOver = null;
+
     if (!this.hot.view.isMouseDown() || controller.column) {
       return;
     }
@@ -965,6 +978,23 @@ export class NestedHeaders extends BasePlugin {
       columnsToSelect = [columnIndex, columnIndex + origColspan - 1, headerLevel];
     }
 
+    this.#columnsToSelectOnMouseOver = columnsToSelect;
+  };
+
+  /**
+   * Applies the column selection computed in `beforeOnCellMouseOver`. Running in the `afterOnCellMouseOver`
+   * hook keeps the selection cancellable - the core skips this hook when `stopImmediatePropagation` is called
+   * in a `beforeOnCellMouseOver` listener, so a drag over nested headers can be blocked the same way it is for
+   * regular column headers.
+   */
+  #onAfterOnCellMouseOver = () => {
+    if (this.#columnsToSelectOnMouseOver === null) {
+      return;
+    }
+
+    const columnsToSelect = this.#columnsToSelectOnMouseOver;
+
+    this.#columnsToSelectOnMouseOver = null;
     this.hot.selection.selectColumns(...columnsToSelect);
   };
 


### PR DESCRIPTION
### Context

The PR fixes a bug discovered while investigating [#6026](https://github.com/handsontable/handsontable/issues/6026).

The original issue reported a JavaScript error when dragging over (nested) headers while a `beforeOnCellMouseDown` listener called `stopImmediatePropagation()`. That crash **no longer reproduces** in `17.1.0` — accumulated guards (`setRangeEnd` empty-check, NestedHeaders' `getSelectedRangeActive()` null-check) resolved it.

However, verifying the issue surfaced a distinct, related bug: the documented way to fully block header selection — calling `stopImmediatePropagation()` in **both** `beforeOnCellMouseDown` and `beforeOnCellMouseOver` — works for **plain** column headers but **not** for **nested** headers. With nested headers the drag still mutated the selection.

Root cause: `NestedHeaders.#onBeforeOnCellMouseOver` performed the `selectColumns` mutation inside the `before` hook, and it runs before the user's hook. `TableView` only checks the propagation flag *after* the before-hooks, so the mutation had already happened. The mousedown path doesn't have this problem because it performs its `selectColumns` in `afterOnCellMouseDown`, which `TableView` gates.

The fix makes the mouseover path symmetric with the mousedown path: `#onBeforeOnCellMouseOver` now only sets the `controller` flags and stashes the computed range, and the actual `selectColumns` is deferred to a new `#onAfterOnCellMouseOver` handler, which `TableView` skips when propagation is stopped. This is order-independent and non-breaking — behavior changes only when a hook explicitly stops propagation; the default zero-config drag-select path is untouched.

### How has this been tested?

Added 3 E2E specs in `handsontable/src/plugins/nestedHeaders/__tests__/selection.spec.js`:

1. `beforeOnCellMouseDown` + `stopImmediatePropagation` → header click does not start a selection.
2. Both `beforeOnCellMouseDown` and `beforeOnCellMouseOver` stop the event → drag over nested headers leaves the selection untouched (the fix).
3. No hooks → normal nested-header column drag-select still works (proves the test is non-vacuous).

No unit test: this is pure hook/event orchestration (no unit-testable logic in isolation), and the repository convention for mouse-drag selection behavior is E2E.

Regression suites (theme `main`), all green and no console exceptions:

```bash
npm run test:e2e --prefix handsontable -- --testPathPattern='nestedHeaders/__tests__'   # 183 specs, 0 failures
npm run test:e2e --prefix handsontable -- --testPathPattern='collapsibleColumns'          # 115 specs, 0 failures
npm run test:e2e --prefix handsontable -- --testPathPattern='mergeCells'                   # 478 specs, 0 failures
npm run eslint --prefix handsontable
npm run test:types --prefix handsontable
npm run build --prefix handsontable
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. https://github.com/handsontable/handsontable/issues/6026
2. DEV-1919

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1919

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted hook-order change in NestedHeaders selection; default drag-select behavior is unchanged unless hooks stop propagation.
> 
> **Overview**
> Fixes **nested column headers** ignoring `stopImmediatePropagation()` in `beforeOnCellMouseOver` during drag-selection, so blocking header selection matches plain column headers.
> 
> The **NestedHeaders** plugin no longer calls `selectColumns` inside `#onBeforeOnCellMouseOver`. It stashes the computed range in `#columnsToSelectOnMouseOver` and applies it in a new **`afterOnCellMouseOver`** handler, which the core skips when propagation is stopped—same pattern as the existing mousedown path.
> 
> Adds E2E coverage for blocked mousedown/mouseover hooks and unchanged default drag-select, plus changelog entry **12794**. Also adds **`x-workspace-id`** to ClickUp MCP config in `.mcp.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5f9625a6fefcce1b49c0c58bf3d92a1654f2e22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->