### PR TITLE
Fix #3927: keep `null` in numeric/date/time cells instead of overwriting with an empty string

### DIFF
--- a/.changelogs/12797.json
+++ b/.changelogs/12797.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed `numeric`, `date`, and `time` cells being overwritten with an empty string instead of keeping `null` when the editor is opened without input, the cell is cleared, or an empty value is pasted.",
+  "type": "fixed",
+  "issueOrPR": 12797,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.claude/skills/handsontable-celltype-dev/SKILL.md
+++ b/.claude/skills/handsontable-celltype-dev/SKILL.md
@@ -55,6 +55,10 @@ New cell types must be added to `src/dataMap/metaManager/metaSchema.ts` so Hands
 - **All components are optional.** A cell type can omit `validator` if no validation is needed, or omit `editor` for read-only display types.
 - **Individual overrides win.** If a user sets both `type: 'myType'` and `renderer: customRenderer`, the explicit `renderer` takes precedence over the one from the cell type.
 
+## Empty values
+
+A cell type whose values have no valid empty-string representation (numeric, date, time, intl-date, intl-time) must normalize `''` to `null` so opening an editor without input, clearing a cell, pasting, or `setDataAtCell('')` keeps the value as `null` instead of `''`. Do this through `valueSetter` (runs in the shared `processChanges` path, so it covers every write). Use the `emptyStringToNull` helper from `src/helpers/mixed.ts` (date/time types assign it directly; numeric returns `null` for `''` before its own parsing). Leave the `text` type unchanged — `''` is a valid text value.
+
 ## Reference implementations
 
 - `src/cellTypes/numericType/numericType.ts` - Composes numeric editor, renderer, and validator.

--- a/docs/content/guides/cell-types/date-cell-type/date-cell-type.md
+++ b/docs/content/guides/cell-types/date-cell-type/date-cell-type.md
@@ -379,6 +379,8 @@ The [`dateFormat`](@/api/options.md#dateformat) option controls how dates are di
 
 After configuring the date cell type, cells display dates formatted according to your `dateFormat` configuration. Clicking an `intl-date` or `date` cell opens a native date picker. Source data is stored in ISO 8601 format (`YYYY-MM-DD`) regardless of the display format.
 
+When you clear a date cell or paste an empty value into it, Handsontable stores `null` instead of an empty string. This keeps the cell's value usable in formulas, sorting, and server-side processing.
+
 ## Related articles
 
 **Related guides**

--- a/docs/content/guides/cell-types/numeric-cell-type/numeric-cell-type.md
+++ b/docs/content/guides/cell-types/numeric-cell-type/numeric-cell-type.md
@@ -390,6 +390,8 @@ you edit a numeric cell:
 
 After configuring the numeric cell type, cells right-align their values and display them using the format you defined in `numericFormat`. Invalid (non-numeric) input is rejected. The underlying data source stores the raw number.
 
+When you clear a numeric cell, open its editor without typing, or paste an empty value into it, Handsontable stores `null` instead of an empty string. This keeps the cell's value usable in formulas, sorting, and server-side processing.
+
 ## Related articles
 
 **Related guides**

--- a/docs/content/guides/cell-types/time-cell-type/time-cell-type.md
+++ b/docs/content/guides/cell-types/time-cell-type/time-cell-type.md
@@ -402,6 +402,8 @@ The [`timeFormat`](@/api/options.md#timeformat) option controls how times are di
 
 After configuring the time cell type, cells display time values formatted according to your `timeFormat` configuration. Clicking an `intl-time` or `time` cell opens a native time picker. Source data is stored in 24-hour format (`HH:mm`, `HH:mm:ss`, or `HH:mm:ss.SSS`) regardless of the display format.
 
+When you clear a time cell or paste an empty value into it, Handsontable stores `null` instead of an empty string. This keeps the cell's value usable in formulas, sorting, and server-side processing.
+
 ## Related articles
 
 **Related guides**

--- a/handsontable/src/__tests__/settings/columns.spec.js
+++ b/handsontable/src/__tests__/settings/columns.spec.js
@@ -225,7 +225,8 @@ describe('settings', () => {
           await setDataAtCell(0, 0, '');
           await waitForNextAnimationFrames(2);
 
-          expect(onAfterValidate).toHaveBeenCalledWith(true, '', 0, 'date');
+          // A `date` cell has no valid empty-string representation, so `''` becomes `null` (issue #3927).
+          expect(onAfterValidate).toHaveBeenCalledWith(true, null, 0, 'date');
         });
       });
     });

--- a/handsontable/src/cellTypes/dateType/__tests__/dateType.unit.ts
+++ b/handsontable/src/cellTypes/dateType/__tests__/dateType.unit.ts
@@ -62,6 +62,7 @@ describe('DateCellType', () => {
         sourceDataValidator: expect.any(Function),
         sourceDataWarningMessage: expect.any(String),
         valueFormatter: expect.any(Function),
+        valueSetter: expect.any(Function),
       });
     });
   });

--- a/handsontable/src/cellTypes/dateType/dateType.ts
+++ b/handsontable/src/cellTypes/dateType/dateType.ts
@@ -5,6 +5,7 @@ import {
   dateValidator,
   sourceDataValidator,
 } from '../../validators/dateValidator';
+import { emptyStringToNull } from '../../helpers/mixed';
 
 export const CELL_TYPE: 'date' = 'date';
 export const DateCellType = {
@@ -15,4 +16,5 @@ export const DateCellType = {
   sourceDataValidator,
   sourceDataWarningMessage: SOURCE_DATA_WARNING_MESSAGE,
   valueFormatter,
+  valueSetter: emptyStringToNull,
 };

--- a/handsontable/src/cellTypes/intlDateType/__tests__/intlDateType.unit.js
+++ b/handsontable/src/cellTypes/intlDateType/__tests__/intlDateType.unit.js
@@ -64,6 +64,7 @@ describe('IntlDateCellType', () => {
         sourceDataValidator: IntlDateCellType.sourceDataValidator,
         valueFormatter: IntlDateCellType.valueFormatter,
         sourceDataWarningMessage: IntlDateCellType.sourceDataWarningMessage,
+        valueSetter: IntlDateCellType.valueSetter,
       });
     });
   });

--- a/handsontable/src/cellTypes/intlDateType/intlDateType.ts
+++ b/handsontable/src/cellTypes/intlDateType/intlDateType.ts
@@ -5,6 +5,7 @@ import {
   intlDateValidator,
   sourceDataValidator,
 } from '../../validators/intlDateValidator';
+import { emptyStringToNull } from '../../helpers/mixed';
 
 export const CELL_TYPE = 'intl-date';
 export const IntlDateCellType = {
@@ -15,4 +16,5 @@ export const IntlDateCellType = {
   sourceDataValidator,
   sourceDataWarningMessage: SOURCE_DATA_WARNING_MESSAGE,
   valueFormatter,
+  valueSetter: emptyStringToNull,
 };

--- a/handsontable/src/cellTypes/intlTimeType/__tests__/intlTimeType.unit.js
+++ b/handsontable/src/cellTypes/intlTimeType/__tests__/intlTimeType.unit.js
@@ -64,6 +64,7 @@ describe('IntlTimeCellType', () => {
         sourceDataValidator: IntlTimeCellType.sourceDataValidator,
         valueFormatter: IntlTimeCellType.valueFormatter,
         sourceDataWarningMessage: IntlTimeCellType.sourceDataWarningMessage,
+        valueSetter: IntlTimeCellType.valueSetter,
       });
     });
   });

--- a/handsontable/src/cellTypes/intlTimeType/intlTimeType.ts
+++ b/handsontable/src/cellTypes/intlTimeType/intlTimeType.ts
@@ -5,6 +5,7 @@ import {
   intlTimeValidator,
   sourceDataValidator,
 } from '../../validators/intlTimeValidator';
+import { emptyStringToNull } from '../../helpers/mixed';
 
 export const CELL_TYPE = 'intl-time';
 export const IntlTimeCellType = {
@@ -15,4 +16,5 @@ export const IntlTimeCellType = {
   sourceDataValidator,
   sourceDataWarningMessage: SOURCE_DATA_WARNING_MESSAGE,
   valueFormatter,
+  valueSetter: emptyStringToNull,
 };

--- a/handsontable/src/cellTypes/numericType/__tests__/numericType.unit.ts
+++ b/handsontable/src/cellTypes/numericType/__tests__/numericType.unit.ts
@@ -69,6 +69,15 @@ describe('NumericCellType', () => {
   });
 
   describe('valueSetter', () => {
+    it('should convert an empty string to `null` so the cell is not overwritten with `""`', () => {
+      expect(valueSetter('', 0, 0, {})).toBe(null);
+    });
+
+    it('should keep non-string empty values untouched', () => {
+      expect(valueSetter(null, 0, 0, {})).toBe(null);
+      expect(valueSetter(undefined, 0, 0, {})).toBe(undefined);
+    });
+
     it('should parse grouped values for dot-decimal numeric formats', () => {
       expect(valueSetter('100,000', 0, 0, {
         locale: 'en-US',

--- a/handsontable/src/cellTypes/numericType/accessors/valueSetter.ts
+++ b/handsontable/src/cellTypes/numericType/accessors/valueSetter.ts
@@ -6,6 +6,7 @@ import {
   getParsedNumber,
 } from '../../../helpers/number';
 import { isNullish } from '../../../dataMap/metaManager/utils';
+import { emptyStringToNull } from '../../../helpers/mixed';
 import type { CellProperties } from '../../../settings';
 
 /**
@@ -64,6 +65,12 @@ function getCellDecimalSeparator(cellMeta: CellProperties) {
 export function valueSetter(newValue: unknown, _row: number, _column: number, cellMeta: CellProperties): unknown {
   if (typeof newValue !== 'string') {
     return newValue;
+  }
+
+  // A numeric cell has no valid empty-string representation, so keep it as `null`
+  // instead of storing `''` (which breaks formulas, sorting, and server-side parsing).
+  if (newValue === '') {
+    return null;
   }
 
   const decimalSeparator = getCellDecimalSeparator(cellMeta);

--- a/handsontable/src/cellTypes/numericType/accessors/valueSetter.ts
+++ b/handsontable/src/cellTypes/numericType/accessors/valueSetter.ts
@@ -6,7 +6,6 @@ import {
   getParsedNumber,
 } from '../../../helpers/number';
 import { isNullish } from '../../../dataMap/metaManager/utils';
-import { emptyStringToNull } from '../../../helpers/mixed';
 import type { CellProperties } from '../../../settings';
 
 /**

--- a/handsontable/src/cellTypes/timeType/__tests__/timeType.unit.ts
+++ b/handsontable/src/cellTypes/timeType/__tests__/timeType.unit.ts
@@ -63,6 +63,7 @@ describe('TimeCellType', () => {
         sourceDataValidator: expect.any(Function),
         sourceDataWarningMessage: expect.any(String),
         valueFormatter: expect.any(Function),
+        valueSetter: expect.any(Function),
       });
     });
   });

--- a/handsontable/src/cellTypes/timeType/timeType.ts
+++ b/handsontable/src/cellTypes/timeType/timeType.ts
@@ -5,6 +5,7 @@ import {
   timeValidator,
   sourceDataValidator,
 } from '../../validators/timeValidator';
+import { emptyStringToNull } from '../../helpers/mixed';
 
 export const CELL_TYPE: 'time' = 'time';
 export const TimeCellType = {
@@ -15,4 +16,5 @@ export const TimeCellType = {
   sourceDataValidator,
   sourceDataWarningMessage: SOURCE_DATA_WARNING_MESSAGE,
   valueFormatter,
+  valueSetter: emptyStringToNull,
 };

--- a/handsontable/src/editors/dateEditor/__tests__/dateEditor.spec.js
+++ b/handsontable/src/editors/dateEditor/__tests__/dateEditor.spec.js
@@ -539,6 +539,47 @@ describe('DateEditor', () => {
     expect(editableElement.getAttribute('dir')).toBeNull();
   });
 
+  describe('empty values (issue #3927)', () => {
+    it('should keep `null` when opening and closing the editor without typing', async() => {
+      handsontable({
+        data: [['2019-01-01'], [null]],
+        columns: [{ type: 'date', dateFormat: 'YYYY-MM-DD', correctFormat: true }],
+      });
+
+      await selectCell(1, 0);
+      await keyDownUp('enter'); // open
+
+      const editor = getActiveEditor();
+
+      editor.finishEditing(); // confirm without typing
+      await sleep(30);
+
+      expect(getSourceDataAtCell(1, 0)).toBe(null);
+    });
+
+    it('should store `null` (not "") when setting an empty string via `setDataAtCell`', async() => {
+      handsontable({
+        data: [['2019-01-01']],
+        columns: [{ type: 'date', dateFormat: 'YYYY-MM-DD', correctFormat: true }],
+      });
+
+      await setDataAtCell(0, 0, '');
+
+      expect(getSourceDataAtCell(0, 0)).toBe(null);
+    });
+
+    it('should store `null` (not "") when populating an empty value', async() => {
+      handsontable({
+        data: [['2019-01-01']],
+        columns: [{ type: 'date', dateFormat: 'YYYY-MM-DD', correctFormat: true }],
+      });
+
+      await populateFromArray(0, 0, [['']]);
+
+      expect(getSourceDataAtCell(0, 0)).toBe(null);
+    });
+  });
+
   describe('IME support', () => {
     it('should focus editable element after a timeout when selecting the cell if `imeFastEdit` is enabled', async() => {
       handsontable({

--- a/handsontable/src/editors/numericEditor/__tests__/numericEditor.spec.js
+++ b/handsontable/src/editors/numericEditor/__tests__/numericEditor.spec.js
@@ -1161,6 +1161,61 @@ describe('NumericEditor', () => {
     });
   });
 
+  describe('empty values (issue #3927)', () => {
+    it('should keep `null` when opening and closing the editor without typing', async() => {
+      handsontable({
+        data: [[10], [20], [null]],
+        columns: [{ type: 'numeric' }],
+      });
+
+      await selectCell(2, 0);
+      await keyDownUp('enter'); // open
+      await keyDownUp('enter'); // confirm without typing
+
+      expect(getSourceDataAtCell(2, 0)).toBe(null);
+      expect(getDataAtCell(2, 0)).toBe(null);
+    });
+
+    it('should store `null` (not "") when clearing a numeric cell through the editor', async() => {
+      handsontable({
+        data: [[10]],
+        columns: [{ type: 'numeric' }],
+      });
+
+      await selectCell(0, 0);
+      await keyDownUp('enter');
+
+      const editor = getActiveEditor();
+
+      editor.setValue('');
+      await keyDownUp('enter');
+
+      expect(getSourceDataAtCell(0, 0)).toBe(null);
+    });
+
+    it('should store `null` (not "") when pasting/populating an empty value', async() => {
+      handsontable({
+        data: [[10]],
+        columns: [{ type: 'numeric' }],
+      });
+
+      await populateFromArray(0, 0, [['']]);
+
+      expect(getSourceDataAtCell(0, 0)).toBe(null);
+    });
+
+    it('should store `null` (not "") when setting an empty string via `setDataAtCell`', async() => {
+      handsontable({
+        data: [[10]],
+        columns: [{ type: 'numeric' }],
+      });
+
+      await setDataAtCell(0, 0, '');
+
+      expect(getSourceDataAtCell(0, 0)).toBe(null);
+    });
+  });
+
   describe('IME support', () => {
     it('should focus editable element after a timeout when selecting the cell if `imeFastEdit` is enabled', async() => {
       handsontable({

--- a/handsontable/src/editors/timeEditor/__tests__/timeEditor.spec.js
+++ b/handsontable/src/editors/timeEditor/__tests__/timeEditor.spec.js
@@ -66,4 +66,45 @@ describe('TimeEditor', () => {
 
     expect(editableElement.getAttribute('dir')).toBe('ltr');
   });
+
+  describe('empty values (issue #3927)', () => {
+    it('should keep `null` when opening and closing the editor without typing', async() => {
+      handsontable({
+        data: [['10:30:00'], [null]],
+        columns: [{ type: 'time', timeFormat: 'h:mm:ss a', correctFormat: true }],
+      });
+
+      await selectCell(1, 0);
+      await keyDownUp('enter'); // open
+
+      const editor = getActiveEditor();
+
+      editor.finishEditing(); // confirm without typing
+      await sleep(30);
+
+      expect(getSourceDataAtCell(1, 0)).toBe(null);
+    });
+
+    it('should store `null` (not "") when setting an empty string via `setDataAtCell`', async() => {
+      handsontable({
+        data: [['10:30:00']],
+        columns: [{ type: 'time', timeFormat: 'h:mm:ss a', correctFormat: true }],
+      });
+
+      await setDataAtCell(0, 0, '');
+
+      expect(getSourceDataAtCell(0, 0)).toBe(null);
+    });
+
+    it('should store `null` (not "") when populating an empty value', async() => {
+      handsontable({
+        data: [['10:30:00']],
+        columns: [{ type: 'time', timeFormat: 'h:mm:ss a', correctFormat: true }],
+      });
+
+      await populateFromArray(0, 0, [['']]);
+
+      expect(getSourceDataAtCell(0, 0)).toBe(null);
+    });
+  });
 });

--- a/handsontable/src/helpers/__tests__/mixed.unit.ts
+++ b/handsontable/src/helpers/__tests__/mixed.unit.ts
@@ -5,6 +5,7 @@ import {
   isUndefined,
   isEmpty,
   isRegExp,
+  emptyStringToNull,
 } from '../mixed';
 
 describe('Mixed helper', () => {
@@ -105,6 +106,29 @@ describe('Mixed helper', () => {
       expect(isEmpty('a')).toBeFalsy();
       expect(isEmpty([])).toBeFalsy();
       expect(isEmpty({})).toBeFalsy();
+    });
+  });
+
+  describe('emptyStringToNull', () => {
+    it('should convert an empty string to `null`', () => {
+      expect(emptyStringToNull('')).toBe(null);
+    });
+
+    it('should leave every other value untouched', () => {
+      expect(emptyStringToNull(null)).toBe(null);
+      expect(emptyStringToNull(undefined)).toBe(undefined);
+      expect(emptyStringToNull(0)).toBe(0);
+      expect(emptyStringToNull(NaN)).toBe(NaN);
+      expect(emptyStringToNull(false)).toBe(false);
+      expect(emptyStringToNull('a')).toBe('a');
+      expect(emptyStringToNull(' ')).toBe(' ');
+      expect(emptyStringToNull('2019-01-01')).toBe('2019-01-01');
+
+      const arr: unknown[] = [];
+      const obj = {};
+
+      expect(emptyStringToNull(arr)).toBe(arr);
+      expect(emptyStringToNull(obj)).toBe(obj);
     });
   });
 

--- a/handsontable/src/helpers/mixed.ts
+++ b/handsontable/src/helpers/mixed.ts
@@ -60,6 +60,21 @@ export function isEmpty(variable: unknown): boolean {
 }
 
 /**
+ * Normalizes an empty string to `null`, leaving every other value untouched.
+ *
+ * Used by cell types where an empty string has no valid representation (for example
+ * `numeric`, `date`, and `time`). It keeps an originally empty cell as `null` instead
+ * of overwriting it with `''` when the editor is opened without input, the value is
+ * cleared, or an empty value is pasted.
+ *
+ * @param {*} value The value to normalize.
+ * @returns {*} `null` when the value is an empty string, otherwise the original value.
+ */
+export function emptyStringToNull(value: unknown): unknown {
+  return value === '' ? null : value;
+}
+
+/**
  * Check if given variable is a regular expression.
  *
  * @param {*} variable Variable to check.

--- a/handsontable/src/validators/dateValidator/__tests__/dateValidator.spec.js
+++ b/handsontable/src/validators/dateValidator/__tests__/dateValidator.spec.js
@@ -38,7 +38,7 @@ describe('dateValidator', () => {
 
     await waitForNextAnimationFrames(2);
 
-    expect(onAfterValidate).toHaveBeenCalledWith(true, '', 0, 'date');
+    expect(onAfterValidate).toHaveBeenCalledWith(true, null, 0, 'date');
   });
 
   it('should not positively validate a non-date string', async() => {
@@ -250,7 +250,7 @@ describe('dateValidator', () => {
 
       await waitForNextAnimationFrames(2);
 
-      expect(onAfterValidate).toHaveBeenCalledWith(false, '', 1, 'date');
+      expect(onAfterValidate).toHaveBeenCalledWith(false, null, 1, 'date');
     });
 
     it('should not validate `null` when allowEmpty is set as `false`', async() => {
@@ -312,7 +312,7 @@ describe('dateValidator', () => {
 
       await waitForNextAnimationFrames(2);
 
-      expect(onAfterValidate).toHaveBeenCalledWith(true, '', 0, 'date');
+      expect(onAfterValidate).toHaveBeenCalledWith(true, null, 0, 'date');
     });
 
     it('should not positively validate a non-ISO date string', async() => {
@@ -373,7 +373,7 @@ describe('dateValidator', () => {
 
         await waitForNextAnimationFrames(2);
 
-        expect(onAfterValidate).toHaveBeenCalledWith(false, '', 1, 'date');
+        expect(onAfterValidate).toHaveBeenCalledWith(false, null, 1, 'date');
       });
     });
   });

--- a/handsontable/src/validators/numericValidator/__tests__/numericValidator.spec.js
+++ b/handsontable/src/validators/numericValidator/__tests__/numericValidator.spec.js
@@ -27,7 +27,7 @@ describe('numericValidator', () => {
     ];
   };
 
-  it('should validate an empty string (default behavior)', async() => {
+  it('should normalize an empty string to `null` and validate it (default behavior)', async() => {
     const onAfterValidate = jasmine.createSpy('onAfterValidate');
 
     handsontable({
@@ -43,7 +43,8 @@ describe('numericValidator', () => {
     await setDataAtCell(2, 0, '');
     await waitForNextAnimationFrames(2);
 
-    expect(onAfterValidate).toHaveBeenCalledWith(true, '', 2, 'id');
+    // A numeric cell has no valid empty-string representation, so `''` becomes `null` (issue #3927).
+    expect(onAfterValidate).toHaveBeenCalledWith(true, null, 2, 'id');
   });
 
   it('should not validate non numeric string', async() => {
@@ -158,7 +159,8 @@ describe('numericValidator', () => {
       await setDataAtCell(2, 0, '');
       await waitForNextAnimationFrames(2);
 
-      expect(onAfterValidate).toHaveBeenCalledWith(false, '', 2, 'id');
+      // A numeric cell has no valid empty-string representation, so `''` becomes `null` (issue #3927).
+      expect(onAfterValidate).toHaveBeenCalledWith(false, null, 2, 'id');
     });
 
     it('should not validate `null` when allowEmpty is set as `false`', async() => {

--- a/handsontable/src/validators/timeValidator/__tests__/timeValidator.spec.js
+++ b/handsontable/src/validators/timeValidator/__tests__/timeValidator.spec.js
@@ -38,7 +38,7 @@ describe('timeValidator', () => {
 
     await waitForNextAnimationFrames(2);
 
-    expect(onAfterValidate).toHaveBeenCalledWith(true, '', 0, 'time');
+    expect(onAfterValidate).toHaveBeenCalledWith(true, null, 0, 'time');
   });
 
   it('should not positively validate a non-date format', async() => {
@@ -139,7 +139,7 @@ describe('timeValidator', () => {
 
       await waitForNextAnimationFrames(2);
 
-      expect(onAfterValidate).toHaveBeenCalledWith(false, '', 1, 'time');
+      expect(onAfterValidate).toHaveBeenCalledWith(false, null, 1, 'time');
     });
 
     it('should not validate `null` when allowEmpty is set as `false`', async() => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Context

Cells of type `numeric`, `date`, and `time` (and the `intl-date` / `intl-time` variants) correctly start as `null`, which renders as empty. But opening the editor and confirming without typing — or clearing the cell, pasting an empty value, or calling `setDataAtCell(r, c, '')` — overwrote the `null` with an empty string `''`. The wrong type then broke formula calculation, sorting, and server-side processing.

This fixes [#3927](https://github.com/handsontable/handsontable/issues/3927).

### Approach

Empty values are normalized to `null` through the cell-type `valueSetter` accessor, which runs in the shared `processChanges` chokepoint in `core.ts`. That single point covers every write path — editor edits, `setDataAtCell`/`setDataAtRowProp`, paste, and autofill — mirroring exactly where the long-standing `beforeChange` workaround operated.

- New shared helper `emptyStringToNull()` in `helpers/mixed.ts`.
- `numeric` cell type `valueSetter` returns `null` for an empty string before its numeric parsing.
- `date`, `time`, `intl-date`, and `intl-time` cell types use `emptyStringToNull` as their `valueSetter`.

The `text` cell type is intentionally left unchanged — `''` is a valid text value, so its behavior is preserved.

**Behavior change:** an empty string written to a `numeric`/`date`/`time` cell is now stored as `null` rather than `''`. This aligns the stored value with the cell type and is the fix requested in the issue. No public API, option default, hook, or CSS class changed.

### How has this been tested?

- Unit tests for `emptyStringToNull` and the numeric `valueSetter` empty case.
- E2E tests for the numeric, date, and time editors covering: opening/closing the editor without typing, clearing a cell, pasting an empty value, and `setDataAtCell('')` — all keep `null`.
- Updated the date/time/numeric validator and column-binding specs that previously codified the old `''` behavior.
- Full core unit suite (2796 tests) and full E2E suite pass (the only 2 remaining E2E failures — MultiSelectEditor dropdown min-width — are pre-existing on `develop` and unrelated to this change).
- Manual GUI verification on a local build (see walkthrough video below).

[issue_3927_numeric_date_time_keep_null.mp4](https://cursor.com/agents/bc-832ff897-4a68-4bd9-8f48-964967abbf51/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue_3927_numeric_date_time_keep_null.mp4)

Opening the numeric editor without typing keeps `null`; pasting/clearing empty values into row 3 keeps numeric/date/time as `null` while the text cell keeps `""`.

[Numeric editor opened without typing keeps null](https://cursor.com/agents/bc-832ff897-4a68-4bd9-8f48-964967abbf51/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue_3927_numeric_editor_keeps_null.webp)
[Pasting empty values keeps numeric/date/time null, text empty string](https://cursor.com/agents/bc-832ff897-4a68-4bd9-8f48-964967abbf51/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue_3927_paste_empty_keeps_null.webp)

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/3927

### Affected project(s):
- [x] `handsontable`

### Checklist:
- [x] I have reviewed the guidelines about Contributing to Handsontable and I confirm that my code follows the code style of this project.
- [ ] I have signed the Contributor License Agreement
- [x] My change requires a change to the documentation.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-832ff897-4a68-4bd9-8f48-964967abbf51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-832ff897-4a68-4bd9-8f48-964967abbf51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

