### PR TITLE
DEV-482 Extra cells are produced after merging and unmerging cells an…

### DIFF
--- a/.changelogs/12798.json
+++ b/.changelogs/12798.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed clears stale cell meta after a merge is removed (unmerge)",
+  "type": "fixed",
+  "issueOrPR": 12798,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/mergeCells/__tests__/mergeCells.spec.js
+++ b/handsontable/src/plugins/mergeCells/__tests__/mergeCells.spec.js
@@ -1715,6 +1715,48 @@ describe('MergeCells', () => {
     expect(getCellMeta(4, 4).copyable).toBe(false);
   });
 
+  it('should clear the "spanned"/"colspan"/"rowspan"/"hidden" cell meta after performing unmerge', async() => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      mergeCells: [
+        { row: 1, col: 1, rowspan: 1, colspan: 3 },
+      ],
+    });
+
+    const plugin = getPlugin('mergeCells');
+
+    // the merge parent carries the span flags, the covered cells are hidden
+    expect(getCellMeta(1, 1).spanned).toBe(true);
+    expect(getCellMeta(1, 1).colspan).toBe(3);
+    expect(getCellMeta(1, 2).hidden).toBe(true);
+    expect(getCellMeta(1, 3).hidden).toBe(true);
+
+    plugin.unmerge(1, 1, 1, 3);
+
+    // after unmerge the cached meta must not linger (it would leak into `toHTML`, copy, etc.)
+    expect(getCellMeta(1, 1).spanned).toBeUndefined();
+    expect(getCellMeta(1, 1).colspan).toBeUndefined();
+    expect(getCellMeta(1, 1).rowspan).toBeUndefined();
+    expect(getCellMeta(1, 2).hidden).toBeUndefined();
+    expect(getCellMeta(1, 3).hidden).toBeUndefined();
+  });
+
+  it('should not emit stale colspan/rowspan in `toHTML` output after performing unmerge', async() => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      mergeCells: [
+        { row: 1, col: 1, rowspan: 1, colspan: 3 },
+      ],
+    });
+
+    getPlugin('mergeCells').unmerge(1, 1, 1, 3);
+
+    const html = hot().toHTML();
+
+    expect(html).not.toContain('colspan');
+    expect(html).not.toContain('rowspan');
+  });
+
   it('should not collapse the main table\'s row height when the merge cell covers all cells width', async() => {
     handsontable({
       data: createSpreadsheetData(5, 5),

--- a/handsontable/src/plugins/mergeCells/__tests__/mergeCells.spec.js
+++ b/handsontable/src/plugins/mergeCells/__tests__/mergeCells.spec.js
@@ -1757,6 +1757,79 @@ describe('MergeCells', () => {
     expect(html).not.toContain('rowspan');
   });
 
+  it('should not emit stale colspan/rowspan in `toHTML` output after a batched unmerge', async() => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      mergeCells: [
+        { row: 1, col: 1, rowspan: 1, colspan: 3 },
+      ],
+    });
+
+    // Prime the per-render meta memo while the merge is still active, so the in-batch read below
+    // hits the memoized path - the one on which the old lazy `afterGetCellMeta` cleanup is skipped.
+    expect(getCellMeta(1, 1).colspan).toBe(3);
+
+    let parentMeta;
+    let coveredMeta;
+    let html;
+
+    // The unmerge runs without a real render (suspended inside `batch`), so the meta must be
+    // cleared eagerly in `unmergeRange` and cannot rely on `afterGetCellMeta` recomputing. The
+    // read happens inside the batch on purpose: `batch` ends with a render that clears the memo,
+    // so reading after it would mask the stale-meta path (the trap the original tests fell into).
+    hot().batch(() => {
+      getPlugin('mergeCells').unmerge(1, 1, 1, 3);
+
+      // snapshot primitives - the meta object is a live reference mutated by the closing render
+      parentMeta = { ...getCellMeta(1, 1) };
+      coveredMeta = { ...getCellMeta(1, 2) };
+      html = hot().toHTML();
+    });
+
+    expect(parentMeta.spanned).toBeUndefined();
+    expect(parentMeta.colspan).toBeUndefined();
+    expect(parentMeta.rowspan).toBeUndefined();
+    expect(coveredMeta.hidden).toBeUndefined();
+    expect(html).not.toContain('colspan');
+    expect(html).not.toContain('rowspan');
+  });
+
+  it('should not emit stale colspan/rowspan in `toHTML` output after the plugin is disabled within a batch', async() => {
+    handsontable({
+      data: createSpreadsheetData(5, 5),
+      mergeCells: [
+        { row: 1, col: 1, rowspan: 1, colspan: 3 },
+      ],
+    });
+
+    // Prime the per-render meta memo while the merge is still active, so the in-batch read below
+    // hits the memoized path - the one on which the old lazy `afterGetCellMeta` cleanup is skipped.
+    expect(getCellMeta(1, 1).colspan).toBe(3);
+
+    let parentMeta;
+    let coveredMeta;
+    let html;
+
+    // Disabling the plugin drops the whole collection via `clearCollections`. The internal render
+    // is suspended by `batch`, so - just like the unmerge case - the span meta must be cleared
+    // eagerly. The read happens inside the batch, before the closing render clears the memo.
+    hot().batch(() => {
+      getPlugin('mergeCells').disablePlugin();
+
+      // snapshot primitives - the meta object is a live reference mutated by the closing render
+      parentMeta = { ...getCellMeta(1, 1) };
+      coveredMeta = { ...getCellMeta(1, 2) };
+      html = hot().toHTML();
+    });
+
+    expect(parentMeta.spanned).toBeUndefined();
+    expect(parentMeta.colspan).toBeUndefined();
+    expect(parentMeta.rowspan).toBeUndefined();
+    expect(coveredMeta.hidden).toBeUndefined();
+    expect(html).not.toContain('colspan');
+    expect(html).not.toContain('rowspan');
+  });
+
   it('should not collapse the main table\'s row height when the merge cell covers all cells width', async() => {
     handsontable({
       data: createSpreadsheetData(5, 5),

--- a/handsontable/src/plugins/mergeCells/__tests__/mergeCells.spec.js
+++ b/handsontable/src/plugins/mergeCells/__tests__/mergeCells.spec.js
@@ -1751,7 +1751,7 @@ describe('MergeCells', () => {
 
     getPlugin('mergeCells').unmerge(1, 1, 1, 3);
 
-    const html = hot().toHTML();
+    const html = toHTML();
 
     expect(html).not.toContain('colspan');
     expect(html).not.toContain('rowspan');
@@ -1777,13 +1777,13 @@ describe('MergeCells', () => {
     // cleared eagerly in `unmergeRange` and cannot rely on `afterGetCellMeta` recomputing. The
     // read happens inside the batch on purpose: `batch` ends with a render that clears the memo,
     // so reading after it would mask the stale-meta path (the trap the original tests fell into).
-    hot().batch(() => {
+    batch(() => {
       getPlugin('mergeCells').unmerge(1, 1, 1, 3);
 
       // snapshot primitives - the meta object is a live reference mutated by the closing render
       parentMeta = { ...getCellMeta(1, 1) };
       coveredMeta = { ...getCellMeta(1, 2) };
-      html = hot().toHTML();
+      html = toHTML();
     });
 
     expect(parentMeta.spanned).toBeUndefined();
@@ -1813,13 +1813,13 @@ describe('MergeCells', () => {
     // Disabling the plugin drops the whole collection via `clearCollections`. The internal render
     // is suspended by `batch`, so - just like the unmerge case - the span meta must be cleared
     // eagerly. The read happens inside the batch, before the closing render clears the memo.
-    hot().batch(() => {
+    batch(() => {
       getPlugin('mergeCells').disablePlugin();
 
       // snapshot primitives - the meta object is a live reference mutated by the closing render
       parentMeta = { ...getCellMeta(1, 1) };
       coveredMeta = { ...getCellMeta(1, 2) };
-      html = hot().toHTML();
+      html = toHTML();
     });
 
     expect(parentMeta.spanned).toBeUndefined();

--- a/handsontable/src/plugins/mergeCells/mergeCells.ts
+++ b/handsontable/src/plugins/mergeCells/mergeCells.ts
@@ -424,6 +424,10 @@ export class MergeCells extends BasePlugin {
    * Clears the merged cells from the merged cell container.
    */
   clearCollections(): void {
+    arrayEach(this.mergedCellsCollection.mergedCells, (mergedCell: MergedCellCoords) => {
+      this.#resetMergedCellMeta(mergedCell);
+    });
+
     this.mergedCellsCollection.clear();
   }
 
@@ -563,6 +567,28 @@ export class MergeCells extends BasePlugin {
   }
 
   /**
+   * Eagerly removes the merge-related cell meta (`hidden`, `copyable`, `spanned`, `rowspan`,
+   * `colspan`) for every cell covered by the provided merged cell. Done at the moment the merge
+   * is dropped — rather than lazily in `afterGetCellMeta` — so the stale flags cannot linger in
+   * the cached meta and leak into consumers that read it directly (e.g. `toHTML`) when the
+   * following render is suspended/batched and never actually runs.
+   *
+   * @param {MergedCellCoords} mergedCell The merged cell whose meta should be reset.
+   */
+  #resetMergedCellMeta(mergedCell: MergedCellCoords) {
+    rangeEach(0, mergedCell.rowspan - 1, (i) => {
+      rangeEach(0, mergedCell.colspan - 1, (j) => {
+        this.hot.removeCellMeta(mergedCell.row + i, mergedCell.col + j, 'hidden');
+        this.hot.removeCellMeta(mergedCell.row + i, mergedCell.col + j, 'copyable');
+      });
+    });
+
+    this.hot.removeCellMeta(mergedCell.row, mergedCell.col, 'spanned');
+    this.hot.removeCellMeta(mergedCell.row, mergedCell.col, 'rowspan');
+    this.hot.removeCellMeta(mergedCell.row, mergedCell.col, 'colspan');
+  }
+
+  /**
    * Unmerges the selection provided as a cell range. If no cell range is provided, it uses the current selection.
    *
    * @private
@@ -583,15 +609,7 @@ export class MergeCells extends BasePlugin {
 
     arrayEach(mergedCells, (currentCollection: MergedCellCoords) => {
       this.mergedCellsCollection.remove(currentCollection.row, currentCollection.col);
-
-      rangeEach(0, currentCollection.rowspan - 1, (i) => {
-        rangeEach(0, currentCollection.colspan - 1, (j) => {
-          this.hot.removeCellMeta(currentCollection.row + i, currentCollection.col + j, 'hidden');
-          this.hot.removeCellMeta(currentCollection.row + i, currentCollection.col + j, 'copyable');
-        });
-      });
-
-      this.hot.removeCellMeta(currentCollection.row, currentCollection.col, 'spanned');
+      this.#resetMergedCellMeta(currentCollection);
     });
 
     this.hot.runHooks('afterUnmergeCells', cellRange, auto);
@@ -1200,15 +1218,6 @@ export class MergeCells extends BasePlugin {
         cellProperties.colspan = mergeParent.colspan;
         cellProperties.spanned = true;
       }
-    } else {
-      // The cell is no longer part of a merge (e.g. after `unmerge`). The cell meta object is
-      // cached, so the span/hidden flags set by a previous merge would linger and leak into
-      // consumers that read meta directly (e.g. `toHTML`). Reset them here, where we already
-      // know there is no merge parent.
-      delete cellProperties.rowspan;
-      delete cellProperties.colspan;
-      delete cellProperties.spanned;
-      delete cellProperties.hidden;
     }
   };
 

--- a/handsontable/src/plugins/mergeCells/mergeCells.ts
+++ b/handsontable/src/plugins/mergeCells/mergeCells.ts
@@ -1200,6 +1200,15 @@ export class MergeCells extends BasePlugin {
         cellProperties.colspan = mergeParent.colspan;
         cellProperties.spanned = true;
       }
+    } else {
+      // The cell is no longer part of a merge (e.g. after `unmerge`). The cell meta object is
+      // cached, so the span/hidden flags set by a previous merge would linger and leak into
+      // consumers that read meta directly (e.g. `toHTML`). Reset them here, where we already
+      // know there is no merge parent.
+      delete cellProperties.rowspan;
+      delete cellProperties.colspan;
+      delete cellProperties.spanned;
+      delete cellProperties.hidden;
     }
   };
 


### PR DESCRIPTION
### Context
Fixed clears stale cell meta after a merge is removed (unmerge).

  Previously the #onAfterGetCellMeta hook set colspan/rowspan/spanned/hidden when a merge existed, but never reset them once the merge was gone. The live grid still rendered correctly (the renderer sets <td>  attributes directly), but consumers reading meta — e.g. toHTML() — got the stale colspan=3 plus the now-revealed cells, so the row broke.
  Now the "no merge parent" branch deletes those flags, so after unmerge the meta is clean and toHTML() returns a correct row.

### How has this been tested?
npm run test:e2e -- --testPathPattern=mergeCells.spec


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/7309
2. DEV-482
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.


ClickUp task: https://app.clickup.com/t/9015210959/DEV-482


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized bug fix in the mergeCells plugin with focused tests; behavior change only clears incorrect cached meta after unmerge/disable, with no API or breaking changes.
> 
> **Overview**
> Fixes stale merge-related cell meta (`spanned`, `colspan`, `rowspan`, `hidden`, `copyable`) left on cells after a merge is removed, which could break **`toHTML()`** and other code that reads meta directly while the on-screen grid still looked correct.
> 
> The **MergeCells** plugin now **eagerly** strips those flags via a shared **`#resetMergedCellMeta`** helper when **`unmergeRange`** drops a merge and when **`clearCollections`** runs (e.g. disabling the plugin or resetting merges). That avoids relying on a later render or lazy **`afterGetCellMeta`** updates when work runs inside **`batch()`** and meta is memoized.
> 
> New e2e tests cover plain unmerge, **`toHTML`** output, batched unmerge, and batched plugin disable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a0b6ddc59b1af382f9c9681cc73e32381323d6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->