### PR TITLE
DEV-1921: Fix misleading JSDoc for afterSetDataAtCell and afterSetDataAtRowProp hooks

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -4,7 +4,8 @@
       "type": "http",
       "url": "https://mcp.clickup.com/mcp",
       "headers": {
-        "Authorization": "Bearer ${CLICKUP_API_TOKEN}"
+        "Authorization": "Bearer ${CLICKUP_API_TOKEN}",
+        "x-workspace-id": "9015210959"
       }
     },
     "github": {

--- a/handsontable/src/core/hooks/constants.ts
+++ b/handsontable/src/core/hooks/constants.ts
@@ -1249,7 +1249,9 @@ export const REGISTERED_HOOKS = [
   'afterRemoveCellMeta',
 
   /**
-   * Fired after cell data was changed.
+   * Fired after [`setDataAtCell`](@/api/core.md#setdataatcell) is called and changes are processed,
+   * before they are validated and applied to the data source.
+   * Use [`afterChange`](@/api/hooks.md#afterchange) if you need to react after the data has been written.
    *
    * @event Hooks#afterSetDataAtCell
    * @param {Array} changes An array of changes in format `[[row, column, oldValue, value], ...]`.
@@ -1259,8 +1261,9 @@ export const REGISTERED_HOOKS = [
   'afterSetDataAtCell',
 
   /**
-   * Fired after cell data was changed.
-   * Called only when [`setDataAtRowProp`](@/api/core.md#setdataatrowprop) was executed.
+   * Fired after [`setDataAtRowProp`](@/api/core.md#setdataatrowprop) is called and changes are processed,
+   * before they are validated and applied to the data source.
+   * Use [`afterChange`](@/api/hooks.md#afterchange) if you need to react after the data has been written.
    *
    * @event Hooks#afterSetDataAtRowProp
    * @param {Array} changes An array of changes in format `[[row, prop, oldValue, value], ...]`.


### PR DESCRIPTION
### Context

The PR fixes misleading JSDoc descriptions for the `afterSetDataAtCell` and `afterSetDataAtRowProp` hooks. Both were documented as "Fired after cell data was changed", but the data is **not yet written** when these hooks fire — they run after `processChanges` but before `validateChanges` and `applyChanges`. The hook name is intentional ("after the method was called and changes were processed"), but the old description created a false expectation about data state.

Updated descriptions now accurately state when the hooks fire and point users to `afterChange` for post-write reactions.

Community report: https://github.com/handsontable/handsontable/issues/12795

### How has this been tested?

JSDoc-only change — no behavioral change. No tests required.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1921
2. https://github.com/handsontable/handsontable/issues/12795

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1921

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only for Handsontable hooks with no runtime behavior change; `.mcp.json` is local tooling config.
> 
> **Overview**
> **Corrects hook documentation** for `afterSetDataAtCell` and `afterSetDataAtRowProp` in `handsontable/src/core/hooks/constants.ts`. Both no longer say data was already changed; they now state the hooks run after the corresponding API call and change processing, **before** validation and applying values to the data source, and point integrators to **`afterChange`** when they need to run logic after data is written.
> 
> Separately, **`.mcp.json`** adds a ClickUp MCP header `x-workspace-id` (and fixes JSON trailing comma on the auth header line) so the ClickUp integration targets workspace `9015210959`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78632c434caaff7ec15cf4338550a618177d5f76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->