### PR TITLE
DEV-1922: Fix dynamic hot-column add/remove/reorder in Vue 3 wrapper

### DIFF
--- a/.changelogs/12800.json
+++ b/.changelogs/12800.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed the Vue 3 wrapper not updating the grid when `HotColumn` components were added, removed, or reordered dynamically.",
+  "type": "fixed",
+  "issueOrPR": 12800,
+  "breaking": false,
+  "framework": "vue"
+}

--- a/docs/content/guides/getting-started/vue3-hot-column/vue/example5.vue
+++ b/docs/content/guides/getting-started/vue3-hot-column/vue/example5.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable, HotColumn } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+type TaskRow = {
+  name: string;
+  assignee: string;
+  due: string;
+  status: string;
+};
+
+const tasks = ref<TaskRow[]>([
+  { name: 'Update API docs', assignee: 'Ana García', due: '2025-06-30', status: 'In progress' },
+  { name: 'Deploy hotfix', assignee: 'James Okafor', due: '2025-06-18', status: 'Blocked' },
+  { name: 'Review pull request', assignee: 'Li Wei', due: '2025-06-21', status: 'In progress' },
+]);
+
+const allColumns = [
+  { data: 'name', title: 'Task' },
+  { data: 'assignee', title: 'Assignee' },
+  { data: 'due', title: 'Due date' },
+  { data: 'status', title: 'Status' },
+];
+
+const columns = ref([...allColumns.slice(0, 2)]);
+
+const settings = ref<GridSettings>({
+  height: 'auto',
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+const addColumn = () => {
+  const next = allColumns[columns.value.length];
+
+  if (next) {
+    columns.value.push(next);
+  }
+};
+
+const removeColumn = () => {
+  if (columns.value.length > 1) {
+    columns.value.pop();
+  }
+};
+</script>
+
+<template>
+  <div id="example5">
+    <div class="example-controls-container">
+      <div class="controls">
+        <button type="button" class="button button--primary"
+                :disabled="columns.length >= allColumns.length" @click="addColumn">
+          Add column
+        </button>
+        <button type="button" class="button button--primary"
+                :disabled="columns.length <= 1" @click="removeColumn">
+          Remove column
+        </button>
+      </div>
+    </div>
+    <HotTable :data="tasks" :settings="settings">
+      <HotColumn v-for="column in columns" :key="column.data" :data="column.data" :title="column.title" />
+    </HotTable>
+  </div>
+</template>

--- a/docs/content/guides/getting-started/vue3-hot-column/vue3-hot-column.md
+++ b/docs/content/guides/getting-started/vue3-hot-column/vue3-hot-column.md
@@ -57,6 +57,20 @@ You can declare a custom renderer by creating a function that matches the [`Base
 
 :::
 
+## Render columns dynamically
+
+You can render `<HotColumn/>` components with `v-for` and drive them from a reactive array. When you add, remove, or reorder entries in that array, the grid updates its columns to match. Use a stable `key` (for example, the column's `data` property) so reordering preserves each column's settings.
+
+::: example #example5 :vue3
+
+@[code](@/content/guides/getting-started/vue3-hot-column/vue/example5.vue)
+
+:::
+
+Dynamic rendering also works when a `<HotColumn/>` is nested inside your own wrapper component.
+
+Custom renderers and editors are passed as functions through the `renderer` and `editor` props, as shown above. The Vue 3 wrapper does not render cells from Vue components.
+
 ## Result
 
 Using `HotColumn` child components, each column reads its settings declaratively from Vue props rather than from a flat `columns` array, keeping your template in sync with your column configuration.

--- a/wrappers/vue3/AGENTS.md
+++ b/wrappers/vue3/AGENTS.md
@@ -16,6 +16,13 @@
 - `provide()` exposes settings to HotColumn children
 - Data syncs by reference (no deep copying)
 
+### Dynamic `HotColumn` ordering and updates
+
+`HotColumn` children register their settings in `HotTable`'s `columnsCache` (a `Map` keyed by the column instance) via `provide`/`inject`. Do **not** order columns by `Map` insertion order - it is wrong for mid-list inserts and reorders. Instead:
+
+- Each `HotColumn` renders an invisible comment anchor (`createCommentVNode`) instead of `null`. Handsontable appends its DOM to the container without clearing pre-existing nodes, so the anchors survive. `getColumnSettings()` orders columns by the anchors' `compareDocumentPosition`, which is correct for inserts, removals, and reorders, and works at any nesting depth (including a `HotColumn` inside a user wrapper component).
+- Children call the injected `refreshColumns()` on `mounted`, `unmounted`, and a deep `$props` watch. `HotTable` also calls it from its `updated()` hook to catch reorders of keyed children (which fire no child lifecycle hook). Calls coalesce into one `$nextTick` flush that runs `updateSettings({ columns })` only when the settings-object array changed (compared by reference and order).
+
 ## Key Files
 
 - `src/HotTable.vue`, `src/HotColumn.vue`, `src/helpers.ts`, `src/types.ts`

--- a/wrappers/vue3/src/HotColumn.vue
+++ b/wrappers/vue3/src/HotColumn.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 // eslint-disable-next-line  @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import { defineComponent } from 'vue';
+import { defineComponent, createCommentVNode } from 'vue';
 // TODO: The line above is ts-ignored because rollup-plugin-typescript2 throws an error otherwise.
 // It's most probably caused by outdated rollup-plugin-vue which is no longer maintained.
 
@@ -13,7 +13,7 @@ import {
 const HotColumn = defineComponent({
   name: 'HotColumn',
   props: propFactory('HotColumn'),
-  inject: ['columnsCache'],
+  inject: ['columnsCache', 'refreshColumns'],
   methods: {
     /**
      * Create the column settings based on the data provided to the `hot-column`
@@ -34,14 +34,30 @@ const HotColumn = defineComponent({
       this.columnsCache.set(this, columnSettings);
     }
   },
+  watch: {
+    $props: {
+      handler() {
+        this.createColumnSettings();
+        this.refreshColumns();
+      },
+      deep: true,
+    },
+  },
   mounted() {
     this.createColumnSettings();
+    this.refreshColumns();
   },
   unmounted() {
     this.columnsCache.delete(this);
+    this.refreshColumns();
   },
   render() {
-    return null;
+    // Render an (invisible) comment anchor instead of nothing, so the parent
+    // `HotTable` can order columns by the anchors' document position. This keeps
+    // ordering correct for dynamic inserts, removals, and reorders - and works
+    // regardless of how deeply the `hot-column` is nested inside wrapper
+    // components - because `provide`/`inject` and the anchor both cross nesting.
+    return createCommentVNode('hot-column');
   }
 });
 

--- a/wrappers/vue3/src/HotTable.vue
+++ b/wrappers/vue3/src/HotTable.vue
@@ -1,5 +1,9 @@
 <template>
   <div :id="id" style="height: 100%">
+    <!-- `hot-column` children render invisible comment anchors in source order.
+         Handsontable appends its own DOM to this container without clearing
+         pre-existing nodes, so the anchors survive; the parent reads their
+         document position to order the columns. -->
     <slot></slot>
   </div>
 </template>
@@ -27,7 +31,8 @@ const HotTable = defineComponent({
   props: propFactory('HotTable'),
   provide() {
     return {
-      columnsCache: this.columnsCache
+      columnsCache: this.columnsCache,
+      refreshColumns: this.refreshColumns,
     };
   },
   watch: {
@@ -79,6 +84,7 @@ const HotTable = defineComponent({
       },
       columnSettings: null as HotTableProps[],
       columnsCache: new Map<VNode, HotTableProps>(),
+      columnsRefreshScheduled: false,
       get hotInstance(): Handsontable | null {
         if (!this.__hotInstance || (this.__hotInstance && !this.__hotInstance.isDestroyed)) {
 
@@ -168,17 +174,94 @@ const HotTable = defineComponent({
     /**
      * Get settings for the columns provided in the `hot-column` components.
      *
+     * The columns are ordered by the document position of each `hot-column`'s
+     * anchor node, not by the `columnsCache` insertion order. This keeps the
+     * order correct when columns are inserted in the middle, removed, or
+     * reordered, and when a `hot-column` is nested inside a wrapper component.
+     *
      * @returns {HotTableProps[] | undefined}
      */
     getColumnSettings(): HotTableProps[] | void {
-      const columnSettings: HotTableProps[] = Array.from(this.columnsCache.values());
+      const orderedColumns = Array.from(this.columnsCache.entries())
+        .sort(([columnA], [columnB]) => {
+          const anchorA = (columnA as { $el?: Node }).$el;
+          const anchorB = (columnB as { $el?: Node }).$el;
 
-      return columnSettings.length ? columnSettings : void 0;
+          if (!anchorA || !anchorB) {
+            return 0;
+          }
+
+          const position = anchorA.compareDocumentPosition(anchorB);
+
+          // eslint-disable-next-line no-bitwise
+          if (position & Node.DOCUMENT_POSITION_FOLLOWING) {
+            return -1;
+          }
+
+          // eslint-disable-next-line no-bitwise
+          if (position & Node.DOCUMENT_POSITION_PRECEDING) {
+            return 1;
+          }
+
+          return 0;
+        })
+        .map(([, columnSettings]) => columnSettings);
+
+      return orderedColumns.length ? orderedColumns : void 0;
+    },
+
+    /**
+     * Re-read the column settings declared by `hot-column` children and push them
+     * to the Handsontable instance. Called by children on mount, prop change, and
+     * unmount, and by the parent on reorder. Multiple notifications in the same
+     * tick are coalesced into a single `updateSettings` call.
+     */
+    refreshColumns(): void {
+      if (this.columnsRefreshScheduled) {
+        return;
+      }
+
+      this.columnsRefreshScheduled = true;
+
+      this.$nextTick(() => {
+        this.columnsRefreshScheduled = false;
+
+        if (!this.hotInstance) {
+          return;
+        }
+
+        const newColumnSettings = this.getColumnSettings();
+        const previousColumnSettings = this.columnSettings;
+
+        // Each `hot-column` rebuilds its settings object whenever its props change,
+        // so an unchanged column keeps the same object reference. Comparing the
+        // arrays by reference and order is cheaper than a deep compare and avoids
+        // an `updateSettings` call on unrelated re-renders (e.g. data-only updates).
+        const isUnchanged =
+          (!previousColumnSettings && !newColumnSettings) ||
+          (!!previousColumnSettings && !!newColumnSettings &&
+            previousColumnSettings.length === newColumnSettings.length &&
+            previousColumnSettings.every((settings, index) => settings === newColumnSettings[index]));
+
+        if (isUnchanged) {
+          return;
+        }
+
+        this.columnSettings = newColumnSettings || null;
+        this.hotInstance.updateSettings({ columns: newColumnSettings || void 0 });
+      });
     },
   },
   mounted() {
     this.columnSettings = this.getColumnSettings();
     this.hotInit();
+  },
+  updated() {
+    // Reordering keyed `hot-column` children reuses their instances and fires no
+    // child lifecycle hook, so the children cannot notify on their own. The slot
+    // vnodes do change, which re-renders `HotTable` - refresh from here to cover
+    // reorders (coalesced with any child-triggered refresh).
+    this.refreshColumns();
   },
   beforeUnmount() {
     if (this.hotInstance) {

--- a/wrappers/vue3/test/hotColumn.spec.ts
+++ b/wrappers/vue3/test/hotColumn.spec.ts
@@ -1,4 +1,5 @@
 import { config, mount } from '@vue/test-utils';
+import { nextTick } from 'vue';
 import { registerAllCellTypes } from 'handsontable/registry';
 import HotTable from '../src/HotTable.vue';
 import HotColumn from '../src/HotColumn.vue';
@@ -60,6 +61,332 @@ describe('createColumnSettings', () => {
     expect(hotInstance.getSettings().columns[2].title).toBe('title-3');
     expect(hotInstance.getSettings().columns[2].readOnly).toBe(true);
     expect(hotInstance.getSettings().columns[2].renderer()).toBe('test-value3');
+
+    testWrapper.unmount();
+  });
+});
+
+describe('Dynamic HotColumn add/remove', () => {
+  const columnTitles = hotInstance =>
+    (hotInstance.getSettings().columns || []).map(column => column.title);
+
+  it('should drop column settings when a HotColumn is removed from the end', async() => {
+    const App = {
+      components: { HotTable, HotColumn },
+      data() {
+        return {
+          data: createSampleData(2, 3),
+          columns: ['Sales', 'Marketing', 'Engineering'],
+        };
+      },
+      template: `
+        <HotTable :data="data" licenseKey="non-commercial-and-evaluation"
+                  :autoRowSize="false" :autoColumnSize="false"
+                  :width="300" :height="300" :rowHeights="23" :colWidths="50">
+          <HotColumn v-for="title in columns" :key="title" :title="title"></HotColumn>
+        </HotTable>
+      `
+    };
+
+    const testWrapper = mount(App, { attachTo: document.getElementById('app') });
+    const { hotInstance } = testWrapper.getComponent(HotTable).vm;
+
+    expect(hotInstance.countCols()).toBe(3);
+    expect(columnTitles(hotInstance)).toEqual(['Sales', 'Marketing', 'Engineering']);
+
+    testWrapper.vm.columns.pop();
+
+    await nextTick();
+    await nextTick();
+
+    expect(hotInstance.countCols()).toBe(2);
+    expect(columnTitles(hotInstance)).toEqual(['Sales', 'Marketing']);
+
+    testWrapper.unmount();
+  });
+
+  it('should drop column settings when a HotColumn is removed from the middle (stable keys)', async() => {
+    const App = {
+      components: { HotTable, HotColumn },
+      data() {
+        return {
+          data: createSampleData(2, 3),
+          columns: ['Sales', 'Marketing', 'Engineering'],
+        };
+      },
+      template: `
+        <HotTable :data="data" licenseKey="non-commercial-and-evaluation"
+                  :autoRowSize="false" :autoColumnSize="false"
+                  :width="300" :height="300" :rowHeights="23" :colWidths="50">
+          <HotColumn v-for="title in columns" :key="title" :title="title"></HotColumn>
+        </HotTable>
+      `
+    };
+
+    const testWrapper = mount(App, { attachTo: document.getElementById('app') });
+    const { hotInstance } = testWrapper.getComponent(HotTable).vm;
+
+    expect(hotInstance.countCols()).toBe(3);
+
+    testWrapper.vm.columns = ['Sales', 'Engineering'];
+
+    await nextTick();
+    await nextTick();
+
+    expect(hotInstance.countCols()).toBe(2);
+    expect(columnTitles(hotInstance)).toEqual(['Sales', 'Engineering']);
+
+    testWrapper.unmount();
+  });
+
+  it('should reduce columns to one when all-but-one HotColumns are removed', async() => {
+    const App = {
+      components: { HotTable, HotColumn },
+      data() {
+        return {
+          data: createSampleData(2, 3),
+          columns: ['Sales', 'Marketing', 'Engineering'],
+        };
+      },
+      template: `
+        <HotTable :data="data" licenseKey="non-commercial-and-evaluation"
+                  :autoRowSize="false" :autoColumnSize="false"
+                  :width="300" :height="300" :rowHeights="23" :colWidths="50">
+          <HotColumn v-for="title in columns" :key="title" :title="title"></HotColumn>
+        </HotTable>
+      `
+    };
+
+    const testWrapper = mount(App, { attachTo: document.getElementById('app') });
+    const { hotInstance } = testWrapper.getComponent(HotTable).vm;
+
+    expect(hotInstance.countCols()).toBe(3);
+
+    testWrapper.vm.columns = ['Marketing'];
+
+    await nextTick();
+    await nextTick();
+
+    expect(hotInstance.countCols()).toBe(1);
+    expect(columnTitles(hotInstance)).toEqual(['Marketing']);
+
+    testWrapper.unmount();
+  });
+
+  it('should reflect the new order when HotColumns are reordered via keys', async() => {
+    const App = {
+      components: { HotTable, HotColumn },
+      data() {
+        return {
+          data: createSampleData(2, 3),
+          columns: ['Sales', 'Marketing', 'Engineering'],
+        };
+      },
+      template: `
+        <HotTable :data="data" licenseKey="non-commercial-and-evaluation"
+                  :autoRowSize="false" :autoColumnSize="false"
+                  :width="300" :height="300" :rowHeights="23" :colWidths="50">
+          <HotColumn v-for="title in columns" :key="title" :title="title"></HotColumn>
+        </HotTable>
+      `
+    };
+
+    const testWrapper = mount(App, { attachTo: document.getElementById('app') });
+    const { hotInstance } = testWrapper.getComponent(HotTable).vm;
+
+    expect(columnTitles(hotInstance)).toEqual(['Sales', 'Marketing', 'Engineering']);
+
+    testWrapper.vm.columns = ['Engineering', 'Sales', 'Marketing'];
+
+    await nextTick();
+    await nextTick();
+
+    expect(hotInstance.countCols()).toBe(3);
+    expect(columnTitles(hotInstance)).toEqual(['Engineering', 'Sales', 'Marketing']);
+
+    testWrapper.unmount();
+  });
+
+  it('should handle an add then remove then add cycle', async() => {
+    const App = {
+      components: { HotTable, HotColumn },
+      data() {
+        return {
+          data: createSampleData(2, 3),
+          columns: ['Sales', 'Marketing'],
+        };
+      },
+      template: `
+        <HotTable :data="data" licenseKey="non-commercial-and-evaluation"
+                  :autoRowSize="false" :autoColumnSize="false"
+                  :width="300" :height="300" :rowHeights="23" :colWidths="50">
+          <HotColumn v-for="title in columns" :key="title" :title="title"></HotColumn>
+        </HotTable>
+      `
+    };
+
+    const testWrapper = mount(App, { attachTo: document.getElementById('app') });
+    const { hotInstance } = testWrapper.getComponent(HotTable).vm;
+
+    expect(hotInstance.countCols()).toBe(2);
+
+    testWrapper.vm.columns.push('Engineering');
+
+    await nextTick();
+    await nextTick();
+
+    expect(hotInstance.countCols()).toBe(3);
+    expect(columnTitles(hotInstance)).toEqual(['Sales', 'Marketing', 'Engineering']);
+
+    testWrapper.vm.columns.splice(1, 1);
+
+    await nextTick();
+    await nextTick();
+
+    expect(hotInstance.countCols()).toBe(2);
+    expect(columnTitles(hotInstance)).toEqual(['Sales', 'Engineering']);
+
+    testWrapper.vm.columns.push('Support');
+
+    await nextTick();
+    await nextTick();
+
+    expect(hotInstance.countCols()).toBe(3);
+    expect(columnTitles(hotInstance)).toEqual(['Sales', 'Engineering', 'Support']);
+
+    testWrapper.unmount();
+  });
+
+  it('should keep the renderer on a surviving column after another column is removed', async() => {
+    const App = {
+      components: { HotTable, HotColumn },
+      data() {
+        return {
+          data: createSampleData(2, 2),
+          columns: [
+            { title: 'Sales', renderer: () => 'sales-cell' },
+            { title: 'Marketing', renderer: () => 'marketing-cell' },
+          ],
+        };
+      },
+      template: `
+        <HotTable :data="data" licenseKey="non-commercial-and-evaluation"
+                  :autoRowSize="false" :autoColumnSize="false"
+                  :width="300" :height="300" :rowHeights="23" :colWidths="50">
+          <HotColumn v-for="column in columns" :key="column.title"
+                     :title="column.title" :renderer="column.renderer"></HotColumn>
+        </HotTable>
+      `
+    };
+
+    const testWrapper = mount(App, { attachTo: document.getElementById('app') });
+    const { hotInstance } = testWrapper.getComponent(HotTable).vm;
+
+    expect(hotInstance.countCols()).toBe(2);
+
+    testWrapper.vm.columns = [{ title: 'Sales', renderer: () => 'sales-cell' }];
+
+    await nextTick();
+    await nextTick();
+
+    expect(hotInstance.countCols()).toBe(1);
+
+    const survivingColumns = hotInstance.getSettings().columns;
+
+    expect(survivingColumns[0].title).toBe('Sales');
+    expect(survivingColumns[0].renderer()).toBe('sales-cell');
+
+    testWrapper.unmount();
+  });
+
+  it('should keep the column index mapper in sync when the column count changes', async() => {
+    const App = {
+      components: { HotTable, HotColumn },
+      data() {
+        return {
+          data: createSampleData(3, 4),
+          columns: ['Sales', 'Marketing', 'Engineering', 'Support'],
+        };
+      },
+      template: `
+        <HotTable :data="data" licenseKey="non-commercial-and-evaluation"
+                  :autoRowSize="false" :autoColumnSize="false"
+                  :width="400" :height="300" :rowHeights="23" :colWidths="50">
+          <HotColumn v-for="title in columns" :key="title" :title="title"></HotColumn>
+        </HotTable>
+      `
+    };
+
+    const testWrapper = mount(App, { attachTo: document.getElementById('app') });
+    const { hotInstance } = testWrapper.getComponent(HotTable).vm;
+
+    expect(hotInstance.countCols()).toBe(4);
+    expect(hotInstance.columnIndexMapper.getNumberOfIndexes()).toBe(4);
+
+    testWrapper.vm.columns = ['Sales', 'Engineering'];
+
+    await nextTick();
+    await nextTick();
+
+    expect(hotInstance.countCols()).toBe(2);
+    expect(hotInstance.columnIndexMapper.getNumberOfIndexes()).toBe(2);
+
+    testWrapper.vm.columns = ['Sales', 'Engineering', 'Support', 'Finance', 'Legal'];
+
+    await nextTick();
+    await nextTick();
+
+    expect(hotInstance.countCols()).toBe(5);
+    expect(hotInstance.columnIndexMapper.getNumberOfIndexes()).toBe(5);
+
+    testWrapper.unmount();
+  });
+
+  it('should react to dynamic columns nested inside a wrapper component', async() => {
+    const MyHotColumn = {
+      components: { HotColumn },
+      props: ['title'],
+      template: '<HotColumn :title="title"></HotColumn>'
+    };
+
+    const App = {
+      components: { HotTable, MyHotColumn },
+      data() {
+        return {
+          data: createSampleData(2, 3),
+          columns: ['Sales', 'Marketing', 'Engineering'],
+        };
+      },
+      template: `
+        <HotTable :data="data" licenseKey="non-commercial-and-evaluation"
+                  :autoRowSize="false" :autoColumnSize="false"
+                  :width="300" :height="300" :rowHeights="23" :colWidths="50">
+          <MyHotColumn v-for="title in columns" :key="title" :title="title"></MyHotColumn>
+        </HotTable>
+      `
+    };
+
+    const testWrapper = mount(App, { attachTo: document.getElementById('app') });
+    const { hotInstance } = testWrapper.getComponent(HotTable).vm;
+
+    expect(hotInstance.countCols()).toBe(3);
+    expect(columnTitles(hotInstance)).toEqual(['Sales', 'Marketing', 'Engineering']);
+
+    testWrapper.vm.columns = ['Sales', 'Engineering'];
+
+    await nextTick();
+    await nextTick();
+
+    expect(hotInstance.countCols()).toBe(2);
+    expect(columnTitles(hotInstance)).toEqual(['Sales', 'Engineering']);
+
+    testWrapper.vm.columns.push('Finance');
+
+    await nextTick();
+    await nextTick();
+
+    expect(hotInstance.countCols()).toBe(3);
+    expect(columnTitles(hotInstance)).toEqual(['Sales', 'Engineering', 'Finance']);
 
     testWrapper.unmount();
   });


### PR DESCRIPTION
### Context

The PR fixes dynamic `hot-column` columns in the Vue 3 wrapper. When `<HotColumn>` components are rendered with `v-for` and the backing array changes, adding, removing, or reordering a column did not update the grid. This is the long-standing problem reported in #7544 and #7547.

Root cause: the wrapper read column settings once at mount and never watched the `columnsCache`, and it derived column order from `Map` insertion order (wrong for mid-list inserts and reorders).

Fix:

- `HotColumn` renders an invisible comment anchor (instead of `null`) and notifies `HotTable` via an injected `refreshColumns()` on mount, unmount, and a deep `$props` watch.
- `HotTable` orders columns by the anchors' document position (`compareDocumentPosition`), which is correct for inserts, removals, and reorders, and works at any nesting depth. Its `updated()` hook covers reorders of keyed children (which fire no child lifecycle hook). Notifications coalesce into a single `updateSettings({ columns })` per tick, skipped when the settings-object array is unchanged (reference comparison).
- Because Handsontable appends to its container without clearing pre-existing nodes, the anchors survive — so there is no DOM-structure change to the shipped container (`<div :id><slot/></div>` on `$el` is unchanged).

This also supports a `<HotColumn>` nested inside a user wrapper component (#7547 point 2). Out of scope: component-based cell renderers (Vue 3 uses function renderers only) and #7547 point 3 (Vuex/large-data performance).


https://github.com/user-attachments/assets/49462ff1-d3f8-4a50-a1d0-2274dd1bdf1a


### How has this been tested?

- New dynamic-column suite in `wrappers/vue3/test/hotColumn.spec.ts` (remove from end/middle, reduce to one, reorder, add→remove→add, renderer survival, column-count/index-mapper sync, wrapper-component nesting); existing static `createColumnSettings` test kept.
- `npm run test --prefix wrappers/vue3` — 32/32 passing.
- `npm run lint --prefix wrappers/vue3` — clean (on `src`/`test`).
- All four wrapper build variants compile.
- Manual real-browser check (Chrome): add/remove/reorder and wrapper-nested mode update `countCols`, `columnIndexMapper`, settings, and rendered DOM headers; comment anchors survive; no console errors.
- Docs example `example5.vue` verified rendering and working in the local docs site.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. #7544
2. #7547
3. DEV-1922

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [x] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1922

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Vue 3 column registration and ordering for all HotColumn usage; behavior is well-tested but touches grid update timing and DOM anchor ordering.
> 
> **Overview**
> Fixes the Vue 3 wrapper so a grid driven by **`v-for` `<HotColumn>`** children stays in sync when the column list changes.
> 
> **`HotColumn`** now renders an invisible comment anchor (instead of nothing), watches props deeply, and calls an injected **`refreshColumns()`** on mount, unmount, and prop updates. **`HotTable`** orders columns by those anchors’ document position (not `Map` insertion order), coalesces refreshes into one **`updateSettings({ columns })`** per tick (skipped when the settings array is unchanged by reference), and runs **`refreshColumns()`** from **`updated()`** so keyed reorders work without child lifecycle hooks.
> 
> Adds a docs example for dynamic columns, **`AGENTS.md`** notes on the pattern, a changelog entry, and broad Jest coverage (add/remove/reorder, renderers, index mapper, wrapper nesting).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e121390a993c03011a57d875b8cf0eb694728122. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->