### PR TITLE
DEV-1925 If the table fits well within the viewport, border line is n…

### DIFF
--- a/.changelogs/12802.json
+++ b/.changelogs/12802.json
@@ -1,8 +1,8 @@
 {
   "issuesOrigin": "public",
-  "title": "Fixed a missing selection border edge when a selection sat flush against a frozen-pane boundary (`fixedRowsTop` / `fixedColumnsStart`)",
+  "title": "Fixed a missing selection border edge when a selection sat flush against a frozen-pane boundary (`fixedRowsTop` / `fixedRowsBottom` / `fixedColumnsStart`)",
   "type": "fixed",
-  "issueOrPR": 12781,
+  "issueOrPR": 12802,
   "breaking": false,
   "framework": "none"
 }

--- a/.changelogs/12802.json
+++ b/.changelogs/12802.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "public",
-  "title": "Fixed a missing selection border edge when a selection sat flush against a frozen-pane boundary (`fixedRowsTop` / `fixedRowsBottom` / `fixedColumnsStart`)",
+  "title": "Fixed missing selection border edges and active header highlight accents along frozen-pane boundaries (`fixedRowsTop` / `fixedRowsBottom` / `fixedColumnsStart`).",
   "type": "fixed",
   "issueOrPR": 12802,
   "breaking": false,

--- a/.changelogs/12802.json
+++ b/.changelogs/12802.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed a missing selection border edge when a selection sat flush against a frozen-pane boundary (`fixedRowsTop` / `fixedColumnsStart`)",
+  "type": "fixed",
+  "issueOrPR": 12781,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/src/overlay/top.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/top.ts
@@ -11,6 +11,7 @@ import {
   setOverlayPosition,
   resetCssTransform,
 } from '../../../../helpers/dom/element';
+import { isMobileBrowser } from '../../../../helpers/browser';
 import TopOverlayTable from './../table/top';
 import { Overlay } from './_base';
 import { getCornerStyle } from '../selection';
@@ -226,6 +227,60 @@ export class TopOverlay extends Overlay {
   }
 
   /**
+   * Tells whether the holder must reserve the selection corner's protruding half-height (#6937) for
+   * the given focus selection.
+   *
+   * The corner (the autofill fill handle on desktop, the selection handles on mobile) is drawn at the
+   * selection's bottom-end. The top overlay renders ONLY the frozen top rows, so it must reserve that
+   * protruding space only when the bottom-end corner actually falls within those frozen rows.
+   * Otherwise the corner is drawn by another overlay and reserving here just makes the top clone's
+   * holder taller than its own table — the extra strip stays painted at the frozen-row seam and shows
+   * as a leftover top border after horizontal scroll (e.g. a single cell flush against the freeze
+   * line, whose corner sits one row below the frozen block).
+   *
+   * Beyond that range check: on mobile the selection handles always protrude, so we only need the
+   * range condition; on desktop we additionally require the fill handle to be actually enabled (its
+   * `cornerVisible` border setting resolves truthy), mirroring the visibility gate in `Border#appear`.
+   *
+   * @private
+   * @param {object|null} focusSelection The focus Selection instance (or `null` when none).
+   * @returns {boolean}
+   */
+  shouldReserveSelectionCornerOffset(
+    focusSelection: {
+      settings: Record<string, unknown>;
+      cellRange?: { getBottomEndCorner: () => { row: number | null } } | null;
+    } | null
+  ): boolean {
+    if (!focusSelection || !focusSelection.cellRange) {
+      return false;
+    }
+
+    const fixedRowsTop = (this.wtSettings.getSetting('fixedRowsTop') as number) ?? 0;
+    const bottomEndRow = focusSelection.cellRange.getBottomEndCorner().row;
+
+    // The corner is at the selection's bottom-end; reserve only when it lands inside the frozen rows
+    // this overlay renders.
+    if (bottomEndRow === null || bottomEndRow >= fixedRowsTop) {
+      return false;
+    }
+
+    if (isMobileBrowser()) {
+      return true;
+    }
+
+    const border = focusSelection.settings.border as
+      { cornerVisible?: boolean | ((...args: unknown[]) => boolean) } | undefined;
+    const cornerVisible = border?.cornerVisible;
+
+    if (typeof cornerVisible === 'function') {
+      return !!cornerVisible(focusSelection.settings.layerLevel);
+    }
+
+    return !!cornerVisible;
+  }
+
+  /**
    * Adjust overlay root childs size.
    */
   adjustRootChildrenSize() {
@@ -235,8 +290,13 @@ export class TopOverlay extends Overlay {
 
     const { holder } = this.clone.wtTable;
     const cornerStyle = getCornerStyle(this.wot);
-    const selectionCornerOffset = this.wot.selectionManager
-      .getFocusSelection() ? parseInt(cornerStyle.height as string, 10) / 2 : 0;
+    const focusSelection = this.wot.selectionManager.getFocusSelection();
+    // Reserve the selection corner's protruding half-height only when the corner actually lands in
+    // this overlay's frozen rows (and is actually drawn there). Otherwise the holder ends up taller
+    // than its table and the extra strip leaves a leftover top border at the freeze seam. See the
+    // helper for the full condition.
+    const selectionCornerOffset = this.shouldReserveSelectionCornerOffset(focusSelection)
+      ? parseInt(cornerStyle.height as string, 10) / 2 : 0;
 
     this.clone.wtTable.hider.style.width = this.hider.style.width;
     const holderParent = holder.parentNode as HTMLElement;

--- a/handsontable/src/3rdparty/walkontable/src/overlay/top.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/top.ts
@@ -16,6 +16,7 @@ import TopOverlayTable from './../table/top';
 import { Overlay } from './_base';
 import { getCornerStyle } from '../selection';
 import type { Selection } from '../selection';
+import type { BorderInstanceSettings } from '../selection/border/types';
 import {
   CLONE_TOP,
 } from './constants';
@@ -256,8 +257,7 @@ export class TopOverlay extends Overlay {
       return true;
     }
 
-    const border = focusSelection.settings.border as
-      { cornerVisible?: boolean | ((...args: unknown[]) => boolean) } | undefined;
+    const border = focusSelection.settings.border as BorderInstanceSettings['border'];
     const cornerVisible = border?.cornerVisible;
 
     if (typeof cornerVisible === 'function') {

--- a/handsontable/src/3rdparty/walkontable/src/overlay/top.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/top.ts
@@ -227,20 +227,11 @@ export class TopOverlay extends Overlay {
   }
 
   /**
-   * Tells whether the holder must reserve the selection corner's protruding half-height (#6937) for
-   * the given focus selection.
-   *
-   * The corner (the autofill fill handle on desktop, the selection handles on mobile) is drawn at the
-   * selection's bottom-end. The top overlay renders ONLY the frozen top rows, so it must reserve that
-   * protruding space only when the bottom-end corner actually falls within those frozen rows.
-   * Otherwise the corner is drawn by another overlay and reserving here just makes the top clone's
-   * holder taller than its own table — the extra strip stays painted at the frozen-row seam and shows
-   * as a leftover top border after horizontal scroll (e.g. a single cell flush against the freeze
-   * line, whose corner sits one row below the frozen block).
-   *
-   * Beyond that range check: on mobile the selection handles always protrude, so we only need the
-   * range condition; on desktop we additionally require the fill handle to be actually enabled (its
-   * `cornerVisible` border setting resolves truthy), mirroring the visibility gate in `Border#appear`.
+   * Tells whether the holder must reserve the selection corner's protruding half-height (#6937),
+   * needed only when the selection's bottom-end corner falls within the frozen top rows this overlay
+   * renders — otherwise the reserved strip leaves a leftover top border at the seam. On mobile the
+   * handles always protrude so the range check suffices; on desktop the fill handle must also be
+   * enabled (`cornerVisible` truthy), mirroring `Border#appear`.
    *
    * @private
    * @param {object|null} focusSelection The focus Selection instance (or `null` when none).
@@ -291,10 +282,8 @@ export class TopOverlay extends Overlay {
     const { holder } = this.clone.wtTable;
     const cornerStyle = getCornerStyle(this.wot);
     const focusSelection = this.wot.selectionManager.getFocusSelection();
-    // Reserve the selection corner's protruding half-height only when the corner actually lands in
-    // this overlay's frozen rows (and is actually drawn there). Otherwise the holder ends up taller
-    // than its table and the extra strip leaves a leftover top border at the freeze seam. See the
-    // helper for the full condition.
+    // Reserve the corner's protruding half-height only when it lands in this overlay's frozen rows;
+    // otherwise the holder grows taller than its table and leaves a leftover top border at the seam.
     const selectionCornerOffset = this.shouldReserveSelectionCornerOffset(focusSelection)
       ? parseInt(cornerStyle.height as string, 10) / 2 : 0;
 

--- a/handsontable/src/3rdparty/walkontable/src/overlay/top.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/top.ts
@@ -244,7 +244,7 @@ export class TopOverlay extends Overlay {
       return false;
     }
 
-    const fixedRowsTop = (this.wtSettings.getSetting('fixedRowsTop') as number) ?? 0;
+    const fixedRowsTop = this.wtSettings.getSetting('fixedRowsTop') as number;
     const bottomEndRow = focusSelection.cellRange.getBottomEndCorner().row;
 
     // The corner is at the selection's bottom-end; reserve only when it lands inside the frozen rows

--- a/handsontable/src/3rdparty/walkontable/src/overlay/top.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/top.ts
@@ -15,6 +15,7 @@ import { isMobileBrowser } from '../../../../helpers/browser';
 import TopOverlayTable from './../table/top';
 import { Overlay } from './_base';
 import { getCornerStyle } from '../selection';
+import type { Selection } from '../selection';
 import {
   CLONE_TOP,
 } from './constants';
@@ -234,15 +235,10 @@ export class TopOverlay extends Overlay {
    * enabled (`cornerVisible` truthy), mirroring `Border#appear`.
    *
    * @private
-   * @param {object|null} focusSelection The focus Selection instance (or `null` when none).
+   * @param {Selection|null} focusSelection The focus Selection instance (or `null` when none).
    * @returns {boolean}
    */
-  shouldReserveSelectionCornerOffset(
-    focusSelection: {
-      settings: Record<string, unknown>;
-      cellRange?: { getBottomEndCorner: () => { row: number | null } } | null;
-    } | null
-  ): boolean {
+  shouldReserveSelectionCornerOffset(focusSelection: Selection | null): boolean {
     if (!focusSelection || !focusSelection.cellRange) {
       return false;
     }

--- a/handsontable/src/3rdparty/walkontable/src/selection/border/border.ts
+++ b/handsontable/src/3rdparty/walkontable/src/selection/border/border.ts
@@ -689,10 +689,79 @@ class Border {
   }
 
   /**
+   * Shared inline-axis writer for the row/bottom freeze edges. Given the boundary cells and an
+   * already-resolved vertical position, writes the horizontal anchor + width (RTL-aware) on the
+   * supplied border element and reveals it. The top and bottom freeze edges differ only in which
+   * gridline they sit on and which element they reuse, so they delegate the identical inline math
+   * here. Cheap range/cell-lookup guards run before any reflow-forcing `offset()`, so non-drawing
+   * calls leave the styles untouched.
+   *
+   * @private
+   * @param {number} boundaryRow The row whose edge carries the freeze line.
+   * @param {CSSStyleDeclaration} style The border element to position (`topStyle` or `bottomStyle`).
+   * @param {number} firstColumn The first column index to span (clamped to the overlay).
+   * @param {number} lastColumn The last column index to span (clamped to the overlay).
+   * @param {boolean} isRtl Whether the grid is rendered right-to-left.
+   * @param {number} delta The along-axis length extension (`ceil(borderWidth / 2)`).
+   * @param {Function} resolveTop Resolves the edge's `top` (px) from the boundary cell and offsets.
+   * @returns {boolean} `true` when the edge was drawn.
+   */
+  drawHorizontalFreezeEdge(
+    boundaryRow: number,
+    style: CSSStyleDeclaration,
+    firstColumn: number,
+    lastColumn: number,
+    isRtl: boolean,
+    delta: number,
+    resolveTop: (
+      boundaryTD: HTMLElement, boundaryOffset: { top: number, left: number }, containerTop: number
+    ) => number
+  ): boolean {
+    if (lastColumn < firstColumn) {
+      return false;
+    }
+
+    const { wtTable } = this.wot;
+    const boundaryTD = wtTable.getCell(this.wot.createCellCoords(boundaryRow, firstColumn));
+    const boundaryEndTD = wtTable.getCell(this.wot.createCellCoords(boundaryRow, lastColumn));
+
+    if (!isHTMLElement(boundaryTD) || !isHTMLElement(boundaryEndTD)) {
+      return false;
+    }
+
+    const containerOffset = offset(wtTable.TABLE);
+    const boundaryOffset = offset(boundaryTD);
+    const endOffset = offset(boundaryEndTD);
+
+    // The `-1` overlaps the border shared with the previous column, mirroring `appear`. At column 0
+    // there is no previous column, so drop the shift and shorten the line to avoid protruding past
+    // the pane edge.
+    const startShift = firstColumn === 0 ? 0 : 1;
+
+    this.disappear();
+    style.top = `${resolveTop(boundaryTD, boundaryOffset, containerOffset.top)}px`;
+
+    if (isRtl) {
+      // `firstColumn` (lowest index) is the visual-right cell, `lastColumn` the visual-left one.
+      const spanRightX = boundaryOffset.left + outerWidth(boundaryTD);
+      const tableRightX = containerOffset.left + outerWidth(wtTable.TABLE);
+
+      style.right = `${tableRightX - spanRightX - startShift}px`;
+      style.width = `${spanRightX - endOffset.left + delta - (1 - startShift)}px`;
+    } else {
+      style.left = `${boundaryOffset.left - containerOffset.left - startShift}px`;
+      style.width =
+        `${endOffset.left + outerWidth(boundaryEndTD) - boundaryOffset.left + delta - (1 - startShift)}px`;
+    }
+
+    style.display = 'block';
+
+    return true;
+  }
+
+  /**
    * Draws the selection's top edge on the row freeze line across the given (clamped) column span,
    * anchored one pixel inside the freeze line by a constant so borders of different widths line up.
-   * Cheap range/cell-lookup guards run before any reflow-forcing `offset()`, so non-drawing calls
-   * leave the styles untouched.
    *
    * @private
    * @param {number} firstColumn The first column index to span (clamped to the overlay).
@@ -703,56 +772,21 @@ class Border {
    */
   drawRowFreezeEdge(
     firstColumn: number, lastColumn: number, isRtl: boolean, delta: number): boolean {
-    if (lastColumn < firstColumn) {
-      return false;
-    }
-
-    const { wtTable } = this.wot;
     const boundaryRow = (this.wot.getSetting('fixedRowsTop') as number) - 1;
-    const boundaryTD = wtTable.getCell(this.wot.createCellCoords(boundaryRow, firstColumn));
-    const boundaryEndTD = wtTable.getCell(this.wot.createCellCoords(boundaryRow, lastColumn));
 
-    if (!isHTMLElement(boundaryTD) || !isHTMLElement(boundaryEndTD)) {
-      return false;
-    }
-
-    const containerOffset = offset(wtTable.TABLE);
-    const boundaryOffset = offset(boundaryTD);
-    const freezeLineY = boundaryOffset.top + outerHeight(boundaryTD);
-    const endOffset = offset(boundaryEndTD);
-
-    // The `-1` overlaps the border shared with the previous column, mirroring `appear`. At column 0
-    // there is no previous column, so drop the shift and shorten the line to avoid protruding past
-    // the pane edge.
-    const atFirstColumn = firstColumn === 0;
-    const startShift = atFirstColumn ? 0 : 1;
-
-    this.disappear();
-    this.topStyle!.top = `${freezeLineY - containerOffset.top - 1}px`;
-
-    if (isRtl) {
-      // `firstColumn` (lowest index) is the visual-right cell, `lastColumn` the visual-left one.
-      const spanRightX = boundaryOffset.left + outerWidth(boundaryTD);
-      const tableRightX = containerOffset.left + outerWidth(wtTable.TABLE);
-
-      this.topStyle!.right = `${tableRightX - spanRightX - startShift}px`;
-      this.topStyle!.width = `${spanRightX - endOffset.left + delta - (1 - startShift)}px`;
-    } else {
-      this.topStyle!.left = `${boundaryOffset.left - containerOffset.left - startShift}px`;
-      this.topStyle!.width =
-        `${endOffset.left + outerWidth(boundaryEndTD) - boundaryOffset.left + delta - (1 - startShift)}px`;
-    }
-
-    this.topStyle!.display = 'block';
-
-    return true;
+    // The seam sits on the boundary cell's BOTTOM edge, one pixel up to overlap the shared gridline.
+    return this.drawHorizontalFreezeEdge(
+      boundaryRow, this.topStyle!, firstColumn, lastColumn, isRtl, delta,
+      (boundaryTD, boundaryOffset, containerTop) =>
+        boundaryOffset.top + outerHeight(boundaryTD) - containerTop - 1
+    );
   }
 
   /**
    * Mirror of {@link Border#drawRowFreezeEdge} for the bottom freeze line: draws the selection's
    * bottom edge on the `fixedRowsBottom` line across the given (clamped) column span. The boundary
    * cell is the FIRST bottom-frozen row, and the freeze line is its TOP edge (= bottom of the last
-   * non-frozen row). Uses the `bottom` border element; guard/reflow behavior matches the top variant.
+   * non-frozen row). Uses the `bottom` border element.
    *
    * @private
    * @param {number} firstColumn The first column index to span (clamped to the overlay).
@@ -763,54 +797,18 @@ class Border {
    */
   drawRowFreezeBottomEdge(
     firstColumn: number, lastColumn: number, isRtl: boolean, delta: number): boolean {
-    if (lastColumn < firstColumn) {
-      return false;
-    }
-
-    const { wtTable } = this.wot;
     const fixedRowsBottom = this.wot.getSetting('fixedRowsBottom') as number;
     const totalRows = this.wot.getSetting('totalRows') as number;
     const boundaryRow = totalRows - fixedRowsBottom;
-    const boundaryTD = wtTable.getCell(this.wot.createCellCoords(boundaryRow, firstColumn));
-    const boundaryEndTD = wtTable.getCell(this.wot.createCellCoords(boundaryRow, lastColumn));
 
-    if (!isHTMLElement(boundaryTD) || !isHTMLElement(boundaryEndTD)) {
-      return false;
-    }
-
-    const containerOffset = offset(wtTable.TABLE);
-    const boundaryOffset = offset(boundaryTD);
-    // The freeze line is the TOP edge of the first bottom-frozen row.
-    const freezeLineY = boundaryOffset.top;
-    const endOffset = offset(boundaryEndTD);
-
-    // The `-1` overlaps the border shared with the previous column, mirroring `drawRowFreezeEdge`.
-    const atFirstColumn = firstColumn === 0;
-    const startShift = atFirstColumn ? 0 : 1;
-
-    this.disappear();
-    // Position the edge the same way `appear` does its bottom border — `cellBottom - thickness +
-    // delta` — so borders of different widths stay aligned on the gridline. `cellBottom` here is the
-    // freeze line.
-    const bottomThickness = parseInt(this.bottomStyle!.height, 10);
-
-    this.bottomStyle!.top = `${freezeLineY - containerOffset.top - bottomThickness + delta}px`;
-
-    if (isRtl) {
-      const spanRightX = boundaryOffset.left + outerWidth(boundaryTD);
-      const tableRightX = containerOffset.left + outerWidth(wtTable.TABLE);
-
-      this.bottomStyle!.right = `${tableRightX - spanRightX - startShift}px`;
-      this.bottomStyle!.width = `${spanRightX - endOffset.left + delta - (1 - startShift)}px`;
-    } else {
-      this.bottomStyle!.left = `${boundaryOffset.left - containerOffset.left - startShift}px`;
-      this.bottomStyle!.width =
-        `${endOffset.left + outerWidth(boundaryEndTD) - boundaryOffset.left + delta - (1 - startShift)}px`;
-    }
-
-    this.bottomStyle!.display = 'block';
-
-    return true;
+    // The freeze line is the boundary cell's TOP edge; position like `appear`'s bottom border
+    // (`cellBottom - thickness + delta`, where `cellBottom` is the freeze line) so borders of
+    // different widths stay aligned on the gridline.
+    return this.drawHorizontalFreezeEdge(
+      boundaryRow, this.bottomStyle!, firstColumn, lastColumn, isRtl, delta,
+      (_boundaryTD, boundaryOffset, containerTop) =>
+        boundaryOffset.top - containerTop - parseInt(this.bottomStyle!.height, 10) + delta
+    );
   }
 
   /**
@@ -877,10 +875,65 @@ class Border {
   }
 
   /**
-   * Draws the `borderWidth`-sized square bridging the top and inline-start edges where a selection
-   * corner lands on both freeze lines, since that square sits in the corner overlay's frozen×frozen
-   * region that occludes both edges' tips. Anchored one pixel inside the freeze corner and reuses the
-   * `top` border element; reflow/guard behavior mirrors the freeze-edge helpers.
+   * Shared writer for the freeze-corner squares. Draws the `borderWidth`-sized square bridging a
+   * row/bottom edge and the inline-start edge where a selection corner lands on both freeze lines,
+   * since that square sits in the corner overlay's frozen×frozen region that occludes both edges'
+   * tips. Anchored one pixel inside the freeze column; the caller resolves the vertical position and
+   * the border element to reuse. Reflow/guard behavior mirrors the freeze-edge helpers.
+   *
+   * @private
+   * @param {number} boundaryRow The row whose edge carries the freeze line.
+   * @param {CSSStyleDeclaration} style The border element to position (`topStyle` or `bottomStyle`).
+   * @param {boolean} isRtl Whether the grid is rendered right-to-left.
+   * @param {number} borderWidth The configured border width in pixels.
+   * @param {Function} resolveTop Resolves the square's `top` (px) from the boundary cell and offsets.
+   * @returns {boolean} `true` when the corner square was drawn.
+   */
+  drawFreezeCorner(
+    boundaryRow: number,
+    style: CSSStyleDeclaration,
+    isRtl: boolean,
+    borderWidth: number,
+    resolveTop: (
+      boundaryTD: HTMLElement, boundaryOffset: { top: number, left: number }, containerTop: number
+    ) => number
+  ): boolean {
+    const { wtTable } = this.wot;
+    const boundaryColumn = (this.wot.getSetting('fixedColumnsStart') as number) - 1;
+    const boundaryTD = wtTable.getCell(this.wot.createCellCoords(boundaryRow, boundaryColumn));
+
+    if (!isHTMLElement(boundaryTD)) {
+      return false;
+    }
+
+    const containerOffset = offset(wtTable.TABLE);
+    const boundaryOffset = offset(boundaryTD);
+
+    this.disappear();
+    style.top = `${resolveTop(boundaryTD, boundaryOffset, containerOffset.top)}px`;
+    style.height = `${borderWidth}px`;
+    style.width = `${borderWidth}px`;
+
+    if (isRtl) {
+      // RTL: the frozen pane is on the right, so the freeze line is the boundary cell's LEFT edge;
+      // the square sits one pixel inside it (to the right) via the `right` anchor.
+      const tableRightX = containerOffset.left + outerWidth(wtTable.TABLE);
+
+      style.right = `${tableRightX - boundaryOffset.left - 1}px`;
+    } else {
+      const freezeLineX = boundaryOffset.left + outerWidth(boundaryTD);
+
+      style.left = `${freezeLineX - containerOffset.left - 1}px`;
+    }
+
+    style.display = 'block';
+
+    return true;
+  }
+
+  /**
+   * Draws the corner square bridging the top and inline-start edges where a selection corner lands on
+   * both the `fixedRowsTop` and `fixedColumnsStart` freeze lines. Reuses the `top` border element.
    *
    * @private
    * @param {boolean} isRtl Whether the grid is rendered right-to-left.
@@ -888,48 +941,21 @@ class Border {
    * @returns {boolean} `true` when the corner square was drawn.
    */
   drawFrozenBoundaryCorner(isRtl: boolean, borderWidth: number): boolean {
-    const { wtTable } = this.wot;
     const boundaryRow = (this.wot.getSetting('fixedRowsTop') as number) - 1;
-    const boundaryColumn = (this.wot.getSetting('fixedColumnsStart') as number) - 1;
-    const boundaryTD = wtTable.getCell(this.wot.createCellCoords(boundaryRow, boundaryColumn));
 
-    if (!isHTMLElement(boundaryTD)) {
-      return false;
-    }
-
-    const containerOffset = offset(wtTable.TABLE);
-    const boundaryOffset = offset(boundaryTD);
-    const freezeLineY = boundaryOffset.top + outerHeight(boundaryTD);
-
-    this.disappear();
-    this.topStyle!.top = `${freezeLineY - containerOffset.top - 1}px`;
-    this.topStyle!.height = `${borderWidth}px`;
-    this.topStyle!.width = `${borderWidth}px`;
-
-    if (isRtl) {
-      // RTL: the frozen pane is on the right, so the freeze line is the boundary cell's LEFT edge;
-      // the square sits one pixel inside it (to the right) via the `right` anchor.
-      const tableRightX = containerOffset.left + outerWidth(wtTable.TABLE);
-
-      this.topStyle!.right = `${tableRightX - boundaryOffset.left - 1}px`;
-    } else {
-      const freezeLineX = boundaryOffset.left + outerWidth(boundaryTD);
-
-      this.topStyle!.left = `${freezeLineX - containerOffset.left - 1}px`;
-    }
-
-    this.topStyle!.display = 'block';
-
-    return true;
+    // The square sits on the boundary cell's BOTTOM edge (the top freeze line), one pixel up.
+    return this.drawFreezeCorner(
+      boundaryRow, this.topStyle!, isRtl, borderWidth,
+      (boundaryTD, boundaryOffset, containerTop) =>
+        boundaryOffset.top + outerHeight(boundaryTD) - containerTop - 1
+    );
   }
 
   /**
-   * Bottom mirror of {@link Border#drawFrozenBoundaryCorner}: draws the `borderWidth`-sized square
-   * bridging the bottom and inline-start edges where a selection corner lands on both the
-   * `fixedRowsBottom` and `fixedColumnsStart` freeze lines, since that square sits in the bottom corner
-   * overlay's frozen×frozen region that occludes both edges' tips. The boundary cell is the FIRST
-   * bottom-frozen row, and the bottom freeze line is its TOP edge. Reuses the `bottom` border element;
-   * reflow/guard behavior mirrors the top variant.
+   * Bottom mirror of {@link Border#drawFrozenBoundaryCorner}: draws the corner square bridging the
+   * bottom and inline-start edges where a selection corner lands on both the `fixedRowsBottom` and
+   * `fixedColumnsStart` freeze lines. The boundary cell is the FIRST bottom-frozen row and the bottom
+   * freeze line is its TOP edge. Reuses the `bottom` border element.
    *
    * @private
    * @param {boolean} isRtl Whether the grid is rendered right-to-left.
@@ -937,45 +963,18 @@ class Border {
    * @returns {boolean} `true` when the corner square was drawn.
    */
   drawFrozenBottomBoundaryCorner(isRtl: boolean, borderWidth: number): boolean {
-    const { wtTable } = this.wot;
     const fixedRowsBottom = this.wot.getSetting('fixedRowsBottom') as number;
     const totalRows = this.wot.getSetting('totalRows') as number;
     const boundaryRow = totalRows - fixedRowsBottom;
-    const boundaryColumn = (this.wot.getSetting('fixedColumnsStart') as number) - 1;
-    const boundaryTD = wtTable.getCell(this.wot.createCellCoords(boundaryRow, boundaryColumn));
-
-    if (!isHTMLElement(boundaryTD)) {
-      return false;
-    }
-
-    const containerOffset = offset(wtTable.TABLE);
-    const boundaryOffset = offset(boundaryTD);
-    // The bottom freeze line is the TOP edge of the first bottom-frozen row.
-    const freezeLineY = boundaryOffset.top;
     const delta = Math.ceil(borderWidth / 2);
 
-    this.disappear();
-    // Align the square with the bottom edge's vertical position (`cellBottom - thickness + delta`,
-    // where `cellBottom` is the freeze line) so it joins seamlessly.
-    this.bottomStyle!.top = `${freezeLineY - containerOffset.top - borderWidth + delta}px`;
-    this.bottomStyle!.height = `${borderWidth}px`;
-    this.bottomStyle!.width = `${borderWidth}px`;
-
-    if (isRtl) {
-      // RTL: the frozen pane is on the right, so the freeze line is the boundary cell's LEFT edge;
-      // the square sits one pixel inside it (to the right) via the `right` anchor.
-      const tableRightX = containerOffset.left + outerWidth(wtTable.TABLE);
-
-      this.bottomStyle!.right = `${tableRightX - boundaryOffset.left - 1}px`;
-    } else {
-      const freezeLineX = boundaryOffset.left + outerWidth(boundaryTD);
-
-      this.bottomStyle!.left = `${freezeLineX - containerOffset.left - 1}px`;
-    }
-
-    this.bottomStyle!.display = 'block';
-
-    return true;
+    // Align with the bottom edge's vertical position (`cellBottom - thickness + delta`, where
+    // `cellBottom` is the freeze line = the boundary cell's TOP edge) so it joins seamlessly.
+    return this.drawFreezeCorner(
+      boundaryRow, this.bottomStyle!, isRtl, borderWidth,
+      (_boundaryTD, boundaryOffset, containerTop) =>
+        boundaryOffset.top - containerTop - borderWidth + delta
+    );
   }
 
   /**
@@ -1165,7 +1164,7 @@ class Border {
     // master when the whole selection is in frozen columns (then the inline-start pane occludes it and
     // the corner overlay owns the edge). `inline_start` always hides its row-edge duplicate.
     const seamAllFrozenCols =
-      originalToColumn < ((this.wot.getSetting('fixedColumnsStart') as number) ?? 0);
+      originalToColumn < (this.wot.getSetting('fixedColumnsStart') as number);
 
     if (this.isFrozenBoundaryEdge('row', originalFromRow) &&
         (overlayName === 'inline_start' || (wtTable.isMaster && seamAllFrozenCols))) {

--- a/handsontable/src/3rdparty/walkontable/src/selection/border/border.ts
+++ b/handsontable/src/3rdparty/walkontable/src/selection/border/border.ts
@@ -523,16 +523,21 @@ class Border {
   }
 
   /**
-   * Draws the single selection-border edge that lies exactly on a frozen-pane boundary.
+   * Draws the selection-border edge(s) that lie exactly on a frozen-pane boundary.
    *
-   * When `fixedRowsTop`/`fixedColumnsStart` are used, a selection located in the master pane but
-   * flush against the freeze line has its top/inline-start edge drawn by the master overlay right
-   * on that line, where the frozen overlay (stacked above the master) occludes it. This method
-   * re-draws that one edge inside the frozen overlay (`top` / `inline_start`), just within its
-   * clipped area, so the edge becomes visible. It is a no-op unless the relevant fixed-pane option
-   * is active and the selection's edge is flush with the boundary (`fromRow === fixedRowsTop` /
-   * `fromColumn === fixedColumnsStart`). `appear` hides the matching master edge under the same
-   * condition, so exactly one line is drawn.
+   * When `fixedRowsTop`/`fixedColumnsStart` are used, a selection edge flush against the freeze line
+   * is rendered by the master right on that line, where the frozen overlays (stacked above the
+   * master) occlude it. This re-draws that edge inside the frozen overlay(s) that own it — each
+   * clamped to its own rendered range — so the edge stays visible. `appear` hides the matching
+   * master edge under the same `isFrozenBoundaryEdge` condition, so exactly one line is drawn per
+   * segment.
+   *
+   * A single edge can span more than one frozen overlay when the selection also crosses the
+   * perpendicular freeze line. For example the inline-start edge of a selection that reaches up into
+   * the frozen rows is drawn partly by the `inline_start` overlay (across its non-frozen rows) and
+   * partly by the `top_inline_start_corner` overlay (across its frozen rows); each overlay draws
+   * only the slice it renders. The row-freeze edge behaves symmetrically across the `top` and corner
+   * overlays.
    *
    * @param {number[]} corners The selection corners `[fromRow, fromColumn, toRow, toColumn]`.
    * @returns {boolean} `true` when a boundary edge was drawn (regular drawing should be skipped).
@@ -542,8 +547,9 @@ class Border {
     const overlayName = wtTable.name;
     const isTopOverlay = overlayName === 'top';
     const isInlineStartOverlay = overlayName === 'inline_start';
+    const isCornerOverlay = overlayName === 'top_inline_start_corner';
 
-    if (!isTopOverlay && !isInlineStartOverlay) {
+    if (!isTopOverlay && !isInlineStartOverlay && !isCornerOverlay) {
       return false;
     }
 
@@ -552,11 +558,6 @@ class Border {
     // is direction-agnostic.
     const isRtl = this.wot.wtSettings.getSetting('rtlMode');
     const [fromRow, fromColumn, toRow, toColumn] = corners;
-    // Cross-axis offset for the thin dimension of the boundary line. The frozen overlay clips its
-    // content at the freeze line, so the line is anchored by its FAR edge (bottom for `top`,
-    // inline-end for `inline_start`) flush to that line — i.e. shifted by its own thickness — to keep
-    // it fully inside the clipped pane for borders thicker than 1px. This intentionally differs from
-    // the `-1` table-border compensation used on the along-axis (which mirrors the regular `appear`).
     const borderWidth = this.settings.border?.width ?? 0;
     // Along-axis extension applied to the line's length, mirroring `appear` (which adds
     // `ceil(borderWidth / 2)` to every edge's width/height so the corners meet). Without it the
@@ -564,76 +565,113 @@ class Border {
     // for borders thicker than 1px.
     const delta = Math.ceil(borderWidth / 2);
 
-    // The cheap integer/DOM-lookup guards below run first; `offset()` (which forces a layout
-    // reflow) is deferred to the success path so the common bail-outs stay reflow-free.
-    if (isTopOverlay) {
-      const fixedRowsTop = this.wot.getSetting('fixedRowsTop') as number;
-
-      // Decision shared with the master's suppression via `isFrozenBoundaryEdge`, so both panes
-      // agree on which one owns the edge. The rendered-range and cell-lookup guards below are
-      // defensive: if any fails, the edge is off-screen or not renderable in this overlay, in which
-      // case it simply stays hidden on both panes (a visual no-op).
-      if (!this.isFrozenBoundaryEdge('row', fromRow)) {
-        return false;
-      }
-
+    // The row-freeze edge (selection top edge on the row freeze line) is owned by the `top` overlay
+    // across the non-frozen columns and by the corner overlay across the frozen columns the
+    // selection reaches. Each overlay clamps the span to its own rendered columns, so together they
+    // cover the whole edge with no overlap. `getFirstRenderedColumn`/`getLastRenderedColumn` return
+    // the frozen block for the corner overlay and the scrolled viewport for the `top` overlay.
+    if (this.isFrozenBoundaryEdge('row', fromRow) && (isTopOverlay || isCornerOverlay)) {
       const firstColumn = Math.max(fromColumn, wtTable.getFirstRenderedColumn());
       const lastColumn = Math.min(toColumn, wtTable.getLastRenderedColumn());
 
-      if (lastColumn < firstColumn) {
-        return false;
+      if (this.drawRowFreezeEdge(firstColumn, lastColumn, isRtl, borderWidth, delta)) {
+        return true;
       }
-
-      const boundaryRow = fixedRowsTop - 1;
-      const boundaryTD = wtTable.getCell(this.wot.createCellCoords(boundaryRow, firstColumn));
-      const boundaryEndTD = wtTable.getCell(this.wot.createCellCoords(boundaryRow, lastColumn));
-
-      if (!isHTMLElement(boundaryTD) || !isHTMLElement(boundaryEndTD)) {
-        return false;
-      }
-
-      const containerOffset = offset(wtTable.TABLE);
-      const boundaryOffset = offset(boundaryTD);
-      const freezeLineY = boundaryOffset.top + outerHeight(boundaryTD);
-      const endOffset = offset(boundaryEndTD);
-
-      this.disappear();
-      this.topStyle!.top = `${freezeLineY - containerOffset.top - borderWidth}px`;
-
-      if (isRtl) {
-        // `firstColumn` (lowest index) is the visual-right cell, `lastColumn` the visual-left one.
-        const spanRightX = boundaryOffset.left + outerWidth(boundaryTD);
-        const tableRightX = containerOffset.left + outerWidth(wtTable.TABLE);
-
-        this.topStyle!.right = `${tableRightX - spanRightX - 1}px`;
-        this.topStyle!.width = `${spanRightX - endOffset.left + delta}px`;
-      } else {
-        this.topStyle!.left = `${boundaryOffset.left - containerOffset.left - 1}px`;
-        this.topStyle!.width = `${endOffset.left + outerWidth(boundaryEndTD) - boundaryOffset.left + delta}px`;
-      }
-
-      this.topStyle!.display = 'block';
-
-      return true;
     }
 
-    // inline_start overlay → draw the inline-start (left, in LTR) edge on the column freeze line.
-    const fixedColumnsStart = this.wot.getSetting('fixedColumnsStart') as number;
+    // The column-freeze edge (selection inline-start edge on the column freeze line) is owned by the
+    // `inline_start` overlay across the non-frozen rows and by the corner overlay across the frozen
+    // rows the selection reaches. Mirror of the branch above on the column axis.
+    if (this.isFrozenBoundaryEdge('column', fromColumn) && (isInlineStartOverlay || isCornerOverlay)) {
+      const firstRow = Math.max(fromRow, wtTable.getFirstRenderedRow());
+      const lastRow = Math.min(toRow, wtTable.getLastRenderedRow());
 
-    // Mirror of the top branch on the column axis. Decision shared with the master via
-    // `isFrozenBoundaryEdge`; the later guards are defensive (see the top branch).
-    if (!this.isFrozenBoundaryEdge('column', fromColumn)) {
+      if (this.drawColumnFreezeEdge(firstRow, lastRow, isRtl, borderWidth, delta)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Draws the selection's top edge on the row freeze line across the given (already clamped) column
+   * span within the current overlay. The line is anchored by its bottom edge flush to the freeze
+   * line — shifted up by its own thickness — to keep it inside the clipped pane for borders thicker
+   * than 1px. The cheap range/cell-lookup guards run before any `offset()` (which forces a layout
+   * reflow), so non-drawing calls stay reflow-free and leave the styles untouched for the caller to
+   * try the other axis.
+   *
+   * @private
+   * @param {number} firstColumn The first column index to span (clamped to the overlay).
+   * @param {number} lastColumn The last column index to span (clamped to the overlay).
+   * @param {boolean} isRtl Whether the grid is rendered right-to-left.
+   * @param {number} borderWidth The configured border width in pixels.
+   * @param {number} delta The along-axis length extension (`ceil(borderWidth / 2)`).
+   * @returns {boolean} `true` when the edge was drawn.
+   */
+  drawRowFreezeEdge(
+    firstColumn: number, lastColumn: number, isRtl: boolean, borderWidth: number, delta: number): boolean {
+    if (lastColumn < firstColumn) {
       return false;
     }
 
-    const firstRow = Math.max(fromRow, wtTable.getFirstRenderedRow());
-    const lastRow = Math.min(toRow, wtTable.getLastRenderedRow());
+    const { wtTable } = this.wot;
+    const boundaryRow = (this.wot.getSetting('fixedRowsTop') as number) - 1;
+    const boundaryTD = wtTable.getCell(this.wot.createCellCoords(boundaryRow, firstColumn));
+    const boundaryEndTD = wtTable.getCell(this.wot.createCellCoords(boundaryRow, lastColumn));
 
+    if (!isHTMLElement(boundaryTD) || !isHTMLElement(boundaryEndTD)) {
+      return false;
+    }
+
+    const containerOffset = offset(wtTable.TABLE);
+    const boundaryOffset = offset(boundaryTD);
+    const freezeLineY = boundaryOffset.top + outerHeight(boundaryTD);
+    const endOffset = offset(boundaryEndTD);
+
+    this.disappear();
+    this.topStyle!.top = `${freezeLineY - containerOffset.top - borderWidth}px`;
+
+    if (isRtl) {
+      // `firstColumn` (lowest index) is the visual-right cell, `lastColumn` the visual-left one.
+      const spanRightX = boundaryOffset.left + outerWidth(boundaryTD);
+      const tableRightX = containerOffset.left + outerWidth(wtTable.TABLE);
+
+      this.topStyle!.right = `${tableRightX - spanRightX - 1}px`;
+      this.topStyle!.width = `${spanRightX - endOffset.left + delta}px`;
+    } else {
+      this.topStyle!.left = `${boundaryOffset.left - containerOffset.left - 1}px`;
+      this.topStyle!.width = `${endOffset.left + outerWidth(boundaryEndTD) - boundaryOffset.left + delta}px`;
+    }
+
+    this.topStyle!.display = 'block';
+
+    return true;
+  }
+
+  /**
+   * Draws the selection's inline-start edge on the column freeze line across the given (already
+   * clamped) row span within the current overlay. The line is anchored by its inline-end edge flush
+   * to the freeze line — shifted by its own thickness — to keep it inside the clipped pane for
+   * borders thicker than 1px. Guard/reflow behavior mirrors `drawRowFreezeEdge`.
+   *
+   * @private
+   * @param {number} firstRow The first row index to span (clamped to the overlay).
+   * @param {number} lastRow The last row index to span (clamped to the overlay).
+   * @param {boolean} isRtl Whether the grid is rendered right-to-left.
+   * @param {number} borderWidth The configured border width in pixels.
+   * @param {number} delta The along-axis length extension (`ceil(borderWidth / 2)`).
+   * @returns {boolean} `true` when the edge was drawn.
+   */
+  drawColumnFreezeEdge(
+    firstRow: number, lastRow: number, isRtl: boolean, borderWidth: number, delta: number): boolean {
     if (lastRow < firstRow) {
       return false;
     }
 
-    const boundaryColumn = fixedColumnsStart - 1;
+    const { wtTable } = this.wot;
+    const boundaryColumn = (this.wot.getSetting('fixedColumnsStart') as number) - 1;
     const boundaryTD = wtTable.getCell(this.wot.createCellCoords(firstRow, boundaryColumn));
     const boundaryEndTD = wtTable.getCell(this.wot.createCellCoords(lastRow, boundaryColumn));
 

--- a/handsontable/src/3rdparty/walkontable/src/selection/border/border.ts
+++ b/handsontable/src/3rdparty/walkontable/src/selection/border/border.ts
@@ -628,10 +628,10 @@ class Border {
     const bottomRowEdgeOwned = this.isFrozenBottomBoundaryEdge(toRow) &&
       !this.isBottomBoundaryCornerScrolledOut(toRow);
 
-    // The row-freeze edge is split between the `top` overlay (non-frozen columns) and the corner
-    // overlay (frozen columns), each clamped to its own rendered column range so together they cover
-    // the edge without overlap. The rendered (not visible) range keeps a partially scrolled boundary
-    // column pinned to the freeze line; scroll occlusion is handled by `rowEdgeOwned`.
+    // The row-freeze edge straddles the freeze line: the master draws its lower half (below the seam)
+    // and the frozen overlay its upper half (above the seam, on top of the opaque pane), so together
+    // they show the full thickness in both selection and edit modes. Split between the `top` overlay
+    // (non-frozen columns) and the corner overlay (frozen columns), each clamped to its rendered range.
     if (rowEdgeOwned && (isTopOverlay || isCornerOverlay)) {
       const firstColumn = Math.max(fromColumn, wtTable.getFirstRenderedColumn());
       const lastColumn = Math.min(toColumn, wtTable.getLastRenderedColumn());
@@ -790,11 +790,8 @@ class Border {
 
     this.disappear();
     // Position the edge the same way `appear` does its bottom border — `cellBottom - thickness +
-    // delta` — so borders of different widths (e.g. the thick focus cell vs. the thinner area cells)
-    // stay aligned on the gridline instead of the thicker one hanging 1px lower. `cellBottom` here is
-    // the freeze line. The result is at most `-ceil(thickness / 2)`, so the `bottom` overlay's top clip
-    // only trims the half that lies above the seam (which the master would draw) — the edge stays
-    // visible and on the line.
+    // delta` — so borders of different widths stay aligned on the gridline. `cellBottom` here is the
+    // freeze line.
     const bottomThickness = parseInt(this.bottomStyle!.height, 10);
 
     this.bottomStyle!.top = `${freezeLineY - containerOffset.top - bottomThickness + delta}px`;
@@ -994,6 +991,10 @@ class Border {
     // A selection flush against a frozen-pane boundary has its top/inline-start edge rendered by the
     // master on the freeze line, where the frozen overlay occludes it. Re-draw it inside the frozen
     // overlay so it stays visible; no-op unless `fixedRowsTop`/`fixedColumnsStart` is used.
+    //
+    // When it draws, we return early and intentionally skip the rest of `appear` (corner/fill handle,
+    // the other edges): in these overlays the selection's cell isn't rendered here — only the seam
+    // edge slice is — so there is nothing else to draw.
     if (this.drawFrozenBoundaryEdge(corners)) {
       return;
     }
@@ -1005,6 +1006,7 @@ class Border {
     const originalFromRow = fromRow;
     const originalFromColumn = fromColumn;
     const originalToRow = toRow;
+    const originalToColumn = toColumn;
 
     // borders can not be rendered on headers so hide them
     if (fromRow < 0 && toRow < 0 || fromColumn < 0 && toColumn < 0) {
@@ -1158,18 +1160,28 @@ class Border {
     // edge is hidden on the master and `inline_start`; the column-freeze edge on the master and `top`.
     const overlayName = wtTable.name;
 
+    // The master keeps drawing the seam top edge (its straddling lower half stays visible below the
+    // frozen pane / editor); the frozen overlay adds the upper half on top of the pane. Only hide the
+    // master when the whole selection is in frozen columns (then the inline-start pane occludes it and
+    // the corner overlay owns the edge). `inline_start` always hides its row-edge duplicate.
+    const seamAllFrozenCols =
+      originalToColumn < ((this.wot.getSetting('fixedColumnsStart') as number) ?? 0);
+
     if (this.isFrozenBoundaryEdge('row', originalFromRow) &&
-        (wtTable.isMaster || overlayName === 'inline_start')) {
+        (overlayName === 'inline_start' || (wtTable.isMaster && seamAllFrozenCols))) {
       this.topStyle!.display = 'none';
     }
     if (this.isFrozenBoundaryEdge('column', originalFromColumn) &&
         (wtTable.isMaster || overlayName === 'top' || overlayName === 'bottom')) {
       this.startStyle!.display = 'none';
     }
-    // The bottom-freeze edge is owned by the `bottom`/`bottom_inline_start_corner` overlays; hide the
-    // master's and `inline_start`'s redraw of it so the lines don't stack into a doubled border.
+    // The bottom-freeze edge straddles its seam: the master draws the half above the freeze line and
+    // the `bottom` overlay the half below it (on top of the opaque bottom pane), so together they show
+    // the full thickness in both selection and edit modes. Hide the master only when the whole
+    // selection is in frozen columns (then the inline-start pane occludes it and the bottom corner owns
+    // the edge); `inline_start` always hides its duplicate.
     if (this.isFrozenBottomBoundaryEdge(originalToRow) &&
-        (wtTable.isMaster || overlayName === 'inline_start')) {
+        (overlayName === 'inline_start' || (wtTable.isMaster && seamAllFrozenCols))) {
       this.bottomStyle!.display = 'none';
     }
 

--- a/handsontable/src/3rdparty/walkontable/src/selection/border/border.ts
+++ b/handsontable/src/3rdparty/walkontable/src/selection/border/border.ts
@@ -609,11 +609,19 @@ class Border {
 
     // The row-freeze edge (selection top edge on the row freeze line) is owned by the `top` overlay
     // across the non-frozen columns and by the corner overlay across the frozen columns the
-    // selection reaches. Each overlay clamps the span to its own rendered columns, so together they
-    // cover the whole edge with no overlap. `getFirstRenderedColumn`/`getLastRenderedColumn` return
-    // the frozen block for the corner overlay and the scrolled viewport for the `top` overlay.
+    // selection reaches. Each overlay clamps the span to its own columns, so together they cover the
+    // whole edge with no overlap. The inline-start bound uses `getFirstVisibleColumn` (not
+    // `...Rendered`): in the `top` overlay the rendered range includes the off-screen buffer columns
+    // that have scrolled behind the inline-start frozen pane, so clamping to rendered would keep
+    // drawing the edge for a boundary cell already occluded by the pane — the line would slide over
+    // the frozen columns as you scroll horizontally. The visible range excludes those, mirroring the
+    // scroll-aware occlusion check `isBoundaryCornerScrolledOut` does on the perpendicular axis. The
+    // inline-end bound stays `getLastRenderedColumn`: there is no pane on that side, so a line
+    // running a buffer column past the viewport is harmlessly clipped by the container, and using the
+    // visible bound there would instead leave a gap at a partially visible last column. For the
+    // corner overlay both visible and rendered resolve to the same sticky frozen block.
     if (rowEdgeOwned && (isTopOverlay || isCornerOverlay)) {
-      const firstColumn = Math.max(fromColumn, wtTable.getFirstRenderedColumn());
+      const firstColumn = Math.max(fromColumn, wtTable.getFirstVisibleColumn());
       const lastColumn = Math.min(toColumn, wtTable.getLastRenderedColumn());
 
       if (this.drawRowFreezeEdge(firstColumn, lastColumn, isRtl, delta)) {

--- a/handsontable/src/3rdparty/walkontable/src/selection/border/border.ts
+++ b/handsontable/src/3rdparty/walkontable/src/selection/border/border.ts
@@ -547,6 +547,43 @@ class Border {
   }
 
   /**
+   * Mirror of {@link Border#isFrozenBoundaryEdge} for the bottom freeze line: tells whether the
+   * selection's bottom edge lands exactly on the `fixedRowsBottom` boundary (the line between the last
+   * non-frozen row and the first bottom-frozen row), and is therefore owned by the bottom overlay.
+   *
+   * @private
+   * @param {number} toIndex The selection's bottom corner row index.
+   * @returns {boolean}
+   */
+  isFrozenBottomBoundaryEdge(toIndex: number): boolean {
+    const fixedRowsBottom = this.wot.getSetting('fixedRowsBottom') as number;
+    const totalRows = this.wot.getSetting('totalRows') as number;
+
+    return fixedRowsBottom > 0 && toIndex === totalRows - fixedRowsBottom - 1;
+  }
+
+  /**
+   * Mirror of {@link Border#isBoundaryCornerScrolledOut} for the bottom freeze line: tells whether the
+   * selection's bottom boundary cell has scrolled behind the bottom frozen pane in the master viewport
+   * (it then drops below the last visible master row), so the edge must not be drawn.
+   *
+   * @private
+   * @param {number} toIndex The selection's bottom boundary corner row index.
+   * @returns {boolean} `true` when the boundary corner is scrolled out (edge must not be drawn).
+   */
+  isBottomBoundaryCornerScrolledOut(toIndex: number): boolean {
+    const masterTable = this.wot.cloneSource?.wtTable;
+
+    if (!masterTable) {
+      return false;
+    }
+
+    const lastVisible = masterTable.getLastVisibleRow();
+
+    return lastVisible >= 0 && toIndex > lastVisible;
+  }
+
+  /**
    * Draws the selection-border edge(s) that lie exactly on a frozen-pane boundary, where the master
    * renders them on the freeze line under the occluding frozen overlay. Re-draws each such edge
    * inside the frozen overlay(s) that own it (clamped to each overlay's rendered range), while
@@ -561,8 +598,11 @@ class Border {
     const isTopOverlay = overlayName === 'top';
     const isInlineStartOverlay = overlayName === 'inline_start';
     const isCornerOverlay = overlayName === 'top_inline_start_corner';
+    const isBottomOverlay = overlayName === 'bottom';
+    const isBottomCornerOverlay = overlayName === 'bottom_inline_start_corner';
 
-    if (!isTopOverlay && !isInlineStartOverlay && !isCornerOverlay) {
+    if (!isTopOverlay && !isInlineStartOverlay && !isCornerOverlay &&
+        !isBottomOverlay && !isBottomCornerOverlay) {
       return false;
     }
 
@@ -583,6 +623,11 @@ class Border {
     const columnEdgeOwned = this.isFrozenBoundaryEdge('column', fromColumn) &&
       !this.isBoundaryCornerScrolledOut('column', fromColumn);
 
+    // The bottom-freeze counterpart of `rowEdgeOwned`: the selection's bottom edge lands on the
+    // `fixedRowsBottom` line and its boundary cell is still visible in the master.
+    const bottomRowEdgeOwned = this.isFrozenBottomBoundaryEdge(toRow) &&
+      !this.isBottomBoundaryCornerScrolledOut(toRow);
+
     // The row-freeze edge is split between the `top` overlay (non-frozen columns) and the corner
     // overlay (frozen columns), each clamped to its own rendered column range so together they cover
     // the edge without overlap. The rendered (not visible) range keeps a partially scrolled boundary
@@ -597,12 +642,27 @@ class Border {
     }
 
     // The column-freeze edge is split between the `inline_start` overlay (non-frozen rows) and the
-    // corner overlay (frozen rows). Mirror of the branch above on the column axis.
-    if (columnEdgeOwned && (isInlineStartOverlay || isCornerOverlay)) {
+    // top/bottom corner overlays (top-frozen / bottom-frozen rows), each clamped to its own rendered
+    // row range so together they cover the edge without overlap. Mirror of the row-freeze branch on
+    // the column axis. Without the bottom corner the slice that reaches down into the bottom-frozen
+    // rows would be occluded by that overlay and left undrawn.
+    if (columnEdgeOwned && (isInlineStartOverlay || isCornerOverlay || isBottomCornerOverlay)) {
       const firstRow = Math.max(fromRow, wtTable.getFirstRenderedRow());
       const lastRow = Math.min(toRow, wtTable.getLastRenderedRow());
 
       if (this.drawColumnFreezeEdge(firstRow, lastRow, isRtl, delta)) {
+        return true;
+      }
+    }
+
+    // The bottom-freeze edge is split between the `bottom` overlay (non-frozen columns) and the bottom
+    // corner overlay (frozen columns), mirroring the row-freeze branch on the bottom axis. The bottom
+    // overlay occludes the master's edge on the freeze line, so re-draw it here.
+    if (bottomRowEdgeOwned && (isBottomOverlay || isBottomCornerOverlay)) {
+      const firstColumn = Math.max(fromColumn, wtTable.getFirstRenderedColumn());
+      const lastColumn = Math.min(toColumn, wtTable.getLastRenderedColumn());
+
+      if (this.drawRowFreezeBottomEdge(firstColumn, lastColumn, isRtl, delta)) {
         return true;
       }
     }
@@ -612,6 +672,15 @@ class Border {
     // connecting square here to close it.
     if (isCornerOverlay && rowEdgeOwned && columnEdgeOwned) {
       if (this.drawFrozenBoundaryCorner(isRtl, borderWidth)) {
+        return true;
+      }
+    }
+
+    // Bottom mirror of the branch above: when the corner lands on BOTH the bottom and column freeze
+    // lines, the bottom and start edges meet in the bottom corner overlay's frozen×frozen square,
+    // which occludes their tips. Draw that connecting square here to close the gap.
+    if (isBottomCornerOverlay && bottomRowEdgeOwned && columnEdgeOwned) {
+      if (this.drawFrozenBottomBoundaryCorner(isRtl, borderWidth)) {
         return true;
       }
     }
@@ -675,6 +744,74 @@ class Border {
     }
 
     this.topStyle!.display = 'block';
+
+    return true;
+  }
+
+  /**
+   * Mirror of {@link Border#drawRowFreezeEdge} for the bottom freeze line: draws the selection's
+   * bottom edge on the `fixedRowsBottom` line across the given (clamped) column span. The boundary
+   * cell is the FIRST bottom-frozen row, and the freeze line is its TOP edge (= bottom of the last
+   * non-frozen row). Uses the `bottom` border element; guard/reflow behavior matches the top variant.
+   *
+   * @private
+   * @param {number} firstColumn The first column index to span (clamped to the overlay).
+   * @param {number} lastColumn The last column index to span (clamped to the overlay).
+   * @param {boolean} isRtl Whether the grid is rendered right-to-left.
+   * @param {number} delta The along-axis length extension (`ceil(borderWidth / 2)`).
+   * @returns {boolean} `true` when the edge was drawn.
+   */
+  drawRowFreezeBottomEdge(
+    firstColumn: number, lastColumn: number, isRtl: boolean, delta: number): boolean {
+    if (lastColumn < firstColumn) {
+      return false;
+    }
+
+    const { wtTable } = this.wot;
+    const fixedRowsBottom = this.wot.getSetting('fixedRowsBottom') as number;
+    const totalRows = this.wot.getSetting('totalRows') as number;
+    const boundaryRow = totalRows - fixedRowsBottom;
+    const boundaryTD = wtTable.getCell(this.wot.createCellCoords(boundaryRow, firstColumn));
+    const boundaryEndTD = wtTable.getCell(this.wot.createCellCoords(boundaryRow, lastColumn));
+
+    if (!isHTMLElement(boundaryTD) || !isHTMLElement(boundaryEndTD)) {
+      return false;
+    }
+
+    const containerOffset = offset(wtTable.TABLE);
+    const boundaryOffset = offset(boundaryTD);
+    // The freeze line is the TOP edge of the first bottom-frozen row.
+    const freezeLineY = boundaryOffset.top;
+    const endOffset = offset(boundaryEndTD);
+
+    // The `-1` overlaps the border shared with the previous column, mirroring `drawRowFreezeEdge`.
+    const atFirstColumn = firstColumn === 0;
+    const startShift = atFirstColumn ? 0 : 1;
+
+    this.disappear();
+    // Position the edge the same way `appear` does its bottom border — `cellBottom - thickness +
+    // delta` — so borders of different widths (e.g. the thick focus cell vs. the thinner area cells)
+    // stay aligned on the gridline instead of the thicker one hanging 1px lower. `cellBottom` here is
+    // the freeze line. The result is at most `-ceil(thickness / 2)`, so the `bottom` overlay's top clip
+    // only trims the half that lies above the seam (which the master would draw) — the edge stays
+    // visible and on the line.
+    const bottomThickness = parseInt(this.bottomStyle!.height, 10);
+
+    this.bottomStyle!.top = `${freezeLineY - containerOffset.top - bottomThickness + delta}px`;
+
+    if (isRtl) {
+      const spanRightX = boundaryOffset.left + outerWidth(boundaryTD);
+      const tableRightX = containerOffset.left + outerWidth(wtTable.TABLE);
+
+      this.bottomStyle!.right = `${tableRightX - spanRightX - startShift}px`;
+      this.bottomStyle!.width = `${spanRightX - endOffset.left + delta - (1 - startShift)}px`;
+    } else {
+      this.bottomStyle!.left = `${boundaryOffset.left - containerOffset.left - startShift}px`;
+      this.bottomStyle!.width =
+        `${endOffset.left + outerWidth(boundaryEndTD) - boundaryOffset.left + delta - (1 - startShift)}px`;
+    }
+
+    this.bottomStyle!.display = 'block';
 
     return true;
   }
@@ -790,6 +927,61 @@ class Border {
   }
 
   /**
+   * Bottom mirror of {@link Border#drawFrozenBoundaryCorner}: draws the `borderWidth`-sized square
+   * bridging the bottom and inline-start edges where a selection corner lands on both the
+   * `fixedRowsBottom` and `fixedColumnsStart` freeze lines, since that square sits in the bottom corner
+   * overlay's frozen×frozen region that occludes both edges' tips. The boundary cell is the FIRST
+   * bottom-frozen row, and the bottom freeze line is its TOP edge. Reuses the `bottom` border element;
+   * reflow/guard behavior mirrors the top variant.
+   *
+   * @private
+   * @param {boolean} isRtl Whether the grid is rendered right-to-left.
+   * @param {number} borderWidth The configured border width in pixels.
+   * @returns {boolean} `true` when the corner square was drawn.
+   */
+  drawFrozenBottomBoundaryCorner(isRtl: boolean, borderWidth: number): boolean {
+    const { wtTable } = this.wot;
+    const fixedRowsBottom = this.wot.getSetting('fixedRowsBottom') as number;
+    const totalRows = this.wot.getSetting('totalRows') as number;
+    const boundaryRow = totalRows - fixedRowsBottom;
+    const boundaryColumn = (this.wot.getSetting('fixedColumnsStart') as number) - 1;
+    const boundaryTD = wtTable.getCell(this.wot.createCellCoords(boundaryRow, boundaryColumn));
+
+    if (!isHTMLElement(boundaryTD)) {
+      return false;
+    }
+
+    const containerOffset = offset(wtTable.TABLE);
+    const boundaryOffset = offset(boundaryTD);
+    // The bottom freeze line is the TOP edge of the first bottom-frozen row.
+    const freezeLineY = boundaryOffset.top;
+    const delta = Math.ceil(borderWidth / 2);
+
+    this.disappear();
+    // Align the square with the bottom edge's vertical position (`cellBottom - thickness + delta`,
+    // where `cellBottom` is the freeze line) so it joins seamlessly.
+    this.bottomStyle!.top = `${freezeLineY - containerOffset.top - borderWidth + delta}px`;
+    this.bottomStyle!.height = `${borderWidth}px`;
+    this.bottomStyle!.width = `${borderWidth}px`;
+
+    if (isRtl) {
+      // RTL: the frozen pane is on the right, so the freeze line is the boundary cell's LEFT edge;
+      // the square sits one pixel inside it (to the right) via the `right` anchor.
+      const tableRightX = containerOffset.left + outerWidth(wtTable.TABLE);
+
+      this.bottomStyle!.right = `${tableRightX - boundaryOffset.left - 1}px`;
+    } else {
+      const freezeLineX = boundaryOffset.left + outerWidth(boundaryTD);
+
+      this.bottomStyle!.left = `${freezeLineX - containerOffset.left - 1}px`;
+    }
+
+    this.bottomStyle!.display = 'block';
+
+    return true;
+  }
+
+  /**
    * Show border around one or many cells.
    *
    * @param {Array} corners The corner coordinates.
@@ -812,6 +1004,7 @@ class Border {
     // master's boundary edge (so it isn't doubled by the frozen overlay's edge).
     const originalFromRow = fromRow;
     const originalFromColumn = fromColumn;
+    const originalToRow = toRow;
 
     // borders can not be rendered on headers so hide them
     if (fromRow < 0 && toRow < 0 || fromColumn < 0 && toColumn < 0) {
@@ -970,8 +1163,14 @@ class Border {
       this.topStyle!.display = 'none';
     }
     if (this.isFrozenBoundaryEdge('column', originalFromColumn) &&
-        (wtTable.isMaster || overlayName === 'top')) {
+        (wtTable.isMaster || overlayName === 'top' || overlayName === 'bottom')) {
       this.startStyle!.display = 'none';
+    }
+    // The bottom-freeze edge is owned by the `bottom`/`bottom_inline_start_corner` overlays; hide the
+    // master's and `inline_start`'s redraw of it so the lines don't stack into a doubled border.
+    if (this.isFrozenBottomBoundaryEdge(originalToRow) &&
+        (wtTable.isMaster || overlayName === 'inline_start')) {
+      this.bottomStyle!.display = 'none';
     }
 
     let cornerVisibleSetting = this.settings.border?.cornerVisible;

--- a/handsontable/src/3rdparty/walkontable/src/selection/border/border.ts
+++ b/handsontable/src/3rdparty/walkontable/src/selection/border/border.ts
@@ -523,6 +523,39 @@ class Border {
   }
 
   /**
+   * Tells whether the selection's boundary corner (the cell flush with a frozen-pane line) has
+   * scrolled behind the frozen pane in the master (scroll-aware) viewport.
+   *
+   * The frozen overlay always renders the whole frozen block, so `drawFrozenBoundaryEdge` would
+   * re-draw the boundary edge pinned to the freeze line even after the selected cell flush with that
+   * line has scrolled out of the scrollable area — leaving a stuck line at the seam. The frozen
+   * overlay can't see that on its own (its own rendered range is sticky), so we consult the master,
+   * whose viewport starts at the freeze line and tracks the scroll. The edge stays in sync with the
+   * cell: drawn only while that cell is still fully visible next to the freeze line, hidden once it
+   * is even partially occluded by the pane (at which point the freeze line falls mid-cell and a line
+   * there would be wrong). When hidden, `drawFrozenBoundaryEdge` returns `false` and the regular
+   * `appear` path clamps the selection out of the frozen overlay and calls `disappear`.
+   *
+   * @private
+   * @param {'row'|'column'} axis The freeze axis to test (`row` → vertical, `column` → horizontal).
+   * @param {number} fromIndex The selection's boundary corner index on that axis.
+   * @returns {boolean} `true` when the boundary corner is scrolled out (edge must not be drawn).
+   */
+  isBoundaryCornerScrolledOut(axis: 'row' | 'column', fromIndex: number): boolean {
+    const masterTable = this.wot.cloneSource?.wtTable;
+
+    if (!masterTable) {
+      return false;
+    }
+
+    const firstVisible = axis === 'row'
+      ? masterTable.getFirstVisibleRow()
+      : masterTable.getFirstVisibleColumn();
+
+    return firstVisible >= 0 && fromIndex < firstVisible;
+  }
+
+  /**
    * Draws the selection-border edge(s) that lie exactly on a frozen-pane boundary.
    *
    * When `fixedRowsTop`/`fixedColumnsStart` are used, a selection edge flush against the freeze line
@@ -565,16 +598,25 @@ class Border {
     // for borders thicker than 1px.
     const delta = Math.ceil(borderWidth / 2);
 
+    // Resolve the two boundary predicates once — they are scroll/settings-only and reused by every
+    // branch below (including the corner-connector check), so computing them up front avoids the
+    // duplicate lookups. `rowEdgeOwned`/`columnEdgeOwned` are true when the selection's top/start edge
+    // lands on the freeze line AND its boundary cell is still visible (not scrolled behind the pane).
+    const rowEdgeOwned = this.isFrozenBoundaryEdge('row', fromRow) &&
+      !this.isBoundaryCornerScrolledOut('row', fromRow);
+    const columnEdgeOwned = this.isFrozenBoundaryEdge('column', fromColumn) &&
+      !this.isBoundaryCornerScrolledOut('column', fromColumn);
+
     // The row-freeze edge (selection top edge on the row freeze line) is owned by the `top` overlay
     // across the non-frozen columns and by the corner overlay across the frozen columns the
     // selection reaches. Each overlay clamps the span to its own rendered columns, so together they
     // cover the whole edge with no overlap. `getFirstRenderedColumn`/`getLastRenderedColumn` return
     // the frozen block for the corner overlay and the scrolled viewport for the `top` overlay.
-    if (this.isFrozenBoundaryEdge('row', fromRow) && (isTopOverlay || isCornerOverlay)) {
+    if (rowEdgeOwned && (isTopOverlay || isCornerOverlay)) {
       const firstColumn = Math.max(fromColumn, wtTable.getFirstRenderedColumn());
       const lastColumn = Math.min(toColumn, wtTable.getLastRenderedColumn());
 
-      if (this.drawRowFreezeEdge(firstColumn, lastColumn, isRtl, borderWidth, delta)) {
+      if (this.drawRowFreezeEdge(firstColumn, lastColumn, isRtl, delta)) {
         return true;
       }
     }
@@ -582,11 +624,26 @@ class Border {
     // The column-freeze edge (selection inline-start edge on the column freeze line) is owned by the
     // `inline_start` overlay across the non-frozen rows and by the corner overlay across the frozen
     // rows the selection reaches. Mirror of the branch above on the column axis.
-    if (this.isFrozenBoundaryEdge('column', fromColumn) && (isInlineStartOverlay || isCornerOverlay)) {
+    if (columnEdgeOwned && (isInlineStartOverlay || isCornerOverlay)) {
       const firstRow = Math.max(fromRow, wtTable.getFirstRenderedRow());
       const lastRow = Math.min(toRow, wtTable.getLastRenderedRow());
 
-      if (this.drawColumnFreezeEdge(firstRow, lastRow, isRtl, borderWidth, delta)) {
+      if (this.drawColumnFreezeEdge(firstRow, lastRow, isRtl, delta)) {
+        return true;
+      }
+    }
+
+    // A selection whose top-inline-start corner lands on BOTH freeze lines (e.g. the single cell
+    // flush with the row AND the column freeze line) has its top edge drawn by the `top` overlay and
+    // its start edge by the `inline_start` overlay. The `borderWidth`-sized square where those two
+    // edges meet falls inside the frozen×frozen region owned by the corner overlay, which is painted
+    // above both — so each edge's tip is occluded there and the lines stop a step short of each
+    // other. Neither freeze-edge branch above draws it (the selection spans no frozen cell, so both
+    // clamp empty in the corner overlay). Draw that connecting square in the corner overlay to close
+    // the gap. Only reached when the branches above did not already draw (cross-seam selections cover
+    // the corner via their frozen-cell slices).
+    if (isCornerOverlay && rowEdgeOwned && columnEdgeOwned) {
+      if (this.drawFrozenBoundaryCorner(isRtl, borderWidth)) {
         return true;
       }
     }
@@ -596,22 +653,23 @@ class Border {
 
   /**
    * Draws the selection's top edge on the row freeze line across the given (already clamped) column
-   * span within the current overlay. The line is anchored by its bottom edge flush to the freeze
-   * line — shifted up by its own thickness — to keep it inside the clipped pane for borders thicker
-   * than 1px. The cheap range/cell-lookup guards run before any `offset()` (which forces a layout
-   * reflow), so non-drawing calls stay reflow-free and leave the styles untouched for the caller to
-   * try the other axis.
+   * span within the current overlay. The line is anchored by its top edge one pixel inside the
+   * freeze line (a fixed table-border compensation, independent of the border width), the same way
+   * `appear` anchors a regular top edge to the cell's top gridline. Anchoring by a constant — rather
+   * than by the border thickness — keeps borders of different widths (e.g. the 2px focus border and
+   * the 1px area/fill border) sharing the same top edge so they line up. The cheap range/cell-lookup
+   * guards run before any `offset()` (which forces a layout reflow), so non-drawing calls stay
+   * reflow-free and leave the styles untouched for the caller to try the other axis.
    *
    * @private
    * @param {number} firstColumn The first column index to span (clamped to the overlay).
    * @param {number} lastColumn The last column index to span (clamped to the overlay).
    * @param {boolean} isRtl Whether the grid is rendered right-to-left.
-   * @param {number} borderWidth The configured border width in pixels.
    * @param {number} delta The along-axis length extension (`ceil(borderWidth / 2)`).
    * @returns {boolean} `true` when the edge was drawn.
    */
   drawRowFreezeEdge(
-    firstColumn: number, lastColumn: number, isRtl: boolean, borderWidth: number, delta: number): boolean {
+    firstColumn: number, lastColumn: number, isRtl: boolean, delta: number): boolean {
     if (lastColumn < firstColumn) {
       return false;
     }
@@ -630,19 +688,27 @@ class Border {
     const freezeLineY = boundaryOffset.top + outerHeight(boundaryTD);
     const endOffset = offset(boundaryEndTD);
 
+    // The `-1` lifts the line one pixel toward the inline start so it overlaps the border shared with
+    // the column before it, mirroring `appear`. At the grid's first column (column 0) there is no
+    // column before, so that overlap would protrude one pixel past the pane's inline-start edge; drop
+    // it there and shorten the line by the same pixel to keep its inline-end in place.
+    const atFirstColumn = firstColumn === 0;
+    const startShift = atFirstColumn ? 0 : 1;
+
     this.disappear();
-    this.topStyle!.top = `${freezeLineY - containerOffset.top - borderWidth}px`;
+    this.topStyle!.top = `${freezeLineY - containerOffset.top - 1}px`;
 
     if (isRtl) {
       // `firstColumn` (lowest index) is the visual-right cell, `lastColumn` the visual-left one.
       const spanRightX = boundaryOffset.left + outerWidth(boundaryTD);
       const tableRightX = containerOffset.left + outerWidth(wtTable.TABLE);
 
-      this.topStyle!.right = `${tableRightX - spanRightX - 1}px`;
-      this.topStyle!.width = `${spanRightX - endOffset.left + delta}px`;
+      this.topStyle!.right = `${tableRightX - spanRightX - startShift}px`;
+      this.topStyle!.width = `${spanRightX - endOffset.left + delta - (1 - startShift)}px`;
     } else {
-      this.topStyle!.left = `${boundaryOffset.left - containerOffset.left - 1}px`;
-      this.topStyle!.width = `${endOffset.left + outerWidth(boundaryEndTD) - boundaryOffset.left + delta}px`;
+      this.topStyle!.left = `${boundaryOffset.left - containerOffset.left - startShift}px`;
+      this.topStyle!.width =
+        `${endOffset.left + outerWidth(boundaryEndTD) - boundaryOffset.left + delta - (1 - startShift)}px`;
     }
 
     this.topStyle!.display = 'block';
@@ -652,20 +718,23 @@ class Border {
 
   /**
    * Draws the selection's inline-start edge on the column freeze line across the given (already
-   * clamped) row span within the current overlay. The line is anchored by its inline-end edge flush
-   * to the freeze line — shifted by its own thickness — to keep it inside the clipped pane for
-   * borders thicker than 1px. Guard/reflow behavior mirrors `drawRowFreezeEdge`.
+   * clamped) row span within the current overlay. The line is anchored by its inline-start edge one
+   * pixel inside the freeze line (a fixed table-border compensation, independent of the border
+   * width), the same way `appear` anchors a regular start edge to the cell's inline-start gridline.
+   * Anchoring by a constant — rather than by the border thickness — keeps borders of different widths
+   * (e.g. the 2px focus border and the 1px area/fill border) sharing the same inline-start edge, so
+   * they line up instead of the thicker one bleeding a pixel further out. Guard/reflow behavior
+   * mirrors `drawRowFreezeEdge`.
    *
    * @private
    * @param {number} firstRow The first row index to span (clamped to the overlay).
    * @param {number} lastRow The last row index to span (clamped to the overlay).
    * @param {boolean} isRtl Whether the grid is rendered right-to-left.
-   * @param {number} borderWidth The configured border width in pixels.
    * @param {number} delta The along-axis length extension (`ceil(borderWidth / 2)`).
    * @returns {boolean} `true` when the edge was drawn.
    */
   drawColumnFreezeEdge(
-    firstRow: number, lastRow: number, isRtl: boolean, borderWidth: number, delta: number): boolean {
+    firstRow: number, lastRow: number, isRtl: boolean, delta: number): boolean {
     if (lastRow < firstRow) {
       return false;
     }
@@ -683,23 +752,87 @@ class Border {
     const boundaryOffset = offset(boundaryTD);
     const endOffset = offset(boundaryEndTD);
 
+    // The `-1` lifts the line by one pixel so it overlaps the border shared with the row above, the
+    // same way `appear` aligns the start edge. At the grid's first row (row 0) there is no row above,
+    // so that overlap would protrude one pixel past the pane's top; drop it there and shorten the
+    // line by the same pixel to keep its bottom in place.
+    const atFirstRow = firstRow === 0;
+    let edgeTop = boundaryOffset.top - containerOffset.top - 1;
+    let edgeHeight = endOffset.top + outerHeight(boundaryEndTD) - boundaryOffset.top + delta;
+
+    if (atFirstRow) {
+      edgeTop += 1;
+      edgeHeight = Math.max(edgeHeight - 1, 0);
+    }
+
     this.disappear();
-    this.startStyle!.top = `${boundaryOffset.top - containerOffset.top - 1}px`;
+    this.startStyle!.top = `${edgeTop}px`;
 
     if (isRtl) {
       // RTL: the frozen pane sits on the right, so the freeze line is the boundary cell's LEFT edge,
-      // and the edge is drawn just inside it (to the right) via the `right` anchor.
+      // and the edge is drawn one pixel inside it (to the right) via the `right` anchor.
       const tableRightX = containerOffset.left + outerWidth(wtTable.TABLE);
 
-      this.startStyle!.right = `${tableRightX - boundaryOffset.left - borderWidth}px`;
+      this.startStyle!.right = `${tableRightX - boundaryOffset.left - 1}px`;
     } else {
       const freezeLineX = boundaryOffset.left + outerWidth(boundaryTD);
 
-      this.startStyle!.left = `${freezeLineX - containerOffset.left - borderWidth}px`;
+      this.startStyle!.left = `${freezeLineX - containerOffset.left - 1}px`;
     }
 
-    this.startStyle!.height = `${endOffset.top + outerHeight(boundaryEndTD) - boundaryOffset.top + delta}px`;
+    this.startStyle!.height = `${edgeHeight}px`;
     this.startStyle!.display = 'block';
+
+    return true;
+  }
+
+  /**
+   * Draws the `borderWidth`-sized square that bridges the top edge (drawn by the `top` overlay) and
+   * the inline-start edge (drawn by the `inline_start` overlay) where a selection corner lands on
+   * both freeze lines at once. That square sits in the frozen×frozen region — owned by the corner
+   * overlay and painted above the other two — so it must be drawn here or the two edges' tips are
+   * occluded and the lines stop a step short of meeting. Anchored one pixel inside the freeze corner
+   * (the same fixed table-border compensation the freeze-edge helpers use) so it lines up with both
+   * edges regardless of border width. Reuses the `top` border element (the corner overlay draws no
+   * other boundary edge in this case). Reflow/guard behavior mirrors the freeze-edge helpers.
+   *
+   * @private
+   * @param {boolean} isRtl Whether the grid is rendered right-to-left.
+   * @param {number} borderWidth The configured border width in pixels.
+   * @returns {boolean} `true` when the corner square was drawn.
+   */
+  drawFrozenBoundaryCorner(isRtl: boolean, borderWidth: number): boolean {
+    const { wtTable } = this.wot;
+    const boundaryRow = (this.wot.getSetting('fixedRowsTop') as number) - 1;
+    const boundaryColumn = (this.wot.getSetting('fixedColumnsStart') as number) - 1;
+    const boundaryTD = wtTable.getCell(this.wot.createCellCoords(boundaryRow, boundaryColumn));
+
+    if (!isHTMLElement(boundaryTD)) {
+      return false;
+    }
+
+    const containerOffset = offset(wtTable.TABLE);
+    const boundaryOffset = offset(boundaryTD);
+    const freezeLineY = boundaryOffset.top + outerHeight(boundaryTD);
+
+    this.disappear();
+    this.topStyle!.top = `${freezeLineY - containerOffset.top - 1}px`;
+    this.topStyle!.height = `${borderWidth}px`;
+    this.topStyle!.width = `${borderWidth}px`;
+
+    if (isRtl) {
+      // RTL: the frozen pane is on the right, so the freeze line is the boundary cell's LEFT edge;
+      // the square sits one pixel inside it (to the right) via the `right` anchor.
+      const tableRightX = containerOffset.left + outerWidth(wtTable.TABLE);
+
+      this.topStyle!.right = `${tableRightX - boundaryOffset.left - 1}px`;
+    } else {
+      const freezeLineX = boundaryOffset.left + outerWidth(boundaryTD);
+
+      this.topStyle!.left = `${freezeLineX - containerOffset.left - 1}px`;
+    }
+
+    this.topStyle!.display = 'block';
 
     return true;
   }
@@ -877,16 +1010,26 @@ class Border {
     this.endStyle!.display = 'block';
 
     // A selection edge that lands exactly on a frozen-pane boundary is owned by the frozen overlay
-    // (drawn by `drawFrozenBoundaryEdge`). Hide it on the master so the two lines don't stack into a
-    // doubled/thicker border. The shared `isFrozenBoundaryEdge` predicate guarantees the master and
-    // the frozen overlay take this decision on identical inputs.
-    if (wtTable.isMaster) {
-      if (this.isFrozenBoundaryEdge('row', originalFromRow)) {
-        this.topStyle!.display = 'none';
-      }
-      if (this.isFrozenBoundaryEdge('column', originalFromColumn)) {
-        this.startStyle!.display = 'none';
-      }
+    // (drawn by `drawFrozenBoundaryEdge`). Hide it on every other overlay that renders a cell along
+    // that line and would otherwise draw the same edge in its regular flow, so the two lines don't
+    // stack into a doubled/thicker border. The shared `isFrozenBoundaryEdge` predicate guarantees all
+    // overlays take this decision on identical inputs.
+    //
+    // The row-freeze (top) edge is owned by the `top`/corner overlay. It is doubled by the master
+    // (non-frozen cols) and by the `inline_start` overlay (frozen-col cells flush with the row line —
+    // e.g. a selected frozen-column cell in the first non-frozen row), so both must hide it. The
+    // column-freeze (start) edge is owned by the `inline_start`/corner overlay; it is doubled by the
+    // master and by the `top` overlay (frozen-row cells flush with the column line — e.g. a selected
+    // cell in the first non-frozen column but a frozen row), so both must hide it.
+    const overlayName = wtTable.name;
+
+    if (this.isFrozenBoundaryEdge('row', originalFromRow) &&
+        (wtTable.isMaster || overlayName === 'inline_start')) {
+      this.topStyle!.display = 'none';
+    }
+    if (this.isFrozenBoundaryEdge('column', originalFromColumn) &&
+        (wtTable.isMaster || overlayName === 'top')) {
+      this.startStyle!.display = 'none';
     }
 
     let cornerVisibleSetting = this.settings.border?.cornerVisible;

--- a/handsontable/src/3rdparty/walkontable/src/selection/border/border.ts
+++ b/handsontable/src/3rdparty/walkontable/src/selection/border/border.ts
@@ -500,6 +500,173 @@ class Border {
   }
 
   /**
+   * Tells whether a selection edge lands exactly on a frozen-pane boundary and is therefore owned
+   * by the frozen overlay (drawn by `drawFrozenBoundaryEdge` and hidden on the master). It depends
+   * only on the global fixed-pane settings and the raw selection corner, so the master and the
+   * frozen overlay always evaluate it on identical inputs.
+   *
+   * @private
+   * @param {'row'|'column'} axis The freeze axis to test (`row` → `fixedRowsTop`, `column` → `fixedColumnsStart`).
+   * @param {number} fromIndex The selection's top (`row`) or inline-start (`column`) corner index.
+   * @returns {boolean}
+   */
+  isFrozenBoundaryEdge(axis: 'row' | 'column', fromIndex: number): boolean {
+    if (axis === 'row') {
+      const fixedRowsTop = this.wot.getSetting('fixedRowsTop') as number;
+
+      return fixedRowsTop > 0 && fromIndex === fixedRowsTop;
+    }
+
+    const fixedColumnsStart = this.wot.getSetting('fixedColumnsStart') as number;
+
+    return fixedColumnsStart > 0 && fromIndex === fixedColumnsStart;
+  }
+
+  /**
+   * Draws the single selection-border edge that lies exactly on a frozen-pane boundary.
+   *
+   * When `fixedRowsTop`/`fixedColumnsStart` are used, a selection located in the master pane but
+   * flush against the freeze line has its top/inline-start edge drawn by the master overlay right
+   * on that line, where the frozen overlay (stacked above the master) occludes it. This method
+   * re-draws that one edge inside the frozen overlay (`top` / `inline_start`), just within its
+   * clipped area, so the edge becomes visible. It is a no-op unless the relevant fixed-pane option
+   * is active and the selection's edge is flush with the boundary (`fromRow === fixedRowsTop` /
+   * `fromColumn === fixedColumnsStart`). `appear` hides the matching master edge under the same
+   * condition, so exactly one line is drawn.
+   *
+   * @param {number[]} corners The selection corners `[fromRow, fromColumn, toRow, toColumn]`.
+   * @returns {boolean} `true` when a boundary edge was drawn (regular drawing should be skipped).
+   */
+  drawFrozenBoundaryEdge(corners: number[]): boolean {
+    const { wtTable } = this.wot;
+    const overlayName = wtTable.name;
+    const isTopOverlay = overlayName === 'top';
+    const isInlineStartOverlay = overlayName === 'inline_start';
+
+    if (!isTopOverlay && !isInlineStartOverlay) {
+      return false;
+    }
+
+    // In RTL the horizontal axis is mirrored: edges are anchored with `right` (measured from the
+    // table's right edge), exactly like the regular flow in `appear`. Row-freeze (vertical) geometry
+    // is direction-agnostic.
+    const isRtl = this.wot.wtSettings.getSetting('rtlMode');
+    const [fromRow, fromColumn, toRow, toColumn] = corners;
+    // Cross-axis offset for the thin dimension of the boundary line. The frozen overlay clips its
+    // content at the freeze line, so the line is anchored by its FAR edge (bottom for `top`,
+    // inline-end for `inline_start`) flush to that line — i.e. shifted by its own thickness — to keep
+    // it fully inside the clipped pane for borders thicker than 1px. This intentionally differs from
+    // the `-1` table-border compensation used on the along-axis (which mirrors the regular `appear`).
+    const borderWidth = this.settings.border?.width ?? 0;
+    // Along-axis extension applied to the line's length, mirroring `appear` (which adds
+    // `ceil(borderWidth / 2)` to every edge's width/height so the corners meet). Without it the
+    // boundary line falls short of the side edges drawn by the master, leaving a gap at the corner
+    // for borders thicker than 1px.
+    const delta = Math.ceil(borderWidth / 2);
+
+    // The cheap integer/DOM-lookup guards below run first; `offset()` (which forces a layout
+    // reflow) is deferred to the success path so the common bail-outs stay reflow-free.
+    if (isTopOverlay) {
+      const fixedRowsTop = this.wot.getSetting('fixedRowsTop') as number;
+
+      // Decision shared with the master's suppression via `isFrozenBoundaryEdge`, so both panes
+      // agree on which one owns the edge. The rendered-range and cell-lookup guards below are
+      // defensive: if any fails, the edge is off-screen or not renderable in this overlay, in which
+      // case it simply stays hidden on both panes (a visual no-op).
+      if (!this.isFrozenBoundaryEdge('row', fromRow)) {
+        return false;
+      }
+
+      const firstColumn = Math.max(fromColumn, wtTable.getFirstRenderedColumn());
+      const lastColumn = Math.min(toColumn, wtTable.getLastRenderedColumn());
+
+      if (lastColumn < firstColumn) {
+        return false;
+      }
+
+      const boundaryRow = fixedRowsTop - 1;
+      const boundaryTD = wtTable.getCell(this.wot.createCellCoords(boundaryRow, firstColumn));
+      const boundaryEndTD = wtTable.getCell(this.wot.createCellCoords(boundaryRow, lastColumn));
+
+      if (!isHTMLElement(boundaryTD) || !isHTMLElement(boundaryEndTD)) {
+        return false;
+      }
+
+      const containerOffset = offset(wtTable.TABLE);
+      const boundaryOffset = offset(boundaryTD);
+      const freezeLineY = boundaryOffset.top + outerHeight(boundaryTD);
+      const endOffset = offset(boundaryEndTD);
+
+      this.disappear();
+      this.topStyle!.top = `${freezeLineY - containerOffset.top - borderWidth}px`;
+
+      if (isRtl) {
+        // `firstColumn` (lowest index) is the visual-right cell, `lastColumn` the visual-left one.
+        const spanRightX = boundaryOffset.left + outerWidth(boundaryTD);
+        const tableRightX = containerOffset.left + outerWidth(wtTable.TABLE);
+
+        this.topStyle!.right = `${tableRightX - spanRightX - 1}px`;
+        this.topStyle!.width = `${spanRightX - endOffset.left + delta}px`;
+      } else {
+        this.topStyle!.left = `${boundaryOffset.left - containerOffset.left - 1}px`;
+        this.topStyle!.width = `${endOffset.left + outerWidth(boundaryEndTD) - boundaryOffset.left + delta}px`;
+      }
+
+      this.topStyle!.display = 'block';
+
+      return true;
+    }
+
+    // inline_start overlay → draw the inline-start (left, in LTR) edge on the column freeze line.
+    const fixedColumnsStart = this.wot.getSetting('fixedColumnsStart') as number;
+
+    // Mirror of the top branch on the column axis. Decision shared with the master via
+    // `isFrozenBoundaryEdge`; the later guards are defensive (see the top branch).
+    if (!this.isFrozenBoundaryEdge('column', fromColumn)) {
+      return false;
+    }
+
+    const firstRow = Math.max(fromRow, wtTable.getFirstRenderedRow());
+    const lastRow = Math.min(toRow, wtTable.getLastRenderedRow());
+
+    if (lastRow < firstRow) {
+      return false;
+    }
+
+    const boundaryColumn = fixedColumnsStart - 1;
+    const boundaryTD = wtTable.getCell(this.wot.createCellCoords(firstRow, boundaryColumn));
+    const boundaryEndTD = wtTable.getCell(this.wot.createCellCoords(lastRow, boundaryColumn));
+
+    if (!isHTMLElement(boundaryTD) || !isHTMLElement(boundaryEndTD)) {
+      return false;
+    }
+
+    const containerOffset = offset(wtTable.TABLE);
+    const boundaryOffset = offset(boundaryTD);
+    const endOffset = offset(boundaryEndTD);
+
+    this.disappear();
+    this.startStyle!.top = `${boundaryOffset.top - containerOffset.top - 1}px`;
+
+    if (isRtl) {
+      // RTL: the frozen pane sits on the right, so the freeze line is the boundary cell's LEFT edge,
+      // and the edge is drawn just inside it (to the right) via the `right` anchor.
+      const tableRightX = containerOffset.left + outerWidth(wtTable.TABLE);
+
+      this.startStyle!.right = `${tableRightX - boundaryOffset.left - borderWidth}px`;
+    } else {
+      const freezeLineX = boundaryOffset.left + outerWidth(boundaryTD);
+
+      this.startStyle!.left = `${freezeLineX - containerOffset.left - borderWidth}px`;
+    }
+
+    this.startStyle!.height = `${endOffset.top + outerHeight(boundaryEndTD) - boundaryOffset.top + delta}px`;
+    this.startStyle!.display = 'block';
+
+    return true;
+  }
+
+  /**
    * Show border around one or many cells.
    *
    * @param {Array} corners The corner coordinates.
@@ -509,7 +676,20 @@ class Border {
       return;
     }
 
+    // A selection located in the master pane but flush against a frozen-pane boundary has its
+    // top/inline-start edge rendered by the master overlay right on the freeze line, where the
+    // frozen overlay (painted above the master) occludes it. Re-draw that single edge inside the
+    // frozen overlay so it stays visible. No-op unless `fixedRowsTop`/`fixedColumnsStart` is used.
+    if (this.drawFrozenBoundaryEdge(corners)) {
+      return;
+    }
+
     let [fromRow, fromColumn, toRow, toColumn] = corners;
+
+    // Capture the top-start corner before the clamping below mutates it — used to suppress the
+    // master's boundary edge (so it isn't doubled by the frozen overlay's edge).
+    const originalFromRow = fromRow;
+    const originalFromColumn = fromColumn;
 
     // borders can not be rendered on headers so hide them
     if (fromRow < 0 && toRow < 0 || fromColumn < 0 && toColumn < 0) {
@@ -657,6 +837,19 @@ class Border {
     this.endStyle![inlinePosProperty] = `${inlineStartPos + width - parseInt(this.endStyle!.width, 10) + delta}px`;
     this.endStyle!.height = `${height + delta}px`;
     this.endStyle!.display = 'block';
+
+    // A selection edge that lands exactly on a frozen-pane boundary is owned by the frozen overlay
+    // (drawn by `drawFrozenBoundaryEdge`). Hide it on the master so the two lines don't stack into a
+    // doubled/thicker border. The shared `isFrozenBoundaryEdge` predicate guarantees the master and
+    // the frozen overlay take this decision on identical inputs.
+    if (wtTable.isMaster) {
+      if (this.isFrozenBoundaryEdge('row', originalFromRow)) {
+        this.topStyle!.display = 'none';
+      }
+      if (this.isFrozenBoundaryEdge('column', originalFromColumn)) {
+        this.startStyle!.display = 'none';
+      }
+    }
 
     let cornerVisibleSetting = this.settings.border?.cornerVisible;
 

--- a/handsontable/src/3rdparty/walkontable/src/selection/border/border.ts
+++ b/handsontable/src/3rdparty/walkontable/src/selection/border/border.ts
@@ -500,10 +500,9 @@ class Border {
   }
 
   /**
-   * Tells whether a selection edge lands exactly on a frozen-pane boundary and is therefore owned
-   * by the frozen overlay (drawn by `drawFrozenBoundaryEdge` and hidden on the master). It depends
-   * only on the global fixed-pane settings and the raw selection corner, so the master and the
-   * frozen overlay always evaluate it on identical inputs.
+   * Tells whether a selection edge lands exactly on a frozen-pane boundary and is therefore owned by
+   * the frozen overlay. Depends only on the fixed-pane settings and the raw corner, so every overlay
+   * evaluates it on identical inputs.
    *
    * @private
    * @param {'row'|'column'} axis The freeze axis to test (`row` → `fixedRowsTop`, `column` → `fixedColumnsStart`).
@@ -524,17 +523,9 @@ class Border {
 
   /**
    * Tells whether the selection's boundary corner (the cell flush with a frozen-pane line) has
-   * scrolled behind the frozen pane in the master (scroll-aware) viewport.
-   *
-   * The frozen overlay always renders the whole frozen block, so `drawFrozenBoundaryEdge` would
-   * re-draw the boundary edge pinned to the freeze line even after the selected cell flush with that
-   * line has scrolled out of the scrollable area — leaving a stuck line at the seam. The frozen
-   * overlay can't see that on its own (its own rendered range is sticky), so we consult the master,
-   * whose viewport starts at the freeze line and tracks the scroll. The edge stays in sync with the
-   * cell: drawn only while that cell is still fully visible next to the freeze line, hidden once it
-   * is even partially occluded by the pane (at which point the freeze line falls mid-cell and a line
-   * there would be wrong). When hidden, `drawFrozenBoundaryEdge` returns `false` and the regular
-   * `appear` path clamps the selection out of the frozen overlay and calls `disappear`.
+   * scrolled behind the frozen pane in the master viewport. The frozen overlay can't detect this
+   * itself (its rendered range is sticky), so we consult the scroll-aware master and stop drawing the
+   * edge once the cell is occluded by the pane.
    *
    * @private
    * @param {'row'|'column'} axis The freeze axis to test (`row` → vertical, `column` → horizontal).
@@ -556,21 +547,10 @@ class Border {
   }
 
   /**
-   * Draws the selection-border edge(s) that lie exactly on a frozen-pane boundary.
-   *
-   * When `fixedRowsTop`/`fixedColumnsStart` are used, a selection edge flush against the freeze line
-   * is rendered by the master right on that line, where the frozen overlays (stacked above the
-   * master) occlude it. This re-draws that edge inside the frozen overlay(s) that own it — each
-   * clamped to its own rendered range — so the edge stays visible. `appear` hides the matching
-   * master edge under the same `isFrozenBoundaryEdge` condition, so exactly one line is drawn per
-   * segment.
-   *
-   * A single edge can span more than one frozen overlay when the selection also crosses the
-   * perpendicular freeze line. For example the inline-start edge of a selection that reaches up into
-   * the frozen rows is drawn partly by the `inline_start` overlay (across its non-frozen rows) and
-   * partly by the `top_inline_start_corner` overlay (across its frozen rows); each overlay draws
-   * only the slice it renders. The row-freeze edge behaves symmetrically across the `top` and corner
-   * overlays.
+   * Draws the selection-border edge(s) that lie exactly on a frozen-pane boundary, where the master
+   * renders them on the freeze line under the occluding frozen overlay. Re-draws each such edge
+   * inside the frozen overlay(s) that own it (clamped to each overlay's rendered range), while
+   * `appear` hides the matching master edge so exactly one line is drawn per segment.
    *
    * @param {number[]} corners The selection corners `[fromRow, fromColumn, toRow, toColumn]`.
    * @returns {boolean} `true` when a boundary edge was drawn (regular drawing should be skipped).
@@ -586,38 +566,27 @@ class Border {
       return false;
     }
 
-    // In RTL the horizontal axis is mirrored: edges are anchored with `right` (measured from the
-    // table's right edge), exactly like the regular flow in `appear`. Row-freeze (vertical) geometry
-    // is direction-agnostic.
+    // In RTL the horizontal axis is mirrored: edges are anchored with `right`, like the regular flow
+    // in `appear`. Row-freeze (vertical) geometry is direction-agnostic.
     const isRtl = this.wot.wtSettings.getSetting('rtlMode');
     const [fromRow, fromColumn, toRow, toColumn] = corners;
     const borderWidth = this.settings.border?.width ?? 0;
-    // Along-axis extension applied to the line's length, mirroring `appear` (which adds
-    // `ceil(borderWidth / 2)` to every edge's width/height so the corners meet). Without it the
-    // boundary line falls short of the side edges drawn by the master, leaving a gap at the corner
-    // for borders thicker than 1px.
+    // Along-axis length extension mirroring `appear`'s `ceil(borderWidth / 2)`, so corners meet.
+    // Without it the line falls short of the master's side edges for borders thicker than 1px.
     const delta = Math.ceil(borderWidth / 2);
 
-    // Resolve the two boundary predicates once — they are scroll/settings-only and reused by every
-    // branch below (including the corner-connector check), so computing them up front avoids the
-    // duplicate lookups. `rowEdgeOwned`/`columnEdgeOwned` are true when the selection's top/start edge
-    // lands on the freeze line AND its boundary cell is still visible (not scrolled behind the pane).
+    // `rowEdgeOwned`/`columnEdgeOwned` are true when the selection's top/start edge lands on the
+    // freeze line AND its boundary cell is still visible. Resolved once and reused by every branch
+    // below.
     const rowEdgeOwned = this.isFrozenBoundaryEdge('row', fromRow) &&
       !this.isBoundaryCornerScrolledOut('row', fromRow);
     const columnEdgeOwned = this.isFrozenBoundaryEdge('column', fromColumn) &&
       !this.isBoundaryCornerScrolledOut('column', fromColumn);
 
-    // The row-freeze edge (selection top edge on the row freeze line) is owned by the `top` overlay
-    // across the non-frozen columns and by the corner overlay across the frozen columns the
-    // selection reaches. Each overlay clamps the span to its own rendered columns, so together they
-    // cover the whole edge with no overlap. Both bounds use the rendered range
-    // (`getFirstRenderedColumn`/`getLastRenderedColumn`), not the visible one: a line that runs a
-    // buffer column past the viewport on either side is harmlessly clipped by the container, whereas
-    // clamping to the visible range drops the edge at a partially scrolled boundary column (the line
-    // disappears instead of staying pinned to the freeze line). The scroll-aware occlusion of a
-    // boundary cell that has scrolled behind the frozen pane is handled separately by the
-    // `rowEdgeOwned` predicate via `isBoundaryCornerScrolledOut`, not by this clamp. For the corner
-    // overlay both ranges resolve to the same sticky frozen block.
+    // The row-freeze edge is split between the `top` overlay (non-frozen columns) and the corner
+    // overlay (frozen columns), each clamped to its own rendered column range so together they cover
+    // the edge without overlap. The rendered (not visible) range keeps a partially scrolled boundary
+    // column pinned to the freeze line; scroll occlusion is handled by `rowEdgeOwned`.
     if (rowEdgeOwned && (isTopOverlay || isCornerOverlay)) {
       const firstColumn = Math.max(fromColumn, wtTable.getFirstRenderedColumn());
       const lastColumn = Math.min(toColumn, wtTable.getLastRenderedColumn());
@@ -627,9 +596,8 @@ class Border {
       }
     }
 
-    // The column-freeze edge (selection inline-start edge on the column freeze line) is owned by the
-    // `inline_start` overlay across the non-frozen rows and by the corner overlay across the frozen
-    // rows the selection reaches. Mirror of the branch above on the column axis.
+    // The column-freeze edge is split between the `inline_start` overlay (non-frozen rows) and the
+    // corner overlay (frozen rows). Mirror of the branch above on the column axis.
     if (columnEdgeOwned && (isInlineStartOverlay || isCornerOverlay)) {
       const firstRow = Math.max(fromRow, wtTable.getFirstRenderedRow());
       const lastRow = Math.min(toRow, wtTable.getLastRenderedRow());
@@ -639,15 +607,9 @@ class Border {
       }
     }
 
-    // A selection whose top-inline-start corner lands on BOTH freeze lines (e.g. the single cell
-    // flush with the row AND the column freeze line) has its top edge drawn by the `top` overlay and
-    // its start edge by the `inline_start` overlay. The `borderWidth`-sized square where those two
-    // edges meet falls inside the frozen×frozen region owned by the corner overlay, which is painted
-    // above both — so each edge's tip is occluded there and the lines stop a step short of each
-    // other. Neither freeze-edge branch above draws it (the selection spans no frozen cell, so both
-    // clamp empty in the corner overlay). Draw that connecting square in the corner overlay to close
-    // the gap. Only reached when the branches above did not already draw (cross-seam selections cover
-    // the corner via their frozen-cell slices).
+    // When the corner lands on BOTH freeze lines, the top and start edges meet in the frozen×frozen
+    // square owned by the corner overlay, which occludes both their tips and leaves a gap. Draw that
+    // connecting square here to close it.
     if (isCornerOverlay && rowEdgeOwned && columnEdgeOwned) {
       if (this.drawFrozenBoundaryCorner(isRtl, borderWidth)) {
         return true;
@@ -658,14 +620,10 @@ class Border {
   }
 
   /**
-   * Draws the selection's top edge on the row freeze line across the given (already clamped) column
-   * span within the current overlay. The line is anchored by its top edge one pixel inside the
-   * freeze line (a fixed table-border compensation, independent of the border width), the same way
-   * `appear` anchors a regular top edge to the cell's top gridline. Anchoring by a constant — rather
-   * than by the border thickness — keeps borders of different widths (e.g. the 2px focus border and
-   * the 1px area/fill border) sharing the same top edge so they line up. The cheap range/cell-lookup
-   * guards run before any `offset()` (which forces a layout reflow), so non-drawing calls stay
-   * reflow-free and leave the styles untouched for the caller to try the other axis.
+   * Draws the selection's top edge on the row freeze line across the given (clamped) column span,
+   * anchored one pixel inside the freeze line by a constant so borders of different widths line up.
+   * Cheap range/cell-lookup guards run before any reflow-forcing `offset()`, so non-drawing calls
+   * leave the styles untouched.
    *
    * @private
    * @param {number} firstColumn The first column index to span (clamped to the overlay).
@@ -694,10 +652,9 @@ class Border {
     const freezeLineY = boundaryOffset.top + outerHeight(boundaryTD);
     const endOffset = offset(boundaryEndTD);
 
-    // The `-1` lifts the line one pixel toward the inline start so it overlaps the border shared with
-    // the column before it, mirroring `appear`. At the grid's first column (column 0) there is no
-    // column before, so that overlap would protrude one pixel past the pane's inline-start edge; drop
-    // it there and shorten the line by the same pixel to keep its inline-end in place.
+    // The `-1` overlaps the border shared with the previous column, mirroring `appear`. At column 0
+    // there is no previous column, so drop the shift and shorten the line to avoid protruding past
+    // the pane edge.
     const atFirstColumn = firstColumn === 0;
     const startShift = atFirstColumn ? 0 : 1;
 
@@ -723,14 +680,9 @@ class Border {
   }
 
   /**
-   * Draws the selection's inline-start edge on the column freeze line across the given (already
-   * clamped) row span within the current overlay. The line is anchored by its inline-start edge one
-   * pixel inside the freeze line (a fixed table-border compensation, independent of the border
-   * width), the same way `appear` anchors a regular start edge to the cell's inline-start gridline.
-   * Anchoring by a constant — rather than by the border thickness — keeps borders of different widths
-   * (e.g. the 2px focus border and the 1px area/fill border) sharing the same inline-start edge, so
-   * they line up instead of the thicker one bleeding a pixel further out. Guard/reflow behavior
-   * mirrors `drawRowFreezeEdge`.
+   * Draws the selection's inline-start edge on the column freeze line across the given (clamped) row
+   * span, anchored one pixel inside the freeze line by a constant so borders of different widths line
+   * up. Guard/reflow behavior mirrors `drawRowFreezeEdge`.
    *
    * @private
    * @param {number} firstRow The first row index to span (clamped to the overlay).
@@ -758,10 +710,8 @@ class Border {
     const boundaryOffset = offset(boundaryTD);
     const endOffset = offset(boundaryEndTD);
 
-    // The `-1` lifts the line by one pixel so it overlaps the border shared with the row above, the
-    // same way `appear` aligns the start edge. At the grid's first row (row 0) there is no row above,
-    // so that overlap would protrude one pixel past the pane's top; drop it there and shorten the
-    // line by the same pixel to keep its bottom in place.
+    // The `-1` overlaps the border shared with the row above, like `appear`. At row 0 there is no row
+    // above, so drop the shift and shorten the line to avoid protruding past the pane top.
     const atFirstRow = firstRow === 0;
     let edgeTop = boundaryOffset.top - containerOffset.top - 1;
     let edgeHeight = endOffset.top + outerHeight(boundaryEndTD) - boundaryOffset.top + delta;
@@ -793,14 +743,10 @@ class Border {
   }
 
   /**
-   * Draws the `borderWidth`-sized square that bridges the top edge (drawn by the `top` overlay) and
-   * the inline-start edge (drawn by the `inline_start` overlay) where a selection corner lands on
-   * both freeze lines at once. That square sits in the frozen×frozen region — owned by the corner
-   * overlay and painted above the other two — so it must be drawn here or the two edges' tips are
-   * occluded and the lines stop a step short of meeting. Anchored one pixel inside the freeze corner
-   * (the same fixed table-border compensation the freeze-edge helpers use) so it lines up with both
-   * edges regardless of border width. Reuses the `top` border element (the corner overlay draws no
-   * other boundary edge in this case). Reflow/guard behavior mirrors the freeze-edge helpers.
+   * Draws the `borderWidth`-sized square bridging the top and inline-start edges where a selection
+   * corner lands on both freeze lines, since that square sits in the corner overlay's frozen×frozen
+   * region that occludes both edges' tips. Anchored one pixel inside the freeze corner and reuses the
+   * `top` border element; reflow/guard behavior mirrors the freeze-edge helpers.
    *
    * @private
    * @param {boolean} isRtl Whether the grid is rendered right-to-left.
@@ -853,10 +799,9 @@ class Border {
       return;
     }
 
-    // A selection located in the master pane but flush against a frozen-pane boundary has its
-    // top/inline-start edge rendered by the master overlay right on the freeze line, where the
-    // frozen overlay (painted above the master) occludes it. Re-draw that single edge inside the
-    // frozen overlay so it stays visible. No-op unless `fixedRowsTop`/`fixedColumnsStart` is used.
+    // A selection flush against a frozen-pane boundary has its top/inline-start edge rendered by the
+    // master on the freeze line, where the frozen overlay occludes it. Re-draw it inside the frozen
+    // overlay so it stays visible; no-op unless `fixedRowsTop`/`fixedColumnsStart` is used.
     if (this.drawFrozenBoundaryEdge(corners)) {
       return;
     }
@@ -1015,18 +960,9 @@ class Border {
     this.endStyle!.height = `${height + delta}px`;
     this.endStyle!.display = 'block';
 
-    // A selection edge that lands exactly on a frozen-pane boundary is owned by the frozen overlay
-    // (drawn by `drawFrozenBoundaryEdge`). Hide it on every other overlay that renders a cell along
-    // that line and would otherwise draw the same edge in its regular flow, so the two lines don't
-    // stack into a doubled/thicker border. The shared `isFrozenBoundaryEdge` predicate guarantees all
-    // overlays take this decision on identical inputs.
-    //
-    // The row-freeze (top) edge is owned by the `top`/corner overlay. It is doubled by the master
-    // (non-frozen cols) and by the `inline_start` overlay (frozen-col cells flush with the row line —
-    // e.g. a selected frozen-column cell in the first non-frozen row), so both must hide it. The
-    // column-freeze (start) edge is owned by the `inline_start`/corner overlay; it is doubled by the
-    // master and by the `top` overlay (frozen-row cells flush with the column line — e.g. a selected
-    // cell in the first non-frozen column but a frozen row), so both must hide it.
+    // A boundary edge owned by the frozen overlay must be hidden on every other overlay that would
+    // redraw it in its regular flow, so the lines don't stack into a doubled border. The row-freeze
+    // edge is hidden on the master and `inline_start`; the column-freeze edge on the master and `top`.
     const overlayName = wtTable.name;
 
     if (this.isFrozenBoundaryEdge('row', originalFromRow) &&

--- a/handsontable/src/3rdparty/walkontable/src/selection/border/border.ts
+++ b/handsontable/src/3rdparty/walkontable/src/selection/border/border.ts
@@ -609,19 +609,17 @@ class Border {
 
     // The row-freeze edge (selection top edge on the row freeze line) is owned by the `top` overlay
     // across the non-frozen columns and by the corner overlay across the frozen columns the
-    // selection reaches. Each overlay clamps the span to its own columns, so together they cover the
-    // whole edge with no overlap. The inline-start bound uses `getFirstVisibleColumn` (not
-    // `...Rendered`): in the `top` overlay the rendered range includes the off-screen buffer columns
-    // that have scrolled behind the inline-start frozen pane, so clamping to rendered would keep
-    // drawing the edge for a boundary cell already occluded by the pane — the line would slide over
-    // the frozen columns as you scroll horizontally. The visible range excludes those, mirroring the
-    // scroll-aware occlusion check `isBoundaryCornerScrolledOut` does on the perpendicular axis. The
-    // inline-end bound stays `getLastRenderedColumn`: there is no pane on that side, so a line
-    // running a buffer column past the viewport is harmlessly clipped by the container, and using the
-    // visible bound there would instead leave a gap at a partially visible last column. For the
-    // corner overlay both visible and rendered resolve to the same sticky frozen block.
+    // selection reaches. Each overlay clamps the span to its own rendered columns, so together they
+    // cover the whole edge with no overlap. Both bounds use the rendered range
+    // (`getFirstRenderedColumn`/`getLastRenderedColumn`), not the visible one: a line that runs a
+    // buffer column past the viewport on either side is harmlessly clipped by the container, whereas
+    // clamping to the visible range drops the edge at a partially scrolled boundary column (the line
+    // disappears instead of staying pinned to the freeze line). The scroll-aware occlusion of a
+    // boundary cell that has scrolled behind the frozen pane is handled separately by the
+    // `rowEdgeOwned` predicate via `isBoundaryCornerScrolledOut`, not by this clamp. For the corner
+    // overlay both ranges resolve to the same sticky frozen block.
     if (rowEdgeOwned && (isTopOverlay || isCornerOverlay)) {
-      const firstColumn = Math.max(fromColumn, wtTable.getFirstVisibleColumn());
+      const firstColumn = Math.max(fromColumn, wtTable.getFirstRenderedColumn());
       const lastColumn = Math.min(toColumn, wtTable.getLastRenderedColumn());
 
       if (this.drawRowFreezeEdge(firstColumn, lastColumn, isRtl, delta)) {

--- a/handsontable/src/3rdparty/walkontable/src/selection/manager.ts
+++ b/handsontable/src/3rdparty/walkontable/src/selection/manager.ts
@@ -18,10 +18,12 @@ import {
   removeClass,
   addClass,
   setAttribute,
-  removeAttribute
+  removeAttribute,
+  isHTMLElement
 } from '../../../../helpers/dom/element';
 import { SelectionScanner } from './scanner';
 import Border from './border/border';
+import { ACTIVE_HEADER_TYPE } from './constants';
 
 /**
  * Module responsible for rendering selections (CSS classes) and borders based on the
@@ -259,6 +261,12 @@ export class SelectionManager {
 
       const corners = selection.getCorners();
 
+      if (selectionType === ACTIVE_HEADER_TYPE && className) {
+        this.#markFrozenColumnSeamHeader(corners, className as string, classNamesMap);
+        this.#markFrozenTopRowSeamHeader(corners, className as string, classNamesMap);
+        this.#markFrozenBottomRowSeamHeader(corners, className as string, classNamesMap);
+      }
+
       this.#activeOverlaysWot!.getSetting('onBeforeDrawBorders', corners, selectionType);
       borderInstance?.appear(corners);
     }
@@ -290,6 +298,170 @@ export class SelectionManager {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       setAttribute(element, [...headerAttributesMap.get(element)]);
     });
+  }
+
+  /**
+   * Tags the last frozen column header with a seam class when the first non-frozen column is the
+   * active header. That header's inline-start edge lands on the frozen-pane seam, which is drawn by
+   * the frozen overlay (a separate table) and is therefore out of reach of the neighbour `:has()`
+   * rule that gives every other active header its inline-start accent. The class lets the theme color
+   * that seam to match. No-op unless `fixedColumnsStart` is used and this is the frozen overlay.
+   *
+   * @param {number[]} corners The active-header selection corners `[fromRow, fromColumn, toRow, toColumn]`.
+   * @param {string} activeHeaderClassName The active header class name (the seam class derives from it).
+   * @param {Map} classNamesMap The render cycle's element→classNames map (applied and cleaned up later).
+   */
+  #markFrozenColumnSeamHeader(
+    corners: number[],
+    activeHeaderClassName: string,
+    classNamesMap: Map<HTMLElement, Map<string, number>>
+  ) {
+    const wot = this.#activeOverlaysWot!;
+    const fixedColumnsStart = wot.getSetting('fixedColumnsStart') as number;
+
+    if (fixedColumnsStart <= 0) {
+      return;
+    }
+
+    const { wtTable } = wot;
+
+    // Only the overlay that renders the frozen columns (and nothing past them) owns the seam line.
+    if (wtTable.getLastRenderedColumn() !== fixedColumnsStart - 1) {
+      return;
+    }
+
+    // The selection's inline-start column must sit exactly on the freeze line.
+    if (Math.min(corners[1], corners[3]) !== fixedColumnsStart) {
+      return;
+    }
+
+    const seamClassName = `${activeHeaderClassName}-seam`;
+    const headerLevels = wtTable.getColumnHeadersCount();
+
+    for (let level = 0; level < headerLevels; level++) {
+      const th = wtTable.getColumnHeader(fixedColumnsStart - 1, level) as HTMLElement | undefined;
+
+      if (isHTMLElement(th)) {
+        if (classNamesMap.has(th)) {
+          classNamesMap.get(th)!.set(seamClassName, 1);
+        } else {
+          classNamesMap.set(th, new Map<string, number>([[seamClassName, 1]]));
+        }
+      }
+    }
+  }
+
+  /**
+   * Row-axis mirror of {@link SelectionManager#markFrozenColumnSeamHeader} for the top freeze:
+   * tags the last top-frozen row header with a seam class when the first non-frozen row is the
+   * active header. That row's top edge lands on the top freeze line, which is drawn by the top
+   * overlay (a separate table) and is therefore out of reach of the `:has(+ tr ...)` rule that gives
+   * every other active row header its top accent. The class lets the theme color the seam's bottom
+   * border to match. No-op unless `fixedRowsTop` is used and this is the top overlay.
+   *
+   * @param {number[]} corners The active-header selection corners `[fromRow, fromColumn, toRow, toColumn]`.
+   * @param {string} activeHeaderClassName The active header class name (the seam class derives from it).
+   * @param {Map} classNamesMap The render cycle's element→classNames map (applied and cleaned up later).
+   */
+  #markFrozenTopRowSeamHeader(
+    corners: number[],
+    activeHeaderClassName: string,
+    classNamesMap: Map<HTMLElement, Map<string, number>>
+  ) {
+    const wot = this.#activeOverlaysWot!;
+    const fixedRowsTop = wot.getSetting('fixedRowsTop') as number;
+
+    if (fixedRowsTop <= 0) {
+      return;
+    }
+
+    const { wtTable } = wot;
+    const lastFrozenRow = fixedRowsTop - 1;
+
+    // Only the overlay that renders the top-frozen rows (ending exactly on the freeze line) owns the
+    // seam line.
+    if (wtTable.getLastRenderedRow() !== lastFrozenRow) {
+      return;
+    }
+
+    // The selection's top row must sit exactly on the first non-frozen row.
+    if (Math.min(corners[0], corners[2]) !== fixedRowsTop) {
+      return;
+    }
+
+    const seamClassName = `${activeHeaderClassName}-row-seam-top`;
+    const headerLevels = (wot.getSetting('rowHeaders') as Function[]).length;
+
+    for (let level = 0; level < headerLevels; level++) {
+      const th = wtTable.getRowHeader(lastFrozenRow, level) as HTMLElement | undefined;
+
+      // Overlays without row headers (e.g. the plain `top` overlay) return a TD here; only tag actual
+      // row-header cells.
+      if (isHTMLElement(th) && th.nodeName === 'TH') {
+        if (classNamesMap.has(th)) {
+          classNamesMap.get(th)!.set(seamClassName, 1);
+        } else {
+          classNamesMap.set(th, new Map<string, number>([[seamClassName, 1]]));
+        }
+      }
+    }
+  }
+
+  /**
+   * Row-axis mirror of {@link SelectionManager#markFrozenColumnSeamHeader} for the bottom freeze:
+   * tags the first bottom-frozen row header with a seam class when the last non-frozen row is the
+   * active header. That row's bottom edge lands on the bottom freeze line, which is drawn by the
+   * bottom overlay (a separate table) and is therefore out of reach of the `:has(+ tr ...)` rule that
+   * gives every other active row header its top accent. The class lets the theme color the seam's top
+   * border to match. No-op unless `fixedRowsBottom` is used and this is the bottom overlay.
+   *
+   * @param {number[]} corners The active-header selection corners `[fromRow, fromColumn, toRow, toColumn]`.
+   * @param {string} activeHeaderClassName The active header class name (the seam class derives from it).
+   * @param {Map} classNamesMap The render cycle's element→classNames map (applied and cleaned up later).
+   */
+  #markFrozenBottomRowSeamHeader(
+    corners: number[],
+    activeHeaderClassName: string,
+    classNamesMap: Map<HTMLElement, Map<string, number>>
+  ) {
+    const wot = this.#activeOverlaysWot!;
+    const fixedRowsBottom = wot.getSetting('fixedRowsBottom') as number;
+
+    if (fixedRowsBottom <= 0) {
+      return;
+    }
+
+    const { wtTable } = wot;
+    const totalRows = wot.getSetting('totalRows') as number;
+    const firstFrozenRow = totalRows - fixedRowsBottom;
+
+    // Only the overlay that renders the bottom-frozen rows (starting exactly on the freeze line) owns
+    // the seam line.
+    if (wtTable.getFirstRenderedRow() !== firstFrozenRow) {
+      return;
+    }
+
+    // The selection's bottom row must sit exactly on the last non-frozen row.
+    if (Math.max(corners[0], corners[2]) !== firstFrozenRow - 1) {
+      return;
+    }
+
+    const seamClassName = `${activeHeaderClassName}-row-seam-bottom`;
+    const headerLevels = (wot.getSetting('rowHeaders') as Function[]).length;
+
+    for (let level = 0; level < headerLevels; level++) {
+      const th = wtTable.getRowHeader(firstFrozenRow, level) as HTMLElement | undefined;
+
+      // Overlays without row headers (e.g. the plain `bottom` overlay) return a TD here; only tag
+      // actual row-header cells.
+      if (isHTMLElement(th) && th.nodeName === 'TH') {
+        if (classNamesMap.has(th)) {
+          classNamesMap.get(th)!.set(seamClassName, 1);
+        } else {
+          classNamesMap.set(th, new Map<string, number>([[seamClassName, 1]]));
+        }
+      }
+    }
   }
 
   /**

--- a/handsontable/src/3rdparty/walkontable/src/selection/manager.ts
+++ b/handsontable/src/3rdparty/walkontable/src/selection/manager.ts
@@ -301,6 +301,26 @@ export class SelectionManager {
   }
 
   /**
+   * Adds a seam class to a header element in the render cycle's class map, creating the per-element
+   * entry on first use. Shared by the frozen column/row seam taggers.
+   *
+   * @param {Map} classNamesMap The render cycle's element→classNames map (applied and cleaned up later).
+   * @param {HTMLElement} th The header element to tag.
+   * @param {string} seamClassName The seam class to add.
+   */
+  #tagSeamClass(
+    classNamesMap: Map<HTMLElement, Map<string, number>>,
+    th: HTMLElement,
+    seamClassName: string
+  ) {
+    if (classNamesMap.has(th)) {
+      classNamesMap.get(th)!.set(seamClassName, 1);
+    } else {
+      classNamesMap.set(th, new Map<string, number>([[seamClassName, 1]]));
+    }
+  }
+
+  /**
    * Tags the last frozen column header with a seam class when the first non-frozen column is the
    * active header. That header's inline-start edge lands on the frozen-pane seam, which is drawn by
    * the frozen overlay (a separate table) and is therefore out of reach of the neighbour `:has()`
@@ -342,11 +362,7 @@ export class SelectionManager {
       const th = wtTable.getColumnHeader(fixedColumnsStart - 1, level) as HTMLElement | undefined;
 
       if (isHTMLElement(th)) {
-        if (classNamesMap.has(th)) {
-          classNamesMap.get(th)!.set(seamClassName, 1);
-        } else {
-          classNamesMap.set(th, new Map<string, number>([[seamClassName, 1]]));
-        }
+        this.#tagSeamClass(classNamesMap, th, seamClassName);
       }
     }
   }
@@ -390,7 +406,7 @@ export class SelectionManager {
     }
 
     const seamClassName = `${activeHeaderClassName}-row-seam-top`;
-    const headerLevels = (wot.getSetting('rowHeaders') as Function[]).length;
+    const headerLevels = wtTable.getRowHeadersCount();
 
     for (let level = 0; level < headerLevels; level++) {
       const th = wtTable.getRowHeader(lastFrozenRow, level) as HTMLElement | undefined;
@@ -398,11 +414,7 @@ export class SelectionManager {
       // Overlays without row headers (e.g. the plain `top` overlay) return a TD here; only tag actual
       // row-header cells.
       if (isHTMLElement(th) && th.nodeName === 'TH') {
-        if (classNamesMap.has(th)) {
-          classNamesMap.get(th)!.set(seamClassName, 1);
-        } else {
-          classNamesMap.set(th, new Map<string, number>([[seamClassName, 1]]));
-        }
+        this.#tagSeamClass(classNamesMap, th, seamClassName);
       }
     }
   }
@@ -447,7 +459,7 @@ export class SelectionManager {
     }
 
     const seamClassName = `${activeHeaderClassName}-row-seam-bottom`;
-    const headerLevels = (wot.getSetting('rowHeaders') as Function[]).length;
+    const headerLevels = wtTable.getRowHeadersCount();
 
     for (let level = 0; level < headerLevels; level++) {
       const th = wtTable.getRowHeader(firstFrozenRow, level) as HTMLElement | undefined;
@@ -455,11 +467,7 @@ export class SelectionManager {
       // Overlays without row headers (e.g. the plain `bottom` overlay) return a TD here; only tag
       // actual row-header cells.
       if (isHTMLElement(th) && th.nodeName === 'TH') {
-        if (classNamesMap.has(th)) {
-          classNamesMap.get(th)!.set(seamClassName, 1);
-        } else {
-          classNamesMap.set(th, new Map<string, number>([[seamClassName, 1]]));
-        }
+        this.#tagSeamClass(classNamesMap, th, seamClassName);
       }
     }
   }

--- a/handsontable/src/3rdparty/walkontable/test/spec/selection/frozenBoundaryEdge.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/selection/frozenBoundaryEdge.spec.js
@@ -33,6 +33,7 @@ describe('Frozen boundary edge', () => {
       master: borders.find(b => b.wot.wtTable.isMaster),
       top: borders.find(b => b.wot.wtTable.name === 'top'),
       inlineStart: borders.find(b => b.wot.wtTable.name === 'inline_start'),
+      corner: borders.find(b => b.wot.wtTable.name === 'top_inline_start_corner'),
     };
   }
 
@@ -178,5 +179,47 @@ describe('Frozen boundary edge', () => {
     expect([master, inlineStart].filter(startShown).length).toBe(1);
     expect(startShown(inlineStart)).toBe(true);
     expect(startShown(master)).toBe(false);
+  });
+
+  // Cross-seam: a boundary edge that also crosses the PERPENDICULAR freeze line is split between two
+  // frozen overlays. The `inline_start` overlay renders only the non-frozen (scrolled) rows, so the
+  // slice of the column-freeze edge that reaches up into the frozen rows must come from the corner
+  // overlay — otherwise the master hides the whole edge and the frozen-row part disappears.
+  it('column edge crossing the row freeze line is drawn by inline_start + corner and hidden on master', async() => {
+    spec().$wrapper.width(300);
+    const { wt, selections } = build({ fixedRowsTop: 2, fixedColumnsStart: 2 });
+
+    // Selection flush against the column freeze line (column === fixedColumnsStart) reaching from the
+    // first non-frozen row (row 2) up into a frozen row (row 1).
+    selections.getFocus()
+      .clear()
+      .add(new Walkontable.CellCoords(2, 2))
+      .add(new Walkontable.CellCoords(1, 2));
+    wt.draw();
+
+    const { master, inlineStart, corner } = overlayBorders(wt, selections.getFocus());
+
+    expect(startShown(master)).toBe(false);
+    expect(startShown(inlineStart)).toBe(true); // non-frozen row slice (C3)
+    expect(startShown(corner)).toBe(true); // frozen row slice (C2)
+  });
+
+  it('row edge crossing the column freeze line is drawn by top + corner and hidden on master', async() => {
+    spec().$wrapper.width(300);
+    const { wt, selections } = build({ fixedRowsTop: 2, fixedColumnsStart: 2 });
+
+    // Selection flush against the row freeze line (row === fixedRowsTop) reaching from the first
+    // non-frozen column (column 2) left into a frozen column (column 1).
+    selections.getFocus()
+      .clear()
+      .add(new Walkontable.CellCoords(2, 2))
+      .add(new Walkontable.CellCoords(2, 1));
+    wt.draw();
+
+    const { master, top, corner } = overlayBorders(wt, selections.getFocus());
+
+    expect(topShown(master)).toBe(false);
+    expect(topShown(top)).toBe(true); // non-frozen column slice
+    expect(topShown(corner)).toBe(true); // frozen column slice
   });
 });

--- a/handsontable/src/3rdparty/walkontable/test/spec/selection/frozenBoundaryEdge.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/selection/frozenBoundaryEdge.spec.js
@@ -222,4 +222,148 @@ describe('Frozen boundary edge', () => {
     expect(topShown(top)).toBe(true); // non-frozen column slice
     expect(topShown(corner)).toBe(true); // frozen column slice
   });
+
+  // No-doubling: a cell inside the frozen ROWS but flush with the COLUMN freeze line is rendered by
+  // the `top` overlay, which would draw its own start edge in the regular flow — doubling the freeze
+  // edge the corner overlay owns. The `top` overlay (and the master) must hide that start edge.
+  it('frozen-row cell on the column freeze line: start edge only on corner, hidden on top + master', async() => {
+    spec().$wrapper.width(300);
+    const { wt, selections } = build({ fixedRowsTop: 2, fixedColumnsStart: 2 });
+
+    // row 0 = frozen row, column 2 = column freeze line.
+    selections.getFocus().clear().add(new Walkontable.CellCoords(0, 2));
+    wt.draw();
+
+    const { master, top, corner } = overlayBorders(wt, selections.getFocus());
+
+    expect([master, top, corner].filter(startShown).length).toBe(1);
+    expect(startShown(corner)).toBe(true);
+    expect(startShown(top)).toBe(false);
+    expect(startShown(master)).toBe(false);
+  });
+
+  // Symmetric no-doubling: a cell inside the frozen COLUMNS but flush with the ROW freeze line is
+  // rendered in the visible frozen-column area by the `inline_start` overlay, which must hide its top
+  // edge (owned by the corner). The `top` overlay also renders that frozen column, but it sits behind
+  // the corner overlay, so its (occluded) duplicate edge is harmless — the same way the cross-seam
+  // cases let `top` and `corner` overlap. The count therefore covers the visible-area overlays only.
+  it('frozen-column cell on the row freeze line: visible top edge only on corner, hidden on inline_start + master', async() => {
+    spec().$wrapper.width(300);
+    const { wt, selections } = build({ fixedRowsTop: 2, fixedColumnsStart: 2 });
+
+    // row 2 = row freeze line, column 0 = frozen column.
+    selections.getFocus().clear().add(new Walkontable.CellCoords(2, 0));
+    wt.draw();
+
+    const { master, inlineStart, corner } = overlayBorders(wt, selections.getFocus());
+
+    expect([master, inlineStart, corner].filter(topShown).length).toBe(1);
+    expect(topShown(corner)).toBe(true);
+    expect(topShown(inlineStart)).toBe(false);
+    expect(topShown(master)).toBe(false);
+  });
+
+  // The single cell flush with BOTH freeze lines: the top edge (top overlay) and the start edge
+  // (inline_start overlay) meet inside the frozen×frozen region owned by the corner overlay, which
+  // draws a connecting square there so the two lines join instead of leaving a gap.
+  it('single cell on both freeze lines: corner overlay draws the connecting square', async() => {
+    spec().$wrapper.width(300);
+    const { wt, selections } = build({ fixedRowsTop: 2, fixedColumnsStart: 2 });
+
+    selections.getFocus().clear().add(new Walkontable.CellCoords(2, 2));
+    wt.draw();
+
+    const { top, inlineStart, corner } = overlayBorders(wt, selections.getFocus());
+
+    expect(topShown(top)).toBe(true); // row-freeze edge
+    expect(startShown(inlineStart)).toBe(true); // column-freeze edge
+    expect(topShown(corner)).toBe(true); // connecting square (reuses the top border element)
+  });
+
+  // The freeze edge must not protrude above the grid: at row 0 there is no row above to overlap, so
+  // the line's top must stay within the pane (the `-1` overlap is dropped). Catches the regression
+  // where the column-freeze edge poked one pixel above the top-left corner.
+  it('column freeze edge at row 0 does not protrude above the pane', async() => {
+    spec().$wrapper.width(300);
+    const { wt, selections } = build({ fixedRowsTop: 2, fixedColumnsStart: 2 });
+
+    selections.getFocus().clear().add(new Walkontable.CellCoords(0, 2));
+    wt.draw();
+
+    const { corner } = overlayBorders(wt, selections.getFocus());
+
+    expect(startShown(corner)).toBe(true);
+    expect(parseInt(corner.startStyle.top, 10)).toBeGreaterThanOrEqual(0);
+  });
+
+  // The freeze edge is anchored a fixed pixel inside the freeze line, independent of the border
+  // width, so borders of different widths (e.g. focus 2px vs area/fill 1px) share the same edge
+  // instead of the thicker one bleeding further out. A 4px border must still sit ~1px inside the
+  // line — not 4px — keeping its inline-start edge aligned with a 1px border's.
+  it('column freeze edge anchors a constant pixel inside the line regardless of border width', async() => {
+    spec().$wrapper.width(300);
+    const { wt, selections } = build({ fixedColumnsStart: 2, borderWidth: 4 });
+
+    selections.getFocus().clear().add(new Walkontable.CellCoords(1, 2));
+    wt.draw();
+
+    const { inlineStart } = overlayBorders(wt, selections.getFocus());
+    // Freeze line = right edge of the last frozen column (column 1) in the inline_start overlay.
+    const boundaryCell = inlineStart.wot.wtTable.getCell(new Walkontable.CellCoords(1, 1));
+    const freezeLineRight = boundaryCell.getBoundingClientRect().right;
+    const edgeLeft = inlineStart.start.getBoundingClientRect().left;
+
+    // The drawn edge's inline-start sits one pixel inside the freeze line (constant), not 4px.
+    expect(Math.round(freezeLineRight - edgeLeft)).toBe(1);
+  });
+
+  // Scroll-out: the frozen overlay renders the frozen block whatever the scroll, so without consulting
+  // the master it would keep the column-freeze edge pinned to the seam even after the selected
+  // boundary column scrolls behind the pane — a line stuck at the freeze line. Once the boundary
+  // column is no longer visible in the master viewport, the edge must disappear. Built standalone with
+  // many narrow-viewport columns so the horizontal scroll genuinely pushes the boundary column out.
+  it('column freeze edge disappears once the boundary column scrolls behind the pane', async() => {
+    createDataArray(100, 30);
+    spec().$wrapper.width(200).height(200);
+    const selections = createSelectionController({ border: { width: 1, color: 'red' } });
+    const wt = walkontable({
+      data: getData,
+      totalRows: 100,
+      totalColumns: 30,
+      fixedColumnsStart: 2,
+      selections,
+    });
+
+    wt.draw();
+
+    // Cell flush with the column freeze line (column === fixedColumnsStart).
+    selections.getFocus().clear().add(new Walkontable.CellCoords(1, 2));
+    wt.draw();
+
+    expect(startShown(overlayBorders(wt, selections.getFocus()).inlineStart)).toBe(true);
+
+    // Scroll far right so column 2 slides behind the frozen pane and leaves the master viewport.
+    wt.scrollViewport(new Walkontable.CellCoords(1, 25));
+    wt.draw();
+
+    expect(wt.wtTable.getFirstVisibleColumn()).toBeGreaterThan(2); // precondition: boundary column is out
+    expect(startShown(overlayBorders(wt, selections.getFocus()).inlineStart)).toBe(false);
+  });
+
+  // Symmetric to the row-0 protrusion guard: at column 0 there is no column before the boundary cell,
+  // so the row-freeze edge's `-1` inline-start overlap must be dropped to avoid poking one pixel past
+  // the pane's inline-start edge.
+  it('row freeze edge at column 0 does not protrude past the inline-start of the pane', async() => {
+    spec().$wrapper.width(300);
+    const { wt, selections } = build({ fixedRowsTop: 2, fixedColumnsStart: 2 });
+
+    // row 2 = row freeze line, column 0 = first (frozen) column.
+    selections.getFocus().clear().add(new Walkontable.CellCoords(2, 0));
+    wt.draw();
+
+    const { corner } = overlayBorders(wt, selections.getFocus());
+
+    expect(topShown(corner)).toBe(true);
+    expect(parseInt(corner.topStyle.left, 10)).toBeGreaterThanOrEqual(0);
+  });
 });

--- a/handsontable/src/3rdparty/walkontable/test/spec/selection/frozenBoundaryEdge.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/selection/frozenBoundaryEdge.spec.js
@@ -70,7 +70,7 @@ describe('Frozen boundary edge', () => {
     return { wt, selections };
   }
 
-  it('LTR / fixedRowsTop: top edge is drawn on the top overlay and hidden on the master', async() => {
+  it('LTR / fixedRowsTop: seam top edge is drawn by BOTH the master (lower half) and the top overlay (upper half)', async() => {
     const { wt, selections } = build({ fixedRowsTop: 2 });
 
     // cell flush with the row freeze line: row === fixedRowsTop
@@ -78,21 +78,22 @@ describe('Frozen boundary edge', () => {
 
     const { master, top } = overlayBorders(wt, selections.getFocus());
 
-    expect([master, top].filter(topShown).length).toBe(1);
+    // The edge straddles the freeze line: the master shows the half below the seam, the top overlay
+    // the half above it (on top of the opaque frozen pane). Together they form the full thickness in
+    // both selection and edit modes.
+    expect(topShown(master)).toBe(true);
     expect(topShown(top)).toBe(true);
-    expect(topShown(master)).toBe(false);
   });
 
-  it('RTL / fixedRowsTop: top edge is drawn on the top overlay and hidden on the master', async() => {
+  it('RTL / fixedRowsTop: seam top edge is drawn by BOTH the master and the top overlay', async() => {
     const { wt, selections } = build({ rtl: true, fixedRowsTop: 2 });
 
     spec().$table.find('tbody tr:eq(2) td:eq(1)').simulate('mousedown');
 
     const { master, top } = overlayBorders(wt, selections.getFocus());
 
-    expect([master, top].filter(topShown).length).toBe(1);
+    expect(topShown(master)).toBe(true);
     expect(topShown(top)).toBe(true);
-    expect(topShown(master)).toBe(false);
   });
 
   it('LTR / fixedColumnsStart: start edge is drawn on the inline_start overlay and hidden on the master', async() => {
@@ -127,17 +128,41 @@ describe('Frozen boundary edge', () => {
   // Without that delta a gap opens at the corner for borders thicker than 1px. The thin dimension
   // stays equal to the configured border width. `outerWidth`/`outerHeight` map to `offsetWidth`/
   // `offsetHeight`, so the assertions read the boundary cell's offset size directly.
+  // Regression for the reported "top border ~1px thinner" bug (cell D4 with fixedRowsTop +
+  // fixedColumnsLeft). The seam top edge must keep its FULL thickness by STRADDLING the freeze line
+  // (like a normal cell border), with the master and the top overlay drawing the same straddling
+  // position so their visible halves combine on the line in both selection and edit modes.
+  it('LTR / fixedRowsTop: seam top edge straddles the freeze line at full thickness on master + overlay', async() => {
+    const { wt, selections } = build({ fixedRowsTop: 2, borderWidth: 2 });
+
+    spec().$table.find('tbody tr:eq(2) td:eq(1)').simulate('mousedown');
+
+    const { master, top } = overlayBorders(wt, selections.getFocus());
+    // freeze line = top of the selected cell (its top edge lands on the row freeze line)
+    const cell = wt.wtTable.getCell(new Walkontable.CellCoords(2, 1));
+    const freezeLineY = cell.getBoundingClientRect().top;
+    const masterEdge = master.top.getBoundingClientRect();
+    const topEdge = top.top.getBoundingClientRect();
+
+    // both layers draw the full thickness at the same straddling position
+    expect(Math.round(masterEdge.height)).toBe(2);
+    expect(Math.round(topEdge.height)).toBe(2);
+    expect(Math.round(masterEdge.top)).toBe(Math.round(topEdge.top));
+    // straddling: the edge spans the freeze line (part above for the overlay, part below for the master)
+    expect(Math.round(masterEdge.top)).toBeLessThan(Math.round(freezeLineY));
+    expect(Math.round(masterEdge.bottom)).toBeGreaterThan(Math.round(freezeLineY));
+  });
+
   it('LTR / fixedRowsTop: top edge length = spanned cell width + ceil(borderWidth / 2)', async() => {
     const { wt, selections } = build({ fixedRowsTop: 2, borderWidth: 4 });
 
     spec().$table.find('tbody tr:eq(2) td:eq(1)').simulate('mousedown');
 
-    const { top } = overlayBorders(wt, selections.getFocus());
-    // boundary cell = last frozen row (fixedRowsTop - 1) in the selected (single) column
-    const boundaryCellWidth = spec().$table.find('tbody tr:eq(1) td:eq(1)')[0].offsetWidth;
+    const { master } = overlayBorders(wt, selections.getFocus());
+    const boundaryCellWidth = spec().$table.find('tbody tr:eq(2) td:eq(1)')[0].offsetWidth;
 
-    expect(parseInt(top.topStyle.width, 10)).toBe(boundaryCellWidth + Math.ceil(4 / 2));
-    expect(parseInt(top.topStyle.height, 10)).toBe(4);
+    expect(parseInt(master.topStyle.width, 10)).toBe(boundaryCellWidth + Math.ceil(4 / 2));
+    expect(parseInt(master.topStyle.height, 10)).toBe(4);
   });
 
   it('RTL / fixedRowsTop: top edge length = spanned cell width + ceil(borderWidth / 2)', async() => {
@@ -146,11 +171,11 @@ describe('Frozen boundary edge', () => {
 
     spec().$table.find('tbody tr:eq(2) td:eq(1)').simulate('mousedown');
 
-    const { top } = overlayBorders(wt, selections.getFocus());
-    const boundaryCellWidth = spec().$table.find('tbody tr:eq(1) td:eq(1)')[0].offsetWidth;
+    const { master } = overlayBorders(wt, selections.getFocus());
+    const boundaryCellWidth = spec().$table.find('tbody tr:eq(2) td:eq(1)')[0].offsetWidth;
 
-    expect(parseInt(top.topStyle.width, 10)).toBe(boundaryCellWidth + Math.ceil(4 / 2));
-    expect(parseInt(top.topStyle.height, 10)).toBe(4);
+    expect(parseInt(master.topStyle.width, 10)).toBe(boundaryCellWidth + Math.ceil(4 / 2));
+    expect(parseInt(master.topStyle.height, 10)).toBe(4);
   });
 
   it('LTR / fixedColumnsStart: start edge length = spanned cell height + ceil(borderWidth / 2)', async() => {
@@ -167,7 +192,7 @@ describe('Frozen boundary edge', () => {
     expect(parseInt(inlineStart.startStyle.width, 10)).toBe(4);
   });
 
-  it('combined fixedRowsTop + fixedColumnsStart: each boundary edge is drawn on its own overlay only', async() => {
+  it('combined fixedRowsTop + fixedColumnsStart: row edge straddles (master + top), column edge on inline_start', async() => {
     spec().$wrapper.width(300);
     const { wt, selections } = build({ fixedRowsTop: 2, fixedColumnsStart: 2 });
 
@@ -176,10 +201,9 @@ describe('Frozen boundary edge', () => {
 
     const { master, top, inlineStart } = overlayBorders(wt, selections.getFocus());
 
-    // row edge owned by the top overlay
-    expect([master, top].filter(topShown).length).toBe(1);
+    // row edge straddles the seam: master (lower half) + top overlay (upper half)
+    expect(topShown(master)).toBe(true);
     expect(topShown(top)).toBe(true);
-    expect(topShown(master)).toBe(false);
 
     // column edge owned by the inline_start overlay
     expect([master, inlineStart].filter(startShown).length).toBe(1);
@@ -210,7 +234,7 @@ describe('Frozen boundary edge', () => {
     expect(startShown(corner)).toBe(true); // frozen row slice (C2)
   });
 
-  it('row edge crossing the column freeze line is drawn by top + corner and hidden on master', async() => {
+  it('row edge crossing the column freeze line is drawn by master + top (non-frozen) and corner (frozen slice)', async() => {
     spec().$wrapper.width(300);
     const { wt, selections } = build({ fixedRowsTop: 2, fixedColumnsStart: 2 });
 
@@ -224,8 +248,8 @@ describe('Frozen boundary edge', () => {
 
     const { master, top, corner } = overlayBorders(wt, selections.getFocus());
 
-    expect(topShown(master)).toBe(false);
-    expect(topShown(top)).toBe(true); // non-frozen column slice
+    expect(topShown(master)).toBe(true); // straddle: lower half on the master
+    expect(topShown(top)).toBe(true); // straddle: upper half on the top overlay (non-frozen columns)
     expect(topShown(corner)).toBe(true); // frozen column slice
   });
 
@@ -269,9 +293,9 @@ describe('Frozen boundary edge', () => {
     expect(topShown(master)).toBe(false);
   });
 
-  // The single cell flush with BOTH freeze lines: the top edge (top overlay) and the start edge
-  // (inline_start overlay) meet inside the frozen×frozen region owned by the corner overlay, which
-  // draws a connecting square there so the two lines join instead of leaving a gap.
+  // The single cell flush with BOTH freeze lines: the top edge (straddling: master + top overlay) and
+  // the start edge (inline_start overlay) meet inside the frozen×frozen region owned by the corner
+  // overlay, which draws a connecting square there so the two lines join instead of leaving a gap.
   it('single cell on both freeze lines: corner overlay draws the connecting square', async() => {
     spec().$wrapper.width(300);
     const { wt, selections } = build({ fixedRowsTop: 2, fixedColumnsStart: 2 });
@@ -279,9 +303,9 @@ describe('Frozen boundary edge', () => {
     selections.getFocus().clear().add(new Walkontable.CellCoords(2, 2));
     wt.draw();
 
-    const { top, inlineStart, corner } = overlayBorders(wt, selections.getFocus());
+    const { master, inlineStart, corner } = overlayBorders(wt, selections.getFocus());
 
-    expect(topShown(top)).toBe(true); // row-freeze edge
+    expect(topShown(master)).toBe(true); // row-freeze edge (master draws the straddle's lower half)
     expect(startShown(inlineStart)).toBe(true); // column-freeze edge
     expect(topShown(corner)).toBe(true); // connecting square (reuses the top border element)
   });
@@ -373,10 +397,10 @@ describe('Frozen boundary edge', () => {
     expect(parseInt(corner.topStyle.left, 10)).toBeGreaterThanOrEqual(0);
   });
 
-  // Bottom-freeze mirror of the `fixedRowsTop` case: a selection whose bottom edge lands on the
-  // `fixedRowsBottom` line is rendered by the master under the bottom overlay, so the bottom overlay
-  // re-draws it and the master hides it — exactly one bottom edge, never zero, never doubled.
-  it('LTR / fixedRowsBottom: bottom edge is drawn on the bottom overlay and hidden on the master', async() => {
+  // Bottom-freeze mirror of the `fixedRowsTop` straddle: the bottom edge on the `fixedRowsBottom` line
+  // straddles the seam, drawn by BOTH the master (half above the line) and the bottom overlay (half
+  // below it, on top of the opaque bottom pane), so the full thickness shows in selection and edit.
+  it('LTR / fixedRowsBottom: seam bottom edge is drawn by BOTH the master and the bottom overlay', async() => {
     const { wt, selections } = build({ fixedRowsBottom: 2 });
 
     // cell flush with the bottom freeze line: row === totalRows - fixedRowsBottom - 1 (8 - 2 - 1 = 5)
@@ -384,21 +408,54 @@ describe('Frozen boundary edge', () => {
 
     const { master, bottom } = overlayBorders(wt, selections.getFocus());
 
-    expect([master, bottom].filter(bottomShown).length).toBe(1);
+    expect(bottomShown(master)).toBe(true);
     expect(bottomShown(bottom)).toBe(true);
-    expect(bottomShown(master)).toBe(false);
   });
 
-  it('RTL / fixedRowsBottom: bottom edge is drawn on the bottom overlay and hidden on the master', async() => {
+  it('RTL / fixedRowsBottom: seam bottom edge is drawn by BOTH the master and the bottom overlay', async() => {
     const { wt, selections } = build({ rtl: true, fixedRowsBottom: 2 });
 
     spec().$table.find('tbody tr:eq(5) td:eq(1)').simulate('mousedown');
 
     const { master, bottom } = overlayBorders(wt, selections.getFocus());
 
-    expect([master, bottom].filter(bottomShown).length).toBe(1);
+    expect(bottomShown(master)).toBe(true);
     expect(bottomShown(bottom)).toBe(true);
-    expect(bottomShown(master)).toBe(false);
+  });
+
+  // Regression for the reported "bottom line thin" bug (cell D47 with fixedRowsBottom). Built like the
+  // real case — a tall table scrolled to the bottom so the bottom pane sits flush against the last
+  // non-frozen row. The master draws the seam bottom edge at full thickness inside the cell (above the
+  // freeze line), where it is NOT occluded by the bottom pane below — so it must no longer be hidden.
+  it('LTR / fixedRowsBottom: seam bottom edge keeps full thickness on the master (not hidden, not clipped)', async() => {
+    createDataArray(100, 8);
+    spec().$wrapper.width(300).height(200);
+    const selections = createSelectionController({ border: { width: 2, color: 'red' } });
+    const wt = walkontable({
+      data: getData,
+      totalRows: 100,
+      totalColumns: 8,
+      fixedRowsBottom: 2,
+      selections,
+    });
+
+    wt.draw();
+    // bottom boundary row = totalRows - fixedRowsBottom - 1 = 97
+    selections.getFocus().clear().add(new Walkontable.CellCoords(97, 1));
+    wt.draw();
+    // scroll to the bottom so row 97 is visible and flush against the sticky bottom pane
+    wt.scrollViewport(new Walkontable.CellCoords(97, 1));
+    wt.draw();
+
+    const { master } = overlayBorders(wt, selections.getFocus());
+    const cell = wt.wtTable.getCell(new Walkontable.CellCoords(97, 1));
+    const freezeLineY = cell.getBoundingClientRect().bottom;
+    const masterEdge = master.bottom.getBoundingClientRect();
+
+    expect(bottomShown(master)).toBe(true);
+    expect(Math.round(masterEdge.height)).toBe(2); // full focus thickness
+    // the edge sits at the cell bottom, above the freeze line — not clipped by the bottom pane below it
+    expect(Math.round(masterEdge.bottom)).toBeLessThanOrEqual(Math.round(freezeLineY) + 1);
   });
 
   // Regression for the reported bug: a selection flush with the COLUMN freeze line whose span reaches
@@ -465,11 +522,11 @@ describe('Frozen boundary edge', () => {
     expect(startShown(bottomCorner)).toBe(true); // bottom-frozen row slice (rows 6, 7)
   });
 
-  // Bottom mirror of "row edge crossing the column freeze line is drawn by top + corner": a bottom
-  // edge that also reaches left into the frozen columns is split between the `bottom` overlay (non-
-  // frozen columns) and the bottom corner overlay (frozen columns). The `inline_start` overlay renders
-  // the boundary cell too, so it must hide its duplicate bottom edge.
-  it('bottom edge crossing the column freeze line is drawn by bottom + bottom corner, hidden on master + inline_start', async() => {
+  // Bottom mirror of "row edge crossing the column freeze line": a bottom edge that also reaches left
+  // into the frozen columns. Its straddle's upper half is on the master (non-frozen columns); the lower
+  // half is split between the `bottom` overlay (non-frozen columns) and the bottom corner overlay
+  // (frozen columns). The `inline_start` overlay must hide its duplicate bottom edge.
+  it('bottom edge crossing the column freeze line is drawn by master + bottom (non-frozen) and bottom corner (frozen)', async() => {
     spec().$wrapper.width(300);
     const { wt, selections } = build({ fixedRowsBottom: 2, fixedColumnsStart: 2 });
 
@@ -483,10 +540,10 @@ describe('Frozen boundary edge', () => {
 
     const { master, inlineStart, bottom, bottomCorner } = overlayBorders(wt, selections.getFocus());
 
-    expect(bottomShown(master)).toBe(false);
+    expect(bottomShown(master)).toBe(true); // straddle: upper half on the master
     expect(bottomShown(inlineStart)).toBe(false); // occluded duplicate hidden
-    expect(bottomShown(bottom)).toBe(true); // non-frozen column slice (column 2)
-    expect(bottomShown(bottomCorner)).toBe(true); // frozen column slice (column 1)
+    expect(bottomShown(bottom)).toBe(true); // lower half, non-frozen column slice (column 2)
+    expect(bottomShown(bottomCorner)).toBe(true); // lower half, frozen column slice (column 1)
   });
 
   // Scroll-out mirror: the bottom overlay renders the bottom-frozen block whatever the scroll, so
@@ -553,4 +610,5 @@ describe('Frozen boundary edge', () => {
     expect(parseInt(bottom.bottomStyle.width, 10)).toBe(boundaryCellWidth + Math.ceil(4 / 2));
     expect(parseInt(bottom.bottomStyle.height, 10)).toBe(4);
   });
+
 });

--- a/handsontable/src/3rdparty/walkontable/test/spec/selection/frozenBoundaryEdge.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/selection/frozenBoundaryEdge.spec.js
@@ -34,13 +34,18 @@ describe('Frozen boundary edge', () => {
       top: borders.find(b => b.wot.wtTable.name === 'top'),
       inlineStart: borders.find(b => b.wot.wtTable.name === 'inline_start'),
       corner: borders.find(b => b.wot.wtTable.name === 'top_inline_start_corner'),
+      bottom: borders.find(b => b.wot.wtTable.name === 'bottom'),
+      bottomCorner: borders.find(b => b.wot.wtTable.name === 'bottom_inline_start_corner'),
     };
   }
 
   const topShown = b => !!b && !!b.topStyle && b.topStyle.display === 'block';
   const startShown = b => !!b && !!b.startStyle && b.startStyle.display === 'block';
+  const bottomShown = b => !!b && !!b.bottomStyle && b.bottomStyle.display === 'block';
 
-  function build({ rtl = false, fixedRowsTop = 0, fixedColumnsStart = 0, borderWidth = 1 } = {}) {
+  function build({
+    rtl = false, fixedRowsTop = 0, fixedRowsBottom = 0, fixedColumnsStart = 0, borderWidth = 1
+  } = {}) {
     if (rtl) {
       $('html').attr('dir', 'rtl');
     }
@@ -51,6 +56,7 @@ describe('Frozen boundary edge', () => {
       totalRows: 8,
       totalColumns: 8,
       fixedRowsTop,
+      fixedRowsBottom,
       fixedColumnsStart,
       selections,
       onCellMouseDown(event, coords) {
@@ -365,5 +371,186 @@ describe('Frozen boundary edge', () => {
 
     expect(topShown(corner)).toBe(true);
     expect(parseInt(corner.topStyle.left, 10)).toBeGreaterThanOrEqual(0);
+  });
+
+  // Bottom-freeze mirror of the `fixedRowsTop` case: a selection whose bottom edge lands on the
+  // `fixedRowsBottom` line is rendered by the master under the bottom overlay, so the bottom overlay
+  // re-draws it and the master hides it — exactly one bottom edge, never zero, never doubled.
+  it('LTR / fixedRowsBottom: bottom edge is drawn on the bottom overlay and hidden on the master', async() => {
+    const { wt, selections } = build({ fixedRowsBottom: 2 });
+
+    // cell flush with the bottom freeze line: row === totalRows - fixedRowsBottom - 1 (8 - 2 - 1 = 5)
+    spec().$table.find('tbody tr:eq(5) td:eq(1)').simulate('mousedown');
+
+    const { master, bottom } = overlayBorders(wt, selections.getFocus());
+
+    expect([master, bottom].filter(bottomShown).length).toBe(1);
+    expect(bottomShown(bottom)).toBe(true);
+    expect(bottomShown(master)).toBe(false);
+  });
+
+  it('RTL / fixedRowsBottom: bottom edge is drawn on the bottom overlay and hidden on the master', async() => {
+    const { wt, selections } = build({ rtl: true, fixedRowsBottom: 2 });
+
+    spec().$table.find('tbody tr:eq(5) td:eq(1)').simulate('mousedown');
+
+    const { master, bottom } = overlayBorders(wt, selections.getFocus());
+
+    expect([master, bottom].filter(bottomShown).length).toBe(1);
+    expect(bottomShown(bottom)).toBe(true);
+    expect(bottomShown(master)).toBe(false);
+  });
+
+  // Regression for the reported bug: a selection flush with the COLUMN freeze line whose span reaches
+  // DOWN into the bottom-frozen rows. The `inline_start` overlay renders only the non-frozen rows, so
+  // the slice of the column-freeze edge inside the bottom-frozen rows must come from the bottom corner
+  // overlay — otherwise the master hides the whole edge, the bottom overlay's copy is occluded by the
+  // corner, and the bottom rows lose their start edge (the "D48/D49 missing left edge" symptom).
+  it('column edge crossing the bottom freeze line is drawn by inline_start + bottom corner, hidden on master + bottom', async() => {
+    spec().$wrapper.width(300);
+    const { wt, selections } = build({ fixedRowsBottom: 2, fixedColumnsStart: 2 });
+
+    // Column flush with the freeze line (column === fixedColumnsStart) from the last non-frozen row
+    // (row 5) down into the bottom-frozen rows (rows 6, 7).
+    selections.getFocus()
+      .clear()
+      .add(new Walkontable.CellCoords(5, 2))
+      .add(new Walkontable.CellCoords(7, 2));
+    wt.draw();
+
+    const { master, inlineStart, bottom, bottomCorner } = overlayBorders(wt, selections.getFocus());
+
+    expect(startShown(master)).toBe(false);
+    expect(startShown(bottom)).toBe(false); // occluded duplicate hidden
+    expect(startShown(inlineStart)).toBe(true); // non-frozen row slice (row 5)
+    expect(startShown(bottomCorner)).toBe(true); // bottom-frozen row slice (rows 6, 7)
+  });
+
+  // Bottom mirror of the "single cell on both freeze lines" case: the bottom edge (bottom overlay) and
+  // the start edge (inline_start overlay) meet inside the bottom corner overlay's frozen×frozen region,
+  // which draws a connecting square (reusing the bottom border element) so the lines join.
+  it('single cell on bottom + column freeze lines: bottom corner draws the connecting square', async() => {
+    spec().$wrapper.width(300);
+    const { wt, selections } = build({ fixedRowsBottom: 2, fixedColumnsStart: 2 });
+
+    // row 5 = bottom freeze line, column 2 = column freeze line.
+    selections.getFocus().clear().add(new Walkontable.CellCoords(5, 2));
+    wt.draw();
+
+    const { inlineStart, bottom, bottomCorner } = overlayBorders(wt, selections.getFocus());
+
+    expect(bottomShown(bottom)).toBe(true); // bottom-freeze edge
+    expect(startShown(inlineStart)).toBe(true); // column-freeze edge
+    expect(bottomShown(bottomCorner)).toBe(true); // connecting square (reuses the bottom border element)
+  });
+
+  // RTL counterpart of the reported-bug regression: the column-freeze edge crossing down into the
+  // bottom-frozen rows must still be split between `inline_start` and the bottom corner, hidden on the
+  // master and the (occluded) `bottom` overlay.
+  it('RTL / column edge crossing the bottom freeze line is drawn by inline_start + bottom corner', async() => {
+    spec().$wrapper.width(300);
+    const { wt, selections } = build({ rtl: true, fixedRowsBottom: 2, fixedColumnsStart: 2 });
+
+    selections.getFocus()
+      .clear()
+      .add(new Walkontable.CellCoords(5, 2))
+      .add(new Walkontable.CellCoords(7, 2));
+    wt.draw();
+
+    const { master, inlineStart, bottom, bottomCorner } = overlayBorders(wt, selections.getFocus());
+
+    expect(startShown(master)).toBe(false);
+    expect(startShown(bottom)).toBe(false); // occluded duplicate hidden
+    expect(startShown(inlineStart)).toBe(true); // non-frozen row slice (row 5)
+    expect(startShown(bottomCorner)).toBe(true); // bottom-frozen row slice (rows 6, 7)
+  });
+
+  // Bottom mirror of "row edge crossing the column freeze line is drawn by top + corner": a bottom
+  // edge that also reaches left into the frozen columns is split between the `bottom` overlay (non-
+  // frozen columns) and the bottom corner overlay (frozen columns). The `inline_start` overlay renders
+  // the boundary cell too, so it must hide its duplicate bottom edge.
+  it('bottom edge crossing the column freeze line is drawn by bottom + bottom corner, hidden on master + inline_start', async() => {
+    spec().$wrapper.width(300);
+    const { wt, selections } = build({ fixedRowsBottom: 2, fixedColumnsStart: 2 });
+
+    // Selection flush against the bottom freeze line (row === totalRows - fixedRowsBottom - 1 = 5)
+    // reaching from the first non-frozen column (column 2) left into a frozen column (column 1).
+    selections.getFocus()
+      .clear()
+      .add(new Walkontable.CellCoords(5, 2))
+      .add(new Walkontable.CellCoords(5, 1));
+    wt.draw();
+
+    const { master, inlineStart, bottom, bottomCorner } = overlayBorders(wt, selections.getFocus());
+
+    expect(bottomShown(master)).toBe(false);
+    expect(bottomShown(inlineStart)).toBe(false); // occluded duplicate hidden
+    expect(bottomShown(bottom)).toBe(true); // non-frozen column slice (column 2)
+    expect(bottomShown(bottomCorner)).toBe(true); // frozen column slice (column 1)
+  });
+
+  // Scroll-out mirror: the bottom overlay renders the bottom-frozen block whatever the scroll, so
+  // without consulting the master it would keep the bottom-freeze edge pinned to the seam even after
+  // the selected boundary row scrolls above the pane. Once the boundary row drops out of the master
+  // viewport (scrolled up to the top), the edge must disappear.
+  it('bottom freeze edge disappears once the boundary row scrolls above the pane', async() => {
+    createDataArray(100, 8);
+    spec().$wrapper.width(300).height(200);
+    const selections = createSelectionController({ border: { width: 1, color: 'red' } });
+    const wt = walkontable({
+      data: getData,
+      totalRows: 100,
+      totalColumns: 8,
+      fixedRowsBottom: 2,
+      selections,
+    });
+
+    wt.draw();
+
+    // Cell flush with the bottom freeze line (row === totalRows - fixedRowsBottom - 1 = 97).
+    selections.getFocus().clear().add(new Walkontable.CellCoords(97, 1));
+    wt.draw();
+
+    // Scroll to the bottom so the boundary row is visible and the edge is drawn.
+    wt.scrollViewport(new Walkontable.CellCoords(97, 1));
+    wt.draw();
+
+    expect(bottomShown(overlayBorders(wt, selections.getFocus()).bottom)).toBe(true);
+
+    // Scroll up to the top so row 97 leaves the master viewport (only the frozen rows 98/99 stay).
+    wt.scrollViewport(new Walkontable.CellCoords(0, 1));
+    wt.draw();
+
+    expect(wt.wtTable.getLastVisibleRow()).toBeLessThan(97); // precondition: boundary row is out
+    expect(bottomShown(overlayBorders(wt, selections.getFocus()).bottom)).toBe(false);
+  });
+
+  // Geometry mirror of the top-edge length tests: the bottom edge must reach the side edges the master
+  // draws, so its length is the spanned (boundary) cell width plus the half-border delta
+  // (`ceil(borderWidth / 2)`); the thin dimension equals the configured border width.
+  it('LTR / fixedRowsBottom: bottom edge length = spanned cell width + ceil(borderWidth / 2)', async() => {
+    const { wt, selections } = build({ fixedRowsBottom: 2, borderWidth: 4 });
+
+    spec().$table.find('tbody tr:eq(5) td:eq(1)').simulate('mousedown');
+
+    const { bottom } = overlayBorders(wt, selections.getFocus());
+    // boundary cell = first bottom-frozen row (totalRows - fixedRowsBottom = 6) in the selected column
+    const boundaryCellWidth = spec().$table.find('tbody tr:eq(6) td:eq(1)')[0].offsetWidth;
+
+    expect(parseInt(bottom.bottomStyle.width, 10)).toBe(boundaryCellWidth + Math.ceil(4 / 2));
+    expect(parseInt(bottom.bottomStyle.height, 10)).toBe(4);
+  });
+
+  it('RTL / fixedRowsBottom: bottom edge length = spanned cell width + ceil(borderWidth / 2)', async() => {
+    spec().$wrapper.width(300);
+    const { wt, selections } = build({ rtl: true, fixedRowsBottom: 2, borderWidth: 4 });
+
+    spec().$table.find('tbody tr:eq(5) td:eq(1)').simulate('mousedown');
+
+    const { bottom } = overlayBorders(wt, selections.getFocus());
+    const boundaryCellWidth = spec().$table.find('tbody tr:eq(6) td:eq(1)')[0].offsetWidth;
+
+    expect(parseInt(bottom.bottomStyle.width, 10)).toBe(boundaryCellWidth + Math.ceil(4 / 2));
+    expect(parseInt(bottom.bottomStyle.height, 10)).toBe(4);
   });
 });

--- a/handsontable/src/3rdparty/walkontable/test/spec/selection/frozenBoundaryEdge.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/selection/frozenBoundaryEdge.spec.js
@@ -1,0 +1,182 @@
+/**
+ * Regression coverage for `Border#drawFrozenBoundaryEdge`.
+ *
+ * A selection edge that lands exactly on a frozen-pane boundary is rendered by the master overlay
+ * right on the freeze line, where the frozen overlay (stacked above) occludes it. The master hides
+ * that edge and the frozen overlay re-draws it, so the edge must be visible in EXACTLY ONE overlay:
+ * drawn on the frozen overlay (`top` / `inline_start`), hidden on the master — never zero (missing),
+ * never two (doubled). This must hold in both LTR and RTL.
+ */
+describe('Frozen boundary edge', () => {
+  beforeEach(function() {
+    this.$wrapper = $('<div></div>').addClass('handsontable');
+    this.$container = $('<div></div>');
+    this.$wrapper.width(100).height(200);
+    this.$table = $('<table></table>').addClass('htCore');
+    this.$wrapper.append(this.$container);
+    this.$container.append(this.$table);
+    this.$wrapper.appendTo('body');
+    createDataArray(100, 8);
+  });
+
+  afterEach(function() {
+    $('html').attr('dir', 'ltr');
+    $('.wtHolder').remove();
+    this.$wrapper.remove();
+    this.wotInstance.destroy();
+  });
+
+  function overlayBorders(wt, selection) {
+    const borders = wt.selectionManager.getBorderInstances(selection);
+
+    return {
+      master: borders.find(b => b.wot.wtTable.isMaster),
+      top: borders.find(b => b.wot.wtTable.name === 'top'),
+      inlineStart: borders.find(b => b.wot.wtTable.name === 'inline_start'),
+    };
+  }
+
+  const topShown = b => !!b && !!b.topStyle && b.topStyle.display === 'block';
+  const startShown = b => !!b && !!b.startStyle && b.startStyle.display === 'block';
+
+  function build({ rtl = false, fixedRowsTop = 0, fixedColumnsStart = 0, borderWidth = 1 } = {}) {
+    if (rtl) {
+      $('html').attr('dir', 'rtl');
+    }
+    const selections = createSelectionController({ border: { width: borderWidth, color: 'red' } });
+    const wt = walkontable({
+      rtlMode: rtl,
+      data: getData,
+      totalRows: 8,
+      totalColumns: 8,
+      fixedRowsTop,
+      fixedColumnsStart,
+      selections,
+      onCellMouseDown(event, coords) {
+        selections.getFocus().clear().add(coords);
+        wt.draw();
+      }
+    });
+
+    wt.draw();
+
+    return { wt, selections };
+  }
+
+  it('LTR / fixedRowsTop: top edge is drawn on the top overlay and hidden on the master', async() => {
+    const { wt, selections } = build({ fixedRowsTop: 2 });
+
+    // cell flush with the row freeze line: row === fixedRowsTop
+    spec().$table.find('tbody tr:eq(2) td:eq(1)').simulate('mousedown');
+
+    const { master, top } = overlayBorders(wt, selections.getFocus());
+
+    expect([master, top].filter(topShown).length).toBe(1);
+    expect(topShown(top)).toBe(true);
+    expect(topShown(master)).toBe(false);
+  });
+
+  it('RTL / fixedRowsTop: top edge is drawn on the top overlay and hidden on the master', async() => {
+    const { wt, selections } = build({ rtl: true, fixedRowsTop: 2 });
+
+    spec().$table.find('tbody tr:eq(2) td:eq(1)').simulate('mousedown');
+
+    const { master, top } = overlayBorders(wt, selections.getFocus());
+
+    expect([master, top].filter(topShown).length).toBe(1);
+    expect(topShown(top)).toBe(true);
+    expect(topShown(master)).toBe(false);
+  });
+
+  it('LTR / fixedColumnsStart: start edge is drawn on the inline_start overlay and hidden on the master', async() => {
+    spec().$wrapper.width(300);
+    const { wt, selections } = build({ fixedColumnsStart: 2 });
+
+    // cell flush with the column freeze line: column === fixedColumnsStart
+    spec().$table.find('tbody tr:eq(1) td:eq(2)').simulate('mousedown');
+
+    const { master, inlineStart } = overlayBorders(wt, selections.getFocus());
+
+    expect([master, inlineStart].filter(startShown).length).toBe(1);
+    expect(startShown(inlineStart)).toBe(true);
+    expect(startShown(master)).toBe(false);
+  });
+
+  it('RTL / fixedColumnsStart: start edge is drawn on the inline_start overlay and hidden on the master', async() => {
+    spec().$wrapper.width(300);
+    const { wt, selections } = build({ rtl: true, fixedColumnsStart: 2 });
+
+    spec().$table.find('tbody tr:eq(1) td:eq(2)').simulate('mousedown');
+
+    const { master, inlineStart } = overlayBorders(wt, selections.getFocus());
+
+    expect([master, inlineStart].filter(startShown).length).toBe(1);
+    expect(startShown(inlineStart)).toBe(true);
+    expect(startShown(master)).toBe(false);
+  });
+
+  // Geometry: the boundary edge must reach the side edges drawn by the master, so — like `appear` —
+  // its length is the spanned cell dimension plus the half-border delta (`ceil(borderWidth / 2)`).
+  // Without that delta a gap opens at the corner for borders thicker than 1px. The thin dimension
+  // stays equal to the configured border width. `outerWidth`/`outerHeight` map to `offsetWidth`/
+  // `offsetHeight`, so the assertions read the boundary cell's offset size directly.
+  it('LTR / fixedRowsTop: top edge length = spanned cell width + ceil(borderWidth / 2)', async() => {
+    const { wt, selections } = build({ fixedRowsTop: 2, borderWidth: 4 });
+
+    spec().$table.find('tbody tr:eq(2) td:eq(1)').simulate('mousedown');
+
+    const { top } = overlayBorders(wt, selections.getFocus());
+    // boundary cell = last frozen row (fixedRowsTop - 1) in the selected (single) column
+    const boundaryCellWidth = spec().$table.find('tbody tr:eq(1) td:eq(1)')[0].offsetWidth;
+
+    expect(parseInt(top.topStyle.width, 10)).toBe(boundaryCellWidth + Math.ceil(4 / 2));
+    expect(parseInt(top.topStyle.height, 10)).toBe(4);
+  });
+
+  it('RTL / fixedRowsTop: top edge length = spanned cell width + ceil(borderWidth / 2)', async() => {
+    spec().$wrapper.width(300);
+    const { wt, selections } = build({ rtl: true, fixedRowsTop: 2, borderWidth: 4 });
+
+    spec().$table.find('tbody tr:eq(2) td:eq(1)').simulate('mousedown');
+
+    const { top } = overlayBorders(wt, selections.getFocus());
+    const boundaryCellWidth = spec().$table.find('tbody tr:eq(1) td:eq(1)')[0].offsetWidth;
+
+    expect(parseInt(top.topStyle.width, 10)).toBe(boundaryCellWidth + Math.ceil(4 / 2));
+    expect(parseInt(top.topStyle.height, 10)).toBe(4);
+  });
+
+  it('LTR / fixedColumnsStart: start edge length = spanned cell height + ceil(borderWidth / 2)', async() => {
+    spec().$wrapper.width(300);
+    const { wt, selections } = build({ fixedColumnsStart: 2, borderWidth: 4 });
+
+    spec().$table.find('tbody tr:eq(1) td:eq(2)').simulate('mousedown');
+
+    const { inlineStart } = overlayBorders(wt, selections.getFocus());
+    // boundary cell = last frozen column (fixedColumnsStart - 1) in the selected (single) row
+    const boundaryCellHeight = spec().$table.find('tbody tr:eq(1) td:eq(1)')[0].offsetHeight;
+
+    expect(parseInt(inlineStart.startStyle.height, 10)).toBe(boundaryCellHeight + Math.ceil(4 / 2));
+    expect(parseInt(inlineStart.startStyle.width, 10)).toBe(4);
+  });
+
+  it('combined fixedRowsTop + fixedColumnsStart: each boundary edge is drawn on its own overlay only', async() => {
+    spec().$wrapper.width(300);
+    const { wt, selections } = build({ fixedRowsTop: 2, fixedColumnsStart: 2 });
+
+    // corner cell flush with BOTH freeze lines: row === fixedRowsTop && column === fixedColumnsStart
+    spec().$table.find('tbody tr:eq(2) td:eq(2)').simulate('mousedown');
+
+    const { master, top, inlineStart } = overlayBorders(wt, selections.getFocus());
+
+    // row edge owned by the top overlay
+    expect([master, top].filter(topShown).length).toBe(1);
+    expect(topShown(top)).toBe(true);
+    expect(topShown(master)).toBe(false);
+
+    // column edge owned by the inline_start overlay
+    expect([master, inlineStart].filter(startShown).length).toBe(1);
+    expect(startShown(inlineStart)).toBe(true);
+    expect(startShown(master)).toBe(false);
+  });
+});

--- a/handsontable/src/3rdparty/walkontable/test/spec/selection/frozenBoundarySeamHeader.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/selection/frozenBoundarySeamHeader.spec.js
@@ -1,0 +1,235 @@
+/**
+ * Regression coverage for the frozen-pane active-header seam classes tagged by `SelectionManager`
+ * (`#markFrozenColumnSeamHeader` / `#markFrozenTopRowSeamHeader` / `#markFrozenBottomRowSeamHeader`).
+ *
+ * When an active header's highlighted column/row sits on the first/last NON-frozen track, its
+ * inline-start / top / bottom accent falls on the frozen-pane seam, which is drawn by a separate
+ * overlay table and is out of reach of the neighbour `:has()` CSS rule. The manager tags the adjacent
+ * frozen header (last frozen on the freeze line) with a `-seam` / `-row-seam-top` / `-row-seam-bottom`
+ * class so the theme can colour that seam to match. The contract verified here:
+ *   - the class lands on the NEIGHBOUR frozen header, never on the active header itself,
+ *   - only when the active track is flush with the freeze line (not deeper, not inside the pane),
+ *   - never without the matching `fixed*` setting, and
+ *   - it is cleaned up once the active header no longer sits on the line.
+ */
+describe('Frozen boundary seam header', () => {
+  beforeEach(function() {
+    this.$wrapper = $('<div></div>').addClass('handsontable').css({ overflow: 'hidden' });
+    this.$container = $('<div></div>');
+    this.$wrapper.width(300).height(300);
+    this.$table = $('<table></table>').addClass('htCore');
+    this.$wrapper.append(this.$container);
+    this.$container.append(this.$table);
+    this.$wrapper.appendTo('body');
+    createDataArray(20, 8);
+  });
+
+  afterEach(function() {
+    $('html').attr('dir', 'ltr');
+    $('.wtHolder').remove();
+    this.$wrapper.remove();
+    this.wotInstance.destroy();
+  });
+
+  const COLUMN_SEAM = 'ht__active_highlight-seam';
+  const TOP_ROW_SEAM = 'ht__active_highlight-row-seam-top';
+  const BOTTOM_ROW_SEAM = 'ht__active_highlight-row-seam-bottom';
+
+  const headerFactory =
+    count => Array.from({ length: count }, () => (index, TH) => { TH.innerHTML = index + 1; });
+
+  function build({
+    rtl = false, fixedRowsTop = 0, fixedRowsBottom = 0, fixedColumnsStart = 0,
+    rowHeaderLevels = 1, columnHeaderLevels = 1,
+  } = {}) {
+    if (rtl) {
+      $('html').attr('dir', 'rtl');
+    }
+
+    const selections = createSelectionController();
+    const wt = walkontable({
+      rtlMode: rtl,
+      data: getData,
+      totalRows: 8,
+      totalColumns: 8,
+      rowHeaders: headerFactory(rowHeaderLevels),
+      columnHeaders: headerFactory(columnHeaderLevels),
+      fixedRowsTop,
+      fixedRowsBottom,
+      fixedColumnsStart,
+      selections,
+    });
+
+    wt.draw();
+
+    return { wt, selections };
+  }
+
+  // Every header carrying the seam class anywhere in the grid.
+  const seamHeaders = cls => spec().$wrapper.find(`.${cls}`).toArray();
+
+  describe('column seam (fixedColumnsStart)', () => {
+    it('LTR: tags the last frozen column header when the first non-frozen column header is active', async() => {
+      const { wt, selections } = build({ fixedColumnsStart: 2 });
+
+      // Active column header on the first non-frozen column; its inline-start edge is the freeze seam.
+      selections.getActiveHeader().add(new Walkontable.CellCoords(-1, 2));
+      wt.draw();
+
+      const tagged = seamHeaders(COLUMN_SEAM);
+
+      expect(tagged.length).toBeGreaterThan(0);
+      tagged.forEach((th) => {
+        expect(th.nodeName).toBe('TH');
+        // The seam class rides the neighbour (last frozen) header, never the active one.
+        expect(th.classList.contains('ht__active_highlight')).toBe(false);
+      });
+
+      // It is exactly the last frozen column header (column fixedColumnsStart - 1) in the inline_start overlay.
+      const lastFrozen = wt.wtOverlays.inlineStartOverlay.clone.wtTable.getColumnHeader(1);
+
+      expect(lastFrozen.classList.contains(COLUMN_SEAM)).toBe(true);
+    });
+
+    it('RTL: tags the same last frozen column header (the rule is index-based, direction-agnostic)', async() => {
+      const { wt, selections } = build({ rtl: true, fixedColumnsStart: 2 });
+
+      selections.getActiveHeader().add(new Walkontable.CellCoords(-1, 2));
+      wt.draw();
+
+      const lastFrozen = wt.wtOverlays.inlineStartOverlay.clone.wtTable.getColumnHeader(1);
+
+      expect(lastFrozen.classList.contains(COLUMN_SEAM)).toBe(true);
+    });
+
+    it('tags every column-header level of the last frozen column', async() => {
+      const { wt, selections } = build({ fixedColumnsStart: 2, columnHeaderLevels: 2 });
+
+      selections.getActiveHeader().add(new Walkontable.CellCoords(-1, 2));
+      wt.draw();
+
+      const cloneTable = wt.wtOverlays.inlineStartOverlay.clone.wtTable;
+
+      expect(cloneTable.getColumnHeader(1, 0).classList.contains(COLUMN_SEAM)).toBe(true);
+      expect(cloneTable.getColumnHeader(1, 1).classList.contains(COLUMN_SEAM)).toBe(true);
+    });
+
+    it('does NOT tag when the active column header is inside the frozen pane', async() => {
+      const { wt, selections } = build({ fixedColumnsStart: 2 });
+
+      selections.getActiveHeader().add(new Walkontable.CellCoords(-1, 1)); // a frozen column
+      wt.draw();
+
+      expect(seamHeaders(COLUMN_SEAM).length).toBe(0);
+    });
+
+    it('does NOT tag when the active column header is past the freeze line', async() => {
+      const { wt, selections } = build({ fixedColumnsStart: 2 });
+
+      selections.getActiveHeader().add(new Walkontable.CellCoords(-1, 4)); // not flush with the seam
+      wt.draw();
+
+      expect(seamHeaders(COLUMN_SEAM).length).toBe(0);
+    });
+
+    it('never tags a column seam without fixedColumnsStart', async() => {
+      const { wt, selections } = build({});
+
+      selections.getActiveHeader().add(new Walkontable.CellCoords(-1, 2));
+      wt.draw();
+
+      expect(seamHeaders(COLUMN_SEAM).length).toBe(0);
+    });
+  });
+
+  describe('top row seam (fixedRowsTop)', () => {
+    it('tags the last top-frozen row header when the first non-frozen row header is active', async() => {
+      const { wt, selections } = build({ fixedRowsTop: 2 });
+
+      // Active row header on the first non-frozen row; its top edge is the top-freeze seam.
+      selections.getActiveHeader().add(new Walkontable.CellCoords(2, -1));
+      wt.draw();
+
+      const tagged = seamHeaders(TOP_ROW_SEAM);
+
+      expect(tagged.length).toBeGreaterThan(0);
+      tagged.forEach((th) => {
+        expect(th.nodeName).toBe('TH');
+        expect(th.classList.contains('ht__active_highlight')).toBe(false);
+      });
+
+      // The row headers of the top-frozen rows live in the top-inline-start corner overlay.
+      const lastFrozenRowHeader = wt.wtOverlays.topInlineStartCornerOverlay.clone.wtTable.getRowHeader(1);
+
+      expect(lastFrozenRowHeader.classList.contains(TOP_ROW_SEAM)).toBe(true);
+    });
+
+    it('does NOT tag when the active row header is inside the top-frozen pane', async() => {
+      const { wt, selections } = build({ fixedRowsTop: 2 });
+
+      selections.getActiveHeader().add(new Walkontable.CellCoords(1, -1)); // a frozen row
+      wt.draw();
+
+      expect(seamHeaders(TOP_ROW_SEAM).length).toBe(0);
+    });
+
+    it('never tags a top row seam without fixedRowsTop', async() => {
+      const { wt, selections } = build({});
+
+      selections.getActiveHeader().add(new Walkontable.CellCoords(2, -1));
+      wt.draw();
+
+      expect(seamHeaders(TOP_ROW_SEAM).length).toBe(0);
+    });
+  });
+
+  describe('bottom row seam (fixedRowsBottom)', () => {
+    it('tags the first bottom-frozen row header when the last non-frozen row header is active', async() => {
+      const { wt, selections } = build({ fixedRowsBottom: 2 });
+
+      // firstFrozenRow = totalRows - fixedRowsBottom = 6; the last non-frozen row is 5.
+      selections.getActiveHeader().add(new Walkontable.CellCoords(5, -1));
+      wt.draw();
+
+      const tagged = seamHeaders(BOTTOM_ROW_SEAM);
+
+      expect(tagged.length).toBeGreaterThan(0);
+      tagged.forEach((th) => {
+        expect(th.nodeName).toBe('TH');
+        expect(th.classList.contains('ht__active_highlight')).toBe(false);
+      });
+
+      // The row headers of the bottom-frozen rows live in the bottom-inline-start corner overlay.
+      const firstFrozenRowHeader = wt.wtOverlays.bottomInlineStartCornerOverlay.clone.wtTable.getRowHeader(6);
+
+      expect(firstFrozenRowHeader.classList.contains(BOTTOM_ROW_SEAM)).toBe(true);
+    });
+
+    it('does NOT tag when the active row header is inside the bottom-frozen pane', async() => {
+      const { wt, selections } = build({ fixedRowsBottom: 2 });
+
+      selections.getActiveHeader().add(new Walkontable.CellCoords(6, -1)); // a frozen row
+      wt.draw();
+
+      expect(seamHeaders(BOTTOM_ROW_SEAM).length).toBe(0);
+    });
+
+    it('does NOT tag when the active row header is above the last non-frozen row', async() => {
+      const { wt, selections } = build({ fixedRowsBottom: 2 });
+
+      selections.getActiveHeader().add(new Walkontable.CellCoords(4, -1)); // not flush with the seam
+      wt.draw();
+
+      expect(seamHeaders(BOTTOM_ROW_SEAM).length).toBe(0);
+    });
+
+    it('never tags a bottom row seam without fixedRowsBottom', async() => {
+      const { wt, selections } = build({});
+
+      selections.getActiveHeader().add(new Walkontable.CellCoords(5, -1));
+      wt.draw();
+
+      expect(seamHeaders(BOTTOM_ROW_SEAM).length).toBe(0);
+    });
+  });
+});

--- a/handsontable/src/styles/base/_base.scss
+++ b/handsontable/src/styles/base/_base.scss
@@ -304,6 +304,22 @@
         color: var(--ht-header-active-foreground-color);
         background-color: var(--ht-header-active-background-color);
       }
+
+      // An active header's inline-start edge has width 0 (only `:first-child`/`:nth-child(2)` reserve
+      // it), so its accent went missing there while the inline-end side kept it — most visible on
+      // frozen columns. Color the shared gridline on the inline-start neighbour instead, so every
+      // active column header shows a matching inline-start accent.
+      &:has(+ th.ht__active_highlight) {
+        border-inline-end-color: var(--ht-header-active-border-color);
+      }
+
+      // Boundary seam: when the first non-frozen column is the active header, its inline-start edge
+      // falls on the frozen-pane seam drawn by the frozen overlay (a separate table), out of reach of
+      // the `:has()` rule above. `SelectionManager` tags the last frozen header with this class so the
+      // seam gets the same accent.
+      &.ht__active_highlight-seam {
+        border-inline-end-color: var(--ht-header-active-border-color);
+      }
     }
 
     // Header in Row
@@ -342,10 +358,6 @@
           color: var(--ht-header-row-foreground-color);
           background-color: var(--ht-header-row-background-color);
 
-          &.ht__active_highlight {
-            box-shadow: 0 -1px 0 0 var(--ht-header-active-border-color);
-          }
-
           .relative {
             padding: var(--ht-cell-vertical-padding) var(--ht-cell-horizontal-padding);
             min-height: 100%;
@@ -361,6 +373,16 @@
             border-inline-end-color: var(--ht-border-color);
           }
         }
+      }
+
+      // An active row header's top edge sits on the bottom gridline of the row above. Colour that
+      // real border instead of drawing a box-shadow on the active header itself, so the accent rides
+      // the layout gridline and never drifts a pixel (the box-shadow rounded independently and, on
+      // the first row of each overlay table, doubled with the `tr:first-child` border-top below).
+      // Mirror of the column-header `:has(+ th.ht__active_highlight)` rule on the row axis. The first
+      // row of each overlay (no row above to borrow from) is handled by `tr:first-child`.
+      tr:has(+ tr > th.ht__active_highlight) th {
+        border-bottom-color: var(--ht-header-active-border-color);
       }
     }
 
@@ -399,7 +421,11 @@
         border-top-color: var(--ht-border-color);
         border-top-width: 1px;
 
-        &.ht__active_highlight {
+        // `-row-seam-bottom`: tagged by SelectionManager on the first bottom-frozen row header when
+        // the last non-frozen row is active. Its top border is the bottom-freeze seam, out of reach
+        // of the `:has(+ tr ...)` accent rule (separate overlay table), so colour it here.
+        &.ht__active_highlight,
+        &.ht__active_highlight-row-seam-bottom {
           border-top-color: var(--ht-header-active-border-color);
         }
       }
@@ -410,7 +436,11 @@
       td {
         border-bottom-color: var(--ht-border-color);
 
-        &.ht__active_highlight {
+        // `-row-seam-top`: tagged by SelectionManager on the last top-frozen row header when the first
+        // non-frozen row is active. Its bottom border is the top-freeze seam, out of reach of the
+        // `:has(+ tr ...)` accent rule (separate overlay table), so colour it here.
+        &.ht__active_highlight,
+        &.ht__active_highlight-row-seam-top {
           border-bottom-color: var(--ht-header-active-border-color);
         }
       }


### PR DESCRIPTION
### Context
Fixed a bug where a selection's border edge disappeared when the selection sat flush against a frozen-pane boundary (fixedRowsTop, fixedRowsBottom, fixedColumnsStart). The root cause was that the master  overlay drew that edge exactly on the seam line, where the frozen overlay stacked on top occluded it.

  Selection border edge (selection/border/border.ts)

  1. Added a drawFrozenBoundaryEdge method that detects this case and re-draws the edge inside the appropriate frozen overlay. The edge is split across overlays (top, inline_start, bottom, and both
  corners) and clamped to each one's rendered range, so the segments cover it without overlap or gaps.
  2. Added helper methods drawRowFreezeEdge, drawColumnFreezeEdge, and drawRowFreezeBottomEdge to draw the individual edge slices on the top-row, column, and bottom-row freeze lines.
  3. For a selection corner that lands on both freeze lines at once, drawFrozenBoundaryCorner and drawFrozenBottomBoundaryCorner close the connecting square at the corner.
  4. Added isFrozenBoundaryEdge and isFrozenBottomBoundaryEdge to determine whether a given edge lies on a freeze line and is therefore owned by the frozen overlay.
  5. Added isBoundaryCornerScrolledOut and isBottomBoundaryCornerScrolledOut, which consult the scroll-aware master to stop drawing the edge once the boundary cell scrolls behind the pane.

  Rendering details

  6. A "straddle" approach is used: the master draws the half of the edge below the seam and the overlay draws the half above it, preserving full thickness in both selection and edit modes.
  7. The master hides its seam edge only when the whole selection falls within frozen columns (seamAllFrozenCols), preventing a doubled line.
  8. Correctly handles RTL mode (anchoring via right) and the row/column-0 edge cases, where the line must not protrude past the pane.

  Corner offset (overlay/top.ts)

  9. Added a shouldReserveSelectionCornerOffset method that reserves the selection corner's protruding half-height only when the corner actually falls within the frozen top rows, eliminating a leftover
  edge at the seam (#6937).

  Active header highlight accent (selection/manager.ts, styles/base/_base.scss)

  10. The active-header inline-start accent was drawn with zero width (only reserved on :first-child/:nth-child(2)) and the active row-header accent used a box-shadow that rounded independently and
  doubled on the first row of each overlay. Replaced both with real, layout-aligned gridline borders so every active header shows a matching accent.
  11. Because a header flush with a frozen-pane seam is rendered in a separate overlay table — out of reach of the neighbour :has() rule — SelectionManager now tags the boundary header
  (#markFrozenColumnSeamHeader, #markFrozenTopRowSeamHeader, #markFrozenBottomRowSeamHeader) with -seam / -row-seam-top / -row-seam-bottom classes, which the theme colors to match.

  Tests

  12. Added frozenBoundaryEdge.spec.js with regression coverage across LTR/RTL, all three freeze axes, corner squares, scroll-out, border-thickness, and protrusion edge cases.

### How has this been tested?
npm run test:walkontable -- --testPathPattern=frozenBoundaryEdge

GridSettings add
fixedColumnsLeft: 2,
fixedRowsTop: 2,
fixedRowsBottom: 3

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/6392
2.
3.

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.


ClickUp task: https://app.clickup.com/t/9015210959/DEV-1925



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large, overlay-specific changes to core Walkontable selection border rendering and header styling; behaviour is well covered by new specs but regressions could still show up in frozen-pane + RTL + scroll edge cases.
> 
> **Overview**
> Fixes **missing or doubled selection borders** and **broken active-header highlights** when selections or headers sit on `fixedRowsTop`, `fixedRowsBottom`, or `fixedColumnsStart` seams.
> 
> **Selection borders:** `Border#appear` now delegates seam edges to `drawFrozenBoundaryEdge`, which redraws boundary segments in the owning frozen overlays (top, inline_start, bottom, corners), splits spans across overlays, straddles row/bottom seams between master and overlay where needed, hides duplicate edges elsewhere, drops edges when the boundary cell scrolls out of the master viewport, and closes corner gaps when both freeze lines meet. RTL and thick-border geometry are handled explicitly.
> 
> **Top overlay:** `TopOverlay#shouldReserveSelectionCornerOffset` limits the extra holder height for the fill handle to cases where the focus corner actually lies in frozen top rows (mirroring desktop `cornerVisible`), avoiding a stray line at the seam.
> 
> **Active headers:** `SelectionManager` tags neighbour frozen headers with `-seam` / `-row-seam-top` / `-row-seam-bottom` when the active header is flush with a freeze line; `_base.scss` uses real gridline borders and `:has()` (plus those seam classes) so accents align at overlay boundaries.
> 
> Regression specs: `frozenBoundaryEdge.spec.js`, `frozenBoundarySeamHeader.spec.js`; changelog entry for #12802.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b35129beb0f1f90dd4170250cc040c1b3d6363cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->