### PR TITLE
DEV-1926: Fix context menu inserting two rows on iPad Safari

### DIFF
--- a/.changelogs/12804.json
+++ b/.changelogs/12804.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed context menu inserting two rows instead of one when tapping \"Insert row above\" or \"Insert row below\" on iPad (Safari).",
+  "type": "fixed",
+  "issueOrPR": 12804,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/src/event.ts
+++ b/handsontable/src/3rdparty/walkontable/src/event.ts
@@ -138,6 +138,15 @@ class Event {
    */
   #deferredTouchStartEvent: TouchEvent | null = null;
   /**
+   * Timestamp (ms) of the most recent `onMouseUp` call that originated from a touch gesture.
+   * Used to suppress the browser-synthesized `mouseup` event that fires after `touchend` on
+   * devices that register both touch and mouse listeners (e.g. iPad Safari), which would
+   * otherwise trigger `onCellMouseUp` — and context-menu commands — a second time.
+   *
+   * @type {number}
+   */
+  #lastTouchMouseUpAt: number = 0;
+  /**
    * @type {boolean}
    */
   #mouseDown: boolean = false;
@@ -215,7 +224,16 @@ class Event {
 
     const initMouseEvents = () => {
       this.#eventManager.addEventListener(this.#wtTable.holder, 'mouseup',
-        (event: MouseEvent) => this.onMouseUp(event));
+        (event: MouseEvent) => {
+          // On devices that register both touch and mouse listeners (e.g. iPad Safari),
+          // `touchend` fires first and calls `onMouseUp` directly. The browser then
+          // synthesizes a `mouseup` event ~0-50 ms later; suppress it to prevent
+          // context-menu commands from executing twice.
+          if (Date.now() - this.#lastTouchMouseUpAt < 500) {
+            return;
+          }
+          this.onMouseUp(event);
+        });
       this.#eventManager.addEventListener(this.#wtTable.holder, 'mousedown',
         (event: MouseEvent) => this.onMouseDown(event));
     };
@@ -737,6 +755,7 @@ class Event {
     // before/after hooks (e.g. nestedHeaders, ContextMenu close logic).
     // Suppress only for pure scroll gestures, where onMouseDown was never fired.
     if (!wasScrolled || this.#longPressFired) {
+      this.#lastTouchMouseUpAt = Date.now();
       this.onMouseUp(event);
     }
 


### PR DESCRIPTION
### Context

On iPad Safari, selecting **Insert row above** or **Insert row below** from the context menu inserts **two rows** instead of one. Mac, iPhone, and Android are not affected.

**Root cause:** iPadOS Safari reports a desktop user-agent, so `isMobileBrowser()` returns `false`. However `isTouchSupported()` returns `true`. Walkontable's `registerEvents()` therefore calls both `initTouchEvents()` and `initMouseEvents()`, registering listeners for both event families on the same element.

When the user taps a menu item:
1. `touchend` fires → `onTouchEnd()` directly calls `this.onMouseUp(event)` → `onCellMouseUp` → `beforeOnCellMouseUp` → `executeCommand()` **(first insert)**
2. The browser then synthesizes a `mouseup` event → the `mouseup` listener registered in `initMouseEvents()` calls `onMouseUp(event)` again → `executeCommand()` **(second insert)**

**Fix:** Stamp `#lastTouchMouseUpAt = Date.now()` immediately before `onTouchEnd` calls `onMouseUp`. The `mouseup` listener in `initMouseEvents` skips calling `onMouseUp` if fewer than 500 ms have elapsed since that timestamp, suppressing the duplicate synthesized event.

### Related

- GitHub issue: https://github.com/handsontable/handsontable/issues/12803
- ClickUp: https://app.clickup.com/t/9015210959/DEV-1926

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement
- [ ] Breaking change
- [ ] Translation

### Affected project(s)

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist

- [x] The fix is targeted at the correct layer (Walkontable event deduplication)
- [ ] E2E test added (requires BrowserStack / real iPad — cannot run in headless CI)


---
_Generated by [Claude Code](https://claude.ai/code/session_0184DoCLi8qW26muYz5g1cDa)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core pointer event routing in Walkontable; the 500 ms window could theoretically affect rapid touch-then-real-mouse sequences on hybrid devices, though scope is limited to duplicate suppression after touch `mouseup`.
> 
> **Overview**
> Fixes **double execution** of context-menu actions (e.g. inserting two rows) when tapping menu items on **iPad Safari**, where Walkontable registers both touch and mouse listeners.
> 
> Walkontable now records when `onTouchEnd` drives `onMouseUp`, and the holder **`mouseup`** handler **ignores** a follow-up browser-synthesized `mouseup` within **500 ms**, so `onCellMouseUp` and command handlers run once per tap.
> 
> A changelog entry documents the public fix for issue **12804**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75eadcf5c09f4abe5ef6ea7343fba92bf4bd8dce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->