### PR TITLE
PRO-1302: Fix .tsx/.jsx code highlighting in docs example loader

### DIFF
--- a/docs/src/plugins/__tests__/framework-loader.test.mjs
+++ b/docs/src/plugins/__tests__/framework-loader.test.mjs
@@ -252,3 +252,66 @@ test('changes outside the content directory are ignored', async () => {
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+/**
+ * Builds a temp content tree with a React example that embeds both a .jsx and a
+ * .tsx source file, so the fenced-code language mapping can be asserted.
+ *
+ * @returns {{ contentDir: string, root: string }}
+ */
+function createReactFixture() {
+  const root = mkdtempSync(join(tmpdir(), 'hot-loader-'));
+  const contentDir = join(root, 'content');
+  const reactDir = join(contentDir, 'guides', 'intro', 'react');
+
+  mkdirSync(reactDir, { recursive: true });
+
+  writeFileSync(join(contentDir, 'index.md'), '---\ntitle: Home\n---\n\nWelcome.\n');
+
+  writeFileSync(
+    join(contentDir, 'guides', 'intro', 'intro.md'),
+    [
+      '---',
+      'title: Introduction',
+      'permalink: /intro',
+      '---',
+      '',
+      'Intro body.',
+      '',
+      '::: example #ex1',
+      '@[code](@/content/guides/intro/react/example1.jsx)',
+      '@[code](@/content/guides/intro/react/example1.tsx)',
+      ':::',
+      '',
+    ].join('\n')
+  );
+
+  writeFileSync(join(reactDir, 'example1.jsx'), 'export const Grid = () => <HotTable data={[]} />;\n');
+  writeFileSync(join(reactDir, 'example1.tsx'), 'export const Grid = (): JSX.Element => <HotTable data={[]} />;\n');
+
+  return { contentDir, root };
+}
+
+test('.jsx/.tsx examples render with jsx/tsx code fences, not js/ts', async () => {
+  const { contentDir, root } = createReactFixture();
+
+  try {
+    const { ctx, store } = createContext();
+
+    await frameworkLoader({ contentDir }).load(ctx);
+
+    const html = store.get('react-data-grid/intro').rendered.html;
+
+    // The fix: .jsx/.tsx extensions map to the jsx/tsx Shiki grammars, so the
+    // angle-bracket markup highlights correctly.
+    assert.ok(html.includes('````jsx title="JavaScript"'), 'expected a jsx code fence');
+    assert.ok(html.includes('````tsx title="TypeScript"'), 'expected a tsx code fence');
+
+    // Regression guard: before the fix these fell back to the plain js/ts
+    // grammars, which mis-colored JSX. The tab labels stay JavaScript/TypeScript.
+    assert.ok(!html.includes('````javascript title='), '.jsx must not fall back to a javascript fence');
+    assert.ok(!html.includes('````typescript title='), '.tsx must not fall back to a typescript fence');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/docs/src/plugins/framework-loader.mjs
+++ b/docs/src/plugins/framework-loader.mjs
@@ -86,8 +86,8 @@ try {
 const EXT_TO_LANG = {
   js: 'javascript',
   ts: 'typescript',
-  jsx: 'javascript',
-  tsx: 'typescript',
+  jsx: 'jsx',
+  tsx: 'tsx',
   html: 'html',
   css: 'css',
   vue: 'vue',
@@ -105,6 +105,8 @@ const META_LANG = {
   typescript: 'typescript',
   ts: 'typescript',
   js: 'javascript',
+  tsx: 'tsx',
+  jsx: 'jsx',
   properties: 'properties',
 };
 


### PR DESCRIPTION
### Context

The PR fixes incorrect syntax highlighting of React `.jsx` and `.tsx` code examples across the documentation site.

The docs `@[code]` example importer (`docs/src/plugins/framework-loader.mjs`) builds a fenced code block for each embedded example and tags it with a Shiki grammar derived from the file extension. The extension-to-grammar map (`EXT_TO_LANG`) pointed `.jsx` at the plain `javascript` grammar and `.tsx` at the plain `typescript` grammar. Those grammars do not understand JSX, so the angle-bracket markup in React examples -- component tags, props, and self-closing elements like `<HotTable ... />` -- was rendered without JSX-aware highlighting.

This affects every page that embeds a React `.jsx`/`.tsx` example. The server-side Supabase recipe in #12805 is a concrete, reviewable example: open its React tab and the JSX in `example1.tsx` highlights with the plain TypeScript grammar rather than the TSX grammar. The bug was first noticed there.

The fix maps `jsx -> jsx` and `tsx -> tsx` in `EXT_TO_LANG`, and adds the same two entries to `META_LANG` so explicit `@[code tsx]` / `@[code jsx]` hints resolve to the JSX-aware grammars as well. Expressive Code + Shiki already load the full language bundle, so the `jsx`/`tsx` grammars resolve with no further config. The tab labels ("JavaScript" / "TypeScript") come from a separate map (`EXT_TO_LABEL`) and are intentionally left unchanged -- only the highlighting grammar changes.

[skip changelog] -- docs-site tooling only; no package source is touched.

### How has this been tested?

- Added a regression test in `docs/src/plugins/__tests__/framework-loader.test.mjs` that embeds both a `.jsx` and a `.tsx` example and asserts the rendered output uses ` ```jsx ` / ` ```tsx ` fences (and does **not** fall back to ` ```javascript ` / ` ```typescript `), while the tab labels stay "JavaScript" / "TypeScript". The test was confirmed to fail when the fix is reverted, so it genuinely guards the regression.
- `npm run docs:test:plugins` -> 50/50 pass.
- `eslint` clean on both changed files.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. PRO-1302
2. Surfaced by the Supabase server-side recipe in #12805 (React `.tsx`/`.jsx` examples that show the mis-highlighting).

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

(Documentation site tooling only -- no published package source is affected.)

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/86cabnqwg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only loader mapping and test changes; no published packages or runtime product behavior.
> 
> **Overview**
> Fixes **incorrect syntax highlighting** for embedded React `.jsx` and `.tsx` examples in the docs site.
> 
> The framework loader’s extension-to-grammar maps (`EXT_TO_LANG` and `META_LANG`) now route `.jsx`/`.tsx` (and explicit `@[code jsx]` / `@[code tsx]` hints) to the **`jsx`/`tsx`** Shiki grammars instead of plain `javascript`/`typescript`, so JSX markup highlights correctly. Tab labels from `EXT_TO_LABEL` are unchanged.
> 
> A **regression test** loads a temp page with both file types and asserts rendered fences use `jsx`/`tsx` and do not fall back to `javascript`/`typescript`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06072f1b4d46d42852eeba27d466899a7a795d5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->