### PR TITLE
RELEASE-631: Update new/updated tags in documentation sidebar

### DIFF
--- a/docs/content/guides/accessories-and-menus/context-menu/context-menu.md
+++ b/docs/content/guides/accessories-and-menus/context-menu/context-menu.md
@@ -18,7 +18,6 @@ vue:
   metaTitle: Context menu - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Accessories and menus
-menuTag: updated
 ---
 The context menu provides cell-level actions accessible by right-clicking. This page lists all available menu items and their configuration keys.
 

--- a/docs/content/guides/accessories-and-menus/export-to-csv/export-to-csv.md
+++ b/docs/content/guides/accessories-and-menus/export-to-csv/export-to-csv.md
@@ -16,7 +16,6 @@ vue:
   metaTitle: Export to CSV - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Accessories and menus
-menuTag: updated
 ---
 Export your grid's raw data to the CSV format, as a downloadable file, a blob, or a string. Customize your export using Handsontable's configuration options.
 

--- a/docs/content/guides/accessories-and-menus/export-to-excel/export-to-excel.md
+++ b/docs/content/guides/accessories-and-menus/export-to-excel/export-to-excel.md
@@ -18,7 +18,6 @@ vue:
   metaTitle: Export to Excel - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Accessories and menus
-menuTag: new
 ---
 Export your grid data to an Excel (`.xlsx`) file, preserving cell types, styling, formulas, merged cells, and more.
 

--- a/docs/content/guides/cell-types/date-cell-type/date-cell-type.md
+++ b/docs/content/guides/cell-types/date-cell-type/date-cell-type.md
@@ -13,6 +13,7 @@ vue:
   metaTitle: Date cell type - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types
+menuTag: updated
 ---
 Display, format, sort, and filter dates correctly by using the date cell type.
 

--- a/docs/content/guides/cell-types/numeric-cell-type/numeric-cell-type.md
+++ b/docs/content/guides/cell-types/numeric-cell-type/numeric-cell-type.md
@@ -13,6 +13,7 @@ vue:
   metaTitle: Numeric cell type - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types
+menuTag: updated
 ---
 Display, format, sort, and filter numbers correctly by using the numeric cell type.
 

--- a/docs/content/guides/cell-types/password-cell-type/password-cell-type.md
+++ b/docs/content/guides/cell-types/password-cell-type/password-cell-type.md
@@ -13,6 +13,7 @@ vue:
   metaTitle: Password cell type - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types
+menuTag: updated
 ---
 Use the password cell type to mask confidential values by rendering entered characters as symbols.
 

--- a/docs/content/guides/cell-types/time-cell-type/time-cell-type.md
+++ b/docs/content/guides/cell-types/time-cell-type/time-cell-type.md
@@ -13,6 +13,7 @@ vue:
   metaTitle: Time cell type - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types
+menuTag: updated
 ---
 Display, format, sort, and filter time values correctly by using the time cell type. Edit times via the cell editor.
 

--- a/docs/content/guides/dialog/notification/notification.md
+++ b/docs/content/guides/dialog/notification/notification.md
@@ -18,7 +18,7 @@ vue:
   metaTitle: Notification - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Dialog
-menuTag: new
+menuTag: updated
 ---
 
 Show non-blocking toast notifications for save confirmations, errors, and other transient feedback. Toasts are anchored to the Handsontable root, support stacking per corner, and work with the design system themes.

--- a/docs/content/guides/getting-started/server-side-data/server-side-data.md
+++ b/docs/content/guides/getting-started/server-side-data/server-side-data.md
@@ -18,7 +18,6 @@ vue:
   metaTitle: Server-side data - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Getting started
-menuTag: new
 ---
 Use the [`dataProvider`](@/api/options.md#dataprovider) option so Handsontable loads row data from your backend instead of keeping the full dataset in the browser. The grid stays aligned with paging, column sorting, and (optionally) column filters that run on the server. The same configuration wires **create**, **update**, and **remove** to your API. When the `dataProvider` object is **complete** (all required keys valid), Handsontable ignores a static [`data`](@/api/options.md#data) array and loads rows only through `fetchRows`. If you still pass a `data` array with a complete provider, Handsontable logs a console warning that `data` is ignored.
 

--- a/docs/content/guides/optimization/bundle-size/bundle-size.md
+++ b/docs/content/guides/optimization/bundle-size/bundle-size.md
@@ -15,6 +15,7 @@ vue:
   metaTitle: Bundle size - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Optimization
+menuTag: updated
 ---
 Reduce the size of your JavaScript bundle by getting rid of redundant Handsontable modules.
 

--- a/docs/content/guides/optimization/performance/performance.md
+++ b/docs/content/guides/optimization/performance/performance.md
@@ -15,7 +15,6 @@ vue:
   metaTitle: Performance - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Optimization
-menuTag: updated
 ---
 Boost your grid's performance by setting a constant column size, suspending rendering, deciding how many rows and columns are pre-rendered, and more.
 

--- a/docs/content/guides/rows/rows-pagination/rows-pagination.md
+++ b/docs/content/guides/rows/rows-pagination/rows-pagination.md
@@ -26,7 +26,6 @@ vue:
   metaTitle: Row pagination - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Rows
-menuTag: updated
 ---
 Split large data sets into pages to improve usability and rendering performance. Pagination operates fully on the client side and automatically recomputes the total page count whenever rows are added, removed, filtered, or otherwise modified.
 

--- a/docs/content/guides/security/security/security.md
+++ b/docs/content/guides/security/security/security.md
@@ -13,6 +13,7 @@ vue:
   metaTitle: Security - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Security
+menuTag: updated
 ---
 Learn about the security measures we take to make sure you can safely implement Handsontable in your client-side application.
 

--- a/docs/content/recipes/data-management/server-side-expressjs/server-side-expressjs.md
+++ b/docs/content/recipes/data-management/server-side-expressjs/server-side-expressjs.md
@@ -23,6 +23,7 @@ vue:
   metaTitle: Server-side Data with Express.js - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Data Management
+menuTag: new
 ---
 
 This tutorial shows how to wire Handsontable's `dataProvider` plugin to an Express.js 4 backend. The backend provides paginated, sorted, and filtered server-side data with full CRUD operations using PostgreSQL via TypeORM and Zod for request validation.

--- a/docs/content/recipes/data-management/server-side-symfony/server-side-symfony.md
+++ b/docs/content/recipes/data-management/server-side-symfony/server-side-symfony.md
@@ -23,6 +23,7 @@ vue:
   metaTitle: Server-side data with Symfony - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Data Management
+menuTag: new
 ---
 
 This tutorial shows how to connect Handsontable's `dataProvider` plugin to a Symfony backend. You will build a product inventory grid that loads data with server-side pagination, sorting, and filtering, and that persists row create, update, and delete operations to a Symfony/Doctrine database. The recipe covers two API styles: a **REST API** (Steps 1–8) and an optional **GraphQL** variant using `webonyx/graphql-php` (Step 9).


### PR DESCRIPTION
### Context

The PR refreshes the `new` and `updated` sidebar badges (`menuTag` frontmatter) across the documentation for the 18.0 release. The previous tag pass was #12455 (RELEASE-504, for 17.1), so badges left over from that cycle are now stale.

Tags were reconciled against the authoritative 18.0 signal: the [Migrating from 17.1 to 18.0](https://github.com/handsontable/handsontable/blob/develop/docs/content/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md) guide (breaking changes §1–6), the 18.0 changelog entries, and the docs content diff since the 17.1 tag pass (excluding mechanical Vue-example / `id:` migration noise).

Result: **9 `new`, 10 `updated`**.

**Set `new`** (new pages in 18.0):
- `recipes/data-management/server-side-expressjs`
- `recipes/data-management/server-side-symfony`

**Set `updated`** (notable 18.0 changes):
- `cell-types/numeric-cell-type` — Numbro.js removed, `Intl.NumberFormat`
- `cell-types/date-cell-type` — Moment.js/Pikaday removed, `intl-date` / ISO 8601
- `cell-types/time-cell-type` — `intl-time` / ISO 8601
- `security/security` — built-in DOMPurify removed, `sanitizer` option
- `cell-types/password-cell-type` — new `hashRevealDelay` option
- `optimization/bundle-size` — numbro/moment/pikaday/DOMPurify dependencies removed

**Changed `new` → `updated`**:
- `dialog/notification` — toasts now render in the grid's overlay layer

**Removed stale tags** (17.1 or older, no notable 18.0 change):
- `optimization/performance`, `accessories-and-menus/export-to-csv`, `accessories-and-menus/context-menu`, `accessories-and-menus/export-to-excel`, `rows/rows-pagination`, `getting-started/server-side-data`

**Kept** (still valid 18.0): `drag-to-scroll`, `layout-slots`, `ai-tools/*` (3), `typescript-types`, `recipes/cell-types/radio` (new); `columns/column-groups`, `styling/theme-customization`, `tools-and-building/modules` (updated).

### How has this been tested?

- Frontmatter-only change (`menuTag` key). Verified every tagged page is registered in `guides/sidebar.js` or `recipes/sidebar.js` so the badge renders.
- Verified YAML frontmatter parses correctly with gray-matter after each edit.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. RELEASE-631

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/86caadmjf/RELEASE-631

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation frontmatter only; no runtime or API behavior changes.
> 
> **Overview**
> Updates **`menuTag`** frontmatter on docs pages so sidebar **new** / **updated** badges match the 18.0 release instead of leftover 17.1 tags.
> 
> **Adds `menuTag: updated`** on guides tied to 18.0 changes (numeric/date/time/password cell types, security/sanitizer, bundle size).
> 
> **Adds `menuTag: new`** on the Express.js and Symfony server-side data recipes.
> 
> **Changes Notification** from `new` to **`updated`**.
> 
> **Removes stale `menuTag` lines** where 18.0 did not materially change the page (context menu, export CSV/Excel, performance, rows pagination, server-side data getting-started guide).
> 
> No prose or example code changes—YAML frontmatter only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 815419cadf4bb1fb12bea59b71df8fbc791182ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->