### PR TITLE
RELEASE-629: Document 18.0 wrapper DOM structure change in migration guide

### DIFF
--- a/docs/content/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md
@@ -406,6 +406,96 @@ createTheme('my-theme', {
 });
 ```
 
+## 7. Update CSS selectors and DOM queries for the new wrapper structure
+
+Handsontable 18.0 adds wrapper layout slots and a `layout` option that controls the order of UI elements rendered around the grid, such as pagination and dialogs. To support this, the built-in UI now mounts into dedicated wrapper containers, which changes the DOM structure that Handsontable renders around the grid.
+
+The grid table itself is unchanged. Only the container elements between your root element and the grid table are different.
+
+### Who is affected
+
+You are affected if any of the following apply:
+
+- Your CSS targets Handsontable's wrapper elements with direct-child (`>`), `:first-child`, `:only-child`, or `:nth-child()` selectors.
+- Your JavaScript queries the DOM relative to `.ht-root-wrapper` or `.ht-grid` (for example, with `querySelector` or `children`).
+- You traverse the DOM from the grid root element with a fixed number of `parentNode` or `firstElementChild` steps.
+
+### What changed
+
+**Before (17.1):**
+
+```html
+<div class="ht-root-wrapper">
+  <div class="ht-grid">
+    <div class="ht-wrapper handsontable"></div>
+  </div>
+</div>
+```
+
+**After (18.0):**
+
+```html
+<div class="ht-root-wrapper">
+  <div class="ht-slot-top"></div>
+  <div class="ht-grid">
+    <div class="ht-grid-content">
+      <div class="ht-wrapper handsontable"></div>
+    </div>
+  </div>
+  <div class="ht-slot-bottom"></div>
+  <div class="ht-overlay"></div>
+</div>
+```
+
+Two changes can break existing selectors:
+
+- A new `.ht-grid-content` element wraps the grid root element inside `.ht-grid`.
+- New sibling containers (`.ht-slot-top`, `.ht-slot-bottom`, and `.ht-overlay`) are added inside `.ht-root-wrapper`, so `.ht-grid` is no longer the only child.
+
+### How to migrate
+
+Update selectors that assumed the old structure. Account for the new `.ht-grid-content` wrapper and the new sibling containers.
+
+**Before:**
+
+```css
+.ht-root-wrapper > .ht-grid > .handsontable {
+  border: 1px solid #a0aec0;
+}
+
+.ht-root-wrapper > :first-child {
+  margin-top: 0;
+}
+```
+
+**After:**
+
+```css
+.ht-grid-content > .handsontable {
+  border: 1px solid #a0aec0;
+}
+
+.ht-grid {
+  margin-top: 0;
+}
+```
+
+For DOM queries, target the grid root element by its class instead of by position:
+
+**Before:**
+
+```javascript
+const grid = wrapper.querySelector('.ht-grid').firstElementChild;
+```
+
+**After:**
+
+```javascript
+const grid = wrapper.querySelector('.ht-wrapper.handsontable');
+```
+
+Use class-based selectors instead of positional ones, so future layout slot additions do not break your code.
+
 ## Summary of breaking changes
 
 | Change | Who is affected | Action required |
@@ -417,6 +507,7 @@ createTheme('my-theme', {
 | DOMPurify removed; no built-in HTML sanitization | Projects rendering untrusted user HTML | Add a `sanitizer` function (for example, using DOMPurify) to the Handsontable configuration |
 | `saveManualColumnWidths()`, `loadManualColumnWidths()`, `saveManualRowHeights()`, `loadManualRowHeights()` now no-op | Any project calling these methods | Remove calls; implement custom persistence if needed |
 | `--ht-wrapper-border-radius` renamed to `--ht-border-radius`; `--ht-wrapper-border-width` and `--ht-wrapper-border-color` removed | Projects overriding these theme variables or passing the matching JS tokens | Rename to `--ht-border-radius` / `borderRadius`; recreate a wrapper border with `box-shadow` if needed |
+| Wrapper DOM structure changed -- new `.ht-grid-content`, `.ht-slot-top`, `.ht-slot-bottom`, and `.ht-overlay` elements | Projects with CSS selectors or DOM queries targeting Handsontable's wrapper elements by position | Update selectors to be class-based; account for the new `.ht-grid-content` wrapper and sibling slot containers |
 
 ## Related resources
 


### PR DESCRIPTION
### Context

The PR adds a missing breaking-change section to the 17.1 → 18.0 migration guide.

While validating the guide against the `release/18.0.0` changelog, the wrapper DOM structure change from [#12094](https://github.com/handsontable/handsontable/issues/12094) (flagged **Breaking change** in the 18.0.0 changelog) had no migration coverage. The change adds layout slots and a `layout` option; to support them the built-in UI now mounts into new wrapper containers. This shifts the DOM that Handsontable renders around the grid, which breaks consumer CSS selectors and DOM queries that target wrapper elements by position.

The before/after DOM in the new section was verified against the `17.1.0` tag and current `core.ts`:
- New `.ht-grid-content` wraps the grid root element inside `.ht-grid`.
- New sibling containers `.ht-slot-top`, `.ht-slot-bottom`, and `.ht-overlay` are added inside `.ht-root-wrapper`.

The other 18.0.0 changelog breaking entries were already covered by existing sections, except for three changelog defects that are out of scope for this docs PR and tracked separately under RELEASE-629:
- `#12728` (Core undo/redo methods) and the `PersistentState` clause of `#0` duplicate removals already shipped in 17.0.0 (also listed under the 17.0.0 changelog section).
- `#1836` claims the Angular peer-dep minimum was raised to 19, but the shipped `release/18.0.0` `@handsontable/angular-wrapper` declares `@angular/core: ">=16.0.0 <23.0.0"` — no such bump exists.

### How has this been tested?

- Docs-only change. No source code affected.
- Verified the rendered Markdown structure, heading levels, and language-tagged code fences.
- Cross-checked DOM snippets against the `17.1.0` tag and `handsontable/src/core.ts` on `develop`.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. RELEASE-629

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/RELEASE-629

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only; no runtime or API behavior changes.
> 
> **Overview**
> Adds **section 7** to the 17.1 → 18.0 migration guide for the **wrapper DOM structure** breaking change (layout slots / `layout` option in 18.0).
> 
> The new section explains who is affected (positional CSS, DOM queries under `.ht-root-wrapper` / `.ht-grid`, fixed parent walks), shows **17.1 vs 18.0** HTML (`.ht-grid-content`, `.ht-slot-top`, `.ht-slot-bottom`, `.ht-overlay`), and gives **before/after** examples for CSS and `querySelector` patterns. It recommends **class-based** selectors instead of `:first-child` / child-position assumptions.
> 
> The **summary table** gains a row for this change so it sits alongside the other 18.0 breaking entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1946c7a04013aec09bb50c78cad98962edacf5d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->