### PR TITLE
RELEASE-628: List deprecated resize methods in deprecation policy

### DIFF
--- a/.changelogs/12727.json
+++ b/.changelogs/12727.json
@@ -2,7 +2,7 @@
   "issuesOrigin": "private",
   "title": "Removed the deprecated `PersistentState` plugin, its `persistentState` option, and the `persistentStateSave`, `persistentStateLoad`, and `persistentStateReset` hooks. Deprecated `saveManualColumnWidths()`, `loadManualColumnWidths()`, `saveManualRowHeights()`, and `loadManualRowHeights()` — these now no-op and will be removed in the next major release.",
   "type": "removed",
-  "issueOrPR": 0,
+  "issueOrPR": 12727,
   "breaking": true,
   "framework": "none"
 }

--- a/docs/content/guides/upgrade-and-migration/deprecation-policy/deprecation-policy.md
+++ b/docs/content/guides/upgrade-and-migration/deprecation-policy/deprecation-policy.md
@@ -57,7 +57,14 @@ The following dependencies were deprecated in version 17.0 and removed in versio
 
 ## List of current deprecations
 
-There are no active deprecations scheduled for removal in the next major version.
+The following methods were deprecated in version 18.0 and are scheduled for removal in a future major release. They are no-ops kept for backward compatibility, as the `PersistentState` plugin has been removed.
+
+| Deprecated | Plugin | Migration guide |
+| ---------- | ------ | --------------- |
+| `saveManualColumnWidths()` | `ManualColumnResize` | [Migrate from 17.1 to 18.0 → Resize-state methods](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#5-stop-calling-deprecated-resize-state-methods) |
+| `loadManualColumnWidths()` | `ManualColumnResize` | [Migrate from 17.1 to 18.0 → Resize-state methods](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#5-stop-calling-deprecated-resize-state-methods) |
+| `saveManualRowHeights()` | `ManualRowResize` | [Migrate from 17.1 to 18.0 → Resize-state methods](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#5-stop-calling-deprecated-resize-state-methods) |
+| `loadManualRowHeights()` | `ManualRowResize` | [Migrate from 17.1 to 18.0 → Resize-state methods](@/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md#5-stop-calling-deprecated-resize-state-methods) |
 
 
 


### PR DESCRIPTION
### Context

The PR updates the deprecation policy page, which incorrectly stated there were no active deprecations. Version 18.0 removed the `PersistentState` plugin and left four resize-state methods as no-op stubs that emit a runtime deprecation warning. These methods are still callable and scheduled for removal in a future major release, so they belong in the "List of current deprecations" section.

The PR also fixes an invalid changelog entry: `.changelogs/12727.json` had `"issueOrPR": 0`, corrected to `12727` (the PersistentState removal PR).

Listed methods:

- `saveManualColumnWidths()` / `loadManualColumnWidths()` (`ManualColumnResize`)
- `saveManualRowHeights()` / `loadManualRowHeights()` (`ManualRowResize`)

Each row links the relevant section of the 17.1-to-18.0 migration guide.

### How has this been tested?

- Docs-only change. Verified the migration-guide anchor (`#5-stop-calling-deprecated-resize-state-methods`) matches the `github-slugger` slug used by the existing "Removed in version 18.0" table links in the same page.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. RELEASE-628

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/RELEASE-628

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and changelog metadata only; no runtime or API behavior changes.
> 
> **Overview**
> Updates the **deprecation policy** so it no longer claims there are no active deprecations. The **List of current deprecations** section now documents four **18.0** no-op resize helpers (`saveManualColumnWidths`, `loadManualColumnWidths`, `saveManualRowHeights`, `loadManualRowHeights`) tied to `ManualColumnResize` / `ManualRowResize`, with links to the 17.1→18.0 migration guide resize-state section.
> 
> Also fixes `.changelogs/12727.json` by setting **`issueOrPR`** from `0` to **`12727`** for the PersistentState removal entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2c16a1429b9c203620242129e661423fc48e5df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->