### PR TITLE
DEV-1930: Preserve imperative cell meta across updateSettings

### DIFF
--- a/.changelogs/12811.json
+++ b/.changelogs/12811.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed cell meta set with `setCellMeta` (for example, `readOnly`) being reset by `updateSettings`.",
+  "type": "fixed",
+  "issueOrPR": 12811,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/__tests__/core/setCellMeta.spec.js
+++ b/handsontable/src/__tests__/core/setCellMeta.spec.js
@@ -207,4 +207,114 @@ describe('Core.setCellMeta', () => {
     expect(getCellMeta(0, 0).renderer).toBe(mockRenderer);
     expect(getCellMeta(0, 0).editor).toBe(mockEditor);
   });
+
+  describe('preserving imperative cell meta across updateSettings (#4446)', () => {
+    it('should preserve a `setCellMeta` value after `updateSettings` with the `columns` option', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      await setCellMeta(0, 0, 'readOnly', true);
+
+      expect(getCellMeta(0, 0).readOnly).toBe(true);
+
+      await updateSettings({
+        columns: [{}, {}, {}, {}, {}],
+      });
+
+      expect(getCellMeta(0, 0).readOnly).toBe(true);
+    });
+
+    it('should preserve a `setCellMeta` value after `updateSettings` with the `cells` option', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      await setCellMeta(0, 0, 'readOnly', true);
+
+      await updateSettings({
+        cells() {
+          return {};
+        },
+      });
+
+      expect(getCellMeta(0, 0).readOnly).toBe(true);
+    });
+
+    it('should preserve a `setCellMeta` value after `updateSettings` with the `cell` option for other cells', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      await setCellMeta(0, 0, 'readOnly', true);
+
+      await updateSettings({
+        cell: [
+          { row: 1, col: 1, className: 'htRight' },
+        ],
+      });
+
+      expect(getCellMeta(0, 0).readOnly).toBe(true);
+      expect(getCellMeta(1, 1).className).toBe('htRight');
+    });
+
+    it('should let the declarative `cell` option win over a preserved imperative value on a direct conflict', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      await setCellMeta(0, 0, 'className', 'from-set-cell-meta');
+
+      await updateSettings({
+        cell: [
+          { row: 0, col: 0, className: 'from-cell-option' },
+        ],
+      });
+
+      expect(getCellMeta(0, 0).className).toBe('from-cell-option');
+    });
+
+    it('should preserve a `setCellMeta` value across multiple consecutive `updateSettings` calls', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      await setCellMeta(0, 0, 'readOnly', true);
+
+      await updateSettings({ columns: [{}, {}, {}, {}, {}] });
+      await updateSettings({ columns: [{}, {}, {}, {}, {}] });
+
+      expect(getCellMeta(0, 0).readOnly).toBe(true);
+    });
+
+    it('should preserve a `setCellMeta` value at its shifted position after inserting a row and then calling `updateSettings`', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+      });
+
+      await setCellMeta(2, 0, 'readOnly', true);
+      await alter('insert_row_above', 0, 1);
+
+      expect(getCellMeta(3, 0).readOnly).toBe(true);
+
+      await updateSettings({ columns: [{}, {}, {}, {}, {}] });
+
+      expect(getCellMeta(3, 0).readOnly).toBe(true);
+    });
+
+    it('should still fire the `afterCellMetaReset` hook on `updateSettings`', async() => {
+      const afterCellMetaReset = jasmine.createSpy('afterCellMetaReset');
+
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        afterCellMetaReset,
+      });
+
+      afterCellMetaReset.calls.reset();
+
+      await updateSettings({ columns: [{}, {}, {}, {}, {}] });
+
+      expect(afterCellMetaReset).toHaveBeenCalled();
+    });
+  });
 });

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -3139,6 +3139,10 @@ export default function Core(
    * Since 12.0.0 passing `data` inside `settings` objects no longer results in resetting states corresponding to rows and columns
    * (for example, row/column sequence, column width, row height, frozen columns etc.).
    *
+   * Cell meta set imperatively through [[setCellMeta]] (for example, by the user or the context menu) is preserved across
+   * `updateSettings`, even when `settings` includes `cell`, `cells`, or `columns`. On a direct conflict, a value re-stated
+   * through the declarative `cell` option takes precedence over the preserved imperative value.
+   *
    * When [[Hooks#hasExternalDataSource]] is true, Handsontable clears and rebinds the placeholder dataset only during
    * initialization or when `settings` includes `data` or `dataProvider`. Other keys alone (for example `height`) do not clear loaded rows.
    * If only `columns` changes, the column map is rebuilt without clearing rows.
@@ -3331,9 +3335,19 @@ export default function Core(
 
     const columnSetting = tableMeta.columns;
 
-    // Clear cell meta cache
+    // Clear cell meta cache. Cell meta set imperatively through `setCellMeta` (for example, by the
+    // user or the context menu) is snapshotted beforehand and replayed afterward, so that it
+    // survives the clear instead of being discarded (see GitHub issue #4446).
     if (settings.cell !== undefined || settings.cells !== undefined || settings.columns !== undefined) {
+      const userDefinedCellMetas = metaManager.getUserDefinedCellMetas();
+
       metaManager.clearCache();
+
+      // Replay before the column and `cell` option re-application, so that a value re-stated through
+      // the declarative `cell` option still wins on a direct conflict (preserving legacy behavior).
+      userDefinedCellMetas.forEach(({ physicalRow, physicalColumn, key, value }) => {
+        metaManager.setCellMeta(physicalRow, physicalColumn, key, value);
+      });
     }
 
     if (clen > 0) {
@@ -3354,9 +3368,19 @@ export default function Core(
     }
 
     if (isDefined(settings.cell)) {
-      (settings.cell as Record<string, unknown>[]).forEach((cell: Record<string, unknown>) => {
-        instance.setCellMetaObject(cell.row as number, cell.col as number, cell);
-      });
+      // The `cell` option is declarative - it is re-applied from settings on every `updateSettings`
+      // call. Recording is disabled so these writes are not tracked as user-defined (and a key
+      // re-stated here de-marks any imperative value), keeping `updateSettings({ cell: [] })` able
+      // to remove previously declared entries.
+      metaManager.disableUserDefinedMetaRecording();
+
+      try {
+        (settings.cell as Record<string, unknown>[]).forEach((cell: Record<string, unknown>) => {
+          instance.setCellMetaObject(cell.row as number, cell.col as number, cell);
+        });
+      } finally {
+        metaManager.enableUserDefinedMetaRecording();
+      }
     }
 
     instance.runHooks('afterCellMetaReset');

--- a/handsontable/src/dataMap/metaManager/__tests__/metaManager.unit.ts
+++ b/handsontable/src/dataMap/metaManager/__tests__/metaManager.unit.ts
@@ -221,6 +221,41 @@ describe('MetaManager', () => {
     });
   });
 
+  describe('getUserDefinedCellMetas()', () => {
+    it('should pass a method call to CellMeta layer', () => {
+      const metaManager = new MetaManager();
+
+      spyOn(metaManager.cellMeta, 'getUserDefinedMetas').and.returnValue(['foo']);
+
+      expect(metaManager.getUserDefinedCellMetas()).toEqual(['foo']);
+      expect(metaManager.cellMeta.getUserDefinedMetas).toHaveBeenCalledWith();
+    });
+  });
+
+  describe('enableUserDefinedMetaRecording()', () => {
+    it('should pass a method call to CellMeta layer', () => {
+      const metaManager = new MetaManager();
+
+      spyOn(metaManager.cellMeta, 'enableUserDefinedMetaRecording');
+
+      metaManager.enableUserDefinedMetaRecording();
+
+      expect(metaManager.cellMeta.enableUserDefinedMetaRecording).toHaveBeenCalledWith();
+    });
+  });
+
+  describe('disableUserDefinedMetaRecording()', () => {
+    it('should pass a method call to CellMeta layer', () => {
+      const metaManager = new MetaManager();
+
+      spyOn(metaManager.cellMeta, 'disableUserDefinedMetaRecording');
+
+      metaManager.disableUserDefinedMetaRecording();
+
+      expect(metaManager.cellMeta.disableUserDefinedMetaRecording).toHaveBeenCalledWith();
+    });
+  });
+
   describe('createRow()', () => {
     it('should pass a method call to CellMeta layer', () => {
       const metaManager = new MetaManager();

--- a/handsontable/src/dataMap/metaManager/index.ts
+++ b/handsontable/src/dataMap/metaManager/index.ts
@@ -262,6 +262,32 @@ export default class MetaManager {
   }
 
   /**
+   * Returns a flat snapshot of all cell meta properties that were set imperatively through
+   * `setCellMeta` (for example, by the user or by the context menu), keyed by physical coordinates.
+   * Used to preserve user-defined meta across a `clearCache` call during `updateSettings`.
+   *
+   * @returns {{physicalRow: number, physicalColumn: number, key: string, value: *}[]}
+   */
+  getUserDefinedCellMetas() {
+    return this.cellMeta.getUserDefinedMetas();
+  }
+
+  /**
+   * Enables tracking of user-defined cell meta properties set through `setCellMeta`.
+   */
+  enableUserDefinedMetaRecording() {
+    this.cellMeta.enableUserDefinedMetaRecording();
+  }
+
+  /**
+   * Disables tracking of user-defined cell meta properties. Writes made while disabled are treated
+   * as declarative (for example, the `cell` option applied during `updateSettings`).
+   */
+  disableUserDefinedMetaRecording() {
+    this.cellMeta.disableUserDefinedMetaRecording();
+  }
+
+  /**
    * Creates one or more rows at specific position.
    *
    * @param {number} physicalRow The physical row index which points from what position the row is added.

--- a/handsontable/src/dataMap/metaManager/metaLayers/__tests__/cellMeta.unit.ts
+++ b/handsontable/src/dataMap/metaManager/metaLayers/__tests__/cellMeta.unit.ts
@@ -768,5 +768,22 @@ describe('ColumnMeta', () => {
       expect(meta.getMeta(0, 0).className).toBe('from-cell-option');
       expect(meta.getUserDefinedMetas()).toEqual([]);
     });
+
+    it('should keep recording suspended until every disable call is balanced by an enable call', () => {
+      const globalMeta = new GlobalMeta();
+      const columnMeta = new ColumnMeta(globalMeta);
+      const meta = new CellMeta(columnMeta);
+
+      meta.disableUserDefinedMetaRecording(); // outer scope (for example, the `cell` option loop)
+      meta.disableUserDefinedMetaRecording(); // nested scope (for example, a re-entrant updateSettings)
+      meta.enableUserDefinedMetaRecording(); // closing the nested scope must not re-enable recording yet
+      meta.setMeta(0, 0, 'readOnly', true); // still within the outer scope - declarative, not tracked
+      meta.enableUserDefinedMetaRecording(); // closing the outer scope re-enables recording
+      meta.setMeta(1, 1, 'className', 'htRight'); // tracked
+
+      expect(meta.getUserDefinedMetas()).toEqual([
+        { physicalRow: 1, physicalColumn: 1, key: 'className', value: 'htRight' },
+      ]);
+    });
   });
 });

--- a/handsontable/src/dataMap/metaManager/metaLayers/__tests__/cellMeta.unit.ts
+++ b/handsontable/src/dataMap/metaManager/metaLayers/__tests__/cellMeta.unit.ts
@@ -691,4 +691,82 @@ describe('ColumnMeta', () => {
       expect(meta.getMeta(4, 10)._test).toBe(undefined);
     });
   });
+
+  describe('getUserDefinedMetas()', () => {
+    it('should return properties set through `setMeta` keyed by physical coordinates', () => {
+      const globalMeta = new GlobalMeta();
+      const columnMeta = new ColumnMeta(globalMeta);
+      const meta = new CellMeta(columnMeta);
+
+      meta.setMeta(0, 0, 'readOnly', true);
+      meta.setMeta(2, 3, 'className', 'htRight');
+
+      expect(meta.getUserDefinedMetas()).toEqual([
+        { physicalRow: 0, physicalColumn: 0, key: 'readOnly', value: true },
+        { physicalRow: 2, physicalColumn: 3, key: 'className', value: 'htRight' },
+      ]);
+    });
+
+    it('should not return properties set through `updateMeta` (for example, the `cells` option)', () => {
+      const globalMeta = new GlobalMeta();
+      const columnMeta = new ColumnMeta(globalMeta);
+      const meta = new CellMeta(columnMeta);
+
+      meta.updateMeta(0, 0, { readOnly: true });
+
+      expect(meta.getUserDefinedMetas()).toEqual([]);
+    });
+
+    it('should not return a property removed through `removeMeta`', () => {
+      const globalMeta = new GlobalMeta();
+      const columnMeta = new ColumnMeta(globalMeta);
+      const meta = new CellMeta(columnMeta);
+
+      meta.setMeta(0, 0, 'readOnly', true);
+      meta.removeMeta(0, 0, 'readOnly');
+
+      expect(meta.getUserDefinedMetas()).toEqual([]);
+    });
+
+    it('should return the shifted physical coordinates after inserting a row', () => {
+      const globalMeta = new GlobalMeta();
+      const columnMeta = new ColumnMeta(globalMeta);
+      const meta = new CellMeta(columnMeta);
+
+      meta.setMeta(2, 0, 'readOnly', true);
+      meta.createRow(0, 1);
+
+      expect(meta.getUserDefinedMetas()).toEqual([
+        { physicalRow: 3, physicalColumn: 0, key: 'readOnly', value: true },
+      ]);
+    });
+  });
+
+  describe('user-defined meta recording', () => {
+    it('should not track a property set through `setMeta` while recording is disabled', () => {
+      const globalMeta = new GlobalMeta();
+      const columnMeta = new ColumnMeta(globalMeta);
+      const meta = new CellMeta(columnMeta);
+
+      meta.disableUserDefinedMetaRecording();
+      meta.setMeta(0, 0, 'readOnly', true);
+
+      expect(meta.getMeta(0, 0).readOnly).toBe(true);
+      expect(meta.getUserDefinedMetas()).toEqual([]);
+    });
+
+    it('should de-mark a previously tracked property when it is overwritten while recording is disabled', () => {
+      const globalMeta = new GlobalMeta();
+      const columnMeta = new ColumnMeta(globalMeta);
+      const meta = new CellMeta(columnMeta);
+
+      meta.setMeta(0, 0, 'className', 'from-set-cell-meta');
+      meta.disableUserDefinedMetaRecording();
+      meta.setMeta(0, 0, 'className', 'from-cell-option');
+      meta.enableUserDefinedMetaRecording();
+
+      expect(meta.getMeta(0, 0).className).toBe('from-cell-option');
+      expect(meta.getUserDefinedMetas()).toEqual([]);
+    });
+  });
 });

--- a/handsontable/src/dataMap/metaManager/metaLayers/cellMeta.ts
+++ b/handsontable/src/dataMap/metaManager/metaLayers/cellMeta.ts
@@ -50,13 +50,14 @@ export default class CellMeta {
    */
   metas = new LazyFactoryMap(() => this._createRow());
   /**
-   * Flag that determines whether properties set through `setMeta` are tracked as user-defined.
-   * When recording is disabled, `setMeta` treats writes as declarative (for example, the `cell`
-   * option applied during `updateSettings`) and de-marks the affected key.
+   * Counts how many times user-defined meta recording has been suspended without a matching
+   * resume. Recording is active only when the count is `0`. A counter (rather than a boolean) keeps
+   * nested suspend/resume scopes correct - for example, when a re-entrant `updateSettings` runs from
+   * a `setCellMeta` hook while the outer `cell` option loop is still applying declarative writes.
    *
-   * @type {boolean}
+   * @type {number}
    */
-  #isRecordingUserDefinedMeta = true;
+  #userDefinedMetaRecordingSuspendCount = 0;
 
   /**
    * Initializes the cell meta layer with a reference to the ColumnMeta layer used as the prototype source for new cell meta objects.
@@ -66,19 +67,25 @@ export default class CellMeta {
   }
 
   /**
-   * Enables tracking of user-defined cell meta properties. Subsequent `setMeta` calls mark their
-   * keys as user-defined, so they are preserved across `updateSettings`.
+   * Resumes tracking of user-defined cell meta properties by closing one suspension scope opened by
+   * `disableUserDefinedMetaRecording`. Recording becomes active again only once every suspension has
+   * been closed. Subsequent `setMeta` calls then mark their keys as user-defined, so they are
+   * preserved across `updateSettings`.
    */
   enableUserDefinedMetaRecording() {
-    this.#isRecordingUserDefinedMeta = true;
+    if (this.#userDefinedMetaRecordingSuspendCount > 0) {
+      this.#userDefinedMetaRecordingSuspendCount -= 1;
+    }
   }
 
   /**
-   * Disables tracking of user-defined cell meta properties. Subsequent `setMeta` calls are treated
-   * as declarative writes and de-mark their keys, so they are not preserved across `updateSettings`.
+   * Suspends tracking of user-defined cell meta properties. While suspended, `setMeta` calls are
+   * treated as declarative writes and de-mark their keys, so they are not preserved across
+   * `updateSettings`. Suspensions nest - each call must be matched by an `enableUserDefinedMetaRecording`
+   * call before recording resumes.
    */
   disableUserDefinedMetaRecording() {
-    this.#isRecordingUserDefinedMeta = false;
+    this.#userDefinedMetaRecordingSuspendCount += 1;
   }
 
   /**
@@ -179,7 +186,7 @@ export default class CellMeta {
     (cellMeta._automaticallyAssignedMetaProps as Set<string> | undefined)?.delete(key);
     cellMeta[key] = value;
 
-    if (this.#isRecordingUserDefinedMeta) {
+    if (this.#userDefinedMetaRecordingSuspendCount === 0) {
       if (cellMeta._userDefinedMetaProps === undefined) {
         cellMeta._userDefinedMetaProps = new Set();
       }

--- a/handsontable/src/dataMap/metaManager/metaLayers/cellMeta.ts
+++ b/handsontable/src/dataMap/metaManager/metaLayers/cellMeta.ts
@@ -1,6 +1,6 @@
 import { extendByMetaType, assert } from '../utils';
 import LazyFactoryMap from '../lazyFactoryMap';
-import { extend } from '../../../helpers/object';
+import { extend, hasOwnProperty } from '../../../helpers/object';
 import { isDefined } from '../../../helpers/mixed';
 import { isUnsignedNumber } from '../../../helpers/number';
 import type ColumnMeta from './columnMeta';
@@ -49,12 +49,36 @@ export default class CellMeta {
    * @type {LazyFactoryMap<number, LazyFactoryMap<number, object>>}
    */
   metas = new LazyFactoryMap(() => this._createRow());
+  /**
+   * Flag that determines whether properties set through `setMeta` are tracked as user-defined.
+   * When recording is disabled, `setMeta` treats writes as declarative (for example, the `cell`
+   * option applied during `updateSettings`) and de-marks the affected key.
+   *
+   * @type {boolean}
+   */
+  #isRecordingUserDefinedMeta = true;
 
   /**
    * Initializes the cell meta layer with a reference to the ColumnMeta layer used as the prototype source for new cell meta objects.
    */
   constructor(columnMeta: ColumnMeta) {
     this.columnMeta = columnMeta;
+  }
+
+  /**
+   * Enables tracking of user-defined cell meta properties. Subsequent `setMeta` calls mark their
+   * keys as user-defined, so they are preserved across `updateSettings`.
+   */
+  enableUserDefinedMetaRecording() {
+    this.#isRecordingUserDefinedMeta = true;
+  }
+
+  /**
+   * Disables tracking of user-defined cell meta properties. Subsequent `setMeta` calls are treated
+   * as declarative writes and de-mark their keys, so they are not preserved across `updateSettings`.
+   */
+  disableUserDefinedMetaRecording() {
+    this.#isRecordingUserDefinedMeta = false;
   }
 
   /**
@@ -154,6 +178,16 @@ export default class CellMeta {
 
     (cellMeta._automaticallyAssignedMetaProps as Set<string> | undefined)?.delete(key);
     cellMeta[key] = value;
+
+    if (this.#isRecordingUserDefinedMeta) {
+      if (cellMeta._userDefinedMetaProps === undefined) {
+        cellMeta._userDefinedMetaProps = new Set();
+      }
+
+      (cellMeta._userDefinedMetaProps as Set<string>).add(key);
+    } else {
+      (cellMeta._userDefinedMetaProps as Set<string> | undefined)?.delete(key);
+    }
   }
 
   /**
@@ -167,6 +201,7 @@ export default class CellMeta {
     const cellMeta = this.metas.obtain(physicalRow).obtain(physicalColumn);
 
     delete cellMeta[key];
+    (cellMeta._userDefinedMetaProps as Set<string> | undefined)?.delete(key);
   }
 
   /**
@@ -212,6 +247,37 @@ export default class CellMeta {
     return Array.from((rowsMeta.get(physicalRow) as LazyFactoryMap))
       .sort(([a], [b]) => a - b)
       .map(([, meta]) => meta);
+  }
+
+  /**
+   * Returns a flat snapshot of all cell meta properties that were set imperatively through
+   * `setMeta` (tracked in each cell's `_userDefinedMetaProps`). The coordinates are read from the
+   * map keys (physical indexes), not from the meta object's `row`/`col` properties, which are only
+   * populated on `getCellMeta` and become stale after row or column shifts. Used to preserve
+   * user-defined meta across a cache clear during `updateSettings`.
+   *
+   * @returns {{physicalRow: number, physicalColumn: number, key: string, value: *}[]}
+   */
+  getUserDefinedMetas(): { physicalRow: number, physicalColumn: number, key: string, value: unknown }[] {
+    const result: { physicalRow: number, physicalColumn: number, key: string, value: unknown }[] = [];
+
+    for (const [physicalRow, rowMap] of this.metas) {
+      for (const [physicalColumn, meta] of rowMap) {
+        const userDefinedProps = meta._userDefinedMetaProps as Set<string> | undefined;
+
+        if (userDefinedProps === undefined) {
+          continue; // eslint-disable-line no-continue
+        }
+
+        userDefinedProps.forEach((key) => {
+          if (hasOwnProperty(meta, key)) {
+            result.push({ physicalRow, physicalColumn, key, value: meta[key] });
+          }
+        });
+      }
+    }
+
+    return result;
   }
 
   /**

--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -133,6 +133,17 @@ export default (): Record<string, unknown> => {
     _automaticallyAssignedMetaProps: undefined,
 
     /**
+     * Information on which of the cell meta properties were set imperatively through `setCellMeta`
+     * (for example, by the user or by the context menu). These properties are preserved across
+     * `updateSettings` calls, unlike the properties applied from the declarative `cell` option.
+     *
+     * @private
+     * @type {Set}
+     * @default undefined
+     */
+    _userDefinedMetaProps: undefined,
+
+    /**
      * The `activeHeaderClassName` option lets you add a CSS class name
      * to every currently-active, currently-selected header (when a whole column or row is selected).
      *


### PR DESCRIPTION
### Context

The PR fixes [#4446](https://github.com/handsontable/handsontable/issues/4446) (open since 2017, reproduced through every major since): cell meta set imperatively — `readOnly` toggled via the context menu, or any `setCellMeta(...)` value — is silently lost when `updateSettings()` is called with a `cell`, `cells`, or `columns` key.

Root cause: `updateSettings` calls `metaManager.clearCache()` whenever the incoming settings contain `cell`/`cells`/`columns`, which wipes the entire cell-meta store. Afterward only declarative meta is re-applied (`columns` and the `cell` array), so imperative `setCellMeta` values had no replay path.

Fix: properties set through `CellMeta#setMeta` are tracked per cell-meta object (the `cells()` function goes through `updateMeta`, so it is not tracked and its staleness is still dropped). On `updateSettings`, that user-defined meta is snapshotted before the clear and replayed after. The declarative `cell` option is applied with recording disabled so it stays declarative — `updateSettings({ cell: [] })` still removes entries. Replay happens before the `cell` re-application, so a value re-stated through the `cell` option still wins on a direct conflict (conflict precedence unchanged from today).

Not a breaking change per the policy: no default value changes, no API or hook is renamed/removed, and `afterCellMetaReset` still fires (Formulas re-initialization is unaffected). It is an observable behavior change to `updateSettings` — the bug fix itself.

### How has this been tested?

Added 7 E2E specs and 9 unit tests, verified RED → GREEN (the new specs fail on the unfixed build with `Expected false to be true`).

```bash
# Unit (meta layer)
npm run test:unit.jest --prefix handsontable -- --testPathPattern='metaManager.*unit'   # 180 passed

# E2E (rebuild dist first)
npm run build --prefix handsontable
npm run test:e2e --prefix handsontable -- --testPathPattern='setCellMeta'                # 21 passed
```

Regression suites run green: `updateSettings|readOnly` (30), `formulas|contextMenu` (913), `__tests__/core/|mergeCells` (1530). `npm run eslint --prefix handsontable` clean on changed files. Also verified manually in a browser via a local repro page.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. #4446
2. [DEV-1930](https://app.clickup.com/t/9015210959/DEV-1930)

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core `updateSettings` / cell-meta lifecycle (observable behavior fix) with nested suspend/resume for recording; well-tested but touches a central code path used by context menu and plugins.
> 
> **Overview**
> Fixes long-standing behavior where **`setCellMeta`** values (e.g. **`readOnly`** from the context menu) were dropped whenever **`updateSettings`** included **`cell`**, **`cells`**, or **`columns`**, because the meta cache was cleared with no replay path.
> 
> **`CellMeta`** now tracks keys set via **`setMeta`** in **`_userDefinedMetaProps`**. On **`updateSettings`**, those entries are snapshotted before **`clearCache`**, replayed afterward (before column/`cell` re-application), and still follow physical coordinates after row/column shifts. Declarative **`cell`** writes run with recording disabled so **`updateSettings({ cell: [] })`** can still remove declared meta; on a direct conflict, the **`cell`** option still wins. **`cells`** / **`updateMeta`** are not tracked, so their stale values are not preserved.
> 
> Docs and changelog updated; new E2E and unit coverage for preservation, conflicts, consecutive updates, and **`afterCellMetaReset`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b78b613ef77d12ecff1fa4d49e26db5a035e0d2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->