### PR TITLE
Cherry-pick docs fixes to release/18.0.0 (DEV-1764, DEV-1786, DEV-1921, #12772)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -4,7 +4,8 @@
       "type": "http",
       "url": "https://mcp.clickup.com/mcp",
       "headers": {
-        "Authorization": "Bearer ${CLICKUP_API_TOKEN}"
+        "Authorization": "Bearer ${CLICKUP_API_TOKEN}",
+        "x-workspace-id": "9015210959"
       }
     },
     "github": {

--- a/docs/.eslintrc.js
+++ b/docs/.eslintrc.js
@@ -27,6 +27,7 @@ module.exports = {
     '**/components/VersionComparison/**/*.ts',
     '**/content/config.ts',
     '**/content.config.ts',
+    '**/src/config/docsearch.ts',
   ],
   rules: {
     'no-restricted-globals': 'off',

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -784,9 +784,7 @@ export default defineConfig({
         ...(isProduction
           ? [
               starlightDocSearch({
-                appId: 'MMN6OTJMGX',
-                apiKey: 'c2430302c91e0162df988d4b383c9d8b',
-                indexName: 'handsontable',
+                clientOptionsModule: './src/config/docsearch.ts',
               }),
             ]
           : []),

--- a/docs/cloudflare/_worker.js
+++ b/docs/cloudflare/_worker.js
@@ -7,6 +7,7 @@
  *
  * Redirect priority order (first match wins):
  *   1. /docs/next/:splat                   → /docs/:splat
+ *  1a. /docs/sitemap.xml                   → /docs/sitemap-index.xml
  *   2. / → /docs
  *  2a. /0.8.0/*                            → /docs/javascript-data-grid/changelog
  *  2b. /docs/redirect?pageId=*             → /docs/javascript-data-grid/changelog
@@ -703,6 +704,12 @@ export default {
       const dest = `/docs${splat}${url.search}`;
 
       return redirect301(abs(dest, url));
+    }
+
+    // -- 1a. /docs/sitemap.xml → /docs/sitemap-index.xml ---------------------
+    // Redirect the legacy single-file sitemap URL to Astro's sitemap index.
+    if (path === '/docs/sitemap.xml') {
+      return redirect301(abs('/docs/sitemap-index.xml', url));
     }
 
     // -- 2. Root / → /docs ---------------------------------------------------

--- a/docs/content/guides/getting-started/events-and-hooks/react/example3.css
+++ b/docs/content/guides/getting-started/events-and-hooks/react/example3.css
@@ -1,3 +1,3 @@
-#example3 {
+.example-3-max-width {
   max-width: 440px;
 }

--- a/docs/content/guides/getting-started/events-and-hooks/react/example3.jsx
+++ b/docs/content/guides/getting-started/events-and-hooks/react/example3.jsx
@@ -68,7 +68,7 @@ const ExampleComponent = () => {
         </div>
       </div>
 
-      <HotTable id="hot" {...settings} />
+      <HotTable className="example-3-max-width" id="hot" {...settings} />
     </div>
   );
 };

--- a/docs/content/guides/getting-started/events-and-hooks/react/example3.tsx
+++ b/docs/content/guides/getting-started/events-and-hooks/react/example3.tsx
@@ -68,7 +68,7 @@ const ExampleComponent = () => {
         </div>
       </div>
 
-      <HotTable id="hot" {...settings} />
+      <HotTable className="example-3-max-width" id="hot" {...settings} />
     </div>
   );
 };

--- a/docs/content/guides/getting-started/events-and-hooks/vue/example3.vue
+++ b/docs/content/guides/getting-started/events-and-hooks/vue/example3.vue
@@ -53,7 +53,7 @@ function onColHeadersChange(event: Event) {
 </script>
 
 <template>
-  <div id="example3">
+  <div id="example3" class="example-3-max-width">
     <div class="example-controls-container">
       <div class="controls">
         <label>
@@ -82,7 +82,7 @@ function onColHeadersChange(event: Event) {
 </template>
 
 <style>
-#example3 {
+.example-3-max-width {
   max-width: 440px;
 }
 </style>

--- a/docs/docker/redirects.conf
+++ b/docs/docker/redirects.conf
@@ -198,6 +198,9 @@ rewrite ^/docs/((\d+\.\d+|next)/)?demo-formula-support/?$ /docs/$1$framework/for
 rewrite ^/docs/((\d+\.\d+|next)/)?demo-using-callbacks/?$ /docs/$1$framework/events-and-hooks/ permanent;
 rewrite ^/docs/((\d+\.\d+|next)/)?demo-react-simple-examples/?$ /docs/$1$framework/react-simple-example/ permanent;
 
+# Redirect legacy single-file sitemap URL to Astro's sitemap index
+rewrite ^/docs/sitemap\.xml$ /docs/sitemap-index.xml permanent;
+
 # Redirect all urls without framework prefix e.g. from /docs/[path] to /docs/javascript-data-grid/[path].
 # Except those that already contain a name in the path:
 #  * /javascript-data-grid/
@@ -211,12 +214,12 @@ rewrite ^/docs/((\d+\.\d+|next)/)?demo-react-simple-examples/?$ /docs/$1$framewo
 #  * /scripts/
 #  * /img/
 #  * /404.html
-#  * /sitemap.xml
+#  * /sitemap*.xml (sitemap-index.xml, sitemap-0.xml, etc.)
 #  * /securitum-certificate.pdf
 #  * /seqred-certificate.pdf
 #  * /testarmy-certificate.pdf
 #  * /testarmy-certificate-2024.pdf
 #  * /testarmy-certificate-2025.pdf
 
-rewrite ^/docs/((?:\d+\.\d+|next)/)(?!(?:javascript|react|angular)-data-grid|redirect|assets/|data/|handsontable|@handsontable/|img/|scripts/|404\.html|sitemap\.xml|securitum-certificate\.pdf|seqred-certificate\.pdf|testarmy-certificate\.pdf|testarmy-certificate-2024\.pdf|testarmy-certificate-2025\.pdf)(.+)$ /docs/$1$framework/$2 permanent;
-rewrite ^/docs/(?!\d+\.\d+|next\/)(?!(?:javascript|react|angular)-data-grid|redirect|assets/|data/|handsontable/|@handsontable/|img/|scripts/|404\.html|sitemap\.xml|securitum-certificate\.pdf|seqred-certificate\.pdf|testarmy-certificate\.pdf|testarmy-certificate-2024\.pdf|testarmy-certificate-2025\.pdf)(.+)$ /docs/$framework/$1 permanent;
+rewrite ^/docs/((?:\d+\.\d+|next)/)(?!(?:javascript|react|angular)-data-grid|redirect|assets/|data/|handsontable|@handsontable/|img/|scripts/|404\.html|sitemap[^/]*\.xml|securitum-certificate\.pdf|seqred-certificate\.pdf|testarmy-certificate\.pdf|testarmy-certificate-2024\.pdf|testarmy-certificate-2025\.pdf)(.+)$ /docs/$1$framework/$2 permanent;
+rewrite ^/docs/(?!\d+\.\d+|next\/)(?!(?:javascript|react|angular)-data-grid|redirect|assets/|data/|handsontable/|@handsontable/|img/|scripts/|404\.html|sitemap[^/]*\.xml|securitum-certificate\.pdf|seqred-certificate\.pdf|testarmy-certificate\.pdf|testarmy-certificate-2024\.pdf|testarmy-certificate-2025\.pdf)(.+)$ /docs/$framework/$1 permanent;

--- a/docs/netlify/_redirects
+++ b/docs/netlify/_redirects
@@ -1,5 +1,8 @@
 / /docs
 
+# Redirect legacy single-file sitemap URL to Astro's sitemap index
+/docs/sitemap.xml /docs/sitemap-index.xml 301
+
 /docs/:version/redirect pageId=:pageId /docs/javascript-data-grid/changelog 301
 /docs/redirect pageId=:pageId /docs/javascript-data-grid/changelog 301
 

--- a/docs/src/config/docsearch.ts
+++ b/docs/src/config/docsearch.ts
@@ -1,0 +1,87 @@
+import type { DocSearchClientOptions } from '@astrojs/starlight-docsearch';
+
+// The Algolia crawler stores hierarchy.lvl0 as raw HTML text, so ampersands
+// and other special characters arrive encoded (e.g. "Data &amp; tools").
+// DocSearch renders lvl0 as plain React children (not dangerouslySetInnerHTML),
+// so the browser never decodes the entities — we must do it here.
+const HTML_ENTITIES: Record<string, string> = {
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&#039;': "'",
+  '&apos;': "'",
+};
+const decodeHtml = (str: string | null | undefined): string | null | undefined =>
+  str ? str.replace(/&(?:amp|lt|gt|quot|#039|apos);/g, (e) => HTML_ENTITIES[e] ?? e) : str;
+
+export default {
+  appId: 'MMN6OTJMGX',
+  apiKey: 'c2430302c91e0162df988d4b383c9d8b',
+  indexName: 'handsontable',
+  transformItems(items: any[]) {
+    return items.map((item) => {
+      const url: string = item.url ?? '';
+      const framework = url.includes('/react-data-grid/')
+        ? 'React'
+        : url.includes('/angular-data-grid/')
+          ? 'Angular'
+          : url.includes('/vue-data-grid/')
+            ? 'Vue'
+            : 'JavaScript';
+
+      const suffix = ` · ${framework}`;
+      const lvl1 = item.hierarchy?.lvl1;
+      const snippetLvl1 = item._snippetResult?.hierarchy?.lvl1;
+
+      const highlightLvl0 = item._highlightResult?.hierarchy?.lvl0;
+
+      return {
+        ...item,
+        hierarchy: {
+          ...item.hierarchy,
+          // lvl0 is the section header — decode entities (fallback path).
+          lvl0: decodeHtml(item.hierarchy?.lvl0),
+          // lvl1 is the breadcrumb; append the framework label.
+          lvl1: lvl1 ? `${lvl1}${suffix}` : framework,
+        },
+        // The section title is built from _highlightResult.hierarchy.lvl0.value
+        // (see the go() function in @docsearch/js), so we must decode there too.
+        _highlightResult: item._highlightResult
+          ? {
+              ...item._highlightResult,
+              hierarchy: item._highlightResult.hierarchy
+                ? {
+                    ...item._highlightResult.hierarchy,
+                    lvl0: highlightLvl0
+                      ? { ...highlightLvl0, value: decodeHtml(highlightLvl0.value) }
+                      : undefined,
+                  }
+                : undefined,
+            }
+          : undefined,
+        // DocSearch renders _snippetResult.hierarchy.lvl1.value first (it sends
+        // attributesToSnippet: ["hierarchy.lvl1:N", ...] in every search query),
+        // so we must update this field too or the suffix never appears.
+        _snippetResult: item._snippetResult
+          ? {
+              ...item._snippetResult,
+              hierarchy: item._snippetResult.hierarchy
+                ? {
+                    ...item._snippetResult.hierarchy,
+                    lvl1: snippetLvl1
+                      ? {
+                          ...snippetLvl1,
+                          value: snippetLvl1.value
+                            ? `${snippetLvl1.value}${suffix}`
+                            : framework,
+                        }
+                      : undefined,
+                  }
+                : undefined,
+            }
+          : undefined,
+      };
+    });
+  },
+} satisfies DocSearchClientOptions;

--- a/handsontable/src/core/hooks/constants.ts
+++ b/handsontable/src/core/hooks/constants.ts
@@ -1249,7 +1249,9 @@ export const REGISTERED_HOOKS = [
   'afterRemoveCellMeta',
 
   /**
-   * Fired after cell data was changed.
+   * Fired after [`setDataAtCell`](@/api/core.md#setdataatcell) is called and changes are processed,
+   * before they are validated and applied to the data source.
+   * Use [`afterChange`](@/api/hooks.md#afterchange) if you need to react after the data has been written.
    *
    * @event Hooks#afterSetDataAtCell
    * @param {Array} changes An array of changes in format `[[row, column, oldValue, value], ...]`.
@@ -1259,8 +1261,9 @@ export const REGISTERED_HOOKS = [
   'afterSetDataAtCell',
 
   /**
-   * Fired after cell data was changed.
-   * Called only when [`setDataAtRowProp`](@/api/core.md#setdataatrowprop) was executed.
+   * Fired after [`setDataAtRowProp`](@/api/core.md#setdataatrowprop) is called and changes are processed,
+   * before they are validated and applied to the data source.
+   * Use [`afterChange`](@/api/hooks.md#afterchange) if you need to react after the data has been written.
    *
    * @event Hooks#afterSetDataAtRowProp
    * @param {Array} changes An array of changes in format `[[row, prop, oldValue, value], ...]`.


### PR DESCRIPTION
### Context

The PR cherry-picks four bug fixes from `develop` to `release/18.0.0`:

1. **DEV-1921 (#12799)** — Fix misleading JSDoc for `afterSetDataAtCell` and `afterSetDataAtRowProp` hooks. Both hooks fire before `validateChanges`/`applyChanges`, so the data has not been written yet when they run. Updated descriptions to reflect the actual timing and point users to `afterChange` for post-write reactions.

2. **#12772** — Fix CSS specificity of the React hook example in the events-and-hooks guide (also fixes the Vue variant).

3. **DEV-1786 (#12789)** — Show framework labels (JavaScript, React, Angular, Vue) in Algolia search results and decode HTML entities in section headers (`Data &amp; tools` → `Data & tools`).

4. **DEV-1764 (#12774)** — Fix missing `sitemap-index.xml` in nginx/Netlify/Cloudflare redirects config so search engines can find the sitemap.

### How has this been tested?

- Changes originate from `develop` where they were reviewed and tested individually.
- No new code changes — pure cherry-picks.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1921
2. DEV-1786
3. DEV-1764
4. #12772 (docs: fixed specificity of the react hook example)

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, redirect, and search UI changes only; hook behavior is unchanged and JSDoc updates do not affect runtime.
> 
> **Overview**
> Cherry-picks four reviewed fixes from `develop` into `release/18.0.0` with no new runtime logic beyond docs and redirect config.
> 
> **Handsontable hooks (DEV-1921):** JSDoc for `afterSetDataAtCell` and `afterSetDataAtRowProp` now states they run after the setters process changes but **before** validation and writing to the data source, and directs readers to `afterChange` for post-write handling.
> 
> **Docs search (DEV-1786):** Production DocSearch is wired through `docs/src/config/docsearch.ts` via `clientOptionsModule`. A `transformItems` hook decodes HTML entities in section titles and appends framework labels (JavaScript, React, Angular, Vue) on result breadcrumbs/snippets.
> 
> **Sitemap (DEV-1764):** Netlify, nginx (`redirects.conf`), and Cloudflare worker add a **301** from `/docs/sitemap.xml` to `/docs/sitemap-index.xml`. Nginx framework-prefix rules exclude `sitemap*.xml` so those URLs are not rewritten away.
> 
> **Events-and-hooks example (#12772):** React/Vue example 3 use class `example-3-max-width` for max-width styling so layout rules apply correctly on `HotTable` (CSS specificity).
> 
> Also adds ClickUp MCP `x-workspace-id` and ESLint ignore for `docsearch.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c465f7613a5a0af1ea7e65d05f5072c6f4ea7171. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->