### PR TITLE
fix(ci): deploy docs to Cloudflare Pages apex, not previews

### DIFF
--- a/.github/workflows/docs-production.yml
+++ b/.github/workflows/docs-production.yml
@@ -112,6 +112,10 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CF_PROJECT_NAME: handsontable-docs
+          # Production deployments target --branch main below, so the project's
+          # production branch must be "main" for the deploy to be served at the
+          # apex handsontable-docs.pages.dev (otherwise it is a preview).
+          CF_PRODUCTION_BRANCH: main
 
       - name: Deploy production to Cloudflare Pages
         continue-on-error: true

--- a/.github/workflows/docs-production.yml
+++ b/.github/workflows/docs-production.yml
@@ -112,10 +112,12 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CF_PROJECT_NAME: handsontable-docs
-          # Production deployments target --branch main below, so the project's
-          # production branch must be "main" for the deploy to be served at the
-          # apex handsontable-docs.pages.dev (otherwise it is a preview).
-          CF_PRODUCTION_BRANCH: main
+          # "production" is a stable Cloudflare Pages branch label, NOT a git
+          # branch (the real prod git branch is e.g. prod-docs/18.0). The deploy
+          # below passes the same label to --branch, so the deployment is served
+          # at the apex handsontable-docs.pages.dev. Using the per-version git
+          # branch here would move the apex on every release.
+          CF_PAGES_APEX_BRANCH: production
 
       - name: Deploy production to Cloudflare Pages
         continue-on-error: true
@@ -126,7 +128,7 @@ jobs:
           ./node_modules/.bin/wrangler pages deploy \
             "$GITHUB_WORKSPACE/docs/netlify/docs" \
             --project-name handsontable-docs \
-            --branch main
+            --branch production
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/docs-staging.yml
+++ b/.github/workflows/docs-staging.yml
@@ -250,7 +250,8 @@ jobs:
           CF_PROJECT_NAME: handsontable-docs-staging
           # Develop builds deploy to --branch develop below, so the apex
           # handsontable-docs-staging.pages.dev tracks the develop branch.
-          CF_PRODUCTION_BRANCH: develop
+          # (Here the label happens to match a real, long-lived git branch.)
+          CF_PAGES_APEX_BRANCH: develop
 
       - name: Deploy to Cloudflare Pages
         id: cf-pages-deploy

--- a/.github/workflows/docs-staging.yml
+++ b/.github/workflows/docs-staging.yml
@@ -207,23 +207,54 @@ jobs:
             ✅ Preview documentation is available now
             Current staging version of documentation is available at: [${{ env.NETLIFY_SITE_URL }}/docs](${{ env.NETLIFY_SITE_URL }}/docs)
 
+      # Decide how this build maps to a Cloudflare Pages deployment:
+      #   - push/dispatch on develop -> deploy to the production branch
+      #     ("develop"), which Cloudflare serves at the apex
+      #     handsontable-docs-staging.pages.dev.
+      #   - a PR build -> deploy to branch "pr-<N>", served as an isolated
+      #     preview at pr-<N>.handsontable-docs-staging.pages.dev.
+      # Any deploy whose branch differs from the project's production_branch
+      # is a preview, so the branch passed here determines apex vs preview.
+      - name: Determine Cloudflare Pages target
+        id: cf-target
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # https://github.com/actions/github-script/releases/tag/v8.0.0
+        with:
+          script: |
+            const prNumber = '${{ steps.resolve-pr.outputs.number }}';
+            const ref = context.ref || '';
+
+            if (ref === 'refs/heads/develop') {
+              core.setOutput('deploy', 'true');
+              core.setOutput('branch', 'develop');
+              core.setOutput('is_production', 'true');
+            } else if (prNumber) {
+              core.setOutput('deploy', 'true');
+              core.setOutput('branch', `pr-${prNumber}`);
+              core.setOutput('is_production', 'false');
+            } else {
+              core.setOutput('deploy', 'false');
+            }
+
       - name: Add Cloudflare worker to deploy
-        if: ${{ steps.resolve-pr.outputs.number }}
+        if: ${{ steps.cf-target.outputs.deploy == 'true' }}
         continue-on-error: true
         run: cp cloudflare/_worker.js netlify/deploy/_worker.js
 
       - name: Ensure Cloudflare Pages project exists
-        if: ${{ steps.resolve-pr.outputs.number }}
+        if: ${{ steps.cf-target.outputs.deploy == 'true' }}
         continue-on-error: true
         run: node cloudflare/ensureProject.mjs
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CF_PROJECT_NAME: handsontable-docs-staging
+          # Develop builds deploy to --branch develop below, so the apex
+          # handsontable-docs-staging.pages.dev tracks the develop branch.
+          CF_PRODUCTION_BRANCH: develop
 
-      - name: Deploy preview to Cloudflare Pages
+      - name: Deploy to Cloudflare Pages
         id: cf-pages-deploy
-        if: ${{ steps.resolve-pr.outputs.number }}
+        if: ${{ steps.cf-target.outputs.deploy == 'true' }}
         continue-on-error: true
         # Install wrangler in /tmp to avoid npm failures inside the pnpm workspace
         working-directory: /tmp
@@ -232,7 +263,7 @@ jobs:
           ./node_modules/.bin/wrangler pages deploy \
             "$GITHUB_WORKSPACE/docs/netlify/deploy" \
             --project-name handsontable-docs-staging \
-            --branch "pr-${{ steps.resolve-pr.outputs.number }}"
+            --branch "${{ steps.cf-target.outputs.branch }}"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -249,6 +280,14 @@ jobs:
             |---|---|
             | Netlify | [${{ env.NETLIFY_SITE_URL }}/docs](${{ env.NETLIFY_SITE_URL }}/docs) |
             | Cloudflare Pages | [https://pr-${{ steps.resolve-pr.outputs.number }}.handsontable-docs-staging.pages.dev/docs](https://pr-${{ steps.resolve-pr.outputs.number }}.handsontable-docs-staging.pages.dev/docs) |
+
+      - name: Post Cloudflare Pages apex summary
+        if: ${{ steps.cf-target.outputs.is_production == 'true' && steps.cf-pages-deploy.outcome == 'success' }}
+        run: |
+          echo "## ☁️ Staging docs deployed to Cloudflare Pages apex" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Production deployment of the staging project (branch \`develop\`)." >> $GITHUB_STEP_SUMMARY
+          echo "**URL:** https://handsontable-docs-staging.pages.dev/docs" >> $GITHUB_STEP_SUMMARY
 
       - name: Post RC staging summary
         if: ${{ steps.release-info.outputs.is_release == 'true' }}

--- a/docs/cloudflare/ensureProject.mjs
+++ b/docs/cloudflare/ensureProject.mjs
@@ -1,12 +1,15 @@
 /**
  * Ensures a Cloudflare Pages project exists, creating it if it does not.
  *
- * Also reconciles the project's production branch: a Cloudflare Pages
- * deployment is only served at the apex `<project>.pages.dev` when it is
- * deployed to the branch that matches the project's `production_branch`.
- * Any other branch becomes a preview deployment. When the project already
- * exists with a different production branch, this script patches it so the
- * apex URL tracks the branch the workflow actually deploys to.
+ * Also reconciles the project's apex branch: a Cloudflare Pages deployment is
+ * only served at the apex `<project>.pages.dev` when it is deployed to the
+ * branch that matches the project's `production_branch` (Cloudflare's term).
+ * Any other branch becomes a preview deployment. This value is a Cloudflare
+ * label, NOT a git branch -- the workflow passes the same value to
+ * `wrangler pages deploy --branch`. It must stay stable (e.g. 'production',
+ * 'develop'); using a per-version git branch such as `prod-docs/18.0` would
+ * move the apex on every release. When the project already exists with a
+ * different value, this script patches it so the apex tracks the right branch.
  *
  * Required environment variables:
  *   CLOUDFLARE_API_TOKEN - API token with Pages:Edit permission
@@ -14,11 +17,12 @@
  *   CF_PROJECT_NAME - Name of the Pages project to ensure
  *
  * Optional environment variables:
- *   CF_PRODUCTION_BRANCH - Production branch for the project (default: 'develop')
+ *   CF_PAGES_APEX_BRANCH - Cloudflare Pages branch label served at the apex
+ *                          (must match the `wrangler --branch` value; default: 'develop')
  */
 import { CF_API, accountId, cfFetch } from './cfFetch.mjs';
 
-const { CF_PROJECT_NAME: projectName, CF_PRODUCTION_BRANCH: productionBranch = 'develop' } = process.env;
+const { CF_PROJECT_NAME: projectName, CF_PAGES_APEX_BRANCH: apexBranch = 'develop' } = process.env;
 
 if (!projectName) {
   throw new Error('Missing required environment variable: CF_PROJECT_NAME');
@@ -30,28 +34,28 @@ if (getResponse.ok) {
   const { result } = await getResponse.json();
   const currentBranch = result?.production_branch;
 
-  if (currentBranch === productionBranch) {
+  if (currentBranch === apexBranch) {
     // eslint-disable-next-line no-console
-    console.log(`Project "${projectName}" already exists with production branch "${productionBranch}".`);
+    console.log(`Project "${projectName}" already exists with apex branch "${apexBranch}".`);
     process.exit(0);
   }
 
   // eslint-disable-next-line no-console
-  console.log(`Project "${projectName}" production branch is "${currentBranch}", updating to "${productionBranch}"...`);
+  console.log(`Project "${projectName}" apex branch is "${currentBranch}", updating to "${apexBranch}"...`);
 
   const patchResponse = await cfFetch(`/accounts/${accountId}/pages/projects/${projectName}`, {
     method: 'PATCH',
-    body: JSON.stringify({ production_branch: productionBranch }),
+    body: JSON.stringify({ production_branch: apexBranch }),
   });
 
   if (!patchResponse.ok) {
     const body = await patchResponse.text();
 
-    throw new Error(`Failed to update production branch for "${projectName}" (HTTP ${patchResponse.status}): ${body}`);
+    throw new Error(`Failed to update apex branch for "${projectName}" (HTTP ${patchResponse.status}): ${body}`);
   }
 
   // eslint-disable-next-line no-console
-  console.log(`Project "${projectName}" production branch updated to "${productionBranch}".`);
+  console.log(`Project "${projectName}" apex branch updated to "${apexBranch}".`);
   process.exit(0);
 }
 
@@ -74,7 +78,7 @@ const createResponse = await cfFetch(`/accounts/${accountId}/pages/projects`, {
   method: 'POST',
   body: JSON.stringify({
     name: projectName,
-    production_branch: productionBranch,
+    production_branch: apexBranch,
   }),
 });
 

--- a/docs/cloudflare/ensureProject.mjs
+++ b/docs/cloudflare/ensureProject.mjs
@@ -1,14 +1,24 @@
 /**
  * Ensures a Cloudflare Pages project exists, creating it if it does not.
  *
+ * Also reconciles the project's production branch: a Cloudflare Pages
+ * deployment is only served at the apex `<project>.pages.dev` when it is
+ * deployed to the branch that matches the project's `production_branch`.
+ * Any other branch becomes a preview deployment. When the project already
+ * exists with a different production branch, this script patches it so the
+ * apex URL tracks the branch the workflow actually deploys to.
+ *
  * Required environment variables:
  *   CLOUDFLARE_API_TOKEN - API token with Pages:Edit permission
  *   CLOUDFLARE_ACCOUNT_ID - Cloudflare account ID
  *   CF_PROJECT_NAME - Name of the Pages project to ensure
+ *
+ * Optional environment variables:
+ *   CF_PRODUCTION_BRANCH - Production branch for the project (default: 'develop')
  */
 import { CF_API, accountId, cfFetch } from './cfFetch.mjs';
 
-const { CF_PROJECT_NAME: projectName } = process.env;
+const { CF_PROJECT_NAME: projectName, CF_PRODUCTION_BRANCH: productionBranch = 'develop' } = process.env;
 
 if (!projectName) {
   throw new Error('Missing required environment variable: CF_PROJECT_NAME');
@@ -17,8 +27,31 @@ if (!projectName) {
 const getResponse = await cfFetch(`/accounts/${accountId}/pages/projects/${projectName}`);
 
 if (getResponse.ok) {
+  const { result } = await getResponse.json();
+  const currentBranch = result?.production_branch;
+
+  if (currentBranch === productionBranch) {
+    // eslint-disable-next-line no-console
+    console.log(`Project "${projectName}" already exists with production branch "${productionBranch}".`);
+    process.exit(0);
+  }
+
   // eslint-disable-next-line no-console
-  console.log(`Project "${projectName}" already exists.`);
+  console.log(`Project "${projectName}" production branch is "${currentBranch}", updating to "${productionBranch}"...`);
+
+  const patchResponse = await cfFetch(`/accounts/${accountId}/pages/projects/${projectName}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ production_branch: productionBranch }),
+  });
+
+  if (!patchResponse.ok) {
+    const body = await patchResponse.text();
+
+    throw new Error(`Failed to update production branch for "${projectName}" (HTTP ${patchResponse.status}): ${body}`);
+  }
+
+  // eslint-disable-next-line no-console
+  console.log(`Project "${projectName}" production branch updated to "${productionBranch}".`);
   process.exit(0);
 }
 
@@ -41,7 +74,7 @@ const createResponse = await cfFetch(`/accounts/${accountId}/pages/projects`, {
   method: 'POST',
   body: JSON.stringify({
     name: projectName,
-    production_branch: 'develop',
+    production_branch: productionBranch,
   }),
 });
 


### PR DESCRIPTION
### Context

The PR fixes the docs Cloudflare Pages deployments, which only ever produced **preview** deployments and never populated the apex URLs:

- `handsontable-docs.pages.dev` (production) stayed empty.
- `handsontable-docs-staging.pages.dev` (staging) stayed empty.

Root cause: a Cloudflare Pages deployment is served at the apex `<project>.pages.dev` only when its `wrangler --branch` matches the project's `production_branch` (Cloudflare's term for the branch label served at the apex — not a git branch). Any other branch is a preview. `docs/cloudflare/ensureProject.mjs` created both projects with `production_branch: 'develop'`, but the workflows deployed to non-matching branches:

| Project | Deploy `--branch` | CF apex branch | Result |
|---|---|---|---|
| `handsontable-docs` | `main` | `develop` | preview |
| `handsontable-docs-staging` | `pr-<N>` | `develop` | preview |

This PR aligns the CF apex branch label with what each workflow deploys and makes `ensureProject.mjs` reconcile the label on already-existing projects.

Changes:

- `docs/cloudflare/ensureProject.mjs` — adds optional `CF_PAGES_APEX_BRANCH` env var (default `develop`) and now PATCHes the project's `production_branch` when it differs, instead of exiting early. This makes the fix self-healing on the next workflow run.
- `.github/workflows/docs-production.yml` — passes `CF_PAGES_APEX_BRANCH: production` and deploys `--branch production`, so production lands on `handsontable-docs.pages.dev`. `production` is a **stable** Cloudflare label, deliberately decoupled from the real per-version git branch (e.g. `prod-docs/18.0`) — using the git branch would move the apex on every release.
- `.github/workflows/docs-staging.yml` — new `cf-target` step routes the deploy: push/dispatch on `develop` deploys `--branch develop` (apex), while PR builds keep `--branch pr-<N>` (isolated preview). Passes `CF_PAGES_APEX_BRANCH: develop` (here the label coincides with the real long-lived `develop` branch) and adds an apex deploy step summary.

Rollout note: changing the apex branch label only affects future deployments — Cloudflare does not retroactively promote existing previews. Re-running each workflow once (a `prod-docs/**` build for production, a `develop` push touching `docs/**` for staging) populates the apex URLs. The PATCH requires an API token with Pages:Edit (write) scope.

### How has this been tested?

CI/tooling-only change. Validated locally:

```bash
node --check docs/cloudflare/ensureProject.mjs
cd docs && node -e "const yaml=require('js-yaml'),fs=require('fs');['../.github/workflows/docs-staging.yml','../.github/workflows/docs-production.yml'].forEach(f=>{yaml.load(fs.readFileSync(f,'utf8'));console.log('OK',f)})"
```

Both workflows parse and the script passes the syntax check. End-to-end verification happens on the next docs-staging (develop) and docs-production runs.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

N/A — CI/deployment fix.

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog] — CI/tooling-only change, no package source modified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/deployment-only changes; no application runtime code. Wrong branch labels could misroute docs until the next successful deploy, but scope is limited to Cloudflare Pages wiring.
> 
> **Overview**
> Fixes Cloudflare Pages docs deploys so builds land on **apex** URLs (`handsontable-docs.pages.dev` and `handsontable-docs-staging.pages.dev`) instead of only creating previews. Cloudflare serves the apex only when `wrangler --branch` matches the project’s `production_branch` label.
> 
> **`ensureProject.mjs`** now accepts `CF_PAGES_APEX_BRANCH` (default `develop`) and **PATCHes** `production_branch` when it drifts, so existing projects self-heal on the next run.
> 
> **Production workflow** sets apex label `production` and deploys with `--branch production` (stable label, not per-version git branches like `prod-docs/18.0`), replacing `main`.
> 
> **Staging workflow** adds a **`cf-target`** step: `develop` pushes deploy to branch `develop` (apex); PR builds still use `pr-<N>` previews. Cloudflare steps run when `deploy == 'true'` (not only when a PR number exists). A job summary is posted on successful develop apex deploys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7423d6b76023b9b02d50dde10d93b4e75bd700ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->