### PR TITLE
fix(ci): deploy 17.1 docs to Cloudflare Pages apex (handsontable-docs.pages.dev)

### DIFF
--- a/.github/workflows/docs-production.yml
+++ b/.github/workflows/docs-production.yml
@@ -112,6 +112,12 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CF_PROJECT_NAME: handsontable-docs
+          # "production" is a stable Cloudflare Pages branch label, NOT a git
+          # branch (the real prod git branch is e.g. prod-docs/17.1). The deploy
+          # below passes the same label to --branch, so the deployment is served
+          # at the apex handsontable-docs.pages.dev. Using the per-version git
+          # branch here would move the apex on every release.
+          CF_PAGES_APEX_BRANCH: production
 
       - name: Deploy production to Cloudflare Pages
         continue-on-error: true
@@ -122,7 +128,7 @@ jobs:
           ./node_modules/.bin/wrangler pages deploy \
             "$GITHUB_WORKSPACE/docs/netlify/docs" \
             --project-name handsontable-docs \
-            --branch main
+            --branch production
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/docs-production.yml
+++ b/.github/workflows/docs-production.yml
@@ -101,11 +101,16 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_PREVIEW_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_PROD_SITE_ID }}
 
+      # Cloudflare Pages deploy is independent of Netlify: !cancelled() lets
+      # these steps run even when the Netlify publish above fails, so the apex
+      # handsontable-docs.pages.dev still updates.
       - name: Add Cloudflare worker to production deploy
+        if: ${{ !cancelled() }}
         continue-on-error: true
         run: cp cloudflare/_worker.js netlify/docs/_worker.js
 
       - name: Ensure Cloudflare Pages production project exists
+        if: ${{ !cancelled() }}
         continue-on-error: true
         run: node cloudflare/ensureProject.mjs
         env:
@@ -120,6 +125,7 @@ jobs:
           CF_PAGES_APEX_BRANCH: production
 
       - name: Deploy production to Cloudflare Pages
+        if: ${{ !cancelled() }}
         continue-on-error: true
         # Install wrangler in /tmp to avoid npm failures inside the pnpm workspace
         working-directory: /tmp

--- a/docs/cloudflare/ensureProject.mjs
+++ b/docs/cloudflare/ensureProject.mjs
@@ -1,14 +1,28 @@
 /**
  * Ensures a Cloudflare Pages project exists, creating it if it does not.
  *
+ * Also reconciles the project's apex branch: a Cloudflare Pages deployment is
+ * only served at the apex `<project>.pages.dev` when it is deployed to the
+ * branch that matches the project's `production_branch` (Cloudflare's term).
+ * Any other branch becomes a preview deployment. This value is a Cloudflare
+ * label, NOT a git branch -- the workflow passes the same value to
+ * `wrangler pages deploy --branch`. It must stay stable (e.g. 'production',
+ * 'develop'); using a per-version git branch such as `prod-docs/18.0` would
+ * move the apex on every release. When the project already exists with a
+ * different value, this script patches it so the apex tracks the right branch.
+ *
  * Required environment variables:
  *   CLOUDFLARE_API_TOKEN - API token with Pages:Edit permission
  *   CLOUDFLARE_ACCOUNT_ID - Cloudflare account ID
  *   CF_PROJECT_NAME - Name of the Pages project to ensure
+ *
+ * Optional environment variables:
+ *   CF_PAGES_APEX_BRANCH - Cloudflare Pages branch label served at the apex
+ *                          (must match the `wrangler --branch` value; default: 'develop')
  */
 import { CF_API, accountId, cfFetch } from './cfFetch.mjs';
 
-const { CF_PROJECT_NAME: projectName } = process.env;
+const { CF_PROJECT_NAME: projectName, CF_PAGES_APEX_BRANCH: apexBranch = 'develop' } = process.env;
 
 if (!projectName) {
   throw new Error('Missing required environment variable: CF_PROJECT_NAME');
@@ -17,8 +31,31 @@ if (!projectName) {
 const getResponse = await cfFetch(`/accounts/${accountId}/pages/projects/${projectName}`);
 
 if (getResponse.ok) {
+  const { result } = await getResponse.json();
+  const currentBranch = result?.production_branch;
+
+  if (currentBranch === apexBranch) {
+    // eslint-disable-next-line no-console
+    console.log(`Project "${projectName}" already exists with apex branch "${apexBranch}".`);
+    process.exit(0);
+  }
+
   // eslint-disable-next-line no-console
-  console.log(`Project "${projectName}" already exists.`);
+  console.log(`Project "${projectName}" apex branch is "${currentBranch}", updating to "${apexBranch}"...`);
+
+  const patchResponse = await cfFetch(`/accounts/${accountId}/pages/projects/${projectName}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ production_branch: apexBranch }),
+  });
+
+  if (!patchResponse.ok) {
+    const body = await patchResponse.text();
+
+    throw new Error(`Failed to update apex branch for "${projectName}" (HTTP ${patchResponse.status}): ${body}`);
+  }
+
+  // eslint-disable-next-line no-console
+  console.log(`Project "${projectName}" apex branch updated to "${apexBranch}".`);
   process.exit(0);
 }
 
@@ -41,7 +78,7 @@ const createResponse = await cfFetch(`/accounts/${accountId}/pages/projects`, {
   method: 'POST',
   body: JSON.stringify({
     name: projectName,
-    production_branch: 'develop',
+    production_branch: apexBranch,
   }),
 });
 


### PR DESCRIPTION
### Context

The PR makes the `prod-docs/17.1` docs deploy to the apex `https://handsontable-docs.pages.dev/` instead of a preview deployment. It is the back-port of the production-side fix from #12815.

`prod-docs/17.1` already deploys to the `handsontable-docs` Cloudflare Pages project, but it has the same bug `develop` had: `docs/cloudflare/ensureProject.mjs` creates the project with `production_branch: 'develop'`, while the workflow deploys with `--branch main`. A Cloudflare Pages deployment is served at the apex `<project>.pages.dev` only when its `wrangler --branch` matches the project's `production_branch` (Cloudflare's term -- a stable branch label, not a git branch). Because the two never matched, every deploy became a preview and the apex stayed empty.

This PR aligns both to the stable label `production`, decoupled from the per-version git branch `prod-docs/17.1` (using the git branch would move the apex on every release).

Changes (2 files):

- `docs/cloudflare/ensureProject.mjs` — adds the optional `CF_PAGES_APEX_BRANCH` env var (default `develop`) and now PATCHes an existing project's `production_branch` when it differs, instead of exiting early. Self-healing on the next workflow run.
- `.github/workflows/docs-production.yml` — passes `CF_PAGES_APEX_BRANCH: production` to the ensure step and deploys `--branch production`, so the deployment lands on `handsontable-docs.pages.dev`.

The Cloudflare files and deploy steps already exist on this branch, so no new files are added.

Rollout note: the apex flips on the next `prod-docs/17.1` production run -- Cloudflare does not retroactively promote existing previews. The `ensureProject.mjs` PATCH requires a `CLOUDFLARE_API_TOKEN` with Pages:Edit (write) scope.

Note: `handsontable-docs` is a single shared production project. Whichever `prod-docs/*` branch deploys last to `--branch production` owns the apex.

### How has this been tested?

CI/tooling-only change. Validated locally:

```bash
node --check docs/cloudflare/ensureProject.mjs
cd docs && node -e "const yaml=require('js-yaml'),fs=require('fs');yaml.load(fs.readFileSync('../.github/workflows/docs-production.yml','utf8'));console.log('OK')"
```

Both the script and the workflow parse. End-to-end verification happens on the next `prod-docs/17.1` production run.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

Back-port of #12815 to `prod-docs/17.1`.

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog] — CI/tooling-only change, no package source modified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and Cloudflare Pages configuration only; no application runtime changes, though the shared apex reflects whichever `prod-docs/*` branch deploys last to `production`.
> 
> **Overview**
> Fixes production docs landing on **preview** URLs instead of **`handsontable-docs.pages.dev`** by aligning Cloudflare’s `production_branch` with **`wrangler pages deploy --branch`**.
> 
> **`docs/cloudflare/ensureProject.mjs`** adds optional **`CF_PAGES_APEX_BRANCH`** (default `develop`) and, when the project already exists, **PATCHes** `production_branch` if it differs instead of exiting early. New projects use that label on create.
> 
> **`.github/workflows/docs-production.yml`** sets **`CF_PAGES_APEX_BRANCH: production`**, deploys with **`--branch production`** (replacing `main`), and gates Cloudflare steps with **`if: !cancelled()`** so the apex can still update when Netlify publish fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1743c1a92699b273ef4bc19b2cf1e6cdc02726a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->