### PR TITLE
fix(ci): run Cloudflare Pages deploy even when Netlify publish fails

### DIFF
--- a/.github/workflows/docs-production.yml
+++ b/.github/workflows/docs-production.yml
@@ -101,11 +101,16 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_PREVIEW_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_PROD_SITE_ID }}
 
+      # Cloudflare Pages deploy is independent of Netlify: !cancelled() lets
+      # these steps run even when the Netlify publish above fails, so the apex
+      # handsontable-docs.pages.dev still updates.
       - name: Add Cloudflare worker to production deploy
+        if: ${{ !cancelled() }}
         continue-on-error: true
         run: cp cloudflare/_worker.js netlify/docs/_worker.js
 
       - name: Ensure Cloudflare Pages production project exists
+        if: ${{ !cancelled() }}
         continue-on-error: true
         run: node cloudflare/ensureProject.mjs
         env:
@@ -120,6 +125,7 @@ jobs:
           CF_PAGES_APEX_BRANCH: production
 
       - name: Deploy production to Cloudflare Pages
+        if: ${{ !cancelled() }}
         continue-on-error: true
         # Install wrangler in /tmp to avoid npm failures inside the pnpm workspace
         working-directory: /tmp

--- a/.github/workflows/docs-staging.yml
+++ b/.github/workflows/docs-staging.yml
@@ -215,8 +215,12 @@ jobs:
       #     preview at pr-<N>.handsontable-docs-staging.pages.dev.
       # Any deploy whose branch differs from the project's production_branch
       # is a preview, so the branch passed here determines apex vs preview.
+      # Cloudflare Pages deploy is independent of Netlify: !cancelled() lets
+      # these steps run even when the Netlify publish above fails, so the apex
+      # handsontable-docs-staging.pages.dev still updates.
       - name: Determine Cloudflare Pages target
         id: cf-target
+        if: ${{ !cancelled() }}
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # https://github.com/actions/github-script/releases/tag/v8.0.0
         with:
           script: |
@@ -236,12 +240,12 @@ jobs:
             }
 
       - name: Add Cloudflare worker to deploy
-        if: ${{ steps.cf-target.outputs.deploy == 'true' }}
+        if: ${{ !cancelled() && steps.cf-target.outputs.deploy == 'true' }}
         continue-on-error: true
         run: cp cloudflare/_worker.js netlify/deploy/_worker.js
 
       - name: Ensure Cloudflare Pages project exists
-        if: ${{ steps.cf-target.outputs.deploy == 'true' }}
+        if: ${{ !cancelled() && steps.cf-target.outputs.deploy == 'true' }}
         continue-on-error: true
         run: node cloudflare/ensureProject.mjs
         env:
@@ -255,7 +259,7 @@ jobs:
 
       - name: Deploy to Cloudflare Pages
         id: cf-pages-deploy
-        if: ${{ steps.cf-target.outputs.deploy == 'true' }}
+        if: ${{ !cancelled() && steps.cf-target.outputs.deploy == 'true' }}
         continue-on-error: true
         # Install wrangler in /tmp to avoid npm failures inside the pnpm workspace
         working-directory: /tmp
@@ -271,7 +275,7 @@ jobs:
 
       - name: Update sticky PR comment with Cloudflare Pages URL
         uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v3.0.4
-        if: ${{ steps.resolve-pr.outputs.number && steps.cf-pages-deploy.outcome == 'success' }}
+        if: ${{ !cancelled() && steps.resolve-pr.outputs.number && steps.cf-pages-deploy.outcome == 'success' }}
         with:
           number: ${{ steps.resolve-pr.outputs.number }}
           message: |
@@ -283,7 +287,7 @@ jobs:
             | Cloudflare Pages | [https://pr-${{ steps.resolve-pr.outputs.number }}.handsontable-docs-staging.pages.dev/docs](https://pr-${{ steps.resolve-pr.outputs.number }}.handsontable-docs-staging.pages.dev/docs) |
 
       - name: Post Cloudflare Pages apex summary
-        if: ${{ steps.cf-target.outputs.is_production == 'true' && steps.cf-pages-deploy.outcome == 'success' }}
+        if: ${{ !cancelled() && steps.cf-target.outputs.is_production == 'true' && steps.cf-pages-deploy.outcome == 'success' }}
         run: |
           echo "## ☁️ Staging docs deployed to Cloudflare Pages apex" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/docs-staging.yml
+++ b/.github/workflows/docs-staging.yml
@@ -186,6 +186,7 @@ jobs:
           cp _redirects deploy/_redirects
 
       - name: Publish preview to Netlify
+        id: netlify-publish
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # https://github.com/nick-fields/retry/releases/tag/v3.0.2
         with:
           timeout_seconds: 1600
@@ -278,13 +279,18 @@ jobs:
         if: ${{ !cancelled() && steps.resolve-pr.outputs.number && steps.cf-pages-deploy.outcome == 'success' }}
         with:
           number: ${{ steps.resolve-pr.outputs.number }}
+          # The Netlify row is only included when the Netlify publish actually
+          # succeeded -- this comment can now run after a failed Netlify publish
+          # (Cloudflare deploy is decoupled), so it must not claim a Netlify URL
+          # that was never published. When Netlify failed, the expression yields
+          # an empty trailing line and only the Cloudflare row is listed.
           message: |
             ✅ Preview documentation is available now
 
             | Platform | URL |
             |---|---|
-            | Netlify | [${{ env.NETLIFY_SITE_URL }}/docs](${{ env.NETLIFY_SITE_URL }}/docs) |
             | Cloudflare Pages | [https://pr-${{ steps.resolve-pr.outputs.number }}.handsontable-docs-staging.pages.dev/docs](https://pr-${{ steps.resolve-pr.outputs.number }}.handsontable-docs-staging.pages.dev/docs) |
+            ${{ steps.netlify-publish.outcome == 'success' && format('| Netlify | [{0}/docs]({0}/docs) |', env.NETLIFY_SITE_URL) || '' }}
 
       - name: Post Cloudflare Pages apex summary
         if: ${{ !cancelled() && steps.cf-target.outputs.is_production == 'true' && steps.cf-pages-deploy.outcome == 'success' }}


### PR DESCRIPTION
### Context

The PR fixes the docs Cloudflare Pages deploy so it no longer depends on the Netlify publish succeeding. Follow-up to #12815.

After #12815 merged, `https://handsontable-docs-staging.pages.dev/` still returned 404. Root cause: in both docs workflows the Cloudflare Pages steps run *after* the Netlify publish step, and that Netlify step currently fails with `Error: Project not found. Please rerun "netlify link"` (a pre-existing Netlify token/site issue, unrelated to the Cloudflare work). Because the Netlify publish step is not `continue-on-error`, GitHub Actions aborts the job and **skips every later step** — so the Cloudflare deploy never runs and the apex stays empty.

Example failed run: the `Publish preview to Netlify` step failed and `Determine Cloudflare Pages target`, `Ensure Cloudflare Pages project exists`, and `Deploy to Cloudflare Pages` were all skipped.

This PR decouples the two: the Cloudflare Pages steps now carry `if: ${{ !cancelled() }}`, so they run regardless of the Netlify publish outcome. The build output the Cloudflare deploy uses (`netlify/deploy` for staging, `netlify/docs` for production) is produced by an earlier build step that succeeds, so the deploy has content even when the Netlify upload fails.

The Netlify steps themselves are left untouched — this PR does not change the Netlify setup. The `Project not found` failure is a separate Netlify-side issue to resolve independently.

Changes (2 files):

- `.github/workflows/docs-staging.yml` — adds `!cancelled()` to the `cf-target`, worker-copy, ensure-project, deploy, sticky-comment, and apex-summary steps.
- `.github/workflows/docs-production.yml` — adds `!cancelled()` to the worker-copy, ensure-project, and deploy steps.

Rollout note: the staging apex populates on the next `develop` push touching `docs/**`; the production apex on the next `prod-docs/**` run. The `ensureProject.mjs` PATCH still requires a `CLOUDFLARE_API_TOKEN` with Pages:Edit scope.

### How has this been tested?

CI/tooling-only change. Validated locally:

```bash
cd docs && node -e "const yaml=require('js-yaml'),fs=require('fs');['../.github/workflows/docs-staging.yml','../.github/workflows/docs-production.yml'].forEach(f=>{yaml.load(fs.readFileSync(f,'utf8'));console.log('OK',f)})"
```

Both workflows parse. End-to-end verification happens on the next docs-staging (`develop`) run, where the Cloudflare deploy should now run despite the Netlify failure.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

Follow-up to #12815.

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog] — CI/tooling-only change, no package source modified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only changes; no application code or secrets handling changes beyond when deploy steps run.
> 
> **Overview**
> Docs staging and production workflows now treat **Cloudflare Pages** as independent of **Netlify publish**, so apex/preview URLs can update when Netlify upload fails after a successful build.
> 
> In **`docs-production.yml`** and **`docs-staging.yml`**, Cloudflare steps (worker copy, `ensureProject.mjs`, `wrangler pages deploy`, and related staging-only steps) gain **`if: ${{ !cancelled() }}`** (combined with existing deploy guards where applicable), with comments explaining the decoupling.
> 
> **`docs-staging.yml`** also assigns **`id: netlify-publish`** to the Netlify step and updates the sticky PR comment table so the **Netlify** row appears only when that step **`outcome == 'success'`**, avoiding a dead link when Cloudflare still deploys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc5e991bd7c7d5879c81e7b17c0c342180f842ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->