### PR TITLE
DEV-890: Document AutoRowSize/AutoColumnSize requirement for scrollViewportTo

### DIFF
--- a/docs/content/guides/columns/column-width/column-width.md
+++ b/docs/content/guides/columns/column-width/column-width.md
@@ -337,6 +337,12 @@ This feature is made possible thanks to the [`AutoColumnSize`](@/api/autoColumnS
 
 To increase the performance, you can turn off this feature by defining the fixed size for the specified column or all columns.
 
+::: tip
+
+If you call [`scrollViewportTo()`](@/api/core.md#scrollviewportto) and your columns have non-standard widths (for example, set by a custom renderer or CSS), make sure `AutoColumnSize` is enabled. Without it, the method may scroll to an incorrect position.
+
+:::
+
 ## Size of the container
 
 Setting the dimensions of the container that holds Handsontable is described in detail on the [Grid size](@/guides/getting-started/grid-size/grid-size.md) page.
@@ -359,6 +365,7 @@ Setting the dimensions of the container that holds Handsontable is described in 
 <div class="boxes-list">
 
 - [getColWidth()](@/api/core.md#getcolwidth)
+- [scrollViewportTo()](@/api/core.md#scrollviewportto)
 
 </div>
 

--- a/docs/content/guides/rows/row-height/row-height.md
+++ b/docs/content/guides/rows/row-height/row-height.md
@@ -36,7 +36,7 @@ The default (and minimum) row height is calculated based on the used theme's lin
 If your cell contents require heights greater than default (because you use multiline text, or [custom renderers](@/guides/cell-functions/cell-renderer/cell-renderer.md), or custom styles), use one of the following configurations to avoid potential layout problems:
   - Configure your row heights in advance: set the [`minRowHeights`](@/api/options.md#minrowheights) option to a [number](#set-row-heights-to-a-number), or an [array](#set-row-heights-with-an-array), or a [function](#set-row-heights-with-a-function). This requires you to know the heights beforehand, but results in the best runtime performance.
   - Set the [`manualRowResize`](@/api/options.md#manualrowresize) option to an array, to configure initial row heights and let your users [adjust the row heights manually](#adjust-row-heights-manually).
-  - Enable the [`AutoRowSize`](@/api/autoRowSize.md) plugin, by setting `autoRowSize: true`. This tells Handsontable to measure the actual row heights in the DOM. It impacts runtime performance but is accurate.
+  - Enable the [`AutoRowSize`](@/api/autoRowSize.md) plugin, by setting `autoRowSize: true`. This tells Handsontable to measure the actual row heights in the DOM. It impacts runtime performance but is accurate. Also enable `AutoRowSize` if you call [`scrollViewportTo()`](@/api/core.md#scrollviewportto) -- the method relies on accurate row height measurements to scroll to the correct position.
 
 ## Set row heights to a number
 
@@ -245,6 +245,7 @@ You can adjust the size of one or multiple rows simultaneously, even if the sele
 <div class="boxes-list">
 
 - [getRowHeight()](@/api/core.md#getrowheight)
+- [scrollViewportTo()](@/api/core.md#scrollviewportto)
 
 </div>
 

--- a/handsontable/src/plugins/autoColumnSize/autoColumnSize.ts
+++ b/handsontable/src/plugins/autoColumnSize/autoColumnSize.ts
@@ -63,6 +63,12 @@ const COLUMN_SIZE_MAP_NAME = 'autoColumnSize';
  *   }
  * ```
  *
+ * ::: tip
+ * If you use custom renderers or custom styles that produce non-standard column widths, and you call
+ * {@link Core#scrollViewportTo}, make sure `AutoColumnSize` is enabled. Without it, `scrollViewportTo()` calculates
+ * scroll positions based on incorrect column widths and may scroll to an incorrect position.
+ * :::
+ *
  * To configure this plugin see {@link Options#autoColumnSize}.
  *
  * @example

--- a/handsontable/src/plugins/autoRowSize/autoRowSize.ts
+++ b/handsontable/src/plugins/autoRowSize/autoRowSize.ts
@@ -53,6 +53,12 @@ const AUTO_ROW_SIZE_CLASS_NAME = 'htAutoRowSize';
  * In those cases, to ensure that the row heights are properly recalculated, you need to call the {@link AutoRowSize#recalculateAllRowsHeight} method after calling {@link Core#updateSettings}.
  * :::
  *
+ * ::: tip
+ * If you use custom renderers, multiline text, or custom styles that produce non-standard row heights, and you call
+ * {@link Core#scrollViewportTo}, you must enable `AutoRowSize`. Without it, `scrollViewportTo()` calculates scroll
+ * positions based on the default row height and may scroll to an incorrect position.
+ * :::
+ *
  * To configure this plugin see {@link Options#autoRowSize}.
  *
  * @example


### PR DESCRIPTION
### Context

The PR adds a note to the `AutoRowSize` and `AutoColumnSize` plugin docs (both JSDoc and the row-height / column-width guides) explaining that these plugins must be enabled when calling `scrollViewportTo()` on a grid with non-standard row heights or column widths.

The dependency is real: `scrollViewportTo()` computes the scroll offset by summing row heights / column widths via `getRowHeight()` / `getColWidth()`. When `AutoRowSize`/`AutoColumnSize` is disabled, those methods return `undefined` for content-driven sizes, and the code falls back to the default row height / column width — causing the viewport to land on the wrong position.

Tracked in ClickUp task [DEV-890](https://app.clickup.com/t/9015210959/DEV-890).

### How has this been tested?

This is a documentation-only change (JSDoc + guide pages prose). No code logic was modified.
Verified by tracing the `scrollViewportTo → sumCellSizes → getRowHeight/getColWidth → modifyRowHeight/modifyColWidth hook` chain in the current source.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-890

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-890

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prose and JSDoc updates only; no application logic or tests were modified.
> 
> **Overview**
> Documentation-only change clarifying that **`scrollViewportTo()`** needs accurate row/column dimensions when the grid uses **non-standard heights or widths** (custom renderers, CSS, multiline content).
> 
> **`AutoColumnSize`** and **`AutoRowSize`** plugin JSDoc now include tips that disabling these plugins can make `scrollViewportTo()` use default sizes and scroll to the wrong place. The **column-width** and **row-height** guides add matching tips in the overview/performance sections, and both guides list **`scrollViewportTo()`** under related core methods.
> 
> No runtime or API behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3299ce5176455ad895327e21165b48d3e8ccfbff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->