### PR TITLE
DEV-901: Trigger column summary data type error on button click, not on page load

### DIFF
--- a/docs/content/guides/columns/column-summary/angular/example8.ts
+++ b/docs/content/guides/columns/column-summary/angular/example8.ts
@@ -1,10 +1,17 @@
 /* file: app.component.ts */
-import { Component } from '@angular/core';
-import { GridSettings, HotTableModule} from '@handsontable/angular-wrapper';
+import { Component, ViewChild } from '@angular/core';
+import { GridSettings, HotTableComponent, HotTableModule } from '@handsontable/angular-wrapper';
 
 @Component({
   selector: 'app-example8',
   template: `
+    <div class="example-controls-container">
+      <div class="controls">
+        <button class="button button--primary" (click)="throwErrors()">
+          Throw data type errors
+        </button>
+      </div>
+    </div>
     <hot-table
       [settings]="hotSettings!" [data]="hotData">
     </hot-table>
@@ -13,6 +20,7 @@ import { GridSettings, HotTableModule} from '@handsontable/angular-wrapper';
   imports: [HotTableModule],
 })
 export class AppComponent {
+  @ViewChild(HotTableComponent, { static: false }) readonly hotTable!: HotTableComponent;
 
   readonly hotData = [[0, 1, 2], ['3c', '4b', 5], [], []];
 
@@ -25,22 +33,39 @@ export class AppComponent {
         destinationRow: 0,
         destinationColumn: 0,
         reversedRowCoords: true,
-        // enable throwing data type errors for this column summary
-        suppressDataTypeErrors: false,
       },
       {
         type: 'sum',
         destinationRow: 0,
         destinationColumn: 1,
         reversedRowCoords: true,
-        // enable throwing data type errors for this column summary
-        suppressDataTypeErrors: false,
       },
     ],
     autoWrapRow: true,
     autoWrapCol: true,
     height: 'auto',
   };
+
+  throwErrors(): void {
+    this.hotTable?.hotInstance?.updateSettings({
+      columnSummary: [
+        {
+          type: 'sum',
+          destinationRow: 0,
+          destinationColumn: 0,
+          reversedRowCoords: true,
+          suppressDataTypeErrors: false,
+        },
+        {
+          type: 'sum',
+          destinationRow: 0,
+          destinationColumn: 1,
+          reversedRowCoords: true,
+          suppressDataTypeErrors: false,
+        },
+      ],
+    });
+  }
 }
 /* end-file */
 

--- a/docs/content/guides/columns/column-summary/column-summary.md
+++ b/docs/content/guides/columns/column-summary/column-summary.md
@@ -1095,8 +1095,9 @@ To throw data type errors, set the [`suppressDataTypeErrors`](@/api/columnSummar
 
 ::: only-for javascript
 
-::: example #example11 --js 1 --ts 2
+::: example #example11 --html 1 --js 2 --ts 3
 
+@[code](@/content/guides/columns/column-summary/javascript/example11.html)
 @[code](@/content/guides/columns/column-summary/javascript/example11.js)
 @[code](@/content/guides/columns/column-summary/javascript/example11.ts)
 

--- a/docs/content/guides/columns/column-summary/javascript/example11.html
+++ b/docs/content/guides/columns/column-summary/javascript/example11.html
@@ -1,0 +1,6 @@
+<div class="example-controls-container">
+  <div class="controls">
+    <button id="throwErrorsButton" class="button button--primary">Throw data type errors</button>
+  </div>
+</div>
+<div id="example11"></div>

--- a/docs/content/guides/columns/column-summary/javascript/example11.js
+++ b/docs/content/guides/columns/column-summary/javascript/example11.js
@@ -5,8 +5,9 @@ import { registerAllModules } from 'handsontable/registry';
 registerAllModules();
 
 const container = document.querySelector('#example11');
+const throwErrorsButton = document.querySelector('#throwErrorsButton');
 
-new Handsontable(container, {
+const hot = new Handsontable(container, {
   licenseKey: 'non-commercial-and-evaluation',
   data: [[0, 1, 2], ['3c', '4b', 5], [], []],
   colHeaders: true,
@@ -17,19 +18,36 @@ new Handsontable(container, {
       destinationRow: 0,
       destinationColumn: 0,
       reversedRowCoords: true,
-      // enable throwing data type errors for this column summary
-      suppressDataTypeErrors: false,
     },
     {
       type: 'sum',
       destinationRow: 0,
       destinationColumn: 1,
       reversedRowCoords: true,
-      // enable throwing data type errors for this column summary
-      suppressDataTypeErrors: false,
     },
   ],
   autoWrapRow: true,
   autoWrapCol: true,
   height: 'auto',
+});
+
+throwErrorsButton.addEventListener('click', () => {
+  hot.updateSettings({
+    columnSummary: [
+      {
+        type: 'sum',
+        destinationRow: 0,
+        destinationColumn: 0,
+        reversedRowCoords: true,
+        suppressDataTypeErrors: false,
+      },
+      {
+        type: 'sum',
+        destinationRow: 0,
+        destinationColumn: 1,
+        reversedRowCoords: true,
+        suppressDataTypeErrors: false,
+      },
+    ],
+  });
 });

--- a/docs/content/guides/columns/column-summary/javascript/example11.ts
+++ b/docs/content/guides/columns/column-summary/javascript/example11.ts
@@ -5,8 +5,9 @@ import { registerAllModules } from 'handsontable/registry';
 registerAllModules();
 
 const container = document.querySelector('#example11')!;
+const throwErrorsButton = document.querySelector('#throwErrorsButton')!;
 
-new Handsontable(container, {
+const hot = new Handsontable(container, {
   licenseKey: 'non-commercial-and-evaluation',
   data: [[0, 1, 2], ['3c', '4b', 5], [], []],
   colHeaders: true,
@@ -17,19 +18,36 @@ new Handsontable(container, {
       destinationRow: 0,
       destinationColumn: 0,
       reversedRowCoords: true,
-      // enable throwing data type errors for this column summary
-      suppressDataTypeErrors: false,
     },
     {
       type: 'sum',
       destinationRow: 0,
       destinationColumn: 1,
       reversedRowCoords: true,
-      // enable throwing data type errors for this column summary
-      suppressDataTypeErrors: false,
     },
   ],
   autoWrapRow: true,
   autoWrapCol: true,
   height: 'auto',
+});
+
+throwErrorsButton.addEventListener('click', () => {
+  hot.updateSettings({
+    columnSummary: [
+      {
+        type: 'sum',
+        destinationRow: 0,
+        destinationColumn: 0,
+        reversedRowCoords: true,
+        suppressDataTypeErrors: false,
+      },
+      {
+        type: 'sum',
+        destinationRow: 0,
+        destinationColumn: 1,
+        reversedRowCoords: true,
+        suppressDataTypeErrors: false,
+      },
+    ],
+  });
 });

--- a/docs/content/guides/columns/column-summary/react/example11.jsx
+++ b/docs/content/guides/columns/column-summary/react/example11.jsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import { HotTable } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
 
@@ -5,21 +6,16 @@ import { registerAllModules } from 'handsontable/registry';
 registerAllModules();
 
 const ExampleComponent = () => {
-  return (
-    <HotTable
-      autoWrapRow={true}
-      autoWrapCol={true}
-      licenseKey="non-commercial-and-evaluation"
-      data={[[0, 1, 2], ['3c', '4b', 5], [], []]}
-      colHeaders={true}
-      rowHeaders={true}
-      columnSummary={[
+  const hotRef = useRef(null);
+
+  const throwErrors = () => {
+    hotRef.current?.hotInstance?.updateSettings({
+      columnSummary: [
         {
           type: 'sum',
           destinationRow: 0,
           destinationColumn: 0,
           reversedRowCoords: true,
-          // enable throwing data type errors for this column summary
           suppressDataTypeErrors: false,
         },
         {
@@ -27,12 +23,46 @@ const ExampleComponent = () => {
           destinationRow: 0,
           destinationColumn: 1,
           reversedRowCoords: true,
-          // enable throwing data type errors for this column summary
           suppressDataTypeErrors: false,
         },
-      ]}
-      height="auto"
-    />
+      ],
+    });
+  };
+
+  return (
+    <>
+      <div className="example-controls-container">
+        <div className="controls">
+          <button className="button button--primary" onClick={throwErrors}>
+            Throw data type errors
+          </button>
+        </div>
+      </div>
+      <HotTable
+        ref={hotRef}
+        autoWrapRow={true}
+        autoWrapCol={true}
+        licenseKey="non-commercial-and-evaluation"
+        data={[[0, 1, 2], ['3c', '4b', 5], [], []]}
+        colHeaders={true}
+        rowHeaders={true}
+        columnSummary={[
+          {
+            type: 'sum',
+            destinationRow: 0,
+            destinationColumn: 0,
+            reversedRowCoords: true,
+          },
+          {
+            type: 'sum',
+            destinationRow: 0,
+            destinationColumn: 1,
+            reversedRowCoords: true,
+          },
+        ]}
+        height="auto"
+      />
+    </>
   );
 };
 

--- a/docs/content/guides/columns/column-summary/react/example11.tsx
+++ b/docs/content/guides/columns/column-summary/react/example11.tsx
@@ -1,25 +1,21 @@
-import { HotTable } from '@handsontable/react-wrapper';
+import { useRef } from 'react';
+import { HotTable, HotTableRef } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
 
 // register Handsontable's modules
 registerAllModules();
 
 const ExampleComponent = () => {
-  return (
-    <HotTable
-      autoWrapRow={true}
-      autoWrapCol={true}
-      licenseKey="non-commercial-and-evaluation"
-      data={[[0, 1, 2], ['3c', '4b', 5], [], []]}
-      colHeaders={true}
-      rowHeaders={true}
-      columnSummary={[
+  const hotRef = useRef<HotTableRef>(null);
+
+  const throwErrors = () => {
+    hotRef.current?.hotInstance?.updateSettings({
+      columnSummary: [
         {
           type: 'sum',
           destinationRow: 0,
           destinationColumn: 0,
           reversedRowCoords: true,
-          // enable throwing data type errors for this column summary
           suppressDataTypeErrors: false,
         },
         {
@@ -27,12 +23,46 @@ const ExampleComponent = () => {
           destinationRow: 0,
           destinationColumn: 1,
           reversedRowCoords: true,
-          // enable throwing data type errors for this column summary
           suppressDataTypeErrors: false,
         },
-      ]}
-      height="auto"
-    />
+      ],
+    });
+  };
+
+  return (
+    <>
+      <div className="example-controls-container">
+        <div className="controls">
+          <button className="button button--primary" onClick={throwErrors}>
+            Throw data type errors
+          </button>
+        </div>
+      </div>
+      <HotTable
+        ref={hotRef}
+        autoWrapRow={true}
+        autoWrapCol={true}
+        licenseKey="non-commercial-and-evaluation"
+        data={[[0, 1, 2], ['3c', '4b', 5], [], []]}
+        colHeaders={true}
+        rowHeaders={true}
+        columnSummary={[
+          {
+            type: 'sum',
+            destinationRow: 0,
+            destinationColumn: 0,
+            reversedRowCoords: true,
+          },
+          {
+            type: 'sum',
+            destinationRow: 0,
+            destinationColumn: 1,
+            reversedRowCoords: true,
+          },
+        ]}
+        height="auto"
+      />
+    </>
   );
 };
 

--- a/docs/content/guides/columns/column-summary/vue/example11.vue
+++ b/docs/content/guides/columns/column-summary/vue/example11.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
 
 // register Handsontable's modules
 registerAllModules();
+
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 
 const hotSettings = ref<GridSettings>({
   autoWrapRow: true,
@@ -20,24 +22,48 @@ const hotSettings = ref<GridSettings>({
       destinationRow: 0,
       destinationColumn: 0,
       reversedRowCoords: true,
-      // enable throwing data type errors for this column summary
-      suppressDataTypeErrors: false,
     },
     {
       type: 'sum',
       destinationRow: 0,
       destinationColumn: 1,
       reversedRowCoords: true,
-      // enable throwing data type errors for this column summary
-      suppressDataTypeErrors: false,
     },
   ],
   height: 'auto',
 });
+
+function throwErrors() {
+  hotRef.value?.hotInstance?.updateSettings({
+    columnSummary: [
+      {
+        type: 'sum',
+        destinationRow: 0,
+        destinationColumn: 0,
+        reversedRowCoords: true,
+        suppressDataTypeErrors: false,
+      },
+      {
+        type: 'sum',
+        destinationRow: 0,
+        destinationColumn: 1,
+        reversedRowCoords: true,
+        suppressDataTypeErrors: false,
+      },
+    ],
+  });
+}
 </script>
 
 <template>
   <div id="example11">
-    <HotTable :settings="hotSettings" />
+    <div class="example-controls-container">
+      <div class="controls">
+        <button class="button button--primary" @click="throwErrors">
+          Throw data type errors
+        </button>
+      </div>
+    </div>
+    <HotTable ref="hotRef" :settings="hotSettings" />
   </div>
 </template>


### PR DESCRIPTION
### Context

The PR fixes example11 on the column-summary docs page throwing a `ColumnSummary plugin: cell at (1, ) is not in a numeric format` error on every page load. The example was initialized with `suppressDataTypeErrors: false` and non-numeric data (`'3c'`, `'4b'`), causing the error to be logged by the browser on every page visit. This was flagged as potentially hurting Google Search Console signals.

The fix moves the error trigger to a "Throw data type errors" button click. All four framework variants (JavaScript, React, Angular, Vue) now initialize with `suppressDataTypeErrors: true` (the default) so no error is thrown on load. Clicking the button calls `updateSettings` with `suppressDataTypeErrors: false`, which re-triggers the column summary calculation and throws the expected error.

### How has this been tested?

Manual verification on the docs dev server:
- Page loads with no console errors in the "Throw data type errors" section.
- Clicking the button triggers the `ColumnSummary plugin: cell at (1, ) is not in a numeric format` error in the console.
- Tested across JS, React, Angular, and Vue tabs.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-901

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-901

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and live examples only; no changes to Handsontable runtime or wrapper packages.
> 
> **Overview**
> Fixes the **Throw data type errors** docs demo (example11 / Angular example8) logging a `ColumnSummary` numeric-format error on every page load when non-numeric sample data was paired with `suppressDataTypeErrors: false` at init.
> 
> Initial `columnSummary` config no longer sets `suppressDataTypeErrors: false` (default suppression stays on). A **Throw data type errors** control was added for JavaScript (new `example11.html`), React, Vue, and Angular; clicking it calls `updateSettings` with `suppressDataTypeErrors: false` so the error is demonstrated only on demand. The JavaScript guide embed now includes the HTML snippet for the button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8ff25f34218b8bae03b522316e1b012b2344963. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->