### PR TITLE
DEV-1931: Add JSDoc multiline format rule to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,13 @@ These standards apply to **all** documentation across the monorepo — guides, t
 - **When docs are required:** any public-API change updates JSDoc/Typedoc + guides; any user-facing behavior change is documented; any breaking change adds a migration guide step; a PR that adds a new docs page goes in the changelog (no `[skip changelog]`).
 - **Writing style (most-violated):** short sentences, active voice, American English (`behavior` not `behaviour`), "you" not "we", Oxford comma, no evaluative adjectives ("easy"/"simple"/"obvious"), en dashes (–) in non-site text. Full list in `.ai/DOC-STANDARDS.md`.
 - **Trademarks:** pages mentioning "Excel" (and "Google Sheets") need the trademark disclaimer — see `.ai/DOC-STANDARDS.md`.
+- **JSDoc format:** always use the multiline block style — never the single-line form. Every JSDoc comment must be written as:
+  ```js
+  /**
+   * Description here.
+   */
+  ```
+  Never: `/** Description here. */`. Applies to all `.ts`, `.mjs`, and `.js` source files.
 
 ---
 


### PR DESCRIPTION
### Context

The PR adds a JSDoc formatting rule to the monorepo-level `AGENTS.md` (Documentation standards section). The team always uses the multiline block style for JSDoc comments, never the single-line form, but this was not written down anywhere agents would read. Without it, agents default to single-line `/** Foo. */` which is harder to read and extend. The rule now enforces:

```js
/**
 * Description here.
 */
```

Never: `/** Description here. */`

Applies to all `.ts`, `.mjs`, and `.js` source files.

### How has this been tested?

- Documentation-only change to `AGENTS.md` — no code logic changed, no tests required.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1931

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1931

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update to `AGENTS.md` with no code, build, or API impact.
> 
> **Overview**
> Documents a team JSDoc convention in the monorepo **Documentation standards** section of `AGENTS.md`: agents must use **multiline** `/** … */` blocks (with `*` on each line), not single-line `/** Description here. */`, for all `.ts`, `.mjs`, and `.js` source.
> 
> The change is guidance-only so automated edits align with existing human style; it does not change lint rules or runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6e222e01c91cf3e39a648266fdaaf4336ed3604. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->