### PR TITLE
DEV-907: Fix compareFunctionFactory snippets to respect sortOrder

### DIFF
--- a/docs/content/guides/rows/rows-sorting/rows-sorting.md
+++ b/docs/content/guides/rows/rows-sorting/rows-sorting.md
@@ -529,8 +529,8 @@ const configurationOptions = {
   columnSorting: {
     compareFunctionFactory: function(sortOrder, columnMeta) {
       return function(value, nextValue) {
-        if (value < nextValue) return -1;
-        if (value > nextValue) return 1;
+        if (value < nextValue) return sortOrder === 'asc' ? -1 : 1;
+        if (value > nextValue) return sortOrder === 'asc' ? 1 : -1;
         return 0;
       };
     },
@@ -547,8 +547,8 @@ const configurationOptions = {
   columnSorting={{
     compareFunctionFactory: function(sortOrder, columnMeta) {
       return function(value, nextValue) {
-        if (value < nextValue) return -1;
-        if (value > nextValue) return 1;
+        if (value < nextValue) return sortOrder === 'asc' ? -1 : 1;
+        if (value > nextValue) return sortOrder === 'asc' ? 1 : -1;
         return 0;
       };
     },
@@ -567,8 +567,8 @@ const configurationOptions: GridSettings = {
   columnSorting: {
     compareFunctionFactory: function(sortOrder, columnMeta) {
       return function(value, nextValue) {
-        if (value < nextValue) return -1;
-        if (value > nextValue) return 1;
+        if (value < nextValue) return sortOrder === 'asc' ? -1 : 1;
+        if (value > nextValue) return sortOrder === 'asc' ? 1 : -1;
         return 0;
       };
     },
@@ -589,8 +589,8 @@ const hotSettings = {
   columnSorting: {
     compareFunctionFactory: function(sortOrder, columnMeta) {
       return function(value, nextValue) {
-        if (value < nextValue) return -1;
-        if (value > nextValue) return 1;
+        if (value < nextValue) return sortOrder === 'asc' ? -1 : 1;
+        if (value > nextValue) return sortOrder === 'asc' ? 1 : -1;
         return 0;
       };
     },


### PR DESCRIPTION
### Context

The PR fixes incorrect `compareFunctionFactory` code examples in the rows-sorting guide. The existing snippets returned hardcoded `-1` / `1` regardless of `sortOrder`, meaning a custom comparator always sorted the same way irrespective of ascending/descending direction. The fix adds `sortOrder === 'asc' ? -1 : 1`-style ternaries so both sort directions work correctly.

The issue was reported by a client and tracked in ClickUp task DEV-907.

### How has this been tested?

This is a docs-only change (guide markdown). No code logic was modified. Manual verification: the corrected comparator matches the implementation in the [Handsontable blog post](https://handsontable.com/blog/feature-spotlight-multi-column-sorting) and the [jsfiddle demo](https://jsfiddle.net/vycq8dh5/2/) referenced in the task.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-907

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-907

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API behavior modified.
> 
> **Overview**
> Updates the **Add a custom comparator** examples in `rows-sorting.md` so `compareFunctionFactory` uses the `sortOrder` argument instead of always returning the same `-1` / `1` signs.
> 
> The inner comparator now returns `sortOrder === 'asc' ? -1 : 1` (and the mirrored case for `>`), so ascending and descending sorts behave correctly when users copy the snippet. The same change is applied across the JavaScript, React, Angular, and Vue doc blocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8be9ced272bb4022341f84aba4f0fb35629f5004. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->