### PR TITLE
feat(docs): docs-owned Content-Security-Policy + security headers on Cloudflare Pages

### DIFF
--- a/docs/cloudflare/_worker.js
+++ b/docs/cloudflare/_worker.js
@@ -693,8 +693,50 @@ const FLAT_REACT_PAGES = {
 // Main worker
 // ---------------------------------------------------------------------------
 
-export default {
-  async fetch(request, env) {
+// ---------------------------------------------------------------------------
+//  Security headers
+// ---------------------------------------------------------------------------
+// This docs site owns its own Content-Security-Policy so the policy reaches the
+// browser directly from Cloudflare Pages. The handsontable.com marketing Worker
+// reverse-proxies /docs and must NOT overwrite this CSP.
+//
+// It is the proven handsontable.com baseline policy plus the docs-only hosts
+// the marketing policy lacks: Algolia DocSearch (https://*.algolia.net and
+// https://*.algolianet.com). The baseline already covers the docs AI assistant
+// (hot-docs-assistant.netlify.app), CodeSandbox embeds, GTM/GA/Hotjar/Sentry/
+// Cookiebot, api.github.com, and *.handsontable.com (which covers
+// status.handsontable.com and the version-switcher data on handsontable.com).
+//
+// Set here rather than in a Pages `_headers` file because the policy exceeds the
+// 2000-character-per-line `_headers` limit and a CSP cannot be split across
+// multiple Content-Security-Policy lines.
+const CONTENT_SECURITY_POLICY = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://google.com https://js-eu1.hsforms.net https://static.reo.dev/ https://static.hsappstatic.net https://js-eu1.hs-analytics.net https://js-eu1.hsadspixel.net https://js-eu1.hscollectedforms.net https://js-eu1.hs-banner.com https://js-eu1.hs-scripts.com https://www.redditstatic.com https://bat.bing.com https://bat.bing.net https://dev.visualwebsiteoptimizer.com https://analytics.ahrefs.com https://*.cloudflareinsights.com https://sbl.onfastspring.com https://plausible.io https://*.typeform.com https://*.zendesk.com https://*.zdassets.com https://*.hotjar.com https://snap.licdn.com https://static.ads-twitter.com https://analytics.twitter.com https://consentcdn.cookiebot.com https://consent.cookiebot.com https://handsontable.piwik.pro https://handsontable.containers.piwik.pro https://*.list-manage.com https://docs.handsontable.com https://s3.amazonaws.com https://unpkg.com https://cdn.jsdelivr.net https://buttons.github.io https://code.jquery.com https://cdn.headwayapp.co https://www.google.com https://www.gstatic.com https://www.googleadservices.com https://www.googletagmanager.com https://*.google-analytics.com https://tagmanager.google.com https://script.crazyegg.com https://*.cloudfront.net https://*.cloudflare.com https://*.s3.amazonaws.com https://*.doubleclick.net https://connect.facebook.net https://*.sentry-cdn.com; img-src * 'self' data: https:; style-src 'self' 'unsafe-inline' https://sbl.onfastspring.com https://plausible.io https://*.typeform.com https://*.zendesk.com https://*.zdassets.com https://www.googletagmanager.com https://*.hotjar.com https://*.cloudflare.com https://fonts.googleapis.com https://tagmanager.google.com https://cdn.jsdelivr.net; font-src 'self' data: https://*.zendesk.com https://*.zdassets.com https://*.hotjar.com https://fonts.gstatic.com; frame-src 'self' 'unsafe-inline' https://google.com https://js-eu1.hsforms.net https://app.netlify.com https://handsontablestore.onfastspring.com https://handsontablestore.test.onfastspring.com https://*.doubleclick.net https://plausible.io https://*.typeform.com https://*.zendesk.com https://*.zdassets.com https://examples.handsontable.com https://handsontable.github.io https://*.hotjar.com https://consentcdn.cookiebot.com https://www.google.com https://headway-widget.net https://www.youtube.com https://player.vimeo.com https://codesandbox.io https://www.youtube-nocookie.com https://www.facebook.com https://www.googletagmanager.com/; object-src 'self'; connect-src 'self' https://hot-docs-assistant.netlify.app https://*.algolia.net https://*.algolianet.com https://browser.sentry-cdn.com https://api.reo.dev https://api-eu1.hubapi.com https://static.hsappstatic.net https://forms-eu1.hscollectedforms.net https://ads.reddit.com https://www.redditstatic.com https://pixel-config.reddit.com https://www.googleadservices.com https://bat.bing.net https://bat.bing.com https://dev.visualwebsiteoptimizer.com https://api.github.com https://analytics.ahrefs.com https://ingesteer.services-prod.nsvcs.net https://plausible.io https://*.linkedin.com https://*.zendesk.com https://adservice.google.com https://*.zdassets.com https://*.hotjar.com https://*.hotjar.io wss://*.hotjar.com https://consentcdn.cookiebot.com https://cdn.linkedin.oribi.io https://www.google.com https://google.com https://stats.g.doubleclick.net https://googleads.g.doubleclick.net https://*.doubleclick.net https://www.google.pl https://*.google-analytics.com https://*.analytics.google.com https://*.googlesyndication.com https://*.handsontable.com https://www.googletagmanager.com https://handsontable.com https://handsontablestore.test.onfastspring.com https://handsontablestore.onfastspring.com https://snap.licdn.com https://www.facebook.com https://*.sentry.io; worker-src 'self' blob:; frame-ancestors 'self';";
+
+const SECURITY_HEADERS = {
+  'Content-Security-Policy': CONTENT_SECURITY_POLICY,
+  'X-Frame-Options': 'SAMEORIGIN',
+  'X-Content-Type-Options': 'nosniff',
+  'Referrer-Policy': 'strict-origin-when-cross-origin',
+  'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload',
+};
+
+// Apply the security headers to served documents/assets. Redirects (3xx) are
+// passed through untouched.
+function withSecurityHeaders(response) {
+  if (response.status >= 300 && response.status < 400) {
+    return response;
+  }
+
+  const decorated = new Response(response.body, response);
+
+  for (const [name, value] of Object.entries(SECURITY_HEADERS)) {
+    decorated.headers.set(name, value);
+  }
+
+  return decorated;
+}
+
+async function route(request, env) {
     const url = new URL(request.url);
     const path = url.pathname;
 
@@ -1124,5 +1166,10 @@ export default {
 
     // -- 19. Fallback: serve static assets via env.ASSETS --------------------
     return env.ASSETS.fetch(request);
+}
+
+export default {
+  async fetch(request, env) {
+    return withSecurityHeaders(await route(request, env));
   },
 };


### PR DESCRIPTION
### Context

The PR makes the docs site emit its **own** complete Content-Security-Policy (and the standard security headers) directly from Cloudflare Pages, so the docs own their policy instead of inheriting the marketing site's.

**Problem.** `handsontable.com` is a Cloudflare Worker (`handsontable/handsontable.com-v2`, `src/worker.js`) that reverse-proxies `handsontable.com/docs/*` to this Pages site and overwrites the response `Content-Security-Policy` with the marketing CSP. The docs' own policy never reaches the browser, so docs-specific hosts get blocked (e.g. the docs AI assistant calling `https://hot-docs-assistant.netlify.app/api/chat` is refused by `connect-src`).

**Fix.** This docs site now sets its own CSP + `X-Frame-Options`, `X-Content-Type-Options: nosniff`, `Referrer-Policy`, and `Strict-Transport-Security` on every served response. The marketing Worker will be changed **separately** (in `handsontable.com-v2`) to stop overwriting CSP on `/docs`.

### Where the headers are set, and why

The docs deploy to Cloudflare Pages through an advanced-mode `docs/cloudflare/_worker.js` (it already re-implements all redirects). The headers are applied there, wrapping the `env.ASSETS` responses:

- A full CSP for this site is ~3.9 KB. Cloudflare Pages `_headers` enforces a **2000-character-per-line** limit and a CSP **cannot** be split across multiple `Content-Security-Policy` lines, so `_headers` is not viable. Setting it as a real response header in the worker has no such limit.
- Redirect responses (3xx) are passed through unchanged; only served documents/assets get the headers.

### Which hosts are allowed, and why

The policy is the **proven `handsontable.com` baseline CSP** (it already covers everything the docs load — see below) **plus the one docs-only gap it lacked: Algolia DocSearch** (`https://*.algolia.net`, `https://*.algolianet.com`).

I deliberately did **not** hand-trim to a minimal docs-only set. The docs load the same analytics/consent/error stack as marketing, and those integrations pull many downstream hosts:

| Integration (confirmed loading on docs) | Hosts it needs | In baseline? |
|---|---|---|
| Docs AI assistant | `hot-docs-assistant.netlify.app` (connect) | ✅ |
| Algolia DocSearch | `*.algolia.net`, `*.algolianet.com` (connect) | ➕ **added** |
| GitHub stars | `api.github.com` (connect) | ✅ |
| Version switcher / status | `handsontable.com`, `*.handsontable.com` (covers `status.handsontable.com`) | ✅ |
| GTM → GA / Ads | googletagmanager, `*.google-analytics.com`, `*.doubleclick.net`, googleadservices … (script/connect/img) | ✅ |
| Hotjar | `*.hotjar.com`, `*.hotjar.io`, `wss://*.hotjar.com` | ✅ |
| Sentry | `*.sentry-cdn.com` (script), `*.sentry.io` (ingest/connect) | ✅ |
| Cookiebot | `consent.cookiebot.com`, `consentcdn.cookiebot.com` | ✅ |
| CodeSandbox embeds | `codesandbox.io` (frame) | ✅ |
| Headway changelog | `cdn.headwayapp.co` (script), `headway-widget.net` (frame) | ✅ |

A hand-trimmed policy risks omitting a downstream host (e.g. Sentry ingest, GA, the DoubleClick collect endpoint) and re-introducing the exact `connect-src` blocks this work is meant to remove. The few marketing-funnel hosts that never load on docs (HubSpot forms, FastSpring store, Reddit/Bing/Twitter/LinkedIn pixels, etc.) are harmless to keep and can be trimmed in a follow-up once verified in the browser.

### How has this been tested?

Executed the worker locally with a mocked `env.ASSETS` (`node`-imported the ES module):

- **Page (200 HTML):** single `Content-Security-Policy` header present, includes `hot-docs-assistant.netlify.app`, `*.algolia.net` + `*.algolianet.com`, `*.doubleclick.net`; plus `X-Frame-Options: SAMEORIGIN`, `X-Content-Type-Options: nosniff`, `Strict-Transport-Security`.
- **Redirect (`/` → 301):** passes through with no CSP (correct).
- `node --check` passes.

Live `curl -I` verification of `https://handsontable-docs-staging.pages.dev/docs/...` and the proxied `https://handsontable.com/docs/...` can only happen **after** this worker deploys (next `develop`/PR-preview run) **and** the separate `handsontable.com-v2` change to stop overwriting CSP on `/docs` lands — otherwise the marketing Worker's CSP still wins on the proxied URL.

### Dependent change (separate repo)

`handsontable.com-v2` `src/worker.js` must stop overwriting `Content-Security-Policy` on `/docs/*` so the docs-owned policy reaches the browser.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog] — docs-site infrastructure change, no package source modified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad CSP and header changes affect every served docs page and can break third-party integrations (search, assistant, analytics) if allowlists are wrong; impact is limited to docs delivery, not application auth or data.
> 
> **Overview**
> **Docs responses from Cloudflare Pages now carry their own security headers**, so the browser can use a docs-tailored policy instead of relying on the marketing site’s proxied CSP.
> 
> The Pages worker adds a large **Content-Security-Policy** (marketing baseline plus **Algolia DocSearch** `connect-src` hosts), plus **X-Frame-Options**, **X-Content-Type-Options**, **Referrer-Policy**, and **HSTS**. Headers are set in `_worker.js` because the CSP exceeds Pages `_headers` line limits. **`withSecurityHeaders`** decorates **200-level** asset/page responses; **3xx redirects** are left unchanged.
> 
> Request handling is refactored: redirect and asset logic lives in **`route(request, env)`**, and **`export default.fetch`** returns **`withSecurityHeaders(await route(...))`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6193c27bba3c2f94115a4f1bf01513f33800334. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->