### PR TITLE
docs(formulas): add Custom functions section with COMMISSION example (DEV-921)

### DIFF
--- a/docs/angular-type-check/check.mjs
+++ b/docs/angular-type-check/check.mjs
@@ -163,6 +163,7 @@ function runCheck({ label, htDir }) {
       paths: {
         handsontable: [htDir],
         'handsontable/*': [`${htDir}/*`],
+        'hyperformula/typings/*': ['node_modules/hyperformula/typings/*'],
       },
     },
     include: ['./.tmp/**/*.ts', './types/**/*.d.ts'],

--- a/docs/content/guides/formulas/formula-calculation/angular/example5.html
+++ b/docs/content/guides/formulas/formula-calculation/angular/example5.html
@@ -1,0 +1,3 @@
+<div>
+  <app-example5></app-example5>
+</div>

--- a/docs/content/guides/formulas/formula-calculation/angular/example5.ts
+++ b/docs/content/guides/formulas/formula-calculation/angular/example5.ts
@@ -1,0 +1,82 @@
+/* file: app.component.ts */
+import { Component } from '@angular/core';
+import { GridSettings, HotTableModule } from '@handsontable/angular-wrapper';
+import { FunctionArgumentType, FunctionPlugin, HyperFormula } from 'hyperformula';
+import type { ProcedureAst } from 'hyperformula/typings/parser/Ast';
+import type { InterpreterState } from 'hyperformula/typings/interpreter/InterpreterState';
+import type { InterpreterValue } from 'hyperformula/typings/interpreter/InterpreterValue';
+
+class CommissionPlugin extends FunctionPlugin {
+  commission(ast: ProcedureAst, state: InterpreterState): InterpreterValue {
+    return this.runFunction(
+      ast.args,
+      state,
+      this.metadata('COMMISSION'),
+      (revenue: number, rate: number): number => revenue * (rate / 100),
+    );
+  }
+}
+
+CommissionPlugin.implementedFunctions = {
+  COMMISSION: {
+    method: 'commission',
+    parameters: [
+      { argumentType: FunctionArgumentType.NUMBER },
+      { argumentType: FunctionArgumentType.NUMBER },
+    ],
+  },
+};
+
+HyperFormula.registerFunctionPlugin(CommissionPlugin, {
+  enGB: { COMMISSION: 'COMMISSION' },
+});
+
+@Component({
+  standalone: true,
+  imports: [HotTableModule],
+  selector: 'app-example5',
+  template: `
+    <hot-table [settings]="gridSettings" [data]="data"></hot-table>
+  `,
+})
+export class AppComponent {
+  readonly data: (string | number)[][] = [
+    ['Sales rep', 'Revenue (USD)', 'Commission rate (%)', 'Commission amount (USD)'],
+    ['Ana García', 45000, 8, '=COMMISSION(B2,C2)'],
+    ['James Okafor', 62000, 10, '=COMMISSION(B3,C3)'],
+    ['Li Wei', 38000, 8, '=COMMISSION(B4,C4)'],
+    ['Maria Santos', 71000, 12, '=COMMISSION(B5,C5)'],
+    ['David Kim', 29000, 7, '=COMMISSION(B6,C6)'],
+  ];
+
+  readonly gridSettings: GridSettings = {
+    colHeaders: true,
+    rowHeaders: true,
+    height: 'auto',
+    formulas: { engine: HyperFormula },
+    autoWrapRow: true,
+    autoWrapCol: true,
+  };
+}
+/* end-file */
+
+
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+/* end-file */

--- a/docs/content/guides/formulas/formula-calculation/formula-calculation.md
+++ b/docs/content/guides/formulas/formula-calculation/formula-calculation.md
@@ -906,6 +906,103 @@ HyperFormula instance. The "Totals" row references those names directly as `=Q1_
 For more information about named expressions, refer to the
 [HyperFormula named expressions docs](https://hyperformula.handsontable.com/guide/named-expressions.html).
 
+## Custom functions
+
+Use custom functions when the built-in HyperFormula functions do not cover your business logic. HyperFormula lets you extend the formula engine with your own functions. A custom function
+is a class that extends `FunctionPlugin` and declares its supported functions in a static
+`implementedFunctions` property. Register it with `HyperFormula.registerFunctionPlugin()`
+**before** passing the `HyperFormula` class to the `formulas.engine` option -- if you register
+after Handsontable has already built the engine, the custom function is not available.
+
+The `parameters` array in `implementedFunctions` specifies argument types. Common values:
+
+- `FunctionArgumentType.NUMBER` -- a numeric argument.
+- `FunctionArgumentType.STRING` -- a string argument.
+- `FunctionArgumentType.ANY` -- accepts any type.
+
+The second argument to `registerFunctionPlugin` maps your function name to each registered language pack. Without it, HyperFormula does not recognize the function name in formulas and returns `#NAME?`.
+
+```javascript
+import { FunctionPlugin, FunctionArgumentType, HyperFormula } from 'hyperformula';
+
+class CommissionPlugin extends FunctionPlugin {
+  commission(ast, state) {
+    return this.runFunction(ast.args, state, this.metadata('COMMISSION'), (revenue, rate) => {
+      return revenue * (rate / 100);
+    });
+  }
+}
+
+CommissionPlugin.implementedFunctions = {
+  COMMISSION: {
+    method: 'commission',
+    parameters: [
+      { argumentType: FunctionArgumentType.NUMBER },
+      { argumentType: FunctionArgumentType.NUMBER },
+    ],
+  },
+};
+
+// Call this before new Handsontable(...) or HyperFormula.buildEmpty().
+HyperFormula.registerFunctionPlugin(CommissionPlugin, {
+  enGB: { COMMISSION: 'COMMISSION' },
+});
+```
+
+### Demo: custom COMMISSION function
+
+The example below defines a `COMMISSION(revenue, rate)` function that computes
+`revenue * rate / 100`. Column D in the grid uses `=COMMISSION(B2,C2)` to calculate
+each sales representative's commission amount.
+
+::: only-for javascript
+
+::: example #example-custom-functions --html 1 --js 2 --ts 3
+
+@[code](@/content/guides/formulas/formula-calculation/javascript/example-custom-functions.html)
+@[code](@/content/guides/formulas/formula-calculation/javascript/example-custom-functions.js)
+@[code](@/content/guides/formulas/formula-calculation/javascript/example-custom-functions.ts)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #example-custom-functions :react --js 1 --ts 2
+
+@[code](@/content/guides/formulas/formula-calculation/react/example-custom-functions.jsx)
+@[code](@/content/guides/formulas/formula-calculation/react/example-custom-functions.tsx)
+
+:::
+
+:::
+
+::: only-for angular
+
+::: example #example5 :angular --ts 1 --html 2
+
+@[code](@/content/guides/formulas/formula-calculation/angular/example5.ts)
+@[code](@/content/guides/formulas/formula-calculation/angular/example5.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example-custom-functions :vue3
+
+@[code](@/content/guides/formulas/formula-calculation/vue/example-custom-functions.vue)
+
+:::
+
+:::
+
+For the full argument type reference, error handling patterns, and advanced options such as
+function aliases and async functions, see the
+[HyperFormula custom functions guide](https://hyperformula.handsontable.com/guide/custom-functions.html).
+
 ## View the explainer video
 
 <div class="docs-video-embed">

--- a/docs/content/guides/formulas/formula-calculation/javascript/example-custom-functions.html
+++ b/docs/content/guides/formulas/formula-calculation/javascript/example-custom-functions.html
@@ -1,0 +1,1 @@
+<div id="example-custom-functions"></div>

--- a/docs/content/guides/formulas/formula-calculation/javascript/example-custom-functions.js
+++ b/docs/content/guides/formulas/formula-calculation/javascript/example-custom-functions.js
@@ -1,0 +1,43 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+import { FunctionArgumentType, FunctionPlugin, HyperFormula } from 'hyperformula';
+// Register all Handsontable's modules.
+registerAllModules();
+class CommissionPlugin extends FunctionPlugin {
+    commission(ast, state) {
+        return this.runFunction(ast.args, state, this.metadata('COMMISSION'), (revenue, rate) => revenue * (rate / 100));
+    }
+}
+CommissionPlugin.implementedFunctions = {
+    COMMISSION: {
+        method: 'commission',
+        parameters: [
+            { argumentType: FunctionArgumentType.NUMBER },
+            { argumentType: FunctionArgumentType.NUMBER },
+        ],
+    },
+};
+HyperFormula.registerFunctionPlugin(CommissionPlugin, {
+    enGB: { COMMISSION: 'COMMISSION' },
+});
+const data = [
+    ['Sales rep', 'Revenue (USD)', 'Commission rate (%)', 'Commission amount (USD)'],
+    ['Ana García', 45000, 8, '=COMMISSION(B2,C2)'],
+    ['James Okafor', 62000, 10, '=COMMISSION(B3,C3)'],
+    ['Li Wei', 38000, 8, '=COMMISSION(B4,C4)'],
+    ['Maria Santos', 71000, 12, '=COMMISSION(B5,C5)'],
+    ['David Kim', 29000, 7, '=COMMISSION(B6,C6)'],
+];
+const container = document.querySelector('#example-custom-functions');
+new Handsontable(container, {
+    data,
+    colHeaders: true,
+    rowHeaders: true,
+    height: 'auto',
+    formulas: {
+        engine: HyperFormula,
+    },
+    autoWrapRow: true,
+    autoWrapCol: true,
+    licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/formulas/formula-calculation/javascript/example-custom-functions.ts
+++ b/docs/content/guides/formulas/formula-calculation/javascript/example-custom-functions.ts
@@ -1,0 +1,58 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+import { FunctionArgumentType, FunctionPlugin, HyperFormula } from 'hyperformula';
+import type { ProcedureAst } from 'hyperformula/typings/parser/Ast';
+import type { InterpreterState } from 'hyperformula/typings/interpreter/InterpreterState';
+import type { InterpreterValue } from 'hyperformula/typings/interpreter/InterpreterValue';
+
+// Register all Handsontable's modules.
+registerAllModules();
+
+class CommissionPlugin extends FunctionPlugin {
+  commission(ast: ProcedureAst, state: InterpreterState): InterpreterValue {
+    return this.runFunction(
+      ast.args,
+      state,
+      this.metadata('COMMISSION'),
+      (revenue: number, rate: number): number => revenue * (rate / 100),
+    );
+  }
+}
+
+CommissionPlugin.implementedFunctions = {
+  COMMISSION: {
+    method: 'commission',
+    parameters: [
+      { argumentType: FunctionArgumentType.NUMBER },
+      { argumentType: FunctionArgumentType.NUMBER },
+    ],
+  },
+};
+
+HyperFormula.registerFunctionPlugin(CommissionPlugin, {
+  enGB: { COMMISSION: 'COMMISSION' },
+});
+
+const data: (string | number)[][] = [
+  ['Sales rep', 'Revenue (USD)', 'Commission rate (%)', 'Commission amount (USD)'],
+  ['Ana García', 45000, 8, '=COMMISSION(B2,C2)'],
+  ['James Okafor', 62000, 10, '=COMMISSION(B3,C3)'],
+  ['Li Wei', 38000, 8, '=COMMISSION(B4,C4)'],
+  ['Maria Santos', 71000, 12, '=COMMISSION(B5,C5)'],
+  ['David Kim', 29000, 7, '=COMMISSION(B6,C6)'],
+];
+
+const container = document.querySelector('#example-custom-functions')!;
+
+new Handsontable(container, {
+  data,
+  colHeaders: true,
+  rowHeaders: true,
+  height: 'auto',
+  formulas: {
+    engine: HyperFormula,
+  },
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/formulas/formula-calculation/react/example-custom-functions.jsx
+++ b/docs/content/guides/formulas/formula-calculation/react/example-custom-functions.jsx
@@ -1,0 +1,57 @@
+import { FunctionArgumentType, FunctionPlugin, HyperFormula } from 'hyperformula';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+class CommissionPlugin extends FunctionPlugin {
+  commission(ast, state) {
+    return this.runFunction(
+      ast.args,
+      state,
+      this.metadata('COMMISSION'),
+      (revenue, rate) => revenue * (rate / 100),
+    );
+  }
+}
+
+CommissionPlugin.implementedFunctions = {
+  COMMISSION: {
+    method: 'commission',
+    parameters: [
+      { argumentType: FunctionArgumentType.NUMBER },
+      { argumentType: FunctionArgumentType.NUMBER },
+    ],
+  },
+};
+
+HyperFormula.registerFunctionPlugin(CommissionPlugin, {
+  enGB: { COMMISSION: 'COMMISSION' },
+});
+
+const data = [
+  ['Sales rep', 'Revenue (USD)', 'Commission rate (%)', 'Commission amount (USD)'],
+  ['Ana García', 45000, 8, '=COMMISSION(B2,C2)'],
+  ['James Okafor', 62000, 10, '=COMMISSION(B3,C3)'],
+  ['Li Wei', 38000, 8, '=COMMISSION(B4,C4)'],
+  ['Maria Santos', 71000, 12, '=COMMISSION(B5,C5)'],
+  ['David Kim', 29000, 7, '=COMMISSION(B6,C6)'],
+];
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={data}
+      colHeaders={true}
+      rowHeaders={true}
+      height="auto"
+      formulas={{ engine: HyperFormula }}
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/formulas/formula-calculation/react/example-custom-functions.tsx
+++ b/docs/content/guides/formulas/formula-calculation/react/example-custom-functions.tsx
@@ -1,0 +1,61 @@
+import { FunctionArgumentType, FunctionPlugin, HyperFormula } from 'hyperformula';
+import type { ProcedureAst } from 'hyperformula/typings/parser/Ast';
+import type { InterpreterState } from 'hyperformula/typings/interpreter/InterpreterState';
+import type { InterpreterValue } from 'hyperformula/typings/interpreter/InterpreterValue';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import type { DetailedSettings } from 'handsontable/plugins/formulas';
+
+// register Handsontable's modules
+registerAllModules();
+
+class CommissionPlugin extends FunctionPlugin {
+  commission(ast: ProcedureAst, state: InterpreterState): InterpreterValue {
+    return this.runFunction(
+      ast.args,
+      state,
+      this.metadata('COMMISSION'),
+      (revenue: number, rate: number): number => revenue * (rate / 100),
+    );
+  }
+}
+
+CommissionPlugin.implementedFunctions = {
+  COMMISSION: {
+    method: 'commission',
+    parameters: [
+      { argumentType: FunctionArgumentType.NUMBER },
+      { argumentType: FunctionArgumentType.NUMBER },
+    ],
+  },
+};
+
+HyperFormula.registerFunctionPlugin(CommissionPlugin, {
+  enGB: { COMMISSION: 'COMMISSION' },
+});
+
+const data: (string | number)[][] = [
+  ['Sales rep', 'Revenue (USD)', 'Commission rate (%)', 'Commission amount (USD)'],
+  ['Ana García', 45000, 8, '=COMMISSION(B2,C2)'],
+  ['James Okafor', 62000, 10, '=COMMISSION(B3,C3)'],
+  ['Li Wei', 38000, 8, '=COMMISSION(B4,C4)'],
+  ['Maria Santos', 71000, 12, '=COMMISSION(B5,C5)'],
+  ['David Kim', 29000, 7, '=COMMISSION(B6,C6)'],
+];
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={data}
+      colHeaders={true}
+      rowHeaders={true}
+      height="auto"
+      formulas={{ engine: HyperFormula } as DetailedSettings}
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/formulas/formula-calculation/vue/example-custom-functions.vue
+++ b/docs/content/guides/formulas/formula-calculation/vue/example-custom-functions.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import { ref, markRaw } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import { FunctionArgumentType, FunctionPlugin, HyperFormula } from 'hyperformula';
+import type { ProcedureAst } from 'hyperformula/typings/parser/Ast';
+import type { InterpreterState } from 'hyperformula/typings/interpreter/InterpreterState';
+import type { InterpreterValue } from 'hyperformula/typings/interpreter/InterpreterValue';
+import type { GridSettings } from 'handsontable/settings';
+import type { DetailedSettings } from 'handsontable/plugins/formulas';
+
+// register Handsontable's modules
+registerAllModules();
+
+class CommissionPlugin extends FunctionPlugin {
+  commission(ast: ProcedureAst, state: InterpreterState): InterpreterValue {
+    return this.runFunction(
+      ast.args,
+      state,
+      this.metadata('COMMISSION'),
+      (revenue: number, rate: number): number => revenue * (rate / 100),
+    );
+  }
+}
+
+CommissionPlugin.implementedFunctions = {
+  COMMISSION: {
+    method: 'commission',
+    parameters: [
+      { argumentType: FunctionArgumentType.NUMBER },
+      { argumentType: FunctionArgumentType.NUMBER },
+    ],
+  },
+};
+
+HyperFormula.registerFunctionPlugin(CommissionPlugin, {
+  enGB: { COMMISSION: 'COMMISSION' },
+});
+
+const data: (string | number)[][] = [
+  ['Sales rep', 'Revenue (USD)', 'Commission rate (%)', 'Commission amount (USD)'],
+  ['Ana García', 45000, 8, '=COMMISSION(B2,C2)'],
+  ['James Okafor', 62000, 10, '=COMMISSION(B3,C3)'],
+  ['Li Wei', 38000, 8, '=COMMISSION(B4,C4)'],
+  ['Maria Santos', 71000, 12, '=COMMISSION(B5,C5)'],
+  ['David Kim', 29000, 7, '=COMMISSION(B6,C6)'],
+];
+
+const hotSettings = ref<GridSettings>({
+  data,
+  colHeaders: true,
+  rowHeaders: true,
+  height: 'auto',
+  formulas: { engine: markRaw(HyperFormula) } as DetailedSettings,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example-custom-functions">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>


### PR DESCRIPTION
### Context
Implements DEV-921: adds a **Custom functions** section with an interactive working example to the formula-calculation guide.

The section demonstrates how to extend HyperFormula with a user-defined `COMMISSION(revenue, rate)` function using `FunctionPlugin`. Key requirement documented: the second argument to `registerFunctionPlugin` must include a language translation entry (`{ enGB: { COMMISSION: 'COMMISSION' } }`) — without it, `isFunctionTranslated()` returns false and formulas evaluate to `#NAME?`.

### How has this been tested?
Verified on dev server: the demo grid renders for all four framework variants (JS, React, Angular, Vue) with correct commission amounts (Ana García: 3600, James Okafor: 6200, Li Wei: 3040, Maria Santos: 8520, David Kim: 2030).

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. DEV-921

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example-only changes with a small docs CI tsconfig path tweak; no runtime library behavior changes.
> 
> **Overview**
> Adds a **Custom functions** section to the formula-calculation guide explaining how to extend HyperFormula with `FunctionPlugin`, register plugins **before** `formulas.engine`, and supply language mappings so formulas do not evaluate to `#NAME?`.
> 
> The section includes a **COMMISSION(revenue, rate)** walkthrough and new live examples for JavaScript, React, Angular (`example5`), and Vue. Angular docs type-checking gains a `hyperformula/typings/*` path mapping so examples that import HyperFormula internal typings compile in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93c46e0835edb43a7a634807103667b2f2647461. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->