### PR TITLE
DEV-1933: Fix multiselect cell type showing wrong column data after column move (#12812)

### DIFF
--- a/.changelogs/12827.json
+++ b/.changelogs/12827.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed `multiselect` cell type displaying a neighbouring column's value after moving the column with `manualColumnMove`.",
+  "type": "fixed",
+  "issueOrPR": 12827,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/renderers/multiSelectRenderer/__tests__/multiSelectRenderer.spec.js
+++ b/handsontable/src/renderers/multiSelectRenderer/__tests__/multiSelectRenderer.spec.js
@@ -199,6 +199,51 @@ describe('multiSelectRenderer', () => {
       });
     });
 
+    describe('moving columns', () => {
+      it('should render chips reflecting the underlying cell data after a column move (#12812)', async() => {
+        handsontable({
+          data: [
+            ['Airport A', choices.slice(0, 2)],
+            ['Airport B', choices.slice(2, 4)],
+          ],
+          columns: [
+            {},
+            {
+              type: 'multiselect',
+              source: choices,
+              width: 500,
+            },
+          ],
+          manualColumnMove: true,
+        });
+
+        getPlugin('manualColumnMove').moveColumn(1, 0);
+        await render();
+
+        // The multiselect column is now at visual index 0 and must keep its own data.
+        const expectedPerRow = [choices.slice(0, 2), choices.slice(2, 4)];
+
+        for (let visualRow = 0; visualRow < expectedPerRow.length; visualRow++) {
+          const expected = expectedPerRow[visualRow];
+          const chipsContainer =
+            $(`table.htCore tr:eq(${visualRow}) td:eq(0) .ht-multi-select-chips-container`);
+          const renderedChips = chipsContainer.find('.ht-multi-select-chip');
+
+          expect(renderedChips.length).toEqual(expected.length);
+
+          for (let i = 0; i < expected.length; i++) {
+            const expectedText = expected[i].value || expected[i];
+
+            expect(renderedChips.eq(i).text()).toEqual(expectedText);
+          }
+        }
+
+        // The text column moved to visual index 1 and renders plain text, not chips.
+        expect($('table.htCore tr:eq(0) td:eq(1)').text()).toEqual('Airport A');
+        expect($('table.htCore tr:eq(0) td:eq(1) .ht-multi-select-chips-container').length).toEqual(0);
+      });
+    });
+
     describe('removing a chip', () => {
       it('should remove the chip from the cell data when clicking the remove button', async() => {
         const choicesLongOptions = choices.map(choice => (choice.value ?

--- a/handsontable/src/renderers/multiSelectRenderer/__tests__/multiSelectRenderer.unit.js
+++ b/handsontable/src/renderers/multiSelectRenderer/__tests__/multiSelectRenderer.unit.js
@@ -23,4 +23,30 @@ describe('multiSelectRenderer', () => {
       expect(getRenderer(RENDERER_TYPE)).toBeInstanceOf(Function);
     });
   });
+
+  describe('reading the source data (#12812)', () => {
+    it('should read source data using the physical row and the visual column index', () => {
+      // `getSourceDataAtCell` expects a physical row but a visual column. Converting the
+      // column to a physical index here double-translates it once columns are reordered,
+      // which made the renderer display a neighbouring column's value.
+      const visualRow = 2;
+      const visualColumn = 3;
+      const physicalRow = 7;
+      const getSourceDataAtCell = jest.fn(() => []);
+      const toPhysicalColumn = jest.fn(() => 9);
+      const hotInstance = {
+        rootDocument: document,
+        getSettings: () => ({ ariaTags: false }),
+        toPhysicalRow: () => physicalRow,
+        toPhysicalColumn,
+        getSourceDataAtCell,
+      };
+      const TD = document.createElement('td');
+
+      multiSelectRenderer(hotInstance, TD, visualRow, visualColumn, visualColumn, 'value', {});
+
+      expect(getSourceDataAtCell).toHaveBeenCalledWith(physicalRow, visualColumn);
+      expect(toPhysicalColumn).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/handsontable/src/renderers/multiSelectRenderer/multiSelectRenderer.ts
+++ b/handsontable/src/renderers/multiSelectRenderer/multiSelectRenderer.ts
@@ -44,8 +44,7 @@ export function multiSelectRenderer(
   const { rootDocument } = hotInstance;
   const isAriaEnabled = hotInstance.getSettings().ariaTags;
   const physicalRow = hotInstance.toPhysicalRow(row);
-  const physicalColumn = typeof col === 'string' ? col : hotInstance.toPhysicalColumn(col);
-  const sourceData = hotInstance.getSourceDataAtCell(physicalRow, physicalColumn);
+  const sourceData = hotInstance.getSourceDataAtCell(physicalRow, col);
   const values = parseValue(sourceData);
 
   empty(TD);


### PR DESCRIPTION
### Context

The PR fixes [#12812](https://github.com/handsontable/handsontable/issues/12812): with a `multiselect` cell type column and `manualColumnMove` enabled, moving the multiselect column made its chips render a neighbouring column's value instead of its own data.

Root cause is in `multiSelectRenderer`. It resolved the source data with:

```js
const physicalColumn = hotInstance.toPhysicalColumn(col);
const sourceData = hotInstance.getSourceDataAtCell(physicalRow, physicalColumn);
```

`getSourceDataAtCell(row, column)` is asymmetric — `row` is a physical index, but `column` is a **visual** index (it runs `colToProp` internally). The renderer pre-converted the column to a physical index, so it got translated twice. While `manualColumnMove` is inactive visual == physical and the bug is invisible; once a column is moved the renderer reads the wrong column.

Data, cell meta, `getSourceDataAtCell`, and `getDataAtCell` were all correct — only the rendered chips were wrong. The sibling `multiSelectType` `valueSetter` already passes the visual column directly, so the fix aligns the renderer with the established pattern: pass the visual `col` straight through (keeping the physical row conversion).

Not a breaking change — no default value changes, no API or hook renamed or removed.

### How has this been tested?

Added a regression test at both levels (verified to fail on the pre-fix code, pass after):

- Unit:
  ```
  npm run test:unit --prefix handsontable --testPathPattern=multiSelectRenderer
  ```
  Asserts the renderer reads with the physical row + visual column and never calls `toPhysicalColumn`.
- E2E:
  ```
  npm run test:e2e --prefix handsontable --testPathPattern=multiSelectRenderer
  ```
  Moves the multiselect column with `manualColumnMove` and verifies chips reflect the column's own data (array-of-strings and array-of-objects `source` variants).

Also reproduced and verified the fix manually in a vanilla JS page (text column + multiselect column, move via the `manualColumnMove` plugin).

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. #12812
2. DEV-1933

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/86cacyrz4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line renderer fix aligned with existing API usage; scoped to multiselect display with column reordering.
> 
> **Overview**
> Fixes **multiselect** chips showing a neighbouring column’s values when **`manualColumnMove`** reorders columns.
> 
> `multiSelectRenderer` no longer converts the column to a physical index before calling `getSourceDataAtCell`. It now passes the **visual** column (with a **physical** row), matching how that API expects indices and how `multiSelectType` already behaves—avoiding double translation after column moves.
> 
> Regression coverage adds a unit test on the index contract and an e2e test that moves the multiselect column and asserts chips and plain text stay on the right columns. A changelog entry documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24958ace255df2fa62a39ba6d9ec5529bd53bad2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->