### PR TITLE
DEV-941: Fix punctuation in Core methods JSDoc

### DIFF
--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -2275,7 +2275,7 @@ export default function Core(
    * @memberof Core#
    * @function destroyEditor
    * @param {boolean} [revertOriginal=false] If `true`, the previous value will be restored. Otherwise, the edited value will be saved.
-   * @param {boolean} [prepareEditorIfNeeded=true] If `true` the editor under the selected cell will be prepared to open.
+   * @param {boolean} [prepareEditorIfNeeded=true] If `true`, the editor under the selected cell will be prepared to open.
    */
   this.destroyEditor = function(revertOriginal = false, prepareEditorIfNeeded = true) {
     editorManager.closeEditor(revertOriginal);
@@ -2892,8 +2892,8 @@ export default function Core(
    * @memberof Core#
    * @function updateData
    * @since 11.1.0
-   * @param {Array} data An [array of arrays](@/guides/getting-started/binding-to-data/binding-to-data.md#array-of-arrays), or an [array of objects](@/guides/getting-started/binding-to-data/binding-to-data.md#array-of-objects), that contains Handsontable's data
-   * @param {string} [source] The source of the `updateData()` call
+   * @param {Array} data An [array of arrays](@/guides/getting-started/binding-to-data/binding-to-data.md#array-of-arrays), or an [array of objects](@/guides/getting-started/binding-to-data/binding-to-data.md#array-of-objects), that contains Handsontable's data.
+   * @param {string} [source] The source of the `updateData()` call.
    * @fires Hooks#beforeUpdateData
    * @fires Hooks#afterUpdateData
    * @fires Hooks#afterChange
@@ -2942,8 +2942,8 @@ export default function Core(
    *
    * @memberof Core#
    * @function loadData
-   * @param {Array} data An [array of arrays](@/guides/getting-started/binding-to-data/binding-to-data.md#array-of-arrays), or an [array of objects](@/guides/getting-started/binding-to-data/binding-to-data.md#array-of-objects), that contains Handsontable's data
-   * @param {string} [source] The source of the `loadData()` call
+   * @param {Array} data An [array of arrays](@/guides/getting-started/binding-to-data/binding-to-data.md#array-of-arrays), or an [array of objects](@/guides/getting-started/binding-to-data/binding-to-data.md#array-of-objects), that contains Handsontable's data.
+   * @param {string} [source] The source of the `loadData()` call.
    * @fires Hooks#beforeLoadData
    * @fires Hooks#afterLoadData
    * @fires Hooks#afterChange
@@ -3593,7 +3593,7 @@ export default function Core(
    *                                inserted or removed. Can also be an array of arrays, in format `[[index, amount],...]`.
    * @param {number} [amount] The amount of rows or columns to be inserted or removed (default: `1`).
    * @param {string} [source] Source indicator.
-   * @param {boolean} [keepEmptyRows] If set to `true`: prevents removing empty rows.
+   * @param {boolean} [keepEmptyRows] If set to `true`, prevents removing empty rows.
    * @example
    * ```js
    * // above row 10 (by visual index), insert 1 new row
@@ -5106,8 +5106,8 @@ export default function Core(
    * @param {number|string} column A visual column index (`number`), or a column property's value (`string`).
    * @param {number} [endRow] If selecting a range: the visual row index of the last cell in the range.
    * @param {number|string} [endColumn] If selecting a range: the visual column index (or a column property's value) of the last cell in the range.
-   * @param {boolean} [scrollToCell=true] `true`: scroll the viewport to the newly-selected cells. `false`: keep the previous viewport.
-   * @param {boolean} [changeListener=true] `true`: switch the keyboard focus to Handsontable. `false`: keep the
+   * @param {boolean} [scrollToCell=true] If `true`, scrolls the viewport to the newly-selected cells. If `false`, keeps the previous viewport.
+   * @param {boolean} [changeListener=true] If `true`, switches the keyboard focus to Handsontable. If `false`, keeps the
    * previous keyboard focus. If an element outside Handsontable (such as a custom input) currently owns the browser
    * focus, it remains focused after the call.
    * @returns {boolean} `true`: the selection was successful, `false`: the selection failed.
@@ -5188,8 +5188,8 @@ export default function Core(
    * @param {Array[]|CellRange[]} coords Visual coordinates,
    * passed either as an array of arrays (`[[rowStart, columnStart, rowEnd, columnEnd], ...]`)
    * or as an array of [`CellRange`](@/api/cellRange.md) objects.
-   * @param {boolean} [scrollToCell=true] `true`: scroll the viewport to the newly-selected cells. `false`: keep the previous viewport.
-   * @param {boolean} [changeListener=true] `true`: switch the keyboard focus to Handsontable. `false`: keep the
+   * @param {boolean} [scrollToCell=true] If `true`, scrolls the viewport to the newly-selected cells. If `false`, keeps the previous viewport.
+   * @param {boolean} [changeListener=true] If `true`, switches the keyboard focus to Handsontable. If `false`, keeps the
    * previous keyboard focus. If an element outside Handsontable (such as a custom input) currently owns the browser
    * focus, it remains focused after the call.
    * @returns {boolean} `true`: the selection was successful, `false`: the selection failed.
@@ -5332,12 +5332,10 @@ export default function Core(
    * @since 0.38.2
    * @memberof Core#
    * @function selectAll
-   * @param {boolean} [includeRowHeaders=false] `true` If the selection should include the row headers,
-   * `false` otherwise.
-   * @param {boolean} [includeColumnHeaders=false] `true` If the selection should include the column
-   * headers, `false` otherwise.
+   * @param {boolean} [includeRowHeaders=false] If `true`, includes the row headers in the selection.
+   * @param {boolean} [includeColumnHeaders=false] If `true`, includes the column headers in the selection.
    *
-   * @param {object} [options] Additional object with options. Since 14.0.0
+   * @param {object} [options] Additional object with options. Since 14.0.0.
    * @param {{row: number, col: number} | boolean} [options.focusPosition] The argument allows changing the cell/header
    * focus position. The value takes an object with a `row` and `col` properties from -N to N, where
    * negative values point to the headers and positive values point to the cell range. If `false`, the focus


### PR DESCRIPTION
### Context

The PR fixes punctuation inconsistencies in the JSDoc comments for `Core` methods in `handsontable/src/core.ts`, which renders as the public API reference at `/api/core`.

Users noticed inconsistencies in how boolean parameters were documented — some used `If \`true\`:` (colon), others used `If \`true\`,` (comma), and some were missing the comma entirely. A few `@param` descriptions also had missing terminal periods.

Changes made:
- `alter()` — `keepEmptyRows`: changed `If set to \`true\`:` → `If set to \`true\`,`
- `destroyEditor()` — `prepareEditorIfNeeded`: added missing comma after `` `true` ``
- `selectCell()` and `selectCells()` — `scrollToCell` and `changeListener`: rewrote from `` `true`: description `` to `If \`true\`, description` format
- `selectAll()` — `includeRowHeaders` and `includeColumnHeaders`: fixed reversed `` `true` If ... `` pattern to `If \`true\`, ...`
- `updateData()` and `loadData()` — `data` and `source` params: added missing terminal periods
- `selectAll()` — `options` param: added missing period after version note

ClickUp task: https://app.clickup.com/t/9015210959/DEV-941

### How has this been tested?

These are JSDoc comment-only changes — no executable code was modified. Verified by grepping for all known inconsistency patterns after each fix:

```bash
grep -n "@param.*\`true\`:\|@param.*\`false\`:" handsontable/src/core.ts  # 0 matches
grep -n "If \`true\`[^,]" handsontable/src/core.ts                         # 0 matches
grep -n "\`true\` If\|\`false\` If" handsontable/src/core.ts               # 0 matches
grep -n "If set to \`true\`:" handsontable/src/core.ts                     # 0 matches
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-941

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only edits to JSDoc; no runtime or type behavior changes.
> 
> **Overview**
> Aligns **Core** public API JSDoc in `handsontable/src/core.ts` so boolean `@param` descriptions and sentence endings read consistently in the generated `/api/core` reference.
> 
> Boolean flags on `destroyEditor`, `alter`, `selectCell`, `selectCells`, and `selectAll` now use the **`If \`true\`, …`** pattern instead of mixed `` `true`: … ``, `` `true` If … ``, or `` If set to \`true\`: `` styles. `scrollToCell` and `changeListener` on the selection helpers are rewritten the same way.
> 
> `updateData` and `loadData` `@param` lines for `data` and `source` gain trailing periods; `selectAll`’s `options` note gets a period after the version tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7af8331ad26fb75e12329577597195a51ca242e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->