### PR TITLE
DEV-1057: add string type to selectColumns startColumn/endColumn JSDoc params

### DIFF
--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -5246,8 +5246,8 @@ export default function Core(
    * @memberof Core#
    * @since 0.38.0
    * @function selectColumns
-   * @param {number} startColumn The visual column index from which the selection starts.
-   * @param {number} [endColumn=startColumn] The visual column index to which the selection finishes. If `endColumn`
+   * @param {number | string} startColumn The visual column index or column property from which the selection starts.
+   * @param {number | string} [endColumn=startColumn] The visual column index or column property to which the selection finishes. If `endColumn`
    * is not defined the column defined by `startColumn` will be selected.
    * @param {number | { row: number, col: number } | CellCoords} [focusPosition=0] The argument allows changing the cell/header focus
    * position. The value can take visual row index from -N to N, where negative values point to the headers and positive


### PR DESCRIPTION
### Context

The PR fixes a missing `string` type in the JSDoc `@param` tags for `startColumn` and `endColumn` in the `selectColumns` method (`handsontable/src/core.ts`). Both parameters accept `number | string` (visual column index or column property name), which is already reflected correctly in the TypeScript definition (`types/core.d.ts`), but the JSDoc only listed `number`. This caused the generated API docs page to show an incomplete type.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1057

### How has this been tested?

- Confirmed the TypeScript definition in `types/core.d.ts` matches the updated JSDoc.
- The generated docs API page at `/api/core/#selectcolumns` will reflect the corrected types after the next docs build.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1057

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only JSDoc change with no runtime or type-definition edits in this diff.
> 
> **Overview**
> Updates the **`selectColumns`** JSDoc on `Core` so **`startColumn`** and **`endColumn`** are documented as **`number | string`**, matching column-by-index or column-property usage already shown in the examples and implemented in `selection.selectColumns` (string values are resolved via `propToCol`).
> 
> This is a **documentation-only** fix so generated API docs no longer imply only numeric column indexes; runtime behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48f817304f0d49ef9b4da743e7ec1ea0fdd046bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->