### PR TITLE
DEV-1144: fix className JSDoc - remove incorrect 'currently-selected' description

### DIFF
--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -697,14 +697,14 @@ export default (): Record<string, unknown> => {
     checkedTemplate: undefined,
 
     /**
-     * The `className` option lets you add CSS class names to every currently-selected element.
+     * The `className` option lets you add CSS class names to every cell that has this option set.
      *
      * You can set the `className` option to one of the following:
      *
-     * | Setting             | Description                                                      |
-     * | ------------------- | ---------------------------------------------------------------- |
-     * | A string            | Add a single CSS class name to every currently-selected element  |
-     * | An array of strings | Add multiple CSS class names to every currently-selected element |
+     * | Setting             | Description                                         |
+     * | ------------------- | --------------------------------------------------- |
+     * | A string            | Add a single CSS class name to every matching cell  |
+     * | An array of strings | Add multiple CSS class names to every matching cell |
      *
      * ::: tip
      * Don't change the `className` metadata of the [column summary](@/guides/columns/column-summary/column-summary.md) row.
@@ -733,12 +733,10 @@ export default (): Record<string, unknown> => {
      *
      * @example
      * ```js
-     * // add a `your-class-name` CSS class name
-     * // to every currently-selected element
+     * // add a `your-class-name` CSS class name to every cell
      * className: 'your-class-name',
      *
-     * // add `first-class-name` and `second-class-name` CSS class names
-     * // to every currently-selected element
+     * // add `first-class-name` and `second-class-name` CSS class names to every cell
      * className: ['first-class-name', 'second-class-name'],
      * ```
      */


### PR DESCRIPTION
### Context

The PR fixes an incorrect description of the `className` option in the JSDoc (`handsontable/src/dataMap/metaManager/metaSchema.ts`).

The previous description said the class name is added to "every currently-selected element", implying it is selection-aware. That is wrong. `className` is applied by `baseRenderer` on every render cycle to cells that have the property set via cell metadata — selection state is irrelevant. Options like `currentRowClassName` and `currentColClassName` are the selection-aware equivalents.

The fix removes all "currently-selected" references from the `className` JSDoc and replaces them with accurate language ("every cell that has this option set" / "every matching cell").

Fixes: DEV-1144

### How has this been tested?

Documentation-only change — no runtime behavior altered. Verified with:

```bash
grep -n "currently-selected" handsontable/src/dataMap/metaManager/metaSchema.ts
# returns 0 results near the className block
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1144

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1144

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits in JSDoc with no code or API behavior changes.
> 
> **Overview**
> Updates the **`className`** option JSDoc in `metaSchema.ts` so it no longer says classes apply to “every currently-selected element.”
> 
> The description and option table now state that classes apply to **every cell that has this option set** / **every matching cell**, and the `@example` comments are aligned. Runtime behavior is unchanged; this only fixes misleading docs that conflated `className` with selection-aware options like `currentRowClassName` and `currentColClassName`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff551c73ec19cc7b9c3c3acf9f543de9a2ce6f10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->