### PR TITLE
DEV-843: Fix incorrect getData() JSDoc description

### DIFF
--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -3033,11 +3033,17 @@ export default function Core(
   };
 
   /**
-   * Returns the current data object (the same one that was passed by `data` configuration option or `loadData` method,
-   * unless some modifications have been applied (i.e. Sequence of rows/columns was changed, some row/column was skipped).
-   * If that's the case - use the {@link Core#getSourceData} method.).
+   * Returns the current visual data as a 2D array.
    *
-   * Optionally you can provide cell range by defining `row`, `column`, `row2`, `column2` to get only a fragment of table data.
+   * Unlike the source data (which may be an array of objects), `getData()` always
+   * returns an array of arrays regardless of the original data format. The returned
+   * data reflects the current visual state of the grid: rows and columns are in their
+   * current visual order, after any sorting, filtering, or reordering.
+   *
+   * To retrieve the data in its original source format, use the {@link Core#getSourceData} method instead.
+   *
+   * Optionally you can provide a cell range by defining `row`, `column`, `row2`, `column2`
+   * to get only a fragment of the data.
    *
    * @memberof Core#
    * @function getData
@@ -3045,7 +3051,7 @@ export default function Core(
    * @param {number} [column] From visual column index.
    * @param {number} [row2] To visual row index.
    * @param {number} [column2] To visual column index.
-   * @returns {Array[]} Array with the data.
+   * @returns {Array[]} A 2D array of cell values in the current visual order.
    * @example
    * ```js
    * // Get all data (in order how it is rendered in the table).


### PR DESCRIPTION
### Context

The PR fixes an inaccurate `getData()` JSDoc description that has been misleading users. The old text stated:

> Returns the current data object (the same one that was passed by `data` configuration option or `loadData` method, unless some modifications have been applied ...).

This is incorrect in two ways:
1. `getData()` does **not** return the same object — it builds a fresh 2D array via `DataMap.getRange()`.
2. `getData()` does **not** preserve the original data format — even when source data is an array of objects, `getData()` always returns an array of arrays (extracting scalar cell values row by row).

The fix replaces the misleading description with an accurate one: `getData()` always returns a 2D array reflecting the current visual state of the grid, and users who need data in the original source format should use `getSourceData()` instead.

### How has this been tested?

This is a documentation-only change (JSDoc comment). The API behavior is unchanged.

- ESLint: `npm run eslint --prefix handsontable` — passes with no errors.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-843

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-843

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change in `core.ts`; no API or runtime behavior changes.
> 
> **Overview**
> **Documentation-only fix** for `Core#getData()` JSDoc in `handsontable/src/core.ts` (DEV-843). Runtime behavior is unchanged.
> 
> The old comment implied `getData()` returns the same data object as `data` / `loadData` (with caveats about row/column changes). The updated text states that **`getData()` always returns a fresh 2D array** of cell values in **current visual order** (after sort, filter, reorder), not the original source shape (e.g. array of objects). It points readers to **`getSourceData()`** for data in the original source format. Param/return descriptions are tightened (visual indexes, optional range, `@returns` wording).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8ee28d531056338c12e17456b12decd0f61f336. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->