### PR TITLE
DEV-751: fix beforeCreateRow index parameter description in JSDoc

### DIFF
--- a/handsontable/src/core/hooks/constants.ts
+++ b/handsontable/src/core/hooks/constants.ts
@@ -345,11 +345,13 @@ export const REGISTERED_HOOKS = [
   'afterCreateCol',
 
   /**
-   * Fired before created a new row.
+   * Fired before a new row is created.
    *
    * @event Hooks#beforeCreateRow
-   * @param {number} index Represents the visual index of first newly created row in the data source array.
-   * @param {number} amount Number of newly created rows in the data source array.
+   * @param {number} index Represents the visual index at which new row(s) are about to be inserted.
+   *                       Note that the actual visual index of the inserted row(s) may differ - use the
+   *                       `afterCreateRow` hook to get the final position.
+   * @param {number} amount Number of rows to be created.
    * @param {string} [source] String that identifies source of hook call
    *                          ([list of all available sources](@/guides/getting-started/events-and-hooks/events-and-hooks.md#definition-for-source-argument)).
    * @returns {*|boolean} If false is returned the action is canceled.


### PR DESCRIPTION
### Context

The PR fixes the JSDoc description of the `beforeCreateRow` hook's first parameter (`index`). The description was identical to `afterCreateRow`'s, which is incorrect — the two hooks fire at different points and receive different values for `index`:

- `beforeCreateRow(index, ...)` — `index` is the visual row index at which insertion is **requested** (the row does not exist yet)
- `afterCreateRow(index, ...)` — `index` is the visual index of the **newly created** row (after insertion)

This discrepancy was introduced by PR #10136, which changed the hook's behavior but did not update the JSDoc. The updated description now clarifies the insertion-point semantics and cross-references `afterCreateRow` for getting the final row position.

### How has this been tested?

This is a JSDoc-only change. Verified by:
- Building the core package (`npm --prefix handsontable run build`) and confirming the updated description appears in `handsontable/tmp/core/hooks/constants.js`
- Running `npm --prefix docs run docs:api` and confirming the correct description appears in the generated `docs/content/api/hooks.md`

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-751

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-751

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API behavior changes.
> 
> **Overview**
> Updates **JSDoc only** for the `beforeCreateRow` hook in `handsontable/src/core/hooks/constants.ts` so it no longer mirrors `afterCreateRow`.
> 
> The hook description is reworded, and the `index` / `amount` `@param` text now states that `index` is the **visual insertion point** before rows exist, with a note that the final index may differ and `afterCreateRow` should be used for the post-insert position. Generated API docs pick this up from the same source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d40382c8076c1668830ec7d687018e5709dc44b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->