### PR TITLE
DEV-855: Document double-click fill handle (auto-autofill) behavior

### DIFF
--- a/docs/content/guides/cell-features/autofill-values/autofill-values.md
+++ b/docs/content/guides/cell-features/autofill-values/autofill-values.md
@@ -30,7 +30,20 @@ Autofill lets users drag the fill handle to copy or extend values across adjacen
 
 ## Autofill in all directions
 
-Using the tiny square known as the 'fill handle' in the corner of the selected cell, you can drag it (drag-down) to repeat the values from the cell. Double click the fill handle in `cell B4` where the value is `30` to fill the selection down to the last value in neighboring column, just like it would in Excel or Google Sheets.
+Using the tiny square known as the 'fill handle' in the corner of the selected cell, you can drag it to repeat or extend values across adjacent cells.
+
+You can also **double-click the fill handle** to autofill downward without dragging. Double-click the fill handle in `cell B4` where the value is `30` to see this in action.
+
+### How double-click autofill determines the range
+
+Handsontable scans the rows below your selection and fills down to the last row where the column immediately to the left or right of your selection contains a value. In the example below, the year column (column A) acts as the guide -- rows 2020 and 2021 have values there, so the fill extends through both rows.
+
+Two conditions must be met for the fill to happen:
+
+- **All cells below the selection in the filled column(s) must be empty.** If any cell below the selection in those columns contains data, double-clicking does nothing.
+- At least one column adjacent to your selection must have data in the rows below.
+
+**Visual difference from drag-fill:** When you drag the fill handle, a preview border shows the target range as you drag. When you double-click, no drag-preview appears -- the cells populate immediately based on the adjacent column data.
 
 ::: only-for javascript
 


### PR DESCRIPTION
### Context

The PR expands the "Autofill in all directions" section of the autofill guide to properly document the double-click fill handle behavior (auto-autofill). Previously, a single sentence mentioned the double-click feature without explaining how it works, making it nearly invisible to users.

The new content explains:
- How double-clicking the fill handle triggers an automatic downward fill without dragging.
- How the fill range is determined: Handsontable scans adjacent columns (left and right) to find how far to extend the fill.
- The blocking condition: if any cell below the selection in the filled columns already contains data, the fill does nothing.
- The visual difference from drag-fill: no drag-preview border appears — the cells populate immediately.

### How has this been tested?

- Docs-only change. Verified manually against the source code in `handsontable/src/plugins/autofill/autofill.ts` (`getIndexOfLastAdjacentFilledInRow`, `selectAdjacent`, `#onCellCornerDblClick`).
- No unit or E2E tests required for documentation prose changes.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-855

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-855

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only prose in the autofill guide; no runtime or API changes.
> 
> **Overview**
> Expands the **Autofill in all directions** guide so double-clicking the fill handle is documented as a first-class workflow, not a one-line aside.
> 
> Adds a subsection on **how the downward range is chosen** (adjacent left/right columns guide the last row), **when double-click does nothing** (non-empty cells below in the filled columns, or no adjacent data), and how that differs visually from drag-fill (no preview border; immediate fill).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f46c3826315690748462c4abc4bed7b8727741e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->