### PR TITLE
DEV-718: Fix afterValidate/beforeValidate prop parameter JSDoc description

### DIFF
--- a/handsontable/src/core/hooks/constants.ts
+++ b/handsontable/src/core/hooks/constants.ts
@@ -1311,7 +1311,8 @@ export const REGISTERED_HOOKS = [
    * @param {boolean} isValid `true` if valid, `false` if not.
    * @param {*} value The value in question.
    * @param {number} row Visual row index.
-   * @param {string|number} prop Property name / visual column index.
+   * @param {string|number} prop Property name or column index. For array-based data, this is the physical column
+   *                            index. When `columns[i].data` is a function, this is the visual column index.
    * @param {string} [source] String that identifies source of hook call
    *                          ([list of all available sources](@/guides/getting-started/events-and-hooks/events-and-hooks.md#definition-for-source-argument)).
    * @returns {undefined | boolean} If `false` the cell will be marked as invalid, `true` otherwise.
@@ -1876,7 +1877,8 @@ export const REGISTERED_HOOKS = [
    * @event Hooks#beforeValidate
    * @param {*} value Value of the cell.
    * @param {number} row Visual row index.
-   * @param {string|number} prop Property name / column index.
+   * @param {string|number} prop Property name or column index. For array-based data, this is the physical column
+   *                            index. When `columns[i].data` is a function, this is the visual column index.
    * @param {string} [source] String that identifies source of hook call
    *                          ([list of all available sources](@/guides/getting-started/events-and-hooks/events-and-hooks.md#definition-for-source-argument)).
    */


### PR DESCRIPTION
### Context

The PR fixes incorrect JSDoc descriptions for the `prop` parameter in the `afterValidate` and `beforeValidate` hooks.

The `afterValidate` hook described `prop` as "Property name / visual column index", and `beforeValidate` described it as "Property name / column index". Both were inaccurate: for array-of-arrays data, `prop` receives the **physical** column index (the position in the underlying data array, resolved via `colToProp`); for object-based data, it receives the string property name; and when `columns[i].data` is a function, it receives the **visual** column index (fixed separately in DEV-1663). The updated descriptions reflect all three cases.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-718

### How has this been tested?

- JSDoc-only change; no runtime behavior is modified
- ESLint passed: `npm run eslint --prefix handsontable`

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-718

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> JSDoc-only change in hook constants; no executable code or validation logic is modified.
> 
> **Overview**
> Corrects the JSDoc for the **`prop`** argument on **`beforeValidate`** and **`afterValidate`** in `handsontable/src/core/hooks/constants.ts`.
> 
> The old text implied a visual column index in some cases; the updated docs state that **`prop`** is a property name or column index—**physical** column index for array-based data, a string property name for object data, and **visual** column index when `columns[i].data` is a function. **No runtime or API behavior changes**—documentation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39192cd735197c5046c7adcc075b1d58e3bb51d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->