### PR TITLE
DEV-440: Document select cell type keyboard navigation

### DIFF
--- a/docs/content/guides/cell-types/select-cell-type/select-cell-type.md
+++ b/docs/content/guides/cell-types/select-cell-type/select-cell-type.md
@@ -75,6 +75,15 @@ The select cell type is a simpler form of the [dropdown](@/guides/cell-types/dro
 
 After configuring the select cell type, cells render a native HTML `<select>` element when the user activates them. The user picks a value from the list and the selected value is written to the data source.
 
+## Keyboard navigation
+
+Open the editor by pressing <kbd>**Enter**</kbd> or <kbd>**F2**</kbd>, or by double-clicking the cell. While the editor is open, use these keys to navigate the options:
+
+- <kbd>**↑**</kbd> selects the previous option, and <kbd>**↓**</kbd> selects the next option. See the [select editor keyboard shortcuts](@/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md#select-editor-keyboard-shortcuts).
+- <kbd>**Enter**</kbd> confirms the selected option and closes the editor. <kbd>**Escape**</kbd> cancels the change and closes the editor.
+
+The cell uses a native HTML `<select>` element, so you can also type a character to jump to the next option that starts with that character. This typeahead comes from the browser, and its exact behavior varies between browsers.
+
 ## Related articles
 
 **Related guides**

--- a/docs/content/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md
+++ b/docs/content/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md
@@ -133,6 +133,15 @@ These keyboard shortcuts work in the [`handsontable`](@/guides/cell-types/handso
 | <kbd>**↑**</kbd> | <kbd>**↑**</kbd> | Move to the cell above the active cell | &cross; | &cross; |
 | <kbd>**↓**</kbd> | <kbd>**↓**</kbd> | Move to the cell below the active cell | &cross; | &cross; |
 
+### Select editor keyboard shortcuts
+
+These keyboard shortcuts work in the [`select`](@/guides/cell-types/select-cell-type/select-cell-type.md) cell editor.
+
+| Windows          | macOS            | Action                          |  Excel  | Sheets  |
+| ---------------- | ---------------- | ------------------------------- | :-----: | :-----: |
+| <kbd>**↑**</kbd> | <kbd>**↑**</kbd> | Select the previous option      | &cross; | &cross; |
+| <kbd>**↓**</kbd> | <kbd>**↓**</kbd> | Select the next option          | &cross; | &cross; |
+
 ## Plugin keyboard shortcuts
 
 These keyboard shortcuts work with particular plugins.

--- a/handsontable/src/editors/selectEditor/__tests__/keyboardShortcuts.spec.js
+++ b/handsontable/src/editors/selectEditor/__tests__/keyboardShortcuts.spec.js
@@ -75,4 +75,72 @@ describe('keyboard navigation', () => {
       expect(getSelectedRange()).toEqualCellRange(['highlight: 1,0 from: 1,0 to: 1,0']);
     });
   });
+
+  describe('"ArrowUp"', () => {
+    it('should select the previous option when the editor is opened in full edit mode', async() => {
+      handsontable({
+        data: [['Kia'], ['Nissan'], ['Toyota']],
+        columns: [{
+          type: 'select',
+          selectOptions: ['Kia', 'Nissan', 'Toyota', 'Honda', 'Mazda'],
+        }],
+      });
+
+      await selectCell(1, 0);
+      await keyDownUp('enter');
+      await keyDownUp('arrowup');
+
+      expect(getActiveEditor().select.value).toBe('Kia');
+    });
+
+    it('should not change the option when the first option is already selected', async() => {
+      handsontable({
+        data: [['Kia'], ['Nissan'], ['Toyota']],
+        columns: [{
+          type: 'select',
+          selectOptions: ['Kia', 'Nissan', 'Toyota', 'Honda', 'Mazda'],
+        }],
+      });
+
+      await selectCell(0, 0);
+      await keyDownUp('enter');
+      await keyDownUp('arrowup');
+
+      expect(getActiveEditor().select.value).toBe('Kia');
+    });
+  });
+
+  describe('"ArrowDown"', () => {
+    it('should select the next option when the editor is opened in full edit mode', async() => {
+      handsontable({
+        data: [['Kia'], ['Nissan'], ['Toyota']],
+        columns: [{
+          type: 'select',
+          selectOptions: ['Kia', 'Nissan', 'Toyota', 'Honda', 'Mazda'],
+        }],
+      });
+
+      await selectCell(1, 0);
+      await keyDownUp('enter');
+      await keyDownUp('arrowdown');
+
+      expect(getActiveEditor().select.value).toBe('Toyota');
+    });
+
+    it('should not change the option when the last option is already selected', async() => {
+      handsontable({
+        data: [['Kia'], ['Nissan'], ['Mazda']],
+        columns: [{
+          type: 'select',
+          selectOptions: ['Kia', 'Nissan', 'Toyota', 'Honda', 'Mazda'],
+        }],
+      });
+
+      await selectCell(2, 0);
+      await keyDownUp('enter');
+      await keyDownUp('arrowdown');
+
+      expect(getActiveEditor().select.value).toBe('Mazda');
+    });
+  });
 });


### PR DESCRIPTION
### Context

The PR documents how to navigate between `select` cell type options with the keyboard. This behavior has existed for a long time but was never documented — originally reported in GitHub issue #10142 (and tracked as dev-handsontable #763 / DEV-440). The Slack discussion at the time concluded the behavior is intentional and useful for accessibility, but was never written down.

Two behaviors are now covered:

- **Arrow navigation** — in full edit mode, `↑` / `↓` move to the previous / next option. This is implemented by Handsontable (`SelectEditor.registerShortcuts()`) and previously had no test coverage.
- **Typeahead** — because the editor renders a native HTML `<select>`, typing a character jumps to the next option starting with that character. This is native, browser-provided behavior, so it is documented as prose with a browser-dependency caveat rather than as a guaranteed Handsontable shortcut.

I verified the typeahead still works in the current build via Chrome DevTools (pressing `1` cycled `10 → 11 → 13`, pressing `3` jumped to `32` — matching the original 2022 reproduction).

The keyboard-shortcuts reference page gains a `Select editor keyboard shortcuts` section (arrows only), mirroring the existing `checkbox` and `handsontable` editor sections. The select cell type guide gains a `Keyboard navigation` section linking to it.

### How has this been tested?

- Added E2E tests for `ArrowUp` / `ArrowDown` option navigation (including first/last-option edge cases):
  - `npm run test:e2e --prefix handsontable --testPathPattern=selectEditor/__tests__/keyboardShortcuts` → 13 specs, 0 failures
- Confirmed the new tests actually execute (sentinel-break produced exactly the expected single failure, then reverted).
- Manually verified native typeahead in a current local build via Chrome DevTools.
- `npm run eslint --prefix handsontable` → clean.
- Verified the new in-page anchor (`#select-editor-keyboard-shortcuts`) matches the docs slug convention.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. [DEV-440](https://app.clickup.com/t/9015210959/DEV-440)
2. #10142

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

 [skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test coverage only; select editor behavior is unchanged.
> 
> **Overview**
> Documents long-standing **select** cell editor keyboard behavior that was never written up (DEV-440 / #10142).
> 
> The **select cell type** guide gains a **Keyboard navigation** section: opening the editor (Enter, F2, double-click), **↑** / **↓** to move between options (with a link to the shortcuts reference), Enter/Escape to confirm or cancel, plus a note that native `<select>` **typeahead** is browser-dependent.
> 
> The **keyboard shortcuts** reference adds a **Select editor keyboard shortcuts** table for **↑** / **↓** only, aligned with the checkbox and `handsontable` editor sections.
> 
> **E2E tests** lock in `ArrowUp` / `ArrowDown` option navigation in full edit mode, including when the selection is already on the first or last option. No editor implementation changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b37a8b5d91049731959a04048e8576b1db25b6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->