### PR TITLE
DEV-600: Make Events and Hooks demo checkbox list responsive

### DIFF
--- a/docs/src/styles/overrides/example-specific.css
+++ b/docs/src/styles/overrides/example-specific.css
@@ -97,17 +97,6 @@
   border-right: 1px solid var(--sl-color-gray-5);
 }
 
-/* First column — extra left padding to align with content */
-#hooksList li:nth-child(3n+2) {
-  padding-left: 1rem;
-}
-
-/* Last column — no right border, extra right padding */
-#hooksList li:nth-child(3n+1):not(:first-child) {
-  border-right: 0;
-  padding-right: 1rem;
-}
-
 #hooksList li:hover {
   background-color: var(--sl-color-gray-6, rgba(255, 255, 255, 0.03));
 }
@@ -139,6 +128,61 @@
   padding: 0.5rem 1rem;
   border-radius: 0;
   background: transparent;
+}
+
+/* ── Hooks list: responsive column count ──────────────────────────────
+   Long hook names become unreadable when squeezed into 3 columns on small
+   screens, so the column count adapts to the viewport. The breakpoints match
+   the rest of the docs layout (see src/styles/layout/responsive.css).
+   The "Select all" row spans 1 / -1, so it follows any column count. */
+
+/* Desktop (≥72rem): three columns — the original layout. */
+@media (min-width: 72rem) {
+  #hooksList {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  /* First column — extra left padding to align with content */
+  #hooksList li:nth-child(3n+2) {
+    padding-left: 1rem;
+  }
+
+  /* Last column — no right border, extra right padding */
+  #hooksList li:nth-child(3n+1):not(:first-child) {
+    border-right: 0;
+    padding-right: 1rem;
+  }
+}
+
+/* Tablet (50–72rem): two columns. */
+@media (min-width: 50rem) and (max-width: 71.99rem) {
+  #hooksList {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  /* First column — extra left padding to align with content */
+  #hooksList li:nth-child(2n) {
+    padding-left: 1rem;
+  }
+
+  /* Last column — no right border, extra right padding */
+  #hooksList li:nth-child(2n+1):not(:first-child) {
+    border-right: 0;
+    padding-right: 1rem;
+  }
+}
+
+/* Mobile (<50rem): single column — every item spans the full width. */
+@media (max-width: 49.99rem) {
+  #hooksList {
+    grid-template-columns: 1fr;
+  }
+
+  #hooksList li {
+    border-right: 0;
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
 }
 
 /* Aside inside hooks example */


### PR DESCRIPTION
### Context

The PR fixes the "Events and Hooks" guide demo, where the interactive list of hook checkboxes was rendered in a fixed 3-column grid. On small screens (e.g. iPhone 13 Pro, ~390px wide) the three columns squeezed each hook name into an unreadable, ellipsis-truncated sliver, so the reader could not tell which hook a checkbox enables (DEV-600).

The fix makes the column count responsive, reusing the breakpoints already defined in the docs layout (`docs/src/styles/layout/responsive.css`):

- `< 50rem` (phones) -- 1 column
- `50rem - 71.99rem` (tablet) -- 2 columns
- `>= 72rem` (desktop) -- 3 columns (unchanged from before)

The change is CSS-only, in `docs/src/styles/overrides/example-specific.css`. The base `#hooksList li` rule is now column-agnostic, and each column count lives in its own mutually-exclusive media query so the `nth-child` column-edge border/padding rules never collide across breakpoints. The "Select all" row already spans `grid-column: 1 / -1`, so it follows any column count automatically. The demo's JS only generates `<li>` items and is unchanged, and all framework tabs share this global stylesheet, so they all inherit the responsive behavior.

`[skip changelog]` -- docs-site CSS only; no package source, JS, or markdown changed.

### How has this been tested?

- Manual visual check of the `#hooksList` markup + CSS rendered at three viewport widths using Playwright:
  - 390px -- 1 column, full hook names readable, list scrolls within its 280px box.
  - 950px -- 2 columns, correct center divider, no stray last-column border.
  - 1200px -- 3 columns, visually identical to the previous layout.
- At every width the "Select all" row spans the full width and column borders/padding align correctly.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-600

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-600

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only CSS for a demo list; no runtime or package behavior changes.
> 
> **Overview**
> Fixes the **Events and Hooks** guide demo where `#hooksList` stayed on a fixed 3-column grid and truncated hook names on narrow viewports.
> 
> Column-edge padding and borders are moved out of the global `#hooksList li` rules into **viewport-specific media queries** aligned with `responsive.css`: **1 column** below 50rem, **2 columns** from 50rem–71.99rem, and **3 columns** from 72rem up (same desktop look as before). Each breakpoint uses its own `nth-child` rules so column borders/padding do not clash. Mobile drops right borders and uses horizontal padding so labels can use the full width.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb96cdae5d964773b3367672db284dd472ef2bef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->