### PR TITLE
docs(changelog-17): clarify stretchH 'last' width fix in 17.1.0 (#11761)

### DIFF
--- a/docs/content/guides/upgrade-and-migration/changelog-17/changelog-17.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-17/changelog-17.md
@@ -52,7 +52,7 @@ For more information about this release, see:
 #### Fixed
 - Fixed an issue where the Nested Rows plugin was disabled after calling updateSettings with an empty data array. [#10556](https://github.com/handsontable/handsontable/issues/10556)
 - Fixed `setSourceDataAtCell()` updating parent rows instead of nested child rows when `nestedRows` is enabled. [#10657](https://github.com/handsontable/handsontable/issues/10657)
-- Fixed an issue where the stretchH: 'last' option would ignore the defined column width when the viewport was too narrow, causing the last column to shrink to 0px. [#11761](https://github.com/handsontable/handsontable/issues/11761)
+- Fixed an issue where the `stretchH: 'last'` option ignored the column's defined `width` value when the viewport was too narrow, causing the last column to shrink to `0px`. As of 17.1.0, the defined `width` is always respected — the last column will never be rendered below its configured width, regardless of viewport size. Prior to this fix, a sufficiently narrow container could collapse the last column to `0px` even when an explicit width was set. [#11761](https://github.com/handsontable/handsontable/issues/11761)
 - Fixed a stack overflow error when pasting large datasets (50,000+ rows) by optimizing array operations in the HTML table parser. [#11784](https://github.com/handsontable/handsontable/issues/11784)
 - Fixed incorrect JSDoc type annotations for the `modifyAutofillRange` hook parameters. The parameters `entireArea` and `startArea` are now correctly documented as `number[]` (a flat 4-element array) instead of the generic `Array` type, and the `@returns` type annotation has been added. [#11862](https://github.com/handsontable/handsontable/issues/11862)
 - Fixed filter by value input performance degradation when searchMode: apply option is enabled. [#12104](https://github.com/handsontable/handsontable/issues/12104)
@@ -62,7 +62,6 @@ For more information about this release, see:
 - Fixed comment editor positioning for merged cells [#12115](https://github.com/handsontable/handsontable/pull/12115)
 - Fixed the Filters plugin incorrectly applying filter conditions after columns were moved with the ManualColumnMove plugin. [#11832](https://github.com/handsontable/handsontable/issues/11832)
 - Fixed column resizing being misaligned and calculating incorrect widths when the grid container has a CSS `transform: scale()` applied. [#11838](https://github.com/handsontable/handsontable/issues/11838)
-- Fixed the `stretchH: 'last'` option ignoring the defined column width and shrinking the last column to 0px when the viewport was too narrow. [#11761](https://github.com/handsontable/handsontable/issues/11761)
 - Fixed HyperFormula errors when MultiSelect cells store array values. [#12135](https://github.com/handsontable/handsontable/pull/12135)
 - Fixed `setSourceDataAtCell()` updating a parent row instead of the intended nested child row when the `nestedRows` option was enabled. [#10657](https://github.com/handsontable/handsontable/issues/10657)
 - Fixed `setDataAtRowProp()` incorrectly canceling an active editor session when the programmatic update targeted a different cell in the same row. [#4305](https://github.com/handsontable/handsontable/issues/4305)


### PR DESCRIPTION
## Summary

Clarifies the changelog entry for issue [#11761](https://github.com/handsontable/handsontable/issues/11761) in the 17.1.0 Fixed section to accurately describe the corrected behavior of `stretchH: 'last'`.

## What changed

The previous entry for #11761 appeared twice with slightly different wording, and neither version was explicit enough about the corrected contract. This PR:

- **Merges** the two duplicate #11761 entries into one authoritative entry.
- **Expands** the entry to clearly state that as of 17.1.0, the `stretchH: 'last'` option always honors the column's defined `width` value — the last column will never be rendered below its configured width regardless of viewport size.
- **Adds** a brief before/after note: prior to 17.1.0, a narrow container could collapse the last column to `0px` even when an explicit `width` was set; this is no longer the case.
- **Removes** the implication (via the duplicate/ambiguous phrasing) that collapsing to `0px` was an accepted trade-off.

## Motivation

An eval test (V171-003) revealed that the existing changelog wording was ambiguous enough to lead an AI assistant to incorrectly conclude that `0px` collapse under `stretchH: 'last'` remained expected behavior in 17.1. The updated entry makes the fix unambiguous for both human readers and automated tooling.

## Files changed

- `docs/content/guides/upgrade-and-migration/changelog-17/changelog-17.md`