### PR TITLE
DEV-720: Simplify updateSettings description to current behavior

### DIFF
--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -3139,11 +3139,8 @@ export default function Core(
    * __Note__, that although the `updateSettings` method doesn't overwrite the previously declared settings, it might reset
    * the settings made post-initialization. (for example - ignore changes made using the columnResize feature).
    *
-   * Since 8.0.0 passing `columns` or `data` inside `settings` objects will result in resetting states corresponding to rows and columns
-   * (for example, row/column sequence, column width, row height, frozen columns etc.).
-   *
-   * Since 12.0.0 passing `data` inside `settings` objects no longer results in resetting states corresponding to rows and columns
-   * (for example, row/column sequence, column width, row height, frozen columns etc.).
+   * Passing `columns` inside the `settings` object resets the states corresponding to rows and columns
+   * (for example, row/column sequence, column width, row height, frozen columns etc.). Passing `data` does not reset these states.
    *
    * Cell meta set imperatively through [[setCellMeta]] (for example, by the user or the context menu) is preserved across
    * `updateSettings`, even when `settings` includes `cell`, `cells`, or `columns`. On a direct conflict, a value re-stated


### PR DESCRIPTION
### Context

The PR simplifies the `updateSettings` API reference description. The description previously explained its behavior as a version history -- one paragraph for "Since 8.0.0..." and another for "Since 12.0.0..." -- forcing the reader to mentally diff the two to work out what the method does today. Version 8 shipped in 2020 and version 12 well before now, so the historical framing is noise for current users.

The two paragraphs are replaced with a single statement of the current, verified behavior (confirmed against `handsontable/src/core.ts`): passing `columns` resets the states corresponding to rows and columns; passing `data` does not.

### How has this been tested?

- Documentation-only JSDoc change -- no behavior change, so no unit/E2E tests added.
- `npm run eslint --prefix handsontable` -- passes (JSDoc lint clean).

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-720

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog] -- documentation-only JSDoc change.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-720

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> JSDoc-only change with no code or behavior impact.
> 
> **Overview**
> Replaces the **`updateSettings`** JSDoc version-history notes (“Since 8.0.0…”, “Since 12.0.0…”) with one description of **current** behavior: including **`columns`** in the settings object resets row/column-related state (sequence, widths, heights, frozen columns, etc.); including **`data`** does **not** reset that state.
> 
> No runtime or API changes—comments only in `handsontable/src/core.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60042e169222e74de60b1eff2b858c5b4ba4dd8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->