### PR TITLE
DEV-1939: Fix RC docs preview not building due to .js extension in measure-module-sizes script

### DIFF
--- a/.github/workflows/docs-staging.yml
+++ b/.github/workflows/docs-staging.yml
@@ -157,12 +157,15 @@ jobs:
 
       # RC release branches: measure module sizes (same as production workflow).
       - name: Update module size measurements
+        id: measure-module-sizes
         if: ${{ steps.release-info.outputs.is_release == 'true' }}
+        continue-on-error: true
         working-directory: .
         run: |
           npm run measure:module-sizes --prefix handsontable
 
       - name: Build docs (for staging preview)
+        id: build-docs
         run: |
           npm run build
         env:
@@ -312,3 +315,67 @@ jobs:
           echo "This staging build uses production docs settings (BUILD_MODE=production) for release branch \`${{ steps.release-info.outputs.target_version }}\`." >> $GITHUB_STEP_SUMMARY
           echo "The published \`handsontable\` version from package.json (including any RC tag) is used in examples and CodeSandbox links." >> $GITHUB_STEP_SUMMARY
           echo "Use it to verify the docs before the final release." >> $GITHUB_STEP_SUMMARY
+
+      - name: Fail if module size measurements errored
+        if: ${{ steps.measure-module-sizes.outcome == 'failure' }}
+        run: |
+          echo "::error::Module size measurements failed. The docs were deployed but module-sizes.json may be stale."
+          exit 1
+
+      - name: Prepare RC docs failure Slack payload
+        if: ${{ !cancelled() && failure() && steps.release-info.outputs.is_release == 'true' }}
+        env:
+          RC_VERSION: ${{ steps.release-info.outputs.target_version }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+          MEASURE_OUTCOME: ${{ steps.measure-module-sizes.outcome }}
+          BUILD_OUTCOME: ${{ steps.build-docs.outcome }}
+          NETLIFY_OUTCOME: ${{ steps.netlify-publish.outcome }}
+        run: |
+          BRANCH='${{ github.ref_name }}'
+
+          FAILURES=""
+          if [ "$MEASURE_OUTCOME" = "failure" ]; then
+            FAILURES="${FAILURES}• *Module size measurements* failed — \`module-sizes.json\` may be stale\n"
+          fi
+          if [ "$BUILD_OUTCOME" = "failure" ]; then
+            FAILURES="${FAILURES}• *Docs build* failed\n"
+          fi
+          if [ "$NETLIFY_OUTCOME" = "failure" ]; then
+            FAILURES="${FAILURES}• *Netlify publish* failed — preview may not be available\n"
+          fi
+          if [ -z "$FAILURES" ]; then
+            FAILURES="• Unknown failure — check the Actions run for details\n"
+          fi
+
+          jq -n \
+            --arg version  "${RC_VERSION}" \
+            --arg branch   "${BRANCH}" \
+            --arg run_url  "${RUN_URL}" \
+            --arg repo_url "${REPO_URL}" \
+            --arg failures "$FAILURES" \
+          '{
+            text: ("❌ RC docs staging failed for " + $version),
+            blocks: [
+              {
+                type: "section",
+                text: { type: "mrkdwn", text: (":x: *RC docs staging deployment failed for <" + $repo_url + "/tree/" + $branch + "|" + $version + ">*") }
+              },
+              {
+                type: "section",
+                text: { type: "mrkdwn", text: $failures }
+              },
+              {
+                type: "context",
+                elements: [{ type: "mrkdwn", text: ("<" + $run_url + "|🔗 View GitHub Actions run>") }]
+              }
+            ]
+          }' > /tmp/slack-rc-docs-failure.json
+
+      - name: Notify Slack on RC docs failure
+        if: ${{ !cancelled() && failure() && steps.release-info.outputs.is_release == 'true' }}
+        uses: slackapi/slack-github-action@03ea5433c137af7c0495bc0cad1af10403fc800c # https://github.com/slackapi/slack-github-action/releases/tag/v3.0.2
+        with:
+          webhook: ${{ secrets.SLACK_RELEASE_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload-file-path: /tmp/slack-rc-docs-failure.json

--- a/docs/content/guides/tools-and-building/modules/module-sizes.json
+++ b/docs/content/guides/tools-and-building/modules/module-sizes.json
@@ -1,218 +1,222 @@
 {
-  "version": "17.0.1",
-  "measuredAt": "2026-04-08",
+  "version": "17.1.0",
+  "measuredAt": "2026-06-24",
   "base": {
     "full": {
-      "raw": 1420300,
-      "gzip": 316590
+      "raw": 1160560,
+      "gzip": 278816
     },
     "base": {
-      "raw": 631124,
-      "gzip": 141249
+      "raw": 629143,
+      "gzip": 138756
     }
   },
   "cellTypes": {
     "AutocompleteCellType": {
-      "raw": 15072,
-      "gzip": 4161
+      "raw": 15505,
+      "gzip": 4436
     },
     "CheckboxCellType": {
-      "raw": 5963,
-      "gzip": 1980
+      "raw": 6168,
+      "gzip": 2036
     },
     "DateCellType": {
-      "raw": 87245,
-      "gzip": 28221
+      "raw": 2286,
+      "gzip": 919
     },
     "DropdownCellType": {
-      "raw": 15496,
-      "gzip": 4266
+      "raw": 16117,
+      "gzip": 4616
     },
     "HandsontableCellType": {
-      "raw": 6502,
-      "gzip": 1549
+      "raw": 6369,
+      "gzip": 1561
     },
     "IntlDateCellType": {
-      "raw": 1747,
-      "gzip": 742
+      "raw": 2575,
+      "gzip": 1013
     },
     "IntlTimeCellType": {
-      "raw": 1761,
-      "gzip": 740
+      "raw": 2312,
+      "gzip": 956
     },
     "MultiSelectCellType": {
-      "raw": 24036,
-      "gzip": 6160
+      "raw": 24455,
+      "gzip": 6379
     },
     "NumericCellType": {
-      "raw": 44066,
-      "gzip": 17097
+      "raw": 2592,
+      "gzip": 927
     },
     "PasswordCellType": {
-      "raw": 1409,
-      "gzip": 284
+      "raw": 4655,
+      "gzip": 1134
     },
     "SelectCellType": {
-      "raw": 3071,
-      "gzip": 651
+      "raw": 3404,
+      "gzip": 726
     },
     "TextCellType": {
       "raw": 7,
-      "gzip": -14
+      "gzip": 11
     },
     "TimeCellType": {
-      "raw": 64177,
-      "gzip": 20993
+      "raw": 2044,
+      "gzip": 864
     }
   },
   "plugins": {
     "AutoColumnSize": {
-      "raw": 22148,
-      "gzip": 5805
+      "raw": 20636,
+      "gzip": 5716
     },
     "AutoRowSize": {
-      "raw": 22659,
-      "gzip": 5901
+      "raw": 20940,
+      "gzip": 5706
     },
     "Autofill": {
-      "raw": 15519,
-      "gzip": 4533
+      "raw": 19533,
+      "gzip": 5700
     },
     "BindRowsWithHeaders": {
-      "raw": 9279,
-      "gzip": 2714
+      "raw": 8462,
+      "gzip": 2499
     },
     "CollapsibleColumns": {
-      "raw": 14316,
-      "gzip": 4160
+      "raw": 15281,
+      "gzip": 4373
     },
     "ColumnSorting": {
-      "raw": 85351,
-      "gzip": 26581
+      "raw": 21444,
+      "gzip": 6303
     },
     "ColumnSummary": {
-      "raw": 20186,
-      "gzip": 5178
+      "raw": 19436,
+      "gzip": 5304
     },
     "Comments": {
-      "raw": 32548,
-      "gzip": 7987
+      "raw": 34347,
+      "gzip": 8438
     },
     "ContextMenu": {
-      "raw": 42715,
-      "gzip": 10857
+      "raw": 40483,
+      "gzip": 10705
     },
     "CopyPaste": {
-      "raw": 27449,
-      "gzip": 7876
+      "raw": 27841,
+      "gzip": 7774
     },
     "CustomBorders": {
-      "raw": 16786,
-      "gzip": 4836
+      "raw": 16305,
+      "gzip": 4814
     },
     "Dialog": {
-      "raw": 19403,
-      "gzip": 5672
+      "raw": 19883,
+      "gzip": 5645
     },
     "DragToScroll": {
-      "raw": 9547,
-      "gzip": 2752
-    },
-    "DropdownMenu": {
-      "raw": 45898,
-      "gzip": 11706
-    },
-    "EmptyDataState": {
-      "raw": 18366,
-      "gzip": 5156
-    },
-    "ExportFile": {
-      "raw": 39868,
-      "gzip": 12465
-    },
-    "Filters": {
-      "raw": 155351,
-      "gzip": 42730
-    },
-    "Formulas": {
-      "raw": 96068,
-      "gzip": 28576
-    },
-    "HiddenColumns": {
-      "raw": 22888,
-      "gzip": 5781
-    },
-    "HiddenRows": {
-      "raw": 22567,
-      "gzip": 5726
-    },
-    "Loading": {
-      "raw": 9901,
-      "gzip": 3061
-    },
-    "ManualColumnFreeze": {
-      "raw": 9510,
-      "gzip": 2759
-    },
-    "ManualColumnMove": {
-      "raw": 16551,
+      "raw": 17522,
       "gzip": 4739
     },
+    "DropdownMenu": {
+      "raw": 43721,
+      "gzip": 11670
+    },
+    "EmptyDataState": {
+      "raw": 18401,
+      "gzip": 5163
+    },
+    "ExportFile": {
+      "raw": 38791,
+      "gzip": 12533
+    },
+    "Filters": {
+      "raw": 90878,
+      "gzip": 22960
+    },
+    "Formulas": {
+      "raw": 34504,
+      "gzip": 9132
+    },
+    "HiddenColumns": {
+      "raw": 23593,
+      "gzip": 5874
+    },
+    "HiddenRows": {
+      "raw": 23239,
+      "gzip": 5812
+    },
+    "Loading": {
+      "raw": 9759,
+      "gzip": 2954
+    },
+    "ManualColumnFreeze": {
+      "raw": 9747,
+      "gzip": 2785
+    },
+    "ManualColumnMove": {
+      "raw": 16737,
+      "gzip": 4755
+    },
     "ManualColumnResize": {
-      "raw": 14904,
-      "gzip": 4230
+      "raw": 16371,
+      "gzip": 4460
     },
     "ManualRowMove": {
-      "raw": 15556,
-      "gzip": 4429
+      "raw": 15598,
+      "gzip": 4423
     },
     "ManualRowResize": {
-      "raw": 14643,
-      "gzip": 4201
+      "raw": 16256,
+      "gzip": 4429
     },
     "MergeCells": {
-      "raw": 52181,
-      "gzip": 12303
+      "raw": 51904,
+      "gzip": 13222
     },
     "MultiColumnSorting": {
-      "raw": 88214,
-      "gzip": 27052
+      "raw": 23719,
+      "gzip": 6744
     },
     "MultipleSelectionHandles": {
-      "raw": 10921,
-      "gzip": 2974
+      "raw": 10435,
+      "gzip": 2921
     },
     "NestedHeaders": {
-      "raw": 42803,
-      "gzip": 11593
+      "raw": 42667,
+      "gzip": 12100
     },
     "NestedRows": {
-      "raw": 35073,
-      "gzip": 8082
+      "raw": 31048,
+      "gzip": 7893
+    },
+    "Notification": {
+      "raw": 24968,
+      "gzip": 6760
     },
     "Pagination": {
-      "raw": 28903,
-      "gzip": 7547
+      "raw": 27353,
+      "gzip": 7297
     },
     "Search": {
-      "raw": 9953,
-      "gzip": 2849
+      "raw": 9503,
+      "gzip": 2831
     },
     "StretchColumns": {
-      "raw": 13372,
-      "gzip": 3762
+      "raw": 13417,
+      "gzip": 3696
     },
     "TouchScroll": {
-      "raw": 9326,
-      "gzip": 2668
+      "raw": 9040,
+      "gzip": 2586
     },
     "TrimRows": {
-      "raw": 9604,
-      "gzip": 2728
+      "raw": 9116,
+      "gzip": 2623
     },
     "UndoRedo": {
-      "raw": 29268,
-      "gzip": 6104
+      "raw": 22508,
+      "gzip": 5769
     }
   }
 }

--- a/docs/content/guides/tools-and-building/modules/modules.md
+++ b/docs/content/guides/tools-and-building/modules/modules.md
@@ -744,14 +744,14 @@ The table below lists all of Handsontable's modules:
 The tables below show the minified and gzip sizes of each module when bundled on top of the base module. The **gzip** column represents the size after gzip compression - the most relevant metric for network transfer.
 
 <!-- module-sizes:start -->
-Measurements were made with esbuild using minification, against **Handsontable 17.0.1** (2026-04-08).
+Measurements were made with esbuild using minification, against **Handsontable 17.1.0** (2026-06-24).
 
 **Base module sizes:**
 
 | Package | Minified | Gzip |
 | ------- | -------- | ---- |
-| `handsontable` (full, no tree shaking) | 1420.3 kB | 316.6 kB |
-| `handsontable/base` | 631.1 kB | 141.2 kB |
+| `handsontable` (full, no tree shaking) | 1160.6 kB | 278.8 kB |
+| `handsontable/base` | 629.1 kB | 138.8 kB |
 
 **Size added by each optional module (on top of `handsontable/base`):**
 
@@ -759,19 +759,19 @@ Measurements were made with esbuild using minification, against **Handsontable 1
 
 | Module | Minified | Gzip |
 | ------ | -------- | ---- |
-| `AutocompleteCellType` | +15.1 kB | +4.2 kB |
-| `CheckboxCellType` | +6.0 kB | +2.0 kB |
-| `DateCellType` | +87.2 kB | +28.2 kB |
-| `DropdownCellType` | +15.5 kB | +4.3 kB |
-| `HandsontableCellType` | +6.5 kB | +1.5 kB |
-| `IntlDateCellType` | +1.7 kB | +0.7 kB |
-| `IntlTimeCellType` | +1.8 kB | +0.7 kB |
-| `MultiSelectCellType` | +24.0 kB | +6.2 kB |
-| `NumericCellType` | +44.1 kB | +17.1 kB |
-| `PasswordCellType` | +1.4 kB | +0.3 kB |
-| `SelectCellType` | +3.1 kB | +0.7 kB |
+| `AutocompleteCellType` | +15.5 kB | +4.4 kB |
+| `CheckboxCellType` | +6.2 kB | +2.0 kB |
+| `DateCellType` | +2.3 kB | +0.9 kB |
+| `DropdownCellType` | +16.1 kB | +4.6 kB |
+| `HandsontableCellType` | +6.4 kB | +1.6 kB |
+| `IntlDateCellType` | +2.6 kB | +1.0 kB |
+| `IntlTimeCellType` | +2.3 kB | +1.0 kB |
+| `MultiSelectCellType` | +24.5 kB | +6.4 kB |
+| `NumericCellType` | +2.6 kB | +0.9 kB |
+| `PasswordCellType` | +4.7 kB | +1.1 kB |
+| `SelectCellType` | +3.4 kB | +0.7 kB |
 | `TextCellType` | included in base | included in base |
-| `TimeCellType` | +64.2 kB | +21.0 kB |
+| `TimeCellType` | +2.0 kB | +0.9 kB |
 
 :::
 
@@ -779,43 +779,44 @@ Measurements were made with esbuild using minification, against **Handsontable 1
 
 | Module | Minified | Gzip |
 | ------ | -------- | ---- |
-| `AutoColumnSize` | +22.1 kB | +5.8 kB |
-| `AutoRowSize` | +22.7 kB | +5.9 kB |
-| `Autofill` | +15.5 kB | +4.5 kB |
-| `BindRowsWithHeaders` | +9.3 kB | +2.7 kB |
-| `CollapsibleColumns` | +14.3 kB | +4.2 kB |
-| `ColumnSorting` | +85.4 kB | +26.6 kB |
-| `ColumnSummary` | +20.2 kB | +5.2 kB |
-| `Comments` | +32.5 kB | +8.0 kB |
-| `ContextMenu` | +42.7 kB | +10.9 kB |
-| `CopyPaste` | +27.4 kB | +7.9 kB |
-| `CustomBorders` | +16.8 kB | +4.8 kB |
-| `Dialog` | +19.4 kB | +5.7 kB |
-| `DragToScroll` | +9.5 kB | +2.8 kB |
-| `DropdownMenu` | +45.9 kB | +11.7 kB |
+| `AutoColumnSize` | +20.6 kB | +5.7 kB |
+| `AutoRowSize` | +20.9 kB | +5.7 kB |
+| `Autofill` | +19.5 kB | +5.7 kB |
+| `BindRowsWithHeaders` | +8.5 kB | +2.5 kB |
+| `CollapsibleColumns` | +15.3 kB | +4.4 kB |
+| `ColumnSorting` | +21.4 kB | +6.3 kB |
+| `ColumnSummary` | +19.4 kB | +5.3 kB |
+| `Comments` | +34.3 kB | +8.4 kB |
+| `ContextMenu` | +40.5 kB | +10.7 kB |
+| `CopyPaste` | +27.8 kB | +7.8 kB |
+| `CustomBorders` | +16.3 kB | +4.8 kB |
+| `Dialog` | +19.9 kB | +5.6 kB |
+| `DragToScroll` | +17.5 kB | +4.7 kB |
+| `DropdownMenu` | +43.7 kB | +11.7 kB |
 | `EmptyDataState` | +18.4 kB | +5.2 kB |
-| `ExportFile` | +39.9 kB | +12.5 kB |
-| `Filters` | +155.4 kB | +42.7 kB |
-| `Formulas` | +96.1 kB | +28.6 kB |
-| `HiddenColumns` | +22.9 kB | +5.8 kB |
-| `HiddenRows` | +22.6 kB | +5.7 kB |
-| `Loading` | +9.9 kB | +3.1 kB |
-| `ManualColumnFreeze` | +9.5 kB | +2.8 kB |
-| `ManualColumnMove` | +16.6 kB | +4.7 kB |
-| `ManualColumnResize` | +14.9 kB | +4.2 kB |
+| `ExportFile` | +38.8 kB | +12.5 kB |
+| `Filters` | +90.9 kB | +23.0 kB |
+| `Formulas` | +34.5 kB | +9.1 kB |
+| `HiddenColumns` | +23.6 kB | +5.9 kB |
+| `HiddenRows` | +23.2 kB | +5.8 kB |
+| `Loading` | +9.8 kB | +3.0 kB |
+| `ManualColumnFreeze` | +9.7 kB | +2.8 kB |
+| `ManualColumnMove` | +16.7 kB | +4.8 kB |
+| `ManualColumnResize` | +16.4 kB | +4.5 kB |
 | `ManualRowMove` | +15.6 kB | +4.4 kB |
-| `ManualRowResize` | +14.6 kB | +4.2 kB |
-| `MergeCells` | +52.2 kB | +12.3 kB |
-| `MultiColumnSorting` | +88.2 kB | +27.1 kB |
-| `MultipleSelectionHandles` | +10.9 kB | +3.0 kB |
-| `NestedHeaders` | +42.8 kB | +11.6 kB |
-| `NestedRows` | +35.1 kB | +8.1 kB |
-| `Pagination` | +28.9 kB | +7.5 kB |
-| `Search` | +10.0 kB | +2.8 kB |
-| `StretchColumns` | +13.4 kB | +3.8 kB |
-| `TouchScroll` | +9.3 kB | +2.7 kB |
-| `TrimRows` | +9.6 kB | +2.7 kB |
-| `UndoRedo` | +29.3 kB | +6.1 kB |
+| `ManualRowResize` | +16.3 kB | +4.4 kB |
+| `MergeCells` | +51.9 kB | +13.2 kB |
+| `MultiColumnSorting` | +23.7 kB | +6.7 kB |
+| `MultipleSelectionHandles` | +10.4 kB | +2.9 kB |
+| `NestedHeaders` | +42.7 kB | +12.1 kB |
+| `NestedRows` | +31.0 kB | +7.9 kB |
+| `Notification` | +25.0 kB | +6.8 kB |
+| `Pagination` | +27.4 kB | +7.3 kB |
+| `Search` | +9.5 kB | +2.8 kB |
+| `StretchColumns` | +13.4 kB | +3.7 kB |
+| `TouchScroll` | +9.0 kB | +2.6 kB |
+| `TrimRows` | +9.1 kB | +2.6 kB |
+| `UndoRedo` | +22.5 kB | +5.8 kB |
 
 :::
 

--- a/handsontable/scripts/measure-module-sizes.mjs
+++ b/handsontable/scripts/measure-module-sizes.mjs
@@ -36,10 +36,10 @@ mkdirSync(TMP_DIR, { recursive: true });
 const SRC_DIR = resolve(__dirname, '..', 'src');
 
 /**
- * Reads an index.js barrel file and returns all imported class names that pass
+ * Reads an index.ts barrel file and returns all imported class names that pass
  * the given filter. Handles both single-line and multi-line import blocks.
  *
- * @param {string} indexPath Absolute path to the index.js barrel file.
+ * @param {string} indexPath Absolute path to the index.ts barrel file.
  * @param {Function} filter Predicate to include a name.
  * @returns {string[]} Sorted list of matching names.
  */
@@ -61,13 +61,13 @@ function parseImportNames(indexPath, filter) {
 }
 
 /**
- * Auto-detects cell type class names from src/cellTypes/index.js.
+ * Auto-detects cell type class names from src/cellTypes/index.ts.
  *
  * @returns {string[]} Sorted list of cell type class names.
  */
 function detectCellTypes() {
   return parseImportNames(
-    resolve(SRC_DIR, 'cellTypes', 'index.js'),
+    resolve(SRC_DIR, 'cellTypes', 'index.ts'),
     name => /^[A-Z]\w+CellType$/.test(name)
   );
 }
@@ -82,7 +82,7 @@ function detectPlugins() {
   const EXCLUDE = new Set(['BasePlugin', 'DataProvider']);
 
   return parseImportNames(
-    resolve(SRC_DIR, 'plugins', 'index.js'),
+    resolve(SRC_DIR, 'plugins', 'index.ts'),
     name => /^[A-Z]/.test(name) && !EXCLUDE.has(name)
   );
 }


### PR DESCRIPTION
### Context

The PR fixes the RC docs preview (`rc-handsontable-x-y-z.netlify.app`) never being deployed after RC releases.

**Root cause:** `handsontable/scripts/measure-module-sizes.mjs` hardcoded `src/cellTypes/index.js` and `src/plugins/index.js`, but both files are `.ts` (the codebase migrated to TypeScript). This caused an `ENOENT` crash in `docs-staging.yml` at the "Update module size measurements" step, which has no `continue-on-error`, so the entire job was killed — docs were never built, Netlify was never deployed.

**Evidence:** Both `docs-staging` runs on `release/18.0.0` (runs [28004106308](https://github.com/handsontable/handsontable/actions/runs/28004106308) and [27950003387](https://github.com/handsontable/handsontable/actions/runs/27950003387)) failed at this step with `ENOENT: no such file or directory, open '.../src/cellTypes/index.js'`.

**Changes:**

1. `handsontable/scripts/measure-module-sizes.mjs` — fix `.js` → `.ts` for `cellTypes/index` and `plugins/index` barrel references; also refreshes `module-sizes.json` and `modules.md` from 17.0.1 to 17.1.0.
2. `.github/workflows/docs-staging.yml`:
   - Add `continue-on-error: true` + step IDs so docs still deploy even if measurement fails
   - Add "Fail if module size measurements errored" terminal step so the job turns red when measurement fails (error is visible, not silently swallowed)
   - Add Slack failure notification for RC branches only (fires on any step failure, same `SLACK_RELEASE_WEBHOOK_URL` channel as `publish.yml`, names which step failed)

### How has this been tested?

- Ran `node handsontable/scripts/measure-module-sizes.mjs` locally — previously crashed with ENOENT, now completes successfully and updates `module-sizes.json`
- Reviewed the `docs-staging.yml` flow manually for all failure paths (measurement fails, docs build fails, Netlify fails)

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1939

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1939

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/docs workflow and measurement script path fixes plus regenerated docs data; no runtime product code changes.
> 
> **Overview**
> RC docs staging was blocked because **`measure-module-sizes.mjs`** still opened `cellTypes/index.js` and `plugins/index.js` after those barrels moved to **`.ts`**, so the RC workflow died on ENOENT before docs built or Netlify deployed.
> 
> The script now points at **`index.ts`** for cell types and plugins. Regenerated **`module-sizes.json`** and the **Build weight** section in **`modules.md`** for **17.1.0**, including the **`Notification`** plugin row and updated bundle deltas.
> 
> **`docs-staging.yml`** gives the measure step **`continue-on-error`** and step IDs so deploy can continue, adds a **terminal fail** when measurement still errors (stale sizes, visible red job), and **Slack** alerts on RC release-branch failures for measure, docs build, or Netlify publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e188529cad1254b0574f4844eb42bc245b7adf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->