### PR TITLE
DEV-1122: Add flexbox positioning guidance to v16 migration guide

### DIFF
--- a/docs/content/guides/upgrade-and-migration/migrating-from-15.3-to-16.0/migrating-from-15.3-to-16.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-15.3-to-16.0/migrating-from-15.3-to-16.0.md
@@ -79,6 +79,24 @@ Here's a side-by-side comparison of the old and new DOM structures:
 - Portal Element: New div.ht-portal with ht-theme class for absolutely positioned elements
 - Root Element: rootElement is now created internally by Handsontable instead of using the user-provided container directly
 
+### Positioning Handsontable in flex layouts
+
+Handsontable now creates its own root element (`.ht-root-wrapper`) inside your container and styles it with `height: 100%`. For that to work, the container must have a height the browser can resolve. When you place the container in a flex layout without a resolved height, `height: 100%` resolves to `0`, the root element collapses, and the grid is no longer visible.
+
+To position the grid inside a flex layout, give the flex parent a defined height and let the container fill the available space:
+
+```html
+<div style="display: flex; height: 500px">
+  <div id="example" style="flex: 1; min-width: 0">
+    <!-- Handsontable mounts here and fills the flex item -->
+  </div>
+</div>
+```
+
+With the React and Vue wrappers, the mounting element already receives `height: 100%`, so this mainly affects vanilla JavaScript and any container you size yourself.
+
+For more ways to set the grid's height, including fixed and percentage-based containers, see [Grid size](@/guides/getting-started/grid-size/grid-size.md#troubleshooting-with-100-height).
+
 ## 2. Updated the CSS variables
 
 In Handsontable 16.0, Handsontable improves the CSS variables system to adjust theme colors, variable order, and customization options. Here are the key changes:


### PR DESCRIPTION
### Context

The PR adds guidance on positioning Handsontable inside flex layouts to the v15.3 → v16.0 migration guide.

When upgrading from Handsontable 15.3 to 16.x, a client reported that their table disappeared when the container used `display: flex`. This is a consequence of the new v16 DOM structure: Handsontable now creates its own root element (`.ht-root-wrapper`) inside the user's container and styles it with `height: 100%`. When that container sits in a flex layout without a resolved height, `height: 100%` resolves to `0`, the root element collapses, and the grid is no longer visible.

The new subsection sits under "1. Introducing the new DOM structure" (next to its cause), explains the issue, shows a working `display: flex` snippet, notes that the React and Vue wrappers already set `height: 100%` on the mounting element, and cross-links to the Grid size guide rather than duplicating it.

This is a documentation-only change. `[skip changelog]`

### How has this been tested?

The proposed CSS was verified against real published builds in a headless browser, measuring the rendered `.ht-root-wrapper` height across several flex/fixed-height layouts:

- `16.0.1`: nearly every layout collapses `.ht-root-wrapper` to `0px` (a since-fixed 16.0.x core bug, PR #11769).
- `16.2.0` and `17.1.0`: all standard layouts work, including the documented snippet (flex parent with a defined height + container `flex: 1; min-width: 0`).

The documented rule (the container needs a resolvable height; in flex layouts give the flex parent a defined height and let the container fill it) is correct on current and maintained Handsontable, and is consistent with the existing Grid size guide.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1122
2. Migrated from GitHub issue handsontable/dev-handsontable#2887

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation (this PR is the documentation change).

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1122

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API impact.
> 
> **Overview**
> Adds a **“Positioning Handsontable in flex layouts”** subsection under the v16 DOM-structure migration section.
> 
> It documents why grids can disappear after upgrade when the mount node is in `display: flex` without a resolvable height (`.ht-root-wrapper` uses `height: 100%` and can collapse to `0`), includes a working flex-parent + `flex: 1; min-width: 0` HTML example, notes that React/Vue wrappers already apply `height: 100%` on the mount element, and links to the Grid size guide for other height setups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddfe79337d7f5772c02303dbd9753fb1752c3df3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->