### PR TITLE
DEV-933: Document fragmentSelection limit under selectionMode single

### DIFF
--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -2927,6 +2927,11 @@ export default (): Record<string, unknown> => {
      * | `true`            | Enable text selection in multiple cells at a time |
      * | `'cell'`          | Enable text selection in one cell at a time       |
      *
+     * With `fragmentSelection: true`, copying text across multiple cells requires a
+     * [`selectionMode`](@/api/options.md#selectionmode) that allows selecting more than one cell.
+     * When [`selectionMode`](@/api/options.md#selectionmode) is set to `'single'`, copying is
+     * limited to a single cell.
+     *
      * @memberof Options#
      * @type {boolean|string}
      * @default false
@@ -5246,6 +5251,9 @@ export default (): Record<string, unknown> => {
      * | `'single'`   | Allow the user to select only one cell at a time.            |
      * | `'range'`    | Allow the user to select one range of cells at a time.       |
      * | `'multiple'` | Allow the user to select multiple ranges of cells at a time. |
+     *
+     * When `selectionMode` is set to `'single'`, copying with
+     * [`fragmentSelection`](@/api/options.md#fragmentselection) enabled is limited to a single cell.
      *
      * Read more:
      * - [Selection: Selecting ranges](@/guides/cell-features/selection/selection.md#select-ranges)


### PR DESCRIPTION
### Context

The PR documents an interaction reported on the forum: with `fragmentSelection` enabled, users cannot copy text spanning multiple cells when `selectionMode: 'single'` is set.

This is expected behavior, not a bug. Handsontable's copy operates on the selected cell range (`onCopy` -> `setCopyableText()` -> `getSelectedRangeActive()`), and `selectionMode: 'single'` forces that range to a single cell. So even though `fragmentSelection: true` still lets you highlight text across cells natively, Ctrl/Cmd+C captures only the single active cell. The note is framed around copying rather than selecting, because native highlighting still works under single mode.

Both the `fragmentSelection` and `selectionMode` JSDoc blocks in `metaSchema.ts` now describe this limitation and cross-link each other. The generated `docs/content/api/options.md` is rebuilt by CI from `handsontable/tmp` and is not hand-committed.

### How has this been tested?

- JSDoc-only change, no runtime behavior change.
- ESLint passes on the changed file: `cd handsontable && node_modules/.bin/eslint src/dataMap/metaManager/metaSchema.ts`
- Behavior confirmed by source analysis: `selection.ts:454` (single mode forces one-cell range) and `copyPaste.ts:717,444` (copy uses the selected range).

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-933

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog] - JSDoc/docs-only change with no source behavior change.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-933

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> JSDoc-only documentation with no code behavior changes.
> 
> **Overview**
> Adds JSDoc notes in `metaSchema.ts` for **`fragmentSelection`** and **`selectionMode`** so the API docs explain an expected interaction: with **`fragmentSelection: true`**, clipboard copy only spans multiple cells when **`selectionMode`** allows more than one selected cell; with **`selectionMode: 'single'`**, copy is limited to one cell even if native text highlighting can cross cells.
> 
> Each option block now cross-links the other via `@/api/options.md` anchors. Generated `options.md` is rebuilt in CI—no runtime or type changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 383ad0b0904369a98c5ddf9e55896e9f66b02af2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->