### PR TITLE
DEV-948: Document numeric cell type validator and grouping format

### DIFF
--- a/docs/content/guides/cell-types/numeric-cell-type/numeric-cell-type.md
+++ b/docs/content/guides/cell-types/numeric-cell-type/numeric-cell-type.md
@@ -17,7 +17,7 @@ menuTag: updated
 ---
 Display, format, sort, and filter numbers correctly by using the numeric cell type.
 
-The numeric cell type formats numbers using Intl.NumberFormat, right-aligns values, and restricts input to valid numbers.
+The numeric cell type formats numbers using Intl.NumberFormat, right-aligns values, and validates input, marking non-numeric values as invalid.
 
 [[toc]]
 
@@ -315,6 +315,18 @@ settings = {
 - **Percent**: Use `style: 'percent'` for percentage formatting
 - **Unit**: Use `style: 'unit'` with a `unit` property (e.g., `'kilometer'`, `'liter'`)
 
+To add thousands separators and a fixed number of decimal places, use `useGrouping` together with
+`minimumFractionDigits` and `maximumFractionDigits`:
+
+```js
+numericFormat: {
+  style: 'decimal',
+  useGrouping: true, // adds thousands separators, for example 1,000,000
+  minimumFractionDigits: 2, // always shows two decimal places
+  maximumFractionDigits: 2,
+}
+```
+
 **Available options:**
 
 **Style options:**
@@ -387,9 +399,28 @@ you edit a numeric cell:
   automatically after editing, based on your [`numericFormat`](@/api/options.md#numericformat)
   configuration.
 
+## Validate numbers
+
+The numeric cell type includes a built-in validator. When a cell is validated, any value that is not a
+valid number is marked with the `htInvalid` CSS class, which renders as a red cell background in the
+default theme. Themes control the actual color.
+
+Validation runs after you edit a cell. To validate and mark values that are already in the data source
+(for example, after [`loadData()`](@/api/core.md#loaddata)), call
+[`validateCells()`](@/api/core.md#validatecells).
+
+Two options control how the validator treats values:
+
+- [`allowInvalid`](@/api/options.md#allowinvalid) (default `true`): invalid values are kept, saved to
+  the data source, and marked as invalid. Set `allowInvalid` to `false` to reject invalid input and
+  keep the [cell editor](@/guides/cell-functions/cell-editor/cell-editor.md) open until you enter a
+  valid number.
+- [`allowEmpty`](@/api/options.md#allowempty) (default `true`): empty cells pass validation. Set
+  `allowEmpty` to `false` to mark empty cells as invalid.
+
 ## Result
 
-After configuring the numeric cell type, cells right-align their values and display them using the format you defined in `numericFormat`. Invalid (non-numeric) input is rejected. The underlying data source stores the raw number.
+After configuring the numeric cell type, cells right-align their values and display them using the format you defined in `numericFormat`. Invalid (non-numeric) values are marked as invalid -- see [Validate numbers](#validate-numbers). The underlying data source stores the raw number.
 
 ## Related articles
 
@@ -409,6 +440,9 @@ After configuring the numeric cell type, cells right-align their values and disp
 - [locale](@/api/options.md#locale)
 - [type](@/api/options.md#type)
 - [valueFormatter](@/api/options.md#valueformatter)
+- [validator](@/api/options.md#validator)
+- [allowInvalid](@/api/options.md#allowinvalid)
+- [allowEmpty](@/api/options.md#allowempty)
 
 </div>
 
@@ -420,6 +454,7 @@ After configuring the numeric cell type, cells right-align their values and disp
 - [getCellMetaAtRow()](@/api/core.md#getcellmetaatrow)
 - [getCellsMeta()](@/api/core.md#getcellsmeta)
 - [getDataType()](@/api/core.md#getdatatype)
+- [validateCells()](@/api/core.md#validatecells)
 - [setCellMeta()](@/api/core.md#setcellmeta)
 - [setCellMetaObject()](@/api/core.md#setcellmetaobject)
 - [removeCellMeta()](@/api/core.md#removecellmeta)


### PR DESCRIPTION
### Context

The PR updates the [Numeric cell type guide](https://handsontable.com/docs/javascript-data-grid/numeric-cell-type/) to address DEV-948.

The original task requested three changes, two of which are now outdated:

1. **Declare `numbro` before the example** -- skipped. `numbro` was removed in v18.0 and the page already documents the native `Intl.NumberFormat` API (since v17.0), so there is no `numbro` left to declare.
2. **Add examples for value alterations like `thousandSeparated` / `mantissa`** -- these are obsolete `numbro` pattern keys. Their `Intl.NumberFormat` equivalents (`useGrouping`, `minimumFractionDigits`, `maximumFractionDigits`) were already in the option tables, so this PR adds one short worked snippet as their direct successor.
3. **Document the built-in validator that marks incorrect cells** -- the actionable item. The numeric cell type composes a built-in validator that marks non-numeric cells with the `htInvalid` CSS class (red in the default theme), which was undocumented.

The PR also clarifies imprecise wording: with the default `allowInvalid: true`, invalid input is accepted and marked, not rejected.

### How has this been tested?

Docs-only change. The documented behavior was verified empirically by building a numeric-column grid (from the local `dist`) and driving it in a browser:

- With default settings, editing a numeric cell to a non-numeric value keeps the value and adds the `htInvalid` class (not rejected).
- Pre-existing invalid data in the data source is not marked until `validateCells()` is called, after which it gains `htInvalid` and the value is retained.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-948

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog] -- docs-only change.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-948

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API code touched.
> 
> **Overview**
> Updates the **Numeric cell type** guide so behavior matches the product: invalid input is **marked** (not described as rejected), and the built-in validator is documented.
> 
> Adds a **Validate numbers** section covering `htInvalid`, post-edit validation vs calling **`validateCells()`** after **`loadData()`**, and how **`allowInvalid`** / **`allowEmpty`** affect invalid and empty values. The intro and **Result** sections are aligned with that wording.
> 
> Adds a short **`numericFormat`** example for thousands separators plus fixed decimals (`useGrouping`, `minimumFractionDigits`, `maximumFractionDigits`) as the `Intl` successor to old numbro-style options. Related articles now link **`validator`**, **`allowInvalid`**, **`allowEmpty`**, and **`validateCells()`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d22291689e00db241d53ecde853a786843a16b9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->