### PR TITLE
DEV-927: Add recipe for adding a column to an object-based dataset

### DIFF
--- a/docs/content/recipes/context-menu/add-column-object-data/add-column-object-data.md
+++ b/docs/content/recipes/context-menu/add-column-object-data/add-column-object-data.md
@@ -118,7 +118,7 @@ const colHeaders = ['SKU', 'Supplier', 'Stock', 'Category'];
 contextMenu: {
   items: {
     add_column: { /* defined in Step 3 */ },
-    sep1: '-',
+    sep1: '---------',
     row_above: { name: 'Insert row above' },
     row_below: { name: 'Insert row below' },
     remove_row: { name: 'Remove row' },
@@ -130,7 +130,7 @@ contextMenu: {
 
 - Passing an object to `contextMenu.items` lists the exact items that appear. The built-in `col_left` and `col_right` keys are omitted because they throw on object data.
 - `add_column` is a custom key that replaces them with logic that works for object data.
-- `'-'` renders a separator between the custom action and the built-in row operations.
+- `'---------'` is the predefined separator token. It renders a visual divider between the custom action and the built-in row operations.
 
 ## Step 3: Implement "Add column"
 

--- a/docs/content/recipes/context-menu/add-column-object-data/add-column-object-data.md
+++ b/docs/content/recipes/context-menu/add-column-object-data/add-column-object-data.md
@@ -1,0 +1,191 @@
+---
+id: k7m3p9q2
+title: Add a column to an object-based dataset
+metaTitle: Add a column to an object-based dataset - JavaScript Data Grid | Handsontable
+description: Learn how to add a column at runtime through the context menu when your grid uses an object-based dataset, where the built-in column-insert items do not apply.
+permalink: /recipes/context-menu/add-column-object-data
+canonicalUrl: /recipes/context-menu/add-column-object-data
+tags:
+  - recipes
+  - context menu
+  - columns
+  - object data
+react:
+  id: r4n8t1w5
+  metaTitle: Add a column to an object-based dataset - React Data Grid | Handsontable
+angular:
+  id: a6c2v7x3
+  metaTitle: Add a column to an object-based dataset - Angular Data Grid | Handsontable
+vue:
+  id: v9b5d3f8
+  metaTitle: Add a column to an object-based dataset - Vue Data Grid | Handsontable
+searchCategory: Recipes
+category: Context Menu
+type: how-to
+---
+
+In this tutorial, you will add a column to an object-based dataset through a custom context menu item. You will learn why the built-in column-insert items are unavailable for object data and how to extend the `columns` setting at runtime.
+
+::: only-for javascript vue
+
+::: example #example1 :hot-recipe --js 1 --css 2
+
+@[code](@/content/recipes/context-menu/add-column-object-data/javascript/example1.js)
+@[code](@/content/recipes/context-menu/add-column-object-data/javascript/example1.css)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #example1 :react-advanced --css 1 --js 2 --ts 3
+
+@[code](@/content/recipes/context-menu/add-column-object-data/react/example1.css)
+@[code](@/content/recipes/context-menu/add-column-object-data/react/example1.jsx)
+@[code](@/content/recipes/context-menu/add-column-object-data/react/example1.tsx)
+
+:::
+
+:::
+
+::: only-for angular
+
+::: example #example1 :angular --ts 1 --html 2 --css 3
+
+@[code](@/content/recipes/context-menu/add-column-object-data/angular/example1.ts)
+@[code](@/content/recipes/context-menu/add-column-object-data/angular/example1.html)
+@[code](@/content/recipes/context-menu/add-column-object-data/angular/example1.css)
+
+:::
+
+:::
+
+## Overview
+
+**Difficulty:** Intermediate
+**Time:** ~15 minutes
+
+When your data is an array of objects, each column maps to an object property through the `columns` setting. The built-in **Insert column left** and **Insert column right** menu items rely on `alter('insert_col_start')`, which Handsontable rejects for object data:
+
+> Cannot create new column. When data source in an object, you can only have as much columns as defined in first data row, data schema or in the 'columns' setting.
+
+To add a column over object data, you extend the `columns` setting yourself, add the matching property to every row, and re-apply the configuration with `updateSettings`. This recipe wires that into a custom **Add column** menu item.
+
+## Before you begin
+
+You need a working Handsontable instance with an object-based dataset. If you are starting fresh, install it first:
+
+```bash
+npm install handsontable
+```
+
+Then import and register all modules:
+
+```javascript
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+```
+
+## Step 1: Set up the object dataset and column configuration
+
+```javascript
+const data = [
+  { sku: 'SKU-4821', supplier: 'Harbor Goods', stock: 142, category: 'Electronics' },
+  // ...more rows
+];
+
+const columns = [
+  { data: 'sku', width: 120 },
+  { data: 'supplier', width: 170 },
+  { data: 'stock', width: 90 },
+  { data: 'category', width: 130 },
+];
+const colHeaders = ['SKU', 'Supplier', 'Stock', 'Category'];
+```
+
+**What's happening:**
+
+- `data` is an array of row objects. Each object key (`sku`, `supplier`, ...) maps to one column.
+- `columns` binds each column to a property through its `data` key. The column order follows this array, not the order of keys inside the row objects.
+- Keep `columns` and `colHeaders` in variables you can mutate. The custom menu item edits these arrays and feeds them back through `updateSettings`.
+
+## Step 2: Configure the context menu without the built-in column items
+
+```javascript
+contextMenu: {
+  items: {
+    add_column: { /* defined in Step 3 */ },
+    sep1: '-',
+    row_above: { name: 'Insert row above' },
+    row_below: { name: 'Insert row below' },
+    remove_row: { name: 'Remove row' },
+  },
+},
+```
+
+**What's happening:**
+
+- Passing an object to `contextMenu.items` lists the exact items that appear. The built-in `col_left` and `col_right` keys are omitted because they throw on object data.
+- `add_column` is a custom key that replaces them with logic that works for object data.
+- `'-'` renders a separator between the custom action and the built-in row operations.
+
+## Step 3: Implement "Add column"
+
+```javascript
+let newColumnCount = 0;
+
+// inside contextMenu.items
+add_column: {
+  name: 'Add column',
+  callback(key, selection) {
+    const insertAt = selection[0].start.col + 1;
+
+    newColumnCount += 1;
+    const newKey = `custom_${newColumnCount}`;
+
+    // 1. Add the new property to every source row object.
+    hot.getSourceData().forEach((row) => {
+      row[newKey] = '';
+    });
+
+    // 2. Extend the `columns` and `colHeaders` arrays at the clicked position.
+    columns.splice(insertAt, 0, { data: newKey, width: 130, className: 'ht-new-column' });
+    colHeaders.splice(insertAt, 0, `Custom ${newColumnCount}`);
+
+    // 3. Apply the new structure.
+    hot.updateSettings({ columns, colHeaders });
+  },
+},
+```
+
+**What's happening:**
+
+1. `selection[0].start.col` is the visual index of the right-clicked column. Adding `1` inserts the new column directly to its right; use the value as-is to insert to its left.
+2. `newColumnCount` produces a unique property key (`custom_1`, `custom_2`, ...) so each new column binds to a fresh object property. Use a counter rather than a random value to keep keys predictable.
+3. `hot.getSourceData()` returns the array of row objects. Adding `row[newKey] = ''` gives every row an empty value for the new column, so the cells start blank and editable.
+4. `columns.splice(insertAt, 0, ...)` inserts the new column descriptor, and `colHeaders.splice(...)` inserts its header. The `className` marks the new column for styling.
+5. `hot.updateSettings({ columns, colHeaders })` re-applies the configuration. Because each row object now has the new property, the column renders with the data already in place.
+
+## How it works - complete flow
+
+1. The user right-clicks a cell. Handsontable opens the context menu with the custom **Add column** item and the selected built-in row items.
+2. **Add column** computes the insert position from the clicked column, generates a unique property key, and adds that property to every row object.
+3. The `columns` and `colHeaders` arrays gain a matching entry at the same position.
+4. `updateSettings` re-maps the columns. The new column appears with a highlighted header background and accepts edits like any other column.
+
+## What you learned
+
+- Object data cannot use the built-in `col_left` / `col_right` items, because `alter('insert_col_*')` is rejected when the data source is an object.
+- Omit those keys from `contextMenu.items` and add a custom item instead.
+- To add a column over object data: add the property to each row object, extend `columns` and `colHeaders`, then call `updateSettings`.
+- Column order follows the `columns` array, so `splice` controls where the new column appears.
+- `selection[0].start.col` gives you the right-clicked column for positioning.
+
+## Next steps
+
+- Set [`dataSchema`](@/api/options.md#dataschema) so rows added later also include the new property.
+- Add a `disabled()` function to the menu item to limit how many columns users can add.
+- Explore the [Context menu guide](@/guides/accessories-and-menus/context-menu/context-menu.md) for the full list of built-in item keys and advanced configuration.

--- a/docs/content/recipes/context-menu/add-column-object-data/angular/example1.css
+++ b/docs/content/recipes/context-menu/add-column-object-data/angular/example1.css
@@ -1,0 +1,3 @@
+td.ht-new-column {
+  background-color: #e3f2fd;
+}

--- a/docs/content/recipes/context-menu/add-column-object-data/angular/example1.html
+++ b/docs/content/recipes/context-menu/add-column-object-data/angular/example1.html
@@ -1,0 +1,3 @@
+<div>
+  <example1-add-column-object-data></example1-add-column-object-data>
+</div>

--- a/docs/content/recipes/context-menu/add-column-object-data/angular/example1.ts
+++ b/docs/content/recipes/context-menu/add-column-object-data/angular/example1.ts
@@ -1,0 +1,102 @@
+/* file: app.component.ts */
+import { Component, ViewChild } from '@angular/core';
+import { GridSettings, HotTableComponent, HotTableModule } from '@handsontable/angular-wrapper';
+import type Handsontable from 'handsontable/base';
+
+/* start:skip-in-preview */
+const data: Handsontable.RowObject[] = [
+  { sku: 'SKU-4821', supplier: 'Harbor Goods', stock: 142, category: 'Electronics' },
+  { sku: 'SKU-0093', supplier: 'Alpine Supply Co.', stock: 0, category: 'Apparel' },
+  { sku: 'SKU-7311', supplier: 'Meadow Foods', stock: 67, category: 'Grocery' },
+  { sku: 'SKU-2250', supplier: 'Harbor Goods', stock: 318, category: 'Electronics' },
+  { sku: 'SKU-9047', supplier: 'Northwind Traders', stock: 12, category: 'Hardware' },
+  { sku: 'SKU-6638', supplier: 'Alpine Supply Co.', stock: 205, category: 'Apparel' },
+];
+/* end:skip-in-preview */
+
+type ColumnConfig = { data: string; width: number; className?: string };
+
+// `columns` and `colHeaders` are kept in mutable variables so the custom menu
+// item can extend them and push the change back through `updateSettings`.
+const columns: ColumnConfig[] = [
+  { data: 'sku', width: 120 },
+  { data: 'supplier', width: 170 },
+  { data: 'stock', width: 90 },
+  { data: 'category', width: 130 },
+];
+const colHeaders = ['SKU', 'Supplier', 'Stock', 'Category'];
+
+let newColumnCount = 0;
+
+@Component({
+  standalone: true,
+  imports: [HotTableModule],
+  selector: 'example1-add-column-object-data',
+  template: `
+    <div>
+      <hot-table [data]="data" [settings]="gridSettings"></hot-table>
+    </div>
+  `,
+})
+export class AppComponent {
+  @ViewChild(HotTableComponent, { static: false }) readonly hotTable!: HotTableComponent;
+
+  readonly data: Handsontable.RowObject[] = data;
+
+  readonly gridSettings: GridSettings = {
+    rowHeaders: true,
+    colHeaders,
+    columns,
+    height: 'auto',
+    width: '100%',
+    contextMenu: {
+      items: {
+        add_column: {
+          name: 'Add column',
+          callback: (_key: string, selection: Array<{ start: { col: number } }>) => {
+            const hot = this.hotTable?.hotInstance;
+
+            if (!hot) return;
+
+            const insertAt = selection[0].start.col + 1;
+
+            newColumnCount += 1;
+            const newKey = `custom_${newColumnCount}`;
+
+            (hot.getSourceData() as Array<Record<string, unknown>>).forEach((row) => {
+              row[newKey] = '';
+            });
+
+            columns.splice(insertAt, 0, { data: newKey, width: 130, className: 'ht-new-column' });
+            colHeaders.splice(insertAt, 0, `Custom ${newColumnCount}`);
+
+            hot.updateSettings({ columns, colHeaders });
+          },
+        },
+        sep1: { name: '---------' },
+        row_above: { name: 'Insert row above' },
+        row_below: { name: 'Insert row below' },
+        remove_row: { name: 'Remove row' },
+      },
+    },
+  };
+}
+/* end-file */
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+/* end-file */

--- a/docs/content/recipes/context-menu/add-column-object-data/javascript/example1.css
+++ b/docs/content/recipes/context-menu/add-column-object-data/javascript/example1.css
@@ -1,0 +1,3 @@
+td.ht-new-column {
+  background-color: #e3f2fd;
+}

--- a/docs/content/recipes/context-menu/add-column-object-data/javascript/example1.js
+++ b/docs/content/recipes/context-menu/add-column-object-data/javascript/example1.js
@@ -1,0 +1,70 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+/* start:skip-in-preview */
+const data = [
+  { sku: 'SKU-4821', supplier: 'Harbor Goods', stock: 142, category: 'Electronics' },
+  { sku: 'SKU-0093', supplier: 'Alpine Supply Co.', stock: 0, category: 'Apparel' },
+  { sku: 'SKU-7311', supplier: 'Meadow Foods', stock: 67, category: 'Grocery' },
+  { sku: 'SKU-2250', supplier: 'Harbor Goods', stock: 318, category: 'Electronics' },
+  { sku: 'SKU-9047', supplier: 'Northwind Traders', stock: 12, category: 'Hardware' },
+  { sku: 'SKU-6638', supplier: 'Alpine Supply Co.', stock: 205, category: 'Apparel' },
+];
+/* end:skip-in-preview */
+
+// `columns` and `colHeaders` are kept in mutable variables so the custom menu
+// item can extend them and push the change back through `updateSettings`.
+const columns = [
+  { data: 'sku', width: 120 },
+  { data: 'supplier', width: 170 },
+  { data: 'stock', width: 90 },
+  { data: 'category', width: 130 },
+];
+const colHeaders = ['SKU', 'Supplier', 'Stock', 'Category'];
+
+let newColumnCount = 0;
+
+const container = document.querySelector('#example1');
+
+const hot = new Handsontable(container, {
+  data,
+  rowHeaders: true,
+  colHeaders,
+  columns,
+  height: 'auto',
+  width: '100%',
+  contextMenu: {
+    items: {
+      // Object data blocks the built-in `col_left` / `col_right` items, so a
+      // custom action does the work instead.
+      add_column: {
+        name: 'Add column',
+        callback(key, selection) {
+          const insertAt = selection[0].start.col + 1;
+
+          newColumnCount += 1;
+          const newKey = `custom_${newColumnCount}`;
+
+          // 1. Add the new property to every source row object.
+          hot.getSourceData().forEach((row) => {
+            row[newKey] = '';
+          });
+
+          // 2. Extend the `columns` and `colHeaders` arrays at the clicked position.
+          columns.splice(insertAt, 0, { data: newKey, width: 130, className: 'ht-new-column' });
+          colHeaders.splice(insertAt, 0, `Custom ${newColumnCount}`);
+
+          // 3. Apply the new structure.
+          hot.updateSettings({ columns, colHeaders });
+        },
+      },
+      sep1: '-',
+      row_above: { name: 'Insert row above' },
+      row_below: { name: 'Insert row below' },
+      remove_row: { name: 'Remove row' },
+    },
+  },
+  licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/recipes/context-menu/add-column-object-data/javascript/example1.js
+++ b/docs/content/recipes/context-menu/add-column-object-data/javascript/example1.js
@@ -60,7 +60,7 @@ const hot = new Handsontable(container, {
           hot.updateSettings({ columns, colHeaders });
         },
       },
-      sep1: '-',
+      sep1: '---------',
       row_above: { name: 'Insert row above' },
       row_below: { name: 'Insert row below' },
       remove_row: { name: 'Remove row' },

--- a/docs/content/recipes/context-menu/add-column-object-data/react/example1.css
+++ b/docs/content/recipes/context-menu/add-column-object-data/react/example1.css
@@ -1,0 +1,3 @@
+td.ht-new-column {
+  background-color: #e3f2fd;
+}

--- a/docs/content/recipes/context-menu/add-column-object-data/react/example1.jsx
+++ b/docs/content/recipes/context-menu/add-column-object-data/react/example1.jsx
@@ -65,7 +65,7 @@ const ExampleComponent = () => {
               hot.updateSettings({ columns, colHeaders });
             },
           },
-          sep1: '-',
+          sep1: '---------',
           row_above: { name: 'Insert row above' },
           row_below: { name: 'Insert row below' },
           remove_row: { name: 'Remove row' },

--- a/docs/content/recipes/context-menu/add-column-object-data/react/example1.jsx
+++ b/docs/content/recipes/context-menu/add-column-object-data/react/example1.jsx
@@ -1,0 +1,79 @@
+import { useRef } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import './example1.css';
+
+registerAllModules();
+
+/* start:skip-in-preview */
+const data = [
+  { sku: 'SKU-4821', supplier: 'Harbor Goods', stock: 142, category: 'Electronics' },
+  { sku: 'SKU-0093', supplier: 'Alpine Supply Co.', stock: 0, category: 'Apparel' },
+  { sku: 'SKU-7311', supplier: 'Meadow Foods', stock: 67, category: 'Grocery' },
+  { sku: 'SKU-2250', supplier: 'Harbor Goods', stock: 318, category: 'Electronics' },
+  { sku: 'SKU-9047', supplier: 'Northwind Traders', stock: 12, category: 'Hardware' },
+  { sku: 'SKU-6638', supplier: 'Alpine Supply Co.', stock: 205, category: 'Apparel' },
+];
+/* end:skip-in-preview */
+
+// `columns` and `colHeaders` live outside the component so the custom menu item
+// can extend them and push the change back through `updateSettings`.
+const columns = [
+  { data: 'sku', width: 120 },
+  { data: 'supplier', width: 170 },
+  { data: 'stock', width: 90 },
+  { data: 'category', width: 130 },
+];
+const colHeaders = ['SKU', 'Supplier', 'Stock', 'Category'];
+
+let newColumnCount = 0;
+
+const ExampleComponent = () => {
+  const hotRef = useRef(null);
+
+  return (
+    <HotTable
+      ref={hotRef}
+      id="example1"
+      data={data}
+      rowHeaders={true}
+      colHeaders={colHeaders}
+      columns={columns}
+      height="auto"
+      width="100%"
+      contextMenu={{
+        items: {
+          add_column: {
+            name: 'Add column',
+            callback(key, selection) {
+              const hot = hotRef.current?.hotInstance;
+
+              if (!hot) return;
+
+              const insertAt = selection[0].start.col + 1;
+
+              newColumnCount += 1;
+              const newKey = `custom_${newColumnCount}`;
+
+              hot.getSourceData().forEach((row) => {
+                row[newKey] = '';
+              });
+
+              columns.splice(insertAt, 0, { data: newKey, width: 130, className: 'ht-new-column' });
+              colHeaders.splice(insertAt, 0, `Custom ${newColumnCount}`);
+
+              hot.updateSettings({ columns, colHeaders });
+            },
+          },
+          sep1: '-',
+          row_above: { name: 'Insert row above' },
+          row_below: { name: 'Insert row below' },
+          remove_row: { name: 'Remove row' },
+        },
+      }}
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/context-menu/add-column-object-data/react/example1.tsx
+++ b/docs/content/recipes/context-menu/add-column-object-data/react/example1.tsx
@@ -67,7 +67,7 @@ const ExampleComponent = () => {
               hot.updateSettings({ columns, colHeaders });
             },
           },
-          sep1: '-',
+          sep1: '---------',
           row_above: { name: 'Insert row above' },
           row_below: { name: 'Insert row below' },
           remove_row: { name: 'Remove row' },

--- a/docs/content/recipes/context-menu/add-column-object-data/react/example1.tsx
+++ b/docs/content/recipes/context-menu/add-column-object-data/react/example1.tsx
@@ -1,0 +1,81 @@
+import { useRef } from 'react';
+import { HotTable, HotTableRef } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import './example1.css';
+
+registerAllModules();
+
+/* start:skip-in-preview */
+const data = [
+  { sku: 'SKU-4821', supplier: 'Harbor Goods', stock: 142, category: 'Electronics' },
+  { sku: 'SKU-0093', supplier: 'Alpine Supply Co.', stock: 0, category: 'Apparel' },
+  { sku: 'SKU-7311', supplier: 'Meadow Foods', stock: 67, category: 'Grocery' },
+  { sku: 'SKU-2250', supplier: 'Harbor Goods', stock: 318, category: 'Electronics' },
+  { sku: 'SKU-9047', supplier: 'Northwind Traders', stock: 12, category: 'Hardware' },
+  { sku: 'SKU-6638', supplier: 'Alpine Supply Co.', stock: 205, category: 'Apparel' },
+];
+/* end:skip-in-preview */
+
+type ColumnConfig = { data: string; width: number; className?: string };
+
+// `columns` and `colHeaders` live outside the component so the custom menu item
+// can extend them and push the change back through `updateSettings`.
+const columns: ColumnConfig[] = [
+  { data: 'sku', width: 120 },
+  { data: 'supplier', width: 170 },
+  { data: 'stock', width: 90 },
+  { data: 'category', width: 130 },
+];
+const colHeaders = ['SKU', 'Supplier', 'Stock', 'Category'];
+
+let newColumnCount = 0;
+
+const ExampleComponent = () => {
+  const hotRef = useRef<HotTableRef>(null);
+
+  return (
+    <HotTable
+      ref={hotRef}
+      id="example1"
+      data={data}
+      rowHeaders={true}
+      colHeaders={colHeaders}
+      columns={columns}
+      height="auto"
+      width="100%"
+      contextMenu={{
+        items: {
+          add_column: {
+            name: 'Add column',
+            callback(_key: string, selection: Array<{ start: { col: number } }>) {
+              const hot = hotRef.current?.hotInstance;
+
+              if (!hot) return;
+
+              const insertAt = selection[0].start.col + 1;
+
+              newColumnCount += 1;
+              const newKey = `custom_${newColumnCount}`;
+
+              (hot.getSourceData() as Array<Record<string, unknown>>).forEach((row) => {
+                row[newKey] = '';
+              });
+
+              columns.splice(insertAt, 0, { data: newKey, width: 130, className: 'ht-new-column' });
+              colHeaders.splice(insertAt, 0, `Custom ${newColumnCount}`);
+
+              hot.updateSettings({ columns, colHeaders });
+            },
+          },
+          sep1: '-',
+          row_above: { name: 'Insert row above' },
+          row_below: { name: 'Insert row below' },
+          remove_row: { name: 'Remove row' },
+        },
+      }}
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/context-menu/context-menu.md
+++ b/docs/content/recipes/context-menu/context-menu.md
@@ -32,6 +32,7 @@ Current recipes:
 <div class="boxes-list">
 
 - [Custom context menu actions](@/recipes/context-menu/custom-context-menu/custom-context-menu.md)
+- [Add a column to an object-based dataset](@/recipes/context-menu/add-column-object-data/add-column-object-data.md)
 - [Programmatic row operations](@/recipes/context-menu/row-operations/row-operations.md)
 
 </div>

--- a/docs/content/recipes/sidebar.js
+++ b/docs/content/recipes/sidebar.js
@@ -10,6 +10,7 @@ const columnManagementItems = [
 
 const contextMenuItems = [
   { path: 'context-menu/custom-context-menu/custom-context-menu', title: 'Custom context menu actions', onlyFor: ['javascript', 'react', 'angular', 'vue'] },
+  { path: 'context-menu/add-column-object-data/add-column-object-data', title: 'Add a column to an object-based dataset', onlyFor: ['javascript', 'react', 'angular', 'vue'] },
   { path: 'context-menu/row-operations/row-operations', title: 'Programmatic row operations', onlyFor: ['javascript', 'react', 'angular', 'vue'] },
 ];
 


### PR DESCRIPTION
### Context

The PR adds a new documentation recipe showing how to add a column at runtime through the context menu when the grid uses an object-based dataset.

When data is an array of objects (or `columns` is configured), Handsontable's core rejects `alter('insert_col_start' / 'insert_col_end')` -- `isColumnModificationAllowed()` returns `false` -- so the built-in "Insert column" context-menu items cannot work. Developers who want users to add columns over object data must hand-roll a custom action, which was previously undocumented (reported in DEV-927 / dev-handsontable#2009).

The recipe documents the supported workaround: omit the built-in column items, add a custom **Add column** item that adds the new property to every row object, extends the `columns` and `colHeaders` arrays at the clicked position, and re-applies them with `updateSettings`.

Placement follows the current Diátaxis docs structure: this is a how-to recipe under `recipes/context-menu/`, alongside the existing `custom-context-menu` recipe. The reference context-menu guide is unchanged and is linked from the recipe's "Next steps".

`[skip changelog]` -- docs-only change.

### How has this been tested?

Verified locally with `npm run dev` (docs site) and a browser, on all three framework variants:

- JavaScript, React, and Angular: the page renders, the live example mounts, right-clicking a cell shows the custom **Add column** item (and no built-in `col_left` / `col_right` items), and clicking it inserts a working, editable, highlighted column at the clicked position over the object dataset.
- No example-related console errors on any variant.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-927

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

(Documentation only -- no source package affected.)

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation. (This PR is the documentation change.)

ClickUp task: https://app.clickup.com/t/9015210959/DEV-927

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example assets only; no changes to Handsontable packages or runtime behavior.
> 
> **Overview**
> Adds a **Context Menu** how-to that documents the supported workaround when built-in **Insert column** items fail on object-based grids: a custom **Add column** action that mutates row objects, `columns`, and `colHeaders`, then calls `updateSettings`.
> 
> The new page includes live examples for JavaScript, React (JSX/TSX), and Angular, plus minimal CSS for newly added columns. The recipe is linked from the context-menu recipes index and `docs/content/recipes/sidebar.js`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e448e100bb98f386d5f9d136a6f35c65286ee343. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->