### PR TITLE
DEV-1941: Fix hooks API page rendering as code on non-JS variants

### DIFF
--- a/handsontable/src/core/hooks/constants.ts
+++ b/handsontable/src/core/hooks/constants.ts
@@ -909,8 +909,8 @@ export const REGISTERED_HOOKS = [
    *                                  Handsontable uses to control scroll behavior after selection.
    * @param {number} selectionLayerLevel The number which indicates what selection layer is currently modified.
    * @example
-   * ```js
    * ::: only-for javascript
+   * ```js
    * new Handsontable(element, {
    *   afterSelectionByProp: (row, column, row2, column2, preventScrolling, selectionLayerLevel) => {
    *     // setting if prevent scrolling after selection
@@ -992,8 +992,8 @@ export const REGISTERED_HOOKS = [
    *                                  Property `preventScrolling.value` expects a boolean value that
    *                                  Handsontable uses to control scroll behavior after selection.
    * @example
-   * ```js
    * ::: only-for javascript
+   * ```js
    * new Handsontable(element, {
    *   afterSelectionFocusSet: (row, column, preventScrolling) => {
    *     // If set to `false` (default): when focused cell selection is outside the viewport,
@@ -2325,8 +2325,8 @@ export const REGISTERED_HOOKS = [
    *                       that correspond to the previously selected area.
    * @returns {*} If returns `false` then pasting is canceled.
    * @example
-   * ```js
    * ::: only-for javascript
+   * ```js
    * // To disregard a single row, remove it from array using data.splice(i, 1).
    * new Handsontable(example, {
    *   beforePaste: (data, coords) => {


### PR DESCRIPTION
### Context

The PR fixes the API hooks documentation rendering broken on the non-JavaScript variants (Vue, React, Angular). On those pages the content after `#afterselectionbyprop` (and again near `#beforepaste`) rendered as plain text inside a code block instead of compiled markdown.

The cause is in three hook JSDoc examples in `handsontable/src/core/hooks/constants.ts` (`afterSelectionByProp`, `afterSelectionFocusSet`, `beforePaste`). Their JavaScript example put the opening code fence **before** the `::: only-for javascript` marker:

```
@example
```js                      <- outside the only-for block
::: only-for javascript
new Handsontable(...)
```                        <- closing fence inside the block
:::
```

The docs build's `filterOnlyFor()` (`docs/src/plugins/framework-loader.mjs`) strips the entire `only-for javascript` block on non-JS pages. That removed the closing fence but left the opening ` ```js ` orphaned, producing an unclosed code fence that swallowed the rest of the page.

The fix swaps the two lines so the `::: only-for javascript` marker comes first and the fence sits inside the block - matching the `only-for react` / `only-for angular` blocks in the same comments and every other example in the file. Both fences are now stripped together on non-JS pages and kept together on the JS page.

This is a JSDoc-comment-only change - no runtime behavior changes.

### How has this been tested?

- `npm run eslint --prefix handsontable` on the changed file - passes.
- `npm run build --prefix handsontable` - rebuilt core so the JSDoc propagates to `tmp/`.
- `npm run docs:api` (in `docs/`) - regenerated `content/api/hooks.md`; confirmed the three hooks now emit `::: only-for javascript` before ` ```js `.
- Ran the docs `filterOnlyFor()` logic against the regenerated `hooks.md` for all four frameworks - code fences are balanced in every variant (javascript 36, react 36, angular 58, vue 12). Before the fix the non-JS variants were unbalanced.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1941

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog] - JSDoc/documentation-content-only change, no runtime behavior change.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1941

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> JSDoc-only reordering in hook constants; no runtime or API behavior changes.
> 
> **Overview**
> Fixes broken **hooks API** pages on Vue, React, and Angular where content after certain anchors rendered as one giant code block.
> 
> In `constants.ts`, the `@example` blocks for **`afterSelectionByProp`**, **`afterSelectionFocusSet`**, and **`beforePaste`** had the opening ` ```js ` fence *before* `::: only-for javascript`. The docs **`filterOnlyFor`** step drops the whole JavaScript-only block on non-JS variants but left that opening fence behind, so markdown stayed unclosed and swallowed the rest of the page.
> 
> The change puts **`::: only-for javascript` first** and nests the fence inside the block, matching the other hook examples—so both fences are stripped together on framework-specific pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 048d50a0ed256932a6a1f2ed3b2ff6b371cc67dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->