### PR TITLE
DEV-892: Document max row/column rendering limit in grid-size guide

### DIFF
--- a/docs/content/guides/getting-started/grid-size/grid-size.md
+++ b/docs/content/guides/getting-started/grid-size/grid-size.md
@@ -475,6 +475,26 @@ You can listen for two hooks, [`beforeRefreshDimensions`](@/api/hooks.md#beforer
 
 :::
 
+## Known limitations
+
+Handsontable relies on the browser's native scrollbars. Browsers cap how tall (or wide) a scrollable area can be, measured in CSS pixels. The taller the scroll area grows past that cap, the more rendering glitches appear - rows become misaligned, the autofill handle turns blurry, and eventually cell borders disappear.
+
+The point where these glitches start depends on the browser, the operating system, and the device. The following approximate values were measured on macOS, and mark where problems begin rather than a hard cutoff:
+
+| Browser | Glitches start around |
+| ------- | --------------------- |
+| Chrome  | ~8,000,000 px         |
+| Firefox | ~3,500,000 px         |
+| Safari  | ~16,000,000 px        |
+
+These values are approximate, were measured on specific browser versions, and can change as browsers update.
+
+To estimate the maximum number of rows, divide the browser's pixel limit by your row height. With the default row height of 23 px, Chrome stays reliable up to about 350,000 rows (8,000,000 / 23). To estimate the maximum number of columns, divide the pixel limit by your column width. With a column width of 50 px, that's about 160,000 columns (8,000,000 / 50).
+
+Taller rows or wider columns lower these limits proportionally. For example, with a row height of 100 px, Chrome's limit drops to about 80,000 rows (8,000,000 / 100).
+
+If your dataset can grow past these limits, load it in smaller chunks, for example with server-side or lazy data loading.
+
 ## Related articles
 
 **Related guides**


### PR DESCRIPTION
### Context

The PR adds a "Known limitations" section to the **Grid size** guide documenting the maximum number of rows and columns Handsontable can render correctly.

Handsontable relies on the browser's native scrollbars. Browsers cap how tall (or wide) a scrollable area can be, measured in CSS pixels. For very large datasets the scroll track grows past that cap, and the grid starts to render incorrectly - rows misalign, the autofill handle blurs, and cell borders disappear. This limit is browser-, OS-, and device-dependent and was previously undocumented, so users hitting it (for example, ~500k rows in Chrome) had no explanation.

The new section explains the cause, lists approximate per-browser pixel thresholds (Chrome ~8M, Firefox ~3.5M, Safari ~16M px) with an explicit caveat that the values are approximate and version-dependent, and shows how to convert a pixel budget into a safe row/column count.

### How has this been tested?

- Docs-only change (prose and a table) added to an existing, registered page. No code examples, frontmatter, or sidebar changes.
- Verified the section renders before "Related articles" and appears in the page table of contents.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-892

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-892

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only prose and a table; no runtime, API, or configuration changes.
> 
> **Overview**
> Adds a **Known limitations** section to the **Grid size** guide (before **Related articles**) so users understand why very large row/column counts break rendering.
> 
> The section explains that native scrollbar scroll areas hit browser-specific CSS pixel caps, lists approximate glitch thresholds for Chrome, Firefox, and Safari on macOS, and notes the numbers are approximate and version-dependent. It also shows how to translate those pixel budgets into safe row/column counts using row height and column width, and points to chunked, server-side, or lazy loading when datasets may exceed those bounds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1387f8317d4f15f99a5de6e7ff8503865786b685. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->