### PR TITLE
DEV-932: Document mergeCells effect on viewport getter methods

### DIFF
--- a/docs/content/guides/cell-features/merge-cells/merge-cells.md
+++ b/docs/content/guides/cell-features/merge-cells/merge-cells.md
@@ -200,6 +200,23 @@ The example below uses virtualized merged cells. It's also recommended to increa
 
 :::
 
+## Effect on viewport getter methods
+
+With merged cells, the rendered range extends to fit any merged cell that crosses the viewport edge. This is the same expansion that the `virtualized` option turns off. As a result, the rendered-range getters can return indexes beyond what you see on the screen:
+
+- [`getFirstRenderedVisibleRow()`](@/api/core.md#getfirstrenderedvisiblerow), [`getLastRenderedVisibleRow()`](@/api/core.md#getlastrenderedvisiblerow), [`getFirstRenderedVisibleColumn()`](@/api/core.md#getfirstrenderedvisiblecolumn), and [`getLastRenderedVisibleColumn()`](@/api/core.md#getlastrenderedvisiblecolumn).
+- [`AutoRowSize.getFirstVisibleRow()`](@/api/autoRowSize.md#getfirstvisiblerow) and [`AutoRowSize.getLastVisibleRow()`](@/api/autoRowSize.md#getlastvisiblerow), which delegate to the rendered-row getters.
+- [`AutoColumnSize.getFirstVisibleColumn()`](@/api/autoColumnSize.md#getfirstvisiblecolumn) and [`AutoColumnSize.getLastVisibleColumn()`](@/api/autoColumnSize.md#getlastvisiblecolumn), which delegate to the rendered-column getters.
+
+For example, a merged cell that spans columns 0 to 100 makes `getLastVisibleColumn()` return an index near 100, even when the viewport shows far fewer columns.
+
+To read the actual visible viewport, use the fully-visible or partially-visible getters, which ignore the merge-cell expansion:
+
+- [`getFirstFullyVisibleRow()`](@/api/core.md#getfirstfullyvisiblerow), [`getLastFullyVisibleRow()`](@/api/core.md#getlastfullyvisiblerow), [`getFirstFullyVisibleColumn()`](@/api/core.md#getfirstfullyvisiblecolumn), and [`getLastFullyVisibleColumn()`](@/api/core.md#getlastfullyvisiblecolumn).
+- [`getFirstPartiallyVisibleRow()`](@/api/core.md#getfirstpartiallyvisiblerow), [`getLastPartiallyVisibleRow()`](@/api/core.md#getlastpartiallyvisiblerow), [`getFirstPartiallyVisibleColumn()`](@/api/core.md#getfirstpartiallyvisiblecolumn), and [`getLastPartiallyVisibleColumn()`](@/api/core.md#getlastpartiallyvisiblecolumn).
+
+Setting `virtualized` to `true` also removes the range expansion, but it is a performance option -- the rendered-range getters still include buffered rows and columns outside the viewport.
+
 ## Behavior during row/column reorder and column freeze
 
 When a merged cell's underlying rows or columns are reordered (through [`manualColumnMove`](@/api/options.md#manualcolumnmove), [`manualRowMove`](@/api/options.md#manualrowmove), or [`manualColumnFreeze`](@/api/options.md#manualcolumnfreeze)), Handsontable follows the merge to the new visual position. Two side effects can occur:

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -5667,6 +5667,11 @@ export default function Core(
   /**
    * Returns the first rendered row in the DOM (usually, it is not visible in the table's viewport).
    *
+   * When the {@link MergeCells} plugin is enabled with its default `virtualized: false` setting, a merged
+   * cell that crosses the viewport edge extends the rendered row range, so this method can return a row
+   * index further from the viewport than usual. For the actual visible viewport, use
+   * {@link Core#getFirstFullyVisibleRow} or {@link Core#getFirstPartiallyVisibleRow}.
+   *
    * @since 14.6.0
    * @memberof Core#
    * @function getFirstRenderedVisibleRow
@@ -5678,6 +5683,11 @@ export default function Core(
 
   /**
    * Returns the last rendered row in the DOM (usually, it is not visible in the table's viewport).
+   *
+   * When the {@link MergeCells} plugin is enabled with its default `virtualized: false` setting, a merged
+   * cell that crosses the viewport edge extends the rendered row range, so this method can return a row
+   * index further from the viewport than usual. For the actual visible viewport, use
+   * {@link Core#getLastFullyVisibleRow} or {@link Core#getLastPartiallyVisibleRow}.
    *
    * @since 14.6.0
    * @memberof Core#
@@ -5691,6 +5701,11 @@ export default function Core(
   /**
    * Returns the first rendered column in the DOM (usually, it is not visible in the table's viewport).
    *
+   * When the {@link MergeCells} plugin is enabled with its default `virtualized: false` setting, a merged
+   * cell that crosses the viewport edge extends the rendered column range, so this method can return a
+   * column index further from the viewport than usual. For the actual visible viewport, use
+   * {@link Core#getFirstFullyVisibleColumn} or {@link Core#getFirstPartiallyVisibleColumn}.
+   *
    * @since 14.6.0
    * @memberof Core#
    * @function getFirstRenderedVisibleColumn
@@ -5702,6 +5717,11 @@ export default function Core(
 
   /**
    * Returns the last rendered column in the DOM (usually, it is not visible in the table's viewport).
+   *
+   * When the {@link MergeCells} plugin is enabled with its default `virtualized: false` setting, a merged
+   * cell that crosses the viewport edge extends the rendered column range, so this method can return a
+   * column index further from the viewport than usual. For the actual visible viewport, use
+   * {@link Core#getLastFullyVisibleColumn} or {@link Core#getLastPartiallyVisibleColumn}.
    *
    * @since 14.6.0
    * @memberof Core#

--- a/handsontable/src/plugins/autoColumnSize/autoColumnSize.ts
+++ b/handsontable/src/plugins/autoColumnSize/autoColumnSize.ts
@@ -617,6 +617,11 @@ export class AutoColumnSize extends BasePlugin {
   /**
    * Gets the first visible column.
    *
+   * When the {@link MergeCells} plugin is enabled with its default `virtualized: false` setting, a merged
+   * cell that crosses the viewport edge extends the rendered column range. In that case this method can
+   * return a column index outside the strictly visible viewport. To read the actual visible viewport, use
+   * {@link Core#getFirstFullyVisibleColumn} or {@link Core#getFirstPartiallyVisibleColumn}.
+   *
    * @returns {number} Returns visual column index, -1 if table is not rendered or if there are no columns to base the the calculations on.
    */
   getFirstVisibleColumn(): number {
@@ -625,6 +630,11 @@ export class AutoColumnSize extends BasePlugin {
 
   /**
    * Gets the last visible column.
+   *
+   * When the {@link MergeCells} plugin is enabled with its default `virtualized: false` setting, a merged
+   * cell that crosses the viewport edge extends the rendered column range. In that case this method can
+   * return a column index outside the strictly visible viewport. To read the actual visible viewport, use
+   * {@link Core#getLastFullyVisibleColumn} or {@link Core#getLastPartiallyVisibleColumn}.
    *
    * @returns {number} Returns visual column index or -1 if table is not rendered.
    */

--- a/handsontable/src/plugins/autoRowSize/autoRowSize.ts
+++ b/handsontable/src/plugins/autoRowSize/autoRowSize.ts
@@ -626,6 +626,11 @@ export class AutoRowSize extends BasePlugin {
   /**
    * Get the first visible row.
    *
+   * When the {@link MergeCells} plugin is enabled with its default `virtualized: false` setting, a merged
+   * cell that crosses the viewport edge extends the rendered row range. In that case this method can
+   * return a row index outside the strictly visible viewport. To read the actual visible viewport, use
+   * {@link Core#getFirstFullyVisibleRow} or {@link Core#getFirstPartiallyVisibleRow}.
+   *
    * @returns {number} Returns row index, -1 if table is not rendered or if there are no rows to base the the calculations on.
    */
   getFirstVisibleRow(): number {
@@ -634,6 +639,11 @@ export class AutoRowSize extends BasePlugin {
 
   /**
    * Gets the last visible row.
+   *
+   * When the {@link MergeCells} plugin is enabled with its default `virtualized: false` setting, a merged
+   * cell that crosses the viewport edge extends the rendered row range. In that case this method can
+   * return a row index outside the strictly visible viewport. To read the actual visible viewport, use
+   * {@link Core#getLastFullyVisibleRow} or {@link Core#getLastPartiallyVisibleRow}.
    *
    * @returns {number} Returns row index or -1 if table is not rendered.
    */


### PR DESCRIPTION
### Context

The PR documents that the `MergeCells` plugin extends row/column virtualization, which alters the output of the viewport getter methods. When `mergeCells` is enabled with its default `virtualized: false` setting, a merged cell that crosses the viewport edge expands the *rendered* range, so `getFirstVisibleRow`/`getLastVisibleColumn` (on `AutoRowSize`/`AutoColumnSize`) and the underlying core `getFirst/LastRenderedVisible*` methods can return indexes outside the strictly visible viewport — for example, a merge spanning columns 0–100 makes `getLastVisibleColumn()` return an index near 100.

This was reported in [#11153](https://github.com/handsontable/handsontable/issues/11153) and confirmed as intended behavior, with a request to document it. Since then, public alternatives have been added (the `getFirst/LastFullyVisible*` and `getFirst/LastPartiallyVisible*` methods, since 14.6.0) that report the actual visible viewport, plus the `mergeCells.virtualized` performance option. The docs now point users to these instead of the original private-API workaround.

Changes (documentation only, no behavior change):

- JSDoc caveat on `AutoColumnSize#getFirstVisibleColumn` / `getLastVisibleColumn` and `AutoRowSize#getFirstVisibleRow` / `getLastVisibleRow`.
- JSDoc caveat on the core `getFirst/LastRenderedVisible{Row,Column}` methods.
- New "Effect on viewport getter methods" section in the Merge cells guide.

[skip changelog]

### How has this been tested?

- Verified the behavior empirically in a browser (built `dist`, `mergeCells` with `virtualized: false`, a merge straddling the viewport edge): the rendered/plugin getters reported merge-expanded indexes, while `getFirst/LastFullyVisible*` and `getFirst/LastPartiallyVisible*` reported the on-screen viewport.
- `npm run eslint --prefix handsontable` — clean.
- `npm --prefix handsontable run build` then `npm run docs:api` (from `docs/`) — the generated API pages render the new caveats with correct `@/api/...` links.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-932
2. #11153

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-932

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and JSDoc only; no runtime or API behavior changes.
> 
> **Overview**
> Documents **intended** behavior where `mergeCells` with default `virtualized: false` expands the rendered row/column range when a merge crosses the viewport edge, so rendered-range and plugin “visible” getters can return indexes beyond what is on screen.
> 
> Adds a **“Effect on viewport getter methods”** section to the Merge cells guide listing affected APIs (`getFirst/LastRenderedVisible*`, `AutoRowSize` / `AutoColumnSize` visible getters) and pointing integrators to **`getFirst/LastFullyVisible*`** and **`getFirst/LastPartiallyVisible*`** for the true viewport. Notes that `mergeCells.virtualized: true` disables merge expansion but rendered getters still reflect virtualization buffers.
> 
> Matching **JSDoc caveats** are added on those Core and plugin methods so generated API docs carry the same guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84d0dabebd291ca94e6af023ed9f5228cb1a4890. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->