### PR TITLE
DEV-247: Document noValue class on empty checkbox cells

### DIFF
--- a/docs/content/guides/cell-types/checkbox-cell-type/checkbox-cell-type.md
+++ b/docs/content/guides/cell-types/checkbox-cell-type/checkbox-cell-type.md
@@ -124,6 +124,20 @@ If you want to use values other than `true` and `false`, you have to provide thi
 
 :::
 
+## Cells with no value
+
+When a checkbox cell's value is empty (`null`, `undefined`, or an empty string) and matches neither [`checkedTemplate`](@/api/options.md#checkedtemplate) nor [`uncheckedTemplate`](@/api/options.md#uncheckedtemplate), Handsontable renders an unchecked checkbox and adds a `noValue` CSS class to it.
+
+By default, the `noValue` class reduces the checkbox's opacity, so cells with no value look faded and stay visually distinct from cells set to the unchecked value.
+
+To change how these cells look, target the `noValue` class in your CSS:
+
+```css
+.handsontable .htCheckboxRendererInput.noValue {
+  opacity: 1;
+}
+```
+
 ## Checkbox labels
 
 To add a label to the checkbox, use the [`label`](@/api/options.md#label) option. You can declare where the label will be injected with this option - either before or after the checkbox element. You can also declare from which data source the label text will be updated.


### PR DESCRIPTION
### Context

The PR documents an existing, undocumented behavior of the checkbox cell type. When a checkbox cell's value is empty (`null`, `undefined`, or an empty string) and matches neither `checkedTemplate` nor `uncheckedTemplate`, the renderer leaves the checkbox unchecked and adds a `noValue` CSS class to it (see `handsontable/src/renderers/checkboxRenderer/checkboxRenderer.ts`). The stylesheet renders `.htCheckboxRendererInput.noValue` at reduced opacity, so these cells look faded and are visually distinct from `false` cells. The checkbox cell type guide never explained this, leaving users without a documented way to understand or restyle these cells.

This is a documentation-only change. The behavior was verified on the latest version and is correct as-is, so no library change is needed.

### How has this been tested?

- Manually previewed the checkbox cell type guide page and confirmed the new "Cells with no value" section renders between "Checkbox template" and "Checkbox labels", appears in the table of contents, and the `checkedTemplate` / `uncheckedTemplate` links resolve.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-247

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-247

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API impact.
> 
> **Overview**
> Adds a **Cells with no value** section to the checkbox cell type guide, placed after **Checkbox template** and before **Checkbox labels**.
> 
> It documents that when a cell value is empty (`null`, `undefined`, or `""`) and does not match `checkedTemplate` or `uncheckedTemplate`, the grid shows an unchecked checkbox with the `noValue` CSS class on `.htCheckboxRendererInput`, which defaults to reduced opacity so empty cells look different from explicit unchecked values. A short CSS example shows how to override that styling (e.g. `opacity: 1`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bfcd763acf15382998153dca101dda42bf66cbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->