### PR TITLE
DEV-260: Document row headers as an array and as a function

### DIFF
--- a/docs/content/guides/rows/row-header/angular/example2.html
+++ b/docs/content/guides/rows/row-header/angular/example2.html
@@ -1,0 +1,3 @@
+<div>
+    <app-example2></app-example2>
+</div>

--- a/docs/content/guides/rows/row-header/angular/example2.ts
+++ b/docs/content/guides/rows/row-header/angular/example2.ts
@@ -1,0 +1,56 @@
+/* file: app.component.ts */
+import { Component } from '@angular/core';
+import { GridSettings, HotTableModule} from '@handsontable/angular-wrapper';
+
+@Component({
+  selector: 'app-example2',
+  template: `
+    <hot-table
+      [settings]="hotSettings!" [data]="hotData">
+    </hot-table>
+  `,
+  standalone: true,
+  imports: [HotTableModule],
+})
+export class AppComponent {
+
+  readonly hotData = [
+    [42000, 31000, 11000],
+    [45500, 33200, 12300],
+    [48700, 35100, 13600],
+    [51200, 36800, 14400],
+    [54800, 38900, 15900],
+    [57300, 40100, 17200],
+  ];
+
+  readonly hotSettings: GridSettings = {
+    colHeaders: ['Revenue', 'Expenses', 'Profit'],
+    rowHeaders: ['January', 'February', 'March', 'April', 'May', 'June'],
+    rowHeaderWidth: 80,
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true,
+  };
+}
+/* end-file */
+
+
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+/* end-file */

--- a/docs/content/guides/rows/row-header/angular/example3.html
+++ b/docs/content/guides/rows/row-header/angular/example3.html
@@ -1,0 +1,3 @@
+<div>
+    <app-example3></app-example3>
+</div>

--- a/docs/content/guides/rows/row-header/angular/example3.ts
+++ b/docs/content/guides/rows/row-header/angular/example3.ts
@@ -1,0 +1,57 @@
+/* file: app.component.ts */
+import { Component } from '@angular/core';
+import { GridSettings, HotTableModule} from '@handsontable/angular-wrapper';
+
+@Component({
+  selector: 'app-example3',
+  template: `
+    <hot-table
+      [settings]="hotSettings!" [data]="hotData">
+    </hot-table>
+  `,
+  standalone: true,
+  imports: [HotTableModule],
+})
+export class AppComponent {
+
+  readonly hotData = [
+    [42000, 31000, 11000],
+    [45500, 33200, 12300],
+    [48700, 35100, 13600],
+    [51200, 36800, 14400],
+    [54800, 38900, 15900],
+    [57300, 40100, 17200],
+  ];
+
+  readonly hotSettings: GridSettings = {
+    colHeaders: ['Revenue', 'Expenses', 'Profit'],
+    rowHeaders(index: number) {
+      return `Row ${index + 1}`;
+    },
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true,
+  };
+}
+/* end-file */
+
+
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+/* end-file */

--- a/docs/content/guides/rows/row-header/javascript/example2.js
+++ b/docs/content/guides/rows/row-header/javascript/example2.js
@@ -1,0 +1,22 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+// Register all Handsontable's modules.
+registerAllModules();
+const container = document.querySelector('#example2');
+new Handsontable(container, {
+    data: [
+        [42000, 31000, 11000],
+        [45500, 33200, 12300],
+        [48700, 35100, 13600],
+        [51200, 36800, 14400],
+        [54800, 38900, 15900],
+        [57300, 40100, 17200],
+    ],
+    colHeaders: ['Revenue', 'Expenses', 'Profit'],
+    rowHeaders: ['January', 'February', 'March', 'April', 'May', 'June'],
+    rowHeaderWidth: 80,
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true,
+    licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/rows/row-header/javascript/example2.ts
+++ b/docs/content/guides/rows/row-header/javascript/example2.ts
@@ -1,0 +1,25 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+// Register all Handsontable's modules.
+registerAllModules();
+
+const container = document.querySelector('#example2')!;
+
+new Handsontable(container, {
+  data: [
+    [42000, 31000, 11000],
+    [45500, 33200, 12300],
+    [48700, 35100, 13600],
+    [51200, 36800, 14400],
+    [54800, 38900, 15900],
+    [57300, 40100, 17200],
+  ],
+  colHeaders: ['Revenue', 'Expenses', 'Profit'],
+  rowHeaders: ['January', 'February', 'March', 'April', 'May', 'June'],
+  rowHeaderWidth: 80,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/rows/row-header/javascript/example3.js
+++ b/docs/content/guides/rows/row-header/javascript/example3.js
@@ -1,0 +1,23 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+// Register all Handsontable's modules.
+registerAllModules();
+const container = document.querySelector('#example3');
+new Handsontable(container, {
+    data: [
+        [42000, 31000, 11000],
+        [45500, 33200, 12300],
+        [48700, 35100, 13600],
+        [51200, 36800, 14400],
+        [54800, 38900, 15900],
+        [57300, 40100, 17200],
+    ],
+    colHeaders: ['Revenue', 'Expenses', 'Profit'],
+    rowHeaders(index) {
+        return `Row ${index + 1}`;
+    },
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true,
+    licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/rows/row-header/javascript/example3.ts
+++ b/docs/content/guides/rows/row-header/javascript/example3.ts
@@ -1,0 +1,26 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+// Register all Handsontable's modules.
+registerAllModules();
+
+const container = document.querySelector('#example3')!;
+
+new Handsontable(container, {
+  data: [
+    [42000, 31000, 11000],
+    [45500, 33200, 12300],
+    [48700, 35100, 13600],
+    [51200, 36800, 14400],
+    [54800, 38900, 15900],
+    [57300, 40100, 17200],
+  ],
+  colHeaders: ['Revenue', 'Expenses', 'Profit'],
+  rowHeaders(index) {
+    return `Row ${index + 1}`;
+  },
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/rows/row-header/react/example2.jsx
+++ b/docs/content/guides/rows/row-header/react/example2.jsx
@@ -1,0 +1,29 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={[
+        [42000, 31000, 11000],
+        [45500, 33200, 12300],
+        [48700, 35100, 13600],
+        [51200, 36800, 14400],
+        [54800, 38900, 15900],
+        [57300, 40100, 17200],
+      ]}
+      colHeaders={['Revenue', 'Expenses', 'Profit']}
+      rowHeaders={['January', 'February', 'March', 'April', 'May', 'June']}
+      rowHeaderWidth={80}
+      height="auto"
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/rows/row-header/react/example2.tsx
+++ b/docs/content/guides/rows/row-header/react/example2.tsx
@@ -1,0 +1,29 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={[
+        [42000, 31000, 11000],
+        [45500, 33200, 12300],
+        [48700, 35100, 13600],
+        [51200, 36800, 14400],
+        [54800, 38900, 15900],
+        [57300, 40100, 17200],
+      ]}
+      colHeaders={['Revenue', 'Expenses', 'Profit']}
+      rowHeaders={['January', 'February', 'March', 'April', 'May', 'June']}
+      rowHeaderWidth={80}
+      height="auto"
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/rows/row-header/react/example3.jsx
+++ b/docs/content/guides/rows/row-header/react/example3.jsx
@@ -1,0 +1,30 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={[
+        [42000, 31000, 11000],
+        [45500, 33200, 12300],
+        [48700, 35100, 13600],
+        [51200, 36800, 14400],
+        [54800, 38900, 15900],
+        [57300, 40100, 17200],
+      ]}
+      colHeaders={['Revenue', 'Expenses', 'Profit']}
+      rowHeaders={(index) => {
+        return `Row ${index + 1}`;
+      }}
+      height="auto"
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/rows/row-header/react/example3.tsx
+++ b/docs/content/guides/rows/row-header/react/example3.tsx
@@ -1,0 +1,30 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={[
+        [42000, 31000, 11000],
+        [45500, 33200, 12300],
+        [48700, 35100, 13600],
+        [51200, 36800, 14400],
+        [54800, 38900, 15900],
+        [57300, 40100, 17200],
+      ]}
+      colHeaders={['Revenue', 'Expenses', 'Profit']}
+      rowHeaders={(index) => {
+        return `Row ${index + 1}`;
+      }}
+      height="auto"
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/rows/row-header/row-header.md
+++ b/docs/content/guides/rows/row-header/row-header.md
@@ -17,6 +17,7 @@ vue:
   metaTitle: Row headers - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Rows
+menuTag: updated
 ---
 Use default row headers (1, 2, 3), or set them to custom values provided by an array or a function.
 
@@ -27,6 +28,100 @@ Use default row headers (1, 2, 3), or set them to custom values provided by an a
 Row headers are gray-colored columns that are used to label each row. By default, these headers are filled with numbers displayed in ascending order.
 
 To turn the headers on, set the option [`rowHeaders`](@/api/options.md#rowheaders) to `true`.
+
+## Row headers as an array
+
+An array of labels can be used to set the [`rowHeaders`](@/api/options.md#rowheaders) as shown in the example below:
+
+::: only-for javascript
+
+::: example #example2 --js 1 --ts 2
+
+@[code](@/content/guides/rows/row-header/javascript/example2.js)
+@[code](@/content/guides/rows/row-header/javascript/example2.ts)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #example2 :react --js 1 --ts 2
+
+@[code](@/content/guides/rows/row-header/react/example2.jsx)
+@[code](@/content/guides/rows/row-header/react/example2.tsx)
+
+:::
+
+:::
+
+::: only-for angular
+
+::: example #example2 :angular --ts 1 --html 2
+
+@[code](@/content/guides/rows/row-header/angular/example2.ts)
+@[code](@/content/guides/rows/row-header/angular/example2.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example2 :vue3
+
+@[code](@/content/guides/rows/row-header/vue/example2.vue)
+
+:::
+
+:::
+
+## Row headers as a function
+
+The [`rowHeaders`](@/api/options.md#rowheaders) can also be populated using a function as shown in the example below:
+
+::: only-for javascript
+
+::: example #example3 --js 1 --ts 2
+
+@[code](@/content/guides/rows/row-header/javascript/example3.js)
+@[code](@/content/guides/rows/row-header/javascript/example3.ts)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #example3 :react --js 1 --ts 2
+
+@[code](@/content/guides/rows/row-header/react/example3.jsx)
+@[code](@/content/guides/rows/row-header/react/example3.tsx)
+
+:::
+
+:::
+
+::: only-for angular
+
+::: example #example3 :angular --ts 1 --html 2
+
+@[code](@/content/guides/rows/row-header/angular/example3.ts)
+@[code](@/content/guides/rows/row-header/angular/example3.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example3 :vue3
+
+@[code](@/content/guides/rows/row-header/vue/example3.vue)
+
+:::
+
+:::
 
 ## Bind rows with headers
 

--- a/docs/content/guides/rows/row-header/vue/example2.vue
+++ b/docs/content/guides/rows/row-header/vue/example2.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    [42000, 31000, 11000],
+    [45500, 33200, 12300],
+    [48700, 35100, 13600],
+    [51200, 36800, 14400],
+    [54800, 38900, 15900],
+    [57300, 40100, 17200],
+  ],
+  colHeaders: ['Revenue', 'Expenses', 'Profit'],
+  rowHeaders: ['January', 'February', 'March', 'April', 'May', 'June'],
+  rowHeaderWidth: 80,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example2">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/rows/row-header/vue/example3.vue
+++ b/docs/content/guides/rows/row-header/vue/example3.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    [42000, 31000, 11000],
+    [45500, 33200, 12300],
+    [48700, 35100, 13600],
+    [51200, 36800, 14400],
+    [54800, 38900, 15900],
+    [57300, 40100, 17200],
+  ],
+  colHeaders: ['Revenue', 'Expenses', 'Profit'],
+  rowHeaders: (index) => {
+    return `Row ${index + 1}`;
+  },
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example3">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>


### PR DESCRIPTION
### Context

The PR adds documentation for the `rowHeaders` option's array and function forms, which were previously undocumented on the [Row header](https://handsontable.com/docs/row-header/) page. The Column header page already documents the equivalent array and function forms of `colHeaders`, so the Row header page was missing parity. `rowHeaders` accepts the same shape as `colHeaders` (`boolean | string[] | ((row: number) => string)`), so this brings the page up to par by documenting all three modes (default numbers, custom array, custom function).

Two new sections are added after the Overview:

- **Row headers as an array** -- sets `rowHeaders` to an array of labels.
- **Row headers as a function** -- populates `rowHeaders` from a function that receives the row index.

Each section ships runnable examples for all four frameworks (JavaScript, React, Angular, Vue). Examples use domain-realistic data (monthly financial figures) per the current docs content standards.

### How has this been tested?

Ran the docs site locally (`npm run dev` from `docs/`, Node 22) and verified in a browser across all four framework routes (`javascript-`, `react-`, `angular-`, `vue-data-grid/row-header/`):

- The array example renders row headers `January`–`June`.
- The function example renders `Row 1`–`Row 6`.
- No console errors on any page, including the Angular JIT and Vue mounts.

JS variants were generated with `npm run docs:code-examples:generate-js` from the authored TypeScript sources.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

This is a documentation-only change.

### Related issue(s):

1. DEV-260

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

Documentation only.

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation. (This PR *is* the documentation change.)

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-260

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example assets only; no runtime or library behavior changes.
> 
> **Overview**
> Expands the **Row header** guide so `rowHeaders` is documented for **custom label arrays** and **index-based functions**, matching how **Column header** already covers `colHeaders`. The page front matter gets `menuTag: updated`.
> 
> Two new sections sit after Overview: **Row headers as an array** (`example2`, month names + `rowHeaderWidth`) and **Row headers as a function** (`example3`, `Row ${index + 1}`). Each section wires live examples for JavaScript, React, Angular, and Vue (JS/TS where applicable).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66105dd159b0e10a09f338d43c03ed45b3d0b20d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->