### PR TITLE
DEV-303: Removed mention about unused HandsontablePreview component

### DIFF
--- a/docs/README-EDITING.md
+++ b/docs/README-EDITING.md
@@ -229,22 +229,6 @@ The `example` Markdown container offers the following options:
 | `--no-edit`    | No       | `--no-edit`     | `--no-edit`                                                                                                                                                                                                                                                 | Removes the **Edit** button.                                                                          |
 | `--tab <tab>`  | No       | `--tab preview` | `code` \| `html` \| `css` \| `preview`                                                                                                                                                                                                                      | Sets a tab as open by default.                                                                        |
 
-### Non-editable examples
-You can also embed an example without the tabbed container.
-To display just the result of the code you want to present, use the `<HandsontablePreview>` component. The code wrapped in this component and a markdown code block will be rendered with the context of the current Handsontable version.
-```js
-<HandsontablePreview>
-```js
-  // enter the Handsontable-related code here.
-  const containerElement = document.querySelector('#hot');
-
-  new Handsontable(containerElement, {});
-```
-</HandsontablePreview>
-```
-
-**Note: Remember to place all the needed HTML and `<style>` elements in the markdown file as well.**
-
 ## React style guide
 
 When you edit React examples and code samples, follow the guidelines below.


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
`HandsontablePreview` component was removed, but it was still mentioned in the editing readme. This PR remove this mention.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Tests not needed.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://app.clickup.com/t/9015210959/DEV-303

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, API, or product behavior impact.
> 
> **Overview**
> Removes the **Non-editable examples** subsection from `docs/README-EDITING.md`, which described embedding results with `<HandsontablePreview>` and related markdown code-block usage.
> 
> That guidance is obsolete because **`HandsontablePreview` was removed** from the docs stack; leaving it would mislead contributors about supported authoring patterns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91db9cd402064abded04655ceb3455aeb5e3ef62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->