### PR TITLE
DEV-284: Document commonly used hooks on the Events and hooks page

### DIFF
--- a/docs/content/guides/getting-started/events-and-hooks/events-and-hooks.md
+++ b/docs/content/guides/getting-started/events-and-hooks/events-and-hooks.md
@@ -23,6 +23,7 @@ vue:
   metaTitle: Events and hooks - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Data management
+menuTag: updated
 ---
 Run your code before or after specific data grid actions, using Handsontable's API hooks (callbacks). For example, control what happens with the user's input.
 
@@ -214,6 +215,68 @@ const hotSettings = ref({
 
 The first argument may be modified and passed on through the Handsontable hooks that are next in the queue. This characteristic is shared between `before` and `after` hooks but is more common with the former. Before something happens, we can run the data through a pipeline of hooks that may modify or reject the operation. This provides many possibilities to extend the default Handsontable functionality and customize it for your application.
 
+## Commonly used hooks
+
+Handsontable exposes hundreds of hooks. The ones below are the hooks you reach for most often, grouped by what they do. Unlike the [`source` argument list](#definition-for-source-argument) further down this page, this grouping is about purpose, not about which callbacks receive a `source` argument.
+
+**Lifecycle** -- run code as the grid instance starts up.
+
+<div class="boxes-list">
+
+- [beforeInit](@/api/hooks.md#beforeinit) -- fired before the Handsontable instance is initialized.
+- [afterInit](@/api/hooks.md#afterinit) -- fired after the Handsontable instance is initialized.
+
+</div>
+
+**Data changes** -- react to or alter the user's edits. Returning `false` from [`beforeChange`](@/api/hooks.md#beforechange) rejects the change.
+
+<div class="boxes-list">
+
+- [beforeChange](@/api/hooks.md#beforechange) -- fired before one or more cells change. Use it to silently alter or reject changes before the grid re-renders.
+- [afterChange](@/api/hooks.md#afterchange) -- fired after one or more cells change.
+
+</div>
+
+**Row and column structure (CRUD)** -- track rows and columns being added or removed. Each `before` variant can return `false` to block the operation.
+
+<div class="boxes-list">
+
+- [afterCreateRow](@/api/hooks.md#aftercreaterow) -- fired after a new row is created.
+- [afterCreateCol](@/api/hooks.md#aftercreatecol) -- fired after a new column is created.
+- [afterRemoveRow](@/api/hooks.md#afterremoverow) -- fired after one or more rows are removed.
+- [afterRemoveCol](@/api/hooks.md#afterremovecol) -- fired after one or more columns are removed.
+
+</div>
+
+**Selection** -- respond to the user selecting cells.
+
+<div class="boxes-list">
+
+- [afterSelection](@/api/hooks.md#afterselection) -- fired after one or more cells are selected, for example during a mouse move.
+- [afterSelectionEnd](@/api/hooks.md#afterselectionend) -- fired after the selection ends, for example on mouse up.
+
+</div>
+
+**Mouse interaction** -- respond to mouse actions on cells.
+
+<div class="boxes-list">
+
+- [afterOnCellMouseDown](@/api/hooks.md#afteroncellmousedown) -- fired after a `mousedown` event on a cell.
+- [afterOnCellMouseUp](@/api/hooks.md#afteroncellmouseup) -- fired after a `mouseup` event on a cell.
+- [afterOnCellMouseOver](@/api/hooks.md#afteroncellmouseover) -- fired after a `mouseover` event on a cell.
+- [afterOnCellMouseOut](@/api/hooks.md#afteroncellmouseout) -- fired after a `mouseout` event on a cell.
+
+</div>
+
+**Keyboard interaction** -- respond to or override key presses. See the [`beforeKeyDown`](#the-beforekeydown-callback) section below for a demo.
+
+<div class="boxes-list">
+
+- [beforeKeyDown](@/api/hooks.md#beforekeydown) -- fired before a `keydown` event is handled. Use it to stop default key bindings.
+- [afterDocumentKeyDown](@/api/hooks.md#afterdocumentkeydown) -- fired after a `keydown` event is handled.
+
+</div>
+
 ::: only-for react
 
 ## External control
@@ -305,7 +368,7 @@ List of callbacks that operate on the `source` parameter:
 - [afterSetDataAtRowProp](@/api/hooks.md#aftersetdataatrowprop)
 - [afterSetSourceDataAtCell](@/api/hooks.md#aftersetsourcedataatcell)
 - [afterRemoveCol](@/api/hooks.md#afterremovecol)
-- [afterRemoveRow](@/api/hooks.md#aftermoverow)
+- [afterRemoveRow](@/api/hooks.md#afterremoverow)
 - [afterValidate](@/api/hooks.md#aftervalidate)
 - [beforeChange](@/api/hooks.md#beforechange)
 - [beforeChangeRender](@/api/hooks.md#beforechangerender)


### PR DESCRIPTION
### Context

The PR adds a "Commonly used hooks" section to the [Events and hooks](https://handsontable.com/docs/javascript-data-grid/events-and-hooks/) guide. The page explains how hooks work (events, middleware, the `source` argument, `beforeKeyDown`) but never points a reader at which hooks matter most. The new section groups the hooks you reach for most often by purpose -- lifecycle, data changes, row/column CRUD, selection, mouse, and keyboard -- each with a link to its API reference and a one-line description. The framing makes it distinct from the existing `source`-argument list further down the page.

It also fixes a broken in-page API anchor: `afterRemoveRow` linked to `#aftermoverow` (a typo that 404s) and now links to `#afterremoverow`.

All hook names and anchors were verified against `handsontable/src/core/hooks/constants.ts`.

`[skip changelog]` -- docs-only change, no source code touched.

### How has this been tested?

- Docs-only change. Anchors verified statically against `handsontable/src/core/hooks/constants.ts` and against existing `#definition-for-source-argument` links already used throughout `docs/content/api/hooks.md`.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-284

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-284

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates with no runtime or API behavior changes.
> 
> **Overview**
> Adds a **Commonly used hooks** section to the Events and hooks guide so readers can find the most important hooks by purpose (lifecycle, data changes, row/column CRUD, selection, mouse, and keyboard), each with API links and short descriptions. The intro clarifies this is separate from the existing **`source` argument** hook list lower on the page.
> 
> Marks the guide with **`menuTag: updated`**.
> 
> Fixes a broken API link for **`afterRemoveRow`** in the `source`-parameter list (`#aftermoverow` → `#afterremoverow`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf6b495befeeee07a3528549e5555c57461c92ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->