### PR TITLE
docs: Add missing sidebar menuTags and document the convention

### DIFF
--- a/.claude/skills/writing-docs-pages/SKILL.md
+++ b/.claude/skills/writing-docs-pages/SKILL.md
@@ -28,8 +28,11 @@ react:
   metaTitle: Feature Name - React Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features    # Must match a sidebar category exactly
+menuTag: new | updated     # Optional; sidebar badge
 ---
 ```
+
+Set `menuTag: new` when you create a new page and `menuTag: updated` when you make a substantive content change to an existing page. Omit it for trivial fixes (typos, snippet/link corrections) and for changelog and migration-guide pages; leave any existing tag in place.
 
 ## 2. Page Structure
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -407,6 +407,7 @@ react:
   metaTitle: Feature Name - React Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features
+menuTag: new | updated    # Optional; sidebar badge -- see rule below
 ---
 ```
 
@@ -415,6 +416,7 @@ category: Cell features
 - `title` is the only H1. Do not add `# Title` in the Markdown body.
 - `description` is used in SEO meta and link previews -- make it specific and accurate.
 - `tags` must be lowercase kebab-case.
+- `menuTag` controls the sidebar badge. Set `menuTag: new` when you add a new page, and `menuTag: updated` when you make a substantive content change to an existing page. Omit it for trivial fixes -- typos, snippet/link corrections -- and for changelog and migration-guide pages. Existing tags are refreshed by hand for releases (for example, the RELEASE-631 batch), so leave any existing tag in place.
 
 ---
 
@@ -441,6 +443,8 @@ Do not use relative paths (`../`) for internal links.
 ## 2.9 Sidebar Registration
 
 Register new pages in `content/guides/sidebar.js`. A page not registered there will not appear in navigation.
+
+A page's sidebar badge (**New** / **Updated**) is driven by the `menuTag` frontmatter field (see Section 2.6), not by `sidebar.js`.
 
 ---
 
@@ -471,6 +475,7 @@ Copy and complete this checklist in your PR description:
 - [ ] Tutorials have "What you learned" and "Next steps" sections
 - [ ] How-tos have a "Result" section
 - [ ] New page registered in `content/guides/sidebar.js`
+- [ ] `menuTag: new` set on new pages / `menuTag: updated` set on substantively changed pages (omit for trivial fixes, changelogs, and migration guides)
 - [ ] `id` field uses 8 random alphanumeric chars (existing IDs are unchanged)
 - [ ] Microsoft trademark disclaimer added where "Excel" is mentioned
 - [ ] TypeScript example exists; JS generated via `npm run docs:code-examples:generate-js`

--- a/docs/content/guides/cell-features/autofill-values/autofill-values.md
+++ b/docs/content/guides/cell-features/autofill-values/autofill-values.md
@@ -21,6 +21,7 @@ vue:
   metaTitle: Autofill values - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features
+menuTag: updated
 ---
 Copy a cell's value into multiple other cells, using the "fill handle" UI element. Configure the direction of copying, and more, through Handsontable's API.
 

--- a/docs/content/guides/cell-features/merge-cells/merge-cells.md
+++ b/docs/content/guides/cell-features/merge-cells/merge-cells.md
@@ -13,6 +13,7 @@ vue:
   metaTitle: Merge cells - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features
+menuTag: updated
 ---
 Merge adjacent cells, using the <kbd>**Ctrl**</kbd>+<kbd>**M**</kbd> shortcut or the context menu. Control merged cells, using Handsontable's API.
 

--- a/docs/content/guides/cell-types/checkbox-cell-type/checkbox-cell-type.md
+++ b/docs/content/guides/cell-types/checkbox-cell-type/checkbox-cell-type.md
@@ -13,6 +13,7 @@ vue:
   metaTitle: Checkbox cell type - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types
+menuTag: updated
 ---
 Create interactive elements that can be checked or unchecked, by using the checkbox cell type.
 

--- a/docs/content/guides/cell-types/select-cell-type/select-cell-type.md
+++ b/docs/content/guides/cell-types/select-cell-type/select-cell-type.md
@@ -13,6 +13,7 @@ vue:
   metaTitle: Select cell type - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types
+menuTag: updated
 ---
 Use the select cell type to collect user input with an HTML `<select>` element that creates a multi-item dropdown list.
 

--- a/docs/content/guides/columns/column-width/column-width.md
+++ b/docs/content/guides/columns/column-width/column-width.md
@@ -22,6 +22,7 @@ vue:
   metaTitle: Column widths - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Columns
+menuTag: updated
 ---
 Configure column widths, using an array or a function. Let your users manually change column widths using Handsontable's interface.
 

--- a/docs/content/guides/formulas/formula-calculation/formula-calculation.md
+++ b/docs/content/guides/formulas/formula-calculation/formula-calculation.md
@@ -23,6 +23,7 @@ vue:
   metaTitle: Formula calculation - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Formulas
+menuTag: updated
 ---
 The `Formulas` plugin adds spreadsheet-style calculation to Handsontable, powered by [HyperFormula](https://hyperformula.handsontable.com/). It supports ~400 built-in functions, cross-sheet references, named expressions, and custom function implementations.
 

--- a/docs/content/guides/getting-started/custom-id-class-style/custom-id-class-style.md
+++ b/docs/content/guides/getting-started/custom-id-class-style/custom-id-class-style.md
@@ -18,6 +18,7 @@ vue:
   metaTitle: Custom ID, class, and style - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Getting started
+menuTag: new
 ---
 
 Apply a custom `id`, `class`, and inline `style` to the Handsontable container, to target the grid with your own CSS or JavaScript selectors.

--- a/docs/content/guides/getting-started/grid-size/grid-size.md
+++ b/docs/content/guides/getting-started/grid-size/grid-size.md
@@ -18,6 +18,7 @@ vue:
   metaTitle: Grid size - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Getting started
+menuTag: updated
 ---
 Set the width and height of the grid, using either absolute values or values relative to the parent container.
 

--- a/docs/content/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md
+++ b/docs/content/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md
@@ -23,6 +23,7 @@ vue:
   metaTitle: Keyboard shortcuts - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Navigation
+menuTag: updated
 ---
 Access all Handsontable features using just your keyboard. Use shortcuts you know from Google Sheets or Microsoft Excel.
 

--- a/docs/content/guides/rows/row-height/row-height.md
+++ b/docs/content/guides/rows/row-height/row-height.md
@@ -24,6 +24,7 @@ vue:
   metaTitle: Row heights - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Rows
+menuTag: updated
 ---
 Configure row heights, using a number, an array or a function. Let your users manually change row heights using Handsontable's interface.
 

--- a/docs/content/recipes/context-menu/add-column-object-data/add-column-object-data.md
+++ b/docs/content/recipes/context-menu/add-column-object-data/add-column-object-data.md
@@ -21,6 +21,7 @@ vue:
   metaTitle: Add a column to an object-based dataset - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Context Menu
+menuTag: new
 type: how-to
 ---
 


### PR DESCRIPTION
### Context

The PR adds the `new`/`updated` sidebar `menuTag` to documentation pages that were changed on `develop` in the last few days but shipped without a tag, and documents the convention so future changes get it automatically.

The docs sidebar shows a **New** / **Updated** badge driven by the `menuTag` frontmatter field (`docs/src/sidebar.mjs`). These tags are maintained per release; the last batch update was the RELEASE-631 PR (#12807). Pages merged after that baseline (2026-06-23 → 06-25) introduced or changed content but did not receive the matching tag, so the sidebar badges are out of date. The gap recurred because nothing in the agent-facing docs told authors to set `menuTag`.

This PR has two commits:

1. **Add missing tags** to 11 pages:
   - `menuTag: new` (2 new pages): `custom-id-class-style`, `recipes/context-menu/add-column-object-data`.
   - `menuTag: updated` (9 substantively changed pages): `checkbox-cell-type`, `grid-size`, `merge-cells`, `select-cell-type`, `keyboard-shortcuts`, `formula-calculation`, `autofill-values`, `column-width`, `row-height`.
   - Excluded by convention: changelog/migration-guide pages, the recipe index page, and example-only/snippet fixes.

2. **Document the convention** for agents: a rule and example in `docs/AGENTS.md` §2.6, a note in §2.9, a §2.10 PR-checklist item, and a matching note in the `writing-docs-pages` skill.

### How has this been tested?

- Docs-only frontmatter and agent-guidance change; no source code touched.
- Verified each target page now carries the expected tag: `grep -rn "menuTag:" docs/content/...` shows 2 `new` and 9 `updated`.
- Pages already correctly tagged (`events-and-hooks`, `numeric-cell-type`, `modules`, `column-groups`) were left unchanged.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

N/A — documentation maintenance across several already-merged pages.

### Affected project(s):

- [x] `handsontable` (documentation only)
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation. (This PR is the documentation change.)

[skip changelog] — documentation-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only frontmatter and agent guidance; no runtime or product code changes.
> 
> **Overview**
> Syncs **New** / **Updated** sidebar badges with recent doc changes and encodes the rule for future PRs.
> 
> **Frontmatter:** Adds `menuTag: new` on `custom-id-class-style` and the `add-column-object-data` recipe; adds `menuTag: updated` on nine guides (autofill, merge cells, checkbox/select cell types, column width, row height, grid size, keyboard shortcuts, formula calculation). Badges come from `menuTag` via `docs/src/sidebar.mjs`, not `sidebar.js`.
> 
> **Authoring docs:** Documents `menuTag` in `docs/AGENTS.md` (§2.6, §2.9, §2.10 checklist), the `writing-docs-pages` skill, and when to omit tags (trivial fixes, changelogs, migration guides; leave existing release tags unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3df90ee6654fa7cd7d33ba8e56cf64e6ddef812. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->