### PR TITLE
DEV-306: Document filter clearing, AND/OR conditions, and dropdown menu items

### DIFF
--- a/docs/content/guides/accessories-and-menus/context-menu/context-menu.md
+++ b/docs/content/guides/accessories-and-menus/context-menu/context-menu.md
@@ -120,6 +120,10 @@ You can define the items in the menu by passing the [`contextMenu`](@/api/option
 | [`filter_action_bar`](@/api/contextMenu.md)              | Apply the configured filter. Requires: [`Filters`](@/api/filters.md)                                                                                                 |
 | [`export_file`](@/api/contextMenu.md)                    | Open the Export submenu with "To CSV" and "To Excel" items. Requires: [`ExportFile`](@/api/exportFile.md). The Excel item is hidden when no XLSX engine is configured. |
 
+The `filter_by_condition`, `filter_by_condition2`, `filter_operators`, `filter_by_value`, and
+`filter_action_bar` items build the filtering interface and take effect only in the dropdown (column)
+menu, not in the context menu. See [Filter menu items](@/guides/columns/column-menu/column-menu.md#filter-menu-items).
+
 To see the context menu, right-click on a cell. On touch devices, long-press a cell to open the context menu.
 
 ::: only-for javascript

--- a/docs/content/guides/columns/column-filter/column-filter.md
+++ b/docs/content/guides/columns/column-filter/column-filter.md
@@ -26,6 +26,7 @@ vue:
   metaTitle: Column filter - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Columns
+menuTag: updated
 ---
 Filter data by values or by a set of conditions, using Handsontable's intuitive user interface or
 flexible API.
@@ -447,6 +448,10 @@ The following table contains all available filter operators for each built-in da
 | date                                                             | Default operators plus:<br><br>Before (exclusive -- boundary date excluded)<br>Before or equal to (boundary date included)<br>After (exclusive -- boundary date excluded)<br>After or equal to (boundary date included)<br>Is between<br>Tomorrow<br>Today<br>Yesterday                                                |
 | intl-date                                                        | Default operators plus:<br><br>Before (exclusive -- boundary date excluded)<br>Before or equal to (boundary date included)<br>After (exclusive -- boundary date excluded)<br>After or equal to (boundary date included)<br>Is between<br>Tomorrow<br>Today<br>Yesterday                                                |
 | intl-time                                                        | Default operators plus:<br><br>Begins with<br>Ends with<br>Contains<br>Does not contain<br>Before (exclusive -- boundary time excluded)<br>Before or equal to (boundary time included)<br>After (exclusive -- boundary time excluded)<br>After or equal to (boundary time included)<br>Is between                      |
+
+The **None** operator clears the column's filter. Its programmatic equivalent is
+[`filters.removeConditions(column)`](@/api/filters.md#removeconditions). For more on clearing
+filters with the API, see [Clear a column filter](#clear-a-column-filter).
 
 ## Filter data on initialization
 
@@ -1066,6 +1071,116 @@ Mind that before you apply new filter conditions, you need to clear the previous
 :::
 
 :::
+
+### Combine multiple filter conditions
+
+A column can hold more than one condition. The fourth argument of
+[`filters.addCondition()`](@/api/filters.md#addcondition) sets the logical operation that joins the
+conditions for that column:
+
+- `'conjunction'` -- AND logic. Every condition must match. This is the default, so you can omit the
+  argument.
+- `'disjunction'` -- OR logic. At least one condition must match.
+
+Apply the same operation to all conditions in a column. Don't mix `'conjunction'` and
+`'disjunction'` for a single column.
+
+The following snippet keeps the rows where the price (column index `2`) is less than `200` **or**
+greater than `400`.
+
+::: only-for javascript
+
+```js
+const filters = handsontableInstance.getPlugin('filters');
+
+// clear the column's existing conditions first
+filters.clearConditions(2);
+
+// match rows where the price is less than 200 OR greater than 400
+filters.addCondition(2, 'lt', [200], 'disjunction');
+filters.addCondition(2, 'gt', [400], 'disjunction');
+filters.filter();
+```
+
+:::
+
+::: only-for react
+
+```jsx
+const filters = hotTableComponentRef.current.hotInstance.getPlugin('filters');
+
+// clear the column's existing conditions first
+filters.clearConditions(2);
+
+// match rows where the price is less than 200 OR greater than 400
+filters.addCondition(2, 'lt', [200], 'disjunction');
+filters.addCondition(2, 'gt', [400], 'disjunction');
+filters.filter();
+```
+
+:::
+
+::: only-for angular
+
+```ts
+const filters = this.hotTable.hotInstance!.getPlugin('filters');
+
+// clear the column's existing conditions first
+filters.clearConditions(2);
+
+// match rows where the price is less than 200 OR greater than 400
+filters.addCondition(2, 'lt', [200], 'disjunction');
+filters.addCondition(2, 'gt', [400], 'disjunction');
+filters.filter();
+```
+
+:::
+
+::: only-for vue
+
+```js
+const filters = hotTableRef.value.hotInstance.getPlugin('filters');
+
+// clear the column's existing conditions first
+filters.clearConditions(2);
+
+// match rows where the price is less than 200 OR greater than 400
+filters.addCondition(2, 'lt', [200], 'disjunction');
+filters.addCondition(2, 'gt', [400], 'disjunction');
+filters.filter();
+```
+
+:::
+
+The dropdown menu shows at most two conditions plus one **Filter by value** condition per column.
+If you add more conditions than that, they still filter the data but don't appear in the menu. See
+[Known limitations](#known-limitations).
+
+### Clear a column filter
+
+To clear the conditions for a single column, call
+[`filters.removeConditions(column)`](@/api/filters.md#removeconditions). This is the programmatic
+equivalent of selecting the **None** operator in the column menu.
+
+```js
+const filters = handsontableInstance.getPlugin('filters');
+
+// clear the filter for the column at index 2
+filters.removeConditions(2);
+filters.filter();
+```
+
+To clear the conditions for every column at once, call
+[`filters.clearConditions()`](@/api/filters.md#clearconditions) without an argument.
+
+Adding the `'none'` condition with [`addCondition()`](@/api/filters.md#addcondition) has no
+filtering effect, because `'none'` matches every row:
+
+```js
+// matches all rows -- the column stays unfiltered
+filters.addCondition(2, 'none', []);
+filters.filter();
+```
 
 ## Import the filtering module
 

--- a/docs/content/guides/columns/column-menu/column-menu.md
+++ b/docs/content/guides/columns/column-menu/column-menu.md
@@ -119,6 +119,22 @@ To use the default dropdown contents, set it to `true`, or to customize it by se
 
 :::
 
+## Filter menu items
+
+When the [`Filters`](@/api/filters.md) plugin is enabled, it adds the following items to the
+dropdown menu. These items build the filtering interface and work only in the dropdown menu, not in
+the [context menu](@/guides/accessories-and-menus/context-menu/context-menu.md).
+
+| Key                                            | Action                                                                                       |
+| ---------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| [`filter_by_condition`](@/api/filters.md)      | Add the first filter condition.                                                              |
+| [`filter_by_condition2`](@/api/filters.md)     | Add the second filter condition. Required for the second condition's select element.         |
+| [`filter_operators`](@/api/filters.md)         | Select the operator (**And** or **Or**) that joins the two conditions.                       |
+| [`filter_by_value`](@/api/filters.md)          | Select the values to keep.                                                                   |
+| [`filter_action_bar`](@/api/filters.md)        | Apply or cancel the filter with the **OK** and **Cancel** buttons.                           |
+
+For a complete filtering guide, see [Column filter](@/guides/columns/column-filter/column-filter.md).
+
 ## Related keyboard shortcuts
 
 | Windows                                                  | macOS                                                       | Action                                                                                                       |  Excel  | Sheets  |

--- a/handsontable/src/plugins/filters/filters.ts
+++ b/handsontable/src/plugins/filters/filters.ts
@@ -539,7 +539,7 @@ export class Filters extends BasePlugin {
    * | `intl_time_between` | Between times (locale-aware) | `[fromTimeString: string, toTimeString: string]`, e.g. `['08:00', '12:00']` |
    * | `lt` | Less than | `[value: number]`, e.g. `[10]` |
    * | `lte` | Less than or equal | `[value: number]`, e.g. `[10]` |
-   * | `none` | None (no filter) | `[]` |
+   * | `none` | None (no filter) | `[]`. Matches every row, so it has no filtering effect. To clear a column's filter, use [`removeConditions()`](@/api/filters.md#removeconditions) instead. |
    * | `not_between` | Not between | `[from: number\|string, to: number\|string]`, e.g. `[10, 50]` |
    * | `not_contains` | Not contains | `[value: string]`, e.g. `['ing']` |
    * | `not_empty` | Not empty | `[]` |
@@ -901,6 +901,9 @@ export class Filters extends BasePlugin {
 
   /**
    * Removes conditions at specified column index.
+   *
+   * This is the programmatic equivalent of selecting the `None` operator in the column menu – both
+   * clear the column's filter.
    *
    * @param {number} column Visual column index.
    */


### PR DESCRIPTION
### Context

The PR fills three documentation gaps in the Filters feature, originally raised in DEV-306 (migrated from GitHub #525). Two of the issue's asks were already resolved by later work (the full `addCondition()` condition table with examples, and documenting `filter_by_condition2`), so this PR addresses the three gaps that remained:

1. **Clearing a filter / the `None` operator was undocumented.** The docs only described `none` as "None (no filter)", which is insufficient programmatically. Verified in source that clicking **OK** in the column menu always calls `removeConditions()` first (`filters.ts`), so selecting **None** is the equivalent of `removeConditions(column)`, and `addCondition(col, 'none', [])` is a match-all no-op. This is now explained in the Column filter guide (a new "Clear a column filter" section plus a note on the operators table) and clarified in the `removeConditions()` and `addCondition()` JSDoc.
2. **No worked AND/OR example.** The `operationId` parameter (`conjunction` / `disjunction`) was described in prose but never shown combining two conditions. Added a "Combine multiple filter conditions" section with a `disjunction` example.
3. **Filter menu items were documented only under the context menu.** The `filter_*` items are injected solely via the `afterDropdownMenuDefaultOptions` hook and work only in the dropdown (column) menu. Added a dedicated "Filter menu items" table to the Column menu guide and a clarifying note in the Context menu guide.

The core change is a comment-only JSDoc edit (no functional change).

`[skip changelog]` -- documentation and JSDoc-comment changes only.

### How has this been tested?

- `npx eslint src/plugins/filters/filters.ts` (from `handsontable/`) -- passes, validates the JSDoc edit.
- Docs prose reviewed against `docs/CLAUDE.md` style rules; button labels (**OK** / **Cancel**) and operator labels (**And** / **Or**) verified against `src/i18n/languages/en-US.ts`.
- Note: the generated `docs/content/api/filters.md` was not regenerated (requires a full core rebuild for a comment-only change).

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

Documentation-only change.

### Related issue(s):

1. DEV-306

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-306

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and comment-only JSDoc updates; no runtime or API behavior changes.
> 
> **Overview**
> Documentation-only PR that closes gaps in the Filters guides and JSDoc (DEV-306).
> 
> The **Column filter** guide now explains that **None** maps to `filters.removeConditions(column)`, adds a **Combine multiple filter conditions** section with `conjunction` / `disjunction` examples (JS/React/Angular/Vue), and a **Clear a column filter** section covering `removeConditions`, `clearConditions`, and why `addCondition(..., 'none', [])` is a no-op. The operators table links to those sections.
> 
> The **Column menu** guide gains a **Filter menu items** table; the **Context menu** guide notes that `filter_*` keys only apply in the column dropdown, with cross-links between guides.
> 
> `filters.ts` JSDoc is updated for the `none` condition and `removeConditions()` to match the new prose (no behavior change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed3a642d6f0a2c0278750baf085080496680b84e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->