### PR TITLE
DEV-588: Document the title option in the Column headers guide

### DIFF
--- a/docs/content/guides/columns/column-header/angular/example6.html
+++ b/docs/content/guides/columns/column-header/angular/example6.html
@@ -1,0 +1,3 @@
+<div>
+  <app-example6></app-example6>
+</div>

--- a/docs/content/guides/columns/column-header/angular/example6.ts
+++ b/docs/content/guides/columns/column-header/angular/example6.ts
@@ -1,0 +1,61 @@
+/* file: app.component.ts */
+import { Component } from '@angular/core';
+import { GridSettings, HotTableModule} from '@handsontable/angular-wrapper';
+
+@Component({
+  selector: 'app-example6',
+  template: `
+    <hot-table
+      [settings]="hotSettings!" [data]="hotData">
+    </hot-table>
+  `,
+  standalone: true,
+  imports: [HotTableModule],
+})
+export class AppComponent {
+
+  readonly hotData = [
+    [1, 'Ana García', 'Product Manager', 'Spain', '2022-03-14'],
+    [2, 'James Okafor', 'Senior Engineer', 'Nigeria', '2021-07-02'],
+    [3, 'Li Wei', 'Data Analyst', 'China', '2023-01-19'],
+    [4, 'Sofia Rossi', 'UX Designer', 'Italy', '2020-11-30'],
+    [5, 'Mateo Fernández', 'Engineering Lead', 'Argentina', '2019-05-08'],
+  ];
+
+  readonly hotSettings: GridSettings = {
+    // Set each column header label with the `title` option inside `columns`.
+    columns: [
+      { title: 'ID' },
+      { title: 'Full name' },
+      { title: 'Position' },
+      { title: 'Country' },
+      { title: 'Start date' },
+    ],
+    rowHeaders: true,
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true
+  };
+}
+/* end-file */
+
+
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+/* end-file */

--- a/docs/content/guides/columns/column-header/column-header.md
+++ b/docs/content/guides/columns/column-header/column-header.md
@@ -13,6 +13,7 @@ vue:
   metaTitle: Column headers - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Columns
+menuTag: updated
 ---
 Use default column headers (A, B, C), or set them to custom values provided by an array or a function.
 
@@ -158,6 +159,53 @@ The [`colHeaders`](@/api/options.md#colheaders) can also be populated using a fu
 
 @[code](@/content/guides/columns/column-header/angular/example3.ts)
 @[code](@/content/guides/columns/column-header/angular/example3.html)
+
+:::
+
+:::
+
+## Header labels in the columns option
+
+When you configure columns individually with the [`columns`](@/api/options.md#columns) option, set a column's header label with that column's [`title`](@/api/options.md#title) option. If both are set, a column's `title` takes precedence over the matching [`colHeaders`](@/api/options.md#colheaders) entry.
+
+::: only-for javascript
+
+::: example #example6 --js 1 --ts 2
+
+@[code](@/content/guides/columns/column-header/javascript/example6.js)
+@[code](@/content/guides/columns/column-header/javascript/example6.ts)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #example6 :react --js 1 --ts 2
+
+@[code](@/content/guides/columns/column-header/react/example6.jsx)
+@[code](@/content/guides/columns/column-header/react/example6.tsx)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example6 :vue3
+
+@[code](@/content/guides/columns/column-header/vue/example6.vue)
+
+:::
+
+:::
+
+::: only-for angular
+
+::: example #example6 :angular --ts 1 --html 2
+
+@[code](@/content/guides/columns/column-header/angular/example6.ts)
+@[code](@/content/guides/columns/column-header/angular/example6.html)
 
 :::
 

--- a/docs/content/guides/columns/column-header/javascript/example6.js
+++ b/docs/content/guides/columns/column-header/javascript/example6.js
@@ -1,0 +1,27 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+// Register all Handsontable's modules.
+registerAllModules();
+const container = document.querySelector('#example6');
+new Handsontable(container, {
+    data: [
+        [1, 'Ana García', 'Product Manager', 'Spain', '2022-03-14'],
+        [2, 'James Okafor', 'Senior Engineer', 'Nigeria', '2021-07-02'],
+        [3, 'Li Wei', 'Data Analyst', 'China', '2023-01-19'],
+        [4, 'Sofia Rossi', 'UX Designer', 'Italy', '2020-11-30'],
+        [5, 'Mateo Fernández', 'Engineering Lead', 'Argentina', '2019-05-08'],
+    ],
+    // Set each column header label with the `title` option inside `columns`.
+    columns: [
+        { title: 'ID' },
+        { title: 'Full name' },
+        { title: 'Position' },
+        { title: 'Country' },
+        { title: 'Start date' },
+    ],
+    rowHeaders: true,
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true,
+    licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/columns/column-header/javascript/example6.ts
+++ b/docs/content/guides/columns/column-header/javascript/example6.ts
@@ -1,0 +1,30 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+// Register all Handsontable's modules.
+registerAllModules();
+
+const container = document.querySelector('#example6')!;
+
+new Handsontable(container, {
+  data: [
+    [1, 'Ana García', 'Product Manager', 'Spain', '2022-03-14'],
+    [2, 'James Okafor', 'Senior Engineer', 'Nigeria', '2021-07-02'],
+    [3, 'Li Wei', 'Data Analyst', 'China', '2023-01-19'],
+    [4, 'Sofia Rossi', 'UX Designer', 'Italy', '2020-11-30'],
+    [5, 'Mateo Fernández', 'Engineering Lead', 'Argentina', '2019-05-08'],
+  ],
+  // Set each column header label with the `title` option inside `columns`.
+  columns: [
+    { title: 'ID' },
+    { title: 'Full name' },
+    { title: 'Position' },
+    { title: 'Country' },
+    { title: 'Start date' },
+  ],
+  rowHeaders: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/columns/column-header/react/example6.jsx
+++ b/docs/content/guides/columns/column-header/react/example6.jsx
@@ -1,0 +1,34 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={[
+        [1, 'Ana García', 'Product Manager', 'Spain', '2022-03-14'],
+        [2, 'James Okafor', 'Senior Engineer', 'Nigeria', '2021-07-02'],
+        [3, 'Li Wei', 'Data Analyst', 'China', '2023-01-19'],
+        [4, 'Sofia Rossi', 'UX Designer', 'Italy', '2020-11-30'],
+        [5, 'Mateo Fernández', 'Engineering Lead', 'Argentina', '2019-05-08'],
+      ]}
+      // Set each column header label with the `title` option inside `columns`.
+      columns={[
+        { title: 'ID' },
+        { title: 'Full name' },
+        { title: 'Position' },
+        { title: 'Country' },
+        { title: 'Start date' },
+      ]}
+      rowHeaders={true}
+      height="auto"
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/columns/column-header/react/example6.tsx
+++ b/docs/content/guides/columns/column-header/react/example6.tsx
@@ -1,0 +1,34 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={[
+        [1, 'Ana García', 'Product Manager', 'Spain', '2022-03-14'],
+        [2, 'James Okafor', 'Senior Engineer', 'Nigeria', '2021-07-02'],
+        [3, 'Li Wei', 'Data Analyst', 'China', '2023-01-19'],
+        [4, 'Sofia Rossi', 'UX Designer', 'Italy', '2020-11-30'],
+        [5, 'Mateo Fernández', 'Engineering Lead', 'Argentina', '2019-05-08'],
+      ]}
+      // Set each column header label with the `title` option inside `columns`.
+      columns={[
+        { title: 'ID' },
+        { title: 'Full name' },
+        { title: 'Position' },
+        { title: 'Country' },
+        { title: 'Start date' },
+      ]}
+      rowHeaders={true}
+      height="auto"
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/columns/column-header/vue/example6.vue
+++ b/docs/content/guides/columns/column-header/vue/example6.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    [1, 'Ana García', 'Product Manager', 'Spain', '2022-03-14'],
+    [2, 'James Okafor', 'Senior Engineer', 'Nigeria', '2021-07-02'],
+    [3, 'Li Wei', 'Data Analyst', 'China', '2023-01-19'],
+    [4, 'Sofia Rossi', 'UX Designer', 'Italy', '2020-11-30'],
+    [5, 'Mateo Fernández', 'Engineering Lead', 'Argentina', '2019-05-08'],
+  ],
+  // Set each column header label with the `title` option inside `columns`.
+  columns: [
+    { title: 'ID' },
+    { title: 'Full name' },
+    { title: 'Position' },
+    { title: 'Country' },
+    { title: 'Start date' },
+  ],
+  rowHeaders: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example6">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -754,8 +754,11 @@ export default (): Record<string, unknown> => {
      * | An array | Define your own column headers (e.g. `['One', 'Two', 'Three', ...]`) |
      * | A function | Define your own column headers, using a function                     |
      *
+     * To set the header label of an individual column, use that column's [`title`](#title) option.
+     *
      * Read more:
      * - [Column header](@/guides/columns/column-header/column-header.md)
+     * - [`title`](#title)
      *
      * @memberof Options#
      * @type {boolean|string[]|Function}
@@ -5876,8 +5879,11 @@ export default (): Record<string, unknown> => {
      *
      * You can set the `title` option to a string.
      *
+     * To set the labels of all column headers at once, use the [`colHeaders`](#colheaders) option.
+     *
      * Read more:
      * - [Column header](@/guides/columns/column-header/column-header.md)
+     * - [`colHeaders`](#colheaders)
      * - [`columns`](#columns)
      *
      * @memberof Options#


### PR DESCRIPTION
### Context

The PR adds documentation for the `title` option to the "Column headers" guide and cross-links the related API options. The [Column headers guide](https://handsontable.com/docs/javascript-data-grid/column-header/) documented `colHeaders` (as `true`, an array, and a function) but never explained that a column's header label can also be set per-column with the [`title`](https://handsontable.com/docs/javascript-data-grid/api/options/#title) option inside `columns`. The `colHeaders` and `title` API references also lacked links to each other, even though they configure the same feature.

This addresses the long-standing docs task DEV-588 (migrated from `dev-handsontable#1032`, 2023). Each of its three items was verified as still undone before implementation.

Changes:

- New guide section **"Header labels in the columns option"** with a runnable demo (`example6`) in all four frameworks (JavaScript, React, Vue, Angular). The section notes that a column's `title` takes precedence over the matching `colHeaders` entry.
- Added a cross-link from the `colHeaders` API reference to `title`.
- Added a cross-link from the `title` API reference to `colHeaders`.

`[skip changelog]` — documentation-only change (guide content, code examples, and JSDoc comments); no behavior change.

### How has this been tested?

- Rebuilt the core (`npm --prefix handsontable run build`) and regenerated the API docs (`npm --prefix docs run docs:api`); confirmed the regenerated `options.md` renders the new `title` ↔ `colHeaders` cross-links.
- The new `example6` mirrors the existing, shipped `example2` embedding structure 1:1; the per-column `title` behavior it demonstrates is already covered by `handsontable/src/__tests__/colHeader.spec.js` ("should be possible to set colHeaders using columns title property").
- `npx eslint` on the changed `metaSchema.ts` passes (JSDoc rules).
- Note: the Astro docs dev server OOMs in the current environment, so a live in-browser mount of the new examples was not captured.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-588

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-588

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and JSDoc comment changes only; no runtime or library behavior is modified.
> 
> **Overview**
> Documents how to set column header labels with **`title`** inside **`columns`**, including precedence over matching **`colHeaders`** entries.
> 
> Adds a new **Header labels in the columns option** section to the Column headers guide with runnable **`example6`** demos for JavaScript, React, Vue, and Angular, and marks the guide with **`menuTag: updated`**.
> 
> Cross-links **`colHeaders`** and **`title`** in **`metaSchema.ts`** JSDoc so the generated API docs point readers between the two options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c8a05ee7586f199499ccdd6ac853ac60bb5fba1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->