### PR TITLE
DEV-473: Document async validation and its effect on hook order

### DIFF
--- a/docs/content/guides/cell-functions/cell-validator/cell-validator.md
+++ b/docs/content/guides/cell-functions/cell-validator/cell-validator.md
@@ -13,6 +13,7 @@ vue:
   metaTitle: Cell validator - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell functions
+menuTag: updated
 ---
 
 Cell validators run when a user finishes editing a cell. Use them to enforce data rules such as required fields, numeric ranges, or pattern matching.
@@ -276,7 +277,7 @@ Callback console log:
 
 Edit the above grid to see the `changes` argument from the callback.
 
-Mind that changes in table are applied after running all validators (both synchronous and and asynchronous) from every changed cell.
+Changes in the table are applied after all validators (both synchronous and asynchronous) for every changed cell finish. Validation always runs asynchronously, even when a validator calls its callback synchronously, so [`afterChange`](@/api/hooks.md#afterchange) fires after validation completes. To act on a validated value, use the [`afterChange`](@/api/hooks.md#afterchange) or [`afterValidate`](@/api/hooks.md#aftervalidate) hook. For how a validator changes the order in which hooks fire, see [How validation affects hook order](@/guides/getting-started/events-and-hooks/events-and-hooks.md#how-validation-affects-hook-order).
 
 ## Related API reference
 

--- a/docs/content/guides/getting-started/events-and-hooks/events-and-hooks.md
+++ b/docs/content/guides/getting-started/events-and-hooks/events-and-hooks.md
@@ -277,6 +277,32 @@ Handsontable exposes hundreds of hooks. The ones below are the hooks you reach f
 
 </div>
 
+## How validation affects hook order
+
+When an edited cell has a [`validator`](@/api/options.md#validator), Handsontable runs the validation asynchronously. This applies to every validator, including one that calls its callback synchronously. It also applies to the built-in validators that cell types such as [`numeric`](@/guides/cell-types/numeric-cell-type/numeric-cell-type.md), [`date`](@/guides/cell-types/date-cell-type/date-cell-type.md), [`time`](@/guides/cell-types/time-cell-type/time-cell-type.md), [`dropdown`](@/guides/cell-types/dropdown-cell-type/dropdown-cell-type.md), and [`autocomplete`](@/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md) use, so a cell can run a validator even without a custom `validator` function. The grid commits the change and fires the change-related hooks only after the validators for all edited cells resolve. As a result, the order in which hooks fire during an edit depends on whether the edited cell runs a validator.
+
+When the edited cell runs no validator, the hooks fire synchronously:
+
+1. [`beforeKeyDown`](@/api/hooks.md#beforekeydown)
+2. [`beforeChange`](@/api/hooks.md#beforechange)
+3. [`beforeChangeRender`](@/api/hooks.md#beforechangerender)
+4. [`afterChange`](@/api/hooks.md#afterchange)
+5. [`afterSelection`](@/api/hooks.md#afterselection)
+
+When the edited cell runs a validator, the grid defers the change until validation finishes, so [`afterSelection`](@/api/hooks.md#afterselection) fires before the change is committed:
+
+1. [`beforeKeyDown`](@/api/hooks.md#beforekeydown)
+2. [`beforeChange`](@/api/hooks.md#beforechange)
+3. [`beforeValidate`](@/api/hooks.md#beforevalidate)
+4. [`afterSelection`](@/api/hooks.md#afterselection)
+5. [`afterValidate`](@/api/hooks.md#aftervalidate)
+6. [`beforeChangeRender`](@/api/hooks.md#beforechangerender)
+7. [`afterChange`](@/api/hooks.md#afterchange)
+
+The exact sequence depends on how you confirm the edit. The lists above describe confirming an edit with <kbd>**Enter**</kbd> or <kbd>**Tab**</kbd>, which moves the selection and fires [`afterSelection`](@/api/hooks.md#afterselection) while validation is still pending.
+
+To act on a committed, validated value, use the [`afterChange`](@/api/hooks.md#afterchange) or [`afterValidate`](@/api/hooks.md#aftervalidate) hook. Don't rely on a hook firing before or after [`afterSelection`](@/api/hooks.md#afterselection), because a validator changes that order. The [`beforeValidate`](@/api/hooks.md#beforevalidate) and [`afterValidate`](@/api/hooks.md#aftervalidate) hooks fire only when a validator is defined.
+
 ::: only-for react
 
 ## External control


### PR DESCRIPTION
### Context

The PR documents a long-standing, undocumented behavior: when an edited cell runs a validator, Handsontable runs the validation asynchronously, which changes the order in which hooks fire during an edit. This was reported in DEV-473 (migrated from GitHub #824). A maintainer confirmed the behavior is expected but noted the process was never described in the documentation.

Verified against the current code and empirically in the browser (Handsontable 17.1.0):

- Without a validator, hooks fire synchronously: `beforeChange` -> `beforeChangeRender` -> `afterChange` -> `afterSelection`.
- With a validator, the change is deferred to a microtask, so `afterSelection` fires before the change commits: `beforeChange` -> `beforeValidate` -> `afterSelection` -> `afterValidate` -> `beforeChangeRender` -> `afterChange`.
- Validation is always asynchronous, even when a validator calls its callback synchronously (`core.ts` wraps the validator call in `queueMicrotask`).
- This also applies to the built-in validators used by the `numeric`, `date`, `time`, `dropdown`, and `autocomplete` cell types, so a cell can run a validator without a custom `validator` function.

Changes:

- `events-and-hooks.md` -- new "How validation affects hook order" section explaining the mechanism and the with/without-validator hook order.
- `cell-validator.md` -- expanded the existing note on validator timing, fixed a typo, and cross-linked to the new section.

### How has this been tested?

- Documentation-only change. No automated tests apply.
- Behavior reconfirmed manually in a browser: drove Enter- and Tab-committed edits on grids with a custom validator, a `numeric` cell type, and no validator, and captured hook-firing order from the console. The documented sequences match the observed output.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-473

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog] -- documentation-only change.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-473

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime, API, or behavior changes.
> 
> **Overview**
> Documents previously undocumented behavior: **cell validators always run asynchronously**, so change-related hooks fire in a different order than edits without validation.
> 
> Adds **How validation affects hook order** to the events-and-hooks guide with explicit sequences for edits with and without a validator (including built-in validators from numeric/date/time/dropdown/autocomplete cell types). It explains that **`afterSelection` can run before the change commits** when validation is pending (e.g. Enter/Tab), and recommends **`afterChange`** or **`afterValidate`** for acting on validated values.
> 
> Updates the cell-validator guide with the same timing guidance, fixes wording/typo in the validator callback note, marks the page **updated**, and cross-links to the new section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6ec406f60f400c333b2ce0811b35ab5f01a249d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->