### PR TITLE
DEV-1946: Move the Result section before the Related block in guides docs

### DIFF
--- a/docs/content/guides/accessibility/accessibility/accessibility.md
+++ b/docs/content/guides/accessibility/accessibility/accessibility.md
@@ -287,6 +287,10 @@ We make sure our data grid remains accessible by taking the following measures:
 - Dynamic ARIA attributes are sometimes omitted by screen readers.
 - The `aria-rowcount` attribute is intentionally set to `-1`, as most screen readers either ignore or misinterpret it. This configuration ensures accuracy with screen readers such as VoiceOver. We plan to revise this approach once screen readers consistently handle the `aria-rowcount` attribute correctly.
 
+## Result
+
+Your grid now supports keyboard navigation, screen reader announcements, and ARIA attributes for all major interactive elements.
+
 ## API reference
 
 For the list of [options](@/guides/getting-started/configuration-options/configuration-options.md), methods, and [Handsontable hooks](@/guides/getting-started/events-and-hooks/events-and-hooks.md) related to accessibility, see the following API reference pages:
@@ -329,7 +333,3 @@ Didn't find what you need? Try this:
 - [Contact our technical support](https://handsontable.com/contact?category=technical_support) to get help
 
 </div>
-
-## Result
-
-Your grid now supports keyboard navigation, screen reader announcements, and ARIA attributes for all major interactive elements.

--- a/docs/content/guides/cell-features/autofill-values/autofill-values.md
+++ b/docs/content/guides/cell-features/autofill-values/autofill-values.md
@@ -136,6 +136,10 @@ In this configuration, the fill handle is restricted to move only vertically. Ne
 
 :::
 
+## Result
+
+The fill handle appears on the selected cell. Dragging it copies or extends values into adjacent cells in the configured direction.
+
 ## Related API reference
 
 **Configuration options**
@@ -163,7 +167,3 @@ In this configuration, the fill handle is restricted to move only vertically. Ne
 - [Autofill](@/api/autofill.md)
 
 </div>
-
-## Result
-
-The fill handle appears on the selected cell. Dragging it copies or extends values into adjacent cells in the configured direction.

--- a/docs/content/guides/cell-features/clipboard/clipboard.md
+++ b/docs/content/guides/cell-features/clipboard/clipboard.md
@@ -346,6 +346,10 @@ Examples of how to use them are provided in their descriptions.
 3. `document.execCommand` can be called only during an immediate-execute event, such as a `MouseEvent` or a `KeyboardEvent`.
 4. Clipboard operations don’t work in Chrome 133+ with Handsontable 14.6.0, 14.6.1, or 15.0.0. Update to 14.6.2 or 15.0.1+. See the [incident announcement](https://handsontable.com/blog/incident-report-handsontable-14.6-15.0-clipboard-disruption-in-chrome-133) for details.
 
+## Result
+
+Users can copy, cut, and paste cell data using keyboard shortcuts or the context menu. Programmatic copy and cut operations work by calling `document.execCommand()` after selecting the target cells.
+
 ## Related keyboard shortcuts
 
 | Windows                                | macOS                                 | Action                                                          |  Excel  | Sheets  |
@@ -407,7 +411,3 @@ Examples of how to use them are provided in their descriptions.
 - [CopyPaste](@/api/copyPaste.md)
 
 </div>
-
-## Result
-
-Users can copy, cut, and paste cell data using keyboard shortcuts or the context menu. Programmatic copy and cut operations work by calling `document.execCommand()` after selecting the target cells.

--- a/docs/content/guides/cell-features/comments/comments.md
+++ b/docs/content/guides/cell-features/comments/comments.md
@@ -333,6 +333,10 @@ To display comments after a pre-configured time delay, use the [`displayDelay`](
 
 :::
 
+## Result
+
+Cells with comments display a small indicator in the corner. Users can view, edit, or delete comments through the context menu, and pre-configured comments appear when the table loads.
+
 ## Related keyboard shortcuts
 
 | Windows                                                 | macOS                                                      | Action                                  |  Excel  | Sheets  |
@@ -351,7 +355,3 @@ To display comments after a pre-configured time delay, use the [`displayDelay`](
 - [comments](@/api/options.md#comments)
 
 </div>
-
-## Result
-
-Cells with comments display a small indicator in the corner. Users can view, edit, or delete comments through the context menu, and pre-configured comments appear when the table loads.

--- a/docs/content/guides/cell-features/conditional-formatting/conditional-formatting.md
+++ b/docs/content/guides/cell-features/conditional-formatting/conditional-formatting.md
@@ -78,6 +78,10 @@ This demo shows how to use the cell type renderer feature to make some condition
 
 :::
 
+## Result
+
+Cells that match the defined conditions display the configured styles -- colors, fonts, or borders -- automatically updating as data changes.
+
 ## Related articles
 
 **Related guides**
@@ -115,7 +119,3 @@ This demo shows how to use the cell type renderer feature to make some condition
 - [CustomBorders](@/api/customBorders.md)
 
 </div>
-
-## Result
-
-Cells that match the defined conditions display the configured styles -- colors, fonts, or borders -- automatically updating as data changes.

--- a/docs/content/guides/cell-features/disabled-cells/disabled-cells.md
+++ b/docs/content/guides/cell-features/disabled-cells/disabled-cells.md
@@ -276,6 +276,10 @@ To make specific cells non-editable, set `editor: false` in the cell configurati
 
 :::
 
+## Result
+
+Read-only cells display with the `htDimmed` CSS class and block paste and drag-to-fill operations. Non-editable cells block manual editing but allow copy-paste and drag-to-fill.
+
 ## Related API reference
 
 **Configuration options**
@@ -286,7 +290,3 @@ To make specific cells non-editable, set `editor: false` in the cell configurati
 - [readOnlyCellClassName](@/api/options.md#readonlycellclassname)
 
 </div>
-
-## Result
-
-Read-only cells display with the `htDimmed` CSS class and block paste and drag-to-fill operations. Non-editable cells block manual editing but allow copy-paste and drag-to-fill.

--- a/docs/content/guides/cell-features/formatting-cells/formatting-cells.md
+++ b/docs/content/guides/cell-features/formatting-cells/formatting-cells.md
@@ -189,6 +189,10 @@ The example below demonstrates different border styles applied to various cell r
 
 :::
 
+## Result
+
+Cells display the configured CSS classes, inline styles, or custom borders. The appearance updates each time the grid renders, keeping styles in sync with your configuration.
+
 ## Related articles
 
 **Related guides**
@@ -226,7 +230,3 @@ The example below demonstrates different border styles applied to various cell r
 - [CustomBorders](@/api/customBorders.md)
 
 </div>
-
-## Result
-
-Cells display the configured CSS classes, inline styles, or custom borders. The appearance updates each time the grid renders, keeping styles in sync with your configuration.

--- a/docs/content/guides/cell-features/merge-cells/merge-cells.md
+++ b/docs/content/guides/cell-features/merge-cells/merge-cells.md
@@ -227,6 +227,10 @@ When a merged cell's underlying rows or columns are reordered (through [`manualC
 
 [`undo`](@/api/options.md#undo) and [`redo`](@/api/options.md#redo) restore the pre-move state, including any merges that were split or dropped by the reorder.
 
+## Result
+
+Cells at the configured positions are now merged. Users see a single cell spanning multiple rows or columns.
+
 ## Related keyboard shortcuts
 
 | Windows                                | macOS                                  | Action                              |  Excel  | Sheets  |
@@ -265,7 +269,3 @@ When a merged cell's underlying rows or columns are reordered (through [`manualC
 - [MergeCells](@/api/mergeCells.md)
 
 </div>
-
-## Result
-
-Cells at the configured positions are now merged. Users see a single cell spanning multiple rows or columns.

--- a/docs/content/guides/cell-features/selection/selection.md
+++ b/docs/content/guides/cell-features/selection/selection.md
@@ -318,6 +318,10 @@ To jump across a horizontal edge:
 - When cell selection is on a column's first cell, press <kbd>**↑**</kbd>.
 - When cell selection is on a column's last cell, press <kbd>**↓**</kbd>, or press <kbd>**Enter**</kbd>.
 
+## Result
+
+Users can select cells using the configured mode -- single cell, range, or multiple ranges. Programmatic selections take effect immediately and fire the relevant selection hooks.
+
 ## Related keyboard shortcuts
 
 | Windows                                                       | macOS                                                        | Action                                                                           |  Excel  | Sheets  |
@@ -398,7 +402,3 @@ To jump across a horizontal edge:
 - [DragToScroll](@/api/dragToScroll.md)
 
 </div>
-
-## Result
-
-Users can select cells using the configured mode -- single cell, range, or multiple ranges. Programmatic selections take effect immediately and fire the relevant selection hooks.

--- a/docs/content/guides/cell-features/text-alignment/text-alignment.md
+++ b/docs/content/guides/cell-features/text-alignment/text-alignment.md
@@ -114,6 +114,10 @@ The following code sample configures the grid to use `htCenter` and configures i
 
 :::
 
+## Result
+
+Cells display the configured horizontal or vertical alignment. Global settings apply to all cells, and per-cell settings take precedence over the global defaults.
+
 ## Related API reference
 
 **Configuration options**
@@ -132,7 +136,3 @@ The following code sample configures the grid to use `htCenter` and configures i
 - [beforeCellAlignment](@/api/hooks.md#beforecellalignment)
 
 </div>
-
-## Result
-
-Cells display the configured horizontal or vertical alignment. Global settings apply to all cells, and per-cell settings take precedence over the global defaults.

--- a/docs/content/guides/cell-functions/cell-editor/cell-editor.md
+++ b/docs/content/guides/cell-functions/cell-editor/cell-editor.md
@@ -418,6 +418,10 @@ class ExtendedSelectEditor extends MySelectEditor {
 
 :::
 
+## Result
+
+You now have a custom cell editor that controls how values are entered in your data grid. You can extend a built-in editor for small changes, or build from `BaseEditor` for a completely custom editing experience.
+
 ## Related keyboard shortcuts
 
 | Windows | macOS | Action | Excel | Sheets |
@@ -514,7 +518,3 @@ class ExtendedSelectEditor extends MySelectEditor {
 - [beforeGetCellMeta](@/api/hooks.md#beforegetcellmeta)
 
 </div>
-
-## Result
-
-You now have a custom cell editor that controls how values are entered in your data grid. You can extend a built-in editor for small changes, or build from `BaseEditor` for a completely custom editing experience.

--- a/docs/content/guides/cell-functions/cell-renderer/cell-renderer.md
+++ b/docs/content/guides/cell-functions/cell-renderer/cell-renderer.md
@@ -477,6 +477,10 @@ Cell renderers are called separately for every displayed cell, during every tabl
 
 If you only need to format the displayed value (e.g., add units, format dates, or apply text transformations), consider using the [`valueFormatter`](@/api/options.md#valueformatter) option instead of a custom renderer. The `valueFormatter` is called before the renderer and focuses solely on value transformation, making it more performant for simple formatting tasks. Use a renderer when you need to modify the DOM structure, add custom HTML elements, or handle complex visual layouts.
 
+## Result
+
+You now have a custom cell renderer that controls how cell content appears in the DOM. You can use a built-in renderer by alias, register and reuse your own with `registerRenderer()`, or write inline renderer functions for full control over the cell's HTML structure.
+
 ## Related API
 
 ### Overview
@@ -774,7 +778,3 @@ In this example, `valueFormatter` adds the currency symbol and formatting, while
 - [beforeRenderer](@/api/hooks.md#beforerenderer)
 
 </div>
-
-## Result
-
-You now have a custom cell renderer that controls how cell content appears in the DOM. You can use a built-in renderer by alias, register and reuse your own with `registerRenderer()`, or write inline renderer functions for full control over the cell's HTML structure.

--- a/docs/content/guides/cell-functions/cell-validator/cell-validator.md
+++ b/docs/content/guides/cell-functions/cell-validator/cell-validator.md
@@ -278,6 +278,10 @@ Edit the above grid to see the `changes` argument from the callback.
 
 Mind that changes in table are applied after running all validators (both synchronous and and asynchronous) from every changed cell.
 
+## Result
+
+You now have a cell validator that enforces data rules when a user finishes editing. Register it under an alias to reference it by name across your column configuration, and use `allowInvalid: false` to keep the editor open until the user enters a valid value.
+
 ## Related API reference
 
 **APIs**
@@ -327,7 +331,3 @@ Mind that changes in table are applied after running all validators (both synchr
 - [beforeValidate](@/api/hooks.md#beforevalidate)
 
 </div>
-
-## Result
-
-You now have a cell validator that enforces data rules when a user finishes editing. Register it under an alias to reference it by name across your column configuration, and use `allowInvalid: false` to keep the editor open until the user enters a valid value.

--- a/docs/content/guides/formulas/formula-calculation/formula-calculation.md
+++ b/docs/content/guides/formulas/formula-calculation/formula-calculation.md
@@ -1045,6 +1045,10 @@ details, [contact our Sales Team](https://handsontable.com/get-a-quote).
 
 :::
 
+## Result
+
+After setting up the `Formulas` plugin with a HyperFormula engine, cells that contain a formula (starting with `=`) are evaluated automatically. Editing a cell updates all dependent formula cells in real time, and cross-sheet references stay in sync across linked Handsontable instances.
+
 ## Related articles
 
 **HyperFormula documentation**
@@ -1098,7 +1102,3 @@ details, [contact our Sales Team](https://handsontable.com/get-a-quote).
 - [Formulas](@/api/formulas.md)
 
 </div>
-
-## Result
-
-After setting up the `Formulas` plugin with a HyperFormula engine, cells that contain a formula (starting with `=`) are evaluated automatically. Editing a cell updates all dependent formula cells in real time, and cross-sheet references stay in sync across linked Handsontable instances.

--- a/docs/content/guides/getting-started/configuration-options/configuration-options.md
+++ b/docs/content/guides/getting-started/configuration-options/configuration-options.md
@@ -1303,6 +1303,10 @@ Use [`initialState`](@/api/options.md#initialstate) to apply these options only 
 
 :::
 
+## Result
+
+Your grid now applies configuration options at the scope you specified -- grid-wide, per column, per row, or per individual cell -- using Handsontable's cascading configuration system.
+
 ## Related API reference
 
 **Configuration options**
@@ -1341,7 +1345,3 @@ Use [`initialState`](@/api/options.md#initialstate) to apply these options only 
 - [afterUpdateSettings](@/api/hooks.md#afterupdatesettings)
 
 </div>
-
-## Result
-
-Your grid now applies configuration options at the scope you specified -- grid-wide, per column, per row, or per individual cell -- using Handsontable's cascading configuration system.

--- a/docs/content/guides/getting-started/grid-size/grid-size.md
+++ b/docs/content/guides/getting-started/grid-size/grid-size.md
@@ -496,6 +496,10 @@ Taller rows or wider columns lower these limits proportionally. For example, wit
 
 If your dataset can grow past these limits, load it in smaller chunks, for example with server-side or lazy data loading.
 
+## Result
+
+Your grid now renders at the dimensions you specified, responding to container size or fixed pixel values as configured.
+
 ## Related articles
 
 **Related guides**
@@ -537,7 +541,3 @@ If your dataset can grow past these limits, load it in smaller chunks, for examp
 - [beforeRefreshDimensions](@/api/hooks.md#beforerefreshdimensions)
 
 </div>
-
-## Result
-
-Your grid now renders at the dimensions you specified, responding to container size or fixed pixel values as configured.

--- a/docs/content/guides/getting-started/installation/installation.md
+++ b/docs/content/guides/getting-started/installation/installation.md
@@ -511,6 +511,10 @@ To set Handsontable's [configuration options](@/guides/getting-started/configura
 
 </div>
 
+## Result
+
+Handsontable is installed and ready to use in your project. Import it and create your first grid instance.
+
 ## Related articles
 
 **Related guides**
@@ -546,7 +550,3 @@ To set Handsontable's [configuration options](@/guides/getting-started/configura
 - [construct](@/api/hooks.md#construct)
 
 </div>
-
-## Result
-
-Handsontable is installed and ready to use in your project. Import it and create your first grid instance.

--- a/docs/content/guides/getting-started/license-key/license-key.md
+++ b/docs/content/guides/getting-started/license-key/license-key.md
@@ -240,6 +240,10 @@ _The license key for Handsontable expired on `[expiration_date]`, and is not val
 
 To get a commercial license key for your Handsontable copy, contact our [Sales Team](https://handsontable.com/get-a-quote).
 
+## Result
+
+Your grid is now licensed. A valid commercial key removes the license notice from the grid header.
+
 ## Related articles
 
 ### Related guides
@@ -258,7 +262,3 @@ To get a commercial license key for your Handsontable copy, contact our [Sales T
   - [`licenseKey`](@/api/options.md#licensekey)
 
 </div>
-
-## Result
-
-Your grid is now licensed. A valid commercial key removes the license notice from the grid header.

--- a/docs/content/guides/getting-started/saving-data/saving-data.md
+++ b/docs/content/guides/getting-started/saving-data/saving-data.md
@@ -78,6 +78,10 @@ The example below handles data by using `fetch`. Note that this is just a mockup
 
 To persist table state (e.g. column order, column widths, row order) across page reloads, use the browser's [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) API or [`sessionStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage) in your application. Listen to the appropriate hooks (e.g. `afterColumnMove`, `afterColumnResize`) and save or restore state as needed.
 
+## Result
+
+Changes made in the grid are now persisted to your backend or local state on every edit.
+
 ## Related API reference
 
 **Core methods**
@@ -96,7 +100,3 @@ To persist table state (e.g. column order, column widths, row order) across page
 - [afterChange](@/api/hooks.md#afterchange)
 
 </div>
-
-## Result
-
-Changes made in the grid are now persisted to your backend or local state on every edit.

--- a/docs/content/guides/navigation/custom-shortcuts/custom-shortcuts.md
+++ b/docs/content/guides/navigation/custom-shortcuts/custom-shortcuts.md
@@ -333,6 +333,10 @@ const hotSettings = ref({
 
 :::
 
+## Result
+
+After completing these steps, you have custom keyboard shortcuts registered in the target context. The shortcuts trigger your callbacks when the user presses the configured key combination, and only when the specified context is active.
+
 ## Reference
 
 ### Keyboard shortcut contexts
@@ -410,10 +414,6 @@ For the list of [options](@/guides/getting-started/configuration-options/configu
 - [beforeKeyDown](@/api/hooks.md#beforekeydown)
 
 </div>
-
-## Result
-
-After completing these steps, you have custom keyboard shortcuts registered in the target context. The shortcuts trigger your callbacks when the user presses the configured key combination, and only when the specified context is active.
 
 ## Troubleshooting
 

--- a/docs/content/guides/navigation/focus-scopes/focus-scopes.md
+++ b/docs/content/guides/navigation/focus-scopes/focus-scopes.md
@@ -364,6 +364,10 @@ The focus scope manager automatically:
 - Switches the shortcuts context to the scope's specified context name when the scope is activated
 - Handles tab navigation between scopes
 
+## Result
+
+After registering a focus scope, Handsontable automatically activates it when the user clicks inside the container or tabs to it. The associated shortcuts context switches accordingly, and tab navigation flows through your registered scopes in the correct order.
+
 ## API reference
 
 For the complete API reference, see the following pages:
@@ -405,10 +409,6 @@ For the complete API reference, see the following pages:
 - [beforeKeyDown](@/api/hooks.md#beforekeydown)
 
 </div>
-
-## Result
-
-After registering a focus scope, Handsontable automatically activates it when the user clicks inside the container or tabs to it. The associated shortcuts context switches accordingly, and tab navigation flows through your registered scopes in the correct order.
 
 ## Related blog articles
 

--- a/docs/content/guides/rows/row-moving/row-moving.md
+++ b/docs/content/guides/rows/row-moving/row-moving.md
@@ -84,6 +84,10 @@ This renders the rows in the following order:
 
 The array must contain all physical row indexes (its length must equal the total number of rows). After the initial render, users can still drag rows to change the order further.
 
+## Result
+
+After completing this guide, you can reorder rows by dragging them with the mouse or by calling `dragRows()` and `moveRows()` programmatically. You can also set a pre-defined row order at initialization.
+
 ## API reference
 
 ### dragRows vs moveRows
@@ -145,7 +149,3 @@ The [`moveRows`](@/api/manualRowMove.md#moverows) function cannot perform some a
 - [ManualRowMove](@/api/manualRowMove.md)
 
 </div>
-
-## Result
-
-After completing this guide, you can reorder rows by dragging them with the mouse or by calling `dragRows()` and `moveRows()` programmatically. You can also set a pre-defined row order at initialization.

--- a/docs/content/guides/rows/rows-pagination/rows-pagination.md
+++ b/docs/content/guides/rows/rows-pagination/rows-pagination.md
@@ -464,6 +464,10 @@ When pagination is enabled:
 - The [`height`](@/api/options.md#height) option set as `auto` is not supported when the `pageSize: 'auto'` is set.
 - Pagination always displays a fixed number of rows per page (default is `10`), regardless of data changes such as hiding, trimming, filtering, removing, adding, or pasting rows - unless `pageSize: 'auto'` is set.
 
+## Result
+
+After completing this guide, your grid divides rows into pages with built-in navigation controls. You can configure the page size, customize the UI position, control pagination programmatically, and react to page changes using hooks.
+
 ## Related blog articles
 
 <div class="boxes-list gray">
@@ -507,10 +511,6 @@ When pagination is enabled:
 - [MergeCells](@/api/mergeCells.md)
 
 </div>
-
-## Result
-
-After completing this guide, your grid divides rows into pages with built-in navigation controls. You can configure the page size, customize the UI position, control pagination programmatically, and react to page changes using hooks.
 
 ## Troubleshooting
 

--- a/docs/content/guides/rows/rows-sorting/rows-sorting.md
+++ b/docs/content/guides/rows/rows-sorting/rows-sorting.md
@@ -1416,6 +1416,10 @@ import { registerPlugin, ColumnSorting } from 'handsontable/plugins';
 registerPlugin(ColumnSorting);
 ```
 
+## Result
+
+After completing this guide, users can sort rows by clicking column headers, and you can control sort order programmatically. You can use `ColumnSorting` for single-column sorting or `MultiColumnSorting` for multi-column sorting with custom priority.
+
 ## Related keyboard shortcuts
 
 | Windows | macOS | Action | Excel | Sheets |
@@ -1444,10 +1448,6 @@ registerPlugin(ColumnSorting);
 | `indicator` | `boolean` | `true` | When `true`, a sort-order arrow icon is shown in the column header. |
 | `compareFunctionFactory` | `function` | -- | A factory that returns a custom comparator function. See [Add a custom comparator](#add-a-custom-comparator). |
 | `initialConfig` | `object` | -- | Sort config applied at initialization. Contains `column` (visual index) and `sortOrder` (`'asc'` or `'desc'`). |
-
-## Result
-
-After completing this guide, users can sort rows by clicking column headers, and you can control sort order programmatically. You can use `ColumnSorting` for single-column sorting or `MultiColumnSorting` for multi-column sorting with custom priority.
 
 ## API reference
 

--- a/docs/content/guides/styling/themes/themes.md
+++ b/docs/content/guides/styling/themes/themes.md
@@ -601,6 +601,10 @@ In some cases, global styles enforced by the browser or operating system can imp
 - **High contrast mode in Windows**: To style the component when Windows' high contrast mode is active, use the `forced-colors` media query. This allows you to detect and adapt to forced color settings. [Read more](https://blogs.windows.com/msedgedev/2020/09/17/styling-for-windows-high-contrast-with-new-standards-for-forced-colors/)
 - **Auto dark theme in Google Chrome**: Chrome automatically applies a dark theme in some scenarios. To detect and manage this behavior, refer to the official [Chrome guide](https://developer.chrome.com/blog/auto-dark-theme)
 
+## Result
+
+Your grid now renders with the theme you configured. You can switch color schemes and density modes at runtime using the Theme API.
+
 ## Related blog articles
 
 <div class="boxes-list gray">
@@ -623,7 +627,3 @@ Didn't find what you need? Try this:
 - [Contact our technical support](https://handsontable.com/contact?category=technical_support) to get help
 
 </div>
-
-## Result
-
-Your grid now renders with the theme you configured. You can switch color schemes and density modes at runtime using the Theme API.

--- a/docs/content/guides/tools-and-building/custom-builds/custom-builds.md
+++ b/docs/content/guides/tools-and-building/custom-builds/custom-builds.md
@@ -290,6 +290,10 @@ From the `/wrappers/vue3` directory, you can also run individual Vue `build` tas
 
 :::
 
+## Result
+
+You now have a local build of Handsontable. The output files in `handsontable/dist/` and `handsontable/tmp/` reflect your source changes.
+
 ## Related guides
 
 <div class="boxes-list">
@@ -303,7 +307,3 @@ From the `/wrappers/vue3` directory, you can also run individual Vue `build` tas
 - [Testing](@/guides/tools-and-building/testing/testing.md)
 
 </div>
-
-## Result
-
-You now have a local build of Handsontable. The output files in `handsontable/dist/` and `handsontable/tmp/` reflect your source changes.

--- a/docs/content/guides/tools-and-building/modules/modules.md
+++ b/docs/content/guides/tools-and-building/modules/modules.md
@@ -1344,6 +1344,10 @@ You can also use modules with Handsontable's framework wrappers:
 
 :::
 
+## Result
+
+Your bundle now includes only the modules you imported, reducing its size compared to the full Handsontable package.
+
 ## Related articles
 
 **Related guides**
@@ -1371,7 +1375,3 @@ You can also use modules with Handsontable's framework wrappers:
 - [Handsontable 11.0.0: modularization for React, Angular, and Vue](https://handsontable.com/blog/handsontable-11.0.0-modularization-for-react-angular-and-vue)
 
 </div>
-
-## Result
-
-Your bundle now includes only the modules you imported, reducing its size compared to the full Handsontable package.

--- a/docs/content/guides/tools-and-building/testing/testing.md
+++ b/docs/content/guides/tools-and-building/testing/testing.md
@@ -84,6 +84,10 @@ To avoid unintended changes to Handsontable's UI, we use automated visual regres
 
 Learn more on our [GitHub](https://github.com/handsontable/handsontable/blob/develop/visual-tests/README.md).
 
+## Result
+
+Your tests ran and reported pass or fail results. A green test suite confirms your change does not introduce regressions.
+
 ## Related guides
 
 <div class="boxes-list">
@@ -97,7 +101,3 @@ Learn more on our [GitHub](https://github.com/handsontable/handsontable/blob/dev
 :::
 
 </div>
-
-## Result
-
-Your tests ran and reported pass or fail results. A green test suite confirms your change does not introduce regressions.

--- a/docs/content/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md
@@ -1164,12 +1164,12 @@ See the [Formula calculation](@/guides/formulas/formula-calculation/formula-calc
 | `core-js` dependency removed                      | Add `core-js` or other polyfills in your app if you support older environments |
 | Built-in HyperFormula (deprecation)               | In 18.0, import HyperFormula yourself and pass it to the Formulas plugin with `licenseKey: 'internal-use-in-handsontable'` |
 
+## Result
+
+Your application now runs on Handsontable 17.0.
+
 ## Related resources
 
 - [Themes](@/guides/styling/themes/themes.md) - Learn about the theming system
 - [Theme Customization](@/guides/styling/theme-customization/theme-customization.md) - Customize themes with CSS variables
 - [Legacy Style](@/guides/styling/legacy-style/legacy-style.md) - Information about the legacy style deprecation
-
-## Result
-
-Your application now runs on Handsontable 17.0.

--- a/docs/content/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-17.1-to-18.0/migrating-from-17.1-to-18.0.md
@@ -509,6 +509,10 @@ Use class-based selectors instead of positional ones, so future layout slot addi
 | `--ht-wrapper-border-radius` renamed to `--ht-border-radius`; `--ht-wrapper-border-width` and `--ht-wrapper-border-color` removed | Projects overriding these theme variables or passing the matching JS tokens | Rename to `--ht-border-radius` / `borderRadius`; recreate a wrapper border with `box-shadow` if needed |
 | Wrapper DOM structure changed -- new `.ht-grid-content`, `.ht-slot-top`, `.ht-slot-bottom`, and `.ht-overlay` elements | Projects with CSS selectors or DOM queries targeting Handsontable's wrapper elements by position | Update selectors to be class-based; account for the new `.ht-grid-content` wrapper and sibling slot containers |
 
+## Result
+
+Your application now runs on Handsontable 18.0.
+
 ## Related resources
 
 - [TypeScript types](@/guides/tools-and-building/typescript-types/typescript-types.md)
@@ -517,7 +521,3 @@ Use class-based selectors instead of positional ones, so future layout slot addi
 - [Date cell type](@/guides/cell-types/date-cell-type/date-cell-type.md)
 - [Time cell type](@/guides/cell-types/time-cell-type/time-cell-type.md)
 - [Security](@/guides/security/security/security.md)
-
-## Result
-
-Your application now runs on Handsontable 18.0.


### PR DESCRIPTION
### Context

The PR fixes the section ordering on documentation guide pages where the **Result** section appeared *after* the **Related API reference** / Related block (for example, [cell-editor](https://handsontable.com/docs/javascript-data-grid/cell-editor/) and [cell-validator](https://handsontable.com/docs/javascript-data-grid/cell-validator/)).

The Diátaxis migration appended each `## Result` summary at the very end of the page, below the reference appendix. The how-to template order is **content → Result → Related**, so the wrap-up must precede the related/reference material.

The fix moves each trailing `## Result` to immediately before the first heading of the trailing reference cluster (`Related*` / `Reference` / `API reference`), keeping `## Troubleshooting` last on pages that have it. It applies to **30 affected guide pages**. On `installation.md`, only the misplaced trailing `Result` is moved; the framework-specific `Result` inside the `only-for` block is left in place.

The change is a pure prose reorder - no content was added or removed, and no `only-for` / `example` directive fences were affected.

### How has this been tested?

- Verified per file that the set of non-empty lines is identical before and after (pure reorder, nothing added or dropped).
- Re-ran a detection sweep across `content/guides/` - zero pages have `Result` after a `Related` / `Reference` / `API reference` heading.
- Confirmed no moved `Result` block contains a `:::` or code fence, so directive pairing cannot have desynced; fence counts remain balanced.
- Eyeballed the source ordering on the tricky pages: `cell-editor` (`only-for` blocks), `installation` (two `Result` sections), and `accessibility` / `themes` (`Troubleshooting` stays last).

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1946

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1946

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only reordering plus CI workflow trigger changes; no runtime product code paths affected.
> 
> **Overview**
> **Documentation guides** now follow the Diátaxis how-to flow: on ~30 guide pages, each trailing **`## Result`** block is moved to sit **before** the first **Related** / **Reference** / **API reference** section (with **Troubleshooting** still last where present). Content is unchanged—only section order.
> 
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 393a85755bfd3fb503c1752d77e0201a48f22a3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->