### PR TITLE
DEV-340: Clarify select cell type usage and label its demo column

### DIFF
--- a/docs/content/guides/cell-types/select-cell-type/angular/example1.ts
+++ b/docs/content/guides/cell-types/select-cell-type/angular/example1.ts
@@ -20,8 +20,8 @@ export class AppComponent {
 
   readonly gridSettings: GridSettings = {
     height: 'auto',
-    colWidths: [50, 70, 50],
-    colHeaders: true,
+    colWidths: [70, 90, 80],
+    colHeaders: ['Year', 'Make', 'In stock'],
     autoWrapRow: true,
     autoWrapCol: true,
     columns: [

--- a/docs/content/guides/cell-types/select-cell-type/javascript/example1.js
+++ b/docs/content/guides/cell-types/select-cell-type/javascript/example1.js
@@ -12,8 +12,8 @@ new Handsontable(container, {
     ['2018', 'Toyota', 20],
     ['2019', 'Nissan', 30],
   ],
-  colWidths: [50, 70, 50],
-  colHeaders: true,
+  colWidths: [70, 90, 80],
+  colHeaders: ['Year', 'Make', 'In stock'],
   columns: [
     {},
     {

--- a/docs/content/guides/cell-types/select-cell-type/javascript/example1.ts
+++ b/docs/content/guides/cell-types/select-cell-type/javascript/example1.ts
@@ -12,8 +12,8 @@ new Handsontable(container, {
     ['2018', 'Toyota', 20],
     ['2019', 'Nissan', 30],
   ],
-  colWidths: [50, 70, 50],
-  colHeaders: true,
+  colWidths: [70, 90, 80],
+  colHeaders: ['Year', 'Make', 'In stock'],
   columns: [
     {},
     {

--- a/docs/content/guides/cell-types/select-cell-type/react/example1.jsx
+++ b/docs/content/guides/cell-types/select-cell-type/react/example1.jsx
@@ -12,8 +12,8 @@ const ExampleComponent = () => {
         ['2018', 'Toyota', 20],
         ['2019', 'Nissan', 30],
       ]}
-      colWidths={[50, 70, 50]}
-      colHeaders={true}
+      colWidths={[70, 90, 80]}
+      colHeaders={['Year', 'Make', 'In stock']}
       columns={[
         {},
         {

--- a/docs/content/guides/cell-types/select-cell-type/react/example1.tsx
+++ b/docs/content/guides/cell-types/select-cell-type/react/example1.tsx
@@ -12,8 +12,8 @@ const ExampleComponent = () => {
         ['2018', 'Toyota', 20],
         ['2019', 'Nissan', 30],
       ]}
-      colWidths={[50, 70, 50]}
-      colHeaders={true}
+      colWidths={[70, 90, 80]}
+      colHeaders={['Year', 'Make', 'In stock']}
       columns={[
         {},
         {

--- a/docs/content/guides/cell-types/select-cell-type/select-cell-type.md
+++ b/docs/content/guides/cell-types/select-cell-type/select-cell-type.md
@@ -29,6 +29,8 @@ The select cell type is a simpler form of the [dropdown](@/guides/cell-types/dro
 
 > **Note:** The select editor is intended as a reference implementation for writing custom editors rather than as a fully-featured editor. It is a much simpler form of the [Dropdown editor](@/guides/cell-types/dropdown-cell-type/dropdown-cell-type.md). Use the dropdown cell type in your projects for a better user experience.
 
+In the demo below, the **Make** column uses the select cell type. The cell looks like plain text -- there is no dropdown arrow to indicate it. A single click only selects the cell. To open the list of options, double-click the cell or press <kbd>**Enter**</kbd>.
+
 ::: only-for javascript
 
 ::: example #example1 --js 1 --ts 2
@@ -74,7 +76,7 @@ The select cell type is a simpler form of the [dropdown](@/guides/cell-types/dro
 
 ## Result
 
-After configuring the select cell type, cells render a native HTML `<select>` element when the user activates them. The user picks a value from the list and the selected value is written to the data source.
+After configuring the select cell type, cells in the **Make** column render a native HTML `<select>` element when the user activates them. The user picks a value from the list and the selected value is written to the data source.
 
 ## Keyboard navigation
 

--- a/docs/content/guides/cell-types/select-cell-type/vue/example1.vue
+++ b/docs/content/guides/cell-types/select-cell-type/vue/example1.vue
@@ -13,8 +13,8 @@ const hotSettings = ref<GridSettings>({
     ['2018', 'Toyota', 20],
     ['2019', 'Nissan', 30],
   ],
-  colWidths: [50, 70, 50],
-  colHeaders: true,
+  colWidths: [70, 90, 80],
+  colHeaders: ['Year', 'Make', 'In stock'],
   columns: [
     {},
     {


### PR DESCRIPTION
### Context

The PR improves the [select cell type guide](https://handsontable.com/docs/javascript-data-grid/select-cell-type/) based on HotJar session feedback reported in DEV-340. Two problems surfaced:

1. Users could not tell **which column** in the demo used the select cell type. The grid showed generic `A` / `B` / `C` headers, and the select cell renders as plain text with no dropdown arrow, so nothing signalled which column was interactive.
2. Users **single-clicked** the cell, saw nothing happen, and gave up — the page never stated that a single click only selects the cell and that you need to double-click (or press `Enter`) to open the list.

The keyboard-navigation half of the original issue was already shipped separately as DEV-340's sibling task DEV-440 (#12835), so this PR focuses on the remaining discoverability gap:

- Added a lead-in paragraph in the **Usage** section, at the demo, naming the **Make** column and explaining the mouse interaction (a single click only selects; double-click or `Enter` opens the options).
- Named the **Make** column in the **Result** sentence.
- Gave the demo real column headers (`Year` / `Make` / `In stock`) across all framework variants so it is self-evident which column is the select, and widened the columns to fit.

The optional explainer video from the issue is intentionally skipped — the docs do not embed video/GIFs.

### How has this been tested?

- Docs-only change (guide content + example settings). No source code is affected.
- Verified the `colHeaders: true` → array swap is consistent and identical across all six example files (js, ts, jsx, tsx, angular ts, vue).
- Confirmed no mirror copy of this demo exists outside the guide folder (only build artifacts).
- Static review of the rendered Markdown structure; the existing **Keyboard navigation** section is left intact.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-340

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-340

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example settings only; no runtime or API changes.
> 
> **Overview**
> Improves discoverability of the select cell type guide (DEV-340) with docs and demo tweaks only—no library code.
> 
> The **Usage** section now calls out the **Make** column and explains that select cells look like plain text (no arrow), that a single click only selects, and that double-click or **Enter** opens the options. The **Result** section likewise refers to the **Make** column.
> 
> All framework demos (`javascript`, `typescript`, `react`, `angular`, `vue`) switch from generic `colHeaders: true` to **`Year` / `Make` / `In stock`**, and `colWidths` widen from `[50, 70, 50]` to `[70, 90, 80]` so headers fit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45798b8cb77fb9d56fb6f05f07ab50163a7408e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->