### PR TITLE
DEV-1200: Update outdated known limitations in undo-redo guide

### DIFF
--- a/docs/content/guides/accessories-and-menus/undo-redo/undo-redo.md
+++ b/docs/content/guides/accessories-and-menus/undo-redo/undo-redo.md
@@ -21,6 +21,7 @@ vue:
   metaTitle: Undo and redo - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Accessories and menus
+menuTag: updated
 ---
 Revert and restore your changes, using the undo and redo features.
 
@@ -85,11 +86,11 @@ Make some changes to the grid below and the use the <kbd>**Ctrl**</kbd>/<kbd>⌘
 ## Known limitations
 
 Not all user-triggered actions are recorded in the undo-and-redo history.
-Here's the list of all unsupported features:
+The following actions are not supported:
 
-- [Rows sorting](@/guides/rows/rows-sorting/rows-sorting.md)
-- [Column filter](@/guides/columns/column-filter/column-filter.md)
-- [Row moving](@/guides/rows/row-moving/row-moving.md)
+- [Column resizing](@/guides/columns/column-width/column-width.md) and [row resizing](@/guides/rows/row-height/row-height.md)
+- [Hiding columns](@/guides/columns/column-hiding/column-hiding.md) and [hiding rows](@/guides/rows/row-hiding/row-hiding.md)
+- [Trimming rows](@/guides/rows/row-trimming/row-trimming.md)
 
 ## Related keyboard shortcuts
 


### PR DESCRIPTION
### Context

The PR fixes the outdated **Known limitations** section in the *Undo and redo* guide. The section listed rows sorting, column filter, and row moving as actions not recorded in the undo-and-redo history. All three are now fully supported by the `UndoRedo` plugin (shipped in 14.6.0) -- they each have a dedicated action (`ColumnSortAction`, `FiltersAction`, `RowMoveAction`/`ColumnMoveAction`) registered in `handsontable/src/plugins/undoRedo/actions/index.ts` with E2E coverage.

The stale list is replaced with the actions that genuinely are not tracked by undo/redo today: column/row resizing, column/row hiding, and row trimming (their plugins have no `UndoRedo` integration).

This is a docs-content-only change. No source code is touched.

### How has this been tested?

- Verified each new link target resolves to an existing guide page (`column-width`, `row-height`, `column-hiding`, `row-hiding`, `row-trimming`).
- Confirmed against source that `manualRowResize`, `manualColumnResize`, `hiddenRows`, `hiddenColumns`, and `trimRows` have no undo/redo integration, while sort/filter/move actions are registered in the undoRedo actions index.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. #2307
2. DEV-1200

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1200

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API impact.
> 
> **Overview**
> Updates the **Undo and redo** guide so **Known limitations** matches current `UndoRedo` behavior.
> 
> Sorting, column filter, and row moving are removed from the unsupported list (they are tracked since 14.6.0). The section now documents actions that still are not in undo/redo history: column/row resizing, hiding columns/rows, and trimming rows, with links to the relevant guides. Front matter adds `menuTag: updated` and the intro line is tightened.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a96d4b99d94a5cb29189e3d03a4796534e94aec9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->