### PR TITLE
DEV-1809: Remove unorm from the third-party licenses page

### DIFF
--- a/docs/content/guides/technical-specification/third-party-licenses/third-party-licenses.md
+++ b/docs/content/guides/technical-specification/third-party-licenses/third-party-licenses.md
@@ -54,9 +54,4 @@ The dependencies below apply only if you use the [`Formulas`](@/api/formulas.md)
     <p class="meta">Author: Scott Corgan<br>License: Open source (MIT)</p>
     <p class="url"><a href="https://github.com/scottcorgan/tiny-emitter" target="_blank" rel="noopener noreferrer">https://github.com/scottcorgan/tiny-emitter</a></p>
   </div>
-  <div class="ht-info-card">
-    <p class="name"><strong>unorm</strong></p>
-    <p class="meta">Author: Matsuza, Bjarke Walling<br>License: Open source (MIT)</p>
-    <p class="url"><a href="https://github.com/walling/unorm" target="_blank" rel="noopener noreferrer">https://github.com/walling/unorm</a></p>
-  </div>
 </div>


### PR DESCRIPTION
### Context

The PR fixes the [Third-party licenses page](https://handsontable.com/docs/javascript-data-grid/third-party-licenses/), which listed `unorm` as a dependency of the `Formulas` plugin. `unorm` is no longer distributed - HyperFormula dropped it in favor of the native `String.prototype.normalize()`, and it no longer appears anywhere in the shipped `hyperformula` bundle.

DEV-1809 originally asked the page to note that some listed dependencies are deprecated. While investigating, we confirmed the better fix is to remove the entry that is genuinely no longer distributed. The remaining cards stay accurate:

- `bessel` and `jStat` are deprecated/unmaintained on npm but their source is still **vendored** into the shipped HyperFormula bundle (`bessel.js (C) ... SheetJS`, `Copyright (c) 2013 jStat`), so their license notices must remain.
- `Chevrotain` and `tiny-emitter` are current HyperFormula runtime dependencies.
- `javascript-algorithms` is still used by the `LinkedList` in the `MergeCells` plugin.

The core dependencies removed in PRO-986 (`numbro`, `moment`, `Pikaday`, `DOMPurify`) were already removed from this page in #12689, so no action was needed for those.

`[skip changelog]` - docs-only change.

### How has this been tested?

Verified statically against the shipped HyperFormula bundle:

```shell
HF=$(find . -path '*/hyperformula/package.json' | head -1 | xargs dirname)
# unorm absent (no matches):
grep -nwiE 'unorm|matsuza|walling' "$HF/dist/hyperformula.js"
# bessel + jStat still bundled (both present, correctly kept):
grep -niE 'bessel\.js \(C\)|Copyright \(c\) 2013 jStat' "$HF/dist/hyperformula.js"
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1809

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1809

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update with no runtime or licensing impact on the product.
> 
> **Overview**
> Removes the **unorm** info card from the Formulas plugin section of the third-party licenses documentation.
> 
> **unorm** is no longer shipped with HyperFormula (replaced by native `String.prototype.normalize()`), so the page no longer lists it as a distributed dependency. Other Formulas-related entries are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d069da124621843281e59fbfb5ac2cbc3935cfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->