### PR TITLE
DEV-685: Drop minSpareRows from Binding to data guide examples

### DIFF
--- a/docs/content/guides/getting-started/binding-to-data/angular/example1.ts
+++ b/docs/content/guides/getting-started/binding-to-data/angular/example1.ts
@@ -28,7 +28,6 @@ export class AppComponent {
     height: 'auto',
     width: 'auto',
     autoWrapRow: true,
-    minSpareRows: 1,
     autoWrapCol: true
   };
 }

--- a/docs/content/guides/getting-started/binding-to-data/angular/example2.ts
+++ b/docs/content/guides/getting-started/binding-to-data/angular/example2.ts
@@ -23,7 +23,6 @@ export class AppComponent {
 
   readonly gridSettings: GridSettings = {
     colHeaders: true,
-    minSpareRows: 1,
     height: 'auto',
     width: 'auto',
     columns: [

--- a/docs/content/guides/getting-started/binding-to-data/angular/example3.ts
+++ b/docs/content/guides/getting-started/binding-to-data/angular/example3.ts
@@ -30,7 +30,6 @@ export class AppComponent {
     colHeaders: true,
     height: 'auto',
     width: 'auto',
-    minSpareRows: 1,
     autoWrapRow: true,
     autoWrapCol: true
   };

--- a/docs/content/guides/getting-started/binding-to-data/angular/example4.ts
+++ b/docs/content/guides/getting-started/binding-to-data/angular/example4.ts
@@ -42,7 +42,6 @@ export class AppComponent {
           return {};
       }
     },
-    minSpareRows: 1,
     autoWrapRow: true,
     autoWrapCol: true
   };

--- a/docs/content/guides/getting-started/binding-to-data/angular/example5.ts
+++ b/docs/content/guides/getting-started/binding-to-data/angular/example5.ts
@@ -34,7 +34,6 @@ export class AppComponent {
       { data: 'name.last' },
       { data: 'address' },
     ],
-    minSpareRows: 1,
     autoWrapRow: true,
     autoWrapCol: true
   };

--- a/docs/content/guides/getting-started/binding-to-data/angular/example6.ts
+++ b/docs/content/guides/getting-started/binding-to-data/angular/example6.ts
@@ -33,7 +33,6 @@ export class AppComponent {
       { data: 'name.last' },
       { data: 'address' },
     ],
-    minSpareRows: 1,
     autoWrapRow: true,
     autoWrapCol: true
   };

--- a/docs/content/guides/getting-started/binding-to-data/angular/example7.ts
+++ b/docs/content/guides/getting-started/binding-to-data/angular/example7.ts
@@ -90,7 +90,6 @@ export class AppComponent {
       { data: property('name') },
       { data: property('address') },
     ],
-    minSpareRows: 1,
     autoWrapRow: true,
     autoWrapCol: true
   };

--- a/docs/content/guides/getting-started/binding-to-data/javascript/example1.js
+++ b/docs/content/guides/getting-started/binding-to-data/javascript/example1.js
@@ -21,7 +21,6 @@ new Handsontable(container, {
   height: 'auto',
   width: 'auto',
   colHeaders: true,
-  minSpareRows: 1,
   autoWrapRow: true,
   autoWrapCol: true,
   licenseKey: 'non-commercial-and-evaluation',

--- a/docs/content/guides/getting-started/binding-to-data/javascript/example1.ts
+++ b/docs/content/guides/getting-started/binding-to-data/javascript/example1.ts
@@ -21,7 +21,6 @@ new Handsontable(container, {
   height: 'auto',
   width: 'auto',
   colHeaders: true,
-  minSpareRows: 1,
   autoWrapRow: true,
   autoWrapCol: true,
   licenseKey: 'non-commercial-and-evaluation',

--- a/docs/content/guides/getting-started/binding-to-data/javascript/example2.js
+++ b/docs/content/guides/getting-started/binding-to-data/javascript/example2.js
@@ -17,7 +17,6 @@ const data = [
 new Handsontable(container, {
   data,
   colHeaders: true,
-  minSpareRows: 1,
   height: 'auto',
   width: 'auto',
   columns: [

--- a/docs/content/guides/getting-started/binding-to-data/javascript/example2.ts
+++ b/docs/content/guides/getting-started/binding-to-data/javascript/example2.ts
@@ -17,7 +17,6 @@ const data: (string | number)[][] = [
 new Handsontable(container, {
   data,
   colHeaders: true,
-  minSpareRows: 1,
   height: 'auto',
   width: 'auto',
   columns: [

--- a/docs/content/guides/getting-started/binding-to-data/javascript/example3.js
+++ b/docs/content/guides/getting-started/binding-to-data/javascript/example3.js
@@ -18,7 +18,6 @@ new Handsontable(container, {
   colHeaders: true,
   height: 'auto',
   width: 'auto',
-  minSpareRows: 1,
   autoWrapRow: true,
   autoWrapCol: true,
   licenseKey: 'non-commercial-and-evaluation',

--- a/docs/content/guides/getting-started/binding-to-data/javascript/example3.ts
+++ b/docs/content/guides/getting-started/binding-to-data/javascript/example3.ts
@@ -25,7 +25,6 @@ new Handsontable(container, {
   colHeaders: true,
   height: 'auto',
   width: 'auto',
-  minSpareRows: 1,
   autoWrapRow: true,
   autoWrapCol: true,
   licenseKey: 'non-commercial-and-evaluation',

--- a/docs/content/guides/getting-started/binding-to-data/javascript/example4.js
+++ b/docs/content/guides/getting-started/binding-to-data/javascript/example4.js
@@ -30,7 +30,6 @@ new Handsontable(container, {
         return {};
     }
   },
-  minSpareRows: 1,
   autoWrapRow: true,
   autoWrapCol: true,
   licenseKey: 'non-commercial-and-evaluation',

--- a/docs/content/guides/getting-started/binding-to-data/javascript/example4.ts
+++ b/docs/content/guides/getting-started/binding-to-data/javascript/example4.ts
@@ -37,7 +37,6 @@ new Handsontable(container, {
         return {};
     }
   },
-  minSpareRows: 1,
   autoWrapRow: true,
   autoWrapCol: true,
   licenseKey: 'non-commercial-and-evaluation',

--- a/docs/content/guides/getting-started/binding-to-data/javascript/example5.js
+++ b/docs/content/guides/getting-started/binding-to-data/javascript/example5.js
@@ -17,7 +17,6 @@ new Handsontable(container, {
   height: 'auto',
   width: 'auto',
   columns: [{ data: 'id' }, { data: 'name.first' }, { data: 'name.last' }, { data: 'address' }],
-  minSpareRows: 1,
   autoWrapRow: true,
   autoWrapCol: true,
   licenseKey: 'non-commercial-and-evaluation',

--- a/docs/content/guides/getting-started/binding-to-data/javascript/example5.ts
+++ b/docs/content/guides/getting-started/binding-to-data/javascript/example5.ts
@@ -24,7 +24,6 @@ new Handsontable(container, {
   height: 'auto',
   width: 'auto',
   columns: [{ data: 'id' }, { data: 'name.first' }, { data: 'name.last' }, { data: 'address' }],
-  minSpareRows: 1,
   autoWrapRow: true,
   autoWrapCol: true,
   licenseKey: 'non-commercial-and-evaluation',

--- a/docs/content/guides/getting-started/binding-to-data/javascript/example6.js
+++ b/docs/content/guides/getting-started/binding-to-data/javascript/example6.js
@@ -15,7 +15,6 @@ new Handsontable(container, {
   height: 'auto',
   width: 'auto',
   columns: [{ data: 'id' }, { data: 'name.first' }, { data: 'name.last' }, { data: 'address' }],
-  minSpareRows: 1,
   autoWrapRow: true,
   autoWrapCol: true,
   licenseKey: 'non-commercial-and-evaluation',

--- a/docs/content/guides/getting-started/binding-to-data/javascript/example6.ts
+++ b/docs/content/guides/getting-started/binding-to-data/javascript/example6.ts
@@ -15,7 +15,6 @@ new Handsontable(container, {
   height: 'auto',
   width: 'auto',
   columns: [{ data: 'id' }, { data: 'name.first' }, { data: 'name.last' }, { data: 'address' }],
-  minSpareRows: 1,
   autoWrapRow: true,
   autoWrapCol: true,
   licenseKey: 'non-commercial-and-evaluation',

--- a/docs/content/guides/getting-started/binding-to-data/javascript/example7.js
+++ b/docs/content/guides/getting-started/binding-to-data/javascript/example7.js
@@ -19,7 +19,6 @@ new Handsontable(container, {
   width: 'auto',
   colHeaders: ['ID', 'Name', 'Address'],
   columns: [{ data: property('id') }, { data: property('name') }, { data: property('address') }],
-  minSpareRows: 1,
   autoWrapRow: true,
   autoWrapCol: true,
   licenseKey: 'non-commercial-and-evaluation',

--- a/docs/content/guides/getting-started/binding-to-data/javascript/example7.ts
+++ b/docs/content/guides/getting-started/binding-to-data/javascript/example7.ts
@@ -26,7 +26,6 @@ new Handsontable(container, {
   width: 'auto',
   colHeaders: ['ID', 'Name', 'Address'],
   columns: [{ data: property('id') }, { data: property('name') }, { data: property('address') }],
-  minSpareRows: 1,
   autoWrapRow: true,
   autoWrapCol: true,
   licenseKey: 'non-commercial-and-evaluation',

--- a/docs/content/guides/getting-started/binding-to-data/react/example1.jsx
+++ b/docs/content/guides/getting-started/binding-to-data/react/example1.jsx
@@ -21,7 +21,6 @@ const ExampleComponent = () => (
     height="auto"
     width="auto"
     colHeaders={true}
-    minSpareRows={1}
     autoWrapRow={true}
     autoWrapCol={true}
     licenseKey="non-commercial-and-evaluation"

--- a/docs/content/guides/getting-started/binding-to-data/react/example1.tsx
+++ b/docs/content/guides/getting-started/binding-to-data/react/example1.tsx
@@ -22,7 +22,6 @@ const ExampleComponent: FC = () => (
     height="auto"
     width="auto"
     colHeaders={true}
-    minSpareRows={1}
     autoWrapRow={true}
     autoWrapCol={true}
     licenseKey="non-commercial-and-evaluation"

--- a/docs/content/guides/getting-started/binding-to-data/react/example2.jsx
+++ b/docs/content/guides/getting-started/binding-to-data/react/example2.jsx
@@ -17,7 +17,6 @@ const ExampleComponent = () => (
   <HotTable
     data={data}
     colHeaders={true}
-    minSpareRows={1}
     height="auto"
     width="auto"
     columns={[

--- a/docs/content/guides/getting-started/binding-to-data/react/example2.tsx
+++ b/docs/content/guides/getting-started/binding-to-data/react/example2.tsx
@@ -18,7 +18,6 @@ const ExampleComponent: FC = () => (
   <HotTable
     data={data}
     colHeaders={true}
-    minSpareRows={1}
     height="auto"
     width="auto"
     columns={[

--- a/docs/content/guides/getting-started/binding-to-data/react/example3.jsx
+++ b/docs/content/guides/getting-started/binding-to-data/react/example3.jsx
@@ -18,7 +18,6 @@ const ExampleComponent = () => (
     colHeaders={true}
     height="auto"
     width="auto"
-    minSpareRows={1}
     autoWrapRow={true}
     autoWrapCol={true}
     licenseKey="non-commercial-and-evaluation"

--- a/docs/content/guides/getting-started/binding-to-data/react/example3.tsx
+++ b/docs/content/guides/getting-started/binding-to-data/react/example3.tsx
@@ -25,7 +25,6 @@ const ExampleComponent: FC = () => (
     colHeaders={true}
     height="auto"
     width="auto"
-    minSpareRows={1}
     autoWrapRow={true}
     autoWrapCol={true}
     licenseKey="non-commercial-and-evaluation"

--- a/docs/content/guides/getting-started/binding-to-data/react/example4.jsx
+++ b/docs/content/guides/getting-started/binding-to-data/react/example4.jsx
@@ -34,7 +34,6 @@ const ExampleComponent = () => {
 
         return columnMeta;
       }}
-      minSpareRows={1}
       autoWrapRow={true}
       autoWrapCol={true}
       licenseKey="non-commercial-and-evaluation"

--- a/docs/content/guides/getting-started/binding-to-data/react/example4.tsx
+++ b/docs/content/guides/getting-started/binding-to-data/react/example4.tsx
@@ -41,7 +41,6 @@ const ExampleComponent: FC = () => {
 
         return columnMeta;
       }}
-      minSpareRows={1}
       autoWrapRow={true}
       autoWrapCol={true}
       licenseKey="non-commercial-and-evaluation"

--- a/docs/content/guides/getting-started/binding-to-data/react/example5.jsx
+++ b/docs/content/guides/getting-started/binding-to-data/react/example5.jsx
@@ -17,7 +17,6 @@ const ExampleComponent = () => (
     height="auto"
     width="auto"
     columns={[{ data: 'id' }, { data: 'name.first' }, { data: 'name.last' }, { data: 'address' }]}
-    minSpareRows={1}
     autoWrapRow={true}
     autoWrapCol={true}
     licenseKey="non-commercial-and-evaluation"

--- a/docs/content/guides/getting-started/binding-to-data/react/example5.tsx
+++ b/docs/content/guides/getting-started/binding-to-data/react/example5.tsx
@@ -24,7 +24,6 @@ const ExampleComponent: FC = () => (
     height="auto"
     width="auto"
     columns={[{ data: 'id' }, { data: 'name.first' }, { data: 'name.last' }, { data: 'address' }]}
-    minSpareRows={1}
     autoWrapRow={true}
     autoWrapCol={true}
     licenseKey="non-commercial-and-evaluation"

--- a/docs/content/guides/getting-started/binding-to-data/react/example6.jsx
+++ b/docs/content/guides/getting-started/binding-to-data/react/example6.jsx
@@ -21,7 +21,6 @@ const ExampleComponent = () => (
     height="auto"
     width="auto"
     columns={[{ data: 'id' }, { data: 'name.first' }, { data: 'name.last' }, { data: 'address' }]}
-    minSpareRows={1}
     autoWrapRow={true}
     autoWrapCol={true}
     licenseKey="non-commercial-and-evaluation"

--- a/docs/content/guides/getting-started/binding-to-data/react/example6.tsx
+++ b/docs/content/guides/getting-started/binding-to-data/react/example6.tsx
@@ -22,7 +22,6 @@ const ExampleComponent: FC = () => (
     height="auto"
     width="auto"
     columns={[{ data: 'id' }, { data: 'name.first' }, { data: 'name.last' }, { data: 'address' }]}
-    minSpareRows={1}
     autoWrapRow={true}
     autoWrapCol={true}
     licenseKey="non-commercial-and-evaluation"

--- a/docs/content/guides/getting-started/binding-to-data/react/example7.jsx
+++ b/docs/content/guides/getting-started/binding-to-data/react/example7.jsx
@@ -56,7 +56,6 @@ const ExampleComponent = () => (
     width="auto"
     colHeaders={['ID', 'Name', 'Address']}
     columns={[{ data: property('id') }, { data: property('name') }, { data: property('address') }]}
-    minSpareRows={1}
     autoWrapRow={true}
     autoWrapCol={true}
     licenseKey="non-commercial-and-evaluation"

--- a/docs/content/guides/getting-started/binding-to-data/react/example7.tsx
+++ b/docs/content/guides/getting-started/binding-to-data/react/example7.tsx
@@ -77,7 +77,6 @@ const ExampleComponent: FC = () => (
     width="auto"
     colHeaders={['ID', 'Name', 'Address']}
     columns={[{ data: property('id') }, { data: property('name') }, { data: property('address') }]}
-    minSpareRows={1}
     autoWrapRow={true}
     autoWrapCol={true}
     licenseKey="non-commercial-and-evaluation"

--- a/docs/content/guides/getting-started/binding-to-data/vue/example1.vue
+++ b/docs/content/guides/getting-started/binding-to-data/vue/example1.vue
@@ -20,7 +20,6 @@ const hotSettings = ref<GridSettings>({
   height: 'auto',
   width: 'auto',
   colHeaders: true,
-  minSpareRows: 1,
   autoWrapRow: true,
   autoWrapCol: true,
   licenseKey: 'non-commercial-and-evaluation',

--- a/docs/content/guides/getting-started/binding-to-data/vue/example2.vue
+++ b/docs/content/guides/getting-started/binding-to-data/vue/example2.vue
@@ -16,7 +16,6 @@ const hotSettings = ref<GridSettings>({
     ['2021', 10, 11, 12, 13, 15, 16],
   ],
   colHeaders: true,
-  minSpareRows: 1,
   height: 'auto',
   width: 'auto',
   columns: [

--- a/docs/content/guides/getting-started/binding-to-data/vue/example3.vue
+++ b/docs/content/guides/getting-started/binding-to-data/vue/example3.vue
@@ -17,7 +17,6 @@ const hotSettings = ref<GridSettings>({
   colHeaders: true,
   height: 'auto',
   width: 'auto',
-  minSpareRows: 1,
   autoWrapRow: true,
   autoWrapCol: true,
   licenseKey: 'non-commercial-and-evaluation',

--- a/docs/content/guides/getting-started/binding-to-data/vue/example4.vue
+++ b/docs/content/guides/getting-started/binding-to-data/vue/example4.vue
@@ -32,7 +32,6 @@ const hotSettings = ref<GridSettings>({
 
     return columnMeta;
   },
-  minSpareRows: 1,
   autoWrapRow: true,
   autoWrapCol: true,
   licenseKey: 'non-commercial-and-evaluation',

--- a/docs/content/guides/getting-started/binding-to-data/vue/example5.vue
+++ b/docs/content/guides/getting-started/binding-to-data/vue/example5.vue
@@ -16,7 +16,6 @@ const hotSettings = ref<GridSettings>({
   height: 'auto',
   width: 'auto',
   columns: [{ data: 'id' }, { data: 'name.first' }, { data: 'name.last' }, { data: 'address' }],
-  minSpareRows: 1,
   autoWrapRow: true,
   autoWrapCol: true,
   licenseKey: 'non-commercial-and-evaluation',

--- a/docs/content/guides/getting-started/binding-to-data/vue/example6.vue
+++ b/docs/content/guides/getting-started/binding-to-data/vue/example6.vue
@@ -22,7 +22,6 @@ const hotSettings = ref<GridSettings>({
   height: 'auto',
   width: 'auto',
   columns: [{ data: 'id' }, { data: 'name.first' }, { data: 'name.last' }, { data: 'address' }],
-  minSpareRows: 1,
   autoWrapRow: true,
   autoWrapCol: true,
   licenseKey: 'non-commercial-and-evaluation',

--- a/docs/content/guides/getting-started/binding-to-data/vue/example7.vue
+++ b/docs/content/guides/getting-started/binding-to-data/vue/example7.vue
@@ -53,7 +53,6 @@ const hotSettings = ref<GridSettings>({
   width: 'auto',
   colHeaders: ['ID', 'Name', 'Address'],
   columns: [{ data: property('id') }, { data: property('name') }, { data: property('address') }],
-  minSpareRows: 1,
   autoWrapRow: true,
   autoWrapCol: true,
   licenseKey: 'non-commercial-and-evaluation',


### PR DESCRIPTION
### Context

The PR removes the `minSpareRows: 1` option from the examples in the [Binding to data](https://handsontable.com/docs/binding-to-data/) guide.

Examples 1-7 set `minSpareRows: 1`, but the guide's prose never mentions it. This misleads readers: the option looks either required for data binding or like the dataset ships with a trailing empty row. Neither is true. None of these examples demonstrate spare rows - they teach data structures (array of arrays, array of objects, column mapping, `dataSchema`, function sources), and examples 9-11 already omit the option. Removing it does not change what any example demonstrates.

The change drops the single `minSpareRows` line from examples 1-7 across all four framework variants (JavaScript, React, Angular, Vue). The guide markdown needs no edits - it never referenced the option, and the `collapse={...}` ranges target the data arrays above the removed line.

### How has this been tested?

- Docs-only change. Verified statically: each diff is a single-line removal, no `minSpareRows` remains in the guide folder, and the markdown `collapse={...}` line ranges still align with their data arrays.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-685

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-685

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation example snippets only; no runtime or library code changes.
> 
> **Overview**
> Removes **`minSpareRows: 1`** (or the React/Vue equivalent) from **Binding to data** guide examples **1–7** across **JavaScript, TypeScript, React, Angular, and Vue** sample files.
> 
> The guide prose never documents spare rows, so the option looked required for binding or implied an extra empty row in the sample data. Examples **9–11** already omit it; this aligns **1–7** without changing what each demo teaches (data shapes, column mapping, `dataSchema`, function sources). **No guide markdown** is edited.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a291f79df0ded6526e1eb8edcca28293dee55d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->