### PR TITLE
DEV-913: Correct readOnly demo in the Configuration options guide

### DIFF
--- a/docs/content/guides/getting-started/configuration-options/angular/example2.ts
+++ b/docs/content/guides/getting-started/configuration-options/angular/example2.ts
@@ -30,7 +30,6 @@ export class AppComponent {
     rowHeaders: true,
     colHeaders: true,
     columns: (index: number) => ({
-      type: index > 0 ? 'numeric' : 'text',
       readOnly: index === 2 || index === 8,
     })
   };

--- a/docs/content/guides/getting-started/configuration-options/javascript/example2.js
+++ b/docs/content/guides/getting-started/configuration-options/javascript/example2.js
@@ -23,7 +23,6 @@ const hot = new Handsontable(container, {
   readOnly: false,
   columns: (index) => {
     return {
-      type: index > 0 ? 'numeric' : 'text',
       readOnly: index === 2 || index === 8,
     };
   },

--- a/docs/content/guides/getting-started/configuration-options/javascript/example2.ts
+++ b/docs/content/guides/getting-started/configuration-options/javascript/example2.ts
@@ -24,7 +24,6 @@ const hot = new Handsontable(container, {
   readOnly: false,
   columns: (index: number) => {
     return {
-      type: index > 0 ? 'numeric' : 'text',
       readOnly: index === 2 || index === 8,
     };
   },

--- a/docs/content/guides/getting-started/configuration-options/react/example2.jsx
+++ b/docs/content/guides/getting-started/configuration-options/react/example2.jsx
@@ -25,7 +25,6 @@ const ExampleComponent = () => {
       colHeaders={true}
       readOnly={false}
       columns={(index) => ({
-        type: index > 0 ? 'numeric' : 'text',
         readOnly: index === 2 || index === 8,
       })}
     />

--- a/docs/content/guides/getting-started/configuration-options/react/example2.tsx
+++ b/docs/content/guides/getting-started/configuration-options/react/example2.tsx
@@ -27,7 +27,6 @@ const ExampleComponent: FC = () => {
       colHeaders={true}
       readOnly={false}
       columns={(index: number) => ({
-        type: index > 0 ? 'numeric' : 'text',
         readOnly: index === 2 || index === 8,
       })}
     />

--- a/docs/content/guides/getting-started/configuration-options/vue/example2.vue
+++ b/docs/content/guides/getting-started/configuration-options/vue/example2.vue
@@ -23,7 +23,6 @@ const hotSettings = ref<GridSettings>({
   readOnly: false,
   columns(index) {
     return {
-      type: index > 0 ? 'numeric' : 'text',
       readOnly: index === 2 || index === 8,
     };
   },


### PR DESCRIPTION
### Context

The PR fixes the `set-column-options` demo in the Configuration options guide. The `columns` function set `type: index > 0 ? 'numeric' : 'text'`, applying the `numeric` cell type to every column except the first. The example data is plain text, so the `numeric` type does not make sense here, and the surrounding prose only describes the `readOnly` behavior - it never mentions cell types. This left readers with an unexplained, misleading configuration.

This change removes the `type` line from all framework variants (JS, TS, React, Angular, Vue) so the demo matches the text, which explains only that columns `2` and `8` are read-only.

### How has this been tested?

- Docs-only example change. Verified the prose at `configuration-options.md` describes only `readOnly`, so no prose update is needed.
- Confirmed no remaining `index > 0 ? 'numeric'` references in the guide.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-913

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-913

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation example edits only; no runtime or library behavior changes.
> 
> **Overview**
> Fixes the **set-column-options** (`example2`) snippets in the Configuration options guide so they only demonstrate **`readOnly`** on columns 2 and 8, matching the surrounding documentation.
> 
> Removes the **`type: index > 0 ? 'numeric' : 'text'`** line from the `columns` callback in every framework variant (JavaScript, TypeScript, React, Angular, Vue). That setting was unrelated to the guide text and conflicted with the plain-text sample data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f56bf4029faf1c3d0e364b5fb20a55817c0bc751. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->