### PR TITLE
DEV-455: Document getSettings() cascading configuration scope

### DIFF
--- a/docs/content/guides/getting-started/configuration-options/configuration-options.md
+++ b/docs/content/guides/getting-started/configuration-options/configuration-options.md
@@ -193,6 +193,12 @@ The [`cells`](@/api/options.md#cells) option is a function invoked before Handso
 
 For more details on Handsontable's cascading configuration, see the [MetaManager class](https://github.com/handsontable/handsontable/blob/master/handsontable/src/dataMap/metaManager/index.js).
 
+To read configuration at runtime, use the method that matches the level you need:
+
+- [`getSettings()`](@/api/core.md#getsettings) returns global grid settings only.
+- [`getColumnMeta()`](@/api/core.md#getcolumnmeta) returns column-level meta for a given column.
+- [`getCellMeta()`](@/api/core.md#getcellmeta) returns the effective merged meta for a given cell.
+
 ### Plugin options
 
 Configuration options come from:

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -3532,11 +3532,36 @@ export default function Core(
   };
 
   /**
-   * Returns the object settings.
+   * Returns the current global grid settings object.
+   *
+   * The returned object contains the settings passed to the constructor or the most recent
+   * `updateSettings()` call. It reflects the
+   * [grid-level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options)
+   * configuration only.
+   *
+   * It does not include merged per-cell or per-column values. Configuration options cascade from
+   * grid to column to cell (see
+   * [Cascading configuration](@/guides/getting-started/configuration-options/configuration-options.md#cascading-configuration)).
+   * To read the effective value for a specific cell, use [[getCellMeta]]. To read column-level meta, use [[getColumnMeta]].
    *
    * @memberof Core#
    * @function getSettings
-   * @returns {TableMeta} Object containing the current table settings.
+   * @returns {TableMeta} Object containing the current global grid settings.
+   * @example
+   * ```js
+   * const hot = new Handsontable(container, {
+   *   readOnly: false,
+   *   columns: (index) => ({
+   *     readOnly: index === 2 || index === 8,
+   *   }),
+   * });
+   *
+   * // returns `false` (global grid-level setting)
+   * hot.getSettings().readOnly;
+   *
+   * // returns `true` for column 2 (merged column and cell meta)
+   * hot.getCellMeta(0, 2).readOnly;
+   * ```
    */
   this.getSettings = function() {
     return tableMeta as unknown as GridSettings;
@@ -4265,6 +4290,11 @@ export default function Core(
   /**
    * Returns the cell properties object for the given `row` and `column` coordinates.
    *
+   * The returned object reflects the effective cell configuration after
+   * [cascading configuration](@/guides/getting-started/configuration-options/configuration-options.md#cascading-configuration)
+   * (grid, column, and cell levels). To read global grid settings only, use [[getSettings]].
+   * To read column-level meta, use [[getColumnMeta]].
+   *
    * @memberof Core#
    * @function getCellMeta
    * @param {number} row Visual row index.
@@ -4298,6 +4328,11 @@ export default function Core(
 
   /**
    * Returns the meta information for the provided column.
+   *
+   * The returned object reflects the column-level configuration after
+   * [cascading configuration](@/guides/getting-started/configuration-options/configuration-options.md#cascading-configuration)
+   * (grid and column levels). To read global grid settings only, use [[getSettings]].
+   * To read the effective configuration for a specific cell, use [[getCellMeta]].
    *
    * @since 14.5.0
    * @memberof Core#


### PR DESCRIPTION
### Context

`getSettings()` API documentation did not explain that it returns global grid settings only, not merged per-cell configuration. This caused confusion about the cascading configuration model (reported since 2018 in handsontable/handsontable#8478).

This change expands the `getSettings()` JSDoc with a link to the cascading configuration guide, an example contrasting `getSettings().readOnly` with `getCellMeta().readOnly`, and cross-links to `getCellMeta()` and `getColumnMeta()`. The Configuration options guide now lists which method to use at each configuration level.

### How has this been tested?

- Docs-only JSDoc and guide prose change; no runtime behavior change.
- `npx eslint src/core.ts` in `handsontable/` passes.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-455
2. handsontable/handsontable#8478

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-455

Made with [Cursor](https://cursor.com)