### PR TITLE
DEV-483: Document function prop in beforeChange/afterChange hooks

### DIFF
--- a/docs/content/guides/getting-started/binding-to-data/binding-to-data.md
+++ b/docs/content/guides/getting-started/binding-to-data/binding-to-data.md
@@ -17,6 +17,7 @@ vue:
   metaTitle: Binding to data - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Getting started
+menuTag: updated
 ---
 Fill your data grid with various data structures, including an array of arrays or an array of objects.
 
@@ -360,6 +361,32 @@ The example below shows how to use such objects:
 :::
 
 :::
+
+### Identify changed columns in hooks
+
+When you use a [function data source](#function-data-source-and-schema), each column's [`data`](@/api/options.md#data) option is a getter/setter function. In [`beforeChange`](@/api/hooks.md#beforechange) and [`afterChange`](@/api/hooks.md#afterchange), the second element of each change tuple is `prop`. With function-based columns, `prop` is that accessor function -- not a property name or a column index.
+
+To find which column changed, call [`propToCol()`](@/api/core.md#proptocol) on the `prop` value:
+
+```javascript
+afterChange(changes, source) {
+  if (source === 'loadData' || !changes) {
+    return;
+  }
+
+  changes.forEach(([row, prop, oldValue, newValue]) => {
+    const column = this.propToCol(prop);
+
+    // column is the visual column index
+  });
+}
+```
+
+You can also compare `prop` to the accessor function you defined in `columns`, if you keep a reference to it.
+
+Unlike [`beforeValidate`](@/api/hooks.md#beforevalidate) and [`afterValidate`](@/api/hooks.md#aftervalidate), change hooks pass the accessor function as `prop`. The grid needs that reference to write values back to your data model.
+
+For more on change hooks, see [Events and hooks](@/guides/getting-started/events-and-hooks/events-and-hooks.md).
 
 ### No data
 

--- a/docs/content/guides/getting-started/events-and-hooks/events-and-hooks.md
+++ b/docs/content/guides/getting-started/events-and-hooks/events-and-hooks.md
@@ -237,6 +237,8 @@ Handsontable exposes hundreds of hooks. The ones below are the hooks you reach f
 
 </div>
 
+When [`columns[].data`](@/api/options.md#columns) is a function, the `prop` field in each change tuple is that accessor function. Use [`propToCol()`](@/api/core.md#proptocol) to resolve the visual column index. See [Binding to data: Identify changed columns in hooks](@/guides/getting-started/binding-to-data/binding-to-data.md#identify-changed-columns-in-hooks).
+
 **Row and column structure (CRUD)** -- track rows and columns being added or removed. Each `before` variant can return `false` to block the operation.
 
 <div class="boxes-list">

--- a/handsontable/src/__tests__/hooks/afterChange.spec.js
+++ b/handsontable/src/__tests__/hooks/afterChange.spec.js
@@ -61,5 +61,64 @@ describe('Hook', () => {
         expect(called).toBe(true);
       });
     });
+
+    it('should pass the column accessor function as prop with function-based data accessor', async() => {
+      const props = [];
+
+      function model(opts) {
+        const priv = { id: undefined, name: undefined };
+
+        for (const key in opts) {
+          if (Object.prototype.hasOwnProperty.call(opts, key)) {
+            priv[key] = opts[key];
+          }
+        }
+
+        return {
+          attr(attr, val) {
+            if (typeof val === 'undefined') {
+              return priv[attr];
+            }
+
+            priv[attr] = val;
+
+            return this;
+          }
+        };
+      }
+
+      function property(attr) {
+        return (row, value) => row.attr(attr, value);
+      }
+
+      handsontable({
+        data: [
+          model({ id: 1, name: 'Ted' }),
+          model({ id: 2, name: 'Frank' }),
+        ],
+        dataSchema: model,
+        columns: [
+          { data: property('id'), type: 'numeric' },
+          { data: property('name') },
+        ],
+        afterChange(changes, source) {
+          if (source === 'loadData') {
+            return;
+          }
+
+          changes.forEach((change) => {
+            props.push(change[1]);
+          });
+        }
+      });
+
+      await setDataAtCell(0, 1, 'Updated');
+
+      await waitForNextAnimationFrames();
+
+      expect(props.length).toBe(1);
+      expect(typeof props[0]).toBe('function');
+      expect(propToCol(props[0])).toBe(1);
+    });
   });
 });

--- a/handsontable/src/__tests__/hooks/beforeChange.spec.js
+++ b/handsontable/src/__tests__/hooks/beforeChange.spec.js
@@ -187,5 +187,58 @@ describe('Hook', () => {
         expect(called).toBe(true);
       });
     });
+
+    it('should pass the column accessor function as prop with function-based data accessor', async() => {
+      const props = [];
+
+      function model(opts) {
+        const priv = { id: undefined, name: undefined };
+
+        for (const key in opts) {
+          if (Object.prototype.hasOwnProperty.call(opts, key)) {
+            priv[key] = opts[key];
+          }
+        }
+
+        return {
+          attr(attr, val) {
+            if (typeof val === 'undefined') {
+              return priv[attr];
+            }
+
+            priv[attr] = val;
+
+            return this;
+          }
+        };
+      }
+
+      function property(attr) {
+        return (row, value) => row.attr(attr, value);
+      }
+
+      handsontable({
+        data: [
+          model({ id: 1, name: 'Ted' }),
+          model({ id: 2, name: 'Frank' }),
+        ],
+        dataSchema: model,
+        columns: [
+          { data: property('id'), type: 'numeric' },
+          { data: property('name') },
+        ],
+        beforeChange(changes) {
+          changes.forEach((change) => {
+            props.push(change[1]);
+          });
+        }
+      });
+
+      await setDataAtCell(0, 1, 'Updated');
+
+      expect(props.length).toBe(1);
+      expect(typeof props[0]).toBe('function');
+      expect(propToCol(props[0])).toBe(1);
+    });
   });
 });

--- a/handsontable/src/core/hooks/constants.ts
+++ b/handsontable/src/core/hooks/constants.ts
@@ -140,7 +140,14 @@ export const REGISTERED_HOOKS = [
    * __Note:__ For performance reasons, the `changes` array is null for `"loadData"` source.
    *
    * @event Hooks#afterChange
-   * @param {Array[]} changes 2D array containing information about each of the edited cells `[[row, prop, oldVal, newVal], ...]`. `row` is a visual row index.
+   * @param {Array[]} changes 2D array containing information about each of the edited cells `[[row, prop, oldVal, newVal], ...]`.
+   *                          `row` is a visual row index. `prop` is a property name, a column index, or – when
+   *                          [`columns[].data`](@/api/options.md#columns) is a function – the column accessor function.
+   *                          To resolve a visual column index from `prop`, call [`propToCol()`](@/api/core.md#proptocol).
+   *                          Unlike [`beforeValidate`](@/api/hooks.md#beforevalidate) and
+   *                          [`afterValidate`](@/api/hooks.md#aftervalidate), this hook passes the accessor function
+   *                          as `prop` so the grid can write data back. Read more:
+   *                          [Binding to data: Identify changed columns in hooks](@/guides/getting-started/binding-to-data/binding-to-data.md#identify-changed-columns-in-hooks).
    * @param {string} [source] String that identifies source of hook call ([list of all available sources](@/guides/getting-started/events-and-hooks/events-and-hooks.md#definition-for-source-argument)).
    * @example
    * ::: only-for javascript
@@ -1389,7 +1396,14 @@ export const REGISTERED_HOOKS = [
    * To ignore the user's changes, use a nullified array or return `false`.
    *
    * @event Hooks#beforeChange
-   * @param {Array[]} changes 2D array containing information about each of the edited cells `[[row, prop, oldVal, newVal], ...]`. `row` is a visual row index.
+   * @param {Array[]} changes 2D array containing information about each of the edited cells `[[row, prop, oldVal, newVal], ...]`.
+   *                          `row` is a visual row index. `prop` is a property name, a column index, or – when
+   *                          [`columns[].data`](@/api/options.md#columns) is a function – the column accessor function.
+   *                          To resolve a visual column index from `prop`, call [`propToCol()`](@/api/core.md#proptocol).
+   *                          Unlike [`beforeValidate`](@/api/hooks.md#beforevalidate) and
+   *                          [`afterValidate`](@/api/hooks.md#aftervalidate), this hook passes the accessor function
+   *                          as `prop` so the grid can write data back. Read more:
+   *                          [Binding to data: Identify changed columns in hooks](@/guides/getting-started/binding-to-data/binding-to-data.md#identify-changed-columns-in-hooks).
    * @param {string} [source] String that identifies source of hook call
    *                          ([list of all available sources](@/guides/getting-started/events-and-hooks/events-and-hooks.md#definition-for-source-argument)).
    * @returns {undefined | boolean} If `false` all changes were cancelled, `true` otherwise.

--- a/handsontable/src/settings.ts
+++ b/handsontable/src/settings.ts
@@ -36,7 +36,9 @@ export interface ColumnDataGetterSetterFunction {
 }
 
 /**
- * A cell change represented by `[row, column, prevValue, nextValue]`.
+ * A cell change represented by `[row, prop, oldValue, newValue]`.
+ * `prop` is a property name, a column index, or a {@link ColumnDataGetterSetterFunction} when
+ * `columns[].data` is a function.
  */
 export type CellChange = [number, string | number | ColumnDataGetterSetterFunction, CellValue, CellValue];
 


### PR DESCRIPTION
### Context

When `columns[].data` is a function (function-based data source), `beforeChange` and `afterChange` pass that accessor function as the `prop` field in each change tuple. This behavior is required for `datamap.set()` to write values back, but it was not documented. Users reported difficulty identifying which column changed (forum thread linked from #8466).

This PR documents the contract in hook JSDoc, the binding-to-data and events-and-hooks guides, and adds E2E regression tests that lock the public hook behavior.

Related: ClickUp DEV-483, GitHub #8466.

[skip changelog]

### How has this been tested?

- `npm run build --prefix handsontable`
- E2E tests added in `beforeChange.spec.js` and `afterChange.spec.js` (not run locally — Puppeteer Chrome unavailable in agent environment). To verify:

```bash
npm run build --prefix handsontable
npm run test:e2e --prefix handsontable -- --testPathPattern='beforeChange|afterChange'
```

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. #8466
2. DEV-483

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, type comments, and regression tests only; no changes to data-map or hook execution logic.
> 
> **Overview**
> Documents that when **`columns[].data`** is a function, **`beforeChange`** and **`afterChange`** pass the column accessor function as **`prop`** (not a property name or index), and explains how to resolve the visual column with **`propToCol()`**.
> 
> Adds a **Binding to data** section with an **`afterChange`** example, a cross-link in **Events and hooks**, expanded JSDoc on those hooks in **`constants.ts`**, and clarifies the **`CellChange`** type in **`settings.ts`**. Marks the binding guide with **`menuTag: updated`**.
> 
> Adds E2E tests in **`beforeChange.spec.js`** and **`afterChange.spec.js`** that assert **`prop`** is a function and **`propToCol(prop)`** matches the edited column—no runtime hook behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02aba0f84343e03636ebef0974a684ff0aeefa15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->