### PR TITLE
docs: Fix docs staging preview race by building PR previews on PRs

### DIFF
--- a/.github/workflows/docs-staging.yml
+++ b/.github/workflows/docs-staging.yml
@@ -1,14 +1,24 @@
 name: Docs Staging Deployment
 
 on:
+  # Build PR previews on the pull_request event. The PR number comes from the
+  # event payload, so the preview always knows which PR to comment on - unlike
+  # the old push-driven build, which raced PR creation and often resolved no PR
+  # (no preview comment, no Cloudflare deploy). The paths filter limits PR
+  # builds to pull requests that change documentation files.
   pull_request:
-    types: [ labeled, synchronize ]
+    types: [ opened, reopened, synchronize ]
+    paths:
+      - 'docs/**'
+      - 'handsontable/package.json'
+  # Push builds cover the non-PR contexts only: develop (apex staging) and
+  # release/* (RC staging, triggered by the handsontable/package.json version
+  # bump). Other branches get their preview from the pull_request event above,
+  # so they are intentionally not built on push (avoids a duplicate build).
   push:
-    branches-ignore:
-      - 'prod-docs/**'
-      - 'master'
-    # Trigger on docs changes (all branches) and on handsontable/package.json
-    # changes (so RC version bumps on release/* branches trigger a rebuild).
+    branches:
+      - develop
+      - 'release/**'
     paths:
       - 'docs/**'
       - 'handsontable/package.json'
@@ -24,8 +34,15 @@ defaults:
 
 jobs:
   preview:
-    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'ci:docs-deploy') }}
-    name: Build and push Preview to Netlify (on pull request label)
+    name: Build and push Preview to Netlify
+    # Release branches build their production-mode RC staging from the push
+    # trigger above, and that push build also resolves and comments on the open
+    # release PR (its head is the release branch). Skip the pull_request build
+    # for release-head PRs so they are not also built in dev mode on a separate
+    # concurrency key, which would deploy twice and post a duplicate comment.
+    # The prefix match is intentionally broader than the release/x.y.z version
+    # pattern; any release/* head PR defers to its push build.
+    if: ${{ !(github.event_name == 'pull_request' && startsWith(github.head_ref, 'release/')) }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
This PR fixes a race in the docs staging preview workflow. Previously the preview was built by the `push` event, which resolved the PR number by listing open PRs for the branch. When the push fired before the PR was created (the usual "push branch, then open PR" sequence), no PR was found, so the preview comment and the Cloudflare Pages deploy were skipped even though the Netlify build succeeded. The result: no preview comment on the PR, and maintainers had to re-run the job manually.

The workflow now builds PR previews on the `pull_request` event, where the PR number is available directly from the event payload, so the preview always knows which PR to comment on. A `paths` filter limits PR builds to pull requests that change documentation files. The `push` trigger is narrowed to `develop` (apex staging) and `release/*` (RC staging); other branches now get their preview from the `pull_request` event only, which also avoids a duplicate build per push.

Notes on the trade-offs of staying with native workflow params:
- The `ci:docs-deploy` label no longer forces a build on a PR that changes zero docs files (this would require inspecting changed files in a script step).
- Non-PR branches other than `develop` / `release/*` no longer get a push-triggered staging build.


### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
- validated the YAML parses and inspected the run history of PR #12860, which showed the `push` build resolving an empty PR number (preview comment and Cloudflare steps skipped) because the resolve step ran 4 seconds before the PR was created.
- Tested flow in one of the PRs

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow trigger and job-condition changes only; no application runtime impact, with intentional trade-offs (no label-forced builds, no push previews on arbitrary branches).
> 
> **Overview**
> Fixes docs staging previews that often **never posted a PR comment or deployed to Cloudflare** because the workflow ran on `push` and looked up the PR by branch—frequently before the PR existed.
> 
> **PR previews** now run on `pull_request` (`opened`, `reopened`, `synchronize`) with `paths` limited to `docs/**` and `handsontable/package.json`, so the PR number comes from the event payload. **`push`** is restricted to `develop` and `release/**` (same path filters) for apex and RC staging, avoiding a second build for feature branches.
> 
> The preview job no longer depends on the **`ci:docs-deploy`** label. **`release/*` head PRs** skip the `pull_request` job so only the push-driven RC build runs—preventing duplicate Netlify deploys and sticky comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba287a95b12be84345dee7d48a7be1e6f115b840. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->