### PR TITLE
DEV-599: Document trimDropdown and visibleRows in Dropdown guide

### DIFF
--- a/docs/content/guides/cell-types/dropdown-cell-type/angular/example4.html
+++ b/docs/content/guides/cell-types/dropdown-cell-type/angular/example4.html
@@ -1,0 +1,3 @@
+<div>
+  <example4-dropdown-cell-type></example4-dropdown-cell-type>
+</div>

--- a/docs/content/guides/cell-types/dropdown-cell-type/angular/example4.ts
+++ b/docs/content/guides/cell-types/dropdown-cell-type/angular/example4.ts
@@ -1,0 +1,76 @@
+/* file: app.component.ts */
+import { Component } from '@angular/core';
+import { GridSettings, HotTableModule} from '@handsontable/angular-wrapper';
+
+const departments = [
+  'Engineering and Platform Infrastructure',
+  'Marketing and Brand Communications',
+  'Financial Planning and Analysis',
+  'People Operations and Talent Acquisition',
+  'Customer Success and Enterprise Accounts',
+];
+
+@Component({
+  selector: 'example4-dropdown-cell-type',
+  standalone: true,
+  imports: [HotTableModule],
+  template: ` <div>
+    <hot-table [data]="data" [settings]="gridSettings"></hot-table>
+  </div>`,
+})
+export class AppComponent {
+
+  readonly data = [
+    ['Ana García', departments[0], departments[0]],
+    ['James Okafor', departments[1], departments[1]],
+    ['Li Wei', departments[2], departments[2]],
+    ['Sofia Rossi', departments[3], departments[3]],
+  ];
+
+  readonly gridSettings: GridSettings = {
+    height: 'auto',
+    colHeaders: ['Employee', 'Department (default)', 'Department (full width)'],
+    autoWrapRow: true,
+    autoWrapCol: true,
+    columns: [
+      {},
+      {
+        type: 'dropdown',
+        source: departments,
+        width: 140,
+        // trim the list to the cell's width (default)
+        trimDropdown: true,
+      },
+      {
+        type: 'dropdown',
+        source: departments,
+        width: 140,
+        // expand the list to fit its longest option
+        trimDropdown: false,
+      },
+    ]
+  };
+}
+
+/* end-file */
+
+
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+/* end-file */

--- a/docs/content/guides/cell-types/dropdown-cell-type/angular/example5.html
+++ b/docs/content/guides/cell-types/dropdown-cell-type/angular/example5.html
@@ -1,0 +1,3 @@
+<div>
+  <example5-dropdown-cell-type></example5-dropdown-cell-type>
+</div>

--- a/docs/content/guides/cell-types/dropdown-cell-type/angular/example5.ts
+++ b/docs/content/guides/cell-types/dropdown-cell-type/angular/example5.ts
@@ -1,0 +1,81 @@
+/* file: app.component.ts */
+import { Component } from '@angular/core';
+import { GridSettings, HotTableModule} from '@handsontable/angular-wrapper';
+
+const jobTitles = [
+  'Software Engineer',
+  'Senior Software Engineer',
+  'Staff Engineer',
+  'Engineering Manager',
+  'Product Manager',
+  'Product Designer',
+  'Data Analyst',
+  'Data Scientist',
+  'Marketing Specialist',
+  'Account Executive',
+  'Customer Success Manager',
+  'Finance Analyst',
+  'Recruiter',
+  'Office Manager',
+];
+
+@Component({
+  selector: 'example5-dropdown-cell-type',
+  standalone: true,
+  imports: [HotTableModule],
+  template: ` <div>
+    <hot-table [data]="data" [settings]="gridSettings"></hot-table>
+  </div>`,
+})
+export class AppComponent {
+
+  readonly data = [
+    ['Ana García', 'Senior Software Engineer', 'Senior Software Engineer'],
+    ['James Okafor', 'Product Manager', 'Product Manager'],
+    ['Li Wei', 'Data Scientist', 'Data Scientist'],
+    ['Sofia Rossi', 'Account Executive', 'Account Executive'],
+  ];
+
+  readonly gridSettings: GridSettings = {
+    height: 'auto',
+    colHeaders: ['Employee', 'Job title (default)', 'Job title (compact)'],
+    autoWrapRow: true,
+    autoWrapCol: true,
+    columns: [
+      {},
+      {
+        type: 'dropdown',
+        source: jobTitles,
+      },
+      {
+        type: 'dropdown',
+        source: jobTitles,
+        // show 3 options at a time, then scroll
+        visibleRows: 3,
+      },
+    ]
+  };
+}
+
+/* end-file */
+
+
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+/* end-file */

--- a/docs/content/guides/cell-types/dropdown-cell-type/dropdown-cell-type.md
+++ b/docs/content/guides/cell-types/dropdown-cell-type/dropdown-cell-type.md
@@ -18,6 +18,7 @@ vue:
   metaTitle: Dropdown cell type - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types
+menuTag: updated
 ---
 Collect user input with a searchable list of choices, by using the dropdown cell type.
 
@@ -229,6 +230,115 @@ When working with object-based dropdown data, you can use methods like [`getSour
 ::: tip
 
 **Note:** When the `source` option is declared as an array of `key` + `value` objects, the data in the edited cell should also be an object with `key` + `value` properties.
+
+:::
+
+## Set the dropdown width
+
+By default, the dropdown list matches the width of the edited cell, so long options can be truncated. To let the list expand to fit its longest option, set [`trimDropdown`](@/api/options.md#trimdropdown) to `false`.
+
+| Setting          | Description                                               |
+| ---------------- | --------------------------------------------------------- |
+| `true` (default) | Match the dropdown list's width to the edited cell.       |
+| `false`          | Scale the dropdown list's width to its longest option.    |
+
+In the example below, the **Department (default)** column trims the list to the cell, while the **Department (full width)** column expands it. Open a cell in each column to compare.
+
+::: only-for javascript
+
+::: example #example4 .docs-height-small --js 1 --ts 2
+
+@[code](@/content/guides/cell-types/dropdown-cell-type/javascript/example4.js)
+@[code](@/content/guides/cell-types/dropdown-cell-type/javascript/example4.ts)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #example4 .docs-height-small :react --js 1 --ts 2
+
+@[code](@/content/guides/cell-types/dropdown-cell-type/react/example4.jsx)
+@[code](@/content/guides/cell-types/dropdown-cell-type/react/example4.tsx)
+
+:::
+
+:::
+
+::: only-for angular
+
+::: example #example4 .docs-height-small :angular --ts 1 --html 2
+
+@[code](@/content/guides/cell-types/dropdown-cell-type/angular/example4.ts)
+@[code](@/content/guides/cell-types/dropdown-cell-type/angular/example4.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example4 .docs-height-small :vue3
+
+@[code](@/content/guides/cell-types/dropdown-cell-type/vue/example4.vue)
+
+:::
+
+:::
+
+## Set the dropdown height
+
+By default, the dropdown list shows up to 10 options before a scrollbar appears. To change how many options are visible at once, set [`visibleRows`](@/api/options.md#visiblerows) to the number of options you want to show.
+
+::: tip
+
+If the grid has a fixed [`height`](@/api/options.md#height) set, the dropdown list can be constrained by the available space and show fewer rows than the `visibleRows` value.
+
+:::
+
+In the example below, the **Job title (default)** column uses the default height, while the **Job title (compact)** column shows three options at a time. Open a cell in each column to compare.
+
+::: only-for javascript
+
+::: example #example5 .docs-height-small --js 1 --ts 2
+
+@[code](@/content/guides/cell-types/dropdown-cell-type/javascript/example5.js)
+@[code](@/content/guides/cell-types/dropdown-cell-type/javascript/example5.ts)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #example5 .docs-height-small :react --js 1 --ts 2
+
+@[code](@/content/guides/cell-types/dropdown-cell-type/react/example5.jsx)
+@[code](@/content/guides/cell-types/dropdown-cell-type/react/example5.tsx)
+
+:::
+
+:::
+
+::: only-for angular
+
+::: example #example5 .docs-height-small :angular --ts 1 --html 2
+
+@[code](@/content/guides/cell-types/dropdown-cell-type/angular/example5.ts)
+@[code](@/content/guides/cell-types/dropdown-cell-type/angular/example5.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example5 .docs-height-small :vue3
+
+@[code](@/content/guides/cell-types/dropdown-cell-type/vue/example5.vue)
+
+:::
 
 :::
 

--- a/docs/content/guides/cell-types/dropdown-cell-type/javascript/example4.js
+++ b/docs/content/guides/cell-types/dropdown-cell-type/javascript/example4.js
@@ -1,0 +1,42 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+// Register all Handsontable's modules.
+registerAllModules();
+const container = document.querySelector('#example4');
+const departments = [
+    'Engineering and Platform Infrastructure',
+    'Marketing and Brand Communications',
+    'Financial Planning and Analysis',
+    'People Operations and Talent Acquisition',
+    'Customer Success and Enterprise Accounts',
+];
+new Handsontable(container, {
+    height: 'auto',
+    licenseKey: 'non-commercial-and-evaluation',
+    data: [
+        ['Ana García', departments[0], departments[0]],
+        ['James Okafor', departments[1], departments[1]],
+        ['Li Wei', departments[2], departments[2]],
+        ['Sofia Rossi', departments[3], departments[3]],
+    ],
+    colHeaders: ['Employee', 'Department (default)', 'Department (full width)'],
+    columns: [
+        {},
+        {
+            type: 'dropdown',
+            source: departments,
+            width: 140,
+            // trim the list to the cell's width (default)
+            trimDropdown: true,
+        },
+        {
+            type: 'dropdown',
+            source: departments,
+            width: 140,
+            // expand the list to fit its longest option
+            trimDropdown: false,
+        },
+    ],
+    autoWrapRow: true,
+    autoWrapCol: true,
+});

--- a/docs/content/guides/cell-types/dropdown-cell-type/javascript/example4.ts
+++ b/docs/content/guides/cell-types/dropdown-cell-type/javascript/example4.ts
@@ -1,0 +1,45 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+// Register all Handsontable's modules.
+registerAllModules();
+
+const container = document.querySelector('#example4')!;
+const departments = [
+  'Engineering and Platform Infrastructure',
+  'Marketing and Brand Communications',
+  'Financial Planning and Analysis',
+  'People Operations and Talent Acquisition',
+  'Customer Success and Enterprise Accounts',
+];
+
+new Handsontable(container, {
+  height: 'auto',
+  licenseKey: 'non-commercial-and-evaluation',
+  data: [
+    ['Ana García', departments[0], departments[0]],
+    ['James Okafor', departments[1], departments[1]],
+    ['Li Wei', departments[2], departments[2]],
+    ['Sofia Rossi', departments[3], departments[3]],
+  ],
+  colHeaders: ['Employee', 'Department (default)', 'Department (full width)'],
+  columns: [
+    {},
+    {
+      type: 'dropdown',
+      source: departments,
+      width: 140,
+      // trim the list to the cell's width (default)
+      trimDropdown: true,
+    },
+    {
+      type: 'dropdown',
+      source: departments,
+      width: 140,
+      // expand the list to fit its longest option
+      trimDropdown: false,
+    },
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+});

--- a/docs/content/guides/cell-types/dropdown-cell-type/javascript/example5.js
+++ b/docs/content/guides/cell-types/dropdown-cell-type/javascript/example5.js
@@ -1,0 +1,47 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+// Register all Handsontable's modules.
+registerAllModules();
+const container = document.querySelector('#example5');
+const jobTitles = [
+    'Software Engineer',
+    'Senior Software Engineer',
+    'Staff Engineer',
+    'Engineering Manager',
+    'Product Manager',
+    'Product Designer',
+    'Data Analyst',
+    'Data Scientist',
+    'Marketing Specialist',
+    'Account Executive',
+    'Customer Success Manager',
+    'Finance Analyst',
+    'Recruiter',
+    'Office Manager',
+];
+new Handsontable(container, {
+    height: 'auto',
+    licenseKey: 'non-commercial-and-evaluation',
+    data: [
+        ['Ana García', 'Senior Software Engineer', 'Senior Software Engineer'],
+        ['James Okafor', 'Product Manager', 'Product Manager'],
+        ['Li Wei', 'Data Scientist', 'Data Scientist'],
+        ['Sofia Rossi', 'Account Executive', 'Account Executive'],
+    ],
+    colHeaders: ['Employee', 'Job title (default)', 'Job title (compact)'],
+    columns: [
+        {},
+        {
+            type: 'dropdown',
+            source: jobTitles,
+        },
+        {
+            type: 'dropdown',
+            source: jobTitles,
+            // show 3 options at a time, then scroll
+            visibleRows: 3,
+        },
+    ],
+    autoWrapRow: true,
+    autoWrapCol: true,
+});

--- a/docs/content/guides/cell-types/dropdown-cell-type/javascript/example5.ts
+++ b/docs/content/guides/cell-types/dropdown-cell-type/javascript/example5.ts
@@ -1,0 +1,50 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+// Register all Handsontable's modules.
+registerAllModules();
+
+const container = document.querySelector('#example5')!;
+const jobTitles = [
+  'Software Engineer',
+  'Senior Software Engineer',
+  'Staff Engineer',
+  'Engineering Manager',
+  'Product Manager',
+  'Product Designer',
+  'Data Analyst',
+  'Data Scientist',
+  'Marketing Specialist',
+  'Account Executive',
+  'Customer Success Manager',
+  'Finance Analyst',
+  'Recruiter',
+  'Office Manager',
+];
+
+new Handsontable(container, {
+  height: 'auto',
+  licenseKey: 'non-commercial-and-evaluation',
+  data: [
+    ['Ana García', 'Senior Software Engineer', 'Senior Software Engineer'],
+    ['James Okafor', 'Product Manager', 'Product Manager'],
+    ['Li Wei', 'Data Scientist', 'Data Scientist'],
+    ['Sofia Rossi', 'Account Executive', 'Account Executive'],
+  ],
+  colHeaders: ['Employee', 'Job title (default)', 'Job title (compact)'],
+  columns: [
+    {},
+    {
+      type: 'dropdown',
+      source: jobTitles,
+    },
+    {
+      type: 'dropdown',
+      source: jobTitles,
+      // show 3 options at a time, then scroll
+      visibleRows: 3,
+    },
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+});

--- a/docs/content/guides/cell-types/dropdown-cell-type/react/example4.jsx
+++ b/docs/content/guides/cell-types/dropdown-cell-type/react/example4.jsx
@@ -1,0 +1,50 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const departments = [
+  'Engineering and Platform Infrastructure',
+  'Marketing and Brand Communications',
+  'Financial Planning and Analysis',
+  'People Operations and Talent Acquisition',
+  'Customer Success and Enterprise Accounts',
+];
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      height="auto"
+      data={[
+        ['Ana García', departments[0], departments[0]],
+        ['James Okafor', departments[1], departments[1]],
+        ['Li Wei', departments[2], departments[2]],
+        ['Sofia Rossi', departments[3], departments[3]],
+      ]}
+      colHeaders={['Employee', 'Department (default)', 'Department (full width)']}
+      columns={[
+        {},
+        {
+          type: 'dropdown',
+          source: departments,
+          width: 140,
+          // trim the list to the cell's width (default)
+          trimDropdown: true,
+        },
+        {
+          type: 'dropdown',
+          source: departments,
+          width: 140,
+          // expand the list to fit its longest option
+          trimDropdown: false,
+        },
+      ]}
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/cell-types/dropdown-cell-type/react/example4.tsx
+++ b/docs/content/guides/cell-types/dropdown-cell-type/react/example4.tsx
@@ -1,0 +1,50 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const departments = [
+  'Engineering and Platform Infrastructure',
+  'Marketing and Brand Communications',
+  'Financial Planning and Analysis',
+  'People Operations and Talent Acquisition',
+  'Customer Success and Enterprise Accounts',
+];
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      height="auto"
+      data={[
+        ['Ana García', departments[0], departments[0]],
+        ['James Okafor', departments[1], departments[1]],
+        ['Li Wei', departments[2], departments[2]],
+        ['Sofia Rossi', departments[3], departments[3]],
+      ]}
+      colHeaders={['Employee', 'Department (default)', 'Department (full width)']}
+      columns={[
+        {},
+        {
+          type: 'dropdown',
+          source: departments,
+          width: 140,
+          // trim the list to the cell's width (default)
+          trimDropdown: true,
+        },
+        {
+          type: 'dropdown',
+          source: departments,
+          width: 140,
+          // expand the list to fit its longest option
+          trimDropdown: false,
+        },
+      ]}
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/cell-types/dropdown-cell-type/react/example5.jsx
+++ b/docs/content/guides/cell-types/dropdown-cell-type/react/example5.jsx
@@ -1,0 +1,55 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const jobTitles = [
+  'Software Engineer',
+  'Senior Software Engineer',
+  'Staff Engineer',
+  'Engineering Manager',
+  'Product Manager',
+  'Product Designer',
+  'Data Analyst',
+  'Data Scientist',
+  'Marketing Specialist',
+  'Account Executive',
+  'Customer Success Manager',
+  'Finance Analyst',
+  'Recruiter',
+  'Office Manager',
+];
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      height="auto"
+      data={[
+        ['Ana García', 'Senior Software Engineer', 'Senior Software Engineer'],
+        ['James Okafor', 'Product Manager', 'Product Manager'],
+        ['Li Wei', 'Data Scientist', 'Data Scientist'],
+        ['Sofia Rossi', 'Account Executive', 'Account Executive'],
+      ]}
+      colHeaders={['Employee', 'Job title (default)', 'Job title (compact)']}
+      columns={[
+        {},
+        {
+          type: 'dropdown',
+          source: jobTitles,
+        },
+        {
+          type: 'dropdown',
+          source: jobTitles,
+          // show 3 options at a time, then scroll
+          visibleRows: 3,
+        },
+      ]}
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/cell-types/dropdown-cell-type/react/example5.tsx
+++ b/docs/content/guides/cell-types/dropdown-cell-type/react/example5.tsx
@@ -1,0 +1,55 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const jobTitles = [
+  'Software Engineer',
+  'Senior Software Engineer',
+  'Staff Engineer',
+  'Engineering Manager',
+  'Product Manager',
+  'Product Designer',
+  'Data Analyst',
+  'Data Scientist',
+  'Marketing Specialist',
+  'Account Executive',
+  'Customer Success Manager',
+  'Finance Analyst',
+  'Recruiter',
+  'Office Manager',
+];
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      height="auto"
+      data={[
+        ['Ana García', 'Senior Software Engineer', 'Senior Software Engineer'],
+        ['James Okafor', 'Product Manager', 'Product Manager'],
+        ['Li Wei', 'Data Scientist', 'Data Scientist'],
+        ['Sofia Rossi', 'Account Executive', 'Account Executive'],
+      ]}
+      colHeaders={['Employee', 'Job title (default)', 'Job title (compact)']}
+      columns={[
+        {},
+        {
+          type: 'dropdown',
+          source: jobTitles,
+        },
+        {
+          type: 'dropdown',
+          source: jobTitles,
+          // show 3 options at a time, then scroll
+          visibleRows: 3,
+        },
+      ]}
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/cell-types/dropdown-cell-type/vue/example4.vue
+++ b/docs/content/guides/cell-types/dropdown-cell-type/vue/example4.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const departments = [
+  'Engineering and Platform Infrastructure',
+  'Marketing and Brand Communications',
+  'Financial Planning and Analysis',
+  'People Operations and Talent Acquisition',
+  'Customer Success and Enterprise Accounts',
+];
+
+const hotSettings = ref<GridSettings>({
+  height: 'auto',
+  data: [
+    ['Ana García', departments[0], departments[0]],
+    ['James Okafor', departments[1], departments[1]],
+    ['Li Wei', departments[2], departments[2]],
+    ['Sofia Rossi', departments[3], departments[3]],
+  ],
+  colHeaders: ['Employee', 'Department (default)', 'Department (full width)'],
+  columns: [
+    {},
+    {
+      type: 'dropdown',
+      source: departments,
+      width: 140,
+      // trim the list to the cell's width (default)
+      trimDropdown: true,
+    },
+    {
+      type: 'dropdown',
+      source: departments,
+      width: 140,
+      // expand the list to fit its longest option
+      trimDropdown: false,
+    },
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example4">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-types/dropdown-cell-type/vue/example5.vue
+++ b/docs/content/guides/cell-types/dropdown-cell-type/vue/example5.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const jobTitles = [
+  'Software Engineer',
+  'Senior Software Engineer',
+  'Staff Engineer',
+  'Engineering Manager',
+  'Product Manager',
+  'Product Designer',
+  'Data Analyst',
+  'Data Scientist',
+  'Marketing Specialist',
+  'Account Executive',
+  'Customer Success Manager',
+  'Finance Analyst',
+  'Recruiter',
+  'Office Manager',
+];
+
+const hotSettings = ref<GridSettings>({
+  height: 'auto',
+  data: [
+    ['Ana García', 'Senior Software Engineer', 'Senior Software Engineer'],
+    ['James Okafor', 'Product Manager', 'Product Manager'],
+    ['Li Wei', 'Data Scientist', 'Data Scientist'],
+    ['Sofia Rossi', 'Account Executive', 'Account Executive'],
+  ],
+  colHeaders: ['Employee', 'Job title (default)', 'Job title (compact)'],
+  columns: [
+    {},
+    {
+      type: 'dropdown',
+      source: jobTitles,
+    },
+    {
+      type: 'dropdown',
+      source: jobTitles,
+      // show 3 options at a time, then scroll
+      visibleRows: 3,
+    },
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example5">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>


### PR DESCRIPTION
### Context

The PR adds documentation for the `trimDropdown` and `visibleRows` options in the [Dropdown cell type](https://handsontable.com/docs/javascript-data-grid/dropdown-cell-type/) guide. Both options were listed only under the guide's related-options links, with no explanation or example, despite controlling the dropdown list's width and height. This addresses DEV-599 (migrated from GitHub #1722), including the follow-up comment that asked for `visibleRows` coverage as well.

What changed:

- Added a **"Set the dropdown width"** section explaining `trimDropdown`, with a `true`/`false` comparison table and a runnable example (`example4`).
- Added a **"Set the dropdown height"** section explaining `visibleRows`, with a tip about the fixed-`height` clipping behavior and a runnable example (`example5`).
- Added `example4` and `example5` for all four frameworks (JavaScript, React, Angular, Vue 3) using HR-domain sample data.
- Set `menuTag: updated` on the guide's frontmatter.

`[skip changelog]` — documentation-only change.

### How has this been tested?

- Generated the JavaScript variants from the TypeScript sources via `npm run docs:code-examples:generate-js`; transpiled without errors.
- Verified both examples render and visibly demonstrate their option in a browser against the built `handsontable.full.min.js` bundle:
  - `trimDropdown: true` truncates long options to the cell width; `trimDropdown: false` expands the list to fit the longest option.
  - `visibleRows: 3` shows three options with a scrollbar, versus the default of ten.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-599

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-599

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and runnable examples only; no library or runtime behavior changes.
> 
> **Overview**
> The **Dropdown cell type** guide now explains **`trimDropdown`** and **`visibleRows`**, which were only linked before with no narrative or demos.
> 
> A **Set the dropdown width** section documents **`trimDropdown`** (default vs expanding the list to the longest option), includes a comparison table, and wires **example4** for JavaScript, React, Angular, and Vue 3.
> 
> A **Set the dropdown height** section documents **`visibleRows`** (default 10 visible rows vs a custom count), notes clipping when the grid has a fixed **`height`**, and wires **example5** for the same frameworks.
> 
> Frontmatter **`menuTag: updated`** marks the guide as refreshed in the docs menu.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0495718bd7b5e6c58ba786b29e3e20625814b862. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->