### PR TITLE
DEV-590: Document NestedRows lack of moveRows support

### DIFF
--- a/docs/content/guides/rows/row-moving/row-moving.md
+++ b/docs/content/guides/rows/row-moving/row-moving.md
@@ -13,6 +13,7 @@ vue:
   metaTitle: Row moving - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Rows
+menuTag: updated
 ---
 Change the order of rows, either manually (dragging them to another location), or programmatically (using Handsontable's API methods).
 
@@ -110,6 +111,8 @@ The [`moveRows`](@/api/manualRowMove.md#moverows) method has a `finalIndex` para
 </span>
 
 The [`moveRows`](@/api/manualRowMove.md#moverows) function cannot perform some actions, e.g., more than one element can't be moved to the last position. In this scenario, the move will be cancelled. The Plugin's [`isMovePossible`](@/api/manualRowMove.md#ismovepossible) API method and the `movePossible` parameters `beforeRowMove` and `afterRowMove` hooks help in determine such situations.
+
+The [`moveRows`](@/api/manualRowMove.md#moverows) method is also inactive when the [`NestedRows`](@/api/nestedRows.md) plugin is enabled - see [Row parent-child known limitations](@/guides/rows/row-parent-child/row-parent-child.md#known-limitations).
 
 ### Related API reference
 

--- a/docs/content/guides/rows/row-parent-child/row-parent-child.md
+++ b/docs/content/guides/rows/row-parent-child/row-parent-child.md
@@ -22,6 +22,7 @@ vue:
   metaTitle: Row parent-child - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Rows
+menuTag: updated
 ---
 Reflect the parent-child relationship of your data, using the [`NestedRows`](@/api/nestedRows.md) plugin's interactive UI elements such as expand and collapse
 buttons or an extended context menu.
@@ -171,6 +172,9 @@ When you use the parent-child row structure, the following Handsontable features
 - [Data source as an array of arrays](@/guides/getting-started/binding-to-data/binding-to-data.md#array-of-arrays)
 - [Column filter](@/guides/columns/column-filter/column-filter.md)
 - [Rows sorting](@/guides/rows/rows-sorting/rows-sorting.md)
+- [Manual row moving via `moveRows()`](@/api/manualRowMove.md#moverows) - use [`dragRows()`](@/api/manualRowMove.md#dragrows) instead
+
+When the `NestedRows` plugin is enabled, the `ManualRowMove` plugin's [`moveRows()`](@/api/manualRowMove.md#moverows) method has no effect and logs a console warning. To move rows programmatically, use [`dragRows()`](@/api/manualRowMove.md#dragrows) instead.
 
 ### Keyboard shortcuts
 


### PR DESCRIPTION
### Context

The PR adds documentation noting that the `NestedRows` plugin does not support manual row moving via `moveRows()`. Since Handsontable 8.0.0, `moveRows()` has no effect when `NestedRows` is enabled (it logs a console warning and instructs users to call `dragRows()` instead — see `handsontable/src/plugins/nestedRows/utils/rowMoveController.ts`). This limitation was undocumented: the Row parent-child guide's "Known limitations" section listed three unsupported features but omitted manual row moving.

This closes the documentation gap so readers learn to use `dragRows()` under `NestedRows`, in the place they expect it.

[skip changelog]

### How has this been tested?

Docs-only change, verified statically:

- Re-read the edited "Known limitations" section and the row-moving `dragRows vs moveRows` section.
- Confirmed all internal links use the `@/...md` form and anchors resolve (`#moverows`, `#dragrows`, `#known-limitations`, `#nestedrows`).
- Confirmed the documented behavior matches source (`rowMoveController.ts` warning).
- Confirmed docs-site voice (second person, present tense, hyphens, no banned words).

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-590

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-590

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates with no runtime or API behavior changes.
> 
> **Overview**
> Documents that **`moveRows()`** does nothing when **`NestedRows`** is on (console warning since 8.0.0) and that **`dragRows()`** is the supported programmatic API.
> 
> The **Row parent-child** guide’s **Known limitations** list now includes manual row moving via `moveRows()`, with a short explanation and links to **`dragRows()`**. The **Row moving** guide’s **dragRows vs moveRows** section adds a cross-link to that limitations section. Both guides are marked **`menuTag: updated`** in front matter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddcbb99d8fc4405532e4282ca3db901cc5889162. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->