### PR TITLE
DEV-592: Document index type returned by afterFormulasValuesUpdate

### DIFF
--- a/handsontable/src/core/hooks/constants.ts
+++ b/handsontable/src/core/hooks/constants.ts
@@ -2866,6 +2866,10 @@ export const REGISTERED_HOOKS = [
    *
    * This hook gets also fired on Handsontable's initialization, returning the addresses and values of all cells.
    *
+   * The `row` and `col` of each address are HyperFormula engine indexes, not Handsontable visual indexes.
+   * They match Handsontable's physical and visual indexes only when no rows or columns are moved, trimmed, or hidden.
+   * Once you reorder, trim, or hide rows or columns, the engine indexes diverge from the visual ones.
+   *
    * Read more:
    * - [Guides: Formula calculation](@/guides/formulas/formula-calculation/formula-calculation.md)
    * - [HyperFormula documentation: `valuesUpdated`](https://hyperformula.handsontable.com/api/interfaces/listeners.html#valuesupdated)


### PR DESCRIPTION
### Context

The PR adds a clarification to the `afterFormulasValuesUpdate` hook documentation. A client asked whether the `row` and `col` returned in each change's `address` are physical or visual indexes, and the docs did not say (DEV-592, migrated from GitHub #1043).

The returned `address` carries the raw HyperFormula engine index — `#exportChangeValue` in `formulas.ts` only rewrites `newValue` and never remaps `address.row`/`col` to a visual index. Because the engine maintains its own index space (`getVisualIndexFromHfIndex` in `axisSyncer.ts` is a non-identity mapping), the engine index matches Handsontable's physical and visual indexes only when no rows or columns are moved, trimmed, or hidden. This PR documents that in the hook's JSDoc.

The API hooks reference page is generated from this JSDoc, so the JSDoc is the only source to edit.

### How has this been tested?

- This is a JSDoc-comment-only change with no runtime behavior change, so no unit or E2E tests were added.
- `npm run eslint --prefix handsontable` passes for the changed file.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-592

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-592

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> JSDoc-only change with no runtime behavior; lowest risk documentation update.
> 
> **Overview**
> Clarifies the **`afterFormulasValuesUpdate`** hook JSDoc so integrators know what **`address.row`** and **`address.col`** mean.
> 
> The new text states they are **HyperFormula engine indexes**, not Handsontable visual indexes. They line up with physical/visual indexes only when rows and columns are not moved, trimmed, or hidden; after reordering, trimming, or hiding, engine indexes can differ from what you see in the grid. This feeds the generated API hooks reference—no runtime or type changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a0c8279aa794ed106340a00f266b697203c8323. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->