### PR TITLE
DEV-490: Document that moving rows does not mutate the data model

### DIFF
--- a/docs/content/guides/getting-started/binding-to-data/binding-to-data.md
+++ b/docs/content/guides/getting-started/binding-to-data/binding-to-data.md
@@ -444,6 +444,9 @@ To change the number of rows or columns rendered by default, use the [`startRows
 Handsontable binds to your data source by reference, not by values. We don't copy the input dataset, and we rely on
 JavaScript to handle the objects. Any data entered into the grid will alter the original data source.
 
+This applies to cell value edits. Structural changes such as moving, sorting, or filtering rows do not reorder the
+source array - Handsontable stores that order as index metadata instead. For details, see [Row moving](@/guides/rows/row-moving/row-moving.md#data-model-behavior).
+
 ::: tip
 
 Handsontable initializes the source data for the table using a reference, but you shouldn't rely on it. For

--- a/docs/content/guides/getting-started/saving-data/saving-data.md
+++ b/docs/content/guides/getting-started/saving-data/saving-data.md
@@ -76,7 +76,9 @@ The example below handles data by using `fetch`. Note that this is just a mockup
 
 ## Save data locally
 
-To persist table state (e.g. column order, column widths, row order) across page reloads, use the browser's [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) API or [`sessionStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage) in your application. Listen to the appropriate hooks (e.g. `afterColumnMove`, `afterColumnResize`) and save or restore state as needed.
+To persist table state (e.g. column order, column widths, row order) across page reloads, use the browser's [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) API or [`sessionStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage) in your application. Listen to the appropriate hooks (e.g. [`afterColumnMove`](@/api/hooks.md#aftercolumnmove), [`afterRowMove`](@/api/hooks.md#afterrowmove), [`afterColumnResize`](@/api/hooks.md#aftercolumnresize)) and save or restore state as needed.
+
+The [`afterChange`](@/api/hooks.md#afterchange) hook does not fire for structural changes such as row moves. To save a new row order, listen to [`afterRowMove`](@/api/hooks.md#afterrowmove) and read the current order with [`getData()`](@/api/core.md#getdata). For more on how moves affect the data model, see [Row moving](@/guides/rows/row-moving/row-moving.md#data-model-behavior).
 
 ## Result
 

--- a/docs/content/guides/rows/row-moving/row-moving.md
+++ b/docs/content/guides/rows/row-moving/row-moving.md
@@ -85,6 +85,31 @@ This renders the rows in the following order:
 
 The array must contain all physical row indexes (its length must equal the total number of rows). After the initial render, users can still drag rows to change the order further.
 
+## Data model behavior
+
+Moving rows does not reorder your source data array. Handsontable stores the new order as index metadata through its [`IndexMapper`](@/api/indexMapper.md), and leaves the original `sourceData` array untouched. This affects how you read and save the data:
+
+- [`getData()`](@/api/core.md#getdata) returns rows in their current visual order, so it reflects any moves. Call it inside the [`afterRowMove`](@/api/hooks.md#afterrowmove) hook to get an order-accurate snapshot to persist.
+- [`getSourceData()`](@/api/core.md#getsourcedata) returns rows in their original physical order, ignoring any moves.
+
+To save the new order after a move, listen to the [`afterRowMove`](@/api/hooks.md#afterrowmove) hook:
+
+```js
+afterRowMove(movedRows, finalIndex, dropIndex, movePossible, orderChanged) {
+  if (orderChanged) {
+    const reorderedData = this.getData();
+
+    // persist reorderedData to your backend or local state
+  }
+}
+```
+
+::: only-for react
+
+In React, binding the [`data`](@/api/options.md#data) prop to a state variable does not keep that state in sync with row moves. The move updates Handsontable's internal index order, but your bound state still holds the original order. To align your state with the displayed order, update it explicitly from the [`afterRowMove`](@/api/hooks.md#afterrowmove) hook using [`getData()`](@/api/core.md#getdata).
+
+:::
+
 ## Result
 
 After completing this guide, you can reorder rows by dragging them with the mouse or by calling `dragRows()` and `moveRows()` programmatically. You can also set a pre-defined row order at initialization.


### PR DESCRIPTION
### Context

The PR documents that moving rows does not reorder the underlying source data array. Handsontable stores the new order as index metadata through `IndexMapper` and leaves the original `sourceData` array untouched. This behavior was undocumented, which led to confusion - most notably the DEV-490 report that the React data model does not update when moving rows.

The change clarifies, across three existing guide pages:

- Moving rows leaves `sourceData` unchanged; `getData()` returns the current visual (post-move) order while `getSourceData()` returns the original physical order.
- To persist a new row order, listen to `afterRowMove` and read `getData()` - `afterChange` does not fire for structural changes like moves.
- In React, a `data` prop bound to a state variable does not auto-sync with row moves; state must be updated explicitly from `afterRowMove`.

Files changed:
- `guides/rows/row-moving/row-moving.md` - new "Data model behavior" section (primary), with a React-specific `::: only-for react` note.
- `guides/getting-started/saving-data/saving-data.md` - "Save data locally" now covers `afterRowMove` and notes `afterChange` does not fire on moves.
- `guides/getting-started/binding-to-data/binding-to-data.md` - clarifies the by-reference guarantee covers value edits, not structural reordering, with a cross-link.

[skip changelog]

### How has this been tested?

Docs-only change. Verified statically:

- Confirmed the `afterRowMove` hook signature against `handsontable/src/core/hooks/constants.ts` (`movedRows, finalIndex, dropIndex, movePossible, orderChanged`).
- Confirmed all referenced API anchors exist: `core.md#getdata`, `core.md#getsourcedata`, `hooks.md#afterrowmove`, `hooks.md#aftercolumnmove`, `hooks.md#aftercolumnresize`, `options.md#data`, `indexMapper.md`, and the cross-link target `row-moving.md#data-model-behavior`.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-490

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-490

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API behavior modifications.
> 
> **Overview**
> Documents that **row moves change visual order via `IndexMapper`, not the underlying `sourceData` array**, addressing confusion (e.g. React state not updating after drag).
> 
> The **row-moving** guide adds a **Data model behavior** section: `getData()` vs `getSourceData()`, persisting order from **`afterRowMove`** with `getData()`, plus a React-only note that the **`data` prop does not auto-sync** after moves.
> 
> **Binding to data** now limits the by-reference guarantee to **cell edits** and points readers to row-moving for structural reordering. **Saving data** adds hook links for local persistence and states that **`afterChange` does not run for row moves**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45d83d34ea4ffb4b3344970b7851626d8ba28612. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->