### PR TITLE
DEV-1950: Replace IndexMapper Map translation caches with Int32Array

### DIFF
--- a/.changelogs/12880.json
+++ b/.changelogs/12880.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Improved the performance of sorting, filtering, and row/column hiding on large datasets by speeding up internal index translation.",
+  "type": "changed",
+  "issueOrPR": 12880,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/translations/__tests__/indexMapper.unit.ts
+++ b/handsontable/src/translations/__tests__/indexMapper.unit.ts
@@ -353,6 +353,26 @@ describe('IndexMapper', () => {
     indexMapper.unregisterMap('uniqueName');
   });
 
+  it('should return `null` from index translations for non-integer keys (e.g. `__proto__`, `constructor`, string-numeric)', () => {
+    const indexMapper = new IndexMapper();
+
+    indexMapper.initToLength(5);
+
+    // The translation caches are backed by typed arrays. Non-integer keys must be treated as misses (as the
+    // previous Map-backed cache did), so they neither leak prototype-chain values (`__proto__`, `constructor`)
+    // nor coerce string-numeric keys (`'0'` -> slot 0).
+    expect(indexMapper.getVisualFromPhysicalIndex('__proto__' as unknown as number)).toBe(null);
+    expect(indexMapper.getVisualFromPhysicalIndex('constructor' as unknown as number)).toBe(null);
+    expect(indexMapper.getVisualFromPhysicalIndex('0' as unknown as number)).toBe(null);
+    expect(indexMapper.getRenderableFromVisualIndex('__proto__' as unknown as number)).toBe(null);
+    expect(indexMapper.getRenderableFromVisualIndex('constructor' as unknown as number)).toBe(null);
+    expect(indexMapper.getRenderableFromVisualIndex('0' as unknown as number)).toBe(null);
+
+    // Integer keys still resolve normally.
+    expect(indexMapper.getVisualFromPhysicalIndex(0)).toBe(0);
+    expect(indexMapper.getRenderableFromVisualIndex(0)).toBe(0);
+  });
+
   it('should translate indexes from visual to physical and the other way round properly', () => {
     const indexMapper = new IndexMapper();
     const trimmingMap = new TrimmingMap();

--- a/handsontable/src/translations/indexMapper.ts
+++ b/handsontable/src/translations/indexMapper.ts
@@ -172,19 +172,23 @@ export class IndexMapper {
    */
   renderablePhysicalIndexesCache: number[] = [];
   /**
-   * Visual indexes (native map's value) corresponding to physical indexes (native map's index).
+   * Visual indexes (typed array value) corresponding to physical indexes (typed array index).
+   * `-1` marks a physical index with no visual index (trimmed). Backed by a typed array instead of a
+   * `Map` to avoid per-rebuild hashing churn on large datasets.
    *
    * @private
-   * @type {Map}
+   * @type {Int32Array}
    */
-  fromPhysicalToVisualIndexesCache = new Map<number | null, number>();
+  fromPhysicalToVisualIndexesCache: Int32Array = new Int32Array(0);
   /**
-   * Visual indexes (native map's value) corresponding to physical indexes (native map's index).
+   * Renderable indexes (typed array value) corresponding to visual indexes (typed array index).
+   * `-1` marks a visual index with no renderable index (hidden). Backed by a typed array instead of a
+   * `Map` to avoid per-rebuild hashing churn on large datasets.
    *
    * @private
-   * @type {Map}
+   * @type {Int32Array}
    */
-  fromVisualToRenderableIndexesCache = new Map<number | null, number>();
+  fromVisualToRenderableIndexesCache: Int32Array = new Int32Array(0);
   /**
    * Map of observed IndexMap instances to their registered callback sets.
    * Used by {@link IndexMapper#observeMapChange} to track which maps are being
@@ -397,10 +401,17 @@ export class IndexMapper {
    * @returns {number|null} Returns a visual index of the index mapper.
    */
   getVisualFromPhysicalIndex(physicalIndex: number): number | null {
-    const visualIndex = this.fromPhysicalToVisualIndexesCache.get(physicalIndex);
+    // The typed-array cache coerces non-integer keys: a string like `'0'` would index slot 0 and
+    // `'__proto__'`/`'constructor'` would return prototype-chain values. The previous `Map` treated those
+    // as misses, so reject any non-integer key here to keep that exact-key semantics.
+    if (!Number.isInteger(physicalIndex)) {
+      return null;
+    }
 
-    // Index in the table boundaries provided by the `DataMap`.
-    return visualIndex ?? null;
+    const visualIndex = this.fromPhysicalToVisualIndexesCache[physicalIndex];
+
+    // Index in the table boundaries provided by the `DataMap`. `-1`/`undefined` means no mapping.
+    return visualIndex === undefined || visualIndex === -1 ? null : visualIndex;
   }
 
   /**
@@ -420,10 +431,16 @@ export class IndexMapper {
    * @returns {null|number}
    */
   getRenderableFromVisualIndex(visualIndex: number): number | null {
-    const renderableIndex = this.fromVisualToRenderableIndexesCache.get(visualIndex);
+    // Reject non-integer keys (string-numeric, `'__proto__'`, etc.) to keep the previous `Map`'s
+    // exact-key semantics — see getVisualFromPhysicalIndex.
+    if (!Number.isInteger(visualIndex)) {
+      return null;
+    }
 
-    // Index in the renderable table boundaries.
-    return renderableIndex ?? null;
+    const renderableIndex = this.fromVisualToRenderableIndexesCache[visualIndex];
+
+    // Index in the renderable table boundaries. `-1`/`undefined` means no mapping.
+    return renderableIndex === undefined || renderableIndex === -1 ? null : renderableIndex;
   }
 
   /**
@@ -446,28 +463,32 @@ export class IndexMapper {
       return null;
     }
 
-    if (this.fromVisualToRenderableIndexesCache.has(fromVisualIndex)) {
+    const renderableCache = this.fromVisualToRenderableIndexesCache;
+    const fromRenderableIndex = renderableCache[fromVisualIndex];
+
+    // The visual index is already visible when it has a renderable mapping. The `typeof number` check
+    // keeps non-integer keys (e.g. `'__proto__'`) from matching prototype-chain values.
+    if (typeof fromRenderableIndex === 'number' && fromRenderableIndex !== -1) {
       return fromVisualIndex;
     }
 
-    const visibleIndexes = Array.from(this.fromVisualToRenderableIndexesCache.keys());
-    let index = -1;
+    // Scan outward for the nearest visible visual index in the requested direction
+    // (`searchDirection` is `1` or `-1`, so the same loop covers both directions).
+    const length = renderableCache.length;
 
-    if (searchDirection > 0) {
-      index = visibleIndexes.findIndex(visualIndex => visualIndex !== null && visualIndex > fromVisualIndex);
-    } else {
-      index = visibleIndexes.reverse().findIndex(visualIndex => visualIndex !== null && visualIndex < fromVisualIndex);
-    }
-
-    if (index === -1) {
-      if (searchAlsoOtherWayAround) {
-        return this.getNearestNotHiddenIndex(fromVisualIndex, -searchDirection as 1 | -1, false);
+    for (let visualIndex = fromVisualIndex + searchDirection;
+      visualIndex >= 0 && visualIndex < length;
+      visualIndex += searchDirection) {
+      if (renderableCache[visualIndex] !== -1) {
+        return visualIndex;
       }
-
-      return null;
     }
 
-    return visibleIndexes[index];
+    if (searchAlsoOtherWayAround) {
+      return this.getNearestNotHiddenIndex(fromVisualIndex, -searchDirection as 1 | -1, false);
+    }
+
+    return null;
   }
 
   /**
@@ -858,22 +879,44 @@ export class IndexMapper {
   }
 
   /**
+   * Returns a `-1`-filled `Int32Array` of the given length, reusing the passed one when its length
+   * matches so a cache rebuild does not allocate a new buffer.
+   *
+   * @private
+   * @param {Int32Array} cache The existing cache to reuse when possible.
+   * @param {number} length The required length.
+   * @returns {Int32Array}
+   */
+  #allocateIndexCache(cache: Int32Array, length: number): Int32Array {
+    if (cache.length === length) {
+      cache.fill(-1);
+
+      return cache;
+    }
+
+    return new Int32Array(length).fill(-1);
+  }
+
+  /**
    * Update cache for translations from physical to visual indexes.
    *
    * @private
    */
   cacheFromPhysicalToVisualIndexes(): void {
     const nrOfNotTrimmedIndexes = this.getNotTrimmedIndexesLength();
-
-    this.fromPhysicalToVisualIndexesCache.clear();
+    const cache = this.#allocateIndexCache(this.fromPhysicalToVisualIndexesCache, this.getNumberOfIndexes());
 
     for (let visualIndex = 0; visualIndex < nrOfNotTrimmedIndexes; visualIndex += 1) {
       const physicalIndex = this.getPhysicalFromVisualIndex(visualIndex);
 
-      // Every visual index have corresponding physical index, but some physical indexes may don't have
-      // corresponding visual indexes (physical indexes may represent trimmed indexes, beyond the table boundaries)
-      this.fromPhysicalToVisualIndexesCache.set(physicalIndex, visualIndex);
+      // Every visual index has a corresponding physical index. Physical indexes with no visual index
+      // (trimmed indexes, beyond the table boundaries) keep the `-1` sentinel.
+      if (physicalIndex !== null) {
+        cache[physicalIndex] = visualIndex;
+      }
     }
+
+    this.fromPhysicalToVisualIndexesCache = cache;
   }
 
   /**
@@ -883,16 +926,20 @@ export class IndexMapper {
    */
   cacheFromVisualToRenderableIndexes(): void {
     const nrOfRenderableIndexes = this.getRenderableIndexesLength();
-
-    this.fromVisualToRenderableIndexesCache.clear();
+    const cache = this.#allocateIndexCache(this.fromVisualToRenderableIndexesCache, this.getNotTrimmedIndexesLength());
 
     for (let renderableIndex = 0; renderableIndex < nrOfRenderableIndexes; renderableIndex += 1) {
       // Can't use getRenderableFromVisualIndex here because we're building the cache here
       const physicalIndex = this.getPhysicalFromRenderableIndex(renderableIndex);
       const visualIndex = this.getVisualFromPhysicalIndex(physicalIndex!);
 
-      this.fromVisualToRenderableIndexesCache.set(visualIndex, renderableIndex);
+      // Visual indexes with no renderable index (hidden indexes) keep the `-1` sentinel.
+      if (visualIndex !== null) {
+        cache[visualIndex] = renderableIndex;
+      }
     }
+
+    this.fromVisualToRenderableIndexesCache = cache;
   }
   /**
    * Destroys the IndexMapper instance. Clears all registered map observers


### PR DESCRIPTION
### Context

The PR speeds up `IndexMapper`'s index-translation cache rebuild, part of the rendering/memory performance initiative.

`IndexMapper` stored its two translation caches — `fromPhysicalToVisualIndexesCache` and `fromVisualToRenderableIndexesCache` — as `Map<number, number>`, rebuilt on every `updateCache` via `clear()` + N× `set()` (per-entry hashing + GC pressure). That rebuild runs on every sort, filter, hide, trim, and move, and scaled poorly with dataset size (~53 ms per rebuild at 1M rows; two rebuilds per operation).

This change backs both caches with reused `-1`-sentinel `Int32Array`s. The rebuild becomes a near-constant sub-millisecond `fill` + sequential write, `getNearestNotHiddenIndex` scans the typed array directly instead of materializing `Array.from(cache.keys())`, and the lookups guard non-integer keys with `Number.isInteger` to preserve the `Map`'s exact-key semantics (string-numeric and `__proto__`/`constructor` keys still miss). The change is internal to `IndexMapper` — no public API, default setting, hook, or CSS change.

Measured cache rebuild (Map vs Int32Array), one rebuild:

| Rows | Map | Int32Array | Speedup |
| --- | --- | --- | --- |
| 50k | 1.39 ms | 0.18 ms | 7.5x |
| 500k | 21.6 ms | 0.55 ms | 39x |
| 1M | 52.9 ms | 0.39 ms | 137x |

In-browser 100k-row sort: both-cache rebuild 25.3 ms to 1.2 ms. Memory is ~16x lower for dense (no/light-trim) datasets. Per-lookup performance is unchanged.

### How has this been tested?

- Added a regression unit test asserting non-integer keys (`__proto__`, `constructor`, string-numeric `'0'`) miss, matching the previous `Map` exact-key semantics.
- `npm run test:unit --prefix handsontable --testPathPattern=translations` — 194/194.
- `npm run test:e2e --prefix handsontable --testPathPattern="hiddenRows|hiddenColumns|columnSorting|trimRows"` — 985/0.
- `npm run test:e2e --prefix handsontable --testPathPattern="filters|manualColumnMove|manualRowMove"` — 659/0.
- `npm run test:e2e --prefix handsontable --testPathPattern="setSourceDataAtCell"` — 18/0 (covers the `__proto__` prototype-pollution guard).
- `npm run test:types --prefix handsontable` and ESLint — clean.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1950

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/86cafmf3d

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core index translation used across rendering and CRUD paths; behavior is intended to match Map semantics but the storage and nearest-visible search algorithm changed.
> 
> **Overview**
> **IndexMapper** now backs its physical↔visual and visual↔renderable translation caches with reused `-1`-sentinel **`Int32Array`** buffers instead of **`Map`**, so cache rebuilds on sort/filter/hide/trim/move avoid per-entry hashing and allocation churn on large grids.
> 
> Rebuild paths use **`#allocateIndexCache`** (fill + reuse when length matches) and write mappings directly; missing entries stay **`-1`** and still surface as **`null`** from the public getters. **`getVisualFromPhysicalIndex`**, **`getRenderableFromVisualIndex`**, and **`getNearestNotHiddenIndex`** add **`Number.isInteger`** guards and scan the typed array in **`getNearestNotHiddenIndex`** instead of **`Array.from(cache.keys())`**.
> 
> A unit test locks in that non-integer keys (`__proto__`, `constructor`, `'0'`) miss like the old **`Map`** behavior. A changelog entry notes faster sorting, filtering, and row/column hiding on large datasets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5f4e165c46705a5521b65f092ac512ec8fa02d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->