### PR TITLE
DEV-1951: Optimize isValidISODate to drop per-cell Date allocation

### DIFF
--- a/.changelogs/12881.json
+++ b/.changelogs/12881.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Improved initialization time for large date-typed datasets by validating ISO dates arithmetically instead of constructing a `Date` object for every cell.",
+  "type": "changed",
+  "issueOrPR": 12881,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/helpers/__tests__/dateTime.unit.js
+++ b/handsontable/src/helpers/__tests__/dateTime.unit.js
@@ -124,11 +124,40 @@ describe('Date helper', () => {
       expect(isValidISODate('2020-04-31')).toBe(false);
     });
 
+    it('should return false for the 31st in every 30-day month', () => {
+      expect(isValidISODate('2020-04-31')).toBe(false);
+      expect(isValidISODate('2020-06-31')).toBe(false);
+      expect(isValidISODate('2020-09-31')).toBe(false);
+      expect(isValidISODate('2020-11-31')).toBe(false);
+    });
+
+    it('should apply Gregorian leap-year rules to February 29', () => {
+      // Divisible by 4 (not by 100) - leap.
+      expect(isValidISODate('2024-02-29')).toBe(true);
+      // Not divisible by 4 - common.
+      expect(isValidISODate('2023-02-29')).toBe(false);
+      // Divisible by 100 but not 400 - common.
+      expect(isValidISODate('1900-02-29')).toBe(false);
+      expect(isValidISODate('2100-02-29')).toBe(false);
+      // Divisible by 400 - leap.
+      expect(isValidISODate('2000-02-29')).toBe(true);
+      expect(isValidISODate('2400-02-29')).toBe(true);
+    });
+
     it('should return true for valid ISO date string', () => {
       expect(isValidISODate('2020-01-01')).toBe(true);
       expect(isValidISODate('2020-12-31')).toBe(true);
       expect(isValidISODate('2016-02-29')).toBe(true);
       expect(isValidISODate('2000-01-15')).toBe(true);
+    });
+
+    it('should accept the last valid day of 30-day months and the year boundaries', () => {
+      expect(isValidISODate('2020-04-30')).toBe(true);
+      expect(isValidISODate('2020-06-30')).toBe(true);
+      expect(isValidISODate('2020-09-30')).toBe(true);
+      expect(isValidISODate('2020-11-30')).toBe(true);
+      expect(isValidISODate('0001-01-01')).toBe(true);
+      expect(isValidISODate('9999-12-31')).toBe(true);
     });
 
     it('should return false for ISO-like string with extra characters', () => {

--- a/handsontable/src/helpers/dateTime.ts
+++ b/handsontable/src/helpers/dateTime.ts
@@ -36,15 +36,36 @@ export function parseToLocalDate(value: unknown): Date | null {
 }
 
 /**
+ * Number of days in each month for a non-leap year, indexed by zero-based month.
+ */
+const DAYS_IN_MONTH = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+/**
+ * Checks if a year is a leap year in the proleptic Gregorian calendar.
+ */
+function isLeapYear(year: number): boolean {
+  return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+}
+
+/**
  * Checks if a string is a valid ISO 8601 date.
  */
 export function isValidISODate(value: unknown): value is string {
   if (typeof value !== 'string' || !ISO_DATE_REGEX.test(value)) {
     return false;
   }
-  const date = new Date(value);
 
-  return !Number.isNaN(date.getTime()) && value === date.toISOString().slice(0, 10);
+  // The regex guarantees the YYYY-MM-DD shape with month 01-12 and day 01-31. The only remaining
+  // check is the calendar bound: that the day fits the given month and year (e.g. rejecting 02-30,
+  // 04-31, or 02-29 in a non-leap year). Doing this arithmetically avoids constructing a Date and
+  // round-tripping through toISOString() for every cell, which dominated load time on large
+  // date-typed grids.
+  const year = +value.slice(0, 4);
+  const month = +value.slice(5, 7);
+  const day = +value.slice(8, 10);
+  const maxDay = month === 2 && isLeapYear(year) ? 29 : DAYS_IN_MONTH[month - 1];
+
+  return day <= maxDay;
 }
 
 /**


### PR DESCRIPTION
### Context

The PR optimizes `isValidISODate` (`handsontable/src/helpers/dateTime.ts`) to remove a per-cell `Date` allocation that dominated load time on large date-typed grids.

It is the split-out follow-up promised in DEV-1942 (#12847). Once that PR removed the eager full-grid cell-meta scan, profiling a fully `date`-typed 100k×100 grid showed the remaining load cost was source-data validation calling `isValidISODate` ~10M times. The old implementation validated each value with `new Date(value)` + `date.toISOString().slice(0, 10)` — two allocations and a UTC round-trip per cell.

After the ISO regex passes, the value is already guaranteed to be `YYYY-MM-DD` with month `01`–`12` and day `01`–`31`. The only thing the `Date` round-trip actually checked was the calendar bound — rejecting impossible dates the regex still allows (`02-30`, `04-31`, `02-29` in a non-leap year). That is pure days-in-month arithmetic with the Gregorian leap-year rule, so the `Date` object and `toISOString()` are unnecessary.

The new implementation computes `day <= daysInMonth(year, month)` directly. No `Date`, no string allocation per cell. Behavior is identical for every input — consumers (`dateValidator`, `dateEditor`, `formulas/utils`) only use the boolean result, and the regex gate is unchanged.

**Measured (Node microbenchmark, 10,000,000 calls):**

| | Before | After |
|---|--:|--:|
| Time for 10M calls | 7,600 ms | 1,188 ms |
| Throughput | 1.3M calls/s | 8.4M calls/s |

≈ **6.4× faster** — about 6.4 s saved on a 100k×100 fully-date grid load.

### How has this been tested?

- **Correctness parity** — an exhaustive cross-check of the new arithmetic against the old `Date` round-trip over 13 representative years (leap, non-leap, century-non-leap `1900`/`2100`, century-leap `2000`/`2400`) × all 12 months × days `01`–`31`, plus malformed/non-string inputs: **4,853 checks, 0 mismatches.**
- **Unit tests** — extended `handsontable/src/helpers/__tests__/dateTime.unit.js` with the 31st-of-every-30-day-month cases, the full Gregorian leap-year matrix for Feb 29, and year boundaries (`0001-01-01`, `9999-12-31`):

  ```
  npm run test:unit --prefix handsontable --testPathPattern=dateTime
  # 30 passed, 30 total
  ```
- **Lint:** `npx eslint src/helpers/dateTime.ts src/helpers/__tests__/dateTime.unit.js` — clean.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1951

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1951

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Hot-path validation logic changed for every ISO date check during grid load; risk is mitigated by exhaustive parity checks and expanded unit tests, but any calendar edge-case bug would affect date columns broadly.
> 
> **Overview**
> **`isValidISODate`** in `dateTime.ts` no longer builds a `Date` and compares via `toISOString()` after the ISO regex passes. It now parses year/month/day from the string and checks calendar validity with **`DAYS_IN_MONTH`**, **`isLeapYear`**, and **`day <= maxDay`**, which removes per-cell allocations on large date-typed grids while keeping the same boolean contract for validators and editors.
> 
> Unit coverage for **`isValidISODate`** adds 31st-in-30-day-month cases, a full Gregorian Feb 29 matrix, and year boundaries (`0001-01-01`, `9999-12-31`). A changelog entry documents faster initialization for large date datasets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b27f37264f602333aeb27b4c1c4524a63269aa7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->