### PR TITLE
DEV-457: Document setCellMeta() needs render() for visual changes

### DIFF
--- a/docs/content/guides/getting-started/configuration-options/configuration-options.md
+++ b/docs/content/guides/getting-started/configuration-options/configuration-options.md
@@ -17,6 +17,7 @@ vue:
   metaTitle: Configuration options - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Getting started
+menuTag: updated
 ---
 Configure your grid down to each column, row, and cell, using various built-in options that control Handsontable's behavior and user interface.
 
@@ -1024,6 +1025,8 @@ hot?.getCellMeta(1, 1).readOnly;
 ```
 
 :::
+
+[`setCellMeta()`](@/api/core.md#setcellmeta) updates a cell's metadata but doesn't repaint the grid on its own. To make a visual change appear -- such as a new `className`, `type`, or `readOnly` state -- call [`render()`](@/api/core.md#render) afterward. If you change several cells at once, wrap the calls in [`batch()`](@/api/core.md#batch) so the grid renders only once.
 
 ## Implement custom logic
 

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -2615,7 +2615,8 @@ export default function Core(
    * to the DOM. While rendering the table all cell renderers are recalled.
    *
    * Calling this method manually is not recommended. Handsontable tries to render itself by choosing the most
-   * optimal moments in its lifecycle.
+   * optimal moments in its lifecycle. After [setCellMeta()](@/api/core.md#setcellmeta) changes visual cell
+   * properties, call this method to apply them, or wrap multiple calls in [batch()](@/api/core.md#batch).
    *
    * @memberof Core#
    * @function render
@@ -4288,6 +4289,10 @@ export default function Core(
 
   /**
    * Sets a property defined by the `key` property to the meta object of a cell corresponding to params `row` and `column`.
+   *
+   * This method updates internal cell metadata only. It does not repaint the grid. To reflect visual changes (such as
+   * `className`, `type`, or `readOnly`), call [render()](@/api/core.md#render) afterward, or wrap multiple calls in
+   * [batch()](@/api/core.md#batch).
    *
    * @memberof Core#
    * @function setCellMeta


### PR DESCRIPTION
### Context

The PR documents that `setCellMeta()` updates internal cell metadata but does not repaint the grid on its own. Readers who change visual properties such as `className`, `type`, or `readOnly` need to call `render()` afterward, or wrap multiple calls in `batch()`.

Changes:
- Add a framework-agnostic note to the configuration options guide ("Change cell options" section).
- Expand `setCellMeta()` JSDoc with the repaint requirement and Typedoc links to `render()` and `batch()`.
- Add a `setCellMeta()` exception sentence to the `render()` JSDoc so the existing "not recommended to call manually" guidance is not read as an absolute prohibition.

[skip changelog]

### How has this been tested?

- `npm --prefix handsontable run build`
- `npm run docs:api` (in `docs/`) — confirmed generated `core.md` entries for `setCellMeta` and `render`
- `npm --prefix handsontable run eslint`

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-457

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-457

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and JSDoc-only changes with no runtime behavior changes.
> 
> **Overview**
> **Documents that `setCellMeta()` only updates metadata and does not repaint the grid**, so visual properties (`className`, `type`, `readOnly`, etc.) need a follow-up [`render()`](@/api/core.md#render), or multiple updates wrapped in [`batch()`](@/api/core.md#batch).
> 
> Adds the same guidance in the configuration options guide (“Change cell options”), expands `setCellMeta()` JSDoc in `core.ts`, and adjusts `render()` JSDoc so the “don’t call manually” note explicitly allows calling `render()` after `setCellMeta()`. The guide front matter gets `menuTag: updated`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e02814b75ade51c311038ade143d9654b134b4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->