### PR TITLE
DEV-650: Fix error when removing frozen column with fixedColumnsLeft

### DIFF
--- a/.changelogs/12883.json
+++ b/.changelogs/12883.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed an error thrown when removing a frozen column while using the legacy fixedColumnsLeft option.",
+  "type": "fixed",
+  "issueOrPR": 12883,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/__tests__/settings/fixedColumnsStart.spec.js
+++ b/handsontable/src/__tests__/settings/fixedColumnsStart.spec.js
@@ -350,6 +350,20 @@ describe('settings', () => {
       });
     });
 
+    it('should not throw when removing a frozen column using only fixedColumnsLeft', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        fixedColumnsLeft: 2,
+      });
+
+      expect(getSettings().fixedColumnsStart).toBe(2);
+
+      await alter('remove_col', 0);
+
+      expect(getSettings().fixedColumnsStart).toBe(1);
+      expect(getInlineStartClone().find('tbody tr:eq(0) td').length).toBe(1);
+    });
+
     it('should limit fixed columns to dataset columns length', async() => {
       handsontable({
         data: createSpreadsheetData(3, 3),

--- a/handsontable/src/__tests__/settings/fixedColumnsStart.spec.js
+++ b/handsontable/src/__tests__/settings/fixedColumnsStart.spec.js
@@ -364,6 +364,27 @@ describe('settings', () => {
       expect(getInlineStartClone().find('tbody tr:eq(0) td').length).toBe(1);
     });
 
+    it('should not throw when undoing/redoing the removal of a frozen column using only fixedColumnsLeft', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        fixedColumnsLeft: 2,
+      });
+
+      await alter('remove_col', 0);
+
+      expect(getSettings().fixedColumnsStart).toBe(1);
+
+      getPlugin('undoRedo').undo();
+
+      expect(getSettings().fixedColumnsStart).toBe(2);
+      expect(getInlineStartClone().find('tbody tr:eq(0) td').length).toBe(2);
+
+      getPlugin('undoRedo').redo();
+
+      expect(getSettings().fixedColumnsStart).toBe(1);
+      expect(getInlineStartClone().find('tbody tr:eq(0) td').length).toBe(1);
+    });
+
     it('should limit fixed columns to dataset columns length', async() => {
       handsontable({
         data: createSpreadsheetData(3, 3),

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -1103,7 +1103,12 @@ export default function Core(
               const fixedColumnsStart = tableMeta.fixedColumnsStart;
 
               if (fixedColumnsStart >= calcIndex + 1) {
-                tableMeta.fixedColumnsStart -= Math.min(groupAmount, fixedColumnsStart - calcIndex);
+                // Since 12.0.0, the "fixedColumnsLeft" is replaced with the "fixedColumnsStart" option.
+                // However, keeping the old name still in effect. When both option names are used together,
+                // the error is thrown. To prevent that, the engine needs to modify the original option key
+                // to bypass the validation.
+                (tableMeta as unknown as { _fixedColumnsStart: number })._fixedColumnsStart -=
+                  Math.min(groupAmount, fixedColumnsStart - calcIndex);
               }
 
               if (Array.isArray(tableMeta.colHeaders)) {

--- a/handsontable/src/plugins/undoRedo/actions/removeColumn.ts
+++ b/handsontable/src/plugins/undoRedo/actions/removeColumn.ts
@@ -151,7 +151,11 @@ export class RemoveColumnAction extends BaseAction {
     const settings = hot.getSettings();
 
     // Changing by the reference as `updateSettings` doesn't work the best.
-    settings.fixedColumnsStart = this.fixedColumnsStart;
+    // Since 12.0.0, the "fixedColumnsLeft" is replaced with the "fixedColumnsStart" option.
+    // However, keeping the old name still in effect. When both option names are used together,
+    // the error is thrown. To prevent that, the engine needs to modify the original option key
+    // to bypass the validation.
+    (settings as unknown as { _fixedColumnsStart: number })._fixedColumnsStart = this.fixedColumnsStart;
 
     const ascendingIndexes = this.indexes.slice(0).sort((a, b) => a - b);
     const sortByIndexes = (elem: unknown, j: number, arr: unknown[]) => arr[this.indexes.indexOf(ascendingIndexes[j])];


### PR DESCRIPTION
### Context

The PR fixes an error thrown when removing a frozen column while only the legacy `fixedColumnsLeft` option is set. During `alter('remove_col', ...)`, the engine decremented `tableMeta.fixedColumnsStart`, which invoked the watched setter on `globalMeta.meta` and incorrectly tripped the `fixedColumnsLeft`/`fixedColumnsStart` usage-conflict guard. The fix writes `_fixedColumnsStart` directly for this internal update, matching the existing pattern in `manualColumnFreeze`.

### How has this been tested?

- Added E2E regression test in `fixedColumnsStart.spec.js`
- `npm run test:e2e --prefix handsontable -- --testPathPattern=fixedColumnsStart` (41 specs, 0 failures)
- `npm run test:e2e --prefix handsontable -- --testPathPattern=manualColumnFreeze` (27 specs, 0 failures)
- `npm run test:unit --prefix handsontable -- --testPathPattern=extendMetaProperties` (16 tests, 0 failures)
- `npm run build --prefix handsontable`
- `npm run eslint --prefix handsontable`
- `npm run test:types --prefix handsontable`

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-650

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-650

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change aligned with existing `manualColumnFreeze` behavior, with new e2e tests and no public API changes.
> 
> **Overview**
> Fixes a crash when deleting a column while only the legacy **`fixedColumnsLeft`** option is set. Internal updates during **`remove_col`** (and undo of that action) now adjust **`_fixedColumnsStart`** instead of going through the **`fixedColumnsStart`** setter, so the engine no longer falsely triggers the “don’t use both option names” guard.
> 
> Regression coverage was added for column removal and undo/redo with **`fixedColumnsLeft`**, plus a changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 401697928a4e64980f72dfb46c146749f8bfff78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->