### PR TITLE
DEV-1952: Add PositionCache uniform-size fast path

### DIFF
--- a/.changelogs/12884.json
+++ b/.changelogs/12884.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Improved initial render time and memory usage for large datasets with uniform row heights and column widths.",
+  "type": "changed",
+  "issueOrPR": 12884,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/src/settings.ts
+++ b/handsontable/src/3rdparty/walkontable/src/settings.ts
@@ -194,6 +194,15 @@ export default class Settings {
       rowHeightByOverlayName() {
         // return undefined means use default size for the rendered cell content
       },
+      rowHeightsUniform() {
+        // return true only when every row is guaranteed the default height (enables the
+        // PositionCache arithmetic fast path). Conservative default: false.
+        return false;
+      },
+      columnWidthsUniform() {
+        // return true only when every column is guaranteed the default width.
+        return false;
+      },
       defaultColumnWidth: 50,
       selections: null,
       hideBorderOnMouseDownOver: false,

--- a/handsontable/src/3rdparty/walkontable/src/utils/positionCache.ts
+++ b/handsontable/src/3rdparty/walkontable/src/utils/positionCache.ts
@@ -2,6 +2,7 @@ export interface PositionCacheConfig {
   totalItemsFn: () => number;
   sizeFn: (index: number) => number;
   defaultSizeFn: () => number;
+  isUniformFn?: () => boolean;
 }
 
 /**
@@ -47,6 +48,29 @@ export class PositionCache {
    * @type {Function}
    */
   readonly #defaultSizeFn: () => number;
+  /**
+   * Optional predicate. When it returns `true`, every item is guaranteed to have the same size,
+   * so the prefix sum array and the O(n) build loop are skipped and offsets are computed
+   * arithmetically. The predicate must be conservative: return `false` whenever any per-item
+   * size override may exist.
+   *
+   * @type {Function|undefined}
+   */
+  readonly #isUniformFn?: () => boolean;
+  /**
+   * The shared size used when the cache is in uniform mode. `null` when the cache is in
+   * prefix-sum mode (heterogeneous sizes) or not yet built.
+   *
+   * @type {number|null}
+   */
+  #uniformSize: number | null = null;
+  /**
+   * Whether the cache has been built in either mode (prefix-sum or uniform). Tracked separately
+   * from `prefixSum` because uniform mode keeps `prefixSum` as `null`.
+   *
+   * @type {boolean}
+   */
+  #built: boolean = false;
 
   /**
    * @param {object} config The configuration object.
@@ -54,16 +78,19 @@ export class PositionCache {
    * @param {Function} config.sizeFn A function that returns the size for a given index.
    * @param {Function} config.defaultSizeFn A function that returns the default size for items
    *   that return NaN/undefined.
+   * @param {Function} [config.isUniformFn] Optional predicate; when `true`, all items share one size.
    */
-  constructor({ totalItemsFn, sizeFn, defaultSizeFn }: PositionCacheConfig) {
+  constructor({ totalItemsFn, sizeFn, defaultSizeFn, isUniformFn }: PositionCacheConfig) {
     this.#totalItemsFn = totalItemsFn;
     this.#sizeFn = sizeFn;
     this.#defaultSizeFn = defaultSizeFn;
+    this.#isUniformFn = isUniformFn;
   }
 
   /**
    * Builds the prefix sum by reading the current total items, size function,
-   * and default size from the configured providers.
+   * and default size from the configured providers. When the optional uniform predicate
+   * reports that all items share one size, the array allocation and the O(n) loop are skipped.
    */
   build() {
     const totalItems = this.#totalItemsFn();
@@ -71,6 +98,21 @@ export class PositionCache {
     const defaultSize = this.#defaultSizeFn();
 
     this.totalItems = totalItems;
+    this.#built = true;
+
+    if (this.#isUniformFn?.()) {
+      // Sample the LAST item, never the first rendered one: `getDefaultRowHeight` adds a 1px
+      // border compensation to the first rendered visible row, so sampling index 0 at build time
+      // (scroll position 0) would propagate that +1 to every arithmetic offset.
+      const sampled = totalItems > 0 ? sizeFn(totalItems - 1) : NaN;
+
+      this.#uniformSize = isNaN(sampled) ? defaultSize : sampled;
+      this.prefixSum = null;
+
+      return;
+    }
+
+    this.#uniformSize = null;
     this.prefixSum = new Float64Array(totalItems + 1);
     this.prefixSum[0] = 0;
 
@@ -88,6 +130,14 @@ export class PositionCache {
    * @returns {number} The cumulative size before this index.
    */
   getOffset(index: number): number {
+    if (this.#uniformSize !== null) {
+      if (index <= 0) {
+        return 0;
+      }
+
+      return Math.min(index, this.totalItems) * this.#uniformSize;
+    }
+
     if (!this.prefixSum || index <= 0) {
       return 0;
     }
@@ -106,6 +156,14 @@ export class PositionCache {
    *   Returns `0` when there are no items (`totalItems === 0`), including when `offset > 0`.
    */
   findIndexAtOffset(offset: number): number {
+    if (this.#uniformSize !== null) {
+      if (offset <= 0 || this.totalItems === 0) {
+        return 0;
+      }
+
+      return Math.min(Math.floor(offset / this.#uniformSize), this.totalItems - 1);
+    }
+
     if (!this.isBuilt() || offset <= 0 || this.totalItems === 0) {
       return 0;
     }
@@ -134,7 +192,15 @@ export class PositionCache {
    * @returns {number} The size of the item (difference between consecutive prefix sums).
    */
   getSizeAt(index: number): number {
-    if (!this.prefixSum || index < 0 || index >= this.totalItems) {
+    if (index < 0 || index >= this.totalItems) {
+      return 0;
+    }
+
+    if (this.#uniformSize !== null) {
+      return this.#uniformSize;
+    }
+
+    if (!this.prefixSum) {
       return 0;
     }
 
@@ -146,7 +212,7 @@ export class PositionCache {
    * count has changed.
    */
   ensureBuilt() {
-    if (!this.isBuilt() || this.totalItems !== this.#totalItemsFn()) {
+    if (!this.#built || this.totalItems !== this.#totalItemsFn()) {
       this.build();
     }
   }
@@ -157,6 +223,10 @@ export class PositionCache {
    * @returns {number}
    */
   getTotalSize() {
+    if (this.#uniformSize !== null) {
+      return this.totalItems * this.#uniformSize;
+    }
+
     if (!this.prefixSum) {
       return 0;
     }
@@ -170,11 +240,14 @@ export class PositionCache {
    */
   invalidate() {
     this.prefixSum = null;
+    this.#uniformSize = null;
+    this.#built = false;
     this.totalItems = 0;
   }
 
   /**
-   * Returns whether the cache has been built.
+   * Returns whether the cache holds a prefix-sum array (heterogeneous mode). Uniform mode keeps
+   * `prefixSum` as `null`, so this is `false` there; use it only as the prefix-sum type guard.
    *
    * @returns {boolean}
    */

--- a/handsontable/src/3rdparty/walkontable/src/viewport.ts
+++ b/handsontable/src/3rdparty/walkontable/src/viewport.ts
@@ -171,6 +171,12 @@ class Viewport {
       totalItemsFn: () => wtSettings.getSetting<number>('totalRows'),
       sizeFn: sourceRow => wtTable.getRowHeight(sourceRow) ?? NaN,
       defaultSizeFn: () => wtSettings.getSetting('stylesHandler').getDefaultRowHeight(),
+      // Uniform fast path: every row is the default height only when the core-side config reports
+      // it (no per-row `rowHeights`/`minRowHeights`, no `modifyRowHeight` hook) AND walkontable has
+      // measured no oversized rows. Any of these invalidates the cache, so the next build
+      // re-evaluates this predicate.
+      isUniformFn: () => wtSettings.getSetting<boolean>('rowHeightsUniform') &&
+        Object.keys(this.oversizedRows).length === 0,
     });
     /**
      * Cumulative column width prefix sum cache. Enables O(log n) scroll-to-column lookups
@@ -182,6 +188,10 @@ class Viewport {
       totalItemsFn: () => wtSettings.getSetting<number>('totalColumns'),
       sizeFn: sourceCol => wtTable.getColumnWidth(sourceCol),
       defaultSizeFn: () => DEFAULT_COLUMN_WIDTH,
+      // Uniform fast path: every column is the default width only when the core-side config reports
+      // it (no per-column `colWidths`, no `modifyColWidth` hook — note `autoColumnSize` is on by
+      // default and registers that hook, so this is true only when `colWidths` is set).
+      isUniformFn: () => wtSettings.getSetting<boolean>('columnWidthsUniform'),
     });
 
     this.eventManager = eventManager;

--- a/handsontable/src/3rdparty/walkontable/test/unit/utils/positionCache.unit.js
+++ b/handsontable/src/3rdparty/walkontable/test/unit/utils/positionCache.unit.js
@@ -8,15 +8,17 @@ import { PositionCache } from '../../../src/utils/positionCache';
  * @param {number} defaultSize The default size.
  * @returns {object} An object with `cache` and setters to swap config at runtime.
  */
-function createCache(totalItems, sizeFn, defaultSize) {
+function createCache(totalItems, sizeFn, defaultSize, isUniformFn) {
   let _totalItems = totalItems;
   let _sizeFn = sizeFn;
   let _defaultSize = defaultSize;
+  let _isUniform = typeof isUniformFn === 'function' ? isUniformFn() : !!isUniformFn;
 
   const cache = new PositionCache({
     totalItemsFn: () => _totalItems,
     sizeFn: i => _sizeFn(i),
     defaultSizeFn: () => _defaultSize,
+    isUniformFn: () => _isUniform,
   });
 
   return {
@@ -24,6 +26,7 @@ function createCache(totalItems, sizeFn, defaultSize) {
     setTotalItems(n) { _totalItems = n; },
     setSizeFn(fn) { _sizeFn = fn; },
     setDefaultSize(v) { _defaultSize = v; },
+    setUniform(v) { _isUniform = v; },
   };
 }
 
@@ -248,6 +251,112 @@ describe('PositionCache', () => {
 
       expect(sizeFn).not.toHaveBeenCalled();
       expect(cache.getSizeAt(0)).toBe(10);
+    });
+  });
+
+  describe('uniform mode', () => {
+    it('should skip the prefix sum array when the uniform predicate is true', () => {
+      const { cache } = createCache(1000, () => 20, 20, true);
+
+      cache.build();
+
+      expect(cache.prefixSum).toBe(null);
+      expect(cache.totalItems).toBe(1000);
+    });
+
+    it('should not scan every item to build (only samples the last one)', () => {
+      const sizeFn = jest.fn(() => 20);
+      const { cache } = createCache(100000, sizeFn, 20, true);
+
+      cache.build();
+
+      // arithmetic mode reads a single representative size, never the full O(n) loop
+      expect(sizeFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('should compute offsets/sizes/total arithmetically and equal a full prefix-sum build', () => {
+      const SIZE = 23;
+      const COUNT = 5000;
+      const uniform = createCache(COUNT, () => SIZE, SIZE, true).cache;
+      const full = createCache(COUNT, () => SIZE, SIZE, false).cache;
+
+      uniform.build();
+      full.build();
+
+      expect(uniform.prefixSum).toBe(null);
+      expect(full.prefixSum).not.toBe(null);
+
+      for (const i of [0, 1, 2, 1000, 2500, COUNT - 1, COUNT, COUNT + 10]) {
+        expect(uniform.getOffset(i)).toBe(full.getOffset(i));
+        expect(uniform.getSizeAt(i)).toBe(full.getSizeAt(i));
+      }
+      for (const off of [-5, 0, 1, 22, 23, 24, 100000, SIZE * COUNT, SIZE * COUNT + 50]) {
+        expect(uniform.findIndexAtOffset(off)).toBe(full.findIndexAtOffset(off));
+      }
+      expect(uniform.getTotalSize()).toBe(full.getTotalSize());
+      expect(uniform.getTotalSize()).toBe(SIZE * COUNT);
+    });
+
+    it('should sample the LAST item for the uniform size (avoids first-item border compensation)', () => {
+      // index 0 is intentionally larger (mirrors the +1 first-rendered-row compensation);
+      // a correct uniform cache must NOT propagate it to every row.
+      const { cache } = createCache(10, i => (i === 0 ? 24 : 23), 23, true);
+
+      cache.build();
+
+      expect(cache.getSizeAt(0)).toBe(23);
+      expect(cache.getOffset(10)).toBe(230);
+      expect(cache.getTotalSize()).toBe(230);
+    });
+
+    it('should fall back to defaultSize when the sampled item returns NaN', () => {
+      const { cache } = createCache(100, () => NaN, 18, true);
+
+      cache.build();
+
+      expect(cache.getSizeAt(0)).toBe(18);
+      expect(cache.getTotalSize()).toBe(1800);
+    });
+
+    it('should treat uniform mode as built so ensureBuilt does not rebuild', () => {
+      const sizeFn = jest.fn(() => 20);
+      const { cache } = createCache(50, sizeFn, 20, true);
+
+      cache.ensureBuilt();
+      const callsAfterFirst = sizeFn.mock.calls.length;
+
+      cache.ensureBuilt();
+
+      expect(sizeFn.mock.calls.length).toBe(callsAfterFirst);
+    });
+
+    it('should rebuild as a full prefix sum after the predicate flips to false (e.g. an oversized row appears)', () => {
+      const sizes = { 3: 50 };
+      const { cache, setUniform } = createCache(10, i => sizes[i] ?? 20, 20, true);
+
+      cache.build();
+      expect(cache.prefixSum).toBe(null);
+      expect(cache.getSizeAt(3)).toBe(20); // uniform: ignores the override
+
+      // a per-row override appears → caller flips the predicate and invalidates
+      setUniform(false);
+      cache.invalidate();
+      cache.ensureBuilt();
+
+      expect(cache.prefixSum).not.toBe(null);
+      expect(cache.getSizeAt(3)).toBe(50); // heterogeneous: honors the override
+      expect(cache.getOffset(4)).toBe(20 * 3 + 50);
+    });
+
+    it('should clear uniform mode on invalidate', () => {
+      const { cache } = createCache(100, () => 20, 20, true);
+
+      cache.build();
+      cache.invalidate();
+
+      expect(cache.getSizeAt(0)).toBe(0);
+      expect(cache.getOffset(5)).toBe(0);
+      expect(cache.getTotalSize()).toBe(0);
     });
   });
 });

--- a/handsontable/src/3rdparty/walkontable/test/unit/utils/positionCache.unit.js
+++ b/handsontable/src/3rdparty/walkontable/test/unit/utils/positionCache.unit.js
@@ -6,6 +6,7 @@ import { PositionCache } from '../../../src/utils/positionCache';
  * @param {number} totalItems The total number of items.
  * @param {Function} sizeFn A function that returns the size for a given index.
  * @param {number} defaultSize The default size.
+ * @param {boolean|Function} [isUniformFn] Whether (or a predicate returning whether) all items share one size.
  * @returns {object} An object with `cache` and setters to swap config at runtime.
  */
 function createCache(totalItems, sizeFn, defaultSize, isUniformFn) {
@@ -290,7 +291,7 @@ describe('PositionCache', () => {
         expect(uniform.getOffset(i)).toBe(full.getOffset(i));
         expect(uniform.getSizeAt(i)).toBe(full.getSizeAt(i));
       }
-      for (const off of [-5, 0, 1, 22, 23, 24, 100000, SIZE * COUNT, SIZE * COUNT + 50]) {
+      for (const off of [-5, 0, 1, 22, 23, 24, 100000, SIZE * COUNT, (SIZE * COUNT) + 50]) {
         expect(uniform.findIndexAtOffset(off)).toBe(full.findIndexAtOffset(off));
       }
       expect(uniform.getTotalSize()).toBe(full.getTotalSize());
@@ -345,7 +346,7 @@ describe('PositionCache', () => {
 
       expect(cache.prefixSum).not.toBe(null);
       expect(cache.getSizeAt(3)).toBe(50); // heterogeneous: honors the override
-      expect(cache.getOffset(4)).toBe(20 * 3 + 50);
+      expect(cache.getOffset(4)).toBe((20 * 3) + 50);
     });
 
     it('should clear uniform mode on invalidate', () => {

--- a/handsontable/src/tableView.ts
+++ b/handsontable/src/tableView.ts
@@ -35,6 +35,18 @@ import {
 } from './helpers/a11y';
 
 /**
+ * Checks whether a size setting (`rowHeights`, `minRowHeights`, or `colWidths`) guarantees a uniform
+ * size for every item. Only a plain number (or unset) is uniform; an array or function defines
+ * per-item sizes, and a string is treated conservatively as non-uniform.
+ *
+ * @param {unknown} value The size setting value.
+ * @returns {boolean}
+ */
+function isUniformSizeSetting(value: unknown): boolean {
+  return value === undefined || value === null || typeof value === 'number';
+}
+
+/**
  * @class TableView
  * @private
  */
@@ -870,6 +882,16 @@ class TableView {
 
         return this.hot.runHooks('modifyRowHeightByOverlayName',
           this.hot.getRowHeight(visualRowIndex), visualRowIndex, overlayType);
+      },
+      rowHeightsUniform: () => {
+        const { rowHeights, minRowHeights } = this.hot.getSettings();
+
+        return isUniformSizeSetting(rowHeights) && isUniformSizeSetting(minRowHeights) &&
+          !this.hot.hasHook('modifyRowHeight');
+      },
+      columnWidthsUniform: () => {
+        return isUniformSizeSetting(this.hot.getSettings().colWidths) &&
+          !this.hot.hasHook('modifyColWidth');
       },
       cellRenderer: (renderedRowIndex: number, renderedColumnIndex: number, TD: HTMLTableCellElement) => {
         const [visualRowIndex, visualColumnIndex] = this


### PR DESCRIPTION
### Context

The PR adds a uniform-size fast path to Walkontable's `PositionCache` (the cumulative row-height / column-width prefix sum used for scroll↔index mapping).

Today `PositionCache.build()` always allocates a `Float64Array(totalItems + 1)` and runs an O(rows) loop calling `sizeFn(i)` for **every** row — even when all rows are the default height (the common case). On a 1,000,000 × 100 grid this wastes ~7.6 MB and ~300 ms per build, and the cache rebuilds on every row-count change (sort / filter / trim), so it also taxes large-dataset operations.

The fix: when every item is guaranteed the default size, skip the array and the loop and compute offsets arithmetically (`offset = i × size`). The predicate is conservative — it falls back to the full prefix-sum build whenever a per-item size override may exist, so it is never wrong:

- `rowHeights` & `minRowHeights` are a number or unset (an array/function means per-row sizes)
- no `modifyRowHeight` hook is registered (`!hot.hasHook('modifyRowHeight')`) — this generically covers `AutoRowSize`, `ManualRowResize`, `MergeCells`, and `HiddenRows` without naming them, because plugin hooks are auto-removed on disable
- Walkontable has measured no oversized rows (`oversizedRows` is empty)

The column predicate is symmetric (`colWidths` + `!hasHook('modifyColWidth')`). `AutoColumnSize` is on by default and registers `modifyColWidth`, so columns take the fast path only when `colWidths` is set (which disables `AutoColumnSize`).

The config half of the predicate is computed in `TableView` (no `core.ts` change); the `oversizedRows`-empty half lives in the viewport. Every override-introducing event already invalidates the cache (`updateSettings`, `markOversizedRows`, the resize plugins), so the next build re-evaluates the predicate. The uniform size is sampled from the last row, never the first rendered one (which carries a +1px border compensation that must not propagate to every offset).

Measured (in-repo `perf-phase0.html`, 1,000,000 × 100 uniform-height grid, Chrome via CDP):

| Metric | Before | After |
|---|--:|--:|
| rowHeightCache prefix-sum array | 7.6 MB | 0 (arithmetic) |
| rowHeightCache rebuild | 300 ms | 0 ms |
| First render | 819 ms | 539 ms (−34%) |

Limitation: a single oversized/variable row, any `modifyRowHeight`/`modifyColWidth` plugin, or array/function `rowHeights`/`colWidths` flips that axis back to the full prefix-sum build — neutral, never a regression.

No default setting, public API, hook, or CSS class changes.

### How has this been tested?

- Unit (Jest): `npm run test:unit --prefix handsontable --testPathPattern=positionCache` — 24/24, including new uniform-mode tests that assert the arithmetic path equals a full prefix-sum build for `getOffset` / `getSizeAt` / `findIndexAtOffset` / `getTotalSize` across uniform, number, array, function, oversized, and post-invalidation configs.
- Rendering engine: `npm run test:walkontable --prefix handsontable` — 687 specs, 0 failures, 2 pending (identical to baseline; the dropped ≤1px first-row compensation caused no regression).
- Fallback path (E2E): `npm run test:e2e --prefix handsontable --testPathPattern="autoRowSize|manualRowResize"` — 123 specs, 0 failures (confirms a registered `modifyRowHeight` hook routes back to the full build).
- `npm run test:types --prefix handsontable` and `npm run eslint --prefix handsontable` — clean.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1952

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1952

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes scroll-to-index math in the viewport layer; incorrect uniform detection could mis-scroll, but predicates are conservative and existing invalidation paths force full rebuilds when overrides appear.
> 
> **Overview**
> Adds a **uniform-size fast path** to Walkontable’s `PositionCache` so large grids with identical row heights and column widths avoid allocating an O(n) `Float64Array` and scanning every index on rebuild.
> 
> When a conservative `isUniformFn` predicate is true, the cache uses arithmetic (`offset = index × size`, `findIndexAtOffset` via division) after sampling size from the **last** row/column (not index 0, to avoid first-row border compensation). `TableView` exposes `rowHeightsUniform` / `columnWidthsUniform` from plain numeric or unset `rowHeights`, `minRowHeights`, and `colWidths`, and absence of `modifyRowHeight` / `modifyColWidth` hooks; rows also require no measured `oversizedRows`. Any doubt or cache invalidation falls back to the existing prefix-sum build.
> 
> New unit tests cover uniform mode parity with the full build, invalidation, and predicate flips. Changelog notes faster initial render and lower memory for large uniform datasets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d37be5ae05746c4d8a0551a047a1c8aca4e6ad05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->