### PR TITLE
DEV-651: Document modifyColWidth max-width on Column widths page

### DIFF
--- a/docs/content/guides/columns/column-width/angular/example7.html
+++ b/docs/content/guides/columns/column-width/angular/example7.html
@@ -1,0 +1,3 @@
+<div>
+  <app-example7></app-example7>
+</div>

--- a/docs/content/guides/columns/column-width/angular/example7.ts
+++ b/docs/content/guides/columns/column-width/angular/example7.ts
@@ -1,0 +1,63 @@
+/* file: app.component.ts */
+import { Component } from '@angular/core';
+import { GridSettings, HotTableModule } from '@handsontable/angular-wrapper';
+
+@Component({
+  selector: 'app-example7',
+  template: `
+    <hot-table
+      [settings]="hotSettings!" [data]="hotData">
+    </hot-table>
+  `,
+  standalone: true,
+  imports: [HotTableModule],
+})
+export class AppComponent {
+
+  readonly hotData = [
+    ['SKU-4821', 'Bolt', 142],
+    ['SKU-0093', 'Stainless steel mounting bracket', 67],
+    ['SKU-1147', 'Washer', 210],
+    ['SKU-2205', 'Hex nut assortment pack', 38],
+    ['SKU-3310', 'Cable tie', 95],
+  ];
+
+  readonly hotSettings: GridSettings = {
+    width: '100%',
+    height: 'auto',
+    colHeaders: ['SKU', 'Product', 'Stock'],
+    rowHeaders: true,
+    colWidths: [90, undefined, 60],
+    modifyColWidth(width: number, column: number) {
+      if (column === 1 && width > 150) {
+        return 100;
+      }
+
+      return width;
+    },
+    autoWrapRow: true,
+    autoWrapCol: true,
+  };
+}
+/* end-file */
+
+
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+/* end-file */

--- a/docs/content/guides/columns/column-width/column-width.md
+++ b/docs/content/guides/columns/column-width/column-width.md
@@ -176,6 +176,67 @@ In this example, the size of all columns is set using a function by taking a col
 
 :::
 
+## Set a dynamic maximum column width
+
+Use the [`modifyColWidth`](@/api/hooks.md#modifycolwidth) hook to cap how wide a column can grow based on its content. The hook receives the width that Handsontable already calculated for the column. Return a smaller number to limit it. This pattern is [middleware](@/guides/getting-started/events-and-hooks/events-and-hooks.md#middleware): you modify a value on its way through the width pipeline instead of setting a fixed size up front.
+
+Unlike [`colWidths`](@/api/options.md#colwidths), a cap in `modifyColWidth` does not force every cell onto one width. Short values keep a narrow column on a single line. When content would exceed your threshold, the column shrinks to your cap and the text wraps.
+
+Leave `colWidths` unset for columns you want to auto-size (or set the entry to `undefined` in an array). The [`AutoColumnSize`](@/api/autoColumnSize.md) plugin must stay enabled so Handsontable can measure content first. Setting `colWidths` as a single number disables auto-sizing for all columns.
+
+You can also enforce a minimum width by returning `Math.max(width, minWidth)` from the same hook.
+
+::: tip
+
+- Auto-sized columns never go below 50px.
+- [`stretchH`](@/api/options.md#stretchh) runs after your hook and can widen columns beyond your cap.
+- When [`manualColumnResize`](@/api/options.md#manualcolumnresize) is enabled, a width the user set by dragging overrides the hook for that column.
+
+:::
+
+::: only-for javascript
+
+::: example #example7 --js 1 --ts 2
+
+@[code](@/content/guides/columns/column-width/javascript/example7.js)
+@[code](@/content/guides/columns/column-width/javascript/example7.ts)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #example7 :react --js 1 --ts 2
+
+@[code](@/content/guides/columns/column-width/react/example7.jsx)
+@[code](@/content/guides/columns/column-width/react/example7.tsx)
+
+:::
+
+:::
+
+::: only-for angular
+
+::: example #example7 :angular --ts 1 --html 2
+
+@[code](@/content/guides/columns/column-width/angular/example7.ts)
+@[code](@/content/guides/columns/column-width/angular/example7.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example7 :vue3
+
+@[code](@/content/guides/columns/column-width/vue/example7.vue)
+
+:::
+
+:::
+
 ## Adjust the column width manually
 
 Set the option [`manualColumnResize`](@/api/options.md#manualcolumnresize) to `true` to allow users to manually resize the column width by dragging the handle between the adjacent column headers. If you double-click on that handle, the width will be instantly adjusted to the size of the longest value in the column. Don't forget to enable column headers by setting [`colHeaders`](@/api/options.md#colheaders) to `true`.

--- a/docs/content/guides/columns/column-width/javascript/example7.js
+++ b/docs/content/guides/columns/column-width/javascript/example7.js
@@ -1,0 +1,27 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+// Register all Handsontable's modules.
+registerAllModules();
+const container = document.querySelector('#example7');
+new Handsontable(container, {
+    data: [
+        ['SKU-4821', 'Bolt', 142],
+        ['SKU-0093', 'Stainless steel mounting bracket', 67],
+        ['SKU-1147', 'Washer', 210],
+        ['SKU-2205', 'Hex nut assortment pack', 38],
+        ['SKU-3310', 'Cable tie', 95],
+    ],
+    width: '100%',
+    height: 'auto',
+    colHeaders: ['SKU', 'Product', 'Stock'],
+    rowHeaders: true,
+    colWidths: [90, undefined, 60],
+    modifyColWidth(width, column) {
+        if (column === 1 && width > 150) {
+            return 100;
+        }
+    },
+    autoWrapRow: true,
+    autoWrapCol: true,
+    licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/columns/column-width/javascript/example7.ts
+++ b/docs/content/guides/columns/column-width/javascript/example7.ts
@@ -1,0 +1,30 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+// Register all Handsontable's modules.
+registerAllModules();
+
+const container = document.querySelector('#example7')!;
+
+new Handsontable(container, {
+  data: [
+    ['SKU-4821', 'Bolt', 142],
+    ['SKU-0093', 'Stainless steel mounting bracket', 67],
+    ['SKU-1147', 'Washer', 210],
+    ['SKU-2205', 'Hex nut assortment pack', 38],
+    ['SKU-3310', 'Cable tie', 95],
+  ],
+  width: '100%',
+  height: 'auto',
+  colHeaders: ['SKU', 'Product', 'Stock'],
+  rowHeaders: true,
+  colWidths: [90, undefined, 60],
+  modifyColWidth(width, column) {
+    if (column === 1 && width > 150) {
+      return 100;
+    }
+  },
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/columns/column-width/react/example7.jsx
+++ b/docs/content/guides/columns/column-width/react/example7.jsx
@@ -1,0 +1,34 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={[
+        ['SKU-4821', 'Bolt', 142],
+        ['SKU-0093', 'Stainless steel mounting bracket', 67],
+        ['SKU-1147', 'Washer', 210],
+        ['SKU-2205', 'Hex nut assortment pack', 38],
+        ['SKU-3310', 'Cable tie', 95],
+      ]}
+      width="100%"
+      height="auto"
+      colHeaders={['SKU', 'Product', 'Stock']}
+      rowHeaders={true}
+      colWidths={[90, undefined, 60]}
+      modifyColWidth={(width, column) => {
+        if (column === 1 && width > 150) {
+          return 100;
+        }
+      }}
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/columns/column-width/react/example7.tsx
+++ b/docs/content/guides/columns/column-width/react/example7.tsx
@@ -1,0 +1,34 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={[
+        ['SKU-4821', 'Bolt', 142],
+        ['SKU-0093', 'Stainless steel mounting bracket', 67],
+        ['SKU-1147', 'Washer', 210],
+        ['SKU-2205', 'Hex nut assortment pack', 38],
+        ['SKU-3310', 'Cable tie', 95],
+      ]}
+      width="100%"
+      height="auto"
+      colHeaders={['SKU', 'Product', 'Stock']}
+      rowHeaders={true}
+      colWidths={[90, undefined, 60]}
+      modifyColWidth={(width, column) => {
+        if (column === 1 && width > 150) {
+          return 100;
+        }
+      }}
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/columns/column-width/vue/example7.vue
+++ b/docs/content/guides/columns/column-width/vue/example7.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['SKU-4821', 'Bolt', 142],
+    ['SKU-0093', 'Stainless steel mounting bracket', 67],
+    ['SKU-1147', 'Washer', 210],
+    ['SKU-2205', 'Hex nut assortment pack', 38],
+    ['SKU-3310', 'Cable tie', 95],
+  ],
+  width: '100%',
+  height: 'auto',
+  colHeaders: ['SKU', 'Product', 'Stock'],
+  rowHeaders: true,
+  colWidths: [90, undefined, 60],
+  modifyColWidth(width, column) {
+    if (column === 1 && width > 150) {
+      return 100;
+    }
+  },
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example7">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/getting-started/events-and-hooks/events-and-hooks.md
+++ b/docs/content/guides/getting-started/events-and-hooks/events-and-hooks.md
@@ -145,6 +145,8 @@ const hotSettings = ref({
 
 Note that the first argument is the current width that we're going to modify. Later arguments are immutable, and additional information can be used to decide whether the data should be modified.
 
+For content-aware maximum width capping, see the [Column widths](@/guides/columns/column-width/column-width.md#set-a-dynamic-maximum-column-width) guide.
+
 ## Handsontable hooks
 
 We refer to all callbacks as "Handsontable hooks" because, although they share some characteristics with events and middleware, they combine them both in a unique structure. You may already be familiar with the concept as we're not the only ones that use the hooks convention.

--- a/handsontable/src/core/hooks/constants.ts
+++ b/handsontable/src/core/hooks/constants.ts
@@ -1939,6 +1939,16 @@ export const REGISTERED_HOOKS = [
    * @param {number} width Current column width.
    * @param {number} column Visual column index.
    * @param {string} [source] String that identifies source of hook call.
+   * @see {@link https://handsontable.com/docs/javascript-data-grid/column-width/ Column width}
+   * @example
+   * ```js
+   * // Cap the Product column at 100px when content would exceed 150px.
+   * modifyColWidth(width, column) {
+   *   if (column === 1 && width > 150) {
+   *     return 100;
+   *   }
+   * }
+   * ```
    */
   'modifyColWidth',
 

--- a/handsontable/src/core/hooks/constants.ts
+++ b/handsontable/src/core/hooks/constants.ts
@@ -1939,7 +1939,7 @@ export const REGISTERED_HOOKS = [
    * @param {number} width Current column width.
    * @param {number} column Visual column index.
    * @param {string} [source] String that identifies source of hook call.
-   * @see {@link https://handsontable.com/docs/javascript-data-grid/column-width/ Column width}
+   * @see [Column width](@/guides/columns/column-width/column-width.md)
    * @example
    * ```js
    * // Cap the Product column at 100px when content would exceed 150px.


### PR DESCRIPTION
### Context

The PR adds documentation for using the `modifyColWidth` hook to cap column width based on content. The Column widths guide listed the hook in Related API and tagged `max-width`/`min-width`, but never explained the content-aware cap pattern described in DEV-651.

Changes:
- New "Set a dynamic maximum column width" section on the Column widths guide with `example7` (JS, React, Angular, Vue)
- Cross-link from Events and hooks middleware section
- `modifyColWidth` JSDoc `@example` and `@see` link in API reference source

[skip changelog]

### How has this been tested?

- `npm run docs:validate-highlights` (pass)
- `npm run build` in `docs/` (pass, 1254 pages)

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-651

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-651

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and JSDoc only; no grid runtime or wrapper package behavior changes.
> 
> **Overview**
> Adds documentation for capping column width with the **`modifyColWidth`** hook after auto-sizing, instead of only listing the hook in Related API.
> 
> The **Column widths** guide gains a **Set a dynamic maximum column width** section that explains the middleware pattern (return a smaller width than Handsontable calculated), how it differs from fixed **`colWidths`**, keeping **`AutoColumnSize`** enabled, optional min-width via **`Math.max`**, and caveats for **`stretchH`**, **`manualColumnResize`**, and the 50px auto-size floor. Live **`example7`** demos are wired for JavaScript, TypeScript, React, Angular, and Vue (Product column capped at 100px when content would exceed 150px).
> 
> The **Events and hooks** middleware section links to that guide. **`modifyColWidth`** hook JSDoc in **`handsontable/src/core/hooks/constants.ts`** adds a **`@see`** to the guide and an inline **`@example`** matching the docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe4b6ab906028966a3f9f3781c4a37240ed09d5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->