### PR TITLE
DEV-1953: Bulk single-pass row-trimming write in filters

### DIFF
--- a/.changelogs/12886.json
+++ b/.changelogs/12886.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Improved filtering performance on large datasets by writing the row-trimming state in a single bulk operation instead of scanning and updating it row by row.",
+  "type": "changed",
+  "issueOrPR": 12886,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/filters/filters.ts
+++ b/handsontable/src/plugins/filters/filters.ts
@@ -3,7 +3,6 @@ import { BasePlugin } from '../base';
 import { arrayEach, arrayMap } from '../../helpers/array';
 import { toSingleLine } from '../../helpers/templateLiteralTag';
 import { warn } from '../../helpers/console';
-import { rangeEach } from '../../helpers/number';
 import { addClass, isBottomMostColumnHeader, isHTMLElement, removeClass } from '../../helpers/dom/element';
 import { isKey } from '../../helpers/unicode';
 import { getValueGetterValue } from '../../utils/valueAccessors';
@@ -995,24 +994,23 @@ export class Filters extends BasePlugin {
     );
 
     if (allowFiltering !== false && needToFilter) {
-      const trimmedRows: number[] = [];
       const dataFilter = this._createDataFilter();
       const rowIndexesToShow = arrayMap(dataFilter.filter(),
         rowData => (rowData as { meta: { row: number } }).meta.row);
       const rowIndexesToShowAssertion = createArrayAssertion(rowIndexesToShow);
+      const countSourceRows = this.hot.countSourceRows();
+      // Build the trimmed-state array in a single pass (`true` marks a row hidden by the filter), then
+      // write it to the map in one bulk `setValues` call. The previous approach scanned the dataset
+      // twice (a `clear()` that rebuilt the whole array, then a `rangeEach` pass) and fired a map
+      // `change` per trimmed row; for large datasets that was a measurable share of `filter()` time.
+      const trimmedRowsState = new Array(countSourceRows);
+
+      for (let physicalRow = 0; physicalRow < countSourceRows; physicalRow++) {
+        trimmedRowsState[physicalRow] = !rowIndexesToShowAssertion(physicalRow);
+      }
 
       this.hot.batchExecution(() => {
-        this.filtersRowsMap?.clear();
-
-        rangeEach(this.hot.countSourceRows() - 1, (row: number) => {
-          if (!rowIndexesToShowAssertion(row)) {
-            trimmedRows.push(row);
-          }
-        });
-
-        arrayEach(trimmedRows, (physicalRow) => {
-          this.filtersRowsMap?.setValueAtIndex(physicalRow, true);
-        });
+        this.filtersRowsMap?.setValues(trimmedRowsState);
       }, true);
 
       if (!navigableHeaders && !rowIndexesToShow.length) {


### PR DESCRIPTION
### Context

The PR speeds up `Filters.filter()` on large datasets, part of the rendering/memory performance initiative.

`filter()` performed three O(rows) operations on every filter run: `filtersRowsMap.clear()` (which rebuilt the entire boolean array), a separate `rangeEach` pass to collect the complement (trimmed) rows, and then a per-trimmed-row `setValueAtIndex` call — each of which fired a map `change`. On a 100,000-row grid that was a measurable share of the total filter time.

The fix builds the trimmed-state boolean array in a **single pass** (`true` marks a row hidden by the filter) and writes it with **one bulk `setValues`** call, inside the existing `batchExecution(..., true)` so the index cache still updates once, synchronously, exactly as before. The change is internal to the plugin; the observable trimmed result is identical, and there is no change to any default setting, public API, CSS class, or hook. The now-unused `rangeEach` import was removed.

Measured on the in-repo `performance-tests` filtering scenario (100,000 rows × 100 cols, `addCondition(0, 'contains', ['1'])` then `filter()`, `beforeFilter`→`afterFilter` hook delta, 3 iterations):

| Metric | Before | After | Change |
|---|--:|--:|--:|
| `filter()` (avg) | 69.4 ms | 58.2 ms | **−16%** |
| per-iteration | 76 / 68.1 / 64.1 | 58.3 / 58.9 / 57.3 | lower + tighter variance |

Two adjacent ideas were measured and **not** shipped: the `AggregatedCollection.getMergedValues` matrix rebuild (~3 ms with a single trimming map — not worth optimizing) and the per-row cost of `getDataMapAtColumn` (dominated by real data access and the `isMatch` predicate; higher risk, deferred).

### How has this been tested?

- Unit: `npm run test:unit --prefix handsontable -- --testPathPattern=filters` → 211/211 pass.
- E2E: `npm run test:e2e --prefix handsontable -- --testPathPattern=filters` → 265 specs, 0 failures.
- Lint: `npx eslint src/plugins/filters/filters.ts` → clean.
- Performance: in-repo `performance-tests` filtering scenario, before/after numbers above.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1953

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1953

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal plugin optimization with identical trimming semantics; no API, hook, or default-setting changes.
> 
> **Overview**
> Speeds up **`Filters.filter()`** on large grids by changing how hidden (trimmed) rows are written to `filtersRowsMap`.
> 
> Instead of **`clear()`**, a second full-row scan to collect trimmed indexes, and **per-row `setValueAtIndex`** (each firing a map change), the plugin now builds one boolean array in a **single pass** (`true` = row hidden) and applies it with **`setValues`** inside the existing **`batchExecution(..., true)`**. Filter results and public behavior stay the same; the unused **`rangeEach`** import is removed. A changelog entry documents the improvement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bfbc99d93432cb9dc3a74cc1f04ce81c45575b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->