### PR TITLE
Docs: add tags and Result sections to eight rewritten guides

### DIFF
--- a/docs/content/guides/accessories-and-menus/export-to-csv/export-to-csv.md
+++ b/docs/content/guides/accessories-and-menus/export-to-csv/export-to-csv.md
@@ -186,6 +186,10 @@ To prevent this attack, set the [`sanitizeValues` option](#sanitizevalues-boolea
 :::
 :::
 
+## Result
+
+After completing this guide, you can export grid data as a downloadable CSV file, a JavaScript Blob, or a string. You can customize delimiters, ranges, headers, and value sanitization through the export configuration.
+
 ## Available methods
 
 ::: only-for react

--- a/docs/content/guides/cell-features/comments/comments.md
+++ b/docs/content/guides/cell-features/comments/comments.md
@@ -31,8 +31,8 @@ Set the [`comments`](@/api/options.md#comments) configuration option to `true` t
 ```js
 const hot = new Handsontable(container, {
   data: [
-    ['A1', 'B1', 'C1'],
-    ['A2', 'B2', 'C2'],
+    ['Update API docs', 'Ana García', 'In progress'],
+    ['Deploy hotfix', 'James Okafor', 'Blocked'],
   ],
   comments: true,
   autoWrapRow: true,
@@ -47,8 +47,8 @@ const hot = new Handsontable(container, {
 ```jsx
 <HotTable
   data={[
-    ['A1', 'B1', 'C1'],
-    ['A2', 'B2', 'C2'],
+    ['Update API docs', 'Ana García', 'In progress'],
+    ['Deploy hotfix', 'James Okafor', 'Blocked'],
   ]}
   comments={true}
 />
@@ -60,8 +60,8 @@ const hot = new Handsontable(container, {
 
 ```ts
 data = [
-  ["A1", "B1", "C1"],
-  ["A2", "B2", "C2"],
+  ["Update API docs", "Ana García", "In progress"],
+  ["Deploy hotfix", "James Okafor", "Blocked"],
 ];
 settings = {
   comments: true,
@@ -79,8 +79,8 @@ settings = {
 ```js
 const hotSettings = {
   data: [
-    ['A1', 'B1', 'C1'],
-    ['A2', 'B2', 'C2'],
+    ['Update API docs', 'Ana García', 'In progress'],
+    ['Deploy hotfix', 'James Okafor', 'Blocked'],
   ],
   comments: true,
   autoWrapRow: true,

--- a/docs/content/guides/columns/column-hiding/column-hiding.md
+++ b/docs/content/guides/columns/column-hiding/column-hiding.md
@@ -7,6 +7,10 @@ description:
   clutter and improve the grid's performance.
 permalink: /column-hiding
 canonicalUrl: /column-hiding
+tags:
+  - hiding
+  - hidden columns
+  - HiddenColumns
 react:
   metaTitle: Column hiding - React Data Grid | Handsontable
 angular:
@@ -348,6 +352,10 @@ object, set the [`copyPasteEnabled`](@/api/hiddenColumns.md) property to `false`
 :::
 
 :::
+
+## Result
+
+After completing this guide, you can hide columns from the grid without changing source data. You can configure default hidden columns, UI indicators, context menu items, and copy-paste behavior.
 
 ## Column hiding API methods
 

--- a/docs/content/guides/columns/column-moving/column-moving.md
+++ b/docs/content/guides/columns/column-moving/column-moving.md
@@ -5,6 +5,10 @@ metaTitle: Column moving - JavaScript Data Grid | Handsontable
 description: Change the order of columns, either manually (dragging them to another location), or programmatically (using Handsontable's API methods).
 permalink: /column-moving
 canonicalUrl: /column-moving
+tags:
+  - moving
+  - manual column move
+  - ManualColumnMove
 react:
   metaTitle: Column moving - React Data Grid | Handsontable
 angular:
@@ -175,6 +179,10 @@ This renders the columns in the following order:
 - Visual position 2 → physical column `2`
 
 The array must contain all physical column indexes (its length must equal the total number of columns). After the initial render, users can still drag columns to change the order further.
+
+## Result
+
+After completing this guide, you can reorder columns by dragging them with the mouse or by calling `dragColumns()` and `moveColumns()` programmatically. You can also set a pre-defined column order at initialization.
 
 ## Drag and move actions of the [`ManualColumnMove`](@/api/manualColumnMove.md) plugin
 

--- a/docs/content/guides/columns/column-summary/column-summary.md
+++ b/docs/content/guides/columns/column-summary/column-summary.md
@@ -1137,6 +1137,10 @@ To throw data type errors, set the [`suppressDataTypeErrors`](@/api/columnSummar
 
 :::
 
+## Result
+
+After completing this guide, your grid calculates and displays column aggregates using built-in or custom summary functions. You can target specific cell ranges, control rounding, and handle non-numeric values.
+
 ## Related API reference
 
 **Configuration options**

--- a/docs/content/guides/rows/row-freezing/row-freezing.md
+++ b/docs/content/guides/rows/row-freezing/row-freezing.md
@@ -75,6 +75,10 @@ The following example specifies two fixed rows with `fixedRowsTop: 2`. Horizonta
 
 :::
 
+## Result
+
+After completing this guide, the rows you specify with `fixedRowsTop` or `fixedRowsBottom` stay visible while you scroll through the rest of the grid.
+
 ## Related API reference
 
 **Configuration options**

--- a/docs/content/guides/rows/row-hiding/row-hiding.md
+++ b/docs/content/guides/rows/row-hiding/row-hiding.md
@@ -5,6 +5,10 @@ metaTitle: Row hiding - JavaScript Data Grid | Handsontable
 description: Hide individual rows to avoid rendering them as DOM elements. It helps you reduce screen clutter and improve the grid's performance.
 permalink: /row-hiding
 canonicalUrl: /row-hiding
+tags:
+  - hiding
+  - hidden rows
+  - HiddenRows
 react:
   metaTitle: Row hiding - React Data Grid | Handsontable
 angular:
@@ -319,6 +323,10 @@ To exclude hidden rows from copying and pasting, in the `hiddenRows` object, set
 :::
 
 :::
+
+## Result
+
+After completing this guide, you can hide rows from the grid without changing source data. You can configure default hidden rows, UI indicators, context menu items, and copy-paste behavior.
 
 ## Row hiding API methods
 

--- a/docs/content/guides/rows/row-trimming/row-trimming.md
+++ b/docs/content/guides/rows/row-trimming/row-trimming.md
@@ -5,6 +5,10 @@ metaTitle: Row trimming - JavaScript Data Grid | Handsontable
 description: Hide individual rows from your interface and exclude them from the rendering process and DataMap. This feature is similar, but not the same, as "hiding rows".
 permalink: /row-trimming
 canonicalUrl: /row-trimming
+tags:
+  - trimming
+  - trim rows
+  - TrimRows
 react:
   metaTitle: Row trimming - React Data Grid | Handsontable
 angular:


### PR DESCRIPTION
[skip changelog]

### Context

The PR adds the remaining polish gaps on eight rewritten documentation guides from the Documentation (backlog) ClickUp list. Each page was already migrated to the modern Diátaxis format; this change closes the blockers so the linked tasks can be completed.

Changes per guide:

- **DEV-636** (`row-trimming.md`): add `tags` frontmatter
- **DEV-581** (`column-moving.md`): add `tags` and `## Result`
- **DEV-578** (`row-hiding.md`): add `tags` and `## Result`
- **DEV-569** (`column-hiding.md`): add `tags` and `## Result`
- **DEV-584** (`row-freezing.md`): add `## Result`
- **DEV-572** (`export-to-csv.md`): add `## Result`
- **DEV-570** (`column-summary.md`): add `## Result`
- **DEV-576** (`comments.md`): replace banned `A1`/`B1`/`C1` inline placeholder data with project-management sample data

No permalinks, example IDs, sidebar entries, or `menuTag` values were changed.

### How has this been tested?

- Verified banned placeholder data is removed:

  ```bash
  rg 'A1|B1|C1' docs/content/guides/cell-features/comments/comments.md
  ```

  (no matches)

- Confirmed `tags` and `## Result` sections are present in all eight updated `.md` files
- Manual spot-check pending in local preview:

  ```bash
  cd docs && npm run dev
  ```

  Pages: `/row-trimming`, `/column-moving`, `/row-hiding`, `/column-hiding`, `/row-freezing`, `/export-to-csv`, `/column-summary`, `/comments`

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-636
2. DEV-581
3. DEV-578
4. DEV-569
5. DEV-584
6. DEV-572
7. DEV-570
8. DEV-576

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

### Docs PR checklist (`docs/AGENTS.md` §2.10)

- [x] `type:` field present in frontmatter on all eight pages
- [x] Pages use the correct Diátaxis how-to template
- [x] No banned placeholder data (`foo`, `bar`, `A1`, `Column1`, etc.)
- [x] How-tos have a `## Result` section
- [x] Active voice and second person ("you") in added prose

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown documentation edits only; no runtime, API, or routing changes.
> 
> **Overview**
> Documentation-only polish on **eight** Diátaxis how-to guides so they match `docs/AGENTS.md` expectations (search tags, outcome summaries, and banned placeholder data).
> 
> **`## Result` sections** were added before the API reference blocks on export-to-csv, column-hiding, column-moving, column-summary, row-freezing, and row-hiding, summarizing what readers can do after the guide.
> 
> **Frontmatter `tags`** were added for discoverability on column-hiding, column-moving, row-hiding, and row-trimming (plugin names and related keywords).
> 
> In **comments**, inline enable-the-plugin snippets across JS/React/Angular/Vue now use project-management sample rows instead of **`A1`/`B1`/`C1`** placeholders.
> 
> Permalinks, examples, and sidebar entries are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44d3997254507f4de5478556796440ffaa9be780. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->