### PR TITLE
Docs: fix CSS imports from handsontable/styles/ falling through to pnpm virtual store

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -178,6 +178,28 @@ function resolveMonorepoPackages() {
         return resolve(HOT_TMP, 'index.mjs');
       }
 
+      // ── Handsontable CSS (styles/) ─────────────────────────────────────
+      // styles/ is gitignored build output. Prefer the built file; when the
+      // build has not run yet, map theme .min.css imports to the source CSS
+      // in src/themes/static/css/theme/ so the docs server always resolves
+      // to a local file and never falls through to pnpm's virtual store.
+      if (id.startsWith('handsontable/styles/') && id.endsWith('.css')) {
+        const cssFileName = id.slice('handsontable/styles/'.length);
+        const builtPath = resolve(HOT_DIR, 'styles', cssFileName);
+
+        if (existsSync(builtPath)) return builtPath;
+
+        // Strip ".min" suffix to locate the unminified source counterpart.
+        const srcBaseName = cssFileName.replace(/\.min\.css$/, '.css');
+        const srcThemePath = resolve(HOT_DIR, 'src/themes/static/css/theme', srcBaseName);
+
+        if (existsSync(srcThemePath)) return srcThemePath;
+
+        const srcIconsPath = resolve(HOT_DIR, 'src/themes/static/css/icons', srcBaseName);
+
+        if (existsSync(srcIconsPath)) return srcIconsPath;
+      }
+
       if (id.startsWith('handsontable/')) {
         const sub = id.slice('handsontable/'.length);
         const mjsPath = resolve(HOT_TMP, `${sub}.mjs`);


### PR DESCRIPTION
Closes #12890

## What changed

Extended the `resolveMonorepoPackages` Vite plugin in `docs/astro.config.mjs` with an explicit CSS handler for `handsontable/styles/*.css` imports.

**Root cause:** `handsontable/styles/` is gitignored build output — it only exists after `npm run build --prefix handsontable`. When the plugin's `existsSync` check on `HOT_DIR/styles/<file>` failed (directory not built), the plugin returned `undefined`. Vite then fell through to the pnpm workspace resolver and resolved the import to the pnpm virtual store path:
```
/node_modules/.pnpm/handsontable@17.0.1/node_modules/handsontable/styles/ht-theme-main.min.css
```
If pnpm had a cached copy of the published npm package at that version, the loaded CSS came from the **published package** rather than the local workspace build, causing theme styles to appear stale or broken on `dev.handsontable.com`.

**Fix:** Added a dedicated `handsontable/styles/` check in `resolveId` that:
1. Returns the built file at `HOT_DIR/styles/<file>` when it exists (normal production path).
2. Falls back to the unminified source CSS in `src/themes/static/css/theme/` (stripping `.min` from the filename) when the build hasn't run yet, so the docs server always resolves to a local monorepo file.

[skip changelog]

---
_Generated by [Claude Code](https://claude.ai/code/session_012nQ137S7FW8UksgcBV1sei)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Change is limited to docs `astro.config.mjs` import resolution for theme CSS; no auth, data, or core grid runtime impact.
> 
> **Overview**
> **Fixes docs dev/build loading stale theme CSS** when `handsontable/styles/` has not been built yet.
> 
> The `resolveMonorepoPackages` Vite plugin now handles `handsontable/styles/*.css` **before** the generic `handsontable/*` resolver. It uses `HOT_DIR/styles/<file>` when the gitignored build output exists; otherwise it maps `.min.css` imports to source files under `src/themes/static/css/theme/` or `icons/`. That keeps resolution on the workspace package instead of falling through to pnpm’s virtual store (published npm CSS).
> 
> **Risk is low:** docs-only Vite `resolveId` behavior; no runtime product logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 800d503818d02f1e50641741c5d8e317cf7297ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->