### PR TITLE
DEV-341: Improve handsontable cell type demo layout

### DIFF
--- a/docs/content/guides/cell-types/handsontable-cell-type/angular/example1.ts
+++ b/docs/content/guides/cell-types/handsontable-cell-type/angular/example1.ts
@@ -2,17 +2,6 @@
 import { Component } from '@angular/core';
 import { GridSettings, HotTableModule} from '@handsontable/angular-wrapper';
 
-const colorData = [
-  ['yellow'],
-  ['red'],
-  ['orange'],
-  ['green'],
-  ['blue'],
-  ['gray'],
-  ['black'],
-  ['white'],
-];
-
 const manufacturerData = [
   { name: 'BMW', country: 'Germany', owner: 'Bayerische Motoren Werke AG' },
   { name: 'Chrysler', country: 'USA', owner: 'Chrysler Group LLC' },
@@ -64,18 +53,12 @@ export class AppComponent {
       },
       { type: 'numeric' },
       {
-        type: 'handsontable',
-        handsontable: {
-          colHeaders: false,
-          data: colorData,
-        },
+        type: 'dropdown',
+        source: ['yellow', 'red', 'orange', 'green', 'blue', 'gray', 'black', 'white'],
       },
       {
-        type: 'handsontable',
-        handsontable: {
-          colHeaders: false,
-          data: colorData,
-        },
+        type: 'dropdown',
+        source: ['yellow', 'red', 'orange', 'green', 'blue', 'gray', 'black', 'white'],
       },
     ]
   };

--- a/docs/content/guides/cell-types/handsontable-cell-type/handsontable-cell-type.md
+++ b/docs/content/guides/cell-types/handsontable-cell-type/handsontable-cell-type.md
@@ -13,6 +13,7 @@ vue:
   metaTitle: Handsontable cell type - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types
+menuTag: updated
 ---
 Add a spreadsheet editor in a popup, by using the Handsontable cell type.
 
@@ -31,6 +32,8 @@ HOT-in-HOT opens by any of the following:
 While HOT-in-HOT is opened, the text field above the HOT-in-HOT remains focused at all times.
 
 ## Basic example
+
+The first column uses the handsontable cell type for a searchable manufacturer list. The color columns use the [dropdown cell type](@/guides/cell-types/dropdown-cell-type/dropdown-cell-type.md) for compact selection from a short list.
 
 ::: only-for javascript
 

--- a/docs/content/guides/cell-types/handsontable-cell-type/javascript/example1.js
+++ b/docs/content/guides/cell-types/handsontable-cell-type/javascript/example1.js
@@ -1,63 +1,52 @@
 import Handsontable from 'handsontable/base';
 import { registerAllModules } from 'handsontable/registry';
-
 // Register all Handsontable's modules.
 registerAllModules();
-
-const colorData = [['yellow'], ['red'], ['orange'], ['green'], ['blue'], ['gray'], ['black'], ['white']];
 const manufacturerData = [
-  { name: 'BMW', country: 'Germany', owner: 'Bayerische Motoren Werke AG' },
-  { name: 'Chrysler', country: 'USA', owner: 'Chrysler Group LLC' },
-  { name: 'Nissan', country: 'Japan', owner: 'Nissan Motor Company Ltd' },
-  { name: 'Suzuki', country: 'Japan', owner: 'Suzuki Motor Corporation' },
-  { name: 'Toyota', country: 'Japan', owner: 'Toyota Motor Corporation' },
-  { name: 'Volvo', country: 'Sweden', owner: 'Zhejiang Geely Holding Group' },
+    { name: 'BMW', country: 'Germany', owner: 'Bayerische Motoren Werke AG' },
+    { name: 'Chrysler', country: 'USA', owner: 'Chrysler Group LLC' },
+    { name: 'Nissan', country: 'Japan', owner: 'Nissan Motor Company Ltd' },
+    { name: 'Suzuki', country: 'Japan', owner: 'Suzuki Motor Corporation' },
+    { name: 'Toyota', country: 'Japan', owner: 'Toyota Motor Corporation' },
+    { name: 'Volvo', country: 'Sweden', owner: 'Zhejiang Geely Holding Group' },
 ];
-
 const container = document.querySelector('#example1');
-
 new Handsontable(container, {
-  height: 'auto',
-  licenseKey: 'non-commercial-and-evaluation',
-  data: [
-    ['Tesla', 2017, 'black', 'black'],
-    ['Nissan', 2018, 'blue', 'blue'],
-    ['Chrysler', 2019, 'yellow', 'black'],
-    ['Volvo', 2020, 'white', 'gray'],
-  ],
-  colHeaders: ['Car', 'Year', 'Chassis color', 'Bumper color'],
-  columns: [
-    {
-      type: 'handsontable',
-      handsontable: {
-        colHeaders: ['Marque', 'Country', 'Parent company'],
-        autoColumnSize: true,
-        data: manufacturerData,
-        getValue() {
-          const selection = this.getSelectedLast();
-
-          // Get the manufacturer name of the clicked row and ignore header
-          // coordinates (negative values)
-          return this.getSourceDataAtRow(Math.max(selection[0], 0)).name;
+    height: 'auto',
+    licenseKey: 'non-commercial-and-evaluation',
+    data: [
+        ['Tesla', 2017, 'black', 'black'],
+        ['Nissan', 2018, 'blue', 'blue'],
+        ['Chrysler', 2019, 'yellow', 'black'],
+        ['Volvo', 2020, 'white', 'gray'],
+    ],
+    colHeaders: ['Car', 'Year', 'Chassis color', 'Bumper color'],
+    columns: [
+        {
+            type: 'handsontable',
+            handsontable: {
+                colHeaders: ['Marque', 'Country', 'Parent company'],
+                autoColumnSize: true,
+                data: manufacturerData,
+                getValue() {
+                    const selection = this.getSelectedLast();
+                    // Get the manufacturer name of the clicked row and ignore header
+                    // coordinates (negative values)
+                    const row = this.getSourceDataAtRow(Math.max(selection?.[0] ?? 0, 0));
+                    return row.name;
+                },
+            },
         },
-      },
-    },
-    { type: 'numeric' },
-    {
-      type: 'handsontable',
-      handsontable: {
-        colHeaders: false,
-        data: colorData,
-      },
-    },
-    {
-      type: 'handsontable',
-      handsontable: {
-        colHeaders: false,
-        data: colorData,
-      },
-    },
-  ],
-  autoWrapRow: true,
-  autoWrapCol: true,
+        { type: 'numeric' },
+        {
+            type: 'dropdown',
+            source: ['yellow', 'red', 'orange', 'green', 'blue', 'gray', 'black', 'white'],
+        },
+        {
+            type: 'dropdown',
+            source: ['yellow', 'red', 'orange', 'green', 'blue', 'gray', 'black', 'white'],
+        },
+    ],
+    autoWrapRow: true,
+    autoWrapCol: true,
 });

--- a/docs/content/guides/cell-types/handsontable-cell-type/javascript/example1.ts
+++ b/docs/content/guides/cell-types/handsontable-cell-type/javascript/example1.ts
@@ -10,8 +10,6 @@ interface Manufacturer {
   owner: string;
 }
 
-const colorData: [string][] = [['yellow'], ['red'], ['orange'], ['green'], ['blue'], ['gray'], ['black'], ['white']];
-
 const manufacturerData: Manufacturer[] = [
   { name: 'BMW', country: 'Germany', owner: 'Bayerische Motoren Werke AG' },
   { name: 'Chrysler', country: 'USA', owner: 'Chrysler Group LLC' },
@@ -53,18 +51,12 @@ new Handsontable(container, {
     },
     { type: 'numeric' },
     {
-      type: 'handsontable',
-      handsontable: {
-        colHeaders: false,
-        data: colorData,
-      },
+      type: 'dropdown',
+      source: ['yellow', 'red', 'orange', 'green', 'blue', 'gray', 'black', 'white'],
     },
     {
-      type: 'handsontable',
-      handsontable: {
-        colHeaders: false,
-        data: colorData,
-      },
+      type: 'dropdown',
+      source: ['yellow', 'red', 'orange', 'green', 'blue', 'gray', 'black', 'white'],
     },
   ],
   autoWrapRow: true,

--- a/docs/content/guides/cell-types/handsontable-cell-type/react/example1.jsx
+++ b/docs/content/guides/cell-types/handsontable-cell-type/react/example1.jsx
@@ -5,7 +5,6 @@ import { registerAllModules } from 'handsontable/registry';
 registerAllModules();
 
 const ExampleComponent = () => {
-  const colorData = [['yellow'], ['red'], ['orange'], ['green'], ['blue'], ['gray'], ['black'], ['white']];
   const manufacturerData = [
     { name: 'BMW', country: 'Germany', owner: 'Bayerische Motoren Werke AG' },
     { name: 'Chrysler', country: 'USA', owner: 'Chrysler Group LLC' },
@@ -40,24 +39,20 @@ const ExampleComponent = () => {
 
               // Get the manufacturer name of the clicked row and ignore header
               // coordinates (negative values)
-              return this.getSourceDataAtRow(Math.max(selection[0], 0)).name;
+              const row = this.getSourceDataAtRow(Math.max(selection?.[0] ?? 0, 0));
+
+              return row.name;
             },
           },
         },
         { type: 'numeric' },
         {
-          type: 'handsontable',
-          handsontable: {
-            colHeaders: false,
-            data: colorData,
-          },
+          type: 'dropdown',
+          source: ['yellow', 'red', 'orange', 'green', 'blue', 'gray', 'black', 'white'],
         },
         {
-          type: 'handsontable',
-          handsontable: {
-            colHeaders: false,
-            data: colorData,
-          },
+          type: 'dropdown',
+          source: ['yellow', 'red', 'orange', 'green', 'blue', 'gray', 'black', 'white'],
         },
       ]}
     />

--- a/docs/content/guides/cell-types/handsontable-cell-type/react/example1.tsx
+++ b/docs/content/guides/cell-types/handsontable-cell-type/react/example1.tsx
@@ -5,8 +5,6 @@ import { registerAllModules } from 'handsontable/registry';
 registerAllModules();
 
 const ExampleComponent = () => {
-  const colorData = [['yellow'], ['red'], ['orange'], ['green'], ['blue'], ['gray'], ['black'], ['white']];
-
   const manufacturerData = [
     { name: 'BMW', country: 'Germany', owner: 'Bayerische Motoren Werke AG' },
     { name: 'Chrysler', country: 'USA', owner: 'Chrysler Group LLC' },
@@ -49,18 +47,12 @@ const ExampleComponent = () => {
         },
         { type: 'numeric' },
         {
-          type: 'handsontable',
-          handsontable: {
-            colHeaders: false,
-            data: colorData,
-          },
+          type: 'dropdown',
+          source: ['yellow', 'red', 'orange', 'green', 'blue', 'gray', 'black', 'white'],
         },
         {
-          type: 'handsontable',
-          handsontable: {
-            colHeaders: false,
-            data: colorData,
-          },
+          type: 'dropdown',
+          source: ['yellow', 'red', 'orange', 'green', 'blue', 'gray', 'black', 'white'],
         },
       ]}
     />

--- a/docs/content/guides/cell-types/handsontable-cell-type/vue/example1.vue
+++ b/docs/content/guides/cell-types/handsontable-cell-type/vue/example1.vue
@@ -7,8 +7,6 @@ import type { GridSettings } from 'handsontable/settings';
 // register Handsontable's modules
 registerAllModules();
 
-const colorData = [['yellow'], ['red'], ['orange'], ['green'], ['blue'], ['gray'], ['black'], ['white']];
-
 const manufacturerData = [
   { name: 'BMW', country: 'Germany', owner: 'Bayerische Motoren Werke AG' },
   { name: 'Chrysler', country: 'USA', owner: 'Chrysler Group LLC' },
@@ -49,18 +47,12 @@ const hotSettings = ref<GridSettings>({
     },
     { type: 'numeric' },
     {
-      type: 'handsontable',
-      handsontable: {
-        colHeaders: false,
-        data: colorData,
-      },
+      type: 'dropdown',
+      source: ['yellow', 'red', 'orange', 'green', 'blue', 'gray', 'black', 'white'],
     },
     {
-      type: 'handsontable',
-      handsontable: {
-        colHeaders: false,
-        data: colorData,
-      },
+      type: 'dropdown',
+      source: ['yellow', 'red', 'orange', 'green', 'blue', 'gray', 'black', 'white'],
     },
   ],
   licenseKey: 'non-commercial-and-evaluation',


### PR DESCRIPTION
[skip changelog]

### Context

DEV-341 improves the developer experience on the Handsontable cell type guide. HotJar feedback showed users were confused by the demo layout, especially the last two columns that used nested HOT-in-HOT editors for simple color lists.

This change keeps the manufacturer picker in column 0 as the handsontable cell type showcase and switches the color columns to dropdown editors. It also adds brief copy explaining the column roles and marks the page as updated.

Related: dev-handsontable#594

### How has this been tested?

- `cd docs && npm run build` -- docs site builds successfully
- Verified built page at `/docs/javascript-data-grid/handsontable-cell-type/` contains updated copy and dropdown column config in the embedded example

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-341
2. dev-handsontable#594

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and embedded examples only; no library or runtime product code changes.
> 
> **Overview**
> Updates the **Handsontable cell type** guide so the basic example highlights HOT-in-HOT only where it fits: column 0 stays a nested grid for the manufacturer list, while **chassis** and **bumper** color columns switch from nested `handsontable` editors to **`dropdown`** with a fixed color `source`. The shared examples (JS/TS, React, Angular, Vue) drop `colorData` and align the manufacturer `getValue()` path with optional chaining on the selection row index.
> 
> The guide adds a short **Basic example** note linking dropdown for short lists, sets **`menuTag: updated`**, and includes minor formatting in the JS sample.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d39f447856641723831eda766f567c12ffdd87d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->