### PR TITLE
DEV-466: Document cascading level for configuration options

### DIFF
--- a/docs/content/guides/getting-started/configuration-options/configuration-options.md
+++ b/docs/content/guides/getting-started/configuration-options/configuration-options.md
@@ -17,6 +17,7 @@ vue:
   metaTitle: Configuration options - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Getting started
+menuTag: updated
 ---
 Configure your grid down to each column, row, and cell, using various built-in options that control Handsontable's behavior and user interface.
 
@@ -184,6 +185,8 @@ When you modify the bottom-level cell options (using the [`cell`](@/api/options.
 - Any unchanged options are inherited from the mid-level column options or the top-level grid options.
 
 When you modify any options with the [`cells`](@/api/options.md#cells) function, the changes overwrite all other options.
+
+Unless an option's [reference entry](@/api/options.md) states otherwise, you can set it at any cascading level - the grid level, the [`columns`](@/api/options.md#columns) level, the [`cells`](@/api/options.md#cells) level, and the [`cell`](@/api/options.md#cell) level. An option marked as grid-level only has no effect when you set it per column or per cell.
 
 ::: tip
 

--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -304,6 +304,9 @@ export default (): Record<string, unknown> => {
      * - **Insert row above**
      * - **Insert row below**
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @memberof Options#
      * @type {boolean}
      * @default true
@@ -380,6 +383,9 @@ export default (): Record<string, unknown> => {
      * Read more:
      * - [Context menu](@/guides/accessories-and-menus/context-menu/context-menu.md)
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @memberof Options#
      * @type {boolean}
      * @default true
@@ -436,6 +442,9 @@ export default (): Record<string, unknown> => {
      * Read more:
      * - [Plugins: `AutoColumnSize`](@/api/autoColumnSize.md)
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @memberof Options#
      * @type {object|boolean}
      * @default undefined
@@ -481,6 +490,9 @@ export default (): Record<string, unknown> => {
      * Read more:
      * - [Plugins: `AutoRowSize`](@/api/autoRowSize.md)
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @memberof Options#
      * @type {object|boolean}
      * @default undefined
@@ -501,6 +513,9 @@ export default (): Record<string, unknown> => {
      * | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
      * | `false` (default) | When you select a bottom-most cell, pressing <kbd>**↓**</kbd> doesn't do anything.<br><br>When you select a top-most cell, pressing <kbd>**↑**</kbd> doesn't do anything.                                                                    |
      * | `true`            | When you select a bottom-most cell, pressing <kbd>**↓**</kbd> takes you to the top-most cell of the next column.<br><br>When you select a top-most cell, pressing <kbd>**↑**</kbd> takes you to the bottom-most cell of the previous column. |
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @memberof Options#
      * @type {boolean}
@@ -528,6 +543,9 @@ export default (): Record<string, unknown> => {
      *
      * \* The exact key depends on your [`layoutDirection`](#layoutdirection) configuration.<br>
      * \*\* Unless [`tabNavigation`](#tabnavigation) is set to `false`.
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @memberof Options#
      * @type {boolean}
@@ -590,6 +608,9 @@ export default (): Record<string, unknown> => {
      * Read more:
      * - [Configuration options: Setting cell options](@/guides/getting-started/configuration-options/configuration-options.md#set-cell-options)
      * - [`columns`](#columns)
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @memberof Options#
      * @type {Array[]}
@@ -772,6 +793,9 @@ export default (): Record<string, unknown> => {
      * - [Column header](@/guides/columns/column-header/column-header.md)
      * - [`title`](#title)
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @memberof Options#
      * @type {boolean|string[]|Function}
      * @default null
@@ -847,6 +871,9 @@ export default (): Record<string, unknown> => {
      * | A number | Set the same height for every column header         |
      * | An array | Set different heights for individual column headers |
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @memberof Options#
      * @type {number|number[]}
      * @default undefined
@@ -881,6 +908,9 @@ export default (): Record<string, unknown> => {
      * - [`minCols`](#minCols)
      * - [`maxCols`](#maxCols)
      * - [`data`](#data)
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @memberof Options#
      * @type {object[]|Function}
@@ -1020,6 +1050,9 @@ export default (): Record<string, unknown> => {
      * - [Column summary](@/guides/columns/column-summary/column-summary.md)
      * - [Plugins: `ColumnSummary`](@/api/columnSummary.md)
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @memberof Options#
      * @type {object[]|Function}
      * @default undefined
@@ -1072,6 +1105,9 @@ export default (): Record<string, unknown> => {
      * - [Column width](@/guides/columns/column-width/column-width.md)
      * - [Hooks: `modifyColWidth`](@/api/hooks.md#modifyColWidth)
      * - [`autoColumnSize`](#autoColumnSize)
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @memberof Options#
      * @type {number|number[]|string|string[]|Array<undefined>|Function}
@@ -1160,6 +1196,9 @@ export default (): Record<string, unknown> => {
      * - [`readOnly`](#readOnly)
      * - [`commentedCellClassName`](#commentedCellClassName)
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @memberof Options#
      * @type {boolean|object[]}
      * @default false
@@ -1206,6 +1245,9 @@ export default (): Record<string, unknown> => {
      * - [Context menu: Context menu with specific options](@/guides/accessories-and-menus/context-menu/context-menu.md#context-menu-with-specific-options)
      * - [Context menu: Context menu with fully custom configuration options](@/guides/accessories-and-menus/context-menu/context-menu.md#context-menu-with-a-fully-custom-configuration)
      * - [Plugins: `ContextMenu`](@/api/contextMenu.md)
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @memberof Options#
      * @type {boolean|string[]|object}
@@ -1330,6 +1372,9 @@ export default (): Record<string, unknown> => {
      * - [Plugins: `CopyPaste`](@/api/copyPaste.md)
      * - [Guides: Clipboard](@/guides/cell-features/clipboard/clipboard.md)
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @memberof Options#
      * @type {object|boolean}
      * @default true
@@ -1386,6 +1431,9 @@ export default (): Record<string, unknown> => {
      * - [`TableClassName`](#TableClassName)
      * - [`className`](#className)
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @memberof Options#
      * @type {string}
      * @default undefined
@@ -1414,6 +1462,9 @@ export default (): Record<string, unknown> => {
      * - [`noWordWrapClassName`](#noWordWrapClassName)
      * - [`TableClassName`](#TableClassName)
      * - [`className`](#className)
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @memberof Options#
      * @type {string}
@@ -1444,6 +1495,9 @@ export default (): Record<string, unknown> => {
      * - [`noWordWrapClassName`](#noWordWrapClassName)
      * - [`TableClassName`](#TableClassName)
      * - [`className`](#className)
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @memberof Options#
      * @type {string}
@@ -1500,6 +1554,9 @@ export default (): Record<string, unknown> => {
      * - [Plugins: `CustomBorders`](@/api/customBorders.md)
      * - [Layout direction](@/guides/internationalization/layout-direction/layout-direction.md)
      * - [`layoutDirection`](#layoutDirection)
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @memberof Options#
      * @type {boolean|object[]}
@@ -1596,6 +1653,9 @@ export default (): Record<string, unknown> => {
      * - [`startRows`](#startRows)
      * - [`startCols`](#startCols)
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @memberof Options#
      * @type {Array[]|object[]}
      * @default undefined
@@ -1636,6 +1696,9 @@ export default (): Record<string, unknown> => {
      * map cleanly to your backend. Pair with **`pagination`** for server-side paging.
      * Valid cell edits apply at once; if **`onRowsUpdate`** fails or **`beforeRowsMutation`** blocks the update, affected cells roll back.
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @since 17.1.0
      * @memberof Options#
      * @type {object}
@@ -1674,6 +1737,9 @@ export default (): Record<string, unknown> => {
      * the dots in the object keys and you don't want Handsontable to interpret them as a nested object path, set this option to `false`.
      *
      * The option only works when defined in the global table settings.
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @since 14.4.0
      * @memberof Options#
@@ -1722,6 +1788,9 @@ export default (): Record<string, unknown> => {
      * - [Binding to data: Array of objects with custom data schema](@/guides/getting-started/binding-to-data/binding-to-data.md#array-of-objects-with-custom-data-schema)
      * - [Binding to data: Function data source and schema](@/guides/getting-started/binding-to-data/binding-to-data.md#function-data-source-and-schema)
      * - [`data`](#data)
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @memberof Options#
      * @type {object|Function}
@@ -1935,9 +2004,6 @@ export default (): Record<string, unknown> => {
      * | `'header'`        | - Show single-cell selection<br>- Show range selection<br>- Don't show header selection             |
      * | An array          | A combination of `'current'`, `'area'`, and/or `'header'`                                           |
      *
-     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
-     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
-     *
      * When set to any non-`false` value, the second-click deselect behavior
      * (Ctrl/Cmd+click on an already-selected cell removing it from a multi-cell selection)
      * is also skipped. Without visible feedback, toggling layers off can cause unexpected
@@ -2008,6 +2074,9 @@ export default (): Record<string, unknown> => {
      *
      * Read more:
      * - [Plugins: `Dialog`](@/api/dialog.md)
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @since 16.1.0
      * @memberof Options#
@@ -2166,6 +2235,9 @@ export default (): Record<string, unknown> => {
      *
      * Read more:
      * - [Plugins: `DragToScroll`](@/api/dragToScroll.md)
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @memberof Options#
      * @type {boolean|object}
@@ -2356,6 +2428,9 @@ export default (): Record<string, unknown> => {
      * Read more:
      * - [Plugins: `EmptyDataState`](@/api/emptyDataState.md)
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @since 16.2.0
      * @memberof Options#
      * @type {boolean|object}
@@ -2421,6 +2496,9 @@ export default (): Record<string, unknown> => {
      * Read more:
      * - [`enterMoves`](#enterMoves)
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @memberof Options#
      * @type {boolean}
      * @default true
@@ -2481,6 +2559,9 @@ export default (): Record<string, unknown> => {
      *
      * Read more:
      * - [`enterBeginsEditing`](#enterBeginsEditing)
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @memberof Options#
      * @type {object|Function}
@@ -2563,6 +2644,9 @@ export default (): Record<string, unknown> => {
      *
      * Read more:
      * - [AutoFill values](@/guides/cell-features/autofill-values/autofill-values.md)
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @memberof Options#
      * @type {boolean|string|object}
@@ -2703,6 +2787,9 @@ export default (): Record<string, unknown> => {
      * - [Plugins: `Filters`](@/api/filters.md)
      * - [`dropdownMenu`](#dropdownMenu)
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @memberof Options#
      * @type {boolean}
      * @default undefined
@@ -2746,6 +2833,9 @@ export default (): Record<string, unknown> => {
      * Read more:
      * - [`fixedColumnsStart`](#fixedcolumnsstart)
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @memberof Options#
      * @type {number}
      * @default 0
@@ -2769,6 +2859,9 @@ export default (): Record<string, unknown> => {
      * - [Layout direction](@/guides/internationalization/layout-direction/layout-direction.md)
      * - [`fixedColumnsLeft`](#fixedcolumnsleft)
      * - [`layoutDirection`](#layoutDirection)
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @memberof Options#
      * @type {number}
@@ -2812,6 +2905,9 @@ export default (): Record<string, unknown> => {
      * - [Row freezing](@/guides/rows/row-freezing/row-freezing.md)
      * - [`height`](#height)
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @memberof Options#
      * @type {number}
      * @default 0
@@ -2837,6 +2933,9 @@ export default (): Record<string, unknown> => {
      * Read more:
      * - [Row freezing](@/guides/rows/row-freezing/row-freezing.md)
      * - [`height`](#height)
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @memberof Options#
      * @type {number}
@@ -2871,6 +2970,9 @@ export default (): Record<string, unknown> => {
      * - [Formula calculation](@/guides/formulas/formula-calculation/formula-calculation.md)
      * - [HyperFormula documentation: Client-side installation](https://handsontable.github.io/hyperformula/guide/client-side-installation)
      * - [HyperFormula documentation: Configuration options](https://handsontable.github.io/hyperformula/api/interfaces/configparams.html)
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @memberof Options#
      * @type {object}
@@ -2946,6 +3048,9 @@ export default (): Record<string, unknown> => {
      * [`selectionMode`](@/api/options.md#selectionmode) that allows selecting more than one cell.
      * When [`selectionMode`](@/api/options.md#selectionmode) is set to `'single'`, copying is
      * limited to a single cell.
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @memberof Options#
      * @type {boolean|string}
@@ -3096,6 +3201,9 @@ export default (): Record<string, unknown> => {
      * Read more:
      * - [Grid size](@/guides/getting-started/grid-size/grid-size.md)
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @memberof Options#
      * @type {number|'auto'|string|Function}
      * @default undefined
@@ -3143,6 +3251,9 @@ export default (): Record<string, unknown> => {
      * - [Plugins: `HiddenColumns`](@/api/hiddenColumns.md)
      * - [Column hiding](@/guides/columns/column-hiding/column-hiding.md)
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @memberof Options#
      * @type {boolean|object}
      * @default undefined
@@ -3189,6 +3300,9 @@ export default (): Record<string, unknown> => {
      * - [Plugins: `HiddenRows`](@/api/hiddenRows.md)
      * - [Row hiding](@/guides/rows/row-hiding/row-hiding.md)
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @memberof Options#
      * @type {boolean|object}
      * @default undefined
@@ -3218,6 +3332,9 @@ export default (): Record<string, unknown> => {
      * `initialState` and table settings, the table settings take precedence.
      * Note: The `initialState` option is ignored when passed to the
      * [`updateSettings()`](@/api/core.md#updatesettings) method.
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @since 16.1.0
      * @memberof Options#
@@ -3270,6 +3387,9 @@ export default (): Record<string, unknown> => {
      * because of its incompatibility with some of the accessibility features.
      *
      * Enabling this option can make a negative impact on how some screen readers handle reading the table cells.
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @since 14.0.0
      * @memberof Options#
@@ -3501,6 +3621,9 @@ export default (): Record<string, unknown> => {
      * - [`fixedColumnsStart`](#fixedcolumnsstart)
      * - [`customBorders`](#customBorders)
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @memberof Options#
      * @type {string}
      * @default 'inherit'
@@ -3531,6 +3654,9 @@ export default (): Record<string, unknown> => {
      * modal layer, such as the dialog) are not orderable through this option. The license
      * notification is not orderable either; it always renders last in the `bottom` slot.
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @since 18.0.0
      * @memberof Options#
      * @type {object}
@@ -3559,6 +3685,9 @@ export default (): Record<string, unknown> => {
      *
      * Read more:
      * - [License key](@/guides/getting-started/license-key/license-key.md)
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @memberof Options#
      * @type {string}
@@ -3637,6 +3766,10 @@ export default (): Record<string, unknown> => {
      *
      * Read more:
      * - [Plugins: `Loading`](@/api/loading.md)
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @since 16.1.0
      * @memberof Options#
      * @type {boolean|object}
@@ -3680,6 +3813,9 @@ export default (): Record<string, unknown> => {
      * Read more:
      * - [Plugins: `Notification`](@/api/notification.md)
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @since 17.1.0
      * @memberof Options#
      * @type {boolean|object}
@@ -3705,6 +3841,9 @@ export default (): Record<string, unknown> => {
      *
      * Read more:
      * - [Column freezing](@/guides/columns/column-freezing/column-freezing.md#user-triggered-freeze)
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @memberof Options#
      * @type {boolean}
@@ -3732,6 +3871,9 @@ export default (): Record<string, unknown> => {
      *
      * Read more:
      * - [Column moving](@/guides/columns/column-moving/column-moving.md)
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @memberof Options#
      * @type {boolean|number[]}
@@ -3767,6 +3909,9 @@ export default (): Record<string, unknown> => {
      * Read more:
      * - [Column width: Column stretching](@/guides/columns/column-width/column-width.md#column-stretching)
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @memberof Options#
      * @type {boolean|number[]}
      * @default undefined
@@ -3800,6 +3945,9 @@ export default (): Record<string, unknown> => {
      *
      * Read more:
      * - [Row moving](@/guides/rows/row-moving/row-moving.md)
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @memberof Options#
      * @type {boolean|number[]}
@@ -3835,6 +3983,9 @@ export default (): Record<string, unknown> => {
      * Read more:
      * - [Row height: Adjust the row height manually](@/guides/rows/row-height/row-height.md#adjust-the-row-height-manually)
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @memberof Options#
      * @type {boolean|number[]}
      * @default undefined
@@ -3862,6 +4013,9 @@ export default (): Record<string, unknown> => {
      * Handsontable trims columns from the right.
      * - At runtime: for example, when inserting columns.
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @memberof Options#
      * @type {number}
      * @default Infinity
@@ -3882,6 +4036,9 @@ export default (): Record<string, unknown> => {
      * - At initialization: if the `maxRows` value is lower than the initial number of rows,
      * Handsontable trims rows from the bottom.
      * - At runtime: for example, when inserting rows.
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @memberof Options#
      * @type {number}
@@ -4000,6 +4157,9 @@ export default (): Record<string, unknown> => {
      * - The [`dataSchema`](#dataSchema) option
      * - The [`columns`](#columns) option
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @memberof Options#
      * @type {number}
      * @default 0
@@ -4017,6 +4177,9 @@ export default (): Record<string, unknown> => {
      * Alias for the [`rowHeights`](#rowHeights) option.
      *
      * See the [`rowHeights`](#rowHeights) option description for more information.
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @since 16.2.0
      * @memberof Options#
@@ -4053,6 +4216,9 @@ export default (): Record<string, unknown> => {
      * Handsontable adds empty rows at the bottom.
      * - At runtime: for example, when removing rows.
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @memberof Options#
      * @type {number}
      * @default 0
@@ -4082,6 +4248,9 @@ export default (): Record<string, unknown> => {
      * - The [`dataSchema`](#dataSchema) option
      * - The [`columns`](#columns) option
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @memberof Options#
      * @type {number}
      * @default 0
@@ -4103,6 +4272,9 @@ export default (): Record<string, unknown> => {
      * they are counted into the `minSpareRows` value.
      *
      * The total number of rows can't exceed the [`maxRows`](#maxRows) value.
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @memberof Options#
      * @type {number}
@@ -4194,6 +4366,9 @@ export default (): Record<string, unknown> => {
     /**
      * When set to `true`, the `navigableHeaders` option lets you navigate [row headers](@/guides/rows/row-header/row-header.md) and [column headers](@/guides/columns/column-header/column-header.md), using the arrow keys or the <kbd>**Tab**</kbd> key (if the [`tabNavigation`](#tabNavigation) option is set to `true`).
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @since 14.0.0
      * @memberof Options#
      * @type {boolean}
@@ -4216,6 +4391,9 @@ export default (): Record<string, unknown> => {
      * <kbd>Tab</kbd> and <kbd>Shift</kbd>+<kbd>Tab</kbd> keyboard shortcuts. The Handsontable
      * no more captures that shortcuts to make the grid navigation available (`tabNavigation: true`)
      * but returns control to the browser so the native page navigation is possible.
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @since 14.0.0
      * @memberof Options#
@@ -4283,6 +4461,9 @@ export default (): Record<string, unknown> => {
      * - [Column groups: Nested headers](@/guides/columns/column-groups/column-groups.md#nested-headers)
      * - [Column groups: Choose which columns stay visible when collapsed](@/guides/columns/column-groups/column-groups.md#choose-which-columns-stay-visible-when-collapsed)
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @memberof Options#
      * @type {boolean|Array[]}
      * @default undefined
@@ -4321,6 +4502,9 @@ export default (): Record<string, unknown> => {
      *
      * Read more:
      * - [Plugins: `NestedRows`](@/guides/rows/row-parent-child/row-parent-child.md)
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @example
      * ```js
@@ -4467,6 +4651,9 @@ export default (): Record<string, unknown> => {
      * Handsontable automatically triggers a rerender to ensure correct layout and dimensions.
      * Set this option to `false` if you want to control rendering manually (e.g. by calling `render()` yourself).
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @memberof Options#
      * @type {boolean}
      * @default true
@@ -4491,6 +4678,9 @@ export default (): Record<string, unknown> => {
      * | `true` (default) | On a mouse click outside of the grid, clear the current [selection](@/guides/cell-features/selection/selection.md) |
      * | `false`          | On a mouse click outside of the grid, keep the current [selection](@/guides/cell-features/selection/selection.md)  |
      * | A function       | A function that takes the click event target and returns a boolean                                       |
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @memberof Options#
      * @type {boolean|Function}
@@ -4546,6 +4736,9 @@ export default (): Record<string, unknown> => {
      * Read more:
      * - [Rows pagination](@/guides/rows/rows-pagination/rows-pagination.md)
      * - [Plugins: `Pagination`](@/api/pagination.md)
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @since 16.1.0
      * @memberof Options#
@@ -4645,6 +4838,9 @@ export default (): Record<string, unknown> => {
      * | `false` (default) | Don't prevent overflowing        |
      * | `'horizontal'`      | Prevent horizontal overflowing |
      * | `'vertical'`        | Prevent vertical overflowing   |
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @memberof Options#
      * @type {string|boolean}
@@ -4780,6 +4976,9 @@ export default (): Record<string, unknown> => {
      * Read more:
      * - [Row virtualization](@/guides/rows/row-virtualization/row-virtualization.md)
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @memberof Options#
      * @type {boolean}
      * @default false
@@ -4807,6 +5006,9 @@ export default (): Record<string, unknown> => {
      *
      * Read more:
      * - [Column virtualization](@/guides/columns/column-virtualization/column-virtualization.md)
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @since 14.1.0
      * @memberof Options#
@@ -5062,6 +5264,9 @@ export default (): Record<string, unknown> => {
      * Read more:
      * - [Row header](@/guides/rows/row-header/row-header.md)
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @memberof Options#
      * @type {boolean|string[]|Function}
      * @default undefined
@@ -5093,6 +5298,9 @@ export default (): Record<string, unknown> => {
      * | -------- | ----------------------------------------------- |
      * | A number | Set the same width for every row header         |
      * | An array | Set different widths for individual row headers |
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @memberof Options#
      * @type {number|number[]}
@@ -5129,6 +5337,9 @@ export default (): Record<string, unknown> => {
      *
      * Read more:
      * - [Row height](@/guides/rows/row-height/row-height.md)
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @memberof Options#
      * @type {number|number[]|string|string[]|Array<undefined>|Function}
@@ -5272,6 +5483,9 @@ export default (): Record<string, unknown> => {
      *
      * Read more:
      * - [Selection: Selecting ranges](@/guides/cell-features/selection/selection.md#select-ranges)
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @memberof Options#
      * @type {string}
@@ -5557,6 +5771,9 @@ export default (): Record<string, unknown> => {
      * `startCols` and `minSpareCols`.
      * :::
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @memberof Options#
      * @type {number}
      * @default 5
@@ -5581,6 +5798,9 @@ export default (): Record<string, unknown> => {
      * minimum number of spare rows. As a result, the total initial row count will be the maximum of
      * `startRows` and `minSpareRows`.
      * :::
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @memberof Options#
      * @type {number}
@@ -5610,6 +5830,9 @@ export default (): Record<string, unknown> => {
      *
      * Read more:
      * - [Column width: Column stretching](@/guides/columns/column-width/column-width.md#column-stretching)
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @memberof Options#
      * @type {string}
@@ -5686,6 +5909,9 @@ export default (): Record<string, unknown> => {
      * - [`commentedCellClassName`](#commentedCellClassName)
      * - [`className`](#className)
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @memberof Options#
      * @type {string|string[]}
      * @default undefined
@@ -5742,6 +5968,9 @@ export default (): Record<string, unknown> => {
      * Read more:
      * - [Themes](@/guides/styling/themes/themes.md)
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @memberof Options#
      * @type {string|undefined}
      * @default undefined
@@ -5778,6 +6007,9 @@ export default (): Record<string, unknown> => {
      * Read more:
      * - [Themes](@/guides/styling/themes/themes.md)
      * - [`themeName`](#themeName)
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @memberof Options#
      * @type {ThemeBuilder|string|undefined}
@@ -5836,6 +6068,9 @@ export default (): Record<string, unknown> => {
      * Read more:
      * - [Themes](@/guides/styling/themes/themes.md)
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @memberof Options#
      * @type {boolean}
      * @default true
@@ -5863,6 +6098,9 @@ export default (): Record<string, unknown> => {
      * | -------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
      * | `row`    | Number | - On pressing <kbd>**Tab**</kbd>, move selection `row` rows down<br>- On pressing <kbd>**Shift**</kbd>+<kbd>**Tab**</kbd>, move selection `row` rows up              |
      * | `col`    | Number | - On pressing <kbd>**Tab**</kbd>, move selection `col` columns right<br>- On pressing <kbd>**Shift**</kbd>+<kbd>**Tab**</kbd>, move selection `col` columns left     |
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @memberof Options#
      * @type {object|Function}
@@ -5897,6 +6135,9 @@ export default (): Record<string, unknown> => {
      * - [Column header](@/guides/columns/column-header/column-header.md)
      * - [`colHeaders`](#colheaders)
      * - [`columns`](#columns)
+     *
+     * This option can only be set at the [`columns`](#columns) level.
+     * It has no effect when set at the grid level, or in the [`cells`](#cells) or [`cell`](#cell) options.
      *
      * @memberof Options#
      * @type {string}
@@ -5983,6 +6224,9 @@ export default (): Record<string, unknown> => {
      * Read more:
      * - [Plugins: `TrimRows`](@/api/trimRows.md)
      * - [Row trimming](@/guides/rows/row-trimming/row-trimming.md)
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @memberof Options#
      * @type {boolean|number[]}
@@ -6157,6 +6401,9 @@ export default (): Record<string, unknown> => {
      *
      * Read more:
      * - [Undo and redo](@/guides/accessories-and-menus/undo-redo/undo-redo.md)
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @memberof Options#
      * @type {boolean}
@@ -6363,6 +6610,9 @@ export default (): Record<string, unknown> => {
      * Read more:
      * - [Performance: Define the number of pre-rendered rows and columns](@/guides/optimization/performance/performance.md#define-the-number-of-pre-rendered-rows-and-columns)
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @memberof Options#
      * @type {number|'auto'}
      * @default 'auto'
@@ -6394,6 +6644,9 @@ export default (): Record<string, unknown> => {
      * - [Performance: Define the number of pre-rendered rows and columns](@/guides/optimization/performance/performance.md#define-the-number-of-pre-rendered-rows-and-columns)
      * - [Column virtualization](@/guides/columns/column-virtualization/column-virtualization.md)
      *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
+     *
      * @memberof Options#
      * @type {number|'auto'}
      * @default 'auto'
@@ -6424,6 +6677,9 @@ export default (): Record<string, unknown> => {
      * Read more:
      * - [Performance: Define the number of pre-rendered rows and columns](@/guides/optimization/performance/performance.md#define-the-number-of-pre-rendered-rows-and-columns)
      * - [Column virtualization](@/guides/columns/column-virtualization/column-virtualization.md)
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @memberof Options#
      * @since 1.14.7
@@ -6458,6 +6714,9 @@ export default (): Record<string, unknown> => {
      * Read more:
      * - [Performance: Define the number of pre-rendered rows and columns](@/guides/optimization/performance/performance.md#define-the-number-of-pre-rendered-rows-and-columns)
      * - [Row virtualization](@/guides/rows/row-virtualization/row-virtualization.md)
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @memberof Options#
      * @since 1.14.7
@@ -6639,6 +6898,9 @@ export default (): Record<string, unknown> => {
      *
      * This option is only respected when set in the table settings. It does not work when defined per column
      * or per cell (e.g. in `columns` or cell meta).
+     *
+     * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
+     * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
      *
      * @since 17.0.0
      * @memberof Options#


### PR DESCRIPTION
### Context

The PR documents which cascading level (grid, column, or cell) each configuration option applies to, addressing DEV-466. Before this change, only 20 of ~160 documented options carried a level annotation, so developers could not tell from the API reference whether a given option works when set per column or per cell.

There is no machine-readable source of option levels in the codebase — the metaManager prototype chain accepts almost any option at any level, and the effective level depends on whether the consuming code reads the option from cell/column meta or only from grid-level settings. Each option was audited by its read site: options read via `cellProperties`/`getCellMeta`/`getColumnMeta` cascade; options read only via `getSettings()`/`tableMeta` are grid-level only.

Following the chosen "exceptions + blanket rule" approach, only the real exceptions are annotated in the reference, and a blanket statement in the configuration-options guide covers the rest:

- Added a grid-level-only note to 88 options (plugin-enable flags and structural/layout/data/selection options).
- Added a column-level-only note to `title`.
- Removed the existing grid-level-only note on `disableVisualSelection` — it was incorrect, as the option is read per-cell via `getCellMeta` and therefore cascades.
- Added a blanket paragraph to the "Cascading configuration" section of the configuration-options guide stating that any option not marked otherwise can be set at any cascading level.

This is documentation-only (JSDoc comments and one guide paragraph) — no runtime behavior changes. The generated `docs/content/api/options.md` is gitignored and regenerated from the JSDoc.

### How has this been tested?

- `npm run eslint --prefix handsontable` on the modified `metaSchema.ts` — no issues.
- Rebuilt and regenerated the API reference to confirm the annotations render correctly:
  - `npm --prefix handsontable run build:commonjs`
  - `npm --prefix docs run docs:api`
- Verified rendered output: 97 grid-level-only public options plus the `title` column-only note render correctly; `disableVisualSelection` no longer shows a grid-only note.
- Ran a read-site negative test over the full grid-only set (including the pre-existing annotations) and a coverage scan of the unmarked options to confirm no grid-only option was left unannotated.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

Documentation-only change (JSDoc + guide).

### Related issue(s):

1. DEV-466

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation (this PR is that documentation change).

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-466

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> JSDoc and guide text only; no application logic or tests changed.
> 
> **Overview**
> Documents **which cascading level** each Handsontable configuration option applies to (grid, column, or cell), so the API reference matches how options are actually read at runtime.
> 
> **`metaSchema.ts` JSDoc:** Adds a standard **grid-level-only** note to dozens of options (plugins, layout, data, selection, etc.). **`title`** is documented as **columns-level only**. **`disableVisualSelection`** no longer claims grid-only—it cascades via cell meta.
> 
> **Configuration options guide:** Adds a **blanket rule** under cascading configuration: unless an option’s reference says otherwise, it can be set at any level; grid-only options have no effect per column/cell. Marks the guide with `menuTag: updated`.
> 
> Documentation-only; no runtime behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 157fa5d9a043fd3b9d8bfbc88de10aa16f039219. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->