### PR TITLE
DEV-1954: Improve pinned bottom rows scroll performance

### DIFF
--- a/.changelogs/12894.json
+++ b/.changelogs/12894.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Improved vertical scrolling performance for grids with pinned bottom rows (`fixedRowsBottom`).",
+  "type": "changed",
+  "issueOrPR": 12894,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/src/overlays.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlays.ts
@@ -953,6 +953,12 @@ class Overlays {
    */
   refresh(fastDraw = false) {
     const isScrollTriggered = this.verticalScrolling || this.horizontalScrolling;
+    // On a pure vertical scroll the bottom overlay (and its inline-start corner) render the same fixed
+    // rows over the same visible columns, so their DOM is unchanged - a full re-render is wasted work and
+    // forces an expensive style/layout/paint of the clone subtree on every scroll frame. Reposition them
+    // (fast draw) instead. Any horizontal scroll changes the visible columns, and a non-scroll redraw
+    // (data, settings, resize) clears both flags, so those paths still trigger a full re-render.
+    const bottomFastDraw = fastDraw || (this.verticalScrolling && !this.horizontalScrolling);
 
     if (isScrollTriggered) {
       this.#postponedAdjustElementsSize();
@@ -961,7 +967,7 @@ class Overlays {
     }
 
     if (this.bottomOverlay.clone) {
-      this.bottomOverlay.refresh(fastDraw);
+      this.bottomOverlay.refresh(bottomFastDraw);
     }
 
     this.inlineStartOverlay.refresh(fastDraw);
@@ -972,7 +978,7 @@ class Overlays {
     }
 
     if (this.bottomInlineStartCornerOverlay && this.bottomInlineStartCornerOverlay.clone) {
-      this.bottomInlineStartCornerOverlay.refresh(fastDraw);
+      this.bottomInlineStartCornerOverlay.refresh(bottomFastDraw);
     }
   }
 

--- a/handsontable/src/3rdparty/walkontable/test/spec/scroll/scroll.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/scroll/scroll.spec.js
@@ -875,6 +875,53 @@ describe('WalkontableScroll', () => {
       expect(lastRow.find('td:last').text()).toBe('K7');
     });
 
+    it('should keep the bottom overlay rows correct on vertical scroll and re-render its columns on ' +
+      'horizontal scroll', async() => {
+      // The bottom overlay fast-draws (repositions without re-rendering) on a pure vertical scroll, because
+      // its fixed rows over the same visible columns do not change. This guards that the optimization does
+      // not stale the overlay vertically, and that a horizontal scroll still refreshes its columns (the
+      // overlay's columns must always track the master's).
+      createDataArray(100, 100);
+      spec().$wrapper.width(245 + getScrollbarWidth()).height(186 + getScrollbarWidth());
+
+      const wt = walkontable({
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
+        fixedRowsBottom: 2,
+      });
+
+      wt.draw();
+
+      const stripRowNumber = text => text.replace(/\d+$/, '');
+      const bottomTable = () => $(wt.wtOverlays.bottomOverlay.clone.wtTable.TABLE);
+      const bottomFirstCells = () => bottomTable().find('tbody tr').toArray().map(tr => $(tr).find('td:first').text());
+      const columnsOf = $table => $table.find('tbody tr:first td').toArray().map(td => stripRowNumber(td.textContent));
+      const bottomColumns = () => columnsOf(bottomTable());
+      const masterColumns = () => columnsOf(getTableMaster());
+
+      // A real vertical scroll drives the fast-draw path for the bottom overlay.
+      wt.wtTable.holder.scrollTop = 400;
+      wt.draw();
+
+      await sleep(50);
+
+      // The bottom overlay still renders the two fixed bottom rows (the last rows of the data) ...
+      expect(bottomFirstCells().length).toBe(2);
+      expect(bottomFirstCells()[0]).toMatch(/99$/);
+      expect(bottomFirstCells()[1]).toMatch(/100$/);
+      // ... and its columns stay in sync with the master (not staled by the fast draw).
+      expect(bottomColumns()).toEqual(masterColumns());
+
+      // A horizontal scroll changes the visible columns, so the bottom overlay must re-render to match.
+      wt.wtTable.holder.scrollLeft = 400;
+      wt.draw();
+
+      await sleep(50);
+
+      expect(bottomColumns()).toEqual(masterColumns());
+    });
+
     it('should update the scroll position of overlays only once, when scrolling the master table', async() => {
       createDataArray(100, 100);
       spec().$wrapper.width(245 + getScrollbarWidth()).height(186 + getScrollbarWidth());


### PR DESCRIPTION
### Context

The PR improves vertical scroll performance for grids with pinned bottom rows (`fixedRowsBottom`).

Vertical scrolling was ~2× slower whenever `fixedRowsBottom` was set. Measured with a per-frame `requestAnimationFrame` timing harness at 100k rows × 100 columns: a grid with no fixed regions scrolls at ~27 ms/frame, but with `fixedRowsBottom: 2` it dropped to ~62 ms/frame (~20 fps). `fixedRowsTop` and `fixedColumnsStart` were free — only the bottom region regressed. This matches an external benchmark in which Handsontable's pinned-row scrolling fell from 29 to 22 FPS.

Root cause: a vertical scroll brings new rows into the main viewport, which forces the master table into a full draw. The full-draw path calls `wtOverlays.refresh(false)`, which re-renders **every** overlay clone — including the bottom overlay. But the bottom overlay shows fixed rows over the same visible columns, so on a pure vertical scroll its rendered output is identical; re-rendering it (and the resulting browser style/layout/paint of the clone subtree) on every frame is wasted work. The top overlay and header overlays are cheap; the bottom data-row overlay is not.

Fix: in `overlays.ts` `refresh()`, on a pure vertical scroll (`verticalScrolling && !horizontalScrolling`) the bottom overlay and its inline-start corner are fast-drawn (repositioned, not re-rendered). Any horizontal/diagonal scroll changes the visible columns, and a non-scroll redraw (data, settings, resize) clears both scroll flags, so those paths still trigger a full re-render. The engine already tracks scroll direction, so no new state was added.

Result: bottom-mode frame time dropped from ~62 ms to ~24 ms — back in line with the no-fixed-rows baseline.

### How has this been tested?

- New regression test in `src/3rdparty/walkontable/test/spec/scroll/scroll.spec.js`: with `fixedRowsBottom`, a vertical scroll keeps the bottom overlay showing the correct last rows and its columns in sync with the master; a horizontal scroll re-renders its columns. Runs under both LTR and RTL.
- `npm run test:walkontable --prefix handsontable` — 728 specs, 0 failures.
- Verified in a real browser (Chrome) that the bottom overlay reached via the fast-draw path is byte-identical to a forced full draw at the same scroll offset (position, cell content, and row heights), across three configurations: uniform row heights, an oversized bottom-pinned row, and `autoColumnSize` + `wordWrap` + `autoRowSize`.
- `npm run eslint --prefix handsontable` — clean.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1954

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1954

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core overlay refresh timing during scroll; incorrect fast-draw could desync pinned bottom rows/columns, though horizontal and full-draw paths are preserved and a new test guards the behavior.
> 
> **Overview**
> Improves **vertical scroll performance** when **`fixedRowsBottom`** is set by avoiding full re-renders of the bottom pinned overlay on every scroll frame.
> 
> In Walkontable **`Overlays#refresh()`**, when scroll is **vertical only** (`verticalScrolling && !horizontalScrolling`), the **bottom overlay** and **bottom inline-start corner** now use **fast draw** (reposition without re-rendering cell DOM). Horizontal scroll or non-scroll redraws still force a full refresh so visible columns stay aligned with the master table.
> 
> Adds a **changelog** entry and a **scroll spec** that checks pinned bottom rows and column sync after vertical scroll, and column refresh after horizontal scroll (LTR/RTL via existing suite).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2b43ee95a7e682c8f59c4bf6829096cd3f7189d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->