### PR TITLE
DEV-1959: Evict React portal container cache on viewport exit

### DIFF
--- a/.changelogs/12895.json
+++ b/.changelogs/12895.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a memory leak in the React wrapper where the portal containers used by component-based renderers were retained for every scrolled cell instead of being released once a cell left the viewport.",
+  "type": "fixed",
+  "issueOrPR": 12895,
+  "breaking": false,
+  "framework": "react"
+}

--- a/wrappers/react-wrapper/src/hotTableContext.tsx
+++ b/wrappers/react-wrapper/src/hotTableContext.tsx
@@ -61,6 +61,15 @@ export interface HotTableContextImpl {
   readonly clearRenderedCellCache: () => void;
 
   /**
+   * Returns the number of portal containers currently retained by the cache.
+   * Diagnostic hook used to assert the cache stays bounded to the viewport
+   * (it must not grow with the total scrolled row/column count).
+   *
+   * @returns {number} The portal container cache size.
+   */
+  readonly getPortalContainerCacheSize: () => number;
+
+  /**
    * Set the renderers portal manager dispatch function.
    *
    * @param {RenderersPortalManagerRef} pm The PortalManager dispatch function.
@@ -90,8 +99,16 @@ const HotTableContextProvider: FC<PropsWithChildren> = ({ children }) => {
   const renderedCellCache = useRef<Map<string, HTMLTableCellElement>>(new Map());
   const clearRenderedCellCache = useCallback(() => renderedCellCache.current.clear(), []);
   const portalCache = useRef<Map<string, ReactPortal>>(new Map());
-  const clearPortalCache = useCallback(() => portalCache.current.clear(), []);
   const portalContainerCache = useRef<Map<string, HTMLElement>>(new Map());
+  // Keys of the portal containers rendered in the current view-render pass.
+  // Reset every `beforeViewRender` and used after the render to evict
+  // containers whose cells left the viewport (see pushCellPortalsIntoPortalManager).
+  const renderedPortalContainerKeys = useRef<Set<string>>(new Set());
+  const clearPortalCache = useCallback(() => {
+    portalCache.current.clear();
+    renderedPortalContainerKeys.current.clear();
+  }, []);
+  const getPortalContainerCacheSize = useCallback(() => portalContainerCache.current.size, []);
 
   const getRendererWrapper = useCallback((Renderer: ComponentType<HotRendererProps>): typeof Handsontable.renderers.BaseRenderer => {
     return function __internalRenderer(instance, TD, row, col, prop, value, cellProperties) {
@@ -134,6 +151,7 @@ const HotTableContextProvider: FC<PropsWithChildren> = ({ children }) => {
         }
 
         portalContainerCache.current.set(portalContainerKey, portalContainer);
+        renderedPortalContainerKeys.current.add(portalContainerKey);
         portalCache.current.set(portalKey, portal);
       }
 
@@ -149,6 +167,20 @@ const HotTableContextProvider: FC<PropsWithChildren> = ({ children }) => {
   }, []);
 
   const pushCellPortalsIntoPortalManager = useCallback(() => {
+    // Evict portal containers whose cells were not rendered in this pass (e.g.
+    // scrolled out of the viewport). Their container DIVs are already detached
+    // from the DOM, so without this they would be retained forever, leaking
+    // O(rows × cols) detached nodes for component-based renderers. Containers
+    // still in the viewport stay cached, preserving the in-place reuse that
+    // avoids remounting renderer components on every grid render (#10800).
+    const liveKeys = renderedPortalContainerKeys.current;
+
+    portalContainerCache.current.forEach((_, cacheKey) => {
+      if (!liveKeys.has(cacheKey)) {
+        portalContainerCache.current.delete(cacheKey);
+      }
+    });
+
     renderersPortalManager.current!([...portalCache.current.values()]);
   }, []);
 
@@ -160,9 +192,10 @@ const HotTableContextProvider: FC<PropsWithChildren> = ({ children }) => {
     getRendererWrapper,
     clearPortalCache,
     clearRenderedCellCache,
+    getPortalContainerCacheSize,
     setRenderersPortalManagerRef,
     pushCellPortalsIntoPortalManager
-  }), [setHotColumnSettings, trimColumnSettings, getRendererWrapper, clearRenderedCellCache, setRenderersPortalManagerRef, pushCellPortalsIntoPortalManager]);
+  }), [setHotColumnSettings, trimColumnSettings, getRendererWrapper, clearRenderedCellCache, getPortalContainerCacheSize, setRenderersPortalManagerRef, pushCellPortalsIntoPortalManager]);
 
   return (
     <HotTableContext.Provider value={contextImpl}>{children}</HotTableContext.Provider>

--- a/wrappers/react-wrapper/test/portalContainerCache.spec.tsx
+++ b/wrappers/react-wrapper/test/portalContainerCache.spec.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import { act } from '@testing-library/react';
+import { HotTable } from '../src/hotTable';
+import { useHotTableContext } from '../src/hotTableContext';
+import {
+  createSpreadsheetData,
+  mockElementDimensions,
+  mountComponentWithRef,
+  sleep,
+} from './_helpers';
+import { HotRendererProps, HotTableRef } from '../src/types';
+
+// Regression tests for the portal-container cache leak (PLAN A4): the wrapper
+// kept one detached container DIV per (row, col) ever rendered with a
+// component-based renderer and never evicted them, so scrolling grew retained
+// DOM as O(rows × cols). The cache must stay bounded to the viewport.
+describe('Portal container cache eviction', () => {
+  const VISIBLE_ROWS = Math.ceil(300 / 23); // height / rowHeights ≈ 14 visible rows
+  const COLS = 3;
+
+  it('should keep the portal container cache bounded to the viewport while scrolling a tall grid', async () => {
+    let capturedContext: ReturnType<typeof useHotTableContext> | undefined;
+
+    function Cell(props: HotRendererProps) {
+      // A renderer component renders inside the context provider, so it can
+      // read the diagnostic cache size.
+      capturedContext = useHotTableContext();
+
+      return <span>{String(props.value)}</span>;
+    }
+
+    const ROWS = 1000;
+
+    const hotInstance = mountComponentWithRef<HotTableRef>((
+      <HotTable licenseKey="non-commercial-and-evaluation"
+                id="test-hot"
+                data={createSpreadsheetData(ROWS, COLS)}
+                width={300}
+                height={300}
+                rowHeights={23}
+                colWidths={50}
+                autoRowSize={false}
+                autoColumnSize={false}
+                init={function () {
+                  mockElementDimensions(this.rootElement, 300, 300);
+                }}
+                renderer={(props) => <Cell {...props} />}
+      />
+    ), false).hotInstance!;
+
+    await sleep(100);
+
+    // Scroll the full height of the dataset in viewport-sized steps.
+    for (let row = 0; row < ROWS; row += VISIBLE_ROWS) {
+      await act(async () => {
+        hotInstance.scrollViewportTo({ row: Math.min(row, ROWS - 1), col: 0 });
+        hotInstance.render();
+      });
+      await sleep(10);
+    }
+
+    await sleep(50);
+
+    const cacheSize = capturedContext!.getPortalContainerCacheSize();
+
+    // Bounded to a few viewports' worth of cells (visible rows + overscan × cols),
+    // NOT O(rows × cols). Measured: 39 with eviction vs 2781 without, for this
+    // 1000 × 3 grid scrolled top-to-bottom.
+    const viewportCells = (VISIBLE_ROWS + 4) * COLS;
+
+    expect(cacheSize).toBeGreaterThan(0);
+    expect(cacheSize).toBeLessThanOrEqual(viewportCells);
+    expect(cacheSize).toBeLessThan(ROWS * COLS);
+  });
+
+  it('should evict the container of a cell that scrolled out of the viewport (remounts on return)', async () => {
+    let nextSeed = 0;
+    const seeds = new Map<string, number>();
+
+    function SeededCell(props: HotRendererProps) {
+      // useState initialiser runs once per mount. A fresh seed on return proves
+      // the previous container was evicted (not reused from the cache).
+      const [seed] = React.useState(() => {
+        nextSeed += 1;
+        return nextSeed;
+      });
+
+      seeds.set(`${props.row}-${props.col}`, seed);
+
+      return <span data-cell={`${props.row}-${props.col}`} data-seed={seed}>{String(props.value)}</span>;
+    }
+
+    const ROWS = 1000;
+
+    const hotInstance = mountComponentWithRef<HotTableRef>((
+      <HotTable licenseKey="non-commercial-and-evaluation"
+                id="test-hot"
+                data={createSpreadsheetData(ROWS, COLS)}
+                width={300}
+                height={300}
+                rowHeights={23}
+                colWidths={50}
+                autoRowSize={false}
+                autoColumnSize={false}
+                init={function () {
+                  mockElementDimensions(this.rootElement, 300, 300);
+                }}
+                renderer={(props) => <SeededCell {...props} />}
+      />
+    ), false).hotInstance!;
+
+    await sleep(100);
+
+    const seedBefore = seeds.get('0-0');
+
+    expect(seedBefore).toBeGreaterThan(0);
+
+    // Scroll far past cell (0, 0) so its container leaves the viewport...
+    await act(async () => {
+      hotInstance.scrollViewportTo({ row: ROWS - 1, col: 0 });
+      hotInstance.render();
+    });
+    await sleep(50);
+
+    // ...then back to the top.
+    await act(async () => {
+      hotInstance.scrollViewportTo({ row: 0, col: 0 });
+      hotInstance.render();
+    });
+    await sleep(50);
+
+    const seedAfter = seeds.get('0-0');
+
+    // The component remounted with a fresh seed because its container was
+    // evicted on scroll-out. (The cached value would be identical without eviction.)
+    expect(seedAfter).toBeGreaterThan(seedBefore!);
+  });
+});


### PR DESCRIPTION
### Context

The PR fixes a memory leak in the React wrapper's portal-container cache for component-based renderers.

`portalContainerCache` in `wrappers/react-wrapper/src/hotTableContext.tsx` was written on every cell render (one detached container `<div>` per `(row, col)`) but never evicted. Scrolling a large grid with a component renderer therefore grew retained (detached) DOM as O(rows × cols), so heap usage rose with scroll distance and never came back down. The cache could not simply be cleared each frame because cross-frame reuse of in-viewport containers is what prevents renderer components from remounting on every grid render (#10800).

The fix tracks the portal-container keys rendered in each `beforeViewRender` → `afterViewRender` pass in a per-frame `Set`, then (in `pushCellPortalsIntoPortalManager`, on `afterViewRender`) evicts any cached container that was not rendered in this pass — i.e. cells that scrolled out of the viewport. Containers still in the viewport stay cached, so the #10800 in-place reuse is preserved.

This is safe by construction: the only writer of the cache is `cellRenderer`, which runs only on the full-draw branch that also fires the `beforeViewRender`/`afterViewRender` bracket. The fast-draw (scroll) path repositions overlays without calling the cell renderer, so there is no code path that writes the cache without the prune running.

This is item A4 of the rendering/memory performance initiative (the React wrapper half of the cache-retention family addressed by DEV-1940/1942/1945).

**Measured** (jsdom, 1000 × 3 grid scrolled top → bottom): retained portal containers **2781 → 39** (= viewport, −98.6%).

**Behavior note:** component-renderer local state (`useState`) is no longer retained when a cell scrolls out of the viewport and back — the component remounts fresh (previously the leak happened to preserve it). This is not a breaking change: no default setting, public API, CSS class, or hook changes, and renderer components are not a documented state-persistence surface.

### How has this been tested?

- New `wrappers/react-wrapper/test/portalContainerCache.spec.tsx`:
  - bounded-retention measurement — after scrolling a 1000 × 3 grid top to bottom, the container cache stays viewport-bounded (39) instead of growing to ~3000;
  - scroll-out eviction — a renderer component remounts (fresh seed) after its cell scrolls out and back.
- Full React wrapper suite (includes the #10800 reuse regression tests):

```bash
npm run test --prefix wrappers/react-wrapper
```

  → 75/75 suites pass.
- TypeScript: `npx tsc --noEmit -p wrappers/react-wrapper/tsconfig.json` — clean (only pre-existing config-deprecation warnings).

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1959

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [x] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1959

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hot-path renderer/portal lifecycle in the React wrapper; behavior change means renderer local state is lost when cells scroll out and back (intended tradeoff for the leak fix).
> 
> **Overview**
> Fixes a **memory leak** in `@handsontable/react-wrapper` where `portalContainerCache` kept one detached portal container per cell ever drawn with a component renderer, so scrolling large grids grew retained DOM without bound.
> 
> Each view-render pass now records which portal-container keys were actually rendered; when `pushCellPortalsIntoPortalManager` runs (after render), entries **not** in that set are removed from the cache. Containers still in the viewport stay cached so in-place reuse and avoidance of per-frame remounts (#10800) is unchanged.
> 
> `clearPortalCache` also clears the per-pass key set. **`getPortalContainerCacheSize`** is exposed on context for tests/diagnostics. Regression coverage asserts viewport-bounded cache size after full scroll and remount after scroll-out/scroll-back. Changelog entry for the React framework fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3a0f19c8915412917dc5025dde7a62b4980a806. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->