### PR TITLE
DEV-626: Improve nestedRows guide demo

### DIFF
--- a/docs/content/guides/rows/row-parent-child/angular/example1.ts
+++ b/docs/content/guides/rows/row-parent-child/angular/example1.ts
@@ -1,5 +1,6 @@
 /* file: app.component.ts */
 import { Component } from '@angular/core';
+import Handsontable from 'handsontable';
 import { GridSettings, HotTableModule} from '@handsontable/angular-wrapper';
 
 @Component({
@@ -22,29 +23,45 @@ export class AppComponent {
       label: null,
       __children: [
         {
-          title: "Don't Wanna Fight",
-          artist: 'Alabama Shakes',
-          label: 'ATO Records',
+          category: 'Major label releases',
+          artist: null,
+          title: null,
+          label: null,
+          __children: [
+            {
+              title: "Don't Wanna Fight",
+              artist: 'Alabama Shakes',
+              label: 'ATO Records',
+            },
+            {
+              title: 'What Kind Of Man',
+              artist: 'Florence & The Machine',
+              label: 'Republic',
+            },
+            {
+              title: 'Something From Nothing',
+              artist: 'Foo Fighters',
+              label: 'RCA Records',
+            },
+          ],
         },
         {
-          title: 'What Kind Of Man',
-          artist: 'Florence & The Machine',
-          label: 'Republic',
-        },
-        {
-          title: 'Something From Nothing',
-          artist: 'Foo Fighters',
-          label: 'RCA Records',
-        },
-        {
-          title: "Ex's & Oh's",
-          artist: 'Elle King',
-          label: 'RCA Records',
-        },
-        {
-          title: 'Moaning Lisa Smile',
-          artist: 'Wolf Alice',
-          label: 'RCA Records/Dirty Hit',
+          category: 'Independent releases',
+          artist: null,
+          title: null,
+          label: null,
+          __children: [
+            {
+              title: 'Moaning Lisa Smile',
+              artist: 'Wolf Alice',
+              label: 'RCA Records/Dirty Hit',
+            },
+            {
+              title: "Ex's & Oh's",
+              artist: 'Elle King',
+              label: 'RCA Records',
+            },
+          ],
         },
       ],
     },
@@ -150,6 +167,9 @@ export class AppComponent {
     autoWrapRow: true,
     autoWrapCol: true,
     height: 'auto',
+    afterInit(this: Handsontable) {
+      this.getPlugin('nestedRows').collapsingUI.collapseChildren(8);
+    },
   };
 }
 /* end-file */

--- a/docs/content/guides/rows/row-parent-child/angular/example1.ts
+++ b/docs/content/guides/rows/row-parent-child/angular/example1.ts
@@ -168,7 +168,7 @@ export class AppComponent {
     autoWrapCol: true,
     height: 'auto',
     afterInit(this: Handsontable) {
-      this.getPlugin('nestedRows').collapsingUI.collapseChildren(8);
+      this.getPlugin('nestedRows').collapsingUI?.collapseChildren(8);
     },
   };
 }

--- a/docs/content/guides/rows/row-parent-child/javascript/example1.js
+++ b/docs/content/guides/rows/row-parent-child/javascript/example1.js
@@ -1,147 +1,163 @@
 import Handsontable from 'handsontable/base';
 import { registerAllModules } from 'handsontable/registry';
-
 // Register all Handsontable's modules.
 registerAllModules();
-
 const sourceDataObject = [
-  {
-    category: 'Best Rock Performance',
-    artist: null,
-    title: null,
-    label: null,
-    __children: [
-      {
-        title: "Don't Wanna Fight",
-        artist: 'Alabama Shakes',
-        label: 'ATO Records',
-      },
-      {
-        title: 'What Kind Of Man',
-        artist: 'Florence & The Machine',
-        label: 'Republic',
-      },
-      {
-        title: 'Something From Nothing',
-        artist: 'Foo Fighters',
-        label: 'RCA Records',
-      },
-      {
-        title: "Ex's & Oh's",
-        artist: 'Elle King',
-        label: 'RCA Records',
-      },
-      {
-        title: 'Moaning Lisa Smile',
-        artist: 'Wolf Alice',
-        label: 'RCA Records/Dirty Hit',
-      },
-    ],
-  },
-  {
-    category: 'Best Metal Performance',
-    __children: [
-      {
-        title: 'Cirice',
-        artist: 'Ghost',
-        label: 'Loma Vista Recordings',
-      },
-      {
-        title: 'Identity',
-        artist: 'August Burns Red',
-        label: 'Fearless Records',
-      },
-      {
-        title: '512',
-        artist: 'Lamb Of God',
-        label: 'Epic Records',
-      },
-      {
-        title: 'Thank You',
-        artist: 'Sevendust',
-        label: '7Bros Records',
-      },
-      {
-        title: 'Custer',
-        artist: 'Slipknot',
-        label: 'Roadrunner Records',
-      },
-    ],
-  },
-  {
-    category: 'Best Rock Song',
-    __children: [
-      {
-        title: "Don't Wanna Fight",
-        artist: 'Alabama Shakes',
-        label: 'ATO Records',
-      },
-      {
-        title: "Ex's & Oh's",
-        artist: 'Elle King',
-        label: 'RCA Records',
-      },
-      {
-        title: 'Hold Back The River',
-        artist: 'James Bay',
-        label: 'Republic',
-      },
-      {
-        title: 'Lydia',
-        artist: 'Highly Suspect',
-        label: '300 Entertainment',
-      },
-      {
-        title: 'What Kind Of Man',
-        artist: 'Florence & The Machine',
-        label: 'Republic',
-      },
-    ],
-  },
-  {
-    category: 'Best Rock Album',
-    __children: [
-      {
-        title: 'Drones',
-        artist: 'Muse',
-        label: 'Warner Bros. Records',
-      },
-      {
-        title: 'Chaos And The Calm',
-        artist: 'James Bay',
-        label: 'Republic',
-      },
-      {
-        title: 'Kintsugi',
-        artist: 'Death Cab For Cutie',
-        label: 'Atlantic',
-      },
-      {
-        title: 'Mister Asylum',
-        artist: 'Highly Suspect',
-        label: '300 Entertainment',
-      },
-      {
-        title: '.5: The Gray Chapter',
-        artist: 'Slipknot',
-        label: 'Roadrunner Records',
-      },
-    ],
-  },
+    {
+        category: 'Best Rock Performance',
+        artist: null,
+        title: null,
+        label: null,
+        __children: [
+            {
+                category: 'Major label releases',
+                artist: null,
+                title: null,
+                label: null,
+                __children: [
+                    {
+                        title: "Don't Wanna Fight",
+                        artist: 'Alabama Shakes',
+                        label: 'ATO Records',
+                    },
+                    {
+                        title: 'What Kind Of Man',
+                        artist: 'Florence & The Machine',
+                        label: 'Republic',
+                    },
+                    {
+                        title: 'Something From Nothing',
+                        artist: 'Foo Fighters',
+                        label: 'RCA Records',
+                    },
+                ],
+            },
+            {
+                category: 'Independent releases',
+                artist: null,
+                title: null,
+                label: null,
+                __children: [
+                    {
+                        title: 'Moaning Lisa Smile',
+                        artist: 'Wolf Alice',
+                        label: 'RCA Records/Dirty Hit',
+                    },
+                    {
+                        title: "Ex's & Oh's",
+                        artist: 'Elle King',
+                        label: 'RCA Records',
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        category: 'Best Metal Performance',
+        __children: [
+            {
+                title: 'Cirice',
+                artist: 'Ghost',
+                label: 'Loma Vista Recordings',
+            },
+            {
+                title: 'Identity',
+                artist: 'August Burns Red',
+                label: 'Fearless Records',
+            },
+            {
+                title: '512',
+                artist: 'Lamb Of God',
+                label: 'Epic Records',
+            },
+            {
+                title: 'Thank You',
+                artist: 'Sevendust',
+                label: '7Bros Records',
+            },
+            {
+                title: 'Custer',
+                artist: 'Slipknot',
+                label: 'Roadrunner Records',
+            },
+        ],
+    },
+    {
+        category: 'Best Rock Song',
+        __children: [
+            {
+                title: "Don't Wanna Fight",
+                artist: 'Alabama Shakes',
+                label: 'ATO Records',
+            },
+            {
+                title: "Ex's & Oh's",
+                artist: 'Elle King',
+                label: 'RCA Records',
+            },
+            {
+                title: 'Hold Back The River',
+                artist: 'James Bay',
+                label: 'Republic',
+            },
+            {
+                title: 'Lydia',
+                artist: 'Highly Suspect',
+                label: '300 Entertainment',
+            },
+            {
+                title: 'What Kind Of Man',
+                artist: 'Florence & The Machine',
+                label: 'Republic',
+            },
+        ],
+    },
+    {
+        category: 'Best Rock Album',
+        __children: [
+            {
+                title: 'Drones',
+                artist: 'Muse',
+                label: 'Warner Bros. Records',
+            },
+            {
+                title: 'Chaos And The Calm',
+                artist: 'James Bay',
+                label: 'Republic',
+            },
+            {
+                title: 'Kintsugi',
+                artist: 'Death Cab For Cutie',
+                label: 'Atlantic',
+            },
+            {
+                title: 'Mister Asylum',
+                artist: 'Highly Suspect',
+                label: '300 Entertainment',
+            },
+            {
+                title: '.5: The Gray Chapter',
+                artist: 'Slipknot',
+                label: 'Roadrunner Records',
+            },
+        ],
+    },
 ];
-
 const container = document.querySelector('#example1');
-
 new Handsontable(container, {
-  data: sourceDataObject,
-  preventOverflow: 'horizontal',
-  rowHeaders: true,
-  colHeaders: ['Category', 'Artist', 'Title', 'Album', 'Label'],
-  nestedRows: true,
-  contextMenu: true,
-  bindRowsWithHeaders: true,
-  autoWrapRow: true,
-  autoWrapCol: true,
-  height: 'auto',
-  licenseKey: 'non-commercial-and-evaluation',
+    data: sourceDataObject,
+    preventOverflow: 'horizontal',
+    rowHeaders: true,
+    colHeaders: ['Category', 'Artist', 'Title', 'Album', 'Label'],
+    nestedRows: true,
+    contextMenu: true,
+    bindRowsWithHeaders: true,
+    autoWrapRow: true,
+    autoWrapCol: true,
+    height: 'auto',
+    licenseKey: 'non-commercial-and-evaluation',
+    // Collapse "Best Metal Performance" on load to demonstrate expand/collapse controls.
+    afterInit() {
+        this.getPlugin('nestedRows').collapsingUI.collapseChildren(8);
+    },
 });

--- a/docs/content/guides/rows/row-parent-child/javascript/example1.ts
+++ b/docs/content/guides/rows/row-parent-child/javascript/example1.ts
@@ -4,21 +4,15 @@ import { registerAllModules } from 'handsontable/registry';
 // Register all Handsontable's modules.
 registerAllModules();
 
-interface Album {
-  title: string;
-  artist: string;
-  label: string;
-}
-
-interface MusicAward {
-  category: string;
+interface MusicRow {
+  category?: string;
   artist?: string | null;
   title?: string | null;
   label?: string | null;
-  __children: Album[];
+  __children?: MusicRow[];
 }
 
-const sourceDataObject: MusicAward[] = [
+const sourceDataObject: MusicRow[] = [
   {
     category: 'Best Rock Performance',
     artist: null,
@@ -26,29 +20,45 @@ const sourceDataObject: MusicAward[] = [
     label: null,
     __children: [
       {
-        title: "Don't Wanna Fight",
-        artist: 'Alabama Shakes',
-        label: 'ATO Records',
+        category: 'Major label releases',
+        artist: null,
+        title: null,
+        label: null,
+        __children: [
+          {
+            title: "Don't Wanna Fight",
+            artist: 'Alabama Shakes',
+            label: 'ATO Records',
+          },
+          {
+            title: 'What Kind Of Man',
+            artist: 'Florence & The Machine',
+            label: 'Republic',
+          },
+          {
+            title: 'Something From Nothing',
+            artist: 'Foo Fighters',
+            label: 'RCA Records',
+          },
+        ],
       },
       {
-        title: 'What Kind Of Man',
-        artist: 'Florence & The Machine',
-        label: 'Republic',
-      },
-      {
-        title: 'Something From Nothing',
-        artist: 'Foo Fighters',
-        label: 'RCA Records',
-      },
-      {
-        title: "Ex's & Oh's",
-        artist: 'Elle King',
-        label: 'RCA Records',
-      },
-      {
-        title: 'Moaning Lisa Smile',
-        artist: 'Wolf Alice',
-        label: 'RCA Records/Dirty Hit',
+        category: 'Independent releases',
+        artist: null,
+        title: null,
+        label: null,
+        __children: [
+          {
+            title: 'Moaning Lisa Smile',
+            artist: 'Wolf Alice',
+            label: 'RCA Records/Dirty Hit',
+          },
+          {
+            title: "Ex's & Oh's",
+            artist: 'Elle King',
+            label: 'RCA Records',
+          },
+        ],
       },
     ],
   },
@@ -158,4 +168,8 @@ new Handsontable(container, {
   autoWrapCol: true,
   height: 'auto',
   licenseKey: 'non-commercial-and-evaluation',
+  // Collapse "Best Metal Performance" on load to demonstrate expand/collapse controls.
+  afterInit() {
+    this.getPlugin('nestedRows').collapsingUI.collapseChildren(8);
+  },
 });

--- a/docs/content/guides/rows/row-parent-child/react/example1.jsx
+++ b/docs/content/guides/rows/row-parent-child/react/example1.jsx
@@ -4,133 +4,149 @@ import { registerAllModules } from 'handsontable/registry';
 // register Handsontable's modules
 registerAllModules();
 
-const ExampleComponent = () => {
-  const sourceDataObject = [
-    {
-      category: 'Best Rock Performance',
-      artist: null,
-      title: null,
-      label: null,
-      __children: [
-        {
-          title: "Don't Wanna Fight",
-          artist: 'Alabama Shakes',
-          label: 'ATO Records',
-        },
-        {
-          title: 'What Kind Of Man',
-          artist: 'Florence & The Machine',
-          label: 'Republic',
-        },
-        {
-          title: 'Something From Nothing',
-          artist: 'Foo Fighters',
-          label: 'RCA Records',
-        },
-        {
-          title: "Ex's & Oh's",
-          artist: 'Elle King',
-          label: 'RCA Records',
-        },
-        {
-          title: 'Moaning Lisa Smile',
-          artist: 'Wolf Alice',
-          label: 'RCA Records/Dirty Hit',
-        },
-      ],
-    },
-    {
-      category: 'Best Metal Performance',
-      __children: [
-        {
-          title: 'Cirice',
-          artist: 'Ghost',
-          label: 'Loma Vista Recordings',
-        },
-        {
-          title: 'Identity',
-          artist: 'August Burns Red',
-          label: 'Fearless Records',
-        },
-        {
-          title: '512',
-          artist: 'Lamb Of God',
-          label: 'Epic Records',
-        },
-        {
-          title: 'Thank You',
-          artist: 'Sevendust',
-          label: '7Bros Records',
-        },
-        {
-          title: 'Custer',
-          artist: 'Slipknot',
-          label: 'Roadrunner Records',
-        },
-      ],
-    },
-    {
-      category: 'Best Rock Song',
-      __children: [
-        {
-          title: "Don't Wanna Fight",
-          artist: 'Alabama Shakes',
-          label: 'ATO Records',
-        },
-        {
-          title: "Ex's & Oh's",
-          artist: 'Elle King',
-          label: 'RCA Records',
-        },
-        {
-          title: 'Hold Back The River',
-          artist: 'James Bay',
-          label: 'Republic',
-        },
-        {
-          title: 'Lydia',
-          artist: 'Highly Suspect',
-          label: '300 Entertainment',
-        },
-        {
-          title: 'What Kind Of Man',
-          artist: 'Florence & The Machine',
-          label: 'Republic',
-        },
-      ],
-    },
-    {
-      category: 'Best Rock Album',
-      __children: [
-        {
-          title: 'Drones',
-          artist: 'Muse',
-          label: 'Warner Bros. Records',
-        },
-        {
-          title: 'Chaos And The Calm',
-          artist: 'James Bay',
-          label: 'Republic',
-        },
-        {
-          title: 'Kintsugi',
-          artist: 'Death Cab For Cutie',
-          label: 'Atlantic',
-        },
-        {
-          title: 'Mister Asylum',
-          artist: 'Highly Suspect',
-          label: '300 Entertainment',
-        },
-        {
-          title: '.5: The Gray Chapter',
-          artist: 'Slipknot',
-          label: 'Roadrunner Records',
-        },
-      ],
-    },
-  ];
+const sourceDataObject = [
+  {
+    category: 'Best Rock Performance',
+    artist: null,
+    title: null,
+    label: null,
+    __children: [
+      {
+        category: 'Major label releases',
+        artist: null,
+        title: null,
+        label: null,
+        __children: [
+          {
+            title: "Don't Wanna Fight",
+            artist: 'Alabama Shakes',
+            label: 'ATO Records',
+          },
+          {
+            title: 'What Kind Of Man',
+            artist: 'Florence & The Machine',
+            label: 'Republic',
+          },
+          {
+            title: 'Something From Nothing',
+            artist: 'Foo Fighters',
+            label: 'RCA Records',
+          },
+        ],
+      },
+      {
+        category: 'Independent releases',
+        artist: null,
+        title: null,
+        label: null,
+        __children: [
+          {
+            title: 'Moaning Lisa Smile',
+            artist: 'Wolf Alice',
+            label: 'RCA Records/Dirty Hit',
+          },
+          {
+            title: "Ex's & Oh's",
+            artist: 'Elle King',
+            label: 'RCA Records',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    category: 'Best Metal Performance',
+    __children: [
+      {
+        title: 'Cirice',
+        artist: 'Ghost',
+        label: 'Loma Vista Recordings',
+      },
+      {
+        title: 'Identity',
+        artist: 'August Burns Red',
+        label: 'Fearless Records',
+      },
+      {
+        title: '512',
+        artist: 'Lamb Of God',
+        label: 'Epic Records',
+      },
+      {
+        title: 'Thank You',
+        artist: 'Sevendust',
+        label: '7Bros Records',
+      },
+      {
+        title: 'Custer',
+        artist: 'Slipknot',
+        label: 'Roadrunner Records',
+      },
+    ],
+  },
+  {
+    category: 'Best Rock Song',
+    __children: [
+      {
+        title: "Don't Wanna Fight",
+        artist: 'Alabama Shakes',
+        label: 'ATO Records',
+      },
+      {
+        title: "Ex's & Oh's",
+        artist: 'Elle King',
+        label: 'RCA Records',
+      },
+      {
+        title: 'Hold Back The River',
+        artist: 'James Bay',
+        label: 'Republic',
+      },
+      {
+        title: 'Lydia',
+        artist: 'Highly Suspect',
+        label: '300 Entertainment',
+      },
+      {
+        title: 'What Kind Of Man',
+        artist: 'Florence & The Machine',
+        label: 'Republic',
+      },
+    ],
+  },
+  {
+    category: 'Best Rock Album',
+    __children: [
+      {
+        title: 'Drones',
+        artist: 'Muse',
+        label: 'Warner Bros. Records',
+      },
+      {
+        title: 'Chaos And The Calm',
+        artist: 'James Bay',
+        label: 'Republic',
+      },
+      {
+        title: 'Kintsugi',
+        artist: 'Death Cab For Cutie',
+        label: 'Atlantic',
+      },
+      {
+        title: 'Mister Asylum',
+        artist: 'Highly Suspect',
+        label: '300 Entertainment',
+      },
+      {
+        title: '.5: The Gray Chapter',
+        artist: 'Slipknot',
+        label: 'Roadrunner Records',
+      },
+    ],
+  },
+];
 
+const ExampleComponent = () => {
   return (
     <HotTable
       data={sourceDataObject}
@@ -144,6 +160,9 @@ const ExampleComponent = () => {
       autoWrapCol={true}
       height="auto"
       licenseKey="non-commercial-and-evaluation"
+      afterInit={function () {
+        this.getPlugin('nestedRows').collapsingUI.collapseChildren(8);
+      }}
     />
   );
 };

--- a/docs/content/guides/rows/row-parent-child/react/example1.tsx
+++ b/docs/content/guides/rows/row-parent-child/react/example1.tsx
@@ -1,136 +1,153 @@
 import { HotTable } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
+import type Handsontable from 'handsontable/base';
 
 // register Handsontable's modules
 registerAllModules();
 
-const ExampleComponent = () => {
-  const sourceDataObject = [
-    {
-      category: 'Best Rock Performance',
-      artist: null,
-      title: null,
-      label: null,
-      __children: [
-        {
-          title: "Don't Wanna Fight",
-          artist: 'Alabama Shakes',
-          label: 'ATO Records',
-        },
-        {
-          title: 'What Kind Of Man',
-          artist: 'Florence & The Machine',
-          label: 'Republic',
-        },
-        {
-          title: 'Something From Nothing',
-          artist: 'Foo Fighters',
-          label: 'RCA Records',
-        },
-        {
-          title: "Ex's & Oh's",
-          artist: 'Elle King',
-          label: 'RCA Records',
-        },
-        {
-          title: 'Moaning Lisa Smile',
-          artist: 'Wolf Alice',
-          label: 'RCA Records/Dirty Hit',
-        },
-      ],
-    },
-    {
-      category: 'Best Metal Performance',
-      __children: [
-        {
-          title: 'Cirice',
-          artist: 'Ghost',
-          label: 'Loma Vista Recordings',
-        },
-        {
-          title: 'Identity',
-          artist: 'August Burns Red',
-          label: 'Fearless Records',
-        },
-        {
-          title: '512',
-          artist: 'Lamb Of God',
-          label: 'Epic Records',
-        },
-        {
-          title: 'Thank You',
-          artist: 'Sevendust',
-          label: '7Bros Records',
-        },
-        {
-          title: 'Custer',
-          artist: 'Slipknot',
-          label: 'Roadrunner Records',
-        },
-      ],
-    },
-    {
-      category: 'Best Rock Song',
-      __children: [
-        {
-          title: "Don't Wanna Fight",
-          artist: 'Alabama Shakes',
-          label: 'ATO Records',
-        },
-        {
-          title: "Ex's & Oh's",
-          artist: 'Elle King',
-          label: 'RCA Records',
-        },
-        {
-          title: 'Hold Back The River',
-          artist: 'James Bay',
-          label: 'Republic',
-        },
-        {
-          title: 'Lydia',
-          artist: 'Highly Suspect',
-          label: '300 Entertainment',
-        },
-        {
-          title: 'What Kind Of Man',
-          artist: 'Florence & The Machine',
-          label: 'Republic',
-        },
-      ],
-    },
-    {
-      category: 'Best Rock Album',
-      __children: [
-        {
-          title: 'Drones',
-          artist: 'Muse',
-          label: 'Warner Bros. Records',
-        },
-        {
-          title: 'Chaos And The Calm',
-          artist: 'James Bay',
-          label: 'Republic',
-        },
-        {
-          title: 'Kintsugi',
-          artist: 'Death Cab For Cutie',
-          label: 'Atlantic',
-        },
-        {
-          title: 'Mister Asylum',
-          artist: 'Highly Suspect',
-          label: '300 Entertainment',
-        },
-        {
-          title: '.5: The Gray Chapter',
-          artist: 'Slipknot',
-          label: 'Roadrunner Records',
-        },
-      ],
-    },
-  ];
+const sourceDataObject = [
+  {
+    category: 'Best Rock Performance',
+    artist: null,
+    title: null,
+    label: null,
+    __children: [
+      {
+        category: 'Major label releases',
+        artist: null,
+        title: null,
+        label: null,
+        __children: [
+          {
+            title: "Don't Wanna Fight",
+            artist: 'Alabama Shakes',
+            label: 'ATO Records',
+          },
+          {
+            title: 'What Kind Of Man',
+            artist: 'Florence & The Machine',
+            label: 'Republic',
+          },
+          {
+            title: 'Something From Nothing',
+            artist: 'Foo Fighters',
+            label: 'RCA Records',
+          },
+        ],
+      },
+      {
+        category: 'Independent releases',
+        artist: null,
+        title: null,
+        label: null,
+        __children: [
+          {
+            title: 'Moaning Lisa Smile',
+            artist: 'Wolf Alice',
+            label: 'RCA Records/Dirty Hit',
+          },
+          {
+            title: "Ex's & Oh's",
+            artist: 'Elle King',
+            label: 'RCA Records',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    category: 'Best Metal Performance',
+    __children: [
+      {
+        title: 'Cirice',
+        artist: 'Ghost',
+        label: 'Loma Vista Recordings',
+      },
+      {
+        title: 'Identity',
+        artist: 'August Burns Red',
+        label: 'Fearless Records',
+      },
+      {
+        title: '512',
+        artist: 'Lamb Of God',
+        label: 'Epic Records',
+      },
+      {
+        title: 'Thank You',
+        artist: 'Sevendust',
+        label: '7Bros Records',
+      },
+      {
+        title: 'Custer',
+        artist: 'Slipknot',
+        label: 'Roadrunner Records',
+      },
+    ],
+  },
+  {
+    category: 'Best Rock Song',
+    __children: [
+      {
+        title: "Don't Wanna Fight",
+        artist: 'Alabama Shakes',
+        label: 'ATO Records',
+      },
+      {
+        title: "Ex's & Oh's",
+        artist: 'Elle King',
+        label: 'RCA Records',
+      },
+      {
+        title: 'Hold Back The River',
+        artist: 'James Bay',
+        label: 'Republic',
+      },
+      {
+        title: 'Lydia',
+        artist: 'Highly Suspect',
+        label: '300 Entertainment',
+      },
+      {
+        title: 'What Kind Of Man',
+        artist: 'Florence & The Machine',
+        label: 'Republic',
+      },
+    ],
+  },
+  {
+    category: 'Best Rock Album',
+    __children: [
+      {
+        title: 'Drones',
+        artist: 'Muse',
+        label: 'Warner Bros. Records',
+      },
+      {
+        title: 'Chaos And The Calm',
+        artist: 'James Bay',
+        label: 'Republic',
+      },
+      {
+        title: 'Kintsugi',
+        artist: 'Death Cab For Cutie',
+        label: 'Atlantic',
+      },
+      {
+        title: 'Mister Asylum',
+        artist: 'Highly Suspect',
+        label: '300 Entertainment',
+      },
+      {
+        title: '.5: The Gray Chapter',
+        artist: 'Slipknot',
+        label: 'Roadrunner Records',
+      },
+    ],
+  },
+];
 
+const ExampleComponent = () => {
   return (
     <HotTable
       data={sourceDataObject}
@@ -144,6 +161,9 @@ const ExampleComponent = () => {
       autoWrapCol={true}
       height="auto"
       licenseKey="non-commercial-and-evaluation"
+      afterInit={function (this: Handsontable) {
+        this.getPlugin('nestedRows').collapsingUI.collapseChildren(8);
+      }}
     />
   );
 };

--- a/docs/content/guides/rows/row-parent-child/row-parent-child.md
+++ b/docs/content/guides/rows/row-parent-child/row-parent-child.md
@@ -87,7 +87,8 @@ The data source must have a specific structure to be used with the _Nested Rows_
 
 The plugin requires the data source to be an array of objects. Each object in the array represents a single _0-level_ entry. _0-level_ refers to an entry, which
 is not a child of any other entry. If an entry has any child entries, they need to be declared again as an _array of objects_. To assign them to a row, create a
-`__children` property in the parent element.
+`__children` property in the parent element. Child objects can define their own `__children` arrays, so you can nest rows to any depth. Handsontable does not
+impose a fixed nesting limit -- the depth is determined by your data structure, and row header indentation grows with each level.
 
 Here's an example:
 
@@ -134,8 +135,9 @@ Here's an example:
 
 :::
 
-In the example above, we’ve created a data object consisting of 2016’s Grammy nominees of the “Rock” genre. Each _0-level_ entry declares a category, while
-their children declare nominees - assigned under the `__children` properties.
+In the example above, we’ve created a data object consisting of 2016’s Grammy nominees of the “Rock” genre. Each _0-level_ entry declares a category. Under
+`Best Rock Performance`, nominees are grouped into subcategories (`Major label releases` and `Independent releases`) at the next level, with individual nominees
+nested one level deeper. The other categories use two levels: category and nominee, assigned under the `__children` properties.
 
 Note that the first 0-level object in the array needs to have all columns defined to display the table properly. They can be declared as `null` or an empty
 string `''`, but they need to be defined. This is optional for the other objects.
@@ -148,7 +150,8 @@ The _Nested Rows_ plugin's user interface is placed in the row headers and the H
 
 Each _parent_ row header contains a `+`/`-` button. It is used to collapse or expand its child rows.
 
-The child row headers have a bigger indentation, to enable the user to clearly recognize the child and parent elements.
+The child row headers have a bigger indentation, to enable the user to clearly recognize the child and parent elements. In the example above, the
+`Best Metal Performance` category loads collapsed so you can see the expand/collapse controls right away.
 
 ### Context Menu
 

--- a/docs/content/guides/rows/row-parent-child/vue/example1.vue
+++ b/docs/content/guides/rows/row-parent-child/vue/example1.vue
@@ -6,21 +6,15 @@ import type { GridSettings } from 'handsontable/settings';
 
 registerAllModules();
 
-interface Album {
-  title: string;
-  artist: string;
-  label: string;
-}
-
-interface MusicAward {
-  category: string;
+interface MusicRow {
+  category?: string;
   artist?: string | null;
   title?: string | null;
   label?: string | null;
-  __children: Album[];
+  __children?: MusicRow[];
 }
 
-const sourceDataObject: MusicAward[] = [
+const sourceDataObject: MusicRow[] = [
   {
     category: 'Best Rock Performance',
     artist: null,
@@ -28,29 +22,45 @@ const sourceDataObject: MusicAward[] = [
     label: null,
     __children: [
       {
-        title: "Don't Wanna Fight",
-        artist: 'Alabama Shakes',
-        label: 'ATO Records',
+        category: 'Major label releases',
+        artist: null,
+        title: null,
+        label: null,
+        __children: [
+          {
+            title: "Don't Wanna Fight",
+            artist: 'Alabama Shakes',
+            label: 'ATO Records',
+          },
+          {
+            title: 'What Kind Of Man',
+            artist: 'Florence & The Machine',
+            label: 'Republic',
+          },
+          {
+            title: 'Something From Nothing',
+            artist: 'Foo Fighters',
+            label: 'RCA Records',
+          },
+        ],
       },
       {
-        title: 'What Kind Of Man',
-        artist: 'Florence & The Machine',
-        label: 'Republic',
-      },
-      {
-        title: 'Something From Nothing',
-        artist: 'Foo Fighters',
-        label: 'RCA Records',
-      },
-      {
-        title: "Ex's & Oh's",
-        artist: 'Elle King',
-        label: 'RCA Records',
-      },
-      {
-        title: 'Moaning Lisa Smile',
-        artist: 'Wolf Alice',
-        label: 'RCA Records/Dirty Hit',
+        category: 'Independent releases',
+        artist: null,
+        title: null,
+        label: null,
+        __children: [
+          {
+            title: 'Moaning Lisa Smile',
+            artist: 'Wolf Alice',
+            label: 'RCA Records/Dirty Hit',
+          },
+          {
+            title: "Ex's & Oh's",
+            artist: 'Elle King',
+            label: 'RCA Records',
+          },
+        ],
       },
     ],
   },
@@ -158,6 +168,9 @@ const hotSettings = ref<GridSettings>({
   autoWrapCol: true,
   height: 'auto',
   licenseKey: 'non-commercial-and-evaluation',
+  afterInit() {
+    this.getPlugin('nestedRows').collapsingUI.collapseChildren(8);
+  },
 });
 </script>
 


### PR DESCRIPTION
[skip changelog]

### Context

The PR improves the Row parent-child guide demo so it better demonstrates `nestedRows` capabilities. The previous example showed only two nesting levels and loaded fully expanded, which made multi-level nesting and collapse controls easy to miss.

Changes:
- Add a third nesting level under `Best Rock Performance` (category → subcategory → nominee).
- Pre-collapse `Best Metal Performance` on load via `afterInit`.
- Document that `__children` can nest recursively with no fixed depth limit.

ClickUp: DEV-626 (migrated from GitHub #1168)

### How has this been tested?

- `npm run docs:validate-highlights` (from `docs/`)
- `npm run docs:test:plugins` (from `docs/`)
- `npm run test:e2e --prefix handsontable -- --testPathPattern=nestedRows/__tests__/ui/collapsing` (13 specs, 0 failures)

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-626
2. #1168

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

## Docs PR checklist

- [x] `type:` field added to frontmatter (tutorial | how-to | reference | explanation)
- [x] Page uses the correct Diátaxis template for its type
- [x] Title matches Diátaxis naming convention for its type
- [x] Intro paragraph states: what, for whom, and what outcome the reader gains
- [x] No banned placeholder data (foo, bar, A1, Column1, etc.)
- [x] All example data is domain-realistic and internally consistent
- [x] All code blocks have language tags (`javascript`, `typescript`, etc.)
- [x] No `var` in code examples; uses `const` / `let`
- [x] All examples include `licenseKey: 'non-commercial-and-evaluation'`
- [x] Heading hierarchy is correct (no skipped levels, e.g., H2 → H4)
- [x] Active voice and second person ("you") used throughout
- [x] No banned words: simply, just, easy, straightforward, note that, please
- [x] Tutorials and how-tos have a Prerequisites section
- [ ] Tutorials have "What you learned" and "Next steps" sections
- [x] How-tos have a "Result" section
- [ ] New page registered in `content/guides/sidebar.js`
- [x] `menuTag: new` set on new pages / `menuTag: updated` set on substantively changed pages (omit for trivial fixes, changelogs, and migration guides)
- [x] `id` field uses 8 random alphanumeric chars (existing IDs are unchanged)
- [ ] Microsoft trademark disclaimer added where "Excel" is mentioned
- [x] TypeScript example exists; JS generated via `npm run docs:code-examples:generate-js`
- [x] `[skip changelog]` in PR body (docs changes don't need changelog entries)

ClickUp task: https://app.clickup.com/t/9015210959/DEV-626

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to documentation and example snippets; no Handsontable runtime or wrapper package code is modified.
> 
> **Overview**
> Updates the **Row parent-child** guide so the live examples show **deeper nesting** and **collapse on load**, not only a flat two-level tree.
> 
> Under **Best Rock Performance**, nominees are regrouped into **Major label releases** and **Independent releases** with a third level of leaf rows. The guide text now states that **`__children` can recurse** with no fixed depth limit from Handsontable.
> 
> All framework examples (JS/TS, React, Vue, Angular) share the same data shape; TS/Vue use a recursive **`MusicRow`** type instead of separate award/album interfaces. Each example adds **`afterInit`** calling **`nestedRows.collapsingUI.collapseChildren(8)`** so **Best Metal Performance** starts collapsed and expand/collapse controls are visible immediately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef1f5e098df601a31971cab1ba46b7659b155d03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->