### PR TITLE
DEV-555: Add guide for adding and removing columns

### DIFF
--- a/docs/content/guides/columns/column-adding/angular/example1.html
+++ b/docs/content/guides/columns/column-adding/angular/example1.html
@@ -1,0 +1,3 @@
+<div>
+    <example1-column-adding></example1-column-adding>
+</div>

--- a/docs/content/guides/columns/column-adding/angular/example1.ts
+++ b/docs/content/guides/columns/column-adding/angular/example1.ts
@@ -1,0 +1,80 @@
+/* file: app.component.ts */
+import { Component, ViewChild } from '@angular/core';
+import { GridSettings, HotTableComponent, HotTableModule } from '@handsontable/angular-wrapper';
+
+@Component({
+  selector: 'example1-column-adding',
+  standalone: true,
+  imports: [HotTableModule],
+  template: ` <div class="example-controls-container">
+      <div class="controls">
+        <button class="button button--primary" (click)="insertColumn()">
+          Insert column
+        </button>
+        <button class="button button--primary" (click)="removeColumn()">
+          Remove last column
+        </button>
+      </div>
+    </div>
+    <div>
+      <hot-table [data]="hotData" [settings]="gridSettings"></hot-table>
+    </div>`,
+})
+export class AppComponent {
+  @ViewChild(HotTableComponent, { static: false }) readonly hotTable!: HotTableComponent;
+
+  readonly hotData = [
+    ['Ana García', 'Engineering', 'Senior Engineer', '2021-04-12'],
+    ['James Okafor', 'Marketing', 'Product Manager', '2022-08-30'],
+    ['Li Wei', 'Engineering', 'Staff Engineer', '2019-02-18'],
+    ['Sofia Rossi', 'Sales', 'Account Executive', '2023-01-09'],
+    ['Diego Fernández', 'Design', 'UX Designer', '2020-11-23'],
+    ['Amara Singh', 'Engineering', 'Engineering Manager', '2018-06-05'],
+  ];
+
+  readonly gridSettings: GridSettings = {
+    colHeaders: ['Name', 'Department', 'Title', 'Hire date'],
+    rowHeaders: true,
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true,
+  };
+
+  insertColumn(): void {
+    const hot = this.hotTable?.hotInstance;
+
+    // insert one column at the end of the grid
+    hot?.alter('insert_col_end', hot.countCols() - 1, 1);
+  }
+
+  removeColumn(): void {
+    const hot = this.hotTable?.hotInstance;
+
+    // remove the last column, but keep at least one column in the grid
+    if (hot && hot.countCols() > 1) {
+      hot.alter('remove_col', hot.countCols() - 1, 1);
+    }
+  }
+}
+/* end-file */
+
+
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+/* end-file */

--- a/docs/content/guides/columns/column-adding/angular/example2.html
+++ b/docs/content/guides/columns/column-adding/angular/example2.html
@@ -1,0 +1,3 @@
+<div>
+    <example2-column-adding></example2-column-adding>
+</div>

--- a/docs/content/guides/columns/column-adding/angular/example2.ts
+++ b/docs/content/guides/columns/column-adding/angular/example2.ts
@@ -1,0 +1,54 @@
+/* file: app.component.ts */
+import { Component } from '@angular/core';
+import { GridSettings, HotTableModule } from '@handsontable/angular-wrapper';
+
+@Component({
+  selector: 'example2-column-adding',
+  standalone: true,
+  imports: [HotTableModule],
+  template: `
+    <hot-table [data]="hotData" [settings]="gridSettings"></hot-table>
+  `,
+})
+export class AppComponent {
+  readonly hotData = [
+    ['Ana García', 'Engineering', 'Senior Engineer', '2021-04-12'],
+    ['James Okafor', 'Marketing', 'Product Manager', '2022-08-30'],
+    ['Li Wei', 'Engineering', 'Staff Engineer', '2019-02-18'],
+    ['Sofia Rossi', 'Sales', 'Account Executive', '2023-01-09'],
+    ['Diego Fernández', 'Design', 'UX Designer', '2020-11-23'],
+    ['Amara Singh', 'Engineering', 'Engineering Manager', '2018-06-05'],
+  ];
+
+  readonly gridSettings: GridSettings = {
+    colHeaders: ['Name', 'Department', 'Title', 'Hire date'],
+    rowHeaders: true,
+    height: 'auto',
+    // show only the column insert and remove items in the context menu
+    contextMenu: ['col_left', 'col_right', 'remove_col'],
+    autoWrapRow: true,
+    autoWrapCol: true,
+  };
+}
+/* end-file */
+
+
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+/* end-file */

--- a/docs/content/guides/columns/column-adding/column-adding.md
+++ b/docs/content/guides/columns/column-adding/column-adding.md
@@ -1,0 +1,204 @@
+---
+type: how-to
+title: Adding and removing columns
+metaTitle: Adding and removing columns - JavaScript Data Grid | Handsontable
+description: Insert and remove columns programmatically with the alter() method, through the context menu, or automatically with spare columns.
+permalink: /column-adding
+canonicalUrl: /column-adding
+tags:
+  - insert column
+  - remove column
+  - alter
+  - add column
+react:
+  metaTitle: Adding and removing columns - React Data Grid | Handsontable
+angular:
+  metaTitle: Adding and removing columns - Angular Data Grid | Handsontable
+vue:
+  metaTitle: Adding and removing columns - Vue Data Grid | Handsontable
+searchCategory: Guides
+category: Columns
+menuTag: new
+---
+Insert and remove columns programmatically with the [`alter()`](@/api/core.md#alter) method, through the context menu, or automatically with spare columns.
+
+[[toc]]
+
+## Insert and remove columns with the API
+
+Call the [`alter()`](@/api/core.md#alter) method to change the column structure programmatically. Pass an action name, a column index, and the number of columns to insert or remove:
+
+- `alter('insert_col_start', index, amount)` inserts columns to the left of the given column index.
+- `alter('insert_col_end', index, amount)` inserts columns to the right of the given column index.
+- `alter('remove_col', index, amount)` removes columns, starting at the given column index.
+
+In the example below, **Insert column** appends a column to the right of the last column, and **Remove last column** removes the last column.
+
+::: only-for javascript
+
+::: example #example1 --html 1 --js 2 --ts 3
+
+@[code](@/content/guides/columns/column-adding/javascript/example1.html)
+@[code](@/content/guides/columns/column-adding/javascript/example1.js)
+@[code](@/content/guides/columns/column-adding/javascript/example1.ts)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #example1 :react --js 1 --ts 2
+
+@[code](@/content/guides/columns/column-adding/react/example1.jsx)
+@[code](@/content/guides/columns/column-adding/react/example1.tsx)
+
+:::
+
+:::
+
+::: only-for angular
+
+::: example #example1 :angular --ts 1 --html 2
+
+@[code](@/content/guides/columns/column-adding/angular/example1.ts)
+@[code](@/content/guides/columns/column-adding/angular/example1.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/columns/column-adding/vue/example1.vue)
+
+:::
+
+:::
+
+The `index` argument uses visual column indexes. The `amount` argument defaults to `1` when omitted.
+
+## Add and remove columns from the context menu
+
+Enable the [`contextMenu`](@/api/options.md#contextmenu) option to let users insert and remove columns by right-clicking a column. The relevant menu items are `col_left` (**Insert column left**), `col_right` (**Insert column right**), and `remove_col` (**Remove column**).
+
+Setting [`contextMenu`](@/api/options.md#contextmenu) to `true` shows the full default menu. To show only the column actions, pass an array of item keys, as in the example below. Right-click a column header or cell to open the menu.
+
+::: only-for javascript
+
+::: example #example2 --js 1 --ts 2
+
+@[code](@/content/guides/columns/column-adding/javascript/example2.js)
+@[code](@/content/guides/columns/column-adding/javascript/example2.ts)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #example2 :react --js 1 --ts 2
+
+@[code](@/content/guides/columns/column-adding/react/example2.jsx)
+@[code](@/content/guides/columns/column-adding/react/example2.tsx)
+
+:::
+
+:::
+
+::: only-for angular
+
+::: example #example2 :angular --ts 1 --html 2
+
+@[code](@/content/guides/columns/column-adding/angular/example2.ts)
+@[code](@/content/guides/columns/column-adding/angular/example2.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example2 :vue3
+
+@[code](@/content/guides/columns/column-adding/vue/example2.vue)
+
+:::
+
+:::
+
+The [`allowInsertColumn`](@/api/options.md#allowinsertcolumn) and [`allowRemoveColumn`](@/api/options.md#allowremovecolumn) options control whether these context menu items are available. Both default to `true`. Set [`allowInsertColumn`](@/api/options.md#allowinsertcolumn) to `false` to hide the insert items, or [`allowRemoveColumn`](@/api/options.md#allowremovecolumn) to `false` to hide the remove item.
+
+## Add spare columns automatically
+
+Set the [`minSpareCols`](@/api/options.md#minsparecols) option to keep a number of empty columns at the end of the grid. When a user enters data in the last empty column, Handsontable adds another empty column, so the grid always has at least the configured number of spare columns.
+
+```js
+const configurationOptions = {
+  // keep at least one empty column at the end of the grid
+  minSpareCols: 1,
+};
+```
+
+[`minSpareCols`](@/api/options.md#minsparecols) defaults to `0`.
+
+## Control and react to column changes
+
+Use Handsontable's hooks to validate or respond to column changes:
+
+- [`beforeCreateCol`](@/api/hooks.md#beforecreatecol) runs before columns are inserted. Return `false` to cancel the insertion.
+- [`afterCreateCol`](@/api/hooks.md#aftercreatecol) runs after columns are inserted.
+- [`beforeRemoveCol`](@/api/hooks.md#beforeremovecol) runs before columns are removed. Return `false` to cancel the removal.
+- [`afterRemoveCol`](@/api/hooks.md#afterremovecol) runs after columns are removed.
+
+For example, block removing the last remaining column:
+
+```js
+const configurationOptions = {
+  beforeRemoveCol(index, amount) {
+    if (this.countCols() - amount < 1) {
+      // cancel the removal
+      return false;
+    }
+  },
+};
+```
+
+## Result
+
+After completing this guide, you can insert and remove columns with the [`alter()`](@/api/core.md#alter) method, let users add and remove columns through the context menu, keep spare columns at the end of the grid, and validate or react to column changes with hooks.
+
+## Related API reference
+
+**Configuration options**
+
+<div class="boxes-list">
+
+- [allowInsertColumn](@/api/options.md#allowinsertcolumn)
+- [allowRemoveColumn](@/api/options.md#allowremovecolumn)
+- [contextMenu](@/api/options.md#contextmenu)
+- [minSpareCols](@/api/options.md#minsparecols)
+
+</div>
+
+**Core methods**
+
+<div class="boxes-list">
+
+- [alter()](@/api/core.md#alter)
+- [countCols()](@/api/core.md#countcols)
+
+</div>
+
+**Hooks**
+
+<div class="boxes-list">
+
+- [afterCreateCol](@/api/hooks.md#aftercreatecol)
+- [afterRemoveCol](@/api/hooks.md#afterremovecol)
+- [beforeCreateCol](@/api/hooks.md#beforecreatecol)
+- [beforeRemoveCol](@/api/hooks.md#beforeremovecol)
+
+</div>

--- a/docs/content/guides/columns/column-adding/javascript/example1.html
+++ b/docs/content/guides/columns/column-adding/javascript/example1.html
@@ -1,0 +1,7 @@
+<div class="example-controls-container">
+  <div class="controls">
+    <button id="insert-column" class="button button--primary">Insert column</button>
+    <button id="remove-column" class="button button--primary">Remove last column</button>
+  </div>
+</div>
+<div id="example1"></div>

--- a/docs/content/guides/columns/column-adding/javascript/example1.js
+++ b/docs/content/guides/columns/column-adding/javascript/example1.js
@@ -1,0 +1,33 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+// register all Handsontable's modules
+registerAllModules();
+const container = document.querySelector('#example1');
+const insertButton = document.querySelector('#insert-column');
+const removeButton = document.querySelector('#remove-column');
+const hot = new Handsontable(container, {
+    data: [
+        ['Ana García', 'Engineering', 'Senior Engineer', '2021-04-12'],
+        ['James Okafor', 'Marketing', 'Product Manager', '2022-08-30'],
+        ['Li Wei', 'Engineering', 'Staff Engineer', '2019-02-18'],
+        ['Sofia Rossi', 'Sales', 'Account Executive', '2023-01-09'],
+        ['Diego Fernández', 'Design', 'UX Designer', '2020-11-23'],
+        ['Amara Singh', 'Engineering', 'Engineering Manager', '2018-06-05'],
+    ],
+    colHeaders: ['Name', 'Department', 'Title', 'Hire date'],
+    rowHeaders: true,
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true,
+    licenseKey: 'non-commercial-and-evaluation',
+});
+insertButton.addEventListener('click', () => {
+    // insert one column at the end of the grid
+    hot.alter('insert_col_end', hot.countCols() - 1, 1);
+});
+removeButton.addEventListener('click', () => {
+    // remove the last column, but keep at least one column in the grid
+    if (hot.countCols() > 1) {
+        hot.alter('remove_col', hot.countCols() - 1, 1);
+    }
+});

--- a/docs/content/guides/columns/column-adding/javascript/example1.ts
+++ b/docs/content/guides/columns/column-adding/javascript/example1.ts
@@ -1,0 +1,38 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+// register all Handsontable's modules
+registerAllModules();
+
+const container = document.querySelector('#example1')!;
+const insertButton = document.querySelector('#insert-column')!;
+const removeButton = document.querySelector('#remove-column')!;
+
+const hot = new Handsontable(container, {
+  data: [
+    ['Ana García', 'Engineering', 'Senior Engineer', '2021-04-12'],
+    ['James Okafor', 'Marketing', 'Product Manager', '2022-08-30'],
+    ['Li Wei', 'Engineering', 'Staff Engineer', '2019-02-18'],
+    ['Sofia Rossi', 'Sales', 'Account Executive', '2023-01-09'],
+    ['Diego Fernández', 'Design', 'UX Designer', '2020-11-23'],
+    ['Amara Singh', 'Engineering', 'Engineering Manager', '2018-06-05'],
+  ],
+  colHeaders: ['Name', 'Department', 'Title', 'Hire date'],
+  rowHeaders: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+insertButton.addEventListener('click', () => {
+  // insert one column at the end of the grid
+  hot.alter('insert_col_end', hot.countCols() - 1, 1);
+});
+
+removeButton.addEventListener('click', () => {
+  // remove the last column, but keep at least one column in the grid
+  if (hot.countCols() > 1) {
+    hot.alter('remove_col', hot.countCols() - 1, 1);
+  }
+});

--- a/docs/content/guides/columns/column-adding/javascript/example2.js
+++ b/docs/content/guides/columns/column-adding/javascript/example2.js
@@ -1,0 +1,23 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+// register all Handsontable's modules
+registerAllModules();
+const container = document.querySelector('#example2');
+new Handsontable(container, {
+    data: [
+        ['Ana García', 'Engineering', 'Senior Engineer', '2021-04-12'],
+        ['James Okafor', 'Marketing', 'Product Manager', '2022-08-30'],
+        ['Li Wei', 'Engineering', 'Staff Engineer', '2019-02-18'],
+        ['Sofia Rossi', 'Sales', 'Account Executive', '2023-01-09'],
+        ['Diego Fernández', 'Design', 'UX Designer', '2020-11-23'],
+        ['Amara Singh', 'Engineering', 'Engineering Manager', '2018-06-05'],
+    ],
+    colHeaders: ['Name', 'Department', 'Title', 'Hire date'],
+    rowHeaders: true,
+    height: 'auto',
+    // show only the column insert and remove items in the context menu
+    contextMenu: ['col_left', 'col_right', 'remove_col'],
+    autoWrapRow: true,
+    autoWrapCol: true,
+    licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/columns/column-adding/javascript/example2.ts
+++ b/docs/content/guides/columns/column-adding/javascript/example2.ts
@@ -1,0 +1,26 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+// register all Handsontable's modules
+registerAllModules();
+
+const container = document.querySelector('#example2')!;
+
+new Handsontable(container, {
+  data: [
+    ['Ana García', 'Engineering', 'Senior Engineer', '2021-04-12'],
+    ['James Okafor', 'Marketing', 'Product Manager', '2022-08-30'],
+    ['Li Wei', 'Engineering', 'Staff Engineer', '2019-02-18'],
+    ['Sofia Rossi', 'Sales', 'Account Executive', '2023-01-09'],
+    ['Diego Fernández', 'Design', 'UX Designer', '2020-11-23'],
+    ['Amara Singh', 'Engineering', 'Engineering Manager', '2018-06-05'],
+  ],
+  colHeaders: ['Name', 'Department', 'Title', 'Hire date'],
+  rowHeaders: true,
+  height: 'auto',
+  // show only the column insert and remove items in the context menu
+  contextMenu: ['col_left', 'col_right', 'remove_col'],
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/columns/column-adding/react/example1.jsx
+++ b/docs/content/guides/columns/column-adding/react/example1.jsx
@@ -1,0 +1,60 @@
+import { useRef } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const ExampleComponent = () => {
+  const hotRef = useRef(null);
+
+  const insertColumn = () => {
+    const hot = hotRef.current?.hotInstance;
+
+    // insert one column at the end of the grid
+    hot?.alter('insert_col_end', hot.countCols() - 1, 1);
+  };
+
+  const removeColumn = () => {
+    const hot = hotRef.current?.hotInstance;
+
+    // remove the last column, but keep at least one column in the grid
+    if (hot && hot.countCols() > 1) {
+      hot.alter('remove_col', hot.countCols() - 1, 1);
+    }
+  };
+
+  return (
+    <>
+      <div className="example-controls-container">
+        <div className="controls">
+          <button className="button button--primary" onClick={insertColumn}>
+            Insert column
+          </button>
+          <button className="button button--primary" onClick={removeColumn}>
+            Remove last column
+          </button>
+        </div>
+      </div>
+      <HotTable
+        ref={hotRef}
+        data={[
+          ['Ana García', 'Engineering', 'Senior Engineer', '2021-04-12'],
+          ['James Okafor', 'Marketing', 'Product Manager', '2022-08-30'],
+          ['Li Wei', 'Engineering', 'Staff Engineer', '2019-02-18'],
+          ['Sofia Rossi', 'Sales', 'Account Executive', '2023-01-09'],
+          ['Diego Fernández', 'Design', 'UX Designer', '2020-11-23'],
+          ['Amara Singh', 'Engineering', 'Engineering Manager', '2018-06-05'],
+        ]}
+        colHeaders={['Name', 'Department', 'Title', 'Hire date']}
+        rowHeaders={true}
+        height="auto"
+        autoWrapRow={true}
+        autoWrapCol={true}
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/columns/column-adding/react/example1.tsx
+++ b/docs/content/guides/columns/column-adding/react/example1.tsx
@@ -1,0 +1,60 @@
+import { useRef } from 'react';
+import { HotTable, HotTableRef } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const ExampleComponent = () => {
+  const hotRef = useRef<HotTableRef>(null);
+
+  const insertColumn = () => {
+    const hot = hotRef.current?.hotInstance;
+
+    // insert one column at the end of the grid
+    hot?.alter('insert_col_end', hot.countCols() - 1, 1);
+  };
+
+  const removeColumn = () => {
+    const hot = hotRef.current?.hotInstance;
+
+    // remove the last column, but keep at least one column in the grid
+    if (hot && hot.countCols() > 1) {
+      hot.alter('remove_col', hot.countCols() - 1, 1);
+    }
+  };
+
+  return (
+    <>
+      <div className="example-controls-container">
+        <div className="controls">
+          <button className="button button--primary" onClick={insertColumn}>
+            Insert column
+          </button>
+          <button className="button button--primary" onClick={removeColumn}>
+            Remove last column
+          </button>
+        </div>
+      </div>
+      <HotTable
+        ref={hotRef}
+        data={[
+          ['Ana García', 'Engineering', 'Senior Engineer', '2021-04-12'],
+          ['James Okafor', 'Marketing', 'Product Manager', '2022-08-30'],
+          ['Li Wei', 'Engineering', 'Staff Engineer', '2019-02-18'],
+          ['Sofia Rossi', 'Sales', 'Account Executive', '2023-01-09'],
+          ['Diego Fernández', 'Design', 'UX Designer', '2020-11-23'],
+          ['Amara Singh', 'Engineering', 'Engineering Manager', '2018-06-05'],
+        ]}
+        colHeaders={['Name', 'Department', 'Title', 'Hire date']}
+        rowHeaders={true}
+        height="auto"
+        autoWrapRow={true}
+        autoWrapCol={true}
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/columns/column-adding/react/example2.jsx
+++ b/docs/content/guides/columns/column-adding/react/example2.jsx
@@ -1,0 +1,30 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={[
+        ['Ana García', 'Engineering', 'Senior Engineer', '2021-04-12'],
+        ['James Okafor', 'Marketing', 'Product Manager', '2022-08-30'],
+        ['Li Wei', 'Engineering', 'Staff Engineer', '2019-02-18'],
+        ['Sofia Rossi', 'Sales', 'Account Executive', '2023-01-09'],
+        ['Diego Fernández', 'Design', 'UX Designer', '2020-11-23'],
+        ['Amara Singh', 'Engineering', 'Engineering Manager', '2018-06-05'],
+      ]}
+      colHeaders={['Name', 'Department', 'Title', 'Hire date']}
+      rowHeaders={true}
+      height="auto"
+      // show only the column insert and remove items in the context menu
+      contextMenu={['col_left', 'col_right', 'remove_col']}
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/columns/column-adding/react/example2.tsx
+++ b/docs/content/guides/columns/column-adding/react/example2.tsx
@@ -1,0 +1,30 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={[
+        ['Ana García', 'Engineering', 'Senior Engineer', '2021-04-12'],
+        ['James Okafor', 'Marketing', 'Product Manager', '2022-08-30'],
+        ['Li Wei', 'Engineering', 'Staff Engineer', '2019-02-18'],
+        ['Sofia Rossi', 'Sales', 'Account Executive', '2023-01-09'],
+        ['Diego Fernández', 'Design', 'UX Designer', '2020-11-23'],
+        ['Amara Singh', 'Engineering', 'Engineering Manager', '2018-06-05'],
+      ]}
+      colHeaders={['Name', 'Department', 'Title', 'Hire date']}
+      rowHeaders={true}
+      height="auto"
+      // show only the column insert and remove items in the context menu
+      contextMenu={['col_left', 'col_right', 'remove_col']}
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/columns/column-adding/vue/example1.vue
+++ b/docs/content/guides/columns/column-adding/vue/example1.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { ref, useTemplateRef } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['Ana García', 'Engineering', 'Senior Engineer', '2021-04-12'],
+    ['James Okafor', 'Marketing', 'Product Manager', '2022-08-30'],
+    ['Li Wei', 'Engineering', 'Staff Engineer', '2019-02-18'],
+    ['Sofia Rossi', 'Sales', 'Account Executive', '2023-01-09'],
+    ['Diego Fernández', 'Design', 'UX Designer', '2020-11-23'],
+    ['Amara Singh', 'Engineering', 'Engineering Manager', '2018-06-05'],
+  ],
+  colHeaders: ['Name', 'Department', 'Title', 'Hire date'],
+  rowHeaders: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+function insertColumn() {
+  const hot = hotRef.value?.hotInstance;
+
+  // insert one column at the end of the grid
+  hot?.alter('insert_col_end', hot.countCols() - 1, 1);
+}
+
+function removeColumn() {
+  const hot = hotRef.value?.hotInstance;
+
+  // remove the last column, but keep at least one column in the grid
+  if (hot && hot.countCols() > 1) {
+    hot.alter('remove_col', hot.countCols() - 1, 1);
+  }
+}
+</script>
+
+<template>
+  <div id="example1">
+    <div class="example-controls-container">
+      <div class="controls">
+        <button class="button button--primary" @click="insertColumn">
+          Insert column
+        </button>
+        <button class="button button--primary" @click="removeColumn">
+          Remove last column
+        </button>
+      </div>
+    </div>
+    <HotTable ref="hotRef" :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-adding/vue/example2.vue
+++ b/docs/content/guides/columns/column-adding/vue/example2.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['Ana García', 'Engineering', 'Senior Engineer', '2021-04-12'],
+    ['James Okafor', 'Marketing', 'Product Manager', '2022-08-30'],
+    ['Li Wei', 'Engineering', 'Staff Engineer', '2019-02-18'],
+    ['Sofia Rossi', 'Sales', 'Account Executive', '2023-01-09'],
+    ['Diego Fernández', 'Design', 'UX Designer', '2020-11-23'],
+    ['Amara Singh', 'Engineering', 'Engineering Manager', '2018-06-05'],
+  ],
+  colHeaders: ['Name', 'Department', 'Title', 'Hire date'],
+  rowHeaders: true,
+  height: 'auto',
+  // show only the column insert and remove items in the context menu
+  contextMenu: ['col_left', 'col_right', 'remove_col'],
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example2">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/sidebar.js
+++ b/docs/content/guides/sidebar.js
@@ -52,6 +52,7 @@ const columnsItems = [
   { path: 'guides/columns/column-header/column-header' },
   { path: 'guides/columns/column-groups/column-groups' },
   { path: 'guides/columns/column-hiding/column-hiding' },
+  { path: 'guides/columns/column-adding/column-adding' },
   { path: 'guides/columns/column-moving/column-moving' },
   { path: 'guides/columns/column-freezing/column-freezing' },
   { path: 'guides/columns/column-width/column-width' },


### PR DESCRIPTION
### Context

The PR adds a new how-to guide, **Adding and removing columns**, under `guides/columns/`. The docs had no dedicated guide for inserting or removing columns - the topic was only mentioned in passing (a few context-menu keys, a bare `alter()` link, and hook names). This guide closes that gap (DEV-555).

The guide covers:

- Inserting and removing columns programmatically with `alter()` (`insert_col_start`, `insert_col_end`, `remove_col`).
- Adding and removing columns from the context menu (`col_left`, `col_right`, `remove_col`) and the `allowInsertColumn` / `allowRemoveColumn` options.
- Keeping spare columns with `minSpareCols`.
- Validating and reacting to column changes with the `beforeCreateCol` / `afterCreateCol` / `beforeRemoveCol` / `afterRemoveCol` hooks.

It ships two live examples across all four frameworks (JavaScript, React, Angular, Vue) and is registered in the sidebar under **Columns**.

### How has this been tested?

Docs-only change. Verified statically:

- All `@[code]` embed paths resolve to existing example files.
- JavaScript examples transpiled cleanly via `npm run docs:code-examples:generate-js`.
- Frontmatter IDs are unique; container ids match the `::: example` directive ids.
- API names, option defaults, and hook names checked against `handsontable/src`.

Not rendered live in-browser.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-555

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-555

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example assets only; no runtime or library code changes.
> 
> **Overview**
> Adds a new **Columns** how-to, **Adding and removing columns** (`/column-adding`), marked with `menuTag: new` in the docs sidebar (between column hiding and column moving).
> 
> The guide documents programmatic insert/remove via `alter()` (`insert_col_start`, `insert_col_end`, `remove_col`), context-menu column actions and `allowInsertColumn` / `allowRemoveColumn`, automatic spare columns with `minSpareCols`, and create/remove column hooks—with a related API section.
> 
> It includes **two live examples** (API buttons + narrowed `contextMenu`) for JavaScript, React, Angular, and Vue under `docs/content/guides/columns/column-adding/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61bb4078d1d1e9fe57990a4cf05d636aff544442. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->