### PR TITLE
DEV-557: Document stretchH and manualColumnResize interaction

### DIFF
--- a/docs/content/guides/columns/column-width/column-width.md
+++ b/docs/content/guides/columns/column-width/column-width.md
@@ -330,6 +330,13 @@ In this example, the first three columns are set to be 80px wide, and the last c
 
 :::
 
+### Column stretching and manual resizing
+
+Column stretching interacts with [`manualColumnResize`](@/api/options.md#manualcolumnresize) in two ways:
+
+- When `stretchH` is `'all'` or `'last'` together with `manualColumnResize: true`, you can still drag to resize a column. Stretching then recalculates, and the other columns adjust so the grid keeps filling the container. If your manual widths add up to more than the container width, stretching stops and the columns keep the sizes you set.
+- When you pass `manualColumnResize` an array of pre-defined widths (for example, `manualColumnResize: [80, 100, 120]`), the columns with explicit widths are excluded from stretching. Only the remaining columns are stretched to fill the container.
+
 ## A note about the performance
 
 As mentioned above, the default width of the column is based on the widest value in any cell within the column. You may be wondering how it's possible for data sets containing hundreds of thousands of records.

--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -3908,6 +3908,10 @@ export default (): Record<string, unknown> => {
      *
      * Read more:
      * - [Column width: Column stretching](@/guides/columns/column-width/column-width.md#column-stretching)
+     * - [Column width: Column stretching and manual resizing](@/guides/columns/column-width/column-width.md#column-stretching-and-manual-resizing)
+     *
+     * When you set initial widths through the array form, those columns are excluded from
+     * [`stretchH`](#stretchh) redistribution. Only the columns without a pre-defined width are stretched.
      *
      * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
      * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.
@@ -5830,6 +5834,11 @@ export default (): Record<string, unknown> => {
      *
      * Read more:
      * - [Column width: Column stretching](@/guides/columns/column-width/column-width.md#column-stretching)
+     * - [Column width: Column stretching and manual resizing](@/guides/columns/column-width/column-width.md#column-stretching-and-manual-resizing)
+     *
+     * When used with [`manualColumnResize`](#manualcolumnresize), columns that have a width set
+     * through pre-defined manual sizes are excluded from stretching. Only the remaining columns
+     * are stretched to fill the container.
      *
      * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
      * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.


### PR DESCRIPTION
### Context

The PR documents how `stretchH` interacts with `manualColumnResize`, which was previously undocumented. The original task (DEV-557) asked to note that `stretchH` "disables" manual column resizing, but the current behavior is more nuanced and that wording is outdated:

- With `stretchH: 'all'` or `'last'` and `manualColumnResize: true`, dragging still works. Stretching recalculates afterward so the other columns compensate and the grid keeps filling its container. If the manual widths exceed the container width, stretching stops.
- With `manualColumnResize` set to an array of pre-defined widths, those columns are excluded from stretching; only the remaining columns are stretched.

This is confirmed by `handsontable/src/plugins/stretchColumns/__tests__/plugins/manualColumnResize.spec.js` and by `#onBeforeStretchingColumnWidth` in the `manualColumnResize` plugin.

Changes:

- Added a "Column stretching and manual resizing" subsection to the Column width guide.
- Added cross-references and notes to the `stretchH` and `manualColumnResize` JSDoc in `metaSchema.ts`.

### How has this been tested?

- `npm run eslint --prefix handsontable` (passes on the edited `metaSchema.ts`).
- Rebuilt core (`build:es` + `build:commonjs`) and regenerated the API reference (`npm run docs:api` from `docs/`); the new prose renders into the `stretchH` and `manualColumnResize` entries of `api/options.md` with no generation errors.
- Verified the documented behavior matches the existing E2E coverage in `manualColumnResize.spec.js` (drag redistributes for `manualColumnResize: true`; pre-defined-array widths are excluded from stretching).

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-557

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-557

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and JSDoc comments only; no runtime or API behavior changes.
> 
> **Overview**
> Documents how **`stretchH`** and **`manualColumnResize`** work together, replacing outdated “stretch disables manual resize” guidance with the current behavior.
> 
> A new **Column stretching and manual resizing** subsection in the Column width guide explains that with **`stretchH: 'all'`** or **`'last'`** and **`manualColumnResize: true`**, drag resizing still works and stretching recalculates so other columns compensate until manual widths exceed the container; and that an array form of **`manualColumnResize`** excludes those columns from stretching.
> 
> Matching notes and links to that guide were added to the **`stretchH`** and **`manualColumnResize`** JSDoc in **`metaSchema.ts`** (surfacing in generated API docs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c25a77318cc1e2fe17f768252d4d9f93613942e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->