### PR TITLE
DEV-560: Document the `this` context of the cells option

### DIFF
--- a/docs/content/guides/getting-started/configuration-options/configuration-options.md
+++ b/docs/content/guides/getting-started/configuration-options/configuration-options.md
@@ -501,6 +501,8 @@ Any options modified through [`cells`](@/api/options.md#cells) overwrite all oth
 - `prop`: if your [`data`](@/api/options.md#data) is an [array of objects](@/guides/getting-started/binding-to-data/binding-to-data.md#array-of-objects), `prop` is a property name for a column's data source object.<br>
 If your [`data`](@/api/options.md#data) is an [array of arrays](@/guides/getting-started/binding-to-data/binding-to-data.md#array-of-arrays), `prop` is the same as `col`.
 
+Inside the `cells` function, `this` is the cell meta object, and `this.instance` is the Handsontable instance. Use `this.instance` to call core API methods -- for example, `this.instance.toVisualRow(row)`.
+
 ```js
 const hot = new Handsontable(container, {
   // the `cells` options overwrite all other options
@@ -542,6 +544,8 @@ The function can take three arguments:<br>
 }}/>
 ```
 
+The arrow function passed to `cells` does not bind `this`, so `this.instance` is not available inside it. To access the Handsontable instance, use the component's ref: `hotTableRef.current.hotInstance`.
+
 :::
 
 ::: only-for angular
@@ -576,6 +580,8 @@ gridSettings: GridSettings = {
 <hot-table [settings]="gridSettings" />
 ```
 
+The arrow function passed to `cells` does not bind `this`, so `this.instance` is not available inside it. To access the Handsontable instance, use the component's ref: `hotTable.hotInstance`.
+
 :::
 
 ::: only-for vue
@@ -597,6 +603,8 @@ const hotSettings = ref({
 ```html
 <HotTable :settings="hotSettings" />
 ```
+
+Because the `cells` function above is a shorthand method, `this` is the cell meta object and `this.instance` is the Handsontable instance -- for example, `this.instance.toVisualRow(row)`. An arrow function (`cells: () => {}`) does not bind `this`; in that case, access the instance via the component's ref: `hotRef.value?.hotInstance`.
 
 :::
 
@@ -1044,6 +1052,8 @@ The function can take three arguments:<br>
    - `prop`: if your [`data`](@/api/options.md#data) is an [array of objects](@/guides/getting-started/binding-to-data/binding-to-data.md#array-of-objects), `prop` is a property name for a column's data source object.<br>
    If your [`data`](@/api/options.md#data) is an [array of arrays](@/guides/getting-started/binding-to-data/binding-to-data.md#array-of-arrays), `prop` is the same as `col`.
 
+Inside the `cells` function, `this` is the cell meta object, and `this.instance` is the Handsontable instance. Use `this.instance` to call core API methods -- for example, `this.instance.toVisualRow(row)`.
+
 ```js
 const hot = new Handsontable(container, {
   cells(row, col) {
@@ -1082,6 +1092,8 @@ The function can take three arguments:<br>
 />
 ```
 
+The arrow function passed to `cells` does not bind `this`, so `this.instance` is not available inside it. To access the Handsontable instance, use the component's ref: `hotTableRef.current.hotInstance`.
+
 :::
 
 ::: only-for angular
@@ -1114,6 +1126,8 @@ gridSettings: GridSettings = {
 <hot-table [settings]="gridSettings" />
 ```
 
+The arrow function passed to `cells` does not bind `this`, so `this.instance` is not available inside it. To access the Handsontable instance, use the component's ref: `hotTable.hotInstance`.
+
 :::
 
 ::: only-for vue
@@ -1133,6 +1147,8 @@ const hotSettings = ref({
 ```html
 <HotTable :settings="hotSettings" />
 ```
+
+Because the `cells` function above is a shorthand method, `this` is the cell meta object and `this.instance` is the Handsontable instance -- for example, `this.instance.toVisualRow(row)`. An arrow function (`cells: () => {}`) does not bind `this`; in that case, access the instance via the component's ref: `hotRef.value?.hotInstance`.
 
 :::
 

--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -646,6 +646,12 @@ export default (): Record<string, unknown> => {
      * | `column`  | Yes      | Number           | A physical column index                                                                                                                                                                                                                                                                                                                 |
      * | `prop`    | No       | String \| Number | If [`data`](#data) is set to an [array of arrays](@/guides/getting-started/binding-to-data/binding-to-data.md#array-of-arrays), `prop` is the same number as `column`.<br><br>If [`data`](#data) is set to an [array of objects](@/guides/getting-started/binding-to-data/binding-to-data.md#array-of-objects), `prop` is a property name for the column's data object. |
      *
+     * Inside a regular (non-arrow) `cells` function, `this` is the cell meta object. Its
+     * `this.instance` property is the Handsontable instance, so you can call core API methods
+     * such as `this.instance.toVisualRow(row)` or `this.instance.toVisualColumn(column)` (as in
+     * the example below). Arrow functions (`cells: () => {}`) do not bind `this`, so
+     * `this.instance` is not available inside them – use a regular or shorthand function instead.
+     *
      * Read more:
      * - [Configuration options: Implementing custom logic](@/guides/getting-started/configuration-options/configuration-options.md#implement-custom-logic)
      * - [Configuration options: Setting row options](@/guides/getting-started/configuration-options/configuration-options.md#set-row-options)


### PR DESCRIPTION
### Context

The PR documents the `this` context of the [`cells`](https://handsontable.com/docs/api/options/#cells) option, which was previously undocumented (DEV-560).

Handsontable invokes the `cells` function as a plain method (`cellMeta.cells(row, column, prop)`), so inside a regular (non-arrow) `cells` function `this` is the cell meta object, and `this.instance` is the Handsontable instance. The API reference example already *used* `this.instance.toVisualRow(row)` without ever explaining what `this` is, and the configuration-options guide had the same gap. Arrow functions do not bind `this`, so `this.instance` is unavailable inside them - a trap for the React/Angular guide variants, which use arrow functions.

This change adds prose explaining `this`/`this.instance` and the arrow-function caveat:

- **API reference** (`metaSchema.ts` JSDoc for `cells`): a paragraph describing `this`, `this.instance`, and the arrow-function limitation.
- **Configuration-options guide**, "Set row options" and "Implement custom logic" sections: a note per framework variant, tailored to the code each variant actually shows. The JavaScript and Vue examples use shorthand methods (where `this` is bound); the React and Angular examples use arrow functions (where it is not, so the note points to the component ref's `hotInstance`).

This is a documentation-only change - no API or behavior change. `[skip changelog]`

### How has this been tested?

- `npm run eslint --prefix handsontable` - passes (JSDoc block-style and `jsdoc/require-jsdoc` rules).
- Static review of the rendered Markdown; all internal links use the `@/...md#anchor` form.
- No unit/E2E tests - no code path is modified.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-560

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-560

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and JSDoc only; no runtime or API behavior changes.
> 
> **Overview**
> Documents how **`this`** works inside the [`cells`](@/api/options.md#cells) callback so it matches runtime behavior (Handsontable calls `cellMeta.cells(...)`, so **`this`** is cell meta and **`this.instance`** is the grid API).
> 
> **API reference** (`metaSchema.ts`): new JSDoc paragraph on **`this` / `this.instance`**, example API usage (`toVisualRow` / `toVisualColumn`), and the arrow-function caveat.
> 
> **Configuration-options guide** (“Set row options” and “Implement custom logic”): framework-specific notes—JS/Vue shorthand methods can use **`this.instance`**; React/Angular arrow examples are told **`this`** is unbound and to use the wrapper ref’s **`hotInstance`** instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c83f391a522a9d235e7a4c34cec161fb2af61be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->