### PR TITLE
Make multiselect editor filtering locale-aware

### DIFF
--- a/.changelogs/12902.json
+++ b/.changelogs/12902.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed the `multiselect` cell type so its option filtering folds case in a locale-aware way, consistent with the `autocomplete` editor, for Turkish, Azeri, and Lithuanian locales.",
+  "type": "fixed",
+  "issueOrPR": 12902,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/editors/multiSelectEditor/multiSelectEditor.ts
+++ b/handsontable/src/editors/multiSelectEditor/multiSelectEditor.ts
@@ -6,6 +6,7 @@ import { DropdownController, type DropdownEntry } from './controllers/dropdownCo
 import { SelectedItemsController } from './controllers/selectedItemsController';
 import { addClass, setAttribute } from '../../helpers/dom/element';
 import { isPrintableChar } from '../../helpers/unicode';
+import { localeLowerCase } from '../../helpers/string';
 import { A11Y_LABEL, A11Y_GROUP } from '../../helpers/a11y';
 import { EDITOR_EDIT_GROUP } from '../../shortcuts/contexts/constants';
 import {
@@ -378,6 +379,7 @@ export class MultiSelectEditor extends BaseEditor {
     query: string,
     filterSelectedItems: boolean = this.#getEditorSetting<boolean>('filterSelectedItems') ?? true
   ): void {
+    const locale = this.cellProperties.locale as string | undefined;
     const filteredItems = this.#getSource().filter((item: unknown) => {
       const value = (typeof item === 'object' && item !== null && 'value' in item)
         ? item.value
@@ -391,7 +393,7 @@ export class MultiSelectEditor extends BaseEditor {
         return String(value).includes(query);
       }
 
-      return String(value).toLowerCase().includes(query.toLowerCase());
+      return localeLowerCase(String(value), locale).includes(localeLowerCase(query, locale));
     });
 
     this.dropdownController!.fillDropdown(filteredItems, this.#selectedItems.getItemsArray());


### PR DESCRIPTION
### Context

The `multiselect` editor filters its options against the typed query with plain `String.prototype.toLowerCase()`:

```ts
return String(value).toLowerCase().includes(query.toLowerCase());
```

That folds case incorrectly in Turkish, Azeri and Lithuanian, where dotted `İ`/`i` and dotless `I`/`ı` are separate letters. With a cell `locale` of `tr-TR`:

- typing `i` matches `IRMAK` (Turkish lowercase is `ırmak`, so it should not match), and
- typing the dotless `ı` fails to match `IGUANA` (Turkish lowercase is `ıguana`, so it should match).

The autocomplete editor, the filters conditions (`contains`, `equal`, `beginsWith`, `endsWith`) and `conditionCollection` already route the same case-insensitive comparison through the `localeLowerCase()` helper added in #12762, reading the cell's `locale` meta. The multiselect editor was the one dropdown editor still on the plain path, so the two editors disagreed on case folding for those locales.

This change applies the existing `localeLowerCase()` helper to `#filterEntries`, mirroring the autocomplete editor. Non-tailored locales (the default `en-US`, German, French, etc.) still take the fast `toLowerCase()` fallback inside the helper, so their behaviour is unchanged.

### How has this been tested?

I reproduced the `localeLowerCase()` logic in isolation and confirmed the new comparison matches the autocomplete editor for `tr-TR`:

- `i` vs `IRMAK` no longer matches (was a false positive),
- dotless `ı` vs `IGUANA` now matches (was a false negative),
- `en-US` results are byte-for-byte identical to the previous `toLowerCase()` path.

I did not run the full browser test suite locally. Happy to add a Turkish-locale E2E spec for the multiselect editor mirroring the autocomplete editor's tests if you'd prefer the regression covered here.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. Follow-up to #12762

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about Contributing to Handsontable and I confirm that my code follows the code style of this project.
- [ ] I have signed the Contributor License Agreement
- [ ] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to non-case-sensitive filtering using an existing helper; case-sensitive mode and default locales are unaffected.
> 
> **Overview**
> The **multiselect** editor’s dropdown search now uses **`localeLowerCase()`** with the cell’s **`locale`** meta for case-insensitive filtering, replacing plain **`toLowerCase()`** on both the option value and query.
> 
> This aligns multiselect behavior with the **autocomplete** editor and fixes incorrect matches in locales such as Turkish (e.g. **`i`** vs **`İ`/`ı`**). **`filteringCaseSensitive`** is unchanged and still uses a direct string **`includes`** check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d5b54dc79bc183e9f688571a7244d61417ab945. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->