### PR TITLE
DEV-1019: Document the allowSampleDuplicates option for autoRowSize

### DIFF
--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -481,9 +481,10 @@ export default (): Record<string, unknown> => {
      *
      * If you set the `autoRowSize` option to an object, you can set the following [`AutoRowSize`](@/api/autoRowSize.md) plugin options:
      *
-     * | Property    | Possible values                 | Description                                                       |
-     * | ----------- | ------------------------------- | ----------------------------------------------------------------- |
-     * | `syncLimit` | A number \| A percentage string | The number/percentage of rows to keep in sync<br>(default: `500`) |
+     * | Property                | Possible values                 | Description                                                                                                |
+     * | ----------------------- | ------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+     * | `syncLimit`             | A number \| A percentage string | The number/percentage of rows to keep in sync<br>(default: `500`)                                          |
+     * | `allowSampleDuplicates` | `true` \| `false`               | When calculating row heights:<br>`true`: Allow duplicate samples<br>`false`: Don't allow duplicate samples |
      *
      * Using the [`rowHeights`](#rowHeights) option forcibly disables the [`AutoRowSize`](@/api/autoRowSize.md) plugin.
      *
@@ -502,7 +503,9 @@ export default (): Record<string, unknown> => {
      * ```js
      * autoRowSize: {
      *   // keep 40% of rows in sync (the rest of rows: async)
-     *   syncLimit: '40%'
+     *   syncLimit: '40%',
+     *   // when calculating row heights, allow duplicate samples
+     *   allowSampleDuplicates: true
      * },
      * ```
      */

--- a/handsontable/src/plugins/autoRowSize/autoRowSize.ts
+++ b/handsontable/src/plugins/autoRowSize/autoRowSize.ts
@@ -40,13 +40,22 @@ const AUTO_ROW_SIZE_CLASS_NAME = 'htAutoRowSize';
  *
  * // as a string (percent)
  * autoRowSize: {syncLimit: '40%'},
- *
- * // allow sample duplication
- * autoRowSize: {syncLimit: '40%', allowSampleDuplicates: true},
  * ```
  *
- * You can also use the `allowSampleDuplicates` option to allow sampling duplicate values when calculating the row
- * height. __Note__, that this might have a negative impact on performance.
+ * To speed up the calculations, the plugin samples a subset of rows rather than measuring every row. By default, it
+ * skips rows whose value it has already sampled, on the assumption that identical values render at the same height.
+ * Set the `allowSampleDuplicates` option to `true` to sample duplicate values as well:
+ *
+ * ```js
+ * autoRowSize: {allowSampleDuplicates: true},
+ * ```
+ *
+ * Enable this option when rows with the same value can still render at different heights - for example, with multiline
+ * text, or with custom renderers that vary a row's height based on its position or other data. Without it, the plugin
+ * may sample only one of those rows and apply its height to the rest, leading to incorrect row heights.
+ *
+ * The tradeoff is performance: allowing duplicates increases the number of rows measured, which lengthens the
+ * calculation and can block the UI for longer on large data sets.
  *
  * ::: tip
  * Note: Updating some of the table's settings can cause the row heights to change (e.g. `wordWrap`, `textEllipsis`, renderers etc.).


### PR DESCRIPTION
### Context

The PR improves the documentation for the `autoRowSize` plugin's `allowSampleDuplicates` option, which was under-documented. The `AutoRowSize` plugin JSDoc only mentioned the option in a single sentence with a generic performance note, and the `autoRowSize` configuration option's property table omitted it entirely - while the sibling `autoColumnSize` option already documented the same setting in full. A reader had no way to learn what `allowSampleDuplicates` does, when to enable it, or its tradeoff.

This change is JSDoc-only (doc comments in `handsontable/src`); it does not alter any runtime behavior.

Changes:
- `handsontable/src/dataMap/metaManager/metaSchema.ts` - added an `allowSampleDuplicates` row to the `autoRowSize` option's property table and extended the `@example` to show it in use, mirroring the existing `autoColumnSize` documentation.
- `handsontable/src/plugins/autoRowSize/autoRowSize.ts` - replaced the one-line mention with an explanation of what the option does (sampling duplicate values), when to enable it (rows with identical values that still render at different heights, e.g. multiline text or position-dependent renderers), and the performance tradeoff. Removed the now-redundant duplicate mention from the `syncLimit` config block.

### How has this been tested?

- `npm run eslint --prefix handsontable` - passes.
- `npm run build --prefix handsontable` - builds successfully.
- No unit or E2E tests apply: this change touches only JSDoc comments and introduces no behavior change.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1019

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog] - documentation-only change (JSDoc), no source behavior change.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1019

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only changes in `metaSchema.ts` and `autoRowSize.ts`; no executable code or configuration defaults are modified.
> 
> **Overview**
> **JSDoc-only** update: documents the existing `autoRowSize.allowSampleDuplicates` option so it matches how `autoColumnSize` is documented.
> 
> In **`metaSchema.ts`**, the `autoRowSize` option table now includes **`allowSampleDuplicates`**, and the config **`@example`** shows it alongside `syncLimit`. In **`autoRowSize.ts`**, the plugin docs explain that row-height sampling skips duplicate cell values by default, when to set **`allowSampleDuplicates: true`** (multiline text, custom renderers, position-dependent heights), and the performance cost of measuring more rows. The option is no longer only mentioned inline in the `syncLimit` example block.
> 
> No runtime or API behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4839649d833d63d847940a451e7c32eabeba960e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->