### PR TITLE
DEV-893: Improve docs search discoverability for no-result terms

### DIFF
--- a/docs/content/guides/cell-features/conditional-formatting/conditional-formatting.md
+++ b/docs/content/guides/cell-features/conditional-formatting/conditional-formatting.md
@@ -13,6 +13,7 @@ vue:
   metaTitle: Conditional formatting - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features
+menuTag: updated
 ---
 Format specified cells, based on dynamic conditions.
 
@@ -81,6 +82,10 @@ This demo shows how to use the cell type renderer feature to make some condition
 ## Result
 
 Cells that match the defined conditions display the configured styles -- colors, fonts, or borders -- automatically updating as data changes.
+
+## Format negative numbers
+
+A frequent conditional-formatting task is styling negative numbers -- for example, showing them in red. The example above does this in its renderer: it checks whether the cell value is below zero and applies a CSS class for negative values. Use the same approach to flag any value that meets a numeric condition, such as amounts over a threshold.
 
 ## Related articles
 

--- a/docs/content/guides/cell-features/formatting-cells/formatting-cells.md
+++ b/docs/content/guides/cell-features/formatting-cells/formatting-cells.md
@@ -13,6 +13,7 @@ vue:
   metaTitle: Formatting cells - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features
+menuTag: updated
 ---
 Change the appearance of cells, using custom CSS classes, inline styles, or custom cell borders.
 
@@ -29,7 +30,9 @@ You can format a cell either using a `CSS` class or with a style applied directl
 
 ## Apply custom CSS class styles
 
-In this example, we add a custom class `custom-cell` to the cell in the top left corner and add a `custom-table` CSS class that highlights the table headers.
+In this example, you add a custom class `custom-cell` to the cell in the top-left corner and a `custom-table` CSS class that highlights the table headers.
+
+To add a CSS class to a cell, column, or row, use the [`className`](@/api/options.md#classname) option. Set it in the grid configuration, in a `columns` entry, or per cell through the [`cells`](@/api/options.md#cells) callback. The class you provide is added to the cell's `<td>` element, where your CSS rules can target it.
 
 ::: only-for javascript
 

--- a/docs/content/guides/cell-functions/cell-renderer/cell-renderer.md
+++ b/docs/content/guides/cell-functions/cell-renderer/cell-renderer.md
@@ -13,6 +13,7 @@ vue:
   metaTitle: Cell renderer - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell functions
+menuTag: updated
 ---
 
 A cell renderer is a function that controls how cell content is displayed in the DOM. Override a built-in renderer or write your own to customize the visual output.
@@ -410,6 +411,33 @@ In the below configuration:
 
 :::
 
+:::
+
+## Render hyperlinks in cells
+
+A common use of a custom renderer is to turn a cell value into a clickable hyperlink. The renderer reads the cell value, builds an anchor (`<a>`) element, and appends it to the cell's DOM node.
+
+```js
+function hyperlinkRenderer(instance, td, row, column, prop, value, cellProperties) {
+  Handsontable.dom.empty(td);
+
+  const link = document.createElement('a');
+
+  link.href = value;
+  link.textContent = value;
+  link.target = '_blank';
+  link.rel = 'noopener noreferrer';
+
+  td.appendChild(link);
+
+  return td;
+}
+```
+
+Assign the renderer to a column through the [`renderer`](@/api/options.md#renderer) option, or register it by alias with `registerRenderer()` as shown in [Register custom cell renderer](#register-custom-cell-renderer).
+
+::: warning Security
+When the link comes from untrusted input, validate the URL before rendering it. An unchecked `href` lets an attacker inject a `javascript:` link or other XSS vector. See [Security](@/guides/security/security/security.md) for details.
 :::
 
 ## Render custom HTML in header

--- a/docs/content/guides/columns/column-summary/column-summary.md
+++ b/docs/content/guides/columns/column-summary/column-summary.md
@@ -21,6 +21,7 @@ vue:
   metaTitle: Column summary - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Columns
+menuTag: updated
 ---
 Calculate sum, min, max, count, average or custom aggregates of individual columns' data, using Handsontable's aggregate functions.
 
@@ -29,6 +30,8 @@ Calculate sum, min, max, count, average or custom aggregates of individual colum
 ## Overview
 
 The [`ColumnSummary`](@/api/columnSummary.md) plugin lets you quickly calculate and display a column summary.
+
+Handsontable's aggregates are column-based: `ColumnSummary` summarizes a range of rows within a column. There is no separate row summary (`rowSummary`) feature. To show a per-row total across columns, compute it in your data source or a [custom renderer](@/guides/cell-functions/cell-renderer/cell-renderer.md).
 
 To customize your column summaries, you can:
 

--- a/docs/content/guides/rows/row-freezing/row-freezing.md
+++ b/docs/content/guides/rows/row-freezing/row-freezing.md
@@ -17,6 +17,7 @@ vue:
   metaTitle: Row freezing - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Rows
+menuTag: updated
 ---
 Lock the position of specified rows, keeping them visible when scrolling.
 
@@ -74,6 +75,21 @@ The following example specifies two fixed rows with `fixedRowsTop: 2`. Horizonta
 :::
 
 :::
+
+## Freeze rows at the bottom
+
+To pin rows to the bottom edge of the grid -- sometimes called footer rows -- use the `fixedRowsBottom` option. The specified number of rows stays visible at the bottom of the viewport while you scroll through the rest of the data.
+
+```js
+const hot = new Handsontable(container, {
+  data: getData(),
+  // freeze the last two rows as a footer
+  fixedRowsBottom: 2,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+```
+
+You can combine `fixedRowsTop` and `fixedRowsBottom` to keep both a header and a footer row in view at the same time.
 
 ## Result
 

--- a/docs/content/guides/rows/row-parent-child/row-parent-child.md
+++ b/docs/content/guides/rows/row-parent-child/row-parent-child.md
@@ -27,6 +27,8 @@ menuTag: updated
 Reflect the parent-child relationship of your data, using the [`NestedRows`](@/api/nestedRows.md) plugin's interactive UI elements such as expand and collapse
 buttons or an extended context menu.
 
+Handsontable renders this structure as a tree grid. The same pattern is also called a master-detail view or grouping rows.
+
 [[toc]]
 
 ## Quick setup


### PR DESCRIPTION
### Context

The PR improves docs search discoverability for a set of terms that returned no results in the docs search analytics tracked in DEV-893 (2024).

The original issue proposed fixing this by adding `tags:` to page frontmatter. That mechanism no longer works: since the issue was filed, the docs site migrated from VuePress to Astro/Starlight + Algolia DocSearch. `tags` is not part of the Starlight content schema (`docs/src/content.config.ts`), no component or loader reads it, and Algolia's crawler indexes rendered HTML (headings and body text) after each production deploy — not frontmatter. The existing `tags:` on pages are inert.

This PR re-scopes the fix to the content level: it moves the high-value search terms into genuine indexed prose and headings, which is the surface Algolia actually crawls.

Pages updated:

- **`row-parent-child.md`** (the issue's headline page) — added a sentence naming the feature's common synonyms (`tree grid`, `master-detail`, `grouping rows`) to the intro; previously these existed only in inert frontmatter tags.
- **`row-freezing.md`** — added a "Freeze rows at the bottom" section covering `fixedRowsBottom` and footer rows (search term: `footer`, 23 searches; previously only `fixedRowsTop` was demonstrated).
- **`cell-renderer.md`** — added a "Render hyperlinks in cells" section with a sanitizer-aware `<a>` renderer (search term: `hyperlink`).
- **`conditional-formatting.md`** — added a "Format negative numbers" section (search term: negative value renderer).
- **`formatting-cells.md`** — added prose naming the `className` option as the mechanism for adding a CSS class (search term: `addClass`); also fixed "we" → "you" per docs voice.
- **`column-summary.md`** — added a disambiguation note clarifying there is no separate `rowSummary` feature (search term: `row summary`).

Out of scope (handed to the team, not fixable in this repo):

- ~9 API-name aliases and misspellings (`updatecell` → `setDataAtCell`, `afterinsert` → `afterCreateRow`, `getvalidator` → `getCellValidator`, `hot.alter`, `customheaderrenderer`, `afterclick`, `translatetrimmedrow`, etc.) and `getMergeCells` (no public getter API exists). These need Algolia synonyms / typo-tolerance configured in the Algolia dashboard, which lives outside this repo.
- `docs/README-EDITING.md` and `docs/AGENTS.md` §2.6 still tell authors that `tags:` feed search. That guidance is stale under the Astro stack and should be corrected in a follow-up.

Note: real discoverability is only verifiable after the Algolia crawler re-indexes a deploy; it cannot be confirmed locally.

[skip changelog]

### How has this been tested?

- Docs-only change to existing guide pages. No source code touched, so no unit or E2E tests apply.
- Static review: confirmed each target term now appears in a rendered heading or body prose (not frontmatter), heading hierarchy is correct (no skipped levels), all code blocks have language tags, the config snippet includes `licenseKey: 'non-commercial-and-evaluation'`, and internal links use the `@/...md#anchor` syntax.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-893

### Affected project(s):

- [x] `handsontable` (documentation)
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-893

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API impact; search effect depends on a post-deploy Algolia re-crawl.
> 
> **Overview**
> Improves **docs search discoverability** (DEV-893) by putting high-traffic query terms into **headings and body text** that Algolia indexes, instead of relying on frontmatter `tags` (not used on the Astro/Starlight stack).
> 
> Six guides get **`menuTag: updated`** and targeted prose: **row parent-child** names tree grid / master-detail / grouping rows; **row freezing** documents **`fixedRowsBottom`** and footer rows; **cell renderer** adds a hyperlink renderer with an XSS warning; **conditional formatting** adds styling negative numbers; **formatting cells** explains **`className`** for CSS classes and shifts to second-person voice; **column summary** clarifies there is no **`rowSummary`** API and points to data/renderer alternatives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ad96cdf02dbf54efad454c027281a90d155867d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->