### PR TITLE
Fix mergeCells JSDoc param type that breaks the docs API build

### DIFF
--- a/handsontable/src/plugins/mergeCells/mergeCells.ts
+++ b/handsontable/src/plugins/mergeCells/mergeCells.ts
@@ -820,7 +820,7 @@ export class MergeCells extends BasePlugin {
    * later target stale rows. Only merges still present in the collection are visited (fully removed ones
    * were already dropped by `shiftCollections`), so each anchor always maps to a valid surviving row.
    *
-   * @param {(physicalRow: number) => number} mapPhysicalRow Maps an old physical row to its new one.
+   * @param {function(number): number} mapPhysicalRow Maps an old physical row to its new one.
    */
   #remapRowAnchors(mapPhysicalRow: (physicalRow: number) => number) {
     this.mergedCellsCollection.mergedCells.forEach((merge) => {


### PR DESCRIPTION
### Context

The PR fixes a JSDoc type expression that breaks the documentation API build (`docs:api`).

`#remapRowAnchors` in `mergeCells.ts` documents its callback parameter with a TypeScript arrow-function type:

```
@param {(physicalRow: number) => number} mapPhysicalRow
```

The docs API generator (`jsdoc-api` / `jsdoc-to-markdown`) parses JSDoc type expressions with catharsis, which does not accept arrow-function syntax. The build fails with:

```
JSDOC_ERROR: Unable to parse a tag's type expression ...
Invalid type expression "(physicalRow: number) => number"
```

This is a regression introduced by #12792 (DEV-404) and breaks every docs build on `develop`, not just one PR. The fix replaces the arrow type with the closure-function syntax already used across the codebase (for example `crud.ts`: `@param {function(object[]): Promise<void>}`):

```
@param {function(number): number} mapPhysicalRow
```

This is a comment-only change. The method's actual TypeScript signature is unchanged, so there is no behavior or public-API change.

[skip changelog]

### How has this been tested?

Verified with the same `jsdoc-api@7.2.0` the docs build uses, parsing both forms of the tag:

- Old arrow type `{(physicalRow: number) => number}` -> fails with the exact CI error.
- New closure type `{function(number): number}` -> parses successfully.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. Regression from #12792 (DEV-404)

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation comment only; no runtime or public API behavior change.
> 
> **Overview**
> Fixes a **docs API build failure** (`docs:api`) caused by an invalid JSDoc type on `#remapRowAnchors` in `mergeCells.ts`.
> 
> The `@param` for `mapPhysicalRow` is changed from a TypeScript-style arrow type `{(physicalRow: number) => number}` to the **closure form** `{function(number): number}`, which catharsis/jsdoc-api can parse and which matches other Handsontable JSDoc (e.g. `range.ts`). **Comment-only** — the TypeScript method signature is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50b5f03ff03237ef6c53417b3c4001c01d5f2e7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->