### PR TITLE
Fix docs deploy crashing on unauthenticated GitHub releases fetch

### DIFF
--- a/.github/workflows/docs-production.yml
+++ b/.github/workflows/docs-production.yml
@@ -81,6 +81,8 @@ jobs:
           docker push $GHA_DOCKER_TAG":v${{steps.get-docs-version.outputs.result}}-${{ github.sha }}"
 
       - name: Build and deploy the production to Netlify (from Docker images)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cd netlify
           mkdir -p docs/docs

--- a/docs/netlify/build_current_version.sh
+++ b/docs/netlify/build_current_version.sh
@@ -1,8 +1,14 @@
 #/bin/bash
+set -euo pipefail
 mkdir -p docs/docs
 node getListOrPreviousVersions.mjs > VERSIONS_VARS
 source VERSIONS_VARS
 rm VERSIONS_VARS
+
+if [ -z "${LATEST_VERSION:-}" ]; then
+    echo "ERROR: LATEST_VERSION is empty - the version list could not be read from the GitHub API." >&2
+    exit 1
+fi
 echo "/docs/$LATEST_VERSION/* /docs/:splat 301" >> _redirects
 for version in $PREVIOUS_VERSIONS
 do

--- a/docs/netlify/build_previous_versions.sh
+++ b/docs/netlify/build_previous_versions.sh
@@ -1,8 +1,14 @@
 #/bin/bash
+set -euo pipefail
 mkdir -p docs/docs
 node getListOrPreviousVersions.mjs > VERSIONS_VARS
 source VERSIONS_VARS
 rm VERSIONS_VARS
+
+if [ -z "${LATEST_VERSION:-}" ]; then
+    echo "ERROR: LATEST_VERSION is empty - the version list could not be read from the GitHub API." >&2
+    exit 1
+fi
 echo "/docs/$LATEST_VERSION/* /docs/:splat 301" >> _redirects
 for version in $PREVIOUS_VERSIONS
 do

--- a/docs/netlify/getListOrPreviousVersions.mjs
+++ b/docs/netlify/getListOrPreviousVersions.mjs
@@ -11,18 +11,60 @@ import semver from 'semver';
 const MIN_DOCS_VERSION = '9.0';
 
 /**
+ * Number of times the releases request is retried before giving up.
+ */
+const MAX_ATTEMPTS = 5;
+
+/**
+ * Fetches the releases list, retrying on transient network failures.
+ *
+ * Unauthenticated requests from CI runner IP addresses are throttled and the connection is often cut
+ * mid-response ("Premature close"). Passing a token (when available) lifts the rate limit, and the
+ * retry loop covers the remaining transient failures.
+ *
+ * @param {Octokit} octokit The Octokit client.
+ * @returns {Promise<object>}
+ */
+async function fetchReleases(octokit) {
+  let lastError;
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      return await octokit.rest.repos.listReleases({
+        owner: 'handsontable',
+        repo: 'handsontable',
+        per_page: 50,
+      });
+    } catch (error) {
+      lastError = error;
+
+      // eslint-disable-next-line no-console
+      console.error(`Attempt ${attempt}/${MAX_ATTEMPTS} to fetch releases failed: ${error.message}`);
+
+      if (attempt < MAX_ATTEMPTS) {
+        const delay = 2 ** attempt * 1000;
+
+        await new Promise((resolve) => {
+          setTimeout(resolve, delay);
+        });
+      }
+    }
+  }
+
+  throw lastError;
+}
+
+/**
  * Reads the list of Docs version from the GitHub using the releases list.
  *
  * @returns {object}
  */
 async function readFromGitHub() {
-  const octokit = new Octokit();
+  // `GITHUB_TOKEN` is optional - when present it lifts the unauthenticated rate limit and makes the
+  // request reliable on CI runners; locally the call still works without it.
+  const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
 
-  const releases = await octokit.rest.repos.listReleases({
-    owner: 'handsontable',
-    repo: 'handsontable',
-    per_page: 50,
-  });
+  const releases = await fetchReleases(octokit);
 
   if (releases.status !== 200) {
     throw new Error('Incorrect response from the GitHub API.');


### PR DESCRIPTION
### Context

The PR fixes the production docs deployment crashing in the "Build and deploy the production to Netlify" step (for example, [this run](https://github.com/handsontable/handsontable/actions/runs/28433590352/job/84253967778)).

The deploy step runs `build_current_version.sh`, which calls `getListOrPreviousVersions.mjs` to read the docs version list. That script created an **unauthenticated** Octokit client (`new Octokit()`) and the workflow step passed no `GITHUB_TOKEN`. Unauthenticated requests from CI runner IPs are throttled, and the large releases response (`per_page=50`, full release-note bodies) is cut mid-stream:

```
RequestError [HttpError]: Invalid response body while trying to fetch
https://api.github.com/repos/handsontable/handsontable/releases?per_page=50: Premature close
```

The failure then cascaded into misleading errors. `build_current_version.sh` had no `set -e`, so after the Node script crashed it kept running with an empty `LATEST_VERSION`:

```
Unable to find image 'ghcr.io/.../handsontable-documentation:v' locally
Error response from daemon: manifest unknown
cp: cannot stat 'docs/docs/404.html': No such file or directory
```

None of this depends on whether the release exists — the release was published; the version-list fetch itself failed.

### Changes

1. `getListOrPreviousVersions.mjs` — authenticate the Octokit client with `process.env.GITHUB_TOKEN` (optional, still works locally without it) and retry the releases request up to 5 times with exponential backoff to cover transient "Premature close" failures.
2. `docs-production.yml` — pass `GITHUB_TOKEN` to the deploy step so the request is authenticated (lifts the unauthenticated rate limit).
3. `build_current_version.sh` and `build_previous_versions.sh` — add `set -euo pipefail` and an explicit guard that fails the build with a clear message when `LATEST_VERSION` is empty, instead of cascading into the misleading docker/`404.html` errors.

### How has this been tested?

- Ran `node getListOrPreviousVersions.mjs` locally (with and without a token) — returns `LATEST_VERSION="18.0"` and the correct previous-versions list.
- `bash -n` syntax check on both shell scripts.
- `eslint` on the modified `.mjs` file — passes.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

CI/tooling fix for the docs production deployment workflow.

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]
