### PR TITLE
docs: Remove obsolete frontmatter id field from authoring rules

### DIFF
--- a/.claude/skills/writing-docs-pages/SKILL.md
+++ b/.claude/skills/writing-docs-pages/SKILL.md
@@ -10,11 +10,10 @@ This skill covers how to create and edit guide pages in `docs/content/guides/`.
 
 ## 1. Frontmatter (required)
 
-Every `.md` file starts with YAML frontmatter. Generate unique 8-character alphanumeric IDs for new pages (never change existing IDs). Each framework variant needs its own ID.
+Every `.md` file starts with YAML frontmatter.
 
 ```yaml
 ---
-id: abc12345              # 8 random alphanumeric chars (never change existing)
 title: Feature Name
 metaTitle: Feature Name - JavaScript Data Grid | Handsontable
 description: Short SEO description under 160 characters.
@@ -24,7 +23,6 @@ tags:
   - keyword1
   - keyword2
 react:
-  id: def67890            # Different ID for React variant
   metaTitle: Feature Name - React Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features    # Must match a sidebar category exactly

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -109,7 +109,6 @@ Use the appropriate template for each Diátaxis type. Do not omit required secti
 ```markdown
 ---
 type: tutorial
-id: <8-char alphanum>
 title: <Verb phrase — Build/Create/Set up X>
 metaTitle: <title> - JavaScript Data Grid | Handsontable
 description: <1-2 sentences summarizing outcome and who benefits>
@@ -150,7 +149,6 @@ In this tutorial, you will [concrete outcome]. You will learn [skill or concept]
 ```markdown
 ---
 type: how-to
-id: <8-char alphanum>
 title: How to [specific goal]
 metaTitle: How to [specific goal] - JavaScript Data Grid | Handsontable
 description: <1-2 sentences: what this achieves and when to use it>
@@ -191,7 +189,6 @@ category: <nav category>
 ```markdown
 ---
 type: reference
-id: <8-char alphanum>
 title: [Component/API/option name]
 metaTitle: [Component/API name] - JavaScript Data Grid | Handsontable
 description: <1-2 sentences describing what this is>
@@ -234,7 +231,6 @@ category: <nav category>
 ```markdown
 ---
 type: explanation
-id: <8-char alphanum>
 title: Understanding [concept]
 metaTitle: Understanding [concept] - JavaScript Data Grid | Handsontable
 description: <1-2 sentences: why this concept matters and who should read this>
@@ -396,14 +392,12 @@ Required fields for all pages:
 ```yaml
 ---
 type: tutorial | how-to | reference | explanation   # Diátaxis type (required)
-id: abc12345              # 8 random alphanumeric chars — NEVER change existing IDs
 title: Feature Name       # Matches H1; do NOT add H1 in body (Starlight renders title once)
 metaTitle: Feature Name - JavaScript Data Grid | Handsontable
 description: Short SEO description (1-2 sentences)
 permalink: /feature-name
 tags: [keyword1, keyword2]  # Optional; kebab-case
 react:
-  id: def67890            # Different ID per framework variant
   metaTitle: Feature Name - React Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features
@@ -412,7 +406,6 @@ menuTag: new | updated    # Optional; sidebar badge -- see rule below
 ```
 
 **Rules:**
-- Never change an existing `id` value. IDs are permanent.
 - `title` is the only H1. Do not add `# Title` in the Markdown body.
 - `description` is used in SEO meta and link previews -- make it specific and accurate.
 - `tags` must be lowercase kebab-case.
@@ -476,7 +469,6 @@ Copy and complete this checklist in your PR description:
 - [ ] How-tos have a "Result" section
 - [ ] New page registered in `content/guides/sidebar.js`
 - [ ] `menuTag: new` set on new pages / `menuTag: updated` set on substantively changed pages (omit for trivial fixes, changelogs, and migration guides)
-- [ ] `id` field uses 8 random alphanumeric chars (existing IDs are unchanged)
 - [ ] Microsoft trademark disclaimer added where "Excel" is mentioned
 - [ ] TypeScript example exists; JS generated via `npm run docs:code-examples:generate-js`
 - [ ] `[skip changelog]` in PR body (docs changes don't need changelog entries)

--- a/docs/README-EDITING.md
+++ b/docs/README-EDITING.md
@@ -18,7 +18,6 @@ Each Markdown file can start with the following frontmatter tags:
 
 | Tag              | Meaning                                              | Default value                                              |
 | ---------------- | ---------------------------------------------------- | ---------------------------------------------------------- |
-| `id`             | The page's unique ID.                                  | Required. Used for redirecting between different versions (e.g., 12.1 to 11.0) of the same documentation page (https://github.com/handsontable/handsontable/pull/10163). Don't change the IDs of existing pages. To add an ID for a new page, generate 8 random alphanumeric characters (https://www.random.org/strings/?num=20&len=8&digits=on&loweralpha=on&unique=on&format=html&rnd=new). |
 | `title`          | The page's header.                                   | If not set, gets generated from the page's parent's title. |
 | `permalink`      | The page's **unique** URL.                           | If not set, gets generated from the Markdown file name.    |
 | `canonicalUrl`   | A canonical URL of the page's latest version.        | None (not required)                                        |
@@ -54,19 +53,16 @@ Frontmatter example:
 
 ```yaml
 ---
-id: 1ezrscdc
 title: Introduction
 metaTitle: Installation - Guide - Handsontable Documentation for Javascript
 description: Easily install the data grid using your preferred package manager or import Handsontable assets directly from the CDN.
 permalink: /api/
 canonicalUrl: /api/
 react:
-  id: xyr8fg2e # The page id should be different for different for other framework variations
   metaTitle: Installation - Guide - Handsontable Documentation for React
   description: Install the wrapper for React via npm, import stylesheets, and use it to get up and running your application.
   customValue: Custom # Custom value that can be used within template and will be available only for React framework
 angular:
-  id: abc12345
   metaTitle: Installation - Guide - Handsontable Documentation for Angular
   description: Install the wrapper for Angular via npm, import stylesheets, and use it to get up and running your application.
 tags:


### PR DESCRIPTION
### Context

The PR removes the obsolete per-page `id` frontmatter field from the documentation authoring rules.

The Astro Starlight docs site no longer uses the `id` frontmatter field (no current guide page carries one), but the authoring rules still instructed authors and AI agents to generate an 8-character `id` for every new page. Following the rule produced an unused `id` on a newly added guide that no sibling page has. This removes the instruction at its source so new pages stop carrying it.

Changes:

- `docs/AGENTS.md` — removed `id` from the four Diátaxis page templates (2.3), the frontmatter schema (2.6), the "never change an existing `id`" rule, and the PR checklist item (2.10).
- `.claude/skills/writing-docs-pages/SKILL.md` — removed the `id` line and the "generate unique 8-character alphanumeric IDs" guidance from the frontmatter section.
- `docs/README-EDITING.md` — removed the `id` table row and the `id` lines from the frontmatter example.

The unrelated example-container `id` (`exampleId`) in `README-EDITING.md` is intentionally left in place.

### How has this been tested?

Documentation/tooling-only change. Verified by grep that no instructional `id`/"8 random alphanumeric" references remain in `docs/` or `.claude/`, and that only the unrelated HTML container `exampleId` survives.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

N/A — follow-up cleanup discovered while reviewing the DEV-555 column-adding guide.

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and AI-authoring guidance only; no runtime, build, or published guide content behavior changes.
> 
> **Overview**
> **Documentation authoring rules no longer tell writers to add a page-level `id` in YAML frontmatter.**
> 
> The Starlight docs site does not use that field anymore, but `docs/AGENTS.md`, `.claude/skills/writing-docs-pages/SKILL.md`, and `docs/README-EDITING.md` still required 8-character IDs (including per-framework `react`/`angular` variants) and checklist rules about never changing them. This PR strips those lines from Diátaxis templates, the frontmatter schema, the PR checklist, the Claude skill example, and the editing guide table/example.
> 
> **Unrelated `exampleId` in example-container docs is unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9a22feb707cbe785de83950205fdce5a3220971. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->