### PR TITLE
chore: Remove outdated rule requiring a GitHub issue per PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,7 +154,6 @@ These standards apply to **all** documentation across the monorepo — guides, t
 
 ### PR requirements
 
-- Every PR must be connected to a GitHub issue.
 - Every PR that changes package source code must include a changelog entry. Use the `changelog-creation` and `pr-creation` skills for the entry format and PR flow.
 - To skip changelog (for non-source-code changes only), write `[skip changelog]` in the PR description.
 - PRs are merged using **"Squash and merge"** in the GitHub UI by the PR author after full approval.
@@ -167,7 +166,6 @@ Follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format. Changel
 ### Visibility of work
 
 - If a task spans multiple days, create a draft PR and commit daily.
-- All work must be tracked as a GitHub issue. If no issue exists, create one.
 
 ---
 


### PR DESCRIPTION
### Context

The PR removes an outdated rule from the monorepo `AGENTS.md` (and its `CLAUDE.md` symlink). PRs no longer need to be connected to a GitHub issue, so the two rules enforcing that requirement are now misleading for both contributors and AI agents reading the config.

Removed:
- `### PR requirements` → "Every PR must be connected to a GitHub issue."
- `### Visibility of work` → "All work must be tracked as a GitHub issue. If no issue exists, create one."

No other section depended on these rules. Branch naming conventions (which optionally reference issue/task IDs) are unaffected.

### How has this been tested?

- Config/documentation-only change; no code paths affected. Verified the two lines were removed and the surrounding sections still read correctly.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

N/A

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to agent/contributor policy text with no runtime or API impact.
> 
> **Overview**
> Updates monorepo contributor/agent guidance in **`AGENTS.md`** so it no longer says every PR or all work must be tied to a GitHub issue.
> 
> Under **Pull requests and changelog**, the **PR requirements** list no longer includes the “connected to a GitHub issue” rule; changelog, `[skip changelog]`, squash merge, and review expectations are unchanged. Under **Visibility of work**, only the draft-PR-for-multi-day-tasks guidance remains—the “track everything as an issue” bullet is gone.
> 
> This is documentation-only; branch naming that optionally uses issue IDs is not modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36d93ba5565c4069e3ed14d54889158210c496e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->