### PR TITLE
DEV-1964: Use GraphQL for docs versions and handle flat Astro image layout

### DIFF
--- a/docs/netlify/build_current_version.sh
+++ b/docs/netlify/build_current_version.sh
@@ -1,25 +1,43 @@
-#/bin/bash
+#!/bin/bash
+# Fail closed: abort on any error, unset variable, or failed pipe stage so a
+# partial bundle never reaches production. The Cloudflare/Netlify deploy steps
+# are gated on this script succeeding.
 set -euo pipefail
+
 mkdir -p docs/docs
 node getListOrPreviousVersions.mjs > VERSIONS_VARS
 source VERSIONS_VARS
 rm VERSIONS_VARS
 
 if [ -z "${LATEST_VERSION:-}" ]; then
-    echo "ERROR: LATEST_VERSION is empty - the version list could not be read from the GitHub API." >&2
+    echo "ERROR: LATEST_VERSION is empty - aborting production docs build." >&2
     exit 1
 fi
+
 echo "/docs/$LATEST_VERSION/* /docs/:splat 301" >> _redirects
-for version in $PREVIOUS_VERSIONS
+
+for version in ${PREVIOUS_VERSIONS:-}
 do
     echo "Building version $version"
-    img_id=$(docker create ghcr.io/handsontable/handsontable/handsontable-documentation:v$version)
-    docker cp $img_id:/usr/share/nginx/html/docs/$version  ./docs/docs/$version
+    img_id=$(docker create "ghcr.io/handsontable/handsontable/handsontable-documentation:v$version")
+
+    # Two image layouts exist. Legacy VuePress images (<= 17.0) nest the site under
+    # /usr/share/nginx/html/docs/<version>/. Astro images (>= 17.1) store the site flat at
+    # /usr/share/nginx/html/docs/. Either way the assembled site needs the version's files under
+    # ./docs/docs/<version>/, so try the nested path first and fall back to copying the flat root.
+    if docker cp "$img_id:/usr/share/nginx/html/docs/$version" "./docs/docs/$version" 2>/dev/null; then
+        echo "  copied nested layout (/docs/$version)"
+    else
+        docker cp "$img_id:/usr/share/nginx/html/docs" "./docs/docs/$version"
+        echo "  copied flat layout (/docs) into /docs/$version"
+    fi
+
+    docker rm "$img_id" >/dev/null
 done
 
 echo "Building current version $LATEST_VERSION"
-img_id=$(docker create ghcr.io/handsontable/handsontable/handsontable-documentation:v$LATEST_VERSION)
-docker cp $img_id:/usr/share/nginx/html/docs  ./docs
+img_id=$(docker create "ghcr.io/handsontable/handsontable/handsontable-documentation:v$LATEST_VERSION")
+docker cp "$img_id:/usr/share/nginx/html/docs" ./docs
 
 cp _redirects docs/_redirects
 cp docs/docs/404.html docs/404.html

--- a/docs/netlify/build_previous_versions.sh
+++ b/docs/netlify/build_previous_versions.sh
@@ -1,13 +1,36 @@
-#/bin/bash
+#!/bin/bash
+# Fail closed: abort on any error, unset variable, or failed pipe stage so a
+# partial bundle never reaches production. The deploy that consumes this output
+# is gated on this script succeeding.
+set -euo pipefail
+
 mkdir -p docs/docs
 node getListOrPreviousVersions.mjs > VERSIONS_VARS
 source VERSIONS_VARS
 rm VERSIONS_VARS
+
+if [ -z "${LATEST_VERSION:-}" ]; then
+    echo "ERROR: LATEST_VERSION is empty - aborting docs build." >&2
+    exit 1
+fi
+
 echo "/docs/$LATEST_VERSION/* /docs/:splat 301" >> _redirects
-for version in $PREVIOUS_VERSIONS
+
+for version in ${PREVIOUS_VERSIONS:-}
 do
     echo "Building version $version"
-    img_id=$(docker create ghcr.io/handsontable/handsontable/handsontable-documentation:v$version)
-    docker cp $img_id:/usr/share/nginx/html/docs/$version  ./docs/docs/$version
-done
+    img_id=$(docker create "ghcr.io/handsontable/handsontable/handsontable-documentation:v$version")
 
+    # Two image layouts exist. Legacy VuePress images (<= 17.0) nest the site under
+    # /usr/share/nginx/html/docs/<version>/. Astro images (>= 17.1) store it flat at
+    # /usr/share/nginx/html/docs/. Either way the assembled site needs the version's files under
+    # ./docs/docs/<version>/, so try the nested path first and fall back to copying the flat root.
+    if docker cp "$img_id:/usr/share/nginx/html/docs/$version" "./docs/docs/$version" 2>/dev/null; then
+        echo "  copied nested layout (/docs/$version)"
+    else
+        docker cp "$img_id:/usr/share/nginx/html/docs" "./docs/docs/$version"
+        echo "  copied flat layout (/docs) into /docs/$version"
+    fi
+
+    docker rm "$img_id" >/dev/null
+done

--- a/docs/netlify/build_previous_versions.sh
+++ b/docs/netlify/build_previous_versions.sh
@@ -1,14 +1,8 @@
 #/bin/bash
-set -euo pipefail
 mkdir -p docs/docs
 node getListOrPreviousVersions.mjs > VERSIONS_VARS
 source VERSIONS_VARS
 rm VERSIONS_VARS
-
-if [ -z "${LATEST_VERSION:-}" ]; then
-    echo "ERROR: LATEST_VERSION is empty - the version list could not be read from the GitHub API." >&2
-    exit 1
-fi
 echo "/docs/$LATEST_VERSION/* /docs/:splat 301" >> _redirects
 for version in $PREVIOUS_VERSIONS
 do

--- a/docs/netlify/getListOrPreviousVersions.mjs
+++ b/docs/netlify/getListOrPreviousVersions.mjs
@@ -11,70 +11,45 @@ import semver from 'semver';
 const MIN_DOCS_VERSION = '9.0';
 
 /**
- * Number of times the releases request is retried before giving up.
- */
-const MAX_ATTEMPTS = 5;
-
-/**
- * Fetches the releases list, retrying on transient network failures.
+ * Reads the list of Docs versions from GitHub using the releases list.
  *
- * Unauthenticated requests from CI runner IP addresses are throttled and the connection is often cut
- * mid-response ("Premature close"). Passing a token (when available) lifts the rate limit, and the
- * retry loop covers the remaining transient failures.
- *
- * @param {Octokit} octokit The Octokit client.
- * @returns {Promise<object>}
- */
-async function fetchReleases(octokit) {
-  let lastError;
-
-  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-    try {
-      return await octokit.rest.repos.listReleases({
-        owner: 'handsontable',
-        repo: 'handsontable',
-        per_page: 50,
-      });
-    } catch (error) {
-      lastError = error;
-
-      // eslint-disable-next-line no-console
-      console.error(`Attempt ${attempt}/${MAX_ATTEMPTS} to fetch releases failed: ${error.message}`);
-
-      if (attempt < MAX_ATTEMPTS) {
-        const delay = 2 ** attempt * 1000;
-
-        await new Promise((resolve) => {
-          setTimeout(resolve, delay);
-        });
-      }
-    }
-  }
-
-  throw lastError;
-}
-
-/**
- * Reads the list of Docs version from the GitHub using the releases list.
+ * Uses the GraphQL API (authenticated with GITHUB_TOKEN) rather than REST
+ * listReleases. REST returns full release bodies (~280 KB) and was consistently
+ * failing on GitHub Actions runners with an undici "Premature close", which
+ * blocked production docs deploys. GraphQL returns only the tag names in a
+ * single small response over a different endpoint.
  *
  * @returns {object}
  */
 async function readFromGitHub() {
-  // `GITHUB_TOKEN` is optional - when present it lifts the unauthenticated rate limit and makes the
-  // request reliable on CI runners; locally the call still works without it.
-  const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
+  const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN || undefined });
 
-  const releases = await fetchReleases(octokit);
+  const result = await octokit.graphql(`
+    query ($owner: String!, $repo: String!) {
+      repository(owner: $owner, name: $repo) {
+        releases(first: 100, orderBy: { field: CREATED_AT, direction: DESC }) {
+          nodes {
+            tagName
+          }
+        }
+      }
+    }
+  `, {
+    owner: 'handsontable',
+    repo: 'handsontable',
+  });
 
-  if (releases.status !== 200) {
-    throw new Error('Incorrect response from the GitHub API.');
+  const nodes = result?.repository?.releases?.nodes;
+
+  if (!Array.isArray(nodes) || nodes.length === 0) {
+    throw new Error('GitHub returned no releases.');
   }
 
   const tags = [];
 
-  releases.data
-    .map(item => item.tag_name)
-    .filter(tag => !semver.prerelease(tag))
+  nodes
+    .map(item => item.tagName)
+    .filter(tag => semver.valid(tag) && !semver.prerelease(tag))
     .sort((a, b) => semver.rcompare(a, b))
     .forEach((tag) => {
       const minorVersion = `${semver.parse(tag).major}.${
@@ -95,9 +70,52 @@ async function readFromGitHub() {
     latestVersion
   };
 }
-const versions = await readFromGitHub();
 
-// eslint-disable-next-line no-console
-console.log(`PREVIOUS_VERSIONS="${versions.previousVersions.join(' ')}"
+/**
+ * Calls readFromGitHub with retries so a transient GitHub API hiccup (rate
+ * limit, "Premature close", 5xx) does not abort the whole production deploy.
+ * After the final attempt the error propagates and the caller fails closed.
+ *
+ * @returns {object}
+ */
+async function readWithRetry() {
+  const maxAttempts = 5;
+  let lastError;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      return await readFromGitHub();
+    } catch (error) {
+      lastError = error;
+
+      if (attempt < maxAttempts) {
+        const delayMs = 2000 * (2 ** (attempt - 1)); // 2s, 4s, 8s, 16s
+
+        // eslint-disable-next-line no-console
+        console.error(`Attempt ${attempt}/${maxAttempts} to read Docs versions failed (${error.message}); retrying in ${delayMs}ms.`);
+        await new Promise((resolve) => { setTimeout(resolve, delayMs); });
+      }
+    }
+  }
+
+  throw lastError;
+}
+
+try {
+  const versions = await readWithRetry();
+
+  if (!versions.latestVersion) {
+    throw new Error('Resolved an empty latest Docs version from the GitHub releases list.');
+  }
+
+  // eslint-disable-next-line no-console
+  console.log(`PREVIOUS_VERSIONS="${versions.previousVersions.join(' ')}"
 LATEST_VERSION="${versions.latestVersion}"`);
-
+} catch (error) {
+  // Exit non-zero so the caller (build_current_version.sh, run under `set -e`)
+  // aborts instead of producing an empty VERSIONS_VARS file and deploying a
+  // partial docs site. The error goes to stderr, not into VERSIONS_VARS.
+  // eslint-disable-next-line no-console
+  console.error(`Failed to read the Docs versions list from GitHub: ${error.message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
### Context

Follow-up to #12912 (DEV-1964). #12912 was merged to develop with an early version of the fix (authenticated REST `listReleases` + retry + native `fetch`). After that merge, two better changes landed on `prod-docs/18.0` and made the 18.0 production docs deploy go green, but they never reached develop:

1. **Read Docs versions via GraphQL.** REST `listReleases` returns full release bodies (~280 KB) and `@octokit/rest@18`'s bundled `node-fetch@2` consistently fails on GitHub Actions runners with an undici "Premature close". GraphQL returns only the tag names in a small response over a different endpoint. This matches the approach already used on `prod-docs/17.1`.
2. **Handle the flat Astro docs image layout.** Legacy VuePress images (<= 17.0) nest the site under `/usr/share/nginx/html/docs/<version>/`. Astro images (>= 17.1) store it flat at `/usr/share/nginx/html/docs/`. The previous-version copy loop in `build_current_version.sh` only handled the nested layout, so it crashed the first time 17.1 was pulled as a previous version (the 18.0 deploy). The loop now tries the nested path and falls back to copying the flat root into `./docs/docs/<version>/`.

Without these on develop, the next release branch (cut from develop) would hit the same "Premature close" and the same docker-cp crash when assembling 18.x Astro images as previous versions.

This brings develop's three `docs/netlify/` files in line with the working `prod-docs/18.0`.

### How has this been tested?

- `prod-docs/18.0` ran the full Docs Production Deployment green with these exact files (run 28437879153). The deploy logs show `copied flat layout (/docs) into /docs/17.1` for the Astro version and `copied nested layout (/docs/<version>)` for 17.0 and older.
- Locally verified the copy loop against the real `v17.1` (flat) and `v17.0` (nested) images — each version's files land under `./docs/docs/<version>/`.
- `node getListOrPreviousVersions.mjs` (with `GITHUB_TOKEN`) returns the correct version list; `eslint` and `bash -n` pass.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1964

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/86cagb8jb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the production docs deploy path (GitHub API + Docker assembly); changes are proven on prod-docs/18.0 but still gate what ships to production.
> 
> **Overview**
> Aligns **develop** Netlify docs assembly with the fixes that already made **18.0** production deploys green: reliable version discovery and correct extraction of both VuePress and Astro documentation images.
> 
> **`getListOrPreviousVersions.mjs`** now loads release **tag names** via **GitHub GraphQL** instead of REST `listReleases`, avoiding large release bodies and runner **“Premature close”** failures. It adds **exponential backoff retries**, **`semver.valid`** filtering, validation of a non-empty latest version, and **`process.exit(1)`** on failure so shell builds under `set -e` never deploy with empty `VERSIONS_VARS`.
> 
> **`build_current_version.sh`** and **`build_previous_versions.sh`** harden the pipeline (`#!/bin/bash`, quoted paths, `${PREVIOUS_VERSIONS:-}`, explicit **fail-closed** comments). The previous-version loop **tries nested** `docker cp` (`/docs/<version>`) first, then **falls back** to copying the flat Astro root (`/docs`) into `./docs/docs/<version>/`, and removes the container after each pull.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4f6b770aaa9d6141ba8c86ed25238b090b4c727. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->