### PR TITLE
DEV-1977: Fix 404 minesweeper — add not-content to exempt grid from Starlight prose spacing

### DIFF
--- a/docs/src/plugins/framework-loader.mjs
+++ b/docs/src/plugins/framework-loader.mjs
@@ -1572,7 +1572,7 @@ export function frameworkLoader({ contentDir }) {
               + `<button class="minesweeper-reset" type="button" aria-label="Reset game">\u{1F642}</button>`
               + `<span class="minesweeper-timer">000</span>`
             + `</div>`
-            + `<div class="minesweeper-grid"></div>`
+            + `<div class="minesweeper-grid not-content"></div>`
             + `<div class="minesweeper-mobile-controls">`
               + `<button class="minesweeper-flag-toggle" type="button" aria-label="Toggle flag mode">`
                 + `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 5a5 5 0 0 1 7 0a5 5 0 0 0 7 0v9a5 5 0 0 1 -7 0a5 5 0 0 0 -7 0v-9"/><path d="M5 21v-7"/></svg>`


### PR DESCRIPTION
### Context

The PR fixes a layout bug on the docs 404 page where the minesweeper game was missing row 9 (cut off at the bottom) and showing a 20px gap between the status bar and the column headers (A–I).

**Root cause:** Starlight's lobotomized-owl prose-spacing rule applies `margin-top: var(--sl-content-gap-y)` (20px) to any non-inline element that follows another non-inline sibling within `.sl-markdown-content`. HOT 18 introduced `<style>` elements inside `.ht-root-wrapper` — these act as non-inline adjacent siblings to `.ht-slot-top`, triggering the rule and pushing all grid content 20px down inside the fixed-height container. The same rule hit HOT's clone overlays (`.ht_clone_top`, etc.) too, misaligning the column header sticky overlay.

The 20px shift consumed space inside the 353px `.minesweeper-grid`, cutting off row 9 entirely and creating the visible gap.

**Fix:** Added the `not-content` class to `.minesweeper-grid` in `framework-loader.mjs`. This is Starlight's built-in opt-out for embedded widgets — descendants become `:where(.not-content *)`, which the prose-spacing selector explicitly excludes. One class, no HOT internals touched, future-proof against any new HOT DOM elements.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1977

### How has this been tested?

- Manually verified on the production page (`https://handsontable.com/docs/trertert`) using Playwright DOM inspection: confirmed `margin-top` on `.ht-slot-top` dropped from 20px → 0px, `ht_clone_top` positioned at 0px from grid top, all 9 rows fitting within the 353px container (`lastRowBottom === 353`).
- Simulated the fix live in the production DOM before applying it to the source.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1977

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-class change to static 404 page markup in the docs loader; no runtime or library behavior changes.
> 
> **Overview**
> Fixes the docs **404** minesweeper layout by adding Starlight’s **`not-content`** class to **`.minesweeper-grid`** in the 404 HTML emitted by `framework-loader.mjs`.
> 
> That opt-out stops the markdown **prose-spacing** rule from applying **20px** top margins to Handsontable’s internal DOM (e.g. after `<style>` nodes in `.ht-root-wrapper`), which had pushed the grid down, left a gap under the status bar, and clipped the bottom row inside the fixed-height container. The change mirrors how live examples already use **`not-content`** and does not alter Handsontable itself.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34aeb77655b0bf2ff8df1bd311a68cae948fa9a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->