### PR TITLE
DEV-1957: Render <kbd> changelog markup as code on version-comparison page

### DIFF
--- a/docs/src/plugins/__tests__/changelog-parser.test.mjs
+++ b/docs/src/plugins/__tests__/changelog-parser.test.mjs
@@ -406,6 +406,75 @@ test('the real v12.0.1 checkbox entry is no longer truncated (DEV-1958)', () => 
   assert.equal(entry.prNumber, 7102);
 });
 
+test('converts <kbd> markup in bullets to inline code', () => {
+  const md = [
+    '## 12.0.0',
+    'Released on May 9th, 2022',
+    '',
+    '#### Added',
+    '- Added support for the <kbd>**Cmd**</kbd> key.',
+    '- Added the <kbd>**Ctrl**</kbd>+<kbd>**S**</kbd> shortcut.',
+    '- Added support for the <kbd>Enter</kbd> key.',
+    '- Added a feature without any keyboard markup.',
+  ].join('\n');
+
+  const result = parseChangelogContent(md);
+
+  assert.deepEqual(
+    result.map((e) => e.title),
+    [
+      'Added support for the `Cmd` key.',
+      'Added the `Ctrl`+`S` shortcut.',
+      'Added support for the `Enter` key.',
+      'Added a feature without any keyboard markup.',
+    ],
+  );
+});
+
+test('converts <kbd> markup while still extracting a trailing PR citation', () => {
+  const md = [
+    '## 12.0.0',
+    'Released on May 9th, 2022',
+    '',
+    '#### Fixed',
+    '- Fixed an issue with the <kbd>**Enter**</kbd> key. [#8546](https://github.com/handsontable/handsontable/pull/8546)',
+  ].join('\n');
+
+  const result = parseChangelogContent(md);
+
+  assert.equal(result.length, 1);
+  assert.equal(result[0].title, 'Fixed an issue with the `Enter` key.');
+  assert.equal(result[0].prNumber, 8546);
+  assert.equal(result[0].prKind, 'pull');
+});
+
+test('converts a dangling, unclosed <kbd> left by a multi-line bullet', () => {
+  // The parser captures only a bullet's first source line, so markup that wraps
+  // (as in changelog-12's "Shift + Page Up/Page Down" breaking change) ends with
+  // an unclosed <kbd>. The remainder must still convert -- no literal tag shown.
+  const md = [
+    '## 12.0.0',
+    'Released on May 9th, 2022',
+    '',
+    '#### Removed',
+    '- **Breaking change**: Removed the <kbd>**Shift**</kbd>+<kbd>**Page Up**</kbd>/<kbd>**Page',
+    '  Down**</kbd> keyboard shortcuts.',
+  ].join('\n');
+
+  const result = parseChangelogContent(md);
+
+  assert.equal(result.length, 1);
+  assert.equal(result[0].title, 'Removed the `Shift`+`Page Up`/`Page`');
+  assert.ok(!/<kbd>/i.test(result[0].title));
+});
+
+test('parseAllChangelogs leaves no raw <kbd> tags in any entry title', () => {
+  const result = parseAllChangelogs();
+  for (const entry of result) {
+    assert.ok(!/<kbd>/i.test(entry.title), `raw <kbd> left in title: ${entry.title}`);
+  }
+});
+
 test('parseAllChangelogs returns entries from every changelog-X file (v6..v17)', () => {
   const result = parseAllChangelogs();
   const majors = new Set(result.map((e) => Number(e.version.split('.')[0])));

--- a/docs/src/plugins/changelog-parser.mjs
+++ b/docs/src/plugins/changelog-parser.mjs
@@ -83,6 +83,35 @@ function extractPrNumber(text) {
   return { prNumber: Number(match[1]), prKind: match[2], body: text.slice(0, match.index).trim() };
 }
 
+/**
+ * Converts inline `<kbd>` markup from a changelog bullet into inline code so it
+ * renders as `<code>` in the version-comparison UI.
+ *
+ * That UI feeds each entry's title through a `react-markdown` instance with no
+ * raw-HTML plugin, so raw `<kbd>` tags would otherwise show as literal text.
+ * Bold markers inside the tag (e.g. `<kbd>**Cmd**</kbd>`) are stripped because
+ * markdown is not processed inside code spans -- leaving `**` would render the
+ * asterisks verbatim.
+ *
+ * The second pass catches a dangling, unclosed `<kbd>`: a few changelog bullets
+ * wrap their markup onto the next source line, and the parser only captures the
+ * first line, so the closing `</kbd>` is missing. Converting the remainder keeps
+ * any literal tag off the page (the trailing text is already truncated by the
+ * single-line capture, independent of this conversion).
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+function convertKbdToCode(text) {
+  return text
+    .replace(/<kbd>\s*(.*?)\s*<\/kbd>/gi, (_, inner) =>
+      `\`${inner.replace(/^\*+|\*+$/g, '').trim()}\``
+    )
+    .replace(/<kbd>\s*(.*)$/i, (_, inner) =>
+      `\`${inner.replace(/^\*+|\*+$/g, '').trim()}\``
+    );
+}
+
 function parseBullet(line) {
   let raw = line.replace(/^- /, '').trim();
   let breaking = false;
@@ -220,7 +249,7 @@ export function parseChangelogContent(markdown) {
       framework,
       prNumber,
       prKind,
-      title: body,
+      title: convertKbdToCode(body),
     });
   }
 


### PR DESCRIPTION
### Context

The PR fixes `<kbd>` keyboard markup rendering as literal text on the docs "Changes between versions" page (e.g. `/docs/javascript-data-grid/changes-between-versions/?from=11.1&to=12.1`). Changelog entries such as `<kbd>**Cmd**</kbd>` were shown verbatim instead of as styled markup.

Root cause: that page is rendered by the `VersionComparison` React component, which feeds each entry's title through `react-markdown@9` configured with only `remark-gfm`. `react-markdown@9` does not render raw HTML without a raw-HTML rehype plugin, so the `<kbd>` tags were emitted as escaped literal text.

The fix converts `<kbd>` markup to inline code at parse time in `changelog-parser.mjs`, so it renders as `<code>` through the existing markdown pipeline -- no new dependency. The helper strips the bold markers inside the tag (markdown is not processed inside code spans) and also handles a dangling, unclosed `<kbd>` left by the few changelog bullets whose markup wraps onto the next source line (which the single-line parser truncates), so no literal tag ever reaches the page.

Note: the `<` escaping in `framework-loader.mjs` was investigated and ruled out as the cause -- it is standard XSS-safe JSON-in-`<script>` encoding that decodes back to `<` on `JSON.parse`, and is intentionally left untouched.

### How has this been tested?

- Added unit tests in `docs/src/plugins/__tests__/changelog-parser.test.mjs` covering: single `<kbd>` conversion, chained keys (`Ctrl`+`S`), plain `<kbd>` without bold, conversion alongside a trailing PR citation, the dangling/unclosed multi-line case, and a guard asserting no real changelog title retains a raw `<kbd>` tag.
- `npm run docs:test:plugins` -- 56/56 pass.
- `npx eslint --ext .mjs` on the changed files -- clean.
- Spot-checked `parseAllChangelogs()` output against the real changelog data: 10 `<kbd>`-derived titles convert correctly (e.g. `Ctrl`/`Cmd`+`Enter`), zero residual `<kbd>` tags.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1957

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`
- [x] `handsontable-documentation`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog] -- docs-site rendering fix, no library source code changed.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1957

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-site parsing/display only; no library runtime, auth, or data-path changes.
> 
> **Overview**
> Fixes keyboard shortcuts showing as literal `<kbd>**Cmd**</kbd>` on the **Changes between versions** page by normalizing changelog bullet text at parse time.
> 
> `changelog-parser.mjs` now runs each entry title through **`convertKbdToCode`**, which turns closed `<kbd>…</kbd>` spans into inline `` `…` `` markdown (so `react-markdown` renders `<code>` without a raw-HTML plugin), strips `**` bold markers inside those tags, and handles a dangling unclosed `<kbd>` when markup wraps past the first line the parser keeps.
> 
> Unit tests cover single and chained keys, PR citation extraction alongside conversion, the multi-line/unclosed case, and a guard that **`parseAllChangelogs()`** leaves no raw `<kbd>` in any title.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9153739a620d52ca6614e7782b42673988acff8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->