### PR TITLE
DEV-1958: Fix truncated changelog entries on changes-between-versions page

### DIFF
--- a/docs/src/plugins/__tests__/changelog-parser.test.mjs
+++ b/docs/src/plugins/__tests__/changelog-parser.test.mjs
@@ -317,6 +317,95 @@ test('does not merge or emit nested sub-bullets', () => {
   assert.equal(result[1].prNumber, 6000);
 });
 
+test('joins a bullet wrapped mid-sentence across physical lines', () => {
+  const md = [
+    '## 12.0.1',
+    'Released on November 18th, 2021',
+    '',
+    '#### Fixed',
+    '- Fixed an issue where checking or unchecking a checkbox in a row with',
+    '  [`autoRowSize: true`](@/api/options.md#autorowsize) and multi-line cell values caused rows to',
+    '  align incorrectly. [#7102](https://github.com/handsontable/handsontable/issues/7102)',
+  ].join('\n');
+
+  const result = parseChangelogContent(md);
+
+  assert.equal(result.length, 1);
+  assert.equal(
+    result[0].title,
+    'Fixed an issue where checking or unchecking a checkbox in a row with '
+      + '[`autoRowSize: true`](@/api/options.md#autorowsize) and multi-line cell values caused rows to '
+      + 'align incorrectly.',
+  );
+});
+
+test('recovers a PR link that sits on a wrapped continuation line', () => {
+  const md = [
+    '## 12.0.1',
+    'Released on November 18th, 2021',
+    '',
+    '#### Fixed',
+    '- Fixed an issue where checking or unchecking a checkbox changed the cell width.',
+    '  [#8211](https://github.com/handsontable/handsontable/issues/8211)',
+  ].join('\n');
+
+  const result = parseChangelogContent(md);
+
+  assert.equal(result.length, 1);
+  assert.equal(result[0].title, 'Fixed an issue where checking or unchecking a checkbox changed the cell width.');
+  assert.equal(result[0].prNumber, 8211);
+  assert.equal(result[0].prKind, 'issues');
+});
+
+test('keeps inline markdown from a wrapped bullet in the title', () => {
+  const md = [
+    '## 12.0.1',
+    'Released on November 18th, 2021',
+    '',
+    '#### Fixed',
+    '- Fixed an issue with',
+    '  [`autoRowSize: true`](@/api/options.md#autorowsize).',
+  ].join('\n');
+
+  const result = parseChangelogContent(md);
+
+  assert.equal(result.length, 1);
+  assert.equal(result[0].title, 'Fixed an issue with [`autoRowSize: true`](@/api/options.md#autorowsize).');
+});
+
+test('does not merge an indented line separated from the bullet by a blank line', () => {
+  const md = [
+    '## 12.0.1',
+    'Released on November 18th, 2021',
+    '',
+    '#### Fixed',
+    '- Fixed a standalone issue.',
+    '',
+    '  Some indented note that is not part of the bullet.',
+  ].join('\n');
+
+  const result = parseChangelogContent(md);
+
+  assert.equal(result.length, 1);
+  assert.equal(result[0].title, 'Fixed a standalone issue.');
+});
+
+test('the real v12.0.1 checkbox entry is no longer truncated (DEV-1958)', () => {
+  const result = parseAllChangelogs();
+  const entry = result.find(
+    (e) => e.version === '12.0.1'
+      && e.category === 'fixed'
+      && e.title.startsWith('Fixed an issue where checking or unchecking a checkbox in a row with'),
+  );
+
+  assert.ok(entry, 'expected the v12.0.1 checkbox/autoRowSize entry to be present');
+  assert.ok(
+    entry.title.includes('align incorrectly'),
+    `entry title is truncated: ${entry.title}`,
+  );
+  assert.equal(entry.prNumber, 7102);
+});
+
 test('parseAllChangelogs returns entries from every changelog-X file (v6..v17)', () => {
   const result = parseAllChangelogs();
   const majors = new Set(result.map((e) => Number(e.version.split('.')[0])));

--- a/docs/src/plugins/changelog-parser.mjs
+++ b/docs/src/plugins/changelog-parser.mjs
@@ -107,8 +107,34 @@ function parseBullet(line) {
   return { breaking, framework, prNumber, prKind, body };
 }
 
+// Merge soft-wrapped bullet continuation lines into their parent bullet.
+// Older changelogs hand-wrap bullets across multiple physical lines; without
+// this the line-based loop below keeps only the first line and silently drops
+// the rest (truncating the entry text and losing trailing PR links).
+function coalesceWrappedBullets(lines) {
+  const result = [];
+  let openBullet = null; // index in `result` of the bullet currently accepting continuations
+
+  for (const line of lines) {
+    if (/^- /.test(line)) {
+      result.push(line);
+      openBullet = result.length - 1;
+    } else if (openBullet !== null && /^\s+\S/.test(line)) {
+      // Indented, non-blank line -> continuation of the open bullet.
+      result[openBullet] += ` ${line.trim()}`;
+    } else {
+      // A blank line, heading, version line, HTML, or non-indented prose
+      // closes the open bullet and is preserved as its own line.
+      openBullet = null;
+      result.push(line);
+    }
+  }
+
+  return result;
+}
+
 export function parseChangelogContent(markdown) {
-  const lines = markdown.split('\n');
+  const lines = coalesceWrappedBullets(markdown.split('\n'));
   const entries = [];
   let currentVersion = null;
   let currentDate = null;


### PR DESCRIPTION
### Context

The PR fixes truncated changelog entries on the **Changes between versions** docs page (`/docs/javascript-data-grid/changes-between-versions/`). Some entries were cut off mid-sentence -- for example "Fixed an issue where checking or unchecking a checkbox in a row with" stopped at "with" (DEV-1958).

The text is complete in the source changelog files; the bug was in the parser that feeds the page. `docs/src/plugins/changelog-parser.mjs` was line-based: it iterated physical lines and skipped any line not starting with `- `. Older changelog files soft-wrap bullets across multiple physical lines, so everything after the first line was silently dropped. This produced two symptoms from one cause:

1. **Mid-sentence truncation** when the wrap fell mid-sentence.
2. **Lost PR links** when the wrap fell after the sentence and the `[#NNNN]` link sat on the continuation line (e.g. the "changed the cell width" entry showed full text but no `#8211`).

The fix adds a `coalesceWrappedBullets` pre-pass that merges indented continuation lines into their parent bullet before the existing line-based loop runs. A blank line still closes a bullet, so blank-line-separated content is not merged. No view/CSS change is needed -- the React component already renders the title through `ReactMarkdown`. This repairs every affected version (heavily 8 and 12) at once.

Note for reviewers: the 11 nested sub-bullets in `changelog-8` now merge into their parent as literal ` - text` (they were dropped entirely before).

### How has this been tested?

- Added 5 unit tests in `docs/src/plugins/__tests__/changelog-parser.test.mjs` covering: mid-sentence join, PR-link recovery from a continuation line, inline-markdown preservation, the blank-line negative guard, and a real-data lock on the v12.0.1 entry (`#7102`, "align incorrectly").
- `npm --prefix docs run docs:test:plugins` -- 57/57 pass.
- `npx eslint src/plugins/changelog-parser.mjs src/plugins/__tests__/changelog-parser.test.mjs` (from `docs/`) -- clean.
- Spot-checked the parsed v12.0.1 `fixed` entries via `parseAllChangelogs()`: the three previously-broken entries now render in full with `#7102`/`#8211`/`#8268` restored.

[skip changelog] -- docs-site source fix only; no `handsontable` package source changed.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1958

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1958

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-site changelog parsing only; no runtime package behavior, with behavior locked by expanded plugin unit tests.
> 
> **Overview**
> Fixes **truncated changelog entries** on the Changes between versions page by adding a **`coalesceWrappedBullets` pre-pass** in `changelog-parser.mjs` that joins indented continuation lines into their parent `- ` bullet before the existing parser runs. Older changelog markdown soft-wraps bullets across physical lines, which previously dropped everything after the first line—cutting titles mid-sentence and **losing trailing `#NNNN` links** when the citation sat on a wrap line.
> 
> A **blank line still closes** an open bullet so separated indented notes are not merged. **Five new unit tests** cover wrapped text, PR recovery, inline markdown, the blank-line guard, and a real **v12.0.1** regression lock (DEV-1958).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cbaabb0edea0da98471339cc6a62f35bbca6f8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->