### PR TITLE
DEV-1956: Recover PR/issue links on changes-between-versions page

### DIFF
--- a/docs/src/plugins/__tests__/changelog-parser.test.mjs
+++ b/docs/src/plugins/__tests__/changelog-parser.test.mjs
@@ -161,6 +161,162 @@ test('captures prKind so issue links and pull links resolve to distinct URLs', (
   assert.equal(result[1].prKind, 'pull');
 });
 
+test('captures a citation trailed by a sentence period', () => {
+  const md = [
+    '## 8.0.0',
+    'Released on November 16th, 2020',
+    '',
+    '#### Changed',
+    '- Removed the experimental `GanttChart` plugin. [#7022](https://github.com/handsontable/handsontable/issues/7022).',
+  ].join('\n');
+
+  const result = parseChangelogContent(md);
+
+  assert.equal(result.length, 1);
+  assert.equal(result[0].prNumber, 7022);
+  assert.equal(result[0].prKind, 'issues');
+  assert.equal(result[0].title, 'Removed the experimental `GanttChart` plugin.');
+});
+
+test('captures a citation trailed by a migration-guide link', () => {
+  const md = [
+    '## 12.0.0',
+    'Released on April 28th, 2022',
+    '',
+    '#### Changed',
+    '- Changed how `updateSettings()` handles data updates. '
+      + '[#7263](https://github.com/handsontable/handsontable/issues/7263) '
+      + '[[migration guide]](@/guides/upgrade-and-migration/migrating-from-11.1-to-12.0/migrating-from-11.1-to-12.0.md#step-1)',
+  ].join('\n');
+
+  const result = parseChangelogContent(md);
+
+  assert.equal(result.length, 1);
+  assert.equal(result[0].prNumber, 7263);
+  assert.equal(result[0].prKind, 'issues');
+  assert.equal(result[0].title, 'Changed how `updateSettings()` handles data updates.');
+});
+
+test('does not capture an ambiguous mid-sentence citation', () => {
+  const md = [
+    '## 8.0.0',
+    'Released on November 16th, 2020',
+    '',
+    '#### Changed',
+    '- Refactored against [#5945](https://github.com/handsontable/handsontable/pull/5945) and more work followed.',
+  ].join('\n');
+
+  const result = parseChangelogContent(md);
+
+  assert.equal(result.length, 1);
+  assert.equal(result[0].prNumber, null);
+});
+
+test('joins a hard-wrapped bullet and extracts the trailing PR link on the last line', () => {
+  const md = [
+    '## 11.1.0',
+    'Released on January 13th, 2022',
+    '',
+    '#### Added',
+    '- Added `updateData()`, a new method that lets you replace',
+    "  Handsontable's data without resetting the states of cells, rows and",
+    '  columns. [#7263](https://github.com/handsontable/handsontable/issues/7263)',
+  ].join('\n');
+
+  const result = parseChangelogContent(md);
+
+  assert.equal(result.length, 1);
+  assert.equal(result[0].prNumber, 7263);
+  assert.equal(result[0].prKind, 'issues');
+  assert.equal(
+    result[0].title,
+    "Added `updateData()`, a new method that lets you replace Handsontable's data "
+      + 'without resetting the states of cells, rows and columns.',
+  );
+});
+
+test('extracts a parenthesized citation that wraps onto a continuation line', () => {
+  const md = [
+    '## 9.0.0',
+    'Released on June 1st, 2021',
+    '',
+    '#### Fixed',
+    '- Fixed a problem with the `IF` formulas not working properly.',
+    '  ([#5870](https://github.com/handsontable/handsontable/issues/5870))',
+  ].join('\n');
+
+  const result = parseChangelogContent(md);
+
+  assert.equal(result.length, 1);
+  assert.equal(result[0].prNumber, 5870);
+  assert.equal(result[0].prKind, 'issues');
+  assert.equal(result[0].title, 'Fixed a problem with the `IF` formulas not working properly.');
+});
+
+test('does not emit bullets inside a boxes-list div', () => {
+  const md = [
+    '## 11.1.0',
+    'Released on January 13th, 2022',
+    '',
+    '<div class="boxes-list gray">',
+    '',
+    '- [Blog post](https://handsontable.com/blog/handsontable-11.1.0)',
+    '- [Documentation (11.1)](https://handsontable.com/docs/11.1/)',
+    '',
+    '</div>',
+    '',
+    '#### Added',
+    '- Added a real feature. [#7263](https://github.com/handsontable/handsontable/pull/7263)',
+  ].join('\n');
+
+  const result = parseChangelogContent(md);
+
+  assert.equal(result.length, 1);
+  assert.equal(result[0].title, 'Added a real feature.');
+  assert.equal(result[0].prNumber, 7263);
+});
+
+test('does not emit a standalone pure-link bullet under a "## Related" heading', () => {
+  const md = [
+    '## 9.0.0',
+    'Released on June 1st, 2021',
+    '',
+    '#### Fixed',
+    '- Fixed a real bug. [#6248](https://github.com/handsontable/handsontable/issues/6248)',
+    '',
+    '## Related',
+    '',
+    '- [Migrating from 8.4 to 9.0](@/guides/upgrade-and-migration/migrating-from-8.4-to-9.0/migrating-from-8.4-to-9.0.md)',
+  ].join('\n');
+
+  const result = parseChangelogContent(md);
+
+  assert.equal(result.length, 1);
+  assert.equal(result[0].title, 'Fixed a real bug.');
+});
+
+test('does not merge or emit nested sub-bullets', () => {
+  const md = [
+    '## 8.0.0',
+    'Released on November 16th, 2020',
+    '',
+    '#### Breaking changes',
+    '- Adjusted plugins to be compatible with upcoming managers',
+    '  [#5945](https://github.com/handsontable/handsontable/pull/5945):',
+    '  - Hidden indexes are not rendered anymore.',
+    '  - The `getColWidth` for hidden index returns 0.',
+    '- A following top-level change. [#6000](https://github.com/handsontable/handsontable/pull/6000)',
+  ].join('\n');
+
+  const result = parseChangelogContent(md);
+
+  // Two top-level bullets only; the two nested sub-bullets are ignored.
+  assert.equal(result.length, 2);
+  assert.ok(result[0].title.startsWith('Adjusted plugins to be compatible with upcoming managers'));
+  assert.ok(!/Hidden indexes/.test(result[0].title));
+  assert.equal(result[1].prNumber, 6000);
+});
+
 test('parseAllChangelogs returns entries from every changelog-X file (v6..v17)', () => {
   const result = parseAllChangelogs();
   const majors = new Set(result.map((e) => Number(e.version.split('.')[0])));

--- a/docs/src/plugins/changelog-parser.mjs
+++ b/docs/src/plugins/changelog-parser.mjs
@@ -69,7 +69,16 @@ function extractPrNumber(text) {
   // `pull`) so consumers can rebuild the correct GitHub destination instead
   // of assuming every reference is a PR. Roughly 55% of changelog bullets
   // historically cite `/issues/...` rather than `/pull/...`.
-  const match = text.match(/\s*\(?\[#(\d+)\]\(https:\/\/github\.com\/handsontable\/handsontable\/(issues|pull)\/\d+\)\s*\)?\s*$/);
+  //
+  // The citation may be wrapped in parentheses, and the older v8/v12 changelogs
+  // trail it with a sentence period/colon and/or a `[migration guide](...)`
+  // link. The end anchor allows that tail so a well-formed, end-of-bullet
+  // citation is still captured -- without matching an ambiguous mid-sentence
+  // reference (anything other than punctuation/whitespace/a migration-guide
+  // link after the citation fails the match).
+  const match = text.match(
+    /\(?\[#(\d+)\]\(https:\/\/github\.com\/handsontable\/handsontable\/(issues|pull)\/\d+\)\)?(?:[.:\s]*\[\[?[^\]]*?migration guide[^\]]*?\]\]?\([^)]*\))?[.:\s]*$/i
+  );
   if (!match) return { prNumber: null, prKind: null, body: text };
   return { prNumber: Number(match[1]), prKind: match[2], body: text.slice(0, match.index).trim() };
 }
@@ -105,14 +114,37 @@ export function parseChangelogContent(markdown) {
   let currentDate = null;
   let currentCategory = null;
   let currentForceBreaking = false;
+  let insideBoxesList = false;
 
   for (let i = 0; i < lines.length; i += 1) {
     const line = lines[i];
+
+    // Track `<div class="boxes-list">` ... `</div>` blocks. Their bullets are
+    // navigation (Blog post, Documentation links), not changelog entries, so
+    // they must not surface on the version-comparison page.
+    if (/<div class="boxes-list/.test(line)) {
+      insideBoxesList = true;
+      continue;
+    }
+    if (insideBoxesList && /<\/div>/.test(line)) {
+      insideBoxesList = false;
+      continue;
+    }
 
     const versionMatch = line.match(/^## (\d+\.\d+\.\d+)\s*$/);
     if (versionMatch) {
       currentVersion = versionMatch[1];
       currentDate = findFirstReleaseDate(lines, i + 1);
+      currentCategory = null;
+      currentForceBreaking = false;
+      continue;
+    }
+
+    // A non-version level-2 heading (e.g. "## Related") ends the release
+    // context. Without this, trailing nav bullets are wrongly attributed to
+    // the previous release's last category.
+    if (/^## /.test(line)) {
+      currentVersion = null;
       currentCategory = null;
       currentForceBreaking = false;
       continue;
@@ -126,9 +158,34 @@ export function parseChangelogContent(markdown) {
     }
 
     if (!currentVersion || !currentCategory) continue;
+    if (insideBoxesList) continue;
     if (!line.startsWith('- ')) continue;
 
-    const { breaking, framework, prNumber, prKind, body } = parseBullet(line);
+    // Reassemble a hard-wrapped bullet. Older changelogs (v8-v12) wrap a single
+    // bullet across indented continuation lines, which would otherwise hide the
+    // trailing `[#NNNN](...)` citation and truncate the entry text. Stop at a
+    // blank line, a heading, the next top-level bullet, or a nested sub-bullet
+    // (`  - `), which stays ignored exactly as before.
+    let bulletText = line;
+    let j = i + 1;
+    while (j < lines.length) {
+      const next = lines[j];
+      if (next.trim() === '') break;
+      if (/^#/.test(next)) break;
+      if (/^- /.test(next)) break;
+      if (/^\s+- /.test(next)) break;
+      if (!/^\s+\S/.test(next)) break;
+      bulletText += ` ${next.trim()}`;
+      j += 1;
+    }
+    i = j - 1;
+
+    const { breaking, framework, prNumber, prKind, body } = parseBullet(bulletText);
+
+    // Skip pure-link bullets such as "- [Migrating from 8.4 to 9.0](@/...)":
+    // a whole-bullet markdown link with no citation is navigation, not a change.
+    if (prNumber === null && /^\[[^\]]*\]\([^)]*\)$/.test(body)) continue;
+
     entries.push({
       version: currentVersion,
       releaseDate: currentDate,


### PR DESCRIPTION
### Context

The PR fixes missing GitHub PR/issue links on the **Changes between versions** docs page (`/docs/javascript-data-grid/changes-between-versions/`). DEV-1956 suspected the linked PRs no longer existed after a repository migration. That is not the case — the references are still present in the changelog source. The page is built by `docs/src/plugins/changelog-parser.mjs`, which parsed each release's bullets **line-by-line**. The older changelogs (v8–v12) hard-wrap a single bullet across several indented lines, so the trailing `[#NNNN](https://github.com/handsontable/handsontable/{issues|pull}/NNNN)` citation sat on a continuation line the parser never read — and was silently dropped. The same single-line capture also truncated the entry text (the sibling report DEV-1958, "cut content").

This PR changes only the parser. Three fixes inside `parseChangelogContent`:

1. **Join hard-wrapped bullets** before parsing, so the trailing citation is found and the full entry text is preserved.
2. **Filter non-change "box"/nav bullets** (Blog post, Documentation (X.Y), Migrating-from links) that previously leaked onto the page as fake, link-less entries — via a `boxes-list` div guard and a pure-link-bullet guard. A non-version `## Related` heading no longer mis-attributes its bullets to the previous release.
3. **Capture a trailing citation** even when it is followed by a sentence `.`/`:` or a `[migration guide](...)` link (common in v8/v12). The match still rejects ambiguous mid-sentence references.

Result: entries rendering with a `#NNNN` link went from **728/1312 (56%)** to **1269/1300 (97.6%)** (the total drops by 12 because the fake nav bullets are now excluded). The 31 remaining unlinked entries are catalogued on the ClickUp task: 3 are changelog-8 source-URL typos (`/issue/` singular, a `#anchor` form, a space in the URL) and 28 genuinely cite no PR.

**Out of scope (surfaced for follow-up):** the version-comparison component renders titles with a runtime `react-markdown` (only `remarkGfm` — no raw-HTML or `@/`-link resolver), so titles containing `<kbd>` markup or internal `[text](@/api/…md)` links render as literal/broken markup. This already affects ~33 newer entries on `develop`; recovering the older entries surfaces ~87 more. The `<kbd>` half is tracked by DEV-1957 — recommend DEV-1957 cover both the `<kbd>` and `@/`-link rendering.

### How has this been tested?

- Added 8 unit tests to `docs/src/plugins/__tests__/changelog-parser.test.mjs` covering: joining a hard-wrapped bullet (link on the last line), a parenthesized wrapped citation, a citation trailed by a period, a citation trailed by a migration-guide link, rejection of a mid-sentence citation, `boxes-list` div filtering, standalone pure-link bullet filtering, and nested sub-bullets not being merged/emitted.
- Full suite green (17/17): `cd docs && node --test src/plugins/__tests__/changelog-parser.test.mjs`
- Lint clean: `cd docs && npx eslint src/plugins/changelog-parser.mjs src/plugins/__tests__/changelog-parser.test.mjs`
- Verified link coverage (728→1269 / total 1300) with a count script that imports `parseAllChangelogs()`. No regression to already-captured entries (the added trailing tail matches empty for end-anchored citations; the join breaks immediately on single-line bullets, so v13–v18 counts are unchanged).

`[skip changelog]` — docs-site parser/test-only change, no library source affected.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1956 (also resolves DEV-1958 "cut content" as a side effect; DEV-1957 noted as follow-up)

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

(Docs site only — `handsontable-documentation`.)

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1956

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-site parser and tests only; no library or runtime product code. Behavior is narrowly scoped with a full unit test suite.
> 
> **Overview**
> Fixes missing GitHub PR/issue links and truncated titles on the **Changes between versions** docs page by improving `changelog-parser.mjs` only.
> 
> **Hard-wrapped bullets** from older changelogs (v8–v12) are now merged across indented continuation lines before parsing, so trailing `[#NNNN](...)` citations and full entry text are preserved.
> 
> **Citation extraction** accepts end-of-bullet tails such as a sentence `.`/`:` or an optional `[migration guide](...)` link, while still rejecting ambiguous mid-sentence references.
> 
> **Navigation noise** is filtered out: bullets inside `boxes-list` divs, pure-link bullets (e.g. migration guides), and content under non-version `##` headings like `## Related` no longer appear as fake changelog entries. Nested sub-bullets are not merged into parent entries.
> 
> Eight new unit tests cover these behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab2549134d453f6536b61a64e2b42ea5957b176e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->