### PR TITLE
DEV-1982: Replace hooks soft-delete array with a linked-list bucket

### DIFF
--- a/.changelogs/12925.json
+++ b/.changelogs/12925.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Improved the performance of the internal hooks (events) dispatch: each hook's callbacks are now stored in a linked list, and removing a hook frees it immediately instead of accumulating skipped entries that were iterated over on every run.",
+  "type": "changed",
+  "issueOrPR": 12925,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/core/hooks/__tests__/bucket.unit.ts
+++ b/handsontable/src/core/hooks/__tests__/bucket.unit.ts
@@ -1,5 +1,15 @@
 import { HooksBucket } from 'handsontable/core/hooks/bucket';
 
+// The entries are intrusive linked-list nodes (they carry a `next` pointer). Project the comparable
+// fields so `toEqual` does not walk the `next` chain.
+const shape = hookEntry => ({
+  callback: hookEntry.callback,
+  orderIndex: hookEntry.orderIndex,
+  runOnce: hookEntry.runOnce,
+  initialHook: hookEntry.initialHook,
+});
+const shapes = hooks => hooks.map(shape);
+
 describe('Bucket', () => {
   describe('add()', () => {
     it('should add hook to the collection', () => {
@@ -11,12 +21,12 @@ describe('Bucket', () => {
       bucket.add('afterChange', fn1);
       bucket.add('afterChange', fn2);
 
-      expect(bucket.getHooks('beforeChange')).toEqual([
-        { callback: fn2, orderIndex: 0, runOnce: false, initialHook: false, skip: false },
+      expect(shapes(bucket.getHooks('beforeChange'))).toEqual([
+        { callback: fn2, orderIndex: 0, runOnce: false, initialHook: false },
       ]);
-      expect(bucket.getHooks('afterChange')).toEqual([
-        { callback: fn1, orderIndex: 0, runOnce: false, initialHook: false, skip: false },
-        { callback: fn2, orderIndex: 0, runOnce: false, initialHook: false, skip: false },
+      expect(shapes(bucket.getHooks('afterChange'))).toEqual([
+        { callback: fn1, orderIndex: 0, runOnce: false, initialHook: false },
+        { callback: fn2, orderIndex: 0, runOnce: false, initialHook: false },
       ]);
     });
 
@@ -29,12 +39,12 @@ describe('Bucket', () => {
       bucket.add('test2', fn1);
       bucket.add('test2', fn2);
 
-      expect(bucket.getHooks('test1')).toEqual([
-        { callback: fn2, orderIndex: 0, runOnce: false, initialHook: false, skip: false },
+      expect(shapes(bucket.getHooks('test1'))).toEqual([
+        { callback: fn2, orderIndex: 0, runOnce: false, initialHook: false },
       ]);
-      expect(bucket.getHooks('test2')).toEqual([
-        { callback: fn1, orderIndex: 0, runOnce: false, initialHook: false, skip: false },
-        { callback: fn2, orderIndex: 0, runOnce: false, initialHook: false, skip: false },
+      expect(shapes(bucket.getHooks('test2'))).toEqual([
+        { callback: fn1, orderIndex: 0, runOnce: false, initialHook: false },
+        { callback: fn2, orderIndex: 0, runOnce: false, initialHook: false },
       ]);
     });
 
@@ -46,26 +56,25 @@ describe('Bucket', () => {
       bucket.add('afterChange', fn1);
       bucket.add('afterChange', fn1);
 
-      expect(bucket.getHooks('afterChange')).toEqual([
-        { callback: fn1, orderIndex: 0, runOnce: false, initialHook: false, skip: false },
+      expect(shapes(bucket.getHooks('afterChange'))).toEqual([
+        { callback: fn1, orderIndex: 0, runOnce: false, initialHook: false },
       ]);
     });
 
-    it('should be possible to re-enable a previously removed hook', () => {
+    it('should fully remove a hook on remove and re-add it as a fresh entry (true delete, no skip flag)', () => {
       const bucket = new HooksBucket();
       const fn1 = function() {};
 
       bucket.add('afterChange', fn1);
       bucket.remove('afterChange', fn1);
 
-      expect(bucket.getHooks('afterChange')).toEqual([
-        { callback: fn1, orderIndex: 0, runOnce: false, initialHook: false, skip: true },
-      ]);
+      // true delete: the entry is gone, not soft-deleted
+      expect(bucket.getHooks('afterChange')).toEqual([]);
 
       bucket.add('afterChange', fn1);
 
-      expect(bucket.getHooks('afterChange')).toEqual([
-        { callback: fn1, orderIndex: 0, runOnce: false, initialHook: false, skip: false },
+      expect(shapes(bucket.getHooks('afterChange'))).toEqual([
+        { callback: fn1, orderIndex: 0, runOnce: false, initialHook: false },
       ]);
     });
 
@@ -79,42 +88,42 @@ describe('Bucket', () => {
 
       bucket.add('test', fn1, { orderIndex: 1 });
 
-      expect(bucket.getHooks('test')).toEqual([
-        { callback: fn1, orderIndex: 1, runOnce: false, initialHook: false, skip: false },
+      expect(shapes(bucket.getHooks('test'))).toEqual([
+        { callback: fn1, orderIndex: 1, runOnce: false, initialHook: false },
       ]);
 
       bucket.add('test', fn2);
 
-      expect(bucket.getHooks('test')).toEqual([
-        { callback: fn2, orderIndex: 0, runOnce: false, initialHook: false, skip: false },
-        { callback: fn1, orderIndex: 1, runOnce: false, initialHook: false, skip: false },
+      expect(shapes(bucket.getHooks('test'))).toEqual([
+        { callback: fn2, orderIndex: 0, runOnce: false, initialHook: false },
+        { callback: fn1, orderIndex: 1, runOnce: false, initialHook: false },
       ]);
 
       bucket.add('test', fn3, { orderIndex: -10 });
 
-      expect(bucket.getHooks('test')).toEqual([
-        { callback: fn3, orderIndex: -10, runOnce: false, initialHook: false, skip: false },
-        { callback: fn2, orderIndex: 0, runOnce: false, initialHook: false, skip: false },
-        { callback: fn1, orderIndex: 1, runOnce: false, initialHook: false, skip: false },
+      expect(shapes(bucket.getHooks('test'))).toEqual([
+        { callback: fn3, orderIndex: -10, runOnce: false, initialHook: false },
+        { callback: fn2, orderIndex: 0, runOnce: false, initialHook: false },
+        { callback: fn1, orderIndex: 1, runOnce: false, initialHook: false },
       ]);
 
       bucket.add('test', fn4, { orderIndex: -2 });
 
-      expect(bucket.getHooks('test')).toEqual([
-        { callback: fn3, orderIndex: -10, runOnce: false, initialHook: false, skip: false },
-        { callback: fn4, orderIndex: -2, runOnce: false, initialHook: false, skip: false },
-        { callback: fn2, orderIndex: 0, runOnce: false, initialHook: false, skip: false },
-        { callback: fn1, orderIndex: 1, runOnce: false, initialHook: false, skip: false },
+      expect(shapes(bucket.getHooks('test'))).toEqual([
+        { callback: fn3, orderIndex: -10, runOnce: false, initialHook: false },
+        { callback: fn4, orderIndex: -2, runOnce: false, initialHook: false },
+        { callback: fn2, orderIndex: 0, runOnce: false, initialHook: false },
+        { callback: fn1, orderIndex: 1, runOnce: false, initialHook: false },
       ]);
 
       bucket.add('test', fn5, { orderIndex: 0 });
 
-      expect(bucket.getHooks('test')).toEqual([
-        { callback: fn3, orderIndex: -10, runOnce: false, initialHook: false, skip: false },
-        { callback: fn4, orderIndex: -2, runOnce: false, initialHook: false, skip: false },
-        { callback: fn2, orderIndex: 0, runOnce: false, initialHook: false, skip: false },
-        { callback: fn5, orderIndex: 0, runOnce: false, initialHook: false, skip: false },
-        { callback: fn1, orderIndex: 1, runOnce: false, initialHook: false, skip: false },
+      expect(shapes(bucket.getHooks('test'))).toEqual([
+        { callback: fn3, orderIndex: -10, runOnce: false, initialHook: false },
+        { callback: fn4, orderIndex: -2, runOnce: false, initialHook: false },
+        { callback: fn2, orderIndex: 0, runOnce: false, initialHook: false },
+        { callback: fn5, orderIndex: 0, runOnce: false, initialHook: false },
+        { callback: fn1, orderIndex: 1, runOnce: false, initialHook: false },
       ]);
     });
 
@@ -127,31 +136,50 @@ describe('Bucket', () => {
 
       bucket.add('test', fn1, { initialHook: true });
 
-      expect(bucket.getHooks('test')).toEqual([
-        { callback: fn1, orderIndex: 0, runOnce: false, initialHook: true, skip: false },
+      expect(shapes(bucket.getHooks('test'))).toEqual([
+        { callback: fn1, orderIndex: 0, runOnce: false, initialHook: true },
       ]);
 
       bucket.add('test', fn2);
 
-      expect(bucket.getHooks('test')).toEqual([
-        { callback: fn1, orderIndex: 0, runOnce: false, initialHook: true, skip: false },
-        { callback: fn2, orderIndex: 0, runOnce: false, initialHook: false, skip: false },
+      expect(shapes(bucket.getHooks('test'))).toEqual([
+        { callback: fn1, orderIndex: 0, runOnce: false, initialHook: true },
+        { callback: fn2, orderIndex: 0, runOnce: false, initialHook: false },
       ]);
 
       bucket.add('test', fn3, { initialHook: true });
 
-      expect(bucket.getHooks('test')).toEqual([
-        { callback: fn3, orderIndex: 0, runOnce: false, initialHook: true, skip: false },
-        { callback: fn2, orderIndex: 0, runOnce: false, initialHook: false, skip: false },
+      expect(shapes(bucket.getHooks('test'))).toEqual([
+        { callback: fn3, orderIndex: 0, runOnce: false, initialHook: true },
+        { callback: fn2, orderIndex: 0, runOnce: false, initialHook: false },
       ]);
 
       bucket.add('test', fn4);
 
-      expect(bucket.getHooks('test')).toEqual([
-        { callback: fn3, orderIndex: 0, runOnce: false, initialHook: true, skip: false },
-        { callback: fn2, orderIndex: 0, runOnce: false, initialHook: false, skip: false },
-        { callback: fn4, orderIndex: 0, runOnce: false, initialHook: false, skip: false },
+      expect(shapes(bucket.getHooks('test'))).toEqual([
+        { callback: fn3, orderIndex: 0, runOnce: false, initialHook: true },
+        { callback: fn2, orderIndex: 0, runOnce: false, initialHook: false },
+        { callback: fn4, orderIndex: 0, runOnce: false, initialHook: false },
       ]);
+    });
+
+    it('should keep the same entry object when an initial hook callback is swapped (reference stability)', () => {
+      const bucket = new HooksBucket();
+      const fn1 = function() {};
+      const fn2 = function() {};
+
+      bucket.add('test', fn1, { initialHook: true });
+
+      // Simulate a wrapper holding the array reference across an update.
+      const held = bucket.getHooks('test');
+      const entry = held[0];
+
+      bucket.add('test', fn2, { initialHook: true });
+
+      // Same entry object, callback swapped in place — the held reference reflects it.
+      expect(bucket.getHooks('test')[0]).toBe(entry);
+      expect(entry.callback).toBe(fn2);
+      expect(held[0].callback).toBe(fn2);
     });
 
     it('should be possible to add hook once', () => {
@@ -163,32 +191,32 @@ describe('Bucket', () => {
 
       bucket.add('test', fn1);
 
-      expect(bucket.getHooks('test')).toEqual([
-        { callback: fn1, orderIndex: 0, runOnce: false, initialHook: false, skip: false },
+      expect(shapes(bucket.getHooks('test'))).toEqual([
+        { callback: fn1, orderIndex: 0, runOnce: false, initialHook: false },
       ]);
 
       bucket.add('test', fn2, { runOnce: true });
 
-      expect(bucket.getHooks('test')).toEqual([
-        { callback: fn1, orderIndex: 0, runOnce: false, initialHook: false, skip: false },
-        { callback: fn2, orderIndex: 0, runOnce: true, initialHook: false, skip: false },
+      expect(shapes(bucket.getHooks('test'))).toEqual([
+        { callback: fn1, orderIndex: 0, runOnce: false, initialHook: false },
+        { callback: fn2, orderIndex: 0, runOnce: true, initialHook: false },
       ]);
 
       bucket.add('test', fn3, { runOnce: false });
 
-      expect(bucket.getHooks('test')).toEqual([
-        { callback: fn1, orderIndex: 0, runOnce: false, initialHook: false, skip: false },
-        { callback: fn2, orderIndex: 0, runOnce: true, initialHook: false, skip: false },
-        { callback: fn3, orderIndex: 0, runOnce: false, initialHook: false, skip: false },
+      expect(shapes(bucket.getHooks('test'))).toEqual([
+        { callback: fn1, orderIndex: 0, runOnce: false, initialHook: false },
+        { callback: fn2, orderIndex: 0, runOnce: true, initialHook: false },
+        { callback: fn3, orderIndex: 0, runOnce: false, initialHook: false },
       ]);
 
       bucket.add('test', fn4, { runOnce: true });
 
-      expect(bucket.getHooks('test')).toEqual([
-        { callback: fn1, orderIndex: 0, runOnce: false, initialHook: false, skip: false },
-        { callback: fn2, orderIndex: 0, runOnce: true, initialHook: false, skip: false },
-        { callback: fn3, orderIndex: 0, runOnce: false, initialHook: false, skip: false },
-        { callback: fn4, orderIndex: 0, runOnce: true, initialHook: false, skip: false },
+      expect(shapes(bucket.getHooks('test'))).toEqual([
+        { callback: fn1, orderIndex: 0, runOnce: false, initialHook: false },
+        { callback: fn2, orderIndex: 0, runOnce: true, initialHook: false },
+        { callback: fn3, orderIndex: 0, runOnce: false, initialHook: false },
+        { callback: fn4, orderIndex: 0, runOnce: true, initialHook: false },
       ]);
     });
   });
@@ -209,6 +237,16 @@ describe('Bucket', () => {
       expect(bucket.has('afterChange')).toBe(false);
       expect(bucket.has('test')).toBe(false);
     });
+
+    it('should return `false` after the last hook is removed', () => {
+      const bucket = new HooksBucket();
+      const fn1 = function() {};
+
+      bucket.add('afterChange', fn1);
+      bucket.remove('afterChange', fn1);
+
+      expect(bucket.has('afterChange')).toBe(false);
+    });
   });
 
   describe('remove()', () => {
@@ -219,8 +257,8 @@ describe('Bucket', () => {
       bucket.add('afterChange', fn1);
 
       expect(bucket.remove('test')).toBe(false);
-      expect(bucket.getHooks('afterChange')).toEqual([
-        { callback: fn1, orderIndex: 0, runOnce: false, initialHook: false, skip: false },
+      expect(shapes(bucket.getHooks('afterChange'))).toEqual([
+        { callback: fn1, orderIndex: 0, runOnce: false, initialHook: false },
       ]);
     });
 
@@ -232,12 +270,12 @@ describe('Bucket', () => {
       bucket.add('afterChange', fn1);
 
       expect(bucket.remove('afterChange', fn2)).toBe(false);
-      expect(bucket.getHooks('afterChange')).toEqual([
-        { callback: fn1, orderIndex: 0, runOnce: false, initialHook: false, skip: false },
+      expect(shapes(bucket.getHooks('afterChange'))).toEqual([
+        { callback: fn1, orderIndex: 0, runOnce: false, initialHook: false },
       ]);
     });
 
-    it('should remove hook and return `true` when the callback does exist in the collection', () => {
+    it('should remove the hook (true delete) and return `true` when the callback exists in the collection', () => {
       const bucket = new HooksBucket();
       const fn1 = function() {};
       const fn2 = function() {};
@@ -248,40 +286,53 @@ describe('Bucket', () => {
       bucket.add('afterChange', fn3);
 
       expect(bucket.remove('afterChange', fn2)).toBe(true);
-      expect(bucket.getHooks('afterChange')).toEqual([
-        { callback: fn1, orderIndex: 0, runOnce: false, initialHook: false, skip: false },
-        { callback: fn2, orderIndex: 0, runOnce: false, initialHook: false, skip: true },
-        { callback: fn3, orderIndex: 0, runOnce: false, initialHook: false, skip: false },
+      // fn2 is gone entirely (no soft-delete), fn1 and fn3 remain in order
+      expect(shapes(bucket.getHooks('afterChange'))).toEqual([
+        { callback: fn1, orderIndex: 0, runOnce: false, initialHook: false },
+        { callback: fn3, orderIndex: 0, runOnce: false, initialHook: false },
       ]);
     });
 
-    it('should remove skipped hook entries from the collection after reaching the limit', () => {
+    it('should remove the head and the tail correctly', () => {
       const bucket = new HooksBucket();
       const fn1 = function() {};
       const fn2 = function() {};
       const fn3 = function() {};
 
-      for (let i = 0; i < 99; i++) {
+      bucket.add('afterChange', fn1);
+      bucket.add('afterChange', fn2);
+      bucket.add('afterChange', fn3);
+
+      bucket.remove('afterChange', fn1); // head
+      bucket.remove('afterChange', fn3); // tail
+
+      expect(shapes(bucket.getHooks('afterChange'))).toEqual([
+        { callback: fn2, orderIndex: 0, runOnce: false, initialHook: false },
+      ]);
+
+      // adding after removing the tail still appends correctly
+      const fn4 = function() {};
+
+      bucket.add('afterChange', fn4);
+
+      expect(shapes(bucket.getHooks('afterChange'))).toEqual([
+        { callback: fn2, orderIndex: 0, runOnce: false, initialHook: false },
+        { callback: fn4, orderIndex: 0, runOnce: false, initialHook: false },
+      ]);
+    });
+
+    it('should delete entries immediately without accumulating skipped slots', () => {
+      const bucket = new HooksBucket();
+
+      for (let i = 0; i < 150; i++) {
         const fnMock = function() {};
 
         bucket.add('afterChange', fnMock);
         bucket.remove('afterChange', fnMock);
+
+        // every add/remove pair leaves the collection empty — no growth, no skipped entries
+        expect(bucket.getHooks('afterChange').length).toBe(0);
       }
-
-      bucket.add('afterChange', fn1);
-
-      expect(bucket.remove('afterChange', fn1)).toBe(true);
-      expect(bucket.getHooks('afterChange').length).toBe(100);
-
-      bucket.add('afterChange', fn2);
-
-      expect(bucket.remove('afterChange', fn2)).toBe(true);
-      expect(bucket.getHooks('afterChange').length).toBe(0);
-
-      bucket.add('afterChange', fn3);
-
-      expect(bucket.remove('afterChange', fn3)).toBe(true);
-      expect(bucket.getHooks('afterChange').length).toBe(1);
     });
   });
 });

--- a/handsontable/src/core/hooks/bucket.ts
+++ b/handsontable/src/core/hooks/bucket.ts
@@ -7,32 +7,36 @@ export interface HookEntry {
   orderIndex: number;
   runOnce: boolean;
   initialHook: boolean;
-  skip: boolean;
+  /**
+   * Intrusive singly-linked-list pointer to the next entry. The entry IS the list node (no wrapper
+   * object) so dispatch reads `entry.callback` with a single indirection. `null` marks the tail.
+   */
+  next: HookEntry | null;
 }
 
 /**
- * The maximum number of hooks that can be skipped before the bucket is cleaned up.
+ * A per-hook singly-linked list. `head`/`tail` allow O(1) append; dispatch walks `head` → `next`.
  */
-const MAX_SKIPPED_HOOKS_COUNT = 100;
+interface HookList {
+  head: HookEntry | null;
+  tail: HookEntry | null;
+}
 
 /**
  * The class represents a collection that allows to manage hooks (add, remove).
+ *
+ * Storage is a `Map<hookName, singly-linked list of entries>`. Removal is a true delete (relink) — there
+ * is no soft-delete `skip` flag and no periodic compaction. An in-flight `run()` stays correct because it
+ * reads `entry.next` fresh after each callback (a later entry removed mid-run is skipped) and never nulls a
+ * removed node's `next` (a callback removing itself can still advance).
  *
  * @class HooksBucket
  */
 export class HooksBucket {
   /**
-   * A map that stores hooks.
+   * A map that stores the per-hook linked lists.
    */
-  #hooks: Map<string, HookEntry[]> = new Map();
-  /**
-   * A map that stores the number of skipped hooks.
-   */
-  #skippedHooksCount: Map<string, number> = new Map();
-  /**
-   * A set that stores hook names that need to be re-sorted.
-   */
-  #needsSort: Set<string> = new Set();
+  #hooks: Map<string, HookList> = new Map();
 
   /**
    * Initializes the bucket and pre-creates empty hook collections for all currently registered hook names.
@@ -42,13 +46,38 @@ export class HooksBucket {
   }
 
   /**
-   * Gets all hooks for the provided hook name.
+   * Gets the internal linked list for the provided hook name. Used by the dispatcher (`Hooks#runHandlers`)
+   * to walk entries without materializing an array on the hot path.
+   *
+   * @param {string} hookName The name of the hook.
+   * @returns {HookList|null}
+   */
+  getList(hookName: string): HookList | null {
+    return this.#hooks.get(hookName) ?? null;
+  }
+
+  /**
+   * Gets all live hooks for the provided hook name as an array, in execution order. The returned entries are
+   * the live list nodes (not copies), so an in-place `addAsFixed` callback swap is reflected in a
+   * previously returned array — relied on by the framework wrappers.
    *
    * @param {string} hookName The name of the hook.
    * @returns {HookEntry[]}
    */
   getHooks(hookName: string): HookEntry[] {
-    return this.#hooks.get(hookName) ?? [];
+    const list = this.#hooks.get(hookName);
+    const result: HookEntry[] = [];
+
+    if (list) {
+      let node = list.head;
+
+      while (node) {
+        result.push(node);
+        node = node.next;
+      }
+    }
+
+    return result;
   }
 
   /**
@@ -63,101 +92,87 @@ export class HooksBucket {
     callback: HookCallback,
     options: { orderIndex?: number; runOnce?: boolean; initialHook?: boolean } = {}
   ) {
-    if (!this.#hooks.has(hookName)) {
-      this.#createHooksCollection(hookName);
+    let list = this.#hooks.get(hookName);
+
+    if (!list) {
+      list = this.#createHooksCollection(hookName);
       REGISTERED_HOOKS.push(hookName);
     }
 
-    const hooks = this.#hooks.get(hookName) ?? [];
-    const existingHook = hooks.find(hook => hook.callback === callback);
-
-    if (existingHook) {
-      if (existingHook.skip === true) {
-        // Re-enable the hook if it was previously added and then removed.
-        existingHook.skip = false;
+    // Adding the same callback twice is silently ignored. With true-delete a match is always a live entry.
+    for (let node = list.head; node !== null; node = node.next) {
+      if (node.callback === callback) {
+        return;
       }
-
-      // adding the same hook twice is now silently ignored
-      return;
     }
 
     const orderIndex = Number.isInteger(options.orderIndex) ? (options.orderIndex ?? 0) : 0;
     const runOnce = !!options.runOnce;
     const initialHook = !!options.initialHook;
 
-    let foundInitialHook = false;
-
     if (initialHook) {
-      const initialHookEntry = hooks.find(hook => hook.initialHook);
+      // Replace the callback of the existing initial hook IN PLACE — keeps the entry object and its
+      // position, so an array previously returned by getHooks() reflects the swap (wrapper contract).
+      for (let node = list.head; node !== null; node = node.next) {
+        if (node.initialHook) {
+          node.callback = callback;
 
-      if (initialHookEntry) {
-        initialHookEntry.callback = callback;
-        foundInitialHook = true;
+          return;
+        }
       }
     }
 
-    if (!foundInitialHook) {
-      hooks.push({
-        callback,
-        orderIndex,
-        runOnce,
-        initialHook,
-        skip: false,
-      });
-
-      let needsSort = this.#needsSort.has(hookName);
-
-      if (!needsSort && orderIndex !== 0) {
-        needsSort = true;
-        this.#needsSort.add(hookName);
-      }
-
-      if (needsSort && hooks.length > 1) {
-        this.#hooks.set(hookName, hooks.toSorted((a, b) => a.orderIndex - b.orderIndex));
-      }
-    }
+    this.#insertByOrder(list, { callback, orderIndex, runOnce, initialHook, next: null });
   }
 
   /**
-   * Checks if there are any hooks for the provided hook name.
+   * Checks if there are any live hooks for the provided hook name.
    *
    * @param {string} hookName The name of the hook.
    * @returns {boolean}
    */
   has(hookName: string): boolean {
-    return this.#hooks.has(hookName) && (this.#hooks.get(hookName)?.length ?? 0) > 0;
+    const list = this.#hooks.get(hookName);
+
+    return !!list && list.head !== null;
   }
 
   /**
-   * Removes a hook from the collection. If the hook was found and removed,
-   * the method returns `true`, otherwise `false`.
+   * Removes a hook from the collection (true delete). Returns `true` if the callback was found and removed,
+   * `false` otherwise.
    *
    * @param {string} hookName The name of the hook.
    * @param {*} callback The callback function to remove.
    * @returns {boolean}
    */
   remove(hookName: string, callback: HookCallback): boolean {
-    if (!this.#hooks.has(hookName)) {
+    const list = this.#hooks.get(hookName);
+
+    if (!list) {
       return false;
     }
 
-    const hooks = this.#hooks.get(hookName) ?? [];
-    const hookEntry = hooks.find(hook => hook.callback === callback);
+    let prev: HookEntry | null = null;
+    let node = list.head;
 
-    if (hookEntry) {
-      let skippedHooksCount = this.#skippedHooksCount.get(hookName) ?? 0;
+    while (node !== null) {
+      if (node.callback === callback) {
+        if (prev) {
+          prev.next = node.next;
+        } else {
+          list.head = node.next;
+        }
 
-      hookEntry.skip = true;
-      skippedHooksCount += 1;
+        if (node === list.tail) {
+          list.tail = prev;
+        }
 
-      if (skippedHooksCount > MAX_SKIPPED_HOOKS_COUNT) {
-        this.#hooks.set(hookName, hooks.filter(hook => !hook.skip));
-        skippedHooksCount = 0;
+        // Intentionally do NOT null `node.next`: an in-flight run() may hold this node and needs to advance.
+        return true;
       }
 
-      this.#skippedHooksCount.set(hookName, skippedHooksCount);
-
-      return true;
+      prev = node;
+      node = node.next;
     }
 
     return false;
@@ -168,16 +183,59 @@ export class HooksBucket {
    */
   destroy() {
     this.#hooks.clear();
-    this.#skippedHooksCount.clear();
   }
 
   /**
-   * Creates a initial collection for the provided hook name.
+   * Inserts an entry keeping the list sorted by ascending `orderIndex`. Entries with an equal `orderIndex`
+   * keep insertion order (stable). The common case (`orderIndex` 0, appended after equal entries) is an
+   * O(1) tail append.
+   *
+   * @param {HookList} list The list to insert into.
+   * @param {HookEntry} entry The entry to insert.
+   */
+  #insertByOrder(list: HookList, entry: HookEntry) {
+    if (list.head === null) {
+      list.head = entry;
+      list.tail = entry;
+
+      return;
+    }
+
+    if (entry.orderIndex >= list.tail!.orderIndex) {
+      list.tail!.next = entry;
+      list.tail = entry;
+
+      return;
+    }
+
+    let prev: HookEntry | null = null;
+    let node: HookEntry | null = list.head;
+
+    while (node !== null && node.orderIndex <= entry.orderIndex) {
+      prev = node;
+      node = node.next;
+    }
+
+    if (prev === null) {
+      entry.next = list.head;
+      list.head = entry;
+    } else {
+      entry.next = node;
+      prev.next = entry;
+    }
+  }
+
+  /**
+   * Creates an initial (empty) collection for the provided hook name.
    *
    * @param {string} hookName The name of the hook.
+   * @returns {HookList}
    */
-  #createHooksCollection(hookName: string) {
-    this.#hooks.set(hookName, []);
-    this.#skippedHooksCount.set(hookName, 0);
+  #createHooksCollection(hookName: string): HookList {
+    const list: HookList = { head: null, tail: null };
+
+    this.#hooks.set(hookName, list);
+
+    return list;
   }
 }

--- a/handsontable/src/core/hooks/index.ts
+++ b/handsontable/src/core/hooks/index.ts
@@ -5,7 +5,7 @@ import { toSingleLine } from '../../helpers/templateLiteralTag';
 import { fastCall } from '../../helpers/function';
 import { REGISTERED_HOOKS, REMOVED_HOOKS, DEPRECATED_HOOKS } from './constants';
 import { HooksBucket } from './bucket';
-import type { HookCallback } from './bucket';
+import type { HookCallback, HookEntry } from './bucket';
 
 /**
  * Template warning message for removed hooks.
@@ -210,16 +210,21 @@ export class Hooks {
     context: Record<string, unknown>, key: string,
     p1?: unknown, p2?: unknown, p3?: unknown, p4?: unknown, p5?: unknown, p6?: unknown
   ) {
-    p1 = this.#runHandlers(this.getBucket().getHooks(key), context, key, null, p1, p2, p3, p4, p5, p6);
-    p1 = this.#runHandlers(this.getBucket(context).getHooks(key), context, key, context, p1, p2, p3, p4, p5, p6);
+    p1 = this.#runHandlers(this.getBucket().getList(key), context, key, null, p1, p2, p3, p4, p5, p6);
+    p1 = this.#runHandlers(this.getBucket(context).getList(key), context, key, context, p1, p2, p3, p4, p5, p6);
 
     return p1;
   }
 
   /**
-   * Runs all callbacks from a single handler list (global or local), threading the return value through p1.
+   * Runs all callbacks from a single hook list (global or local), threading the return value through p1.
    *
-   * @param {Array|null} handlers The list of hook entries to iterate.
+   * Walks the intrusive linked list from `head`. The `tail` captured at loop start is the boundary: hooks
+   * appended DURING this run (after the boundary) do not fire this run, matching the previous array's
+   * frozen-length behavior. `entry.next` is read fresh after each callback so a later entry removed mid-run
+   * is skipped; `remove()` never nulls a removed node's `next`, so a callback removing itself still advances.
+   *
+   * @param {object|null} list The hook list to iterate (or null when the hook has no collection).
    * @param {object} context Handsontable instance used as `this` for each callback.
    * @param {string} key Hook/Event name.
    * @param {object|null} removeContext Context passed to `remove` — null for global handlers.
@@ -232,35 +237,35 @@ export class Hooks {
    * @returns {*} Updated p1 value after running all callbacks.
    */
   #runHandlers(
-    handlers: ReturnType<HooksBucket['getHooks']>,
+    list: ReturnType<HooksBucket['getList']>,
     context: Record<string, unknown>,
     key: string,
     removeContext: Record<string, unknown> | null,
     p1: unknown, p2: unknown, p3: unknown, p4: unknown, p5: unknown, p6: unknown
   ) {
-    const length = handlers ? handlers.length : 0;
-    let index = 0;
+    if (list === null || list.head === null) {
+      return p1;
+    }
 
-    if (length) {
-      // Do not optimize this loop with arrayEach or arrow function! If you do You'll decrease perf because of GC.
-      while (index < length) {
-        if (!handlers[index] || handlers[index].skip) {
-          index += 1;
-          /* eslint-disable no-continue */
-          continue;
-        }
+    let entry: HookEntry | null = list.head;
+    const boundary = list.tail;
 
-        const res = fastCall(handlers[index].callback, context, p1, p2, p3, p4, p5, p6);
+    // Do not optimize this loop with arrayEach or arrow function! If you do You'll decrease perf because of GC.
+    while (entry !== null) {
+      const res = fastCall(entry.callback, context, p1, p2, p3, p4, p5, p6);
 
-        if (res !== undefined) {
-          p1 = res;
-        }
-        if (handlers[index] && handlers[index].runOnce) {
-          this.remove(key, handlers[index].callback, removeContext);
-        }
-
-        index += 1;
+      if (res !== undefined) {
+        p1 = res;
       }
+      if (entry.runOnce) {
+        this.remove(key, entry.callback, removeContext);
+      }
+
+      if (entry === boundary) {
+        break;
+      }
+
+      entry = entry.next;
     }
 
     return p1;


### PR DESCRIPTION
### Context

The PR changes the hook bus (`HooksBucket`) from an array-with-soft-delete to a linked list, as part of the rendering/memory performance initiative.

Each hook's callbacks were stored in an array with a soft-delete `skip` flag: a removed callback stayed in the array and was iterated (then skipped) on every `run()` until a `MAX_SKIPPED_HOOKS_COUNT` (100) compaction pass rebuilt the array. `#runHandlers` also re-read `handlers[index]` several times per entry and checked `.skip` on every iteration.

This replaces that with a purpose-built intrusive singly-linked list per hook (`{head, tail}`; `HookEntry` drops `skip`, gains `next`). The soft-delete `skip` flag, `#skippedHooksCount`, and the `MAX_SKIPPED_HOOKS_COUNT` compaction are removed entirely. `remove()` is now a true relink-delete; `#runHandlers` walks `head → next` with no per-entry skip or bounds check.

The observable dispatch contract is preserved:

- **Mid-run removal** of a later, not-yet-fired handler is still skipped this run — `entry.next` is read *after* each callback, and `remove()` never nulls a removed node's `next` (so a callback removing itself can still advance).
- **Mid-run add** does not fire this run — the `tail` captured at loop start is the boundary.
- **`getHooks()` reference stability** (relied on by the Vue 3 wrapper) — it returns the live entry objects, and `addAsFixed` swaps `.callback` in place on the existing entry.

Two intentional behavior changes, both non-breaking (no public API, default, hook, or CSS change):

- `has()` now returns `false` once the last hook is removed. The array version could return `true` for a collection holding only soft-deleted entries — a latent bug, now fixed.
- Re-adding a previously removed callback inserts a fresh entry at its `orderIndex` position, rather than "re-enabling" the old entry in place.

### Results

Measured with a standalone harness driving the real rebuilt bundle (`Handsontable.hooks`), profiler off, median of 7 runs, same machine. Metric is the latency of a single `hooks.run()` at the given number of registered callbacks on one hook.

| `run()` over | Before (array + soft-delete) | After (linked list) | Speedup |
| --- | --: | --: | --: |
| 1000 live handlers | 8,300 ns | 4,940 ns | 1.68× |
| 500 live (after removing 500) | 4,787 ns | 2,480 ns | 1.93× |
| 901 live, 0 removed | 8,193 ns | 4,931 ns | 1.66× |
| 901 live + 99 removed | 8,707 ns | 5,180 ns | ≈ the 901-live row — no skipped slots to iterate |

The last two rows isolate the soft-delete cost: before, 99 removed-but-not-compacted entries added ~514 ns of empty iteration per `run()`; after, removed entries are gone, so that row collapses onto the plain 901-live figure.

**Scope note (honesty):** the speedup is a large ratio on a small absolute. Real hooks on the render hot path have 0–1 handlers, where dispatch is already sub-microsecond; across a full render frame the difference is on the order of ~0.01 ms. The primary value of this PR is deleting the skip/compaction machinery and making removal a true delete; the throughput win only becomes material for hooks that accumulate many handlers.

### How has this been tested?

- Unit: `npm run test:unit --prefix handsontable --testPathPattern=core/hooks` — 40/40 pass (bucket + index).
- Types: `npm run test:types --prefix handsontable` — clean (downlevel-dts green).
- Build: `npm run build --prefix handsontable` — OK.
- E2E: `npm run test:e2e --prefix handsontable --testPathPattern=core/runHooks` — 6/0; `--testPathPattern=__tests__/hooks/` — 333/0.
- Lint: `npm run eslint --prefix handsontable` — clean.
- Added a unit test asserting `getHooks()` reference stability across an `addAsFixed` callback swap (the wrapper contract), plus true-delete / head-tail-removal / no-skipped-accumulation cases.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1982

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1982
