### PR TITLE
docs(installation): add Skills for Claude Code recommendation to all framework install guides

### DIFF
--- a/docs/content/guides/getting-started/installation/installation.md
+++ b/docs/content/guides/getting-started/installation/installation.md
@@ -79,6 +79,19 @@ pnpm add handsontable @handsontable/angular-wrapper
   </code-block>
 </code-group>
 
+## Install Skills for Claude Code
+
+Skills for Claude Code give Claude AI deep knowledge of Handsontable's APIs, so it can build, configure, and debug your grid accurately. We recommend installing them alongside Handsontable.
+
+In Claude Code, run:
+
+```bash
+/plugin marketplace add handsontable/handsontable-skills
+/plugin install handsontable-skills@handsontable-skills
+```
+
+For more details, see [Skills for Claude Code](@/guides/ai-tools/skills-for-claude-code/skills-for-claude-code.md).
+
 ## Configure `app.config.ts`
 
 In `app.config.ts`, register Handsontable's modules and set global configuration values via the `HOT_GLOBAL_CONFIG` token. You can modify these values at any time using `HotGlobalConfigService`, or override them per table. All properties of `HotGlobalConfig` are optional.
@@ -263,6 +276,19 @@ To install Handsontable locally using a package manager, run one of these comman
   </code-block>
 </code-group>
 
+### Install Skills for Claude Code
+
+Skills for Claude Code give Claude AI deep knowledge of Handsontable's APIs, so it can build, configure, and debug your grid accurately. We recommend installing them alongside Handsontable.
+
+In Claude Code, run:
+
+```bash
+/plugin marketplace add handsontable/handsontable-skills
+/plugin install handsontable-skills@handsontable-skills
+```
+
+For more details, see [Skills for Claude Code](@/guides/ai-tools/skills-for-claude-code/skills-for-claude-code.md).
+
 ### Using a CDN
 
 To get Handsontable's files from a CDN, use the following locations:
@@ -369,6 +395,19 @@ To install Handsontable locally using a package manager, run one of these comman
   </code-block>
 </code-group>
 
+## Install Skills for Claude Code
+
+Skills for Claude Code give Claude AI deep knowledge of Handsontable's APIs, so it can build, configure, and debug your grid accurately. We recommend installing them alongside Handsontable.
+
+In Claude Code, run:
+
+```bash
+/plugin marketplace add handsontable/handsontable-skills
+/plugin install handsontable-skills@handsontable-skills
+```
+
+For more details, see [Skills for Claude Code](@/guides/ai-tools/skills-for-claude-code/skills-for-claude-code.md).
+
 ## Register Handsontable's modules
 
 Import and register all of Handsontable's modules with a single function call:
@@ -456,6 +495,19 @@ To install Handsontable locally using a package manager, run one of these comman
   </code-block>
 </code-group>
 
+## Install Skills for Claude Code
+
+Skills for Claude Code give Claude AI deep knowledge of Handsontable's APIs, so it can build, configure, and debug your grid accurately. We recommend installing them alongside Handsontable.
+
+In Claude Code, run:
+
+```bash
+/plugin marketplace add handsontable/handsontable-skills
+/plugin install handsontable-skills@handsontable-skills
+```
+
+For more details, see [Skills for Claude Code](@/guides/ai-tools/skills-for-claude-code/skills-for-claude-code.md).
+
 ## Register Handsontable's modules
 
 Import and register all of Handsontable's modules with a single function call:
@@ -521,6 +573,7 @@ Handsontable is installed and ready to use in your project. Import it and create
 
 <div class="boxes-list">
 
+- [Skills for Claude Code](@/guides/ai-tools/skills-for-claude-code/skills-for-claude-code.md)
 - [Modules](@/guides/tools-and-building/modules/modules.md)
 
 </div>


### PR DESCRIPTION
### Context

The installation guide for all four frameworks (React, Angular, Vue, JavaScript) now includes a dedicated "Install Skills for Claude Code" step placed immediately after the Handsontable package install commands. This mirrors the recommendation already live on the Skills for Claude Code page and ensures developers see the suggestion at the earliest possible point in the setup flow. A cross-link is also added to the shared Related articles section.

## Motivation

Teams using Claude Code benefit from knowing about the Handsontable skills plugin at install time rather than discovering it later; surfacing it here reduces friction for AI-assisted grid development.
## Files changed

- `docs/content/guides/getting-started/installation/installation.md`

### How has this been tested?
Documentation-only change; verified in local Astro preview across all four framework tabs.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. https://app.clickup.com/t/9015210959/DEV-1980
2.
3.

### Affected project(s):
- [x] `handsontable`
- [x] `@handsontable/angular-wrapper`
- [x] `@handsontable/react-wrapper`
- [x] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime, API, or dependency changes.
> 
> **Overview**
> The **installation** guide now recommends **Skills for Claude Code** right after the Handsontable package install steps for **Angular**, **JavaScript**, **React**, and **Vue**. Each tab adds the same optional step: Claude Code `/plugin marketplace` and `/plugin install` commands for `handsontable-skills`, plus a link to the dedicated Skills guide.
> 
> The shared **Related articles** section at the bottom of `installation.md` now lists **Skills for Claude Code** alongside Modules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b650facafd09e693288a8834418e23d0c3b82498. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->