### PR TITLE
DEV-1981: Fix angular cookie collapsing legacy docs versions to latest

### DIFF
--- a/docs/cloudflare/__tests__/_worker.test.mjs
+++ b/docs/cloudflare/__tests__/_worker.test.mjs
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * `_worker.js` is written as a Cloudflare Workers ES module (`export default
+ * { fetch }`), which the Wrangler/Pages runtime always treats as ESM
+ * regardless of this package's CommonJS-by-default `package.json`. Node's
+ * test runner would fail to `import` it directly under that mismatch, so it
+ * is loaded and evaluated as a plain script instead - the same technique
+ * used to sanity-check the worker locally before deploying it.
+ *
+ * @returns {{fetch: Function}} The worker's default export.
+ */
+function loadWorker() {
+  const workerPath = fileURLToPath(new URL('../_worker.js', import.meta.url));
+  const source = readFileSync(workerPath, 'utf8')
+    .replace('__LATEST_DOCS_VERSION__', '99.9') // Arbitrary version outside every range under test.
+    .replace('export default {', 'module.exports = {');
+  const module = { exports: {} };
+
+  new Function('module', 'exports', `${source}\nreturn module.exports;`)(module, module.exports);
+
+  return module.exports;
+}
+
+function request(path, cookie) {
+  return {
+    url: `https://handsontable.com${path}`,
+    headers: { get: (name) => (name === 'Cookie' && cookie ? `docs_fw=${cookie}` : null) },
+  };
+}
+
+const env = { ASSETS: { fetch: async() => new Response('static-asset-passthrough') } };
+
+async function redirectLocationOf(worker, path, cookie) {
+  const response = await worker.fetch(request(path, cookie), env);
+
+  return response.headers.get('location');
+}
+
+test('bare old-version URL with the angular cookie keeps the requested version (regression for DEV-1981)', async() => {
+  const worker = loadWorker();
+
+  // Versions 12.1-15.3 have no dedicated per-version Angular docs, so the
+  // cookie-based framework redirect must not point at "angular-data-grid"
+  // there - doing so used to get collapsed by the legacy-angular rule into
+  // the unversioned latest docs, silently dropping the requested version.
+  assert.equal(
+    await redirectLocationOf(worker, '/docs/14.4', 'angular'),
+    'https://handsontable.com/docs/14.4/javascript-data-grid',
+  );
+  assert.equal(
+    await redirectLocationOf(worker, '/docs/15.3', 'angular'),
+    'https://handsontable.com/docs/15.3/javascript-data-grid',
+  );
+  assert.equal(
+    await redirectLocationOf(worker, '/docs/12.1', 'angular'),
+    'https://handsontable.com/docs/12.1/javascript-data-grid',
+  );
+});
+
+test('bare version URL with the angular cookie still targets angular-data-grid once dedicated docs exist (16.0+)', async() => {
+  const worker = loadWorker();
+
+  assert.equal(
+    await redirectLocationOf(worker, '/docs/16.2', 'angular'),
+    'https://handsontable.com/docs/16.2/angular-data-grid',
+  );
+  assert.equal(
+    await redirectLocationOf(worker, '/docs/17.1', 'angular'),
+    'https://handsontable.com/docs/17.1/angular-data-grid',
+  );
+});
+
+test('non-angular cookies and versions before the Angular package are unaffected', async() => {
+  const worker = loadWorker();
+
+  assert.equal(
+    await redirectLocationOf(worker, '/docs/14.4', 'javascript'),
+    'https://handsontable.com/docs/14.4/javascript-data-grid',
+  );
+  assert.equal(
+    await redirectLocationOf(worker, '/docs/14.4', 'react'),
+    'https://handsontable.com/docs/14.4/react-data-grid',
+  );
+  assert.equal(
+    await redirectLocationOf(worker, '/docs/14.4', undefined),
+    'https://handsontable.com/docs/14.4/javascript-data-grid',
+  );
+
+  // Pre-12.1 versions predate the Angular package entirely and are served
+  // as-is (no framework subpath to redirect to).
+  const response = await worker.fetch(request('/docs/12.0', 'angular'), env);
+
+  assert.equal(response.status, 200);
+});
+
+test('direct links to the legacy angular-data-grid path still collapse to the unversioned latest docs', async() => {
+  const worker = loadWorker();
+
+  assert.equal(
+    await redirectLocationOf(worker, '/docs/14.4/angular-data-grid/installation'),
+    'https://handsontable.com/docs/angular-data-grid/',
+  );
+  assert.equal(
+    await redirectLocationOf(worker, '/docs/12.0/angular-data-grid'),
+    'https://handsontable.com/docs/javascript-data-grid/',
+  );
+});

--- a/docs/cloudflare/_worker.js
+++ b/docs/cloudflare/_worker.js
@@ -1097,7 +1097,17 @@ async function route(request, env) {
         }
 
         const cookieValue = getCookie(request, 'docs_fw');
-        const framework = getFrameworkFromCookie(cookieValue);
+        let framework = getFrameworkFromCookie(cookieValue);
+
+        // Angular has no dedicated per-version docs before 16.0 (see the
+        // LEGACY_ANGULAR_TO_ANGULAR_SET/_TO_JS_SET rule above). Sending the
+        // angular-cookie framework here would manufacture a
+        // /docs/{version}/angular-data-grid URL that rule 3 then collapses to
+        // the unversioned latest docs, dropping the version requested here.
+        if (framework === 'angular-data-grid' && major < 16) {
+          framework = 'javascript-data-grid';
+        }
+
         const dest = isFrameworkVersion ? `/docs/${version}/${framework}` : `/docs/${version}`;
 
         return redirect302(abs(dest, url));

--- a/docs/netlify/netlify/edge-functions/rewrite_redirect_cookie_docs_x_x.mts
+++ b/docs/netlify/netlify/edge-functions/rewrite_redirect_cookie_docs_x_x.mts
@@ -5,7 +5,7 @@ import { getFrameworkFromCookie } from '../cookieHelper.mts';
 export default async(req: Request, context: Context) => {
   const major = parseInt(context.params['0'], 10);
   const minor = parseInt(context.params['1'], 10);
-  const framework = getFrameworkFromCookie(context.cookies.get('docs_fw'));
+  let framework = getFrameworkFromCookie(context.cookies.get('docs_fw'));
   const version = `${context.params['0']}.${context.params['1']}`;
   const isFrameworkVersion = (major === 12 && minor >= 1) || major >= 13;
 
@@ -15,6 +15,14 @@ export default async(req: Request, context: Context) => {
     const page = await response.text();
 
     return new Response(page, response);
+  }
+
+  // Angular has no dedicated per-version docs before 16.0 - the
+  // redirect_legacy_angular_docs_versions edge function collapses any
+  // /docs/{version}/angular-data-grid URL in that range to the unversioned
+  // latest docs, which would drop the version requested here.
+  if (framework === 'angular-data-grid' && major < 16) {
+    framework = 'javascript-data-grid';
   }
 
   const url = new URL(isFrameworkVersion ? `/docs/${version}/${framework}` : `/docs/${version}`, req.url);

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,7 @@
     "docs:code-examples:generate-js": "node scripts/transpile-doc-example.mjs",
     "build": "npm run docs:api && npm run docs:validate-highlights && astro build",
     "preview": "astro preview",
-    "docs:test:plugins": "node --test src/plugins/__tests__/*.test.mjs src/lib/__tests__/*.test.mjs src/components/__tests__/*.test.mjs",
+    "docs:test:plugins": "node --test src/plugins/__tests__/*.test.mjs src/lib/__tests__/*.test.mjs src/components/__tests__/*.test.mjs cloudflare/__tests__/*.test.mjs",
     "docs:validate-highlights": "node scripts/validate-version-highlights.mjs",
     "docs:lint": "eslint --ext .js,.mjs,.ts,.astro src content",
     "docs:lint:fix": "eslint --ext .js,.mjs,.ts,.astro src content --fix",


### PR DESCRIPTION
### Context

The PR fixes old docs versions (12.1-15.3) sometimes redirecting to the latest docs instead of rendering the requested version - e.g. `handsontable.com/docs/14.4` could end up at the unversioned latest docs, while `handsontable.com/docs/16.2` rendered correctly.

Root cause, reproducible on production with:

```
curl -L -b "docs_fw=angular" https://handsontable.com/docs/14.4
→ https://handsontable.com/docs/angular-data-grid/   (version lost)
```

Two rules in `docs/cloudflare/_worker.js` (the Cloudflare Pages worker that is the production/staging redirect authority) interact badly:

1. Rule 14 handles a bare `/docs/{version}` request and blindly appends the `docs_fw` cookie's framework, e.g. `/docs/14.4/angular-data-grid`.
2. Rule 3 (added in DEV-1608, since versions 12.1-15.3 never had dedicated per-version Angular docs) then collapses any `/docs/{12.1-15.3}/angular-data-grid` path to the unversioned `/docs/angular-data-grid/`.

So any visitor with the site-wide `docs_fw=angular` cookie set (from the framework switcher elsewhere on handsontable.com) landing on a bare old-version URL gets silently bounced off the version they requested. Versions ≥16.0 have real per-version Angular docs, so rule 3 never fires for them - matching the "16.2 works fine" observation. Only the `angular` cookie value is affected; `javascript`/`react`/`vue3` resolve every version correctly.

Fix: in rule 14 (and its Netlify PR-preview equivalent, `redirect_cookie_docs_x_x` edge function), fall back to `javascript-data-grid` when the cookie says `angular` but the requested version has no per-version Angular docs (major < 16).

### How has this been tested?

- Added `docs/cloudflare/__tests__/_worker.test.mjs`, 4 regression tests covering: the bug case (angular cookie + 12.1-15.3 preserves version), the non-bug case (angular cookie + 16.0+ still targets `angular-data-grid`), unaffected cookies/versions, and direct links to the legacy path (rule 3 unchanged). Wired into `docs:test:plugins`, the same script CI runs before every deploy (`docs-production.yml`).
- `npm run docs:test:plugins --prefix docs` - all 56 tests pass.
- Manually verified against a locally-evaluated copy of the real `_worker.js` (loaded and executed as a script, mocking `Request`/`env`) before and after the fix, matching the production repro above.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1981

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`
- [x] `handsontable-documentation` (docs site redirect infrastructure)

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog] - this changes the docs site's deployment/redirect infrastructure only, not the `handsontable` library code.

ClickUp task: https://app.clickup.com/t/86cagxr6j

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow redirect-rule change for one cookie/version combination, mirrored on Netlify, with new automated worker tests in CI.
> 
> **Overview**
> Fixes **DEV-1981**, where visitors with `docs_fw=angular` hitting bare paths like `/docs/14.4` were sent to unversioned latest docs instead of that release.
> 
> Bare `/docs/{version}` handling now **falls back to `javascript-data-grid`** when the cookie resolves to Angular but the major version is **below 16** (no per-version Angular docs). That avoids building `/docs/{version}/angular-data-grid`, which the legacy Angular rule then collapses to `/docs/angular-data-grid/` and drops the version. **16.0+** still redirects to `angular-data-grid`; other cookies and direct legacy `angular-data-grid` URLs are unchanged.
> 
> The same guard is applied in the **Netlify** `rewrite_redirect_cookie_docs_x_x` edge function for preview parity. **Regression tests** load `_worker.js` in Node and assert redirect targets; they are included in **`docs:test:plugins`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65524d61c1e59fc9a08aa8d3d450cdae725ef4bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->