### PR TITLE
DEV-1979: Fix stale latest-version data and version-less links on old docs

### DIFF
--- a/docs/netlify/__tests__/rewriteVersionedPaths.test.mjs
+++ b/docs/netlify/__tests__/rewriteVersionedPaths.test.mjs
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { rewriteVersionedPaths } from '../rewriteVersionedPaths.mjs';
+
+async function withFixtureDir(files, run) {
+  const dir = await mkdtemp(join(tmpdir(), 'rewrite-versioned-paths-'));
+
+  try {
+    for (const [relativePath, content] of Object.entries(files)) {
+      const filePath = join(dir, relativePath);
+      await mkdir(join(filePath, '..'), { recursive: true });
+      await writeFile(filePath, content, 'utf-8');
+    }
+
+    await run(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test('rewrites root-relative href/src references with the version prefix', async () => {
+  await withFixtureDir(
+    {
+      'javascript-data-grid/index.html':
+        '<a href="/docs/react-data-grid/installation/">React</a>' +
+        '<script src="/docs/_astro/chunk.js"></script>',
+    },
+    async (dir) => {
+      const changedCount = await rewriteVersionedPaths(dir, '17.1');
+      const content = await readFile(join(dir, 'javascript-data-grid/index.html'), 'utf-8');
+
+      assert.equal(changedCount, 1);
+      assert.match(content, /href="\/docs\/17\.1\/react-data-grid\/installation\/"/);
+      assert.match(content, /src="\/docs\/17\.1\/_astro\/chunk\.js"/);
+    }
+  );
+});
+
+test('leaves fully-qualified URLs untouched, even ones containing "/docs/"', async () => {
+  const original = '<a href="https://handsontable.com/docs/data/common.json">live data</a>';
+
+  await withFixtureDir({ 'index.html': original }, async (dir) => {
+    const changedCount = await rewriteVersionedPaths(dir, '17.1');
+    const content = await readFile(join(dir, 'index.html'), 'utf-8');
+
+    assert.equal(changedCount, 0);
+    assert.equal(content, original);
+  });
+});
+
+test('is idempotent: does not double-prefix already-versioned paths', async () => {
+  const alreadyPrefixed = '<a href="/docs/17.1/react-data-grid/installation/">React</a>';
+
+  await withFixtureDir({ 'index.html': alreadyPrefixed }, async (dir) => {
+    const changedCount = await rewriteVersionedPaths(dir, '17.1');
+    const content = await readFile(join(dir, 'index.html'), 'utf-8');
+
+    assert.equal(changedCount, 0);
+    assert.equal(content, alreadyPrefixed);
+  });
+});
+
+test('only touches .html files', async () => {
+  const original = '{"href": "/docs/react-data-grid/installation/"}';
+
+  await withFixtureDir({ 'data/common.json': original }, async (dir) => {
+    const changedCount = await rewriteVersionedPaths(dir, '17.1');
+    const content = await readFile(join(dir, 'data/common.json'), 'utf-8');
+
+    assert.equal(changedCount, 0);
+    assert.equal(content, original);
+  });
+});
+
+test('rewrites references nested in subdirectories', async () => {
+  await withFixtureDir(
+    {
+      'react-data-grid/installation/index.html': '<a href="/docs/angular-data-grid/installation/">Angular</a>',
+    },
+    async (dir) => {
+      const changedCount = await rewriteVersionedPaths(dir, '9.0');
+      const content = await readFile(join(dir, 'react-data-grid/installation/index.html'), 'utf-8');
+
+      assert.equal(changedCount, 1);
+      assert.match(content, /href="\/docs\/9\.0\/angular-data-grid\/installation\/"/);
+    }
+  );
+});

--- a/docs/netlify/build_current_version.sh
+++ b/docs/netlify/build_current_version.sh
@@ -30,6 +30,13 @@ do
     else
         docker cp "$img_id:/usr/share/nginx/html/docs" "./docs/docs/$version"
         echo "  copied flat layout (/docs) into /docs/$version"
+
+        # Astro (>=17.1) images are built with an unversioned base, so every
+        # internal href/src is root-relative with no version segment. Rewrite
+        # them now that the build is nested under /docs/$version, otherwise
+        # any link click on this version resolves to the unversioned root
+        # (whatever is currently deployed as latest) instead of staying here.
+        node rewriteVersionedPaths.mjs "./docs/docs/$version" "$version"
     fi
 
     docker rm "$img_id" >/dev/null

--- a/docs/netlify/rewriteVersionedPaths.mjs
+++ b/docs/netlify/rewriteVersionedPaths.mjs
@@ -1,0 +1,76 @@
+// Rewrites root-relative internal links/assets in a previously-built,
+// frozen docs version so they keep working once that version's flat build
+// output gets nested under /docs/<version>/ for production serving.
+//
+// Old (Astro, >=17.1) docs images are built with an unversioned base
+// (`/docs`), so every internal `href="/docs/..."` / `src="/docs/..."`
+// reference is root-relative with no version segment. build_current_version.sh
+// copies that frozen build byte-for-byte into docs/docs/<version>/ for every
+// deploy; without this rewrite, any link click (or asset load) on the nested
+// old version resolves to the unversioned root -- i.e. whatever is currently
+// deployed as latest -- instead of staying on that pinned version.
+//
+// Only rewrites the attribute-anchored form (`="/docs/`), so it can never
+// match a fully-qualified URL such as
+// `https://handsontable.com/docs/data/common.json` (no `="` immediately
+// before `/docs/` in that string).
+//
+// Usage: node rewriteVersionedPaths.mjs <dir> <version>
+
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import { extname, join } from 'node:path';
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Rewrites `href="/docs/..."` / `src="/docs/..."` references in every
+ * `.html` file under `dir` to `href="/docs/<version>/..."`, skipping
+ * references already prefixed with that version (idempotent).
+ *
+ * @param {string} dir - Directory containing one version's built docs.
+ * @param {string} version - e.g. "17.1".
+ * @returns {Promise<number>} Number of files that were changed.
+ */
+export async function rewriteVersionedPaths(dir, version) {
+  const pattern = new RegExp(
+    `((?:href|src)=")\\/docs\\/(?!${escapeRegExp(version)}\\/)`,
+    'g'
+  );
+  const replacement = `$1/docs/${version}/`;
+
+  const entries = await readdir(dir, { recursive: true, withFileTypes: true });
+  const htmlFiles = entries
+    .filter((entry) => entry.isFile() && extname(entry.name) === '.html')
+    .map((entry) => join(entry.parentPath ?? entry.path, entry.name));
+
+  let changedCount = 0;
+
+  for (const file of htmlFiles) {
+    const original = await readFile(file, 'utf-8');
+    const rewritten = original.replace(pattern, replacement);
+
+    if (rewritten !== original) {
+      await writeFile(file, rewritten, 'utf-8');
+      changedCount += 1;
+    }
+  }
+
+  return changedCount;
+}
+
+const isMainModule = process.argv[1] && import.meta.url === `file://${process.argv[1]}`;
+
+if (isMainModule) {
+  const [dir, version] = process.argv.slice(2);
+
+  if (!dir || !version) {
+    console.error('Usage: node rewriteVersionedPaths.mjs <dir> <version>');
+    process.exitCode = 1;
+  } else {
+    const changedCount = await rewriteVersionedPaths(dir, version);
+
+    console.log(`Rewrote version-prefixed links in ${changedCount} file(s) under ${dir} for version ${version}.`);
+  }
+}

--- a/docs/netlify/rewriteVersionedPaths.mjs
+++ b/docs/netlify/rewriteVersionedPaths.mjs
@@ -19,6 +19,7 @@
 
 import { readdir, readFile, writeFile } from 'node:fs/promises';
 import { extname, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -60,7 +61,13 @@ export async function rewriteVersionedPaths(dir, version) {
   return changedCount;
 }
 
-const isMainModule = process.argv[1] && import.meta.url === `file://${process.argv[1]}`;
+// process.argv[1] is not resolved to an absolute path when the script is
+// invoked with a relative one (e.g. `node rewriteVersionedPaths.mjs ...`,
+// as build_current_version.sh does), so comparing it to import.meta.url as
+// a plain string would never match. pathToFileURL() resolves it the same
+// way Node resolves import.meta.url, relative to the current working
+// directory, so the comparison works regardless of how the script is invoked.
+const isMainModule = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 
 if (isMainModule) {
   const [dir, version] = process.argv.slice(2);

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,7 @@
     "docs:code-examples:generate-js": "node scripts/transpile-doc-example.mjs",
     "build": "npm run docs:api && npm run docs:validate-highlights && astro build",
     "preview": "astro preview",
-    "docs:test:plugins": "node --test src/plugins/__tests__/*.test.mjs src/lib/__tests__/*.test.mjs src/components/__tests__/*.test.mjs cloudflare/__tests__/*.test.mjs",
+    "docs:test:plugins": "node --test src/plugins/__tests__/*.test.mjs src/lib/__tests__/*.test.mjs src/components/__tests__/*.test.mjs cloudflare/__tests__/*.test.mjs netlify/__tests__/*.test.mjs",
     "docs:validate-highlights": "node scripts/validate-version-highlights.mjs",
     "docs:lint": "eslint --ext .js,.mjs,.ts,.astro src content",
     "docs:lint:fix": "eslint --ext .js,.mjs,.ts,.astro src content --fix",

--- a/docs/src/components/PageTitle.astro
+++ b/docs/src/components/PageTitle.astro
@@ -111,16 +111,51 @@ const pageHref       = pathname;
 
 </div>
 
-{showNewerBanner && (
-  <aside class="starlight-aside starlight-aside--tip hot-newer-version-banner">
-    <p class="starlight-aside__content">
-      There is a newer version of Handsontable available.
-      <a href={`https://handsontable.com/docs/${latestVersion}/`}>Switch to the latest version &rarr;</a>
-    </p>
-  </aside>
-)}
+<aside
+  id="hot-newer-version-banner"
+  class="starlight-aside starlight-aside--tip hot-newer-version-banner"
+  data-current-minor={currentMinor}
+  hidden={!showNewerBanner}
+>
+  <p class="starlight-aside__content">
+    There is a newer version of Handsontable available.
+    <a id="hot-newer-version-link" href={`https://handsontable.com/docs/${latestVersion}/`}>Switch to the latest version &rarr;</a>
+  </p>
+</aside>
 
 <h1 id="_top">{pageTitle}</h1>
+
+<script>
+  import { shouldShowNewerVersionBanner } from '../lib/newer-version-banner.mjs';
+
+  // The banner above reflects this page's own build-time snapshot of
+  // "latest version", which goes stale on old, frozen doc versions once a
+  // newer version ships (that old branch is never rebuilt just because
+  // production moved on). Re-check against the always-current production
+  // data at page load.
+  const banner = document.getElementById('hot-newer-version-banner') as HTMLElement | null;
+  const link = document.getElementById('hot-newer-version-link') as HTMLAnchorElement | null;
+
+  if (banner && link) {
+    const currentMinor = banner.dataset.currentMinor ?? '';
+
+    fetch('https://handsontable.com/docs/data/common.json')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((docsData) => {
+        if (!docsData?.latestVersion) return;
+
+        const show = shouldShowNewerVersionBanner(currentMinor, docsData.latestVersion);
+
+        banner.hidden = !show;
+        if (show) {
+          link.href = `https://handsontable.com/docs/${docsData.latestVersion}/`;
+        }
+      })
+      .catch(() => {
+        // Offline / network unavailable — keep the build-time rendered state.
+      });
+  }
+</script>
 
 <style>
   /* ── Page title ─────────────────────────────────────────────────────────── */

--- a/docs/src/components/VersionsDropdown.astro
+++ b/docs/src/components/VersionsDropdown.astro
@@ -16,6 +16,8 @@ import { dirname, join, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { readFileSync } from 'fs';
 
+import { computeVersionsDisplay } from '../lib/versions-menu.mjs';
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
 
@@ -70,40 +72,11 @@ if (!docsData) {
   }
 }
 
-const latestVersion = docsData?.latestVersion ?? currentMinor;
-
-// Build the dropdown items: all minor versions with major >= 9.
-const versionItems =
-  docsData?.versionsWithPatches
-    .filter(([v]) => {
-      const major = parseInt(v.split('.')[0], 10);
-      return major >= 9;
-    })
-    .map(([minor, patches]) => ({
-      minor,
-      display: minor.toUpperCase() === 'NEXT' ? 'dev' : minor,
-      // Link to handsontable.com for every published version.
-      href: `https://handsontable.com/docs/${minor}`,
-      isCurrent: minor === currentMinor,
-    })) ?? [];
-
-// Label shown on the dropdown trigger button.
-function getButtonLabel() {
-  if (currentMinor === latestVersion) {
-    const patchVersion =
-      docsData?.versionsWithPatches.find(([v]) => v === latestVersion)?.[1]?.[0] ??
-      rawVersion;
-    const display = currentMinor === 'next' ? 'dev' : patchVersion;
-    return `${display} latest`;
-  }
-  return currentMinor === 'next' ? 'dev' : currentMinor;
-}
-
-const buttonLabel = getButtonLabel();
-const isLatest = currentMinor === latestVersion;
+const { buttonLabel, isLatest, latestVersion, versionItems } =
+  computeVersionsDisplay(docsData, currentMinor, rawVersion);
 ---
 
-<div class="versions-dropdown">
+<div class="versions-dropdown" data-current-minor={currentMinor} data-raw-version={rawVersion}>
   <button
     class="versions-trigger"
     aria-haspopup="menu"
@@ -111,18 +84,20 @@ const isLatest = currentMinor === latestVersion;
     id="versions-trigger"
     type="button"
   >
-    {isLatest
-      ? (
-        <>
-          <span class="versions-trigger__version">
-            {buttonLabel.replace(' latest', '')}
-          </span>
-          {' '}
-          <span class="versions-tag">latest</span>
-        </>
-      )
-      : buttonLabel
-    }
+    <span id="versions-trigger-label">
+      {isLatest
+        ? (
+          <>
+            <span class="versions-trigger__version">
+              {buttonLabel.replace(' latest', '')}
+            </span>
+            {' '}
+            <span class="versions-tag">latest</span>
+          </>
+        )
+        : buttonLabel
+      }
+    </span>
     <svg class="versions-chevron" aria-hidden="true" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6l6 -6"/></svg>
   </button>
 
@@ -148,10 +123,76 @@ const isLatest = currentMinor === latestVersion;
 
 <script>
   import { attachDropdownKeyboardNav } from '../scripts/a11y-utils';
+  import { computeVersionsDisplay } from '../lib/versions-menu.mjs';
 
   const wrapper = document.querySelector('.versions-dropdown') as HTMLElement | null;
   const trigger = document.getElementById('versions-trigger') as HTMLButtonElement | null;
   const menu = document.querySelector('.versions-menu') as HTMLElement | null;
+  const triggerLabel = document.getElementById('versions-trigger-label') as HTMLElement | null;
+
+  // ── Live refresh ─────────────────────────────────────────────────────────
+  // The markup above is rendered from data baked in at this page's own build
+  // time, which goes stale on old, frozen doc versions once a newer version
+  // ships (that old branch is never rebuilt just because production moved
+  // on). Re-fetch the always-current production data at page load and
+  // re-render if it disagrees with what was baked in.
+  if (wrapper && trigger && menu && triggerLabel) {
+    const currentMinor = wrapper.dataset.currentMinor ?? '';
+    const rawVersion = wrapper.dataset.rawVersion ?? currentMinor;
+
+    fetch('https://handsontable.com/docs/data/common.json')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((docsData) => {
+        if (!docsData?.versionsWithPatches) return;
+
+        const { buttonLabel, isLatest, latestVersion, versionItems } =
+          computeVersionsDisplay(docsData, currentMinor, rawVersion);
+
+        // Rebuild the trigger label.
+        triggerLabel.replaceChildren();
+        if (isLatest) {
+          const versionSpan = document.createElement('span');
+          versionSpan.className = 'versions-trigger__version';
+          versionSpan.textContent = buttonLabel.replace(' latest', '');
+          const tag = document.createElement('span');
+          tag.className = 'versions-tag';
+          tag.textContent = 'latest';
+          triggerLabel.append(versionSpan, ' ', tag);
+        } else {
+          triggerLabel.textContent = buttonLabel;
+        }
+
+        // Rebuild the menu items.
+        menu.replaceChildren();
+        for (const { minor, display, href, isCurrent } of versionItems) {
+          const li = document.createElement('li');
+          li.setAttribute('role', 'none');
+
+          const a = document.createElement('a');
+          a.href = href;
+          a.className = isCurrent ? 'versions-item versions-item--current' : 'versions-item';
+          a.setAttribute('role', 'menuitem');
+          a.setAttribute('tabindex', '-1');
+          if (isCurrent) a.setAttribute('aria-current', 'page');
+          if (minor !== latestVersion) a.setAttribute('rel', 'nofollow');
+          a.target = '_self';
+          a.append(display);
+
+          if (minor === latestVersion) {
+            const tag = document.createElement('span');
+            tag.className = 'versions-tag';
+            tag.textContent = 'latest';
+            a.append(tag);
+          }
+
+          li.append(a);
+          menu.append(li);
+        }
+      })
+      .catch(() => {
+        // Offline / network unavailable — keep the build-time rendered state.
+      });
+  }
 
   if (wrapper && trigger && menu) {
     function openMenu() {

--- a/docs/src/components/VersionsDropdown.astro
+++ b/docs/src/components/VersionsDropdown.astro
@@ -140,6 +140,14 @@ const { buttonLabel, isLatest, latestVersion, versionItems } =
     const currentMinor = wrapper.dataset.currentMinor ?? '';
     const rawVersion = wrapper.dataset.rawVersion ?? currentMinor;
 
+    // Astro scopes this component's <style> block by appending a unique
+    // hashed class (e.g. "astro-xzzq4es2") to every element it renders, and
+    // rewriting the CSS selectors to require that class too. Elements built
+    // with document.createElement() don't carry it, so the styles below
+    // would silently not apply to them unless we tag them with it ourselves.
+    const scopeClass = [...wrapper.classList].find((c) => c.startsWith('astro-'));
+    const withScope = (className: string) => (scopeClass ? `${className} ${scopeClass}` : className);
+
     fetch('https://handsontable.com/docs/data/common.json')
       .then((res) => (res.ok ? res.json() : null))
       .then((docsData) => {
@@ -152,10 +160,10 @@ const { buttonLabel, isLatest, latestVersion, versionItems } =
         triggerLabel.replaceChildren();
         if (isLatest) {
           const versionSpan = document.createElement('span');
-          versionSpan.className = 'versions-trigger__version';
+          versionSpan.className = withScope('versions-trigger__version');
           versionSpan.textContent = buttonLabel.replace(' latest', '');
           const tag = document.createElement('span');
-          tag.className = 'versions-tag';
+          tag.className = withScope('versions-tag');
           tag.textContent = 'latest';
           triggerLabel.append(versionSpan, ' ', tag);
         } else {
@@ -170,7 +178,7 @@ const { buttonLabel, isLatest, latestVersion, versionItems } =
 
           const a = document.createElement('a');
           a.href = href;
-          a.className = isCurrent ? 'versions-item versions-item--current' : 'versions-item';
+          a.className = withScope(isCurrent ? 'versions-item versions-item--current' : 'versions-item');
           a.setAttribute('role', 'menuitem');
           a.setAttribute('tabindex', '-1');
           if (isCurrent) a.setAttribute('aria-current', 'page');
@@ -180,7 +188,7 @@ const { buttonLabel, isLatest, latestVersion, versionItems } =
 
           if (minor === latestVersion) {
             const tag = document.createElement('span');
-            tag.className = 'versions-tag';
+            tag.className = withScope('versions-tag');
             tag.textContent = 'latest';
             a.append(tag);
           }

--- a/docs/src/lib/__tests__/versions-menu.test.mjs
+++ b/docs/src/lib/__tests__/versions-menu.test.mjs
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { computeVersionsDisplay } from '../versions-menu.mjs';
+
+const docsData = {
+  latestVersion: '18.0',
+  versionsWithPatches: [
+    ['18.0', ['18.0.1', '18.0.0']],
+    ['17.1', ['17.1.2', '17.1.1', '17.1.0']],
+    ['8.5', ['8.5.0']],
+  ],
+};
+
+test('current minor behind latest: button shows the minor, not "latest"', () => {
+  const { buttonLabel, isLatest, latestVersion } = computeVersionsDisplay(docsData, '17.1');
+
+  assert.equal(buttonLabel, '17.1');
+  assert.equal(isLatest, false);
+  assert.equal(latestVersion, '18.0');
+});
+
+test('current minor matches latest: button shows the latest patch + "latest"', () => {
+  const { buttonLabel, isLatest } = computeVersionsDisplay(docsData, '18.0', '18.0.1');
+
+  assert.equal(buttonLabel, '18.0.1 latest');
+  assert.equal(isLatest, true);
+});
+
+test('"next" (dev) build is always displayed as "dev", never marked latest', () => {
+  const { buttonLabel, isLatest } = computeVersionsDisplay(docsData, 'next');
+
+  assert.equal(buttonLabel, 'dev');
+  assert.equal(isLatest, false);
+});
+
+test('versions with major < 9 are excluded from the dropdown items', () => {
+  const { versionItems } = computeVersionsDisplay(docsData, '18.0');
+
+  assert.deepEqual(versionItems.map((item) => item.minor), ['18.0', '17.1']);
+});
+
+test('dropdown items carry the current-version marker and handsontable.com href', () => {
+  const { versionItems } = computeVersionsDisplay(docsData, '17.1');
+
+  const current = versionItems.find((item) => item.minor === '17.1');
+  const other = versionItems.find((item) => item.minor === '18.0');
+
+  assert.equal(current.isCurrent, true);
+  assert.equal(current.href, 'https://handsontable.com/docs/17.1');
+  assert.equal(other.isCurrent, false);
+});
+
+test('null docsData (e.g. fetch failed) falls back to the current minor as latest, no items', () => {
+  const { buttonLabel, isLatest, latestVersion, versionItems } = computeVersionsDisplay(null, '17.1');
+
+  assert.equal(latestVersion, '17.1');
+  assert.equal(isLatest, true);
+  assert.equal(buttonLabel, '17.1 latest');
+  assert.deepEqual(versionItems, []);
+});
+
+test('falls back to rawVersion when the latest minor has no patch entry', () => {
+  const dataWithoutPatches = { latestVersion: '18.0', versionsWithPatches: [['18.0', []]] };
+  const { buttonLabel } = computeVersionsDisplay(dataWithoutPatches, '18.0', '18.0.0');
+
+  assert.equal(buttonLabel, '18.0.0 latest');
+});

--- a/docs/src/lib/versions-menu.mjs
+++ b/docs/src/lib/versions-menu.mjs
@@ -1,0 +1,60 @@
+/**
+ * Shared, isomorphic logic for the version-switcher dropdown (header).
+ *
+ * Used by both `VersionsDropdown.astro`'s server-rendered frontmatter (build
+ * time) and its client `<script>` (page-load time, using live data fetched
+ * from `https://handsontable.com/docs/data/common.json`) so the two stay in
+ * sync without duplicating the version-list/button-label logic.
+ *
+ * @typedef {object} DocsData
+ * @property {string} latestVersion
+ * @property {[string, string[]][]} versionsWithPatches
+ */
+
+/**
+ * Builds the dropdown items and trigger-button label for the versions
+ * dropdown from the shared docs metadata.
+ *
+ * @param {DocsData | null} docsData
+ * @param {string} currentMinor - e.g. "17.1", or "next" for the dev build.
+ * @param {string} [rawVersion] - Full local patch version (e.g. "17.1.0"),
+ *   used only as a fallback label when `docsData` has no patch entry for
+ *   `currentMinor`. Defaults to `currentMinor` when omitted (client-side).
+ * @returns {{ buttonLabel: string, isLatest: boolean, latestVersion: string, versionItems: Array<{minor: string, display: string, href: string, isCurrent: boolean}> }}
+ */
+export function computeVersionsDisplay(docsData, currentMinor, rawVersion = currentMinor) {
+  const latestVersion = docsData?.latestVersion ?? currentMinor;
+  const isLatest = currentMinor === latestVersion;
+
+  const versionItems =
+    docsData?.versionsWithPatches
+      .filter(([v]) => {
+        const major = parseInt(v.split('.')[0], 10);
+        return major >= 9;
+      })
+      .map(([minor, patches]) => ({
+        minor,
+        display: minor.toUpperCase() === 'NEXT' ? 'dev' : minor,
+        // Link to handsontable.com for every published version.
+        href: `https://handsontable.com/docs/${minor}`,
+        isCurrent: minor === currentMinor,
+      })) ?? [];
+
+  function getButtonLabel() {
+    if (isLatest) {
+      const patchVersion =
+        docsData?.versionsWithPatches.find(([v]) => v === latestVersion)?.[1]?.[0] ??
+        rawVersion;
+      const display = currentMinor === 'next' ? 'dev' : patchVersion;
+      return `${display} latest`;
+    }
+    return currentMinor === 'next' ? 'dev' : currentMinor;
+  }
+
+  return {
+    buttonLabel: getButtonLabel(),
+    isLatest,
+    latestVersion,
+    versionItems,
+  };
+}


### PR DESCRIPTION
### Context

The PR fixes two related bugs reported in DEV-1979 on the pinned `17.1` docs (`https://handsontable.com/docs/17.1/javascript-data-grid/`):

1. The version-switcher dropdown shows `17.1` as "latest" and doesn't list `18.0`, even though `18.0` has since been released.
2. Switching the framework tab (JS → React/Angular/Vue) while browsing `17.1` docs jumps to the `18.0` docs instead of staying on `17.1`.

These turned out to be two independent bugs with unrelated root causes:

- **Stale "latest version" data**: `commonJsonIntegration()` correctly computes the true latest version from the GitHub Releases API, but only at that branch's own Astro build time. `prod-docs/17.1` was last built before `18.0` existed, so `VersionsDropdown.astro` and `PageTitle.astro` (both reading that baked-in data) show whatever was "latest" as of that build, forever — the branch is never rebuilt just because a newer version ships elsewhere. Fixed by moving this to a client-side runtime fetch of the always-current `https://handsontable.com/docs/data/common.json`.
- **Version-less internal links**: every doc version's Astro build (17.1 onward) uses an unversioned base (`/docs`), so all internal hrefs/asset paths are root-relative with no version segment — confirmed directly on the live site. The production multi-version site assembles each old version's frozen build byte-for-byte into a `/docs/<version>/` subfolder with no path rewriting, so any link click (or asset load) on a nested old version resolves to the unversioned root, i.e. whatever is currently deployed as latest. Fixed by rewriting those paths at assembly time in `docs/netlify/build_current_version.sh`.

Rollout: this PR merges the code fix to `develop`. It still needs to be cherry-picked into `prod-docs/17.1` and `prod-docs/18.0`, followed by a manual "Docs Production Deployment" run on each of those two branches to bake the fixes into their frozen Docker images and refresh production.

### How has this been tested?

- Unit tests: `npm --prefix docs run docs:test:plugins` (12 new tests across `src/lib/__tests__/versions-menu.test.mjs` and `netlify/__tests__/rewriteVersionedPaths.test.mjs`, full 64-test suite green).
- Lint: `npx eslint --ext .js,.mjs,.ts,.astro src content netlify` inside `docs/` — no issues.
- Full build: `npm --prefix docs run build` — 1262 pages built successfully; verified the built HTML contains the new `data-current-minor` attributes and the always-rendered (hidden-by-default) newer-version banner, and that both new client scripts bundle correctly with the live-fetch calls intact.
- Ran `node docs/netlify/rewriteVersionedPaths.mjs <dist-copy> 17.1` against a full real build output (not just synthetic fixtures) and confirmed framework-switcher/sidebar/asset links get version-prefixed while the live `common.json` fetch URL stays untouched.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1979

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`
- [x] `handsontable-documentation`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1979

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production docs assembly (HTML link rewriting) and header UX that depends on a live fetch to handsontable.com; mistakes in rewriting could break navigation on pinned versions.
> 
> **Overview**
> Fixes **stale “latest” version UI** on frozen doc builds and **framework/tab navigation jumping to the current latest** when browsing pinned versions (e.g. `17.1`).
> 
> **Runtime version metadata:** `VersionsDropdown` and the newer-version banner in `PageTitle` still SSR from build-time `common.json`, but on page load they **re-fetch** `https://handsontable.com/docs/data/common.json` and update labels, menu items, banner visibility, and the “switch to latest” link. Dropdown display logic is centralized in **`computeVersionsDisplay`** (`versions-menu.mjs`) so SSR and client stay aligned.
> 
> **Nested Astro builds:** For previous versions copied from flat Astro Docker images into `/docs/<version>/`, **`build_current_version.sh`** now runs **`rewriteVersionedPaths.mjs`**, which prefixes root-relative `href`/`src="/docs/..."` in `.html` only (skips absolute URLs and already-versioned paths). Unit tests cover the rewriter and version menu.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba64b19733f8fc65a2a388a03f90f89c37a12a25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->