### PR TITLE
DEV-1984: Fixed url of latest version in "newer version banner"

### DIFF
--- a/docs/src/components/PageTitle.astro
+++ b/docs/src/components/PageTitle.astro
@@ -108,7 +108,7 @@ const pageHref       = pathname;
 >
   <p class="starlight-aside__content">
     There is a newer version of Handsontable available.
-    <a id="hot-newer-version-link" href={`https://handsontable.com/docs/${latestVersion}/`}>Switch to the latest version &rarr;</a>
+    <a id="hot-newer-version-link" href={`https://handsontable.com/docs/`}>Switch to the latest version &rarr;</a>
   </p>
 </aside>
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
"Newer version banner" redirected to the `https://handsontable.com/docs/${latestVersion}/` url, which throws 404, as `https://handsontable.com/docs/18.0/` does not exists.

Changed redirect to simply `https://handsontable.com/docs/` 

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Manual check

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. DEV-1984

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single documentation UI link change with no impact on product runtime, auth, or data handling.
> 
> **Overview**
> Fixes the **“Switch to the latest version”** link in the newer-version banner on `PageTitle.astro`. The href no longer uses `https://handsontable.com/docs/${latestVersion}/`, which could 404 when that version path is not published (e.g. `18.0`). It now points to **`https://handsontable.com/docs/`**, which resolves to current docs.
> 
> Banner visibility and the client-side fetch that refreshes `latestVersion` at load are unchanged; only the initial SSR anchor target is updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89b5c52434091b73ae4ab4c3bfd25bcc08fc3893. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->