### PR TITLE
Fix changelog parser merging nested sub-bullets into parent entries

### DIFF
--- a/docs/src/plugins/__tests__/changelog-parser.test.mjs
+++ b/docs/src/plugins/__tests__/changelog-parser.test.mjs
@@ -448,10 +448,10 @@ test('converts <kbd> markup while still extracting a trailing PR citation', () =
   assert.equal(result[0].prKind, 'pull');
 });
 
-test('converts a dangling, unclosed <kbd> left by a multi-line bullet', () => {
-  // The parser captures only a bullet's first source line, so markup that wraps
-  // (as in changelog-12's "Shift + Page Up/Page Down" breaking change) ends with
-  // an unclosed <kbd>. The remainder must still convert -- no literal tag shown.
+test('joins a <kbd> that wraps across source lines and fully converts it', () => {
+  // The parser joins soft-wrapped continuation lines (as in changelog-12's
+  // "Shift + Page Up/Page Down" breaking change), so a <kbd> split across
+  // source lines is reassembled and every tag converts -- no literal tag shown.
   const md = [
     '## 12.0.0',
     'Released on May 9th, 2022',
@@ -464,7 +464,7 @@ test('converts a dangling, unclosed <kbd> left by a multi-line bullet', () => {
   const result = parseChangelogContent(md);
 
   assert.equal(result.length, 1);
-  assert.equal(result[0].title, 'Removed the `Shift`+`Page Up`/`Page`');
+  assert.equal(result[0].title, 'Removed the `Shift`+`Page Up`/`Page Down` keyboard shortcuts.');
   assert.ok(!/<kbd>/i.test(result[0].title));
 });
 

--- a/docs/src/plugins/changelog-parser.mjs
+++ b/docs/src/plugins/changelog-parser.mjs
@@ -148,6 +148,11 @@ function coalesceWrappedBullets(lines) {
     if (/^- /.test(line)) {
       result.push(line);
       openBullet = result.length - 1;
+    } else if (/^\s+- /.test(line)) {
+      // Nested sub-bullet -> closes the open bullet and is preserved as its
+      // own line (dropped downstream because it does not start with "- ").
+      openBullet = null;
+      result.push(line);
     } else if (openBullet !== null && /^\s+\S/.test(line)) {
       // Indented, non-blank line -> continuation of the open bullet.
       result[openBullet] += ` ${line.trim()}`;


### PR DESCRIPTION
### Context

The PR fixes two failing tests in `docs/src/plugins/__tests__/changelog-parser.test.mjs` that block the `Test plugins` step of the docs production deployment.

Both failures trace to `coalesceWrappedBullets()` in `docs/src/plugins/changelog-parser.mjs` (added in DEV-1958). That function joins soft-wrapped bullet continuation lines into their parent bullet, but treats any indented non-blank line as a continuation - including nested sub-bullets (`  - ...`), which also match `/^\s+\S/`.

This produced two symptoms:

- `does not merge or emit nested sub-bullets` - a real regression: nested sub-bullet text (e.g. "Hidden indexes...") was folded into the parent entry's title.
- `converts a dangling, unclosed <kbd>...` - a stale test whose expectation encoded the pre-DEV-1958 single-line-capture truncation. With continuation lines now correctly joined, the parser produces the full, correct string, so the test expectation had to be updated.

Changes:

1. `coalesceWrappedBullets()` now closes the open bullet when it hits an indented sub-bullet (`/^\s+- /`) instead of merging it. The sub-bullet is preserved as its own line and dropped downstream (the main loop skips lines that do not start with `- `). This matches the intent already encoded by the per-bullet guard `if (/^\s+- /.test(next)) break;`.
2. Updated the `<kbd>` wrap test: corrected the expected title to the full joined-and-converted string (`Removed the ` + "`Shift`+`Page Up`/`Page Down`" + ` keyboard shortcuts.`) and renamed it, since the wrapped `<kbd>` is now joined across source lines and fully converted (no dangling tag).

### How has this been tested?

- `npm --prefix docs run docs:test:plugins` -> `# pass 89 / # fail 0` (previously `# fail 2`).
- ESLint: no errors on the two edited files.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. Fixes the `Test plugins` failure blocking Docs Production Deployment.

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changelog parsing fix with targeted test updates; no runtime product or security impact.
> 
> **Overview**
> **Fixes `coalesceWrappedBullets()`** so indented nested sub-bullets (`  - ...`) close the open parent bullet instead of being folded into its text. Sub-bullets stay on their own lines and are still ignored downstream, aligning with the existing per-bullet guard in `parseChangelogContent`.
> 
> **Updates the wrapped `<kbd>` test** to expect the full joined-and-converted title (`Page Down` included) now that soft-wrapped continuation lines are merged correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dffbe82e94bd41eae15acd89eed566f478270f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->