### PR TITLE
DEV-1987: Skip full-dataset cell-meta resolution on load when no static validator

### DIFF
--- a/.changelogs/12933.json
+++ b/.changelogs/12933.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed a load-time slowdown where `loadData()` and `updateData()` resolved cell metadata for the entire dataset when a `cells` function was configured, even with no validators defined.",
+  "type": "fixed",
+  "issueOrPR": 12933,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/__tests__/core/getCellMeta.spec.js
+++ b/handsontable/src/__tests__/core/getCellMeta.spec.js
@@ -222,7 +222,10 @@ describe('Core.getCellMeta', () => {
 
     const HOT = getInstance();
 
-    expect(called).toBe(50); // default dataset is 5x5 so 25 calls x 2 (for rendering engine and data source validation)
+    // Default dataset is 5x5 → 25 calls for the rendering engine only. Source-data validation no
+    // longer resolves per-cell meta (it runs uncached and skips when no validator is defined), so it
+    // does not re-invoke `cells`.
+    expect(called).toBe(25);
     expect(_this.row).toBe(_row);
     expect(_this.instance).toBe(HOT);
   });

--- a/handsontable/src/__tests__/core/loadData.spec.js
+++ b/handsontable/src/__tests__/core/loadData.spec.js
@@ -355,7 +355,9 @@ describe('Core.loadData', () => {
       cells: cellsSpy,
     });
 
-    expect(cellsSpy.calls.count()).toBe(24); // 12 calls x 2 (for rendering engine and data source validation)
+    // 12 calls for the rendering engine only. Source-data validation no longer resolves per-cell meta
+    // (it runs uncached and skips entirely when no validator is defined), so it does not re-invoke `cells`.
+    expect(cellsSpy.calls.count()).toBe(12);
   });
 
   // https://github.com/handsontable/handsontable/pull/233
@@ -389,7 +391,9 @@ describe('Core.loadData', () => {
       cells: cellsSpy
     });
 
-    expect(cellsSpy.calls.count()).toBe(24); // 12 calls x 2 (for rendering engine and data source validation)
+    // 12 calls for the rendering engine only. Source-data validation no longer resolves per-cell meta
+    // (it runs uncached and skips entirely when no validator is defined), so it does not re-invoke `cells`.
+    expect(cellsSpy.calls.count()).toBe(12);
   });
 
   it('should not invoke the cells callback multiple times with the same row/col (with overlays, separate `loadData`' +

--- a/handsontable/src/__tests__/performance.spec.js
+++ b/handsontable/src/__tests__/performance.spec.js
@@ -89,7 +89,9 @@ describe('Performance', () => {
       }
     });
 
-    expect(count).toBe(2); // 1 for rendering engine, 1 for data source validation
+    // Rendering engine only. Source-data validation resolves meta uncached (it does not run the
+    // `beforeGetCellMeta` hook) and skips entirely when no validator is defined.
+    expect(count).toBe(1);
   });
 
   it('should call getCellMeta minimum number of times for one cell (auto row height, without overlays)', async() => {
@@ -105,7 +107,9 @@ describe('Performance', () => {
       }
     });
 
-    expect(count).toBe(2); // 1 for rendering engine, 1 for data source validation
+    // Rendering engine only. Source-data validation resolves meta uncached (it does not run the
+    // `beforeGetCellMeta` hook) and skips entirely when no validator is defined.
+    expect(count).toBe(1);
   });
 
   it('should call getCellMeta minimum number of times for one cell (auto column width, with left overlay)', async() => {
@@ -122,7 +126,9 @@ describe('Performance', () => {
       }
     });
 
-    expect(count).toBe(2); // 1 for rendering engine, 1 for data source validation
+    // Rendering engine only. Source-data validation resolves meta uncached (it does not run the
+    // `beforeGetCellMeta` hook) and skips entirely when no validator is defined.
+    expect(count).toBe(1);
   });
 
   it('should call getCellMeta minimum number of times for one cell (auto row height, with left overlay)', async() => {
@@ -139,7 +145,9 @@ describe('Performance', () => {
       }
     });
 
-    expect(count).toBe(2); // 1 for rendering engine, 1 for data source validation
+    // Rendering engine only. Source-data validation resolves meta uncached (it does not run the
+    // `beforeGetCellMeta` hook) and skips entirely when no validator is defined.
+    expect(count).toBe(1);
   });
 
   it('should call getCellMeta minimum number of times for one cell (auto column width, with top overlay)', async() => {
@@ -156,7 +164,9 @@ describe('Performance', () => {
       }
     });
 
-    expect(count).toBe(2); // 1 for rendering engine, 1 for data source validation
+    // Rendering engine only. Source-data validation resolves meta uncached (it does not run the
+    // `beforeGetCellMeta` hook) and skips entirely when no validator is defined.
+    expect(count).toBe(1);
   });
 
   it('should call getCellMeta minimum number of times for one cell (auto row height, with top overlay)', async() => {
@@ -173,7 +183,9 @@ describe('Performance', () => {
       }
     });
 
-    expect(count).toBe(2); // 1 for rendering engine, 1 for data source validation
+    // Rendering engine only. Source-data validation resolves meta uncached (it does not run the
+    // `beforeGetCellMeta` hook) and skips entirely when no validator is defined.
+    expect(count).toBe(1);
   });
 
   it('should call getCellMeta minimum number of times for one cell (auto column width, with all overlays)', async() => {
@@ -191,7 +203,9 @@ describe('Performance', () => {
       }
     });
 
-    expect(count).toBe(2); // 1 for rendering engine, 1 for data source validation
+    // Rendering engine only. Source-data validation resolves meta uncached (it does not run the
+    // `beforeGetCellMeta` hook) and skips entirely when no validator is defined.
+    expect(count).toBe(1);
   });
 
   it('should call getCellMeta minimum number of times for one cell (auto row height, with all overlays)', async() => {
@@ -209,7 +223,9 @@ describe('Performance', () => {
       }
     });
 
-    expect(count).toBe(2); // 1 for rendering engine, 1 for data source validation
+    // Rendering engine only. Source-data validation resolves meta uncached (it does not run the
+    // `beforeGetCellMeta` hook) and skips entirely when no validator is defined.
+    expect(count).toBe(1);
   });
 
   it('should call renderer twice for each cell (auto column width)', async() => {

--- a/handsontable/src/__tests__/settings/sourceDataValidator.spec.js
+++ b/handsontable/src/__tests__/settings/sourceDataValidator.spec.js
@@ -30,7 +30,9 @@ describe('settings', () => {
       });
 
       expect(sourceDataValidator).toHaveBeenCalledTimes(25);
-      expect(sourceDataValidator).toHaveBeenCalledWith('E5', getCellMeta(4, 4), 'init');
+      // Source-data validation resolves meta uncached, so the validator receives a meta object that
+      // carries the cascade (including its coordinates) but not the render-time extensions.
+      expect(sourceDataValidator).toHaveBeenCalledWith('E5', jasmine.objectContaining({ row: 4, col: 4 }), 'init');
     });
 
     it('should be called when calling `loadData`', async() => {
@@ -46,7 +48,7 @@ describe('settings', () => {
       await loadData(createSpreadsheetData(5, 5));
 
       expect(sourceDataValidator).toHaveBeenCalledTimes(25);
-      expect(sourceDataValidator).toHaveBeenCalledWith('E5', getCellMeta(4, 4), 'loadData');
+      expect(sourceDataValidator).toHaveBeenCalledWith('E5', jasmine.objectContaining({ row: 4, col: 4 }), 'loadData');
     });
 
     it('should be called when calling `updateData`', async() => {
@@ -62,7 +64,8 @@ describe('settings', () => {
       await updateData(createSpreadsheetData(5, 5));
 
       expect(sourceDataValidator).toHaveBeenCalledTimes(25);
-      expect(sourceDataValidator).toHaveBeenCalledWith('E5', getCellMeta(4, 4), 'updateData');
+      expect(sourceDataValidator)
+        .toHaveBeenCalledWith('E5', jasmine.objectContaining({ row: 4, col: 4 }), 'updateData');
     });
 
     it('should be called when calling `setSourceDataAtCell`', async() => {
@@ -216,7 +219,7 @@ describe('settings', () => {
       ]);
     });
 
-    it('should respect per-row `allowInvalid` set via `beforeGetCellMeta` (otherwise allowInvalid: false)', async() => {
+    it('should NOT apply per-row `allowInvalid` set via `beforeGetCellMeta` (hook not run during validation)', async() => {
       handsontable({
         data: [['2024-01-01'], ['bad'], ['also-bad']],
         columns: [{ type: 'date', dateFormat: 'YYYY-MM-DD' }],
@@ -228,12 +231,66 @@ describe('settings', () => {
         },
       });
 
-      // Row 1 gets allowInvalid:true from the hook, so its invalid value survives; row 2 keeps the
-      // global allowInvalid:false and is blanked. Row 0's meta must not be reused for the whole column.
+      // Source-data validation resolves meta uncached and never runs `beforeGetCellMeta`, so the
+      // hook's per-row `allowInvalid` is ignored: both invalid rows keep the global allowInvalid:false
+      // and are blanked.
       expect(getSourceData()).toEqual([
         ['2024-01-01'],
-        ['bad'],
         [null],
+        [null],
+      ]);
+    });
+
+    it('should NOT apply a `sourceDataValidator` returned from a `cells` function', async() => {
+      const cellsValidator = jasmine.createSpy('cellsValidator').and.returnValue(false);
+
+      handsontable({
+        data: createSpreadsheetData(3, 3),
+        allowInvalid: false,
+        cells() {
+          return { sourceDataValidator: cellsValidator, sourceDataWarningMessage: 'invalid' };
+        },
+      });
+
+      // The validator is injected only through `cells`, which uncached resolution ignores — so it is
+      // never called and no value is blanked.
+      expect(cellsValidator).not.toHaveBeenCalled();
+      expect(getSourceData()).toEqual([
+        ['A1', 'B1', 'C1'],
+        ['A2', 'B2', 'C2'],
+        ['A3', 'B3', 'C3'],
+      ]);
+    });
+
+    it('should not run any validation on load when a `cells` function is set but no validator is defined', async() => {
+      const cells = jasmine.createSpy('cells').and.returnValue({ className: 'x' });
+
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        cells,
+      });
+
+      // The presence of a `cells` function must not trigger source-data validation. Nothing is
+      // blanked and the data is untouched.
+      expect(getSourceData()).toEqual(createSpreadsheetData(5, 5));
+    });
+
+    it('should still validate a `date`-typed column when a `cells` function is also configured', async() => {
+      handsontable({
+        data: [['2024-01-01'], ['not-a-date'], ['2024-03-15']],
+        columns: [{ type: 'date', dateFormat: 'YYYY-MM-DD' }],
+        allowInvalid: false,
+        cells() {
+          return { className: 'x' };
+        },
+      });
+
+      // The column-level (declarative) date validator still runs through the batched path even though
+      // a `cells` function is present, so the invalid source value is blanked.
+      expect(getSourceData()).toEqual([
+        ['2024-01-01'],
+        [null],
+        ['2024-03-15'],
       ]);
     });
 

--- a/handsontable/src/dataMap/__tests__/sourceDataValidator.unit.js
+++ b/handsontable/src/dataMap/__tests__/sourceDataValidator.unit.js
@@ -3,26 +3,30 @@ import { runSourceDataValidators } from '../sourceDataValidator';
 /**
  * Builds a minimal mock Handsontable instance for exercising `runSourceDataValidators` in isolation.
  *
+ * Source-data validation resolves meta through `MetaManager.getCellMetaUncached`, so the mock exposes
+ * that method (not the `Core#getCellMeta` visual-index wrapper) and counts its calls.
+ *
  * @param {object} options Mock configuration.
  * @param {number} options.rows Number of source rows.
  * @param {number} options.cols Number of source cols.
- * @param {Function} [options.validator] The `sourceDataValidator` placed on every cell's meta.
+ * @param {Function} [options.validator] The `sourceDataValidator` placed on every resolved cell meta.
  * @param {boolean} [options.allowInvalid] The `allowInvalid` meta value.
  * @param {object} [options.settings] The settings returned by `getSettings`.
  * @param {Function} [options.getValue] Maps `(row, col)` to a source value.
  * @param {Function} [options.toVisualRow] Maps a physical row to its visual index (or `null`).
- * @param {Array} [options.registeredHooks] Hook names that `hasHook` should report as registered.
  * @param {Array} [options.userDefinedCellMetas] Imperatively-set cell metas (`setCellMeta`) to report.
  * @returns {object} The mock and its spies.
  */
 function createMockHot({
   rows, cols, validator, allowInvalid, settings = {}, getValue, toVisualRow = row => row,
-  registeredHooks = [], userDefinedCellMetas = [],
+  userDefinedCellMetas = [],
 } = {}) {
-  const getCellMeta = jest.fn((visualRow, visualColumn) => {
+  const getCellMetaUncached = jest.fn((physicalRow, physicalColumn, { visualRow, visualColumn }) => {
     const meta = {
-      row: visualRow,
-      col: visualColumn,
+      row: physicalRow,
+      col: physicalColumn,
+      visualRow,
+      visualCol: visualColumn,
       sourceDataWarningMessage: 'invalid',
     };
 
@@ -45,12 +49,13 @@ function createMockHot({
     _getDataSource: () => ({ getAtCell, setAtCell }),
     rowIndexMapper: { getVisualFromPhysicalIndex: toVisualRow },
     columnIndexMapper: { getVisualFromPhysicalIndex: col => col },
-    getCellMeta,
-    hasHook: key => registeredHooks.includes(key),
-    _getMetaManager: () => ({ getUserDefinedCellMetas: () => userDefinedCellMetas }),
+    _getMetaManager: () => ({
+      getCellMetaUncached,
+      getUserDefinedCellMetas: () => userDefinedCellMetas,
+    }),
   };
 
-  return { hot, getCellMeta, getAtCell, setAtCell };
+  return { hot, getCellMetaUncached, getAtCell, setAtCell };
 }
 
 /**
@@ -74,12 +79,12 @@ function makeValidator(rowIndependent, impl = () => true) {
 describe('runSourceDataValidators', () => {
   it('should materialize meta once per column (O(cols)) for a row-independent validator', () => {
     const validator = makeValidator(true);
-    const { hot, getCellMeta } = createMockHot({ rows: 1000, cols: 10, validator });
+    const { hot, getCellMetaUncached } = createMockHot({ rows: 1000, cols: 10, validator });
 
     runSourceDataValidators(hot, 'init');
 
     // One sample meta per column — NOT one per cell.
-    expect(getCellMeta).toHaveBeenCalledTimes(10);
+    expect(getCellMetaUncached).toHaveBeenCalledTimes(10);
     // Every value is still validated.
     expect(validator).toHaveBeenCalledTimes(1000 * 10);
   });
@@ -100,28 +105,46 @@ describe('runSourceDataValidators', () => {
 
   it('should fall back to per-cell meta (O(rows*cols)) for a non-row-independent validator', () => {
     const validator = makeValidator(false);
-    const { hot, getCellMeta } = createMockHot({ rows: 50, cols: 4, validator });
+    const { hot, getCellMetaUncached } = createMockHot({ rows: 50, cols: 4, validator });
 
     runSourceDataValidators(hot, 'init');
 
     // Per-cell scan: the column probe samples column 0, then every cell is resolved.
-    expect(getCellMeta).toHaveBeenCalledTimes((50 * 4) + 1);
+    expect(getCellMetaUncached).toHaveBeenCalledTimes((50 * 4) + 1);
     expect(validator).toHaveBeenCalledTimes(50 * 4);
   });
 
   it('should skip the row scan entirely when no validator is configured', () => {
-    const { hot, getCellMeta, getAtCell } = createMockHot({ rows: 1000, cols: 8 });
+    const { hot, getCellMetaUncached, getAtCell } = createMockHot({ rows: 1000, cols: 8 });
 
     runSourceDataValidators(hot, 'init');
 
     // Only the per-column sample — no per-cell work.
-    expect(getCellMeta).toHaveBeenCalledTimes(8);
+    expect(getCellMetaUncached).toHaveBeenCalledTimes(8);
     expect(getAtCell).not.toHaveBeenCalled();
   });
 
-  it('should use per-cell meta when a `cells` function is configured (even with a row-independent validator)', () => {
+  it('should skip the scan when a `cells` function is configured but no validator exists', () => {
+    // The regression from the forum report: a `cells` function must NOT force full-dataset meta
+    // resolution when nothing carries a source-data validator.
+    const { hot, getCellMetaUncached, getAtCell } = createMockHot({
+      rows: 30000,
+      cols: 20,
+      settings: { cells: () => ({ className: 'x' }) },
+    });
+
+    runSourceDataValidators(hot, 'init');
+
+    // Only the per-column probe runs — the 600k-cell scan is skipped.
+    expect(getCellMetaUncached).toHaveBeenCalledTimes(20);
+    expect(getAtCell).not.toHaveBeenCalled();
+  });
+
+  it('should NOT force per-cell meta for a `cells` function when the validator is column-level', () => {
+    // A `cells` function no longer routes to the per-cell scan: uncached meta ignores it, so a
+    // row-independent column validator is still validated through the batched (O(cols)) path.
     const validator = makeValidator(true);
-    const { hot, getCellMeta } = createMockHot({
+    const { hot, getCellMetaUncached } = createMockHot({
       rows: 20,
       cols: 3,
       validator,
@@ -130,12 +153,26 @@ describe('runSourceDataValidators', () => {
 
     runSourceDataValidators(hot, 'init');
 
-    expect(getCellMeta).toHaveBeenCalledTimes(20 * 3);
+    expect(getCellMetaUncached).toHaveBeenCalledTimes(3);
+    expect(validator).toHaveBeenCalledTimes(20 * 3);
+  });
+
+  it('should NOT force per-cell meta when a `beforeGetCellMeta` hook is registered', () => {
+    // Hooks are never run during uncached resolution, so they cannot introduce a validator and must
+    // not route to the per-cell scan.
+    const validator = makeValidator(true);
+    const { hot, getCellMetaUncached } = createMockHot({ rows: 20, cols: 3, validator });
+
+    runSourceDataValidators(hot, 'init');
+
+    expect(getCellMetaUncached).toHaveBeenCalledTimes(3);
   });
 
   it('should use per-cell meta when a non-empty `cell` array is configured', () => {
+    // A declarative `cell` override is persistent per-cell meta that uncached resolution DOES see, so
+    // it forces the per-cell scan (a stored cell may carry a validator on any row).
     const validator = makeValidator(true);
-    const { hot, getCellMeta } = createMockHot({
+    const { hot, getCellMetaUncached } = createMockHot({
       rows: 20,
       cols: 3,
       validator,
@@ -144,40 +181,14 @@ describe('runSourceDataValidators', () => {
 
     runSourceDataValidators(hot, 'init');
 
-    expect(getCellMeta).toHaveBeenCalledTimes(20 * 3);
-  });
-
-  it('should use per-cell meta when a `beforeGetCellMeta` hook is registered', () => {
-    const validator = makeValidator(true);
-    const { hot, getCellMeta } = createMockHot({
-      rows: 20,
-      cols: 3,
-      validator,
-      registeredHooks: ['beforeGetCellMeta'],
-    });
-
-    runSourceDataValidators(hot, 'init');
-
-    expect(getCellMeta).toHaveBeenCalledTimes(20 * 3);
-  });
-
-  it('should use per-cell meta when an `afterGetCellMeta` hook is registered', () => {
-    const validator = makeValidator(true);
-    const { hot, getCellMeta } = createMockHot({
-      rows: 20,
-      cols: 3,
-      validator,
-      registeredHooks: ['afterGetCellMeta'],
-    });
-
-    runSourceDataValidators(hot, 'init');
-
-    expect(getCellMeta).toHaveBeenCalledTimes(20 * 3);
+    // Column probe (3) + full per-cell scan (20 * 3).
+    expect(getCellMetaUncached).toHaveBeenCalledTimes(3 + (20 * 3));
+    expect(validator).toHaveBeenCalledTimes(20 * 3);
   });
 
   it('should use per-cell meta when imperatively-set cell meta exists (`setCellMeta`)', () => {
     const validator = makeValidator(true);
-    const { hot, getCellMeta } = createMockHot({
+    const { hot, getCellMetaUncached } = createMockHot({
       rows: 20,
       cols: 3,
       validator,
@@ -186,17 +197,35 @@ describe('runSourceDataValidators', () => {
 
     runSourceDataValidators(hot, 'init');
 
-    expect(getCellMeta).toHaveBeenCalledTimes(20 * 3);
+    // Column probe (3) + full per-cell scan (20 * 3).
+    expect(getCellMetaUncached).toHaveBeenCalledTimes(3 + (20 * 3));
+    expect(validator).toHaveBeenCalledTimes(20 * 3);
   });
 
-  it('should keep the batched path when no hooks or imperative meta are present', () => {
+  it('should still scan when a `cell` array is present even if the column probe finds no validator', () => {
+    // No column validator, but a stored cell might carry one — the scan must run (not skip). With no
+    // validator on any cell here it does no validation work, but it must NOT skip the array case.
+    const { hot, getCellMetaUncached, getAtCell } = createMockHot({
+      rows: 20,
+      cols: 3,
+      settings: { cell: [{ row: 5, col: 1 }] },
+    });
+
+    runSourceDataValidators(hot, 'init');
+
+    expect(getCellMetaUncached).toHaveBeenCalledTimes(3 + (20 * 3));
+    // No validator anywhere, so no source value is read.
+    expect(getAtCell).not.toHaveBeenCalled();
+  });
+
+  it('should keep the batched path when no `cell` array or imperative meta are present', () => {
     const validator = makeValidator(true);
-    const { hot, getCellMeta } = createMockHot({ rows: 20, cols: 3, validator });
+    const { hot, getCellMetaUncached } = createMockHot({ rows: 20, cols: 3, validator });
 
     runSourceDataValidators(hot, 'init');
 
     // One sample meta per column — the batched path is preserved.
-    expect(getCellMeta).toHaveBeenCalledTimes(3);
+    expect(getCellMetaUncached).toHaveBeenCalledTimes(3);
   });
 
   it('should blank invalid values when allowInvalid is false (batched path)', () => {
@@ -228,6 +257,25 @@ describe('runSourceDataValidators', () => {
     runSourceDataValidators(hot, 'init');
 
     expect(setAtCell).not.toHaveBeenCalled();
+  });
+
+  it('should blank invalid values on the per-cell path (`cell` array present)', () => {
+    // Guard against over-skipping: with persistent per-cell meta AND a validator, invalid source
+    // values must still be blanked at load.
+    const validator = makeValidator(false, value => value !== 'bad');
+    const { hot, setAtCell } = createMockHot({
+      rows: 3,
+      cols: 2,
+      validator,
+      allowInvalid: false,
+      settings: { cell: [{ row: 0, col: 0 }] },
+      getValue: (r, c) => (r === 2 && c === 1 ? 'bad' : 'ok'),
+    });
+
+    runSourceDataValidators(hot, 'init');
+
+    expect(setAtCell).toHaveBeenCalledTimes(1);
+    expect(setAtCell).toHaveBeenCalledWith(2, 1, null);
   });
 
   it('should skip rows with no visual index (trimmed rows) in the batched path', () => {
@@ -277,10 +325,10 @@ describe('runSourceDataValidators', () => {
 
   it('should do nothing when the dataset is empty', () => {
     const validator = makeValidator(true);
-    const { hot, getCellMeta } = createMockHot({ rows: 0, cols: 5, validator });
+    const { hot, getCellMetaUncached } = createMockHot({ rows: 0, cols: 5, validator });
 
     runSourceDataValidators(hot, 'init');
 
-    expect(getCellMeta).not.toHaveBeenCalled();
+    expect(getCellMetaUncached).not.toHaveBeenCalled();
   });
 });

--- a/handsontable/src/dataMap/metaManager/index.ts
+++ b/handsontable/src/dataMap/metaManager/index.ts
@@ -204,10 +204,10 @@ export default class MetaManager {
    * @param {number} options.visualColumn The visual column index of the currently requested cell meta object.
    * @returns {object}
    */
-  getCellMetaUncached(
+  getCellMetaUncached<M extends object = Record<string, unknown>>(
     physicalRow: number, physicalColumn: number,
     options: { visualRow: number; visualColumn: number }
-  ) {
+  ): M {
     const cellMeta = this.cellMeta.hasMeta(physicalRow, physicalColumn)
       ? this.cellMeta.getMeta(physicalRow, physicalColumn)
       : this.cellMeta.createTransientMeta(physicalColumn);
@@ -217,7 +217,7 @@ export default class MetaManager {
     cellMeta.row = physicalRow;
     cellMeta.col = physicalColumn;
 
-    return cellMeta;
+    return cellMeta as M;
   }
 
   /**

--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -6519,6 +6519,14 @@ export default (): Record<string, unknown> => {
      * Optionally set [`sourceDataWarningMessage`](@/api/options.md#sourcedatawarningmessage) to customize the
      * message logged for invalid values.
      *
+     * __Limitation:__ source-data validation only sees a `sourceDataValidator` (and a validating cell
+     * [`type`](@/api/options.md#type)) that you define in the global settings, the
+     * [`columns`](@/api/options.md#columns) option, the [`cell`](@/api/options.md#cell) option, or with
+     * [`setCellMeta()`](@/api/core.md#setcellmeta). It does __not__ run the [`cells`](@/api/options.md#cells)
+     * function or the [`beforeGetCellMeta`](@/api/hooks.md#beforegetcellmeta) /
+     * [`afterGetCellMeta`](@/api/hooks.md#aftergetcellmeta) hooks, so a validator that you add only through those
+     * is skipped. Define the validator in one of the supported places to validate the source data.
+     *
      * @example
      * ```js
      * sourceDataWarningMessage: 'The source data is invalid.',

--- a/handsontable/src/dataMap/sourceDataValidator.ts
+++ b/handsontable/src/dataMap/sourceDataValidator.ts
@@ -109,10 +109,13 @@ function validateSourceCell(
 }
 
 /**
- * Inspects column-level meta (one sample cell per column, O(cols)) to decide how source-data
- * validation should run. Returns the columns whose validator is row-independent (safe to validate by
- * reusing one column meta), or signals a full per-cell scan when any column carries a validator that
- * may depend on per-row meta.
+ * Inspects column-level meta (one uncached sample per column, O(cols)) to decide how source-data
+ * validation should run. Meta is resolved through `getCellMetaUncached`, so the sample reflects the
+ * global and column layers only — the `cells` function and the `before`/`afterGetCellMeta` hooks are
+ * never run here (see `runSourceDataValidators`). Because column meta does not vary by row, the sample
+ * is taken at physical row 0 regardless of trimming. Returns the columns whose validator is
+ * row-independent (safe to validate by reusing one column meta), or signals a full per-cell scan when
+ * any column carries a validator that may depend on per-row meta.
  *
  * @param {HotInstance} hotInstance The Handsontable instance.
  * @param {number} colSourceCount The number of physical source columns.
@@ -122,12 +125,7 @@ function collectColumnValidators(
   hotInstance: HotInstance,
   colSourceCount: number
 ): { fullScan: boolean; columns: ColumnValidator[] } {
-  const sampleVisualRow = hotInstance.rowIndexMapper.getVisualFromPhysicalIndex(0);
-
-  if (sampleVisualRow === null) {
-    return { fullScan: true, columns: [] };
-  }
-
+  const metaManager = hotInstance._getMetaManager();
   const columns: ColumnValidator[] = [];
 
   for (let physicalColumn = 0; physicalColumn < colSourceCount; physicalColumn += 1) {
@@ -137,7 +135,8 @@ function collectColumnValidators(
       continue;
     }
 
-    const cellMeta = hotInstance.getCellMeta<CellMeta>(sampleVisualRow, visualColumn);
+    const cellMeta = metaManager
+      .getCellMetaUncached<CellMeta>(0, physicalColumn, { visualRow: 0, visualColumn });
     const validator = cellMeta.sourceDataValidator;
 
     if (!isFunction(validator)) {
@@ -157,8 +156,11 @@ function collectColumnValidators(
 }
 
 /**
- * Validates every source cell by resolving meta per cell (O(rows*cols) meta). Used when per-cell meta
- * can vary by row (a `cells` function, a `cell` array, or a row-dependent custom validator).
+ * Validates every source cell by resolving meta per cell (O(rows*cols) meta). Used when a
+ * row-dependent custom validator is configured, or when a cell carries persistent per-cell meta (the
+ * `cell` option or `setCellMeta`) that a single column sample cannot represent. Meta is resolved with
+ * `getCellMetaUncached`, so no per-cell meta object is retained (the scan does not grow the meta cache
+ * to O(rows*cols)) and the `cells` function / `before`/`afterGetCellMeta` hooks are not run.
  *
  * @param {HotInstance} hotInstance The Handsontable instance.
  * @param {DataSource} dataSource The data source.
@@ -177,6 +179,7 @@ function validatePerCell(
   source?: string
 ): void {
   const { rowIndexMapper, columnIndexMapper } = hotInstance;
+  const metaManager = hotInstance._getMetaManager();
 
   for (let row = 0; row < rowSourceCount; row += 1) {
     for (let col = 0; col < colSourceCount; col += 1) {
@@ -187,7 +190,8 @@ function validatePerCell(
         continue;
       }
 
-      const cellMeta = hotInstance.getCellMeta<CellMeta>(visualRow, visualColumn);
+      const cellMeta = metaManager
+        .getCellMetaUncached<CellMeta>(row, col, { visualRow, visualColumn });
 
       if (!isFunction(cellMeta.sourceDataValidator)) {
         continue;
@@ -240,30 +244,36 @@ function validateBatched(
 }
 
 /**
- * Detects whether per-cell meta can vary by row, which makes the row-0 sample unsafe to reuse for the
- * whole column. Meta varies through a `cells` function, an explicit `cell` array, the
- * `beforeGetCellMeta`/`afterGetCellMeta` hooks (a row-dependent `type`/validator/`allowInvalid` can be
- * applied there), or any imperatively-set cell meta (`setCellMeta`) that survives `updateData`.
+ * Detects whether any cell carries persistent per-cell meta that a single column sample cannot
+ * represent — the declarative `cell` option or imperatively-set cell meta (`setCellMeta`). These are
+ * the only per-row sources that `getCellMetaUncached` resolves, so they force the per-cell scan. The
+ * `cells` function and the `before`/`afterGetCellMeta` hooks are deliberately NOT considered here:
+ * source-data validation resolves meta uncached and never runs them, so they cannot change which
+ * cells carry a `sourceDataValidator`.
  *
  * @param {HotInstance} hotInstance The Handsontable instance.
  * @param {GridSettings} settings The resolved grid settings.
  * @returns {boolean} `true` when meta must be resolved per cell.
  */
-function hasRowVaryingMeta(hotInstance: HotInstance, settings: GridSettings): boolean {
-  return isFunction(settings.cells) ||
-    (Array.isArray(settings.cell) && settings.cell.length > 0) ||
-    hotInstance.hasHook('beforeGetCellMeta') ||
-    hotInstance.hasHook('afterGetCellMeta') ||
+function hasStoredPerCellMeta(hotInstance: HotInstance, settings: GridSettings): boolean {
+  return (Array.isArray(settings.cell) && settings.cell.length > 0) ||
     hotInstance._getMetaManager().getUserDefinedCellMetas().length > 0;
 }
 
 /**
  * Runs source-data validators for all cells and emits one aggregated warning per cell type.
  *
- * For the common case (no `cells` function, no `cell` array, no `before`/`afterGetCellMeta` hooks, no
- * imperatively-set cell meta, and only row-independent built-in source validators such as `date`/`time`),
- * validation reuses one column-level meta per column — avoiding the O(rows*cols) cell-meta
- * materialization that otherwise retains a meta object for every cell at load.
+ * Meta is resolved with `getCellMetaUncached`, so validation considers the global and column layers,
+ * the declarative `cell` option, and imperative `setCellMeta` overrides — but never a `cells` function
+ * or the `before`/`afterGetCellMeta` hooks. A cheap O(cols) column probe decides the path:
+ *
+ * - No column exposes a `sourceDataValidator` and no cell carries persistent per-cell meta — there is
+ *   nothing to validate, so the scan is skipped entirely. This is what keeps a large grid with a
+ *   `cells` function (but no validators) from resolving meta for the whole dataset on every load.
+ * - Only row-independent built-in validators (`date`/`time`/`intlDate`/`intlTime`) and no persistent
+ *   per-cell meta — validation reuses one column-level meta per column (O(cols)).
+ * - A row-dependent custom validator, or persistent per-cell meta (`cell`/`setCellMeta`) — validation
+ *   resolves each cell uncached (O(rows*cols) work, but no retained per-cell meta objects).
  *
  * @param {HotInstance} hotInstance The Handsontable instance.
  * @param {string} [source] The source identifier of the operation.
@@ -280,19 +290,20 @@ export function runSourceDataValidators(hotInstance: HotInstance, source?: strin
   const settings = hotInstance.getSettings();
   const dataSource = hotInstance._getDataSource();
   const invalidByMessageType: InvalidItems = new Map();
+  const { fullScan, columns } = collectColumnValidators(hotInstance, colSourceCount);
+  const hasStoredMeta = hasStoredPerCellMeta(hotInstance, settings);
 
-  if (hasRowVaryingMeta(hotInstance, settings)) {
+  // Nothing carries (or could carry) a source-data validator — skip the scan entirely.
+  if (!fullScan && columns.length === 0 && !hasStoredMeta) {
+    return;
+  }
+
+  if (fullScan || hasStoredMeta) {
     validatePerCell(hotInstance, dataSource, rowSourceCount, colSourceCount, invalidByMessageType, source);
   } else {
-    const { fullScan, columns } = collectColumnValidators(hotInstance, colSourceCount);
+    const toVisualRow = (row: number) => hotInstance.rowIndexMapper.getVisualFromPhysicalIndex(row);
 
-    if (fullScan) {
-      validatePerCell(hotInstance, dataSource, rowSourceCount, colSourceCount, invalidByMessageType, source);
-    } else {
-      const toVisualRow = (row: number) => hotInstance.rowIndexMapper.getVisualFromPhysicalIndex(row);
-
-      validateBatched(columns, dataSource, rowSourceCount, toVisualRow, invalidByMessageType, source);
-    }
+    validateBatched(columns, dataSource, rowSourceCount, toVisualRow, invalidByMessageType, source);
   }
 
   invalidByMessageType.forEach((items, message) => {


### PR DESCRIPTION
### Context

The PR fixes the remaining half of the load-time performance regression from #12796 / DEV-1942.

The first optimization (#12847) stopped resolving cell meta for the whole dataset on `loadData()` / `updateData()` — but only when there was no `cells` function, no `cell` array, and no `getCellMeta` hooks. `hasRowVaryingMeta` treated any of those as "meta varies by row" and forced the `validatePerCell` path, which calls `getCellMeta()` for every cell. A customer using a `cells` function with no validators (forum thread [Performance regression during data load in v17](https://forum.handsontable.com/t/performance-regression-during-data-load-in-v17/9079)) still got a full-dataset meta resolution — and `getCellMeta()` permanently retains one meta object per cell.

Reproduced on `18.0.0` and the `develop` nightly (100,000 × 30 = 3,000,000 cells, `cells` function, no validators):

| Metric | Before | After this PR | Change |
|---|--:|--:|--:|
| Initial load freeze | 1,553 ms | 44 ms | ~35× faster |
| JS heap growth on load | +218 MB | ≈ 0 MB | ~−218 MB |
| Retained cell-meta objects | ~3,000,000 | ~viewport | — |

**Fix:** `runSourceDataValidators` now resolves meta with `MetaManager.getCellMetaUncached` (which does not retain a per-cell meta object and does not run the `cells` function or the `before`/`afterGetCellMeta` hooks) and gates on a cheap O(cols) column probe:

- No column validator and no persistent per-cell meta (`cell` / `setCellMeta`) → skip the scan entirely.
- Only row-independent built-in validators (`date`/`time`/`intlDate`/`intlTime`) and no persistent per-cell meta → batched O(cols).
- A row-dependent custom validator or persistent per-cell meta → per-cell scan, but uncached (no retained per-cell meta objects).

`MetaManager.getCellMetaUncached` was made generic (`<M = Record<string, unknown>>`) to match `getCellMeta<M>`, so callers no longer cast the result.

**Behavior change (intentional, signed off):** source-data validation now applies a `sourceDataValidator` (and a validating cell `type`) that you define in the global settings, the `columns` option, the `cell` option, or with `setCellMeta()`. It no longer applies a `sourceDataValidator` (or `type`) that you return only from a `cells` function or set through the `beforeGetCellMeta` / `afterGetCellMeta` hooks, because those are not run during source-data validation. This is documented in the `sourceDataValidator` option reference. It is not a breaking API change (no option, default, hook, or warning shape changes); it only narrows which cell-meta sources source-data validation reads on load.

### How has this been tested?

- Unit — `npm run test:unit --prefix handsontable --testPathPattern=sourceDataValidator.unit` (17 specs): skip when no validator, skip when a `cells` function has no validator, batched O(cols) for row-independent validators, per-cell for `cell`/`setCellMeta`, and blanking on both paths.
- E2E — `npm run test:e2e --prefix handsontable --testPathPattern='settings/sourceDataValidator|settings/sourceDataWarningMessage|core/loadData'` (76 specs, 0 failures): a `cells`-injected validator is not applied, a `date`-typed column still validates when a `cells` function is present, and the `cells` callback is no longer invoked twice on load.
- Types — `npm run test:types` (pass).
- Manual — two CDN demo pages (v18.0.0 vs `develop` nightly) plus a local-build page, measuring `loadData()` freeze, `getCellMeta` call count, and JS heap. Numbers above.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1987
2. #12796

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1987

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Narrows which meta sources apply on load (cells/hooks validators no longer run), which could surprise integrators who relied on that; core load path and validation logic are heavily covered by new and updated tests.
> 
> **Overview**
> Fixes a **load-time performance regression** where `loadData()` / `updateData()` still walked the whole grid when a **`cells` function** was set but **no source-data validators** were defined.
> 
> **`runSourceDataValidators`** now resolves meta via **`MetaManager.getCellMetaUncached`** (no cached meta per cell, no `cells` / `beforeGetCellMeta` / `afterGetCellMeta`). An **O(cols) column probe** picks the path: **skip** when nothing to validate; **batched O(cols)** for row-independent validators; **per-cell uncached scan** only for row-dependent validators or persistent per-cell meta (`cell` / `setCellMeta`). **`hasRowVaryingMeta`** is replaced by **`hasStoredPerCellMeta`**, so `cells` and hooks alone no longer force a full scan.
> 
> **Intentional behavior change:** source-data validation on init/load/update only sees validators from global settings, **`columns`**, **`cell`**, or **`setCellMeta`** — not validators injected only via **`cells`** or **`beforeGetCellMeta`** (documented on the **`sourceDataValidator`** option). **`getCellMetaUncached`** is made generic for typed callers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f5be293f7f6f3f16ade259f6f764ec67a6ff4d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->