### PR TITLE
DEV-1985: Run docs plugin tests on PRs that change docs files

### DIFF
--- a/.github/workflows/docs-checks.yml
+++ b/.github/workflows/docs-checks.yml
@@ -1,12 +1,14 @@
-name: Docs Linter
+name: Docs Checks
 
 on:
   push:
     paths:
       - 'docs/**'
+      - 'handsontable/package.json'
   pull_request:
     paths:
       - 'docs/**'
+      - 'handsontable/package.json'
     types: [ opened, synchronize, reopened ]
 
 concurrency:
@@ -35,3 +37,25 @@ jobs:
 
       - name: Lint
         run: npm run docs:lint --prefix docs
+
+  test-plugins:
+    name: Plugin tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # https://github.com/actions/checkout/releases/tag/v6.0.2
+
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        name: Install pnpm
+
+      - name: Use Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # https://github.com/actions/setup-node/releases/tag/v6.2.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: CI=true pnpm install --frozen-lockfile
+
+      - name: Test plugins
+        run: npm run docs:test:plugins --prefix docs


### PR DESCRIPTION
### Context

The PR adds `docs:test:plugins` as a required-visible check on pull requests that touch docs files, alongside the existing docs linter.

Previously `npm run docs:test:plugins` (93 Node test-runner tests across `docs/src/plugins`, `docs/src/lib`, `docs/src/components`, `docs/cloudflare`, and `docs/netlify`) ran only in `.github/workflows/docs-production.yml`, triggered by pushes to `prod-docs/**` or manual dispatch. A failing plugin test (e.g. the `changelog-parser` bug fixed in #12931) was only surfaced at production-deploy time, after merge, instead of on the PR.

This renames `docs-linter.yml` to `docs-checks.yml` (it now does more than lint) and adds a `test-plugins` job that runs the same test suite whenever a PR touches `docs/**` or `handsontable/package.json` — matching the path filter already used by `docs-staging.yml`.

`docs:test:plugins` runs standalone with no monorepo build or Docker dependency (confirmed locally), so it can run as a lightweight PR check without needing the production Docker image build step used in `docs-production.yml`.

### How has this been tested?

- Ran `npm run docs:test:plugins --prefix docs` locally — all tests pass with no monorepo build step required.
- Validated the resulting `docs-checks.yml` YAML structure.
- This is a CI-only change with no source behavior change, so no unit/E2E tests were added.

**Note:** making the new "Plugin tests" check *required* (blocking merge) is a GitHub branch-protection setting, not something the workflow file can control. After this job runs successfully at least once, a repo admin needs to add "Plugin tests" to the required-checks list for `develop`.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1985

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog] — CI/tooling change only.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1985

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/workflow-only change with no application code or runtime behavior changes.
> 
> **Overview**
> **Renames** the docs workflow to **Docs Checks** and **extends** path filters so pushes/PRs that touch `handsontable/package.json` (in addition to `docs/**`) trigger the same checks.
> 
> A new **Plugin tests** job runs `npm run docs:test:plugins --prefix docs` on those events, mirroring the existing lint job’s setup (checkout, pnpm, Node from `.nvmrc`, frozen install). That surfaces docs plugin/lib/component/adapter tests on PRs instead of only at production deploy time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f496ce1f7dc365c732fca039dca478aa9e6d0bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->