### PR TITLE
DEV-1965: Remove obsolete frontmatter id fields

### DIFF
--- a/docs/content/api/introduction.md
+++ b/docs/content/api/introduction.md
@@ -1,6 +1,5 @@
 ---
 type: explanation
-id: 6o0dghoa
 title: Introduction
 metaTitle: API reference - JavaScript Data Grid | Handsontable
 description: Control the data grid programmatically, using Handsontable's API options and methods.
@@ -8,13 +7,10 @@ permalink: /api/
 canonicalUrl: /api/
 searchCategory: API Reference
 react:
-  id: 45svfigt
   metaTitle: API reference - React Data Grid | Handsontable
 angular:
-  id: 48gjbys8
   metaTitle: API reference - Angular Data Grid | Handsontable
 vue:
-  id: lk8x28al
   metaTitle: API reference - Vue Data Grid | Handsontable
 ---
 This page describes the Handsontable API -- the methods, hooks, and plugin interfaces you use to control the grid programmatically.

--- a/docs/content/api/plugins.md
+++ b/docs/content/api/plugins.md
@@ -1,5 +1,4 @@
 ---
-id: nh39k1d2
 title: Plugins
 metaTitle: 'API reference: Plugins - JavaScript Data Grid | Handsontable'
 description: A complete list of Handsontable's plugins that can extend your data grid's capabilities.
@@ -7,13 +6,10 @@ permalink: /api/plugins
 canonicalUrl: /api/plugins
 searchCategory: API Reference
 react:
-  id: iauj1mv1
   metaTitle: 'API reference: Plugins - React Data Grid | Handsontable'
 angular:
-  id: gueng7dm
   metaTitle: 'API reference: Plugins - Angular Data Grid | Handsontable'
 vue:
-  id: mvftxzxh
   metaTitle: 'API reference: Plugins - Vue Data Grid | Handsontable'
 ---
 |Plugin Name  | Description |

--- a/docs/content/guides/accessories-and-menus/layout-slots/layout-slots.md
+++ b/docs/content/guides/accessories-and-menus/layout-slots/layout-slots.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: la7yk3ts
 title: Layout slots
 metaTitle: Layout slots - JavaScript Data Grid | Handsontable
 description: Place custom UI in the wrapper slots around the grid and control the order of elements within each slot.

--- a/docs/content/guides/ai-tools/ai-docs-assistant/ai-docs-assistant.md
+++ b/docs/content/guides/ai-tools/ai-docs-assistant/ai-docs-assistant.md
@@ -1,18 +1,14 @@
 ---
 type: explanation
-id: ai2b8d5h
 title: AI Docs Assistant
 metaTitle: AI Docs Assistant - JavaScript Data Grid | Handsontable
 description: The Ask AI assistant in the docs header that answers questions about Handsontable APIs, configuration options, hooks, and integration patterns.
 permalink: /ai-docs-assistant
 react:
-  id: ai4f7j1c
   metaTitle: AI Docs Assistant - React Data Grid | Handsontable
 angular:
-  id: ai6r2y9k
   metaTitle: AI Docs Assistant - Angular Data Grid | Handsontable
 vue:
-  id: ai8s3v4p
   metaTitle: AI Docs Assistant - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: AI Tools

--- a/docs/content/guides/ai-tools/ai-theme-builder/ai-theme-builder.md
+++ b/docs/content/guides/ai-tools/ai-theme-builder/ai-theme-builder.md
@@ -1,18 +1,14 @@
 ---
 type: explanation
-id: ai7k4m2n
 title: AI Theme Builder
 metaTitle: AI Theme Builder - JavaScript Data Grid | Handsontable
 description: An AI-assisted tool that turns a written description into a complete Handsontable theme, generating the CSS variables that drive the grid's appearance.
 permalink: /ai-theme-builder
 react:
-  id: ai9p3x5q
   metaTitle: AI Theme Builder - React Data Grid | Handsontable
 angular:
-  id: aiq2v8w1
   metaTitle: AI Theme Builder - Angular Data Grid | Handsontable
 vue:
-  id: aih6t3z4
   metaTitle: AI Theme Builder - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: AI Tools

--- a/docs/content/guides/ai-tools/skills-for-claude-code/skills-for-claude-code.md
+++ b/docs/content/guides/ai-tools/skills-for-claude-code/skills-for-claude-code.md
@@ -1,18 +1,14 @@
 ---
 type: explanation
-id: ai1m9n3t
 title: Skills for Claude Code
 metaTitle: Skills for Claude Code - JavaScript Data Grid | Handsontable
 description: Reusable instructions that teach the Claude coding agent how to work with Handsontable, covering plugin development, cell editors, tests, and documentation examples.
 permalink: /skills-for-claude-code
 react:
-  id: ai5g8h6w
   metaTitle: Skills for Claude Code - React Data Grid | Handsontable
 angular:
-  id: ai7e4u2x
   metaTitle: Skills for Claude Code - Angular Data Grid | Handsontable
 vue:
-  id: ai0a5c1l
   metaTitle: Skills for Claude Code - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: AI Tools

--- a/docs/content/guides/upgrade-and-migration/changelog-6/changelog-6.md
+++ b/docs/content/guides/upgrade-and-migration/changelog-6/changelog-6.md
@@ -1,13 +1,11 @@
 ---
 type: reference
-id: k4mn8vr2
 title: Changelog 6.2.2
 metaTitle: Changelog 6.2.2 - JavaScript Data Grid | Handsontable
 description: See the release notes for Handsontable 6.2.2, the earliest version tracked by the version comparison page.
 permalink: /changelog-6
 canonicalUrl: /changelog-6
 react:
-  id: w5pq3tnh
   metaTitle: Changelog 6.2.2 - React Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration

--- a/docs/content/guides/upgrade-and-migration/changes-between-versions/changes-between-versions.md
+++ b/docs/content/guides/upgrade-and-migration/changes-between-versions/changes-between-versions.md
@@ -1,13 +1,11 @@
 ---
 type: reference
-id: minzqfka
 title: Changes between versions
 metaTitle: Changes between versions - JavaScript Data Grid | Handsontable
 description: Compare two Handsontable versions and see breaking changes, deprecations, new APIs, and fixes between them.
 permalink: /changes-between-versions
 canonicalUrl: /changes-between-versions
 react:
-  id: 3jqraw5z
   metaTitle: Changes between versions - React Data Grid | Handsontable
 searchCategory: Guides
 category: Upgrade and migration

--- a/docs/content/guides/upgrade-and-migration/migrating-from-13.1-to-14.0/migrating-from-13.1-to-14.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-13.1-to-14.0/migrating-from-13.1-to-14.0.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: migrating-13.1-to-14.0
 title: Migrating from 13.1 to 14.0
 metaTitle: Migrating from 13.1 to 14.0 - JavaScript Data Grid | Handsontable
 description: Migrate from Handsontable 13.1 to Handsontable 14.0, released on November 30th, 2023.

--- a/docs/content/guides/upgrade-and-migration/migrating-from-14.6-to-15.0/migrating-from-14.6-to-15.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-14.6-to-15.0/migrating-from-14.6-to-15.0.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: migrating-14.6-to-15.0
 title: Migrating from 14.6 to 15.0
 metaTitle: Migrating from 14.6 to 15.0 - JavaScript Data Grid | Handsontable
 description: Migrate from Handsontable 14.6 to Handsontable 15.0, released on December 16th, 2024.

--- a/docs/content/recipes/accessibility/accessibility.md
+++ b/docs/content/recipes/accessibility/accessibility.md
@@ -8,15 +8,11 @@ searchCategory: Recipes
 hotPlugin: false
 editLink: false
 type: how-to
-id: t1a3b5c7
 react:
-  id: u2b4c6d8
   metaTitle: Accessibility and UX Recipes - React Data Grid | Handsontable
 angular:
-  id: v3c5d7e9
   metaTitle: Accessibility and UX Recipes - Angular Data Grid | Handsontable
 vue:
-  id: 88pek0th
   metaTitle: Accessibility and UX Recipes - Vue Data Grid | Handsontable
 ---
 [[toc]]

--- a/docs/content/recipes/accessibility/aria-grid/aria-grid.md
+++ b/docs/content/recipes/accessibility/aria-grid/aria-grid.md
@@ -1,5 +1,4 @@
 ---
-id: a7f3c2d1
 title: ARIA-friendly grid
 metaTitle: ARIA-Friendly Grid with Row Descriptions - JavaScript Data Grid | Handsontable
 description: Configure Handsontable for screen reader compatibility using ariaTags, tabMoves, aria-label on cells, and aria-sort on headers -- targeting WCAG 2.1 AA compliance.
@@ -12,13 +11,10 @@ tags:
   - wcag
   - recipes
 react:
-  id: 8fduuwvk
   metaTitle: ARIA-Friendly Grid with Row Descriptions - React Data Grid | Handsontable
 angular:
-  id: b3e9f1a2
   metaTitle: ARIA-Friendly Grid with Row Descriptions - Angular Data Grid | Handsontable
 vue:
-  id: huyklmef
   metaTitle: ARIA-Friendly Grid with Row Descriptions - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Accessibility & UX

--- a/docs/content/recipes/accessibility/keyboard-shortcuts/keyboard-shortcuts.md
+++ b/docs/content/recipes/accessibility/keyboard-shortcuts/keyboard-shortcuts.md
@@ -1,5 +1,4 @@
 ---
-id: a3f82c19
 title: Custom keyboard shortcuts
 metaTitle: Custom keyboard shortcuts - JavaScript Data Grid | Handsontable
 description: Register custom keyboard shortcuts in Handsontable using the ShortcutManager API. Add Ctrl+D to duplicate rows and Ctrl+Enter to submit grid data.
@@ -12,13 +11,10 @@ tags:
   - recipes
   - tutorial
 react:
-  id: b2e91d30
   metaTitle: Custom keyboard shortcuts - React Data Grid | Handsontable
 angular:
-  id: c4f03e47
   metaTitle: Custom keyboard shortcuts - Angular Data Grid | Handsontable
 vue:
-  id: 423pgfmi
   metaTitle: Custom keyboard shortcuts - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Accessibility & UX

--- a/docs/content/recipes/cell-types/cell-types.md
+++ b/docs/content/recipes/cell-types/cell-types.md
@@ -7,16 +7,12 @@ searchCategory: Recipes
 hotPlugin: false
 editLink: false
 type: how-to
-id: fe57c058
 description: Practical recipes for creating custom cell types in Handsontable.
 react:
-  id: 4515bc70
   metaTitle: Cell Recipes - React Data Grid | Handsontable
 angular:
-  id: e149d2af
   metaTitle: Cell Recipes - Angular Data Grid | Handsontable
 vue:
-  id: um7f5xlt
   metaTitle: Cell Recipes - Vue Data Grid | Handsontable
 ---
 [[toc]]

--- a/docs/content/recipes/cell-types/color-picker/color-picker.md
+++ b/docs/content/recipes/cell-types/color-picker/color-picker.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: 2d2b22ef
 title: Color picker
 metaTitle: Color Picker Cell Type - JavaScript Data Grid | Handsontable
 description: Learn how to create a Handsontable custom color picker cell using the Pickr library, with a button to open the picker, live preview, hex validation, and nano theme.
@@ -11,13 +10,10 @@ tags:
   - tutorial
   - recipes
 react:
-  id: 050bc847
   metaTitle: Color Picker Cell Type - React Data Grid | Handsontable
 angular:
-  id: a471c83c
   metaTitle: Color Picker Cell Type - Angular Data Grid | Handsontable
 vue:
-  id: y6983gwr
   metaTitle: Color Picker Cell Type - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Cell Types

--- a/docs/content/recipes/cell-types/colorful-picker/colorful-picker.md
+++ b/docs/content/recipes/cell-types/colorful-picker/colorful-picker.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: e50f0177
 title: Colorful Picker
 metaTitle: Color Picker Cell Type - React Data Grid | Handsontable
 description: Learn how to create a custom Handsontable cell type using a color picker for selecting hex colors directly in your data grid.
@@ -12,13 +11,10 @@ tags:
   - tutorial
   - recipes
 react:
-  id: 45ff1241
   metaTitle: Color Picker Cell Type - React Data Grid | Handsontable
 angular:
-  id: 4f6678f9
   metaTitle: Color Picker Cell Type - Angular Data Grid | Handsontable
 vue:
-  id: hvnfgr8y
 searchCategory: Recipes
 category: Cell Types
 ---

--- a/docs/content/recipes/cell-types/feedback-react/feedback-react.md
+++ b/docs/content/recipes/cell-types/feedback-react/feedback-react.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: e107bb0d
 title: Feedback
 metaTitle:  Feedback Cell Type - React Data Grid | Handsontable
 description: Learn how to create a custom feedback cell type in React using EditorComponent—emoji buttons (e.g. thumbs up/down/neutral) for quick selection, keyboard navigation, and per-column config.
@@ -12,13 +11,10 @@ tags:
   - tutorial
   - recipes
 react:
-  id: 41d9ca30
   metaTitle: Feedback Cell Type - React Data Grid | Handsontable
 angular:
-  id: 6af717ed
   metaTitle: Feedback Cell Type - Angular Data Grid | Handsontable
 vue:
-  id: onjzuhn9
 searchCategory: Recipes
 category: Cell Types
 ---

--- a/docs/content/recipes/cell-types/feedback/feedback.md
+++ b/docs/content/recipes/cell-types/feedback/feedback.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: e23f98e7
 title: Feedback
 metaTitle:  Feedback Cell Type - JavaScript Data Grid | Handsontable
 description: Learn how to create a custom Handsontable cell type using emoji buttons for quick feedback selection directly in your data grid.
@@ -11,13 +10,10 @@ tags:
   - tutorial
   - recipes
 react:
-  id: 034db272
   metaTitle: Feedback Cell Type - React Data Grid | Handsontable
 angular:
-  id: 8e13e6d5
   metaTitle: Feedback Cell Type - Angular Data Grid | Handsontable
 vue:
-  id: n99hdtp4
   metaTitle: Feedback Cell Type - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Cell Types

--- a/docs/content/recipes/cell-types/flatpickr/flatpickr.md
+++ b/docs/content/recipes/cell-types/flatpickr/flatpickr.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: c757a3b3
 title: Flatpickr
 metaTitle: Flatpickr Cell Type - JavaScript Data Grid | Handsontable
 description: Learn how to create a custom Handsontable cell type using Flatpickr for a date picker with cross-browser consistency and per-column configuration directly inside your data grid.
@@ -11,13 +10,10 @@ tags:
   - tutorial
   - recipes
 react:
-  id: 580a2104
   metaTitle: Flatpickr Cell Type - React Data Grid | Handsontable
 angular:
-  id: 8748f2d9
   metaTitle: Flatpickr Cell Type - Angular Data Grid | Handsontable
 vue:
-  id: 9gjg0yyt
   metaTitle: Flatpickr Cell Type - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Cell Types

--- a/docs/content/recipes/cell-types/guide-color-picker-angular/guide-color-picker.md
+++ b/docs/content/recipes/cell-types/guide-color-picker-angular/guide-color-picker.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: 7wh7yk48
 title: Color picker
 metaTitle: Color Picker Cell - JavaScript Data Grid | Handsontable
 description: Learn how to create a Handsontable custom color picker cell in Angular using the native HTML5 color input, with live preview and hex validation.
@@ -12,13 +11,10 @@ tags:
   - tutorial
   - recipes
 react:
-  id: g7xbdr4b
   metaTitle: Color Picker Cell - React Data Grid | Handsontable
 angular:
-  id: tgb1xbxy
   metaTitle: Color Picker Cell - Angular Data Grid | Handsontable
 vue:
-  id: 7l56ycyn
   metaTitle: Color Picker Cell - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Cell Types

--- a/docs/content/recipes/cell-types/guide-datepicker-angular/guide-datepicker.md
+++ b/docs/content/recipes/cell-types/guide-datepicker-angular/guide-datepicker.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: 0slrmsni
 title: "Date picker"
 metaTitle: "Date picker - JavaScript Data Grid | Handsontable"
 description: Learn how to create a custom Handsontable cell type using Flatpickr for a powerful, customizable date picker experience directly inside your data grid.
@@ -12,13 +11,10 @@ tags:
   - tutorial
   - recipes
 react:
-  id: n4f2zp8e
   metaTitle: Date picker - React Data Grid | Handsontable
 angular:
-  id: o1ijr8z3
   metaTitle: Date picker - Angular Data Grid | Handsontable
 vue:
-  id: mgyg0ys8
   metaTitle: "Date picker - Vue Data Grid | Handsontable"
 searchCategory: Recipes
 category: Cells

--- a/docs/content/recipes/cell-types/guide-feedback-angular/guide-feedback.md
+++ b/docs/content/recipes/cell-types/guide-feedback-angular/guide-feedback.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: 2rti5w12
 title: "Feedback Editor"
 metaTitle: "Feedback Editor - JavaScript Data Grid | Handsontable"
 description: Learn how to create a custom Handsontable cell type using emoji buttons for quick feedback selection directly in your data grid.
@@ -12,13 +11,10 @@ tags:
   - tutorial
   - recipes
 react:
-  id: 64rvr6nb
   metaTitle: "Feedback Editor - React Data Grid | Handsontable"
 angular:
-  id: dg9oi3jt
   metaTitle: "Feedback Editor - Angular Data Grid | Handsontable"
 vue:
-  id: 5dtfu7cq
   metaTitle: "Feedback Editor - Vue Data Grid | Handsontable"
 searchCategory: Recipes
 category: Cells

--- a/docs/content/recipes/cell-types/guide-rating-angular/guide-rating.md
+++ b/docs/content/recipes/cell-types/guide-rating-angular/guide-rating.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: ibewekco
 title: "Star Rating Editor"
 metaTitle: "Star Rating Editor - JavaScript Data Grid | Handsontable"
 description: Learn how to create a custom Handsontable cell type using SVG stars for intuitive 1-5 star ratings directly in your data grid.
@@ -12,13 +11,10 @@ tags:
   - tutorial
   - recipes
 react:
-  id: a070f35k
   metaTitle: "Star Rating Editor - React Data Grid | Handsontable"
 angular:
-  id: 66fxpbip
   metaTitle: "Star Rating Editor - Angular Data Grid | Handsontable"
 vue:
-  id: lod409ks
   metaTitle: "Star Rating Editor - Vue Data Grid | Handsontable"
 searchCategory: Recipes
 category: Cell Types

--- a/docs/content/recipes/cell-types/moment-date/moment-date.md
+++ b/docs/content/recipes/cell-types/moment-date/moment-date.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: 9f21530e
 title: Moment.js-based date
 metaTitle: Moment.js Cell Type - JavaScript Data Grid | Handsontable
 description: Learn how to create a Handsontable custom date cell type using the Moment.js library
@@ -13,13 +12,10 @@ tags:
   - moment.js
   - date
 react:
-  id: 7d23a45b
   metaTitle: Moment.js date Cell Type - React Data Grid | Handsontable
 angular:
-  id: 3d23a45b
   metaTitle: Moment.js date Cell Type - Angular Data Grid | Handsontable
 vue:
-  id: q6egngqa
   metaTitle: Moment.js date Cell Type - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Cell Types

--- a/docs/content/recipes/cell-types/moment-time/moment-time.md
+++ b/docs/content/recipes/cell-types/moment-time/moment-time.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: 1f21530e
 title: Moment.js-based time
 metaTitle: Moment.js Cell Type - JavaScript Data Grid | Handsontable
 description: Learn how to create a Handsontable custom time cell type using the Moment.js library
@@ -13,13 +12,10 @@ tags:
   - moment.js
   - time
 react:
-  id: 1d23a45b
   metaTitle: Moment.js time Cell Type - React Data Grid | Handsontable
 angular:
-  id: 3c87f9e1
   metaTitle: Moment.js time Cell Type - Angular Data Grid | Handsontable
 vue:
-  id: jplnv73m
   metaTitle: Moment.js time Cell Type - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Cell Types

--- a/docs/content/recipes/cell-types/numbro/numbro.md
+++ b/docs/content/recipes/cell-types/numbro/numbro.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: cf4e768b
 title: Numbro
 metaTitle: Numbro Cell Type - JavaScript Data Grid | Handsontable
 description: Learn how to create a Handsontable custom numbro cell type using the Numbro library
@@ -12,13 +11,10 @@ tags:
   - recipes
   - numbro
 react:
-  id: 9f2d530e
   metaTitle: Numbro Cell Type - React Data Grid | Handsontable
 angular:
-  id: 1e23a45b
   metaTitle: Numbro Cell Type - Angular Data Grid | Handsontable
 vue:
-  id: teohjohf
   metaTitle: Numbro Cell Type - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Cell Types

--- a/docs/content/recipes/cell-types/pikaday/pikaday.md
+++ b/docs/content/recipes/cell-types/pikaday/pikaday.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: 01620d5a
 title: Pikaday
 metaTitle: Pikaday Cell Type - JavaScript Data Grid | Handsontable
 description: Learn how to create a custom Handsontable cell type using Pikaday for a date picker with per-column configuration directly inside your data grid. This guide serves as a migration path for users moving away from the built-in date cell type.
@@ -11,13 +10,10 @@ tags:
   - tutorial
   - recipes
 react:
-  id: 9ac52da1
   metaTitle: Pikaday Cell Type - React Data Grid | Handsontable
 angular:
-  id: b83502de
   metaTitle: Pikaday Cell Type - Angular Data Grid | Handsontable
 vue:
-  id: lnh85yd3
   metaTitle: Pikaday Cell Type - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Cell Types

--- a/docs/content/recipes/cell-types/rating/rating.md
+++ b/docs/content/recipes/cell-types/rating/rating.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: b5f02fb2
 title: Star Rating
 metaTitle:  Star Rating Cell Type - JavaScript Data Grid | Handsontable"
 description: Learn how to create a custom Handsontable cell type using SVG stars for intuitive 1-5 star ratings directly in your data grid.
@@ -11,13 +10,10 @@ tags:
   - tutorial
   - recipes
 react:
-  id: dd56fc85
   metaTitle: Star Rating Cell Type - React Data Grid | Handsontable"
 angular:
-  id: e51f625c
   metaTitle: Star Rating Cell Type - Angular Data Grid | Handsontable"
 vue:
-  id: c6hrb6zp
   metaTitle: Star Rating Cell Type - Vue Data Grid | Handsontable"
 searchCategory: Recipes
 category: Cell Types

--- a/docs/content/recipes/cell-types/react-rating/react-rating.md
+++ b/docs/content/recipes/cell-types/react-rating/react-rating.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: 95c84eb4
 title: Star Rating
 metaTitle: Star Rating Cell Type - React Data Grid | Handsontable
 description: Learn how to create a custom Handsontable cell type using a star rating component for selecting numeric ratings directly in your data grid.
@@ -12,13 +11,10 @@ tags:
   - tutorial
   - recipes
 react:
-  id: 4848b7eb
   metaTitle: Star Rating Cell Type - React Data Grid | Handsontable
 angular:
-  id: 3a4f760c
   metaTitle: Star Rating Cell Type - Angular Data Grid | Handsontable
 vue:
-  id: cmt6617x
 searchCategory: Recipes
 category: Cell Types
 ---

--- a/docs/content/recipes/column-management/column-management.md
+++ b/docs/content/recipes/column-management/column-management.md
@@ -8,15 +8,11 @@ searchCategory: Recipes
 hotPlugin: false
 editLink: false
 type: how-to
-id: z7g9h1i3
 react:
-  id: a8h0i2j4
   metaTitle: Column Management Recipes - React Data Grid | Handsontable
 angular:
-  id: b9i1j3k5
   metaTitle: Column Management Recipes - Angular Data Grid | Handsontable
 vue:
-  id: xhr39rj8
   metaTitle: Column Management Recipes - Vue Data Grid | Handsontable
 ---
 [[toc]]

--- a/docs/content/recipes/column-management/column-visibility/column-visibility.md
+++ b/docs/content/recipes/column-management/column-visibility/column-visibility.md
@@ -1,5 +1,4 @@
 ---
-id: a3f8c2d1
 title: Build a dynamic column visibility toggle
 metaTitle: Dynamic Column Visibility Toggle - JavaScript Data Grid | Handsontable
 description: Build a checkbox list outside the grid that shows or hides columns on demand, while preserving each column's type, renderer, and validator.
@@ -11,13 +10,10 @@ tags:
   - toggle columns
   - column management
 react:
-  id: mab9c608
   metaTitle: Dynamic column visibility - React Data Grid | Handsontable
 angular:
-  id: c7d4e5f6
   metaTitle: Dynamic Column Visibility Toggle - Angular Data Grid | Handsontable
 vue:
-  id: jqwr4haq
   metaTitle: Dynamic Column Visibility Toggle - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Column Management

--- a/docs/content/recipes/column-management/freeze-columns/freeze-columns.md
+++ b/docs/content/recipes/column-management/freeze-columns/freeze-columns.md
@@ -1,5 +1,4 @@
 ---
-id: b4e7c9f2
 title: Freeze and unfreeze columns at runtime
 metaTitle: Freeze and unfreeze columns at runtime - JavaScript Data Grid | Handsontable
 description: Freeze and unfreeze columns dynamically using external buttons that call hot.updateSettings with fixedColumnsStart, and understand how frozen columns interact with manual column reordering.
@@ -12,13 +11,10 @@ tags:
   - manualColumnMove
   - column management
 react:
-  id: c3d8e1f4
   metaTitle: Freeze and unfreeze columns at runtime - React Data Grid | Handsontable
 angular:
-  id: a7b2c5d9
   metaTitle: Freeze and unfreeze columns at runtime - Angular Data Grid | Handsontable
 vue:
-  id: 1r6wwd0v
   metaTitle: Freeze and unfreeze columns at runtime - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Column Management

--- a/docs/content/recipes/context-menu/add-column-object-data/add-column-object-data.md
+++ b/docs/content/recipes/context-menu/add-column-object-data/add-column-object-data.md
@@ -1,5 +1,4 @@
 ---
-id: k7m3p9q2
 title: Add a column to an object-based dataset
 metaTitle: Add a column to an object-based dataset - JavaScript Data Grid | Handsontable
 description: Learn how to add a column at runtime through the context menu when your grid uses an object-based dataset, where the built-in column-insert items do not apply.
@@ -11,13 +10,10 @@ tags:
   - columns
   - object data
 react:
-  id: r4n8t1w5
   metaTitle: Add a column to an object-based dataset - React Data Grid | Handsontable
 angular:
-  id: a6c2v7x3
   metaTitle: Add a column to an object-based dataset - Angular Data Grid | Handsontable
 vue:
-  id: v9b5d3f8
   metaTitle: Add a column to an object-based dataset - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Context Menu

--- a/docs/content/recipes/context-menu/context-menu.md
+++ b/docs/content/recipes/context-menu/context-menu.md
@@ -8,15 +8,11 @@ searchCategory: Recipes
 hotPlugin: false
 editLink: false
 type: how-to
-id: c0j2k4l6
 react:
-  id: d1k3l5m7
   metaTitle: Context Menu Recipes - React Data Grid | Handsontable
 angular:
-  id: e2l4m6n8
   metaTitle: Context Menu Recipes - Angular Data Grid | Handsontable
 vue:
-  id: s4tb6gp7
   metaTitle: Context Menu Recipes - Vue Data Grid | Handsontable
 ---
 [[toc]]

--- a/docs/content/recipes/context-menu/custom-context-menu/custom-context-menu.md
+++ b/docs/content/recipes/context-menu/custom-context-menu/custom-context-menu.md
@@ -1,5 +1,4 @@
 ---
-id: a3f7c819
 title: Custom context menu actions
 metaTitle: Custom context menu actions - JavaScript Data Grid | Handsontable
 description: Learn how to add custom items to Handsontable's right-click context menu, including duplicate row, flag row, and copy row as JSON actions.
@@ -11,13 +10,10 @@ tags:
   - context menu
   - custom actions
 react:
-  id: b8d2f419
   metaTitle: Custom context menu actions - React Data Grid | Handsontable
 angular:
-  id: c5e3a907
   metaTitle: Custom context menu actions - Angular Data Grid | Handsontable
 vue:
-  id: hq16t08r
   metaTitle: Custom context menu actions - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Context Menu

--- a/docs/content/recipes/context-menu/row-operations/row-operations.md
+++ b/docs/content/recipes/context-menu/row-operations/row-operations.md
@@ -1,5 +1,4 @@
 ---
-id: a3f8c1d2
 title: Programmatic row operations
 metaTitle: Programmatic row operations - JavaScript Data Grid | Handsontable
 description: Learn how to add, delete, and reorder rows in Handsontable using external toolbar buttons wired to the alter() API and the ManualRowMove plugin.
@@ -10,13 +9,10 @@ tags:
   - tutorial
   - recipes
 react:
-  id: b4c7d2e5
   metaTitle: Programmatic row operations - React Data Grid | Handsontable
 angular:
-  id: c5d8e3f6
   metaTitle: Programmatic row operations - Angular Data Grid | Handsontable
 vue:
-  id: f2cq2guh
   metaTitle: Programmatic row operations - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Context Menu and Interaction

--- a/docs/content/recipes/data-management/auto-save-backend/auto-save-backend.md
+++ b/docs/content/recipes/data-management/auto-save-backend/auto-save-backend.md
@@ -1,5 +1,4 @@
 ---
-id: j9r2m7x4
 title: Auto-save changes to a backend
 metaTitle: Auto-save changes to a backend - JavaScript Data Grid | Handsontable
 description: Learn how to auto-save Handsontable edits with a debounced afterChange hook, dirty row tracking, and save status feedback.
@@ -13,13 +12,10 @@ tags:
   - data persistence
   - backend sync
 react:
-  id: p6t8v3n1
   metaTitle: Auto-save changes to a backend - React Data Grid | Handsontable
 angular:
-  id: b5c2q9k7
   metaTitle: Auto-save changes to a backend - Angular Data Grid | Handsontable
 vue:
-  id: 5v0khjzx
   metaTitle: Auto-save changes to a backend - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Data Management

--- a/docs/content/recipes/data-management/data-management.md
+++ b/docs/content/recipes/data-management/data-management.md
@@ -8,15 +8,11 @@ searchCategory: Recipes
 hotPlugin: false
 editLink: false
 type: how-to
-id: c4b7e2f1
 react:
-  id: 9d2f6a4b
   metaTitle: Data Management Recipes - React Data Grid | Handsontable
 angular:
-  id: 6e1c8b3d
   metaTitle: Data Management Recipes - Angular Data Grid | Handsontable
 vue:
-  id: ikay0eju
   metaTitle: Data Management Recipes - Vue Data Grid | Handsontable
 ---
 [[toc]]

--- a/docs/content/recipes/data-management/load-data-graphql/load-data-graphql.md
+++ b/docs/content/recipes/data-management/load-data-graphql/load-data-graphql.md
@@ -1,5 +1,4 @@
 ---
-id: 2a7d9f1c
 title: Load data from a GraphQL API
 metaTitle: Load Data from a GraphQL API - JavaScript Data Grid | Handsontable
 description: Learn how to fetch data from a GraphQL API and load it into Handsontable with loading and error states.
@@ -13,13 +12,10 @@ tags:
   - loading state
   - error handling
 react:
-  id: 8c3e5b7a
   metaTitle: Load Data from a GraphQL API - React Data Grid | Handsontable
 angular:
-  id: f1d4a6c9
   metaTitle: Load Data from a GraphQL API - Angular Data Grid | Handsontable
 vue:
-  id: oo25pxah
   metaTitle: Load Data from a GraphQL API - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Data Management

--- a/docs/content/recipes/data-management/load-data-rest-api/load-data-rest-api.md
+++ b/docs/content/recipes/data-management/load-data-rest-api/load-data-rest-api.md
@@ -1,5 +1,4 @@
 ---
-id: 1f8a3c7d
 title: Load data from a REST API
 metaTitle: Load Data from a REST API - JavaScript Data Grid | Handsontable
 description: Fetch JSON data from a REST API and load it into Handsontable with loading and error states.
@@ -16,13 +15,10 @@ tags:
   - pagination
   - server-side data
 react:
-  id: 7c4d2e9a
   metaTitle: Load Data from a REST API - React Data Grid | Handsontable
 angular:
-  id: a3b8c2d1
   metaTitle: Load Data from a REST API - Angular Data Grid | Handsontable
 vue:
-  id: o4k4wnz7
   metaTitle: Load Data from a REST API - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Data Management

--- a/docs/content/recipes/data-management/server-side-django/server-side-django.md
+++ b/docs/content/recipes/data-management/server-side-django/server-side-django.md
@@ -1,5 +1,4 @@
 ---
-id: a3f7c2e1
 title: Server-side data with Django
 metaTitle: Server-side Data with Django - JavaScript Data Grid | Handsontable
 description: Connect Handsontable to a Django REST Framework backend with paginated fetching, server-side sorting and filtering, and full CRUD support.
@@ -12,13 +11,10 @@ tags:
   - data-provider
   - recipe
 react:
-  id: zdsrh5oc
   metaTitle: Server-side data with Django - React Data Grid | Handsontable
 angular:
-  id: q1s3u5w7
   metaTitle: Server-side Data with Django - Angular Data Grid | Handsontable
 vue:
-  id: avzy0eqi
   metaTitle: Server-side Data with Django - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Data Management

--- a/docs/content/recipes/data-management/server-side-expressjs/server-side-expressjs.md
+++ b/docs/content/recipes/data-management/server-side-expressjs/server-side-expressjs.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: b5e92d71
 title: Server-side Data with Express.js
 metaTitle: Server-side Data with Express.js - JavaScript Data Grid | Handsontable
 description: Wire Handsontable's dataProvider plugin to an Express.js 4 backend with paginated, sorted, and filtered server-side data and full CRUD operations backed by PostgreSQL via TypeORM and Zod.
@@ -13,13 +12,10 @@ tags:
   - typescript
   - recipes
 react:
-  id: 7a3c1f8e
   metaTitle: Server-side data with Express.js - React Data Grid | Handsontable
 angular:
-  id: 4n6q9v2w
   metaTitle: Server-side Data with Express.js - Angular Data Grid | Handsontable
 vue:
-  id: 7r84584r
   metaTitle: Server-side Data with Express.js - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Data Management

--- a/docs/content/recipes/data-management/server-side-laravel/server-side-laravel.md
+++ b/docs/content/recipes/data-management/server-side-laravel/server-side-laravel.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: m4n7p2q8
 title: Server-side data with Laravel
 metaTitle: Server-side data with Laravel - JavaScript Data Grid | Handsontable
 description: Connect Handsontable's dataProvider plugin to a Laravel backend -- paginated fetchRows, server-side sorting and filtering, and full CRUD with onRowsCreate, onRowsUpdate, and onRowsRemove.
@@ -13,13 +12,10 @@ tags:
   - recipes
   - dataprovider
 react:
-  id: 1qclffzb
   metaTitle: Server-side data with Laravel - React Data Grid | Handsontable
 angular:
-  id: v9x1z3b5
   metaTitle: Server-side data with Laravel - Angular Data Grid | Handsontable
 vue:
-  id: vzywhp2f
   metaTitle: Server-side data with Laravel - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Data Management

--- a/docs/content/recipes/data-management/server-side-nestjs/server-side-nestjs.md
+++ b/docs/content/recipes/data-management/server-side-nestjs/server-side-nestjs.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: a3f82c91
 title: Server-side Data with NestJS
 metaTitle: Server-side Data with NestJS - JavaScript Data Grid | Handsontable
 description: Wire Handsontable's dataProvider plugin to a NestJS 10 backend with paginated, sorted, and filtered server-side data and full CRUD operations backed by PostgreSQL via TypeORM.
@@ -13,13 +12,10 @@ tags:
   - typescript
   - recipes
 react:
-  id: 02t7jojx
   metaTitle: Server-side data with NestJS - React Data Grid | Handsontable
 angular:
-  id: n3p5r7t9
   metaTitle: Server-side Data with NestJS - Angular Data Grid | Handsontable
 vue:
-  id: f362z4hr
   metaTitle: Server-side Data with NestJS - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Data Management

--- a/docs/content/recipes/data-management/server-side-rails/server-side-rails.md
+++ b/docs/content/recipes/data-management/server-side-rails/server-side-rails.md
@@ -1,5 +1,4 @@
 ---
-id: d8c51f2a
 title: Server-side data with Ruby on Rails
 metaTitle: Server-side Data with Ruby on Rails - JavaScript Data Grid | Handsontable
 description: Connect Handsontable's dataProvider plugin to a Ruby on Rails API-only backend with paginated fetching, server-side sorting and filtering, and full CRUD using the kaminari gem.
@@ -12,13 +11,10 @@ tags:
   - data-provider
   - recipe
 react:
-  id: r4k9m2p7
   metaTitle: Server-side Data with Ruby on Rails - React Data Grid | Handsontable
 angular:
-  id: s6n1q8t3
   metaTitle: Server-side Data with Ruby on Rails - Angular Data Grid | Handsontable
 vue:
-  id: adgrh6zv
   metaTitle: Server-side Data with Ruby on Rails - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Data Management

--- a/docs/content/recipes/data-management/server-side-spring/server-side-spring.md
+++ b/docs/content/recipes/data-management/server-side-spring/server-side-spring.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: b7e4912f
 title: Server-side Data with Spring Boot
 metaTitle: Server-side Data with Spring Boot - JavaScript Data Grid | Handsontable
 description: Wire Handsontable's dataProvider plugin to a Spring Boot 3 backend with JPA-backed pagination, server-side sorting and filtering, and full CRUD operations using H2.
@@ -13,13 +12,10 @@ tags:
   - java
   - recipes
 react:
-  id: tl8m1ydh
   metaTitle: Server-side data with Spring Boot - React Data Grid | Handsontable
 angular:
-  id: d7f9h1j3
   metaTitle: Server-side Data with Spring Boot - Angular Data Grid | Handsontable
 vue:
-  id: yllq4802
   metaTitle: Server-side Data with Spring Boot - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Data Management

--- a/docs/content/recipes/data-management/server-side-symfony/server-side-symfony.md
+++ b/docs/content/recipes/data-management/server-side-symfony/server-side-symfony.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: k3p5q8r2
 title: Server-side data with Symfony
 metaTitle: Server-side data with Symfony - JavaScript Data Grid | Handsontable
 description: Connect Handsontable's dataProvider plugin to a Symfony backend -- paginated fetchRows, server-side sorting and filtering, and full CRUD via REST API or GraphQL.
@@ -13,13 +12,10 @@ tags:
   - recipes
   - dataprovider
 react:
-  id: 9vzlddaa
   metaTitle: Server-side data with Symfony - React Data Grid | Handsontable
 angular:
-  id: h7j2m4n6
   metaTitle: Server-side data with Symfony - Angular Data Grid | Handsontable
 vue:
-  id: nwl1vnb4
   metaTitle: Server-side data with Symfony - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Data Management

--- a/docs/content/recipes/data-management/sync-two-grids/sync-two-grids.md
+++ b/docs/content/recipes/data-management/sync-two-grids/sync-two-grids.md
@@ -1,5 +1,4 @@
 ---
-id: c8f19a4e
 title: Sync two grids
 metaTitle: Sync two grids - JavaScript Data Grid | Handsontable
 description: Learn how to sync edits from a master grid to a detail grid in real time with afterChange, setDataAtCell(), and source guards.
@@ -11,13 +10,10 @@ tags:
   - recipes
   - data synchronization
 react:
-  id: e3b7d2f9
   metaTitle: Sync two grids - React Data Grid | Handsontable
 angular:
-  id: a6d4c1b8
   metaTitle: Sync two grids - Angular Data Grid | Handsontable
 vue:
-  id: cjulyg8p
   metaTitle: Sync two grids - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Data Management

--- a/docs/content/recipes/data-management/undo-redo-custom-ui/undo-redo-custom-ui.md
+++ b/docs/content/recipes/data-management/undo-redo-custom-ui/undo-redo-custom-ui.md
@@ -1,5 +1,4 @@
 ---
-id: e3a8f4c9
 title: Undo / redo with a custom UI
 metaTitle: Undo / redo with a custom UI - JavaScript Data Grid | Handsontable
 description: Build external Undo and Redo buttons that stay in sync with Handsontable undo/redo stack availability.
@@ -13,13 +12,10 @@ tags:
   - redo
   - custom ui
 react:
-  id: b7d1a2f6
   metaTitle: Undo / redo with a custom UI - React Data Grid | Handsontable
 angular:
-  id: c4e9b8a1
   metaTitle: Undo / redo with a custom UI - Angular Data Grid | Handsontable
 vue:
-  id: 3ku6qxps
   metaTitle: Undo / redo with a custom UI - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Data Management

--- a/docs/content/recipes/editing-validation/dependent-dropdowns/dependent-dropdowns.md
+++ b/docs/content/recipes/editing-validation/dependent-dropdowns/dependent-dropdowns.md
@@ -1,5 +1,4 @@
 ---
-id: b4n8q1z5
 title: Dependent dropdowns
 metaTitle: Dependent Dropdowns Recipe - JavaScript Data Grid | Handsontable
 description: Drive a child column dropdown from a parent column using a dependency map, afterChange, setCellMeta, and render.
@@ -12,13 +11,10 @@ tags:
   - dropdown
   - validation
 react:
-  id: c6m2r9s3
   metaTitle: Dependent Dropdowns Recipe - React Data Grid | Handsontable
 angular:
-  id: d8k4t7u1
   metaTitle: Dependent Dropdowns Recipe - Angular Data Grid | Handsontable
 vue:
-  id: 499xqog9
   metaTitle: Dependent Dropdowns Recipe - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Editing and Validation

--- a/docs/content/recipes/editing-validation/editing-validation.md
+++ b/docs/content/recipes/editing-validation/editing-validation.md
@@ -7,16 +7,12 @@ searchCategory: Recipes
 hotPlugin: false
 editLink: false
 type: how-to
-id: k3m9p2x7
 description: Recipes for dependent editors, validation patterns, submit-time checks, and dynamic cell configuration in Handsontable.
 react:
-  id: n5r8w1t4
   metaTitle: Editing and Validation Recipes - React Data Grid | Handsontable
 angular:
-  id: j7v2y6h9
   metaTitle: Editing and Validation Recipes - Angular Data Grid | Handsontable
 vue:
-  id: ack3fz98
   metaTitle: Editing and Validation Recipes - Vue Data Grid | Handsontable
 ---
 [[toc]]

--- a/docs/content/recipes/editing-validation/row-validation-error-summary/row-validation-error-summary.md
+++ b/docs/content/recipes/editing-validation/row-validation-error-summary/row-validation-error-summary.md
@@ -1,5 +1,4 @@
 ---
-id: f2q8n4k1
 title: Row validation with error summary
 metaTitle: Row Validation Error Summary Recipe - JavaScript Data Grid | Handsontable
 description: Validate every row on a Submit action, list failures outside the grid, highlight cells with htInvalid, and clear state when the user fixes a cell.
@@ -11,13 +10,10 @@ tags:
   - recipes
   - validation
 react:
-  id: g5r1m7p3
   metaTitle: Row Validation Error Summary Recipe - React Data Grid | Handsontable
 angular:
-  id: h8s4n9q6
   metaTitle: Row Validation Error Summary Recipe - Angular Data Grid | Handsontable
 vue:
-  id: 94krzohb
   metaTitle: Row Validation Error Summary Recipe - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Editing and Validation

--- a/docs/content/recipes/filtering-and-search/external-search-box/external-search-box.md
+++ b/docs/content/recipes/filtering-and-search/external-search-box/external-search-box.md
@@ -1,5 +1,4 @@
 ---
-id: b4c9e21f
 title: External search box
 metaTitle: External search box recipe - JavaScript Data Grid | Handsontable
 description: Learn how to add an external search input that highlights matching cells in Handsontable as you type.
@@ -12,13 +11,10 @@ tags:
   - search
   - filtering
 react:
-  id: a8e3d17c
   metaTitle: External search box recipe - React Data Grid | Handsontable
 angular:
-  id: d2f7b43a
   metaTitle: External search box recipe - Angular Data Grid | Handsontable
 vue:
-  id: 226dbr7q
   metaTitle: External search box recipe - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Filtering and Search

--- a/docs/content/recipes/filtering-and-search/filtering-and-search.md
+++ b/docs/content/recipes/filtering-and-search/filtering-and-search.md
@@ -7,16 +7,12 @@ searchCategory: Recipes
 hotPlugin: false
 editLink: false
 type: how-to
-id: b7d4k9q2
 description: Practical recipes for building external and in-grid search workflows with Handsontable.
 react:
-  id: r3n8x1m5
   metaTitle: Filtering and Search Recipes - React Data Grid | Handsontable
 angular:
-  id: a4p7c2v9
   metaTitle: Filtering and Search Recipes - Angular Data Grid | Handsontable
 vue:
-  id: h9ns5cm2
   metaTitle: Filtering and Search Recipes - Vue Data Grid | Handsontable
 ---
 [[toc]]

--- a/docs/content/recipes/filtering-and-search/highlight-search-matches/highlight-search-matches.md
+++ b/docs/content/recipes/filtering-and-search/highlight-search-matches/highlight-search-matches.md
@@ -1,5 +1,4 @@
 ---
-id: a7f4d2c1
 title: Highlight search matches
 metaTitle: Highlight Search Matches - JavaScript Data Grid | Handsontable
 description: Learn how to highlight matched text fragments with a custom renderer that safely uses mark tags and updates in real time from a search input.
@@ -12,13 +11,10 @@ tags:
   - search
   - renderer
 react:
-  id: e9b3f6a2
   metaTitle: Highlight Search Matches - React Data Grid | Handsontable
 angular:
-  id: c4d8e1b5
   metaTitle: Highlight Search Matches - Angular Data Grid | Handsontable
 vue:
-  id: trf4mxau
   metaTitle: Highlight Search Matches - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Filtering and Search

--- a/docs/content/recipes/filtering-search/filtering-search.md
+++ b/docs/content/recipes/filtering-search/filtering-search.md
@@ -7,16 +7,12 @@ searchCategory: Recipes
 hotPlugin: false
 editLink: false
 type: how-to
-id: b9f32a7c
 description: Practical recipes for building external filtering and search interfaces with Handsontable.
 react:
-  id: 24e7c1a8
   metaTitle: Filtering and Search Recipes - React Data Grid | Handsontable
 angular:
-  id: d8a41e6f
   metaTitle: Filtering and Search Recipes - Angular Data Grid | Handsontable
 vue:
-  id: g6b02455
   metaTitle: Filtering and Search Recipes - Vue Data Grid | Handsontable
 ---
 [[toc]]

--- a/docs/content/recipes/filtering-search/multi-column-filter-panel/multi-column-filter-panel.md
+++ b/docs/content/recipes/filtering-search/multi-column-filter-panel/multi-column-filter-panel.md
@@ -1,5 +1,4 @@
 ---
-id: a8d14c7b
 title: Multi-column filter panel
 metaTitle: Multi-column Filter Panel - JavaScript Data Grid | Handsontable
 description: Build an external filter panel with a category dropdown and a price range that controls Handsontable filtering through the Filters plugin API.
@@ -13,13 +12,10 @@ tags:
   - search
   - filters plugin
 react:
-  id: c3e8f291
   metaTitle: Multi-column Filter Panel - React Data Grid | Handsontable
 angular:
-  id: f6b25d0a
   metaTitle: Multi-column Filter Panel - Angular Data Grid | Handsontable
 vue:
-  id: ypksrbh0
   metaTitle: Multi-column Filter Panel - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Filtering and Search

--- a/docs/content/recipes/import-export/export-to-pdf/export-to-pdf.md
+++ b/docs/content/recipes/import-export/export-to-pdf/export-to-pdf.md
@@ -1,5 +1,4 @@
 ---
-id: f7a3c82e
 title: Export to PDF
 metaTitle: Export Handsontable to PDF - JavaScript Data Grid | Handsontable
 description: Export grid data to a downloadable PDF with jsPDF and jspdf-autotable, including headers and multi-page tables.
@@ -10,13 +9,10 @@ tags:
   - tutorial
   - recipes
 react:
-  id: a8b4d93f
   metaTitle: Export Handsontable to PDF - React Data Grid | Handsontable
 angular:
-  id: b9c5e04a
   metaTitle: Export Handsontable to PDF - Angular Data Grid | Handsontable
 vue:
-  id: m4s0kgub
   metaTitle: Export Handsontable to PDF - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Import and Export

--- a/docs/content/recipes/import-export/import-csv-excel/import-csv-excel.md
+++ b/docs/content/recipes/import-export/import-csv-excel/import-csv-excel.md
@@ -1,5 +1,4 @@
 ---
-id: h7j2k9m4
 title: Import from CSV or Excel
 metaTitle: Import CSV or Excel - JavaScript Data Grid | Handsontable
 description: Load CSV or XLSX files into Handsontable with PapaParse and SheetJS, preview headers, and handle errors in the browser.
@@ -12,13 +11,10 @@ tags:
   - excel
   - xlsx
 react:
-  id: n5p8q3r6
   metaTitle: Import CSV or Excel - React Data Grid | Handsontable
 angular:
-  id: s9t2u7v0
   metaTitle: Import CSV or Excel - Angular Data Grid | Handsontable
 vue:
-  id: 9z4rb007
   metaTitle: Import CSV or Excel - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Import and Export

--- a/docs/content/recipes/import-export/import-export.md
+++ b/docs/content/recipes/import-export/import-export.md
@@ -7,16 +7,12 @@ searchCategory: Recipes
 hotPlugin: false
 editLink: false
 type: how-to
-id: c4e8a91f
 description: Practical recipes for moving data in and out of Handsontable.
 react:
-  id: d5f9b02a
   metaTitle: Import and Export Recipes - React Data Grid | Handsontable
 angular:
-  id: e6f0c13b
   metaTitle: Import and Export Recipes - Angular Data Grid | Handsontable
 vue:
-  id: z9gel8zf
   metaTitle: Import and Export Recipes - Vue Data Grid | Handsontable
 ---
 [[toc]]

--- a/docs/content/recipes/introduction.md
+++ b/docs/content/recipes/introduction.md
@@ -1,5 +1,4 @@
 ---
-id: 5a27e806
 title: Recipes
 metaTitle: Recipes - JavaScript Data Grid | Handsontable
 description: Developer recipes and step-by-step tutorials for building with Handsontable
@@ -8,13 +7,10 @@ canonicalUrl: /recipes/
 searchCategory: Recipes
 type: how-to
 react:
-  id: 1ae45a27
   metaTitle: Recipes - React Data Grid | Handsontable
 angular:
-  id: d2815b7b
   metaTitle: Recipes - Angular Data Grid | Handsontable
 vue:
-  id: 5axgi4x9
   metaTitle: Recipes - Vue Data Grid | Handsontable
 ---
 

--- a/docs/content/recipes/performance/lazy-loading/lazy-loading.md
+++ b/docs/content/recipes/performance/lazy-loading/lazy-loading.md
@@ -1,5 +1,4 @@
 ---
-id: b3f2a1c9
 title: Lazy loading with pagination
 metaTitle: Lazy loading with pagination - JavaScript Data Grid | Handsontable
 description: Load data page-by-page as the user scrolls to the bottom of the grid, using the afterScrollVertically hook and hot.updateData() to append rows without resetting scroll position.
@@ -14,13 +13,10 @@ tags:
   - lazy loading
   - infinite scroll
 react:
-  id: c4e7d1f8
   metaTitle: Lazy loading with pagination - React Data Grid | Handsontable
 angular:
-  id: d5f8e2a9
   metaTitle: Lazy loading with pagination - Angular Data Grid | Handsontable
 vue:
-  id: agk0hqm7
   metaTitle: Lazy loading with pagination - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Performance

--- a/docs/content/recipes/performance/performance.md
+++ b/docs/content/recipes/performance/performance.md
@@ -8,15 +8,11 @@ searchCategory: Recipes
 hotPlugin: false
 editLink: false
 type: how-to
-id: e7c3b1a9
 react:
-  id: f8d4c2ba
   metaTitle: Performance Recipes - React Data Grid | Handsontable
 angular:
-  id: a9e5d3cb
   metaTitle: Performance Recipes - Angular Data Grid | Handsontable
 vue:
-  id: u4oumcn2
   metaTitle: Performance Recipes - Vue Data Grid | Handsontable
 ---
 [[toc]]

--- a/docs/content/recipes/performance/persist-column-layout/persist-column-layout.md
+++ b/docs/content/recipes/performance/persist-column-layout/persist-column-layout.md
@@ -1,5 +1,4 @@
 ---
-id: f3a9b2d7
 title: Persist and restore column widths and order
 metaTitle: Persist and restore column widths and order - JavaScript Data Grid | Handsontable
 description: Save column widths and column order to localStorage as the user resizes or reorders columns, then restore that layout on grid initialization -- so preferences survive a page refresh.
@@ -15,13 +14,10 @@ tags:
   - afterColumnMove
   - performance
 react:
-  id: a8c2f1e9
   metaTitle: Persist and restore column widths and order - React Data Grid | Handsontable
 angular:
-  id: b5d3e7f0
   metaTitle: Persist and restore column widths and order - Angular Data Grid | Handsontable
 vue:
-  id: zohalhhu
   metaTitle: Persist and restore column widths and order - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Performance

--- a/docs/content/recipes/real-time/chartjs-sync/chartjs-sync.md
+++ b/docs/content/recipes/real-time/chartjs-sync/chartjs-sync.md
@@ -1,5 +1,4 @@
 ---
-id: a3f7b2c9
 title: Sync rows to a Chart.js chart
 metaTitle: Sync selected rows to a Chart.js chart - JavaScript Data Grid | Handsontable
 description: Learn how to sync selected rows from a Handsontable grid to a Chart.js bar chart in real time using the afterSelectionEnd hook.
@@ -12,13 +11,10 @@ tags:
   - selection
   - real-time
 react:
-  id: b5e8d1f4
   metaTitle: Sync selected rows to a Chart.js chart - React Data Grid | Handsontable
 angular:
-  id: c6f9e2a5
   metaTitle: Sync selected rows to a Chart.js chart - Angular Data Grid | Handsontable
 vue:
-  id: w5h61ok1
   metaTitle: Sync selected rows to a Chart.js chart - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Real-time and Integrations

--- a/docs/content/recipes/real-time/real-time.md
+++ b/docs/content/recipes/real-time/real-time.md
@@ -8,15 +8,11 @@ searchCategory: Recipes
 hotPlugin: false
 editLink: false
 type: how-to
-id: w4d6e8f0
 react:
-  id: x5e7f9g1
   metaTitle: Real-time and Integration Recipes - React Data Grid | Handsontable
 angular:
-  id: y6f8g0h2
   metaTitle: Real-time and Integration Recipes - Angular Data Grid | Handsontable
 vue:
-  id: g4d4zmrv
   metaTitle: Real-time and Integration Recipes - Vue Data Grid | Handsontable
 ---
 [[toc]]

--- a/docs/content/recipes/real-time/websocket-updates/websocket-updates.md
+++ b/docs/content/recipes/real-time/websocket-updates/websocket-updates.md
@@ -1,5 +1,4 @@
 ---
-id: b3e7f2a1
 title: Real-time cell updates via WebSocket
 metaTitle: Real-time WebSocket Updates - JavaScript Data Grid | Handsontable
 description: Learn how to connect Handsontable to a WebSocket and update individual cells in real time using setDataAtCell, without re-rendering the entire grid.
@@ -13,13 +12,10 @@ tags:
   - tutorial
   - recipes
 react:
-  id: c4f8a2e7
   metaTitle: Real-time WebSocket Updates - React Data Grid | Handsontable
 angular:
-  id: d9b1e5f3
   metaTitle: Real-time WebSocket Updates - Angular Data Grid | Handsontable
 vue:
-  id: fvoen1lx
   metaTitle: Real-time WebSocket Updates - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Real-time & Integrations

--- a/docs/content/recipes/rendering-styling/conditional-row-coloring/conditional-row-coloring.md
+++ b/docs/content/recipes/rendering-styling/conditional-row-coloring/conditional-row-coloring.md
@@ -1,5 +1,4 @@
 ---
-id: ceb1a2d8
 title: Conditional row coloring
 metaTitle: Conditional row coloring - JavaScript Data Grid | Handsontable
 description: Color entire rows from a status column using the cells callback, className, and scoped CSS that updates after edits.
@@ -11,13 +10,10 @@ tags:
   - recipes
   - styling
 react:
-  id: f7c3e91a
   metaTitle: Conditional row coloring - React Data Grid | Handsontable
 angular:
-  id: b2d804e6
   metaTitle: Conditional row coloring - Angular Data Grid | Handsontable
 vue:
-  id: 99nmgb2v
   metaTitle: Conditional row coloring - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Rendering and styling

--- a/docs/content/recipes/rendering-styling/frozen-summary-row/frozen-summary-row.md
+++ b/docs/content/recipes/rendering-styling/frozen-summary-row/frozen-summary-row.md
@@ -1,5 +1,4 @@
 ---
-id: k9m2xp4q
 title: Frozen summary row
 metaTitle: Frozen summary row recipe - JavaScript Data Grid | Handsontable
 description: Pin a read-only totals row at the bottom with fixedRowsBottom, recalculate on afterChange, and style it with the cells callback.
@@ -12,13 +11,10 @@ tags:
   - fixed rows
   - summary
 react:
-  id: n4w7rt8y
   metaTitle: Frozen summary row recipe - React Data Grid | Handsontable
 angular:
-  id: h3j6vs2b
   metaTitle: Frozen summary row recipe - Angular Data Grid | Handsontable
 vue:
-  id: 3udunsuv
   metaTitle: Frozen summary row recipe - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Rendering and styling

--- a/docs/content/recipes/rendering-styling/rendering-styling.md
+++ b/docs/content/recipes/rendering-styling/rendering-styling.md
@@ -7,16 +7,12 @@ searchCategory: Recipes
 hotPlugin: false
 editLink: false
 type: how-to
-id: a8f3c91d
 description: Practical recipes for row layout, summaries, custom renderers, and visual styling in Handsontable.
 react:
-  id: b2e4d80a
   metaTitle: Rendering and styling recipes - React Data Grid | Handsontable
 angular:
-  id: c7f1a92e
   metaTitle: Rendering and styling recipes - Angular Data Grid | Handsontable
 vue:
-  id: l2jehwoc
   metaTitle: Rendering and styling recipes - Vue Data Grid | Handsontable
 ---
 [[toc]]

--- a/docs/content/recipes/rendering-styling/sparkline-cell-renderer/sparkline-cell-renderer.md
+++ b/docs/content/recipes/rendering-styling/sparkline-cell-renderer/sparkline-cell-renderer.md
@@ -1,5 +1,4 @@
 ---
-id: e4a91c2b
 title: Sparkline cell renderer
 metaTitle: Sparkline cell renderer - JavaScript Data Grid | Handsontable
 description: Build a custom Handsontable cell renderer that draws an inline SVG bar chart from an array of numbers in each cell.
@@ -11,13 +10,10 @@ tags:
   - recipes
   - renderer
 react:
-  id: f8d03a71
   metaTitle: Sparkline cell renderer - React Data Grid | Handsontable
 angular:
-  id: a1c9e582
   metaTitle: Sparkline cell renderer - Angular Data Grid | Handsontable
 vue:
-  id: x00kh9c9
   metaTitle: Sparkline cell renderer - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Rendering and styling

--- a/docs/content/recipes/themes/ant-design/ant-design.md
+++ b/docs/content/recipes/themes/ant-design/ant-design.md
@@ -1,5 +1,4 @@
 ---
-id: f2a9c4d1
 title: Handsontable with Ant Design
 metaTitle: Handsontable with Ant Design - React Data Grid | Handsontable
 description: Integrate Handsontable into a React app that uses Ant Design, and align the grid with your design system tokens through the Theme API.
@@ -15,13 +14,10 @@ tags:
   - themes
   - Theme API
 react:
-  id: a8d3e6f2
   metaTitle: Handsontable with Ant Design - React Data Grid | Handsontable
 angular:
-  id: c4b7e1a9
   metaTitle: Handsontable with Ant Design - Angular Data Grid | Handsontable
 vue:
-  id: 1idm09eu
 searchCategory: Recipes
 category: Themes
 type: how-to

--- a/docs/content/recipes/themes/base-theme/base-theme.md
+++ b/docs/content/recipes/themes/base-theme/base-theme.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: q7n4k2p9
 title: Handsontable with Base Web
 metaTitle: Handsontable with Base Web - React Data Grid | Handsontable
 description: Integrate Handsontable into a React app using Base Web and style a custom theme with your design tokens so the grid matches your design system.
@@ -17,13 +16,10 @@ tags:
   - Theme API
   - custom theme
 react:
-  id: t3m8v6c1
   metaTitle: Handsontable with Base Web - React Data Grid | Handsontable
 angular:
-  id: w5r2d8h4
   metaTitle: Handsontable with Base Web - Angular Data Grid | Handsontable
 vue:
-  id: x4lqd0rx
 searchCategory: Recipes
 category: Themes
 ---

--- a/docs/content/recipes/themes/custom-theme/custom-theme.md
+++ b/docs/content/recipes/themes/custom-theme/custom-theme.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: 8f3c91ab
 title: Handsontable with shadcn/ui
 metaTitle: Handsontable with shadcn/ui - React Data Grid | Handsontable
 description: Integrate Handsontable into a React app using shadcn/ui so the grid matches your design system colors, typography, and dark mode via the Theme API.
@@ -18,13 +17,10 @@ tags:
   - Theme API
   - custom theme
 react:
-  id: 9a4d82bc
   metaTitle: Handsontable with shadcn/ui - React Data Grid | Handsontable
 angular:
-  id: b582k93d
   metaTitle: Handsontable with shadcn/ui - Angular Data Grid | Handsontable
 vue:
-  id: jo0cv4kp
 searchCategory: Recipes
 category: Themes
 ---

--- a/docs/content/recipes/themes/fluent-ui/fluent-ui.md
+++ b/docs/content/recipes/themes/fluent-ui/fluent-ui.md
@@ -1,5 +1,4 @@
 ---
-id: p7f3k9d2
 title: Handsontable with Fluent UI
 metaTitle: Handsontable with Fluent UI - React Data Grid | Handsontable
 description: Integrate Handsontable into a React app with Fluent UI so your grid follows Fluent colors, typography, and spacing.
@@ -15,7 +14,6 @@ tags:
   - themes
   - Theme API
 react:
-  id: v4m8q1t6
   metaTitle: Handsontable with Fluent UI - React Data Grid | Handsontable
 searchCategory: Recipes
 category: Themes

--- a/docs/content/recipes/themes/mui-theme/mui-theme.md
+++ b/docs/content/recipes/themes/mui-theme/mui-theme.md
@@ -1,6 +1,5 @@
 ---
 type: how-to
-id: f2a7b9c1
 title: Handsontable with MUI
 metaTitle: Handsontable with MUI - JavaScript Data Grid | Handsontable
 description: Integrate Handsontable into a React app with MUI so your grid follows Material UI colors, typography, and spacing.
@@ -17,13 +16,10 @@ tags:
   - themes
   - Theme API
 react:
-  id: d4e8a6f2
   metaTitle: Handsontable with MUI - React Data Grid | Handsontable
 angular:
-  id: a3b7c9e1
   metaTitle: Handsontable with MUI - Angular Data Grid | Handsontable
 vue:
-  id: 6qpczr7i
   metaTitle: Handsontable with MUI - Vue Data Grid | Handsontable
 searchCategory: Recipes
 category: Themes

--- a/docs/content/recipes/themes/themes.md
+++ b/docs/content/recipes/themes/themes.md
@@ -7,16 +7,12 @@ searchCategory: Recipes
 hotPlugin: false
 editLink: false
 type: how-to
-id: a8f2d91c
 description: Practical recipes for integrating Handsontable with design systems and UI libraries.
 react:
-  id: b3e4c82d
   metaTitle: Theme Recipes - React Data Grid | Handsontable
 angular:
-  id: c5f6d93e
   metaTitle: Theme Recipes - Angular Data Grid | Handsontable
 vue:
-  id: iyf124u6
   metaTitle: Theme Recipes - Vue Data Grid | Handsontable
 ---
 [[toc]]


### PR DESCRIPTION
### Context

The PR removes obsolete frontmatter `id` fields from existing docs pages after the Astro Starlight migration made those IDs unused. It updates the remaining legacy pages so docs frontmatter follows the current authoring rules and avoids carrying dead metadata.

[skip changelog]

### How has this been tested?

- `npm --prefix docs run docs:test:plugins`
- `npm --prefix docs run build`
- Verified no frontmatter-level `id:` remains under `docs/content/**/*.md`.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
2. https://app.clickup.com/t/9015210959/DEV-1965

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only frontmatter cleanup with no runtime or API changes; risk is limited to docs build/metadata if anything still expected the old `id` fields.
> 
> **Overview**
> Removes legacy **`id`** entries from YAML frontmatter across a large set of docs under **`docs/content`** (API intro/plugins, guides, recipes, migration pages, and related pages). **Framework-specific `id` values nested under `react`, `angular`, and `vue` are removed as well**, while fields such as `title`, `permalink`, `metaTitle`, and `searchCategory` are unchanged.
> 
> This aligns authoring with the **Astro Starlight** docs setup, where those opaque IDs are no longer used for routing or page identity (URLs and metadata come from **`permalink`** and the remaining frontmatter instead).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ee14590f1d79f5198ed050ff70d1577da7ffeb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->