### PR TITLE
DEV-1967: Use version-relative @/ docs links in JSDoc

### DIFF
--- a/handsontable/src/plugins/columnSorting/columnSorting.ts
+++ b/handsontable/src/plugins/columnSorting/columnSorting.ts
@@ -103,7 +103,7 @@ const pluginConflictsState = new WeakMap();
  * }
  *
  * // as an object passed to the `column` property, allows specifying a custom options for the desired column.
- * // please take a look at documentation of `column` property: https://handsontable.com/docs/Options.html#columns
+ * // see the `columns` option documentation: @/api/options.md#columns
  * columns: [{
  *   columnSorting: {
  *     indicator: false, // disable indicator for the first column,

--- a/handsontable/src/plugins/formulas/formulas.ts
+++ b/handsontable/src/plugins/formulas/formulas.ts
@@ -1224,7 +1224,7 @@ export class Formulas extends BasePlugin {
    *
    * @param {Array[]} changes An array of changes in format [[row, prop, oldValue, value], ...].
    * @param {string} [source] String that identifies source of hook call
-   *                          ([list of all available sources]{@link https://handsontable.com/docs/javascript-data-grid/events-and-hooks/#handsontable-hooks}).
+   *                          ([list of all available sources](@/guides/getting-started/events-and-hooks/events-and-hooks.md#definition-for-source-argument)).
    */
   #onAfterSetDataAtCell = (changes: CellChange[], source: string) => {
     if (isBlockedSource(source)) {
@@ -1290,7 +1290,7 @@ export class Formulas extends BasePlugin {
    *
    * @param {Array[]} changes An array of changes in format [[row, column, oldValue, value], ...].
    * @param {string} [source] String that identifies source of hook call
-   *                          ([list of all available sources]{@link https://handsontable.com/docs/javascript-data-grid/events-and-hooks/#handsontable-hooks}).
+   *                          ([list of all available sources](@/guides/getting-started/events-and-hooks/events-and-hooks.md#definition-for-source-argument)).
    */
   #onAfterSetSourceDataAtCell = (changes: CellChange[], source: string) => {
     if (isBlockedSource(source)) {
@@ -1420,7 +1420,7 @@ export class Formulas extends BasePlugin {
    * @param {number} visualRow Represents the visual index of first newly created row in the data source array.
    * @param {number} amount Number of newly created rows in the data source array.
    * @param {string} [source] String that identifies source of hook call
-   *                          ([list of all available sources]{@link https://handsontable.com/docs/javascript-data-grid/events-and-hooks/#handsontable-hooks}).
+   *                          ([list of all available sources](@/guides/getting-started/events-and-hooks/events-and-hooks.md#definition-for-source-argument)).
    */
   #onAfterCreateRow = (visualRow: number, amount: number, source: string) => {
     if (isBlockedSource(source)) {
@@ -1439,7 +1439,7 @@ export class Formulas extends BasePlugin {
    * @param {number} visualColumn Represents the visual index of first newly created column in the data source.
    * @param {number} amount Number of newly created columns in the data source.
    * @param {string} [source] String that identifies source of hook call
-   *                          ([list of all available sources]{@link https://handsontable.com/docs/javascript-data-grid/events-and-hooks/#handsontable-hooks}).
+   *                          ([list of all available sources](@/guides/getting-started/events-and-hooks/events-and-hooks.md#definition-for-source-argument)).
    */
   #onAfterCreateCol = (visualColumn: number, amount: number, source: string) => {
     if (isBlockedSource(source)) {
@@ -1459,7 +1459,7 @@ export class Formulas extends BasePlugin {
    * @param {number} amount An amount of removed rows.
    * @param {number[]} physicalRows An array of physical rows removed from the data source.
    * @param {string} [source] String that identifies source of hook call
-   *                          ([list of all available sources]{@link https://handsontable.com/docs/javascript-data-grid/events-and-hooks/#handsontable-hooks}).
+   *                          ([list of all available sources](@/guides/getting-started/events-and-hooks/events-and-hooks.md#definition-for-source-argument)).
    */
   #onAfterRemoveRow = (row: number, amount: number, physicalRows: number[], source: string) => {
     if (isBlockedSource(source)) {
@@ -1486,7 +1486,7 @@ export class Formulas extends BasePlugin {
    * @param {number} amount An amount of removed columns.
    * @param {number[]} physicalColumns An array of physical columns removed from the data source.
    * @param {string} [source] String that identifies source of hook call
-   *                          ([list of all available sources]{@link https://handsontable.com/docs/javascript-data-grid/events-and-hooks/#handsontable-hooks}).
+   *                          ([list of all available sources](@/guides/getting-started/events-and-hooks/events-and-hooks.md#definition-for-source-argument)).
    */
   #onAfterRemoveCol = (col: number, amount: number, physicalColumns: number[], source: string) => {
     if (isBlockedSource(source)) {


### PR DESCRIPTION
### Context

The PR fixes absolute `handsontable.com/docs` links in core JSDoc so the API reference links stay within the version the reader is viewing. An absolute `{@link https://handsontable.com/docs/...}` link always resolves to the *latest* docs version, so a reader browsing an older version's API reference is silently bumped to latest when clicking it. The JSDoc link post-processor (`docs/scripts/jsdoc-convert/renderer/postProcessors/jsdocLinksFixer.mjs`) deliberately skips any URL containing `://`, so absolute URLs are never rewritten to a version-relative form. The fix uses the internal `@/guides/...` / `@/api/...` link form, which the docs build resolves relative to the version being viewed.

Follow-up from PR #12885, which fixed the first occurrence. This PR covers the remaining pre-existing occurrences.

Changes:

- `handsontable/src/plugins/formulas/formulas.ts` - converted 6 identical `[source]` param links from `([list of all available sources]{@link https://handsontable.com/docs/.../events-and-hooks/#handsontable-hooks})` to `([list of all available sources](@/guides/getting-started/events-and-hooks/events-and-hooks.md#definition-for-source-argument))`, matching the 12+ sibling occurrences in `core/hooks/constants.ts`.
- `handsontable/src/plugins/columnSorting/columnSorting.ts` - replaced the legacy absolute URL `https://handsontable.com/docs/Options.html#columns` with the version-relative `@/api/options.md#columns` reference.

### How has this been tested?

- Audit re-run: `rg -n "handsontable.com/docs" handsontable/src` now shows only out-of-scope runtime `<a href>` strings in `helpers/mixed.ts` (browser console warnings, not JSDoc).
- JSDoc lint: `npm run eslint --prefix handsontable` - no issues on the changed files.
- Verified the `jsdocLinksFixer` post-processor passes both new `@/...` links through unchanged as valid markdown links.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1967

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

This is a JSDoc/comment-only change with no runtime behavior change, so `[skip changelog]`.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1967

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> JSDoc and documentation link text only; no executable code paths change.
> 
> **Overview**
> Replaces remaining **absolute** `handsontable.com/docs` URLs in core JSDoc with **version-relative** `@/guides/...` and `@/api/...` links so API reference clicks stay on the docs version being viewed (absolute links are not rewritten by `jsdocLinksFixer`).
> 
> In **`formulas.ts`**, six identical hook `source` parameter notes now point to `@/guides/getting-started/events-and-hooks/events-and-hooks.md#definition-for-source-argument`, aligned with `core/hooks/constants.ts`. In **`columnSorting.ts`**, the `columns` option example comment now references `@/api/options.md#columns` instead of the legacy `Options.html#columns` URL.
> 
> **No runtime or API behavior changes**—comments and generated doc links only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a6a03f7c7683986418a842ed9375abd3472c705. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->