### PR TITLE
DEV-1030: Improve filter option code snippet

### DIFF
--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -2721,10 +2721,9 @@ export default (): Record<string, unknown> => {
      *   // set the `type` of each cell in this column to `autocomplete`
      *   type: 'autocomplete',
      *   // set options available in every `autocomplete` cell of this column
-     *   source: ['A', 'B', 'C'],
-     *   // when the end user types in `A`, display only the A option
-     *   // when the end user types in `B`, display only the B option
-     *   // when the end user types in `C`, display only the C option
+     *   source: ['Apple', 'Apricot', 'Avocado', 'Banana', 'Blueberry'],
+     *   // when the end user types in `a`, display options that contain `a`
+     *   // when the end user types in `ap`, display only `Apple` and `Apricot`
      *   filter: true
      * }],
      * ```


### PR DESCRIPTION
### Context

The PR improves the `filter` option API documentation example for `autocomplete` so the filtering behavior is clear with realistic, multi-match values.
It addresses DEV-1030 by replacing the old `['A', 'B', 'C']` snippet with a concise fruit list and updated explanatory comments.

### How has this been tested?

- `npm --prefix handsontable run eslint`
- `npm --prefix handsontable run stylelint`

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1030

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1030

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only JSDoc example change; no runtime or API behavior changes.
> 
> **Overview**
> Updates the JSDoc `@example` for the **`filter`** option on autocomplete columns in `metaSchema.ts`.
> 
> The sample **`source`** list is changed from `['A', 'B', 'C']` to a fruit list so substring filtering is easier to see. The inline comments now describe typing **`a`** vs **`ap`** and which options remain, instead of implying one letter maps to one option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f9a4f33eec23a7acca21366cdffe581eaf60e52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->