### PR TITLE
DEV-1051: Clarify filter hook index semantics

### DIFF
--- a/handsontable/src/core/hooks/constants.ts
+++ b/handsontable/src/core/hooks/constants.ts
@@ -2690,7 +2690,7 @@ export const REGISTERED_HOOKS = [
    *
    * | Property     | Possible values                                                         | Description                                                                                                              |
    * | ------------ | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-   * | `column`     | Number                                                                  | A visual index of the column to which the filter will be applied.                                                        |
+   * | `column`     | Number                                                                  | A physical index of the column to which the filter will be applied.                                                      |
    * | `conditions` | Array of objects                                                        | Each object represents one condition. For details, see [`addCondition()`](@/api/filters.md#addcondition).                |
    * | `operation`  | `'conjunction'` \| `'disjunction'` \| `'disjunctionWithExtraCondition'` | An operation to perform on your set of `conditions`. For details, see [`addCondition()`](@/api/filters.md#addcondition). |
    *
@@ -2750,7 +2750,7 @@ export const REGISTERED_HOOKS = [
    *
    * | Property     | Possible values                                                         | Description                                                                                                              |
    * | ------------ | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-   * | `column`     | Number                                                                  | A visual index of the column to which the filter was applied.                                                            |
+   * | `column`     | Number                                                                  | A physical index of the column to which the filter was applied.                                                          |
    * | `conditions` | Array of objects                                                        | Each object represents one condition. For details, see [`addCondition()`](@/api/filters.md#addcondition).                |
    * | `operation`  | `'conjunction'` \| `'disjunction'` \| `'disjunctionWithExtraCondition'` | An operation to perform on your set of `conditions`. For details, see [`addCondition()`](@/api/filters.md#addcondition). |
    *

--- a/handsontable/src/plugins/filters/__tests__/hooks/afterFilter.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/hooks/afterFilter.spec.js
@@ -103,4 +103,38 @@ describe('`afterFilter` hook', () => {
       'highlight: 2,2 from: 2,2 to: 5,5',
     ]);
   });
+
+  it('should be triggered with physical column indexes after moving columns', async() => {
+    const afterFilter = jasmine.createSpy('afterFilter');
+
+    handsontable({
+      data: [
+        ['A1', 'B1', 'C1'],
+        ['A2', 'B2', 'C2'],
+      ],
+      colHeaders: true,
+      dropdownMenu: true,
+      manualColumnMove: true,
+      filters: true,
+      width: 500,
+      height: 300,
+      afterFilter,
+    });
+
+    const plugin = getPlugin('filters');
+    const manualColumnMove = getPlugin('manualColumnMove');
+
+    manualColumnMove.moveColumn(0, 2);
+    await render();
+    plugin.addCondition(2, 'begins_with', ['a']);
+    plugin.filter();
+
+    expect(afterFilter).toHaveBeenCalledWith([
+      {
+        column: 0,
+        operation: 'conjunction',
+        conditions: [{ name: 'begins_with', args: ['a'] }]
+      }
+    ]);
+  });
 });

--- a/handsontable/src/plugins/filters/filters.ts
+++ b/handsontable/src/plugins/filters/filters.ts
@@ -932,11 +932,12 @@ export class Filters extends BasePlugin {
   /**
    * Imports filter conditions to all columns to the plugin. The method accepts
    * the array of conditions with the same structure as the {@link Filters#exportConditions} method returns.
+   * The `column` property in each condition object must be a physical column index.
    * Importing conditions will replace the current conditions. Once replaced, the state of the condition
    * will be reflected in the UI. To apply the changes and filter the table, call
    * the {@link Filters#filter} method eventually.
    *
-   * @param {Array} conditions Array of conditions.
+   * @param {Array} conditions Array of conditions keyed by physical column indexes.
    */
   importConditions(conditions: ColumnConditions[]): void {
     this.conditionCollection?.importAllConditions(conditions);
@@ -944,7 +945,8 @@ export class Filters extends BasePlugin {
 
   /**
    * Exports filter conditions for all columns from the plugin.
-   * The array represents the filter state for each column. For example:
+   * The array represents the filter state for each column and uses physical column indexes in each `column` property.
+   * For example:
    *
    * ```js
    * [


### PR DESCRIPTION
### Context

The PR fixes a documentation mismatch in the Filters hook API: `beforeFilter`/`afterFilter` currently document `conditionsStack[].column` as visual, while runtime behavior uses physical indexes.

### How has this been tested?

- `rtk npm run test:e2e --prefix handsontable --testPathPattern=afterFilter.spec.js`

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1051

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1051

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test-only changes; filter behavior is unchanged.
> 
> **Overview**
> Aligns **Filters** documentation with existing runtime behavior: `conditionsStack[].column` in **`beforeFilter`** and **`afterFilter`** is documented as a **physical** column index, not visual.
> 
> **`importConditions`** / **`exportConditions`** JSDoc now states that each `column` value must use physical indexes, matching what `exportConditions()` already returns from the condition collection.
> 
> Adds an **`afterFilter`** test that moves a column with **`manualColumnMove`**, filters by visual index `2`, and asserts the hook receives `column: 0` (physical). No filtering logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea6ef3d60841add978f87ee9a32ae23ea8039013. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->