### PR TITLE
DEV-1145: Add interactive demo for grid-edge wrap selection

### DIFF
--- a/docs/content/guides/cell-features/selection/angular/example6.html
+++ b/docs/content/guides/cell-features/selection/angular/example6.html
@@ -1,0 +1,3 @@
+<div>
+  <example6-selection></example6-selection>
+</div>

--- a/docs/content/guides/cell-features/selection/angular/example6.ts
+++ b/docs/content/guides/cell-features/selection/angular/example6.ts
@@ -1,0 +1,77 @@
+/* file: app.component.ts */
+import { Component, ViewChild } from '@angular/core';
+import { GridSettings, HotTableComponent, HotTableModule } from '@handsontable/angular-wrapper';
+
+@Component({
+  selector: 'example6-selection',
+  standalone: true,
+  imports: [HotTableModule],
+  template: ` <div class="example-controls-container">
+      <div class="controls">
+        <label>
+          <input type="checkbox" checked (change)="toggleAutoWrapRow($event)">
+          Wrap at the left/right edges (autoWrapRow)
+        </label>
+        <label>
+          <input type="checkbox" checked (change)="toggleAutoWrapCol($event)">
+          Wrap at the top/bottom edges (autoWrapCol)
+        </label>
+      </div>
+      <p>
+        Select a cell, then press <kbd>Tab</kbd> or <kbd>&rarr;</kbd> at the end of a row, or <kbd>Enter</kbd> or
+        <kbd>&darr;</kbd> at the bottom of a column, to see the effect.
+      </p>
+    </div>
+    <div>
+      <hot-table [data]="data" [settings]="gridSettings"></hot-table>
+    </div>`,
+})
+export class AppComponent {
+  @ViewChild(HotTableComponent, { static: false }) readonly hotTable!: HotTableComponent;
+
+  readonly data = [
+    ['SKU-4821', 'Harbor Goods', 'Electronics', 142],
+    ['SKU-0093', 'Alpine Supply Co.', 'Apparel', 67],
+    ['SKU-2210', 'Harbor Goods', 'Electronics', 0],
+    ['SKU-7734', 'Nordic Traders', 'Home Goods', 58],
+    ['SKU-1145', 'Alpine Supply Co.', 'Apparel', 213],
+  ];
+
+  readonly gridSettings: GridSettings = {
+    colHeaders: ['SKU', 'Supplier', 'Category', 'Quantity'],
+    width: 'auto',
+    height: 'auto',
+    rowHeaders: true,
+    autoWrapRow: true,
+    autoWrapCol: true,
+  };
+
+  toggleAutoWrapRow(event: Event): void {
+    this.hotTable?.hotInstance?.updateSettings({ autoWrapRow: (event.target as HTMLInputElement).checked });
+  }
+
+  toggleAutoWrapCol(event: Event): void {
+    this.hotTable?.hotInstance?.updateSettings({ autoWrapCol: (event.target as HTMLInputElement).checked });
+  }
+}
+/* end-file */
+
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+/* end-file */

--- a/docs/content/guides/cell-features/selection/javascript/example6.html
+++ b/docs/content/guides/cell-features/selection/javascript/example6.html
@@ -1,0 +1,8 @@
+<div class="example-controls-container">
+  <div class="controls">
+    <label><input type="checkbox" id="auto-wrap-row" checked> Wrap at the left/right edges (autoWrapRow)</label>
+    <label><input type="checkbox" id="auto-wrap-col" checked> Wrap at the top/bottom edges (autoWrapCol)</label>
+  </div>
+  <p>Select a cell, then press <kbd>Tab</kbd> or <kbd>&rarr;</kbd> at the end of a row, or <kbd>Enter</kbd> or <kbd>&darr;</kbd> at the bottom of a column, to see the effect.</p>
+</div>
+<div id="example6"></div>

--- a/docs/content/guides/cell-features/selection/javascript/example6.js
+++ b/docs/content/guides/cell-features/selection/javascript/example6.js
@@ -1,0 +1,29 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+// Register all Handsontable's modules.
+registerAllModules();
+const container = document.querySelector('#example6');
+const hot = new Handsontable(container, {
+    data: [
+        ['SKU-4821', 'Harbor Goods', 'Electronics', 142],
+        ['SKU-0093', 'Alpine Supply Co.', 'Apparel', 67],
+        ['SKU-2210', 'Harbor Goods', 'Electronics', 0],
+        ['SKU-7734', 'Nordic Traders', 'Home Goods', 58],
+        ['SKU-1145', 'Alpine Supply Co.', 'Apparel', 213],
+    ],
+    colHeaders: ['SKU', 'Supplier', 'Category', 'Quantity'],
+    width: 'auto',
+    height: 'auto',
+    rowHeaders: true,
+    autoWrapRow: true,
+    autoWrapCol: true,
+    licenseKey: 'non-commercial-and-evaluation',
+});
+const autoWrapRowCheckbox = document.querySelector('#auto-wrap-row');
+const autoWrapColCheckbox = document.querySelector('#auto-wrap-col');
+autoWrapRowCheckbox.addEventListener('change', () => {
+    hot.updateSettings({ autoWrapRow: autoWrapRowCheckbox.checked });
+});
+autoWrapColCheckbox.addEventListener('change', () => {
+    hot.updateSettings({ autoWrapCol: autoWrapColCheckbox.checked });
+});

--- a/docs/content/guides/cell-features/selection/javascript/example6.ts
+++ b/docs/content/guides/cell-features/selection/javascript/example6.ts
@@ -1,0 +1,35 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+// Register all Handsontable's modules.
+registerAllModules();
+
+const container = document.querySelector('#example6')!;
+
+const hot = new Handsontable(container, {
+  data: [
+    ['SKU-4821', 'Harbor Goods', 'Electronics', 142],
+    ['SKU-0093', 'Alpine Supply Co.', 'Apparel', 67],
+    ['SKU-2210', 'Harbor Goods', 'Electronics', 0],
+    ['SKU-7734', 'Nordic Traders', 'Home Goods', 58],
+    ['SKU-1145', 'Alpine Supply Co.', 'Apparel', 213],
+  ],
+  colHeaders: ['SKU', 'Supplier', 'Category', 'Quantity'],
+  width: 'auto',
+  height: 'auto',
+  rowHeaders: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+const autoWrapRowCheckbox = document.querySelector<HTMLInputElement>('#auto-wrap-row')!;
+const autoWrapColCheckbox = document.querySelector<HTMLInputElement>('#auto-wrap-col')!;
+
+autoWrapRowCheckbox.addEventListener('change', () => {
+  hot.updateSettings({ autoWrapRow: autoWrapRowCheckbox.checked });
+});
+
+autoWrapColCheckbox.addEventListener('change', () => {
+  hot.updateSettings({ autoWrapCol: autoWrapColCheckbox.checked });
+});

--- a/docs/content/guides/cell-features/selection/react/example6.jsx
+++ b/docs/content/guides/cell-features/selection/react/example6.jsx
@@ -1,0 +1,52 @@
+import { useRef, useState } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const ExampleComponent = () => {
+  const hotRef = useRef(null);
+  const [autoWrapRow, setAutoWrapRow] = useState(true);
+  const [autoWrapCol, setAutoWrapCol] = useState(true);
+
+  return (
+    <>
+      <div className="example-controls-container">
+        <div className="controls">
+          <label>
+            <input type="checkbox" checked={autoWrapRow} onChange={(event) => setAutoWrapRow(event.target.checked)} />{' '}
+            Wrap at the left/right edges (autoWrapRow)
+          </label>
+          <label>
+            <input type="checkbox" checked={autoWrapCol} onChange={(event) => setAutoWrapCol(event.target.checked)} />{' '}
+            Wrap at the top/bottom edges (autoWrapCol)
+          </label>
+        </div>
+        <p>
+          Select a cell, then press <kbd>Tab</kbd> or <kbd>&rarr;</kbd> at the end of a row, or <kbd>Enter</kbd> or{' '}
+          <kbd>&darr;</kbd> at the bottom of a column, to see the effect.
+        </p>
+      </div>
+      <HotTable
+        ref={hotRef}
+        data={[
+          ['SKU-4821', 'Harbor Goods', 'Electronics', 142],
+          ['SKU-0093', 'Alpine Supply Co.', 'Apparel', 67],
+          ['SKU-2210', 'Harbor Goods', 'Electronics', 0],
+          ['SKU-7734', 'Nordic Traders', 'Home Goods', 58],
+          ['SKU-1145', 'Alpine Supply Co.', 'Apparel', 213],
+        ]}
+        colHeaders={['SKU', 'Supplier', 'Category', 'Quantity']}
+        width="auto"
+        height="auto"
+        rowHeaders={true}
+        autoWrapRow={autoWrapRow}
+        autoWrapCol={autoWrapCol}
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/cell-features/selection/react/example6.tsx
+++ b/docs/content/guides/cell-features/selection/react/example6.tsx
@@ -1,0 +1,52 @@
+import { useRef, useState } from 'react';
+import { HotTable, HotTableRef } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const ExampleComponent = () => {
+  const hotRef = useRef<HotTableRef>(null);
+  const [autoWrapRow, setAutoWrapRow] = useState(true);
+  const [autoWrapCol, setAutoWrapCol] = useState(true);
+
+  return (
+    <>
+      <div className="example-controls-container">
+        <div className="controls">
+          <label>
+            <input type="checkbox" checked={autoWrapRow} onChange={(event) => setAutoWrapRow(event.target.checked)} />{' '}
+            Wrap at the left/right edges (autoWrapRow)
+          </label>
+          <label>
+            <input type="checkbox" checked={autoWrapCol} onChange={(event) => setAutoWrapCol(event.target.checked)} />{' '}
+            Wrap at the top/bottom edges (autoWrapCol)
+          </label>
+        </div>
+        <p>
+          Select a cell, then press <kbd>Tab</kbd> or <kbd>&rarr;</kbd> at the end of a row, or <kbd>Enter</kbd> or{' '}
+          <kbd>&darr;</kbd> at the bottom of a column, to see the effect.
+        </p>
+      </div>
+      <HotTable
+        ref={hotRef}
+        data={[
+          ['SKU-4821', 'Harbor Goods', 'Electronics', 142],
+          ['SKU-0093', 'Alpine Supply Co.', 'Apparel', 67],
+          ['SKU-2210', 'Harbor Goods', 'Electronics', 0],
+          ['SKU-7734', 'Nordic Traders', 'Home Goods', 58],
+          ['SKU-1145', 'Alpine Supply Co.', 'Apparel', 213],
+        ]}
+        colHeaders={['SKU', 'Supplier', 'Category', 'Quantity']}
+        width="auto"
+        height="auto"
+        rowHeaders={true}
+        autoWrapRow={autoWrapRow}
+        autoWrapCol={autoWrapCol}
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/cell-features/selection/selection.md
+++ b/docs/content/guides/cell-features/selection/selection.md
@@ -16,6 +16,7 @@ vue:
   metaTitle: Selection - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features
+menuTag: updated
 ---
 Select a single cell, a range of adjacent cells, or multiple non-adjacent ranges of cells.
 
@@ -317,6 +318,52 @@ To jump across a horizontal edge:
 
 - When cell selection is on a column's first cell, press <kbd>**↑**</kbd>.
 - When cell selection is on a column's last cell, press <kbd>**↓**</kbd>, or press <kbd>**Enter**</kbd>.
+
+Use the checkboxes in the demo below to toggle `autoWrapRow` and `autoWrapCol`, then select a cell and use the keyboard to test the wrap-around behavior at the grid's edges.
+
+::: only-for javascript
+
+::: example #example6 --html 1 --js 2 --ts 3
+
+@[code](@/content/guides/cell-features/selection/javascript/example6.html)
+@[code](@/content/guides/cell-features/selection/javascript/example6.js)
+@[code](@/content/guides/cell-features/selection/javascript/example6.ts)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #example6 :react --js 1 --ts 2
+
+@[code](@/content/guides/cell-features/selection/react/example6.jsx)
+@[code](@/content/guides/cell-features/selection/react/example6.tsx)
+
+:::
+
+:::
+
+::: only-for angular
+
+::: example #example6 :angular --ts 1 --html 2
+
+@[code](@/content/guides/cell-features/selection/angular/example6.ts)
+@[code](@/content/guides/cell-features/selection/angular/example6.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example6 :vue3
+
+@[code](@/content/guides/cell-features/selection/vue/example6.vue)
+
+:::
+
+:::
 
 ## Result
 

--- a/docs/content/guides/cell-features/selection/vue/example6.vue
+++ b/docs/content/guides/cell-features/selection/vue/example6.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import { ref, useTemplateRef } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotTableRef = useTemplateRef<InstanceType<typeof HotTable>>('hotTableRef');
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['SKU-4821', 'Harbor Goods', 'Electronics', 142],
+    ['SKU-0093', 'Alpine Supply Co.', 'Apparel', 67],
+    ['SKU-2210', 'Harbor Goods', 'Electronics', 0],
+    ['SKU-7734', 'Nordic Traders', 'Home Goods', 58],
+    ['SKU-1145', 'Alpine Supply Co.', 'Apparel', 213],
+  ],
+  colHeaders: ['SKU', 'Supplier', 'Category', 'Quantity'],
+  width: 'auto',
+  height: 'auto',
+  rowHeaders: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+const toggleAutoWrapRow = (event: Event) => {
+  const hot = hotTableRef.value?.hotInstance;
+
+  hot?.updateSettings({ autoWrapRow: (event.target as HTMLInputElement).checked });
+};
+
+const toggleAutoWrapCol = (event: Event) => {
+  const hot = hotTableRef.value?.hotInstance;
+
+  hot?.updateSettings({ autoWrapCol: (event.target as HTMLInputElement).checked });
+};
+</script>
+
+<template>
+  <div id="example6">
+    <div class="example-controls-container">
+      <div class="controls">
+        <label>
+          <input type="checkbox" checked @change="toggleAutoWrapRow">
+          Wrap at the left/right edges (autoWrapRow)
+        </label>
+        <label>
+          <input type="checkbox" checked @change="toggleAutoWrapCol">
+          Wrap at the top/bottom edges (autoWrapCol)
+        </label>
+      </div>
+      <p>
+        Select a cell, then press <kbd>Tab</kbd> or <kbd>&rarr;</kbd> at the end of a row, or <kbd>Enter</kbd> or
+        <kbd>&darr;</kbd> at the bottom of a column, to see the effect.
+      </p>
+    </div>
+    <HotTable ref="hotTableRef" :settings="hotSettings" />
+  </div>
+</template>


### PR DESCRIPTION
### Context

The PR adds an interactive demo to the "Jump across the grid's edges" section of the Selection guide. That section only described the `autoWrapRow`/`autoWrapCol` keyboard behavior in prose, with no runnable example to try it -- unlike every other section on the page, which pairs an explanation with an `::: example` demo.

The new `example6` demo renders a small grid with two checkboxes bound to `autoWrapRow` and `autoWrapCol`. Toggling a checkbox calls `updateSettings()` on the grid instance, so readers can turn wrapping on or off and immediately test the effect with `Tab`/`Enter`/arrow keys at a grid edge. The demo ships in all four framework variants (JavaScript/TypeScript, React, Angular, Vue) to match the existing example1-5 parity on this page.

### How has this been tested?

- Ran the docs dev server locally and manually verified all four framework variants (`/javascript-data-grid/selection`, `/react-data-grid/selection`, `/angular-data-grid/selection`, `/vue-data-grid/selection`) render the new demo correctly.
- Toggled the `autoWrapRow` and `autoWrapCol` checkboxes in each variant and confirmed via keyboard navigation (`Tab`, `Enter`) that selection wraps or stops wrapping at the grid's edges according to the checkbox state.
- Generated the JavaScript variant from the TypeScript source with `npm run docs:code-examples:generate-js`.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1145

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1145

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and example assets only; no changes to Handsontable core or wrapper runtime behavior.
> 
> **Overview**
> Adds **example6** to the Selection guide’s “Jump across the grid’s edges” section so readers can try **`autoWrapRow`** and **`autoWrapCol`** interactively, matching the other sections that pair prose with runnable demos.
> 
> The demo is a small grid with checkboxes that toggle wrapping (via **`updateSettings`** in vanilla/Angular/Vue, or bound props in React). It ships for **JavaScript/TypeScript, React, Angular, and Vue**. **`selection.md`** wires in the new **`::: example #example6`** blocks, adds a short instruction paragraph, and sets **`menuTag: updated`** in front matter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da3e660d67fe7ccead2081cb8e482da13565338c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->