### PR TITLE
DEV-1058: Fill validator JSDoc placeholder example

### DIFF
--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -6492,7 +6492,7 @@ export default (): Record<string, unknown> => {
      *    {
      *      // add a custom cell validator function
      *      validator(value, callback) {
-     *          ...
+     *        callback(value >= 0 && value <= 100);
      *      }
      *    },
      * ],


### PR DESCRIPTION
### Context

The PR changes the `validator` option API docs example by replacing the placeholder custom validator body (`...`) with a concrete callback implementation. This closes the docs-quality gap tracked in DEV-1058 and aligns with the earlier DEV-1030 docs-example cleanup pattern.

### How has this been tested?

- `npm --prefix handsontable run build`
- `npm --prefix docs run docs:api`
- `npx eslint handsontable/src/dataMap/metaManager/metaSchema.ts`

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1058

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1058

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only JSDoc change in metaSchema with no runtime or API behavior impact.
> 
> **Overview**
> Updates the **`validator`** option JSDoc in `metaSchema.ts` so the custom-function example is no longer a `...` placeholder.
> 
> The example now shows calling **`callback(value >= 0 && value <= 100)`**, matching the usual **`validator(value, callback)`** pattern. Indentation in that snippet is corrected. Generated API docs only; no runtime behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e694bd0d286c260a2b2407489d1fca0144edaa8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->