### PR TITLE
DEV-638: Rewrite formatting cells guide

### DIFF
--- a/docs/content/guides/cell-features/formatting-cells/angular/example1.ts
+++ b/docs/content/guides/cell-features/formatting-cells/angular/example1.ts
@@ -33,7 +33,7 @@ export class AppComponent {
 
   readonly gridSettings: GridSettings = {
     rowHeaders: true,
-    colHeaders: true,
+    colHeaders: ['SKU', 'Product', 'Category', 'Price ($)', 'Stock'],
     stretchH: 'all',
     className: 'custom-table',
     cell: [

--- a/docs/content/guides/cell-features/formatting-cells/angular/example2.ts
+++ b/docs/content/guides/cell-features/formatting-cells/angular/example2.ts
@@ -32,7 +32,7 @@ export class AppComponent {
 
   readonly gridSettings: GridSettings = {
     rowHeaders: true,
-    colHeaders: true,
+    colHeaders: ['SKU', 'Product', 'Category', 'Price ($)', 'Stock'],
     stretchH: 'all',
     cell: [
       {

--- a/docs/content/guides/cell-features/formatting-cells/angular/example3.ts
+++ b/docs/content/guides/cell-features/formatting-cells/angular/example3.ts
@@ -32,7 +32,7 @@ export class AppComponent {
 
   readonly gridSettings: GridSettings = {
     rowHeaders: true,
-    colHeaders: true,
+    colHeaders: ['SKU', 'Product', 'Category', 'Price ($)', 'Stock'],
     stretchH: 'all',
     customBorders: [
       {

--- a/docs/content/guides/cell-features/formatting-cells/formatting-cells.md
+++ b/docs/content/guides/cell-features/formatting-cells/formatting-cells.md
@@ -19,14 +19,20 @@ Change the appearance of cells, using custom CSS classes, inline styles, or cust
 
 [[toc]]
 
-Format cells using CSS classes, inline styles, or the renderer API. Choose the approach that fits your use case.
-
 ## Overview
 
-Handsontable uses the HTML `table` structure so customization is based either on referencing to the already existing elements, such as `TR`/`TD`, or by applying
-your own CSS classes to HTML elements.
+Handsontable renders an HTML `table`, so you can style existing `tr` and `td` elements or attach your own classes.
 
-You can format a cell either using a `CSS` class or with a style applied directly to the DOM element.
+Choose an approach based on your goal:
+
+- Use [`className`](@/api/options.md#classname) when you want reusable static styles.
+- Use [`renderer`](@/api/options.md#renderer) when you need to apply inline styles to specific cells at render time.
+- Use [`customBorders`](@/api/options.md#customborders) when you need custom border widths, colors, or styles for selected ranges.
+
+## Prerequisites
+
+- A Handsontable instance with data loaded.
+- A stylesheet, if you format cells through custom CSS classes.
 
 ## Apply custom CSS class styles
 
@@ -81,7 +87,7 @@ To add a CSS class to a cell, column, or row, use the [`className`](@/api/option
 
 ## Apply inline styles
 
-You can apply inline styles directly to the DOM element using its `style` property. You can use the [`renderer`](@/api/options.md#renderer) option to do that.
+Apply inline styles directly to a cell's DOM element through the `style` property. Use the [`renderer`](@/api/options.md#renderer) option to run this logic on each render.
 
 ::: only-for javascript
 
@@ -128,11 +134,9 @@ You can apply inline styles directly to the DOM element using its `style` proper
 
 ## Custom cell borders
 
-To enable the custom borders feature, set the [`customBorders`](@/api/options.md#customborders) option. This can either be set as `true` or initialized as an
-array with a pre-defined setup. For the list of available settings and methods, visit the [API reference](@/api/customBorders.md).
+To enable custom borders, set [`customBorders`](@/api/options.md#customborders). You can set it to `true` or pass an array with predefined border configuration. For all settings and methods, see the [API reference](@/api/customBorders.md).
 
-In the names of the API properties, the words `start` and `end` refer to the starting and ending edges of the
-[layout direction](@/guides/internationalization/layout-direction/layout-direction.md).
+In API property names, `start` and `end` refer to the starting and ending edges of the [layout direction](@/guides/internationalization/layout-direction/layout-direction.md).
 
 You can customize the border style using the `style` property in the border configuration. The available options are:
 
@@ -142,8 +146,7 @@ You can customize the border style using the `style` property in the border conf
 
 The `style` property can be set for any border edge (`top`, `bottom`, `start`, `end`). When not specified, it defaults to `'solid'`.
 
-The example below demonstrates different border styles applied to various cell ranges:
-
+The following example shows different border styles on selected cell ranges.
 
 ::: only-for javascript
 
@@ -156,8 +159,6 @@ The example below demonstrates different border styles applied to various cell r
 
 :::
 
-<!-- TODO: workaround for the template parsing problem for angular docs  -->
-
 ::: only-for react
 
 ::: example #example3 :react --js 1 --ts 2
@@ -168,8 +169,6 @@ The example below demonstrates different border styles applied to various cell r
 :::
 
 :::
-
-<!-- TODO: workaround for the template parsing problem for angular docs  -->
 
 ::: only-for angular
 
@@ -194,7 +193,7 @@ The example below demonstrates different border styles applied to various cell r
 
 ## Result
 
-Cells display the configured CSS classes, inline styles, or custom borders. The appearance updates each time the grid renders, keeping styles in sync with your configuration.
+The grid renders your configured classes, inline styles, and border definitions. Formatting stays consistent after each render.
 
 ## Related articles
 

--- a/docs/content/guides/cell-features/formatting-cells/javascript/example1.js
+++ b/docs/content/guides/cell-features/formatting-cells/javascript/example1.js
@@ -1,32 +1,29 @@
 import Handsontable from 'handsontable/base';
 import { registerAllModules } from 'handsontable/registry';
-
 // Register all Handsontable's modules.
 registerAllModules();
-
 const container = document.querySelector('#example1');
-
 new Handsontable(container, {
-  data: [
-    ['A1', 'B1', 'C1', 'D1', 'E1'],
-    ['A2', 'B2', 'C2', 'D2', 'E2'],
-    ['A3', 'B3', 'C3', 'D3', 'E3'],
-    ['A4', 'B4', 'C4', 'D4', 'E4'],
-    ['A5', 'B5', 'C5', 'D5', 'E5'],
-  ],
-  rowHeaders: true,
-  colHeaders: true,
-  stretchH: 'all',
-  className: 'custom-table',
-  cell: [
-    {
-      row: 0,
-      col: 0,
-      className: 'custom-cell',
-    },
-  ],
-  height: 'auto',
-  autoWrapRow: true,
-  autoWrapCol: true,
-  licenseKey: 'non-commercial-and-evaluation',
+    data: [
+        ['SKU-4821', 'Laptop Pro 15', 'Electronics', 149900, 42],
+        ['SKU-0093', 'Wireless Mouse', 'Peripherals', 2999, 218],
+        ['SKU-7712', 'USB-C Hub 7-port', 'Peripherals', 5499, 0],
+        ['SKU-3305', 'Mech. Keyboard', 'Peripherals', 8999, 67],
+        ['SKU-9140', '4K Monitor 27"', 'Electronics', 34999, 15],
+    ],
+    rowHeaders: true,
+    colHeaders: ['SKU', 'Product', 'Category', 'Price ($)', 'Stock'],
+    stretchH: 'all',
+    className: 'custom-table',
+    cell: [
+        {
+            row: 0,
+            col: 0,
+            className: 'custom-cell',
+        },
+    ],
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true,
+    licenseKey: 'non-commercial-and-evaluation',
 });

--- a/docs/content/guides/cell-features/formatting-cells/javascript/example1.ts
+++ b/docs/content/guides/cell-features/formatting-cells/javascript/example1.ts
@@ -8,14 +8,14 @@ const container = document.querySelector('#example1')!;
 
 new Handsontable(container, {
   data: [
-    ['A1', 'B1', 'C1', 'D1', 'E1'],
-    ['A2', 'B2', 'C2', 'D2', 'E2'],
-    ['A3', 'B3', 'C3', 'D3', 'E3'],
-    ['A4', 'B4', 'C4', 'D4', 'E4'],
-    ['A5', 'B5', 'C5', 'D5', 'E5'],
+    ['SKU-4821', 'Laptop Pro 15', 'Electronics', 149900, 42],
+    ['SKU-0093', 'Wireless Mouse', 'Peripherals', 2999, 218],
+    ['SKU-7712', 'USB-C Hub 7-port', 'Peripherals', 5499, 0],
+    ['SKU-3305', 'Mech. Keyboard', 'Peripherals', 8999, 67],
+    ['SKU-9140', '4K Monitor 27"', 'Electronics', 34999, 15],
   ],
   rowHeaders: true,
-  colHeaders: true,
+  colHeaders: ['SKU', 'Product', 'Category', 'Price ($)', 'Stock'],
   stretchH: 'all',
   className: 'custom-table',
   cell: [

--- a/docs/content/guides/cell-features/formatting-cells/javascript/example2.js
+++ b/docs/content/guides/cell-features/formatting-cells/javascript/example2.js
@@ -1,41 +1,36 @@
 import Handsontable from 'handsontable/base';
 import { registerAllModules } from 'handsontable/registry';
 import { textRenderer, registerRenderer } from 'handsontable/renderers';
-
 // register Handsontable's modules
 registerAllModules();
-
 const customStylesRenderer = (hotInstance, TD, ...rest) => {
-  textRenderer(hotInstance, TD, ...rest);
-  TD.style.fontWeight = 'bold';
-  TD.style.color = 'green';
-  TD.style.background = '#d7f1e1';
+    textRenderer(hotInstance, TD, ...rest);
+    TD.style.fontWeight = 'bold';
+    TD.style.color = 'green';
+    TD.style.background = '#d7f1e1';
 };
-
 registerRenderer('customStylesRenderer', customStylesRenderer);
-
 const container = document.querySelector('#example2');
-
 new Handsontable(container, {
-  data: [
-    ['A1', 'B1', 'C1', 'D1', 'E1'],
-    ['A2', 'B2', 'C2', 'D2', 'E2'],
-    ['A3', 'B3', 'C3', 'D3', 'E3'],
-    ['A4', 'B4', 'C4', 'D4', 'E4'],
-    ['A5', 'B5', 'C5', 'D5', 'E5'],
-  ],
-  rowHeaders: true,
-  colHeaders: true,
-  stretchH: 'all',
-  cell: [
-    {
-      row: 0,
-      col: 0,
-      renderer: 'customStylesRenderer',
-    },
-  ],
-  height: 'auto',
-  autoWrapRow: true,
-  autoWrapCol: true,
-  licenseKey: 'non-commercial-and-evaluation',
+    data: [
+        ['SKU-4821', 'Laptop Pro 15', 'Electronics', 149900, 42],
+        ['SKU-0093', 'Wireless Mouse', 'Peripherals', 2999, 218],
+        ['SKU-7712', 'USB-C Hub 7-port', 'Peripherals', 5499, 0],
+        ['SKU-3305', 'Mech. Keyboard', 'Peripherals', 8999, 67],
+        ['SKU-9140', '4K Monitor 27"', 'Electronics', 34999, 15],
+    ],
+    rowHeaders: true,
+    colHeaders: ['SKU', 'Product', 'Category', 'Price ($)', 'Stock'],
+    stretchH: 'all',
+    cell: [
+        {
+            row: 0,
+            col: 0,
+            renderer: 'customStylesRenderer',
+        },
+    ],
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true,
+    licenseKey: 'non-commercial-and-evaluation',
 });

--- a/docs/content/guides/cell-features/formatting-cells/javascript/example2.ts
+++ b/docs/content/guides/cell-features/formatting-cells/javascript/example2.ts
@@ -19,14 +19,14 @@ const container = document.querySelector('#example2')!;
 
 new Handsontable(container, {
   data: [
-    ['A1', 'B1', 'C1', 'D1', 'E1'],
-    ['A2', 'B2', 'C2', 'D2', 'E2'],
-    ['A3', 'B3', 'C3', 'D3', 'E3'],
-    ['A4', 'B4', 'C4', 'D4', 'E4'],
-    ['A5', 'B5', 'C5', 'D5', 'E5'],
+    ['SKU-4821', 'Laptop Pro 15', 'Electronics', 149900, 42],
+    ['SKU-0093', 'Wireless Mouse', 'Peripherals', 2999, 218],
+    ['SKU-7712', 'USB-C Hub 7-port', 'Peripherals', 5499, 0],
+    ['SKU-3305', 'Mech. Keyboard', 'Peripherals', 8999, 67],
+    ['SKU-9140', '4K Monitor 27"', 'Electronics', 34999, 15],
   ],
   rowHeaders: true,
-  colHeaders: true,
+  colHeaders: ['SKU', 'Product', 'Category', 'Price ($)', 'Stock'],
   stretchH: 'all',
   cell: [
     {

--- a/docs/content/guides/cell-features/formatting-cells/javascript/example3.js
+++ b/docs/content/guides/cell-features/formatting-cells/javascript/example3.js
@@ -1,68 +1,65 @@
 import Handsontable from 'handsontable/base';
 import { registerAllModules } from 'handsontable/registry';
-
 // Register all Handsontable's modules.
 registerAllModules();
-
 const container = document.querySelector('#example3');
-
 new Handsontable(container, {
-  data: [
-    ['A1', 'B1', 'C1', 'D1', 'E1', 'F1'],
-    ['A2', 'B2', 'C2', 'D2', 'E2', 'F2'],
-    ['A3', 'B3', 'C3', 'D3', 'E3', 'F3'],
-    ['A4', 'B4', 'C4', 'D4', 'E4', 'F4'],
-    ['A5', 'B5', 'C5', 'D5', 'E5', 'F5'],
-  ],
-  rowHeaders: true,
-  colHeaders: true,
-  autoWrapRow: true,
-  autoWrapCol: true,
-  stretchH: 'all',
-  height: 'auto',
-  licenseKey: 'non-commercial-and-evaluation',
-  customBorders: [
-    {
-      range: {
-        from: {
-          row: 1,
-          col: 1,
+    data: [
+        ['SKU-4821', 'Laptop Pro 15', 'Electronics', 149900, 42],
+        ['SKU-0093', 'Wireless Mouse', 'Peripherals', 2999, 218],
+        ['SKU-7712', 'USB-C Hub 7-port', 'Peripherals', 5499, 0],
+        ['SKU-3305', 'Mech. Keyboard', 'Peripherals', 8999, 67],
+        ['SKU-9140', '4K Monitor 27"', 'Electronics', 34999, 15],
+    ],
+    rowHeaders: true,
+    colHeaders: ['SKU', 'Product', 'Category', 'Price ($)', 'Stock'],
+    autoWrapRow: true,
+    autoWrapCol: true,
+    stretchH: 'all',
+    height: 'auto',
+    licenseKey: 'non-commercial-and-evaluation',
+    customBorders: [
+        {
+            range: {
+                from: {
+                    row: 1,
+                    col: 1,
+                },
+                to: {
+                    row: 3,
+                    col: 4,
+                },
+            },
+            top: {
+                width: 2,
+                color: '#5292F7',
+                style: 'dotted',
+            },
+            bottom: {
+                width: 2,
+                color: 'red',
+            },
+            start: {
+                width: 2,
+                color: 'orange',
+                style: 'dashed',
+            },
+            end: {
+                width: 2,
+                color: 'magenta',
+            },
         },
-        to: {
-          row: 3,
-          col: 4,
+        {
+            row: 2,
+            col: 2,
+            start: {
+                width: 2,
+                color: 'red',
+            },
+            end: {
+                width: 1,
+                color: 'green',
+            },
         },
-      },
-      top: {
-        width: 2,
-        color: '#5292F7',
-        style: 'dotted',
-      },
-      bottom: {
-        width: 2,
-        color: 'red',
-      },
-      start: {
-        width: 2,
-        color: 'orange',
-        style: 'dashed',
-      },
-      end: {
-        width: 2,
-        color: 'magenta',
-      },
-    },
-    {
-      row: 2,
-      col: 2,
-      start: {
-        width: 2,
-        color: 'red',
-      },
-      end: {
-        width: 1,
-        color: 'green',
-      },
-    },
-  ],
+    ],
 });

--- a/docs/content/guides/cell-features/formatting-cells/javascript/example3.ts
+++ b/docs/content/guides/cell-features/formatting-cells/javascript/example3.ts
@@ -8,14 +8,14 @@ const container = document.querySelector('#example3')!;
 
 new Handsontable(container, {
   data: [
-    ['A1', 'B1', 'C1', 'D1', 'E1', 'F1'],
-    ['A2', 'B2', 'C2', 'D2', 'E2', 'F2'],
-    ['A3', 'B3', 'C3', 'D3', 'E3', 'F3'],
-    ['A4', 'B4', 'C4', 'D4', 'E4', 'F4'],
-    ['A5', 'B5', 'C5', 'D5', 'E5', 'F5'],
+    ['SKU-4821', 'Laptop Pro 15', 'Electronics', 149900, 42],
+    ['SKU-0093', 'Wireless Mouse', 'Peripherals', 2999, 218],
+    ['SKU-7712', 'USB-C Hub 7-port', 'Peripherals', 5499, 0],
+    ['SKU-3305', 'Mech. Keyboard', 'Peripherals', 8999, 67],
+    ['SKU-9140', '4K Monitor 27"', 'Electronics', 34999, 15],
   ],
   rowHeaders: true,
-  colHeaders: true,
+  colHeaders: ['SKU', 'Product', 'Category', 'Price ($)', 'Stock'],
   autoWrapRow: true,
   autoWrapCol: true,
   stretchH: 'all',

--- a/docs/content/guides/cell-features/formatting-cells/react/example1.jsx
+++ b/docs/content/guides/cell-features/formatting-cells/react/example1.jsx
@@ -8,14 +8,14 @@ const ExampleComponent = () => {
   return (
     <HotTable
       data={[
-        ['A1', 'B1', 'C1', 'D1', 'E1'],
-        ['A2', 'B2', 'C2', 'D2', 'E2'],
-        ['A3', 'B3', 'C3', 'D3', 'E3'],
-        ['A4', 'B4', 'C4', 'D4', 'E4'],
-        ['A5', 'B5', 'C5', 'D5', 'E5'],
+        ['SKU-4821', 'Laptop Pro 15', 'Electronics', 149900, 42],
+        ['SKU-0093', 'Wireless Mouse', 'Peripherals', 2999, 218],
+        ['SKU-7712', 'USB-C Hub 7-port', 'Peripherals', 5499, 0],
+        ['SKU-3305', 'Mech. Keyboard', 'Peripherals', 8999, 67],
+        ['SKU-9140', '4K Monitor 27"', 'Electronics', 34999, 15],
       ]}
       rowHeaders={true}
-      colHeaders={true}
+      colHeaders={['SKU', 'Product', 'Category', 'Price ($)', 'Stock']}
       stretchH="all"
       className="custom-table"
       cell={[

--- a/docs/content/guides/cell-features/formatting-cells/react/example1.tsx
+++ b/docs/content/guides/cell-features/formatting-cells/react/example1.tsx
@@ -8,14 +8,14 @@ const ExampleComponent = () => {
   return (
     <HotTable
       data={[
-        ['A1', 'B1', 'C1', 'D1', 'E1'],
-        ['A2', 'B2', 'C2', 'D2', 'E2'],
-        ['A3', 'B3', 'C3', 'D3', 'E3'],
-        ['A4', 'B4', 'C4', 'D4', 'E4'],
-        ['A5', 'B5', 'C5', 'D5', 'E5'],
+        ['SKU-4821', 'Laptop Pro 15', 'Electronics', 149900, 42],
+        ['SKU-0093', 'Wireless Mouse', 'Peripherals', 2999, 218],
+        ['SKU-7712', 'USB-C Hub 7-port', 'Peripherals', 5499, 0],
+        ['SKU-3305', 'Mech. Keyboard', 'Peripherals', 8999, 67],
+        ['SKU-9140', '4K Monitor 27"', 'Electronics', 34999, 15],
       ]}
       rowHeaders={true}
-      colHeaders={true}
+      colHeaders={['SKU', 'Product', 'Category', 'Price ($)', 'Stock']}
       stretchH="all"
       className="custom-table"
       cell={[

--- a/docs/content/guides/cell-features/formatting-cells/react/example2.jsx
+++ b/docs/content/guides/cell-features/formatting-cells/react/example2.jsx
@@ -16,14 +16,14 @@ const ExampleComponent = () => {
   return (
     <HotTable
       data={[
-        ['A1', 'B1', 'C1', 'D1', 'E1'],
-        ['A2', 'B2', 'C2', 'D2', 'E2'],
-        ['A3', 'B3', 'C3', 'D3', 'E3'],
-        ['A4', 'B4', 'C4', 'D4', 'E4'],
-        ['A5', 'B5', 'C5', 'D5', 'E5'],
+        ['SKU-4821', 'Laptop Pro 15', 'Electronics', 149900, 42],
+        ['SKU-0093', 'Wireless Mouse', 'Peripherals', 2999, 218],
+        ['SKU-7712', 'USB-C Hub 7-port', 'Peripherals', 5499, 0],
+        ['SKU-3305', 'Mech. Keyboard', 'Peripherals', 8999, 67],
+        ['SKU-9140', '4K Monitor 27"', 'Electronics', 34999, 15],
       ]}
       rowHeaders={true}
-      colHeaders={true}
+      colHeaders={['SKU', 'Product', 'Category', 'Price ($)', 'Stock']}
       stretchH="all"
       cell={[
         {

--- a/docs/content/guides/cell-features/formatting-cells/react/example2.tsx
+++ b/docs/content/guides/cell-features/formatting-cells/react/example2.tsx
@@ -17,14 +17,14 @@ const ExampleComponent = () => {
   return (
     <HotTable
       data={[
-        ['A1', 'B1', 'C1', 'D1', 'E1'],
-        ['A2', 'B2', 'C2', 'D2', 'E2'],
-        ['A3', 'B3', 'C3', 'D3', 'E3'],
-        ['A4', 'B4', 'C4', 'D4', 'E4'],
-        ['A5', 'B5', 'C5', 'D5', 'E5'],
+        ['SKU-4821', 'Laptop Pro 15', 'Electronics', 149900, 42],
+        ['SKU-0093', 'Wireless Mouse', 'Peripherals', 2999, 218],
+        ['SKU-7712', 'USB-C Hub 7-port', 'Peripherals', 5499, 0],
+        ['SKU-3305', 'Mech. Keyboard', 'Peripherals', 8999, 67],
+        ['SKU-9140', '4K Monitor 27"', 'Electronics', 34999, 15],
       ]}
       rowHeaders={true}
-      colHeaders={true}
+      colHeaders={['SKU', 'Product', 'Category', 'Price ($)', 'Stock']}
       stretchH="all"
       cell={[
         {

--- a/docs/content/guides/cell-features/formatting-cells/react/example3.jsx
+++ b/docs/content/guides/cell-features/formatting-cells/react/example3.jsx
@@ -8,14 +8,14 @@ const ExampleComponent = () => {
   return (
     <HotTable
       data={[
-        ['A1', 'B1', 'C1', 'D1', 'E1', 'F1'],
-        ['A2', 'B2', 'C2', 'D2', 'E2', 'F2'],
-        ['A3', 'B3', 'C3', 'D3', 'E3', 'F3'],
-        ['A4', 'B4', 'C4', 'D4', 'E4', 'F4'],
-        ['A5', 'B5', 'C5', 'D5', 'E5', 'F5'],
+        ['SKU-4821', 'Laptop Pro 15', 'Electronics', 149900, 42],
+        ['SKU-0093', 'Wireless Mouse', 'Peripherals', 2999, 218],
+        ['SKU-7712', 'USB-C Hub 7-port', 'Peripherals', 5499, 0],
+        ['SKU-3305', 'Mech. Keyboard', 'Peripherals', 8999, 67],
+        ['SKU-9140', '4K Monitor 27"', 'Electronics', 34999, 15],
       ]}
       rowHeaders={true}
-      colHeaders={true}
+      colHeaders={['SKU', 'Product', 'Category', 'Price ($)', 'Stock']}
       stretchH="all"
       height="auto"
       autoWrapRow={true}

--- a/docs/content/guides/cell-features/formatting-cells/react/example3.tsx
+++ b/docs/content/guides/cell-features/formatting-cells/react/example3.tsx
@@ -8,14 +8,14 @@ const ExampleComponent = () => {
   return (
     <HotTable
       data={[
-        ['A1', 'B1', 'C1', 'D1', 'E1', 'F1'],
-        ['A2', 'B2', 'C2', 'D2', 'E2', 'F2'],
-        ['A3', 'B3', 'C3', 'D3', 'E3', 'F3'],
-        ['A4', 'B4', 'C4', 'D4', 'E4', 'F4'],
-        ['A5', 'B5', 'C5', 'D5', 'E5', 'F5'],
+        ['SKU-4821', 'Laptop Pro 15', 'Electronics', 149900, 42],
+        ['SKU-0093', 'Wireless Mouse', 'Peripherals', 2999, 218],
+        ['SKU-7712', 'USB-C Hub 7-port', 'Peripherals', 5499, 0],
+        ['SKU-3305', 'Mech. Keyboard', 'Peripherals', 8999, 67],
+        ['SKU-9140', '4K Monitor 27"', 'Electronics', 34999, 15],
       ]}
       rowHeaders={true}
-      colHeaders={true}
+      colHeaders={['SKU', 'Product', 'Category', 'Price ($)', 'Stock']}
       stretchH="all"
       height="auto"
       autoWrapRow={true}

--- a/docs/content/guides/cell-features/formatting-cells/vue/example1.vue
+++ b/docs/content/guides/cell-features/formatting-cells/vue/example1.vue
@@ -8,14 +8,14 @@ registerAllModules();
 
 const hotSettings = ref<GridSettings>({
   data: [
-    ['A1', 'B1', 'C1', 'D1', 'E1'],
-    ['A2', 'B2', 'C2', 'D2', 'E2'],
-    ['A3', 'B3', 'C3', 'D3', 'E3'],
-    ['A4', 'B4', 'C4', 'D4', 'E4'],
-    ['A5', 'B5', 'C5', 'D5', 'E5'],
+    ['SKU-4821', 'Laptop Pro 15', 'Electronics', 149900, 42],
+    ['SKU-0093', 'Wireless Mouse', 'Peripherals', 2999, 218],
+    ['SKU-7712', 'USB-C Hub 7-port', 'Peripherals', 5499, 0],
+    ['SKU-3305', 'Mech. Keyboard', 'Peripherals', 8999, 67],
+    ['SKU-9140', '4K Monitor 27"', 'Electronics', 34999, 15],
   ],
   rowHeaders: true,
-  colHeaders: true,
+  colHeaders: ['SKU', 'Product', 'Category', 'Price ($)', 'Stock'],
   stretchH: 'all',
   className: 'custom-table',
   cell: [

--- a/docs/content/guides/cell-features/formatting-cells/vue/example2.vue
+++ b/docs/content/guides/cell-features/formatting-cells/vue/example2.vue
@@ -19,14 +19,14 @@ registerRenderer('customStylesRenderer', customStylesRenderer);
 
 const hotSettings: GridSettings = {
   data: [
-    ['A1', 'B1', 'C1', 'D1', 'E1'],
-    ['A2', 'B2', 'C2', 'D2', 'E2'],
-    ['A3', 'B3', 'C3', 'D3', 'E3'],
-    ['A4', 'B4', 'C4', 'D4', 'E4'],
-    ['A5', 'B5', 'C5', 'D5', 'E5'],
+    ['SKU-4821', 'Laptop Pro 15', 'Electronics', 149900, 42],
+    ['SKU-0093', 'Wireless Mouse', 'Peripherals', 2999, 218],
+    ['SKU-7712', 'USB-C Hub 7-port', 'Peripherals', 5499, 0],
+    ['SKU-3305', 'Mech. Keyboard', 'Peripherals', 8999, 67],
+    ['SKU-9140', '4K Monitor 27"', 'Electronics', 34999, 15],
   ],
   rowHeaders: true,
-  colHeaders: true,
+  colHeaders: ['SKU', 'Product', 'Category', 'Price ($)', 'Stock'],
   stretchH: 'all',
   cell: [
     {

--- a/docs/content/guides/cell-features/formatting-cells/vue/example3.vue
+++ b/docs/content/guides/cell-features/formatting-cells/vue/example3.vue
@@ -8,14 +8,14 @@ registerAllModules();
 
 const hotSettings = ref<GridSettings>({
   data: [
-    ['A1', 'B1', 'C1', 'D1', 'E1', 'F1'],
-    ['A2', 'B2', 'C2', 'D2', 'E2', 'F2'],
-    ['A3', 'B3', 'C3', 'D3', 'E3', 'F3'],
-    ['A4', 'B4', 'C4', 'D4', 'E4', 'F4'],
-    ['A5', 'B5', 'C5', 'D5', 'E5', 'F5'],
+    ['SKU-4821', 'Laptop Pro 15', 'Electronics', 149900, 42],
+    ['SKU-0093', 'Wireless Mouse', 'Peripherals', 2999, 218],
+    ['SKU-7712', 'USB-C Hub 7-port', 'Peripherals', 5499, 0],
+    ['SKU-3305', 'Mech. Keyboard', 'Peripherals', 8999, 67],
+    ['SKU-9140', '4K Monitor 27"', 'Electronics', 34999, 15],
   ],
   rowHeaders: true,
-  colHeaders: true,
+  colHeaders: ['SKU', 'Product', 'Category', 'Price ($)', 'Stock'],
   autoWrapRow: true,
   autoWrapCol: true,
   stretchH: 'all',


### PR DESCRIPTION
### Context

The PR rewrites the `formatting-cells` how-to page for DEV-638 by adding missing prerequisites and clearer decision guidance for static CSS classes, inline renderers, and custom borders.
It also replaces placeholder example data with a realistic inventory dataset and explicit column headers across JavaScript, React, Angular, and Vue variants.

### How has this been tested?

- `npm --prefix docs run docs:code-examples:generate-js -- content/guides/cell-features/formatting-cells/javascript/example1.ts`
- `npm --prefix docs run docs:code-examples:generate-js -- content/guides/cell-features/formatting-cells/javascript/example2.ts`
- `npm --prefix docs run docs:code-examples:generate-js -- content/guides/cell-features/formatting-cells/javascript/example3.ts`
- `curl -I http://127.0.0.1:4323/docs/javascript-data-grid/formatting-cells`
- `curl -I http://127.0.0.1:4323/docs/react-data-grid/formatting-cells`
- `curl -I http://127.0.0.1:4323/docs/angular-data-grid/formatting-cells`
- `curl -I http://127.0.0.1:4323/docs/vue-data-grid/formatting-cells`
- Playwright smoke script: validated all four framework pages render `SKU-4821`, no console/page errors, `#custom-cell-borders` anchor resolves, and layout-direction cross-link lands on that anchor.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-638

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to docs and example snippets; no Handsontable library or wrapper runtime code is modified.
> 
> **Overview**
> Rewrites the **formatting cells** how-to for DEV-638 with clearer structure: an overview that maps goals to **`className`**, **`renderer`**, and **`customBorders`**, plus a **Prerequisites** section. Prose is tightened across CSS classes, inline styles, and custom borders; Angular-only TODO comments in the markdown are removed.
> 
> All live examples (JavaScript/TS, React, Angular, Vue) now use a shared **inventory** dataset instead of `A1`/`B1` placeholders, with explicit column headers (`SKU`, `Product`, `Category`, `Price ($)`, `Stock`) instead of `colHeaders: true`. The custom-borders demo drops the extra sixth column so border ranges still match the grid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d482a66703e254fae8166b3402bf9aa3f528b2cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->