### PR TITLE
DEV-1074: Add guide for handling collaboration and simultaneous editing

### DIFF
--- a/docs/content/guides/data-management/collaboration/angular/example1.html
+++ b/docs/content/guides/data-management/collaboration/angular/example1.html
@@ -1,0 +1,3 @@
+<div>
+    <example1-collaboration></example1-collaboration>
+</div>

--- a/docs/content/guides/data-management/collaboration/angular/example1.ts
+++ b/docs/content/guides/data-management/collaboration/angular/example1.ts
@@ -1,0 +1,103 @@
+/* file: app.component.ts */
+import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { GridSettings, HotTableComponent, HotTableModule } from '@handsontable/angular-wrapper';
+import Handsontable from 'handsontable/base';
+
+// marks a change as coming from another collaborator, so it isn't broadcast again
+const REMOTE_SOURCE = 'remotePeer';
+
+@Component({
+  selector: 'example1-collaboration',
+  standalone: true,
+  imports: [HotTableModule],
+  template: ` <div class="example-controls-container">
+      <p class="controls">{{ statusText }}</p>
+    </div>
+    <div>
+      <hot-table [data]="hotData" [settings]="gridSettings"></hot-table>
+    </div>`,
+})
+export class AppComponent implements OnInit, OnDestroy {
+  @ViewChild(HotTableComponent, { static: false }) readonly hotTable!: HotTableComponent;
+
+  statusText = 'A remote update to the first row arrives in 3 seconds.';
+
+  private timeoutId?: ReturnType<typeof setTimeout>;
+
+  readonly hotData = [
+    ['Update onboarding flow', 'Ana García', 'In progress'],
+    ['Fix invoice rounding bug', 'James Okafor', 'Blocked'],
+    ['Write Q3 release notes', 'Li Wei', 'In progress'],
+    ['Migrate auth service', 'Sofia Rossi', 'Done'],
+    ['Design empty states', 'Diego Fernández', 'In progress'],
+  ];
+
+  readonly gridSettings: GridSettings = {
+    colHeaders: ['Task', 'Assignee', 'Status'],
+    rowHeaders: true,
+    height: 'auto',
+    beforeChange: (changes: (Handsontable.CellChange | null)[], source: Handsontable.ChangeSource | string) => {
+      if (source === REMOTE_SOURCE || !changes) {
+        return;
+      }
+
+      changes.forEach((change) => {
+        if (!change) {
+          return;
+        }
+
+        const [row, column, , newValue] = change;
+
+        // send the local edit to your collaboration backend here
+        console.log('Broadcasting local edit:', row, column, newValue);
+      });
+    },
+  };
+
+  ngOnInit(): void {
+    // simulate an update coming from another collaborator - start editing the Status
+    // cell in the first row before the timeout fires to see the update wait for you
+    this.timeoutId = setTimeout(() => this.applyRemoteChange(0, 2, 'Done'), 3000);
+  }
+
+  ngOnDestroy(): void {
+    clearTimeout(this.timeoutId);
+  }
+
+  applyRemoteChange(row: number, column: number, value: string): void {
+    const hot = this.hotTable?.hotInstance;
+    const editor = hot?.getActiveEditor();
+    const editingSameCell = editor?.isOpened() && editor.row === row && editor.col === column;
+
+    if (editingSameCell) {
+      // don't overwrite a cell the local user is editing right now -
+      // check again shortly, and apply the change once the local edit finishes
+      this.timeoutId = setTimeout(() => this.applyRemoteChange(row, column, value), 300);
+
+      return;
+    }
+
+    hot?.setDataAtCell(row, column, value, REMOTE_SOURCE);
+    this.statusText = 'A collaborator marked "Update onboarding flow" as Done.';
+  }
+}
+/* end-file */
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+/* end-file */

--- a/docs/content/guides/data-management/collaboration/collaboration.md
+++ b/docs/content/guides/data-management/collaboration/collaboration.md
@@ -1,0 +1,185 @@
+---
+type: how-to
+title: Handling collaboration and simultaneous editing
+metaTitle: Handling collaboration and simultaneous editing - JavaScript Data Grid | Handsontable
+description: Coordinate edits between multiple users by detecting active edit state, intercepting local changes, and syncing structural and non-data changes across clients.
+permalink: /collaboration
+canonicalUrl: /collaboration
+tags:
+  - collaboration
+  - real-time
+  - hooks
+react:
+  metaTitle: Handling collaboration and simultaneous editing - React Data Grid | Handsontable
+angular:
+  metaTitle: Handling collaboration and simultaneous editing - Angular Data Grid | Handsontable
+vue:
+  metaTitle: Handling collaboration and simultaneous editing - Vue Data Grid | Handsontable
+searchCategory: Guides
+category: Data management
+menuTag: new
+---
+
+Coordinate edits between multiple users by detecting active edit state, intercepting local changes, and syncing structural and non-data changes across clients.
+
+[[toc]]
+
+Handsontable doesn't ship a transport layer or a conflict-resolution algorithm. To build collaborative editing, you send local changes to your own backend (for example, a WebSocket server) and apply changes from other collaborators back into the grid. This guide covers the hooks and methods you use on both sides of that flow.
+
+The examples on this page simulate a remote collaborator locally, so they run without a real backend. In your app, replace the simulated call with the message you receive from your collaboration server.
+
+## Avoid overwriting a cell that's being edited
+
+Applying a remote change to a cell while the local user is still typing in it discards their in-progress edit. Before applying a remote change, check whether the target cell's editor is open with [`getActiveEditor()`](@/api/core.md#getactiveeditor) and [`isOpened()`](@/api/baseEditor.md#isopened). If it is, wait until the local edit finishes, then apply the remote change.
+
+Use the [`beforeChange`](@/api/hooks.md#beforechange) hook to read local edits and send them to other collaborators. Give changes that come from another collaborator a distinct `source` value, so your `beforeChange` handler doesn't broadcast them again.
+
+::: only-for javascript
+
+::: example #example1 --html 1 --js 2 --ts 3
+
+@[code](@/content/guides/data-management/collaboration/javascript/example1.html)
+@[code](@/content/guides/data-management/collaboration/javascript/example1.js)
+@[code](@/content/guides/data-management/collaboration/javascript/example1.ts)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #example1 :react --js 1 --ts 2
+
+@[code](@/content/guides/data-management/collaboration/react/example1.jsx)
+@[code](@/content/guides/data-management/collaboration/react/example1.tsx)
+
+:::
+
+:::
+
+::: only-for angular
+
+::: example #example1 :angular --ts 1 --html 2
+
+@[code](@/content/guides/data-management/collaboration/angular/example1.ts)
+@[code](@/content/guides/data-management/collaboration/angular/example1.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/data-management/collaboration/vue/example1.vue)
+
+:::
+
+:::
+
+A simulated remote update to the **Status** column of the first row arrives 3 seconds after the example loads. Start editing that cell before then, and the remote change waits until you finish.
+
+## Guard and replay structural changes
+
+Row and column changes need the same two-way handling as cell data. Use [`beforeCreateRow`](@/api/hooks.md#beforecreaterow), [`beforeRemoveRow`](@/api/hooks.md#beforeremoverow), [`beforeCreateCol`](@/api/hooks.md#beforecreatecol), and [`beforeRemoveCol`](@/api/hooks.md#beforeremovecol) to read local structural changes and forward them to other collaborators. Each hook receives the `source` argument you passed in, so you can skip re-broadcasting a change that a collaborator sent you.
+
+To apply a structural change from another collaborator, call [`alter()`](@/api/core.md#alter) with the same `source` value:
+
+```js
+const configurationOptions = {
+  beforeCreateRow(index, amount, source) {
+    if (source === 'remotePeer') {
+      // let a structural change from another collaborator through
+      return;
+    }
+
+    // send the local structural change to your collaboration backend here
+  },
+  beforeRemoveRow(index, amount, physicalRows, source) {
+    if (source === 'remotePeer') {
+      return;
+    }
+
+    // send the local structural change to your collaboration backend here
+  },
+};
+
+// apply a structural change received from another collaborator
+hot.alter('insert_row_below', 2, 1, 'remotePeer');
+```
+
+## Sync cell metadata, comments, merged cells, and borders
+
+Collaborators also share state that isn't part of the cell value. [`setCellMeta()`](@/api/core.md#setcellmeta) writes arbitrary metadata (for example, a `className` that flags a cell as locked by another user), but it doesn't repaint the grid on its own - call [`render()`](@/api/core.md#render) afterward.
+
+The [`Comments`](@/api/comments.md), [`MergeCells`](@/api/mergeCells.md), and [`CustomBorders`](@/api/customBorders.md) plugins expose methods you can call with data received from another collaborator:
+
+```js
+// share arbitrary metadata, then repaint to apply it
+hot.setCellMeta(1, 2, 'className', 'is-locked-by-remote-user');
+hot.render();
+
+// mirror a comment left by another collaborator
+hot.getPlugin('comments').setCommentAtCell(1, 2, 'Reviewed - looks good.');
+
+// mirror a merged area created by another collaborator
+hot.getPlugin('mergeCells').merge(0, 0, 0, 1);
+
+// mirror a border added by another collaborator
+hot.getPlugin('customBorders').setBorders([[1, 1, 1, 1]], { start: { width: 2, color: '#2563eb' } });
+```
+
+The [`Comments`](@/api/comments.md) plugin stores comments as cell meta, so [`setCommentAtCell()`](@/api/comments.md#setcommentatcell) and [`removeCommentAtCell()`](@/api/comments.md#removecommentatcell) also trigger [`beforeSetCellMeta`](@/api/hooks.md#beforesetcellmeta) and [`afterSetCellMeta`](@/api/hooks.md#aftersetcellmeta) - handle comment changes there if you're already syncing cell meta through those hooks.
+
+## Result
+
+After completing this guide, your grid detects when a remote update would overwrite a cell the local user is actively editing, broadcasts local data and structural changes to other collaborators, and mirrors remote changes to cell data, rows, columns, comments, merged cells, and borders.
+
+## Related articles
+
+<div class="boxes-list">
+
+- [Events and hooks](@/guides/getting-started/events-and-hooks/events-and-hooks.md)
+- [Comments](@/guides/cell-features/comments/comments.md)
+- [Merge cells](@/guides/cell-features/merge-cells/merge-cells.md)
+
+</div>
+
+## Related API reference
+
+**Core methods**
+
+<div class="boxes-list">
+
+- [alter()](@/api/core.md#alter)
+- [getActiveEditor()](@/api/core.md#getactiveeditor)
+- [render()](@/api/core.md#render)
+- [setCellMeta()](@/api/core.md#setcellmeta)
+- [setDataAtCell()](@/api/core.md#setdataatcell)
+
+</div>
+
+**Hooks**
+
+<div class="boxes-list">
+
+- [afterSetCellMeta](@/api/hooks.md#aftersetcellmeta)
+- [beforeChange](@/api/hooks.md#beforechange)
+- [beforeCreateCol](@/api/hooks.md#beforecreatecol)
+- [beforeCreateRow](@/api/hooks.md#beforecreaterow)
+- [beforeRemoveCol](@/api/hooks.md#beforeremovecol)
+- [beforeRemoveRow](@/api/hooks.md#beforeremoverow)
+- [beforeSetCellMeta](@/api/hooks.md#beforesetcellmeta)
+
+</div>
+
+**Plugins**
+
+<div class="boxes-list">
+
+- [Comments](@/api/comments.md)
+- [CustomBorders](@/api/customBorders.md)
+- [MergeCells](@/api/mergeCells.md)
+
+</div>

--- a/docs/content/guides/data-management/collaboration/javascript/example1.html
+++ b/docs/content/guides/data-management/collaboration/javascript/example1.html
@@ -1,0 +1,4 @@
+<div class="example-controls-container">
+  <p id="remote-update-status" class="controls"></p>
+</div>
+<div id="example1"></div>

--- a/docs/content/guides/data-management/collaboration/javascript/example1.js
+++ b/docs/content/guides/data-management/collaboration/javascript/example1.js
@@ -1,0 +1,46 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+// register all Handsontable's modules
+registerAllModules();
+const container = document.querySelector('#example1');
+const statusText = document.querySelector('#remote-update-status');
+// marks a change as coming from another collaborator, so it isn't broadcast again
+const REMOTE_SOURCE = 'remotePeer';
+const hot = new Handsontable(container, {
+    data: [
+        ['Update onboarding flow', 'Ana García', 'In progress'],
+        ['Fix invoice rounding bug', 'James Okafor', 'Blocked'],
+        ['Write Q3 release notes', 'Li Wei', 'In progress'],
+        ['Migrate auth service', 'Sofia Rossi', 'Done'],
+        ['Design empty states', 'Diego Fernández', 'In progress'],
+    ],
+    colHeaders: ['Task', 'Assignee', 'Status'],
+    rowHeaders: true,
+    height: 'auto',
+    licenseKey: 'non-commercial-and-evaluation',
+    beforeChange(changes, source) {
+        if (source === REMOTE_SOURCE || !changes) {
+            return;
+        }
+        changes.forEach(([row, column, , newValue]) => {
+            // send the local edit to your collaboration backend here
+            console.log('Broadcasting local edit:', row, column, newValue);
+        });
+    },
+});
+function applyRemoteChange(row, column, value) {
+    const editor = hot.getActiveEditor();
+    const editingSameCell = editor?.isOpened() && editor.row === row && editor.col === column;
+    if (editingSameCell) {
+        // don't overwrite a cell the local user is editing right now -
+        // check again shortly, and apply the change once the local edit finishes
+        setTimeout(() => applyRemoteChange(row, column, value), 300);
+        return;
+    }
+    hot.setDataAtCell(row, column, value, REMOTE_SOURCE);
+    statusText.textContent = 'A collaborator marked "Update onboarding flow" as Done.';
+}
+// simulate an update coming from another collaborator - start editing the Status
+// cell in the first row before the timeout fires to see the update wait for you
+statusText.textContent = 'A remote update to the first row arrives in 3 seconds.';
+setTimeout(() => applyRemoteChange(0, 2, 'Done'), 3000);

--- a/docs/content/guides/data-management/collaboration/javascript/example1.ts
+++ b/docs/content/guides/data-management/collaboration/javascript/example1.ts
@@ -1,0 +1,56 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+// register all Handsontable's modules
+registerAllModules();
+
+const container = document.querySelector('#example1')!;
+const statusText = document.querySelector('#remote-update-status')!;
+
+// marks a change as coming from another collaborator, so it isn't broadcast again
+const REMOTE_SOURCE = 'remotePeer';
+
+const hot = new Handsontable(container, {
+  data: [
+    ['Update onboarding flow', 'Ana García', 'In progress'],
+    ['Fix invoice rounding bug', 'James Okafor', 'Blocked'],
+    ['Write Q3 release notes', 'Li Wei', 'In progress'],
+    ['Migrate auth service', 'Sofia Rossi', 'Done'],
+    ['Design empty states', 'Diego Fernández', 'In progress'],
+  ],
+  colHeaders: ['Task', 'Assignee', 'Status'],
+  rowHeaders: true,
+  height: 'auto',
+  licenseKey: 'non-commercial-and-evaluation',
+  beforeChange(changes, source) {
+    if (source === REMOTE_SOURCE || !changes) {
+      return;
+    }
+
+    changes.forEach(([row, column, , newValue]) => {
+      // send the local edit to your collaboration backend here
+      console.log('Broadcasting local edit:', row, column, newValue);
+    });
+  },
+});
+
+function applyRemoteChange(row: number, column: number, value: string) {
+  const editor = hot.getActiveEditor();
+  const editingSameCell = editor?.isOpened() && editor.row === row && editor.col === column;
+
+  if (editingSameCell) {
+    // don't overwrite a cell the local user is editing right now -
+    // check again shortly, and apply the change once the local edit finishes
+    setTimeout(() => applyRemoteChange(row, column, value), 300);
+
+    return;
+  }
+
+  hot.setDataAtCell(row, column, value, REMOTE_SOURCE);
+  statusText.textContent = 'A collaborator marked "Update onboarding flow" as Done.';
+}
+
+// simulate an update coming from another collaborator - start editing the Status
+// cell in the first row before the timeout fires to see the update wait for you
+statusText.textContent = 'A remote update to the first row arrives in 3 seconds.';
+setTimeout(() => applyRemoteChange(0, 2, 'Done'), 3000);

--- a/docs/content/guides/data-management/collaboration/react/example1.jsx
+++ b/docs/content/guides/data-management/collaboration/react/example1.jsx
@@ -1,0 +1,73 @@
+import { useEffect, useRef, useState } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+// marks a change as coming from another collaborator, so it isn't broadcast again
+const REMOTE_SOURCE = 'remotePeer';
+
+const ExampleComponent = () => {
+  const hotRef = useRef(null);
+  const [statusText, setStatusText] = useState('A remote update to the first row arrives in 3 seconds.');
+
+  const applyRemoteChange = (row, column, value) => {
+    const hot = hotRef.current?.hotInstance;
+    const editor = hot?.getActiveEditor();
+    const editingSameCell = editor?.isOpened() && editor.row === row && editor.col === column;
+
+    if (editingSameCell) {
+      // don't overwrite a cell the local user is editing right now -
+      // check again shortly, and apply the change once the local edit finishes
+      setTimeout(() => applyRemoteChange(row, column, value), 300);
+
+      return;
+    }
+
+    hot?.setDataAtCell(row, column, value, REMOTE_SOURCE);
+    setStatusText('A collaborator marked "Update onboarding flow" as Done.');
+  };
+
+  useEffect(() => {
+    // simulate an update coming from another collaborator - start editing the Status
+    // cell in the first row before the timeout fires to see the update wait for you
+    const timeoutId = setTimeout(() => applyRemoteChange(0, 2, 'Done'), 3000);
+
+    return () => clearTimeout(timeoutId);
+  }, []);
+
+  return (
+    <>
+      <div className="example-controls-container">
+        <p className="controls">{statusText}</p>
+      </div>
+      <HotTable
+        ref={hotRef}
+        data={[
+          ['Update onboarding flow', 'Ana García', 'In progress'],
+          ['Fix invoice rounding bug', 'James Okafor', 'Blocked'],
+          ['Write Q3 release notes', 'Li Wei', 'In progress'],
+          ['Migrate auth service', 'Sofia Rossi', 'Done'],
+          ['Design empty states', 'Diego Fernández', 'In progress'],
+        ]}
+        colHeaders={['Task', 'Assignee', 'Status']}
+        rowHeaders={true}
+        height="auto"
+        licenseKey="non-commercial-and-evaluation"
+        beforeChange={(changes, source) => {
+          if (source === REMOTE_SOURCE || !changes) {
+            return;
+          }
+
+          changes.forEach(([row, column, , newValue]) => {
+            // send the local edit to your collaboration backend here
+            console.log('Broadcasting local edit:', row, column, newValue);
+          });
+        }}
+      />
+    </>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/data-management/collaboration/react/example1.tsx
+++ b/docs/content/guides/data-management/collaboration/react/example1.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useRef, useState } from 'react';
+import { HotTable, HotTableRef } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+// marks a change as coming from another collaborator, so it isn't broadcast again
+const REMOTE_SOURCE = 'remotePeer';
+
+const ExampleComponent = () => {
+  const hotRef = useRef<HotTableRef>(null);
+  const [statusText, setStatusText] = useState('A remote update to the first row arrives in 3 seconds.');
+
+  const applyRemoteChange = (row: number, column: number, value: string) => {
+    const hot = hotRef.current?.hotInstance;
+    const editor = hot?.getActiveEditor();
+    const editingSameCell = editor?.isOpened() && editor.row === row && editor.col === column;
+
+    if (editingSameCell) {
+      // don't overwrite a cell the local user is editing right now -
+      // check again shortly, and apply the change once the local edit finishes
+      setTimeout(() => applyRemoteChange(row, column, value), 300);
+
+      return;
+    }
+
+    hot?.setDataAtCell(row, column, value, REMOTE_SOURCE);
+    setStatusText('A collaborator marked "Update onboarding flow" as Done.');
+  };
+
+  useEffect(() => {
+    // simulate an update coming from another collaborator - start editing the Status
+    // cell in the first row before the timeout fires to see the update wait for you
+    const timeoutId = setTimeout(() => applyRemoteChange(0, 2, 'Done'), 3000);
+
+    return () => clearTimeout(timeoutId);
+  }, []);
+
+  return (
+    <>
+      <div className="example-controls-container">
+        <p className="controls">{statusText}</p>
+      </div>
+      <HotTable
+        ref={hotRef}
+        data={[
+          ['Update onboarding flow', 'Ana García', 'In progress'],
+          ['Fix invoice rounding bug', 'James Okafor', 'Blocked'],
+          ['Write Q3 release notes', 'Li Wei', 'In progress'],
+          ['Migrate auth service', 'Sofia Rossi', 'Done'],
+          ['Design empty states', 'Diego Fernández', 'In progress'],
+        ]}
+        colHeaders={['Task', 'Assignee', 'Status']}
+        rowHeaders={true}
+        height="auto"
+        licenseKey="non-commercial-and-evaluation"
+        beforeChange={(changes, source) => {
+          if (source === REMOTE_SOURCE || !changes) {
+            return;
+          }
+
+          changes.forEach(([row, column, , newValue]) => {
+            // send the local edit to your collaboration backend here
+            console.log('Broadcasting local edit:', row, column, newValue);
+          });
+        }}
+      />
+    </>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/data-management/collaboration/vue/example1.vue
+++ b/docs/content/guides/data-management/collaboration/vue/example1.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref, useTemplateRef } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+// marks a change as coming from another collaborator, so it isn't broadcast again
+const REMOTE_SOURCE = 'remotePeer';
+
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
+const statusText = ref('A remote update to the first row arrives in 3 seconds.');
+let timeoutId: ReturnType<typeof setTimeout>;
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['Update onboarding flow', 'Ana García', 'In progress'],
+    ['Fix invoice rounding bug', 'James Okafor', 'Blocked'],
+    ['Write Q3 release notes', 'Li Wei', 'In progress'],
+    ['Migrate auth service', 'Sofia Rossi', 'Done'],
+    ['Design empty states', 'Diego Fernández', 'In progress'],
+  ],
+  colHeaders: ['Task', 'Assignee', 'Status'],
+  rowHeaders: true,
+  height: 'auto',
+  licenseKey: 'non-commercial-and-evaluation',
+  beforeChange(changes, source) {
+    if (source === REMOTE_SOURCE || !changes) {
+      return;
+    }
+
+    changes.forEach(([row, column, , newValue]) => {
+      // send the local edit to your collaboration backend here
+      console.log('Broadcasting local edit:', row, column, newValue);
+    });
+  },
+});
+
+function applyRemoteChange(row: number, column: number, value: string) {
+  const hot = hotRef.value?.hotInstance;
+  const editor = hot?.getActiveEditor();
+  const editingSameCell = editor?.isOpened() && editor.row === row && editor.col === column;
+
+  if (editingSameCell) {
+    // don't overwrite a cell the local user is editing right now -
+    // check again shortly, and apply the change once the local edit finishes
+    timeoutId = setTimeout(() => applyRemoteChange(row, column, value), 300);
+
+    return;
+  }
+
+  hot?.setDataAtCell(row, column, value, REMOTE_SOURCE);
+  statusText.value = 'A collaborator marked "Update onboarding flow" as Done.';
+}
+
+onMounted(() => {
+  // simulate an update coming from another collaborator - start editing the Status
+  // cell in the first row before the timeout fires to see the update wait for you
+  timeoutId = setTimeout(() => applyRemoteChange(0, 2, 'Done'), 3000);
+});
+
+onBeforeUnmount(() => clearTimeout(timeoutId));
+</script>
+
+<template>
+  <div id="example1">
+    <div class="example-controls-container">
+      <p class="controls">{{ statusText }}</p>
+    </div>
+    <HotTable ref="hotRef" :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/sidebar.js
+++ b/docs/content/guides/sidebar.js
@@ -44,6 +44,7 @@ const dataManagementItems = [
   { path: 'guides/accessories-and-menus/export-to-excel/export-to-excel' },
   { path: 'guides/accessories-and-menus/export-to-csv/export-to-csv' },
   { path: 'guides/cell-features/clipboard/clipboard' },
+  { path: 'guides/data-management/collaboration/collaboration' },
 ];
 
 


### PR DESCRIPTION
### Context

The PR adds a how-to guide for handling collaboration and simultaneous editing in Handsontable. This closes a long-standing docs gap (ClickUp DEV-1074, originally migrated from GitHub #2597) raised from a real client escalation and forum reports about incoming remote updates (`setDataAtCell`) overwriting a cell the local user is actively editing.

The guide covers:

- Detecting an in-progress local edit with `getActiveEditor()` / `isOpened()` before applying a remote update, and deferring the update until the local edit finishes.
- Broadcasting local data changes with `beforeChange`, using a `source` marker to avoid re-broadcasting changes that came from another collaborator.
- Guarding and replaying structural changes (`beforeCreateRow`/`beforeRemoveRow`/`beforeCreateCol`/`beforeRemoveCol`, `alter()`).
- Syncing non-data state: cell metadata (`setCellMeta()`), comments, merged cells, and custom borders.

All runnable examples simulate the "remote peer" locally (a timer-based update), so they stay self-contained and require no backend.

### How has this been tested?

- Verified in the docs dev server (`node --max-old-space-size=16384 node_modules/astro/bin/astro.mjs dev`): the page renders at `/collaboration`, appears in the sidebar under **Data management** with a **New** badge, and all internal API/guide links resolve with correct anchors.
- Drove the JavaScript example end-to-end with Playwright: confirmed a simulated remote update is deferred while the target cell is being edited, and is correctly applied once editing finishes — including when the local edit is cancelled (<kbd>Esc</kbd>) rather than committed.
- Confirmed the React, Angular, and Vue variants mount with zero console errors.
- No source code changed; `npm run eslint`/`stylelint` not applicable (guide `content/` is excluded from the docs linter by design).

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1074

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1074

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only additions with no runtime or API changes to the grid libraries.
> 
> **Overview**
> Adds a new **Data management** how-to at `/collaboration` (sidebar entry with **New** badge) for building multi-user editing without a built-in transport layer.
> 
> The guide explains deferring remote `setDataAtCell` updates when `getActiveEditor()` shows the same cell is open, broadcasting local edits via `beforeChange` with a distinct `source` (e.g. `remotePeer`) to avoid echo loops, and documenting structural sync (`beforeCreateRow` / `alter`) plus metadata, comments, merges, and borders. Runnable **JavaScript**, **React**, **Angular**, and **Vue** examples share one pattern: a timer simulates a remote peer updating the first row’s Status after 3 seconds, with retry while the user is still editing.
> 
> No changes to `handsontable` or framework wrapper packages—docs and examples only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0197e7f598d2519735bf4b8522f292096d9aaa5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->