### PR TITLE
DEV-652: Clarify renderer extension guidance docs

### DIFF
--- a/docs/content/guides/cell-functions/cell-renderer/cell-renderer.md
+++ b/docs/content/guides/cell-functions/cell-renderer/cell-renderer.md
@@ -361,6 +361,28 @@ settings = {
 
 :::
 
+When your custom renderer should preserve the default text output, call the built-in `textRenderer()` first. See [Extend a built-in renderer](#extend-a-built-in-renderer).
+
+## Extend a built-in renderer
+
+When you build on top of a built-in renderer, Handsontable does not call that base renderer for you. You call it inside your custom renderer before your extra logic.
+
+Use `textRenderer` as the base when you want plain-text output and then apply styling or additional DOM changes.
+
+Use `htmlRenderer` as the base when your output is trusted HTML and you intentionally render with `innerHTML`.
+
+Skip a base renderer when your renderer fully controls cell output from scratch, for example the image-based `coverRenderer` in [Render custom HTML in cells](#render-custom-html-in-cells).
+
+Both of the following call styles are valid:
+
+```js
+// Legacy style, common in classic JavaScript examples.
+textRenderer.apply(this, arguments);
+
+// Direct invocation style, common in ESM and TypeScript examples.
+textRenderer(instance, td, row, column, prop, value, cellProperties);
+```
+
 ## Render custom HTML in cells
 
 This example shows how to use custom cell renderers to display HTML content in a cell. This is a very powerful feature. Just remember to escape any HTML code that could be used for XSS attacks.
@@ -443,6 +465,8 @@ When the link comes from untrusted input, validate the URL before rendering it. 
 ## Render custom HTML in header
 
 You can also put HTML into row and column headers. If you need to attach events to DOM elements like the checkbox below, just remember to identify the element by class name, not by id. This is because row and column headers are duplicated in the DOM tree and id attribute must be unique.
+
+If your goal is to extend a built-in renderer before adding custom logic, see [Extend a built-in renderer](#extend-a-built-in-renderer).
 
 ::: warning Security
 Handsontable does not include a built-in HTML sanitizer. When header content comes from untrusted sources, supply a [`sanitizer`](@/api/options.md#sanitizer) function to prevent XSS.


### PR DESCRIPTION
### Context

The PR changes the cell renderer guide to close the remaining docs gap from DEV-652. It adds dedicated guidance for extending built-in renderers and links that guidance from related sections so readers can find the pattern quickly.

### How has this been tested?

- Verified markdown update in the edited guide.
- Checked lint diagnostics for the edited file (no issues reported).

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-652

### Affected project(s):

- [x] handsontable
- [ ] @handsontable/angular-wrapper
- [ ] @handsontable/react-wrapper
- [ ] @handsontable/vue3

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-652

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to the cell renderer guide; no runtime or API behavior changes.
> 
> **Overview**
> Closes the DEV-652 docs gap in the **cell renderer** guide by documenting how to **extend built-in renderers** and wiring that section into related topics.
> 
> A new **Extend a built-in renderer** section states that Handsontable does not invoke the base renderer automatically—you must call `textRenderer` or `htmlRenderer` inside your custom renderer (or skip a base when output is fully custom, e.g. `coverRenderer`). It documents both `textRenderer.apply(this, arguments)` and direct invocation for ESM/TypeScript.
> 
> After **Use an alias**, readers are pointed to call `textRenderer()` first when preserving default text output. **Render custom HTML in header** now links to the same section when extending a built-in before custom header logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26b41932da14faa67028812f563eeeba7b883e62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->