### PR TITLE
DEV-660: Clarify async autocomplete docs wording

### DIFF
--- a/docs/content/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md
@@ -18,6 +18,7 @@ vue:
   metaTitle: Autocomplete cell type - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types
+menuTag: updated
 ---
 Collect user input with a list of choices, by using the autocomplete cell type.
 
@@ -30,7 +31,7 @@ You can edit the autocomplete-typed cells in three different ways:
 
 - Flexible mode
 - Strict mode
-- Strict mode using Ajax
+- Strict mode with asynchronous data
 
 In all three modes, the `source` option can be provided in two formats:
 
@@ -139,9 +140,11 @@ In strict mode, the [`allowInvalid`](@/api/options.md#allowinvalid) option deter
 
 :::
 
-## Autocomplete strict mode (Ajax)
+<span id="autocomplete-strict-mode-ajax"></span>
 
-Autocomplete can also be used with Ajax data sources. In the example below, suggestions for the "Car" column are loaded from the server. To load data from a remote *asynchronous* source, assign a function to the 'source' property. The function should perform the server-side request and call the callback function when the result is available.
+## Autocomplete strict mode with asynchronous data
+
+Autocomplete can also use asynchronous data sources. In the example below, suggestions for the "Car" column are loaded from the server with the Fetch API. To load data from a remote source, assign a function to the `source` option. The function receives the query string and the `process` callback. Call `process()` with the result array when the request completes.
 
 ::: only-for javascript
 


### PR DESCRIPTION
## Summary
- Replace outdated "Ajax" terminology in the autocomplete strict-mode docs with asynchronous/fetch-based wording to match the existing examples.
- Rename the strict-mode section label and heading to refer to asynchronous data sources.
- Add `menuTag: updated` and preserve old deep links by keeping the legacy `autocomplete-strict-mode-ajax` anchor in the page.
- [skip changelog]

## Test plan
- [x] `rtk npm --prefix docs run docs:lint`
- [x] Confirm old hash link `#autocomplete-strict-mode-ajax` still resolves on the updated page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime or API behavior changes.
> 
> **Overview**
> Updates the autocomplete cell type guide so strict-mode remote loading is described as **asynchronous data** (Fetch API, `source` function + `process` callback) instead of legacy **Ajax** wording.
> 
> The overview bullet and section heading are renamed accordingly, front matter adds **`menuTag: updated`**, and a hidden **`autocomplete-strict-mode-ajax`** anchor keeps old deep links working. No code or examples change—docs copy only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eeb1f2cf2a19c6265adb705238980fa2435bc2eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->