### PR TITLE
DEV-658: Fix dead bit.ly book link in cell-renderer examples

### DIFF
--- a/docs/content/guides/cell-functions/cell-renderer/angular/example1.ts
+++ b/docs/content/guides/cell-functions/cell-renderer/angular/example1.ts
@@ -31,7 +31,7 @@ export class AppComponent implements OnInit, AfterViewInit {
       title:
         '<a href="https://www.amazon.com/Professional-JavaScript-Developers-Nicholas-Zakas/dp/1118026691">Professional JavaScript for Web Developers</a>',
       description:
-        'This <a href="https://bit.ly/sM1bDf">book</a> provides a developer-level introduction along with more advanced and useful features of <b>JavaScript</b>.',
+        'This <a href="https://www.amazon.com/Professional-JavaScript-Developers-Nicholas-Zakas/dp/1118026691">book</a> provides a developer-level introduction along with more advanced and useful features of <b>JavaScript</b>.',
       cover:
         '/docs/img/examples/professional-javascript-developers-nicholas-zakas.jpg',
     },

--- a/docs/content/guides/cell-functions/cell-renderer/angular/example2.ts
+++ b/docs/content/guides/cell-functions/cell-renderer/angular/example2.ts
@@ -24,7 +24,7 @@ export class AppComponent implements OnInit {
       title:
         '<a href="https://www.amazon.com/Professional-JavaScript-Developers-Nicholas-Zakas/dp/1118026691">Professional JavaScript for Web Developers</a>',
       description:
-        'This <a href="https://bit.ly/sM1bDf">book</a> provides a developer-level introduction along with more advanced and useful features of <b>JavaScript</b>.',
+        'This <a href="https://www.amazon.com/Professional-JavaScript-Developers-Nicholas-Zakas/dp/1118026691">book</a> provides a developer-level introduction along with more advanced and useful features of <b>JavaScript</b>.',
       cover:
         '/docs/img/examples/professional-javascript-developers-nicholas-zakas.jpg',
     },

--- a/docs/content/guides/cell-functions/cell-renderer/angular/example3.ts
+++ b/docs/content/guides/cell-functions/cell-renderer/angular/example3.ts
@@ -43,7 +43,7 @@ export class AppComponent {
       title:
         '<a href="https://www.amazon.com/Professional-JavaScript-Developers-Nicholas-Zakas/dp/1118026691">Professional JavaScript for Web Developers</a>',
       description:
-        'This <a href="https://bit.ly/sM1bDf">book</a> provides a developer-level introduction along with more advanced and useful features of <b>JavaScript</b>.',
+        'This <a href="https://www.amazon.com/Professional-JavaScript-Developers-Nicholas-Zakas/dp/1118026691">book</a> provides a developer-level introduction along with more advanced and useful features of <b>JavaScript</b>.',
       rate: 3
     },
     {

--- a/docs/content/guides/cell-functions/cell-renderer/angular/example4.ts
+++ b/docs/content/guides/cell-functions/cell-renderer/angular/example4.ts
@@ -34,7 +34,7 @@ export class AppComponent implements OnInit, AfterViewInit {
       title:
         '<a href="https://www.amazon.com/Professional-JavaScript-Developers-Nicholas-Zakas/dp/1118026691">Professional JavaScript for Web Developers</a>',
       description:
-        'This <a href="https://bit.ly/sM1bDf">book</a> provides a developer-level introduction along with more advanced and useful features of <b>JavaScript</b>.',
+        'This <a href="https://www.amazon.com/Professional-JavaScript-Developers-Nicholas-Zakas/dp/1118026691">book</a> provides a developer-level introduction along with more advanced and useful features of <b>JavaScript</b>.',
       cover:
         '/docs/img/examples/professional-javascript-developers-nicholas-zakas.jpg',
     },

--- a/docs/content/guides/cell-functions/cell-renderer/angular/example5.ts
+++ b/docs/content/guides/cell-functions/cell-renderer/angular/example5.ts
@@ -56,7 +56,7 @@ export class AppComponent implements AfterViewInit {
       title:
         '<a href="https://www.amazon.com/Professional-JavaScript-Developers-Nicholas-Zakas/dp/1118026691">Professional JavaScript for Web Developers</a>',
       description:
-        'This <a href="https://bit.ly/sM1bDf">book</a> provides a developer-level introduction along with more advanced and useful features of <b>JavaScript</b>.',
+        'This <a href="https://www.amazon.com/Professional-JavaScript-Developers-Nicholas-Zakas/dp/1118026691">book</a> provides a developer-level introduction along with more advanced and useful features of <b>JavaScript</b>.',
       comments: 'I would rate it ★★★★☆',
       cover:
         '/docs/img/examples/professional-javascript-developers-nicholas-zakas.jpg',

--- a/docs/content/guides/cell-functions/cell-renderer/javascript/example4.js
+++ b/docs/content/guides/cell-functions/cell-renderer/javascript/example4.js
@@ -9,7 +9,7 @@ const data = [
     title:
       '<a href="https://www.amazon.com/Professional-JavaScript-Developers-Nicholas-Zakas/dp/1118026691">Professional JavaScript for Web Developers</a>',
     description:
-      'This <a href="https://bit.ly/sM1bDf">book</a> provides a developer-level introduction along with more advanced and useful features of <b>JavaScript</b>.',
+      'This <a href="https://www.amazon.com/Professional-JavaScript-Developers-Nicholas-Zakas/dp/1118026691">book</a> provides a developer-level introduction along with more advanced and useful features of <b>JavaScript</b>.',
     comments: 'I would rate it &#x2605;&#x2605;&#x2605;&#x2605;&#x2606;',
     cover: '/docs/img/examples/professional-javascript-developers-nicholas-zakas.jpg',
   },

--- a/docs/content/guides/cell-functions/cell-renderer/javascript/example4.ts
+++ b/docs/content/guides/cell-functions/cell-renderer/javascript/example4.ts
@@ -17,7 +17,7 @@ const data: Book[] = [
     title:
       '<a href="https://www.amazon.com/Professional-JavaScript-Developers-Nicholas-Zakas/dp/1118026691">Professional JavaScript for Web Developers</a>',
     description:
-      'This <a href="https://bit.ly/sM1bDf">book</a> provides a developer-level introduction along with more advanced and useful features of <b>JavaScript</b>.',
+      'This <a href="https://www.amazon.com/Professional-JavaScript-Developers-Nicholas-Zakas/dp/1118026691">book</a> provides a developer-level introduction along with more advanced and useful features of <b>JavaScript</b>.',
     comments: 'I would rate it &#x2605;&#x2605;&#x2605;&#x2605;&#x2606;',
     cover: '/docs/img/examples/professional-javascript-developers-nicholas-zakas.jpg',
   },

--- a/docs/content/guides/cell-functions/cell-renderer/react/example4.jsx
+++ b/docs/content/guides/cell-functions/cell-renderer/react/example4.jsx
@@ -10,7 +10,7 @@ const ExampleComponent = () => {
       title:
         '<a href="https://www.amazon.com/Professional-JavaScript-Developers-Nicholas-Zakas/dp/1118026691">Professional JavaScript for Web Developers</a>',
       description:
-        'This <a href="https://bit.ly/sM1bDf">book</a> provides a developer-level introduction along with more advanced and useful features of <b>JavaScript</b>.',
+        'This <a href="https://www.amazon.com/Professional-JavaScript-Developers-Nicholas-Zakas/dp/1118026691">book</a> provides a developer-level introduction along with more advanced and useful features of <b>JavaScript</b>.',
       comments: 'I would rate it ★★★★☆',
       cover: '/docs/img/examples/professional-javascript-developers-nicholas-zakas.jpg',
     },

--- a/docs/content/guides/cell-functions/cell-renderer/react/example4.tsx
+++ b/docs/content/guides/cell-functions/cell-renderer/react/example4.tsx
@@ -11,7 +11,7 @@ const ExampleComponent = () => {
       title:
         '<a href="https://www.amazon.com/Professional-JavaScript-Developers-Nicholas-Zakas/dp/1118026691">Professional JavaScript for Web Developers</a>',
       description:
-        'This <a href="https://bit.ly/sM1bDf">book</a> provides a developer-level introduction along with more advanced and useful features of <b>JavaScript</b>.',
+        'This <a href="https://www.amazon.com/Professional-JavaScript-Developers-Nicholas-Zakas/dp/1118026691">book</a> provides a developer-level introduction along with more advanced and useful features of <b>JavaScript</b>.',
       comments: 'I would rate it ★★★★☆',
       cover: '/docs/img/examples/professional-javascript-developers-nicholas-zakas.jpg',
     },

--- a/docs/content/guides/cell-functions/cell-renderer/vue/example4.vue
+++ b/docs/content/guides/cell-functions/cell-renderer/vue/example4.vue
@@ -19,7 +19,7 @@ const data: Book[] = [
     title:
       '<a href="https://www.amazon.com/Professional-JavaScript-Developers-Nicholas-Zakas/dp/1118026691">Professional JavaScript for Web Developers</a>',
     description:
-      'This <a href="https://bit.ly/sM1bDf">book</a> provides a developer-level introduction along with more advanced and useful features of <b>JavaScript</b>.',
+      'This <a href="https://www.amazon.com/Professional-JavaScript-Developers-Nicholas-Zakas/dp/1118026691">book</a> provides a developer-level introduction along with more advanced and useful features of <b>JavaScript</b>.',
     comments: 'I would rate it &#x2605;&#x2605;&#x2605;&#x2605;&#x2606;',
     cover: '/docs/img/examples/professional-javascript-developers-nicholas-zakas.jpg',
   },


### PR DESCRIPTION
### Context

The PR fixes a dead outbound link found in a 2023 broken-link audit (DEV-658). The `description` field of the `cell-renderer` guide's "book" data example linked to a dead `bit.ly/sM1bDf` shortlink for "Professional JavaScript for Web Developers." The sibling `title` field in the same examples already pointed to a working Amazon URL for the same book — only the `description` field's anchor was missed. This fix repoints the `description` anchor to that same working URL across all framework variants of the example.

The remaining 29 links from the original audit were "Edit this page on GitHub" links baked into frozen VuePress-era version snapshots; they're moot since the docs site migrated to Astro Starlight (PR #12195), where edit links are generated dynamically against the live page path.

### How has this been tested?

- Manual review of the diff: verified the replacement URL (`https://www.amazon.com/Professional-JavaScript-Developers-Nicholas-Zakas/dp/1118026691`) matches the `title` field's existing working link in each file.
- `grep -rl "bit.ly/sM1bDf" docs/content/` returns no matches after the change.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-658

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-658

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only sample data changes with no runtime or library behavior impact.
> 
> **Overview**
> Replaces the dead **`bit.ly/sM1bDf`** anchor in the sample book **`description`** HTML with the same working Amazon URL already used on the matching **`title`** field for *Professional JavaScript for Web Developers*.
> 
> The update is applied consistently across **Angular** (`example1`–`example5`), **JavaScript**, **React**, and **Vue** cell-renderer guide examples so live docs demos no longer expose a broken outbound link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2ae153e55edf5ed2d51d22f21d95f1ebe0ac55e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->