### PR TITLE
DEV-647: Add runnable example for the Use sorting hooks section

### DIFF
--- a/docs/content/guides/rows/rows-sorting/angular/example11.html
+++ b/docs/content/guides/rows/rows-sorting/angular/example11.html
@@ -1,0 +1,3 @@
+<div>
+    <app-example11></app-example11>
+</div>

--- a/docs/content/guides/rows/rows-sorting/angular/example11.ts
+++ b/docs/content/guides/rows/rows-sorting/angular/example11.ts
@@ -1,0 +1,124 @@
+/* file: app.component.ts */
+import { Component, ViewChild } from '@angular/core';
+import { GridSettings, HotTableComponent, HotTableModule } from '@handsontable/angular-wrapper';
+import type Handsontable from 'handsontable/base';
+
+interface Row {
+  brand: string;
+  model: string;
+  price: number;
+  sellDate: string;
+}
+
+@Component({
+  standalone: true,
+  imports: [HotTableModule],
+  selector: 'app-example11',
+  template: `
+    <div class="example-controls-container">
+      <div class="controls">
+        <span>{{ status }}</span>
+      </div>
+    </div>
+    <hot-table [data]="data" [settings]="gridSettings"></hot-table>
+  `,
+})
+export class AppComponent {
+  @ViewChild(HotTableComponent, { static: false }) readonly hotTable!: HotTableComponent;
+
+  status = 'Click a column header to sort.';
+
+  readonly data: Row[] = [
+    { brand: 'Jetpulse', model: 'Racing Socks', price: 30, sellDate: '2023-10-11' },
+    { brand: 'Gigabox', model: 'HL Mountain Frame', price: 1890.9, sellDate: '2023-05-03' },
+    { brand: 'Camido', model: 'Cycling Cap', price: 130.1, sellDate: '2023-03-27' },
+    { brand: 'Chatterpoint', model: 'Road Tire Tube', price: 59, sellDate: '2023-08-28' },
+    { brand: 'Eidel', model: 'HL Road Tire', price: 279.99, sellDate: '2023-10-02' },
+  ];
+
+  readonly columnDataKeys: (keyof Row)[] = ['brand', 'model', 'price', 'sellDate'];
+
+  // Simulates a server that receives a sort request and returns sorted rows.
+  sortOnServer(columnKey: keyof Row, sortOrder: string): Promise<Row[]> {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        const sortedData = [...this.data].sort((rowA, rowB) => {
+          if (rowA[columnKey] === rowB[columnKey]) {
+            return 0;
+          }
+
+          return ((rowA[columnKey] as any) > (rowB[columnKey] as any)) === (sortOrder === 'asc') ? 1 : -1;
+        });
+
+        resolve(sortedData);
+      }, 600);
+    });
+  }
+
+  readonly gridSettings: GridSettings = {
+    columns: [
+      { title: 'Brand', type: 'text', data: 'brand' },
+      { title: 'Model', type: 'text', data: 'model' },
+      {
+        title: 'Price',
+        type: 'numeric',
+        data: 'price',
+        locale: 'en-US',
+        numericFormat: { style: 'currency', currency: 'USD', minimumFractionDigits: 2 },
+      },
+      {
+        title: 'Date',
+        type: 'intl-date',
+        data: 'sellDate',
+        locale: 'en-US',
+        dateFormat: { month: 'short', day: 'numeric', year: 'numeric' },
+        className: 'htRight',
+      },
+    ],
+    columnSorting: true,
+    height: 'auto',
+    stretchH: 'all',
+    autoWrapRow: true,
+    autoWrapCol: true,
+    beforeColumnSort: (
+      currentSortConfig: Handsontable.plugins.ColumnSorting.Config[],
+      destinationSortConfigs: Handsontable.plugins.ColumnSorting.Config[]
+    ) => {
+      const [sortConfig] = destinationSortConfigs;
+
+      if (!sortConfig || sortConfig.sortOrder === 'none') {
+        return true;
+      }
+
+      this.status = 'Sorting on the server...';
+
+      this.sortOnServer(this.columnDataKeys[sortConfig.column], sortConfig.sortOrder).then((sortedData) => {
+        this.hotTable?.hotInstance?.loadData(sortedData);
+        this.status = 'Sorted on the server.';
+      });
+
+      // return `false` to cancel Handsontable's own front-end sort
+      return false;
+    },
+  };
+}
+/* end-file */
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+/* end-file */

--- a/docs/content/guides/rows/rows-sorting/angular/example11.ts
+++ b/docs/content/guides/rows/rows-sorting/angular/example11.ts
@@ -1,6 +1,6 @@
 /* file: app.component.ts */
-import { Component, ViewChild } from '@angular/core';
-import { GridSettings, HotTableComponent, HotTableModule } from '@handsontable/angular-wrapper';
+import { Component } from '@angular/core';
+import { GridSettings, HotTableModule } from '@handsontable/angular-wrapper';
 import type Handsontable from 'handsontable/base';
 
 interface Row {
@@ -9,6 +9,16 @@ interface Row {
   price: number;
   sellDate: string;
 }
+
+const originalData: Row[] = [
+  { brand: 'Jetpulse', model: 'Racing Socks', price: 30, sellDate: '2023-10-11' },
+  { brand: 'Gigabox', model: 'HL Mountain Frame', price: 1890.9, sellDate: '2023-05-03' },
+  { brand: 'Camido', model: 'Cycling Cap', price: 130.1, sellDate: '2023-03-27' },
+  { brand: 'Chatterpoint', model: 'Road Tire Tube', price: 59, sellDate: '2023-08-28' },
+  { brand: 'Eidel', model: 'HL Road Tire', price: 279.99, sellDate: '2023-10-02' },
+];
+
+const columnDataKeys: (keyof Row)[] = ['brand', 'model', 'price', 'sellDate'];
 
 @Component({
   standalone: true,
@@ -24,25 +34,26 @@ interface Row {
   `,
 })
 export class AppComponent {
-  @ViewChild(HotTableComponent, { static: false }) readonly hotTable!: HotTableComponent;
-
   status = 'Click a column header to sort.';
+  data: Row[] = originalData;
 
-  readonly data: Row[] = [
-    { brand: 'Jetpulse', model: 'Racing Socks', price: 30, sellDate: '2023-10-11' },
-    { brand: 'Gigabox', model: 'HL Mountain Frame', price: 1890.9, sellDate: '2023-05-03' },
-    { brand: 'Camido', model: 'Cycling Cap', price: 130.1, sellDate: '2023-03-27' },
-    { brand: 'Chatterpoint', model: 'Road Tire Tube', price: 59, sellDate: '2023-08-28' },
-    { brand: 'Eidel', model: 'HL Road Tire', price: 279.99, sellDate: '2023-10-02' },
-  ];
+  // Canceling the front-end sort also stops Handsontable from tracking the column's sort
+  // order, so this example cycles ascending -> descending -> unsorted manually.
+  private activeSort: { column: number; sortOrder: 'asc' | 'desc' } | null = null;
 
-  readonly columnDataKeys: (keyof Row)[] = ['brand', 'model', 'price', 'sellDate'];
+  private getNextSortOrder(column: number): 'asc' | 'desc' | null {
+    if (!this.activeSort || this.activeSort.column !== column) {
+      return 'asc';
+    }
+
+    return this.activeSort.sortOrder === 'asc' ? 'desc' : null;
+  }
 
   // Simulates a server that receives a sort request and returns sorted rows.
-  sortOnServer(columnKey: keyof Row, sortOrder: string): Promise<Row[]> {
+  private sortOnServer(columnKey: keyof Row, sortOrder: string): Promise<Row[]> {
     return new Promise((resolve) => {
       setTimeout(() => {
-        const sortedData = [...this.data].sort((rowA, rowB) => {
+        const sortedData = [...originalData].sort((rowA, rowB) => {
           if (rowA[columnKey] === rowB[columnKey]) {
             return 0;
           }
@@ -84,16 +95,31 @@ export class AppComponent {
       currentSortConfig: Handsontable.plugins.ColumnSorting.Config[],
       destinationSortConfigs: Handsontable.plugins.ColumnSorting.Config[]
     ) => {
-      const [sortConfig] = destinationSortConfigs;
+      const [requestedSort] = destinationSortConfigs;
 
-      if (!sortConfig || sortConfig.sortOrder === 'none') {
-        return true;
+      if (!requestedSort) {
+        // the sorting was cleared programmatically, restore the original row order
+        this.activeSort = null;
+        this.data = originalData;
+
+        return false;
       }
 
+      const nextOrder = this.getNextSortOrder(requestedSort.column);
+
+      if (nextOrder === null) {
+        this.activeSort = null;
+        this.status = 'Cleared the sort.';
+        this.data = originalData;
+
+        return false;
+      }
+
+      this.activeSort = { column: requestedSort.column, sortOrder: nextOrder };
       this.status = 'Sorting on the server...';
 
-      this.sortOnServer(this.columnDataKeys[sortConfig.column], sortConfig.sortOrder).then((sortedData) => {
-        this.hotTable?.hotInstance?.loadData(sortedData);
+      this.sortOnServer(columnDataKeys[requestedSort.column], nextOrder).then((sortedData) => {
+        this.data = sortedData;
         this.status = 'Sorted on the server.';
       });
 

--- a/docs/content/guides/rows/rows-sorting/javascript/exampleSortingHooks.html
+++ b/docs/content/guides/rows/rows-sorting/javascript/exampleSortingHooks.html
@@ -1,0 +1,6 @@
+<div class="example-controls-container">
+  <div class="controls">
+    <span id="exampleSortingHooksStatus">Click a column header to sort.</span>
+  </div>
+</div>
+<div id="exampleSortingHooks"></div>

--- a/docs/content/guides/rows/rows-sorting/javascript/exampleSortingHooks.js
+++ b/docs/content/guides/rows/rows-sorting/javascript/exampleSortingHooks.js
@@ -12,6 +12,15 @@ const data = [
     { brand: 'Eidel', model: 'HL Road Tire', price: 279.99, sellDate: '2023-10-02' },
 ];
 const columnDataKeys = ['brand', 'model', 'price', 'sellDate'];
+// Canceling the front-end sort also stops Handsontable from tracking the column's sort
+// order, so this example cycles ascending -> descending -> unsorted manually.
+let activeSort = null;
+function getNextSortOrder(column) {
+    if (!activeSort || activeSort.column !== column) {
+        return 'asc';
+    }
+    return activeSort.sortOrder === 'asc' ? 'desc' : null;
+}
 // Simulates a server that receives a sort request and returns sorted rows.
 function sortOnServer(columnKey, sortOrder) {
     return new Promise((resolve) => {
@@ -53,13 +62,23 @@ const hot = new Handsontable(container, {
     autoWrapRow: true,
     autoWrapCol: true,
     beforeColumnSort(currentSortConfig, destinationSortConfigs) {
-        const [sortConfig] = destinationSortConfigs;
-        if (!sortConfig || sortConfig.sortOrder === 'none') {
-            // the sorting was cleared, let Handsontable reset the row order on the front end
-            return true;
+        const [requestedSort] = destinationSortConfigs;
+        if (!requestedSort) {
+            // the sorting was cleared programmatically, restore the original row order
+            activeSort = null;
+            hot.loadData(data);
+            return false;
         }
+        const nextOrder = getNextSortOrder(requestedSort.column);
+        if (nextOrder === null) {
+            activeSort = null;
+            status.textContent = 'Cleared the sort.';
+            hot.loadData(data);
+            return false;
+        }
+        activeSort = { column: requestedSort.column, sortOrder: nextOrder };
         status.textContent = 'Sorting on the server...';
-        sortOnServer(columnDataKeys[sortConfig.column], sortConfig.sortOrder).then((sortedData) => {
+        sortOnServer(columnDataKeys[requestedSort.column], nextOrder).then((sortedData) => {
             hot.loadData(sortedData);
             status.textContent = 'Sorted on the server.';
         });

--- a/docs/content/guides/rows/rows-sorting/javascript/exampleSortingHooks.js
+++ b/docs/content/guides/rows/rows-sorting/javascript/exampleSortingHooks.js
@@ -1,0 +1,70 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+// Register all Handsontable's modules.
+registerAllModules();
+const container = document.querySelector('#exampleSortingHooks');
+const status = document.querySelector('#exampleSortingHooksStatus');
+const data = [
+    { brand: 'Jetpulse', model: 'Racing Socks', price: 30, sellDate: '2023-10-11' },
+    { brand: 'Gigabox', model: 'HL Mountain Frame', price: 1890.9, sellDate: '2023-05-03' },
+    { brand: 'Camido', model: 'Cycling Cap', price: 130.1, sellDate: '2023-03-27' },
+    { brand: 'Chatterpoint', model: 'Road Tire Tube', price: 59, sellDate: '2023-08-28' },
+    { brand: 'Eidel', model: 'HL Road Tire', price: 279.99, sellDate: '2023-10-02' },
+];
+const columnDataKeys = ['brand', 'model', 'price', 'sellDate'];
+// Simulates a server that receives a sort request and returns sorted rows.
+function sortOnServer(columnKey, sortOrder) {
+    return new Promise((resolve) => {
+        setTimeout(() => {
+            const sortedData = [...data].sort((rowA, rowB) => {
+                if (rowA[columnKey] === rowB[columnKey]) {
+                    return 0;
+                }
+                return (rowA[columnKey] > rowB[columnKey]) === (sortOrder === 'asc') ? 1 : -1;
+            });
+            resolve(sortedData);
+        }, 600);
+    });
+}
+const hot = new Handsontable(container, {
+    data,
+    columns: [
+        { title: 'Brand', type: 'text', data: 'brand' },
+        { title: 'Model', type: 'text', data: 'model' },
+        {
+            title: 'Price',
+            type: 'numeric',
+            data: 'price',
+            locale: 'en-US',
+            numericFormat: { style: 'currency', currency: 'USD', minimumFractionDigits: 2 },
+        },
+        {
+            title: 'Date',
+            type: 'intl-date',
+            data: 'sellDate',
+            locale: 'en-US',
+            dateFormat: { month: 'short', day: 'numeric', year: 'numeric' },
+            className: 'htRight',
+        },
+    ],
+    columnSorting: true,
+    height: 'auto',
+    stretchH: 'all',
+    autoWrapRow: true,
+    autoWrapCol: true,
+    beforeColumnSort(currentSortConfig, destinationSortConfigs) {
+        const [sortConfig] = destinationSortConfigs;
+        if (!sortConfig || sortConfig.sortOrder === 'none') {
+            // the sorting was cleared, let Handsontable reset the row order on the front end
+            return true;
+        }
+        status.textContent = 'Sorting on the server...';
+        sortOnServer(columnDataKeys[sortConfig.column], sortConfig.sortOrder).then((sortedData) => {
+            hot.loadData(sortedData);
+            status.textContent = 'Sorted on the server.';
+        });
+        // return `false` to cancel Handsontable's own front-end sort
+        return false;
+    },
+    licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/rows/rows-sorting/javascript/exampleSortingHooks.ts
+++ b/docs/content/guides/rows/rows-sorting/javascript/exampleSortingHooks.ts
@@ -1,0 +1,82 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+// Register all Handsontable's modules.
+registerAllModules();
+
+const container = document.querySelector('#exampleSortingHooks')!;
+const status = document.querySelector('#exampleSortingHooksStatus')!;
+
+const data = [
+  { brand: 'Jetpulse', model: 'Racing Socks', price: 30, sellDate: '2023-10-11' },
+  { brand: 'Gigabox', model: 'HL Mountain Frame', price: 1890.9, sellDate: '2023-05-03' },
+  { brand: 'Camido', model: 'Cycling Cap', price: 130.1, sellDate: '2023-03-27' },
+  { brand: 'Chatterpoint', model: 'Road Tire Tube', price: 59, sellDate: '2023-08-28' },
+  { brand: 'Eidel', model: 'HL Road Tire', price: 279.99, sellDate: '2023-10-02' },
+];
+
+const columnDataKeys = ['brand', 'model', 'price', 'sellDate'];
+
+// Simulates a server that receives a sort request and returns sorted rows.
+function sortOnServer(columnKey: string, sortOrder: string) {
+  return new Promise<typeof data>((resolve) => {
+    setTimeout(() => {
+      const sortedData = [...data].sort((rowA: any, rowB: any) => {
+        if (rowA[columnKey] === rowB[columnKey]) {
+          return 0;
+        }
+
+        return (rowA[columnKey] > rowB[columnKey]) === (sortOrder === 'asc') ? 1 : -1;
+      });
+
+      resolve(sortedData);
+    }, 600);
+  });
+}
+
+const hot = new Handsontable(container, {
+  data,
+  columns: [
+    { title: 'Brand', type: 'text', data: 'brand' },
+    { title: 'Model', type: 'text', data: 'model' },
+    {
+      title: 'Price',
+      type: 'numeric',
+      data: 'price',
+      locale: 'en-US',
+      numericFormat: { style: 'currency', currency: 'USD', minimumFractionDigits: 2 },
+    },
+    {
+      title: 'Date',
+      type: 'intl-date',
+      data: 'sellDate',
+      locale: 'en-US',
+      dateFormat: { month: 'short', day: 'numeric', year: 'numeric' },
+      className: 'htRight',
+    },
+  ],
+  columnSorting: true,
+  height: 'auto',
+  stretchH: 'all',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  beforeColumnSort(currentSortConfig, destinationSortConfigs) {
+    const [sortConfig] = destinationSortConfigs;
+
+    if (!sortConfig || sortConfig.sortOrder === 'none') {
+      // the sorting was cleared, let Handsontable reset the row order on the front end
+      return true;
+    }
+
+    status.textContent = 'Sorting on the server...';
+
+    sortOnServer(columnDataKeys[sortConfig.column], sortConfig.sortOrder).then((sortedData) => {
+      hot.loadData(sortedData);
+      status.textContent = 'Sorted on the server.';
+    });
+
+    // return `false` to cancel Handsontable's own front-end sort
+    return false;
+  },
+  licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/rows/rows-sorting/javascript/exampleSortingHooks.ts
+++ b/docs/content/guides/rows/rows-sorting/javascript/exampleSortingHooks.ts
@@ -17,6 +17,18 @@ const data = [
 
 const columnDataKeys = ['brand', 'model', 'price', 'sellDate'];
 
+// Canceling the front-end sort also stops Handsontable from tracking the column's sort
+// order, so this example cycles ascending -> descending -> unsorted manually.
+let activeSort: { column: number; sortOrder: 'asc' | 'desc' } | null = null;
+
+function getNextSortOrder(column: number): 'asc' | 'desc' | null {
+  if (!activeSort || activeSort.column !== column) {
+    return 'asc';
+  }
+
+  return activeSort.sortOrder === 'asc' ? 'desc' : null;
+}
+
 // Simulates a server that receives a sort request and returns sorted rows.
 function sortOnServer(columnKey: string, sortOrder: string) {
   return new Promise<typeof data>((resolve) => {
@@ -61,16 +73,30 @@ const hot = new Handsontable(container, {
   autoWrapRow: true,
   autoWrapCol: true,
   beforeColumnSort(currentSortConfig, destinationSortConfigs) {
-    const [sortConfig] = destinationSortConfigs;
+    const [requestedSort] = destinationSortConfigs;
 
-    if (!sortConfig || sortConfig.sortOrder === 'none') {
-      // the sorting was cleared, let Handsontable reset the row order on the front end
-      return true;
+    if (!requestedSort) {
+      // the sorting was cleared programmatically, restore the original row order
+      activeSort = null;
+      hot.loadData(data);
+
+      return false;
     }
 
+    const nextOrder = getNextSortOrder(requestedSort.column);
+
+    if (nextOrder === null) {
+      activeSort = null;
+      status.textContent = 'Cleared the sort.';
+      hot.loadData(data);
+
+      return false;
+    }
+
+    activeSort = { column: requestedSort.column, sortOrder: nextOrder };
     status.textContent = 'Sorting on the server...';
 
-    sortOnServer(columnDataKeys[sortConfig.column], sortConfig.sortOrder).then((sortedData) => {
+    sortOnServer(columnDataKeys[requestedSort.column], nextOrder).then((sortedData) => {
       hot.loadData(sortedData);
       status.textContent = 'Sorted on the server.';
     });

--- a/docs/content/guides/rows/rows-sorting/react/exampleSortingHooks.jsx
+++ b/docs/content/guides/rows/rows-sorting/react/exampleSortingHooks.jsx
@@ -33,8 +33,24 @@ function sortOnServer(columnKey, sortOrder) {
 }
 
 const ExampleComponent = () => {
-  const hotTableComponentRef = useRef(null);
+  // `data` is kept in state (instead of loaded imperatively) so a `status` update doesn't
+  // make HotTable re-apply the original `data` prop and undo the sort.
+  const [gridData, setGridData] = useState(data);
   const [status, setStatus] = useState('Click a column header to sort.');
+
+  // Canceling the front-end sort also stops Handsontable from tracking the column's sort
+  // order, so this example cycles ascending -> descending -> unsorted manually.
+  const activeSortRef = useRef(null);
+
+  const getNextSortOrder = (column) => {
+    const activeSort = activeSortRef.current;
+
+    if (!activeSort || activeSort.column !== column) {
+      return 'asc';
+    }
+
+    return activeSort.sortOrder === 'asc' ? 'desc' : null;
+  };
 
   return (
     <>
@@ -44,8 +60,7 @@ const ExampleComponent = () => {
         </div>
       </div>
       <HotTable
-        ref={hotTableComponentRef}
-        data={data}
+        data={gridData}
         columns={[
           { title: 'Brand', type: 'text', data: 'brand' },
           { title: 'Model', type: 'text', data: 'model' },
@@ -67,16 +82,31 @@ const ExampleComponent = () => {
         ]}
         columnSorting={true}
         beforeColumnSort={(currentSortConfig, destinationSortConfigs) => {
-          const [sortConfig] = destinationSortConfigs;
+          const [requestedSort] = destinationSortConfigs;
 
-          if (!sortConfig || sortConfig.sortOrder === 'none') {
-            return true;
+          if (!requestedSort) {
+            // the sorting was cleared programmatically, restore the original row order
+            activeSortRef.current = null;
+            setGridData(data);
+
+            return false;
           }
 
+          const nextOrder = getNextSortOrder(requestedSort.column);
+
+          if (nextOrder === null) {
+            activeSortRef.current = null;
+            setStatus('Cleared the sort.');
+            setGridData(data);
+
+            return false;
+          }
+
+          activeSortRef.current = { column: requestedSort.column, sortOrder: nextOrder };
           setStatus('Sorting on the server...');
 
-          sortOnServer(columnDataKeys[sortConfig.column], sortConfig.sortOrder).then((sortedData) => {
-            hotTableComponentRef.current?.hotInstance?.loadData(sortedData);
+          sortOnServer(columnDataKeys[requestedSort.column], nextOrder).then((sortedData) => {
+            setGridData(sortedData);
             setStatus('Sorted on the server.');
           });
 

--- a/docs/content/guides/rows/rows-sorting/react/exampleSortingHooks.jsx
+++ b/docs/content/guides/rows/rows-sorting/react/exampleSortingHooks.jsx
@@ -1,0 +1,96 @@
+import { useRef, useState } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const data = [
+  { brand: 'Jetpulse', model: 'Racing Socks', price: 30, sellDate: '2023-10-11' },
+  { brand: 'Gigabox', model: 'HL Mountain Frame', price: 1890.9, sellDate: '2023-05-03' },
+  { brand: 'Camido', model: 'Cycling Cap', price: 130.1, sellDate: '2023-03-27' },
+  { brand: 'Chatterpoint', model: 'Road Tire Tube', price: 59, sellDate: '2023-08-28' },
+  { brand: 'Eidel', model: 'HL Road Tire', price: 279.99, sellDate: '2023-10-02' },
+];
+
+const columnDataKeys = ['brand', 'model', 'price', 'sellDate'];
+
+// Simulates a server that receives a sort request and returns sorted rows.
+function sortOnServer(columnKey, sortOrder) {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      const sortedData = [...data].sort((rowA, rowB) => {
+        if (rowA[columnKey] === rowB[columnKey]) {
+          return 0;
+        }
+
+        return (rowA[columnKey] > rowB[columnKey]) === (sortOrder === 'asc') ? 1 : -1;
+      });
+
+      resolve(sortedData);
+    }, 600);
+  });
+}
+
+const ExampleComponent = () => {
+  const hotTableComponentRef = useRef(null);
+  const [status, setStatus] = useState('Click a column header to sort.');
+
+  return (
+    <>
+      <div className="example-controls-container">
+        <div className="controls">
+          <span>{status}</span>
+        </div>
+      </div>
+      <HotTable
+        ref={hotTableComponentRef}
+        data={data}
+        columns={[
+          { title: 'Brand', type: 'text', data: 'brand' },
+          { title: 'Model', type: 'text', data: 'model' },
+          {
+            title: 'Price',
+            type: 'numeric',
+            data: 'price',
+            locale: 'en-US',
+            numericFormat: { style: 'currency', currency: 'USD', minimumFractionDigits: 2 },
+          },
+          {
+            title: 'Date',
+            type: 'intl-date',
+            data: 'sellDate',
+            locale: 'en-US',
+            dateFormat: { month: 'short', day: 'numeric', year: 'numeric' },
+            className: 'htRight',
+          },
+        ]}
+        columnSorting={true}
+        beforeColumnSort={(currentSortConfig, destinationSortConfigs) => {
+          const [sortConfig] = destinationSortConfigs;
+
+          if (!sortConfig || sortConfig.sortOrder === 'none') {
+            return true;
+          }
+
+          setStatus('Sorting on the server...');
+
+          sortOnServer(columnDataKeys[sortConfig.column], sortConfig.sortOrder).then((sortedData) => {
+            hotTableComponentRef.current?.hotInstance?.loadData(sortedData);
+            setStatus('Sorted on the server.');
+          });
+
+          // return `false` to cancel Handsontable's own front-end sort
+          return false;
+        }}
+        height="auto"
+        stretchH="all"
+        autoWrapRow={true}
+        autoWrapCol={true}
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/rows/rows-sorting/react/exampleSortingHooks.tsx
+++ b/docs/content/guides/rows/rows-sorting/react/exampleSortingHooks.tsx
@@ -1,0 +1,96 @@
+import { useRef, useState } from 'react';
+import { HotTable, HotTableRef } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const data = [
+  { brand: 'Jetpulse', model: 'Racing Socks', price: 30, sellDate: '2023-10-11' },
+  { brand: 'Gigabox', model: 'HL Mountain Frame', price: 1890.9, sellDate: '2023-05-03' },
+  { brand: 'Camido', model: 'Cycling Cap', price: 130.1, sellDate: '2023-03-27' },
+  { brand: 'Chatterpoint', model: 'Road Tire Tube', price: 59, sellDate: '2023-08-28' },
+  { brand: 'Eidel', model: 'HL Road Tire', price: 279.99, sellDate: '2023-10-02' },
+];
+
+const columnDataKeys = ['brand', 'model', 'price', 'sellDate'];
+
+// Simulates a server that receives a sort request and returns sorted rows.
+function sortOnServer(columnKey: string, sortOrder: string) {
+  return new Promise<typeof data>((resolve) => {
+    setTimeout(() => {
+      const sortedData = [...data].sort((rowA: any, rowB: any) => {
+        if (rowA[columnKey] === rowB[columnKey]) {
+          return 0;
+        }
+
+        return (rowA[columnKey] > rowB[columnKey]) === (sortOrder === 'asc') ? 1 : -1;
+      });
+
+      resolve(sortedData);
+    }, 600);
+  });
+}
+
+const ExampleComponent = () => {
+  const hotTableComponentRef = useRef<HotTableRef>(null);
+  const [status, setStatus] = useState('Click a column header to sort.');
+
+  return (
+    <>
+      <div className="example-controls-container">
+        <div className="controls">
+          <span>{status}</span>
+        </div>
+      </div>
+      <HotTable
+        ref={hotTableComponentRef}
+        data={data}
+        columns={[
+          { title: 'Brand', type: 'text', data: 'brand' },
+          { title: 'Model', type: 'text', data: 'model' },
+          {
+            title: 'Price',
+            type: 'numeric',
+            data: 'price',
+            locale: 'en-US',
+            numericFormat: { style: 'currency', currency: 'USD', minimumFractionDigits: 2 },
+          },
+          {
+            title: 'Date',
+            type: 'intl-date',
+            data: 'sellDate',
+            locale: 'en-US',
+            dateFormat: { month: 'short', day: 'numeric', year: 'numeric' },
+            className: 'htRight',
+          },
+        ]}
+        columnSorting={true}
+        beforeColumnSort={(currentSortConfig, destinationSortConfigs) => {
+          const [sortConfig] = destinationSortConfigs;
+
+          if (!sortConfig || sortConfig.sortOrder === 'none') {
+            return true;
+          }
+
+          setStatus('Sorting on the server...');
+
+          sortOnServer(columnDataKeys[sortConfig.column], sortConfig.sortOrder).then((sortedData) => {
+            hotTableComponentRef.current?.hotInstance?.loadData(sortedData);
+            setStatus('Sorted on the server.');
+          });
+
+          // return `false` to cancel Handsontable's own front-end sort
+          return false;
+        }}
+        height="auto"
+        stretchH="all"
+        autoWrapRow={true}
+        autoWrapCol={true}
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/rows/rows-sorting/react/exampleSortingHooks.tsx
+++ b/docs/content/guides/rows/rows-sorting/react/exampleSortingHooks.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from 'react';
-import { HotTable, HotTableRef } from '@handsontable/react-wrapper';
+import { HotTable } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
 
 // register Handsontable's modules
@@ -33,8 +33,24 @@ function sortOnServer(columnKey: string, sortOrder: string) {
 }
 
 const ExampleComponent = () => {
-  const hotTableComponentRef = useRef<HotTableRef>(null);
+  // `data` is kept in state (instead of loaded imperatively) so a `status` update doesn't
+  // make HotTable re-apply the original `data` prop and undo the sort.
+  const [gridData, setGridData] = useState(data);
   const [status, setStatus] = useState('Click a column header to sort.');
+
+  // Canceling the front-end sort also stops Handsontable from tracking the column's sort
+  // order, so this example cycles ascending -> descending -> unsorted manually.
+  const activeSortRef = useRef<{ column: number; sortOrder: 'asc' | 'desc' } | null>(null);
+
+  const getNextSortOrder = (column: number): 'asc' | 'desc' | null => {
+    const activeSort = activeSortRef.current;
+
+    if (!activeSort || activeSort.column !== column) {
+      return 'asc';
+    }
+
+    return activeSort.sortOrder === 'asc' ? 'desc' : null;
+  };
 
   return (
     <>
@@ -44,8 +60,7 @@ const ExampleComponent = () => {
         </div>
       </div>
       <HotTable
-        ref={hotTableComponentRef}
-        data={data}
+        data={gridData}
         columns={[
           { title: 'Brand', type: 'text', data: 'brand' },
           { title: 'Model', type: 'text', data: 'model' },
@@ -67,16 +82,31 @@ const ExampleComponent = () => {
         ]}
         columnSorting={true}
         beforeColumnSort={(currentSortConfig, destinationSortConfigs) => {
-          const [sortConfig] = destinationSortConfigs;
+          const [requestedSort] = destinationSortConfigs;
 
-          if (!sortConfig || sortConfig.sortOrder === 'none') {
-            return true;
+          if (!requestedSort) {
+            // the sorting was cleared programmatically, restore the original row order
+            activeSortRef.current = null;
+            setGridData(data);
+
+            return false;
           }
 
+          const nextOrder = getNextSortOrder(requestedSort.column);
+
+          if (nextOrder === null) {
+            activeSortRef.current = null;
+            setStatus('Cleared the sort.');
+            setGridData(data);
+
+            return false;
+          }
+
+          activeSortRef.current = { column: requestedSort.column, sortOrder: nextOrder };
           setStatus('Sorting on the server...');
 
-          sortOnServer(columnDataKeys[sortConfig.column], sortConfig.sortOrder).then((sortedData) => {
-            hotTableComponentRef.current?.hotInstance?.loadData(sortedData);
+          sortOnServer(columnDataKeys[requestedSort.column], nextOrder).then((sortedData) => {
+            setGridData(sortedData);
             setStatus('Sorted on the server.');
           });
 

--- a/docs/content/guides/rows/rows-sorting/rows-sorting.md
+++ b/docs/content/guides/rows/rows-sorting/rows-sorting.md
@@ -32,6 +32,7 @@ vue:
   metaTitle: Rows sorting - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Rows
+menuTag: updated
 ---
 Sort rows alphabetically or numerically, in ascending, descending, or a custom order, by one or multiple columns.
 
@@ -607,75 +608,51 @@ Run code before or after sorting using the following [Handsontable hooks](@/guid
 - [`beforeColumnSort`](@/api/hooks.md#beforecolumnsort) — fires before sorting. Return `false` to cancel the sort and keep the current order.
 - [`afterColumnSort`](@/api/hooks.md#aftercolumnsort) — fires after sorting completes.
 
-A common use of `beforeColumnSort` is server-side sorting: cancel the client-side sort, send the sort configuration to a server, and reload the data. A common use of `afterColumnSort` is excluding specific rows from the sorted result.
+A common use of `beforeColumnSort` is server-side sorting: cancel the client-side sort, send the sort configuration to a server, and reload the data. The following example simulates this: it cancels the front-end sort, "asks a server" to sort the rows, and loads the sorted rows back into the grid.
+
+A common use of `afterColumnSort` is excluding specific rows from the sorted result — see the [`afterColumnSort` example](#exclude-rows-from-sorting) in the next section.
 
 ::: only-for javascript
 
-```js
-const configurationOptions = {
-  beforeColumnSort(currentSortConfig, destinationSortConfigs) {
-    // add your code here
-    return false; // return false to block front-end sorting
-  },
-  afterColumnSort(currentSortConfig, sortedSortConfigs) {
-    // add your code here
-  },
-};
-```
+::: example #exampleSortingHooks --html 1 --js 2 --ts 3
+
+@[code](@/content/guides/rows/rows-sorting/javascript/exampleSortingHooks.html)
+@[code](@/content/guides/rows/rows-sorting/javascript/exampleSortingHooks.js)
+@[code](@/content/guides/rows/rows-sorting/javascript/exampleSortingHooks.ts)
+
+:::
 
 :::
 
 ::: only-for react
 
-```jsx
-<HotTable
-  beforeColumnSort={(currentSortConfig, destinationSortConfigs) => {
-    // add your code here
-    return false; // return false to block front-end sorting
-  }}
-  afterColumnSort={(currentSortConfig, sortedSortConfigs) => {
-    // add your code here
-  }}
-/>
-```
+::: example #exampleSortingHooks :react --js 1 --ts 2
+
+@[code](@/content/guides/rows/rows-sorting/react/exampleSortingHooks.jsx)
+@[code](@/content/guides/rows/rows-sorting/react/exampleSortingHooks.tsx)
+
+:::
 
 :::
 
 ::: only-for angular
 
-```ts
-import {GridSettings, HotTableModule} from '@handsontable/angular-wrapper';
+::: example #example11 :angular --ts 1 --html 2
 
-const configurationOptions: GridSettings = {
-  beforeColumnSort(currentSortConfig, destinationSortConfigs) {
-    // add your code here
-    return false; // return false to block front-end sorting
-  },
-  afterColumnSort(currentSortConfig, sortedSortConfigs) {
-    // add your code here
-  },
-};
-```
+@[code](@/content/guides/rows/rows-sorting/angular/example11.ts)
+@[code](@/content/guides/rows/rows-sorting/angular/example11.html)
 
-```html
-<hot-table [settings]="configurationOptions"></hot-table>
-```
+:::
 
 :::
 
 ::: only-for vue
 
-```ts
-const hotSettings = {
-  beforeColumnSort(currentSortConfig, destinationSortConfigs) {
-    // add your code here
-    return false; // return false to block front-end sorting
-  },
-  afterColumnSort(currentSortConfig, sortedSortConfigs) {
-    // add your code here
-  },
-};
-```
+::: example #exampleSortingHooks :vue3
+
+@[code](@/content/guides/rows/rows-sorting/vue/exampleSortingHooks.vue)
+
+:::
 
 :::
 

--- a/docs/content/guides/rows/rows-sorting/vue/exampleSortingHooks.vue
+++ b/docs/content/guides/rows/rows-sorting/vue/exampleSortingHooks.vue
@@ -19,6 +19,18 @@ const data = [
 
 const columnDataKeys = ['brand', 'model', 'price', 'sellDate'];
 
+// Canceling the front-end sort also stops Handsontable from tracking the column's sort
+// order, so this example cycles ascending -> descending -> unsorted manually.
+let activeSort: { column: number; sortOrder: 'asc' | 'desc' } | null = null;
+
+function getNextSortOrder(column: number): 'asc' | 'desc' | null {
+  if (!activeSort || activeSort.column !== column) {
+    return 'asc';
+  }
+
+  return activeSort.sortOrder === 'asc' ? 'desc' : null;
+}
+
 // Simulates a server that receives a sort request and returns sorted rows.
 function sortOnServer(columnKey: string, sortOrder: string) {
   return new Promise<typeof data>((resolve) => {
@@ -63,15 +75,30 @@ const hotSettings = ref<GridSettings>({
   autoWrapRow: true,
   autoWrapCol: true,
   beforeColumnSort(currentSortConfig, destinationSortConfigs) {
-    const [sortConfig] = destinationSortConfigs;
+    const [requestedSort] = destinationSortConfigs;
 
-    if (!sortConfig || sortConfig.sortOrder === 'none') {
-      return true;
+    if (!requestedSort) {
+      // the sorting was cleared programmatically, restore the original row order
+      activeSort = null;
+      (hotRef.value as any)?.hotInstance?.loadData(data);
+
+      return false;
     }
 
+    const nextOrder = getNextSortOrder(requestedSort.column);
+
+    if (nextOrder === null) {
+      activeSort = null;
+      status.value = 'Cleared the sort.';
+      (hotRef.value as any)?.hotInstance?.loadData(data);
+
+      return false;
+    }
+
+    activeSort = { column: requestedSort.column, sortOrder: nextOrder };
     status.value = 'Sorting on the server...';
 
-    sortOnServer(columnDataKeys[sortConfig.column], sortConfig.sortOrder).then((sortedData) => {
+    sortOnServer(columnDataKeys[requestedSort.column], nextOrder).then((sortedData) => {
       (hotRef.value as any)?.hotInstance?.loadData(sortedData);
       status.value = 'Sorted on the server.';
     });

--- a/docs/content/guides/rows/rows-sorting/vue/exampleSortingHooks.vue
+++ b/docs/content/guides/rows/rows-sorting/vue/exampleSortingHooks.vue
@@ -1,0 +1,95 @@
+<script setup lang="ts">
+import { ref, useTemplateRef } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
+const status = ref('Click a column header to sort.');
+
+const data = [
+  { brand: 'Jetpulse', model: 'Racing Socks', price: 30, sellDate: '2023-10-11' },
+  { brand: 'Gigabox', model: 'HL Mountain Frame', price: 1890.9, sellDate: '2023-05-03' },
+  { brand: 'Camido', model: 'Cycling Cap', price: 130.1, sellDate: '2023-03-27' },
+  { brand: 'Chatterpoint', model: 'Road Tire Tube', price: 59, sellDate: '2023-08-28' },
+  { brand: 'Eidel', model: 'HL Road Tire', price: 279.99, sellDate: '2023-10-02' },
+];
+
+const columnDataKeys = ['brand', 'model', 'price', 'sellDate'];
+
+// Simulates a server that receives a sort request and returns sorted rows.
+function sortOnServer(columnKey: string, sortOrder: string) {
+  return new Promise<typeof data>((resolve) => {
+    setTimeout(() => {
+      const sortedData = [...data].sort((rowA: any, rowB: any) => {
+        if (rowA[columnKey] === rowB[columnKey]) {
+          return 0;
+        }
+
+        return (rowA[columnKey] > rowB[columnKey]) === (sortOrder === 'asc') ? 1 : -1;
+      });
+
+      resolve(sortedData);
+    }, 600);
+  });
+}
+
+const hotSettings = ref<GridSettings>({
+  data,
+  columns: [
+    { title: 'Brand', type: 'text', data: 'brand' },
+    { title: 'Model', type: 'text', data: 'model' },
+    {
+      title: 'Price',
+      type: 'numeric',
+      data: 'price',
+      locale: 'en-US',
+      numericFormat: { style: 'currency', currency: 'USD', minimumFractionDigits: 2 },
+    },
+    {
+      title: 'Date',
+      type: 'intl-date',
+      data: 'sellDate',
+      locale: 'en-US',
+      dateFormat: { month: 'short', day: 'numeric', year: 'numeric' },
+      className: 'htRight',
+    },
+  ],
+  columnSorting: true,
+  height: 'auto',
+  stretchH: 'all',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  beforeColumnSort(currentSortConfig, destinationSortConfigs) {
+    const [sortConfig] = destinationSortConfigs;
+
+    if (!sortConfig || sortConfig.sortOrder === 'none') {
+      return true;
+    }
+
+    status.value = 'Sorting on the server...';
+
+    sortOnServer(columnDataKeys[sortConfig.column], sortConfig.sortOrder).then((sortedData) => {
+      (hotRef.value as any)?.hotInstance?.loadData(sortedData);
+      status.value = 'Sorted on the server.';
+    });
+
+    // return `false` to cancel Handsontable's own front-end sort
+    return false;
+  },
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="exampleSortingHooks">
+    <div class="example-controls-container">
+      <div class="controls">
+        <span>{{ status }}</span>
+      </div>
+    </div>
+    <HotTable ref="hotRef" :settings="hotSettings" />
+  </div>
+</template>


### PR DESCRIPTION
### Context

The PR adds the runnable example that was missing from the "Use sorting hooks" section of the [Rows sorting guide](https://handsontable.com/docs/rows-sorting/#use-sorting-hooks). Previously, this section only showed static snippets with `// add your code here` placeholders for `beforeColumnSort` and `afterColumnSort` — unlike every other section on the page, which has a live, editable demo.

The new example simulates server-side sorting: it cancels the front-end sort inside `beforeColumnSort`, "asks a server" to sort the rows (via a `setTimeout`-based mock), and reloads the sorted rows into the grid with `loadData()`. A status line reports the in-progress and completed states. Framework variants (JavaScript, React, Angular, Vue) all follow this page's existing patterns.

The `afterColumnSort` half of the section wasn't duplicated — it already has a full runnable demo in the [Exclude rows from sorting](https://handsontable.com/docs/rows-sorting/#exclude-rows-from-sorting) section, so the guide text now links to it directly instead of shipping a second example for the same hook.

This closes out the remaining item from DEV-647 (the other two items in that ticket — fixing `compareFunctionFactory` to respect `sortOrder`, and the "Exclude rows from sorting" example — were already resolved in earlier PRs).

### How has this been tested?

- Manually reviewed the new example logic (cancel-and-reload flow, `sortOrder`/`none` handling) against the `beforeColumnSort`/`afterColumnSort` hook signatures in `handsontable/src/core/hooks/constants.ts` and `handsontable/src/core/settings.ts`.
- Type-checked each new example file (`.ts`, `.tsx`, Angular `.ts`, Vue `.vue`) with `tsc --noEmit` against the relevant compiler options (no errors).
- Verified `npm run docs:code-examples:generate-js` output for the JS/TS example matches the existing generated-file formatting conventions used elsewhere on this page.
- Local `astro dev` couldn't be exercised in this environment (it hits the known dev-server OOM even at an 8 GB heap) — please sanity-check the rendered page and interactive example on the PR's preview deployment.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-647

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

(Documentation-only change — no package source code affected.)

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-647

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example assets only; no changes to Handsontable or wrapper package source.
> 
> **Overview**
> Replaces placeholder snippets in the **Use sorting hooks** section of the rows sorting guide with **live, editable demos** for JavaScript, React, Angular, and Vue.
> 
> Each demo uses **`beforeColumnSort`** to block client-side sorting, simulates a server sort (delayed mock), reloads rows via **`loadData()`** / bound data, and shows status text. Because returning **`false`** stops Handsontable from tracking header sort state, the examples **manually cycle** ascending → descending → unsorted.
> 
> Guide copy now describes that flow and points **`afterColumnSort`** readers to the existing **Exclude rows from sorting** demo instead of duplicating it. Front matter adds **`menuTag: updated`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 527bbe40e3aef7a94d2f48d0b4775d5825f45ad2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->