### PR TITLE
DEV-648: Add unit-comparison demo to Grid size guide

### DIFF
--- a/docs/content/guides/getting-started/grid-size/angular/example2.css
+++ b/docs/content/guides/getting-started/grid-size/angular/example2.css
@@ -1,0 +1,12 @@
+#exampleParent2 {
+  width: 800px;
+  max-width: 100%;
+  height: 400px;
+  box-sizing: border-box;
+  border: 1px dashed var(--sl-color-gray-5, #d1d5db);
+}
+
+.unit-caption {
+  margin-top: 8px;
+  color: var(--sl-color-text, #485164);
+}

--- a/docs/content/guides/getting-started/grid-size/angular/example2.css
+++ b/docs/content/guides/getting-started/grid-size/angular/example2.css
@@ -6,6 +6,10 @@
   border: 1px dashed var(--sl-color-gray-5, #d1d5db);
 }
 
+#exampleParent2 > hot-table {
+  height: 100%;
+}
+
 .unit-caption {
   margin-top: 8px;
   color: var(--sl-color-text, #485164);

--- a/docs/content/guides/getting-started/grid-size/angular/example2.html
+++ b/docs/content/guides/getting-started/grid-size/angular/example2.html
@@ -1,0 +1,3 @@
+<div>
+  <example2-grid-size></example2-grid-size>
+</div>

--- a/docs/content/guides/getting-started/grid-size/angular/example2.ts
+++ b/docs/content/guides/getting-started/grid-size/angular/example2.ts
@@ -1,0 +1,97 @@
+/* file: app.component.ts */
+import { Component, ViewChild } from '@angular/core';
+import { GridSettings, HotTableComponent, HotTableModule } from '@handsontable/angular-wrapper';
+
+const UNIT_SIZES: Record<string, { width: string; height: string }> = {
+  px: { width: '600px', height: '300px' },
+  '%': { width: '75%', height: '75%' },
+  em: { width: '37.5em', height: '18.75em' },
+  rem: { width: '37.5rem', height: '18.75rem' },
+  vh: { width: '50vh', height: '50vh' },
+  vw: { width: '50vw', height: '50vw' },
+};
+
+const UNIT_CAPTIONS: Record<string, string> = {
+  px: 'A fixed pixel size, independent of any parent element or font size.',
+  '%': "A percentage of the parent container's size (the dashed box).",
+  em: "A multiple of this element's own font size.",
+  rem: "A multiple of the document's root font size.",
+  vh: "A percentage of the browser viewport's height.",
+  vw: "A percentage of the browser viewport's width.",
+};
+
+@Component({
+  selector: 'example2-grid-size',
+  standalone: true,
+  imports: [HotTableModule],
+  template: ` <div class="example-controls-container">
+      <div class="controls">
+        <label for="unitSelect">Grid size unit</label>
+        <select id="unitSelect" (change)="changeUnit($event)">
+          @for (key of unitKeys; track key) {
+            <option [value]="key">{{ key }}</option>
+          }
+        </select>
+      </div>
+      <p class="unit-caption">{{ unitCaption }}</p>
+    </div>
+    <div id="exampleParent2">
+      <hot-table [data]="data" [settings]="gridSettings"></hot-table>
+    </div>`,
+})
+export class AppComponent {
+  @ViewChild(HotTableComponent, { static: false }) readonly hotTable!: HotTableComponent;
+
+  readonly unitKeys = Object.keys(UNIT_SIZES);
+  unitCaption = UNIT_CAPTIONS.px;
+
+  readonly data = [
+    ['SKU-4821', 'Wireless Mouse', 'Electronics', 'Harbor Goods', 142],
+    ['SKU-0093', 'Canvas Tote Bag', 'Apparel', 'Alpine Supply Co.', 67],
+    ['SKU-2210', 'USB-C Hub', 'Electronics', 'Harbor Goods', 0],
+    ['SKU-7734', 'Ceramic Mug Set', 'Home Goods', 'Nordic Traders', 58],
+    ['SKU-1145', 'Wool Scarf', 'Apparel', 'Alpine Supply Co.', 213],
+    ['SKU-3399', 'Bluetooth Speaker', 'Electronics', 'Harbor Goods', 84],
+    ['SKU-5567', 'Cotton T-Shirt', 'Apparel', 'Alpine Supply Co.', 310],
+    ['SKU-8842', 'Desk Lamp', 'Home Goods', 'Nordic Traders', 45],
+    ['SKU-6621', 'Laptop Stand', 'Electronics', 'Harbor Goods', 29],
+    ['SKU-4470', 'Throw Blanket', 'Home Goods', 'Nordic Traders', 76],
+    ['SKU-9983', 'Leather Wallet', 'Apparel', 'Alpine Supply Co.', 132],
+    ['SKU-2287', 'Wireless Charger', 'Electronics', 'Harbor Goods', 97],
+  ];
+
+  readonly gridSettings: GridSettings = {
+    colHeaders: ['SKU', 'Product', 'Category', 'Supplier', 'Quantity'],
+    rowHeaders: true,
+    width: UNIT_SIZES.px.width,
+    height: UNIT_SIZES.px.height,
+  };
+
+  changeUnit(event: Event): void {
+    const unit = UNIT_SIZES[(event.target as HTMLSelectElement).value];
+
+    this.unitCaption = UNIT_CAPTIONS[(event.target as HTMLSelectElement).value];
+    this.hotTable?.hotInstance?.updateSettings({ width: unit.width, height: unit.height });
+  }
+}
+/* end-file */
+
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+/* end-file */

--- a/docs/content/guides/getting-started/grid-size/angular/example2.ts
+++ b/docs/content/guides/getting-started/grid-size/angular/example2.ts
@@ -43,7 +43,7 @@ export class AppComponent {
   @ViewChild(HotTableComponent, { static: false }) readonly hotTable!: HotTableComponent;
 
   readonly unitKeys = Object.keys(UNIT_SIZES);
-  unitCaption = UNIT_CAPTIONS.px;
+  unitCaption = UNIT_CAPTIONS['px'];
 
   readonly data = [
     ['SKU-4821', 'Wireless Mouse', 'Electronics', 'Harbor Goods', 142],
@@ -63,8 +63,8 @@ export class AppComponent {
   readonly gridSettings: GridSettings = {
     colHeaders: ['SKU', 'Product', 'Category', 'Supplier', 'Quantity'],
     rowHeaders: true,
-    width: UNIT_SIZES.px.width,
-    height: UNIT_SIZES.px.height,
+    width: UNIT_SIZES['px'].width,
+    height: UNIT_SIZES['px'].height,
   };
 
   changeUnit(event: Event): void {

--- a/docs/content/guides/getting-started/grid-size/grid-size.md
+++ b/docs/content/guides/getting-started/grid-size/grid-size.md
@@ -166,6 +166,57 @@ If container is a block element, then its parent has to have defined `height`. B
 
 Changes called in [`updateSettings()`](@/api/core.md#updatesettings) will re-render the grid with the new properties.
 
+### Compare size units
+
+Use the dropdown in the demo below to switch the grid's `width` and `height` between `px`, `%`, `em`, `rem`, `vh`, and `vw`, and see how the same grid responds to each unit.
+
+::: only-for javascript
+
+::: example #example2 --html 1 --css 2 --js 3 --ts 4
+
+@[code](@/content/guides/getting-started/grid-size/javascript/example2.html)
+@[code](@/content/guides/getting-started/grid-size/javascript/example2.css)
+@[code](@/content/guides/getting-started/grid-size/javascript/example2.js)
+@[code](@/content/guides/getting-started/grid-size/javascript/example2.ts)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #example2 :react --css 1 --js 2 --ts 3
+
+@[code](@/content/guides/getting-started/grid-size/react/example2.css)
+@[code](@/content/guides/getting-started/grid-size/react/example2.jsx)
+@[code](@/content/guides/getting-started/grid-size/react/example2.tsx)
+
+:::
+
+:::
+
+::: only-for angular
+
+::: example #example2 :angular --css 1 --ts 2 --html 3
+
+@[code](@/content/guides/getting-started/grid-size/angular/example2.css)
+@[code](@/content/guides/getting-started/grid-size/angular/example2.ts)
+@[code](@/content/guides/getting-started/grid-size/angular/example2.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example2 :vue3
+
+@[code](@/content/guides/getting-started/grid-size/vue/example2.vue)
+
+:::
+
+:::
+
 ### Use `'auto'` sizing
 
 Set `height: 'auto'` to make the grid grow to match its content height. Handsontable writes `height: auto; overflow: clip;` as inline styles on the root element. No internal vertical scrollbar is created, so the page itself scrolls when the grid is taller than the viewport.

--- a/docs/content/guides/getting-started/grid-size/javascript/example2.css
+++ b/docs/content/guides/getting-started/grid-size/javascript/example2.css
@@ -6,6 +6,10 @@
   border: 1px dashed var(--sl-color-gray-5, #d1d5db);
 }
 
+#example2 {
+  height: 100%;
+}
+
 .unit-caption {
   margin-top: 8px;
   color: var(--sl-color-text, #485164);

--- a/docs/content/guides/getting-started/grid-size/javascript/example2.css
+++ b/docs/content/guides/getting-started/grid-size/javascript/example2.css
@@ -1,0 +1,12 @@
+#exampleParent2 {
+  width: 800px;
+  max-width: 100%;
+  height: 400px;
+  box-sizing: border-box;
+  border: 1px dashed var(--sl-color-gray-5, #d1d5db);
+}
+
+.unit-caption {
+  margin-top: 8px;
+  color: var(--sl-color-text, #485164);
+}

--- a/docs/content/guides/getting-started/grid-size/javascript/example2.html
+++ b/docs/content/guides/getting-started/grid-size/javascript/example2.html
@@ -1,0 +1,17 @@
+<div class="example-controls-container">
+  <div class="controls">
+    <label for="unitSelect">Grid size unit</label>
+    <select id="unitSelect">
+      <option value="px">px</option>
+      <option value="%">%</option>
+      <option value="em">em</option>
+      <option value="rem">rem</option>
+      <option value="vh">vh</option>
+      <option value="vw">vw</option>
+    </select>
+  </div>
+  <p id="unitCaption" class="unit-caption"></p>
+</div>
+<div id="exampleParent2">
+  <div id="example2"></div>
+</div>

--- a/docs/content/guides/getting-started/grid-size/javascript/example2.js
+++ b/docs/content/guides/getting-started/grid-size/javascript/example2.js
@@ -38,11 +38,11 @@ const hot = new Handsontable(container, {
     ],
     colHeaders: ['SKU', 'Product', 'Category', 'Supplier', 'Quantity'],
     rowHeaders: true,
-    width: UNIT_SIZES.px.width,
-    height: UNIT_SIZES.px.height,
+    width: UNIT_SIZES['px'].width,
+    height: UNIT_SIZES['px'].height,
     licenseKey: 'non-commercial-and-evaluation',
 });
-unitCaption.textContent = UNIT_CAPTIONS.px;
+unitCaption.textContent = UNIT_CAPTIONS['px'];
 unitSelect.addEventListener('change', () => {
     const unit = UNIT_SIZES[unitSelect.value];
     hot.updateSettings({ width: unit.width, height: unit.height });

--- a/docs/content/guides/getting-started/grid-size/javascript/example2.js
+++ b/docs/content/guides/getting-started/grid-size/javascript/example2.js
@@ -1,0 +1,50 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+// Register all Handsontable's modules.
+registerAllModules();
+const UNIT_SIZES = {
+    px: { width: '600px', height: '300px' },
+    '%': { width: '75%', height: '75%' },
+    em: { width: '37.5em', height: '18.75em' },
+    rem: { width: '37.5rem', height: '18.75rem' },
+    vh: { width: '50vh', height: '50vh' },
+    vw: { width: '50vw', height: '50vw' },
+};
+const UNIT_CAPTIONS = {
+    px: 'A fixed pixel size, independent of any parent element or font size.',
+    '%': "A percentage of the parent container's size (the dashed box).",
+    em: "A multiple of this element's own font size.",
+    rem: "A multiple of the document's root font size.",
+    vh: "A percentage of the browser viewport's height.",
+    vw: "A percentage of the browser viewport's width.",
+};
+const container = document.querySelector('#example2');
+const unitSelect = document.querySelector('#unitSelect');
+const unitCaption = document.querySelector('#unitCaption');
+const hot = new Handsontable(container, {
+    data: [
+        ['SKU-4821', 'Wireless Mouse', 'Electronics', 'Harbor Goods', 142],
+        ['SKU-0093', 'Canvas Tote Bag', 'Apparel', 'Alpine Supply Co.', 67],
+        ['SKU-2210', 'USB-C Hub', 'Electronics', 'Harbor Goods', 0],
+        ['SKU-7734', 'Ceramic Mug Set', 'Home Goods', 'Nordic Traders', 58],
+        ['SKU-1145', 'Wool Scarf', 'Apparel', 'Alpine Supply Co.', 213],
+        ['SKU-3399', 'Bluetooth Speaker', 'Electronics', 'Harbor Goods', 84],
+        ['SKU-5567', 'Cotton T-Shirt', 'Apparel', 'Alpine Supply Co.', 310],
+        ['SKU-8842', 'Desk Lamp', 'Home Goods', 'Nordic Traders', 45],
+        ['SKU-6621', 'Laptop Stand', 'Electronics', 'Harbor Goods', 29],
+        ['SKU-4470', 'Throw Blanket', 'Home Goods', 'Nordic Traders', 76],
+        ['SKU-9983', 'Leather Wallet', 'Apparel', 'Alpine Supply Co.', 132],
+        ['SKU-2287', 'Wireless Charger', 'Electronics', 'Harbor Goods', 97],
+    ],
+    colHeaders: ['SKU', 'Product', 'Category', 'Supplier', 'Quantity'],
+    rowHeaders: true,
+    width: UNIT_SIZES.px.width,
+    height: UNIT_SIZES.px.height,
+    licenseKey: 'non-commercial-and-evaluation',
+});
+unitCaption.textContent = UNIT_CAPTIONS.px;
+unitSelect.addEventListener('change', () => {
+    const unit = UNIT_SIZES[unitSelect.value];
+    hot.updateSettings({ width: unit.width, height: unit.height });
+    unitCaption.textContent = UNIT_CAPTIONS[unitSelect.value];
+});

--- a/docs/content/guides/getting-started/grid-size/javascript/example2.ts
+++ b/docs/content/guides/getting-started/grid-size/javascript/example2.ts
@@ -1,0 +1,58 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+// Register all Handsontable's modules.
+registerAllModules();
+
+const UNIT_SIZES: Record<string, { width: string; height: string }> = {
+  px: { width: '600px', height: '300px' },
+  '%': { width: '75%', height: '75%' },
+  em: { width: '37.5em', height: '18.75em' },
+  rem: { width: '37.5rem', height: '18.75rem' },
+  vh: { width: '50vh', height: '50vh' },
+  vw: { width: '50vw', height: '50vw' },
+};
+
+const UNIT_CAPTIONS: Record<string, string> = {
+  px: 'A fixed pixel size, independent of any parent element or font size.',
+  '%': "A percentage of the parent container's size (the dashed box).",
+  em: "A multiple of this element's own font size.",
+  rem: "A multiple of the document's root font size.",
+  vh: "A percentage of the browser viewport's height.",
+  vw: "A percentage of the browser viewport's width.",
+};
+
+const container = document.querySelector('#example2')!;
+const unitSelect = document.querySelector<HTMLSelectElement>('#unitSelect')!;
+const unitCaption = document.querySelector('#unitCaption')!;
+
+const hot = new Handsontable(container, {
+  data: [
+    ['SKU-4821', 'Wireless Mouse', 'Electronics', 'Harbor Goods', 142],
+    ['SKU-0093', 'Canvas Tote Bag', 'Apparel', 'Alpine Supply Co.', 67],
+    ['SKU-2210', 'USB-C Hub', 'Electronics', 'Harbor Goods', 0],
+    ['SKU-7734', 'Ceramic Mug Set', 'Home Goods', 'Nordic Traders', 58],
+    ['SKU-1145', 'Wool Scarf', 'Apparel', 'Alpine Supply Co.', 213],
+    ['SKU-3399', 'Bluetooth Speaker', 'Electronics', 'Harbor Goods', 84],
+    ['SKU-5567', 'Cotton T-Shirt', 'Apparel', 'Alpine Supply Co.', 310],
+    ['SKU-8842', 'Desk Lamp', 'Home Goods', 'Nordic Traders', 45],
+    ['SKU-6621', 'Laptop Stand', 'Electronics', 'Harbor Goods', 29],
+    ['SKU-4470', 'Throw Blanket', 'Home Goods', 'Nordic Traders', 76],
+    ['SKU-9983', 'Leather Wallet', 'Apparel', 'Alpine Supply Co.', 132],
+    ['SKU-2287', 'Wireless Charger', 'Electronics', 'Harbor Goods', 97],
+  ],
+  colHeaders: ['SKU', 'Product', 'Category', 'Supplier', 'Quantity'],
+  rowHeaders: true,
+  width: UNIT_SIZES.px.width,
+  height: UNIT_SIZES.px.height,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+unitCaption.textContent = UNIT_CAPTIONS.px;
+
+unitSelect.addEventListener('change', () => {
+  const unit = UNIT_SIZES[unitSelect.value];
+
+  hot.updateSettings({ width: unit.width, height: unit.height });
+  unitCaption.textContent = UNIT_CAPTIONS[unitSelect.value];
+});

--- a/docs/content/guides/getting-started/grid-size/javascript/example2.ts
+++ b/docs/content/guides/getting-started/grid-size/javascript/example2.ts
@@ -43,12 +43,12 @@ const hot = new Handsontable(container, {
   ],
   colHeaders: ['SKU', 'Product', 'Category', 'Supplier', 'Quantity'],
   rowHeaders: true,
-  width: UNIT_SIZES.px.width,
-  height: UNIT_SIZES.px.height,
+  width: UNIT_SIZES['px'].width,
+  height: UNIT_SIZES['px'].height,
   licenseKey: 'non-commercial-and-evaluation',
 });
 
-unitCaption.textContent = UNIT_CAPTIONS.px;
+unitCaption.textContent = UNIT_CAPTIONS['px'];
 
 unitSelect.addEventListener('change', () => {
   const unit = UNIT_SIZES[unitSelect.value];

--- a/docs/content/guides/getting-started/grid-size/react/example2.css
+++ b/docs/content/guides/getting-started/grid-size/react/example2.css
@@ -1,0 +1,16 @@
+#exampleParent2 {
+  width: 800px;
+  max-width: 100%;
+  height: 400px;
+  box-sizing: border-box;
+  border: 1px dashed var(--sl-color-gray-5, #d1d5db);
+}
+
+#exampleParent2 > div {
+  height: 100%;
+}
+
+.unit-caption {
+  margin-top: 8px;
+  color: var(--sl-color-text, #485164);
+}

--- a/docs/content/guides/getting-started/grid-size/react/example2.jsx
+++ b/docs/content/guides/getting-started/grid-size/react/example2.jsx
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const UNIT_SIZES = {
+  px: { width: '600px', height: '300px' },
+  '%': { width: '75%', height: '75%' },
+  em: { width: '37.5em', height: '18.75em' },
+  rem: { width: '37.5rem', height: '18.75rem' },
+  vh: { width: '50vh', height: '50vh' },
+  vw: { width: '50vw', height: '50vw' },
+};
+
+const UNIT_CAPTIONS = {
+  px: 'A fixed pixel size, independent of any parent element or font size.',
+  '%': "A percentage of the parent container's size (the dashed box).",
+  em: "A multiple of this element's own font size.",
+  rem: "A multiple of the document's root font size.",
+  vh: "A percentage of the browser viewport's height.",
+  vw: "A percentage of the browser viewport's width.",
+};
+
+const data = [
+  ['SKU-4821', 'Wireless Mouse', 'Electronics', 'Harbor Goods', 142],
+  ['SKU-0093', 'Canvas Tote Bag', 'Apparel', 'Alpine Supply Co.', 67],
+  ['SKU-2210', 'USB-C Hub', 'Electronics', 'Harbor Goods', 0],
+  ['SKU-7734', 'Ceramic Mug Set', 'Home Goods', 'Nordic Traders', 58],
+  ['SKU-1145', 'Wool Scarf', 'Apparel', 'Alpine Supply Co.', 213],
+  ['SKU-3399', 'Bluetooth Speaker', 'Electronics', 'Harbor Goods', 84],
+  ['SKU-5567', 'Cotton T-Shirt', 'Apparel', 'Alpine Supply Co.', 310],
+  ['SKU-8842', 'Desk Lamp', 'Home Goods', 'Nordic Traders', 45],
+  ['SKU-6621', 'Laptop Stand', 'Electronics', 'Harbor Goods', 29],
+  ['SKU-4470', 'Throw Blanket', 'Home Goods', 'Nordic Traders', 76],
+  ['SKU-9983', 'Leather Wallet', 'Apparel', 'Alpine Supply Co.', 132],
+  ['SKU-2287', 'Wireless Charger', 'Electronics', 'Harbor Goods', 97],
+];
+
+const ExampleComponent = () => {
+  const [unit, setUnit] = useState('px');
+  const { width, height } = UNIT_SIZES[unit];
+
+  return (
+    <>
+      <div className="example-controls-container">
+        <div className="controls">
+          <label htmlFor="unitSelect">Grid size unit</label>
+          <select id="unitSelect" value={unit} onChange={(event) => setUnit(event.target.value)}>
+            {Object.keys(UNIT_SIZES).map((key) => (
+              <option key={key} value={key}>{key}</option>
+            ))}
+          </select>
+        </div>
+        <p className="unit-caption">{UNIT_CAPTIONS[unit]}</p>
+      </div>
+      <div id="exampleParent2">
+        <HotTable
+          data={data}
+          colHeaders={['SKU', 'Product', 'Category', 'Supplier', 'Quantity']}
+          rowHeaders={true}
+          width={width}
+          height={height}
+          licenseKey="non-commercial-and-evaluation"
+        />
+      </div>
+    </>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/getting-started/grid-size/react/example2.tsx
+++ b/docs/content/guides/getting-started/grid-size/react/example2.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const UNIT_SIZES: Record<string, { width: string; height: string }> = {
+  px: { width: '600px', height: '300px' },
+  '%': { width: '75%', height: '75%' },
+  em: { width: '37.5em', height: '18.75em' },
+  rem: { width: '37.5rem', height: '18.75rem' },
+  vh: { width: '50vh', height: '50vh' },
+  vw: { width: '50vw', height: '50vw' },
+};
+
+const UNIT_CAPTIONS: Record<string, string> = {
+  px: 'A fixed pixel size, independent of any parent element or font size.',
+  '%': "A percentage of the parent container's size (the dashed box).",
+  em: "A multiple of this element's own font size.",
+  rem: "A multiple of the document's root font size.",
+  vh: "A percentage of the browser viewport's height.",
+  vw: "A percentage of the browser viewport's width.",
+};
+
+const data = [
+  ['SKU-4821', 'Wireless Mouse', 'Electronics', 'Harbor Goods', 142],
+  ['SKU-0093', 'Canvas Tote Bag', 'Apparel', 'Alpine Supply Co.', 67],
+  ['SKU-2210', 'USB-C Hub', 'Electronics', 'Harbor Goods', 0],
+  ['SKU-7734', 'Ceramic Mug Set', 'Home Goods', 'Nordic Traders', 58],
+  ['SKU-1145', 'Wool Scarf', 'Apparel', 'Alpine Supply Co.', 213],
+  ['SKU-3399', 'Bluetooth Speaker', 'Electronics', 'Harbor Goods', 84],
+  ['SKU-5567', 'Cotton T-Shirt', 'Apparel', 'Alpine Supply Co.', 310],
+  ['SKU-8842', 'Desk Lamp', 'Home Goods', 'Nordic Traders', 45],
+  ['SKU-6621', 'Laptop Stand', 'Electronics', 'Harbor Goods', 29],
+  ['SKU-4470', 'Throw Blanket', 'Home Goods', 'Nordic Traders', 76],
+  ['SKU-9983', 'Leather Wallet', 'Apparel', 'Alpine Supply Co.', 132],
+  ['SKU-2287', 'Wireless Charger', 'Electronics', 'Harbor Goods', 97],
+];
+
+const ExampleComponent = () => {
+  const [unit, setUnit] = useState('px');
+  const { width, height } = UNIT_SIZES[unit];
+
+  return (
+    <>
+      <div className="example-controls-container">
+        <div className="controls">
+          <label htmlFor="unitSelect">Grid size unit</label>
+          <select id="unitSelect" value={unit} onChange={(event) => setUnit(event.target.value)}>
+            {Object.keys(UNIT_SIZES).map((key) => (
+              <option key={key} value={key}>{key}</option>
+            ))}
+          </select>
+        </div>
+        <p className="unit-caption">{UNIT_CAPTIONS[unit]}</p>
+      </div>
+      <div id="exampleParent2">
+        <HotTable
+          data={data}
+          colHeaders={['SKU', 'Product', 'Category', 'Supplier', 'Quantity']}
+          rowHeaders={true}
+          width={width}
+          height={height}
+          licenseKey="non-commercial-and-evaluation"
+        />
+      </div>
+    </>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/getting-started/grid-size/vue/example2.vue
+++ b/docs/content/guides/getting-started/grid-size/vue/example2.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+import { ref, useTemplateRef } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const UNIT_SIZES: Record<string, { width: string; height: string }> = {
+  px: { width: '600px', height: '300px' },
+  '%': { width: '75%', height: '75%' },
+  em: { width: '37.5em', height: '18.75em' },
+  rem: { width: '37.5rem', height: '18.75rem' },
+  vh: { width: '50vh', height: '50vh' },
+  vw: { width: '50vw', height: '50vw' },
+};
+
+const UNIT_CAPTIONS: Record<string, string> = {
+  px: 'A fixed pixel size, independent of any parent element or font size.',
+  '%': "A percentage of the parent container's size (the dashed box).",
+  em: "A multiple of this element's own font size.",
+  rem: "A multiple of the document's root font size.",
+  vh: "A percentage of the browser viewport's height.",
+  vw: "A percentage of the browser viewport's width.",
+};
+
+const unitKeys = Object.keys(UNIT_SIZES);
+const unit = ref('px');
+const hotTableRef = useTemplateRef<InstanceType<typeof HotTable>>('hotTableRef');
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['SKU-4821', 'Wireless Mouse', 'Electronics', 'Harbor Goods', 142],
+    ['SKU-0093', 'Canvas Tote Bag', 'Apparel', 'Alpine Supply Co.', 67],
+    ['SKU-2210', 'USB-C Hub', 'Electronics', 'Harbor Goods', 0],
+    ['SKU-7734', 'Ceramic Mug Set', 'Home Goods', 'Nordic Traders', 58],
+    ['SKU-1145', 'Wool Scarf', 'Apparel', 'Alpine Supply Co.', 213],
+    ['SKU-3399', 'Bluetooth Speaker', 'Electronics', 'Harbor Goods', 84],
+    ['SKU-5567', 'Cotton T-Shirt', 'Apparel', 'Alpine Supply Co.', 310],
+    ['SKU-8842', 'Desk Lamp', 'Home Goods', 'Nordic Traders', 45],
+    ['SKU-6621', 'Laptop Stand', 'Electronics', 'Harbor Goods', 29],
+    ['SKU-4470', 'Throw Blanket', 'Home Goods', 'Nordic Traders', 76],
+    ['SKU-9983', 'Leather Wallet', 'Apparel', 'Alpine Supply Co.', 132],
+    ['SKU-2287', 'Wireless Charger', 'Electronics', 'Harbor Goods', 97],
+  ],
+  colHeaders: ['SKU', 'Product', 'Category', 'Supplier', 'Quantity'],
+  rowHeaders: true,
+  width: UNIT_SIZES.px.width,
+  height: UNIT_SIZES.px.height,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+const changeUnit = (event: Event) => {
+  const value = (event.target as HTMLSelectElement).value;
+  const size = UNIT_SIZES[value];
+
+  unit.value = value;
+  hotTableRef.value?.hotInstance?.updateSettings({ width: size.width, height: size.height });
+};
+</script>
+
+<template>
+  <div id="example2">
+    <div class="example-controls-container">
+      <div class="controls">
+        <label for="unitSelect">Grid size unit</label>
+        <select id="unitSelect" @change="changeUnit">
+          <option v-for="key in unitKeys" :key="key" :value="key">{{ key }}</option>
+        </select>
+      </div>
+      <p class="unit-caption">{{ UNIT_CAPTIONS[unit] }}</p>
+    </div>
+    <div id="exampleParent2">
+      <HotTable ref="hotTableRef" :settings="hotSettings" />
+    </div>
+  </div>
+</template>
+
+<style>
+#exampleParent2 {
+  width: 800px;
+  max-width: 100%;
+  height: 400px;
+  box-sizing: border-box;
+  border: 1px dashed var(--sl-color-gray-5, #d1d5db);
+}
+
+#exampleParent2 > div {
+  height: 100%;
+}
+
+.unit-caption {
+  margin-top: 8px;
+  color: var(--sl-color-text, #485164);
+}
+</style>

--- a/docs/content/guides/getting-started/grid-size/vue/example2.vue
+++ b/docs/content/guides/getting-started/grid-size/vue/example2.vue
@@ -45,8 +45,8 @@ const hotSettings = ref<GridSettings>({
   ],
   colHeaders: ['SKU', 'Product', 'Category', 'Supplier', 'Quantity'],
   rowHeaders: true,
-  width: UNIT_SIZES.px.width,
-  height: UNIT_SIZES.px.height,
+  width: UNIT_SIZES['px'].width,
+  height: UNIT_SIZES['px'].height,
   licenseKey: 'non-commercial-and-evaluation',
 });
 

--- a/docs/src/styles/interactive-example.css
+++ b/docs/src/styles/interactive-example.css
@@ -161,7 +161,7 @@
   display: none !important;
 }
 
-.example-controls-container .controls:not(:has(button:not([hidden]))):not(:has(input:not([hidden]))) {
+.example-controls-container .controls:not(:has(button:not([hidden]))):not(:has(input:not([hidden]))):not(:has(select:not([hidden]))) {
   display: none;
 }
 


### PR DESCRIPTION
### Context

The PR adds an interactive demo to the [Grid size guide](https://handsontable.com/docs/getting-started/grid-size/) that lets readers compare how `px`, `%`, `em`, `rem`, `vh`, and `vw` affect the same grid. User-session recordings referenced in ClickUp DEV-648 showed readers struggling to predict grid size from a chosen CSS unit, and the guide previously only listed the supported units without demonstrating them.

The demo is a dropdown that calls `hot.updateSettings({ width, height })` with a paired value per unit, plus a caption explaining what each unit is relative to (font-size, root font-size, parent container, or viewport). It's placed right after the guide's existing width/height configuration code samples, as a new "Compare size units" subsection. The existing "Collapse/Expand container" demo in "Manual resizing" is untouched.

### How has this been tested?

- Manual verification on the Cloudflare Pages PR preview across all four framework tabs (JavaScript, React, Angular, Vue3): switching the unit dropdown resizes the grid and updates the caption as expected.
- `npm run docs:code-examples:generate-js -- content/guides/getting-started/grid-size/javascript/example2.ts` to generate the JS variant from the TypeScript source.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-648

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`
- [x] `handsontable-documentation`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-648

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example assets only; no changes to Handsontable core or framework wrappers.
> 
> **Overview**
> Adds a **Compare size units** subsection to the Grid size guide with a new `#example2` live demo for JavaScript, React, Angular, and Vue.
> 
> Readers can pick `px`, `%`, `em`, `rem`, `vh`, or `vw` from a dropdown; the sample grid applies paired `width`/`height` values (via props or `updateSettings`) and shows a short caption for what each unit is relative to. A dashed **800×400px** parent makes `%` sizing easy to see.
> 
> **Docs site CSS:** `interactive-example.css` now treats visible `<select>` controls like buttons/inputs so the unit dropdown is not hidden by the empty-controls rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23cf2f11007dc8b2fea091552e3936c5f4b244e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->