### PR TITLE
DEV-659: Note that async validators keep the editor open

### DIFF
--- a/docs/content/guides/cell-functions/cell-validator/cell-validator.md
+++ b/docs/content/guides/cell-functions/cell-validator/cell-validator.md
@@ -229,6 +229,12 @@ columns: [
 
 :::
 
+::: tip
+
+While a cell's validator resolves, Handsontable keeps that cell's editor open and blocks other cells from entering edit mode. This is expected behavior, not a bug. The example below uses an asynchronous email validator that resolves after 1000 ms, so the editor stays open briefly after you finish typing. For more on how validation affects the editing flow, see [How validation affects hook order](@/guides/getting-started/events-and-hooks/events-and-hooks.md#how-validation-affects-hook-order).
+
+:::
+
 Callback console log:
 
 ::: only-for javascript


### PR DESCRIPTION
### Context

The PR adds a note to the "Full featured example" demo in the cell-validator guide, explaining that Handsontable intentionally keeps a cell's editor open while its validator resolves, and blocks other cells from entering edit mode until validation finishes.

Without this note, users testing the demo's asynchronous email validator (which resolves after 1000 ms) mistake the delay for a frozen or broken editor. This was reported via HotJar session recordings showing the same confusion twice.

No source code change is required: the WAITING-state lock in `baseEditor.ts` / `editorManager.ts` that defers opening a new cell's editor until pending validation resolves is existing, intentional behavior.

### How has this been tested?

- Docs-only change; verified the callout renders correctly by reading the rendered Markdown structure against other `::: tip` usages in the same guide category (e.g. `cell-renderer.md`).
- Verified the cross-linked anchor `#how-validation-affects-hook-order` exists in `docs/content/guides/getting-started/events-and-hooks/events-and-hooks.md`.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-659

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-659

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only clarification with no code or behavior changes.
> 
> **Overview**
> Adds a **`::: tip`** callout in the **Full featured example** section of the cell-validator guide, right before the interactive demo.
> 
> The callout explains that while a validator is still resolving, Handsontable **keeps the current cell’s editor open** and **blocks other cells from edit mode**—intentional behavior, not a bug—and ties that to the demo’s **1000 ms async email validator**. It links to **How validation affects hook order** in the events-and-hooks guide for more detail on editing flow.
> 
> **Docs-only**; no runtime or API changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45206b8d084de7171dd6f5f54bd4319829106e59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->