### PR TITLE
DEV-666: Clarify setBorders borderObject docs

### DIFF
--- a/handsontable/src/plugins/customBorders/customBorders.ts
+++ b/handsontable/src/plugins/customBorders/customBorders.ts
@@ -229,7 +229,12 @@ export class CustomBorders extends BasePlugin {
    * ```
    *
    * @param {Array[]|CellRange[]} selectionRanges Array of selection ranges.
-   * @param {object} borderObject Object with `top`, `right`, `bottom` and `start` properties.
+   * @param {object} borderObject Object with `top`, `bottom`, `start`, and `end` properties.
+   * Each side object can include:
+   * - `width` (`number`) Border width in pixels (default: `1`).
+   * - `color` (`string`) CSS border color value (default: `'#000'`).
+   * - `hide` (`boolean`) Hides a border side when set to `true`.
+   * Legacy aliases `left` and `right` are also supported and are normalized to `start` and `end`.
    */
   setBorders(selectionRanges: unknown[], borderObject?: Record<string, unknown>): void {
     let borderKeys = ['top', 'bottom', 'start', 'end'];


### PR DESCRIPTION
### Context

The PR changes the `setBorders()` API docs so the `borderObject` parameter description matches current CustomBorders behavior and no longer mentions stale side keys.

[skip changelog]

### How has this been tested?

- `rtk npx eslint "handsontable/src/plugins/customBorders/customBorders.ts"`

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-666

### Affected project(s):

- [x] handsontable
- [ ] @handsontable/angular-wrapper
- [ ] @handsontable/react-wrapper
- [ ] @handsontable/vue3

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-666

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only API documentation update with no runtime or behavioral changes.
> 
> **Overview**
> Updates the **`setBorders()`** JSDoc for the **`borderObject`** argument so it matches current CustomBorders behavior.
> 
> The parameter is documented as **`top`**, **`bottom`**, **`start`**, and **`end`** (replacing stale **`right`** wording). Each side can specify **`width`**, **`color`**, and **`hide`**, with defaults called out. **`left`** / **`right`** are noted as legacy aliases normalized to **`start`** / **`end`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0e7c7e78bc458ababcbb905ff7e9b8f349bca4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->