### PR TITLE
DEV-691: Document header sizing options in guides

### DIFF
--- a/docs/content/guides/columns/column-header/angular/example7.html
+++ b/docs/content/guides/columns/column-header/angular/example7.html
@@ -1,0 +1,3 @@
+<div>
+  <app-example7></app-example7>
+</div>

--- a/docs/content/guides/columns/column-header/angular/example7.ts
+++ b/docs/content/guides/columns/column-header/angular/example7.ts
@@ -1,0 +1,51 @@
+/* file: app.component.ts */
+import { Component } from '@angular/core';
+import { GridSettings, HotTableModule } from '@handsontable/angular-wrapper';
+
+@Component({
+  selector: 'app-example7',
+  template: `
+    <hot-table [settings]="hotSettings!" [data]="hotData"></hot-table>
+  `,
+  standalone: true,
+  imports: [HotTableModule],
+})
+export class AppComponent {
+  readonly hotData = [
+    [1, 'Ana Garcia', 'Product Manager', 'Spain', '2022-03-14'],
+    [2, 'James Okafor', 'Senior Engineer', 'Nigeria', '2021-07-02'],
+    [3, 'Li Wei', 'Data Analyst', 'China', '2023-01-19'],
+    [4, 'Sofia Rossi', 'UX Designer', 'Italy', '2020-11-30'],
+    [5, 'Mateo Fernandez', 'Engineering Lead', 'Argentina', '2019-05-08'],
+  ];
+
+  readonly hotSettings: GridSettings = {
+    colHeaders: ['Employee ID', 'Employee full name', 'Current job title', 'Country of residence', 'Employment start date'],
+    rowHeaders: true,
+    colWidths: [100, 130, 130, 130, 130],
+    columnHeaderHeight: 50,
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true,
+  };
+}
+/* end-file */
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+/* end-file */

--- a/docs/content/guides/columns/column-header/column-header.md
+++ b/docs/content/guides/columns/column-header/column-header.md
@@ -307,6 +307,54 @@ If you want to style the header labels, you can pass any number of class names, 
 
 :::
 
+## Column header height
+
+When column labels are longer, header text can wrap and require more vertical space. To control the header size, set [`columnHeaderHeight`](@/api/options.md#columnheaderheight).
+
+You can set this option to one of the following:
+
+- A number - set the same height for every column header.
+- An array - set different heights for individual column header levels.
+
+The example below uses longer labels together with `columnHeaderHeight: 50`.
+
+::: only-for javascript
+
+::: example #example7 --js 1 --ts 2
+@[code](@/content/guides/columns/column-header/javascript/example7.js)
+@[code](@/content/guides/columns/column-header/javascript/example7.ts)
+:::
+
+:::
+
+::: only-for react
+
+::: example #example7 :react --js 1 --ts 2
+@[code](@/content/guides/columns/column-header/react/example7.jsx)
+@[code](@/content/guides/columns/column-header/react/example7.tsx)
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example7 :vue3
+
+@[code](@/content/guides/columns/column-header/vue/example7.vue)
+
+:::
+
+:::
+
+::: only-for angular
+
+::: example #example7 :angular --ts 1 --html 2
+@[code](@/content/guides/columns/column-header/angular/example7.ts)
+@[code](@/content/guides/columns/column-header/angular/example7.html)
+:::
+
+:::
+
 ## Nested headers
 
 More complex data structures can be displayed with multiple headers, each representing a different category of data. To learn more about nested headers, see the [column groups](@/guides/columns/column-groups/column-groups.md) page.

--- a/docs/content/guides/columns/column-header/javascript/example7.js
+++ b/docs/content/guides/columns/column-header/javascript/example7.js
@@ -1,0 +1,22 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+// Register all Handsontable's modules.
+registerAllModules();
+const container = document.querySelector('#example7');
+new Handsontable(container, {
+    data: [
+        [1, 'Ana Garcia', 'Product Manager', 'Spain', '2022-03-14'],
+        [2, 'James Okafor', 'Senior Engineer', 'Nigeria', '2021-07-02'],
+        [3, 'Li Wei', 'Data Analyst', 'China', '2023-01-19'],
+        [4, 'Sofia Rossi', 'UX Designer', 'Italy', '2020-11-30'],
+        [5, 'Mateo Fernandez', 'Engineering Lead', 'Argentina', '2019-05-08'],
+    ],
+    colHeaders: ['Employee ID', 'Employee full name', 'Current job title', 'Country of residence', 'Employment start date'],
+    rowHeaders: true,
+    colWidths: [100, 130, 130, 130, 130],
+    columnHeaderHeight: 50,
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true,
+    licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/columns/column-header/javascript/example7.ts
+++ b/docs/content/guides/columns/column-header/javascript/example7.ts
@@ -1,0 +1,25 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+// Register all Handsontable's modules.
+registerAllModules();
+
+const container = document.querySelector('#example7')!;
+
+new Handsontable(container, {
+  data: [
+    [1, 'Ana Garcia', 'Product Manager', 'Spain', '2022-03-14'],
+    [2, 'James Okafor', 'Senior Engineer', 'Nigeria', '2021-07-02'],
+    [3, 'Li Wei', 'Data Analyst', 'China', '2023-01-19'],
+    [4, 'Sofia Rossi', 'UX Designer', 'Italy', '2020-11-30'],
+    [5, 'Mateo Fernandez', 'Engineering Lead', 'Argentina', '2019-05-08'],
+  ],
+  colHeaders: ['Employee ID', 'Employee full name', 'Current job title', 'Country of residence', 'Employment start date'],
+  rowHeaders: true,
+  colWidths: [100, 130, 130, 130, 130],
+  columnHeaderHeight: 50,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/columns/column-header/react/example7.jsx
+++ b/docs/content/guides/columns/column-header/react/example7.jsx
@@ -1,0 +1,29 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={[
+        [1, 'Ana Garcia', 'Product Manager', 'Spain', '2022-03-14'],
+        [2, 'James Okafor', 'Senior Engineer', 'Nigeria', '2021-07-02'],
+        [3, 'Li Wei', 'Data Analyst', 'China', '2023-01-19'],
+        [4, 'Sofia Rossi', 'UX Designer', 'Italy', '2020-11-30'],
+        [5, 'Mateo Fernandez', 'Engineering Lead', 'Argentina', '2019-05-08'],
+      ]}
+      colHeaders={['Employee ID', 'Employee full name', 'Current job title', 'Country of residence', 'Employment start date']}
+      rowHeaders={true}
+      colWidths={[100, 130, 130, 130, 130]}
+      columnHeaderHeight={50}
+      height="auto"
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/columns/column-header/react/example7.tsx
+++ b/docs/content/guides/columns/column-header/react/example7.tsx
@@ -1,0 +1,29 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={[
+        [1, 'Ana Garcia', 'Product Manager', 'Spain', '2022-03-14'],
+        [2, 'James Okafor', 'Senior Engineer', 'Nigeria', '2021-07-02'],
+        [3, 'Li Wei', 'Data Analyst', 'China', '2023-01-19'],
+        [4, 'Sofia Rossi', 'UX Designer', 'Italy', '2020-11-30'],
+        [5, 'Mateo Fernandez', 'Engineering Lead', 'Argentina', '2019-05-08'],
+      ]}
+      colHeaders={['Employee ID', 'Employee full name', 'Current job title', 'Country of residence', 'Employment start date']}
+      rowHeaders={true}
+      colWidths={[100, 130, 130, 130, 130]}
+      columnHeaderHeight={50}
+      height="auto"
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/columns/column-header/vue/example7.vue
+++ b/docs/content/guides/columns/column-header/vue/example7.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    [1, 'Ana Garcia', 'Product Manager', 'Spain', '2022-03-14'],
+    [2, 'James Okafor', 'Senior Engineer', 'Nigeria', '2021-07-02'],
+    [3, 'Li Wei', 'Data Analyst', 'China', '2023-01-19'],
+    [4, 'Sofia Rossi', 'UX Designer', 'Italy', '2020-11-30'],
+    [5, 'Mateo Fernandez', 'Engineering Lead', 'Argentina', '2019-05-08'],
+  ],
+  colHeaders: ['Employee ID', 'Employee full name', 'Current job title', 'Country of residence', 'Employment start date'],
+  rowHeaders: true,
+  colWidths: [100, 130, 130, 130, 130],
+  columnHeaderHeight: 50,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example7">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/rows/row-header/row-header.md
+++ b/docs/content/guides/rows/row-header/row-header.md
@@ -123,6 +123,17 @@ The [`rowHeaders`](@/api/options.md#rowheaders) can also be populated using a fu
 
 :::
 
+## Row header width
+
+When you use custom row labels, their content can exceed the default header width. To control the header size, set [`rowHeaderWidth`](@/api/options.md#rowheaderwidth).
+
+You can set this option to one of the following:
+
+- A number - set the same width for every row header.
+- An array - set different widths for individual row header levels.
+
+The [Row headers as an array](#row-headers-as-an-array) example uses custom labels together with `rowHeaderWidth: 80`.
+
 ## Bind rows with headers
 
 You can bind row numbers with row headers. This is used mostly to differentiate two business cases in which Handsontable is most often used.
@@ -207,6 +218,7 @@ A tree grid enables you to represent the nested data structures within the data 
 - [currentHeaderClassName](@/api/options.md#currentheaderclassname)
 - [bindRowsWithHeaders](@/api/options.md#bindrowswithheaders)
 - [rowHeaders](@/api/options.md#rowheaders)
+- [rowHeaderWidth](@/api/options.md#rowheaderwidth)
 
 </div>
 


### PR DESCRIPTION
### Context

The PR adds dedicated guidance for `rowHeaderWidth` and `columnHeaderHeight`, so users can discover header sizing behavior directly in the feature guides instead of only through option references.

### How has this been tested?

- `npm run docs:code-examples:generate-js -- content/guides/columns/column-header/javascript/example7.ts`
- Generated React JSX from `react/example7.tsx` to `react/example7.jsx`
- `npm run docs:lint`
- `npm run build`

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. DEV-691
2. https://app.clickup.com/t/9015210959/DEV-691

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and doc examples only; no runtime or library code changes.
> 
> **Overview**
> Adds guide coverage for header sizing so users can find **`columnHeaderHeight`** and **`rowHeaderWidth`** in the feature docs, not only in the API reference.
> 
> The **column headers** guide gets a new **Column header height** section with prose (number vs array) and a new **example7** across JavaScript, TypeScript, React, Vue, and Angular, demonstrating longer labels with `columnHeaderHeight: 50`.
> 
> The **row headers** guide gets a new **Row header width** section that documents the same option shapes and points readers to the existing **Row headers as an array** example (`rowHeaderWidth: 80`). **`rowHeaderWidth`** is also listed under related configuration options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc1dc16cd5ee517e3bfbac3cbc31a9b2a529f10c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->