### PR TITLE
DEV-668: Add save/restore filter settings and get filtered data sections

### DIFF
--- a/docs/content/guides/columns/column-filter/angular/example13.html
+++ b/docs/content/guides/columns/column-filter/angular/example13.html
@@ -1,0 +1,3 @@
+<div>
+  <app-example13></app-example13>
+</div>

--- a/docs/content/guides/columns/column-filter/angular/example13.ts
+++ b/docs/content/guides/columns/column-filter/angular/example13.ts
@@ -1,0 +1,186 @@
+/* file: app.component.ts */
+import { Component, ViewChild } from '@angular/core';
+import { GridSettings, HotTableComponent, HotTableModule } from '@handsontable/angular-wrapper';
+import { Filters } from 'handsontable/plugins';
+import type { ColumnConditions } from 'handsontable/plugins/filters';
+
+@Component({
+  standalone: true,
+  imports: [HotTableModule],
+  selector: 'app-example13',
+  template: `
+    <div class="example-controls-container">
+      <div class="controls">
+        <button (click)="applySampleFilter()">Filter: price &gt; $200</button>
+        <button (click)="saveFilters()">Save filter settings</button>
+        <button (click)="clearFilters()">Clear filters</button>
+        <button (click)="restoreFilters()">Restore filter settings</button>
+      </div>
+    </div>
+
+    <hot-table
+      [settings]="hotSettings!" [data]="hotData">
+    </hot-table>
+  `,
+})
+export class AppComponent {
+  @ViewChild(HotTableComponent, {static: false}) hotTable!: HotTableComponent;
+
+  savedConditions: ColumnConditions[] = [];
+
+  readonly hotData = [
+    {
+      brand: 'Jetpulse',
+      model: 'Racing Socks',
+      price: 30,
+      sellDate: '2023-10-11',
+      sellTime: '01:23',
+      inStock: false,
+    },
+    {
+      brand: 'Gigabox',
+      model: 'HL Mountain Frame',
+      price: 1890.9,
+      sellDate: '2023-05-03',
+      sellTime: '11:27',
+      inStock: false,
+    },
+    {
+      brand: 'Camido',
+      model: 'Cycling Cap',
+      price: 130.1,
+      sellDate: '2023-03-27',
+      sellTime: '03:17',
+      inStock: true,
+    },
+    {
+      brand: 'Chatterpoint',
+      model: 'Road Tire Tube',
+      price: 59,
+      sellDate: '2023-08-28',
+      sellTime: '08:01',
+      inStock: true,
+    },
+    {
+      brand: 'Eidel',
+      model: 'HL Road Tire',
+      price: 279.99,
+      sellDate: '2023-10-02',
+      sellTime: '01:23',
+      inStock: true,
+    },
+  ];
+
+  readonly hotSettings: GridSettings = {
+    columns: [
+      {
+        title: 'Brand',
+        type: 'text',
+        data: 'brand',
+      },
+      {
+        title: 'Model',
+        type: 'text',
+        data: 'model',
+      },
+      {
+        title: 'Price',
+        type: 'numeric',
+        data: 'price',
+        locale: 'en-US',
+        numericFormat: {
+          style: 'currency',
+          currency: 'USD',
+          minimumFractionDigits: 2,
+        },
+      },
+      {
+        title: 'Date',
+        type: 'intl-date',
+        data: 'sellDate',
+        locale: 'en-US',
+        dateFormat: { month: 'short', day: 'numeric', year: 'numeric' },
+        className: 'htRight',
+      },
+      {
+        title: 'Time',
+        type: 'intl-time',
+        data: 'sellTime',
+        locale: 'en-US',
+        timeFormat: { hour: '2-digit', minute: '2-digit', hour12: true },
+        className: 'htRight',
+      },
+      {
+        title: 'In stock',
+        type: 'checkbox',
+        data: 'inStock',
+        className: 'htCenter',
+      },
+    ],
+    // enable filtering
+    filters: true,
+    // enable the column menu
+    dropdownMenu: true,
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true,
+  };
+
+  // get the `Filters` plugin, so you can use its API
+  getFiltersPlugin(): Filters {
+    return this.hotTable.hotInstance!.getPlugin('filters');
+  }
+
+  applySampleFilter() {
+    const filters = this.getFiltersPlugin();
+
+    filters.clearConditions();
+    // filter the 'Price' column (column at index 2) for items over $200
+    filters.addCondition(2, 'gt', [200]);
+    filters.filter();
+  }
+
+  saveFilters() {
+    const filters = this.getFiltersPlugin();
+
+    // `exportConditions()` returns the current conditions, keyed by physical column index
+    this.savedConditions = filters.exportConditions();
+  }
+
+  clearFilters() {
+    const filters = this.getFiltersPlugin();
+
+    filters.clearConditions();
+    filters.filter();
+  }
+
+  restoreFilters() {
+    const filters = this.getFiltersPlugin();
+
+    // `importConditions()` expects the same physical-column-indexed structure
+    filters.importConditions(this.savedConditions);
+    filters.filter();
+  }
+}
+/* end-file */
+
+
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+/* end-file */

--- a/docs/content/guides/columns/column-filter/angular/example14.html
+++ b/docs/content/guides/columns/column-filter/angular/example14.html
@@ -1,0 +1,3 @@
+<div>
+  <app-example14></app-example14>
+</div>

--- a/docs/content/guides/columns/column-filter/angular/example14.ts
+++ b/docs/content/guides/columns/column-filter/angular/example14.ts
@@ -1,0 +1,161 @@
+/* file: app.component.ts */
+import { Component } from '@angular/core';
+import Handsontable from 'handsontable';
+import { GridSettings, HotTableModule } from '@handsontable/angular-wrapper';
+
+@Component({
+  standalone: true,
+  imports: [HotTableModule],
+  selector: 'app-example14',
+  template: `
+    <p>{{ rowCountInfo }}</p>
+
+    <hot-table
+      [settings]="hotSettings!" [data]="hotData">
+    </hot-table>
+  `,
+})
+export class AppComponent {
+  rowCountInfo = '';
+
+  readonly hotData = [
+    {
+      brand: 'Jetpulse',
+      model: 'Racing Socks',
+      price: 30,
+      sellDate: '2023-10-11',
+      sellTime: '01:23',
+      inStock: false,
+    },
+    {
+      brand: 'Gigabox',
+      model: 'HL Mountain Frame',
+      price: 1890.9,
+      sellDate: '2023-05-03',
+      sellTime: '11:27',
+      inStock: false,
+    },
+    {
+      brand: 'Camido',
+      model: 'Cycling Cap',
+      price: 130.1,
+      sellDate: '2023-03-27',
+      sellTime: '03:17',
+      inStock: true,
+    },
+    {
+      brand: 'Chatterpoint',
+      model: 'Road Tire Tube',
+      price: 59,
+      sellDate: '2023-08-28',
+      sellTime: '08:01',
+      inStock: true,
+    },
+    {
+      brand: 'Eidel',
+      model: 'HL Road Tire',
+      price: 279.99,
+      sellDate: '2023-10-02',
+      sellTime: '01:23',
+      inStock: true,
+    },
+  ];
+
+  readonly hotSettings: GridSettings;
+
+  constructor() {
+    // deferred so the update doesn't trigger NG0100 when `afterInit` fires
+    // during the same change-detection cycle that first rendered the template
+    const updateRowCountInfo = (hotInstance: Handsontable) => {
+      setTimeout(() => {
+        // `getData()` returns only the rows that pass the current filters
+        // `getSourceData()` always returns every row, filtered or not
+        this.rowCountInfo = `Showing ${hotInstance.getData().length} of ${hotInstance.getSourceData().length} rows.`;
+      }, 0);
+    };
+
+    this.hotSettings = {
+      columns: [
+        {
+          title: 'Brand',
+          type: 'text',
+          data: 'brand',
+        },
+        {
+          title: 'Model',
+          type: 'text',
+          data: 'model',
+        },
+        {
+          title: 'Price',
+          type: 'numeric',
+          data: 'price',
+          locale: 'en-US',
+          numericFormat: {
+            style: 'currency',
+            currency: 'USD',
+            minimumFractionDigits: 2,
+          },
+        },
+        {
+          title: 'Date',
+          type: 'intl-date',
+          data: 'sellDate',
+          locale: 'en-US',
+          dateFormat: { month: 'short', day: 'numeric', year: 'numeric' },
+          className: 'htRight',
+        },
+        {
+          title: 'Time',
+          type: 'intl-time',
+          data: 'sellTime',
+          locale: 'en-US',
+          timeFormat: { hour: '2-digit', minute: '2-digit', hour12: true },
+          className: 'htRight',
+        },
+        {
+          title: 'In stock',
+          type: 'checkbox',
+          data: 'inStock',
+          className: 'htCenter',
+        },
+      ],
+      // enable filtering
+      filters: true,
+      // enable the column menu
+      dropdownMenu: true,
+      // `afterInit()` and `afterFilter()` are Handsontable hooks
+      afterInit(this: Handsontable) {
+        updateRowCountInfo(this);
+      },
+      afterFilter(this: Handsontable) {
+        updateRowCountInfo(this);
+      },
+      height: 'auto',
+      autoWrapRow: true,
+      autoWrapCol: true,
+    };
+  }
+}
+/* end-file */
+
+
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+/* end-file */

--- a/docs/content/guides/columns/column-filter/column-filter.md
+++ b/docs/content/guides/columns/column-filter/column-filter.md
@@ -735,6 +735,11 @@ filtering doesn't affect them.
 
 :::
 
+If you use [`bindRowsWithHeaders`](@/guides/rows/row-header/row-header.md#bind-rows-with-headers) to
+keep row headers tied to a row's position in the source data, filtering doesn't affect that binding.
+Filtering removes non-matching rows from view instead of renumbering the rows that remain, so bound
+row headers keep pointing to the same row after you filter or clear a filter.
+
 ## Server-side filtering
 
 You can decide to use Handsontable as an intuitive filtering interface, but perform the actual
@@ -1181,6 +1186,115 @@ filtering effect, because `'none'` matches every row:
 filters.addCondition(2, 'none', []);
 filters.filter();
 ```
+
+### Save and restore filter settings
+
+To persist a user's filter selections (for example, across page reloads or between sessions), export
+the current conditions with [`filters.exportConditions()`](@/api/filters.md#exportconditions), and
+store the result. To reapply them later, pass the stored array to
+[`filters.importConditions()`](@/api/filters.md#importconditions), then call
+[`filters.filter()`](@/api/filters.md#filter) to apply the change.
+
+Unlike [`addCondition()`](@/api/filters.md#addcondition), which takes a visual column index, the
+`column` property in each exported condition is a physical column index.
+
+::: only-for javascript
+
+::: example #exampleSaveRestoreFilters --html 1 --js 2 --ts 3
+
+@[code](@/content/guides/columns/column-filter/javascript/exampleSaveRestoreFilters.html)
+@[code](@/content/guides/columns/column-filter/javascript/exampleSaveRestoreFilters.js)
+@[code](@/content/guides/columns/column-filter/javascript/exampleSaveRestoreFilters.ts)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #exampleSaveRestoreFilters :react --js 1 --ts 2
+
+@[code](@/content/guides/columns/column-filter/react/exampleSaveRestoreFilters.jsx)
+@[code](@/content/guides/columns/column-filter/react/exampleSaveRestoreFilters.tsx)
+
+:::
+
+:::
+
+::: only-for angular
+
+::: example #example13 :angular --ts 1 --html 2
+
+@[code](@/content/guides/columns/column-filter/angular/example13.ts)
+@[code](@/content/guides/columns/column-filter/angular/example13.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #exampleSaveRestoreFilters :vue3
+
+@[code](@/content/guides/columns/column-filter/vue/exampleSaveRestoreFilters.vue)
+
+:::
+
+:::
+
+### Get filtered data
+
+After filtering, [`getData()`](@/api/core.md#getdata) returns only the rows that pass the current
+filters, because filtering removes non-matching rows from the grid's data map instead of merely
+hiding them. To read every row regardless of the active filters, use
+[`getSourceData()`](@/api/core.md#getsourcedata).
+
+The following demo uses the [`afterFilter()`](@/api/hooks.md#afterfilter) hook to compare the two
+methods every time the filters change.
+
+::: only-for javascript
+
+::: example #exampleGetFilteredData --html 1 --js 2 --ts 3
+
+@[code](@/content/guides/columns/column-filter/javascript/exampleGetFilteredData.html)
+@[code](@/content/guides/columns/column-filter/javascript/exampleGetFilteredData.js)
+@[code](@/content/guides/columns/column-filter/javascript/exampleGetFilteredData.ts)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #exampleGetFilteredData :react --js 1 --ts 2
+
+@[code](@/content/guides/columns/column-filter/react/exampleGetFilteredData.jsx)
+@[code](@/content/guides/columns/column-filter/react/exampleGetFilteredData.tsx)
+
+:::
+
+:::
+
+::: only-for angular
+
+::: example #example14 :angular --ts 1 --html 2
+
+@[code](@/content/guides/columns/column-filter/angular/example14.ts)
+@[code](@/content/guides/columns/column-filter/angular/example14.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #exampleGetFilteredData :vue3
+
+@[code](@/content/guides/columns/column-filter/vue/exampleGetFilteredData.vue)
+
+:::
+
+:::
 
 ## Import the filtering module
 

--- a/docs/content/guides/columns/column-filter/javascript/exampleGetFilteredData.html
+++ b/docs/content/guides/columns/column-filter/javascript/exampleGetFilteredData.html
@@ -1,0 +1,2 @@
+<p id="rowCountInfo"></p>
+<div id="exampleGetFilteredData"></div>

--- a/docs/content/guides/columns/column-filter/javascript/exampleGetFilteredData.js
+++ b/docs/content/guides/columns/column-filter/javascript/exampleGetFilteredData.js
@@ -1,0 +1,115 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+// Register all Handsontable's modules.
+registerAllModules();
+const container = document.querySelector('#exampleGetFilteredData');
+const rowCountInfo = document.querySelector('#rowCountInfo');
+function updateRowCountInfo(instance) {
+    // `getData()` returns only the rows that pass the current filters
+    const visibleRowCount = instance.getData().length;
+    // `getSourceData()` always returns every row, filtered or not
+    const totalRowCount = instance.getSourceData().length;
+    rowCountInfo.textContent = `Showing ${visibleRowCount} of ${totalRowCount} rows.`;
+}
+const hot = new Handsontable(container, {
+    data: [
+        {
+            brand: 'Jetpulse',
+            model: 'Racing Socks',
+            price: 30,
+            sellDate: '2023-10-11',
+            sellTime: '01:23',
+            inStock: false,
+        },
+        {
+            brand: 'Gigabox',
+            model: 'HL Mountain Frame',
+            price: 1890.9,
+            sellDate: '2023-05-03',
+            sellTime: '11:27',
+            inStock: false,
+        },
+        {
+            brand: 'Camido',
+            model: 'Cycling Cap',
+            price: 130.1,
+            sellDate: '2023-03-27',
+            sellTime: '03:17',
+            inStock: true,
+        },
+        {
+            brand: 'Chatterpoint',
+            model: 'Road Tire Tube',
+            price: 59,
+            sellDate: '2023-08-28',
+            sellTime: '08:01',
+            inStock: true,
+        },
+        {
+            brand: 'Eidel',
+            model: 'HL Road Tire',
+            price: 279.99,
+            sellDate: '2023-10-02',
+            sellTime: '01:23',
+            inStock: true,
+        },
+    ],
+    columns: [
+        {
+            title: 'Brand',
+            type: 'text',
+            data: 'brand',
+        },
+        {
+            title: 'Model',
+            type: 'text',
+            data: 'model',
+        },
+        {
+            title: 'Price',
+            type: 'numeric',
+            data: 'price',
+            locale: 'en-US',
+            numericFormat: {
+                style: 'currency',
+                currency: 'USD',
+                minimumFractionDigits: 2,
+            },
+        },
+        {
+            title: 'Date',
+            type: 'intl-date',
+            data: 'sellDate',
+            locale: 'en-US',
+            dateFormat: { month: 'short', day: 'numeric', year: 'numeric' },
+            className: 'htRight',
+        },
+        {
+            title: 'Time',
+            type: 'intl-time',
+            data: 'sellTime',
+            locale: 'en-US',
+            timeFormat: { hour: '2-digit', minute: '2-digit', hour12: true },
+            className: 'htRight',
+        },
+        {
+            title: 'In stock',
+            type: 'checkbox',
+            data: 'inStock',
+            className: 'htCenter',
+        },
+    ],
+    // enable filtering
+    filters: true,
+    // enable the column menu
+    dropdownMenu: true,
+    // `afterFilter()` fires after Handsontable applies the filters
+    afterFilter() {
+        updateRowCountInfo(this);
+    },
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true,
+    licenseKey: 'non-commercial-and-evaluation',
+});
+updateRowCountInfo(hot);

--- a/docs/content/guides/columns/column-filter/javascript/exampleGetFilteredData.ts
+++ b/docs/content/guides/columns/column-filter/javascript/exampleGetFilteredData.ts
@@ -1,0 +1,121 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+// Register all Handsontable's modules.
+registerAllModules();
+
+const container = document.querySelector('#exampleGetFilteredData')!;
+const rowCountInfo = document.querySelector('#rowCountInfo')!;
+
+function updateRowCountInfo(instance: Handsontable) {
+  // `getData()` returns only the rows that pass the current filters
+  const visibleRowCount = instance.getData().length;
+  // `getSourceData()` always returns every row, filtered or not
+  const totalRowCount = instance.getSourceData().length;
+
+  rowCountInfo.textContent = `Showing ${visibleRowCount} of ${totalRowCount} rows.`;
+}
+
+const hot = new Handsontable(container, {
+  data: [
+    {
+      brand: 'Jetpulse',
+      model: 'Racing Socks',
+      price: 30,
+      sellDate: '2023-10-11',
+      sellTime: '01:23',
+      inStock: false,
+    },
+    {
+      brand: 'Gigabox',
+      model: 'HL Mountain Frame',
+      price: 1890.9,
+      sellDate: '2023-05-03',
+      sellTime: '11:27',
+      inStock: false,
+    },
+    {
+      brand: 'Camido',
+      model: 'Cycling Cap',
+      price: 130.1,
+      sellDate: '2023-03-27',
+      sellTime: '03:17',
+      inStock: true,
+    },
+    {
+      brand: 'Chatterpoint',
+      model: 'Road Tire Tube',
+      price: 59,
+      sellDate: '2023-08-28',
+      sellTime: '08:01',
+      inStock: true,
+    },
+    {
+      brand: 'Eidel',
+      model: 'HL Road Tire',
+      price: 279.99,
+      sellDate: '2023-10-02',
+      sellTime: '01:23',
+      inStock: true,
+    },
+  ],
+  columns: [
+    {
+      title: 'Brand',
+      type: 'text',
+      data: 'brand',
+    },
+    {
+      title: 'Model',
+      type: 'text',
+      data: 'model',
+    },
+    {
+      title: 'Price',
+      type: 'numeric',
+      data: 'price',
+      locale: 'en-US',
+      numericFormat: {
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: 2,
+      },
+    },
+    {
+      title: 'Date',
+      type: 'intl-date',
+      data: 'sellDate',
+      locale: 'en-US',
+      dateFormat: { month: 'short', day: 'numeric', year: 'numeric' },
+      className: 'htRight',
+    },
+    {
+      title: 'Time',
+      type: 'intl-time',
+      data: 'sellTime',
+      locale: 'en-US',
+      timeFormat: { hour: '2-digit', minute: '2-digit', hour12: true },
+      className: 'htRight',
+    },
+    {
+      title: 'In stock',
+      type: 'checkbox',
+      data: 'inStock',
+      className: 'htCenter',
+    },
+  ],
+  // enable filtering
+  filters: true,
+  // enable the column menu
+  dropdownMenu: true,
+  // `afterFilter()` fires after Handsontable applies the filters
+  afterFilter() {
+    updateRowCountInfo(this);
+  },
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+updateRowCountInfo(hot);

--- a/docs/content/guides/columns/column-filter/javascript/exampleSaveRestoreFilters.html
+++ b/docs/content/guides/columns/column-filter/javascript/exampleSaveRestoreFilters.html
@@ -1,0 +1,9 @@
+<div class="example-controls-container">
+  <div class="controls">
+    <button class="applySampleFilter">Filter: price &gt; $200</button>
+    <button class="saveFilters">Save filter settings</button>
+    <button class="clearFilters">Clear filters</button>
+    <button class="restoreFilters">Restore filter settings</button>
+  </div>
+</div>
+<div id="exampleSaveRestoreFilters"></div>

--- a/docs/content/guides/columns/column-filter/javascript/exampleSaveRestoreFilters.js
+++ b/docs/content/guides/columns/column-filter/javascript/exampleSaveRestoreFilters.js
@@ -1,0 +1,124 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+// Register all Handsontable's modules.
+registerAllModules();
+const container = document.querySelector('#exampleSaveRestoreFilters');
+const hot = new Handsontable(container, {
+    data: [
+        {
+            brand: 'Jetpulse',
+            model: 'Racing Socks',
+            price: 30,
+            sellDate: '2023-10-11',
+            sellTime: '01:23',
+            inStock: false,
+        },
+        {
+            brand: 'Gigabox',
+            model: 'HL Mountain Frame',
+            price: 1890.9,
+            sellDate: '2023-05-03',
+            sellTime: '11:27',
+            inStock: false,
+        },
+        {
+            brand: 'Camido',
+            model: 'Cycling Cap',
+            price: 130.1,
+            sellDate: '2023-03-27',
+            sellTime: '03:17',
+            inStock: true,
+        },
+        {
+            brand: 'Chatterpoint',
+            model: 'Road Tire Tube',
+            price: 59,
+            sellDate: '2023-08-28',
+            sellTime: '08:01',
+            inStock: true,
+        },
+        {
+            brand: 'Eidel',
+            model: 'HL Road Tire',
+            price: 279.99,
+            sellDate: '2023-10-02',
+            sellTime: '01:23',
+            inStock: true,
+        },
+    ],
+    columns: [
+        {
+            title: 'Brand',
+            type: 'text',
+            data: 'brand',
+        },
+        {
+            title: 'Model',
+            type: 'text',
+            data: 'model',
+        },
+        {
+            title: 'Price',
+            type: 'numeric',
+            data: 'price',
+            locale: 'en-US',
+            numericFormat: {
+                style: 'currency',
+                currency: 'USD',
+                minimumFractionDigits: 2,
+            },
+        },
+        {
+            title: 'Date',
+            type: 'intl-date',
+            data: 'sellDate',
+            locale: 'en-US',
+            dateFormat: { month: 'short', day: 'numeric', year: 'numeric' },
+            className: 'htRight',
+        },
+        {
+            title: 'Time',
+            type: 'intl-time',
+            data: 'sellTime',
+            locale: 'en-US',
+            timeFormat: { hour: '2-digit', minute: '2-digit', hour12: true },
+            className: 'htRight',
+        },
+        {
+            title: 'In stock',
+            type: 'checkbox',
+            data: 'inStock',
+            className: 'htCenter',
+        },
+    ],
+    // enable filtering
+    filters: true,
+    // enable the column menu
+    dropdownMenu: true,
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true,
+    licenseKey: 'non-commercial-and-evaluation',
+});
+// get the `Filters` plugin, so you can use its API
+const filters = hot.getPlugin('filters');
+let savedConditions = [];
+document.querySelector('.applySampleFilter').addEventListener('click', () => {
+    filters.clearConditions();
+    // filter the 'Price' column (column at index 2) for items over $200
+    filters.addCondition(2, 'gt', [200]);
+    filters.filter();
+});
+document.querySelector('.saveFilters').addEventListener('click', () => {
+    // `exportConditions()` returns the current conditions, keyed by physical column index
+    savedConditions = filters.exportConditions();
+});
+document.querySelector('.clearFilters').addEventListener('click', () => {
+    filters.clearConditions();
+    filters.filter();
+});
+document.querySelector('.restoreFilters').addEventListener('click', () => {
+    // `importConditions()` expects the same physical-column-indexed structure
+    filters.importConditions(savedConditions);
+    filters.filter();
+});

--- a/docs/content/guides/columns/column-filter/javascript/exampleSaveRestoreFilters.ts
+++ b/docs/content/guides/columns/column-filter/javascript/exampleSaveRestoreFilters.ts
@@ -1,0 +1,133 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+import { Filters } from 'handsontable/plugins';
+import type { ColumnConditions } from 'handsontable/plugins/filters';
+
+// Register all Handsontable's modules.
+registerAllModules();
+
+const container = document.querySelector('#exampleSaveRestoreFilters')!;
+const hot = new Handsontable(container, {
+  data: [
+    {
+      brand: 'Jetpulse',
+      model: 'Racing Socks',
+      price: 30,
+      sellDate: '2023-10-11',
+      sellTime: '01:23',
+      inStock: false,
+    },
+    {
+      brand: 'Gigabox',
+      model: 'HL Mountain Frame',
+      price: 1890.9,
+      sellDate: '2023-05-03',
+      sellTime: '11:27',
+      inStock: false,
+    },
+    {
+      brand: 'Camido',
+      model: 'Cycling Cap',
+      price: 130.1,
+      sellDate: '2023-03-27',
+      sellTime: '03:17',
+      inStock: true,
+    },
+    {
+      brand: 'Chatterpoint',
+      model: 'Road Tire Tube',
+      price: 59,
+      sellDate: '2023-08-28',
+      sellTime: '08:01',
+      inStock: true,
+    },
+    {
+      brand: 'Eidel',
+      model: 'HL Road Tire',
+      price: 279.99,
+      sellDate: '2023-10-02',
+      sellTime: '01:23',
+      inStock: true,
+    },
+  ],
+  columns: [
+    {
+      title: 'Brand',
+      type: 'text',
+      data: 'brand',
+    },
+    {
+      title: 'Model',
+      type: 'text',
+      data: 'model',
+    },
+    {
+      title: 'Price',
+      type: 'numeric',
+      data: 'price',
+      locale: 'en-US',
+      numericFormat: {
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: 2,
+      },
+    },
+    {
+      title: 'Date',
+      type: 'intl-date',
+      data: 'sellDate',
+      locale: 'en-US',
+      dateFormat: { month: 'short', day: 'numeric', year: 'numeric' },
+      className: 'htRight',
+    },
+    {
+      title: 'Time',
+      type: 'intl-time',
+      data: 'sellTime',
+      locale: 'en-US',
+      timeFormat: { hour: '2-digit', minute: '2-digit', hour12: true },
+      className: 'htRight',
+    },
+    {
+      title: 'In stock',
+      type: 'checkbox',
+      data: 'inStock',
+      className: 'htCenter',
+    },
+  ],
+  // enable filtering
+  filters: true,
+  // enable the column menu
+  dropdownMenu: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+// get the `Filters` plugin, so you can use its API
+const filters: Filters = hot.getPlugin('filters');
+let savedConditions: ColumnConditions[] = [];
+
+document.querySelector('.applySampleFilter')!.addEventListener('click', () => {
+  filters.clearConditions();
+  // filter the 'Price' column (column at index 2) for items over $200
+  filters.addCondition(2, 'gt', [200]);
+  filters.filter();
+});
+
+document.querySelector('.saveFilters')!.addEventListener('click', () => {
+  // `exportConditions()` returns the current conditions, keyed by physical column index
+  savedConditions = filters.exportConditions();
+});
+
+document.querySelector('.clearFilters')!.addEventListener('click', () => {
+  filters.clearConditions();
+  filters.filter();
+});
+
+document.querySelector('.restoreFilters')!.addEventListener('click', () => {
+  // `importConditions()` expects the same physical-column-indexed structure
+  filters.importConditions(savedConditions);
+  filters.filter();
+});

--- a/docs/content/guides/columns/column-filter/react/exampleGetFilteredData.jsx
+++ b/docs/content/guides/columns/column-filter/react/exampleGetFilteredData.jsx
@@ -1,0 +1,131 @@
+import { useRef, useState } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const ExampleComponent = () => {
+  const hotTableComponentRef = useRef(null);
+  const [rowCountInfo, setRowCountInfo] = useState('');
+
+  const updateRowCountInfo = () => {
+    const hotInstance = hotTableComponentRef.current?.hotInstance;
+
+    if (!hotInstance) {
+      return;
+    }
+
+    // `getData()` returns only the rows that pass the current filters
+    // `getSourceData()` always returns every row, filtered or not
+    setRowCountInfo(`Showing ${hotInstance.getData().length} of ${hotInstance.getSourceData().length} rows.`);
+  };
+
+  return (
+    <>
+      <p>{rowCountInfo}</p>
+      <HotTable
+        ref={hotTableComponentRef}
+        data={[
+          {
+            brand: 'Jetpulse',
+            model: 'Racing Socks',
+            price: 30,
+            sellDate: '2023-10-11',
+            sellTime: '01:23',
+            inStock: false,
+          },
+          {
+            brand: 'Gigabox',
+            model: 'HL Mountain Frame',
+            price: 1890.9,
+            sellDate: '2023-05-03',
+            sellTime: '11:27',
+            inStock: false,
+          },
+          {
+            brand: 'Camido',
+            model: 'Cycling Cap',
+            price: 130.1,
+            sellDate: '2023-03-27',
+            sellTime: '03:17',
+            inStock: true,
+          },
+          {
+            brand: 'Chatterpoint',
+            model: 'Road Tire Tube',
+            price: 59,
+            sellDate: '2023-08-28',
+            sellTime: '08:01',
+            inStock: true,
+          },
+          {
+            brand: 'Eidel',
+            model: 'HL Road Tire',
+            price: 279.99,
+            sellDate: '2023-10-02',
+            sellTime: '01:23',
+            inStock: true,
+          },
+        ]}
+        columns={[
+          {
+            title: 'Brand',
+            type: 'text',
+            data: 'brand',
+          },
+          {
+            title: 'Model',
+            type: 'text',
+            data: 'model',
+          },
+          {
+            title: 'Price',
+            type: 'numeric',
+            data: 'price',
+            locale: 'en-US',
+            numericFormat: {
+              style: 'currency',
+              currency: 'USD',
+              minimumFractionDigits: 2,
+            },
+          },
+          {
+            title: 'Date',
+            type: 'intl-date',
+            data: 'sellDate',
+            locale: 'en-US',
+            dateFormat: { month: 'short', day: 'numeric', year: 'numeric' },
+            className: 'htRight',
+          },
+          {
+            title: 'Time',
+            type: 'intl-time',
+            data: 'sellTime',
+            locale: 'en-US',
+            timeFormat: { hour: '2-digit', minute: '2-digit', hour12: true },
+            className: 'htRight',
+          },
+          {
+            title: 'In stock',
+            type: 'checkbox',
+            data: 'inStock',
+            className: 'htCenter',
+          },
+        ]}
+        // enable filtering
+        filters={true}
+        // enable the column menu
+        dropdownMenu={true}
+        afterInit={updateRowCountInfo}
+        afterFilter={updateRowCountInfo}
+        height="auto"
+        autoWrapRow={true}
+        autoWrapCol={true}
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/columns/column-filter/react/exampleGetFilteredData.tsx
+++ b/docs/content/guides/columns/column-filter/react/exampleGetFilteredData.tsx
@@ -1,0 +1,131 @@
+import { useRef, useState } from 'react';
+import { HotTable, HotTableRef } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const ExampleComponent = () => {
+  const hotTableComponentRef = useRef<HotTableRef>(null);
+  const [rowCountInfo, setRowCountInfo] = useState('');
+
+  const updateRowCountInfo = () => {
+    const hotInstance = hotTableComponentRef.current?.hotInstance;
+
+    if (!hotInstance) {
+      return;
+    }
+
+    // `getData()` returns only the rows that pass the current filters
+    // `getSourceData()` always returns every row, filtered or not
+    setRowCountInfo(`Showing ${hotInstance.getData().length} of ${hotInstance.getSourceData().length} rows.`);
+  };
+
+  return (
+    <>
+      <p>{rowCountInfo}</p>
+      <HotTable
+        ref={hotTableComponentRef}
+        data={[
+          {
+            brand: 'Jetpulse',
+            model: 'Racing Socks',
+            price: 30,
+            sellDate: '2023-10-11',
+            sellTime: '01:23',
+            inStock: false,
+          },
+          {
+            brand: 'Gigabox',
+            model: 'HL Mountain Frame',
+            price: 1890.9,
+            sellDate: '2023-05-03',
+            sellTime: '11:27',
+            inStock: false,
+          },
+          {
+            brand: 'Camido',
+            model: 'Cycling Cap',
+            price: 130.1,
+            sellDate: '2023-03-27',
+            sellTime: '03:17',
+            inStock: true,
+          },
+          {
+            brand: 'Chatterpoint',
+            model: 'Road Tire Tube',
+            price: 59,
+            sellDate: '2023-08-28',
+            sellTime: '08:01',
+            inStock: true,
+          },
+          {
+            brand: 'Eidel',
+            model: 'HL Road Tire',
+            price: 279.99,
+            sellDate: '2023-10-02',
+            sellTime: '01:23',
+            inStock: true,
+          },
+        ]}
+        columns={[
+          {
+            title: 'Brand',
+            type: 'text',
+            data: 'brand',
+          },
+          {
+            title: 'Model',
+            type: 'text',
+            data: 'model',
+          },
+          {
+            title: 'Price',
+            type: 'numeric',
+            data: 'price',
+            locale: 'en-US',
+            numericFormat: {
+              style: 'currency',
+              currency: 'USD',
+              minimumFractionDigits: 2,
+            },
+          },
+          {
+            title: 'Date',
+            type: 'intl-date',
+            data: 'sellDate',
+            locale: 'en-US',
+            dateFormat: { month: 'short', day: 'numeric', year: 'numeric' },
+            className: 'htRight',
+          },
+          {
+            title: 'Time',
+            type: 'intl-time',
+            data: 'sellTime',
+            locale: 'en-US',
+            timeFormat: { hour: '2-digit', minute: '2-digit', hour12: true },
+            className: 'htRight',
+          },
+          {
+            title: 'In stock',
+            type: 'checkbox',
+            data: 'inStock',
+            className: 'htCenter',
+          },
+        ]}
+        // enable filtering
+        filters={true}
+        // enable the column menu
+        dropdownMenu={true}
+        afterInit={updateRowCountInfo}
+        afterFilter={updateRowCountInfo}
+        height="auto"
+        autoWrapRow={true}
+        autoWrapCol={true}
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/columns/column-filter/react/exampleSaveRestoreFilters.jsx
+++ b/docs/content/guides/columns/column-filter/react/exampleSaveRestoreFilters.jsx
@@ -1,0 +1,155 @@
+import { useRef } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const ExampleComponent = () => {
+  const hotTableComponentRef = useRef(null);
+  const savedConditions = useRef([]);
+
+  const applySampleFilter = () => {
+    const filters = hotTableComponentRef.current?.hotInstance?.getPlugin('filters');
+
+    filters?.clearConditions();
+    // filter the 'Price' column (column at index 2) for items over $200
+    filters?.addCondition(2, 'gt', [200]);
+    filters?.filter();
+  };
+
+  const saveFilters = () => {
+    const filters = hotTableComponentRef.current?.hotInstance?.getPlugin('filters');
+
+    // `exportConditions()` returns the current conditions, keyed by physical column index
+    savedConditions.current = filters?.exportConditions() ?? [];
+  };
+
+  const clearFilters = () => {
+    const filters = hotTableComponentRef.current?.hotInstance?.getPlugin('filters');
+
+    filters?.clearConditions();
+    filters?.filter();
+  };
+
+  const restoreFilters = () => {
+    const filters = hotTableComponentRef.current?.hotInstance?.getPlugin('filters');
+
+    // `importConditions()` expects the same physical-column-indexed structure
+    filters?.importConditions(savedConditions.current);
+    filters?.filter();
+  };
+
+  return (
+    <>
+      <div className="example-controls-container">
+        <div className="controls">
+          <button onClick={applySampleFilter}>Filter: price &gt; $200</button>
+          <button onClick={saveFilters}>Save filter settings</button>
+          <button onClick={clearFilters}>Clear filters</button>
+          <button onClick={restoreFilters}>Restore filter settings</button>
+        </div>
+      </div>
+      <HotTable
+        ref={hotTableComponentRef}
+        data={[
+          {
+            brand: 'Jetpulse',
+            model: 'Racing Socks',
+            price: 30,
+            sellDate: '2023-10-11',
+            sellTime: '01:23',
+            inStock: false,
+          },
+          {
+            brand: 'Gigabox',
+            model: 'HL Mountain Frame',
+            price: 1890.9,
+            sellDate: '2023-05-03',
+            sellTime: '11:27',
+            inStock: false,
+          },
+          {
+            brand: 'Camido',
+            model: 'Cycling Cap',
+            price: 130.1,
+            sellDate: '2023-03-27',
+            sellTime: '03:17',
+            inStock: true,
+          },
+          {
+            brand: 'Chatterpoint',
+            model: 'Road Tire Tube',
+            price: 59,
+            sellDate: '2023-08-28',
+            sellTime: '08:01',
+            inStock: true,
+          },
+          {
+            brand: 'Eidel',
+            model: 'HL Road Tire',
+            price: 279.99,
+            sellDate: '2023-10-02',
+            sellTime: '01:23',
+            inStock: true,
+          },
+        ]}
+        columns={[
+          {
+            title: 'Brand',
+            type: 'text',
+            data: 'brand',
+          },
+          {
+            title: 'Model',
+            type: 'text',
+            data: 'model',
+          },
+          {
+            title: 'Price',
+            type: 'numeric',
+            data: 'price',
+            locale: 'en-US',
+            numericFormat: {
+              style: 'currency',
+              currency: 'USD',
+              minimumFractionDigits: 2,
+            },
+          },
+          {
+            title: 'Date',
+            type: 'intl-date',
+            data: 'sellDate',
+            locale: 'en-US',
+            dateFormat: { month: 'short', day: 'numeric', year: 'numeric' },
+            className: 'htRight',
+          },
+          {
+            title: 'Time',
+            type: 'intl-time',
+            data: 'sellTime',
+            locale: 'en-US',
+            timeFormat: { hour: '2-digit', minute: '2-digit', hour12: true },
+            className: 'htRight',
+          },
+          {
+            title: 'In stock',
+            type: 'checkbox',
+            data: 'inStock',
+            className: 'htCenter',
+          },
+        ]}
+        // enable filtering
+        filters={true}
+        // enable the column menu
+        dropdownMenu={true}
+        height="auto"
+        autoWrapRow={true}
+        autoWrapCol={true}
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/columns/column-filter/react/exampleSaveRestoreFilters.tsx
+++ b/docs/content/guides/columns/column-filter/react/exampleSaveRestoreFilters.tsx
@@ -1,0 +1,156 @@
+import { useRef } from 'react';
+import { HotTable, HotTableRef } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import type { ColumnConditions } from 'handsontable/plugins/filters';
+
+// register Handsontable's modules
+registerAllModules();
+
+const ExampleComponent = () => {
+  const hotTableComponentRef = useRef<HotTableRef>(null);
+  const savedConditions = useRef<ColumnConditions[]>([]);
+
+  const applySampleFilter = () => {
+    const filters = hotTableComponentRef.current?.hotInstance?.getPlugin('filters');
+
+    filters?.clearConditions();
+    // filter the 'Price' column (column at index 2) for items over $200
+    filters?.addCondition(2, 'gt', [200]);
+    filters?.filter();
+  };
+
+  const saveFilters = () => {
+    const filters = hotTableComponentRef.current?.hotInstance?.getPlugin('filters');
+
+    // `exportConditions()` returns the current conditions, keyed by physical column index
+    savedConditions.current = filters?.exportConditions() ?? [];
+  };
+
+  const clearFilters = () => {
+    const filters = hotTableComponentRef.current?.hotInstance?.getPlugin('filters');
+
+    filters?.clearConditions();
+    filters?.filter();
+  };
+
+  const restoreFilters = () => {
+    const filters = hotTableComponentRef.current?.hotInstance?.getPlugin('filters');
+
+    // `importConditions()` expects the same physical-column-indexed structure
+    filters?.importConditions(savedConditions.current);
+    filters?.filter();
+  };
+
+  return (
+    <>
+      <div className="example-controls-container">
+        <div className="controls">
+          <button onClick={applySampleFilter}>Filter: price &gt; $200</button>
+          <button onClick={saveFilters}>Save filter settings</button>
+          <button onClick={clearFilters}>Clear filters</button>
+          <button onClick={restoreFilters}>Restore filter settings</button>
+        </div>
+      </div>
+      <HotTable
+        ref={hotTableComponentRef}
+        data={[
+          {
+            brand: 'Jetpulse',
+            model: 'Racing Socks',
+            price: 30,
+            sellDate: '2023-10-11',
+            sellTime: '01:23',
+            inStock: false,
+          },
+          {
+            brand: 'Gigabox',
+            model: 'HL Mountain Frame',
+            price: 1890.9,
+            sellDate: '2023-05-03',
+            sellTime: '11:27',
+            inStock: false,
+          },
+          {
+            brand: 'Camido',
+            model: 'Cycling Cap',
+            price: 130.1,
+            sellDate: '2023-03-27',
+            sellTime: '03:17',
+            inStock: true,
+          },
+          {
+            brand: 'Chatterpoint',
+            model: 'Road Tire Tube',
+            price: 59,
+            sellDate: '2023-08-28',
+            sellTime: '08:01',
+            inStock: true,
+          },
+          {
+            brand: 'Eidel',
+            model: 'HL Road Tire',
+            price: 279.99,
+            sellDate: '2023-10-02',
+            sellTime: '01:23',
+            inStock: true,
+          },
+        ]}
+        columns={[
+          {
+            title: 'Brand',
+            type: 'text',
+            data: 'brand',
+          },
+          {
+            title: 'Model',
+            type: 'text',
+            data: 'model',
+          },
+          {
+            title: 'Price',
+            type: 'numeric',
+            data: 'price',
+            locale: 'en-US',
+            numericFormat: {
+              style: 'currency',
+              currency: 'USD',
+              minimumFractionDigits: 2,
+            },
+          },
+          {
+            title: 'Date',
+            type: 'intl-date',
+            data: 'sellDate',
+            locale: 'en-US',
+            dateFormat: { month: 'short', day: 'numeric', year: 'numeric' },
+            className: 'htRight',
+          },
+          {
+            title: 'Time',
+            type: 'intl-time',
+            data: 'sellTime',
+            locale: 'en-US',
+            timeFormat: { hour: '2-digit', minute: '2-digit', hour12: true },
+            className: 'htRight',
+          },
+          {
+            title: 'In stock',
+            type: 'checkbox',
+            data: 'inStock',
+            className: 'htCenter',
+          },
+        ]}
+        // enable filtering
+        filters={true}
+        // enable the column menu
+        dropdownMenu={true}
+        height="auto"
+        autoWrapRow={true}
+        autoWrapCol={true}
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/columns/column-filter/vue/exampleGetFilteredData.vue
+++ b/docs/content/guides/columns/column-filter/vue/exampleGetFilteredData.vue
@@ -1,0 +1,131 @@
+<script setup lang="ts">
+import { ref, useTemplateRef } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotTableRef = useTemplateRef<InstanceType<typeof HotTable>>('hotTableRef');
+const rowCountInfo = ref('');
+
+const updateRowCountInfo = () => {
+  const hotInstance = hotTableRef.value?.hotInstance;
+
+  if (!hotInstance) {
+    return;
+  }
+
+  // `getData()` returns only the rows that pass the current filters
+  // `getSourceData()` always returns every row, filtered or not
+  rowCountInfo.value = `Showing ${hotInstance.getData().length} of ${hotInstance.getSourceData().length} rows.`;
+};
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    {
+      brand: 'Jetpulse',
+      model: 'Racing Socks',
+      price: 30,
+      sellDate: '2023-10-11',
+      sellTime: '01:23',
+      inStock: false,
+    },
+    {
+      brand: 'Gigabox',
+      model: 'HL Mountain Frame',
+      price: 1890.9,
+      sellDate: '2023-05-03',
+      sellTime: '11:27',
+      inStock: false,
+    },
+    {
+      brand: 'Camido',
+      model: 'Cycling Cap',
+      price: 130.1,
+      sellDate: '2023-03-27',
+      sellTime: '03:17',
+      inStock: true,
+    },
+    {
+      brand: 'Chatterpoint',
+      model: 'Road Tire Tube',
+      price: 59,
+      sellDate: '2023-08-28',
+      sellTime: '08:01',
+      inStock: true,
+    },
+    {
+      brand: 'Eidel',
+      model: 'HL Road Tire',
+      price: 279.99,
+      sellDate: '2023-10-02',
+      sellTime: '01:23',
+      inStock: true,
+    },
+  ],
+  columns: [
+    {
+      title: 'Brand',
+      type: 'text',
+      data: 'brand',
+    },
+    {
+      title: 'Model',
+      type: 'text',
+      data: 'model',
+    },
+    {
+      title: 'Price',
+      type: 'numeric',
+      data: 'price',
+      locale: 'en-US',
+      numericFormat: {
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: 2,
+      },
+    },
+    {
+      title: 'Date',
+      type: 'intl-date',
+      data: 'sellDate',
+      locale: 'en-US',
+      dateFormat: { month: 'short', day: 'numeric', year: 'numeric' },
+      className: 'htRight',
+    },
+    {
+      title: 'Time',
+      type: 'intl-time',
+      data: 'sellTime',
+      locale: 'en-US',
+      timeFormat: { hour: '2-digit', minute: '2-digit', hour12: true },
+      className: 'htRight',
+    },
+    {
+      title: 'In stock',
+      type: 'checkbox',
+      data: 'inStock',
+      className: 'htCenter',
+    },
+  ],
+  // enable filtering
+  filters: true,
+  // enable the column menu
+  dropdownMenu: true,
+  afterInit: updateRowCountInfo,
+  afterFilter: updateRowCountInfo,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="exampleGetFilteredData">
+    <p>{{ rowCountInfo }}</p>
+    <HotTable ref="hotTableRef" :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/columns/column-filter/vue/exampleSaveRestoreFilters.vue
+++ b/docs/content/guides/columns/column-filter/vue/exampleSaveRestoreFilters.vue
@@ -1,0 +1,156 @@
+<script setup lang="ts">
+import { ref, useTemplateRef } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+import type { ColumnConditions } from 'handsontable/plugins/filters';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotTableRef = useTemplateRef<InstanceType<typeof HotTable>>('hotTableRef');
+let savedConditions: ColumnConditions[] = [];
+
+const applySampleFilter = () => {
+  const filters = hotTableRef.value?.hotInstance?.getPlugin('filters');
+
+  filters?.clearConditions();
+  // filter the 'Price' column (column at index 2) for items over $200
+  filters?.addCondition(2, 'gt', [200]);
+  filters?.filter();
+};
+
+const saveFilters = () => {
+  const filters = hotTableRef.value?.hotInstance?.getPlugin('filters');
+
+  // `exportConditions()` returns the current conditions, keyed by physical column index
+  savedConditions = filters?.exportConditions() ?? [];
+};
+
+const clearFilters = () => {
+  const filters = hotTableRef.value?.hotInstance?.getPlugin('filters');
+
+  filters?.clearConditions();
+  filters?.filter();
+};
+
+const restoreFilters = () => {
+  const filters = hotTableRef.value?.hotInstance?.getPlugin('filters');
+
+  // `importConditions()` expects the same physical-column-indexed structure
+  filters?.importConditions(savedConditions);
+  filters?.filter();
+};
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    {
+      brand: 'Jetpulse',
+      model: 'Racing Socks',
+      price: 30,
+      sellDate: '2023-10-11',
+      sellTime: '01:23',
+      inStock: false,
+    },
+    {
+      brand: 'Gigabox',
+      model: 'HL Mountain Frame',
+      price: 1890.9,
+      sellDate: '2023-05-03',
+      sellTime: '11:27',
+      inStock: false,
+    },
+    {
+      brand: 'Camido',
+      model: 'Cycling Cap',
+      price: 130.1,
+      sellDate: '2023-03-27',
+      sellTime: '03:17',
+      inStock: true,
+    },
+    {
+      brand: 'Chatterpoint',
+      model: 'Road Tire Tube',
+      price: 59,
+      sellDate: '2023-08-28',
+      sellTime: '08:01',
+      inStock: true,
+    },
+    {
+      brand: 'Eidel',
+      model: 'HL Road Tire',
+      price: 279.99,
+      sellDate: '2023-10-02',
+      sellTime: '01:23',
+      inStock: true,
+    },
+  ],
+  columns: [
+    {
+      title: 'Brand',
+      type: 'text',
+      data: 'brand',
+    },
+    {
+      title: 'Model',
+      type: 'text',
+      data: 'model',
+    },
+    {
+      title: 'Price',
+      type: 'numeric',
+      data: 'price',
+      locale: 'en-US',
+      numericFormat: {
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: 2,
+      },
+    },
+    {
+      title: 'Date',
+      type: 'intl-date',
+      data: 'sellDate',
+      locale: 'en-US',
+      dateFormat: { month: 'short', day: 'numeric', year: 'numeric' },
+      className: 'htRight',
+    },
+    {
+      title: 'Time',
+      type: 'intl-time',
+      data: 'sellTime',
+      locale: 'en-US',
+      timeFormat: { hour: '2-digit', minute: '2-digit', hour12: true },
+      className: 'htRight',
+    },
+    {
+      title: 'In stock',
+      type: 'checkbox',
+      data: 'inStock',
+      className: 'htCenter',
+    },
+  ],
+  // enable filtering
+  filters: true,
+  // enable the column menu
+  dropdownMenu: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="exampleSaveRestoreFilters">
+    <div class="example-controls-container">
+      <div class="controls">
+        <button @click="applySampleFilter">Filter: price &gt; $200</button>
+        <button @click="saveFilters">Save filter settings</button>
+        <button @click="clearFilters">Clear filters</button>
+        <button @click="restoreFilters">Restore filter settings</button>
+      </div>
+    </div>
+    <HotTable ref="hotTableRef" :settings="hotSettings" />
+  </div>
+</template>


### PR DESCRIPTION
### Context

The PR adds the remaining actionable sections from DEV-668 ("Add more sections to the Column filter page") that hadn't been covered by earlier work. It documents two API-driven filtering workflows and adds a short cross-link note:

- **Save and restore filter settings** -- using [`filters.exportConditions()`](https://handsontable.com/docs/api/filters/#exportconditions) / [`importConditions()`](https://handsontable.com/docs/api/filters/#importconditions), with a demo showing the full export → clear → restore round trip.
- **Get filtered data** -- using the [`afterFilter()`](https://handsontable.com/docs/api/hooks/#afterfilter) hook together with `getData()` / `getSourceData()`, showing that filtering trims rows from the data map (`getData()`) instead of just hiding them, while `getSourceData()` always returns every row.
- A short cross-link note after "Exclude rows from filtering" clarifying that `bindRowsWithHeaders` keeps pointing to the correct row after filtering, since filtering removes rows instead of renumbering them.

Two other items from the original ticket (auto-unchecking "filter by value" checkboxes, and search-as-you-type in filter-by-value) are **not** included -- they'd require documenting private, unexported methods (`#onSelectAllClick`/`#onClearAllClick`/`#onInput` in `multipleSelect.ts`) with no public API surface. Flagging these to engineering as a possible API gap rather than documenting internals.

### How has this been tested?

- Manually cross-checked `exportConditions()`/`importConditions()`/`afterFilter()` signatures and behavior against `handsontable/src/plugins/filters/filters.ts` and `conditionCollection.ts` (confirmed `exportConditions()` returns an independent copy, not live references, so a later `clearConditions()` doesn't mutate an already-saved snapshot).
- Ran the actual example logic in a browser against the locally built `dist/handsontable.js` (save → clear → restore round trip, and `afterFilter`-driven row-count updates for both filter-apply and filter-clear) -- all assertions passed with no console errors.
- Verified all API reference anchors used in the new links (`exportconditions`, `importconditions`, `filter`, `afterfilter`, `getdata`, `getsourcedata`) exist in the generated API docs.
- Did not verify through a full `astro dev`/`astro build` render -- the docs dev server OOM-crashed on first page request in this environment, which is a pre-existing, unrelated issue. The React/Angular/Vue example variants mirror the JS logic that was runtime-verified and follow existing CI-passing examples on the same page.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-668

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-668

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to docs and example snippets; no Handsontable core or wrapper package behavior is modified.
> 
> **Overview**
> Expands the **Column filter** guide with two programmatic workflows and a short clarification on row headers.
> 
> **Save and restore filter settings** documents `filters.exportConditions()` / `importConditions()` (including physical vs visual column indexes) and adds interactive demos that apply a sample filter, save, clear, and restore.
> 
> **Get filtered data** explains that `getData()` reflects only rows that pass filters while `getSourceData()` returns the full dataset, with demos that update a row count via `afterFilter()` (and `afterInit` where needed).
> 
> After **Exclude rows from filtering**, a new note states that `bindRowsWithHeaders` stays aligned with source rows because filtering hides rows rather than renumbering them.
> 
> New example files cover JavaScript, React, Angular (`example13` / `example14`), and Vue for both topics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ce0e67a6142cac89bb579bc11950024c67e5368. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->