### PR TITLE
DEV-669: Add custom-plugin-vs-hook guidance to custom plugins page

### DIFF
--- a/docs/content/guides/getting-started/events-and-hooks/events-and-hooks.md
+++ b/docs/content/guides/getting-started/events-and-hooks/events-and-hooks.md
@@ -33,6 +33,8 @@ Run your code before or after specific data grid actions, using Handsontable's A
 
 Callbacks are used to react before or after actions occur. We refer to them as hooks. Handsontable's hooks share some characteristics with events and middleware, combining them both in a unique structure.
 
+If your logic grows beyond a single hook and needs shared state or a lifecycle, package it as a [custom plugin](@/guides/tools-and-building/custom-plugins/custom-plugins.md) instead.
+
 ## Events
 
 If you only react to emitted hooks and forget about all their other features, you can treat Handsontable's hooks as pure events. You would want to limit your scope to `after` prefixed hooks, so they are emitted after something has happened and the results of the actions are already committed.

--- a/docs/content/guides/tools-and-building/custom-plugins/custom-plugins.md
+++ b/docs/content/guides/tools-and-building/custom-plugins/custom-plugins.md
@@ -17,6 +17,7 @@ vue:
   metaTitle: Custom plugins - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Tools and building
+menuTag: updated
 ---
 Extend Handsontable's functionality by writing your custom plugin. Use the BasePlugin for a quick start.
 
@@ -25,6 +26,8 @@ Extend Handsontable's functionality by writing your custom plugin. Use the BaseP
 ## Overview
 
 Plugins are a great way of extending Handsontable's capabilities. In fact, most Handsontable features are provided by plugins.
+
+Reach for a custom plugin when you need to share state across multiple hooks. A plugin also fits when you need an enable, disable, or update lifecycle, or a reusable, registrable unit for other developers to use. If you only need to react to a single action, add a hook instead - see [Events and hooks](@/guides/getting-started/events-and-hooks/events-and-hooks.md).
 
 ::: only-for react
 


### PR DESCRIPTION
### Context

The PR adds guidance to the custom plugins guide explaining when to write a custom plugin versus when a simple hook is enough. The page previously jumped straight from a generic overview into implementation steps, with no framing for readers deciding whether a custom plugin is the right tool. It also adds a reciprocal cross-reference from the Events and hooks page for readers whose hook-based logic outgrows a single callback.

### How has this been tested?

- Docs-only prose change; no code or examples affected.
- Verified both pages render correctly with the new paragraphs by reading the rendered Markdown structure (no `only-for` blocks affected, headings unchanged).

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-669

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-669

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation prose and navigation metadata only; no runtime or API changes.
> 
> **Overview**
> Adds **decision guidance** on the Custom plugins and Events and hooks guides so readers know when to use a hook versus a custom plugin.
> 
> On **Custom plugins**, the Overview now states that plugins fit shared state across hooks, enable/disable/update lifecycle, or reusable registrable units, and points single-action cases to **Events and hooks**. On **Events and hooks**, the Overview adds the inverse: when hook logic needs shared state or lifecycle, use a **custom plugin** instead. The custom plugins page front matter gets `menuTag: updated`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 309b689b6b1c136eecf08c710b869fef0bb1b485. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->