### PR TITLE
DEV-673: Note AutoColumnSize need on Modules page

### DIFF
--- a/docs/content/guides/tools-and-building/modules/modules.md
+++ b/docs/content/guides/tools-and-building/modules/modules.md
@@ -87,6 +87,12 @@ import Handsontable from 'handsontable/base';
 
 Now, you're ready to use any [optional modules](#optional-modules) of your choice.
 
+::: tip
+
+The base module doesn't resize columns to fit their content. If your columns look too narrow or your content gets clipped, import the [`AutoColumnSize`](@/api/autoColumnSize.md) plugin module (and, for rows, [`AutoRowSize`](@/api/autoRowSize.md)). This differs from [`StretchColumns`](@/api/stretchColumns.md), which stretches columns to fill the available container width instead of fitting them to content.
+
+:::
+
 ## Optional modules
 
 Handsontable's optional modules are grouped into:
@@ -483,6 +489,8 @@ const hotSettings = ref<GridSettings>({
 ### Plugin modules
 
 Plugin modules contain Handsontable's [plugins](@/api/plugins.md).
+
+Some plugin modules affect how content displays by default. For example, without the [`AutoColumnSize`](@/api/autoColumnSize.md) plugin module, columns don't resize to fit their content -- to fill the available container width instead, use [`StretchColumns`](@/api/stretchColumns.md).
 
 You can import the following plugin modules:
 


### PR DESCRIPTION
### Context

The PR adds a note to the Modules page explaining that the base module doesn't resize columns to fit their content, and that the `AutoColumnSize` (and `AutoRowSize`) plugin module is needed for that. Without it, readers following the Modules page's "import only what you need" pattern get a grid with columns that look too narrow, with no explanation why.

The note also disambiguates `AutoColumnSize` from `StretchColumns`, since the original report conflated "resize to content" with "stretch to fill the container width" -- these are two different plugins.

[skip changelog]

### How has this been tested?

- Docs-only content change; verified the new callouts render correctly by reading the rebuilt Markdown and cross-checking links to `@/api/autoColumnSize.md`, `@/api/autoRowSize.md`, and `@/api/stretchColumns.md`.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-673

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-673

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording and links; no runtime or API behavior changes.
> 
> **Overview**
> The **Modules** guide now explains that `handsontable/base` does **not** auto-size columns to content, so narrow or clipped columns are expected until optional plugins are registered.
> 
> A **tip** was added right after the base import example, pointing readers to **`AutoColumnSize`** / **`AutoRowSize`** for content-based sizing and contrasting that with **`StretchColumns`**, which only fills container width. The **Plugin modules** section repeats the same distinction so it is visible when choosing plugins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc3f4cbec23fd346964ed5efeb5afcd5e4e22aa2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->