### PR TITLE
DEV-676: Document formulas language option

### DIFF
--- a/docs/content/guides/formulas/formula-calculation/formula-calculation.md
+++ b/docs/content/guides/formulas/formula-calculation/formula-calculation.md
@@ -1004,6 +1004,46 @@ For the full argument type reference, error handling patterns, and advanced opti
 function aliases and async functions, see the
 [HyperFormula custom functions guide](https://hyperformula.handsontable.com/guide/custom-functions.html).
 
+## Change the formula language
+
+HyperFormula ships with built-in language packs that translate function names and control
+locale-specific formula syntax, such as the argument separator. By default, Handsontable uses
+the English (`enGB`) language pack.
+
+To use a different language, import a language pack from `hyperformula/es/i18n/languages` and
+pass it to the `formulas.language` option:
+
+```javascript
+import { HyperFormula } from 'hyperformula';
+import plPL from 'hyperformula/es/i18n/languages/plPL';
+
+const hot = new Handsontable(container, {
+  data: [
+    ['Company', 'Revenue Q1', 'Revenue Q2', 'Total'],
+    ['Acme Corp', 4200000, 4800000, '=SUMA(B1:C1)'],
+  ],
+  formulas: {
+    engine: HyperFormula,
+    sheetName: 'Sheet1',
+    language: plPL,
+  },
+  licenseKey: 'non-commercial-and-evaluation',
+});
+```
+
+You can also change the language after initialization, with `updateSettings()`:
+
+```javascript
+hot.updateSettings({
+  formulas: {
+    language: plPL,
+  },
+});
+```
+
+For the full list of available language packs, see the
+[HyperFormula localizing functions guide](https://hyperformula.handsontable.com/guide/localizing-functions.html).
+
 ## View the explainer video
 
 <div class="docs-video-embed">

--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -2972,6 +2972,7 @@ export default (): Record<string, unknown> => {
      * | `engine`    | `HyperFormula` \|<br>A [HyperFormula](https://handsontable.github.io/hyperformula/) instance \|<br>A [HyperFormula configuration](https://handsontable.github.io/hyperformula/api/interfaces/configparams.html) object |
      * | `sheetId`   | A number                                                                                                                                                                                                               |
      * | `sheetName` | A string                                                                                                                                                                                                               |
+     * | `language`  | A [HyperFormula language pack](https://handsontable.github.io/hyperformula/guide/localizing-functions.html), imported from `hyperformula/es/i18n/languages`                                                          |
      *
      * Read more:
      * - [Plugins: `Formulas`](@/api/formulas.md)
@@ -3037,6 +3038,22 @@ export default (): Record<string, unknown> => {
      *   sheetId: 1,
      *   sheetName: 'Sheet 1'
      * }
+     *
+     * // set a language pack for the built-in function names and formula syntax
+     * import plPL from 'hyperformula/es/i18n/languages/plPL';
+     *
+     * formulas: {
+     *   engine: HyperFormula,
+     *   sheetName: 'Sheet 1',
+     *   language: plPL
+     * }
+     *
+     * // update the language at runtime
+     * hot.updateSettings({
+     *   formulas: {
+     *     language: plPL
+     *   }
+     * });
      * ```
      */
     formulas: undefined,


### PR DESCRIPTION
### Context

The PR documents the `formulas.language` option, which was previously undocumented (DEV-676). The `Formulas` plugin has supported setting and updating (via `updateSettings`) a HyperFormula language pack for built-in function names and locale-specific formula syntax since the plugin's `SETTING_KEYS` list was introduced, but neither the API reference nor the formula-calculation guide mentioned it.

- Added a `language` row and a runtime `updateSettings` example to the `formulas` option JSDoc in `metaSchema.ts` (source for the API reference).
- Added a "Change the formula language" section to the formula-calculation guide, with a setup snippet, an `updateSettings` snippet, and a link to HyperFormula's localization docs.

No behavior changes -- this documents existing, already-shipped functionality.

### How has this been tested?

- `npm run eslint --prefix handsontable` on the modified file -- no issues.
- `npm run test:types --prefix handsontable` -- passes.
- Verified the documented default (`enGB`) against `hyperformula/es/Config.mjs`.
- Verified `formulas.language` usage against the existing plugin test coverage in `handsontable/src/plugins/formulas/__tests__/initialization.spec.js`.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-676

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-676

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates with no code or behavior changes.
> 
> **Overview**
> Documents the existing **`formulas.language`** option so users can configure HyperFormula locale packs (localized function names and formula syntax such as argument separators).
> 
> The **formula-calculation** guide gains a **Change the formula language** section with a Polish (`plPL`) setup example, a runtime **`updateSettings({ formulas: { language } })`** snippet, and a link to HyperFormula’s localization docs. **`metaSchema.ts`** JSDoc for **`formulas`** now lists **`language`** in the properties table and mirrors the same init/update examples for the generated API reference.
> 
> No runtime or plugin behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86c0b377d42f5d16e35d5166b9739f017f7e24ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->