### PR TITLE
DEV-2017: Filter Algolia search results to current framework

### DIFF
--- a/docs/src/config/docsearch.ts
+++ b/docs/src/config/docsearch.ts
@@ -15,10 +15,52 @@ const HTML_ENTITIES: Record<string, string> = {
 const decodeHtml = (str: string | null | undefined): string | null | undefined =>
   str ? str.replace(/&(?:amp|lt|gt|quot|#039|apos);/g, (e) => HTML_ENTITIES[e] ?? e) : str;
 
+// Mirrors the URL-prefix -> display-name mapping in FrameworkSwitcher.astro.
+// Must match exactly: the Algolia crawler tags each record with the text it
+// scrapes from `.nav-frameworks .dropdown-title .title` on that page, which
+// renders `fullName` from that same mapping (e.g. "Vue 3", not "Vue").
+const FRAMEWORK_TAGS: Array<[prefix: string, tag: string]> = [
+  ['/javascript-data-grid/', 'JavaScript'],
+  ['/react-data-grid/', 'React'],
+  ['/angular-data-grid/', 'Angular'],
+  ['/vue-data-grid/', 'Vue 3'],
+];
+
+// Returns undefined for pages outside all four framework prefixes (if any
+// exist) so search falls back to unfiltered results instead of guessing.
+function getCurrentFrameworkTag(): string | undefined {
+  const { pathname } = window.location;
+
+  return FRAMEWORK_TAGS.find(([prefix]) => pathname.includes(prefix))?.[1];
+}
+
 export default {
   appId: 'MMN6OTJMGX',
   apiKey: 'c2430302c91e0162df988d4b383c9d8b',
   indexName: 'handsontable',
+  // Restricts search results to the framework of the current page. Read
+  // fresh per query (not computed once) because the search widget persists
+  // across Astro View Transitions (`transition:persist="docs-search"` in
+  // Header.astro, DEV-1792), so a value captured at init time would go
+  // stale after a client-side navigation to a different framework's pages.
+  transformSearchClient(searchClient: any) {
+    return {
+      ...searchClient,
+      search(params: any) {
+        const tag = getCurrentFrameworkTag();
+
+        if (!tag) return searchClient.search(params);
+
+        return searchClient.search({
+          ...params,
+          requests: params.requests.map((request: any) => ({
+            ...request,
+            facetFilters: [`tags:${tag}`],
+          })),
+        });
+      },
+    };
+  },
   transformItems(items: any[]) {
     return items.map((item) => {
       const url: string = item.url ?? '';


### PR DESCRIPTION
### Context

The PR fixes docs search returning duplicated results — one hit per framework variant (JavaScript, React, Angular, Vue 3) of the same page/section — instead of only results for the framework the reader is currently browsing.

This used to work before the VuePress → Astro Starlight migration (`PRO-1063`), which deleted the old VuePress Algolia component. That component filtered results server-side via `searchParameters: { facetFilters: [\`tags:${currentFramework}\`] }`. This restriction was never reimplemented in the Astro version. A later fix (DEV-1786) only patched the symptom by appending a `· React`/`· Angular` suffix to result breadcrumbs so duplicates could at least be told apart, without removing the duplicates.

I confirmed against the live production Algolia index that every indexed record still carries exactly one `tags` facet value (`JavaScript`/`React`/`Angular`/`Vue 3`) with complete, mutually exclusive coverage, and that the crawler still tags each record from the same DOM node `FrameworkSwitcher.astro` exposes for this purpose. So restoring `facetFilters` fully fixes this without any Algolia-side (crawler/dashboard) changes.

The fix uses `transformSearchClient` (not the declarative `searchParameters` option) so the current framework is read fresh from `window.location.pathname` on every query, rather than cached once at widget-init time — the search widget is wrapped in `transition:persist="docs-search"` (DEV-1792) for Astro View Transitions, so a value captured once could otherwise go stale after a client-side framework switch.

### How has this been tested?

- Verified directly against the live Algolia index (curl): confirmed `tags:<Framework>` facet counts sum exactly to the total index size (no untagged/framework-agnostic records), and confirmed `facetFilters: ["tags:React"]` etc. correctly scopes results via both the single-index query endpoint and the real `/1/indexes/*/queries` multi-index endpoint the browser client uses.
- Ran the docs dev server in production mode and drove it with a real browser (Chrome DevTools network inspection):
  - On a `javascript-data-grid` page, searching "rows sorting" sends `facetFilters:["tags:JavaScript"]` and returns only `/javascript-data-grid/` results.
  - After switching to `react-data-grid`, the same search sends `facetFilters:["tags:React"]` and returns only `/react-data-grid/` results.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2017

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2017

[skip changelog]


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only client-side search configuration with a safe fallback when no framework prefix matches; no auth, data, or API surface changes.
> 
> **Overview**
> Restores **framework-scoped docs search** so queries only return hits for the framework the reader is on (JavaScript, React, Angular, or Vue 3), instead of duplicate results across all four variants of the same page.
> 
> Adds `transformSearchClient` in `docsearch.ts` to inject `facetFilters: ["tags:<Framework>"]` on every Algolia request. The tag is derived from `window.location.pathname` via a prefix map that must match `FrameworkSwitcher.astro` and the crawler (e.g. **Vue 3**, not Vue). Filtering is recomputed **per search**, not at widget init, because the search UI is `transition:persist` across Astro View Transitions—otherwise the facet would stay wrong after client-side navigation to another framework.
> 
> Pages outside the four framework URL prefixes skip filtering and keep unscoped results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c128b2b85cc64fafeda97928ba42c9dc9a4f9c46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->