### PR TITLE
IT-534: Update share capital to PLN 67,200.00 in LICENSE.txt files

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -2,7 +2,7 @@ Copyright (c) HANDSONCODE sp. z o. o.
 
 HANDSONTABLE is a software distributed by HANDSONCODE sp. z o. o., a Polish corporation based in
 Gdynia, Poland, at Aleja Zwyciestwa 96-98, registered by the District Court in Gdansk under number
-538651, EU tax ID number: PL5862294002, share capital: PLN 62,800.00.
+538651, EU tax ID number: PL5862294002, share capital: PLN 67,200.00.
 
 This software is protected by applicable copyright laws, including international treaties, and dual-
 licensed - depending on whether your use for commercial purposes, meaning intended for or

--- a/examples/next/docs/angular-wrapper/basic-example/LICENSE.txt
+++ b/examples/next/docs/angular-wrapper/basic-example/LICENSE.txt
@@ -3,7 +3,7 @@ Copyright (c) HANDSONCODE sp. z o. o.
 HANDSONTABLE is a software distributed by HANDSONCODE sp. z o. o.,
 a Polish corporation, based in Gdynia, Poland, at 96/98 Aleja Zwycięstwa,
 registered with the National Court Register under number 538651,
-EU tax ID number: PL5862294002, share capital: PLN 62,800.00.
+EU tax ID number: PL5862294002, share capital: PLN 67,200.00.
 
 This software is protected by applicable copyright laws, including
 international treaties, and dual-licensed – depending on whether

--- a/examples/next/docs/angular-wrapper/data-provider/LICENSE.txt
+++ b/examples/next/docs/angular-wrapper/data-provider/LICENSE.txt
@@ -3,7 +3,7 @@ Copyright (c) HANDSONCODE sp. z o. o.
 HANDSONTABLE is a software distributed by HANDSONCODE sp. z o. o.,
 a Polish corporation, based in Gdynia, Poland, at 96/98 Aleja Zwycięstwa,
 registered with the National Court Register under number 538651,
-EU tax ID number: PL5862294002, share capital: PLN 62,800.00.
+EU tax ID number: PL5862294002, share capital: PLN 67,200.00.
 
 This software is protected by applicable copyright laws, including
 international treaties, and dual-licensed – depending on whether

--- a/examples/next/docs/angular-wrapper/demo/LICENSE.txt
+++ b/examples/next/docs/angular-wrapper/demo/LICENSE.txt
@@ -3,7 +3,7 @@ Copyright (c) HANDSONCODE sp. z o. o.
 HANDSONTABLE is a software distributed by HANDSONCODE sp. z o. o.,
 a Polish corporation, based in Gdynia, Poland, at 96/98 Aleja Zwycięstwa,
 registered with the National Court Register under number 538651,
-EU tax ID number: PL5862294002, share capital: PLN 62,800.00.
+EU tax ID number: PL5862294002, share capital: PLN 67,200.00.
 
 This software is protected by applicable copyright laws, including
 international treaties, and dual-licensed – depending on whether

--- a/examples/next/docs/js/basic-example/LICENSE.txt
+++ b/examples/next/docs/js/basic-example/LICENSE.txt
@@ -3,7 +3,7 @@ Copyright (c) HANDSONCODE sp. z o. o.
 HANDSONTABLE is a software distributed by HANDSONCODE sp. z o. o.,
 a Polish corporation, based in Gdynia, Poland, at 96/98 Aleja Zwycięstwa,
 registered with the National Court Register under number 538651,
-EU tax ID number: PL5862294002, share capital: PLN 62,800.00.
+EU tax ID number: PL5862294002, share capital: PLN 67,200.00.
 
 This software is protected by applicable copyright laws, including
 international treaties, and dual-licensed – depending on whether

--- a/examples/next/docs/js/data-provider/LICENSE.txt
+++ b/examples/next/docs/js/data-provider/LICENSE.txt
@@ -3,7 +3,7 @@ Copyright (c) HANDSONCODE sp. z o. o.
 HANDSONTABLE is a software distributed by HANDSONCODE sp. z o. o.,
 a Polish corporation, based in Gdynia, Poland, at 96/98 Aleja Zwycięstwa,
 registered with the National Court Register under number 538651,
-EU tax ID number: PL5862294002, share capital: PLN 62,800.00.
+EU tax ID number: PL5862294002, share capital: PLN 67,200.00.
 
 This software is protected by applicable copyright laws, including
 international treaties, and dual-licensed – depending on whether

--- a/examples/next/docs/js/demo/LICENSE.txt
+++ b/examples/next/docs/js/demo/LICENSE.txt
@@ -3,7 +3,7 @@ Copyright (c) HANDSONCODE sp. z o. o.
 HANDSONTABLE is a software distributed by HANDSONCODE sp. z o. o.,
 a Polish corporation, based in Gdynia, Poland, at 96/98 Aleja Zwycięstwa,
 registered with the National Court Register under number 538651,
-EU tax ID number: PL5862294002, share capital: PLN 62,800.00.
+EU tax ID number: PL5862294002, share capital: PLN 67,200.00.
 
 This software is protected by applicable copyright laws, including
 international treaties, and dual-licensed – depending on whether

--- a/examples/next/docs/react-wrapper/basic-example/LICENSE.txt
+++ b/examples/next/docs/react-wrapper/basic-example/LICENSE.txt
@@ -3,7 +3,7 @@ Copyright (c) HANDSONCODE sp. z o. o.
 HANDSONTABLE is a software distributed by HANDSONCODE sp. z o. o.,
 a Polish corporation, based in Gdynia, Poland, at 96/98 Aleja Zwycięstwa,
 registered with the National Court Register under number 538651,
-EU tax ID number: PL5862294002, share capital: PLN 62,800.00.
+EU tax ID number: PL5862294002, share capital: PLN 67,200.00.
 
 This software is protected by applicable copyright laws, including
 international treaties, and dual-licensed – depending on whether

--- a/examples/next/docs/react-wrapper/data-provider/LICENSE.txt
+++ b/examples/next/docs/react-wrapper/data-provider/LICENSE.txt
@@ -3,7 +3,7 @@ Copyright (c) HANDSONCODE sp. z o. o.
 HANDSONTABLE is a software distributed by HANDSONCODE sp. z o. o.,
 a Polish corporation, based in Gdynia, Poland, at 96/98 Aleja Zwycięstwa,
 registered with the National Court Register under number 538651,
-EU tax ID number: PL5862294002, share capital: PLN 62,800.00.
+EU tax ID number: PL5862294002, share capital: PLN 67,200.00.
 
 This software is protected by applicable copyright laws, including
 international treaties, and dual-licensed – depending on whether

--- a/examples/next/docs/react-wrapper/demo/LICENSE.txt
+++ b/examples/next/docs/react-wrapper/demo/LICENSE.txt
@@ -3,7 +3,7 @@ Copyright (c) HANDSONCODE sp. z o. o.
 HANDSONTABLE is a software distributed by HANDSONCODE sp. z o. o.,
 a Polish corporation, based in Gdynia, Poland, at 96/98 Aleja Zwycięstwa,
 registered with the National Court Register under number 538651,
-EU tax ID number: PL5862294002, share capital: PLN 62,800.00.
+EU tax ID number: PL5862294002, share capital: PLN 67,200.00.
 
 This software is protected by applicable copyright laws, including
 international treaties, and dual-licensed – depending on whether

--- a/examples/next/docs/vue3/data-provider/LICENSE.txt
+++ b/examples/next/docs/vue3/data-provider/LICENSE.txt
@@ -3,7 +3,7 @@ Copyright (c) HANDSONCODE sp. z o. o.
 HANDSONTABLE is a software distributed by HANDSONCODE sp. z o. o.,
 a Polish corporation, based in Gdynia, Poland, at 96/98 Aleja Zwycięstwa,
 registered with the National Court Register under number 538651,
-EU tax ID number: PL5862294002, share capital: PLN 62,800.00.
+EU tax ID number: PL5862294002, share capital: PLN 67,200.00.
 
 This software is protected by applicable copyright laws, including
 international treaties, and dual-licensed – depending on whether

--- a/examples/next/visual-tests/angular-wrapper/basic-example/LICENSE.txt
+++ b/examples/next/visual-tests/angular-wrapper/basic-example/LICENSE.txt
@@ -3,7 +3,7 @@ Copyright (c) HANDSONCODE sp. z o. o.
 HANDSONTABLE is a software distributed by HANDSONCODE sp. z o. o.,
 a Polish corporation, based in Gdynia, Poland, at 96/98 Aleja Zwycięstwa,
 registered with the National Court Register under number 538651,
-EU tax ID number: PL5862294002, share capital: PLN 62,800.00.
+EU tax ID number: PL5862294002, share capital: PLN 67,200.00.
 
 This software is protected by applicable copyright laws, including
 international treaties, and dual-licensed – depending on whether

--- a/examples/next/visual-tests/angular-wrapper/demo/LICENSE.txt
+++ b/examples/next/visual-tests/angular-wrapper/demo/LICENSE.txt
@@ -3,7 +3,7 @@ Copyright (c) HANDSONCODE sp. z o. o.
 HANDSONTABLE is a software distributed by HANDSONCODE sp. z o. o.,
 a Polish corporation, based in Gdynia, Poland, at 96/98 Aleja Zwycięstwa,
 registered with the National Court Register under number 538651,
-EU tax ID number: PL5862294002, share capital: PLN 62,800.00.
+EU tax ID number: PL5862294002, share capital: PLN 67,200.00.
 
 This software is protected by applicable copyright laws, including
 international treaties, and dual-licensed – depending on whether

--- a/examples/next/visual-tests/js/basic-example/LICENSE.txt
+++ b/examples/next/visual-tests/js/basic-example/LICENSE.txt
@@ -3,7 +3,7 @@ Copyright (c) HANDSONCODE sp. z o. o.
 HANDSONTABLE is a software distributed by HANDSONCODE sp. z o. o.,
 a Polish corporation, based in Gdynia, Poland, at 96/98 Aleja Zwycięstwa,
 registered with the National Court Register under number 538651,
-EU tax ID number: PL5862294002, share capital: PLN 62,800.00.
+EU tax ID number: PL5862294002, share capital: PLN 67,200.00.
 
 This software is protected by applicable copyright laws, including
 international treaties, and dual-licensed – depending on whether

--- a/examples/next/visual-tests/js/demo/LICENSE.txt
+++ b/examples/next/visual-tests/js/demo/LICENSE.txt
@@ -3,7 +3,7 @@ Copyright (c) HANDSONCODE sp. z o. o.
 HANDSONTABLE is a software distributed by HANDSONCODE sp. z o. o.,
 a Polish corporation, based in Gdynia, Poland, at 96/98 Aleja Zwycięstwa,
 registered with the National Court Register under number 538651,
-EU tax ID number: PL5862294002, share capital: PLN 62,800.00.
+EU tax ID number: PL5862294002, share capital: PLN 67,200.00.
 
 This software is protected by applicable copyright laws, including
 international treaties, and dual-licensed – depending on whether

--- a/examples/next/visual-tests/react-wrapper/basic-example/LICENSE.txt
+++ b/examples/next/visual-tests/react-wrapper/basic-example/LICENSE.txt
@@ -3,7 +3,7 @@ Copyright (c) HANDSONCODE sp. z o. o.
 HANDSONTABLE is a software distributed by HANDSONCODE sp. z o. o.,
 a Polish corporation, based in Gdynia, Poland, at 96/98 Aleja Zwycięstwa,
 registered with the National Court Register under number 538651,
-EU tax ID number: PL5862294002, share capital: PLN 62,800.00.
+EU tax ID number: PL5862294002, share capital: PLN 67,200.00.
 
 This software is protected by applicable copyright laws, including
 international treaties, and dual-licensed – depending on whether

--- a/examples/next/visual-tests/react-wrapper/demo/LICENSE.txt
+++ b/examples/next/visual-tests/react-wrapper/demo/LICENSE.txt
@@ -3,7 +3,7 @@ Copyright (c) HANDSONCODE sp. z o. o.
 HANDSONTABLE is a software distributed by HANDSONCODE sp. z o. o.,
 a Polish corporation, based in Gdynia, Poland, at 96/98 Aleja Zwycięstwa,
 registered with the National Court Register under number 538651,
-EU tax ID number: PL5862294002, share capital: PLN 62,800.00.
+EU tax ID number: PL5862294002, share capital: PLN 67,200.00.
 
 This software is protected by applicable copyright laws, including
 international treaties, and dual-licensed – depending on whether

--- a/examples/templates/js/LICENSE.txt
+++ b/examples/templates/js/LICENSE.txt
@@ -3,7 +3,7 @@ Copyright (c) HANDSONCODE sp. z o. o.
 HANDSONTABLE is a software distributed by HANDSONCODE sp. z o. o.,
 a Polish corporation, based in Gdynia, Poland, at 96/98 Aleja Zwycięstwa,
 registered with the National Court Register under number 538651,
-EU tax ID number: PL5862294002, share capital: PLN 62,800.00.
+EU tax ID number: PL5862294002, share capital: PLN 67,200.00.
 
 This software is protected by applicable copyright laws, including
 international treaties, and dual-licensed – depending on whether

--- a/examples/templates/react-wrapper/LICENSE.txt
+++ b/examples/templates/react-wrapper/LICENSE.txt
@@ -3,7 +3,7 @@ Copyright (c) HANDSONCODE sp. z o. o.
 HANDSONTABLE is a software distributed by HANDSONCODE sp. z o. o.,
 a Polish corporation, based in Gdynia, Poland, at 96/98 Aleja Zwycięstwa,
 registered with the National Court Register under number 538651,
-EU tax ID number: PL5862294002, share capital: PLN 62,800.00.
+EU tax ID number: PL5862294002, share capital: PLN 67,200.00.
 
 This software is protected by applicable copyright laws, including
 international treaties, and dual-licensed – depending on whether

--- a/wrappers/angular-wrapper/LICENSE.txt
+++ b/wrappers/angular-wrapper/LICENSE.txt
@@ -2,7 +2,7 @@ Copyright (c) HANDSONCODE sp. z o. o.
 
 HANDSONTABLE is a software distributed by HANDSONCODE sp. z o. o., a Polish corporation based in
 Gdynia, Poland, at Aleja Zwyciestwa 96-98, registered by the District Court in Gdansk under number
-538651, EU tax ID number: PL5862294002, share capital: PLN 62,800.00.
+538651, EU tax ID number: PL5862294002, share capital: PLN 67,200.00.
 
 This software is protected by applicable copyright laws, including international treaties, and dual-
 licensed - depending on whether your use for commercial purposes, meaning intended for or

--- a/wrappers/react-wrapper/LICENSE.txt
+++ b/wrappers/react-wrapper/LICENSE.txt
@@ -2,7 +2,7 @@ Copyright (c) HANDSONCODE sp. z o. o.
 
 HANDSONTABLE is a software distributed by HANDSONCODE sp. z o. o., a Polish corporation based in
 Gdynia, Poland, at Aleja Zwyciestwa 96-98, registered by the District Court in Gdansk under number
-538651, EU tax ID number: PL5862294002, share capital: PLN 62,800.00.
+538651, EU tax ID number: PL5862294002, share capital: PLN 67,200.00.
 
 This software is protected by applicable copyright laws, including international treaties, and dual-
 licensed - depending on whether your use for commercial purposes, meaning intended for or

--- a/wrappers/vue3/LICENSE.txt
+++ b/wrappers/vue3/LICENSE.txt
@@ -2,7 +2,7 @@ Copyright (c) HANDSONCODE sp. z o. o.
 
 HANDSONTABLE is a software distributed by HANDSONCODE sp. z o. o., a Polish corporation based in
 Gdynia, Poland, at Aleja Zwyciestwa 96-98, registered by the District Court in Gdansk under number
-538651, EU tax ID number: PL5862294002, share capital: PLN 62,800.00.
+538651, EU tax ID number: PL5862294002, share capital: PLN 67,200.00.
 
 This software is protected by applicable copyright laws, including international treaties, and dual-
 licensed - depending on whether your use for commercial purposes, meaning intended for or


### PR DESCRIPTION
### Context

The PR fixes an outdated legal figure in the `LICENSE.txt` boilerplate. The company's registered share capital changed from `62,800 PLN` to `67,200 PLN`, but the `share capital: PLN 62,800.00.` line was still present in every tracked `LICENSE.txt` copy in this repo. This updates all 22 occurrences to `PLN 67,200.00`.

This is part of a broader cleanup (IT-532) tracked across other actively maintained repos in the org via separate subtasks/PRs.

### How has this been tested?

- Text-only change; verified with `git grep -n "62,800"` (no remaining matches) and `git grep -c "67,200"` (22 files, 1 line changed each).
- `git diff` confirms each file has exactly one line modified, no incidental formatting changes.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. IT-534

### Affected project(s):

- [x] `handsontable`
- [x] `@handsontable/angular-wrapper`
- [x] `@handsontable/react-wrapper`
- [x] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/86cakbe0c

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only legal text updates with no runtime, API, or dependency impact.
> 
> **Overview**
> Updates the HANDSONCODE corporate **share capital** figure in every tracked `LICENSE.txt` from **PLN 62,800.00** to **PLN 67,200.00**, one line per file.
> 
> The change is applied consistently across the root license, framework wrappers (`angular-wrapper`, `react-wrapper`, `vue3`), and bundled example/visual-test copies—no other license wording is modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39dcd209873f4fb24174644bc7fc2a5a2a70289e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->