### PR TITLE
DEV-2018: Fire beforeChange/afterChange on multiselect chip removal

### DIFF
--- a/.changelogs/12968.json
+++ b/.changelogs/12968.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed the `multiselect` cell type not firing `beforeChange` and `afterChange` (or running validation) when a value was removed by clicking the chip's X icon.",
+  "type": "fixed",
+  "issueOrPR": 12968,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/editors/multiSelectEditor/__tests__/multiSelectEditor.spec.js
+++ b/handsontable/src/editors/multiSelectEditor/__tests__/multiSelectEditor.spec.js
@@ -1147,8 +1147,7 @@ describe('MultiSelectEditor', () => {
 
         const removeButton = visibleChips.eq(0).find('.ht-multi-select-chip-remove');
 
-        removeButton.click();
-        await sleep(10);
+        await simulateClick(removeButton);
 
         $dropdown = $('.ht-multi-select-editor');
         $checkedCheckboxes = $dropdown.find('input[type="checkbox"]:checked');
@@ -1199,8 +1198,7 @@ describe('MultiSelectEditor', () => {
 
         const removeButton = visibleChips.eq(0).find('.ht-multi-select-chip-remove');
 
-        removeButton.click();
-        await sleep(10);
+        await simulateClick(removeButton);
 
         getCell(0, 0).click();
         await sleep(10);

--- a/handsontable/src/editors/multiSelectEditor/multiSelectEditor.ts
+++ b/handsontable/src/editors/multiSelectEditor/multiSelectEditor.ts
@@ -167,8 +167,8 @@ export class MultiSelectEditor extends BaseEditor {
     );
 
     this.addHook('afterDestroy', () => this.destroy());
-    this.addHook('afterSetSourceDataAtCell',
-      (changes: unknown[][], source: string) => this.#onAfterSetSourceDataAtCell(changes, source));
+    this.addHook('afterChange',
+      (changes: unknown[][], source: string) => this.#onAfterChange(changes, source));
     this.addHook('afterScrollHorizontally', () => this.refreshDimensions());
     this.addHook('afterScrollVertically', () => this.refreshDimensions());
 
@@ -479,14 +479,16 @@ export class MultiSelectEditor extends BaseEditor {
   }
 
   /**
-   * Handles the afterSetSourceDataAtCell hook to re-sync the dropdown when the renderer updates the source data for the edited cell.
+   * Handles the `afterChange` hook to re-sync the dropdown when the renderer removes a chip from the edited cell.
    */
-  #onAfterSetSourceDataAtCell(changes: unknown[][], source: string): void {
+  #onAfterChange(changes: unknown[][] | null, source: string): void {
     if (
       this.isOpened() &&
       source === `${EDITOR_TYPE}-renderer` &&
-      parseInt(String(changes[0][0]), 10) === this.cellProperties.visualRow &&
-      parseInt(String(changes[0][1]), 10) === this.cellProperties.visualCol
+      Array.isArray(changes) &&
+      changes.length > 0 &&
+      changes[0][0] === this.cellProperties.visualRow &&
+      this.hot.propToCol(changes[0][1] as string | number) === this.cellProperties.visualCol
     ) {
       this.#syncSelectedValues(changes[0][3] as unknown[]);
       this.dropdownController!.fillDropdown(this.#getSource(), this.#selectedItems.getItemsArray());

--- a/handsontable/src/renderers/multiSelectRenderer/__tests__/multiSelectRenderer.spec.js
+++ b/handsontable/src/renderers/multiSelectRenderer/__tests__/multiSelectRenderer.spec.js
@@ -295,7 +295,7 @@ describe('multiSelectRenderer', () => {
 
         const removeButton = visibleChips.eq(0).find('.ht-multi-select-chip-remove');
 
-        removeButton.click();
+        await simulateClick(removeButton);
 
         chipsContainer = $('table.htCore tr:eq(0) td:eq(0) .ht-multi-select-chips-container');
         renderedChips = chipsContainer.find('.ht-multi-select-chip');
@@ -349,7 +349,7 @@ describe('multiSelectRenderer', () => {
         const removeButton = renderedChips.eq(0).find('.ht-multi-select-chip-remove');
         const removedChipText = renderedChips.eq(0).text();
 
-        removeButton.click();
+        await simulateClick(removeButton);
 
         const sourceDataAfter = getSourceDataAtCell(physicalRow, 0);
         const expectedSourceData = sourceDataBefore.filter(
@@ -397,7 +397,7 @@ describe('multiSelectRenderer', () => {
         const removeButton = renderedChips.eq(0).find('.ht-multi-select-chip-remove');
         const removedChipText = renderedChips.eq(0).text();
 
-        removeButton.click();
+        await simulateClick(removeButton);
 
         const expectedSourceData = choices.filter(
           choice => (choice.value || choice) !== removedChipText
@@ -412,6 +412,58 @@ describe('multiSelectRenderer', () => {
         expect(renderedChipsAfter.eq(0).text()).toEqual(choices[1].value || choices[1]);
         expect(renderedChipsAfter.eq(1).text()).toEqual(choices[2].value || choices[2]);
         expect(renderedChipsAfter.eq(2).text()).toEqual(choices[3].value || choices[3]);
+      });
+
+      it('should fire `beforeChange` and `afterChange` (and skip `afterSetSourceDataAtCell`) ' +
+        'when removing a chip via the remove button, matching the editor deselect path (#12966)', async() => {
+        const beforeChangeSpy = jasmine.createSpy('beforeChange');
+        const afterChangeSpy = jasmine.createSpy('afterChange');
+        const afterSetSourceDataAtCellSpy = jasmine.createSpy('afterSetSourceDataAtCell');
+
+        handsontable({
+          data: [
+            { color: choices },
+          ],
+          columns: [
+            {
+              data: 'color',
+              type: 'multiselect',
+              source: choices,
+              width: 500,
+            },
+          ],
+          beforeChange: beforeChangeSpy,
+          afterChange: afterChangeSpy,
+          afterSetSourceDataAtCell: afterSetSourceDataAtCellSpy,
+        });
+
+        const chipsContainer = $('table.htCore tr:eq(0) td:eq(0) .ht-multi-select-chips-container');
+        const renderedChips = chipsContainer.find('.ht-multi-select-chip');
+        const removeButton = renderedChips.eq(0).find('.ht-multi-select-chip-remove');
+        const removedChipText = renderedChips.eq(0).text();
+
+        beforeChangeSpy.calls.reset();
+        afterChangeSpy.calls.reset();
+        afterSetSourceDataAtCellSpy.calls.reset();
+
+        await simulateClick(removeButton);
+
+        const expectedSourceData = choices.filter(
+          choice => (choice.value || choice) !== removedChipText
+        );
+
+        expect(beforeChangeSpy).toHaveBeenCalledTimes(1);
+        expect(afterChangeSpy).toHaveBeenCalledTimes(1);
+        expect(afterSetSourceDataAtCellSpy).not.toHaveBeenCalled();
+
+        const [changes, source] = afterChangeSpy.calls.mostRecent().args;
+
+        expect(source).toBe('multiselect-renderer');
+        expect(changes.length).toBe(1);
+        expect(changes[0][0]).toBe(0);
+        expect(changes[0][1]).toBe('color');
+        expect(changes[0][3]).toEqual(expectedSourceData);
+        expect(getSourceDataAtCell(0, 0)).toEqual(expectedSourceData);
       });
     });
   });

--- a/handsontable/src/renderers/multiSelectRenderer/__tests__/multiSelectRenderer.unit.js
+++ b/handsontable/src/renderers/multiSelectRenderer/__tests__/multiSelectRenderer.unit.js
@@ -11,6 +11,9 @@ import {
   registerCellType,
   MultiSelectCellType,
 } from '../../../cellTypes';
+import {
+  removeValueByKey,
+} from '../utils/utils';
 
 registerCellType(MultiSelectCellType);
 
@@ -47,6 +50,25 @@ describe('multiSelectRenderer', () => {
 
       expect(getSourceDataAtCell).toHaveBeenCalledWith(physicalRow, visualColumn);
       expect(toPhysicalColumn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('removeValueByKey (#12966)', () => {
+    it('should remove the entry matching the given key from a plain string array', () => {
+      expect(removeValueByKey(['Red', 'Green', 'Blue'], 'Green')).toEqual(['Red', 'Blue']);
+    });
+
+    it('should remove the entry matching the given key from a key/value object array', () => {
+      const source = [
+        { key: 'r', value: 'Red' },
+        { key: 'g', value: 'Green' },
+        { key: 'b', value: 'Blue' },
+      ];
+
+      expect(removeValueByKey(source, 'g')).toEqual([
+        { key: 'r', value: 'Red' },
+        { key: 'b', value: 'Blue' },
+      ]);
     });
   });
 });

--- a/handsontable/src/renderers/multiSelectRenderer/multiSelectRenderer.ts
+++ b/handsontable/src/renderers/multiSelectRenderer/multiSelectRenderer.ts
@@ -61,7 +61,7 @@ export function multiSelectRenderer(
   chipsContainer.className = CHIPS_CONTAINER_CLASS;
 
   values.forEach((item) => {
-    const chip = createChipElement(rootDocument, item, isAriaEnabled ?? false, row, prop);
+    const chip = createChipElement(rootDocument, item, isAriaEnabled ?? false, row, col, prop);
 
     chipsContainer.appendChild(chip);
   });

--- a/handsontable/src/renderers/multiSelectRenderer/utils/utils.ts
+++ b/handsontable/src/renderers/multiSelectRenderer/utils/utils.ts
@@ -57,6 +57,7 @@ export function createChipElement(
   item: string | Record<string, string>,
   isAriaEnabled: boolean,
   row: number,
+  col: number,
   prop: string | number
 ): HTMLElement {
   const chip = rootDocument.createElement('span');
@@ -64,6 +65,7 @@ export function createChipElement(
 
   addClass(chip, CHIP_CLASS);
   chip.dataset.row = String(row);
+  chip.dataset.col = String(col);
   chip.dataset.prop = String(prop);
   chip.title = textContent;
 
@@ -99,17 +101,6 @@ export function createOverflowIndicator(rootDocument: Document, count: number): 
   return indicator;
 }
 
-interface HotInstanceWithRoot {
-  rootElement: HTMLElement;
-  toPhysicalRow: (row: number | string) => number;
-  toPhysicalColumn: (col: number | string) => number;
-  propToCol: (prop: string | number) => number;
-  getSourceDataAtCell: (row: number, col: number) => unknown;
-  setSourceDataAtCell: (row: number, col: number | string, value: unknown, source?: string) => void;
-  render: () => void;
-  addHook: (name: string, callback: (...args: unknown[]) => unknown) => void;
-}
-
 /**
  *
  */
@@ -139,18 +130,19 @@ export function registerChipRemovingEvents(
       return;
     }
 
-    const rowIndex = chip.dataset.row;
-    const columnProp = chip.dataset.prop;
-    const physicalRow = hotInstance.toPhysicalRow(Number(rowIndex ?? 0));
-    const physicalColumn = typeof columnProp === 'string'
-      ? columnProp : hotInstance.toPhysicalColumn(Number(columnProp));
-    const visualColumn = hotInstance.propToCol(columnProp ?? '');
+    const visualRow = Number(chip.dataset.row ?? 0);
+    const visualColumn = Number(chip.dataset.col ?? 0);
+    const physicalRow = hotInstance.toPhysicalRow(visualRow);
+    // Read the raw source array, not `getDataAtCell` — the multiselect `valueGetter` turns the
+    // stored array into a display string, which `parseValue` cannot split back into items.
     const currentData = hotInstance.getSourceDataAtCell(physicalRow, visualColumn);
     const keyToRemove = chip.dataset.key;
     const newData = removeValueByKey(parseValue(currentData), keyToRemove);
 
-    hotInstance.setSourceDataAtCell(physicalRow, physicalColumn, newData, `${rendererType}-renderer`);
-    hotInstance.render();
+    // Route the removal through `setDataAtCell` so it runs the standard change and validation
+    // pipeline (`beforeChange` / `afterChange`), matching the editor's deselect path. Writing via
+    // `setSourceDataAtCell` bypassed those hooks and left the two removal paths inconsistent.
+    hotInstance.setDataAtCell(visualRow, visualColumn, newData, `${rendererType}-renderer`);
   });
 
   hotInstance.addHook('beforeOnCellMouseDown', (...args: unknown[]) => {
@@ -160,11 +152,6 @@ export function registerChipRemovingEvents(
       stopImmediatePropagation(event as MouseEvent);
     }
   });
-}
-
-interface HotInstanceWithColWidth {
-  getColWidth: (col: number) => number;
-  addHook: (name: string, callback: (...args: unknown[]) => unknown) => void;
 }
 
 /**


### PR DESCRIPTION
### Context

The PR fixes [#12966](https://github.com/handsontable/handsontable/issues/12966). Removing a value from a `multiselect` cell by clicking the **X icon on a rendered chip** updated the data but did **not** fire `beforeChange` / `afterChange`, and skipped validation. Code that relies on `afterChange` (validation, dirty-tracking, save/persistence) silently missed these edits. Removing the same value via the editor dropdown (deselect) *did* fire `afterChange`, so the two removal paths were inconsistent.

Root cause: the chip remove handler (`registerChipRemovingEvents`) wrote via `setSourceDataAtCell`, which bypasses the `beforeChange` / `afterChange` / validation pipeline.

Fix: chip removal now routes through `setDataAtCell` (visual coordinates), matching the editor's deselect path. The chip stamps its visual column, reads the raw source array (the multiselect `valueGetter` turns the stored array into a display string, so `getDataAtCell` cannot be used), and writes through the standard change + validation pipeline. The editor's open-dropdown sync listener was migrated from `afterSetSourceDataAtCell` to `afterChange` (still filtered on `source === 'multiselect-renderer'`).

**Behavior change (but not breaking change):** chip removal now fires `beforeChange` / `afterChange` (and runs validation) instead of `afterSetSourceDataAtCell`. Consumers using the workaround documented in the issue (listen on `afterSetSourceDataAtCell`, filter `source === 'multiselect-renderer'`) must migrate to `afterChange` filtering the same source. No public API, hook, or default was removed or changed — `afterSetSourceDataAtCell` still fires for real `setSourceDataAtCell` calls — so this is a bug fix, not a breaking change.

### How has this been tested?

TDD: reproduced the failure as a RED spec on a real build, then verified GREEN after the fix. Also verified in a real browser against the issue's exact repro (`beforeChange` + `afterChange` fire with `source: 'multiselect-renderer'`, `afterSetSourceDataAtCell` does not, and the value updates).

- New E2E spec asserting `beforeChange` + `afterChange` fire and `afterSetSourceDataAtCell` does not, matching the editor deselect path.
- Existing chip-removal specs updated to `await simulateClick(...)` (removal is now async through the validation pipeline).
- New unit tests for `removeValueByKey`.

```bash
npm run build --prefix handsontable
npm run test:e2e --prefix handsontable --testPathPattern=multiSelect   # 125 specs, 0 failures
npm run test:unit --prefix handsontable --testPathPattern=multiSelectRenderer
npm run eslint --prefix handsontable
npm run test:types --prefix handsontable
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. #12966
2. DEV-2018

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2018

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 7593c9fe787ba9808b9815ccab7445814ee03be6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->