### PR TITLE
DEV-710: Remove repeated build requirements from custom-builds page

### DIFF
--- a/docs/content/guides/tools-and-building/custom-builds/custom-builds.md
+++ b/docs/content/guides/tools-and-building/custom-builds/custom-builds.md
@@ -84,11 +84,10 @@ Each Handsontable [project](#monorepo) has its own building processes defined in
 
 To run your first build:
 
-1. Install [Node.js](https://nodejs.org/).
-2. Install [pnpm](https://pnpm.io/) (the repository package manager). <br>The version should correspond to the one defined in the `packageManager` field of the root's `package.json`.
-3. Clone the [Handsontable repository](https://github.com/handsontable/handsontable).
-4. From the root directory, run `pnpm install`.<br>pnpm installs all required dependencies, including for the `docs` and `examples` workspaces.
-5. From the root directory, run `pnpm run build`.<br>The script builds all Handsontable packages.
+1. Make sure you meet the [build requirements](#build-requirements).
+2. Clone the [Handsontable repository](https://github.com/handsontable/handsontable).
+3. From the root directory, run `pnpm install`.<br>pnpm installs all required dependencies, including for the `docs` and `examples` workspaces.
+4. From the root directory, run `pnpm run build`.<br>The script builds all Handsontable packages.
 
 ## Build the packages
 


### PR DESCRIPTION
### Context

The PR removes duplicated Node.js/pnpm/npm version guidance from the "Custom builds" page. The "Run your first build" section restated the same version-sourcing rules already documented in "Build requirements" just above it. The section now links back to "Build requirements" instead, matching the pattern already used by the "Build all the packages" section on the same page.

### How has this been tested?

- Manual review of the rendered page structure; no code examples or build tooling affected, docs-only content trim.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-710

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-710

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change with no effect on builds, APIs, or runtime behavior.
> 
> **Overview**
> The **Run your first build** steps no longer repeat Node.js and pnpm install/version guidance. The first step is now **Make sure you meet the [build requirements](#build-requirements)**, aligned with **Build all the packages** and the rest of the page.
> 
> Clone, `pnpm install`, and `pnpm run build` stay the same; only numbering and the removed duplicate prerequisite bullets changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5ddbc3762485768ec803ef605b837651227b4db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->