### PR TITLE
DEV-721: Document that the cell option uses visual indexes

### DIFF
--- a/docs/content/guides/getting-started/configuration-options/configuration-options.md
+++ b/docs/content/guides/getting-started/configuration-options/configuration-options.md
@@ -661,6 +661,8 @@ Options modified through [`cells`](@/api/options.md#cells) overwrite all other o
 
 To apply configuration options to individual cells, use the [`cell`](@/api/options.md#cell) option.
 
+Each entry's `row` and `col` are visual indexes (unlike the [`cells`](@/api/options.md#cells) option, whose `row` and `column` are physical indexes).
+
 ::: only-for javascript
 
 ```js

--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -608,9 +608,13 @@ export default (): Record<string, unknown> => {
      * The `cell` option overwrites the [top-level grid options](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options),
      * and the [`columns`](#columns) options.
      *
+     * Each entry's `row` and `col` are **visual** indexes. This differs from the [`cells`](#cells)
+     * option, whose `row` and `column` are physical indexes.
+     *
      * Read more:
      * - [Configuration options: Setting cell options](@/guides/getting-started/configuration-options/configuration-options.md#set-cell-options)
      * - [`columns`](#columns)
+     * - [`cells`](#cells)
      *
      * This option can only be set at the [grid level](@/guides/getting-started/configuration-options/configuration-options.md#set-grid-options).
      * It has no effect when set in the [`columns`](#columns), [`cells`](#cells), or [`cell`](#cell) options.


### PR DESCRIPTION
### Context

The PR documents that the [`cell`](https://handsontable.com/docs/api/options/#cell) option's `row` and `col` values are **visual** indexes, unlike the sibling [`cells`](https://handsontable.com/docs/api/options/#cells) option, whose `row` and `column` are **physical** indexes. This asymmetry was undocumented and could easily trip users up when combining both options.

The `cell` array is consumed by `Core#setCellMetaObject`, which is explicitly documented (and behaves) as taking visual `row`/`column` arguments, and internally converts them to physical indexes via `toPhysicalRow`/`toPhysicalColumn` before persisting the meta. The `cells` function's own JSDoc already documents its `row`/`column` as physical indexes, and the "Set row options" guide section already calls this out -- the "Set cell options" section and the `cell` option's JSDoc did not have the equivalent note.

### How has this been tested?

This is a JSDoc/prose-only documentation change with no runtime behavior change, so no new tests are required.

- `npm run eslint --prefix handsontable` -- passes
- `npm run test:types --prefix handsontable` -- passes
- Rebuilt `handsontable/tmp/` (ES + CommonJS) and regenerated `docs/content/api/options.md` via `npm run docs:api --prefix docs` to confirm the updated JSDoc renders correctly in the generated API reference

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-721

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-721

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prose and JSDoc only; no code paths or behavior are modified.
> 
> **Overview**
> Documents that the **`cell`** option’s `row` and `col` are **visual** indexes, contrasting with **`cells`**, which uses **physical** `row`/`column`.
> 
> The note is added in the **Set cell options** guide and in the **`cell`** option JSDoc in `metaSchema.ts` (including a cross-reference to **`cells`**). No runtime or API behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 334f8529a93aacae4ea47d18b32527e3815baa50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->