### PR TITLE
DEV-722: Explain HyperFormula trigger for named-expression hooks

### DIFF
--- a/handsontable/src/core/hooks/constants.ts
+++ b/handsontable/src/core/hooks/constants.ts
@@ -2893,6 +2893,12 @@ export const REGISTERED_HOOKS = [
   /**
    * Fired by the {@link Formulas} plugin when a named expression is added to the engine instance.
    *
+   * This hook fires after the HyperFormula engine's `addNamedExpression()` method runs, either
+   * because you called it directly or because you defined the `namedExpressions` configuration option.
+   *
+   * Read more:
+   * - [HyperFormula documentation: `addNamedExpression`](https://hyperformula.handsontable.com/api/classes/hyperformula.html#addnamedexpression)
+   *
    * @since 9.0.0
    * @event Hooks#afterNamedExpressionAdded
    * @param {string} namedExpressionName The name of the added expression.
@@ -2902,6 +2908,11 @@ export const REGISTERED_HOOKS = [
 
   /**
    * Fired by the {@link Formulas} plugin when a named expression is removed from the engine instance.
+   *
+   * This hook fires after the HyperFormula engine's `removeNamedExpression()` method runs.
+   *
+   * Read more:
+   * - [HyperFormula documentation: `removeNamedExpression`](https://hyperformula.handsontable.com/api/classes/hyperformula.html#removenamedexpression)
    *
    * @since 9.0.0
    * @event Hooks#afterNamedExpressionRemoved


### PR DESCRIPTION
[skip changelog]

### Context

The PR clarifies the JSDoc for the `afterNamedExpressionAdded` and `afterNamedExpressionRemoved` hooks. Previously, the docs only said each hook fires "when a named expression is added/removed to/from the engine instance," without saying which HyperFormula method triggers it or linking to HyperFormula's own docs for that method. This made it harder for users to connect the hook to the underlying HyperFormula behavior (e.g. `addNamedExpression()` also runs when the `namedExpressions` configuration option is set at initialization, not just on a direct manual call).

Each hook's JSDoc now names the triggering HyperFormula method and links to its API reference, following the existing "Read more" pattern already used by `afterFormulasValuesUpdate`.

### How has this been tested?

- `npm --prefix handsontable run eslint` — no new lint issues (pre-existing, unrelated `handsontable/no-direct-dom-geometry-read` rule-definition errors exist on `develop` as well, confirmed via `git stash`).
- `npm --prefix handsontable run test:types` — passes.
- `npx eslint src/core/hooks/constants.ts` — no issues found.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-722

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-722

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> JSDoc-only changes with no runtime or API behavior impact.
> 
> **Overview**
> **Documentation-only** update to the JSDoc for `afterNamedExpressionAdded` and `afterNamedExpressionRemoved` in `constants.ts`.
> 
> For **`afterNamedExpressionAdded`**, the docs now state the hook runs after HyperFormula’s `addNamedExpression()`, including when names come from the `namedExpressions` init option—not only from a direct API call. A **Read more** link points to HyperFormula’s `addNamedExpression` API.
> 
> For **`afterNamedExpressionRemoved`**, the docs now tie the hook to `removeNamedExpression()` with the same **Read more** pattern, aligned with how `afterFormulasValuesUpdate` already documents HyperFormula listeners.
> 
> No hook behavior, types, or runtime code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac072f8f33bf113d84bcc6992c4725f78fbf7fb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->