### PR TITLE
DEV-737: Align merge-cells snippets and index docs

### DIFF
--- a/docs/content/guides/cell-features/merge-cells/merge-cells.md
+++ b/docs/content/guides/cell-features/merge-cells/merge-cells.md
@@ -31,21 +31,43 @@ To enable the merge cells feature, set the [`mergeCells`](@/api/options.md#merge
 
 To initialize Handsontable with predefined merged cells, provide merged cells details in form of an array:
 
+The `row` and `col` properties use visual indexes. They refer to positions as displayed in the grid, in the same coordinate space as `selectCell()` and `getCellMeta()`.
+
 ::: only-for javascript
 
-`mergeCells: [{ row: 1, col: 1, rowspan: 2, colspan: 2 }]`
+```js
+mergeCells: [
+  { row: 1, col: 1, rowspan: 3, colspan: 3 },
+  { row: 3, col: 4, rowspan: 2, colspan: 2 },
+  { row: 5, col: 6, rowspan: 3, colspan: 3 },
+]
+```
 
 :::
 
 ::: only-for react
 
-`mergeCells={[{ row: 1, col: 1, rowspan: 2, colspan: 2 }]}`
+```jsx
+mergeCells={[
+  { row: 1, col: 1, rowspan: 3, colspan: 3 },
+  { row: 3, col: 4, rowspan: 2, colspan: 2 },
+  { row: 5, col: 6, rowspan: 3, colspan: 3 },
+]}
+```
 
 :::
 
 ::: only-for angular
 
-`settings = { mergeCells:[{ row: 1, col: 1, rowspan: 2, colspan: 2 }]}`
+```ts
+settings = {
+  mergeCells: [
+    { row: 1, col: 1, rowspan: 3, colspan: 3 },
+    { row: 3, col: 4, rowspan: 2, colspan: 2 },
+    { row: 5, col: 6, rowspan: 3, colspan: 3 },
+  ],
+};
+```
 
 :::
 
@@ -53,7 +75,11 @@ To initialize Handsontable with predefined merged cells, provide merged cells de
 
 ```js
 const hotSettings = {
-  mergeCells: [{ row: 1, col: 1, rowspan: 2, colspan: 2 }],
+  mergeCells: [
+    { row: 1, col: 1, rowspan: 3, colspan: 3 },
+    { row: 3, col: 4, rowspan: 2, colspan: 2 },
+    { row: 5, col: 6, rowspan: 3, colspan: 3 },
+  ],
 };
 ```
 

--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -4105,8 +4105,8 @@ export default (): Record<string, unknown> => {
      *
      * | Property  | Description                                                |
      * | --------- | ---------------------------------------------------------- |
-     * | `row`     | The row index of the merged section's beginning            |
-     * | `col`     | The column index of the merged section's beginning         |
+     * | `row`     | The visual row index of the merged section's beginning     |
+     * | `col`     | The visual column index of the merged section's beginning  |
      * | `rowspan` | The width (as a number of rows) of the merged section      |
      * | `colspan` | The height (as a number of columns ) of the merged section |
      *

--- a/handsontable/src/plugins/mergeCells/mergeCells.ts
+++ b/handsontable/src/plugins/mergeCells/mergeCells.ts
@@ -685,10 +685,10 @@ export class MergeCells extends BasePlugin {
   /**
    * Merges the specified range.
    *
-   * @param {number} startRow Start row of the merged cell.
-   * @param {number} startColumn Start column of the merged cell.
-   * @param {number} endRow End row of the merged cell.
-   * @param {number} endColumn End column of the merged cell.
+   * @param {number} startRow Visual start row of the merged cell.
+   * @param {number} startColumn Visual start column of the merged cell.
+   * @param {number} endRow Visual end row of the merged cell.
+   * @param {number} endColumn Visual end column of the merged cell.
    * @fires Hooks#beforeMergeCells
    * @fires Hooks#afterMergeCells
    */
@@ -702,10 +702,10 @@ export class MergeCells extends BasePlugin {
   /**
    * Unmerges the merged cell in the provided range.
    *
-   * @param {number} startRow Start row of the merged cell.
-   * @param {number} startColumn Start column of the merged cell.
-   * @param {number} endRow End row of the merged cell.
-   * @param {number} endColumn End column of the merged cell.
+   * @param {number} startRow Visual start row of the merged cell.
+   * @param {number} startColumn Visual start column of the merged cell.
+   * @param {number} endRow Visual end row of the merged cell.
+   * @param {number} endColumn Visual end column of the merged cell.
    * @fires Hooks#beforeUnmergeCells
    * @fires Hooks#afterUnmergeCells
    */


### PR DESCRIPTION
### Context

The PR fixes DEV-737 and DEV-733 by aligning the merge-cells guide snippets with the live `example1` configuration and clarifying that merge coordinates (`row`/`col`) are visual indexes in guide and API-facing JSDoc.

[skip changelog]

### How has this been tested?

- `npm --prefix handsontable run build`
- `npm --prefix docs run docs:api`

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-737
2. DEV-733

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and comment-only changes with no behavioral impact on merge cells.
> 
> **Overview**
> Documentation-only updates for merge cells: the guide now states that **`row`** and **`col`** are **visual indexes** (same space as `selectCell()` / `getCellMeta()`), and the JS/React/Angular/Vue initialization snippets match **`example1`** (three merges with fenced code blocks instead of a single minimal one-liner).
> 
> API-facing text is aligned the same way: the **`mergeCells`** option table in **`metaSchema`** labels `row`/`col` as visual row/column indexes, and **`MergeCells.merge()`** / **`unmerge()`** JSDoc parameters are documented as visual start/end coordinates. **No runtime logic changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1934379a176e1910a141928312068db8042129b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->