### PR TITLE
DEV-729: Move ConfigParams link from code comments to prose

### DIFF
--- a/docs/content/guides/formulas/formula-calculation/formula-calculation.md
+++ b/docs/content/guides/formulas/formula-calculation/formula-calculation.md
@@ -220,7 +220,7 @@ const hotSettings = ref({
 
 :::
 
-or
+Or pass a configuration object to customize the engine. For all available options, see the [HyperFormula `ConfigParams` reference](https://hyperformula.handsontable.com/api/interfaces/configparams.html).
 
 ::: only-for javascript
 
@@ -231,7 +231,6 @@ or
       hyperformula: HyperFormula, // or `engine: hyperformulaInstance`
       leapYear1900: false,
       // ...and more engine configuration options.
-      // See https://handsontable.github.io/hyperformula/api/interfaces/configparams.html#number
     },
     // [plugin configuration]
   }
@@ -249,7 +248,6 @@ or
       hyperformula: HyperFormula, // or `engine: hyperformulaInstance`
       leapYear1900: false,
       // ...and more engine configuration options.
-      // See https://handsontable.github.io/hyperformula/api/interfaces/configparams.html#number
     },
     // [plugin configuration]
   }}
@@ -267,7 +265,6 @@ or
       hyperformula: HyperFormula, // or `engine: hyperformulaInstance`
       leapYear1900: false,
       // ...and more engine configuration options.
-      // See https://handsontable.github.io/hyperformula/api/interfaces/configparams.html#number
     },
     // [plugin configuration]
   }
@@ -285,7 +282,6 @@ const hotSettings = ref({
       hyperformula: HyperFormula, // or `engine: hyperformulaInstance`
       leapYear1900: false,
       // ...and more engine configuration options.
-      // See https://handsontable.github.io/hyperformula/api/interfaces/configparams.html#number
     },
     // [plugin configuration]
   },


### PR DESCRIPTION
### Context

The PR fixes DEV-729 by moving the HyperFormula `ConfigParams` reference out of duplicated inline code comments and into shared prose in the formulas guide. This keeps JavaScript, React, Angular, and Vue snippets cleaner while preserving discoverability of engine configuration options.

### How has this been tested?

- Verified the new prose sentence appears once before the framework-specific config-object examples in `docs/content/guides/formulas/formula-calculation/formula-calculation.md`.
- Verified all four framework snippets no longer include the `// See https://handsontable.github.io/hyperformula/api/interfaces/configparams.html#number` comment line.
- Verified no linter diagnostics for the changed file.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. DEV-729
2. n/a
3. n/a

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`
- [x] `handsontable-documentation` (`docs/`)

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]
