### PR TITLE
DEV-753: Document function-based grid sizing in guide

### DIFF
--- a/docs/content/guides/getting-started/grid-size/grid-size.md
+++ b/docs/content/guides/getting-started/grid-size/grid-size.md
@@ -160,6 +160,62 @@ const hotSettings = ref({
 
 :::
 
+You can also pass a function to `width` and `height`. Use this when you calculate dimensions from your current layout. The function can return a number (pixels) or a CSS size string.
+
+:::: only-for javascript
+
+```js
+{
+  width() {
+    return `${window.innerWidth - 64}px`;
+  },
+  height() {
+    return 400;
+  },
+}
+```
+
+::::
+
+:::: only-for react
+
+```jsx
+const getGridWidth = () => `${window.innerWidth - 64}px`;
+const getGridHeight = () => 400;
+
+<HotTable width={getGridWidth} height={getGridHeight} />
+```
+
+::::
+
+:::: only-for angular
+
+```ts
+import { GridSettings } from "@handsontable/angular-wrapper";
+
+gridSettings: GridSettings = {
+  width: () => `${window.innerWidth - 64}px`,
+  height: () => 400,
+};
+```
+
+```html
+<hot-table [settings]="gridSettings" />
+```
+
+::::
+
+:::: only-for vue
+
+```js
+const hotSettings = ref({
+  width: () => `${window.innerWidth - 64}px`,
+  height: () => 400,
+});
+```
+
+::::
+
 These dimensions will be set as inline styles in a container element, and `overflow: hidden` will be added automatically.
 
 If container is a block element, then its parent has to have defined `height`. By default block element is `0px` height, so `100%` from `0px` is still `0px`.


### PR DESCRIPTION
### Context

The PR updates the Grid size guide to close the remaining documentation gap from DEV-753.
Function-based `width` and `height` values were already documented in API/JSDoc, but not in the guide page.

### How has this been tested?

- [x] `rtk npm --prefix docs run docs:lint`
- [x] `rtk npm --prefix docs run build`

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-753

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-753

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the grid-size guide; no product code or behavior changes.
> 
> **Overview**
> **Closes DEV-753** by documenting function-based `width` and `height` on the Grid size guide, matching what was already in API/JSDoc.
> 
> Under **Pass the size in the configuration**, the guide now explains that `width` and `height` can be functions for layout-driven sizing, with return types of pixel numbers or CSS size strings. New **JavaScript, React, Angular, and Vue** snippets show the same pattern (e.g. width from `window.innerWidth - 64` and fixed height `400`). No runtime or wrapper code changes—docs only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a35adaf8bdc5fddeef747f57e667fec3a65ccce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->