### PR TITLE
DEV-754: Clarify beforeCellAlignment payload docs and tests

### DIFF
--- a/handsontable/src/core/hooks/constants.ts
+++ b/handsontable/src/core/hooks/constants.ts
@@ -1380,7 +1380,8 @@ export const REGISTERED_HOOKS = [
    * Fired before aligning the cell contents.
    *
    * @event Hooks#beforeCellAlignment
-   * @param {object} stateBefore An object with class names defining the cell alignment.
+   * @param {object} stateBefore An object where each key is a visual row index and each value is an array
+   *                             of class names indexed by visual column.
    * @param {CellRange[]} range An array of `CellRange` coordinates where the alignment will be applied.
    * @param {string} type Type of the alignment - either `horizontal` or `vertical`.
    * @param {string} alignmentClass String defining the alignment class added to the cell.

--- a/handsontable/src/plugins/contextMenu/__tests__/predefinedItems/alignment.spec.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/predefinedItems/alignment.spec.js
@@ -406,6 +406,42 @@ describe('ContextMenu', () => {
       expect(getCellMeta(2, 3).className).toBe(undefined);
     });
 
+    it('should pass row-indexed alignment state through the `beforeCellAlignment` hook', async() => {
+      const beforeCellAlignment = jasmine.createSpy('beforeCellAlignment');
+
+      handsontable({
+        data: createSpreadsheetData(4, 4),
+        contextMenu: true,
+        beforeCellAlignment,
+        cells(row, col) {
+          if (row === 0 && col === 0) {
+            return { className: 'htCenter' };
+          }
+          if (row === 1 && col === 1) {
+            return { className: 'htTop' };
+          }
+
+          return {};
+        },
+      });
+
+      await selectCell(0, 0, 1, 1);
+      await contextMenu();
+      await selectContextSubmenuOption('Alignment', 'Right');
+
+      const [stateBefore, selectedRange, type, alignmentClass] = beforeCellAlignment.calls.argsFor(0);
+
+      expect(Array.isArray(stateBefore[0])).toBe(true);
+      expect(Array.isArray(stateBefore[1])).toBe(true);
+      expect(stateBefore[0][0]).toBe('htCenter');
+      expect(stateBefore[0][1]).toBe(undefined);
+      expect(stateBefore[1][0]).toBe(undefined);
+      expect(stateBefore[1][1]).toBe('htTop');
+      expect(selectedRange.length).toBe(1);
+      expect(type).toBe('horizontal');
+      expect(alignmentClass).toBe('htRight');
+    });
+
     describe('UI', () => {
       it('should display a disabled entry, when there\'s nothing selected', async() => {
         handsontable({

--- a/handsontable/src/plugins/contextMenu/__tests__/utils.unit.js
+++ b/handsontable/src/plugins/contextMenu/__tests__/utils.unit.js
@@ -1,0 +1,41 @@
+import { getAlignmentClasses } from 'handsontable/plugins/contextMenu/utils';
+
+function createRange(coords) {
+  return {
+    forAll(callback) {
+      coords.forEach(([row, col]) => callback(row, col));
+    },
+  };
+}
+
+describe('contextMenu/utils', () => {
+  describe('getAlignmentClasses', () => {
+    it('should collect class names into row-indexed arrays', () => {
+      const classes = getAlignmentClasses([
+        createRange([[0, 1], [0, 2], [1, 0]]),
+      ], (row, col) => `${row}:${col}`);
+
+      expect(Object.keys(classes)).toEqual(['0', '1']);
+      expect(classes[0][0]).toBeUndefined();
+      expect(classes[0][1]).toBe('0:1');
+      expect(classes[0][2]).toBe('0:2');
+      expect(classes[1][0]).toBe('1:0');
+    });
+
+    it('should skip header coordinates', () => {
+      const visitedCoords = [];
+      const classes = getAlignmentClasses([
+        createRange([[-1, 0], [0, -1], [0, 0], [1, 1]]),
+      ], (row, col) => {
+        visitedCoords.push([row, col]);
+
+        return `${row}:${col}`;
+      });
+
+      expect(visitedCoords).toEqual([[0, 0], [1, 1]]);
+      expect(Object.keys(classes)).toEqual(['0', '1']);
+      expect(classes[0][0]).toBe('0:0');
+      expect(classes[1][1]).toBe('1:1');
+    });
+  });
+});


### PR DESCRIPTION
### Context

The PR fixes inaccurate `beforeCellAlignment` hook documentation by clarifying the `stateBefore` payload shape in core JSDoc, and adds regression tests to validate that runtime shape.

### How has this been tested?

- `npm --prefix handsontable run test:types`
- `npm --prefix handsontable run test:unit --testPathPattern=contextMenu/__tests__/utils.unit`
- `npm --prefix handsontable run test:e2e --testPathPattern=contextMenu/__tests__/predefinedItems/alignment.spec`

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-754

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-754

[skip changelog]


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test-only changes; no production logic modified in this diff.
> 
> **Overview**
> Corrects **JSDoc** for `beforeCellAlignment` so `stateBefore` is described as an object keyed by **visual row index**, with each value an **array of alignment class names by visual column**—replacing the vague “object with class names” wording.
> 
> Adds **regression coverage**: unit tests for `getAlignmentClasses` (row-indexed layout, skipping header coords) and an e2e case that asserts the hook receives that structure when applying alignment from the context menu.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e8da11ba162e438cb6cae7403de964e7cf11e76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->