### PR TITLE
DEV-757: Complete comments guide API reference links

### DIFF
--- a/docs/content/guides/cell-features/comments/comments.md
+++ b/docs/content/guides/cell-features/comments/comments.md
@@ -355,3 +355,22 @@ Cells with comments display a small indicator in the corner. Users can view, edi
 - [comments](@/api/options.md#comments)
 
 </div>
+
+**Hooks**
+
+<div class="boxes-list">
+
+- [afterRemoveCellMeta](@/api/hooks.md#afterremovecellmeta)
+- [afterSetCellMeta](@/api/hooks.md#aftersetcellmeta)
+- [beforeRemoveCellMeta](@/api/hooks.md#beforeremovecellmeta)
+- [beforeSetCellMeta](@/api/hooks.md#beforesetcellmeta)
+
+</div>
+
+**Plugins**
+
+<div class="boxes-list">
+
+- [Comments](@/api/comments.md)
+
+</div>


### PR DESCRIPTION
### Context

The PR updates the Comments guide to complete the Related API reference section for DEV-757 by adding missing Hooks and Plugins links.
This is a docs-only change in docs/content/guides/cell-features/comments/comments.md and does not modify runtime behavior.

### How has this been tested?

- rtk npm --prefix docs run build
- Verified added hook anchors exist in docs/content/api/hooks.md
- Verified the @/api/comments.md link pattern is valid and already used across docs pages

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. DEV-757
2. https://app.clickup.com/t/9015210959/DEV-757
3. [skip changelog]

### Affected project(s):
- [ ] handsontable
- [ ] @handsontable/angular-wrapper
- [ ] @handsontable/react-wrapper
- [ ] @handsontable/vue3

### Checklist:
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or library code touched.
> 
> **Overview**
> Completes the **Related API reference** section at the end of the Comments guide (`comments.md`) for DEV-757.
> 
> It still lists the two configuration options; this change adds **Hooks** links for the four cell-meta hooks used when comments are stored (`afterRemoveCellMeta`, `afterSetCellMeta`, `beforeRemoveCellMeta`, `beforeSetCellMeta`) and a **Plugins** link to the Comments API page. The layout matches other guides (e.g. context menu, autofill).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 653f1725aaa06396579663536c442c99495529b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->