### PR TITLE
DEV-742: Document autoRowSize samplingRatio in API docs

### DIFF
--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -484,6 +484,7 @@ export default (): Record<string, unknown> => {
      * | Property                | Possible values                 | Description                                                                                                |
      * | ----------------------- | ------------------------------- | ---------------------------------------------------------------------------------------------------------- |
      * | `syncLimit`             | A number \| A percentage string | The number/percentage of rows to keep in sync<br>(default: `500`)                                          |
+     * | `samplingRatio`         | A number                        | The number of samples of the same length to be used in row height calculations                             |
      * | `allowSampleDuplicates` | `true` \| `false`               | When calculating row heights:<br>`true`: Allow duplicate samples<br>`false`: Don't allow duplicate samples |
      *
      * Using the [`rowHeights`](#rowHeights) option forcibly disables the [`AutoRowSize`](@/api/autoRowSize.md) plugin.
@@ -504,6 +505,8 @@ export default (): Record<string, unknown> => {
      * autoRowSize: {
      *   // keep 40% of rows in sync (the rest of rows: async)
      *   syncLimit: '40%',
+     *   // when calculating row heights, use 10 samples of the same length
+     *   samplingRatio: 10,
      *   // when calculating row heights, allow duplicate samples
      *   allowSampleDuplicates: true
      * },

--- a/handsontable/src/plugins/autoRowSize/autoRowSize.ts
+++ b/handsontable/src/plugins/autoRowSize/autoRowSize.ts
@@ -44,6 +44,16 @@ const AUTO_ROW_SIZE_CLASS_NAME = 'htAutoRowSize';
  *
  * To speed up the calculations, the plugin samples a subset of rows rather than measuring every row. By default, it
  * skips rows whose value it has already sampled, on the assumption that identical values render at the same height.
+ *
+ * Sampling accepts additional options:
+ * - *samplingRatio* - Defines how many samples for the same length will be used to calculate. Default is `3`.
+ *
+ * ```js
+ *   autoRowSize: {
+ *     samplingRatio: 10,
+ *   }
+ * ```
+ *
  * Set the `allowSampleDuplicates` option to `true` to sample duplicate values as well:
  *
  * ```js


### PR DESCRIPTION
### Context

The PR adds the missing `samplingRatio` documentation for `autoRowSize` so the option docs are aligned with `autoColumnSize` and the generated API reference includes the same guidance.

### How has this been tested?

- `rtk npm run eslint --prefix handsontable`
- `rtk npm run build --prefix handsontable`
- `rtk npm run docs:api --prefix docs`
- Verified generated `docs/content/api/options.md` includes `samplingRatio` in the `autoRowSize` example block.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-742

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-742

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only JSDoc and schema comment updates; no code paths or defaults are modified.
> 
> **Overview**
> Documents the existing **`samplingRatio`** option for **`autoRowSize`** so it matches **`autoColumnSize`** and flows into the generated API reference.
> 
> **`metaSchema.ts`** adds a property row in the options table, extends the **`autoRowSize`** example with `samplingRatio: 10`, and describes how many same-length samples are used for row height calculations. **`autoRowSize.ts`** plugin JSDoc now explains sampling options, notes the default of **`3`**, and includes a short configuration example before the existing **`allowSampleDuplicates`** guidance.
> 
> No runtime or behavior changes—comments and schema docs only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9854eac00e9afae7429657cbac8efac98a95a4fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->