### PR TITLE
DEV-774: Document filter menu focus behavior

### DIFF
--- a/docs/content/guides/accessibility/accessibility/accessibility.md
+++ b/docs/content/guides/accessibility/accessibility/accessibility.md
@@ -107,6 +107,8 @@ Handsontable provides a wide range of [keyboard shortcuts](@/guides/navigation/k
 
 *To use this shortcut, disable the default macOS behavior for the <kbd>**Ctrl**</kbd>+<kbd>**Space**</kbd> key combination, under **System Settings** > **Keyboard** > **Keyboard Shortcuts** > **Input Sources**.
 
+For filter-menu-specific navigation details, including <kbd>**Tab**</kbd> traversal and hover behavior, see [Column filter](@/guides/columns/column-filter/column-filter.md#navigate-the-filter-menu).
+
 ## Support for screen readers
 
 Although semantic HTML doesn't need any additional attributes to be properly interpreted by assistive technologies, some of Handsontable's complex features are not fully covered by the HTML specification. That's why Handsontable provides support for screen readers with ARIA attributes (Accessible Rich Internet Applications) applied to its HTML markup.

--- a/docs/content/guides/accessories-and-menus/column-menu/column-menu.md
+++ b/docs/content/guides/accessories-and-menus/column-menu/column-menu.md
@@ -135,6 +135,7 @@ the [context menu](@/guides/accessories-and-menus/context-menu/context-menu.md).
 | [`filter_action_bar`](@/api/filters.md)        | Apply or cancel the filter with the **OK** and **Cancel** buttons.                           |
 
 For a complete filtering guide, see [Column filter](@/guides/columns/column-filter/column-filter.md).
+For filter-menu keyboard and pointer behavior, see [Navigate the filter menu](@/guides/columns/column-filter/column-filter.md#navigate-the-filter-menu).
 
 ## Related keyboard shortcuts
 

--- a/docs/content/guides/columns/column-filter/column-filter.md
+++ b/docs/content/guides/columns/column-filter/column-filter.md
@@ -1331,6 +1331,17 @@ At the moment, filtering comes with the following limitations:
   [`addCondition()`](@/api/filters.md), the extra conditions are applied to the data but are not
   visible or editable in the dropdown menu.
 
+## Navigate the filter menu
+
+Use keyboard and pointer interactions together to control the filtering UI:
+
+- Press <kbd>**Tab**</kbd> and <kbd>**Shift**</kbd>+<kbd>**Tab**</kbd> to move between filtering components, such as the search input, **Select all**, **Clear all**, condition controls, and action bar controls.
+- When the search input is focused, press <kbd>**Arrow up**</kbd> and <kbd>**Arrow down**</kbd> to move through the **Filter by value** list.
+- When **Select all** or **Clear all** is focused, press <kbd>**Enter**</kbd> or <kbd>**Space**</kbd> to run the action.
+- If you hover a non-filter menu item (for example, **Clear column**), the filter-components focus order resets. The next <kbd>**Tab**</kbd> focuses the first filter component.
+
+For a reference list of filter-related shortcuts, see [Keyboard shortcuts](@/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md#column-filter-keyboard-shortcuts).
+
 ## Related keyboard shortcuts
 
 | Windows                             | macOS                                  | Action            |  Excel  | Sheets  |

--- a/docs/content/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md
+++ b/docs/content/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md
@@ -229,6 +229,10 @@ These keyboard shortcuts work with the [column filter](@/guides/columns/column-f
 | Windows                             | macOS                                  | Action            |  Excel  | Sheets  |
 | ----------------------------------- | -------------------------------------- | ----------------- | :-----: | :-----: |
 | <kbd>**Alt**</kbd>+<kbd>**A**</kbd> | <kbd>⌥</kbd>+<kbd>**A**</kbd> | Clear all filters | &cross; | &cross; |
+| <kbd>**Tab**</kbd> | <kbd>**Tab**</kbd> | Move focus to the next filtering component in the open filter menu. | &cross; | &cross; |
+| <kbd>**Shift**</kbd>+<kbd>**Tab**</kbd> | <kbd>⇧</kbd>+<kbd>**Tab**</kbd> | Move focus to the previous filtering component in the open filter menu. | &cross; | &cross; |
+| <kbd>**↑**</kbd> / <kbd>**↓**</kbd> | <kbd>**↑**</kbd> / <kbd>**↓**</kbd> | When the filter search input is focused, move through the **Filter by value** list. | &cross; | &cross; |
+| <kbd>**Enter**</kbd> / <kbd>**Space**</kbd> | <kbd>**Enter**</kbd> / <kbd>**Space**</kbd> | When **Select all** or **Clear all** is focused, run the action. | &cross; | &cross; |
 
 ### Comments keyboard shortcuts
 

--- a/docs/content/guides/upgrade-and-migration/migrating-from-13.1-to-14.0/migrating-from-13.1-to-14.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-13.1-to-14.0/migrating-from-13.1-to-14.0.md
@@ -46,6 +46,12 @@ The new Handsontable version comes with an updated set of keyboard shortcuts. Mo
 | ------------ | ------------ |
 | Iterates through the content list  | Iterates through the menu items. When focused on the search input, the arrow keys allow iterating through the content list  |
 
+##### Hover behavior in the Filtering menu
+
+| Before  | After  |
+| ------------ | ------------ |
+| After pressing <kbd>TAB</kbd> from the search input to **Select all**, hovering other menu items keeps keyboard focus on **Select all**.  | After pressing <kbd>TAB</kbd> from the search input to **Select all**, hovering a non-filter menu item (for example, **Clear column**) resets the filter-components focus order. The next <kbd>TAB</kbd> moves focus to the first filter component.  |
+
 More information: [Keyboard Shortcuts page in the documentation](@/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md)
 
 ### Check if your template looks fine with the updated colors


### PR DESCRIPTION
### Context

The PR documents the filter-menu focus behavior changes tracked in DEV-774. It clarifies the hover-versus-keyboard-focus behavior introduced in v14+, and aligns migration, filtering, keyboard-shortcuts, and accessibility guidance.

### How has this been tested?

- `npm --prefix docs run docs:lint`
- `npm --prefix docs run build`

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. DEV-774
2. https://app.clickup.com/t/9015210959/DEV-774
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only markdown documentation is touched; no runtime or API behavior changes.
> 
> **Overview**
> **Documentation-only** update for DEV-774: it describes filter-dropdown **keyboard and pointer focus** behavior (especially changes from v14 onward), without changing product code.
> 
> A new **Navigate the filter menu** section in the column filter guide explains **Tab** / **Shift+Tab** across filter controls, **arrow keys** in the search input for the value list, **Enter** / **Space** on **Select all** / **Clear all**, and that **hovering a non-filter menu item** (e.g. **Clear column**) **resets** the filter-components focus order so the next **Tab** returns to the first filter control.
> 
> The keyboard shortcuts reference gains matching **Column filter** rows; accessibility and column menu pages link to the new section; the **13.1 → 14.0** migration guide adds a **Hover behavior in the Filtering menu** before/after table alongside the existing **TAB** filtering-menu note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4e79a1af15d211c2f4067ee9f0738282d083b6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->