### PR TITLE
DEV-1948: Add ASP.NET Core server-side data recipe

### DIFF
--- a/docs/content/recipes/data-management/data-management.md
+++ b/docs/content/recipes/data-management/data-management.md
@@ -31,6 +31,7 @@ Current recipes:
 - [Sync two grids](@/recipes/data-management/sync-two-grids/sync-two-grids.md)
 - [Auto-save changes to a backend](@/recipes/data-management/auto-save-backend/auto-save-backend.md)
 - [Undo / redo with a custom UI](@/recipes/data-management/undo-redo-custom-ui/undo-redo-custom-ui.md)
+- [Server-side data with ASP.NET Core](@/recipes/data-management/server-side-aspnet/server-side-aspnet.md)
 - [Server-side data with Django](@/recipes/data-management/server-side-django/server-side-django.md)
 - [Server-side data with Express.js](@/recipes/data-management/server-side-expressjs/server-side-expressjs.md)
 - [Server-side data with Laravel](@/recipes/data-management/server-side-laravel/server-side-laravel.md)

--- a/docs/content/recipes/data-management/server-side-aspnet/angular/example1.html
+++ b/docs/content/recipes/data-management/server-side-aspnet/angular/example1.html
@@ -1,0 +1,3 @@
+<div>
+  <example1-server-side-aspnet></example1-server-side-aspnet>
+</div>

--- a/docs/content/recipes/data-management/server-side-aspnet/angular/example1.ts
+++ b/docs/content/recipes/data-management/server-side-aspnet/angular/example1.ts
@@ -193,7 +193,6 @@ export class AppComponent {
     contextMenu:    true,
     emptyDataState: true,
     notification:   true,
-    dialog:         true,
     rowHeaders:     true,
     colHeaders: ['Order #', 'Customer', 'Status', 'Total', 'Created'],
     columns: [

--- a/docs/content/recipes/data-management/server-side-aspnet/angular/example1.ts
+++ b/docs/content/recipes/data-management/server-side-aspnet/angular/example1.ts
@@ -1,0 +1,228 @@
+/* file: app.component.ts */
+import {
+  Component,
+  ViewChild,
+  ViewEncapsulation,
+  CUSTOM_ELEMENTS_SCHEMA,
+} from '@angular/core';
+import { HotTableModule, HotTableComponent } from '@handsontable/angular-wrapper';
+import type {
+  DataProviderQueryParameters,
+  RowsCreatePayload,
+  RowUpdatePayload,
+  RowMutationPayload,
+  RowMutationRemovePayload,
+} from 'handsontable/plugins/dataProvider';
+
+const API_BASE = 'http://localhost:5000/api/orders';
+
+// ASP.NET Core's model binder reads: pageSize, sort.prop, sort.order,
+// filters[N].prop/condition/value
+function buildUrl(base: string, params: DataProviderQueryParameters): string {
+  const query = new URLSearchParams();
+
+  query.set('page', String(params.page));
+  query.set('pageSize', String(params.pageSize));
+
+  if (params.sort?.prop) {
+    query.set('sort.prop', params.sort.prop);
+    query.set('sort.order', params.sort.order ?? 'asc');
+  }
+
+  if (params.filters?.length) {
+    let idx = 0;
+    params.filters.forEach(({ prop, conditions }) => {
+      conditions.forEach((cond) => {
+        if (!cond?.name) return;
+        query.set(`filters[${idx}].prop`, prop);
+        query.set(`filters[${idx}].condition`, cond.name);
+        if (cond.args?.[0] != null) {
+          query.set(`filters[${idx}].value`, String(cond.args[0]));
+        }
+        idx++;
+      });
+    });
+  }
+
+  return `${base}?${query}`;
+}
+
+@Component({
+  standalone: true,
+  encapsulation: ViewEncapsulation.None,
+  imports: [HotTableModule],
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  selector: 'example1-server-side-aspnet',
+  template: `
+    <div>
+      <hot-table [settings]="settings"></hot-table>
+    </div>
+  `,
+})
+export class AppComponent {
+  @ViewChild(HotTableComponent) readonly hotRef!: HotTableComponent;
+
+  private removeConfirmed = false;
+
+  settings = {
+    dataProvider: {
+      rowId: 'id',
+
+      // Called on every page change, sort, and filter.
+      fetchRows: async (queryParameters: DataProviderQueryParameters, { signal }: { signal: AbortSignal }) => {
+        const url = buildUrl(API_BASE, queryParameters);
+        const res = await fetch(url, { signal });
+
+        if (!res.ok) throw new Error(`Fetch failed: ${res.status}`);
+
+        // ASP.NET Core returns: { rows: [...], totalRows: n }
+        const json = await res.json();
+        return { rows: json.rows, totalRows: json.totalRows };
+      },
+
+      // Fires when the user inserts rows via the context menu.
+      // payload: { position: 'above'|'below', referenceRowId, rowsAmount }
+      onRowsCreate: async (payload: RowsCreatePayload) => {
+        const newRows = Array.from({ length: payload.rowsAmount ?? 0 }, () => ({
+          orderNumber: `ORD-${Date.now()}-${Math.random().toString(36).slice(2, 6).toUpperCase()}`,
+          customer: 'New Customer',
+          status: 'pending',
+          total: 0,
+        }));
+
+        const res = await fetch(`${API_BASE}/create_rows`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ rows: newRows }),
+        });
+
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({})) as { error?: string };
+          throw new Error(err.error ?? `Create failed: ${res.status}`);
+        }
+
+        const json = await res.json();
+        const info = json.rows.map((r: { orderNumber: string }) => `(order: ${r.orderNumber})`).join(', ');
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (this.hotRef.hotInstance!.getPlugin('notification') as any).showMessage({
+          variant: 'success',
+          title: 'Row added',
+          message: `Created: ${info}`,
+          duration: 3000,
+        });
+
+        return json.rows;
+      },
+
+      // Fires after a cell edit, paste, or autofill batch.
+      onRowsUpdate: async (rows: RowUpdatePayload[]) => {
+        const res = await fetch(`${API_BASE}/update_rows`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            rows: rows.map((r) => ({ id: r.id, changes: r.changes })),
+          }),
+        });
+
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({})) as { error?: string };
+          throw new Error(err.error ?? `Update failed: ${res.status}`);
+        }
+      },
+
+      // Fires after the user confirms deletion.
+      onRowsRemove: async (rowIds: unknown[]) => {
+        const res = await fetch(`${API_BASE}/remove_rows`, {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ rowIds }),
+        });
+
+        if (!res.ok) throw new Error(`Delete failed: ${res.status}`);
+      },
+    },
+
+    // beforeRowsMutation is sync (checks for a strict `=== false` return), so
+    // we can't await an async prompt inline. Instead: cancel the original
+    // attempt, show a notification with Delete/Cancel actions, and on Delete
+    // re-issue the remove via the DataProvider API. The flag lets the second
+    // pass through without re-prompting.
+    beforeRowsMutation: (operation: 'create' | 'update' | 'remove', payload: RowMutationPayload): false | void => {
+      if (operation === 'remove' && !this.removeConfirmed) {
+        const { rowsRemove } = payload as RowMutationRemovePayload;
+        const hot = this.hotRef.hotInstance!;
+        const count = rowsRemove.length;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const notification = (hot.getPlugin('notification') as any);
+        const id = notification.showMessage({
+          variant: 'warning',
+          title: 'Delete rows',
+          message: `Delete ${count} row${count !== 1 ? 's' : ''}? This cannot be undone.`,
+          duration: 0,
+          actions: [
+            {
+              label: 'Delete',
+              type: 'primary',
+              callback: () => {
+                notification.hide(id);
+                this.removeConfirmed = true;
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (hot.getPlugin('dataProvider') as any)
+                  .removeRows(rowsRemove)
+                  .finally(() => {
+                    this.removeConfirmed = false;
+                  });
+              },
+            },
+            {
+              label: 'Cancel',
+              type: 'secondary',
+              callback: () => notification.hide(id),
+            },
+          ],
+        });
+        return false;
+      }
+    },
+
+    pagination:     { pageSize: 10 },
+    columnSorting:  true,
+    filters:        true,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    dropdownMenu:   ['filter_by_condition', 'filter_action_bar'] as any,
+    contextMenu:    true,
+    emptyDataState: true,
+    notification:   true,
+    dialog:         true,
+    rowHeaders:     true,
+    colHeaders: ['Order #', 'Customer', 'Status', 'Total', 'Created'],
+    columns: [
+      { data: 'orderNumber', type: 'text' },
+      { data: 'customer',    type: 'text' },
+      { data: 'status',      type: 'text' },
+      { data: 'total',       type: 'numeric', numericFormat: { style: 'currency' as const, currency: 'USD', minimumFractionDigits: 2, maximumFractionDigits: 2 } },
+      { data: 'createdAt',   type: 'date', dateFormat: { year: 'numeric', month: '2-digit', day: '2-digit' } as const, readOnly: true },
+    ],
+    height:      'auto',
+    licenseKey:  'non-commercial-and-evaluation',
+  };
+}
+/* end-file */
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+/* end-file */

--- a/docs/content/recipes/data-management/server-side-aspnet/javascript/example1.html
+++ b/docs/content/recipes/data-management/server-side-aspnet/javascript/example1.html
@@ -1,0 +1,1 @@
+<div id="example1"></div>

--- a/docs/content/recipes/data-management/server-side-aspnet/javascript/example1.js
+++ b/docs/content/recipes/data-management/server-side-aspnet/javascript/example1.js
@@ -141,7 +141,6 @@ const hot = new Handsontable(container, {
     contextMenu: true,
     emptyDataState: true,
     notification: true,
-    dialog: true,
     colHeaders: ['Order #', 'Customer', 'Status', 'Total', 'Created'],
     columns: [
         { data: 'orderNumber', type: 'text' },

--- a/docs/content/recipes/data-management/server-side-aspnet/javascript/example1.js
+++ b/docs/content/recipes/data-management/server-side-aspnet/javascript/example1.js
@@ -1,0 +1,157 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+registerAllModules();
+// Serializes fetchRows query parameters into a URL the ASP.NET Core model
+// binder understands.
+//
+// Handsontable sends:
+//   sort:    { prop: 'orderNumber', order: 'asc' }  or  null
+//   filters: [{ prop, conditions: [{ name, args }] }]  or  null
+//
+// ASP.NET Core's default model binder reads nested properties from dot
+// notation and collections from bracket-indexed dot notation:
+//   pageSize, sort.prop, sort.order, filters[N].prop/condition/value
+function buildUrl(base, { page, pageSize, sort, filters }) {
+    const params = new URLSearchParams();
+    params.set('page', String(page));
+    params.set('pageSize', String(pageSize));
+    if (sort?.prop) {
+        params.set('sort.prop', sort.prop);
+        params.set('sort.order', sort.order ?? 'asc');
+    }
+    if (filters?.length) {
+        let idx = 0;
+        filters.forEach(({ prop, conditions }) => {
+            (conditions || []).forEach(({ name, args }) => {
+                if (!name)
+                    return;
+                params.set(`filters[${idx}].prop`, prop);
+                params.set(`filters[${idx}].condition`, name);
+                const a = args ?? [];
+                if (a[0] != null)
+                    params.set(`filters[${idx}].value`, String(a[0]));
+                idx++;
+            });
+        });
+    }
+    return `${base}?${params.toString()}`;
+}
+const API_BASE = 'http://localhost:5000/api/orders';
+const container = document.querySelector('#example1');
+let removeConfirmed = false;
+// eslint-disable-next-line no-unused-vars
+const hot = new Handsontable(container, {
+    dataProvider: {
+        rowId: 'id',
+        fetchRows: async (queryParameters, { signal }) => {
+            const url = buildUrl(API_BASE, queryParameters);
+            const res = await fetch(url, { signal });
+            if (!res.ok)
+                throw new Error(`Fetch failed: ${res.status}`);
+            const json = await res.json();
+            return { rows: json.rows, totalRows: json.totalRows };
+        },
+        onRowsCreate: async ({ rowsAmount }) => {
+            const newRows = Array.from({ length: rowsAmount }, () => ({
+                orderNumber: `ORD-${Date.now()}-${Math.random().toString(36).slice(2, 6).toUpperCase()}`,
+                customer: 'New Customer',
+                status: 'pending',
+                total: 0,
+            }));
+            const res = await fetch(`${API_BASE}/create_rows`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ rows: newRows }),
+            });
+            if (!res.ok) {
+                const err = await res.json().catch(() => ({}));
+                throw new Error(err.error ?? `Create failed: ${res.status}`);
+            }
+            const json = await res.json();
+            const info = json.rows.map(r => `(order: ${r.orderNumber})`).join(', ');
+            hot.getPlugin('notification').showMessage({
+                variant: 'success',
+                title: 'Row added',
+                message: `Created: ${info}`,
+                duration: 3000,
+            });
+            return json.rows;
+        },
+        onRowsUpdate: async (rows) => {
+            const payload = rows.map((r) => ({
+                id: r.id,
+                changes: r.changes,
+            }));
+            const res = await fetch(`${API_BASE}/update_rows`, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ rows: payload }),
+            });
+            if (!res.ok) {
+                const err = await res.json().catch(() => ({}));
+                throw new Error(err.error ?? `Update failed: ${res.status}`);
+            }
+        },
+        onRowsRemove: async (rowIds) => {
+            const res = await fetch(`${API_BASE}/remove_rows`, {
+                method: 'DELETE',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ rowIds }),
+            });
+            if (!res.ok)
+                throw new Error(`Delete failed: ${res.status}`);
+        },
+    },
+    beforeRowsMutation(operation, payload) {
+        if (operation === 'remove' && !removeConfirmed) {
+            const rowsRemove = payload.rowsRemove;
+            const count = rowsRemove.length;
+            const notification = hot.getPlugin('notification');
+            const id = notification.showMessage({
+                variant: 'warning',
+                title: 'Delete rows',
+                message: `Delete ${count} row${count !== 1 ? 's' : ''}? This cannot be undone.`,
+                duration: 0,
+                actions: [
+                    {
+                        label: 'Delete',
+                        type: 'primary',
+                        callback: () => {
+                            notification.hide(id);
+                            removeConfirmed = true;
+                            hot.getPlugin('dataProvider').removeRows(rowsRemove).finally(() => {
+                                removeConfirmed = false;
+                            });
+                        },
+                    },
+                    {
+                        label: 'Cancel',
+                        type: 'secondary',
+                        callback: () => notification.hide(id),
+                    },
+                ],
+            });
+            return false;
+        }
+    },
+    pagination: { pageSize: 10 },
+    columnSorting: true,
+    filters: true,
+    dropdownMenu: ['filter_by_condition', 'filter_action_bar'],
+    contextMenu: true,
+    emptyDataState: true,
+    notification: true,
+    dialog: true,
+    colHeaders: ['Order #', 'Customer', 'Status', 'Total', 'Created'],
+    columns: [
+        { data: 'orderNumber', type: 'text' },
+        { data: 'customer', type: 'text' },
+        { data: 'status', type: 'text' },
+        { data: 'total', type: 'numeric', numericFormat: { style: 'currency', currency: 'USD', minimumFractionDigits: 2, maximumFractionDigits: 2 } },
+        { data: 'createdAt', type: 'date', dateFormat: { year: 'numeric', month: '2-digit', day: '2-digit' }, readOnly: true },
+    ],
+    rowHeaders: true,
+    height: 'auto',
+    licenseKey: 'non-commercial-and-evaluation',
+});
+export default hot;

--- a/docs/content/recipes/data-management/server-side-aspnet/javascript/example1.ts
+++ b/docs/content/recipes/data-management/server-side-aspnet/javascript/example1.ts
@@ -172,7 +172,6 @@ const hot = new Handsontable(container, {
   contextMenu:    true,
   emptyDataState: true,
   notification:   true,
-  dialog:         true,
 
   colHeaders: ['Order #', 'Customer', 'Status', 'Total', 'Created'],
   columns: [

--- a/docs/content/recipes/data-management/server-side-aspnet/javascript/example1.ts
+++ b/docs/content/recipes/data-management/server-side-aspnet/javascript/example1.ts
@@ -1,0 +1,191 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+import type { DataProviderQueryParameters } from 'handsontable/plugins/dataProvider';
+
+registerAllModules();
+
+interface AspNetResponse {
+  rows: object[];
+  totalRows: number;
+}
+
+interface OrderRow {
+  id: number;
+  orderNumber: string;
+}
+
+// Serializes fetchRows query parameters into a URL the ASP.NET Core model
+// binder understands.
+//
+// Handsontable sends:
+//   sort:    { prop: 'orderNumber', order: 'asc' }  or  null
+//   filters: [{ prop, conditions: [{ name, args }] }]  or  null
+//
+// ASP.NET Core's default model binder reads nested properties from dot
+// notation and collections from bracket-indexed dot notation:
+//   pageSize, sort.prop, sort.order, filters[N].prop/condition/value
+function buildUrl(base: string, { page, pageSize, sort, filters }: DataProviderQueryParameters): string {
+  const params = new URLSearchParams();
+
+  params.set('page', String(page));
+  params.set('pageSize', String(pageSize));
+
+  if (sort?.prop) {
+    params.set('sort.prop', sort.prop);
+    params.set('sort.order', sort.order ?? 'asc');
+  }
+
+  if (filters?.length) {
+    let idx = 0;
+    filters.forEach(({ prop, conditions }) => {
+      (conditions || []).forEach(({ name, args }) => {
+        if (!name) return;
+        params.set(`filters[${idx}].prop`, prop);
+        params.set(`filters[${idx}].condition`, name);
+        const a = args ?? [];
+        if (a[0] != null) params.set(`filters[${idx}].value`, String(a[0]));
+        idx++;
+      });
+    });
+  }
+
+  return `${base}?${params.toString()}`;
+}
+
+const API_BASE = 'http://localhost:5000/api/orders';
+
+const container = document.querySelector('#example1')!;
+
+let removeConfirmed = false;
+
+// eslint-disable-next-line no-unused-vars
+const hot = new Handsontable(container, {
+  dataProvider: {
+    rowId: 'id',
+
+    fetchRows: async (queryParameters, { signal }) => {
+      const url = buildUrl(API_BASE, queryParameters);
+      const res = await fetch(url, { signal });
+
+      if (!res.ok) throw new Error(`Fetch failed: ${res.status}`);
+
+      const json = await res.json() as AspNetResponse;
+
+      return { rows: json.rows, totalRows: json.totalRows };
+    },
+
+    onRowsCreate: async ({ rowsAmount }) => {
+      const newRows = Array.from({ length: rowsAmount }, () => ({
+        orderNumber: `ORD-${Date.now()}-${Math.random().toString(36).slice(2, 6).toUpperCase()}`,
+        customer: 'New Customer',
+        status: 'pending',
+        total: 0,
+      }));
+
+      const res = await fetch(`${API_BASE}/create_rows`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ rows: newRows }),
+      });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({})) as { error?: string };
+        throw new Error(err.error ?? `Create failed: ${res.status}`);
+      }
+
+      const json = await res.json() as { rows: OrderRow[] };
+      const info = json.rows.map(r => `(order: ${r.orderNumber})`).join(', ');
+      hot.getPlugin('notification').showMessage({
+        variant: 'success',
+        title: 'Row added',
+        message: `Created: ${info}`,
+        duration: 3000,
+      });
+      return json.rows;
+    },
+
+    onRowsUpdate: async (rows) => {
+      const payload = (rows as { id: unknown; changes: unknown }[]).map((r) => ({
+        id: r.id,
+        changes: r.changes,
+      }));
+      const res = await fetch(`${API_BASE}/update_rows`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ rows: payload }),
+      });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({})) as { error?: string };
+        throw new Error(err.error ?? `Update failed: ${res.status}`);
+      }
+    },
+
+    onRowsRemove: async (rowIds) => {
+      const res = await fetch(`${API_BASE}/remove_rows`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ rowIds }),
+      });
+
+      if (!res.ok) throw new Error(`Delete failed: ${res.status}`);
+    },
+  },
+
+  beforeRowsMutation(operation, payload) {
+    if (operation === 'remove' && !removeConfirmed) {
+      const rowsRemove = (payload as { rowsRemove: unknown[] }).rowsRemove;
+      const count = rowsRemove.length;
+      const notification = hot.getPlugin('notification');
+      const id = notification.showMessage({
+        variant: 'warning',
+        title: 'Delete rows',
+        message: `Delete ${count} row${count !== 1 ? 's' : ''}? This cannot be undone.`,
+        duration: 0,
+        actions: [
+          {
+            label: 'Delete',
+            type: 'primary',
+            callback: () => {
+              notification.hide(id);
+              removeConfirmed = true;
+              hot.getPlugin('dataProvider').removeRows(rowsRemove).finally(() => {
+                removeConfirmed = false;
+              });
+            },
+          },
+          {
+            label: 'Cancel',
+            type: 'secondary',
+            callback: () => notification.hide(id),
+          },
+        ],
+      });
+      return false;
+    }
+  },
+
+  pagination:     { pageSize: 10 },
+  columnSorting:  true,
+  filters:        true,
+  dropdownMenu:   ['filter_by_condition', 'filter_action_bar'],
+  contextMenu:    true,
+  emptyDataState: true,
+  notification:   true,
+  dialog:         true,
+
+  colHeaders: ['Order #', 'Customer', 'Status', 'Total', 'Created'],
+  columns: [
+    { data: 'orderNumber', type: 'text' },
+    { data: 'customer',    type: 'text' },
+    { data: 'status',      type: 'text' },
+    { data: 'total',       type: 'numeric', numericFormat: { style: 'currency', currency: 'USD', minimumFractionDigits: 2, maximumFractionDigits: 2 } },
+    { data: 'createdAt',   type: 'date', dateFormat: { year: 'numeric', month: '2-digit', day: '2-digit' }, readOnly: true },
+  ],
+
+  rowHeaders:  true,
+  height:      'auto',
+  licenseKey:  'non-commercial-and-evaluation',
+} as Handsontable.GridSettings);
+
+export default hot;

--- a/docs/content/recipes/data-management/server-side-aspnet/react/example1.jsx
+++ b/docs/content/recipes/data-management/server-side-aspnet/react/example1.jsx
@@ -34,7 +34,8 @@ function buildUrl(base, { page, pageSize, sort, filters }) {
         if (!name) return;
         params.set(`filters[${idx}].prop`, prop);
         params.set(`filters[${idx}].condition`, name);
-        params.set(`filters[${idx}].value`, args?.[0] ?? '');
+        const a = args ?? [];
+        if (a[0] != null) params.set(`filters[${idx}].value`, String(a[0]));
         idx++;
       });
     });
@@ -170,7 +171,6 @@ const ExampleComponent = () => {
         contextMenu={true}
         emptyDataState={true}
         notification={true}
-        dialog={true}
         colHeaders={['Order #', 'Customer', 'Status', 'Total', 'Created']}
         columns={[
           { data: 'orderNumber', type: 'text' },

--- a/docs/content/recipes/data-management/server-side-aspnet/react/example1.jsx
+++ b/docs/content/recipes/data-management/server-side-aspnet/react/example1.jsx
@@ -1,0 +1,190 @@
+import { useCallback, useMemo, useRef } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const API_BASE = 'http://localhost:5000/api/orders';
+
+// Serializes fetchRows query parameters into a URL the ASP.NET Core model
+// binder understands.
+//
+// Handsontable sends:
+//   sort:    { prop: 'orderNumber', order: 'asc' }  or  null
+//   filters: [{ prop, conditions: [{ name, args }] }]  or  null
+//
+// ASP.NET Core's default model binder reads nested properties from dot
+// notation and collections from bracket-indexed dot notation:
+//   pageSize, sort.prop, sort.order, filters[N].prop/condition/value
+function buildUrl(base, { page, pageSize, sort, filters }) {
+  const params = new URLSearchParams();
+
+  params.set('page', String(page));
+  params.set('pageSize', String(pageSize));
+
+  if (sort?.prop) {
+    params.set('sort.prop', sort.prop);
+    params.set('sort.order', sort.order ?? 'asc');
+  }
+
+  if (filters?.length) {
+    let idx = 0;
+    filters.forEach(({ prop, conditions }) => {
+      (conditions || []).forEach(({ name, args }) => {
+        if (!name) return;
+        params.set(`filters[${idx}].prop`, prop);
+        params.set(`filters[${idx}].condition`, name);
+        params.set(`filters[${idx}].value`, args?.[0] ?? '');
+        idx++;
+      });
+    });
+  }
+
+  return `${base}?${params.toString()}`;
+}
+
+const ExampleComponent = () => {
+  const hotRef = useRef(null);
+  const removeConfirmedRef = useRef(false);
+
+  const fetchRows = useCallback(async ({ page, pageSize, sort, filters }, { signal }) => {
+    const url = buildUrl(API_BASE, { page, pageSize, sort, filters });
+    const res = await fetch(url, { signal });
+
+    if (!res.ok) throw new Error(`Fetch failed: ${res.status}`);
+
+    // ASP.NET Core returns: { rows: [...], totalRows: n }
+    const json = await res.json();
+
+    return { rows: json.rows, totalRows: json.totalRows };
+  }, []);
+
+  const onRowsCreate = useCallback(async ({ rowsAmount }) => {
+    const newRows = Array.from({ length: rowsAmount }, () => ({
+      orderNumber: `ORD-${Date.now()}-${Math.random().toString(36).slice(2, 6).toUpperCase()}`,
+      customer: 'New Customer',
+      status: 'pending',
+      total: 0,
+    }));
+
+    const res = await fetch(`${API_BASE}/create_rows`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rows: newRows }),
+    });
+
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.error || `Create failed: ${res.status}`);
+    }
+
+    const json = await res.json();
+    const info = json.rows.map(r => `(order: ${r.orderNumber})`).join(', ');
+    hotRef.current?.hotInstance?.getPlugin('notification').showMessage({
+      variant: 'success',
+      title: 'Row added',
+      message: `Created: ${info}`,
+      duration: 3000,
+    });
+    return json.rows;
+  }, []);
+
+  const onRowsUpdate = useCallback(async (rows) => {
+    const res = await fetch(`${API_BASE}/update_rows`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        rows: rows.map((r) => ({ id: r.id, changes: r.changes })),
+      }),
+    });
+
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.error || `Update failed: ${res.status}`);
+    }
+  }, []);
+
+  const onRowsRemove = useCallback(async (rowIds) => {
+    const res = await fetch(`${API_BASE}/remove_rows`, {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rowIds }),
+    });
+
+    if (!res.ok) throw new Error(`Delete failed: ${res.status}`);
+  }, []);
+
+  const dataProvider = useMemo(
+    () => ({ rowId: 'id', fetchRows, onRowsCreate, onRowsUpdate, onRowsRemove }),
+    [fetchRows, onRowsCreate, onRowsUpdate, onRowsRemove]
+  );
+
+  // beforeRowsMutation is sync (checks for strict === false return).
+  // Cancel the first attempt, show a notification with Delete/Cancel actions,
+  // and on Delete re-issue the remove via the DataProvider API.
+  const beforeRowsMutation = useCallback((operation, payload) => {
+    if (operation === 'remove' && !removeConfirmedRef.current) {
+      const count = payload.rowsRemove.length;
+      const hot = hotRef.current?.hotInstance;
+      if (!hot) return false;
+
+      const notification = hot.getPlugin('notification');
+      const id = notification.showMessage({
+        variant: 'warning',
+        title: 'Delete rows',
+        message: `Delete ${count} row${count !== 1 ? 's' : ''}? This cannot be undone.`,
+        duration: 0,
+        actions: [
+          {
+            label: 'Delete',
+            type: 'primary',
+            callback: () => {
+              notification.hide(id);
+              removeConfirmedRef.current = true;
+              hot.getPlugin('dataProvider').removeRows(payload.rowsRemove).finally(() => {
+                removeConfirmedRef.current = false;
+              });
+            },
+          },
+          {
+            label: 'Cancel',
+            type: 'secondary',
+            callback: () => notification.hide(id),
+          },
+        ],
+      });
+      return false;
+    }
+  }, []);
+
+  return (
+    <div>
+      <HotTable
+        ref={hotRef}
+        dataProvider={dataProvider}
+        beforeRowsMutation={beforeRowsMutation}
+        pagination={{ pageSize: 10 }}
+        columnSorting={true}
+        filters={true}
+        dropdownMenu={['filter_by_condition', 'filter_action_bar']}
+        contextMenu={true}
+        emptyDataState={true}
+        notification={true}
+        dialog={true}
+        colHeaders={['Order #', 'Customer', 'Status', 'Total', 'Created']}
+        columns={[
+          { data: 'orderNumber', type: 'text' },
+          { data: 'customer',    type: 'text' },
+          { data: 'status',      type: 'text' },
+          { data: 'total',       type: 'numeric', numericFormat: { style: 'currency', currency: 'USD', minimumFractionDigits: 2, maximumFractionDigits: 2 } },
+          { data: 'createdAt',   type: 'date', dateFormat: { year: 'numeric', month: '2-digit', day: '2-digit' }, readOnly: true },
+        ]}
+        rowHeaders={true}
+        height="auto"
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </div>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/data-management/server-side-aspnet/react/example1.tsx
+++ b/docs/content/recipes/data-management/server-side-aspnet/react/example1.tsx
@@ -1,0 +1,204 @@
+import { useCallback, useMemo, useRef } from 'react';
+import { HotTable, HotTableRef } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import type {
+  DataProviderQueryParameters,
+  DataProviderFetchOptions,
+  DataProviderFetchResult,
+} from 'handsontable/plugins/dataProvider';
+
+registerAllModules();
+
+const API_BASE = 'http://localhost:5000/api/orders';
+
+interface AspNetResponse {
+  rows: object[];
+  totalRows: number;
+}
+
+// Serializes fetchRows query parameters into a URL the ASP.NET Core model
+// binder understands.
+//
+// Handsontable sends:
+//   sort:    { prop: 'orderNumber', order: 'asc' }  or  null
+//   filters: [{ prop, conditions: [{ name, args }] }]  or  null
+//
+// ASP.NET Core's default model binder reads nested properties from dot
+// notation and collections from bracket-indexed dot notation:
+//   pageSize, sort.prop, sort.order, filters[N].prop/condition/value
+function buildUrl(base: string, { page, pageSize, sort, filters }: DataProviderQueryParameters): string {
+  const params = new URLSearchParams();
+
+  params.set('page', String(page));
+  params.set('pageSize', String(pageSize));
+
+  if (sort?.prop) {
+    params.set('sort.prop', sort.prop);
+    params.set('sort.order', sort.order ?? 'asc');
+  }
+
+  if (filters?.length) {
+    let idx = 0;
+    filters.forEach(({ prop, conditions }) => {
+      (conditions || []).forEach(({ name, args }) => {
+        if (!name) return;
+        params.set(`filters[${idx}].prop`, prop);
+        params.set(`filters[${idx}].condition`, name);
+        const a = args ?? [];
+        if (a[0] != null) params.set(`filters[${idx}].value`, String(a[0]));
+        idx++;
+      });
+    });
+  }
+
+  return `${base}?${params.toString()}`;
+}
+
+const ExampleComponent = () => {
+  const hotRef = useRef<HotTableRef>(null);
+  const removeConfirmedRef = useRef(false);
+
+  const fetchRows = useCallback(
+    async (params: DataProviderQueryParameters, { signal }: DataProviderFetchOptions): Promise<DataProviderFetchResult> => {
+      const url = buildUrl(API_BASE, params);
+      const res = await fetch(url, { signal });
+
+      if (!res.ok) throw new Error(`Fetch failed: ${res.status}`);
+
+      const json = await res.json() as AspNetResponse;
+
+      return { rows: json.rows, totalRows: json.totalRows };
+    },
+    []
+  );
+
+  const onRowsCreate = useCallback(async (payload: unknown): Promise<unknown[]> => {
+    const { rowsAmount } = payload as { rowsAmount: number };
+    const newRows = Array.from({ length: rowsAmount }, () => ({
+      orderNumber: `ORD-${Date.now()}-${Math.random().toString(36).slice(2, 6).toUpperCase()}`,
+      customer: 'New Customer',
+      status: 'pending',
+      total: 0,
+    }));
+
+    const res = await fetch(`${API_BASE}/create_rows`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rows: newRows }),
+    });
+
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({})) as { error?: string };
+      throw new Error(err.error ?? `Create failed: ${res.status}`);
+    }
+
+    const json = await res.json() as { rows: Array<{ orderNumber: string }> };
+    const info = json.rows.map(r => `(order: ${r.orderNumber})`).join(', ');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (hotRef.current?.hotInstance?.getPlugin('notification') as any)?.showMessage({
+      variant: 'success',
+      title: 'Row added',
+      message: `Created: ${info}`,
+      duration: 3000,
+    });
+    return json.rows;
+  }, []);
+
+  const onRowsUpdate = useCallback(async (rows: unknown): Promise<void> => {
+    const payload = (rows as { id: unknown; changes: unknown }[]).map((r) => ({
+      id: r.id,
+      changes: r.changes,
+    }));
+    const res = await fetch(`${API_BASE}/update_rows`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rows: payload }),
+    });
+
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({})) as { error?: string };
+      throw new Error(err.error ?? `Update failed: ${res.status}`);
+    }
+  }, []);
+
+  const onRowsRemove = useCallback(async (rowIds: unknown[]): Promise<void> => {
+    const res = await fetch(`${API_BASE}/remove_rows`, {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ rowIds }),
+    });
+
+    if (!res.ok) throw new Error(`Delete failed: ${res.status}`);
+  }, []);
+
+  const dataProvider = useMemo(
+    () => ({ rowId: 'id', fetchRows, onRowsCreate, onRowsUpdate, onRowsRemove }),
+    [fetchRows, onRowsCreate, onRowsUpdate, onRowsRemove]
+  );
+
+  const beforeRowsMutation = useCallback((operation: string, payload: { rowsRemove: unknown[] }) => {
+    if (operation === 'remove' && !removeConfirmedRef.current) {
+      const count = payload.rowsRemove.length;
+      const hot = hotRef.current?.hotInstance;
+      if (!hot) return false;
+
+      const notification = hot.getPlugin('notification');
+      const id = notification.showMessage({
+        variant: 'warning',
+        title: 'Delete rows',
+        message: `Delete ${count} row${count !== 1 ? 's' : ''}? This cannot be undone.`,
+        duration: 0,
+        actions: [
+          {
+            label: 'Delete',
+            type: 'primary',
+            callback: () => {
+              notification.hide(id);
+              removeConfirmedRef.current = true;
+              hot.getPlugin('dataProvider').removeRows(payload.rowsRemove).finally(() => {
+                removeConfirmedRef.current = false;
+              });
+            },
+          },
+          {
+            label: 'Cancel',
+            type: 'secondary',
+            callback: () => notification.hide(id),
+          },
+        ],
+      });
+      return false;
+    }
+  }, []);
+
+  return (
+    <div>
+      <HotTable
+        ref={hotRef}
+        dataProvider={dataProvider}
+        beforeRowsMutation={beforeRowsMutation}
+        pagination={{ pageSize: 10 }}
+        columnSorting={true}
+        filters={true}
+        dropdownMenu={['filter_by_condition', 'filter_action_bar']}
+        contextMenu={true}
+        emptyDataState={true}
+        notification={true}
+        dialog={true}
+        colHeaders={['Order #', 'Customer', 'Status', 'Total', 'Created']}
+        columns={[
+          { data: 'orderNumber', type: 'text' },
+          { data: 'customer',    type: 'text' },
+          { data: 'status',      type: 'text' },
+          { data: 'total',       type: 'numeric', numericFormat: { style: 'currency', currency: 'USD', minimumFractionDigits: 2, maximumFractionDigits: 2 } },
+          { data: 'createdAt',   type: 'date', dateFormat: { year: 'numeric', month: '2-digit', day: '2-digit' }, readOnly: true },
+        ]}
+        rowHeaders={true}
+        height="auto"
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </div>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/recipes/data-management/server-side-aspnet/react/example1.tsx
+++ b/docs/content/recipes/data-management/server-side-aspnet/react/example1.tsx
@@ -184,7 +184,6 @@ const ExampleComponent = () => {
         contextMenu={true}
         emptyDataState={true}
         notification={true}
-        dialog={true}
         colHeaders={['Order #', 'Customer', 'Status', 'Total', 'Created']}
         columns={[
           { data: 'orderNumber', type: 'text' },

--- a/docs/content/recipes/data-management/server-side-aspnet/server-side-aspnet.md
+++ b/docs/content/recipes/data-management/server-side-aspnet/server-side-aspnet.md
@@ -1,0 +1,327 @@
+---
+title: Server-side data with ASP.NET Core
+metaTitle: Server-side Data with ASP.NET Core - JavaScript Data Grid | Handsontable
+description: Connect Handsontable's dataProvider plugin to an ASP.NET Core Web API backend with paginated fetching, server-side sorting and filtering, and full CRUD using EF Core and SQLite.
+permalink: /recipes/data-management/server-side-aspnet
+canonicalUrl: /recipes/data-management/server-side-aspnet
+tags:
+  - aspnet
+  - asp-net-core
+  - dotnet
+  - entity-framework
+  - server-side
+  - data-provider
+  - recipe
+react:
+  metaTitle: Server-side Data with ASP.NET Core - React Data Grid | Handsontable
+angular:
+  metaTitle: Server-side Data with ASP.NET Core - Angular Data Grid | Handsontable
+vue:
+  metaTitle: Server-side Data with ASP.NET Core - Vue Data Grid | Handsontable
+searchCategory: Recipes
+category: Data Management
+type: how-to
+menuTag: new
+---
+
+This tutorial shows how to wire Handsontable's `dataProvider` plugin to an [ASP.NET Core](https://dotnet.microsoft.com/apps/aspnet) Web API backend. The backend handles pagination, sorting, and filtering on the server. The frontend displays results and sends every edit back to the API.
+
+**Difficulty:** Intermediate  
+**Time:** ~30 minutes  
+**Backend:** .NET 8 SDK, ASP.NET Core MVC controllers, EF Core 8 with SQLite
+
+## What you'll build
+
+An Order Management grid that:
+
+- Loads orders page by page from an ASP.NET Core API
+- Sorts orders by any column on the server
+- Filters orders by column value on the server
+- Creates, updates, and deletes rows via dedicated collection endpoints
+- Uses ASP.NET Core's default camelCase JSON so Handsontable's column keys match the API without extra configuration
+
+## Before you begin
+
+- .NET 8 SDK installed
+- Node.js 18 or later and npm installed
+
+No database server is required -- the backend stores data in a local SQLite file.
+
+## Step 1 -- Create the project and add EF Core
+
+Create a Web API project that uses MVC controllers:
+
+```shell
+dotnet new webapi --use-controllers -n OrdersApi
+cd OrdersApi
+```
+
+Add the EF Core SQLite provider:
+
+```shell
+dotnet add package Microsoft.EntityFrameworkCore.Sqlite
+dotnet add package Microsoft.EntityFrameworkCore.Design
+```
+
+**Why these choices?**
+
+- `--use-controllers` scaffolds the project with `[ApiController]` MVC controllers instead of Minimal API endpoints. Controllers group the pagination, sorting, filtering, and batch-CRUD logic this recipe needs into one typed class, instead of several `app.MapGet`/`app.MapPost` lambdas in `Program.cs`.
+- SQLite requires no separate database server or Docker setup -- the whole backend runs with `dotnet run`. `Microsoft.EntityFrameworkCore.Design` adds the tooling EF Core needs even though this recipe uses `EnsureCreated()` instead of migrations.
+
+## Step 2 -- Define the `Order` entity and the DbContext
+
+Create `Order.cs`:
+
+::: example #cs-order
+
+@[code csharp](@/content/recipes/data-management/server-side-aspnet/server/Order.cs)
+
+:::
+
+Create `AppDbContext.cs`:
+
+::: example #cs-dbcontext
+
+@[code csharp](@/content/recipes/data-management/server-side-aspnet/server/AppDbContext.cs)
+
+:::
+
+**What's happening:**
+
+- The primary key `Id` is auto-incremented by SQLite. It becomes the `rowId` value on the Handsontable side.
+- SQLite has no native `decimal` column type -- EF Core stores `decimal` properties as `TEXT` by default, which sorts and compares lexicographically instead of numerically. `HasConversion<double>()` on `Total` stores it as a real number instead, so sorting by `total` and filtering with `gt`/`gte`/`lt`/`lte` behave correctly. This conversion is SQLite-specific -- PostgreSQL or SQL Server don't need it.
+
+## Step 3 -- Seed the database
+
+Create `DbInitializer.cs`:
+
+::: example #cs-dbinitializer
+
+@[code csharp](@/content/recipes/data-management/server-side-aspnet/server/DbInitializer.cs)
+
+:::
+
+**What's happening:**
+
+- The seed script inserts 50 orders across realistic statuses (`pending`, `paid`, `shipped`, `delivered`, `cancelled`). It checks whether data already exists, so restarting the app doesn't duplicate rows.
+- This recipe calls `Database.EnsureCreated()` in `Program.cs` (Step 4) instead of running EF Core migrations. `EnsureCreated()` creates the schema directly from the model, which is enough for a tutorial. For a production app, use `dotnet ef migrations add` and `Database.Migrate()` instead, so schema changes are versioned.
+
+## Step 4 -- Wire up `Program.cs`
+
+Replace the generated `Program.cs` with:
+
+::: example #cs-program
+
+@[code csharp](@/content/recipes/data-management/server-side-aspnet/server/Program.cs)
+
+:::
+
+**What's happening:**
+
+- `AddDbContext<AppDbContext>` registers the database connection as a scoped service, so each request gets its own `DbContext` instance.
+- `AddScoped<OrdersService>` registers the service built in Step 8.
+- The `using (var scope = ...)` block runs once at startup, before `app.Run()`, to create the SQLite file and seed it.
+
+The resulting routes, all under `/api/orders`, are:
+
+| Method | URL | Handsontable callback |
+|---|---|---|
+| `GET` | `/api/orders` | `fetchRows` |
+| `POST` | `/api/orders/create_rows` | `onRowsCreate` |
+| `PATCH` | `/api/orders/update_rows` | `onRowsUpdate` |
+| `DELETE` | `/api/orders/remove_rows` | `onRowsRemove` |
+
+## Step 5 -- Configure CORS
+
+CORS is registered in `Program.cs` (Step 4). This step explains why.
+
+**What's happening:**
+
+- `AddCors` with `AllowFrontend` permits requests from `http://localhost:5173`, the default Vite dev server port. Without it, the browser blocks every request from the frontend before ASP.NET Core sees it.
+- `app.UseCors("AllowFrontend")` must run **before** `app.MapControllers()`. If the order is reversed, the routing middleware handles the request first and the CORS headers are never attached, so preflight `OPTIONS` requests for `PATCH` and `DELETE` fail.
+
+**Production note:** Replace `http://localhost:5173` with your deployed frontend's domain. Never call `AllowAnyOrigin()` together with `AllowAnyHeader()` and `AllowAnyMethod()` on a policy that also accepts credentials.
+
+## Step 6 -- Decide on the case convention
+
+ASP.NET Core Web API projects serialize JSON with `JsonSerializerDefaults.Web` by default, which camelCases every property: the C# property `OrderNumber` becomes `orderNumber` in the response, and an incoming `{ "orderNumber": "ORD-1001" }` body binds to `OrderNumber` because property-name matching is case-insensitive. This means Handsontable's column `data` keys can use the same camelCase names as the JSON payload with no extra configuration on either side.
+
+**The pitfall:** overriding `JsonSerializerOptions.PropertyNamingPolicy` to `null` -- for example, to match a legacy client that expects PascalCase -- changes every response key at once. If the Handsontable columns still declare `data: 'orderNumber'`, the grid renders empty cells because the server now returns `OrderNumber`.
+
+**Why this matters for the whitelist dictionaries in Step 8:** the sort and filter column whitelists must be keyed by the wire-format name (`orderNumber`), not the C# property name (`OrderNumber`), because that's the string Handsontable actually sends in the query string.
+
+## Step 7 -- Bind Handsontable's query parameters
+
+Create `OrdersQuery.cs`:
+
+::: example #cs-ordersquery
+
+@[code csharp](@/content/recipes/data-management/server-side-aspnet/server/OrdersQuery.cs)
+
+:::
+
+Create `Payloads.cs`:
+
+::: example #cs-payloads
+
+@[code csharp](@/content/recipes/data-management/server-side-aspnet/server/Payloads.cs)
+
+:::
+
+**What's happening:**
+
+Backends built on Express, Rails, or PHP typically parse Handsontable's filters from bracket-notation query parameters: `filters[0][prop]=status`. ASP.NET Core's default model binder doesn't understand that bracket syntax for binding a request into a C# object. Instead, it binds nested properties from **dot notation** and collections of complex types from indexed dot notation:
+
+```
+?page=1&pageSize=10&sort.prop=total&sort.order=desc&filters[0].prop=status&filters[0].condition=eq&filters[0].value=shipped
+```
+
+Given `[FromQuery] OrdersQuery query`, `sort.prop` and `sort.order` populate `query.Sort`, and each `filters[N].*` triple populates one `FilterDto` in `query.Filters` -- all without a custom model binder or per-property `[FromQuery]` attributes. The frontend `buildUrl` function (Step 10) targets this format, which is the only part of this recipe's frontend code that differs from the Express or Rails recipes' `buildUrl`.
+
+`OrderCreateDto` has no `Id` or `CreatedAt` property. Where a dynamically typed backend blocks system-managed fields by filtering a dictionary at runtime, here the type system does it structurally: there's no property for a client to set.
+
+## Step 8 -- Build the service
+
+Create `OrdersService.cs`:
+
+::: example #cs-ordersservice
+
+@[code csharp](@/content/recipes/data-management/server-side-aspnet/server/OrdersService.cs)
+
+:::
+
+### Whitelist sortable and filterable columns
+
+`ColumnMap` maps every wire-format column name Handsontable can send to the matching C# property name. `ApplySort` and `ApplyFilters` both call `ColumnMap.TryGetValue` before touching the query -- an unrecognized column name is silently ignored instead of reaching `EF.Property<T>`. LINQ parameterizes filter *values* automatically, but a column *name* that comes from client input still needs validation before it becomes part of a dynamically built expression.
+
+### Sort helper
+
+`ApplySort` reads `query.Sort?.Prop`. If it's missing or not in `ColumnMap`, the query falls back to `CreatedAt DESC`. Otherwise it calls `EF.Property<object>(o, property)` inside `OrderBy`/`OrderByDescending` so the property to sort by is chosen at runtime, from a name that already passed the whitelist check.
+
+### Filter helper
+
+`ApplyFilters` loops over `query.Filters` and dispatches each one to `ApplyStringFilter` or `ApplyNumericFilter` based on whether the column is in `StringColumns`.
+
+- String columns (`orderNumber`, `customer`, `status`) support `eq`, `neq`, `contains`, `not_contains`, `begins_with`, `ends_with`, `empty`, and `not_empty`. `contains`/`begins_with`/`ends_with` use `EF.Functions.Like` with an explicit `ESCAPE '\'` clause, and `EscapeLike` escapes `%`, `_`, and `\` in the user-supplied value first, so those characters are matched literally instead of acting as LIKE wildcards.
+- The numeric column (`total`) supports `eq`, `neq`, `gt`, `gte`, `lt`, and `lte`. `empty`/`not_empty` are rejected for `total` because it's a non-nullable column -- there's no empty state to check. `decimal.TryParse` guards against malformed numeric input; a value that doesn't parse is ignored rather than throwing a `500`.
+- Multiple filters combine with `AND`, because each call reassigns `query` to a further-restricted `IQueryable`. `dataProvider` doesn't send `OR` groups by default.
+
+### Pagination
+
+`GetOrdersAsync` runs `CountAsync()` on the filtered-but-unsorted query to get `totalRows`, then applies sorting and `Skip`/`Take` for the current page. Handsontable sends a 1-based `page` index, so `Skip` uses `(page - 1) * pageSize`.
+
+### Batch CRUD
+
+- `CreateRowsAsync` builds new `Order` entities from `OrderCreateDto`, inserts them inside a transaction, and returns them with their database-assigned `Id`. `dataProvider` uses the returned rows to replace its client-side placeholder IDs.
+- `UpdateRowsAsync` loads each order by `Id` and applies only the keys present in `EditableColumns` from the `Changes` dictionary -- `id` and `createdAt` are never in that set, so they can't be overwritten even if a client sends them.
+- `RemoveRowsAsync` calls EF Core's `ExecuteDeleteAsync()`, which issues a single `DELETE FROM Orders WHERE Id IN (...)` instead of loading and deleting each row individually.
+
+## Step 9 -- Create the controller
+
+Create `OrdersController.cs`:
+
+::: example #cs-orderscontroller
+
+@[code csharp](@/content/recipes/data-management/server-side-aspnet/server/OrdersController.cs)
+
+:::
+
+This thin controller has no business logic of its own -- every method delegates to `OrdersService` and maps the result to an HTTP response: `201 Created` for new rows, `200 OK` with the updated rows for edits, and `204 No Content` for deletes.
+
+**Antiforgery in API projects:** `dotnet new webapi --use-controllers` scaffolds a project with no antiforgery validation enabled by default -- `AddAntiforgery` and `[ValidateAntiForgeryToken]` are opt-in, and only matter when the app uses cookie-based authentication. A `fetch()` call from the browser using an `Authorization` header (or no authentication at all, as in this recipe) never needs an antiforgery token, because the browser doesn't attach that header automatically the way it attaches cookies.
+
+## Step 10 -- Build the request URL and initialize Handsontable
+
+Run the backend:
+
+```shell
+dotnet run --urls http://localhost:5000
+```
+
+Pinning the URL keeps the port stable -- otherwise the template's `launchSettings.json` can assign a random port on each machine, and the frontend's hardcoded API address (below) would need to change to match. Then start your frontend dev server (for example, `npm run dev` with Vite) and open it in the browser. The complete frontend code is in the files below.
+
+::: only-for javascript vue
+
+::: example #javascript-aspnet --code-only
+
+@[code js](@/content/recipes/data-management/server-side-aspnet/javascript/example1.js)
+
+:::
+
+:::
+
+::: only-for typescript
+
+::: example #typescript-aspnet --code-only
+
+@[code ts](@/content/recipes/data-management/server-side-aspnet/javascript/example1.ts)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #react-aspnet --code-only
+
+@[code](@/content/recipes/data-management/server-side-aspnet/react/example1.jsx)
+
+:::
+
+:::
+
+::: only-for angular
+
+::: example #angular-aspnet --code-only
+
+@[code](@/content/recipes/data-management/server-side-aspnet/angular/example1.ts)
+@[code](@/content/recipes/data-management/server-side-aspnet/angular/example1.html)
+
+:::
+
+:::
+
+**Key options explained:**
+
+| Option | What it does |
+|---|---|
+| `rowId: 'id'` | Tells `dataProvider` which field uniquely identifies a row. Must match the entity's primary key property, serialized to camelCase (`id`). |
+| `{ signal }` in `fetchRows` | Pass the `AbortSignal` to `fetch()` so in-flight requests are canceled when the user sorts or filters before the previous response arrives. |
+| `{ rowsAmount }` in `onRowsCreate` | `dataProvider` passes the number of rows to add. The frontend builds default objects and sends them as `{ rows: [...] }`. Returning `json.rows` lets `dataProvider` replace client-side placeholder IDs with the ones assigned by SQLite. |
+| `beforeRowsMutation` | Intercepts mutations before they run. Return `false` to cancel. Used here to show a delete-confirmation notification with **Delete**/**Cancel** actions instead of deleting immediately. |
+| `pagination: { pageSize: 10 }` | Enables the pagination toolbar. `dataProvider` passes the current page and size to `fetchRows` automatically. |
+| `columnSorting: true` | Enables column header click-to-sort. The sort state is passed to `fetchRows`. |
+| `filters: true` with `dropdownMenu` | Renders the column filter UI. Active conditions are passed to `fetchRows`. |
+| `contextMenu: true` | Enables right-click context menu with **Insert row above / below** and **Remove row** options. |
+| `emptyDataState: true` | Shows a friendly illustration when the API returns zero rows (for example, when a filter matches nothing). |
+| `notification: true` | Shows automatic error toasts when `fetchRows` or a mutation callback throws. Fetch failures include a **Refetch** action. |
+| `dialog: true` | Enables the Dialog plugin used internally by other plugins for confirmation prompts. |
+
+## How it works -- Complete flow
+
+1. **Initial load**: `dataProvider` calls `fetchRows({ page: 1, pageSize: 10 })`. ASP.NET Core returns the first 10 orders and the total row count.
+2. **User clicks a column header**: `columnSorting` updates its sort state and `dataProvider` calls `fetchRows` again with `sort: { prop: 'total', order: 'desc' }`. The frontend builds `sort.prop=total&sort.order=desc`; the controller's `OrdersQuery.Sort` binds it, and `ApplySort` checks `ColumnMap` before calling `OrderByDescending`.
+3. **User applies a column filter**: `Filters` updates its condition list and `dataProvider` calls `fetchRows` with the `filters` array. The frontend serializes each condition as `filters[N].prop/condition/value`; the model binder populates `OrdersQuery.Filters`, and `ApplyFilters` chains `.Where` calls.
+4. **User navigates to page 2**: `dataProvider` calls `fetchRows({ page: 2, pageSize: 10, ... })`. `Skip(10).Take(10)` returns rows 11-20.
+5. **User edits a cell**: `dataProvider` calls `onRowsUpdate` with `[{ id: 7, changes: { total: 142.5 } }]`. The frontend sends `{ rows: [{ id: 7, changes: { total: 142.5 } }] }`. `UpdateRowsAsync` applies only the `total` key inside a transaction.
+6. **User adds a row**: `dataProvider` calls `onRowsCreate`. `CreateRowsAsync` inserts the row and returns it with the database-assigned `id`. `dataProvider` updates its row map so subsequent edits target the correct ID.
+7. **User deletes rows**: `dataProvider` calls `onRowsRemove([3, 7, 14])`. `RemoveRowsAsync` issues a single `DELETE FROM Orders WHERE Id IN (3, 7, 14)`.
+
+## What you learned
+
+- ASP.NET Core Web API projects camelCase JSON by default, so Handsontable's column keys usually need no transformation -- but overriding the naming policy on one side without the other silently breaks the grid.
+- ASP.NET Core's model binder reads nested query parameters from dot notation (`sort.prop`) and indexed collections from `filters[N].prop`, unlike the bracket notation (`filters[0][prop]`) that Express, Rails, and PHP backends parse natively.
+- Validate every column name that reaches `EF.Property<T>` against a fixed whitelist dictionary. Never trust `Sort.Prop` or a filter's `Prop` directly.
+- `HasConversion<double>()` is necessary for `decimal` columns on SQLite, because SQLite has no native decimal type and would otherwise sort and filter the column as text.
+- A typed create DTO with no `Id` or `CreatedAt` property blocks system-managed fields structurally, without runtime filtering.
+- `EF.Functions.Like` with an explicit `ESCAPE` clause, paired with manual escaping of `%`, `_`, and `\`, keeps LIKE-based filters safe from wildcard injection.
+- `UseCors` must run before `MapControllers`, or CORS preflight requests never get their response headers.
+
+## Next steps
+
+- [Server-side data with Spring Boot](@/recipes/data-management/server-side-spring/server-side-spring.md)
+- [Server-side data with Express.js](@/recipes/data-management/server-side-expressjs/server-side-expressjs.md)
+- [Server-side data with NestJS](@/recipes/data-management/server-side-nestjs/server-side-nestjs.md)
+- [Rows pagination guide](@/guides/rows/rows-pagination/rows-pagination.md)
+- [Column filter guide](@/guides/columns/column-filter/column-filter.md)
+- [Rows sorting guide](@/guides/rows/rows-sorting/rows-sorting.md)

--- a/docs/content/recipes/data-management/server-side-aspnet/server-side-aspnet.md
+++ b/docs/content/recipes/data-management/server-side-aspnet/server-side-aspnet.md
@@ -200,10 +200,11 @@ Create `OrdersService.cs`:
 
 ### Filter helper
 
-`ApplyFilters` loops over `query.Filters` and dispatches each one to `ApplyStringFilter` or `ApplyNumericFilter` based on whether the column is in `StringColumns`.
+`ApplyFilters` loops over `query.Filters` and dispatches each one to `ApplyStringFilter`, `ApplyDateFilter`, or `ApplyNumericFilter`, based on whether the column is in `StringColumns`, `DateColumns`, or neither. This three-way split matters because EF Core is strongly typed: calling `EF.Property<decimal>` against a `DateTime` column throws, so each column's filter values must be parsed and compared as the type that column actually is.
 
 - String columns (`orderNumber`, `customer`, `status`) support `eq`, `neq`, `contains`, `not_contains`, `begins_with`, `ends_with`, `empty`, and `not_empty`. `contains`/`begins_with`/`ends_with` use `EF.Functions.Like` with an explicit `ESCAPE '\'` clause, and `EscapeLike` escapes `%`, `_`, and `\` in the user-supplied value first, so those characters are matched literally instead of acting as LIKE wildcards.
-- The numeric column (`total`) supports `eq`, `neq`, `gt`, `gte`, `lt`, and `lte`. `empty`/`not_empty` are rejected for `total` because it's a non-nullable column -- there's no empty state to check. `decimal.TryParse` guards against malformed numeric input; a value that doesn't parse is ignored rather than throwing a `500`.
+- The date column (`createdAt`) supports `eq`, `neq`, `gt`, `gte`, `lt`, and `lte`. `DateTime.TryParse` guards against malformed date input. `eq`/`neq` compare `.Date` on both sides so a filter value of a single day matches every `CreatedAt` timestamp on that day, not just an exact-to-the-second match.
+- The numeric column (`total`) supports `eq`, `neq`, `gt`, `gte`, `lt`, and `lte`. `empty`/`not_empty` are rejected for both `total` and `createdAt` because they're non-nullable columns -- there's no empty state to check. `decimal.TryParse` guards against malformed numeric input; a value that doesn't parse is ignored rather than throwing a `500`.
 - Multiple filters combine with `AND`, because each call reassigns `query` to a further-restricted `IQueryable`. `dataProvider` doesn't send `OR` groups by default.
 
 ### Pagination

--- a/docs/content/recipes/data-management/server-side-aspnet/server-side-aspnet.md
+++ b/docs/content/recipes/data-management/server-side-aspnet/server-side-aspnet.md
@@ -26,11 +26,13 @@ menuTag: new
 
 This tutorial shows how to wire Handsontable's `dataProvider` plugin to an [ASP.NET Core](https://dotnet.microsoft.com/apps/aspnet) Web API backend. The backend handles pagination, sorting, and filtering on the server. The frontend displays results and sends every edit back to the API.
 
+## Overview
+
 **Difficulty:** Intermediate  
 **Time:** ~30 minutes  
 **Backend:** .NET 8 SDK, ASP.NET Core MVC controllers, EF Core 8 with SQLite
 
-## What you'll build
+## What You'll Build
 
 An Order Management grid that:
 
@@ -47,7 +49,7 @@ An Order Management grid that:
 
 No database server is required -- the backend stores data in a local SQLite file.
 
-## Step 1 -- Create the project and add EF Core
+## Step 1: Create the project and add EF Core
 
 Create a Web API project that uses MVC controllers:
 
@@ -68,7 +70,7 @@ dotnet add package Microsoft.EntityFrameworkCore.Design
 - `--use-controllers` scaffolds the project with `[ApiController]` MVC controllers instead of Minimal API endpoints. Controllers group the pagination, sorting, filtering, and batch-CRUD logic this recipe needs into one typed class, instead of several `app.MapGet`/`app.MapPost` lambdas in `Program.cs`.
 - SQLite requires no separate database server or Docker setup -- the whole backend runs with `dotnet run`. `Microsoft.EntityFrameworkCore.Design` adds the tooling EF Core needs even though this recipe uses `EnsureCreated()` instead of migrations.
 
-## Step 2 -- Define the `Order` entity and the DbContext
+## Step 2: Define the `Order` entity and the DbContext
 
 Create `Order.cs`:
 
@@ -91,7 +93,7 @@ Create `AppDbContext.cs`:
 - The primary key `Id` is auto-incremented by SQLite. It becomes the `rowId` value on the Handsontable side.
 - SQLite has no native `decimal` column type -- EF Core stores `decimal` properties as `TEXT` by default, which sorts and compares lexicographically instead of numerically. `HasConversion<double>()` on `Total` stores it as a real number instead, so sorting by `total` and filtering with `gt`/`gte`/`lt`/`lte` behave correctly. This conversion is SQLite-specific -- PostgreSQL or SQL Server don't need it.
 
-## Step 3 -- Seed the database
+## Step 3: Seed the database
 
 Create `DbInitializer.cs`:
 
@@ -106,7 +108,7 @@ Create `DbInitializer.cs`:
 - The seed script inserts 50 orders across realistic statuses (`pending`, `paid`, `shipped`, `delivered`, `cancelled`). It checks whether data already exists, so restarting the app doesn't duplicate rows.
 - This recipe calls `Database.EnsureCreated()` in `Program.cs` (Step 4) instead of running EF Core migrations. `EnsureCreated()` creates the schema directly from the model, which is enough for a tutorial. For a production app, use `dotnet ef migrations add` and `Database.Migrate()` instead, so schema changes are versioned.
 
-## Step 4 -- Wire up `Program.cs`
+## Step 4: Wire up `Program.cs`
 
 Replace the generated `Program.cs` with:
 
@@ -131,18 +133,18 @@ The resulting routes, all under `/api/orders`, are:
 | `PATCH` | `/api/orders/update_rows` | `onRowsUpdate` |
 | `DELETE` | `/api/orders/remove_rows` | `onRowsRemove` |
 
-## Step 5 -- Configure CORS
+## Step 5: Configure CORS
 
 CORS is registered in `Program.cs` (Step 4). This step explains why.
 
 **What's happening:**
 
 - `AddCors` with `AllowFrontend` permits requests from `http://localhost:5173`, the default Vite dev server port. Without it, the browser blocks every request from the frontend before ASP.NET Core sees it.
-- `app.UseCors("AllowFrontend")` must run **before** `app.MapControllers()`. If the order is reversed, the routing middleware handles the request first and the CORS headers are never attached, so preflight `OPTIONS` requests for `PATCH` and `DELETE` fail.
+- `app.UseCors("AllowFrontend")` is registered before `app.MapControllers()` to follow the general ASP.NET Core middleware order -- CORS runs after routing and before authentication/authorization. This project has neither an explicit `UseRouting` call nor any authentication, so swapping these two specific lines wouldn't break anything here. The convention still matters the moment you add `UseAuthentication`/`UseAuthorization`, because CORS has to run before them so a preflight `OPTIONS` request never gets rejected by an auth check.
 
-**Production note:** Replace `http://localhost:5173` with your deployed frontend's domain. Never call `AllowAnyOrigin()` together with `AllowAnyHeader()` and `AllowAnyMethod()` on a policy that also accepts credentials.
+**Production note:** Replace `http://localhost:5173` with your deployed frontend's domain. If you need cookies or an `Authorization` header to travel with cross-origin requests, call `AllowCredentials()` on the policy and list explicit origins -- ASP.NET Core throws at startup if you combine `AllowCredentials()` with `AllowAnyOrigin()`.
 
-## Step 6 -- Decide on the case convention
+## Step 6: Decide on the case convention
 
 ASP.NET Core Web API projects serialize JSON with `JsonSerializerDefaults.Web` by default, which camelCases every property: the C# property `OrderNumber` becomes `orderNumber` in the response, and an incoming `{ "orderNumber": "ORD-1001" }` body binds to `OrderNumber` because property-name matching is case-insensitive. This means Handsontable's column `data` keys can use the same camelCase names as the JSON payload with no extra configuration on either side.
 
@@ -150,7 +152,7 @@ ASP.NET Core Web API projects serialize JSON with `JsonSerializerDefaults.Web` b
 
 **Why this matters for the whitelist dictionaries in Step 8:** the sort and filter column whitelists must be keyed by the wire-format name (`orderNumber`), not the C# property name (`OrderNumber`), because that's the string Handsontable actually sends in the query string.
 
-## Step 7 -- Bind Handsontable's query parameters
+## Step 7: Bind Handsontable's query parameters
 
 Create `OrdersQuery.cs`:
 
@@ -180,7 +182,7 @@ Given `[FromQuery] OrdersQuery query`, `sort.prop` and `sort.order` populate `qu
 
 `OrderCreateDto` has no `Id` or `CreatedAt` property. Where a dynamically typed backend blocks system-managed fields by filtering a dictionary at runtime, here the type system does it structurally: there's no property for a client to set.
 
-## Step 8 -- Build the service
+## Step 8: Build the service
 
 Create `OrdersService.cs`:
 
@@ -203,21 +205,22 @@ Create `OrdersService.cs`:
 `ApplyFilters` loops over `query.Filters` and dispatches each one to `ApplyStringFilter`, `ApplyDateFilter`, or `ApplyNumericFilter`, based on whether the column is in `StringColumns`, `DateColumns`, or neither. This three-way split matters because EF Core is strongly typed: calling `EF.Property<decimal>` against a `DateTime` column throws, so each column's filter values must be parsed and compared as the type that column actually is.
 
 - String columns (`orderNumber`, `customer`, `status`) support `eq`, `neq`, `contains`, `not_contains`, `begins_with`, `ends_with`, `empty`, and `not_empty`. `contains`/`begins_with`/`ends_with` use `EF.Functions.Like` with an explicit `ESCAPE '\'` clause, and `EscapeLike` escapes `%`, `_`, and `\` in the user-supplied value first, so those characters are matched literally instead of acting as LIKE wildcards.
-- The date column (`createdAt`) supports `eq`, `neq`, `gt`, `gte`, `lt`, and `lte`. `DateTime.TryParse` guards against malformed date input. `eq`/`neq` compare `.Date` on both sides so a filter value of a single day matches every `CreatedAt` timestamp on that day, not just an exact-to-the-second match.
-- The numeric column (`total`) supports `eq`, `neq`, `gt`, `gte`, `lt`, and `lte`. `empty`/`not_empty` are rejected for both `total` and `createdAt` because they're non-nullable columns -- there's no empty state to check. `decimal.TryParse` guards against malformed numeric input; a value that doesn't parse is ignored rather than throwing a `500`.
+- The date column (`createdAt`) supports `eq`, `neq`, `gt`, `gte`, `lt`, and `lte`. `DateTime.TryParse` -- with `CultureInfo.InvariantCulture` explicitly, so the parse doesn't depend on the server's OS culture -- guards against malformed date input. `eq`/`neq` compare `.Date` on both sides so a filter value of a single day matches every `CreatedAt` timestamp on that day, not just an exact-to-the-second match.
+- The numeric column (`total`) supports `eq`, `neq`, `gt`, `gte`, `lt`, and `lte`. `empty`/`not_empty` are rejected for both `total` and `createdAt` because they're non-nullable columns -- there's no empty state to check. `decimal.TryParse` -- also pinned to `CultureInfo.InvariantCulture` -- guards against malformed numeric input; a value that doesn't parse is ignored rather than throwing a `500`. Without the invariant culture, a value like `142.5` fails to parse on a server whose default culture uses a comma as the decimal separator, and the filter would silently no-op.
+- Handsontable's Filters plugin offers more conditions than this whitelist covers -- for example, `between`/`not_between` on `total`, and date-specific conditions like `date_before`/`date_after` on `createdAt`. Selecting one of those in the UI produces a filter the server doesn't recognize, so it's ignored and the grid shows unfiltered results. Extending `ApplyNumericFilter`/`ApplyDateFilter` with more `case` arms is a natural next step; this recipe sticks to the condition set the other server-side recipes support.
 - Multiple filters combine with `AND`, because each call reassigns `query` to a further-restricted `IQueryable`. `dataProvider` doesn't send `OR` groups by default.
 
 ### Pagination
 
-`GetOrdersAsync` runs `CountAsync()` on the filtered-but-unsorted query to get `totalRows`, then applies sorting and `Skip`/`Take` for the current page. Handsontable sends a 1-based `page` index, so `Skip` uses `(page - 1) * pageSize`.
+`GetOrdersAsync` runs `CountAsync()` on the filtered-but-unsorted query to get `totalRows`, then applies sorting and `Skip`/`Take` for the current page. Handsontable sends a 1-based `page` index, so `Skip` uses `(page - 1) * pageSize`. `pageSize` is clamped to `MaxPageSize` (100) with `Math.Clamp`, so a client can't force the server to materialize the entire table in one request.
 
 ### Batch CRUD
 
 - `CreateRowsAsync` builds new `Order` entities from `OrderCreateDto`, inserts them inside a transaction, and returns them with their database-assigned `Id`. `dataProvider` uses the returned rows to replace its client-side placeholder IDs.
-- `UpdateRowsAsync` loads each order by `Id` and applies only the keys present in `EditableColumns` from the `Changes` dictionary -- `id` and `createdAt` are never in that set, so they can't be overwritten even if a client sends them.
+- `UpdateRowsAsync` loads each order by `Id` and applies only the keys present in `EditableColumns` from the `Changes` dictionary -- `id` and `createdAt` are never in that set, so they can't be overwritten even if a client sends them. The `total` case also checks `element.ValueKind == JsonValueKind.Number` before calling `GetDecimal()` -- a cleared cell sends JSON `null`, and `GetDecimal()` throws on anything that isn't a JSON number.
 - `RemoveRowsAsync` calls EF Core's `ExecuteDeleteAsync()`, which issues a single `DELETE FROM Orders WHERE Id IN (...)` instead of loading and deleting each row individually.
 
-## Step 9 -- Create the controller
+## Step 9: Create the controller
 
 Create `OrdersController.cs`:
 
@@ -231,7 +234,7 @@ This thin controller has no business logic of its own -- every method delegates 
 
 **Antiforgery in API projects:** `dotnet new webapi --use-controllers` scaffolds a project with no antiforgery validation enabled by default -- `AddAntiforgery` and `[ValidateAntiForgeryToken]` are opt-in, and only matter when the app uses cookie-based authentication. A `fetch()` call from the browser using an `Authorization` header (or no authentication at all, as in this recipe) never needs an antiforgery token, because the browser doesn't attach that header automatically the way it attaches cookies.
 
-## Step 10 -- Build the request URL and initialize Handsontable
+## Step 10: Build the request URL and initialize Handsontable
 
 Run the backend:
 
@@ -295,10 +298,9 @@ Pinning the URL keeps the port stable -- otherwise the template's `launchSetting
 | `filters: true` with `dropdownMenu` | Renders the column filter UI. Active conditions are passed to `fetchRows`. |
 | `contextMenu: true` | Enables right-click context menu with **Insert row above / below** and **Remove row** options. |
 | `emptyDataState: true` | Shows a friendly illustration when the API returns zero rows (for example, when a filter matches nothing). |
-| `notification: true` | Shows automatic error toasts when `fetchRows` or a mutation callback throws. Fetch failures include a **Refetch** action. |
-| `dialog: true` | Enables the Dialog plugin used internally by other plugins for confirmation prompts. |
+| `notification: true` | Shows automatic error toasts when `fetchRows` or a mutation callback throws. Fetch failures include a **Refetch** action. The delete-confirmation prompt in `beforeRowsMutation` is also built on `notification`'s actionable toasts, not a separate dialog. |
 
-## How it works -- Complete flow
+## How It Works -- Complete Flow
 
 1. **Initial load**: `dataProvider` calls `fetchRows({ page: 1, pageSize: 10 })`. ASP.NET Core returns the first 10 orders and the total row count.
 2. **User clicks a column header**: `columnSorting` updates its sort state and `dataProvider` calls `fetchRows` again with `sort: { prop: 'total', order: 'desc' }`. The frontend builds `sort.prop=total&sort.order=desc`; the controller's `OrdersQuery.Sort` binds it, and `ApplySort` checks `ColumnMap` before calling `OrderByDescending`.
@@ -316,7 +318,9 @@ Pinning the URL keeps the port stable -- otherwise the template's `launchSetting
 - `HasConversion<double>()` is necessary for `decimal` columns on SQLite, because SQLite has no native decimal type and would otherwise sort and filter the column as text.
 - A typed create DTO with no `Id` or `CreatedAt` property blocks system-managed fields structurally, without runtime filtering.
 - `EF.Functions.Like` with an explicit `ESCAPE` clause, paired with manual escaping of `%`, `_`, and `\`, keeps LIKE-based filters safe from wildcard injection.
-- `UseCors` must run before `MapControllers`, or CORS preflight requests never get their response headers.
+- ASP.NET Core's general middleware order runs CORS after routing and before authentication/authorization -- keep that convention even in a project like this one that has neither yet, so adding auth later doesn't silently reject preflight requests.
+- Pass `CultureInfo.InvariantCulture` to `decimal.TryParse`/`DateTime.TryParse` in a Web API. Without it, parsing depends on the server's OS culture, and a value the client always formats the same way (JavaScript's `String(142.5)`) can fail or parse differently depending on where the server happens to run.
+- Clamp a client-supplied `pageSize` to a server-side maximum. Without a cap, a single request can force the server to materialize and serialize the entire table.
 
 ## Next steps
 

--- a/docs/content/recipes/data-management/server-side-aspnet/server/AppDbContext.cs
+++ b/docs/content/recipes/data-management/server-side-aspnet/server/AppDbContext.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+using OrdersApi.Models;
+
+namespace OrdersApi.Data;
+
+public class AppDbContext : DbContext
+{
+    public AppDbContext(DbContextOptions<AppDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<Order> Orders => Set<Order>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        // SQLite has no native decimal type. Without this conversion, Total is
+        // stored as TEXT, and ORDER BY and range filters (gt/gte/lt/lte) on it
+        // sort lexicographically instead of numerically.
+        modelBuilder.Entity<Order>()
+            .Property(o => o.Total)
+            .HasConversion<double>();
+    }
+}

--- a/docs/content/recipes/data-management/server-side-aspnet/server/DbInitializer.cs
+++ b/docs/content/recipes/data-management/server-side-aspnet/server/DbInitializer.cs
@@ -1,0 +1,42 @@
+using OrdersApi.Models;
+
+namespace OrdersApi.Data;
+
+public static class DbInitializer
+{
+    private static readonly string[] Statuses = { "pending", "paid", "shipped", "delivered", "cancelled" };
+
+    private static readonly string[] Customers =
+    {
+        "Ana García", "James Okafor", "Li Wei", "Marta Nowak", "Diego Fernández",
+        "Priya Sharma", "Tom Becker", "Fatima Al-Sayed", "Noah Kim", "Elena Rossi",
+    };
+
+    // Seeds 50 orders so pagination, sorting, and filtering are meaningful from
+    // the first load. Guarded so re-running the app doesn't duplicate rows.
+    public static void Seed(AppDbContext db)
+    {
+        if (db.Orders.Any())
+        {
+            return;
+        }
+
+        var random = new Random(42);
+        var orders = new List<Order>();
+
+        for (var i = 1; i <= 50; i++)
+        {
+            orders.Add(new Order
+            {
+                OrderNumber = $"ORD-{1000 + i}",
+                Customer = Customers[random.Next(Customers.Length)],
+                Status = Statuses[random.Next(Statuses.Length)],
+                Total = Math.Round((decimal)(random.NextDouble() * 480 + 20), 2),
+                CreatedAt = DateTime.UtcNow.AddDays(-random.Next(1, 180)),
+            });
+        }
+
+        db.Orders.AddRange(orders);
+        db.SaveChanges();
+    }
+}

--- a/docs/content/recipes/data-management/server-side-aspnet/server/Order.cs
+++ b/docs/content/recipes/data-management/server-side-aspnet/server/Order.cs
@@ -1,0 +1,11 @@
+namespace OrdersApi.Models;
+
+public class Order
+{
+    public int Id { get; set; }
+    public string OrderNumber { get; set; } = string.Empty;
+    public string Customer { get; set; } = string.Empty;
+    public string Status { get; set; } = "pending";
+    public decimal Total { get; set; }
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/docs/content/recipes/data-management/server-side-aspnet/server/OrdersController.cs
+++ b/docs/content/recipes/data-management/server-side-aspnet/server/OrdersController.cs
@@ -1,0 +1,49 @@
+using Microsoft.AspNetCore.Mvc;
+using OrdersApi.Models;
+using OrdersApi.Services;
+
+namespace OrdersApi.Controllers;
+
+[ApiController]
+[Route("api/orders")]
+public class OrdersController : ControllerBase
+{
+    private readonly OrdersService _service;
+
+    public OrdersController(OrdersService service)
+    {
+        _service = service;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetOrders([FromQuery] OrdersQuery query, CancellationToken cancellationToken)
+    {
+        var (rows, totalRows) = await _service.GetOrdersAsync(query, cancellationToken);
+
+        return Ok(new { rows, totalRows });
+    }
+
+    [HttpPost("create_rows")]
+    public async Task<IActionResult> CreateRows([FromBody] CreateRowsRequest request, CancellationToken cancellationToken)
+    {
+        var rows = await _service.CreateRowsAsync(request.Rows, cancellationToken);
+
+        return StatusCode(StatusCodes.Status201Created, new { rows });
+    }
+
+    [HttpPatch("update_rows")]
+    public async Task<IActionResult> UpdateRows([FromBody] UpdateRowsRequest request, CancellationToken cancellationToken)
+    {
+        var rows = await _service.UpdateRowsAsync(request.Rows, cancellationToken);
+
+        return Ok(new { rows });
+    }
+
+    [HttpDelete("remove_rows")]
+    public async Task<IActionResult> RemoveRows([FromBody] RemoveRowsRequest request, CancellationToken cancellationToken)
+    {
+        await _service.RemoveRowsAsync(request.RowIds, cancellationToken);
+
+        return NoContent();
+    }
+}

--- a/docs/content/recipes/data-management/server-side-aspnet/server/OrdersQuery.cs
+++ b/docs/content/recipes/data-management/server-side-aspnet/server/OrdersQuery.cs
@@ -1,0 +1,26 @@
+namespace OrdersApi.Models;
+
+public class SortDto
+{
+    public string? Prop { get; set; }
+    public string? Order { get; set; }
+}
+
+public class FilterDto
+{
+    public string Prop { get; set; } = string.Empty;
+    public string Condition { get; set; } = string.Empty;
+    public string? Value { get; set; }
+}
+
+// Bound from the query string via [FromQuery]. ASP.NET Core's model binder
+// reads nested properties from dot notation (sort.prop, sort.order) and
+// indexed collections from filters[N].prop / .condition / .value -- no
+// custom binder or [FromQuery] attribute per property is needed.
+public class OrdersQuery
+{
+    public int Page { get; set; } = 1;
+    public int PageSize { get; set; } = 10;
+    public SortDto? Sort { get; set; }
+    public List<FilterDto> Filters { get; set; } = new();
+}

--- a/docs/content/recipes/data-management/server-side-aspnet/server/OrdersService.cs
+++ b/docs/content/recipes/data-management/server-side-aspnet/server/OrdersService.cs
@@ -19,6 +19,7 @@ public class OrdersService
     };
 
     private static readonly HashSet<string> StringColumns = new() { "orderNumber", "customer", "status" };
+    private static readonly HashSet<string> DateColumns = new() { "createdAt" };
 
     // System-managed fields (id, createdAt) are deliberately excluded so
     // update_rows can never overwrite them.
@@ -150,9 +151,18 @@ public class OrdersService
                 continue; // unknown column name -- ignored instead of trusted
             }
 
-            query = StringColumns.Contains(filter.Prop)
-                ? ApplyStringFilter(query, property, filter)
-                : ApplyNumericFilter(query, property, filter);
+            if (StringColumns.Contains(filter.Prop))
+            {
+                query = ApplyStringFilter(query, property, filter);
+            }
+            else if (DateColumns.Contains(filter.Prop))
+            {
+                query = ApplyDateFilter(query, property, filter);
+            }
+            else
+            {
+                query = ApplyNumericFilter(query, property, filter);
+            }
         }
 
         return query;
@@ -173,6 +183,31 @@ public class OrdersService
             "ends_with" => query.Where(o => EF.Functions.Like(EF.Property<string>(o, property), $"%{likeValue}", "\\")),
             "empty" => query.Where(o => EF.Property<string>(o, property) == null || EF.Property<string>(o, property) == string.Empty),
             "not_empty" => query.Where(o => EF.Property<string>(o, property) != null && EF.Property<string>(o, property) != string.Empty),
+            _ => query,
+        };
+    }
+
+    private static IQueryable<Order> ApplyDateFilter(IQueryable<Order> query, string property, FilterDto filter)
+    {
+        if (filter.Condition is "empty" or "not_empty")
+        {
+            // CreatedAt is non-nullable -- there's no empty date state to check.
+            return query;
+        }
+
+        if (!DateTime.TryParse(filter.Value, out var value))
+        {
+            return query; // malformed date input -- ignored rather than thrown
+        }
+
+        return filter.Condition switch
+        {
+            "eq" => query.Where(o => EF.Property<DateTime>(o, property).Date == value.Date),
+            "neq" => query.Where(o => EF.Property<DateTime>(o, property).Date != value.Date),
+            "gt" => query.Where(o => EF.Property<DateTime>(o, property) > value),
+            "gte" => query.Where(o => EF.Property<DateTime>(o, property) >= value),
+            "lt" => query.Where(o => EF.Property<DateTime>(o, property) < value),
+            "lte" => query.Where(o => EF.Property<DateTime>(o, property) <= value),
             _ => query,
         };
     }

--- a/docs/content/recipes/data-management/server-side-aspnet/server/OrdersService.cs
+++ b/docs/content/recipes/data-management/server-side-aspnet/server/OrdersService.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using OrdersApi.Data;
 using OrdersApi.Models;
@@ -25,6 +27,10 @@ public class OrdersService
     // update_rows can never overwrite them.
     private static readonly HashSet<string> EditableColumns = new() { "orderNumber", "customer", "status", "total" };
 
+    // Caps how many rows a single request can pull, so a client-supplied
+    // pageSize can't force the server to materialize the whole table.
+    private const int MaxPageSize = 100;
+
     private readonly AppDbContext _db;
 
     public OrdersService(AppDbContext db)
@@ -35,7 +41,7 @@ public class OrdersService
     public async Task<(List<Order> Rows, int TotalRows)> GetOrdersAsync(OrdersQuery query, CancellationToken cancellationToken)
     {
         var page = Math.Max(query.Page, 1);
-        var pageSize = Math.Max(query.PageSize, 1);
+        var pageSize = Math.Clamp(query.PageSize, 1, MaxPageSize);
 
         var filtered = ApplyFilters(_db.Orders.AsNoTracking(), query.Filters);
         var totalRows = await filtered.CountAsync(cancellationToken);
@@ -101,7 +107,7 @@ public class OrdersService
             .ExecuteDeleteAsync(cancellationToken);
     }
 
-    private static void ApplyChanges(Order order, Dictionary<string, System.Text.Json.JsonElement> changes)
+    private static void ApplyChanges(Order order, Dictionary<string, JsonElement> changes)
     {
         foreach (var (key, element) in changes)
         {
@@ -122,7 +128,13 @@ public class OrdersService
                     order.Status = element.GetString() ?? order.Status;
                     break;
                 case "total":
-                    order.Total = element.GetDecimal();
+                    // A cleared cell sends JSON null -- GetDecimal() throws on
+                    // anything that isn't a JSON number, so check first instead
+                    // of leaving Total unchanged from a bad request.
+                    if (element.ValueKind == JsonValueKind.Number)
+                    {
+                        order.Total = element.GetDecimal();
+                    }
                     break;
             }
         }
@@ -195,7 +207,7 @@ public class OrdersService
             return query;
         }
 
-        if (!DateTime.TryParse(filter.Value, out var value))
+        if (!DateTime.TryParse(filter.Value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var value))
         {
             return query; // malformed date input -- ignored rather than thrown
         }
@@ -220,7 +232,7 @@ public class OrdersService
             return query;
         }
 
-        if (!decimal.TryParse(filter.Value, out var value))
+        if (!decimal.TryParse(filter.Value, NumberStyles.Number, CultureInfo.InvariantCulture, out var value))
         {
             return query; // malformed numeric input -- ignored rather than thrown
         }

--- a/docs/content/recipes/data-management/server-side-aspnet/server/OrdersService.cs
+++ b/docs/content/recipes/data-management/server-side-aspnet/server/OrdersService.cs
@@ -1,0 +1,209 @@
+using Microsoft.EntityFrameworkCore;
+using OrdersApi.Data;
+using OrdersApi.Models;
+
+namespace OrdersApi.Services;
+
+public class OrdersService
+{
+    // Maps the wire-format column names Handsontable sends (camelCase) to the
+    // C# property names EF.Property<T> needs. Any prop not in this dictionary
+    // is rejected instead of reaching a query -- this is the whitelist.
+    private static readonly Dictionary<string, string> ColumnMap = new()
+    {
+        ["orderNumber"] = nameof(Order.OrderNumber),
+        ["customer"] = nameof(Order.Customer),
+        ["status"] = nameof(Order.Status),
+        ["total"] = nameof(Order.Total),
+        ["createdAt"] = nameof(Order.CreatedAt),
+    };
+
+    private static readonly HashSet<string> StringColumns = new() { "orderNumber", "customer", "status" };
+
+    // System-managed fields (id, createdAt) are deliberately excluded so
+    // update_rows can never overwrite them.
+    private static readonly HashSet<string> EditableColumns = new() { "orderNumber", "customer", "status", "total" };
+
+    private readonly AppDbContext _db;
+
+    public OrdersService(AppDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task<(List<Order> Rows, int TotalRows)> GetOrdersAsync(OrdersQuery query, CancellationToken cancellationToken)
+    {
+        var page = Math.Max(query.Page, 1);
+        var pageSize = Math.Max(query.PageSize, 1);
+
+        var filtered = ApplyFilters(_db.Orders.AsNoTracking(), query.Filters);
+        var totalRows = await filtered.CountAsync(cancellationToken);
+
+        var rows = await ApplySort(filtered, query.Sort)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(cancellationToken);
+
+        return (rows, totalRows);
+    }
+
+    public async Task<List<Order>> CreateRowsAsync(List<OrderCreateDto> rows, CancellationToken cancellationToken)
+    {
+        await using var transaction = await _db.Database.BeginTransactionAsync(cancellationToken);
+
+        var created = rows.Select(row => new Order
+        {
+            OrderNumber = row.OrderNumber,
+            Customer = row.Customer,
+            Status = row.Status,
+            Total = row.Total,
+            CreatedAt = DateTime.UtcNow,
+        }).ToList();
+
+        _db.Orders.AddRange(created);
+        await _db.SaveChangesAsync(cancellationToken);
+        await transaction.CommitAsync(cancellationToken);
+
+        // Returned with their database-assigned Id so dataProvider can replace
+        // the client's placeholder rows.
+        return created;
+    }
+
+    public async Task<List<Order>> UpdateRowsAsync(List<UpdateRowDto> rows, CancellationToken cancellationToken)
+    {
+        await using var transaction = await _db.Database.BeginTransactionAsync(cancellationToken);
+        var updated = new List<Order>();
+
+        foreach (var row in rows)
+        {
+            var order = await _db.Orders.FindAsync(new object[] { row.Id }, cancellationToken);
+            if (order is null)
+            {
+                continue;
+            }
+
+            ApplyChanges(order, row.Changes);
+            updated.Add(order);
+        }
+
+        await _db.SaveChangesAsync(cancellationToken);
+        await transaction.CommitAsync(cancellationToken);
+
+        return updated;
+    }
+
+    public async Task RemoveRowsAsync(List<int> rowIds, CancellationToken cancellationToken)
+    {
+        // A single DELETE ... WHERE Id IN (...) instead of one round trip per row.
+        await _db.Orders
+            .Where(o => rowIds.Contains(o.Id))
+            .ExecuteDeleteAsync(cancellationToken);
+    }
+
+    private static void ApplyChanges(Order order, Dictionary<string, System.Text.Json.JsonElement> changes)
+    {
+        foreach (var (key, element) in changes)
+        {
+            if (!EditableColumns.Contains(key))
+            {
+                continue;
+            }
+
+            switch (key)
+            {
+                case "orderNumber":
+                    order.OrderNumber = element.GetString() ?? order.OrderNumber;
+                    break;
+                case "customer":
+                    order.Customer = element.GetString() ?? order.Customer;
+                    break;
+                case "status":
+                    order.Status = element.GetString() ?? order.Status;
+                    break;
+                case "total":
+                    order.Total = element.GetDecimal();
+                    break;
+            }
+        }
+    }
+
+    private static IQueryable<Order> ApplySort(IQueryable<Order> query, SortDto? sort)
+    {
+        if (sort?.Prop == null || !ColumnMap.TryGetValue(sort.Prop, out var property))
+        {
+            return query.OrderByDescending(o => o.CreatedAt);
+        }
+
+        var descending = string.Equals(sort.Order, "desc", StringComparison.OrdinalIgnoreCase);
+
+        return descending
+            ? query.OrderByDescending(o => EF.Property<object>(o, property))
+            : query.OrderBy(o => EF.Property<object>(o, property));
+    }
+
+    private static IQueryable<Order> ApplyFilters(IQueryable<Order> query, List<FilterDto> filters)
+    {
+        foreach (var filter in filters)
+        {
+            if (!ColumnMap.TryGetValue(filter.Prop, out var property))
+            {
+                continue; // unknown column name -- ignored instead of trusted
+            }
+
+            query = StringColumns.Contains(filter.Prop)
+                ? ApplyStringFilter(query, property, filter)
+                : ApplyNumericFilter(query, property, filter);
+        }
+
+        return query;
+    }
+
+    private static IQueryable<Order> ApplyStringFilter(IQueryable<Order> query, string property, FilterDto filter)
+    {
+        var value = filter.Value ?? string.Empty;
+        var likeValue = EscapeLike(value);
+
+        return filter.Condition switch
+        {
+            "eq" => query.Where(o => EF.Property<string>(o, property) == value),
+            "neq" => query.Where(o => EF.Property<string>(o, property) != value),
+            "contains" => query.Where(o => EF.Functions.Like(EF.Property<string>(o, property), $"%{likeValue}%", "\\")),
+            "not_contains" => query.Where(o => !EF.Functions.Like(EF.Property<string>(o, property), $"%{likeValue}%", "\\")),
+            "begins_with" => query.Where(o => EF.Functions.Like(EF.Property<string>(o, property), $"{likeValue}%", "\\")),
+            "ends_with" => query.Where(o => EF.Functions.Like(EF.Property<string>(o, property), $"%{likeValue}", "\\")),
+            "empty" => query.Where(o => EF.Property<string>(o, property) == null || EF.Property<string>(o, property) == string.Empty),
+            "not_empty" => query.Where(o => EF.Property<string>(o, property) != null && EF.Property<string>(o, property) != string.Empty),
+            _ => query,
+        };
+    }
+
+    private static IQueryable<Order> ApplyNumericFilter(IQueryable<Order> query, string property, FilterDto filter)
+    {
+        if (filter.Condition is "empty" or "not_empty")
+        {
+            // Total is non-nullable -- there's no empty numeric state to check.
+            return query;
+        }
+
+        if (!decimal.TryParse(filter.Value, out var value))
+        {
+            return query; // malformed numeric input -- ignored rather than thrown
+        }
+
+        return filter.Condition switch
+        {
+            "eq" => query.Where(o => EF.Property<decimal>(o, property) == value),
+            "neq" => query.Where(o => EF.Property<decimal>(o, property) != value),
+            "gt" => query.Where(o => EF.Property<decimal>(o, property) > value),
+            "gte" => query.Where(o => EF.Property<decimal>(o, property) >= value),
+            "lt" => query.Where(o => EF.Property<decimal>(o, property) < value),
+            "lte" => query.Where(o => EF.Property<decimal>(o, property) <= value),
+            _ => query,
+        };
+    }
+
+    // Escapes LIKE metacharacters in user input so they're treated as literals,
+    // not wildcards. Paired with the ESCAPE '\' clause passed to EF.Functions.Like.
+    private static string EscapeLike(string value) =>
+        value.Replace("\\", "\\\\").Replace("%", "\\%").Replace("_", "\\_");
+}

--- a/docs/content/recipes/data-management/server-side-aspnet/server/Payloads.cs
+++ b/docs/content/recipes/data-management/server-side-aspnet/server/Payloads.cs
@@ -1,0 +1,35 @@
+using System.Text.Json;
+
+namespace OrdersApi.Models;
+
+// No Id or CreatedAt property -- the type system blocks clients from setting
+// system-managed fields, instead of filtering them out of a dictionary at
+// runtime.
+public class OrderCreateDto
+{
+    public string OrderNumber { get; set; } = string.Empty;
+    public string Customer { get; set; } = string.Empty;
+    public string Status { get; set; } = "pending";
+    public decimal Total { get; set; }
+}
+
+public class CreateRowsRequest
+{
+    public List<OrderCreateDto> Rows { get; set; } = new();
+}
+
+public class UpdateRowDto
+{
+    public int Id { get; set; }
+    public Dictionary<string, JsonElement> Changes { get; set; } = new();
+}
+
+public class UpdateRowsRequest
+{
+    public List<UpdateRowDto> Rows { get; set; } = new();
+}
+
+public class RemoveRowsRequest
+{
+    public List<int> RowIds { get; set; } = new();
+}

--- a/docs/content/recipes/data-management/server-side-aspnet/server/Program.cs
+++ b/docs/content/recipes/data-management/server-side-aspnet/server/Program.cs
@@ -19,8 +19,10 @@ builder.Services.AddCors(options =>
 
 var app = builder.Build();
 
-// UseCors must run before MapControllers -- registered after, the preflight
-// OPTIONS request reaches the router with no CORS headers attached.
+// General ASP.NET Core middleware order: CORS runs after routing and before
+// authentication/authorization. Keep this placement even without auth yet, so
+// adding UseAuthentication/UseAuthorization later doesn't reject preflight
+// requests.
 app.UseCors("AllowFrontend");
 app.MapControllers();
 

--- a/docs/content/recipes/data-management/server-side-aspnet/server/Program.cs
+++ b/docs/content/recipes/data-management/server-side-aspnet/server/Program.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore;
+using OrdersApi.Data;
+using OrdersApi.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+builder.Services.AddDbContext<AppDbContext>(options =>
+    options.UseSqlite("Data Source=orders.db"));
+builder.Services.AddScoped<OrdersService>();
+
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("AllowFrontend", policy =>
+        policy.WithOrigins("http://localhost:5173")
+            .AllowAnyHeader()
+            .AllowAnyMethod());
+});
+
+var app = builder.Build();
+
+// UseCors must run before MapControllers -- registered after, the preflight
+// OPTIONS request reaches the router with no CORS headers attached.
+app.UseCors("AllowFrontend");
+app.MapControllers();
+
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+    db.Database.EnsureCreated();
+    DbInitializer.Seed(db);
+}
+
+app.Run();

--- a/docs/content/recipes/data-management/server-side-expressjs/server-side-expressjs.md
+++ b/docs/content/recipes/data-management/server-side-expressjs/server-side-expressjs.md
@@ -323,3 +323,4 @@ Handsontable passes an array of `id` strings matching `dataProvider.rowId`. The 
 - Share the Zod schema types between the Express backend and the Handsontable frontend in a monorepo using a shared `packages/types` workspace package.
 - Compare with the [NestJS recipe](@/recipes/data-management/server-side-nestjs/server-side-nestjs.md) to see the same pattern implemented with decorators, a DI container, and `class-validator` instead of Zod.
 - Compare with the [Symfony recipe](@/recipes/data-management/server-side-symfony/server-side-symfony.md) to see the same Handsontable frontend wired to a PHP backend using the same endpoint shapes.
+- Compare with the [ASP.NET Core recipe](@/recipes/data-management/server-side-aspnet/server-side-aspnet.md) to see the same `buildUrl`/`fetchRows` pattern targeting ASP.NET Core's dot-notation query binding instead of Express's bracket notation.

--- a/docs/content/recipes/data-management/server-side-nestjs/server-side-nestjs.md
+++ b/docs/content/recipes/data-management/server-side-nestjs/server-side-nestjs.md
@@ -347,3 +347,4 @@ Handsontable passes an array of `id` strings matching `dataProvider.rowId`. The 
 - Share the DTO types between the NestJS backend and the Handsontable frontend in a monorepo using a shared `packages/types` workspace package.
 - Compare with the [Spring Boot recipe](@/recipes/data-management/server-side-spring/server-side-spring.md) to see the same Handsontable frontend wired to a Java backend using the same endpoint shapes.
 - Compare with the [Symfony recipe](@/recipes/data-management/server-side-symfony/server-side-symfony.md) to see the same Handsontable frontend wired to a PHP backend using the same endpoint shapes.
+- Compare with the [ASP.NET Core recipe](@/recipes/data-management/server-side-aspnet/server-side-aspnet.md) to see the same decorator-and-DI-container pattern implemented with ASP.NET Core MVC controllers and EF Core instead of NestJS and TypeORM.

--- a/docs/content/recipes/data-management/server-side-spring/server-side-spring.md
+++ b/docs/content/recipes/data-management/server-side-spring/server-side-spring.md
@@ -377,3 +377,4 @@ Because `beforeRowsMutation` is synchronous and checks for a strict `=== false` 
 - Secure the API with Spring Security: require authentication for mutation endpoints while keeping `GET /api/products` public.
 - Compare with the [Laravel recipe](@/recipes/data-management/server-side-laravel/server-side-laravel.md) to see the same Handsontable frontend wired to a PHP backend using the same endpoint shapes.
 - Compare with the [Symfony recipe](@/recipes/data-management/server-side-symfony/server-side-symfony.md) to see the same Handsontable frontend wired to a PHP/Symfony backend using the same endpoint shapes.
+- Compare with the [ASP.NET Core recipe](@/recipes/data-management/server-side-aspnet/server-side-aspnet.md) to see the same Handsontable frontend wired to a .NET backend using EF Core instead of Spring Data JPA.

--- a/docs/content/recipes/sidebar.js
+++ b/docs/content/recipes/sidebar.js
@@ -20,6 +20,7 @@ const dataManagementItems = [
   { path: 'data-management/sync-two-grids/sync-two-grids', title: 'Sync two grids', onlyFor: ['javascript', 'angular', 'react'] },
   { path: 'data-management/undo-redo-custom-ui/undo-redo-custom-ui', title: 'Undo / redo with a custom UI', onlyFor: ['javascript', 'angular', 'react', 'vue'] },
   { path: 'data-management/auto-save-backend/auto-save-backend', title: 'Auto-save changes to a backend', onlyFor: ['javascript', 'angular', 'react', 'vue'] },
+  { path: 'data-management/server-side-aspnet/server-side-aspnet', title: 'Server-side data with ASP.NET Core', onlyFor: ['javascript', 'angular', 'react', 'vue'] },
   { path: 'data-management/server-side-django/server-side-django', title: 'Server-side data with Django', onlyFor: ['javascript', 'angular', 'react', 'vue'] },
   { path: 'data-management/server-side-expressjs/server-side-expressjs', title: 'Server-side data with Express.js', onlyFor: ['javascript', 'angular', 'react', 'vue'] },
   { path: 'data-management/server-side-laravel/server-side-laravel', title: 'Server-side data with Laravel', onlyFor: ['javascript', 'angular', 'react', 'vue'] },

--- a/docs/src/plugins/__tests__/framework-loader.test.mjs
+++ b/docs/src/plugins/__tests__/framework-loader.test.mjs
@@ -339,3 +339,63 @@ test('.jsx/.tsx examples render with jsx/tsx code fences, not js/ts', async () =
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+/**
+ * Builds a temp content tree with a server-side-only example (a .cs file with
+ * no runnable JS/TS/Vue entry point), so the fenced-code language mapping for
+ * non-JS backend languages can be asserted.
+ *
+ * @returns {{ contentDir: string, root: string }}
+ */
+function createCsharpFixture() {
+  const root = mkdtempSync(join(tmpdir(), 'hot-loader-'));
+  const contentDir = join(root, 'content');
+  const serverDir = join(contentDir, 'guides', 'intro', 'server');
+
+  mkdirSync(serverDir, { recursive: true });
+
+  writeFileSync(join(contentDir, 'index.md'), '---\ntitle: Home\n---\n\nWelcome.\n');
+
+  writeFileSync(
+    join(contentDir, 'guides', 'intro', 'intro.md'),
+    [
+      '---',
+      'title: Introduction',
+      'permalink: /intro',
+      '---',
+      '',
+      'Intro body.',
+      '',
+      '::: example #ex1',
+      '@[code csharp](@/content/guides/intro/server/Order.cs)',
+      ':::',
+      '',
+    ].join('\n')
+  );
+
+  writeFileSync(join(serverDir, 'Order.cs'), 'public class Order\n{\n    public int Id { get; set; }\n}\n');
+
+  return { contentDir, root };
+}
+
+test('.cs examples render with a csharp code fence, not a plain-text fence', async () => {
+  const { contentDir, root } = createCsharpFixture();
+
+  try {
+    const { ctx, store } = createContext();
+
+    await frameworkLoader({ contentDir }).load(ctx);
+
+    const html = renderedHtmlOf(store, 'javascript-data-grid/intro');
+
+    // The fix: .cs extensions map to the csharp Shiki grammar, so the code
+    // highlights instead of rendering as flat, uncolored text.
+    assert.ok(html.includes('````csharp title="C#"'), 'expected a csharp code fence');
+
+    // Regression guard: before the fix, .cs had no EXT_TO_LANG entry and fell
+    // back to the plain-text grammar (no highlighting).
+    assert.ok(!html.includes('````text title='), '.cs must not fall back to a plain-text fence');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/docs/src/plugins/framework-loader.mjs
+++ b/docs/src/plugins/framework-loader.mjs
@@ -97,6 +97,7 @@ const EXT_TO_LANG = {
   py: 'python',
   rb: 'ruby',
   java: 'java',
+  cs: 'csharp',
   properties: 'properties',
 };
 
@@ -104,6 +105,7 @@ const EXT_TO_LANG = {
 const META_LANG = {
   php: 'php',
   java: 'java',
+  csharp: 'csharp',
   typescript: 'typescript',
   ts: 'typescript',
   js: 'javascript',
@@ -124,6 +126,7 @@ const EXT_TO_LABEL = {
   py: 'Python',
   rb: 'Ruby',
   java: 'Java',
+  cs: 'C#',
   properties: 'Properties',
 };
 
@@ -517,7 +520,7 @@ const PREFIXES = {
 
 // Bump this when the loader logic changes to force Astro's data store to
 // re-process all entries (the store skips entries whose digest hasn't changed).
-const LOADER_VERSION = 'v41';
+const LOADER_VERSION = 'v42';
 
 // ---------------------------------------------------------------------------
 // File listing (recursive, no external glob)


### PR DESCRIPTION
### Context

The PR adds a "Server-side data with ASP.NET Core" recipe, requested repeatedly by users ([#2562](https://github.com/handsontable/handsontable/issues/2562), [#2383](https://github.com/handsontable/handsontable/issues/2383), [#1183](https://github.com/handsontable/handsontable/issues/1183)) and again recently via the docs-assistant bot. The recipe mirrors the existing `server-side-*` family (Rails, Django, Express, NestJS, Spring, Symfony, Laravel) and wires the `dataProvider` plugin to an ASP.NET Core MVC + EF Core + SQLite backend, with paginated fetch, server-side sort/filter, and batch CRUD. Per the task discussion, there's no companion runnable demo repo yet, so the recipe has no GitHub CTA button -- the page itself is the deliverable.

### How has this been tested?

- Started the docs dev server (`ASTRO_DEV_BACKGROUND=1 npm run dev`) and confirmed the new page renders (HTTP 200) under all four framework prefixes: `javascript-data-grid`, `react-data-grid`, `angular-data-grid`, `vue-data-grid`.
- Confirmed the sidebar entry appears under **Data Management** with a **New** badge, and that the Vue variant falls back to the JavaScript example (`only-for javascript vue`) with no React code leaking in.
- Confirmed no GitHub CTA renders on the page (the only `github-example-cta` matches in the rendered HTML are the shared site-wide CSS rule, not an element on this page).
- Verified factual claims against Microsoft Learn / GitHub sources: the `dotnet new webapi --use-controllers` flag, ASP.NET Core's default `PropertyNameCaseInsensitive` + camelCase JSON serialization, and the `EF.Property<T>` dynamic-sort pattern used in `OrdersService.cs`.
- No local `dotnet` SDK was available to compile the C# snippets directly; they were reviewed by hand for namespace/type correctness instead. Flagging this so a reviewer with the .NET 8 SDK can do a `dotnet build` sanity check before merge.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1948

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

(Docs-only change -- `handsontable-documentation`.)

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1948

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and docs build tooling only; no runtime changes to Handsontable packages or application code.
> 
> **Overview**
> Adds a new **Server-side data with ASP.NET Core** recipe that mirrors the existing `server-side-*` family: a long-form tutorial, sample **ASP.NET Core MVC + EF Core + SQLite** backend (orders API with pagination, sort/filter, batch CRUD), and **JavaScript/TypeScript/React/Angular** examples wired through `dataProvider`. The ASP.NET-specific piece is **`buildUrl`** serializing query params for dot-notation model binding (`sort.prop`, `filters[N].prop`, etc.) instead of Express-style bracket notation.
> 
> **Navigation** lists the recipe on the Data Management index and sidebar (with **New** badge). **Express, NestJS, and Spring** recipes gain “compare with ASP.NET Core” next-step links.
> 
> The docs **framework-loader** maps **`.cs`** / `csharp` to Shiki **C#** highlighting (loader version bump + regression test) so embedded server snippets render correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dc17651f015559b0c6d8ef7260598df1effad4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->