### PR TITLE
DEV-2022: Skip column-header re-render on pure vertical scroll

### DIFF
--- a/.changelogs/12987.json
+++ b/.changelogs/12987.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Improved vertical scrolling performance by skipping the column header re-render when the column layout is unchanged.",
+  "type": "changed",
+  "issueOrPR": 12987,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/src/overlay/overlays.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/overlays.ts
@@ -511,13 +511,19 @@ class Overlays {
    *                                   rendering anyway.
    */
   refresh(fastDraw = false) {
-    const isScrollTriggered = this.verticalScrolling || this.horizontalScrolling;
+    // `isScrollDrivenDraw` guards both decisions below: the scroll-direction flags can still be set
+    // during a `forceFullRender` (an `afterScroll` hook may trigger `hot.render()` before the flags are
+    // reset), and a full render enters as `draw(false)` (so `isScrollDrivenDraw` is `false`), which must
+    // fully re-render and size the overlays rather than treat this as a scroll.
+    const isScrollTriggered = this.isScrollDrivenDraw &&
+      (this.verticalScrolling || this.horizontalScrolling);
     // On a pure vertical scroll the bottom overlay (and its inline-start corner) render the same fixed
     // rows over the same visible columns, so their DOM is unchanged - a full re-render is wasted work and
     // forces an expensive style/layout/paint of the clone subtree on every scroll frame. Reposition them
     // (fast draw) instead. Any horizontal scroll changes the visible columns, and a non-scroll redraw
-    // (data, settings, resize) clears both flags, so those paths still trigger a full re-render.
-    const bottomFastDraw = fastDraw || (this.verticalScrolling && !this.horizontalScrolling);
+    // (data, settings, resize) is not scroll-driven, so those paths still trigger a full re-render.
+    const bottomFastDraw = fastDraw ||
+      (this.isScrollDrivenDraw && this.verticalScrolling && !this.horizontalScrolling);
 
     if (isScrollTriggered) {
       this.#postponedAdjustElementsSize();

--- a/handsontable/src/3rdparty/walkontable/src/overlay/overlays.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/overlays.ts
@@ -99,6 +99,18 @@ class Overlays {
   destroyed: boolean = false;
 
   /**
+   * `true` while the in-progress master draw was entered as a fast/scroll draw (`draw(true)`), and
+   * `false` for a full render (`draw(false)`, e.g. a `forceFullRender` from `hot.render()`). Set once
+   * per master draw before the cells are rendered, and read by the draw cycle (master and its clones,
+   * which reach it through the clone source) to gate the column-header render skip. It exists because
+   * the `verticalScrolling`/`horizontalScrolling` flags can still be set when an `afterScroll` hook
+   * synchronously triggers a `forceFullRender`, and a full render must always rebuild the headers.
+   *
+   * @type {boolean}
+   */
+  isScrollDrivenDraw: boolean = false;
+
+  /**
    * Binds the native DOM input listeners (scroll, wheel, key, resize) and translates them into the
    * engine's scroll actions. Extracted as a separate class to isolate the native-input lifecycle
    * from the overlay coordinator; the coordinator keeps a thin public `registerListeners` delegate.

--- a/handsontable/src/3rdparty/walkontable/src/render/index.ts
+++ b/handsontable/src/3rdparty/walkontable/src/render/index.ts
@@ -111,6 +111,19 @@ class Renderer {
   }
 
   /**
+   * Marks this draw as one where the column-header (THEAD) pass may be skipped when the column render
+   * window is unchanged (a pure vertical scroll).
+   *
+   * @param {boolean} skippable Whether the column-header pass may be skipped for this draw.
+   * @returns {Renderer}
+   */
+  setColumnHeadersRenderSkippable(skippable: boolean) {
+    this.renderer.setColumnHeadersRenderSkippable(skippable);
+
+    return this;
+  }
+
+  /**
    * Renders the table.
    */
   render() {

--- a/handsontable/src/3rdparty/walkontable/src/render/tableRenderer.ts
+++ b/handsontable/src/3rdparty/walkontable/src/render/tableRenderer.ts
@@ -185,26 +185,38 @@ export class TableRenderer {
    * window is unchanged. Set once per draw by the draw cycle; only a pure vertical scroll (no data,
    * settings, selection, or column-window change) enables it. Defaults to `false` so every non-scroll
    * draw renders the headers.
+   *
+   * @type {boolean}
    */
   #columnHeadersRenderSkippable: boolean = false;
   /**
    * `true` once the column-header pass has rendered at least once and stored its render window.
+   *
+   * @type {boolean}
    */
   #hasStoredColumnHeaderWindow: boolean = false;
   /**
    * The first rendered column (column filter offset) captured on the last column-header render.
+   *
+   * @type {number}
    */
   #prevColumnHeaderOffset: number = -1;
   /**
    * The number of rendered columns captured on the last column-header render.
+   *
+   * @type {number}
    */
   #prevColumnsToRender: number = -1;
   /**
    * The column headers count captured on the last column-header render.
+   *
+   * @type {number}
    */
   #prevColumnHeadersCount: number = -1;
   /**
    * The row headers count captured on the last column-header render.
+   *
+   * @type {number}
    */
   #prevRowHeadersCount: number = -1;
 

--- a/handsontable/src/3rdparty/walkontable/src/render/tableRenderer.ts
+++ b/handsontable/src/3rdparty/walkontable/src/render/tableRenderer.ts
@@ -180,6 +180,33 @@ export class TableRenderer {
    * Styles handler instance.
    */
   declare stylesHandler: StylesHandler;
+  /**
+   * When `true`, the column-header pass (THEAD) may be skipped for this draw if the column render
+   * window is unchanged. Set once per draw by the draw cycle; only a pure vertical scroll (no data,
+   * settings, selection, or column-window change) enables it. Defaults to `false` so every non-scroll
+   * draw renders the headers.
+   */
+  #columnHeadersRenderSkippable: boolean = false;
+  /**
+   * `true` once the column-header pass has rendered at least once and stored its render window.
+   */
+  #hasStoredColumnHeaderWindow: boolean = false;
+  /**
+   * The first rendered column (column filter offset) captured on the last column-header render.
+   */
+  #prevColumnHeaderOffset: number = -1;
+  /**
+   * The number of rendered columns captured on the last column-header render.
+   */
+  #prevColumnsToRender: number = -1;
+  /**
+   * The column headers count captured on the last column-header render.
+   */
+  #prevColumnHeadersCount: number = -1;
+  /**
+   * The row headers count captured on the last column-header render.
+   */
+  #prevRowHeadersCount: number = -1;
 
   /**
    * Creates a new TableRenderer instance.
@@ -227,6 +254,18 @@ export class TableRenderer {
   setViewportSize(rowsCount: number, columnsCount: number) {
     this.rowsToRender = rowsCount;
     this.columnsToRender = columnsCount;
+  }
+
+  /**
+   * Marks this draw as one where the column-header (THEAD) pass may be skipped, provided the column
+   * render window is unchanged since the last header render. The draw cycle sets this to `true` only
+   * for a pure vertical scroll (nothing but the vertical scroll position changed), and to `false`
+   * otherwise, so any data, settings, selection, or column-window change re-renders the headers.
+   *
+   * @param {boolean} skippable Whether the column-header pass may be skipped for this draw.
+   */
+  setColumnHeadersRenderSkippable(skippable: boolean) {
+    this.#columnHeadersRenderSkippable = skippable;
   }
 
   /**
@@ -318,11 +357,45 @@ export class TableRenderer {
   }
 
   /**
+   * Returns `true` when the column-header (THEAD) pass can be skipped for this draw because it is a
+   * pure vertical scroll and the exact same column render window (offset + counts) was rendered on
+   * the previous header render. The THEAD content is then identical to what is already in the DOM.
+   *
+   * @returns {boolean}
+   */
+  #canSkipColumnHeadersRender() {
+    return this.#columnHeadersRenderSkippable &&
+      this.#hasStoredColumnHeaderWindow &&
+      this.#prevColumnHeaderOffset === (this.columnFilter ? this.columnFilter.offset : 0) &&
+      this.#prevColumnsToRender === this.columnsToRender &&
+      this.#prevColumnHeadersCount === this.columnHeadersCount &&
+      this.#prevRowHeadersCount === this.rowHeadersCount;
+  }
+
+  /**
+   * Stores the current column render window so the next draw can detect whether it is unchanged.
+   */
+  #storeColumnHeaderRenderWindow() {
+    this.#hasStoredColumnHeaderWindow = true;
+    this.#prevColumnHeaderOffset = this.columnFilter ? this.columnFilter.offset : 0;
+    this.#prevColumnsToRender = this.columnsToRender;
+    this.#prevColumnHeadersCount = this.columnHeadersCount;
+    this.#prevRowHeadersCount = this.rowHeadersCount;
+  }
+
+  /**
    * Renders the table.
    */
   render() {
-    this.columnHeaderRows!.render();
-    this.columnHeaders!.render();
+    // On a pure vertical scroll the THEAD (column header rows + cells) is identical draw-to-draw, so
+    // skip re-rendering it. The selection highlight classes on headers are (re)applied by the
+    // separate selection pass, and are unchanged while only the vertical scroll position moves.
+    if (!this.#canSkipColumnHeadersRender()) {
+      this.columnHeaderRows!.render();
+      this.columnHeaders!.render();
+      this.#storeColumnHeaderRenderWindow();
+    }
+
     this.rows!.render();
     this.rowHeaders!.render();
     this.cells!.render();

--- a/handsontable/src/3rdparty/walkontable/src/table/drawCycle.ts
+++ b/handsontable/src/3rdparty/walkontable/src/table/drawCycle.ts
@@ -5,6 +5,7 @@ import {
   CLONE_BOTTOM_INLINE_START_CORNER,
 } from '../overlay';
 import type Table from './baseTable';
+import type { default as Overlays } from '../overlay/overlays';
 
 /**
  * Per-draw mutable scratch shared by the phase functions of a single draw. It also captures the
@@ -125,7 +126,7 @@ function runMasterDrawCycle(table: Table, ctx: DrawContext): void {
     ctx.performRedraw = skipRender.skipRender !== true;
 
     if (ctx.performRedraw) {
-      renderCellBand(table, ctx, filters);
+      renderCellBand(table, ctx, filters, isPureVerticalScrollDraw(wtOverlays));
 
       if (!wtSettings.getSetting('externalRowCalculator')) {
         // Single-pass: the fully/partially-visible calculators were already computed in pass 1
@@ -189,7 +190,8 @@ function runCloneDrawCycle(table: Table, ctx: DrawContext): void {
     const filters = buildRenderFilters(table, ctx);
 
     // A clone's render is never gated by `skipRender` (that gate is master-only), so it always runs.
-    renderCellBand(table, ctx, filters);
+    // The scroll-direction flags live on the master's overlays, reached via the clone source.
+    renderCellBand(table, ctx, filters, isPureVerticalScrollDraw(table.deps.getCloneSource().wtOverlays));
 
     if (table.is(CLONE_BOTTOM)) {
       table.deps.getCloneSource().wtOverlays.adjustElementsSize();
@@ -226,6 +228,20 @@ function buildRenderFilters(table: Table, ctx: DrawContext): { rowFilter: RowFil
 }
 
 /**
+ * Returns `true` when this draw is a pure vertical scroll (only the vertical scroll position moved).
+ * The scroll-direction flags live on the master's overlays, so the master passes its own overlays and
+ * a clone passes its clone source's — each cycle already knows its role, so the resolution stays at the
+ * call site rather than re-branching here. Same signal the bottom-overlay fast-draw uses (see
+ * Overlays#refresh); a pure vertical scroll leaves the column window (and thus the THEAD) unchanged.
+ *
+ * @param {Overlays} wtOverlays The master's overlays object (the owner of the scroll-direction flags).
+ * @returns {boolean}
+ */
+function isPureVerticalScrollDraw(wtOverlays: Overlays): boolean {
+  return !!wtOverlays && wtOverlays.verticalScrolling && !wtOverlays.horizontalScrolling;
+}
+
+/**
  * Renders the header + cell band and measures the rendered rows. Shared by both cycles. The
  * role-specific branches stay inline and verbatim: bottom / bottom-left-corner overlays suppress
  * column headers, and only the master or the bottom clone marks oversized rows.
@@ -234,11 +250,14 @@ function buildRenderFilters(table: Table, ctx: DrawContext): { rowFilter: RowFil
  * @param {DrawContext} ctx The per-draw scratch (supplies the pre-hook header renderers).
  * @param {{ rowFilter: RowFilter, columnFilter: ColumnFilter }} filters The filters just built by
  *   `buildRenderFilters` (passed non-null rather than re-read off the nullable `table.*Filter`).
+ * @param {boolean} columnHeadersRenderSkippable Whether the column-header (THEAD) pass may be skipped
+ *   for this draw (a pure vertical scroll); resolved per role by the caller.
  */
 function renderCellBand(
   table: Table,
   ctx: DrawContext,
   filters: { rowFilter: RowFilter; columnFilter: ColumnFilter },
+  columnHeadersRenderSkippable: boolean,
 ): void {
   table.tableRenderer.setHeaderContentRenderers(ctx.rowHeaders, ctx.columnHeaders);
 
@@ -248,17 +267,7 @@ function renderCellBand(
     table.tableRenderer.setHeaderContentRenderers(ctx.rowHeaders, []);
   }
 
-  // On a pure vertical scroll (nothing but the vertical scroll position moved) the column window is
-  // unchanged, so the THEAD is identical and its re-render is wasted work. The scroll-direction flags
-  // live on the master's overlays; a clone reads them through its clone source. Same signal the
-  // bottom-overlay fast-draw optimization uses (see Overlays#refresh).
-  const wtOverlays = table.isMaster
-    ? table.deps.getWtOverlays()
-    : table.deps.getCloneSource().wtOverlays;
-  const isPureVerticalScroll = !!wtOverlays &&
-    wtOverlays.verticalScrolling && !wtOverlays.horizontalScrolling;
-
-  table.tableRenderer.setColumnHeadersRenderSkippable(isPureVerticalScroll);
+  table.tableRenderer.setColumnHeadersRenderSkippable(columnHeadersRenderSkippable);
 
   table.resetOversizedRows();
 

--- a/handsontable/src/3rdparty/walkontable/src/table/drawCycle.ts
+++ b/handsontable/src/3rdparty/walkontable/src/table/drawCycle.ts
@@ -248,6 +248,18 @@ function renderCellBand(
     table.tableRenderer.setHeaderContentRenderers(ctx.rowHeaders, []);
   }
 
+  // On a pure vertical scroll (nothing but the vertical scroll position moved) the column window is
+  // unchanged, so the THEAD is identical and its re-render is wasted work. The scroll-direction flags
+  // live on the master's overlays; a clone reads them through its clone source. Same signal the
+  // bottom-overlay fast-draw optimization uses (see Overlays#refresh).
+  const wtOverlays = table.isMaster
+    ? table.deps.getWtOverlays()
+    : table.deps.getCloneSource().wtOverlays;
+  const isPureVerticalScroll = !!wtOverlays &&
+    wtOverlays.verticalScrolling && !wtOverlays.horizontalScrolling;
+
+  table.tableRenderer.setColumnHeadersRenderSkippable(isPureVerticalScroll);
+
   table.resetOversizedRows();
 
   table.tableRenderer

--- a/handsontable/src/3rdparty/walkontable/src/table/drawCycle.ts
+++ b/handsontable/src/3rdparty/walkontable/src/table/drawCycle.ts
@@ -73,6 +73,13 @@ function runMasterDrawCycle(table: Table, ctx: DrawContext): void {
   const wtOverlays = table.deps.getWtOverlays();
   const wtViewport = table.deps.getWtViewport();
 
+  // Record whether this master draw was entered as a fast/scroll draw, BEFORE `createCalculators`
+  // below can downgrade `ctx.runFastDraw`. A `forceFullRender` (`hot.render()`) enters as `draw(false)`,
+  // so this is `false` for it even if the scroll-direction flags are still set (an `afterScroll` hook
+  // can trigger a render while they are). The clones read this off the master through their clone
+  // source, so the header-render skip decision stays consistent across the master and its overlays.
+  wtOverlays.isScrollDrivenDraw = ctx.runFastDraw;
+
   wtOverlays.beforeDraw();
   table.holderOffset = table.deps.geometryReader.offset(table.holder);
 
@@ -228,17 +235,22 @@ function buildRenderFilters(table: Table, ctx: DrawContext): { rowFilter: RowFil
 }
 
 /**
- * Returns `true` when this draw is a pure vertical scroll (only the vertical scroll position moved).
- * The scroll-direction flags live on the master's overlays, so the master passes its own overlays and
- * a clone passes its clone source's — each cycle already knows its role, so the resolution stays at the
- * call site rather than re-branching here. Same signal the bottom-overlay fast-draw uses (see
- * Overlays#refresh); a pure vertical scroll leaves the column window (and thus the THEAD) unchanged.
+ * Returns `true` when this draw is a pure vertical scroll (only the vertical scroll position moved),
+ * so the column window (and thus the THEAD) is unchanged. The scroll-direction flags live on the
+ * master's overlays, so the master passes its own overlays and a clone passes its clone source's —
+ * each cycle already knows its role, so the resolution stays at the call site rather than re-branching
+ * here. `isScrollDrivenDraw` guards against a `forceFullRender` that runs while the scroll-direction
+ * flags are still set (an `afterScroll` hook can trigger one): a full render enters as `draw(false)`,
+ * so it is excluded here and always rebuilds the headers.
  *
  * @param {Overlays} wtOverlays The master's overlays object (the owner of the scroll-direction flags).
  * @returns {boolean}
  */
 function isPureVerticalScrollDraw(wtOverlays: Overlays): boolean {
-  return !!wtOverlays && wtOverlays.verticalScrolling && !wtOverlays.horizontalScrolling;
+  return !!wtOverlays &&
+    wtOverlays.isScrollDrivenDraw &&
+    wtOverlays.verticalScrolling &&
+    !wtOverlays.horizontalScrolling;
 }
 
 /**

--- a/handsontable/src/3rdparty/walkontable/test/spec/scroll/columnHeaderRenderSkip.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/scroll/columnHeaderRenderSkip.spec.js
@@ -1,0 +1,119 @@
+describe('Walkontable column-header render skip on vertical scroll', () => {
+  const debug = false;
+
+  beforeEach(function() {
+    this.$wrapper = $('<div></div>').addClass('handsontable').css({ overflow: 'hidden' });
+    this.$wrapper.width(200).height(185);
+    this.$container = $('<div></div>');
+    this.$table = $('<table></table>').addClass('htCore'); // create a table that is not attached to document
+    this.$wrapper.append(this.$container);
+    this.$container.append(this.$table);
+    this.$wrapper.appendTo('body');
+    createDataArray(100, 50);
+  });
+
+  afterEach(function() {
+    if (!debug) {
+      $('.wtHolder').remove();
+    }
+
+    this.$wrapper.remove();
+    this.wotInstance.destroy();
+  });
+
+  function firstBodyCellText() {
+    return getTableMaster().find('tbody tr:first td:first').text();
+  }
+
+  function firstColumnHeaderText() {
+    return getTableMaster().find('thead th').eq(1).text();
+  }
+
+  it('should not re-render the column headers on a pure vertical scroll (band shift)', async() => {
+    const columnHeaders = jasmine.createSpy('columnHeaders').and.callFake((col, TH) => {
+      TH.innerHTML = `C${col}`;
+    });
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      rowHeaders: [function(row, TH) {
+        TH.innerHTML = row + 1;
+      }],
+      columnHeaders: [columnHeaders],
+    });
+
+    wt.draw();
+
+    const bodyBefore = firstBodyCellText();
+    const headerBefore = firstColumnHeaderText();
+
+    columnHeaders.calls.reset();
+
+    // A real vertical scroll drives the draw through the scroll-sync path, which sets the
+    // verticalScrolling flag the header-render skip relies on.
+    wt.wtTable.holder.scrollTop = 400;
+    wt.wtOverlays.syncScrollPositions();
+
+    // The rendered row band actually moved (otherwise the assertion below would be vacuous) ...
+    expect(firstBodyCellText()).not.toBe(bodyBefore);
+    // ... but the column-header content factory was NOT invoked again (the THEAD pass was skipped) ...
+    expect(columnHeaders).not.toHaveBeenCalled();
+    // ... and the header content is unchanged.
+    expect(firstColumnHeaderText()).toBe(headerBefore);
+  });
+
+  it('should re-render the column headers on a horizontal scroll (column window changed)', async() => {
+    const columnHeaders = jasmine.createSpy('columnHeaders').and.callFake((col, TH) => {
+      TH.innerHTML = `C${col}`;
+    });
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      rowHeaders: [function(row, TH) {
+        TH.innerHTML = row + 1;
+      }],
+      columnHeaders: [columnHeaders],
+    });
+
+    wt.draw();
+
+    columnHeaders.calls.reset();
+
+    wt.wtTable.holder.scrollLeft = 400;
+    wt.wtOverlays.syncScrollPositions();
+
+    // A horizontal scroll changes the visible columns, so the headers must be re-rendered.
+    expect(columnHeaders).toHaveBeenCalled();
+  });
+
+  it('should re-render the column headers on a non-scroll draw after a vertical scroll', async() => {
+    const columnHeaders = jasmine.createSpy('columnHeaders').and.callFake((col, TH) => {
+      TH.innerHTML = `C${col}`;
+    });
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      rowHeaders: [function(row, TH) {
+        TH.innerHTML = row + 1;
+      }],
+      columnHeaders: [columnHeaders],
+    });
+
+    wt.draw();
+
+    // Skip the headers on a vertical scroll.
+    wt.wtTable.holder.scrollTop = 400;
+    wt.wtOverlays.syncScrollPositions();
+
+    columnHeaders.calls.reset();
+
+    // A plain, non-scroll draw is not skip-eligible (the scroll flags are reset), so the header
+    // pass must run again - proving the skip is gated to scroll-triggered draws only.
+    wt.draw();
+
+    expect(columnHeaders).toHaveBeenCalled();
+  });
+});

--- a/handsontable/src/3rdparty/walkontable/test/spec/scroll/columnHeaderRenderSkip.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/scroll/columnHeaderRenderSkip.spec.js
@@ -116,4 +116,33 @@ describe('Walkontable column-header render skip on vertical scroll', () => {
 
     expect(columnHeaders).toHaveBeenCalled();
   });
+
+  it('should re-render the column headers on a full render even if the scroll-direction flags are still set', async() => {
+    const columnHeaders = jasmine.createSpy('columnHeaders').and.callFake((col, TH) => {
+      TH.innerHTML = `C${col}`;
+    });
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      rowHeaders: [function(row, TH) {
+        TH.innerHTML = row + 1;
+      }],
+      columnHeaders: [columnHeaders],
+    });
+
+    wt.draw();
+
+    // Simulate the reentrancy window: an `afterScroll` hook can call `hot.render()` (a full,
+    // `forceFullRender` `draw(false)`) while the scroll-direction flags are still set. A full render
+    // must always rebuild the headers, so the skip must NOT fire here.
+    wt.wtOverlays.verticalScrolling = true;
+    wt.wtOverlays.horizontalScrolling = false;
+
+    columnHeaders.calls.reset();
+
+    wt.draw(false); // full render (entered as a non-fast draw), flags still set
+
+    expect(columnHeaders).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
### Context

The PR adds a per-draw skip for the column-header (THEAD) pass during a pure vertical scroll. On a pure vertical scroll the column render window does not change, so the THEAD (column header rows + header cells) is identical draw-to-draw — yet the engine re-renders every column header on all header-bearing overlays on every vertical band shift (`TH.className = ''`, attribute wipe, per-header meta lookup, header class-array rebuild, `updateCellHeader`, and the `afterGetColHeader` hook per TH). This is wasted work on the hottest scroll path.

The skip reuses the engine's existing `verticalScrolling && !horizontalScrolling` scroll-direction flags (the same signal the bottom-overlay fast-draw already trusts) as the "nothing but scroll changed" gate — no new dirty-flag system is introduced. As defense-in-depth it also compares the column render window (offset + counts) per `TableRenderer` before skipping. Any data, settings, selection, or column-window change re-renders the headers.

**Behavior note:** `afterGetColHeader` now fires only when the column window changes (or on any content/settings/selection draw), not on every vertical-scroll frame. All core consumers (filters, dropdownMenu, columnSorting, collapsibleColumns, hiddenColumns) are state-change-driven and route through `hot.render()` (which does not skip), so there is no functional regression.

**Correctness (scroll-driven gate):** the scroll-direction flags alone are not sufficient — `fireScrollCallbacksAndReset` fires the `afterScroll*` hooks before resetting the flags, so an `afterScroll` hook calling `hot.render()` runs a `forceFullRender` (`draw(false)`) while the flags are still set. To keep a full render from wrongly skipping headers, the skip is additionally gated on `Overlays.isScrollDrivenDraw`, set at the top of the master draw cycle from the master's entry `fastDraw` (a `forceFullRender` always enters as `draw(false)`). Clones read it through their clone source, so the header-render decision is consistent across the master and every header-bearing overlay (top, inline-start, and the top-left corner). The bottom and bottom-left-corner overlays do not render column headers at all, but their pre-existing fast-draw (`bottomFastDraw`) and the overlay size-adjust branch in `Overlays.refresh` shared the same latent flag-staleness issue, so the same `isScrollDrivenDraw` gate is applied there too. The top/inline-start overlays and the top-left corner pass the raw `fastDraw` argument for positioning and were never affected.

**Measured (100k × 100, main theme):** column-header re-render fully eliminated on vertical scroll (0 THEAD content mutations across 300 steps, 300 skips / 0 renders on all 4 overlays); horizontal scroll is unchanged (headers correctly re-render when columns move).

### Performance

Per-draw CPU cost (median ms/draw), measured through the real scroll-sync path on a 100k × 100 grid (row + column headers, main theme, 1200 × 600). "Before" is this branch's base (`feature/DEV-1995_Walkontable-single-pass-layout`); "After" is this PR. Interleaved A/B over 9 rounds in the same build (header-skip toggled on/off) so run-to-run drift cancels. Re-confirmed on the final build (including the `isScrollDrivenDraw` gate and the bottom-overlay fix).

| Scenario | Before (DEV-1995) | After (this PR) | Δ |
|---|--:|--:|--:|
| Vertical scroll, 1 row (24px) / draw | 1.389 ms | 1.285 ms | **−7.5%** |
| Vertical scroll, 5 rows (120px) / draw | 3.095 ms | 2.919 ms | **−5.7%** |
| Vertical scroll, ~26 rows (600px) / draw | 3.938 ms | 3.740 ms | **−5.0%** |
| Horizontal scroll (80px) / draw | 0.586 ms | 0.577 ms | −1.5% (noise) |

The column-header (THEAD) re-render is fully skipped on vertical scroll (0 THEAD content mutations across 300 steps; 300 skips / 0 renders on all 4 header-bearing overlays). Horizontal scroll is unchanged, as expected — the column window moves, so the headers must re-render.

### How has this been tested?

New E2E specs plus targeted regression runs:

- `npm run test:walkontable --prefix handsontable` — 753 specs, 0 failures (includes 4 new specs in `test/spec/scroll/columnHeaderRenderSkip.spec.js`, covering the vertical-scroll skip, the horizontal re-render, a non-scroll draw, and a full render with the scroll flags still set).
- `npm run test:types --prefix handsontable`
- `npm run eslint --prefix handsontable`
- `npm run test:e2e --prefix handsontable -- --testPathPattern='colHeader\.spec|rowHeader\.spec|renderSizeProbe'`
- `npm run test:e2e --prefix handsontable -- --testPathPattern='beforeHighlightingColumnHeader|beforeHighlightingRowHeader|beforeSelectionHighlightSet|tableView\.spec|scrollViewportTo|beforeViewportScroll'`
- `npm run test:e2e --prefix handsontable -- --testPathPattern='a11y/headers|a11y/cellStates|nestedHeaders'`
- `npm run test:e2e --prefix handsontable -- --testPathPattern='collapsibleColumns|columnSorting'`
- `npm run test:e2e --prefix handsontable -- --testPathPattern='dropdownMenu|hiddenColumns/__tests__/plugins'`
- Manual (real Chrome): whole-column selection highlight tracks the correct header across vertical scroll with no stale highlight; `updateSettings({ colHeaders })` re-renders headers; header content persists across skipped draws; no console errors.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2022

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2022
