### PR TITLE
Docs: clarify changelog requirements for docs-only PRs

### DIFF
--- a/.ai/DOC-STANDARDS.md
+++ b/.ai/DOC-STANDARDS.md
@@ -9,13 +9,11 @@ The gating policy and a digest of the most-violated rules live in the root `AGEN
 - Any change to a public API (methods, options, hooks, plugins, typings, errors) **must** update the corresponding JSDoc/Typedoc comments and guides.
 - Any change to user-facing behavior or look-and-feel **must** be documented.
 - Any breaking change **must** include a migration guide step (see below).
-- A PR that adds a new documentation page is included in the changelog (do not use `[skip changelog]`).
 
 ## Documentation branch conventions
 
 - Feature docs branches: `docs/issue-xxxx` (e.g., `docs/issue-9024`), branched from the feature branch or `develop`.
 - Release docs branches: `release/x.y.z-docs`, branched from `release/x.y.z`.
-- Documentation-only PRs use `[skip changelog]` in the PR description, **unless** the PR adds a new documentation page.
 
 ## Writing style rules
 

--- a/.changelogs/README.md
+++ b/.changelogs/README.md
@@ -7,6 +7,8 @@ This directory includes temporary changelog entries, in the form of simple `.jso
 
 Every pull request in this repository requires a new changelog entry to be created in this directory, asserted by a GitHub actions workflow. The commit workflow will fail in any PR that does not have a new `.changelogs/*.json` file added. If a pushed commit does not have a PR associated with it, the check is skipped entirely.
 
+Changelog entries are expected only for source-code changes to the library core or the wrappers. Documentation-only, test-only, and CI/tooling PRs should disable the check instead.
+
 **To disable this check**, simply add the following string to the **PR description**:
 
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,7 +121,7 @@ High-level principles. Core-internal detail lives in `handsontable/.ai/ARCHITECT
 
 These standards apply to **all** documentation across the monorepo — guides, the API reference (JSDoc/Typedoc inside `handsontable/src`), code comments, changelog entries, release notes, migration guides, and READMEs. An agent editing core JSDoc applies them without opening `docs/AGENTS.md`. **Full reference: `.ai/DOC-STANDARDS.md`** (the complete 13 writing-style rules, migration-guide spec, trademark rules, and docs branch conventions). The docs *site* has additional mechanics (frontmatter, sidebar, example embedding, voice overrides) in `docs/AGENTS.md`.
 
-- **When docs are required:** any public-API change updates JSDoc/Typedoc + guides; any user-facing behavior change is documented; any breaking change adds a migration guide step; a PR that adds a new docs page goes in the changelog (no `[skip changelog]`).
+- **When docs are required:** any public-API change updates JSDoc/Typedoc + guides; any user-facing behavior change is documented; any breaking change adds a migration guide step.
 - **Writing style (most-violated):** short sentences, active voice, American English (`behavior` not `behaviour`), "you" not "we", Oxford comma, no evaluative adjectives ("easy"/"simple"/"obvious"), en dashes (–) in non-site text. Full list in `.ai/DOC-STANDARDS.md`.
 - **Trademarks:** pages mentioning "Excel" (and "Google Sheets") need the trademark disclaimer — see `.ai/DOC-STANDARDS.md`.
 - **JSDoc format:** always use the multiline block style — never the single-line form. Every JSDoc comment must be written as:


### PR DESCRIPTION
### Context

The PR changes changelog guidance so documentation-only, test-only, and CI/tooling PRs can skip changelog entries. It also keeps the policy consistent across `.ai/DOC-STANDARDS.md`, `.changelogs/README.md`, and `AGENTS.md`.

### How has this been tested?

- Reviewed all edited guidance files for policy consistency and wording alignment.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. N/A
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only policy clarification with no runtime, CI script, or product code changes.
> 
> **Overview**
> Clarifies **when a changelog entry is required** across contributor guidance: entries apply to **library core and wrapper source-code changes**, not documentation-only, test-only, or CI/tooling PRs (those should use **`[skip changelog]`** in the PR description).
> 
> Removes the prior rule that **adding a new documentation page** always requires a changelog entry. The same alignment appears in **`.ai/DOC-STANDARDS.md`**, **`.changelogs/README.md`**, and **`AGENTS.md`** (including trimming redundant docs-branch wording about changelog exceptions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c98f8b7eda37c8c0767ae48b03f4b9c3178d5ea7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->