### PR TITLE
DEV-798: Document editor=false keyboard shortcuts

### DIFF
--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -2362,10 +2362,18 @@ export default (): Record<string, unknown> => {
      * You'll still be able to change cells' content through Handsontable's API
      * or through plugins (e.g. [`CopyPaste`](@/api/copyPaste.md)), though.
      *
+     * When the `editor` option is set to `false`, you can still use these keyboard shortcuts:
+     *
+     * | Shortcut                                | Action                                                      |
+     * | --------------------------------------- | ----------------------------------------------------------- |
+     * | `Delete` / `Backspace`                  | Clear the contents of the selected cells                    |
+     * | `Ctrl` + `Enter` / `Cmd` + `Enter`      | Fill selected cells with the value of the active cell       |
+     *
      * To set the [`editor`](#editor), [`renderer`](#renderer), and [`validator`](#validator)
      * options all at once, use the [`type`](#type) option.
      *
      * Read more:
+     * - [Keyboard shortcuts](@/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md)
      * - [Cell editor](@/guides/cell-functions/cell-editor/cell-editor.md)
      * - [Cell type](@/guides/cell-types/cell-type/cell-type.md)
      * - [Configuration options: Cascading configuration](@/guides/getting-started/configuration-options/configuration-options.md#cascading-configuration)


### PR DESCRIPTION
### Context

The PR changes the `editor` option API description to document which keyboard shortcuts remain available when `editor` is set to `false`, matching DEV-798.

### How has this been tested?

- `npm --prefix handsontable run build:commonjs`
- `npm --prefix docs run docs:api`
- Verified generated `options` API section contains the new shortcuts table and keyboard shortcuts guide link.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-798

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-798

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only JSDoc changes in metaSchema; no runtime or API behavior changes.
> 
> **Overview**
> Updates the **`editor`** option JSDoc in `metaSchema.ts` so disabling cell editors (`editor: false`) is clearer for API consumers.
> 
> Adds a shortcuts table listing **Delete/Backspace** (clear selection) and **Ctrl/Cmd+Enter** (fill down from the active cell) as still available when editors are off. Also adds a **Read more** link to the keyboard shortcuts guide alongside the existing cell editor docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebe53738e211f6126249e6c4af8736d3e273fd25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->