### PR TITLE
DEV-758: Fix CollapsibleColumns API docs links

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,7 @@
     "docs:code-examples:generate-js": "node scripts/transpile-doc-example.mjs",
     "build": "npm run docs:api && npm run docs:validate-highlights && astro build",
     "preview": "astro preview",
-    "docs:test:plugins": "node --test src/plugins/__tests__/*.test.mjs src/lib/__tests__/*.test.mjs src/components/__tests__/*.test.mjs cloudflare/__tests__/*.test.mjs deploy/__tests__/*.test.mjs",
+    "docs:test:plugins": "node --test src/plugins/__tests__/*.test.mjs src/lib/__tests__/*.test.mjs src/components/__tests__/*.test.mjs cloudflare/__tests__/*.test.mjs deploy/__tests__/*.test.mjs scripts/jsdoc-convert/renderer/preProcessors/__tests__/*.test.mjs",
     "docs:validate-highlights": "node scripts/validate-version-highlights.mjs",
     "docs:lint": "eslint --ext .js,.mjs,.ts,.astro src content",
     "docs:lint:fix": "eslint --ext .js,.mjs,.ts,.astro src content --fix",

--- a/docs/scripts/jsdoc-convert/renderer/preProcessors/__tests__/applyOptionsToPlugins.test.mjs
+++ b/docs/scripts/jsdoc-convert/renderer/preProcessors/__tests__/applyOptionsToPlugins.test.mjs
@@ -1,0 +1,137 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { applyOptionsToPlugins } from '../applyOptionsToPlugins.mjs';
+
+const [memorizeOptions, applyPluginOptions] = applyOptionsToPlugins;
+
+const buildOptionsData = (...options) => [
+  {
+    meta: {
+      filename: 'metaSchema.js',
+    },
+  },
+  ...options
+];
+
+const buildPluginData = plugin => [
+  {
+    customTags: [
+      {
+        tag: 'plugin',
+        value: plugin,
+      },
+    ],
+  },
+  {
+    kind: 'constructor',
+    name: plugin,
+  },
+  {
+    kind: 'function',
+    name: 'someMethod',
+  },
+];
+
+const buildPluginDataWithoutCustomTags = plugin => [
+  {
+    kind: 'member',
+    memberof: plugin,
+    name: 'someMember',
+  },
+  {
+    kind: 'constructor',
+    name: plugin,
+  },
+  {
+    kind: 'function',
+    memberof: plugin,
+    name: 'someMethod',
+  },
+];
+
+test('splices options into matching plugin data after the constructor', () => {
+  const option = {
+    category: 'SplicedOptionsPlugin',
+    description: 'Plugin option description.',
+    name: 'splicedOptionsPlugin',
+  };
+
+  memorizeOptions(buildOptionsData(option));
+
+  const pluginData = buildPluginData('SplicedOptionsPlugin');
+  const result = applyPluginOptions(pluginData);
+
+  assert.equal(result[2].name, 'splicedOptionsPlugin');
+  assert.equal(result[2].isOption, true);
+  assert.equal(result[2].category, undefined);
+  assert.equal(result[2].memberof, 'SplicedOptionsPlugin');
+  assert.equal(result[3].name, 'someMethod');
+});
+
+test('splices options into plugin data identified by member ownership', () => {
+  const option = {
+    category: 'MemberOwnedOptionsPlugin',
+    description: 'Member-owned plugin option description.',
+    name: 'memberOwnedOptionsPlugin',
+  };
+
+  memorizeOptions(buildOptionsData(option));
+
+  const result = applyPluginOptions(buildPluginDataWithoutCustomTags('MemberOwnedOptionsPlugin'));
+
+  assert.equal(result[2].name, 'memberOwnedOptionsPlugin');
+  assert.equal(result[2].isOption, true);
+  assert.equal(result[2].memberof, 'MemberOwnedOptionsPlugin');
+});
+
+test('does not splice options into a different plugin', () => {
+  memorizeOptions(buildOptionsData({
+    category: 'OtherOptionsPlugin',
+    description: 'Other option description.',
+    name: 'otherOptionsPlugin',
+  }));
+
+  const pluginData = buildPluginData('PluginWithoutOptions');
+  const result = applyPluginOptions(pluginData);
+
+  assert.deepEqual(result, pluginData);
+});
+
+test('normalizes self-links and option anchors only in injected option descriptions', () => {
+  const option = {
+    category: 'CollapsibleColumns',
+    description: [
+      'The `collapsibleColumns` option configures the [`CollapsibleColumns`](@/api/collapsibleColumns.md) plugin.',
+      '',
+      'Read more:',
+      '- [Plugins: `CollapsibleColumns`](@/api/collapsibleColumns.md)',
+      '- [`nestedHeaders`](#nestedHeaders)',
+    ].join('\n'),
+    name: 'collapsibleColumns',
+  };
+
+  memorizeOptions(buildOptionsData(option));
+
+  const result = applyPluginOptions(buildPluginData('CollapsibleColumns'));
+  const injectedOption = result.find(member => member.name === 'collapsibleColumns');
+
+  assert.equal(
+    option.description,
+    [
+      'The `collapsibleColumns` option configures the [`CollapsibleColumns`](@/api/collapsibleColumns.md) plugin.',
+      '',
+      'Read more:',
+      '- [Plugins: `CollapsibleColumns`](@/api/collapsibleColumns.md)',
+      '- [`nestedHeaders`](#nestedHeaders)',
+    ].join('\n')
+  );
+  assert.equal(
+    injectedOption.description,
+    [
+      'The `collapsibleColumns` option configures the `CollapsibleColumns` plugin.',
+      '',
+      'Read more:',
+      '- [`nestedHeaders`](@/api/options.md#nestedheaders)',
+    ].join('\n')
+  );
+});

--- a/docs/scripts/jsdoc-convert/renderer/preProcessors/applyOptionsToPlugins.mjs
+++ b/docs/scripts/jsdoc-convert/renderer/preProcessors/applyOptionsToPlugins.mjs
@@ -1,6 +1,50 @@
 import { isJsdocOptions, isJsdocPlugin } from '../predictors.mjs';
 
 const optionsPerPlugin = {};
+const escapeRegExp = value => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const toApiFileName = plugin => `${plugin.replace(/^([A-Z])/, (_, upper) => upper.toLowerCase())}.md`;
+const toOptionAnchor = anchor => anchor.toLowerCase();
+const removeSelfLinkListItems = (description, pluginApiFileName) => {
+  const selfLinkPattern = new RegExp(`^\\s*- .*\\]\\(@/api/${escapeRegExp(pluginApiFileName)}(?:#[^)]+)?\\)`);
+
+  return description.split('\n')
+    .filter(line => !selfLinkPattern.test(line))
+    .join('\n');
+};
+const removeSelfLinks = (description, pluginApiFileName) => {
+  const selfLinkPattern = new RegExp(`\\[([^\\]]+)\\]\\(@/api/${escapeRegExp(pluginApiFileName)}(?:#[^)]+)?\\)`, 'g');
+
+  return description.replace(selfLinkPattern, '$1');
+};
+const rewriteLocalOptionAnchors = (description) => {
+  return description.replace(/\]\(#([^)]+)\)/g, (_, anchor) => {
+    return `](@/api/options.md#${toOptionAnchor(anchor)})`;
+  });
+};
+const normalizeInjectedOptionDescription = (description, plugin) => {
+  if (!description) {
+    return description;
+  }
+
+  const pluginApiFileName = toApiFileName(plugin);
+  const withoutSelfLinkListItems = removeSelfLinkListItems(description, pluginApiFileName);
+  const withoutSelfLinks = removeSelfLinks(withoutSelfLinkListItems, pluginApiFileName);
+
+  return rewriteLocalOptionAnchors(withoutSelfLinks);
+};
+const getPluginName = (data) => {
+  const plugin = data[0].customTags
+    ?.filter(tag => tag.tag === 'plugin').pop()
+    ?.value;
+
+  if (plugin) {
+    return plugin;
+  }
+
+  return data
+    .map(member => member.memberof)
+    .find(memberof => optionsPerPlugin[memberof]);
+};
 const memorizeOptions = data => (!isJsdocOptions(data) ? data : data.map((x) => {
   if (x.category) {
     const cat = x.category.trim();
@@ -13,14 +57,12 @@ const memorizeOptions = data => (!isJsdocOptions(data) ? data : data.map((x) => 
 }));
 
 const applyPluginOptions = (data) => {
-  if (isJsdocPlugin(data)) {
-    const plugin = data[0].customTags
-      ?.filter(tag => tag.tag === 'plugin').pop()
-      ?.value;
-
+  if (isJsdocPlugin(data) || data.some(member => optionsPerPlugin[member.memberof])) {
+    const plugin = getPluginName(data);
     const options = optionsPerPlugin[plugin]?.map((option) => {
       return {
         ...option,
+        description: normalizeInjectedOptionDescription(option.description, plugin),
         isOption: true,
         category: undefined,
         memberof: plugin // workaround to force print as a member.

--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -851,6 +851,7 @@ export default (): Record<string, unknown> => {
      *
      * Read more:
      * - [Plugins: `CollapsibleColumns`](@/api/collapsibleColumns.md)
+     * - [Column groups: Collapsible headers](@/guides/columns/column-groups/column-groups.md#collapsible-headers)
      * - [`nestedHeaders`](#nestedHeaders)
      *
      * @memberof Options#

--- a/handsontable/src/plugins/collapsibleColumns/collapsibleColumns.ts
+++ b/handsontable/src/plugins/collapsibleColumns/collapsibleColumns.ts
@@ -60,6 +60,10 @@ const actionDictionary = new Map([
  * To limit this functionality to a smaller group of headers, define the `collapsibleColumns` property as an array
  * of objects, as in the example below.
  *
+ * Read more:
+ * - [Guides: Column groups](@/guides/columns/column-groups/column-groups.md#collapsible-headers)
+ * - [Configuration options: `collapsibleColumns`](@/api/options.md#collapsiblecolumns)
+ *
  * @example
  * ::: only-for javascript
  * ```js


### PR DESCRIPTION
### Context

The PR fixes DEV-758 by restoring reverse links from the `CollapsibleColumns` API reference to the column groups guide and `collapsibleColumns` option documentation.

It also fixes the docs API converter so option JSDoc copied onto plugin API pages does not produce self-links or broken local option anchors.

[skip changelog]

### How has this been tested?

- `rtk npm --prefix docs run docs:test:plugins`
- `rtk npm --prefix handsontable run eslint`
- `rtk npm --prefix docs run docs:lint`
- `rtk npm --prefix handsontable run build`
- `rtk npm --prefix docs run docs:api`
- Manually inspected generated `docs/content/api/collapsibleColumns.md` for the guide link, `options.md#collapsiblecolumns`, and rewritten `options.md#nestedheaders` links.

Manual check URLs for a local docs server:

- `http://localhost:4321/docs/javascript-data-grid/api/collapsible-columns/`
- `http://localhost:4321/docs/javascript-data-grid/api/options/#collapsiblecolumns`
- `http://localhost:4321/docs/javascript-data-grid/column-groups/#collapsible-headers`

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-758

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-758

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and docs build preprocessing only; no runtime grid behavior changes.
> 
> **Overview**
> Fixes **CollapsibleColumns** API documentation cross-links and hardens the JSDoc→API converter when plugin pages embed option docs.
> 
> **Source JSDoc** in `metaSchema` and the CollapsibleColumns plugin now adds “Read more” links to the column groups guide and `options.md#collapsiblecolumns`, so generated pages can link back to guides and the global options reference.
> 
> **`applyOptionsToPlugins`** now resolves plugins by `memberof` when there is no `@plugin` tag, and when options are spliced onto a plugin page it **rewrites only the injected copy** of each option description: strips self-links to that plugin’s API file (including redundant list items), and turns in-page `#option` anchors into `@/api/options.md#…` links. Original option text used elsewhere is unchanged.
> 
> **Tests** cover splicing, member-owned plugins, isolation between plugins, and link normalization; **`docs:test:plugins`** includes the new test file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4ea0368abccf4ef36bc48d857105ac9cdbac9ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->