### PR TITLE
DEV-1991: Restore generated step list styling

### DIFF
--- a/docs/src/components/__tests__/step-list-styles.test.mjs
+++ b/docs/src/components/__tests__/step-list-styles.test.mjs
@@ -8,10 +8,10 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const pageCss = readFileSync(join(__dirname, '../../styles/layout/page.css'), 'utf8');
 
 test('generated step lists have global marker and guide styles', () => {
-  assert.match(pageCss, /\n\.sl-steps\s*\{[\s\S]*margin-top:\s*2rem/);
-  assert.match(pageCss, /\.sl-steps\s*\{[\s\S]*counter-reset:\s*steps-counter/);
-  assert.match(pageCss, /\.sl-steps\s*>\s*li\s*\{[\s\S]*counter-increment:\s*steps-counter/);
-  assert.match(pageCss, /\.sl-steps\s*>\s*li\s*>\s*\*\s*\+\s*\*\s*\{[\s\S]*margin-top:\s*var\(--sl-content-gap-y\)/);
-  assert.match(pageCss, /\.sl-steps\s*>\s*li::before\s*\{[\s\S]*content:\s*counter\(steps-counter\)/);
-  assert.match(pageCss, /\.sl-steps\s*>\s*li::after\s*\{[\s\S]*background-color:\s*var\(--sl-color-hairline-light\)/);
+  assert.match(pageCss, /(?:^|\n)\.sl-steps\s*\{[^}]*margin-top:\s*2rem/);
+  assert.match(pageCss, /\.sl-steps\s*\{[^}]*counter-reset:\s*steps-counter/);
+  assert.match(pageCss, /\.sl-steps\s*>\s*li\s*\{[^}]*counter-increment:\s*steps-counter/);
+  assert.match(pageCss, /\.sl-steps\s*>\s*li\s*>\s*\*\s*\+\s*\*\s*\{[^}]*margin-top:\s*var\(--sl-content-gap-y\)/);
+  assert.match(pageCss, /\.sl-steps\s*>\s*li::before\s*\{[^}]*content:\s*counter\(steps-counter\)/);
+  assert.match(pageCss, /\.sl-steps\s*>\s*li::after\s*\{[^}]*background-color:\s*var\(--sl-color-hairline-light\)/);
 });

--- a/docs/src/components/__tests__/step-list-styles.test.mjs
+++ b/docs/src/components/__tests__/step-list-styles.test.mjs
@@ -8,8 +8,10 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const pageCss = readFileSync(join(__dirname, '../../styles/layout/page.css'), 'utf8');
 
 test('generated step lists have global marker and guide styles', () => {
+  assert.match(pageCss, /\n\.sl-steps\s*\{[\s\S]*margin-top:\s*2rem/);
   assert.match(pageCss, /\.sl-steps\s*\{[\s\S]*counter-reset:\s*steps-counter/);
   assert.match(pageCss, /\.sl-steps\s*>\s*li\s*\{[\s\S]*counter-increment:\s*steps-counter/);
+  assert.match(pageCss, /\.sl-steps\s*>\s*li\s*>\s*\*\s*\+\s*\*\s*\{[\s\S]*margin-top:\s*var\(--sl-content-gap-y\)/);
   assert.match(pageCss, /\.sl-steps\s*>\s*li::before\s*\{[\s\S]*content:\s*counter\(steps-counter\)/);
   assert.match(pageCss, /\.sl-steps\s*>\s*li::after\s*\{[\s\S]*background-color:\s*var\(--sl-color-hairline-light\)/);
 });

--- a/docs/src/components/__tests__/step-list-styles.test.mjs
+++ b/docs/src/components/__tests__/step-list-styles.test.mjs
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pageCss = readFileSync(join(__dirname, '../../styles/layout/page.css'), 'utf8');
+
+test('generated step lists have global marker and guide styles', () => {
+  assert.match(pageCss, /\.sl-steps\s*\{[\s\S]*counter-reset:\s*steps-counter/);
+  assert.match(pageCss, /\.sl-steps\s*>\s*li\s*\{[\s\S]*counter-increment:\s*steps-counter/);
+  assert.match(pageCss, /\.sl-steps\s*>\s*li::before\s*\{[\s\S]*content:\s*counter\(steps-counter\)/);
+  assert.match(pageCss, /\.sl-steps\s*>\s*li::after\s*\{[\s\S]*background-color:\s*var\(--sl-color-hairline-light\)/);
+});

--- a/docs/src/styles/layout/page.css
+++ b/docs/src/styles/layout/page.css
@@ -205,6 +205,14 @@ starlight-toc {
 
 /* Generated recipe steps emit Starlight's `.sl-steps` markup without instantiating
    the `<Steps>` component, so keep the component's global marker styles here. */
+.sl-steps {
+  margin-top: 2rem;
+}
+
+.sl-steps > li > * + * {
+  margin-top: var(--sl-content-gap-y);
+}
+
 @layer starlight.components {
   .sl-steps {
     --bullet-size: calc(var(--sl-line-height) * 1rem);
@@ -213,7 +221,6 @@ starlight-toc {
     list-style: none;
     counter-reset: steps-counter var(--sl-steps-start, 0);
     padding-inline-start: 0;
-    margin-top: 2rem;
   }
 
   .sl-steps > li {

--- a/docs/src/styles/layout/page.css
+++ b/docs/src/styles/layout/page.css
@@ -203,12 +203,79 @@ starlight-toc {
   margin-top: 3rem;
 }
 
-.sl-steps {
-  margin-top: 2rem;
+/* Generated recipe steps emit Starlight's `.sl-steps` markup without instantiating
+   the `<Steps>` component, so keep the component's global marker styles here. */
+@layer starlight.components {
+  .sl-steps {
+    --bullet-size: calc(var(--sl-line-height) * 1rem);
+    --bullet-margin: 0.375rem;
+
+    list-style: none;
+    counter-reset: steps-counter var(--sl-steps-start, 0);
+    padding-inline-start: 0;
+    margin-top: 2rem;
+  }
+
+  .sl-steps > li {
+    counter-increment: steps-counter;
+    position: relative;
+    padding-inline-start: calc(var(--bullet-size) + 1rem);
+    padding-bottom: 2rem;
+    min-height: calc(var(--bullet-size) + var(--bullet-margin));
+  }
+
+  .sl-steps > li + li {
+    margin-top: 0;
+  }
+
+  .sl-steps > li::before {
+    content: counter(steps-counter);
+    position: absolute;
+    top: 0;
+    inset-inline-start: 0;
+    width: var(--bullet-size);
+    height: var(--bullet-size);
+    line-height: var(--bullet-size);
+    font-size: var(--sl-text-xs);
+    font-weight: 600;
+    text-align: center;
+    color: var(--sl-color-white);
+    background-color: var(--sl-color-gray-6);
+    border-radius: 99rem;
+    box-shadow: inset 0 0 0 1px var(--sl-color-gray-5);
+  }
+
+  .sl-steps > li::after {
+    --guide-width: 1px;
+
+    content: '';
+    position: absolute;
+    top: calc(var(--bullet-size) + var(--bullet-margin));
+    bottom: var(--bullet-margin);
+    inset-inline-start: calc((var(--bullet-size) - var(--guide-width)) / 2);
+    width: var(--guide-width);
+    background-color: var(--sl-color-hairline-light);
+  }
 }
 
-.sl-steps > li {
-  padding-bottom: 2rem;
+@layer starlight.content {
+  .sl-steps > li > :first-child {
+    --lh: calc(1em * var(--sl-line-height));
+    --shift-y: calc(0.5 * (var(--bullet-size) - var(--lh)));
+
+    transform: translateY(var(--shift-y));
+    margin-bottom: var(--shift-y);
+  }
+
+  .sl-steps > li > :first-child:where(h1, h2, h3, h4, h5, h6) {
+    --lh: calc(1em * var(--sl-line-height-headings));
+  }
+
+  @supports (--prop: 1lh) {
+    .sl-steps > li > :first-child {
+      --lh: 1lh;
+    }
+  }
 }
 
 .sl-markdown-content ul:not(:where(.not-content *)) {


### PR DESCRIPTION
### Context

The PR fixes a regression from the DEV-1991 docs rendering pipeline update. Generated recipe step lists still emit `<ol class="sl-steps">`, but Starlight 0.41 keeps the marker and guide styling inside the `<Steps>` component, so generated steps rendered as plain ordered headings.

This change restores the Starlight step marker and guide styles globally for generated `.sl-steps` markup and adds a regression test for the CSS rules.

Broken state:
<img width="637" height="119" alt="image" src="https://github.com/user-attachments/assets/5bbd8b03-1304-42a2-be97-8cba467e0aa9" />

Should be:
<img width="623" height="130" alt="image" src="https://github.com/user-attachments/assets/9645d4b1-f82d-4cb7-801e-a86b1f413a0c" />
 

### How has this been tested?

- `npm --prefix docs run docs:lint`
- `npm --prefix docs run docs:test:plugins`

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1991

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1991

Made with [Cursor](https://cursor.com)