### PR TITLE
DEV-2023: Delta-render rows on vertical scroll (rotate surviving rows)

### DIFF
--- a/.changelogs/12995.json
+++ b/.changelogs/12995.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Improved vertical scrolling performance by re-rendering only the rows entering the viewport and reusing the rows that stay.",
+  "type": "changed",
+  "issueOrPR": 12995,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/src/render/cells.ts
+++ b/handsontable/src/3rdparty/walkontable/src/render/cells.ts
@@ -64,6 +64,12 @@ export class CellsRenderer extends BaseRenderer {
     const { rowsToRender, columnsToRender, rows, rowHeaders } = this.table;
 
     for (let visibleRowIndex = 0; visibleRowIndex < rowsToRender; visibleRowIndex++) {
+      // On a delta (row-rotation) draw the surviving rows keep their existing cell content — only the
+      // rows entering the band are re-rendered. On a full draw every row is renderable.
+      if (!this.table.isRowRenderable(visibleRowIndex)) {
+        continue; // eslint-disable-line no-continue
+      }
+
       const sourceRowIndex = this.table.renderedRowToSource(visibleRowIndex);
       const TR = rows!.getRenderedNode(visibleRowIndex);
 

--- a/handsontable/src/3rdparty/walkontable/src/render/index.ts
+++ b/handsontable/src/3rdparty/walkontable/src/render/index.ts
@@ -124,6 +124,19 @@ class Renderer {
   }
 
   /**
+   * Marks this draw as one where the TBODY row band may be delta-rendered (rotate surviving rows,
+   * render only entering rows) when the row window shifted (a pure vertical scroll).
+   *
+   * @param {boolean} renderable Whether the row band may be delta-rendered for this draw.
+   * @returns {Renderer}
+   */
+  setRowDeltaRenderable(renderable: boolean) {
+    this.renderer.setRowDeltaRenderable(renderable);
+
+    return this;
+  }
+
+  /**
    * Renders the table.
    */
   render() {

--- a/handsontable/src/3rdparty/walkontable/src/render/rowHeaders.ts
+++ b/handsontable/src/3rdparty/walkontable/src/render/rowHeaders.ts
@@ -61,6 +61,12 @@ export class RowHeadersRenderer extends BaseRenderer {
     const { rowsToRender, rowHeaderFunctions, rowHeadersCount, rows, cells } = this.table;
 
     for (let visibleRowIndex = 0; visibleRowIndex < rowsToRender; visibleRowIndex++) {
+      // On a delta (row-rotation) draw the surviving rows keep their existing row-header content —
+      // only the rows entering the band are re-rendered. On a full draw every row is renderable.
+      if (!this.table.isRowRenderable(visibleRowIndex)) {
+        continue; // eslint-disable-line no-continue
+      }
+
       const sourceRowIndex = this.table.renderedRowToSource(visibleRowIndex);
       const TR = rows!.getRenderedNode(visibleRowIndex);
 

--- a/handsontable/src/3rdparty/walkontable/src/render/tableRenderer.ts
+++ b/handsontable/src/3rdparty/walkontable/src/render/tableRenderer.ts
@@ -219,6 +219,41 @@ export class TableRenderer {
    * @type {number}
    */
   #prevRowHeadersCount: number = -1;
+  /**
+   * When `true`, the TBODY row band may be delta-rendered for this draw: instead of re-rendering
+   * every rendered row, rotate the surviving TR nodes and run the cell/row-header renderers only for
+   * the rows entering the band. Set once per draw by the draw cycle; only a pure vertical scroll (no
+   * data, settings, selection, or column-window change) enables it. Defaults to `false`.
+   *
+   * @type {boolean}
+   */
+  #rowDeltaRenderable: boolean = false;
+  /**
+   * `true` once a full render has stored the current row render window (offset + count).
+   *
+   * @type {boolean}
+   */
+  #hasStoredRowWindow: boolean = false;
+  /**
+   * The first rendered row (row filter offset, a renderable index) captured on the last render.
+   *
+   * @type {number}
+   */
+  #prevRowOffset: number = -1;
+  /**
+   * The number of rendered rows captured on the last render.
+   *
+   * @type {number}
+   */
+  #prevRowsToRender: number = -1;
+  /**
+   * The half-open range `[start, end)` of visual row indexes that must be rendered on the current
+   * delta draw (the rows entering the band). `null` means "render every rendered row" (a full band
+   * render). Consumed by the cells and row-headers renderers via {@link TableRenderer#isRowRenderable}.
+   *
+   * @type {{ start: number, end: number } | null}
+   */
+  #enteringRowsRange: { start: number; end: number } | null = null;
 
   /**
    * Creates a new TableRenderer instance.
@@ -278,6 +313,32 @@ export class TableRenderer {
    */
   setColumnHeadersRenderSkippable(skippable: boolean) {
     this.#columnHeadersRenderSkippable = skippable;
+  }
+
+  /**
+   * Marks this draw as one where the TBODY row band may be delta-rendered (rotate surviving rows,
+   * render only entering rows), provided the row render window shifted by fewer rows than the band
+   * holds. The draw cycle sets this to `true` only for a pure vertical scroll and to `false`
+   * otherwise, so any data, settings, selection, or column-window change re-renders the whole band.
+   *
+   * @param {boolean} renderable Whether the row band may be delta-rendered for this draw.
+   */
+  setRowDeltaRenderable(renderable: boolean) {
+    this.#rowDeltaRenderable = renderable;
+  }
+
+  /**
+   * Returns `true` when the cell / row-header renderers must render the given visual row on the
+   * current draw. On a full band render this is always `true`; on a delta draw it is `true` only for
+   * the rows entering the band (the surviving rows keep their existing content and are skipped).
+   *
+   * @param {number} visualRowIndex The visual (rendered) row index, `0` to `rowsToRender - 1`.
+   * @returns {boolean}
+   */
+  isRowRenderable(visualRowIndex: number) {
+    const range = this.#enteringRowsRange;
+
+    return range === null || (visualRowIndex >= range.start && visualRowIndex < range.end);
   }
 
   /**
@@ -396,6 +457,89 @@ export class TableRenderer {
   }
 
   /**
+   * Computes the delta-render plan for the TBODY row band. Returns the half-open range of visual row
+   * indexes that must be rendered (the entering rows) and the rotation delta, or `null` when the band
+   * must be fully re-rendered. Delta rendering is only attempted on a pure vertical scroll where the
+   * band size is unchanged and the band shifted by fewer rows than it holds — otherwise every row is
+   * new (or the previous window is unknown), so a full render is both required and no slower.
+   *
+   * The offset is the row filter offset (a renderable index); renderable indexes stay contiguous
+   * across a scroll (hidden rows are already removed from the axis), so the shift is a clean rotation.
+   *
+   * @returns {{ delta: number, start: number, end: number } | null}
+   */
+  #computeRowDeltaPlan() {
+    if (!this.#rowDeltaRenderable || !this.#hasStoredRowWindow) {
+      return null;
+    }
+
+    const offset = this.rowFilter ? this.rowFilter.offset : 0;
+    const count = this.rowsToRender;
+
+    if (count === 0 || count !== this.#prevRowsToRender) {
+      return null;
+    }
+
+    const delta = offset - this.#prevRowOffset;
+
+    if (delta === 0 || Math.abs(delta) >= count) {
+      return null;
+    }
+
+    // Scroll down (delta > 0): the leaving rows are at the top, so the entering rows land at the
+    // bottom of the band. Scroll up (delta < 0): mirror — entering rows land at the top.
+    return delta > 0
+      ? { delta, start: count - delta, end: count }
+      : { delta, start: 0, end: -delta };
+  }
+
+  /**
+   * Rotates the surviving TR nodes of the TBODY in place so DOM child position `i` again holds the
+   * content for rendered row `i`, moving only the leaving nodes (which become the entering slots and
+   * are re-rendered afterwards). The surviving nodes are never re-parented, so any state they hold
+   * (focus, an open editor) is preserved. `moveBefore` (Chrome 133+) is used when available for the
+   * moved nodes with an `appendChild`/`insertBefore` fallback.
+   *
+   * @param {number} delta The signed row shift (positive = scrolled down, negative = scrolled up).
+   */
+  #rotateBodyRows(delta: number) {
+    const tbody = this.rows!.rootNode;
+    const supportsMoveBefore = typeof (tbody as unknown as {
+      moveBefore?: (node: Node, ref: Node | null) => void;
+    }).moveBefore === 'function';
+    const move = (node: Node, ref: Node | null) => {
+      if (supportsMoveBefore) {
+        (tbody as unknown as { moveBefore: (n: Node, r: Node | null) => void }).moveBefore(node, ref);
+      } else if (ref === null) {
+        tbody.appendChild(node);
+      } else {
+        tbody.insertBefore(node, ref);
+      }
+    };
+
+    if (delta > 0) {
+      // Move the top `delta` (leaving) rows to the end, keeping their relative order.
+      for (let i = 0; i < delta; i++) {
+        move(tbody.firstElementChild!, null);
+      }
+    } else {
+      // Move the bottom `|delta|` (leaving) rows to the front, keeping their relative order.
+      for (let i = 0; i < -delta; i++) {
+        move(tbody.lastElementChild!, tbody.firstElementChild);
+      }
+    }
+  }
+
+  /**
+   * Stores the current row render window (offset + count) so the next draw can compute its shift.
+   */
+  #storeRowWindow() {
+    this.#hasStoredRowWindow = true;
+    this.#prevRowOffset = this.rowFilter ? this.rowFilter.offset : 0;
+    this.#prevRowsToRender = this.rowsToRender;
+  }
+
+  /**
    * Renders the table.
    */
   render() {
@@ -408,9 +552,25 @@ export class TableRenderer {
       this.#storeColumnHeaderRenderWindow();
     }
 
+    // On a pure vertical scroll only the row band shifts. Rotate the surviving TR nodes into their
+    // new positions and render only the entering rows; the surviving rows keep their existing cell
+    // content, classes, and ARIA (their source row is unchanged). `#enteringRowsRange` gates the
+    // cell / row-header renderers through `isRowRenderable`. When it is `null`, every row renders.
+    const rowDeltaPlan = this.#computeRowDeltaPlan();
+
+    if (rowDeltaPlan) {
+      this.#rotateBodyRows(rowDeltaPlan.delta);
+      this.#enteringRowsRange = { start: rowDeltaPlan.start, end: rowDeltaPlan.end };
+    } else {
+      this.#enteringRowsRange = null;
+    }
+
     this.rows!.render();
     this.rowHeaders!.render();
     this.cells!.render();
+
+    this.#storeRowWindow();
+    this.#enteringRowsRange = null;
 
     // After the cells are rendered calculate columns width to prepare proper values
     // for colGroup renderer (which renders COL elements).

--- a/handsontable/src/3rdparty/walkontable/src/render/tableRenderer.ts
+++ b/handsontable/src/3rdparty/walkontable/src/render/tableRenderer.ts
@@ -247,13 +247,20 @@ export class TableRenderer {
    */
   #prevRowsToRender: number = -1;
   /**
-   * The half-open range `[start, end)` of visual row indexes that must be rendered on the current
-   * delta draw (the rows entering the band). `null` means "render every rendered row" (a full band
+   * The first visual row index that must be rendered on the current delta draw (the start of the
+   * half-open run of rows entering the band). `-1` means "render every rendered row" (a full band
    * render). Consumed by the cells and row-headers renderers via {@link TableRenderer#isRowRenderable}.
    *
-   * @type {{ start: number, end: number } | null}
+   * @type {number}
    */
-  #enteringRowsRange: { start: number; end: number } | null = null;
+  #enteringRowsStart: number = -1;
+  /**
+   * The end (exclusive) of the half-open run of visual row indexes entering the band on the current
+   * delta draw. Unused when {@link TableRenderer#enteringRowsStart} is `-1` (a full band render).
+   *
+   * @type {number}
+   */
+  #enteringRowsEnd: number = -1;
 
   /**
    * Creates a new TableRenderer instance.
@@ -336,9 +343,8 @@ export class TableRenderer {
    * @returns {boolean}
    */
   isRowRenderable(visualRowIndex: number) {
-    const range = this.#enteringRowsRange;
-
-    return range === null || (visualRowIndex >= range.start && visualRowIndex < range.end);
+    return this.#enteringRowsStart === -1 ||
+      (visualRowIndex >= this.#enteringRowsStart && visualRowIndex < this.#enteringRowsEnd);
   }
 
   /**
@@ -554,15 +560,17 @@ export class TableRenderer {
 
     // On a pure vertical scroll only the row band shifts. Rotate the surviving TR nodes into their
     // new positions and render only the entering rows; the surviving rows keep their existing cell
-    // content, classes, and ARIA (their source row is unchanged). `#enteringRowsRange` gates the
-    // cell / row-header renderers through `isRowRenderable`. When it is `null`, every row renders.
+    // content, classes, and ARIA (their source row is unchanged). `#enteringRowsStart`/`End` gate the
+    // cell / row-header renderers through `isRowRenderable`. `-1` means every row renders (full band).
     const rowDeltaPlan = this.#computeRowDeltaPlan();
 
     if (rowDeltaPlan) {
       this.#rotateBodyRows(rowDeltaPlan.delta);
-      this.#enteringRowsRange = { start: rowDeltaPlan.start, end: rowDeltaPlan.end };
+      this.#enteringRowsStart = rowDeltaPlan.start;
+      this.#enteringRowsEnd = rowDeltaPlan.end;
     } else {
-      this.#enteringRowsRange = null;
+      this.#enteringRowsStart = -1;
+      this.#enteringRowsEnd = -1;
     }
 
     this.rows!.render();
@@ -570,7 +578,8 @@ export class TableRenderer {
     this.cells!.render();
 
     this.#storeRowWindow();
-    this.#enteringRowsRange = null;
+    this.#enteringRowsStart = -1;
+    this.#enteringRowsEnd = -1;
 
     // After the cells are rendered calculate columns width to prepare proper values
     // for colGroup renderer (which renders COL elements).

--- a/handsontable/src/3rdparty/walkontable/src/table/drawCycle.ts
+++ b/handsontable/src/3rdparty/walkontable/src/table/drawCycle.ts
@@ -6,6 +6,7 @@ import {
 } from '../overlay';
 import type Table from './baseTable';
 import type { default as Overlays } from '../overlay/overlays';
+import type { default as Viewport } from '../viewport/viewport';
 
 /**
  * Per-draw mutable scratch shared by the phase functions of a single draw. It also captures the
@@ -133,7 +134,13 @@ function runMasterDrawCycle(table: Table, ctx: DrawContext): void {
     ctx.performRedraw = skipRender.skipRender !== true;
 
     if (ctx.performRedraw) {
-      renderCellBand(table, ctx, filters, isPureVerticalScrollDraw(wtOverlays));
+      renderCellBand(
+        table,
+        ctx,
+        filters,
+        isPureVerticalScrollDraw(wtOverlays),
+        isRowDeltaEligible(wtOverlays, wtViewport),
+      );
 
       if (!wtSettings.getSetting('externalRowCalculator')) {
         // Single-pass: the fully/partially-visible calculators were already computed in pass 1
@@ -197,8 +204,17 @@ function runCloneDrawCycle(table: Table, ctx: DrawContext): void {
     const filters = buildRenderFilters(table, ctx);
 
     // A clone's render is never gated by `skipRender` (that gate is master-only), so it always runs.
-    // The scroll-direction flags live on the master's overlays, reached via the clone source.
-    renderCellBand(table, ctx, filters, isPureVerticalScrollDraw(table.deps.getCloneSource().wtOverlays));
+    // The scroll-direction flags live on the master's overlays, reached via the clone source. The
+    // single-pass predicate reads only shared settings, so the clone's own viewport answers it.
+    const cloneSourceOverlays = table.deps.getCloneSource().wtOverlays;
+
+    renderCellBand(
+      table,
+      ctx,
+      filters,
+      isPureVerticalScrollDraw(cloneSourceOverlays),
+      isRowDeltaEligible(cloneSourceOverlays, table.deps.getWtViewport()),
+    );
 
     if (table.is(CLONE_BOTTOM)) {
       table.deps.getCloneSource().wtOverlays.adjustElementsSize();
@@ -254,6 +270,20 @@ function isPureVerticalScrollDraw(wtOverlays: Overlays): boolean {
 }
 
 /**
+ * Returns `true` when the TBODY row band may be delta-rendered on this draw: it is a pure vertical
+ * scroll AND the viewport allows row-delta rendering (`singlePassLayout` on — so no merged cells —
+ * and the table is not window-scrolled). `allowsRowDeltaRender` reads only shared settings, so each
+ * role can answer it from the viewport it has in hand.
+ *
+ * @param {Overlays} wtOverlays The master's overlays object (the owner of the scroll-direction flags).
+ * @param {Viewport} wtViewport The viewport whose row-delta predicate gates the delta path.
+ * @returns {boolean}
+ */
+function isRowDeltaEligible(wtOverlays: Overlays, wtViewport: Viewport): boolean {
+  return isPureVerticalScrollDraw(wtOverlays) && wtViewport.allowsRowDeltaRender();
+}
+
+/**
  * Renders the header + cell band and measures the rendered rows. Shared by both cycles. The
  * role-specific branches stay inline and verbatim: bottom / bottom-left-corner overlays suppress
  * column headers, and only the master or the bottom clone marks oversized rows.
@@ -264,12 +294,15 @@ function isPureVerticalScrollDraw(wtOverlays: Overlays): boolean {
  *   `buildRenderFilters` (passed non-null rather than re-read off the nullable `table.*Filter`).
  * @param {boolean} columnHeadersRenderSkippable Whether the column-header (THEAD) pass may be skipped
  *   for this draw (a pure vertical scroll); resolved per role by the caller.
+ * @param {boolean} rowDeltaRenderable Whether the TBODY row band may be delta-rendered (rotate
+ *   surviving rows, render only entering rows) for this draw; resolved per role by the caller.
  */
 function renderCellBand(
   table: Table,
   ctx: DrawContext,
   filters: { rowFilter: RowFilter; columnFilter: ColumnFilter },
   columnHeadersRenderSkippable: boolean,
+  rowDeltaRenderable: boolean,
 ): void {
   table.tableRenderer.setHeaderContentRenderers(ctx.rowHeaders, ctx.columnHeaders);
 
@@ -280,6 +313,7 @@ function renderCellBand(
   }
 
   table.tableRenderer.setColumnHeadersRenderSkippable(columnHeadersRenderSkippable);
+  table.tableRenderer.setRowDeltaRenderable(rowDeltaRenderable);
 
   table.resetOversizedRows();
 

--- a/handsontable/src/3rdparty/walkontable/src/viewport/calculatorFactory.ts
+++ b/handsontable/src/3rdparty/walkontable/src/viewport/calculatorFactory.ts
@@ -30,6 +30,7 @@ export interface CalculatorFactory {
   createCalculators(fastDraw?: boolean): boolean;
   createVisibleCalculators(): void;
   usesLayoutSnapshotForCalculators(): boolean;
+  allowsRowDeltaRender(): boolean;
   areAllProposedVisibleRowsAlreadyRendered(
     proposedFullyVisibleRowsCalculator: RowsCalculationType | undefined,
     proposedPartiallyVisibleRowsCalculator: RowsCalculationType | undefined): boolean;
@@ -283,6 +284,24 @@ export const calculatorFactory: CalculatorFactory = {
       !this.isHorizontallyScrollableByWindow() &&
       this.wtSettings.getSetting<boolean>('rowHeightsUniform') &&
       this.wtSettings.getSetting<boolean>('columnWidthsUniform');
+  },
+
+  /**
+   * Decides whether the TBODY row band may be delta-rendered on a pure vertical scroll (rotate the
+   * surviving TR nodes, render only the entering rows). This is a looser gate than the single-pass
+   * layout gate: it drops the uniform-size requirements (row rotation preserves each surviving row's
+   * own content and height, and column widths never change on a vertical scroll), but keeps the two
+   * conditions that make skipping a survivor's re-render unsafe — `singlePassLayout` off (which
+   * `mergeCells` forces, and merged cells recompute their spans per viewport) and window scrolling
+   * (a different scroll/offset model). Anything else takes the full band render unchanged.
+   *
+   * @this Viewport
+   * @returns {boolean}
+   */
+  allowsRowDeltaRender(this: Viewport): boolean {
+    return this.wtSettings.getSetting<boolean>('singlePassLayout') &&
+      !this.isVerticallyScrollableByWindow() &&
+      !this.isHorizontallyScrollableByWindow();
   },
 
   /**

--- a/handsontable/src/3rdparty/walkontable/test/spec/renderer/cells.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/renderer/cells.spec.js
@@ -15,6 +15,10 @@ describe('Walkontable.Renderer.CellsRenderer', () => {
     isAriaEnabled() {
       return true;
     }
+
+    isRowRenderable() {
+      return true;
+    }
   }
 
   function createRenderer() {

--- a/handsontable/src/3rdparty/walkontable/test/spec/renderer/rowHeaders.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/renderer/rowHeaders.spec.js
@@ -13,6 +13,10 @@ describe('Walkontable.Renderer.RowHeadersRenderer', () => {
     isAriaEnabled() {
       return true;
     }
+
+    isRowRenderable() {
+      return true;
+    }
   }
 
   function createRenderer() {

--- a/handsontable/src/3rdparty/walkontable/test/spec/scroll/rowDeltaRender.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/scroll/rowDeltaRender.spec.js
@@ -1,0 +1,153 @@
+describe('Walkontable row delta render on vertical scroll', () => {
+  const debug = false;
+
+  beforeEach(function() {
+    this.$wrapper = $('<div></div>').addClass('handsontable').css({ overflow: 'hidden' });
+    this.$wrapper.width(200).height(400);
+    this.$container = $('<div></div>');
+    this.$table = $('<table></table>').addClass('htCore'); // create a table that is not attached to document
+    this.$wrapper.append(this.$container);
+    this.$container.append(this.$table);
+    this.$wrapper.appendTo('body');
+    createDataArray(100, 50);
+  });
+
+  afterEach(function() {
+    if (!debug) {
+      $('.wtHolder').remove();
+    }
+
+    this.$wrapper.remove();
+    this.wotInstance.destroy();
+  });
+
+  function makeWot(overrides = {}) {
+    const cellRenderer = jasmine.createSpy('cellRenderer').and.callFake((row, col, TD) => {
+      TD.innerHTML = `r${row}c${col}`;
+    });
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      rowHeaders: [function(row, TH) {
+        TH.innerHTML = row + 1;
+      }],
+      columnHeaders: [function(column, TH) {
+        TH.innerHTML = column + 1;
+      }],
+      cellRenderer,
+      ...overrides,
+    });
+
+    return { wt, cellRenderer };
+  }
+
+  function renderedRowCount() {
+    return getTableMaster().find('tbody tr').length;
+  }
+
+  function renderedColCount() {
+    return getTableMaster().find('tbody tr:first td').length;
+  }
+
+  // First TD text of every rendered body row - the ground-truth of what the band shows.
+  function firstColumnTexts() {
+    return getTableMaster().find('tbody tr').map(function() {
+      return $(this).find('td:first').text();
+    }).get();
+  }
+
+  it('should re-render only the rows entering the band on a pure vertical scroll (not the whole band)', async() => {
+    const { wt, cellRenderer } = makeWot();
+
+    wt.draw();
+
+    const rows = renderedRowCount();
+    const cols = renderedColCount();
+    const fullBandCalls = cellRenderer.calls.count();
+
+    expect(fullBandCalls).toBe(rows * cols);
+
+    const rowHeight = getTableMaster().find('tbody tr:first').outerHeight();
+    const shiftRows = Math.floor(rows / 2); // partial shift - fewer rows than the band holds
+
+    cellRenderer.calls.reset();
+
+    // A real vertical scroll drives the draw through the scroll-sync path, which sets the
+    // verticalScrolling flag the delta-render path relies on.
+    wt.wtTable.holder.scrollTop = rowHeight * shiftRows;
+    wt.wtOverlays.syncScrollPositions();
+
+    const deltaCalls = cellRenderer.calls.count();
+
+    // The band moved (some rows entered), so the cell renderer ran ...
+    expect(deltaCalls).toBeGreaterThan(0);
+    // ... but for far fewer cells than a full band render (only the entering rows) ...
+    expect(deltaCalls).toBeLessThan(fullBandCalls);
+    // ... and it ran for whole rows only (columns are unchanged on a vertical scroll).
+    expect(deltaCalls % cols).toBe(0);
+  });
+
+  it('should produce the same body content as a full render after a delta scroll', async() => {
+    const { wt } = makeWot();
+
+    wt.draw();
+
+    const rows = renderedRowCount();
+    const rowHeight = getTableMaster().find('tbody tr:first').outerHeight();
+
+    wt.wtTable.holder.scrollTop = rowHeight * Math.floor(rows / 2);
+    wt.wtOverlays.syncScrollPositions();
+
+    const afterDelta = firstColumnTexts();
+
+    // A full render at the same scroll position re-renders every cell from scratch (ground truth).
+    wt.draw(false);
+
+    const afterFullRender = firstColumnTexts();
+
+    expect(afterDelta).toEqual(afterFullRender);
+  });
+
+  it('should render the whole band on a full (non-scroll) draw even if the scroll-direction flags are still set', async() => {
+    const { wt, cellRenderer } = makeWot();
+
+    wt.draw();
+    wt.draw(false); // settle to the steady-state full-render count
+
+    cellRenderer.calls.reset();
+    wt.draw(false); // baseline: a plain full render at this position
+    const fullBandCalls = cellRenderer.calls.count();
+
+    // Simulate the reentrancy window: an `afterScroll` hook can call `hot.render()` (a full,
+    // `forceFullRender` `draw(false)`) while the scroll-direction flags are still set. A full render
+    // must always rebuild the whole band, so the delta path must NOT fire here.
+    wt.wtOverlays.verticalScrolling = true;
+    wt.wtOverlays.horizontalScrolling = false;
+
+    cellRenderer.calls.reset();
+
+    wt.draw(false); // full render (entered as a non-fast draw), flags still set
+
+    expect(cellRenderer.calls.count()).toBe(fullBandCalls);
+  });
+
+  it('should render the whole band (no delta) when singlePassLayout is off (e.g. merged cells)', async() => {
+    // `mergeCells` forces `singlePassLayout` off; merged cells recompute their spans per viewport, so
+    // rotating surviving rows and skipping their re-render is unsafe. The delta path must not fire.
+    const { wt, cellRenderer } = makeWot({ singlePassLayout: false });
+
+    wt.draw();
+
+    const rowHeight = getTableMaster().find('tbody tr:first').outerHeight();
+
+    cellRenderer.calls.reset();
+
+    wt.wtTable.holder.scrollTop = rowHeight * Math.floor(renderedRowCount() / 2);
+    wt.wtOverlays.syncScrollPositions();
+
+    // Every row currently in the band was re-rendered - no survivor was skipped. Measured at the
+    // post-scroll state so the expectation matches the band actually rendered on this draw.
+    expect(cellRenderer.calls.count()).toBe(renderedRowCount() * renderedColCount());
+  });
+});


### PR DESCRIPTION
### Context

The PR adds content-preserving delta rendering to Walkontable for vertical scrolling.

On a pure vertical scroll the rendered row band only shifts by a few rows, yet today every cell in the band is re-rendered on each band shift — even the rows whose content did not change. `OrderView` addresses the `<tr>`/`<td>` nodes by DOM position and rewrites content per position, so preserving content requires physically moving the nodes.

This change rotates the surviving `<tr>` nodes into their new positions (only the leaving nodes are moved, so a survivor's focus / open editor is never disturbed) and runs the cell and row-header renderers only for the rows entering the band. Surviving rows keep their content, classes, ARIA attributes, and height — their source row is unchanged. It reuses the existing scroll-driven gate (`isScrollDrivenDraw` + `verticalScrolling && !horizontalScrolling`) added for the column-header render skip, including its reentrancy guard.

It is gated to the single-pass path via a new `Viewport.allowsRowDeltaRender()` (`singlePassLayout` on — which `mergeCells` forces off — and the table not window-scrolled). Any other draw (data / settings / selection change, horizontal scroll, whole-band jump, first draw, or a full render) falls back to the existing full band render, so behavior is unchanged there.

The delta output is byte-identical to a full render (verified on the master and every overlay, including frozen columns and variable row heights).

### Performance

Interleaved A/B of a fresh build of this branch vs a fresh build of `develop`, real Chrome (CDP), 100k × 100 grid, main theme, 1200 × 600 viewport. Cost is per scroll-driven draw through the real `syncScrollPositions` path; median of 9 runs of 60 steps each:

| Vertical scroll | develop | this branch | change |
|---|--:|--:|--:|
| 1 row / step (30px) | 1.62 ms | 1.34 ms | **−17%** |
| 5 rows / step (150px) | 4.76 ms | 2.96 ms | **−38%** |

The saving grows with the number of rows entering per step (a 1-row step is partly diluted by sub-row fast draws that never re-render), and scales further on wider grids and heavier custom cell renderers, where per-cell render work dominates the draw. There is run-to-run variance (roughly ±15%); the direction and magnitude are stable across rounds.

### How has this been tested?

- New Walkontable spec `test/spec/scroll/rowDeltaRender.spec.js` (4 specs): only entering rows re-render on a vertical band shift; delta output matches a subsequent full render; a full `draw(false)` with the scroll flags still set rebuilds the whole band (reentrancy); `singlePassLayout: false` (merged cells) disables the delta path.
- Full Walkontable suite: `npm run test:walkontable` — 757 specs, 0 failures.
- Core E2E subsets (fresh build): `npm run test:e2e -- --testPathPattern='core/scroll|selection/scroll|Core_selection|textEditor'` (186/0) and `--testPathPattern='hiddenRows|trimRows|columnSorting|autofill|copyPaste'` (1093/0).
- `npm run test:types` and `npm run eslint --prefix handsontable` pass.
- Manual (Chrome, CDP): interleaved two-build A/B (this branch vs `develop`) for the numbers above; and P1-on vs off produces byte-identical DOM (cell text, `aria-rowindex`, row headers, striping classes, row heights) across mixed up/down scroll on the master + inline-start + top + corner overlays, with frozen columns/rows and with variable row heights; selection highlight stays correct; no console errors.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2023

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/86camepqj

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Walkontable draw/render and DOM row order; incorrect gating or rotation could show wrong cells or break editors/focus, though fallbacks and tests target those cases.
> 
> **Overview**
> Adds **delta row rendering** on pure vertical scrolls: Walkontable rotates existing `<tr>` nodes in the tbody and runs cell and row-header renderers only for rows that enter the viewport, instead of repainting the whole band.
> 
> The draw cycle wires this through `setRowDeltaRenderable` / `isRowDeltaEligible` (pure vertical scroll plus `Viewport.allowsRowDeltaRender()` — `singlePassLayout` on and not window-scrolled). Full draws, horizontal scroll, merged cells (`singlePassLayout` off), and `draw(false)` while scroll flags are set still take the full band path.
> 
> New `rowDeltaRender.spec.js` covers partial re-render, parity with a full render, reentrancy, and the merged-cells fallback; renderer unit mocks implement `isRowRenderable()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02252ce7875e8c864ff999d42a17bdcf66a3eacf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->