### PR TITLE
ci(docs): remove retry wrapper from Cloudflare Pages deploy steps

### DIFF
--- a/.github/workflows/docs-production.yml
+++ b/.github/workflows/docs-production.yml
@@ -161,24 +161,20 @@ jobs:
           CF_PAGES_APEX_BRANCH: production
 
       # Cloudflare Pages is the sole production host, so a failed deploy must
-      # fail the workflow (no continue-on-error here). Retried (unlike the old
-      # Netlify publish, this is single-attempt by default): wrangler retries
-      # asset uploads internally but not deployment creation, and `npm install
-      # wrangler` is an unretried network call too - a transient blip
-      # shouldn't fail a run that already spent 20+ minutes on Docker builds.
+      # fail the workflow (no continue-on-error here) - masking it would
+      # silently leave production stale. Single attempt, no retry wrapper:
+      # retrying was a habit from the flaky Netlify publish; Cloudflare Pages
+      # deploys have not shown that flakiness. On a transient failure, re-run
+      # the workflow from the Actions UI.
       - name: Deploy production to Cloudflare Pages
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # https://github.com/nick-fields/retry/releases/tag/v3.0.2
-        with:
-          timeout_seconds: 600
-          max_attempts: 3
-          retry_on: error
-          command: |
-            cd /tmp
-            npm install wrangler
-            ./node_modules/.bin/wrangler pages deploy \
-              "$GITHUB_WORKSPACE/docs/deploy/docs" \
-              --project-name handsontable-docs \
-              --branch production
+        # Install wrangler in /tmp to avoid npm failures inside the pnpm workspace
+        working-directory: /tmp
+        run: |
+          npm install wrangler
+          ./node_modules/.bin/wrangler pages deploy \
+            "$GITHUB_WORKSPACE/docs/deploy/docs" \
+            --project-name handsontable-docs \
+            --branch production
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/docs-staging.yml
+++ b/.github/workflows/docs-staging.yml
@@ -243,27 +243,21 @@ jobs:
       # failure - continue-on-error keeps steps.cf-pages-deploy.outcome as
       # 'failure' but the job's own success() stays true, and the Slack steps'
       # `failure()` condition only trips on a step that actually failed the job.
-      # Retried (unlike continue-on-error, this preserves hard-failure
-      # semantics once attempts are exhausted): wrangler retries asset
-      # uploads internally but not deployment creation, and `npm install
-      # wrangler` is an unretried network call too - a single transient
-      # Cloudflare API blip shouldn't fail the whole run (and, on release
-      # branches, fire the RC-failure Slack alert).
+      # Single attempt, no retry wrapper: retrying was a habit from the flaky
+      # Netlify publish; Cloudflare Pages deploys have not shown that
+      # flakiness. On a transient failure, re-run the workflow from the
+      # Actions UI.
       - name: Deploy to Cloudflare Pages
         id: cf-pages-deploy
         if: ${{ steps.cf-target.outputs.deploy == 'true' }}
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # https://github.com/nick-fields/retry/releases/tag/v3.0.2
-        with:
-          timeout_seconds: 300
-          max_attempts: 3
-          retry_on: error
-          command: |
-            cd /tmp
-            npm install wrangler
-            ./node_modules/.bin/wrangler pages deploy \
-              "$GITHUB_WORKSPACE/docs/deploy/preview" \
-              --project-name handsontable-docs-staging \
-              --branch "${{ steps.cf-target.outputs.branch }}"
+        # Install wrangler in /tmp to avoid npm failures inside the pnpm workspace
+        working-directory: /tmp
+        run: |
+          npm install wrangler
+          ./node_modules/.bin/wrangler pages deploy \
+            "$GITHUB_WORKSPACE/docs/deploy/preview" \
+            --project-name handsontable-docs-staging \
+            --branch "${{ steps.cf-target.outputs.branch }}"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
### Context

The PR removes the `nick-fields/retry` wrapper from the two Cloudflare Pages deploy steps (`docs-production.yml` "Deploy production to Cloudflare Pages" and `docs-staging.yml` "Deploy to Cloudflare Pages"), following review feedback on #12994: retrying deploys was a habit formed by the flaky Netlify publish, and Cloudflare Pages has not shown that flakiness.

Historical note: these two wrappers were not Netlify leftovers — #12818 added them when it removed `continue-on-error` from the deploy steps, so a transient blip would not fail a run that spent 20+ minutes on Docker builds. Removing them keeps the property that actually matters — **hard, visible failure semantics** (no `continue-on-error`, so a failed deploy can never silently leave production or previews stale). The trade-off is that a rare transient Cloudflare/npm error now requires a manual re-run from the Actions UI.

The steps return to plain `run:` blocks with `working-directory: /tmp` (wrangler is installed there to avoid npm failures inside the pnpm workspace). The staging step keeps its `id: cf-pages-deploy` and `if:` gate, so the RC-failure Slack alert and the sticky PR-comment conditions are unaffected.

This change is intentionally **not** cherry-picked into the #12994 production rollout — it is not a fix, and prod has already deployed successfully from that branch. It reaches the prod-docs branches with the next routine cherry-pick.

### How has this been tested?

- Both workflow files parse as valid YAML.
- Repo-wide grep confirms no `nick-fields/retry` references remain in `.github/workflows/`.
- Behavioral change is deploy-time only; verification happens on the next `docs-staging` run (any docs PR preview) and the next `prod-docs/**` production run.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. Review feedback on #12994; follow-up to #12818

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog] — CI/tooling-only change, no package source modified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to deploy retry behavior; deploy commands and failure visibility are unchanged aside from losing automatic retries on transient errors.
> 
> **Overview**
> Removes the `nick-fields/retry` action from **production** and **staging** Cloudflare Pages deploy steps in `docs-production.yml` and `docs-staging.yml`, replacing them with single-attempt `run:` blocks that still install **wrangler** under `/tmp` and invoke `wrangler pages deploy` unchanged.
> 
> Comments now document that retries were a Netlify-era habit and that transient failures should be handled by **re-running the workflow** from Actions. **Hard failure semantics** remain: no `continue-on-error` on these steps. Staging keeps `id: cf-pages-deploy` and its `if:` gate so RC Slack alerts and sticky PR comments still key off deploy outcome.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b54b8846cdccf6c2640897a948048737153fc290. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->