### PR TITLE
DEV-2024: Fix autofill not applying values when dragged past the table's edge

### DIFF
--- a/.changelogs/12997.json
+++ b/.changelogs/12997.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed an autofill bug where dragging the fill handle of the last column slightly diagonally, past the table's edge, drew the fill border but did not apply the values.",
+  "type": "fixed",
+  "issueOrPR": 12997,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/autofill/__tests__/autofill.spec.js
+++ b/handsontable/src/plugins/autofill/__tests__/autofill.spec.js
@@ -132,6 +132,82 @@ describe('AutoFill', () => {
     expect(getSelected()).toEqual([[0, 1, 3, 5]]);
   });
 
+  it('should fill the cells when the fill handle of the last column is dragged diagonally, ' +
+     'with the pointer moved past the table\'s right edge (#dev-2024)', async() => {
+    handsontable({
+      data: [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+        [1, 2, 3],
+      ],
+      fillHandle: true,
+    });
+
+    await selectCell(0, 2);
+
+    const corners = spec().$container.find('.wtBorder.current.corner').toArray();
+    const fillHandle = corners.find(el => el.offsetWidth > 0 && el.offsetHeight > 0);
+    const handleRect = fillHandle.getBoundingClientRect();
+    const targetRect = getCell(2, 2).getBoundingClientRect();
+
+    $(fillHandle).simulate('mousedown', {
+      clientX: handleRect.left + (handleRect.width / 2),
+      clientY: handleRect.top + (handleRect.height / 2),
+    });
+    // the pointer moves down and slightly to the right, past the table's right edge -
+    // it hovers no cell element, so only the document-level `mousemove` listener fires
+    $(document.documentElement).simulate('mousemove', {
+      clientX: targetRect.right + 5,
+      clientY: targetRect.top + (targetRect.height / 2),
+    });
+    $(document.body).simulate('mouseup');
+
+    expect(getData()).toEqual([
+      [1, 2, 3],
+      [4, 5, 3],
+      [7, 8, 3],
+      [1, 2, 3],
+    ]);
+  });
+
+  it('should not fill any cells when the fill handle is clicked and the pointer moves ' +
+     'within the selected cell only', async() => {
+    handsontable({
+      data: [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+        [1, 2, 3],
+      ],
+      fillHandle: true,
+    });
+
+    await selectCell(0, 2);
+
+    const corners = spec().$container.find('.wtBorder.current.corner').toArray();
+    const fillHandle = corners.find(el => el.offsetWidth > 0 && el.offsetHeight > 0);
+    const handleRect = fillHandle.getBoundingClientRect();
+    const sourceRect = getCell(0, 2).getBoundingClientRect();
+
+    $(fillHandle).simulate('mousedown', {
+      clientX: handleRect.left + (handleRect.width / 2),
+      clientY: handleRect.top + (handleRect.height / 2),
+    });
+    $(document.documentElement).simulate('mousemove', {
+      clientX: sourceRect.left + (sourceRect.width / 2),
+      clientY: sourceRect.top + (sourceRect.height / 2),
+    });
+    $(document.body).simulate('mouseup');
+
+    expect(getData()).toEqual([
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 9],
+      [1, 2, 3],
+    ]);
+  });
+
   it('should not change cell value (drag when fillHandle is set to `false`)', async() => {
     handsontable({
       data: [

--- a/handsontable/src/plugins/autofill/__tests__/autofill.spec.js
+++ b/handsontable/src/plugins/autofill/__tests__/autofill.spec.js
@@ -208,6 +208,95 @@ describe('AutoFill', () => {
     ]);
   });
 
+  it('should not fill any cells when the fill handle is pressed and released without a drag ' +
+     '(pointer jitter stays on the handle)', async() => {
+    handsontable({
+      data: [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+        [1, 2, 3],
+      ],
+      fillHandle: true,
+    });
+
+    await selectCell(0, 2);
+
+    const corners = spec().$container.find('.wtBorder.current.corner').toArray();
+    const fillHandle = corners.find(el => el.offsetWidth > 0 && el.offsetHeight > 0);
+    const handleRect = fillHandle.getBoundingClientRect();
+    const cx = handleRect.left + (handleRect.width / 2);
+    const cy = handleRect.top + (handleRect.height / 2);
+
+    $(fillHandle).simulate('mousedown', { clientX: cx, clientY: cy });
+    // a `mousemove` fired at the handle position itself (a press jitter) must not count as a drag
+    $(document.documentElement).simulate('mousemove', { clientX: cx, clientY: cy });
+    $(document.body).simulate('mouseup');
+
+    expect(getData()).toEqual([
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 9],
+      [1, 2, 3],
+    ]);
+  });
+
+  it('should not fill any cells when the viewport is scrolled after pressing the fill handle, ' +
+     'but before any drag move', async() => {
+    const sourceData = createSpreadsheetData(100, 5);
+
+    handsontable({
+      data: sourceData.map(row => row.slice()),
+      fillHandle: true,
+      height: 200,
+    });
+
+    await selectCell(20, 0);
+
+    const corners = spec().$container.find('.wtBorder.current.corner').toArray();
+    const fillHandle = corners.find(el => el.offsetWidth > 0 && el.offsetHeight > 0);
+    const handleRect = fillHandle.getBoundingClientRect();
+
+    $(fillHandle).simulate('mousedown', {
+      clientX: handleRect.left + (handleRect.width / 2),
+      clientY: handleRect.top + (handleRect.height / 2),
+    });
+    // scrolling replays the last pointer position through the `afterScroll` handler; before any
+    // real `mousemove` there is no such position, so the scroll must not count as a drag
+    await scrollViewportTo({ row: 0, col: 0 });
+    $(document.body).simulate('mouseup');
+
+    expect(getData()).toEqual(sourceData);
+  });
+
+  it('should not fill any cells when the viewport is scrolled after a press jitter on the fill ' +
+     'handle, but before any drag move', async() => {
+    const sourceData = createSpreadsheetData(100, 5);
+
+    handsontable({
+      data: sourceData.map(row => row.slice()),
+      fillHandle: true,
+      height: 200,
+    });
+
+    await selectCell(20, 0);
+
+    const corners = spec().$container.find('.wtBorder.current.corner').toArray();
+    const fillHandle = corners.find(el => el.offsetWidth > 0 && el.offsetHeight > 0);
+    const handleRect = fillHandle.getBoundingClientRect();
+    const cx = handleRect.left + (handleRect.width / 2);
+    const cy = handleRect.top + (handleRect.height / 2);
+
+    $(fillHandle).simulate('mousedown', { clientX: cx, clientY: cy });
+    // a press jitter records a real pointer position without extending the fill; a following
+    // scroll must not re-count that position as a drag step just because the cell under it moved
+    $(document.documentElement).simulate('mousemove', { clientX: cx, clientY: cy });
+    await scrollViewportTo({ row: 0, col: 0 });
+    $(document.body).simulate('mouseup');
+
+    expect(getData()).toEqual(sourceData);
+  });
+
   it('should not change cell value (drag when fillHandle is set to `false`)', async() => {
     handsontable({
       data: [

--- a/handsontable/src/plugins/autofill/autofill.ts
+++ b/handsontable/src/plugins/autofill/autofill.ts
@@ -874,8 +874,17 @@ export class Autofill extends BasePlugin {
     if (this.mouseDownOnCellCorner) {
       const { clientX, clientY } = event;
       const cellCoords = getCellCoordsFromMousePosition(this.hot, clientX, clientY);
+      const selectedRange = this.hot.getSelectedRangeLast();
 
       this.#lastMouseClientPosition = { clientX, clientY };
+
+      // The `beforeOnCellMouseOver`-based counting doesn't fire when the pointer leaves
+      // the table element (e.g. dragging the last column's fill handle at a slight angle,
+      // past the table's edge), so count the drag here as well. Otherwise the fill made
+      // with such a drag would never be committed on mouseup.
+      if (this.handleDraggedCells > 0 && selectedRange && !selectedRange.includes(cellCoords)) {
+        this.handleDraggedCells += 1;
+      }
 
       this.redrawBorders(cellCoords);
     }

--- a/handsontable/src/plugins/autofill/autofill.ts
+++ b/handsontable/src/plugins/autofill/autofill.ts
@@ -126,11 +126,13 @@ export class Autofill extends BasePlugin {
    */
   #currentDragDirection: string | null = null;
   /**
-   * Last mouse client position.
+   * Last mouse client position. Stays `null` until the first `mousemove` of a drag, so a scroll
+   * that happens after pressing the fill handle but before any drag move is not replayed with a
+   * stale or default position.
    *
-   * @type {{ clientX: number, clientY: number }}
+   * @type {{ clientX: number, clientY: number } | null}
    */
-  #lastMouseClientPosition = { clientX: 0, clientY: 0 };
+  #lastMouseClientPosition: { clientX: number, clientY: number } | null = null;
 
   /**
    * Checks if the plugin is enabled in the Handsontable settings.
@@ -831,6 +833,7 @@ export class Autofill extends BasePlugin {
     this.handleDraggedCells = 1;
     this.mouseDownOnCellCorner = true;
     this.#currentDragDirection = null;
+    this.#lastMouseClientPosition = null;
   };
 
   /**
@@ -869,8 +872,12 @@ export class Autofill extends BasePlugin {
    * On mouse move listener.
    *
    * @param {MouseEvent} event `mousemove` event properties.
+   * @param {boolean} [countDragStep=true] Whether a move onto a new cell should be counted as a
+   * drag step. Only genuine pointer moves count; a scroll replay (see `#onAfterScroll`) redraws
+   * the border without counting, otherwise a scroll that shifts the cell under a resting pointer
+   * would register a drag that never happened.
    */
-  #onMouseMove(event: Pick<MouseEvent, 'clientX' | 'clientY'>) {
+  #onMouseMove(event: Pick<MouseEvent, 'clientX' | 'clientY'>, countDragStep = true) {
     if (this.mouseDownOnCellCorner) {
       const { clientX, clientY } = event;
       const cellCoords = getCellCoordsFromMousePosition(this.hot, clientX, clientY);
@@ -882,7 +889,7 @@ export class Autofill extends BasePlugin {
       // the table element (e.g. dragging the last column's fill handle at a slight angle,
       // past the table's edge), so count the drag here as well. Otherwise the fill made
       // with such a drag would never be committed on mouseup.
-      if (this.handleDraggedCells > 0 && selectedRange && !selectedRange.includes(cellCoords)) {
+      if (countDragStep && this.handleDraggedCells > 0 && selectedRange && !selectedRange.includes(cellCoords)) {
         this.handleDraggedCells += 1;
       }
 
@@ -908,8 +915,8 @@ export class Autofill extends BasePlugin {
    * Refreshes the autofill borders using the last mouse client position after scroll.
    */
   #onAfterScroll = () => {
-    if (this.mouseDownOnCellCorner) {
-      this.#onMouseMove(this.#lastMouseClientPosition);
+    if (this.mouseDownOnCellCorner && this.#lastMouseClientPosition) {
+      this.#onMouseMove(this.#lastMouseClientPosition, false);
     }
   };
 


### PR DESCRIPTION
### Context

The PR fixes a v18 regression where autofill did not apply values when the fill handle of the last column was dragged slightly diagonally, with the pointer moving past the table's right edge. The fill border appeared, but the values were not populated on mouseup. The same gesture worked in any other column.

Root cause: `fillIn()` runs on mouseup only when `handleDraggedCells > 1`, and that counter was incremented only in the `beforeOnCellMouseOver` hook — which fires only when the pointer hovers a table cell. Since the fill handle sits at the bottom-right corner of the cell, any rightward angle on the last column moves the pointer off the table element immediately. The document-level `mousemove` listener (added in v18 to draw the fill border outside the table via `getCellCoordsFromMousePosition`) drew the border but never counted the drag, so the fill was discarded on mouseup.

The fix counts the drag in the document-level `mousemove` listener as well, whenever the cell resolved from the mouse position lies outside the selected range. The same gate also covers the other table edges (bottom, top, start).

### How has this been tested?

- New E2E test reproducing the exact gesture: fill handle mousedown on the last column, document-level `mousemove` past the table's right edge (no cell is hovered), mouseup — asserts values are populated.
- New E2E test asserting that a fill-handle click with pointer movement inside the selected cell does not fill anything (guards the new counting logic).
- Full autofill E2E suite: `npm run test:e2e --prefix handsontable --testPathPattern=plugins/autofill` — 154 specs, 0 failures.
- Unit suite: `npm run test:unit --prefix handsontable --testPathPattern=autofill` — 9 passed. (No unit test added: the change is DOM-interaction logic with no new pure-function surface.)
- `npm run test:types`, `npm run eslint --prefix handsontable` — clean.
- Verified manually with Playwright driving real mouse events against the built UMD bundle: the failing diagonal-drag case now fills, straight-down and middle-column drags behave as before.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2024

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2024

https://claude.ai/code/session_016UVExvYuE6c42ULJyZ9PwE

---
_Generated by [Claude Code](https://claude.ai/code/session_016UVExvYuE6c42ULJyZ9PwE)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted interaction fix in the autofill plugin with broad E2E coverage; risk is limited to fill-handle drag detection edge cases, not data or security paths.
> 
> **Overview**
> Fixes a regression where dragging the **last column** fill handle slightly past the table edge showed the fill border but **did not commit values** on mouseup, because drag steps were only counted via cell `mouseover` and never when the pointer left the table.
> 
> The autofill plugin now increments `handleDraggedCells` from the document-level `#onMouseMove` when the resolved cell is outside the current selection, so `fillIn()` runs on release for those gestures. **`#lastMouseClientPosition`** starts as `null` on corner mousedown and is only set on real moves; **`#onAfterScroll`** redraws borders from the last position with **`countDragStep: false`** so scroll or jitter does not fake a drag.
> 
> New E2E cases cover diagonal drag past the right edge, no-fill on click/jitter inside the cell, and scroll before any drag. Changelog entry **12997** documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cc2217a989c8792d2d6b4067fa221e24949751a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->