### PR TITLE
DEV-796: Document navigableHeaders interaction in selectAll() JSDoc

### DIFF
--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -5441,7 +5441,8 @@ export default function Core(
    * @param {{row: number, col: number} | boolean} [options.focusPosition] The argument allows changing the cell/header
    * focus position. The value takes an object with a `row` and `col` properties from -N to N, where
    * negative values point to the headers and positive values point to the cell range. If `false`, the focus
-   * position won't be changed. Example:
+   * position won't be changed. When the {@link Options#navigableHeaders} option is disabled (the default), a
+   * `focusPosition` that points to a header is relocated to the nearest cell in the data set. Example:
    * ```js
    * hot.selectAll(0, 0, {
    * focusPosition: { row: 0, col: 1 },
@@ -5450,7 +5451,9 @@ export default function Core(
    * ```
    *
    * @param {boolean} [options.disableHeadersHighlight] If `true`, disables highlighting the headers even when
-   * the logical coordinates points on them.
+   * the logical coordinates points on them. This only suppresses the highlight shown on headers of a fully-selected
+   * row or column. It doesn't affect the focus indicator on the individual cell or header that holds the focus,
+   * which stays visible even when {@link Options#navigableHeaders} moves the focus onto a header.
    */
   this.selectAll = function(
     includeRowHeaders = true, includeColumnHeaders = includeRowHeaders, options: Record<string, unknown>

--- a/handsontable/src/selection/selection.ts
+++ b/handsontable/src/selection/selection.ts
@@ -1151,9 +1151,12 @@ class Selection {
    * @param {{row: number, col: number} | boolean} [options.focusPosition] The argument allows changing the cell/header
    * focus position. The value takes an object with a `row` and `col` properties from -N to N, where
    * negative values point to the headers and positive values point to the cell range. If `false`, the focus
-   * position won't be changed.
+   * position won't be changed. When the {@link Options#navigableHeaders} option is disabled (the default), a
+   * `focusPosition` that points to a header is relocated to the nearest cell in the data set.
    * @param {boolean} [options.disableHeadersHighlight] If `true`, disables highlighting the headers even when
-   * the logical coordinates points on them.
+   * the logical coordinates points on them. This only suppresses the highlight shown on headers of a fully-selected
+   * row or column. It doesn't affect the focus indicator on the individual cell or header that holds the focus,
+   * which stays visible even when {@link Options#navigableHeaders} moves the focus onto a header.
    */
   selectAll(includeRowHeaders = false, includeColumnHeaders = false, options: {
     focusPosition?: SelectionFocusPosition | boolean; disableHeadersHighlight?: boolean


### PR DESCRIPTION
### Context

The PR fixes incomplete JSDoc for `selectAll()`'s `options.focusPosition` and `options.disableHeadersHighlight` parameters. The original ticket (migrated from a GitHub issue) requested that both descriptions clarify their relationship to the `navigableHeaders` option, since the interaction isn't obvious from the existing text. Some of the requested changes had already shipped in a previous commit; this PR addresses the two remaining items:

- `focusPosition` didn't mention that when `navigableHeaders` is disabled (the default), a `focusPosition` pointing at a header gets relocated to the nearest data cell rather than actually focusing the header.
- `disableHeadersHighlight` didn't clarify that it only suppresses the "active header" strip highlight on a fully-selected row/column, not the individual focus indicator on the cell/header that holds focus.

Both additions were verified against the actual selection logic (`setRangeEnd()`/`CellCoords#normalize()` clamping in `handsontable/src/selection/selection.ts`, and the separate `FOCUS_TYPE` vs. `activeHeader` highlight types) and cross-checked against `selection/__tests__/selection/selectAll.spec.js` assertions, not just paraphrased from the ticket.

The open "3rd form of the verb" wording nit from the original ticket was left alone — `selectAll()`'s current imperative phrasing is already consistent with `selectCells`/`selectColumns`/`selectRows`, so it doesn't need a change.

### How has this been tested?

This is a documentation-only change (JSDoc comments, no runtime behavior change). Verified:

- `npx eslint src/core.ts src/selection/selection.ts` — no issues
- `npx tsc -p tsconfig.json --noEmit` — no errors

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-796

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-796

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only changes in two TypeScript files; no logic, APIs, or tests modified.
> 
> **Overview**
> **Documentation-only** update to `selectAll()` JSDoc on `Core` and `Selection`—no runtime behavior changes.
> 
> The `options.focusPosition` description now states that when **`navigableHeaders` is off** (default), a header coordinate is **relocated to the nearest data cell** instead of focusing the header.
> 
> The `options.disableHeadersHighlight` description now limits scope: it only hides the **full-row/column header strip** on select-all, not the **focus indicator** on the active cell/header (including when focus sits on a header via `navigableHeaders`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee2fc9c71750fcf5ecef8926384fd44da9b9e16c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->