### PR TITLE
DEV-811: Improve shortcut key naming docs

### DIFF
--- a/docs/content/guides/navigation/custom-shortcuts/custom-shortcuts.md
+++ b/docs/content/guides/navigation/custom-shortcuts/custom-shortcuts.md
@@ -372,6 +372,8 @@ The [`keys`](@/api/shortcutContext.md#addshortcut) parameter:
 - Handles key-name discrepancies between browsers (e.g., both `'Spacebar'` and `' '` work)
 - Accepts key names in any order (e.g., both `[['control', 'a']]` and `[['a', 'control']]`) work)
 
+The `control/meta` key name is specific to Handsontable. It matches `Control` on Windows and Linux, and `Meta` on macOS. For arrow keys, use `KeyboardEvent.key` names such as `ArrowLeft`, not display glyphs such as `←`.
+
 ## API reference
 
 For the list of [options](@/guides/getting-started/configuration-options/configuration-options.md), methods, and [Handsontable hooks](@/guides/getting-started/events-and-hooks/events-and-hooks.md) related to keyboard navigation, see the following API reference pages:

--- a/docs/content/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md
+++ b/docs/content/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md
@@ -33,6 +33,8 @@ Access all Handsontable features using just your keyboard. Use shortcuts you kno
 
 This page lists all of Handsontable's default keyboard shortcuts.
 
+To register these keys with [`addShortcut()`](@/api/shortcutContext.md#addshortcut), use key-name strings instead of display glyphs. For example, use `control/meta` for <kbd>⌘</kbd> and `ArrowLeft` for <kbd>←</kbd>. For the full naming convention, see [custom shortcuts](@/guides/navigation/custom-shortcuts/custom-shortcuts.md#addshortcut-parameters).
+
 ## Navigation keyboard shortcuts
 
 These keyboard shortcuts work when you navigate the grid. They come from Handsontable's [`Core`](@/api/core.md), so they work out of the box, with no need for additional plugins.

--- a/handsontable/src/shortcuts/context.ts
+++ b/handsontable/src/shortcuts/context.ts
@@ -65,8 +65,10 @@ export const createContext = (name: string, scope: string = 'table'): Context =>
    * @memberof ShortcutContext#
    * @param {object} options The shortcut's options
    * @param {Array<Array<string>>} options.keys Names of the shortcut's keys,
-   * (coming from [`KeyboardEvent.key`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values)),
-   * in lowercase or uppercase, unified across browsers
+   * in lowercase or uppercase, unified across browsers. You can use
+   * [`KeyboardEvent.key`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values)
+   * values, such as `ArrowLeft`, and the Handsontable-specific `control/meta` virtual key name.
+   * `control/meta` matches `Control` on Windows and Linux, and `Meta` on macOS.
    * @param {Function} options.callback The shortcut's action
    * @param {object} options.group A group of shortcuts to which the shortcut belongs
    * @param {object} [options.runOnlyIf] A condition on which the shortcut's action runs
@@ -185,8 +187,10 @@ export const createContext = (name: string, scope: string = 'table'): Context =>
    *
    * @memberof ShortcutContext#
    * @param {Array<string>} keys Names of the shortcut's keys,
-   * (coming from [`KeyboardEvent.key`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values)),
-   * in lowercase or uppercase, unified across browsers
+   * in lowercase or uppercase, unified across browsers. You can use
+   * [`KeyboardEvent.key`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values)
+   * values, such as `ArrowLeft`, and the Handsontable-specific `control/meta` virtual key name.
+   * `control/meta` matches `Control` on Windows and Linux, and `Meta` on macOS.
    */
   const removeShortcutsByKeys = (keys: string[]): void => {
     const normalizedKeys = normalizeKeys(keys);
@@ -223,8 +227,10 @@ export const createContext = (name: string, scope: string = 'table'): Context =>
    *
    * @memberof ShortcutContext#
    * @param {Array<string>} keys Names of the shortcut's keys,
-   * (coming from [`KeyboardEvent.key`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values)),
-   * in lowercase or uppercase, unified across browsers
+   * in lowercase or uppercase, unified across browsers. You can use
+   * [`KeyboardEvent.key`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values)
+   * values, such as `ArrowLeft`, and the Handsontable-specific `control/meta` virtual key name.
+   * `control/meta` matches `Control` on Windows and Linux, and `Meta` on macOS.
    * @returns {Array}
    */
   const getShortcuts = (keys: string[]): Shortcut[] => {
@@ -239,8 +245,10 @@ export const createContext = (name: string, scope: string = 'table'): Context =>
    *
    * @memberof ShortcutContext#
    * @param {Array<string>} keys Names of the shortcut's keys,
-   * (coming from [`KeyboardEvent.key`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values)),
-   * in lowercase or uppercase, unified across browsers
+   * in lowercase or uppercase, unified across browsers. You can use
+   * [`KeyboardEvent.key`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values)
+   * values, such as `ArrowLeft`, and the Handsontable-specific `control/meta` virtual key name.
+   * `control/meta` matches `Control` on Windows and Linux, and `Meta` on macOS.
    * @returns {boolean}
    */
   const hasShortcut = (keys: string[]): boolean => {


### PR DESCRIPTION
### Context

The PR fixes DEV-811 by documenting how shortcut key names map to displayed keyboard glyphs. The shortcuts guide showed glyphs such as <kbd>⌘</kbd> and <kbd>←</kbd>, while custom shortcut examples used `control/meta` without explaining that it is a Handsontable-specific virtual key name.

[skip changelog]

### How has this been tested?

- `npm run eslint` from `handsontable/`.
- `ReadLints` for `docs/content/guides/navigation/custom-shortcuts/custom-shortcuts.md`, `docs/content/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md`, and `handsontable/src/shortcuts/context.ts`.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-811

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-811

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and comment-only JSDoc updates; no shortcut handling or runtime behavior changes.
> 
> **Overview**
> Closes the gap between **keyboard shortcut tables** (which show glyphs like ⌘ and ←) and **`addShortcut()` key strings** by documenting the naming rules in the guides and in `ShortcutContext` JSDoc.
> 
> The **keyboard shortcuts** guide now tells readers to use strings such as `control/meta` and `ArrowLeft` when registering shortcuts, with a link to the custom shortcuts reference. The **custom shortcuts** guide expands **`addShortcut()` parameters** to explain that `control/meta` is a Handsontable-specific virtual key (Control on Windows/Linux, Meta on macOS) and that arrow keys must use `KeyboardEvent.key` names, not display glyphs.
> 
> **`handsontable/src/shortcuts/context.ts`** updates the `keys` parameter docs on `addShortcut`, `removeShortcutsByKeys`, `getShortcuts`, and `hasShortcut` to match—no runtime logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 928058f22bd5f70cff7070bfa47039d2734caf32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->