### PR TITLE
DEV-813: Document scrollViewportTo legacy signature

### DIFF
--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -5497,6 +5497,9 @@ export default function Core(
   /**
    * Scroll viewport to coordinates specified by the `row` and/or `col` object properties.
    *
+   * The object-based signature was introduced in v14.0.0. The positional arguments form is retained
+   * for backward compatibility.
+   *
    * ```js
    * // scroll the viewport to the visual row index (leave the horizontal scroll untouched)
    * hot.scrollViewportTo({ row: 50 });
@@ -5511,6 +5514,9 @@ export default function Core(
    * }, () => {
    *   // callback function executed after the viewport is scrolled
    * });
+   *
+   * // scroll the viewport using the backward-compatible positional arguments form
+   * hot.scrollViewportTo(50, 50, true, true);
    * ```
    *
    * @memberof Core#


### PR DESCRIPTION
### Context

The PR fixes DEV-813 by documenting the permanently supported positional arguments form of `scrollViewportTo()` in the API JSDoc. The generated API docs already use this JSDoc as the source of truth, so no separate Markdown page is needed.

[skip changelog]

### How has this been tested?

- `npm --prefix handsontable run eslint`

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. DEV-813

### Affected project(s):
- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-813

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no code path or API behavior modifications.
> 
> **Overview**
> **JSDoc-only** update for `scrollViewportTo` in `core.ts` so generated API docs describe both calling styles.
> 
> The block now states that the **object options** form was added in **v14.0.0**, while the **positional** form `(row, col, snapToBottom, snapToRight)` remains supported for backward compatibility. A new example shows `hot.scrollViewportTo(50, 50, true, true)` alongside the existing object-based examples.
> 
> No runtime or type changes; behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 857eeacc36d327c0c446338b0aa36bf5c224ad4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->