### PR TITLE
DEV-815: Document column menu keyboard navigation

### DIFF
--- a/docs/content/guides/accessories-and-menus/column-menu/column-menu.md
+++ b/docs/content/guides/accessories-and-menus/column-menu/column-menu.md
@@ -137,12 +137,27 @@ the [context menu](@/guides/accessories-and-menus/context-menu/context-menu.md).
 For a complete filtering guide, see [Column filter](@/guides/columns/column-filter/column-filter.md).
 For filter-menu keyboard and pointer behavior, see [Navigate the filter menu](@/guides/columns/column-filter/column-filter.md#navigate-the-filter-menu).
 
+## Navigate the column menu
+
+Use keyboard shortcuts to navigate the column menu after you open it:
+
+- Press **Arrow up** and **Arrow down** to move between menu items.
+- Press **Arrow right** to open a submenu in left-to-right layouts. Press **Arrow left** to close it and return to the parent menu.
+- Press **Arrow left** to open a submenu in right-to-left layouts. Press **Arrow right** to close it and return to the parent menu.
+- Press **Home**, **Ctrl**+**Arrow up** on Windows, or **Cmd**+**Arrow up** on macOS to move to the first available item.
+- Press **End**, **Ctrl**+**Arrow down** on Windows, or **Cmd**+**Arrow down** on macOS to move to the last available item.
+- Press **Page Up** and **Page Down** to move by one visible menu page.
+- Press **Enter** or **Space** to run the selected menu item or open its submenu.
+- Press **Escape** to close the column menu or active submenu.
+
+Filter controls inside the column menu use additional navigation rules. For filter-menu keyboard and pointer behavior, see [Navigate the filter menu](@/guides/columns/column-filter/column-filter.md#navigate-the-filter-menu).
+
 ## Related keyboard shortcuts
 
 | Windows                                                  | macOS                                                       | Action                                                                                                       |  Excel  | Sheets  |
 | -------------------------------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | :-----: | :-----: |
 | <kbd>**Shift**</kbd>+<kbd>**Alt**</kbd>+<kbd>**↓**</kbd> | <kbd>⇧</kbd>+<kbd>⌥</kbd>+<kbd>**↓**</kbd> | Open the column menu. Works in any cell, if the respective column header displays the menu button.           | &cross; | &cross; |
-| <kbd>**Shift**</kbd>+<kbd>**Enter**</kbd>                | <kbd>⇧</kbd>+<kbd>**Enter**</kbd>                   | Open the column menu. Works only when you're selecting a column header that displays the column menu button. | &cross; | &cross; |
+| <kbd>**Ctrl**</kbd>+<kbd>**Enter**</kbd>                 | <kbd>⌘</kbd>+<kbd>**Enter**</kbd>                    | Open the column menu. Works only when you're selecting a column header that displays the column menu button. | &cross; | &cross; |
 
 ## Related articles
 

--- a/docs/content/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md
+++ b/docs/content/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md
@@ -224,6 +224,13 @@ These keyboard shortcuts work with the [column menu](@/guides/accessories-and-me
 | -------------------------------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | :-----: | :-----: |
 | <kbd>**Shift**</kbd>+<kbd>**Alt**</kbd>+<kbd>**↓**</kbd> | <kbd>⇧</kbd>+<kbd>⌥</kbd>+<kbd>**↓**</kbd> | Open the column menu. Works in any cell, if the respective column header displays the menu button.           | &cross; | &cross; |
 | <kbd>**Ctrl**</kbd>+<kbd>**Enter**</kbd>                | <kbd>⌘</kbd>+<kbd>**Enter**</kbd>                   | Open the column menu. Works only when you're selecting a column header that displays the column menu button. | &cross; | &cross; |
+| Arrow keys                                               | Arrow keys                                                  | Move one available menu item up, down, left, or right.                                                       | &check; | &check; |
+| <kbd>**Ctrl**</kbd>+<kbd>**↑**</kbd> or <kbd>**Home**</kbd> | <kbd>⌘</kbd>+<kbd>**↑**</kbd> or <kbd>**Home**</kbd> | Move to the first available menu item.                                                                       | &check; | &cross; |
+| <kbd>**Ctrl**</kbd>+<kbd>**↓**</kbd> or <kbd>**End**</kbd> | <kbd>⌘</kbd>+<kbd>**↓**</kbd> or <kbd>**End**</kbd>  | Move to the last available menu item.                                                                        | &check; | &cross; |
+| <kbd>**Page Up**</kbd>                                  | <kbd>**Page Up**</kbd>                              | Move one visible menu page up.                                                                               | &check; | &cross; |
+| <kbd>**Page Down**</kbd>                                | <kbd>**Page Down**</kbd>                            | Move one visible menu page down.                                                                             | &check; | &cross; |
+| <kbd>**Escape**</kbd>                                   | <kbd>**Escape**</kbd>                               | Close the column menu or submenu.                                                                            | &check; | &check; |
+| <kbd>**Enter**</kbd> or <kbd>**Space**</kbd>             | <kbd>**Enter**</kbd> or <kbd>**Space**</kbd>         | Run the action of the selected menu item, or open its submenu.                                               | &check; | &cross; |
 
 ### Column filter keyboard shortcuts
 


### PR DESCRIPTION
### Context

The PR fixes outdated and incomplete keyboard navigation docs for the column menu.
DEV-815 is partially covered already: column-filter navigation is documented, but the column-menu guide did not explain in-menu navigation and still listed a stale header shortcut.

This change aligns the docs with the `DropdownMenu` shortcut registration and the shared `Menu` keyboard shortcuts used by context menus.

### How has this been tested?

- `rtk npm --prefix docs run docs:lint`
- IDE diagnostics for the edited Markdown files.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-815

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-815

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown documentation only; no runtime or API changes.
> 
> **Overview**
> **Documentation-only** update for column menu keyboard behavior (DEV-815).
> 
> The **column menu** guide gains a **Navigate the column menu** section describing in-menu shortcuts (arrows, Home/End, Page Up/Down, Enter/Space, Escape, RTL submenu behavior) and points readers to the filter-menu navigation guide for filter controls inside the menu.
> 
> The **Related keyboard shortcuts** table in that guide is corrected: opening the menu from a column header is documented as **Ctrl/Cmd+Enter** instead of the outdated **Shift+Enter**, matching `DropdownMenu` shortcut registration in code.
> 
> The central **keyboard shortcuts** reference expands the **Column menu** table with the same in-menu navigation rows (aligned with context menu / shared `Menu` behavior) and the corrected header open shortcut.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95ff58f165fce4486c2f3a6e4d112a25812d5f94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->