### PR TITLE
DEV-817: Improve alter API docs

### DIFF
--- a/handsontable/src/__tests__/core/alter.spec.js
+++ b/handsontable/src/__tests__/core/alter.spec.js
@@ -1,0 +1,31 @@
+describe('Core_alter', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  it('should pass the source and keepEmptyRows arguments to the beforeAlter hook', async() => {
+    const beforeAlter = jasmine.createSpy('beforeAlter');
+
+    handsontable({
+      data: [
+        ['SKU-4821', 'Harbor Goods'],
+        ['SKU-0093', 'Alpine Supply Co.'],
+        ['SKU-1180', 'Summit Traders'],
+      ],
+      beforeAlter,
+    });
+
+    await alter('remove_row', 1, 1, 'inventory-cleanup', true);
+
+    expect(beforeAlter).toHaveBeenCalledWith('remove_row', 1, 1, 'inventory-cleanup', true);
+  });
+});

--- a/handsontable/src/__tests__/core/keepEmptyRows.spec.js
+++ b/handsontable/src/__tests__/core/keepEmptyRows.spec.js
@@ -352,4 +352,55 @@ describe('Core_keepEmptyRows', () => {
 
     expect(countCols()).toEqual(2);
   });
+
+  it('should refill rows removed with alter when keepEmptyRows is omitted', async() => {
+    handsontable({
+      data: [
+        ['SKU-4821', 'Harbor Goods'],
+        ['SKU-0093', 'Alpine Supply Co.'],
+        ['SKU-1180', 'Summit Traders'],
+      ],
+      minRows: 4,
+    });
+
+    expect(countRows()).toEqual(4);
+
+    await alter('remove_row', 1, 1);
+
+    expect(countRows()).toEqual(4);
+  });
+
+  it('should not refill rows removed with alter when keepEmptyRows is true', async() => {
+    handsontable({
+      data: [
+        ['SKU-4821', 'Harbor Goods'],
+        ['SKU-0093', 'Alpine Supply Co.'],
+        ['SKU-1180', 'Summit Traders'],
+      ],
+      minRows: 4,
+    });
+
+    expect(countRows()).toEqual(4);
+
+    await alter('remove_row', 1, 1, 'inventory-cleanup', true);
+
+    expect(countRows()).toEqual(3);
+  });
+
+  it('should not refill spare rows removed with alter when keepEmptyRows is true', async() => {
+    handsontable({
+      data: [
+        ['SKU-4821', 'Harbor Goods'],
+        ['SKU-0093', 'Alpine Supply Co.'],
+        ['SKU-1180', 'Summit Traders'],
+      ],
+      minSpareRows: 1,
+    });
+
+    expect(countRows()).toEqual(4);
+
+    await alter('remove_row', 3, 1, 'inventory-cleanup', true);
+
+    expect(countRows()).toEqual(3);
+  });
 });

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -900,8 +900,8 @@ export default function Core(
      *                             format `[[index, amount], [index, amount]...]` this can be used to remove
      *                             non-consecutive columns or rows in one call.
      * @param {number} [amount=1] Amount of rows or columns to remove.
-     * @param {string} [source] Optional. Source of hook runner.
-     * @param {boolean} [keepEmptyRows] Optional. Flag for preventing deletion of empty rows.
+     * @param {string} [source] Optional. Source indicator passed to related hooks.
+     * @param {boolean} [keepEmptyRows] Optional. Flag for skipping the post-alter empty row and column adjustment.
      */
     alter(action: string, index: number | number[][] | undefined, amount = 1, source: string, keepEmptyRows: boolean) {
 
@@ -3630,8 +3630,10 @@ export default function Core(
    * @param {number|number[]} [index] A visual index of the row/column before or after which the new row/column will be
    *                                inserted or removed. Can also be an array of arrays, in format `[[index, amount],...]`.
    * @param {number} [amount] The amount of rows or columns to be inserted or removed (default: `1`).
-   * @param {string} [source] Source indicator.
-   * @param {boolean} [keepEmptyRows] If set to `true`, prevents removing empty rows.
+   * @param {string} [source] Source indicator passed to related hooks.
+   * @param {boolean} [keepEmptyRows] If set to `true`, skips the automatic adjustment that normally adds empty rows
+   *                                  or columns after the operation to satisfy `minRows`, `minSpareRows`,
+   *                                  `minCols`, or `minSpareCols`.
    * @example
    * ```js
    * // above row 10 (by visual index), insert 1 new row
@@ -3651,9 +3653,23 @@ export default function Core(
    * // remove 2 rows, starting from row 10 (by visual index)
    * hot.alter('remove_row', 10, 2);
    *
+   * // remove 2 columns, starting from column 3 (by visual index)
+   * hot.alter('remove_col', 3, 2);
+   *
    * // remove 3 rows, starting from row 1 (by visual index)
    * // remove 2 rows, starting from row 5 (by visual index)
    * hot.alter('remove_row', [[1, 3], [5, 2]]);
+   *
+   * // pass a custom source string to hooks
+   * hot.addHook('afterCreateRow', (index, amount, source) => {
+   *   if (source === 'inventory-import') {
+   *     // Run logic only for rows created by the inventory import.
+   *   }
+   * });
+   * hot.alter('insert_row_above', 0, 1, 'inventory-import');
+   *
+   * // remove a row without immediately adding empty rows required by `minRows` or `minSpareRows`
+   * hot.alter('remove_row', 4, 1, 'inventory-cleanup', true);
    * ```
    */
   this.alter = function(


### PR DESCRIPTION
### Context

The PR fixes DEV-817 by improving the `Core#alter()` API reference source. The old issue asked for clearer examples of `remove_col`, the `source` argument, and `keepEmptyRows`; the current JSDoc still lacked those details and described `keepEmptyRows` imprecisely.

### How has this been tested?

- `rtk npm run test:e2e --prefix handsontable --testPathPattern=keepEmptyRows` - 24 specs, 0 failures.
- `rtk npm run test:e2e --prefix handsontable --testPathPattern=alter` - 54 specs, 0 failures.
- `rtk npm run build --prefix handsontable && rtk npm run docs:api --prefix docs`.
- `rtk npm run eslint --prefix handsontable`.
- `rtk npm run stylelint --prefix handsontable`.
- `ReadLints` on edited files - no linter errors.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-817

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-817

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test-only changes; no runtime logic was modified in the diff.
> 
> **Overview**
> Improves **`Core#alter()`** API documentation in `core.ts` so `source` and **`keepEmptyRows`** match actual behavior. **`keepEmptyRows`** is described as skipping the post-alter adjustment that refills empty rows/columns for `minRows`, `minSpareRows`, `minCols`, and `minSpareCols`—not as blocking deletion of empty rows. New JSDoc examples cover **`remove_col`**, hook **`source`** strings, and **`keepEmptyRows: true`** on row removal.
> 
> Adds e2e coverage: **`beforeAlter`** receives `source` and **`keepEmptyRows`**, and row count after **`remove_row`** with vs without **`keepEmptyRows`** under **`minRows`** / **`minSpareRows`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7451f649e961017c6fbbcd5f288798ec5adb529d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->