### PR TITLE
DEV-825: Improve BaseEditor API docs

### DIFF
--- a/docs/scripts/jsdoc-convert/configuration.mjs
+++ b/docs/scripts/jsdoc-convert/configuration.mjs
@@ -465,7 +465,7 @@ export default {
     'BaseEditor.md': {
       id: 'l025jsly',
       metaTitle: 'BaseEditor - JavaScript Data Grid | Handsontable',
-      description: 'Options, members, and methods of Handsontable\'s BaseEditor API.',
+      description: 'BaseEditor defines the lifecycle that Handsontable cell editors follow. Extend it to create custom editors for the editor option.',
       react: {
         id: 'snc3axwd',
         metaTitle: 'BaseEditor - React Data Grid | Handsontable',

--- a/handsontable/src/editors/baseEditor/baseEditor.ts
+++ b/handsontable/src/editors/baseEditor/baseEditor.ts
@@ -24,7 +24,17 @@ export const EDITOR_STATE = Object.freeze({
 });
 
 /**
+ * The abstract base class for Handsontable cell editors.
+ *
+ * Extend it to create an editor that controls how a cell enters edit mode, reads and writes values,
+ * and returns focus to the grid. Concrete editors implement `init()`, `getValue()`, `setValue()`,
+ * `open()`, `close()`, and `focus()`.
+ *
  * @class BaseEditor
+ * @see https://handsontable.com/docs/javascript-data-grid/cell-editor/
+ * @see https://handsontable.com/docs/javascript-data-grid/cell-function/
+ * @see https://handsontable.com/docs/javascript-data-grid/api/options/#editor
+ * @see https://handsontable.com/docs/react-data-grid/api/hooks/#afterbeginediting
  */
 export class BaseEditor {
   /**
@@ -65,6 +75,8 @@ export class BaseEditor {
   /**
    * Callback to call after closing editor.
    *
+   * @private
+   *
    * @type {Function}
    */
   _closeCallback: ((result: boolean) => void) | null = null;
@@ -75,7 +87,7 @@ export class BaseEditor {
    */
   _closeAfterDataChange = true;
   /**
-   * Currently rendered cell's TD element.
+   * Currently rendered cell's `TD` element.
    *
    * @type {HTMLTableCellElement}
    */
@@ -650,7 +662,7 @@ export class BaseEditor {
   }
 
   /**
-   * Gets className of the edited cell if exist.
+   * Gets the `className` of the edited cell, if it exists.
    *
    * @returns {string}
    */
@@ -674,7 +686,7 @@ export class BaseEditor {
   }
 
   /**
-   * Gets HTMLTableCellElement of the edited cell if exist.
+   * Gets the `HTMLTableCellElement` of the edited cell, if it exists.
    *
    * @returns {HTMLTableCellElement|null}
    */


### PR DESCRIPTION
### Context

The PR fixes DEV-825 by improving the generated `BaseEditor` API documentation. The original issue is partially outdated: the cell editor guide already has the related resources and inline formatting updates, so this change focuses on the remaining generated API content.

The `BaseEditor` API page is generated from source JSDoc and API configuration. This PR adds a clearer `BaseEditor` description, links related editor resources from the source JSDoc, hides the private `_closeCallback` member from the generated page, and formats API terms such as `TD`, `className`, and `HTMLTableCellElement`.

### How has this been tested?

- `rtk npm --prefix handsontable run eslint`
- `rtk npm --prefix handsontable run stylelint`
- `rtk npm --prefix docs run docs:lint`
- `rtk npm --prefix handsontable run build`
- `rtk npm --prefix docs run docs:api`

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-825

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-825

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and JSDoc-only updates; no functional changes to the editor implementation.
> 
> **Overview**
> Improves the generated **BaseEditor** API page (DEV-825) with clearer copy and links, without changing editor runtime behavior.
> 
> The docs SEO blurb in `configuration.mjs` now explains that **BaseEditor** defines the cell-editor lifecycle and that you extend it for custom `editor` implementations. Class-level JSDoc in `baseEditor.ts` adds the same overview, lists the methods custom editors implement, and adds `@see` links to the cell editor guide, cell functions, the `editor` option, and `afterBeginEditing`.
> 
> `_closeCallback` is marked `@private` so it no longer appears on the public API page. Member/method descriptions now use backticks for `TD`, `className`, and `HTMLTableCellElement`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bac96d8bc5aee32f46a2c5d11557aaec25079dd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->