### PR TITLE
DEV-832: Improve Filters getSelectedColumn JSDoc

### DIFF
--- a/handsontable/src/plugins/filters/filters.ts
+++ b/handsontable/src/plugins/filters/filters.ts
@@ -1051,11 +1051,11 @@ export class Filters extends BasePlugin {
   }
 
   /**
-   * Gets last selected column index.
+   * Gets the last selected column as an object with visual and physical indexes.
    *
    * @returns {{visualIndex: number, physicalIndex: number} | null} Returns `null` when a column is
    * not selected. Otherwise, returns an object with `visualIndex` and `physicalIndex` properties containing
-   * the index of the column.
+   * column indexes.
    */
   getSelectedColumn(): { physicalIndex: number, visualIndex: number } | null {
     const highlight = this.hot.getSelectedRangeActive()?.highlight;


### PR DESCRIPTION
### Context

The PR fixes the generated API description for `Filters#getSelectedColumn()`.
DEV-832 points out that the first JSDoc sentence said the method gets a column index, while the method returns an object with `visualIndex` and `physicalIndex` properties.

### How has this been tested?

- `npm --prefix handsontable run build:types`.
- Confirmed `handsontable/tmp/plugins/filters/filters.d.ts` contains the corrected `getSelectedColumn()` summary.
- `npm --prefix handsontable run eslint`.
- `npm --prefix handsontable run stylelint`.
- `npm --prefix handsontable run build`.
- `npm --prefix handsontable run test:unit --testPathPattern=filters`.
- Skipped `npm --prefix handsontable run test:e2e --testPathPattern=filters` at request. The command could not start Puppeteer because Chrome `148.0.7778.97` was missing from the local cache.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-832

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-832

[skip changelog]


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only JSDoc edits with no logic or type signature changes.
> 
> **Overview**
> Updates JSDoc on **`Filters#getSelectedColumn()`** so generated API docs match behavior: the method returns **`null`** or an object with **`visualIndex`** and **`physicalIndex`**, not a single column index.
> 
> Wording in the summary and `@returns` description is adjusted only; **runtime behavior is unchanged**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit affeac93e877f0223c5ada4075adfaf5ffa93f70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->