### PR TITLE
DEV-1219: Fix cell-editor #example3 for Angular and React

### DIFF
--- a/docs/content/guides/cell-functions/cell-editor/angular/example3.html
+++ b/docs/content/guides/cell-functions/cell-editor/angular/example3.html
@@ -1,0 +1,3 @@
+<div>
+  <example3-cell-editor></example3-cell-editor>
+</div>

--- a/docs/content/guides/cell-functions/cell-editor/angular/example3.ts
+++ b/docs/content/guides/cell-functions/cell-editor/angular/example3.ts
@@ -1,0 +1,89 @@
+/* file: app.component.ts */
+import { Component } from '@angular/core';
+import { GridSettings, HotTableModule } from '@handsontable/angular-wrapper';
+import { TextEditor } from 'handsontable/editors';
+import Handsontable from 'handsontable/base';
+
+class PasswordEditor extends TextEditor {
+  override createElements(): void {
+    super.createElements();
+
+    this.TEXTAREA = this.hot.rootDocument.createElement('input') as HTMLInputElement;
+    this.TEXTAREA.setAttribute('type', 'password');
+    this.TEXTAREA.setAttribute('data-hot-input', 'true');
+    this.textareaStyle = this.TEXTAREA.style;
+    this.textareaStyle.width = '0';
+    this.textareaStyle.height = '0';
+    this.TEXTAREA_PARENT.innerText = '';
+    this.TEXTAREA_PARENT.appendChild(this.TEXTAREA);
+  }
+}
+
+function maskedRenderer(
+  _instance: Handsontable.Core,
+  td: HTMLTableCellElement,
+  _row: number,
+  _col: number,
+  _prop: string | number,
+  value: Handsontable.CellValue
+): HTMLTableCellElement {
+  td.innerText = value ? '●●●●●●●●' : '—';
+  td.style.letterSpacing = value ? '2px' : 'normal';
+
+  return td;
+}
+
+@Component({
+  selector: 'example3-cell-editor',
+  standalone: true,
+  imports: [HotTableModule],
+  template: ` <div>
+    <hot-table [settings]="gridSettings"></hot-table>
+  </div>`,
+})
+export class AppComponent {
+
+  readonly gridSettings: GridSettings = {
+    data: [
+      ['Alice Chen', 'alice@example.com', 'Admin', 'Wh1stl3!2024'],
+      ['Bob Garcia', 'bob@example.com', 'Editor', 'P@ssw0rd42'],
+      ['Carol Smith', 'carol@example.com', 'Viewer', 'Tr0ub4dor&3'],
+      ['Dave Kim', 'dave@example.com', 'Editor', 'c0rrectH0rs3'],
+      ['Eve Johnson', 'eve@example.com', 'Admin', 'Sup3rS3cr3t!'],
+    ],
+    colHeaders: ['Name', 'Email', 'Role', 'Password'],
+    columns: [
+      { type: 'text' },
+      { type: 'text' },
+      { type: 'text' },
+      { editor: PasswordEditor as typeof TextEditor, renderer: maskedRenderer },
+    ],
+    colWidths: [130, 190, 70, 130],
+    rowHeaders: true,
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true,
+  };
+}
+/* end-file */
+
+
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+/* end-file */

--- a/docs/content/guides/cell-functions/cell-editor/cell-editor.md
+++ b/docs/content/guides/cell-functions/cell-editor/cell-editor.md
@@ -241,8 +241,8 @@ Override only the methods you need. The `PasswordEditor` below extends `TextEdit
 
 ::: example #example3 :react --js 1 --ts 2
 
-@[code](@/content/guides/cell-functions/cell-editor/react/example2.jsx)
-@[code](@/content/guides/cell-functions/cell-editor/react/example2.tsx)
+@[code](@/content/guides/cell-functions/cell-editor/react/example3.jsx)
+@[code](@/content/guides/cell-functions/cell-editor/react/example3.tsx)
 
 :::
 
@@ -252,8 +252,8 @@ Override only the methods you need. The `PasswordEditor` below extends `TextEdit
 
 ::: example #example3 :angular --ts 1 --html 2
 
-@[code](@/content/guides/cell-functions/cell-editor/angular/example2.ts)
-@[code](@/content/guides/cell-functions/cell-editor/angular/example2.html)
+@[code](@/content/guides/cell-functions/cell-editor/angular/example3.ts)
+@[code](@/content/guides/cell-functions/cell-editor/angular/example3.html)
 
 :::
 

--- a/docs/content/guides/cell-functions/cell-editor/react/example3.jsx
+++ b/docs/content/guides/cell-functions/cell-editor/react/example3.jsx
@@ -1,0 +1,56 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { TextEditor } from 'handsontable/editors/textEditor';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+class PasswordEditor extends TextEditor {
+  createElements() {
+    super.createElements();
+    this.TEXTAREA = this.hot.rootDocument.createElement('input');
+    this.TEXTAREA.setAttribute('type', 'password');
+    this.TEXTAREA.setAttribute('data-hot-input', 'true');
+    this.textareaStyle = this.TEXTAREA.style;
+    this.textareaStyle.width = '0';
+    this.textareaStyle.height = '0';
+    this.TEXTAREA_PARENT.innerText = '';
+    this.TEXTAREA_PARENT.appendChild(this.TEXTAREA);
+  }
+}
+
+function maskedRenderer(_instance, td, _row, _col, _prop, value) {
+  td.innerText = value ? '●●●●●●●●' : '—';
+  td.style.letterSpacing = value ? '2px' : 'normal';
+
+  return td;
+}
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={[
+        ['Alice Chen', 'alice@example.com', 'Admin', 'Wh1stl3!2024'],
+        ['Bob Garcia', 'bob@example.com', 'Editor', 'P@ssw0rd42'],
+        ['Carol Smith', 'carol@example.com', 'Viewer', 'Tr0ub4dor&3'],
+        ['Dave Kim', 'dave@example.com', 'Editor', 'c0rrectH0rs3'],
+        ['Eve Johnson', 'eve@example.com', 'Admin', 'Sup3rS3cr3t!'],
+      ]}
+      colHeaders={['Name', 'Email', 'Role', 'Password']}
+      columns={[
+        { type: 'text' },
+        { type: 'text' },
+        { type: 'text' },
+        { editor: PasswordEditor, renderer: maskedRenderer },
+      ]}
+      colWidths={[130, 190, 70, 130]}
+      rowHeaders={true}
+      autoWrapRow={true}
+      autoWrapCol={true}
+      height="auto"
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/cell-functions/cell-editor/react/example3.tsx
+++ b/docs/content/guides/cell-functions/cell-editor/react/example3.tsx
@@ -1,0 +1,64 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { TextEditor } from 'handsontable/editors/textEditor';
+import { registerAllModules } from 'handsontable/registry';
+import Handsontable from 'handsontable/base';
+
+// register Handsontable's modules
+registerAllModules();
+
+class PasswordEditor extends TextEditor {
+  override createElements(): void {
+    super.createElements();
+    this.TEXTAREA = this.hot.rootDocument.createElement('input') as HTMLInputElement;
+    this.TEXTAREA.setAttribute('type', 'password');
+    this.TEXTAREA.setAttribute('data-hot-input', 'true');
+    this.textareaStyle = this.TEXTAREA.style;
+    this.textareaStyle.width = '0';
+    this.textareaStyle.height = '0';
+    this.TEXTAREA_PARENT.innerText = '';
+    this.TEXTAREA_PARENT.appendChild(this.TEXTAREA);
+  }
+}
+
+function maskedRenderer(
+  _instance: Handsontable.Core,
+  td: HTMLTableCellElement,
+  _row: number,
+  _col: number,
+  _prop: string | number,
+  value: Handsontable.CellValue
+): HTMLTableCellElement {
+  td.innerText = value ? '●●●●●●●●' : '—';
+  td.style.letterSpacing = value ? '2px' : 'normal';
+
+  return td;
+}
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={[
+        ['Alice Chen', 'alice@example.com', 'Admin', 'Wh1stl3!2024'],
+        ['Bob Garcia', 'bob@example.com', 'Editor', 'P@ssw0rd42'],
+        ['Carol Smith', 'carol@example.com', 'Viewer', 'Tr0ub4dor&3'],
+        ['Dave Kim', 'dave@example.com', 'Editor', 'c0rrectH0rs3'],
+        ['Eve Johnson', 'eve@example.com', 'Admin', 'Sup3rS3cr3t!'],
+      ]}
+      colHeaders={['Name', 'Email', 'Role', 'Password']}
+      columns={[
+        { type: 'text' },
+        { type: 'text' },
+        { type: 'text' },
+        { editor: PasswordEditor as typeof TextEditor, renderer: maskedRenderer },
+      ]}
+      colWidths={[130, 190, 70, 130]}
+      rowHeaders={true}
+      autoWrapRow={true}
+      autoWrapCol={true}
+      height="auto"
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+
+export default ExampleComponent;


### PR DESCRIPTION
### Context

The PR fixes the broken `#example3` ("Extending an existing editor") on the [cell editor guide](https://handsontable.com/docs/cell-editor/) for Angular and React.

- **Angular** - the example did not render at all. `#example3` re-embedded `angular/example2.ts` and `angular/example2.html` under a second anchor, so the page contained two `<example2-cell-editor>` elements. `bootstrapApplication` attaches to the **first** element in the document that matches the component selector, so the second container stayed an empty box.
- **React** - the example rendered, but as five empty rows. `#example3` re-embedded `react/example2.jsx`/`.tsx` (`startRows: 5`, no data), while the surrounding section text describes a `PasswordEditor`, and the JavaScript and Vue variants of the same section show a `PasswordEditor` demo with realistic data.

The fix gives `#example3` its own dedicated example files:

- `angular/example3.ts` + `angular/example3.html` with a unique `example3-cell-editor` selector, which resolves the `bootstrapApplication` selector collision.
- `react/example3.tsx` + `react/example3.jsx` mirroring the JavaScript and Vue `PasswordEditor` example (masked renderer, password input, same dataset), so all four frameworks now show consistent content in the "Extending an existing editor" section.

No other guide page re-embeds the same Angular example file under two anchors (verified across `docs/content/guides`).

Part of the "Fix and validate all Angular documentation examples and sandboxes" effort (DEV-1219).

### How has this been tested?

- Verified the root cause in `docs/src/scripts/example-runner.ts` (`bootstrapAngular` uses `bootstrapApplication`, which resolves the host by document-wide selector lookup) and in `docs/src/plugins/framework-loader.mjs` (example file paths resolve from the `@[code]` refs, so the new `example3.*` files are picked up by the runner's glob maps).
- New examples follow the docs Angular standalone component rules (inline template, no `templateUrl`/`styleUrls`, license via `HOT_GLOBAL_CONFIG`) and mirror the already-working `javascript/example1.ts` and `vue/example1.vue` content.
- Docs preview build on this PR renders the page for final visual confirmation.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1219

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1219

https://claude.ai/code/session_01G1jHHzpkuKiVnVRAhhK2My

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1jHHzpkuKiVnVRAhhK2My)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and doc example files only; no runtime library or application code changes.
> 
> **Overview**
> Fixes the **Extending an existing editor** live examples on the cell editor guide by giving `#example3` its own Angular and React sources instead of reusing `example2`.
> 
> **`cell-editor.md`** now embeds `react/example3.*` and `angular/example3.*` for `#example3`. **Angular** adds `example3-cell-editor` with a `PasswordEditor` extending `TextEditor`, a masked password renderer, and sample user data—avoiding duplicate `example2-cell-editor` hosts so `bootstrapApplication` no longer mounts only the first instance. **React** adds matching `example3.jsx` / `example3.tsx` with the same password column demo, replacing the empty five-row `example2` embed so React aligns with JavaScript and Vue in that section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f5391ef0a463230d36efa5c3532601effc03e25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->