### PR TITLE
DEV-826: Improve autocomplete guide

### DIFF
--- a/docs/content/guides/cell-types/autocomplete-cell-type/angular/example8.html
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/angular/example8.html
@@ -1,0 +1,3 @@
+<div>
+  <example8-autocomplete-cell-type></example8-autocomplete-cell-type>
+</div>

--- a/docs/content/guides/cell-types/autocomplete-cell-type/angular/example8.ts
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/angular/example8.ts
@@ -1,0 +1,72 @@
+/* file: app.component.ts */
+import { Component } from '@angular/core';
+import { GridSettings, HotTableModule} from '@handsontable/angular-wrapper';
+
+@Component({
+  selector: 'example8-autocomplete-cell-type',
+  standalone: true,
+  imports: [HotTableModule],
+  template: ` <div>
+    <hot-table [data]="data" [settings]="gridSettings"></hot-table>
+  </div>`
+})
+export class AppComponent {
+  readonly statuses = [
+    'Backlog',
+    'In progress',
+    'Blocked',
+    'Done',
+    'Cancelled',
+  ];
+
+  readonly data = [
+    ['Backlog', 'Backlog'],
+    ['In progress', 'In progress'],
+    ['Blocked', 'Blocked'],
+    ['Done', 'Done'],
+    ['Cancelled', 'Cancelled'],
+  ];
+
+  readonly gridSettings: GridSettings = {
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true,
+    colHeaders: ['Source order (default)', 'Alphabetical order'],
+    columns: [
+      {
+        type: 'autocomplete',
+        source: this.statuses,
+        strict: false,
+      },
+      {
+        type: 'autocomplete',
+        source: this.statuses,
+        strict: false,
+        // sort suggestions alphabetically instead of using the `source` order
+        sortByRelevance: false,
+      },
+    ],
+  };
+}
+/* end-file */
+
+
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+/* end-file */

--- a/docs/content/guides/cell-types/autocomplete-cell-type/angular/example9.html
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/angular/example9.html
@@ -1,0 +1,3 @@
+<div>
+  <example9-autocomplete-cell-type></example9-autocomplete-cell-type>
+</div>

--- a/docs/content/guides/cell-types/autocomplete-cell-type/angular/example9.ts
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/angular/example9.ts
@@ -1,0 +1,72 @@
+/* file: app.component.ts */
+import { Component } from '@angular/core';
+import { GridSettings, HotTableModule} from '@handsontable/angular-wrapper';
+
+@Component({
+  selector: 'example9-autocomplete-cell-type',
+  standalone: true,
+  imports: [HotTableModule],
+  template: ` <div>
+    <hot-table [data]="data" [settings]="gridSettings"></hot-table>
+  </div>`
+})
+export class AppComponent {
+  readonly stockStatuses = [
+    '<span style="color: #1a7f37">In stock</span>',
+    '<span style="color: #b35900">Low stock</span>',
+    '<span style="color: #c92a2a">Out of stock</span>',
+    '<span style="color: #495057">Backordered</span>',
+    '<span style="color: #495057">Discontinued</span>',
+  ];
+
+  readonly data = [
+    [this.stockStatuses[0], this.stockStatuses[0]],
+    [this.stockStatuses[1], this.stockStatuses[1]],
+    [this.stockStatuses[2], this.stockStatuses[2]],
+    [this.stockStatuses[3], this.stockStatuses[3]],
+    [this.stockStatuses[4], this.stockStatuses[4]],
+  ];
+
+  readonly gridSettings: GridSettings = {
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true,
+    colHeaders: ['allowHtml: false (default)', 'allowHtml: true'],
+    columns: [
+      {
+        type: 'autocomplete',
+        source: this.stockStatuses,
+        strict: false,
+      },
+      {
+        type: 'autocomplete',
+        source: this.stockStatuses,
+        strict: false,
+        // render `source` values as HTML — only use with trusted, static data
+        allowHtml: true,
+      },
+    ],
+  };
+}
+/* end-file */
+
+
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+/* end-file */

--- a/docs/content/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md
@@ -42,6 +42,10 @@ In all three modes, the `source` option can be provided in two formats:
 
 This example uses the `autocomplete` feature in the default flexible mode. In this mode, the user can choose one of the suggested options while typing or enter a custom value that is not included in the suggestions.
 
+The [`visibleRows`](@/api/options.md#visiblerows) option sets how many suggestions the dropdown shows without scrolling. The default is 10 rows. The **Chassis color** column sets `visibleRows: 4`, so the dropdown shows only four suggestions at a time and scrolls to reveal the rest.
+
+The [`trimDropdown`](@/api/options.md#trimdropdown) option controls the dropdown's width. By default (`trimDropdown: true`), the dropdown matches the width of the edited cell, which can truncate long suggestions. The **Bumper color** column sets `trimDropdown: false`, so the dropdown expands to fit its widest suggestion, even if that makes it wider than the cell.
+
 ::: only-for javascript
 
 ::: example #example1 .docs-height-small --js 1 --ts 2
@@ -385,6 +389,110 @@ The left column uses the default case-insensitive behavior. The right column has
 
 :::
 
+## The `sortByRelevance` option
+
+By default, the autocomplete dropdown shows suggestions in the order you provide them in the `source` array. Set `sortByRelevance: false` to sort suggestions alphabetically instead.
+
+The left column uses the default behavior (`sortByRelevance: true`) — suggestions keep the order from `source`. The right column has `sortByRelevance: false` — suggestions sort alphabetically.
+
+::: only-for javascript
+
+::: example #example8 .docs-height-small --js 1 --ts 2
+
+@[code](@/content/guides/cell-types/autocomplete-cell-type/javascript/example8.js)
+@[code](@/content/guides/cell-types/autocomplete-cell-type/javascript/example8.ts)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #example8 .docs-height-small :react --js 1 --ts 2
+
+@[code](@/content/guides/cell-types/autocomplete-cell-type/react/example8.jsx)
+@[code](@/content/guides/cell-types/autocomplete-cell-type/react/example8.tsx)
+
+:::
+
+:::
+
+::: only-for angular
+
+::: example #example8 .docs-height-small :angular --ts 1 --html 2
+
+@[code](@/content/guides/cell-types/autocomplete-cell-type/angular/example8.ts)
+@[code](@/content/guides/cell-types/autocomplete-cell-type/angular/example8.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example8 .docs-height-small :vue3
+
+@[code](@/content/guides/cell-types/autocomplete-cell-type/vue/example8.vue)
+
+:::
+
+:::
+
+## The `allowHtml` option
+
+By default, the autocomplete dropdown and cell renderer display `source` values as plain text, so any HTML tags they contain show up literally. Set `allowHtml: true` to render `source` values as HTML instead, for example to show colored status labels.
+
+::: warning Security
+
+Handsontable doesn't sanitize HTML rendered through `allowHtml`. Only enable it for static, trusted `source` data. Rendering `source` values that come from user input creates XSS vulnerabilities. See [Security](@/guides/security/security/security.md) for details.
+
+:::
+
+The left column uses the default behavior (`allowHtml: false`) — HTML tags in `source` show up as plain text. The right column has `allowHtml: true` — the same `source` values render as colored labels.
+
+::: only-for javascript
+
+::: example #example9 .docs-height-small --js 1 --ts 2
+
+@[code](@/content/guides/cell-types/autocomplete-cell-type/javascript/example9.js)
+@[code](@/content/guides/cell-types/autocomplete-cell-type/javascript/example9.ts)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #example9 .docs-height-small :react --js 1 --ts 2
+
+@[code](@/content/guides/cell-types/autocomplete-cell-type/react/example9.jsx)
+@[code](@/content/guides/cell-types/autocomplete-cell-type/react/example9.tsx)
+
+:::
+
+:::
+
+::: only-for angular
+
+::: example #example9 .docs-height-small :angular --ts 1 --html 2
+
+@[code](@/content/guides/cell-types/autocomplete-cell-type/angular/example9.ts)
+@[code](@/content/guides/cell-types/autocomplete-cell-type/angular/example9.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example9 .docs-height-small :vue3
+
+@[code](@/content/guides/cell-types/autocomplete-cell-type/vue/example9.vue)
+
+:::
+
+:::
+
 ## Result
 
 After configuring the autocomplete cell type, cells display a text input that shows matching suggestions as the user types. In strict mode, only values from the source list are accepted. In flexible mode, users can also enter custom values not in the list.
@@ -406,6 +514,7 @@ After configuring the autocomplete cell type, cells display a text input that sh
 <div class="boxes-list">
 
 - [allowHtml](@/api/options.md#allowhtml)
+- [allowInvalid](@/api/options.md#allowinvalid)
 - [filter](@/api/options.md#filter)
 - [filteringCaseSensitive](@/api/options.md#filteringcasesensitive)
 - [sortByRelevance](@/api/options.md#sortbyrelevance)

--- a/docs/content/guides/cell-types/autocomplete-cell-type/javascript/example8.js
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/javascript/example8.js
@@ -1,0 +1,41 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+// Register all Handsontable's modules.
+registerAllModules();
+const statuses = [
+    'Backlog',
+    'In progress',
+    'Blocked',
+    'Done',
+    'Cancelled',
+];
+const container = document.querySelector('#example8');
+new Handsontable(container, {
+    height: 'auto',
+    licenseKey: 'non-commercial-and-evaluation',
+    data: [
+        ['Backlog', 'Backlog'],
+        ['In progress', 'In progress'],
+        ['Blocked', 'Blocked'],
+        ['Done', 'Done'],
+        ['Cancelled', 'Cancelled'],
+    ],
+    colHeaders: ['Source order (default)', 'Alphabetical order'],
+    columns: [
+        {
+            type: 'autocomplete',
+            source: statuses,
+            strict: false,
+            // sortByRelevance: true is the default — suggestions keep the order from `source`
+        },
+        {
+            type: 'autocomplete',
+            source: statuses,
+            strict: false,
+            // sort suggestions alphabetically instead of using the `source` order
+            sortByRelevance: false,
+        },
+    ],
+    autoWrapRow: true,
+    autoWrapCol: true,
+});

--- a/docs/content/guides/cell-types/autocomplete-cell-type/javascript/example8.ts
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/javascript/example8.ts
@@ -1,0 +1,45 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+// Register all Handsontable's modules.
+registerAllModules();
+
+const statuses: string[] = [
+  'Backlog',
+  'In progress',
+  'Blocked',
+  'Done',
+  'Cancelled',
+];
+
+const container = document.querySelector('#example8')!;
+
+new Handsontable(container, {
+  height: 'auto',
+  licenseKey: 'non-commercial-and-evaluation',
+  data: [
+    ['Backlog', 'Backlog'],
+    ['In progress', 'In progress'],
+    ['Blocked', 'Blocked'],
+    ['Done', 'Done'],
+    ['Cancelled', 'Cancelled'],
+  ],
+  colHeaders: ['Source order (default)', 'Alphabetical order'],
+  columns: [
+    {
+      type: 'autocomplete',
+      source: statuses,
+      strict: false,
+      // sortByRelevance: true is the default — suggestions keep the order from `source`
+    },
+    {
+      type: 'autocomplete',
+      source: statuses,
+      strict: false,
+      // sort suggestions alphabetically instead of using the `source` order
+      sortByRelevance: false,
+    },
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+});

--- a/docs/content/guides/cell-types/autocomplete-cell-type/javascript/example9.js
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/javascript/example9.js
@@ -1,0 +1,41 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+// Register all Handsontable's modules.
+registerAllModules();
+const stockStatuses = [
+    '<span style="color: #1a7f37">In stock</span>',
+    '<span style="color: #b35900">Low stock</span>',
+    '<span style="color: #c92a2a">Out of stock</span>',
+    '<span style="color: #495057">Backordered</span>',
+    '<span style="color: #495057">Discontinued</span>',
+];
+const container = document.querySelector('#example9');
+new Handsontable(container, {
+    height: 'auto',
+    licenseKey: 'non-commercial-and-evaluation',
+    data: [
+        [stockStatuses[0], stockStatuses[0]],
+        [stockStatuses[1], stockStatuses[1]],
+        [stockStatuses[2], stockStatuses[2]],
+        [stockStatuses[3], stockStatuses[3]],
+        [stockStatuses[4], stockStatuses[4]],
+    ],
+    colHeaders: ['allowHtml: false (default)', 'allowHtml: true'],
+    columns: [
+        {
+            type: 'autocomplete',
+            source: stockStatuses,
+            strict: false,
+            // allowHtml: false is the default — HTML tags in `source` are shown as plain text
+        },
+        {
+            type: 'autocomplete',
+            source: stockStatuses,
+            strict: false,
+            // render `source` values as HTML — only use with trusted, static data
+            allowHtml: true,
+        },
+    ],
+    autoWrapRow: true,
+    autoWrapCol: true,
+});

--- a/docs/content/guides/cell-types/autocomplete-cell-type/javascript/example9.ts
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/javascript/example9.ts
@@ -1,0 +1,45 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+// Register all Handsontable's modules.
+registerAllModules();
+
+const stockStatuses: string[] = [
+  '<span style="color: #1a7f37">In stock</span>',
+  '<span style="color: #b35900">Low stock</span>',
+  '<span style="color: #c92a2a">Out of stock</span>',
+  '<span style="color: #495057">Backordered</span>',
+  '<span style="color: #495057">Discontinued</span>',
+];
+
+const container = document.querySelector('#example9')!;
+
+new Handsontable(container, {
+  height: 'auto',
+  licenseKey: 'non-commercial-and-evaluation',
+  data: [
+    [stockStatuses[0], stockStatuses[0]],
+    [stockStatuses[1], stockStatuses[1]],
+    [stockStatuses[2], stockStatuses[2]],
+    [stockStatuses[3], stockStatuses[3]],
+    [stockStatuses[4], stockStatuses[4]],
+  ],
+  colHeaders: ['allowHtml: false (default)', 'allowHtml: true'],
+  columns: [
+    {
+      type: 'autocomplete',
+      source: stockStatuses,
+      strict: false,
+      // allowHtml: false is the default — HTML tags in `source` are shown as plain text
+    },
+    {
+      type: 'autocomplete',
+      source: stockStatuses,
+      strict: false,
+      // render `source` values as HTML — only use with trusted, static data
+      allowHtml: true,
+    },
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+});

--- a/docs/content/guides/cell-types/autocomplete-cell-type/react/example8.jsx
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/react/example8.jsx
@@ -1,0 +1,49 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const statuses = [
+  'Backlog',
+  'In progress',
+  'Blocked',
+  'Done',
+  'Cancelled',
+];
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      height="auto"
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+      data={[
+        ['Backlog', 'Backlog'],
+        ['In progress', 'In progress'],
+        ['Blocked', 'Blocked'],
+        ['Done', 'Done'],
+        ['Cancelled', 'Cancelled'],
+      ]}
+      colHeaders={['Source order (default)', 'Alphabetical order']}
+      columns={[
+        {
+          type: 'autocomplete',
+          source: statuses,
+          strict: false,
+          // sortByRelevance: true is the default — suggestions keep the order from `source`
+        },
+        {
+          type: 'autocomplete',
+          source: statuses,
+          strict: false,
+          // sort suggestions alphabetically instead of using the `source` order
+          sortByRelevance: false,
+        },
+      ]}
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/cell-types/autocomplete-cell-type/react/example8.tsx
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/react/example8.tsx
@@ -1,0 +1,49 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const statuses: string[] = [
+  'Backlog',
+  'In progress',
+  'Blocked',
+  'Done',
+  'Cancelled',
+];
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      height="auto"
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+      data={[
+        ['Backlog', 'Backlog'],
+        ['In progress', 'In progress'],
+        ['Blocked', 'Blocked'],
+        ['Done', 'Done'],
+        ['Cancelled', 'Cancelled'],
+      ]}
+      colHeaders={['Source order (default)', 'Alphabetical order']}
+      columns={[
+        {
+          type: 'autocomplete',
+          source: statuses,
+          strict: false,
+          // sortByRelevance: true is the default — suggestions keep the order from `source`
+        },
+        {
+          type: 'autocomplete',
+          source: statuses,
+          strict: false,
+          // sort suggestions alphabetically instead of using the `source` order
+          sortByRelevance: false,
+        },
+      ]}
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/cell-types/autocomplete-cell-type/react/example9.jsx
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/react/example9.jsx
@@ -1,0 +1,49 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const stockStatuses = [
+  '<span style="color: #1a7f37">In stock</span>',
+  '<span style="color: #b35900">Low stock</span>',
+  '<span style="color: #c92a2a">Out of stock</span>',
+  '<span style="color: #495057">Backordered</span>',
+  '<span style="color: #495057">Discontinued</span>',
+];
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      height="auto"
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+      data={[
+        [stockStatuses[0], stockStatuses[0]],
+        [stockStatuses[1], stockStatuses[1]],
+        [stockStatuses[2], stockStatuses[2]],
+        [stockStatuses[3], stockStatuses[3]],
+        [stockStatuses[4], stockStatuses[4]],
+      ]}
+      colHeaders={['allowHtml: false (default)', 'allowHtml: true']}
+      columns={[
+        {
+          type: 'autocomplete',
+          source: stockStatuses,
+          strict: false,
+          // allowHtml: false is the default — HTML tags in `source` are shown as plain text
+        },
+        {
+          type: 'autocomplete',
+          source: stockStatuses,
+          strict: false,
+          // render `source` values as HTML — only use with trusted, static data
+          allowHtml: true,
+        },
+      ]}
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/cell-types/autocomplete-cell-type/react/example9.tsx
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/react/example9.tsx
@@ -1,0 +1,49 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const stockStatuses: string[] = [
+  '<span style="color: #1a7f37">In stock</span>',
+  '<span style="color: #b35900">Low stock</span>',
+  '<span style="color: #c92a2a">Out of stock</span>',
+  '<span style="color: #495057">Backordered</span>',
+  '<span style="color: #495057">Discontinued</span>',
+];
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      height="auto"
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+      data={[
+        [stockStatuses[0], stockStatuses[0]],
+        [stockStatuses[1], stockStatuses[1]],
+        [stockStatuses[2], stockStatuses[2]],
+        [stockStatuses[3], stockStatuses[3]],
+        [stockStatuses[4], stockStatuses[4]],
+      ]}
+      colHeaders={['allowHtml: false (default)', 'allowHtml: true']}
+      columns={[
+        {
+          type: 'autocomplete',
+          source: stockStatuses,
+          strict: false,
+          // allowHtml: false is the default — HTML tags in `source` are shown as plain text
+        },
+        {
+          type: 'autocomplete',
+          source: stockStatuses,
+          strict: false,
+          // render `source` values as HTML — only use with trusted, static data
+          allowHtml: true,
+        },
+      ]}
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/cell-types/autocomplete-cell-type/vue/example8.vue
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/vue/example8.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const statuses: string[] = [
+  'Backlog',
+  'In progress',
+  'Blocked',
+  'Done',
+  'Cancelled',
+];
+
+const hotSettings = ref<GridSettings>({
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  data: [
+    ['Backlog', 'Backlog'],
+    ['In progress', 'In progress'],
+    ['Blocked', 'Blocked'],
+    ['Done', 'Done'],
+    ['Cancelled', 'Cancelled'],
+  ],
+  colHeaders: ['Source order (default)', 'Alphabetical order'],
+  columns: [
+    {
+      type: 'autocomplete',
+      source: statuses,
+      strict: false,
+      // sortByRelevance: true is the default — suggestions keep the order from `source`
+    },
+    {
+      type: 'autocomplete',
+      source: statuses,
+      strict: false,
+      // sort suggestions alphabetically instead of using the `source` order
+      sortByRelevance: false,
+    },
+  ],
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example8">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-types/autocomplete-cell-type/vue/example9.vue
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/vue/example9.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const stockStatuses: string[] = [
+  '<span style="color: #1a7f37">In stock</span>',
+  '<span style="color: #b35900">Low stock</span>',
+  '<span style="color: #c92a2a">Out of stock</span>',
+  '<span style="color: #495057">Backordered</span>',
+  '<span style="color: #495057">Discontinued</span>',
+];
+
+const hotSettings = ref<GridSettings>({
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  data: [
+    [stockStatuses[0], stockStatuses[0]],
+    [stockStatuses[1], stockStatuses[1]],
+    [stockStatuses[2], stockStatuses[2]],
+    [stockStatuses[3], stockStatuses[3]],
+    [stockStatuses[4], stockStatuses[4]],
+  ],
+  colHeaders: ['allowHtml: false (default)', 'allowHtml: true'],
+  columns: [
+    {
+      type: 'autocomplete',
+      source: stockStatuses,
+      strict: false,
+      // allowHtml: false is the default — HTML tags in `source` are shown as plain text
+    },
+    {
+      type: 'autocomplete',
+      source: stockStatuses,
+      strict: false,
+      // render `source` values as HTML — only use with trusted, static data
+      allowHtml: true,
+    },
+  ],
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example9">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>


### PR DESCRIPTION
### Context

The PR fills in documentation gaps flagged in DEV-826 for the [Autocomplete cell type](https://handsontable.com/docs/javascript-data-grid/autocomplete-cell-type/) guide. The `sortByRelevance` and `allowHtml` options were listed in the "Configuration options" reference box but had no demo or explanation anywhere on the page, and `trimDropdown`/`visibleRows` were already demonstrated in code but never explained in prose. `allowInvalid` was documented inline (in the "Autocomplete strict mode" section) but missing from the "Configuration options" reference box.

Changes:
- Added a "The `sortByRelevance` option" section with a two-column comparison example (default source order vs. alphabetical order).
- Added a "The `allowHtml` option" section with a two-column comparison example (escaped text vs. rendered HTML), including a security callout about XSS risk when using untrusted `source` data.
- Added prose explaining `trimDropdown` and `visibleRows` in the existing "Autocomplete flexible mode" section, referencing the demo columns that already exercise them.
- Added `allowInvalid` to the "Configuration options" reference box.

All new examples were added for JavaScript, React, Angular, and Vue to keep framework parity with the rest of the guide.

### How has this been tested?

- Ran the docs dev server (`npm run dev` in `docs/`) and verified the JavaScript, React, Angular, and Vue variants of the page render with no console errors.
- Verified via DOM inspection that the `allowHtml` example escapes HTML by default and renders it as real markup with `allowHtml: true`.
- Verified the `sortByRelevance` example renders both dropdown columns with the expected 5-item source list.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-826

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-826

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to docs and example snippets; no library or runtime behavior is modified.
> 
> **Overview**
> Expands the **Autocomplete cell type** guide to cover options that were listed in the reference box but lacked explanation or demos.
> 
> **Flexible mode** now documents **`visibleRows`** and **`trimDropdown`**, tying them to the existing example columns (Chassis color / Bumper color).
> 
> New sections add **`sortByRelevance`** (example8: source order vs alphabetical) and **`allowHtml`** (example9: escaped vs rendered HTML), each with live examples for JavaScript, React, Angular, and Vue. The **`allowHtml`** section includes a security callout about unsanitized HTML and XSS when using untrusted `source` data.
> 
> The configuration options list gains **`allowInvalid`** so it matches the strict-mode section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38ad3142b8867a960dfb1d10fa81e3cc1c421c3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->