### PR TITLE
DEV-829: Link hook names in setDataAtCell JSDoc

### DIFF
--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -1834,7 +1834,7 @@ export default function Core(
    *
    * @private
    * @param {Array} changes Array in form of [row, prop, oldValue, newValue].
-   * @param {string} source String that identifies how this change will be described in changes array (useful in onChange callback).
+   * @param {string} source String that identifies how this change will be described in changes array (useful in {@link Hooks#afterChange} or {@link Hooks#beforeChange} callbacks).
    * @fires Hooks#beforeChangeRender
    * @fires Hooks#afterChange
    */
@@ -2127,7 +2127,9 @@ export default function Core(
    * @param {number|Array} row Visual row index or array of changes in format `[[row, col, value],...]`.
    * @param {number} [column] Visual column index.
    * @param {string} [value] New value.
-   * @param {string} [source] String that identifies how this change will be described in the changes array (useful in afterChange or beforeChange callback). Set to 'edit' if left empty.
+   * @param {string} [source] String that identifies how this change will be described in the changes array (useful in {@link Hooks#afterChange} or {@link Hooks#beforeChange} callbacks). Set to 'edit' if left empty.
+   * @fires Hooks#beforeChange
+   * @fires Hooks#afterChange
    */
   this.setDataAtCell = function(
     row: number | Array<[number, string | number, unknown]>, column: number | string, value: string, source?: string
@@ -2191,7 +2193,9 @@ export default function Core(
    * @param {number|Array} row Visual row index or array of changes in format `[[row, prop, value], ...]`.
    * @param {string} prop Property name or the source string (e.g. `'first.name'` or `'0'`).
    * @param {string} value Value to be set.
-   * @param {string} [source] String that identifies how this change will be described in changes array (useful in onChange callback).
+   * @param {string} [source] String that identifies how this change will be described in changes array (useful in {@link Hooks#afterChange} or {@link Hooks#beforeChange} callbacks).
+   * @fires Hooks#beforeChange
+   * @fires Hooks#afterChange
    */
   this.setDataAtRowProp = function(
     row: number | Array<[number, string | number, unknown]>, prop: string | number, value: string, source?: string
@@ -2483,8 +2487,10 @@ export default function Core(
    *
    * @memberof Core#
    * @function emptySelectedCells
-   * @param {string} [source] String that identifies how this change will be described in the changes array (useful in afterChange or beforeChange callback). Set to 'edit' if left empty.
+   * @param {string} [source] String that identifies how this change will be described in the changes array (useful in {@link Hooks#afterChange} or {@link Hooks#beforeChange} callbacks). Set to 'edit' if left empty.
    * @since 0.36.0
+   * @fires Hooks#beforeChange
+   * @fires Hooks#afterChange
    */
   this.emptySelectedCells = function(source: string) {
     if (!selection.isSelected() || this.countRows() === 0 || this.countCols() === 0) {


### PR DESCRIPTION
### Context

The PR improves the JSDoc for `setDataAtCell`'s `source` parameter, which described the hooks it's useful with (`afterChange`/`beforeChange`) as plain text instead of linking them, per DEV-829. While fixing this, the same unlinked phrasing was found in `emptySelectedCells` (which delegates to `setDataAtCell` and fires the same hooks), and a related factual error was found in `setDataAtRowProp` and the internal `applyChanges`: both referenced a nonexistent `onChange` hook instead of the real `beforeChange`/`afterChange` hooks.

### How has this been tested?

- `npm --prefix handsontable run eslint`
- `npm --prefix handsontable run test:types`

This is a JSDoc-only change with no runtime behavior change, so no new unit/E2E tests were added.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-829

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-829

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits in `core.ts` with no logic or API behavior changes.
> 
> **Overview**
> JSDoc-only updates in `core.ts` for APIs that accept a `source` string and ultimately fire change hooks.
> 
> The `source` parameter descriptions on **`setDataAtCell`**, **`setDataAtRowProp`**, **`emptySelectedCells`**, and internal **`applyChanges`** now use `{@link Hooks#afterChange}` / `{@link Hooks#beforeChange}` instead of plain text. **`setDataAtRowProp`** and **`applyChanges`** no longer mention a nonexistent **`onChange`** hook.
> 
> **`setDataAtCell`**, **`setDataAtRowProp`**, and **`emptySelectedCells`** also document **`@fires Hooks#beforeChange`** and **`@fires Hooks#afterChange`** so generated docs match actual behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 544a70e692baf94781da3e6214044fac75c07eff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->