### PR TITLE
DEV-830: Add ShortcutManager back-link and runnable custom-shortcuts example

### DIFF
--- a/docs/content/guides/navigation/custom-shortcuts/angular/example1.html
+++ b/docs/content/guides/navigation/custom-shortcuts/angular/example1.html
@@ -1,0 +1,1 @@
+<example1-custom-shortcuts></example1-custom-shortcuts>

--- a/docs/content/guides/navigation/custom-shortcuts/angular/example1.ts
+++ b/docs/content/guides/navigation/custom-shortcuts/angular/example1.ts
@@ -1,0 +1,68 @@
+/* file: app.component.ts */
+import { Component } from '@angular/core';
+import { GridSettings, HotTableModule } from '@handsontable/angular-wrapper';
+import type Handsontable from 'handsontable/base';
+
+@Component({
+  selector: 'example1-custom-shortcuts',
+  standalone: true,
+  imports: [HotTableModule],
+  template: `<div>
+    <hot-table [data]="data" [settings]="gridSettings"></hot-table>
+  </div>`,
+})
+export class AppComponent {
+  readonly data: Array<Array<string | number>> = [
+    ['SKU-4821', 'Wireless Mouse', 128, 'Electronics'],
+    ['SKU-0093', 'Desk Lamp', 42, 'Home Goods'],
+    ['SKU-7734', 'USB-C Cable', 310, 'Electronics'],
+    ['SKU-2210', 'Notebook Set', 87, 'Office Supplies'],
+    ['SKU-5567', 'Water Bottle', 156, 'Outdoor'],
+  ];
+
+  readonly gridSettings: GridSettings = {
+    colHeaders: ['SKU', 'Product', 'Quantity', 'Category'],
+    columns: [{}, {}, { type: 'numeric' }, {}],
+    height: 'auto',
+    afterInit(this: Handsontable) {
+      // get the `grid` context from the `ShortcutManager` API
+      const gridContext = this.getShortcutManager().getContext('grid');
+
+      // register a custom keyboard shortcut in the `grid` context:
+      // pressing Control/Meta+Enter inserts a new row below the selected cell
+      gridContext.addShortcut({
+        keys: [['control/meta', 'enter']],
+        group: 'insertRowBelow',
+        callback: () => {
+          const selected = this.getSelectedRangeLast();
+
+          if (!selected) {
+            return;
+          }
+
+          this.alter('insert_row_below', selected.highlight.row);
+        },
+      });
+    },
+  };
+}
+/* end-file */
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+/* end-file */

--- a/docs/content/guides/navigation/custom-shortcuts/angular/example1.ts
+++ b/docs/content/guides/navigation/custom-shortcuts/angular/example1.ts
@@ -28,6 +28,10 @@ export class AppComponent {
       // get the `grid` context from the `ShortcutManager` API
       const gridContext = this.getShortcutManager().getContext('grid');
 
+      if (!gridContext) {
+        return;
+      }
+
       // register a custom keyboard shortcut in the `grid` context:
       // pressing Control/Meta+Enter inserts a new row below the selected cell
       gridContext.addShortcut({
@@ -36,7 +40,7 @@ export class AppComponent {
         callback: () => {
           const selected = this.getSelectedRangeLast();
 
-          if (!selected) {
+          if (!selected || selected.highlight.row === null) {
             return;
           }
 

--- a/docs/content/guides/navigation/custom-shortcuts/custom-shortcuts.md
+++ b/docs/content/guides/navigation/custom-shortcuts/custom-shortcuts.md
@@ -24,6 +24,7 @@ vue:
   metaTitle: Custom shortcuts - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Navigation
+menuTag: updated
 ---
 Use the [`ShortcutManager`](@/api/shortcutManager.md) API to add, remove, replace, or block keyboard shortcuts in Handsontable.
 
@@ -133,6 +134,45 @@ gridContext.addShortcut({
 
 </li>
 </ol>
+
+### Try it out
+
+The example below registers a custom keyboard shortcut in the `grid` context, using the [`addShortcut()`](@/api/shortcutContext.md#addshortcut) method. Select a cell and press <kbd>Control</kbd>/<kbd>Cmd</kbd> + <kbd>Enter</kbd> to insert a new row below it.
+
+::: only-for javascript
+
+::: example #example1 --js 1 --ts 2
+@[code](@/content/guides/navigation/custom-shortcuts/javascript/example1.js)
+@[code](@/content/guides/navigation/custom-shortcuts/javascript/example1.ts)
+:::
+
+:::
+
+::: only-for react
+
+::: example #example1 :react --js 1 --ts 2
+@[code](@/content/guides/navigation/custom-shortcuts/react/example1.jsx)
+@[code](@/content/guides/navigation/custom-shortcuts/react/example1.tsx)
+:::
+
+:::
+
+::: only-for angular
+
+::: example #example1 :angular --ts 1 --html 2
+@[code](@/content/guides/navigation/custom-shortcuts/angular/example1.ts)
+@[code](@/content/guides/navigation/custom-shortcuts/angular/example1.html)
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example1 :vue3
+@[code](@/content/guides/navigation/custom-shortcuts/vue/example1.vue)
+:::
+
+:::
 
 ### Add a conditional keyboard action
 

--- a/docs/content/guides/navigation/custom-shortcuts/javascript/example1.js
+++ b/docs/content/guides/navigation/custom-shortcuts/javascript/example1.js
@@ -19,16 +19,18 @@ const hot = new Handsontable(container, {
 });
 // get the `grid` context from the `ShortcutManager` API
 const gridContext = hot.getShortcutManager().getContext('grid');
-// register a custom keyboard shortcut in the `grid` context:
-// pressing Control/Meta+Enter inserts a new row below the selected cell
-gridContext.addShortcut({
-    keys: [['control/meta', 'enter']],
-    group: 'insertRowBelow',
-    callback: () => {
-        const selected = hot.getSelectedRangeLast();
-        if (!selected) {
-            return;
-        }
-        hot.alter('insert_row_below', selected.highlight.row);
-    },
-});
+if (gridContext) {
+    // register a custom keyboard shortcut in the `grid` context:
+    // pressing Control/Meta+Enter inserts a new row below the selected cell
+    gridContext.addShortcut({
+        keys: [['control/meta', 'enter']],
+        group: 'insertRowBelow',
+        callback: () => {
+            const selected = hot.getSelectedRangeLast();
+            if (!selected || selected.highlight.row === null) {
+                return;
+            }
+            hot.alter('insert_row_below', selected.highlight.row);
+        },
+    });
+}

--- a/docs/content/guides/navigation/custom-shortcuts/javascript/example1.js
+++ b/docs/content/guides/navigation/custom-shortcuts/javascript/example1.js
@@ -1,0 +1,34 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+// register Handsontable's modules
+registerAllModules();
+const data = [
+    ['SKU-4821', 'Wireless Mouse', 128, 'Electronics'],
+    ['SKU-0093', 'Desk Lamp', 42, 'Home Goods'],
+    ['SKU-7734', 'USB-C Cable', 310, 'Electronics'],
+    ['SKU-2210', 'Notebook Set', 87, 'Office Supplies'],
+    ['SKU-5567', 'Water Bottle', 156, 'Outdoor'],
+];
+const container = document.querySelector('#example1');
+const hot = new Handsontable(container, {
+    data,
+    colHeaders: ['SKU', 'Product', 'Quantity', 'Category'],
+    columns: [{}, {}, { type: 'numeric' }, {}],
+    height: 'auto',
+    licenseKey: 'non-commercial-and-evaluation',
+});
+// get the `grid` context from the `ShortcutManager` API
+const gridContext = hot.getShortcutManager().getContext('grid');
+// register a custom keyboard shortcut in the `grid` context:
+// pressing Control/Meta+Enter inserts a new row below the selected cell
+gridContext.addShortcut({
+    keys: [['control/meta', 'enter']],
+    group: 'insertRowBelow',
+    callback: () => {
+        const selected = hot.getSelectedRangeLast();
+        if (!selected) {
+            return;
+        }
+        hot.alter('insert_row_below', selected.highlight.row);
+    },
+});

--- a/docs/content/guides/navigation/custom-shortcuts/javascript/example1.ts
+++ b/docs/content/guides/navigation/custom-shortcuts/javascript/example1.ts
@@ -1,0 +1,42 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const data: (string | number)[][] = [
+  ['SKU-4821', 'Wireless Mouse', 128, 'Electronics'],
+  ['SKU-0093', 'Desk Lamp', 42, 'Home Goods'],
+  ['SKU-7734', 'USB-C Cable', 310, 'Electronics'],
+  ['SKU-2210', 'Notebook Set', 87, 'Office Supplies'],
+  ['SKU-5567', 'Water Bottle', 156, 'Outdoor'],
+];
+
+const container: Element = document.querySelector('#example1')!;
+
+const hot = new Handsontable(container, {
+  data,
+  colHeaders: ['SKU', 'Product', 'Quantity', 'Category'],
+  columns: [{}, {}, { type: 'numeric' }, {}],
+  height: 'auto',
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+// get the `grid` context from the `ShortcutManager` API
+const gridContext = hot.getShortcutManager().getContext('grid');
+
+// register a custom keyboard shortcut in the `grid` context:
+// pressing Control/Meta+Enter inserts a new row below the selected cell
+gridContext.addShortcut({
+  keys: [['control/meta', 'enter']],
+  group: 'insertRowBelow',
+  callback: () => {
+    const selected = hot.getSelectedRangeLast();
+
+    if (!selected) {
+      return;
+    }
+
+    hot.alter('insert_row_below', selected.highlight.row);
+  },
+});

--- a/docs/content/guides/navigation/custom-shortcuts/javascript/example1.ts
+++ b/docs/content/guides/navigation/custom-shortcuts/javascript/example1.ts
@@ -25,18 +25,20 @@ const hot = new Handsontable(container, {
 // get the `grid` context from the `ShortcutManager` API
 const gridContext = hot.getShortcutManager().getContext('grid');
 
-// register a custom keyboard shortcut in the `grid` context:
-// pressing Control/Meta+Enter inserts a new row below the selected cell
-gridContext.addShortcut({
-  keys: [['control/meta', 'enter']],
-  group: 'insertRowBelow',
-  callback: () => {
-    const selected = hot.getSelectedRangeLast();
+if (gridContext) {
+  // register a custom keyboard shortcut in the `grid` context:
+  // pressing Control/Meta+Enter inserts a new row below the selected cell
+  gridContext.addShortcut({
+    keys: [['control/meta', 'enter']],
+    group: 'insertRowBelow',
+    callback: () => {
+      const selected = hot.getSelectedRangeLast();
 
-    if (!selected) {
-      return;
-    }
+      if (!selected || selected.highlight.row === null) {
+        return;
+      }
 
-    hot.alter('insert_row_below', selected.highlight.row);
-  },
-});
+      hot.alter('insert_row_below', selected.highlight.row);
+    },
+  });
+}

--- a/docs/content/guides/navigation/custom-shortcuts/react/example1.jsx
+++ b/docs/content/guides/navigation/custom-shortcuts/react/example1.jsx
@@ -1,0 +1,59 @@
+import { useRef } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const ExampleComponent = () => {
+  const hotRef = useRef(null);
+
+  const data = [
+    ['SKU-4821', 'Wireless Mouse', 128, 'Electronics'],
+    ['SKU-0093', 'Desk Lamp', 42, 'Home Goods'],
+    ['SKU-7734', 'USB-C Cable', 310, 'Electronics'],
+    ['SKU-2210', 'Notebook Set', 87, 'Office Supplies'],
+    ['SKU-5567', 'Water Bottle', 156, 'Outdoor'],
+  ];
+
+  const afterInitCallback = () => {
+    const hot = hotRef.current?.hotInstance;
+
+    if (!hot) {
+      return;
+    }
+
+    // get the `grid` context from the `ShortcutManager` API
+    const gridContext = hot.getShortcutManager().getContext('grid');
+
+    // register a custom keyboard shortcut in the `grid` context:
+    // pressing Control/Meta+Enter inserts a new row below the selected cell
+    gridContext.addShortcut({
+      keys: [['control/meta', 'enter']],
+      group: 'insertRowBelow',
+      callback: () => {
+        const selected = hot.getSelectedRangeLast();
+
+        if (!selected) {
+          return;
+        }
+
+        hot.alter('insert_row_below', selected.highlight.row);
+      },
+    });
+  };
+
+  return (
+    <HotTable
+      ref={hotRef}
+      data={data}
+      colHeaders={['SKU', 'Product', 'Quantity', 'Category']}
+      columns={[{}, {}, { type: 'numeric' }, {}]}
+      height="auto"
+      afterInit={afterInitCallback}
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/navigation/custom-shortcuts/react/example1.jsx
+++ b/docs/content/guides/navigation/custom-shortcuts/react/example1.jsx
@@ -26,6 +26,10 @@ const ExampleComponent = () => {
     // get the `grid` context from the `ShortcutManager` API
     const gridContext = hot.getShortcutManager().getContext('grid');
 
+    if (!gridContext) {
+      return;
+    }
+
     // register a custom keyboard shortcut in the `grid` context:
     // pressing Control/Meta+Enter inserts a new row below the selected cell
     gridContext.addShortcut({
@@ -34,7 +38,7 @@ const ExampleComponent = () => {
       callback: () => {
         const selected = hot.getSelectedRangeLast();
 
-        if (!selected) {
+        if (!selected || selected.highlight.row === null) {
           return;
         }
 

--- a/docs/content/guides/navigation/custom-shortcuts/react/example1.tsx
+++ b/docs/content/guides/navigation/custom-shortcuts/react/example1.tsx
@@ -1,0 +1,59 @@
+import { useRef } from 'react';
+import { HotTable, HotTableRef } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const ExampleComponent = () => {
+  const hotRef = useRef<HotTableRef>(null);
+
+  const data: (string | number)[][] = [
+    ['SKU-4821', 'Wireless Mouse', 128, 'Electronics'],
+    ['SKU-0093', 'Desk Lamp', 42, 'Home Goods'],
+    ['SKU-7734', 'USB-C Cable', 310, 'Electronics'],
+    ['SKU-2210', 'Notebook Set', 87, 'Office Supplies'],
+    ['SKU-5567', 'Water Bottle', 156, 'Outdoor'],
+  ];
+
+  const afterInitCallback = () => {
+    const hot = hotRef.current?.hotInstance;
+
+    if (!hot) {
+      return;
+    }
+
+    // get the `grid` context from the `ShortcutManager` API
+    const gridContext = hot.getShortcutManager().getContext('grid');
+
+    // register a custom keyboard shortcut in the `grid` context:
+    // pressing Control/Meta+Enter inserts a new row below the selected cell
+    gridContext.addShortcut({
+      keys: [['control/meta', 'enter']],
+      group: 'insertRowBelow',
+      callback: () => {
+        const selected = hot.getSelectedRangeLast();
+
+        if (!selected) {
+          return;
+        }
+
+        hot.alter('insert_row_below', selected.highlight.row);
+      },
+    });
+  };
+
+  return (
+    <HotTable
+      ref={hotRef}
+      data={data}
+      colHeaders={['SKU', 'Product', 'Quantity', 'Category']}
+      columns={[{}, {}, { type: 'numeric' }, {}]}
+      height="auto"
+      afterInit={afterInitCallback}
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/navigation/custom-shortcuts/react/example1.tsx
+++ b/docs/content/guides/navigation/custom-shortcuts/react/example1.tsx
@@ -26,6 +26,10 @@ const ExampleComponent = () => {
     // get the `grid` context from the `ShortcutManager` API
     const gridContext = hot.getShortcutManager().getContext('grid');
 
+    if (!gridContext) {
+      return;
+    }
+
     // register a custom keyboard shortcut in the `grid` context:
     // pressing Control/Meta+Enter inserts a new row below the selected cell
     gridContext.addShortcut({
@@ -34,7 +38,7 @@ const ExampleComponent = () => {
       callback: () => {
         const selected = hot.getSelectedRangeLast();
 
-        if (!selected) {
+        if (!selected || selected.highlight.row === null) {
           return;
         }
 

--- a/docs/content/guides/navigation/custom-shortcuts/vue/example1.vue
+++ b/docs/content/guides/navigation/custom-shortcuts/vue/example1.vue
@@ -25,6 +25,10 @@ const hotSettings = ref<GridSettings>({
     // get the `grid` context from the `ShortcutManager` API
     const gridContext = this.getShortcutManager().getContext('grid');
 
+    if (!gridContext) {
+      return;
+    }
+
     // register a custom keyboard shortcut in the `grid` context:
     // pressing Control/Meta+Enter inserts a new row below the selected cell
     gridContext.addShortcut({
@@ -33,7 +37,7 @@ const hotSettings = ref<GridSettings>({
       callback: () => {
         const selected = this.getSelectedRangeLast();
 
-        if (!selected) {
+        if (!selected || selected.highlight.row === null) {
           return;
         }
 

--- a/docs/content/guides/navigation/custom-shortcuts/vue/example1.vue
+++ b/docs/content/guides/navigation/custom-shortcuts/vue/example1.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type Handsontable from 'handsontable/base';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const data: (string | number)[][] = [
+  ['SKU-4821', 'Wireless Mouse', 128, 'Electronics'],
+  ['SKU-0093', 'Desk Lamp', 42, 'Home Goods'],
+  ['SKU-7734', 'USB-C Cable', 310, 'Electronics'],
+  ['SKU-2210', 'Notebook Set', 87, 'Office Supplies'],
+  ['SKU-5567', 'Water Bottle', 156, 'Outdoor'],
+];
+
+const hotSettings = ref<GridSettings>({
+  data,
+  colHeaders: ['SKU', 'Product', 'Quantity', 'Category'],
+  columns: [{}, {}, { type: 'numeric' }, {}],
+  height: 'auto',
+  afterInit(this: Handsontable) {
+    // get the `grid` context from the `ShortcutManager` API
+    const gridContext = this.getShortcutManager().getContext('grid');
+
+    // register a custom keyboard shortcut in the `grid` context:
+    // pressing Control/Meta+Enter inserts a new row below the selected cell
+    gridContext.addShortcut({
+      keys: [['control/meta', 'enter']],
+      group: 'insertRowBelow',
+      callback: () => {
+        const selected = this.getSelectedRangeLast();
+
+        if (!selected) {
+          return;
+        }
+
+        this.alter('insert_row_below', selected.highlight.row);
+      },
+    });
+  },
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/handsontable/src/shortcuts/context.ts
+++ b/handsontable/src/shortcuts/context.ts
@@ -48,6 +48,10 @@ export function isContextObject(objectToCheck: unknown): objectToCheck is Contex
  *
  * Each `ShortcutContext` object stores and manages its own set of keyboard shortcuts.
  *
+ * You don't create a `ShortcutContext` object directly. Instead, get one from the
+ * [`ShortcutManager`](@/api/shortcutManager.md), through its `getContext()`, `addContext()`, or
+ * `getOrCreateContext()` method.
+ *
  * @alias ShortcutContext
  * @class ShortcutContext
  * @param {string} name The name of the keyboard shortcut context


### PR DESCRIPTION
### Context

The PR closes out the remaining gap from DEV-830 ("Improve shortcut manager page"). A prior audit found the `custom-shortcuts.md` guide already cross-linked `ShortcutManager` and `ShortcutContext` in prose, but two things were still missing:

1. The `ShortcutContext` class JSDoc had no back-link to `ShortcutManager` — the forward link existed in `manager.ts`, but a reader landing on the `ShortcutContext` API page had no pointer back to where a context instance comes from.
2. The guide had no live, runnable example of the shortcuts API — only static code snippets.

This PR adds the JSDoc back-link and a "Try it out" runnable example (all four framework variants: JS/TS, React, Angular, Vue) demonstrating `addShortcut()` by registering a Control/Meta+Enter shortcut that inserts a row below the selected cell.

### How has this been tested?

- `npm run eslint --prefix handsontable` on the modified `context.ts` — no issues.
- `npm run test:types --prefix handsontable` — passes.
- Manually verified all four framework example variants (JavaScript, React, Angular, Vue) in a live `astro dev` session: grid renders with no console errors, and the Control/Meta+Enter shortcut successfully inserts a new row in each variant.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-830

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-830

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and JSDoc-only changes with no runtime or API behavior changes.
> 
> **Overview**
> Adds a **Try it out** section to the custom shortcuts guide with live examples for JavaScript/TypeScript, React, Angular, and Vue. Each demo registers **Control/Meta+Enter** on the `grid` shortcut context to insert a row below the selected cell via `addShortcut()`.
> 
> Marks the guide with `menuTag: updated` and documents on `ShortcutContext` that instances come from `ShortcutManager` (`getContext()`, `addContext()`, `getOrCreateContext()`), closing the API doc cross-link gap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0f77201c4765bec2e2f1f81539a7e1ce3b18a8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->