### PR TITLE
DEV-833: Add hooks and programmatic merge/unmerge examples to merge-cells guide

### DIFF
--- a/docs/content/guides/cell-features/merge-cells/angular/example3.html
+++ b/docs/content/guides/cell-features/merge-cells/angular/example3.html
@@ -1,0 +1,3 @@
+<div>
+  <example3-merge-cells></example3-merge-cells>
+</div>

--- a/docs/content/guides/cell-features/merge-cells/angular/example3.ts
+++ b/docs/content/guides/cell-features/merge-cells/angular/example3.ts
@@ -1,6 +1,7 @@
 /* file: app.component.ts */
 import { Component } from '@angular/core';
 import { GridSettings, HotTableModule } from '@handsontable/angular-wrapper';
+import { CellRange } from 'handsontable/base';
 
 @Component({
   selector: 'example3-merge-cells',
@@ -35,16 +36,19 @@ export class AppComponent {
     mergeCells: true,
     autoWrapRow: true,
     autoWrapCol: true,
-    beforeMergeCells: (cellRange) => {
+    beforeMergeCells: (cellRange: CellRange) => {
       this.logEvent(`beforeMergeCells: rows ${cellRange.from.row}-${cellRange.to.row}, columns ${cellRange.from.col}-${cellRange.to.col}.`);
     },
-    afterMergeCells: (cellRange, mergeParent) => {
+    afterMergeCells: (
+      cellRange: CellRange,
+      mergeParent: { row: number; col: number; rowspan: number; colspan: number }
+    ) => {
       this.logEvent(`afterMergeCells: merged into ${mergeParent.rowspan} row(s) by ${mergeParent.colspan} column(s).`);
     },
-    beforeUnmergeCells: (cellRange) => {
+    beforeUnmergeCells: (cellRange: CellRange) => {
       this.logEvent(`beforeUnmergeCells: rows ${cellRange.from.row}-${cellRange.to.row}, columns ${cellRange.from.col}-${cellRange.to.col}.`);
     },
-    afterUnmergeCells: (cellRange) => {
+    afterUnmergeCells: (cellRange: CellRange) => {
       this.logEvent(`afterUnmergeCells: rows ${cellRange.from.row}-${cellRange.to.row}, columns ${cellRange.from.col}-${cellRange.to.col}.`);
     },
   };

--- a/docs/content/guides/cell-features/merge-cells/angular/example3.ts
+++ b/docs/content/guides/cell-features/merge-cells/angular/example3.ts
@@ -1,0 +1,76 @@
+/* file: app.component.ts */
+import { Component } from '@angular/core';
+import { GridSettings, HotTableModule } from '@handsontable/angular-wrapper';
+
+@Component({
+  selector: 'example3-merge-cells',
+  standalone: true,
+  imports: [HotTableModule],
+  template: `
+    <output class="console" id="example3-output">{{
+      output ||
+        'Select cells, then press Ctrl+M (or use the context menu) to merge or unmerge them. Hook activity appears here.'
+    }}</output>
+    <div>
+      <hot-table [data]="data" [settings]="gridSettings"></hot-table>
+    </div>
+  `,
+})
+export class AppComponent {
+  output = '';
+
+  readonly data = [
+    ['North America', 420000, 465000, 501000],
+    ['Europe', 388000, 402000, 411000],
+    ['APAC', 275000, 298000, 312000],
+    ['Latin America', 142000, 151000, 158000],
+    ['Middle East', 96000, 101000, 108000],
+  ];
+
+  readonly gridSettings: GridSettings = {
+    colHeaders: ['Region', 'Jan 2025', 'Feb 2025', 'Mar 2025'],
+    rowHeaders: true,
+    height: 'auto',
+    contextMenu: true,
+    mergeCells: true,
+    autoWrapRow: true,
+    autoWrapCol: true,
+    beforeMergeCells: (cellRange) => {
+      this.logEvent(`beforeMergeCells: rows ${cellRange.from.row}-${cellRange.to.row}, columns ${cellRange.from.col}-${cellRange.to.col}.`);
+    },
+    afterMergeCells: (cellRange, mergeParent) => {
+      this.logEvent(`afterMergeCells: merged into ${mergeParent.rowspan} row(s) by ${mergeParent.colspan} column(s).`);
+    },
+    beforeUnmergeCells: (cellRange) => {
+      this.logEvent(`beforeUnmergeCells: rows ${cellRange.from.row}-${cellRange.to.row}, columns ${cellRange.from.col}-${cellRange.to.col}.`);
+    },
+    afterUnmergeCells: (cellRange) => {
+      this.logEvent(`afterUnmergeCells: rows ${cellRange.from.row}-${cellRange.to.row}, columns ${cellRange.from.col}-${cellRange.to.col}.`);
+    },
+  };
+
+  private logEvent(message: string): void {
+    this.output = `${message}\n${this.output}`;
+  }
+}
+/* end-file */
+
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+/* end-file */

--- a/docs/content/guides/cell-features/merge-cells/angular/example4.html
+++ b/docs/content/guides/cell-features/merge-cells/angular/example4.html
@@ -1,0 +1,3 @@
+<div>
+  <example4-merge-cells></example4-merge-cells>
+</div>

--- a/docs/content/guides/cell-features/merge-cells/angular/example4.ts
+++ b/docs/content/guides/cell-features/merge-cells/angular/example4.ts
@@ -1,0 +1,75 @@
+/* file: app.component.ts */
+import { Component, ViewChild } from '@angular/core';
+import { GridSettings, HotTableComponent, HotTableModule } from '@handsontable/angular-wrapper';
+
+@Component({
+  selector: 'example4-merge-cells',
+  standalone: true,
+  imports: [HotTableModule],
+  template: `
+    <div class="example-controls-container">
+      <div class="controls">
+        <button id="example4-merge" class="button button--primary" (click)="mergeNoteRow()">
+          Merge the note row
+        </button>
+        <button id="example4-unmerge" class="button button--primary" (click)="unmergeNoteRow()">
+          Unmerge the note row
+        </button>
+      </div>
+    </div>
+    <div>
+      <hot-table [data]="data" [settings]="gridSettings"></hot-table>
+    </div>
+  `,
+})
+export class AppComponent {
+  @ViewChild(HotTableComponent, { static: false }) readonly hotTable!: HotTableComponent;
+
+  readonly data = [
+    ['North America', 420000, 465000, 501000],
+    ['Europe', 388000, 402000, 411000],
+    ['APAC', 275000, 298000, 312000],
+    ['Latin America', 142000, 151000, 158000],
+    ['Middle East', 96000, 101000, 108000],
+    ['Note: Q1 totals include a one-time currency adjustment.', null, null, null],
+  ];
+
+  readonly gridSettings: GridSettings = {
+    colHeaders: ['Region', 'Jan 2025', 'Feb 2025', 'Mar 2025'],
+    rowHeaders: true,
+    height: 'auto',
+    contextMenu: true,
+    mergeCells: true,
+    autoWrapRow: true,
+    autoWrapCol: true,
+  };
+
+  mergeNoteRow(): void {
+    this.hotTable?.hotInstance?.getPlugin('mergeCells').merge(5, 0, 5, 3);
+  }
+
+  unmergeNoteRow(): void {
+    this.hotTable?.hotInstance?.getPlugin('mergeCells').unmerge(5, 0, 5, 3);
+  }
+}
+/* end-file */
+
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+/* end-file */

--- a/docs/content/guides/cell-features/merge-cells/javascript/example3.html
+++ b/docs/content/guides/cell-features/merge-cells/javascript/example3.html
@@ -1,0 +1,2 @@
+<output class="console" id="example3-output">Select cells, then press Ctrl+M (or use the context menu) to merge or unmerge them. Hook activity appears here.</output>
+<div id="example3"></div>

--- a/docs/content/guides/cell-features/merge-cells/javascript/example3.js
+++ b/docs/content/guides/cell-features/merge-cells/javascript/example3.js
@@ -1,0 +1,40 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+// Register all Handsontable's modules.
+registerAllModules();
+const container = document.querySelector('#example3');
+const output = document.querySelector('#example3-output');
+let loggedText = '';
+const logEvent = (message) => {
+    loggedText = `${message}\n${loggedText}`;
+    output.innerText = loggedText;
+};
+new Handsontable(container, {
+    data: [
+        ['North America', 420000, 465000, 501000],
+        ['Europe', 388000, 402000, 411000],
+        ['APAC', 275000, 298000, 312000],
+        ['Latin America', 142000, 151000, 158000],
+        ['Middle East', 96000, 101000, 108000],
+    ],
+    colHeaders: ['Region', 'Jan 2025', 'Feb 2025', 'Mar 2025'],
+    rowHeaders: true,
+    height: 'auto',
+    contextMenu: true,
+    mergeCells: true,
+    autoWrapRow: true,
+    autoWrapCol: true,
+    beforeMergeCells(cellRange) {
+        logEvent(`beforeMergeCells: rows ${cellRange.from.row}-${cellRange.to.row}, columns ${cellRange.from.col}-${cellRange.to.col}.`);
+    },
+    afterMergeCells(cellRange, mergeParent) {
+        logEvent(`afterMergeCells: merged into ${mergeParent.rowspan} row(s) by ${mergeParent.colspan} column(s).`);
+    },
+    beforeUnmergeCells(cellRange) {
+        logEvent(`beforeUnmergeCells: rows ${cellRange.from.row}-${cellRange.to.row}, columns ${cellRange.from.col}-${cellRange.to.col}.`);
+    },
+    afterUnmergeCells(cellRange) {
+        logEvent(`afterUnmergeCells: rows ${cellRange.from.row}-${cellRange.to.row}, columns ${cellRange.from.col}-${cellRange.to.col}.`);
+    },
+    licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/cell-features/merge-cells/javascript/example3.ts
+++ b/docs/content/guides/cell-features/merge-cells/javascript/example3.ts
@@ -1,0 +1,45 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+// Register all Handsontable's modules.
+registerAllModules();
+
+const container = document.querySelector('#example3')!;
+const output = document.querySelector('#example3-output') as HTMLElement;
+
+let loggedText = '';
+
+const logEvent = (message: string) => {
+  loggedText = `${message}\n${loggedText}`;
+  output.innerText = loggedText;
+};
+
+new Handsontable(container, {
+  data: [
+    ['North America', 420000, 465000, 501000],
+    ['Europe', 388000, 402000, 411000],
+    ['APAC', 275000, 298000, 312000],
+    ['Latin America', 142000, 151000, 158000],
+    ['Middle East', 96000, 101000, 108000],
+  ],
+  colHeaders: ['Region', 'Jan 2025', 'Feb 2025', 'Mar 2025'],
+  rowHeaders: true,
+  height: 'auto',
+  contextMenu: true,
+  mergeCells: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  beforeMergeCells(cellRange) {
+    logEvent(`beforeMergeCells: rows ${cellRange.from.row}-${cellRange.to.row}, columns ${cellRange.from.col}-${cellRange.to.col}.`);
+  },
+  afterMergeCells(cellRange, mergeParent) {
+    logEvent(`afterMergeCells: merged into ${mergeParent.rowspan} row(s) by ${mergeParent.colspan} column(s).`);
+  },
+  beforeUnmergeCells(cellRange) {
+    logEvent(`beforeUnmergeCells: rows ${cellRange.from.row}-${cellRange.to.row}, columns ${cellRange.from.col}-${cellRange.to.col}.`);
+  },
+  afterUnmergeCells(cellRange) {
+    logEvent(`afterUnmergeCells: rows ${cellRange.from.row}-${cellRange.to.row}, columns ${cellRange.from.col}-${cellRange.to.col}.`);
+  },
+  licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/cell-features/merge-cells/javascript/example4.html
+++ b/docs/content/guides/cell-features/merge-cells/javascript/example4.html
@@ -1,0 +1,7 @@
+<div class="example-controls-container">
+  <div class="controls">
+    <button id="example4-merge" class="button button--primary">Merge the note row</button>
+    <button id="example4-unmerge" class="button button--primary">Unmerge the note row</button>
+  </div>
+</div>
+<div id="example4"></div>

--- a/docs/content/guides/cell-features/merge-cells/javascript/example4.js
+++ b/docs/content/guides/cell-features/merge-cells/javascript/example4.js
@@ -1,0 +1,31 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+// Register all Handsontable's modules.
+registerAllModules();
+const container = document.querySelector('#example4');
+const mergeButton = document.querySelector('#example4-merge');
+const unmergeButton = document.querySelector('#example4-unmerge');
+const hot = new Handsontable(container, {
+    data: [
+        ['North America', 420000, 465000, 501000],
+        ['Europe', 388000, 402000, 411000],
+        ['APAC', 275000, 298000, 312000],
+        ['Latin America', 142000, 151000, 158000],
+        ['Middle East', 96000, 101000, 108000],
+        ['Note: Q1 totals include a one-time currency adjustment.', null, null, null],
+    ],
+    colHeaders: ['Region', 'Jan 2025', 'Feb 2025', 'Mar 2025'],
+    rowHeaders: true,
+    height: 'auto',
+    contextMenu: true,
+    mergeCells: true,
+    autoWrapRow: true,
+    autoWrapCol: true,
+    licenseKey: 'non-commercial-and-evaluation',
+});
+mergeButton.addEventListener('click', () => {
+    hot.getPlugin('mergeCells').merge(5, 0, 5, 3);
+});
+unmergeButton.addEventListener('click', () => {
+    hot.getPlugin('mergeCells').unmerge(5, 0, 5, 3);
+});

--- a/docs/content/guides/cell-features/merge-cells/javascript/example4.ts
+++ b/docs/content/guides/cell-features/merge-cells/javascript/example4.ts
@@ -1,0 +1,36 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+// Register all Handsontable's modules.
+registerAllModules();
+
+const container = document.querySelector('#example4')!;
+const mergeButton = document.querySelector('#example4-merge')!;
+const unmergeButton = document.querySelector('#example4-unmerge')!;
+
+const hot = new Handsontable(container, {
+  data: [
+    ['North America', 420000, 465000, 501000],
+    ['Europe', 388000, 402000, 411000],
+    ['APAC', 275000, 298000, 312000],
+    ['Latin America', 142000, 151000, 158000],
+    ['Middle East', 96000, 101000, 108000],
+    ['Note: Q1 totals include a one-time currency adjustment.', null, null, null],
+  ],
+  colHeaders: ['Region', 'Jan 2025', 'Feb 2025', 'Mar 2025'],
+  rowHeaders: true,
+  height: 'auto',
+  contextMenu: true,
+  mergeCells: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+mergeButton.addEventListener('click', () => {
+  hot.getPlugin('mergeCells').merge(5, 0, 5, 3);
+});
+
+unmergeButton.addEventListener('click', () => {
+  hot.getPlugin('mergeCells').unmerge(5, 0, 5, 3);
+});

--- a/docs/content/guides/cell-features/merge-cells/merge-cells.md
+++ b/docs/content/guides/cell-features/merge-cells/merge-cells.md
@@ -227,6 +227,111 @@ The example below uses virtualized merged cells. It's also recommended to increa
 
 :::
 
+## React to merge and unmerge events
+
+To run your own logic when cells merge or unmerge, use the [`beforeMergeCells`](@/api/hooks.md#beforemergecells), [`afterMergeCells`](@/api/hooks.md#aftermergecells), [`beforeUnmergeCells`](@/api/hooks.md#beforeunmergecells), and [`afterUnmergeCells`](@/api/hooks.md#afterunmergecells) hooks. Each hook receives the affected `cellRange`, and `afterMergeCells` also receives the resulting `mergeParent` object (`row`, `col`, `rowspan`, `colspan`).
+
+The example below logs a message every time you merge or unmerge cells, using the context menu or the <kbd>**Ctrl**</kbd>+<kbd>**M**</kbd> shortcut.
+
+::: only-for javascript
+
+::: example #example3 --html 1 --js 2 --ts 3
+
+@[code](@/content/guides/cell-features/merge-cells/javascript/example3.html)
+@[code](@/content/guides/cell-features/merge-cells/javascript/example3.js)
+@[code](@/content/guides/cell-features/merge-cells/javascript/example3.ts)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #example3 :react --js 1 --ts 2
+
+@[code](@/content/guides/cell-features/merge-cells/react/example3.jsx)
+@[code](@/content/guides/cell-features/merge-cells/react/example3.tsx)
+
+:::
+
+:::
+
+::: only-for angular
+
+::: example #example3 :angular --ts 1 --html 2
+
+@[code](@/content/guides/cell-features/merge-cells/angular/example3.ts)
+@[code](@/content/guides/cell-features/merge-cells/angular/example3.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example3 :vue3
+
+@[code](@/content/guides/cell-features/merge-cells/vue/example3.vue)
+
+:::
+
+:::
+
+## Merge and unmerge cells programmatically
+
+To merge or unmerge a range without a user action, call the [`MergeCells`](@/api/mergeCells.md) plugin's `merge()` and `unmerge()` methods. Both methods take a visual `startRow`, `startColumn`, `endRow`, and `endColumn`, the same coordinate space as `selectCell()`.
+
+```js
+hot.getPlugin('mergeCells').merge(startRow, startColumn, endRow, endColumn);
+hot.getPlugin('mergeCells').unmerge(startRow, startColumn, endRow, endColumn);
+```
+
+The example below merges and unmerges a footnote row that spans every column, using buttons instead of a manual selection.
+
+::: only-for javascript
+
+::: example #example4 --html 1 --js 2 --ts 3
+
+@[code](@/content/guides/cell-features/merge-cells/javascript/example4.html)
+@[code](@/content/guides/cell-features/merge-cells/javascript/example4.js)
+@[code](@/content/guides/cell-features/merge-cells/javascript/example4.ts)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #example4 :react --js 1 --ts 2
+
+@[code](@/content/guides/cell-features/merge-cells/react/example4.jsx)
+@[code](@/content/guides/cell-features/merge-cells/react/example4.tsx)
+
+:::
+
+:::
+
+::: only-for angular
+
+::: example #example4 :angular --ts 1 --html 2
+
+@[code](@/content/guides/cell-features/merge-cells/angular/example4.ts)
+@[code](@/content/guides/cell-features/merge-cells/angular/example4.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example4 :vue3
+
+@[code](@/content/guides/cell-features/merge-cells/vue/example4.vue)
+
+:::
+
+:::
+
 ## Effect on viewport getter methods
 
 With merged cells, the rendered range extends to fit any merged cell that crosses the viewport edge. This is the same expansion that the `virtualized` option turns off. As a result, the rendered-range getters can return indexes beyond what you see on the screen:

--- a/docs/content/guides/cell-features/merge-cells/react/example3.jsx
+++ b/docs/content/guides/cell-features/merge-cells/react/example3.jsx
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const ExampleComponent = () => {
+  const [output, setOutput] = useState('');
+
+  const logEvent = (message) => {
+    setOutput((previousOutput) => `${message}\n${previousOutput}`);
+  };
+
+  return (
+    <>
+      <output className="console" id="example3-output">
+        {output ||
+          'Select cells, then press Ctrl+M (or use the context menu) to merge or unmerge them. Hook activity appears here.'}
+      </output>
+      <HotTable
+        data={[
+          ['North America', 420000, 465000, 501000],
+          ['Europe', 388000, 402000, 411000],
+          ['APAC', 275000, 298000, 312000],
+          ['Latin America', 142000, 151000, 158000],
+          ['Middle East', 96000, 101000, 108000],
+        ]}
+        colHeaders={['Region', 'Jan 2025', 'Feb 2025', 'Mar 2025']}
+        rowHeaders={true}
+        height="auto"
+        contextMenu={true}
+        mergeCells={true}
+        autoWrapRow={true}
+        autoWrapCol={true}
+        beforeMergeCells={(cellRange) => {
+          logEvent(`beforeMergeCells: rows ${cellRange.from.row}-${cellRange.to.row}, columns ${cellRange.from.col}-${cellRange.to.col}.`);
+        }}
+        afterMergeCells={(cellRange, mergeParent) => {
+          logEvent(`afterMergeCells: merged into ${mergeParent.rowspan} row(s) by ${mergeParent.colspan} column(s).`);
+        }}
+        beforeUnmergeCells={(cellRange) => {
+          logEvent(`beforeUnmergeCells: rows ${cellRange.from.row}-${cellRange.to.row}, columns ${cellRange.from.col}-${cellRange.to.col}.`);
+        }}
+        afterUnmergeCells={(cellRange) => {
+          logEvent(`afterUnmergeCells: rows ${cellRange.from.row}-${cellRange.to.row}, columns ${cellRange.from.col}-${cellRange.to.col}.`);
+        }}
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/cell-features/merge-cells/react/example3.tsx
+++ b/docs/content/guides/cell-features/merge-cells/react/example3.tsx
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const ExampleComponent = () => {
+  const [output, setOutput] = useState('');
+
+  const logEvent = (message: string) => {
+    setOutput((previousOutput) => `${message}\n${previousOutput}`);
+  };
+
+  return (
+    <>
+      <output className="console" id="example3-output">
+        {output ||
+          'Select cells, then press Ctrl+M (or use the context menu) to merge or unmerge them. Hook activity appears here.'}
+      </output>
+      <HotTable
+        data={[
+          ['North America', 420000, 465000, 501000],
+          ['Europe', 388000, 402000, 411000],
+          ['APAC', 275000, 298000, 312000],
+          ['Latin America', 142000, 151000, 158000],
+          ['Middle East', 96000, 101000, 108000],
+        ]}
+        colHeaders={['Region', 'Jan 2025', 'Feb 2025', 'Mar 2025']}
+        rowHeaders={true}
+        height="auto"
+        contextMenu={true}
+        mergeCells={true}
+        autoWrapRow={true}
+        autoWrapCol={true}
+        beforeMergeCells={(cellRange) => {
+          logEvent(`beforeMergeCells: rows ${cellRange.from.row}-${cellRange.to.row}, columns ${cellRange.from.col}-${cellRange.to.col}.`);
+        }}
+        afterMergeCells={(cellRange, mergeParent) => {
+          logEvent(`afterMergeCells: merged into ${mergeParent.rowspan} row(s) by ${mergeParent.colspan} column(s).`);
+        }}
+        beforeUnmergeCells={(cellRange) => {
+          logEvent(`beforeUnmergeCells: rows ${cellRange.from.row}-${cellRange.to.row}, columns ${cellRange.from.col}-${cellRange.to.col}.`);
+        }}
+        afterUnmergeCells={(cellRange) => {
+          logEvent(`afterUnmergeCells: rows ${cellRange.from.row}-${cellRange.to.row}, columns ${cellRange.from.col}-${cellRange.to.col}.`);
+        }}
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/cell-features/merge-cells/react/example4.jsx
+++ b/docs/content/guides/cell-features/merge-cells/react/example4.jsx
@@ -1,0 +1,54 @@
+import { useRef } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const ExampleComponent = () => {
+  const hotRef = useRef(null);
+
+  const mergeNoteRow = () => {
+    hotRef.current?.hotInstance?.getPlugin('mergeCells').merge(5, 0, 5, 3);
+  };
+
+  const unmergeNoteRow = () => {
+    hotRef.current?.hotInstance?.getPlugin('mergeCells').unmerge(5, 0, 5, 3);
+  };
+
+  return (
+    <>
+      <div className="example-controls-container">
+        <div className="controls">
+          <button id="example4-merge" className="button button--primary" onClick={mergeNoteRow}>
+            Merge the note row
+          </button>
+          <button id="example4-unmerge" className="button button--primary" onClick={unmergeNoteRow}>
+            Unmerge the note row
+          </button>
+        </div>
+      </div>
+      <HotTable
+        ref={hotRef}
+        data={[
+          ['North America', 420000, 465000, 501000],
+          ['Europe', 388000, 402000, 411000],
+          ['APAC', 275000, 298000, 312000],
+          ['Latin America', 142000, 151000, 158000],
+          ['Middle East', 96000, 101000, 108000],
+          ['Note: Q1 totals include a one-time currency adjustment.', null, null, null],
+        ]}
+        colHeaders={['Region', 'Jan 2025', 'Feb 2025', 'Mar 2025']}
+        rowHeaders={true}
+        height="auto"
+        contextMenu={true}
+        mergeCells={true}
+        autoWrapRow={true}
+        autoWrapCol={true}
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/cell-features/merge-cells/react/example4.tsx
+++ b/docs/content/guides/cell-features/merge-cells/react/example4.tsx
@@ -1,0 +1,54 @@
+import { useRef } from 'react';
+import { HotTable, HotTableRef } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const ExampleComponent = () => {
+  const hotRef = useRef<HotTableRef>(null);
+
+  const mergeNoteRow = () => {
+    hotRef.current?.hotInstance?.getPlugin('mergeCells').merge(5, 0, 5, 3);
+  };
+
+  const unmergeNoteRow = () => {
+    hotRef.current?.hotInstance?.getPlugin('mergeCells').unmerge(5, 0, 5, 3);
+  };
+
+  return (
+    <>
+      <div className="example-controls-container">
+        <div className="controls">
+          <button id="example4-merge" className="button button--primary" onClick={mergeNoteRow}>
+            Merge the note row
+          </button>
+          <button id="example4-unmerge" className="button button--primary" onClick={unmergeNoteRow}>
+            Unmerge the note row
+          </button>
+        </div>
+      </div>
+      <HotTable
+        ref={hotRef}
+        data={[
+          ['North America', 420000, 465000, 501000],
+          ['Europe', 388000, 402000, 411000],
+          ['APAC', 275000, 298000, 312000],
+          ['Latin America', 142000, 151000, 158000],
+          ['Middle East', 96000, 101000, 108000],
+          ['Note: Q1 totals include a one-time currency adjustment.', null, null, null],
+        ]}
+        colHeaders={['Region', 'Jan 2025', 'Feb 2025', 'Mar 2025']}
+        rowHeaders={true}
+        height="auto"
+        contextMenu={true}
+        mergeCells={true}
+        autoWrapRow={true}
+        autoWrapCol={true}
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/cell-features/merge-cells/vue/example3.vue
+++ b/docs/content/guides/cell-features/merge-cells/vue/example3.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const output = ref('');
+
+const logEvent = (message: string) => {
+  output.value = `${message}\n${output.value}`;
+};
+
+const hotSettings: GridSettings = {
+  data: [
+    ['North America', 420000, 465000, 501000],
+    ['Europe', 388000, 402000, 411000],
+    ['APAC', 275000, 298000, 312000],
+    ['Latin America', 142000, 151000, 158000],
+    ['Middle East', 96000, 101000, 108000],
+  ],
+  colHeaders: ['Region', 'Jan 2025', 'Feb 2025', 'Mar 2025'],
+  rowHeaders: true,
+  height: 'auto',
+  contextMenu: true,
+  mergeCells: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+  beforeMergeCells: (cellRange) => {
+    logEvent(`beforeMergeCells: rows ${cellRange.from.row}-${cellRange.to.row}, columns ${cellRange.from.col}-${cellRange.to.col}.`);
+  },
+  afterMergeCells: (cellRange, mergeParent) => {
+    logEvent(`afterMergeCells: merged into ${mergeParent.rowspan} row(s) by ${mergeParent.colspan} column(s).`);
+  },
+  beforeUnmergeCells: (cellRange) => {
+    logEvent(`beforeUnmergeCells: rows ${cellRange.from.row}-${cellRange.to.row}, columns ${cellRange.from.col}-${cellRange.to.col}.`);
+  },
+  afterUnmergeCells: (cellRange) => {
+    logEvent(`afterUnmergeCells: rows ${cellRange.from.row}-${cellRange.to.row}, columns ${cellRange.from.col}-${cellRange.to.col}.`);
+  },
+};
+</script>
+
+<template>
+  <div id="example3">
+    <output class="console" id="example3-output">{{
+      output ||
+        'Select cells, then press Ctrl+M (or use the context menu) to merge or unmerge them. Hook activity appears here.'
+    }}</output>
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-features/merge-cells/vue/example4.vue
+++ b/docs/content/guides/cell-features/merge-cells/vue/example4.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import { useTemplateRef } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
+
+const hotSettings: GridSettings = {
+  data: [
+    ['North America', 420000, 465000, 501000],
+    ['Europe', 388000, 402000, 411000],
+    ['APAC', 275000, 298000, 312000],
+    ['Latin America', 142000, 151000, 158000],
+    ['Middle East', 96000, 101000, 108000],
+    ['Note: Q1 totals include a one-time currency adjustment.', null, null, null],
+  ],
+  colHeaders: ['Region', 'Jan 2025', 'Feb 2025', 'Mar 2025'],
+  rowHeaders: true,
+  height: 'auto',
+  contextMenu: true,
+  mergeCells: true,
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+};
+
+function mergeNoteRow() {
+  hotRef.value?.hotInstance?.getPlugin('mergeCells').merge(5, 0, 5, 3);
+}
+
+function unmergeNoteRow() {
+  hotRef.value?.hotInstance?.getPlugin('mergeCells').unmerge(5, 0, 5, 3);
+}
+</script>
+
+<template>
+  <div id="example4">
+    <div class="example-controls-container">
+      <div class="controls">
+        <button id="example4-merge" class="button button--primary" @click="mergeNoteRow">
+          Merge the note row
+        </button>
+        <button id="example4-unmerge" class="button button--primary" @click="unmergeNoteRow">
+          Unmerge the note row
+        </button>
+      </div>
+    </div>
+    <HotTable ref="hotRef" :settings="hotSettings" />
+  </div>
+</template>


### PR DESCRIPTION
### Context

The PR adds a hooks example and a programmatic-API example to the `merge-cells` guide. The guide previously only showed static `mergeCells` configuration and a virtualization/performance example — the `beforeMergeCells`, `afterMergeCells`, `beforeUnmergeCells`, and `afterUnmergeCells` hooks were listed only as bare links under "Related API reference", with no prose or code sample, and there was no example of calling `MergeCells.merge()`/`.unmerge()` programmatically.

Adds two new sections:

- **React to merge and unmerge events** -- logs hook activity as the reader merges/unmerges cells via `Ctrl+M` or the context menu.
- **Merge and unmerge cells programmatically** -- two buttons that call `hot.getPlugin('mergeCells').merge()`/`.unmerge()` on a footnote row.

Both ship JS/TS, React, Angular, and Vue variants, following the existing `example1`/`example2` pattern in this guide.

### How has this been tested?

- Started the docs dev server locally and loaded all four framework variants of `/merge-cells` in a real browser (Playwright).
- Verified no console errors/warnings on page load for JS, React, Angular, and Vue.
- Exercised `example3`: selected a range, merged with `Ctrl+M`, confirmed `beforeMergeCells`/`afterMergeCells` log lines with correct row/column/rowspan/colspan; unmerged and confirmed `beforeUnmergeCells`/`afterUnmergeCells` log lines.
- Exercised `example4`: clicked **Merge the note row** and confirmed the footnote cell's `colSpan` changed from `1` to `4`; clicked **Unmerge the note row** and confirmed it reverted to `1`. Verified on all four frameworks.
- Type-checked the new `.ts`/`.tsx` example sources against the real Handsontable types (`tsc --noEmit --strict`) -- no errors.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-833

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

Docs-only change (`docs/content/guides/cell-features/merge-cells/`).

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-833

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to documentation and embedded examples; no runtime library or API behavior is modified.
> 
> **Overview**
> Expands the **merge-cells** guide with two new sections and live **example3** / **example4** samples for JavaScript, TypeScript, React, Angular, and Vue.
> 
> **React to merge and unmerge events** documents the `beforeMergeCells`, `afterMergeCells`, `beforeUnmergeCells`, and `afterUnmergeCells` hooks and adds an interactive demo that logs hook output when users merge or unmerge via **Ctrl+M** or the context menu.
> 
> **Merge and unmerge cells programmatically** explains calling `MergeCells` plugin `merge()` / `unmerge()` with visual coordinates and adds button-driven examples that merge and unmerge a footnote row across all columns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf5c10af223a3621a927f115da1e4ac9192a6390. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->