### PR TITLE
DEV-837: Add beforeAutofill/afterAutofill usage example to autofill-values guide

### DIFF
--- a/docs/content/guides/cell-features/autofill-values/angular/example3.html
+++ b/docs/content/guides/cell-features/autofill-values/angular/example3.html
@@ -1,0 +1,3 @@
+<div>
+  <example3-autofill-values></example3-autofill-values>
+</div>

--- a/docs/content/guides/cell-features/autofill-values/angular/example3.ts
+++ b/docs/content/guides/cell-features/autofill-values/angular/example3.ts
@@ -1,0 +1,70 @@
+/* file: app.component.ts */
+import { Component } from '@angular/core';
+import { GridSettings, HotTableModule } from '@handsontable/angular-wrapper';
+import type Handsontable from 'handsontable/base';
+import type { CellRange } from 'handsontable/base';
+
+@Component({
+  standalone: true,
+  imports: [HotTableModule],
+  selector: 'example3-autofill-values',
+  template: `
+    <output class="console" id="output">{{ output }}</output>
+    <hot-table [data]="data" [settings]="gridSettings"></hot-table>
+  `,
+})
+export class AppComponent {
+  readonly data = [
+    ['', 'Tesla', 'Nissan', 'Toyota', 'Honda'],
+    ['2017', 10, 11, 12, 13],
+    ['2018', 20, 11, 14, 13],
+    ['2019', 30, 15, 12, 13],
+    ['2020', '', '', '', ''],
+    ['2021', '', '', '', ''],
+  ];
+
+  output = 'Drag the fill handle to see the affected range logged here.';
+
+  readonly gridSettings: GridSettings = {
+    rowHeaders: true,
+    colHeaders: true,
+    fillHandle: true,
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true,
+    beforeAutofill: (selectionData: Handsontable.CellValue[][]) =>
+      // This dealership reports sales in batches of 5 cars, so round every
+      // filled value up to the nearest multiple of 5.
+      selectionData.map((row) => row.map((value) => (typeof value === 'number' ? Math.ceil(value / 5) * 5 : value))),
+    afterAutofill: (
+      fillData: Handsontable.CellValue[][],
+      sourceRange: CellRange,
+      targetRange: CellRange,
+      direction: 'up' | 'down' | 'left' | 'right'
+    ) => {
+      this.output =
+        `Filled rows ${targetRange.from.row}-${targetRange.to.row}, ` +
+        `columns ${targetRange.from.col}-${targetRange.to.col} (direction: "${direction}").`;
+    },
+  };
+}
+/* end-file */
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+/* end-file */

--- a/docs/content/guides/cell-features/autofill-values/autofill-values.md
+++ b/docs/content/guides/cell-features/autofill-values/autofill-values.md
@@ -136,6 +136,58 @@ In this configuration, the fill handle is restricted to move only vertically. Ne
 
 :::
 
+## Altering and tracking autofilled values
+
+Use the [`beforeAutofill`](@/api/hooks.md#beforeautofill) hook to change the values Handsontable is about to fill in, and the [`afterAutofill`](@/api/hooks.md#afterautofill) hook to react once the fill completes.
+
+In the example below, drag the fill handle from `cell B4` down through rows `2020` and `2021`. The `beforeAutofill` hook rounds every filled sales figure up to the nearest multiple of 5, and the `afterAutofill` hook logs the affected range and direction to the output box below the grid.
+
+When Handsontable fires [`beforeChange`](@/api/hooks.md#beforechange) or [`afterChange`](@/api/hooks.md#afterchange) as part of an autofill operation, their `source` argument is `Autofill.fill`. Read more about the `source` argument in [Events and hooks: Definition for `source` argument](@/guides/getting-started/events-and-hooks/events-and-hooks.md#definition-for-source-argument).
+
+::: only-for javascript
+
+::: example #example3 --html 1 --js 2 --ts 3
+
+@[code](@/content/guides/cell-features/autofill-values/javascript/example3.html)
+@[code](@/content/guides/cell-features/autofill-values/javascript/example3.js)
+@[code](@/content/guides/cell-features/autofill-values/javascript/example3.ts)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #example3 :react --js 1 --ts 2
+
+@[code](@/content/guides/cell-features/autofill-values/react/example3.jsx)
+@[code](@/content/guides/cell-features/autofill-values/react/example3.tsx)
+
+:::
+
+:::
+
+::: only-for angular
+
+::: example #example3 :angular --ts 1 --html 2
+
+@[code](@/content/guides/cell-features/autofill-values/angular/example3.ts)
+@[code](@/content/guides/cell-features/autofill-values/angular/example3.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example3 :vue3
+
+@[code](@/content/guides/cell-features/autofill-values/vue/example3.vue)
+
+:::
+
+:::
+
 ## Result
 
 The fill handle appears on the selected cell. Dragging it copies or extends values into adjacent cells in the configured direction.

--- a/docs/content/guides/cell-features/autofill-values/javascript/example3.html
+++ b/docs/content/guides/cell-features/autofill-values/javascript/example3.html
@@ -1,0 +1,2 @@
+<output class="console" id="output">Drag the fill handle to see the affected range logged here.</output>
+<div id="example3"></div>

--- a/docs/content/guides/cell-features/autofill-values/javascript/example3.js
+++ b/docs/content/guides/cell-features/autofill-values/javascript/example3.js
@@ -1,0 +1,34 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+// Register all Handsontable's modules.
+registerAllModules();
+const data = [
+    ['', 'Tesla', 'Nissan', 'Toyota', 'Honda'],
+    ['2017', 10, 11, 12, 13],
+    ['2018', 20, 11, 14, 13],
+    ['2019', 30, 15, 12, 13],
+    ['2020', '', '', '', ''],
+    ['2021', '', '', '', ''],
+];
+const container = document.querySelector('#example3');
+const output = document.querySelector('#output');
+new Handsontable(container, {
+    data,
+    rowHeaders: true,
+    colHeaders: true,
+    fillHandle: true,
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true,
+    licenseKey: 'non-commercial-and-evaluation',
+    beforeAutofill(selectionData) {
+        // This dealership reports sales in batches of 5 cars, so round every
+        // filled value up to the nearest multiple of 5.
+        return selectionData.map((row) => row.map((value) => (typeof value === 'number' ? Math.ceil(value / 5) * 5 : value)));
+    },
+    afterAutofill(fillData, sourceRange, targetRange, direction) {
+        output.innerText =
+            `Filled rows ${targetRange.from.row}-${targetRange.to.row}, ` +
+                `columns ${targetRange.from.col}-${targetRange.to.col} (direction: "${direction}").`;
+    },
+});

--- a/docs/content/guides/cell-features/autofill-values/javascript/example3.ts
+++ b/docs/content/guides/cell-features/autofill-values/javascript/example3.ts
@@ -1,0 +1,40 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+// Register all Handsontable's modules.
+registerAllModules();
+
+const data: (string | number)[][] = [
+  ['', 'Tesla', 'Nissan', 'Toyota', 'Honda'],
+  ['2017', 10, 11, 12, 13],
+  ['2018', 20, 11, 14, 13],
+  ['2019', 30, 15, 12, 13],
+  ['2020', '', '', '', ''],
+  ['2021', '', '', '', ''],
+];
+
+const container = document.querySelector('#example3')!;
+const output = document.querySelector('#output') as HTMLElement;
+
+new Handsontable(container, {
+  data,
+  rowHeaders: true,
+  colHeaders: true,
+  fillHandle: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+  beforeAutofill(selectionData) {
+    // This dealership reports sales in batches of 5 cars, so round every
+    // filled value up to the nearest multiple of 5.
+    return selectionData.map((row) =>
+      row.map((value) => (typeof value === 'number' ? Math.ceil(value / 5) * 5 : value))
+    );
+  },
+  afterAutofill(fillData, sourceRange, targetRange, direction) {
+    output.innerText =
+      `Filled rows ${targetRange.from.row}-${targetRange.to.row}, ` +
+      `columns ${targetRange.from.col}-${targetRange.to.col} (direction: "${direction}").`;
+  },
+});

--- a/docs/content/guides/cell-features/autofill-values/react/example3.jsx
+++ b/docs/content/guides/cell-features/autofill-values/react/example3.jsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+// Defined outside the component so autofill can mutate this array in place
+// without a re-render (triggered by `setOutput`) resetting it to its initial values.
+const data = [
+  ['', 'Tesla', 'Nissan', 'Toyota', 'Honda'],
+  ['2017', 10, 11, 12, 13],
+  ['2018', 20, 11, 14, 13],
+  ['2019', 30, 15, 12, 13],
+  ['2020', '', '', '', ''],
+  ['2021', '', '', '', ''],
+];
+
+const ExampleComponent = () => {
+  const [output, setOutput] = useState('Drag the fill handle to see the affected range logged here.');
+
+  return (
+    <>
+      <output className="console" id="output">
+        {output}
+      </output>
+      <HotTable
+        data={data}
+        rowHeaders={true}
+        colHeaders={true}
+        fillHandle={true}
+        height="auto"
+        autoWrapRow={true}
+        autoWrapCol={true}
+        licenseKey="non-commercial-and-evaluation"
+        beforeAutofill={(selectionData) =>
+          // This dealership reports sales in batches of 5 cars, so round every
+          // filled value up to the nearest multiple of 5.
+          selectionData.map((row) => row.map((value) => (typeof value === 'number' ? Math.ceil(value / 5) * 5 : value)))
+        }
+        afterAutofill={(fillData, sourceRange, targetRange, direction) => {
+          setOutput(
+            `Filled rows ${targetRange.from.row}-${targetRange.to.row}, ` +
+              `columns ${targetRange.from.col}-${targetRange.to.col} (direction: "${direction}").`
+          );
+        }}
+      />
+    </>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/cell-features/autofill-values/react/example3.tsx
+++ b/docs/content/guides/cell-features/autofill-values/react/example3.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+// Defined outside the component so autofill can mutate this array in place
+// without a re-render (triggered by `setOutput`) resetting it to its initial values.
+const data = [
+  ['', 'Tesla', 'Nissan', 'Toyota', 'Honda'],
+  ['2017', 10, 11, 12, 13],
+  ['2018', 20, 11, 14, 13],
+  ['2019', 30, 15, 12, 13],
+  ['2020', '', '', '', ''],
+  ['2021', '', '', '', ''],
+];
+
+const ExampleComponent = () => {
+  const [output, setOutput] = useState('Drag the fill handle to see the affected range logged here.');
+
+  return (
+    <>
+      <output className="console" id="output">
+        {output}
+      </output>
+      <HotTable
+        data={data}
+        rowHeaders={true}
+        colHeaders={true}
+        fillHandle={true}
+        height="auto"
+        autoWrapRow={true}
+        autoWrapCol={true}
+        licenseKey="non-commercial-and-evaluation"
+        beforeAutofill={(selectionData) =>
+          // This dealership reports sales in batches of 5 cars, so round every
+          // filled value up to the nearest multiple of 5.
+          selectionData.map((row) => row.map((value) => (typeof value === 'number' ? Math.ceil(value / 5) * 5 : value)))
+        }
+        afterAutofill={(fillData, sourceRange, targetRange, direction) => {
+          setOutput(
+            `Filled rows ${targetRange.from.row}-${targetRange.to.row}, ` +
+              `columns ${targetRange.from.col}-${targetRange.to.col} (direction: "${direction}").`
+          );
+        }}
+      />
+    </>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/cell-features/autofill-values/vue/example3.vue
+++ b/docs/content/guides/cell-features/autofill-values/vue/example3.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const output = ref('Drag the fill handle to see the affected range logged here.');
+
+const data: GridSettings['data'] = [
+  ['', 'Tesla', 'Nissan', 'Toyota', 'Honda'],
+  ['2017', 10, 11, 12, 13],
+  ['2018', 20, 11, 14, 13],
+  ['2019', 30, 15, 12, 13],
+  ['2020', '', '', '', ''],
+  ['2021', '', '', '', ''],
+];
+
+const hotSettings: GridSettings = {
+  data,
+  rowHeaders: true,
+  colHeaders: true,
+  fillHandle: true,
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+  beforeAutofill(selectionData) {
+    // This dealership reports sales in batches of 5 cars, so round every
+    // filled value up to the nearest multiple of 5.
+    return selectionData.map((row) =>
+      row.map((value) => (typeof value === 'number' ? Math.ceil(value / 5) * 5 : value))
+    );
+  },
+  afterAutofill(fillData, sourceRange, targetRange, direction) {
+    output.value =
+      `Filled rows ${targetRange.from.row}-${targetRange.to.row}, ` +
+      `columns ${targetRange.from.col}-${targetRange.to.col} (direction: "${direction}").`;
+  },
+};
+</script>
+
+<template>
+  <div id="example3">
+    <output class="console" id="output">{{ output }}</output>
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>


### PR DESCRIPTION
### Context

The PR adds a usage example for the `beforeAutofill` and `afterAutofill` hooks to the "Autofill values" guide. Previously, these hooks were only linked in the "Related API reference" section with no explanation or example of how to use them, even though they were requested in DEV-837 (originally reported in 2024). The new `example3` shows both altering the values Handsontable is about to autofill (rounding sales figures up to the nearest multiple of 5) and reacting once the fill completes (logging the affected range and direction). The section also cross-links to the existing `Autofill.fill` `source` argument note in the events-and-hooks guide, since that's a recurring support question.

### How has this been tested?

- Ran the docs dev server (`npm run dev --prefix docs`) and manually drag-filled the new example in all four framework variants (JavaScript, React, Angular, Vue) to confirm `beforeAutofill` rounds values correctly and `afterAutofill` logs the correct range/direction.
- While testing the React variant, found and fixed a real bug: `data` was declared inside the component body, so the `afterAutofill`-triggered re-render fed the original unfilled array back into `updateSettings`, silently wiping the fill result. Fixed by hoisting `data` to module scope.
- Ran `npm run typecheck --prefix docs/angular-type-check` (the check behind `.github/workflows/docs-angular-typecheck.yml`) against the new Angular example — passes with no errors.
- Generated the JS variant from the TS source with `npm run docs:code-examples:generate-js`.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-837

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-837

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and doc-site examples only; no changes to Handsontable runtime or wrapper packages.
> 
> **Overview**
> Adds a new **“Altering and tracking autofilled values”** section to the Autofill values guide, with live **example3** for JavaScript, React, Angular, and Vue.
> 
> The examples demonstrate **`beforeAutofill`** transforming filled numbers (rounding up to the nearest multiple of 5) and **`afterAutofill`** writing the filled range and direction to a console output. The prose also points readers to the **`Autofill.fill`** `source` value on related change hooks.
> 
> The React sample keeps grid **`data` at module scope** so an `afterAutofill`-driven re-render does not reset the table to its initial array.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bef889c136a1d9c5ea959ff8d0245a998c4287f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->