### PR TITLE
DEV-1878: Fix cell-editor and events-and-hooks examples failing on deep helper import

### DIFF
--- a/docs/content/guides/cell-functions/cell-editor/cell-editor.md
+++ b/docs/content/guides/cell-functions/cell-editor/cell-editor.md
@@ -152,7 +152,7 @@ Handsontable separates rendering (displaying cell values) from editing (changing
 
 :::
 
-**Overriding keyboard behavior:** Register a [`beforeKeyDown`](@/api/hooks.md#beforekeydown) hook listener and call `Handsontable.dom.stopImmediatePropagation(event)` to prevent `EditorManager` from processing a specific key. The native `event.stopImmediatePropagation()` does not stop Handsontable's internal key pipeline - you must use the `Handsontable.dom` helper (or import `stopImmediatePropagation` from `handsontable/helpers/dom/event`). Register the listener in `open()` and remove it in `close()` so it only intercepts events while your editor is active.
+**Overriding keyboard behavior:** Register a [`beforeKeyDown`](@/api/hooks.md#beforekeydown) hook listener and return `false` to prevent `EditorManager` from processing a specific key. The native `event.stopImmediatePropagation()` does not stop Handsontable's internal key pipeline - you must [block the keyboard shortcut's actions](@/guides/navigation/custom-shortcuts/custom-shortcuts.md#block-a-keyboard-shortcut-s-actions) by returning `false` from the hook's callback. Register the listener in `open()` and remove it in `close()` so it only intercepts events while your editor is active.
 
 **Editor singleton:** Each editor class has exactly one instance per table. The constructor and `init()` run once per table; `prepare()` runs every time you select a cell that uses that editor.
 

--- a/docs/content/guides/cell-functions/cell-editor/javascript/example2.js
+++ b/docs/content/guides/cell-functions/cell-editor/javascript/example2.js
@@ -1,7 +1,6 @@
 import Handsontable from 'handsontable/base';
 import { registerAllModules } from 'handsontable/registry';
 import { BaseEditor } from 'handsontable/editors/baseEditor';
-import { stopImmediatePropagation } from 'handsontable/helpers/dom/event';
 registerAllModules();
 class SelectEditor extends BaseEditor {
   init() {
@@ -44,13 +43,15 @@ class SelectEditor extends BaseEditor {
       const { selectedIndex, length } = this.select;
       if (event.keyCode === 38 && selectedIndex > 0) {
         this.select[selectedIndex - 1].selected = true;
-        stopImmediatePropagation(event);
         event.preventDefault();
+        // block the grid's default arrow-key actions
+        return false;
       }
-      else if (event.keyCode === 40 && selectedIndex < length - 1) {
+      if (event.keyCode === 40 && selectedIndex < length - 1) {
         this.select[selectedIndex + 1].selected = true;
-        stopImmediatePropagation(event);
         event.preventDefault();
+        // block the grid's default arrow-key actions
+        return false;
       }
     });
   }

--- a/docs/content/guides/cell-functions/cell-editor/javascript/example2.ts
+++ b/docs/content/guides/cell-functions/cell-editor/javascript/example2.ts
@@ -1,7 +1,6 @@
 import Handsontable from 'handsontable/base';
 import { registerAllModules } from 'handsontable/registry';
 import { BaseEditor } from 'handsontable/editors/baseEditor';
-import { stopImmediatePropagation } from 'handsontable/helpers/dom/event';
 
 registerAllModules();
 
@@ -65,12 +64,18 @@ class SelectEditor extends BaseEditor {
 
       if (event.keyCode === 38 && selectedIndex > 0) {
         (this.select[selectedIndex - 1] as HTMLOptionElement).selected = true;
-        stopImmediatePropagation(event);
         event.preventDefault();
-      } else if (event.keyCode === 40 && selectedIndex < length - 1) {
+
+        // block the grid's default arrow-key actions
+        return false;
+      }
+
+      if (event.keyCode === 40 && selectedIndex < length - 1) {
         (this.select[selectedIndex + 1] as HTMLOptionElement).selected = true;
-        stopImmediatePropagation(event);
         event.preventDefault();
+
+        // block the grid's default arrow-key actions
+        return false;
       }
     });
   }

--- a/docs/content/guides/cell-functions/cell-editor/vue/example2.vue
+++ b/docs/content/guides/cell-functions/cell-editor/vue/example2.vue
@@ -3,7 +3,6 @@ import { ref } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import { BaseEditor } from 'handsontable/editors/baseEditor';
-import { stopImmediatePropagation } from 'handsontable/helpers/dom/event';
 import type Handsontable from 'handsontable/base';
 import type { GridSettings } from 'handsontable/settings';
 
@@ -69,12 +68,18 @@ class SelectEditor extends BaseEditor {
 
       if (event.keyCode === 38 && selectedIndex > 0) {
         (this.select[selectedIndex - 1] as HTMLOptionElement).selected = true;
-        stopImmediatePropagation(event);
         event.preventDefault();
-      } else if (event.keyCode === 40 && selectedIndex < length - 1) {
+
+        // block the grid's default arrow-key actions
+        return false;
+      }
+
+      if (event.keyCode === 40 && selectedIndex < length - 1) {
         (this.select[selectedIndex + 1] as HTMLOptionElement).selected = true;
-        stopImmediatePropagation(event);
         event.preventDefault();
+
+        // block the grid's default arrow-key actions
+        return false;
       }
     });
   }

--- a/docs/content/guides/getting-started/events-and-hooks/angular/example2.ts
+++ b/docs/content/guides/getting-started/events-and-hooks/angular/example2.ts
@@ -41,10 +41,10 @@ export class AppComponent implements AfterViewInit {
       beforeKeyDown: (e) => {
         const selection = hot?.getSelected()?.[0];
 
-        if (!selection) return;
+        if (!selection) return undefined;
 
         // Ignore header and corner selections (row or column index < 0)
-        if (selection[0] < 0 || selection[1] < 0) return;
+        if (selection[0] < 0 || selection[1] < 0) return undefined;
 
         console.log(selection);
 
@@ -79,6 +79,8 @@ export class AppComponent implements AfterViewInit {
         }
 
         this.lastChange = null;
+
+        return undefined;
       },
     });
   }

--- a/docs/content/guides/getting-started/events-and-hooks/angular/example2.ts
+++ b/docs/content/guides/getting-started/events-and-hooks/angular/example2.ts
@@ -1,7 +1,6 @@
 /* file: app.component.ts */
 import { AfterViewInit, Component, ViewChild } from '@angular/core';
 import { GridSettings, HotTableComponent, HotTableModule} from '@handsontable/angular-wrapper';
-import { stopImmediatePropagation } from 'handsontable/helpers/dom/event';
 
 @Component({
   selector: 'example2-events-hooks',
@@ -51,24 +50,31 @@ export class AppComponent implements AfterViewInit {
 
         // BACKSPACE or DELETE
         if (e.keyCode === 8 || e.keyCode === 46) {
-          stopImmediatePropagation(e);
           // remove data at cell, shift up
           hot.spliceCol(selection[1], selection[0], 1);
           e.preventDefault();
+          this.lastChange = null;
+
+          // block the default deletion behavior
+          return false;
         }
+
         // ENTER
-        else if (e.keyCode === 13) {
+        if (e.keyCode === 13) {
           // if last change affected a single cell and did not change it's values
           if (
             this.lastChange &&
             this.lastChange.length === 1 &&
             this.lastChange[0][2] == this.lastChange[0][3]
           ) {
-            stopImmediatePropagation(e);
             hot.spliceCol(selection[1], selection[0], 0, '');
             // add new cell
             hot.selectCell(selection[0], selection[1]);
             // select new cell
+            this.lastChange = null;
+
+            // block the default Enter behavior
+            return false;
           }
         }
 

--- a/docs/content/guides/getting-started/events-and-hooks/javascript/example2.js
+++ b/docs/content/guides/getting-started/events-and-hooks/javascript/example2.js
@@ -1,6 +1,5 @@
 import Handsontable from 'handsontable/base';
 import { registerAllModules } from 'handsontable/registry';
-import { stopImmediatePropagation } from 'handsontable/helpers/dom/event';
 // Register all Handsontable's modules.
 registerAllModules();
 let lastChange = null;
@@ -35,20 +34,24 @@ hot.updateSettings({
     console.log(selection);
     // BACKSPACE or DELETE
     if (e.keyCode === 8 || e.keyCode === 46) {
-      stopImmediatePropagation(e);
       // remove data at cell, shift up
       hot.spliceCol(selection[1], selection[0], 1);
       e.preventDefault();
+      lastChange = null;
+      // block the default deletion behavior
+      return false;
     }
     // ENTER
-    else if (e.keyCode === 13) {
+    if (e.keyCode === 13) {
       // if last change affected a single cell and did not change it's values
       if (lastChange && lastChange.length === 1 && lastChange[0][2] == lastChange[0][3]) {
-        stopImmediatePropagation(e);
         hot.spliceCol(selection[1], selection[0], 0, '');
         // add new cell
         hot.selectCell(selection[0], selection[1]);
         // select new cell
+        lastChange = null;
+        // block the default Enter behavior
+        return false;
       }
     }
     lastChange = null;

--- a/docs/content/guides/getting-started/events-and-hooks/javascript/example2.ts
+++ b/docs/content/guides/getting-started/events-and-hooks/javascript/example2.ts
@@ -1,6 +1,5 @@
 import Handsontable from 'handsontable/base';
 import { registerAllModules } from 'handsontable/registry';
-import { stopImmediatePropagation } from 'handsontable/helpers/dom/event';
 
 // Register all Handsontable's modules.
 registerAllModules();
@@ -41,20 +40,27 @@ hot.updateSettings({
 
     // BACKSPACE or DELETE
     if (e.keyCode === 8 || e.keyCode === 46) {
-      stopImmediatePropagation(e);
       // remove data at cell, shift up
       hot.spliceCol(selection[1], selection[0], 1);
       e.preventDefault();
+      lastChange = null;
+
+      // block the default deletion behavior
+      return false;
     }
+
     // ENTER
-    else if (e.keyCode === 13) {
+    if (e.keyCode === 13) {
       // if last change affected a single cell and did not change it's values
       if (lastChange && lastChange.length === 1 && lastChange[0]![2] == lastChange[0]![3]) {
-        stopImmediatePropagation(e);
         hot.spliceCol(selection[1], selection[0], 0, '');
         // add new cell
         hot.selectCell(selection[0], selection[1]);
         // select new cell
+        lastChange = null;
+
+        // block the default Enter behavior
+        return false;
       }
     }
 

--- a/docs/content/guides/getting-started/events-and-hooks/react/example2.jsx
+++ b/docs/content/guides/getting-started/events-and-hooks/react/example2.jsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { HotTable } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
-import { stopImmediatePropagation } from 'handsontable/helpers/dom/event';
 
 // register Handsontable's modules
 registerAllModules();
@@ -24,20 +23,27 @@ const ExampleComponent = () => {
 
         // BACKSPACE or DELETE
         if (e.keyCode === 8 || e.keyCode === 46) {
-          stopImmediatePropagation(e);
           // remove data at cell, shift up
           hot.spliceCol(selection[1], selection[0], 1);
           e.preventDefault();
+          lastChange = null;
+
+          // block the default deletion behavior
+          return false;
         }
+
         // ENTER
-        else if (e.keyCode === 13) {
+        if (e.keyCode === 13) {
           // if last change affected a single cell and did not change it's values
           if (lastChange && lastChange.length === 1 && lastChange[0][2] == lastChange[0][3]) {
-            stopImmediatePropagation(e);
             hot.spliceCol(selection[1], selection[0], 0, '');
             // add new cell
             hot.selectCell(selection[0], selection[1]);
             // select new cell
+            lastChange = null;
+
+            // block the default Enter behavior
+            return false;
           }
         }
 

--- a/docs/content/guides/getting-started/events-and-hooks/react/example2.tsx
+++ b/docs/content/guides/getting-started/events-and-hooks/react/example2.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { HotTable, HotTableRef } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
-import { stopImmediatePropagation } from 'handsontable/helpers/dom/event';
 
 // register Handsontable's modules
 registerAllModules();
@@ -26,20 +25,27 @@ const ExampleComponent = () => {
 
         // BACKSPACE or DELETE
         if (e.keyCode === 8 || e.keyCode === 46) {
-          stopImmediatePropagation(e);
           // remove data at cell, shift up
           hot.spliceCol(selection[1], selection[0], 1);
           e.preventDefault();
+          lastChange = null;
+
+          // block the default deletion behavior
+          return false;
         }
+
         // ENTER
-        else if (e.keyCode === 13) {
+        if (e.keyCode === 13) {
           // if last change affected a single cell and did not change it's values
           if (lastChange && lastChange.length === 1 && lastChange[0][2] == lastChange[0][3]) {
-            stopImmediatePropagation(e);
             hot.spliceCol(selection[1], selection[0], 0, '');
             // add new cell
             hot.selectCell(selection[0], selection[1]);
             // select new cell
+            lastChange = null;
+
+            // block the default Enter behavior
+            return false;
           }
         }
 

--- a/docs/content/guides/getting-started/events-and-hooks/vue/example2.vue
+++ b/docs/content/guides/getting-started/events-and-hooks/vue/example2.vue
@@ -2,7 +2,6 @@
 import { ref, onMounted, useTemplateRef } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
-import { stopImmediatePropagation } from 'handsontable/helpers/dom/event';
 import type { GridSettings } from 'handsontable/settings';
 import type { CellChange } from 'handsontable/common';
 
@@ -21,15 +20,28 @@ onMounted(() => {
       if (!selection) return;
       if (selection[0] < 0 || selection[1] < 0) return;
 
+      // BACKSPACE or DELETE
       if (e.keyCode === 8 || e.keyCode === 46) {
-        stopImmediatePropagation(e);
+        // remove data at cell, shift up
         hot.spliceCol(selection[1], selection[0], 1);
         e.preventDefault();
-      } else if (e.keyCode === 13) {
+        lastChange = null;
+
+        // block the default deletion behavior
+        return false;
+      }
+
+      // ENTER
+      if (e.keyCode === 13) {
+        // if last change affected a single cell and did not change its values
         if (lastChange && lastChange.length === 1 && lastChange[0][2] == lastChange[0][3]) {
-          stopImmediatePropagation(e);
           hot.spliceCol(selection[1], selection[0], 0, '');
+          // add new cell
           hot.selectCell(selection[0], selection[1]);
+          lastChange = null;
+
+          // block the default Enter behavior
+          return false;
         }
       }
 


### PR DESCRIPTION
### Context

The PR fixes the `cell-editor/#example2` and `events-and-hooks/#example2` documentation examples, which fail in Vite-based sandboxes (StackBlitz export, and the Angular compile step) with:

```
Missing "./helpers/dom/event" specifier in "handsontable" package
```

The examples deep-import `stopImmediatePropagation` from `handsontable/helpers/dom/event`, but the published package's generated `exports` map (see `handsontable.exports` in `handsontable/package.json`) does not expose any `./helpers/*` subpath, so strict ESM resolvers (Vite, Node ESM) reject the import. The file exists in the published package - it is only missing from the exports map. Since the currently published `handsontable@18.0.0` already lacks the export, only an example-side fix can repair the sandboxes for the current docs.

The fix removes the deep import entirely and uses the officially documented way to stop the key pipeline - returning `false` from the [`beforeKeyDown`](https://handsontable.com/docs/javascript-data-grid/api/hooks/#beforekeydown) hook callback (see the "Block a keyboard shortcut's actions" section of the custom-shortcuts guide). In the shortcut recorder, `result === false` and `isImmediatePropagationStopped(event)` are checked by the same early return (`handsontable/src/shortcuts/recorder.ts`), so the behavior is identical.

Changed files:

- `events-and-hooks` example2: JavaScript (`.ts`/`.js`), React (`.tsx`/`.jsx`), Angular (`.ts`), and Vue (`.vue`) variants - all four carried the same broken import.
- `cell-editor` example2: JavaScript (`.ts`/`.js`) and Vue (`.vue`) variants. The React and Angular pages intentionally show a different, class-based editor example there (no deep import), so no changes were needed for them.
- `cell-editor.md` prose: the "Overriding keyboard behavior" paragraph recommended the same unresolvable deep import; it now points to the `return false` pattern.

Answering the task's verification question: the absence of the from-scratch `SelectEditor` example on the React and Angular cell-editor pages is deliberate (a feature, not a bug) - those pages present the class-based editor approach and link to it instead. For `events-and-hooks`, example2 exists for all four frameworks, and the React/Angular variants had the same broken import (now also fixed).

### How has this been tested?

- Reproduced the reported failure: a scratch Vite project resolving `handsontable` against the locally built package (`handsontable/tmp`, which carries the generated exports map) fails with the exact `Missing "./helpers/dom/event" specifier` error when the old deep import is present, and builds cleanly with the fixed examples.
- Drove both fixed JavaScript examples end-to-end in headless Chromium (Playwright): grids mount without console errors; in `events-and-hooks` example2, <kbd>Backspace</kbd> shifts the column up without opening the editor; in `cell-editor` example2, <kbd>ArrowUp</kbd>/<kbd>ArrowDown</kbd> move the select editor's option without moving the grid selection.
- A/B-compared against the previous `stopImmediatePropagation` semantics (helper body inlined) in the same harness - behavior is identical at every step.
- Regenerated the JavaScript variants from their TypeScript sources.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1878

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1878

https://claude.ai/code/session_01869fHgBTcvWFFk9zbdCvqD

---
_Generated by [Claude Code](https://claude.ai/code/session_01869fHgBTcvWFFk9zbdCvqD)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example-only changes with no runtime library or package export changes.
> 
> **Overview**
> Fixes **cell-editor** and **events-and-hooks** `#example2` sandboxes that failed under Vite/strict ESM because examples imported `stopImmediatePropagation` from `handsontable/helpers/dom/event`, a path not listed in the published package `exports` map.
> 
> All affected examples now **block default keyboard handling** by returning `false` from `beforeKeyDown` (same approach as the custom-shortcuts guide), instead of calling the DOM helper. The **cell-editor** guide’s “Overriding keyboard behavior” section is updated to match.
> 
> Touches JS/TS, React, Vue, and Angular variants for **events-and-hooks** example2, plus JS/TS/Vue for **cell-editor** example2; React/Angular cell-editor pages use different examples and were unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f436f314e0a6045f3c1bcfc3062ff12c6d18e59a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->