### PR TITLE
DEV-2035: Add missing Vue example to Bundle size guide

### DIFF
--- a/docs/content/guides/optimization/bundle-size/bundle-size.md
+++ b/docs/content/guides/optimization/bundle-size/bundle-size.md
@@ -87,6 +87,29 @@ export class ExampleComponent {
 
 :::
 
+::: only-for vue
+
+```vue
+<script setup lang="ts">
+import Handsontable from 'handsontable/base';
+import { HotTable } from '@handsontable/vue3';
+import { registerPlugin, ContextMenu } from 'handsontable/plugins';
+import type { GridSettings } from 'handsontable/settings';
+
+registerPlugin(ContextMenu);
+
+const hotSettings: GridSettings = {
+  contextMenu: true,
+};
+</script>
+
+<template>
+  <HotTable :settings="hotSettings" />
+</template>
+```
+
+:::
+
 ## Related guides
 
 <div class="boxes-list">


### PR DESCRIPTION
### Context

The PR adds the missing Vue example to the Bundle size guide. The page (`/bundle-size`) shows a code example for JavaScript, React, and Angular demonstrating how to import the base module and manually register the `ContextMenu` plugin, but the Vue variant of the page had no equivalent example, making it look incomplete.

The Vue frontmatter (`vue.metaTitle`) was already in place, so only the missing `::: only-for vue` content block needed to be added, mirroring the existing framework examples and the Vue 3 idioms already used elsewhere in the docs (e.g. `modules.md`).

### How has this been tested?

- Docs-only content change; no code paths affected. Verified the new block follows the same `::: only-for vue` / code-fence structure as the existing javascript/react/angular blocks on the page.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2035

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2035

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or library code affected.
> 
> **Overview**
> Adds the missing **Vue 3** code sample on the Bundle size guide so Vue readers see the same pattern as the other frameworks: import `handsontable/base`, register `ContextMenu` via `registerPlugin`, and enable `contextMenu` on `HotTable` with typed `GridSettings`.
> 
> The new `::: only-for vue` block follows the same structure as the existing JavaScript, React, and Angular examples and aligns with Vue idioms used elsewhere in the docs (e.g. `modules.md`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 835da6419e3332316c7d15f153200c4b573e9fc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->