### PR TITLE
DEV-2031: Resolve Changelog link to the latest changelog dynamically

### DIFF
--- a/docs/content/guides/getting-started/introduction/introduction.md
+++ b/docs/content/guides/getting-started/introduction/introduction.md
@@ -105,7 +105,7 @@ Implementing Handsontable requires a certain level of front-end development skil
 
 <div class="boxes-list">
 
-- [Changelog](@/guides/upgrade-and-migration/changelog-17/changelog-17.md)
+- [Changelog](@/guides/upgrade-and-migration/changelog-{{$latestChangelogVersion}}/changelog-{{$latestChangelogVersion}}.md)
 - [Blog](https://handsontable.com/blog)
 - [X](https://x.com/handsontable)
 - [LinkedIn](https://linkedin.com/company/handsontable)

--- a/docs/src/plugins/__tests__/changelog-parser.test.mjs
+++ b/docs/src/plugins/__tests__/changelog-parser.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { parseChangelogContent, parseAllChangelogs } from '../changelog-parser.mjs';
+import { parseChangelogContent, parseAllChangelogs, LATEST_CHANGELOG_MAJOR } from '../changelog-parser.mjs';
 
 test('extracts version and ISO release date from a single release block', () => {
   const md = [
@@ -489,4 +489,11 @@ test('parseAllChangelogs produces no entries with null releaseDate inside major 
   for (const entry of mainline) {
     assert.ok(entry.releaseDate, `release date missing for ${entry.version} (${entry.title})`);
   }
+});
+
+test('LATEST_CHANGELOG_MAJOR matches the highest major version parsed from the changelog files', () => {
+  const result = parseAllChangelogs();
+  const expectedMax = Math.max(...result.map((e) => Number(e.version.split('.')[0])));
+
+  assert.equal(LATEST_CHANGELOG_MAJOR, expectedMax);
 });

--- a/docs/src/plugins/__tests__/framework-loader.test.mjs
+++ b/docs/src/plugins/__tests__/framework-loader.test.mjs
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { frameworkLoader } from '../framework-loader.mjs';
 import { setRenderedHtmlDirForTests, readRenderedHtml } from '../rendered-html-store.mjs';
+import { LATEST_CHANGELOG_MAJOR } from '../changelog-parser.mjs';
 
 // The loader writes each entry's rendered HTML to a file and stores only a
 // marker in the data store (see rendered-html-store.mjs) — keep test writes
@@ -395,6 +396,68 @@ test('.cs examples render with a csharp code fence, not a plain-text fence', asy
     // Regression guard: before the fix, .cs had no EXT_TO_LANG entry and fell
     // back to the plain-text grammar (no highlighting).
     assert.ok(!html.includes('````text title='), '.cs must not fall back to a plain-text fence');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+/**
+ * Builds a temp content tree with an intro page whose "Changelog" link uses
+ * the {{$latestChangelogVersion}} placeholder inside an @/...md reference,
+ * plus a matching changelog-N target page (DEV-2031).
+ *
+ * @returns {{ contentDir: string, root: string }}
+ */
+function createChangelogLinkFixture() {
+  const root = mkdtempSync(join(tmpdir(), 'hot-loader-changelog-'));
+  const contentDir = join(root, 'content');
+  const introDir = join(contentDir, 'guides', 'intro');
+  const changelogDir = join(contentDir, 'guides', 'upgrade-and-migration', `changelog-${LATEST_CHANGELOG_MAJOR}`);
+
+  mkdirSync(introDir, { recursive: true });
+  mkdirSync(changelogDir, { recursive: true });
+
+  writeFileSync(
+    join(introDir, 'intro.md'),
+    [
+      '---',
+      'title: Introduction',
+      'permalink: /intro',
+      '---',
+      '',
+      '[Changelog](@/guides/upgrade-and-migration/changelog-{{$latestChangelogVersion}}/changelog-{{$latestChangelogVersion}}.md)',
+      '',
+    ].join('\n')
+  );
+
+  writeFileSync(
+    join(changelogDir, `changelog-${LATEST_CHANGELOG_MAJOR}.md`),
+    ['---', 'title: Changelog', `permalink: /changelog-${LATEST_CHANGELOG_MAJOR}`, '---', '', 'Changelog body.', ''].join('\n')
+  );
+
+  return { contentDir, root };
+}
+
+test('{{$latestChangelogVersion}} placeholder resolves to the latest changelog page inside an @/...md link', async () => {
+  const { contentDir, root } = createChangelogLinkFixture();
+
+  try {
+    const { ctx, store } = createContext();
+
+    await frameworkLoader({ contentDir }).load(ctx);
+
+    const html = renderedHtmlOf(store, 'javascript-data-grid/intro');
+
+    // The fix: the placeholder is resolved before @/...md link resolution,
+    // so the link lands on the real latest changelog-N page.
+    assert.ok(
+      html.includes(`/docs/javascript-data-grid/changelog-${LATEST_CHANGELOG_MAJOR}/`),
+      `expected link to resolve to the latest changelog (changelog-${LATEST_CHANGELOG_MAJOR})`
+    );
+
+    // Regression guard: if the placeholder were substituted after (or never),
+    // the literal "{{" would leak into the link or the fallback path.
+    assert.ok(!html.includes('{{'), 'no unresolved {{$latestChangelogVersion}} placeholder should remain');
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/docs/src/plugins/changelog-parser.mjs
+++ b/docs/src/plugins/changelog-parser.mjs
@@ -15,6 +15,17 @@ const CHANGELOG_FILES = readdirSync(CHANGELOG_ROOT, { withFileTypes: true })
   .filter(rel => existsSync(resolve(CHANGELOG_ROOT, rel)))
   .sort((a, b) => Number(a.match(/\d+/)[0]) - Number(b.match(/\d+/)[0]));
 
+/**
+ * The highest changelog-N major version with an existing changelog page,
+ * derived from CHANGELOG_FILES. Used to keep the Introduction page's
+ * "Changelog" link pointing at the latest version without manual updates.
+ *
+ * @type {number|null}
+ */
+export const LATEST_CHANGELOG_MAJOR = CHANGELOG_FILES.length > 0
+  ? Number(CHANGELOG_FILES[CHANGELOG_FILES.length - 1].match(/\d+/)[0])
+  : null;
+
 const MONTHS = {
   january: '01', february: '02', march: '03', april: '04',
   may: '05', june: '06', july: '07', august: '08',

--- a/docs/src/plugins/framework-loader.mjs
+++ b/docs/src/plugins/framework-loader.mjs
@@ -13,6 +13,7 @@ import { createRequire } from 'module';
 import { fileURLToPath } from 'url';
 import matter from 'gray-matter';
 import { CURRENT_DOCS_VERSION, CURRENT_DOCS_MINOR_VERSION } from './docs-version.mjs';
+import { LATEST_CHANGELOG_MAJOR } from './changelog-parser.mjs';
 import { convertAsideBodyMarkdown } from './aside-inline-markdown.mjs';
 import { internEcTokenStyles } from './ec-token-styles.mjs';
 import { writeRenderedHtml } from './rendered-html-store.mjs';
@@ -1253,6 +1254,11 @@ function applyVuepressPreprocessing(content, prefix, contentDir) {
   // Staging/dev builds resolve to "develop" (no prod-docs/ prefix, since
   // the prod-docs/develop branch does not exist).
   result = result.replace(/\{\{\s*\$currentMinorVersion\s*\}\}/g, CURRENT_DOCS_MINOR_VERSION);
+
+  // Fix {{$latestChangelogVersion}} → highest existing changelog-N major version.
+  // Keeps the Introduction page's "Changelog" link current without manual edits
+  // on every major release.
+  result = result.replace(/\{\{\s*\$latestChangelogVersion\s*\}\}/g, String(LATEST_CHANGELOG_MAJOR));
 
   // Transform @/framework/path.md links to absolute Starlight URLs using permalinks.
   // When prefix/contentDir are available (framework pages), do full permalink resolution.


### PR DESCRIPTION
### Context

The PR fixes the "Changelog" link in the "Stay in the loop" section of the Introduction page (e.g. `/docs/react-data-grid/`). It was hardcoded to `changelog-17`, so it pointed at a stale major version once `changelog-18` shipped.

Instead of hand-fixing `17` to `18` (which would just make the link stale again at the next major bump, e.g. `19`), the link now resolves through a new `{{$latestChangelogVersion}}` build-time placeholder, resolved in `framework-loader.mjs` from `LATEST_CHANGELOG_MAJOR` — a value auto-derived from the existing `changelog-N` folder auto-discovery logic in `changelog-parser.mjs`. This mirrors the existing `{{$currentVersion}}` / `{{$currentMinorVersion}}` placeholder pattern already used elsewhere on the same page. Ordering matters: the placeholder is substituted before the `@/...md` link-resolution pass, so `resolveAtLink()` always sees a concrete path (e.g. `changelog-18/changelog-18.md`).

### How has this been tested?

- Added a unit test in `src/plugins/__tests__/changelog-parser.test.mjs` asserting `LATEST_CHANGELOG_MAJOR` matches the highest major version independently derived from parsed changelog content.
- Added a unit test in `src/plugins/__tests__/framework-loader.test.mjs` with a temp-fixture intro page using the `{{$latestChangelogVersion}}` placeholder inside an `@/...md` link, asserting it resolves to the real `changelog-N` page and leaves no unresolved `{{` placeholder.
- Ran the full plugin suite: `node --test src/plugins/__tests__/*.test.mjs` (71/71 passing).
- Manually verified in the dev server (`ASTRO_DEV_BACKGROUND=1 npm run dev`, `.astro` cache cleared first) that the Changelog link resolves to `/docs/{prefix}/changelog-18/` on all four framework Introduction pages (`javascript-data-grid`, `react-data-grid`, `angular-data-grid`, `vue-data-grid`), and that the target page returns HTTP 200.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2031

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

(This change is docs-site build infrastructure under `docs/`, not any of the above packages.)

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog] — docs-site build infrastructure change, no library/wrapper source code affected.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2031

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs build-time placeholder and link preprocessing only; no auth, data, or library runtime changes.
> 
> **Overview**
> Fixes the Introduction page **Changelog** link in “Stay in the loop,” which was hardcoded to a fixed `changelog-N` path and went stale after each major docs release.
> 
> The link now uses a **`{{$latestChangelogVersion}}`** build-time placeholder. **`changelog-parser.mjs`** exports **`LATEST_CHANGELOG_MAJOR`** from existing `changelog-N` folder discovery, and **`framework-loader.mjs`** substitutes the placeholder **before** `@/...md` link resolution (same pattern as `{{$currentVersion}}`). Unit tests cover the constant and end-to-end link rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c11043877df5d4be0816bfdc3c24300ad4a65ad9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->