### PR TITLE
DEV-839: Enable more plugins in events-and-hooks demo grid

### DIFF
--- a/docs/content/guides/getting-started/events-and-hooks/javascript/example1.js
+++ b/docs/content/guides/getting-started/events-and-hooks/javascript/example1.js
@@ -1,120 +1,107 @@
 import Handsontable from 'handsontable/base';
 import { registerAllModules } from 'handsontable/registry';
-
 // Register all Handsontable's modules.
 registerAllModules();
-
 const config = {
-  data: [
-    ['', 'Tesla', 'Mazda', 'Mercedes', 'Mini', 'Mitsubishi'],
-    ['2017', 0, 2941, 4303, 354, 5814],
-    ['2018', 3, 2905, 2867, 412, 5284],
-    ['2019', 4, 2517, 4822, 552, 6127],
-    ['2020', 2, 2422, 5399, 776, 4151],
-  ],
-  minRows: 5,
-  minCols: 6,
-  height: 'auto',
-  stretchH: 'all',
-  minSpareRows: 1,
-  autoWrapRow: true,
-  colHeaders: true,
-  contextMenu: true,
-  autoWrapCol: true,
-  licenseKey: 'non-commercial-and-evaluation',
+    data: [
+        ['', 'Tesla', 'Mazda', 'Mercedes', 'Mini', 'Mitsubishi'],
+        ['2017', 0, 2941, 4303, 354, 5814],
+        ['2018', 3, 2905, 2867, 412, 5284],
+        ['2019', 4, 2517, 4822, 552, 6127],
+        ['2020', 2, 2422, 5399, 776, 4151],
+    ],
+    minRows: 5,
+    minCols: 6,
+    height: 'auto',
+    stretchH: 'all',
+    minSpareRows: 1,
+    autoWrapRow: true,
+    colHeaders: true,
+    contextMenu: true,
+    autoWrapCol: true,
+    dropdownMenu: true,
+    filters: true,
+    columnSorting: true,
+    mergeCells: true,
+    comments: true,
+    manualColumnMove: true,
+    manualRowMove: true,
+    licenseKey: 'non-commercial-and-evaluation',
 };
-
 const example1Events = document.getElementById('example1_events');
 const hooksList = document.getElementById('hooksList');
 const hooks = Handsontable.hooks.getRegistered();
-
 hooks.forEach((hook) => {
-  let checked = '';
-
-  if (
-    hook === 'afterChange' ||
-    hook === 'afterSelection' ||
-    hook === 'afterCreateRow' ||
-    hook === 'afterRemoveRow' ||
-    hook === 'afterCreateCol' ||
-    hook === 'afterRemoveCol'
-  ) {
-    checked = 'checked';
-  }
-
-  hooksList.innerHTML += `<li><label><input type="checkbox" ${checked} id="check_${hook}"> ${hook}</label></li>`;
-  config[hook] = function () {
-    log_events(hook, arguments);
-  };
+    let checked = '';
+    if (hook === 'afterChange' ||
+        hook === 'afterSelection' ||
+        hook === 'afterCreateRow' ||
+        hook === 'afterRemoveRow' ||
+        hook === 'afterCreateCol' ||
+        hook === 'afterRemoveCol') {
+        checked = 'checked';
+    }
+    hooksList.innerHTML += `<li><label><input type="checkbox" ${checked} id="check_${hook}"> ${hook}</label></li>`;
+    config[hook] = function () {
+        log_events(hook, arguments);
+    };
 });
-
 const start = new Date().getTime();
 let i = 0;
 let timer;
-
 /**
  * @param event
  * @param data
  */
 function log_events(event, data) {
-  if (document.getElementById(`check_${event}`).checked) {
-    const now = new Date().getTime();
-    const diff = now - start;
-    let str;
-    const vals = [i, `@${(diff / 1000).toFixed(3)}`, `[${event}]`];
-
-    for (let d = 0; d < data.length; d++) {
-      try {
-        str = JSON.stringify(data[d]);
-      } catch (e) {
-        str = data[d].toString();
-      }
-
-      if (str === void 0) {
-        continue;
-      }
-
-      if (str.length > 20) {
-        str = typeof data[d] === 'object' ? `object: ${str.substr(0, 20)}...}` : str.toString();
-      }
-
-      if (d < data.length - 1) {
-        str += ',';
-      }
-
-      vals.push(str);
+    if (document.getElementById(`check_${event}`).checked) {
+        const now = new Date().getTime();
+        const diff = now - start;
+        let str;
+        const vals = [i, `@${(diff / 1000).toFixed(3)}`, `[${event}]`];
+        for (let d = 0; d < data.length; d++) {
+            try {
+                str = JSON.stringify(data[d]);
+            }
+            catch (e) {
+                str = data[d].toString();
+            }
+            if (str === void 0) {
+                continue;
+            }
+            if (str.length > 20) {
+                str = typeof data[d] === 'object' ? `object: ${str.substr(0, 20)}...}` : str.toString();
+            }
+            if (d < data.length - 1) {
+                str += ',';
+            }
+            vals.push(str);
+        }
+        if (window.console) {
+            console.log(i, `@${(diff / 1000).toFixed(3)}`, `[${event}]`, data);
+        }
+        const div = document.createElement('div');
+        const text = document.createTextNode(vals.join(' '));
+        div.appendChild(text);
+        example1Events.appendChild(div);
+        clearTimeout(timer);
+        timer = setTimeout(() => {
+            example1Events.scrollTop = example1Events.scrollHeight;
+        }, 10);
+        i++;
     }
-
-    if (window.console) {
-      console.log(i, `@${(diff / 1000).toFixed(3)}`, `[${event}]`, data);
-    }
-
-    const div = document.createElement('div');
-    const text = document.createTextNode(vals.join(' '));
-
-    div.appendChild(text);
-    example1Events.appendChild(div);
-    clearTimeout(timer);
-    timer = setTimeout(() => {
-      example1Events.scrollTop = example1Events.scrollHeight;
-    }, 10);
-    i++;
-  }
 }
-
 const example1 = document.querySelector('#example1');
-
 new Handsontable(example1, config);
 document.querySelector('#check_select_all').addEventListener('click', function () {
-  const state = this.checked;
-  const inputs = document.querySelectorAll('#hooksList input[type=checkbox]');
-
-  Array.prototype.forEach.call(inputs, (input) => {
-    input.checked = state;
-  });
+    const state = this.checked;
+    const inputs = document.querySelectorAll('#hooksList input[type=checkbox]');
+    Array.prototype.forEach.call(inputs, (input) => {
+        input.checked = state;
+    });
 });
 document.querySelector('#hooksList input[type=checkbox]').addEventListener('click', function () {
-  if (!this.checked) {
-    document.getElementById('check_select_all').checked = false;
-  }
+    if (!this.checked) {
+        document.getElementById('check_select_all').checked = false;
+    }
 });

--- a/docs/content/guides/getting-started/events-and-hooks/javascript/example1.ts
+++ b/docs/content/guides/getting-started/events-and-hooks/javascript/example1.ts
@@ -21,6 +21,13 @@ const config: Handsontable.GridSettings = {
   colHeaders: true,
   contextMenu: true,
   autoWrapCol: true,
+  dropdownMenu: true,
+  filters: true,
+  columnSorting: true,
+  mergeCells: true,
+  comments: true,
+  manualColumnMove: true,
+  manualRowMove: true,
   licenseKey: 'non-commercial-and-evaluation',
 };
 


### PR DESCRIPTION
### Context

The PR fixes the "Events and hooks" guide demo so that hooks listed in the "choose events to log" checkbox list can actually fire.

The demo builds its checkbox list from `Handsontable.hooks.getRegistered()`, which enumerates hooks from every registered module. But the demo grid only enabled `contextMenu`, so hooks belonging to disabled plugins (sorting, filters, merge cells, comments, dropdown menu, row/column move) showed up as checkable options that could never actually fire -- there was no UI in the demo to trigger them.

This enables `dropdownMenu`, `filters`, `columnSorting`, `mergeCells`, `comments`, `manualColumnMove`, and `manualRowMove` on the demo grid so those hooks have a real trigger path.

### How has this been tested?

- Regenerated the JS variant with `npm run docs:code-examples:generate-js -- content/guides/getting-started/events-and-hooks/javascript/example1.ts` (run from `docs/`).
- Manually verified in a local docs dev server (`/docs/javascript-data-grid/events-and-hooks/`):
  - No console errors after the change.
  - Column header dropdown-menu buttons render (filters/sorting/dropdownMenu active).
  - Right-click context menu now includes "Add comment" and "Merge cells".
  - `afterSelection` hook logging still works, confirming the event-log wiring is unaffected.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-839

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-839

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only demo config change with no production library or API impact.
> 
> **Overview**
> Fixes the **Events and hooks** guide demo (`example1`) so checkboxes built from `Handsontable.hooks.getRegistered()` can actually trigger the hooks they represent.
> 
> The grid config now turns on **`dropdownMenu`**, **`filters`**, **`columnSorting`**, **`mergeCells`**, **`comments`**, **`manualColumnMove`**, and **`manualRowMove`** in addition to the existing **`contextMenu`**, giving UI paths for sorting, filtering, merges, comments, and row/column moves. **`example1.ts`** is the source; **`example1.js`** is regenerated and also reflects formatting from the docs codegen pipeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 407e86f126cb4b7cb20d44101251c3bd79d29aeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->