### PR TITLE
DEV-2034: Fix 405 error when saving demo data in saving-data guide

### DIFF
--- a/docs/cloudflare/__tests__/_worker.test.mjs
+++ b/docs/cloudflare/__tests__/_worker.test.mjs
@@ -25,9 +25,10 @@ function loadWorker() {
   return module.exports;
 }
 
-function request(path, cookie) {
+function request(path, cookie, method = 'GET') {
   return {
     url: `https://handsontable.com${path}`,
+    method,
     headers: { get: (name) => (name === 'Cookie' && cookie ? `docs_fw=${cookie}` : null) },
   };
 }
@@ -230,4 +231,27 @@ test('keeps versioned demo redirects on historical disabled cells slugs', async(
     '/docs/15.3/javascript-data-grid/disabled-cells',
     302,
   );
+});
+
+test('answers POST to the saving-data demo\'s save.json mock instead of 405ing (regression for DEV-2034)', async() => {
+  const worker = loadWorker();
+
+  const response = await worker.fetch(request('/docs/scripts/json/save.json', undefined, 'POST'), env);
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get('content-type'), 'application/json');
+  assert.deepEqual(body, { result: 'ok' });
+});
+
+test('still serves save.json as a static asset for GET/HEAD', async() => {
+  const worker = loadWorker();
+
+  const getResponse = await worker.fetch(request('/docs/scripts/json/save.json', undefined, 'GET'), env);
+
+  assert.equal(await getResponse.text(), 'static-asset-passthrough');
+
+  const headResponse = await worker.fetch(request('/docs/scripts/json/save.json', undefined, 'HEAD'), env);
+
+  assert.equal(await headResponse.text(), 'static-asset-passthrough');
 });

--- a/docs/cloudflare/_worker.js
+++ b/docs/cloudflare/_worker.js
@@ -34,6 +34,7 @@
  *  17. /docs/react, /docs/angular, etc.    → framework homes
  *  18. /{/}                               → /docs
  *  19. /docs{/}                           → /docs/(framework)/ (cookie)
+ * 19a. POST /docs/scripts/json/save.json  → mock 200 JSON (saving-data demo)
  *  20. Static asset fallback (env.ASSETS)
  */
 
@@ -1272,6 +1273,19 @@ async function route(request, env) {
           return redirect301(abs(dest, url));
         }
       }
+    }
+
+    // -- 18a. POST to the saving-data demo's mock save endpoint --------------
+    // Cloudflare Pages' static-asset handler only serves GET/HEAD; a POST to
+    // a static file returns 405. The saving-data guide's demo intentionally
+    // POSTs here to illustrate a save request (see saving-data.md's "just a
+    // mockup" note), so answer it directly instead of falling through to
+    // env.ASSETS, which would 405.
+    if (path === '/docs/scripts/json/save.json' && request.method !== 'GET' && request.method !== 'HEAD') {
+      return new Response(JSON.stringify({ result: 'ok' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
     }
 
     // -- 19. Fallback: serve static assets via env.ASSETS --------------------


### PR DESCRIPTION
### Context

The PR fixes a 405 error logged in the browser console when clicking **Save** (or toggling autosave) in the demo on the "Saving data" guide (`/docs/*-data-grid/saving-data/`).

The demo's `example1` (duplicated across the JS, TS, React, Angular, and Vue variants) POSTs to `/docs/scripts/json/save.json`, a static JSON fixture with no backend behind it. Cloudflare Pages' static-asset handler only serves `GET`/`HEAD` for static files, so a `POST` returns `405 Method Not Allowed`. `mode: 'no-cors'` makes the fetch's own `.then()` resolve regardless (the demo still shows "Data saved"), but Chrome DevTools independently logs the raw failed network transaction to the console, which is the error reported in DEV-2034.

This is a regression from the Netlify → Cloudflare Pages migration: Netlify's static-asset CDN served file content regardless of HTTP method, while Cloudflare Pages correctly enforces GET/HEAD-only on static assets. `docs/cloudflare/_worker.js` is the sole, hand-maintained routing authority for the docs site, so the fix adds a narrow rule there that intercepts non-GET/HEAD requests to `/docs/scripts/json/save.json` and answers with a mock `200 {"result":"ok"}` response, restoring the pre-migration behavior. No example code or guide content changed - the guide already documents this as "just a mockup."

### How has this been tested?

- Added a regression test to `docs/cloudflare/__tests__/_worker.test.mjs`: `POST /docs/scripts/json/save.json` now returns `200` with the mock JSON body instead of falling through to the static-asset handler.
- Added a companion test confirming `GET`/`HEAD` to the same path still serve the real static asset (rule doesn't swallow legitimate traffic).
- Ran the full worker suite: `node --test docs/cloudflare/__tests__/_worker.test.mjs` - all 12 tests pass.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2034

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

(This change is confined to the docs site's Cloudflare Pages worker, `docs/cloudflare/_worker.js`.)

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2034

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-path docs routing change with regression tests; no library or auth/data impact.
> 
> **Overview**
> Fixes **405 Method Not Allowed** in DevTools when the **Saving data** guide demo POSTs to `/docs/scripts/json/save.json` on Cloudflare Pages (static assets only allow GET/HEAD).
> 
> `docs/cloudflare/_worker.js` adds rule **19a**: non-GET/HEAD requests to that path return **200** with `{"result":"ok"}` instead of falling through to `env.ASSETS`. GET/HEAD still serve the static fixture.
> 
> Worker tests now pass an HTTP **method** on fake requests and assert POST behavior plus unchanged GET/HEAD passthrough (DEV-2034).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c0018b67a0902e26d1815e05f50d7a92375721c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->