### PR TITLE
DEV-844: Document modifyCopyableRange hook and fix its return type

### DIFF
--- a/.changelogs/13022.json
+++ b/.changelogs/13022.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed the `modifyCopyableRange` hook's type declaration to reflect that its return value is used.",
+  "type": "fixed",
+  "issueOrPR": 13022,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/__tests__/core/settings.types.ts
+++ b/handsontable/src/__tests__/core/settings.types.ts
@@ -1,6 +1,6 @@
 import type Handsontable from 'handsontable';
 import HyperFormula from 'hyperformula';
-import type { CellProperties, CellCoords } from 'handsontable';
+import type { CellProperties, CellCoords, RangeType } from 'handsontable';
 
 // Helpers to verify multiple different settings and prevent TS control-flow from eliminating unreachable values
 declare function oneOf<T extends Array<string | number | boolean | undefined | null | object>>(...args: T): T[number];
@@ -749,7 +749,11 @@ const allSettings: Required<Handsontable.GridSettings> = {
     const _column: number = column;
     const _source: string | undefined = source;
   },
-  modifyCopyableRange: (copyableRanges) => {},
+  modifyCopyableRange: (copyableRanges) => {
+    const _copyableRanges: RangeType[] = copyableRanges;
+
+    return _copyableRanges;
+  },
   modifyFiltersMultiSelectValue: (value, meta) => '123',
   modifyFocusedElement: (row, column, focusedElement) => document.createElement('TD'),
   modifyData: () => {},

--- a/handsontable/src/core/hooks/constants.ts
+++ b/handsontable/src/core/hooks/constants.ts
@@ -2143,10 +2143,69 @@ export const REGISTERED_HOOKS = [
   'modifyAutofillRange',
 
   /**
-   * Fired to allow modifying the copyable range with a callback function.
+   * Fired by {@link CopyPaste} plugin to allow modifying the range that is about to be copied or cut. It's
+   * recalculated whenever the selection changes, and again right before the values are copied or cut to the
+   * clipboard. This hook is fired when {@link Options#copyPaste} option is enabled. It's also fired by the
+   * {@link Autofill} plugin while a fill-handle drag is in progress, to determine the range that would be
+   * copied if the drag ended at the current position.
    *
    * @event Hooks#modifyCopyableRange
-   * @param {Array[]} copyableRanges Array of objects defining copyable cells.
+   * @param {object[]} copyableRanges An array of objects with ranges of the visual indexes (`startRow`, `startCol`,
+   *                                  `endRow`, `endCol`) that are copyable.
+   * @returns {object[]|undefined} The modified array of copyable ranges. If nothing is returned, the ranges
+   *                                passed to the callback are used unchanged.
+   * @example
+   * ::: only-for javascript
+   * ```js
+   * new Handsontable(element, {
+   *   // Copy only the last column of each selected range, regardless of the selection width.
+   *   modifyCopyableRange(copyableRanges) {
+   *     return copyableRanges.map(({ startRow, endRow, endCol }) => ({
+   *       startRow,
+   *       endRow,
+   *       startCol: endCol,
+   *       endCol,
+   *     }));
+   *   }
+   * });
+   * ```
+   * :::
+   *
+   * ::: only-for react
+   * ```jsx
+   * <HotTable
+   *   // Copy only the last column of each selected range, regardless of the selection width.
+   *   modifyCopyableRange={(copyableRanges) => {
+   *     return copyableRanges.map(({ startRow, endRow, endCol }) => ({
+   *       startRow,
+   *       endRow,
+   *       startCol: endCol,
+   *       endCol,
+   *     }));
+   *   }}
+   * />
+   * ```
+   * :::
+   *
+   * ::: only-for angular
+   *```ts
+   * settings = {
+   *   // Copy only the last column of each selected range, regardless of the selection width.
+   *   modifyCopyableRange: (copyableRanges) => {
+   *     return copyableRanges.map(({ startRow, endRow, endCol }) => ({
+   *       startRow,
+   *       endRow,
+   *       startCol: endCol,
+   *       endCol,
+   *     }));
+   *   },
+   * };
+   * ```
+   *
+   * ```html
+   * <hot-table [settings]="settings"></hot-table>
+   * ```
+   * :::
    */
   'modifyCopyableRange',
 

--- a/handsontable/src/core/settings.ts
+++ b/handsontable/src/core/settings.ts
@@ -539,7 +539,7 @@ export interface GridSettings {
   modifyColumnHeaderHeight?: () => void;
   modifyColumnHeaderValue?: (headerValue: string, visualColumnIndex: number, headerLevel: number) => void | string;
   modifyColWidth?: (width: number, column: number, source?: string) => void | number;
-  modifyCopyableRange?: (copyableRanges: RangeType[]) => void;
+  modifyCopyableRange?: (copyableRanges: RangeType[]) => RangeType[] | void;
   modifyData?: (row: number, column: number, valueHolder: { value: CellValue }, ioMode: 'get' | 'set') => void;
   modifyFiltersMultiSelectValue?: (value: string, meta: CellProperties) => void | string;
   modifyFocusedElement?: (row: number, column: number, focusedElement: HTMLElement) => void | HTMLElement;

--- a/handsontable/src/plugins/copyPaste/__tests__/hooks/modifyCopyableRange.spec.js
+++ b/handsontable/src/plugins/copyPaste/__tests__/hooks/modifyCopyableRange.spec.js
@@ -1,0 +1,66 @@
+describe('CopyPaste', () => {
+  const id = 'testContainer';
+
+  beforeEach(function() {
+    this.$container = $(`<div id="${id}"></div>`).appendTo('body');
+    // Installing spy stabilizes the tests. Without that on CI and real browser there are some
+    // differences in results.
+    spyOn(document, 'execCommand');
+  });
+
+  afterEach(function() {
+    if (this.$container) {
+      destroy();
+      this.$container.remove();
+    }
+  });
+
+  describe('`modifyCopyableRange` hook', () => {
+    it('should be called with the ranges that are about to be copied', async() => {
+      const modifyCopyableRange = jasmine.createSpy('modifyCopyableRange');
+
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        copyPaste: true,
+        modifyCopyableRange,
+      });
+
+      const copyEvent = getClipboardEvent();
+      const plugin = getPlugin('CopyPaste');
+
+      await selectCell(1, 2, 3, 4);
+
+      plugin.copyCellsOnly();
+      plugin.onCopy(copyEvent); // emulate native "copy" event
+
+      expect(modifyCopyableRange).toHaveBeenCalledWith(
+        [{ startRow: 1, startCol: 2, endRow: 3, endCol: 4 }],
+      );
+    });
+
+    it('should narrow down what gets copied to the clipboard when a smaller range is returned', async() => {
+      handsontable({
+        data: createSpreadsheetData(5, 5),
+        copyPaste: true,
+        modifyCopyableRange(copyableRanges) {
+          return copyableRanges.map(({ startRow, endRow, startCol, endCol }) => ({
+            startRow,
+            endRow,
+            startCol: Math.max(startCol, endCol),
+            endCol,
+          }));
+        },
+      });
+
+      const copyEvent = getClipboardEvent();
+      const plugin = getPlugin('CopyPaste');
+
+      await selectCell(1, 2, 3, 4);
+
+      plugin.copyCellsOnly();
+      plugin.onCopy(copyEvent); // emulate native "copy" event
+
+      expect(copyEvent.clipboardData.getData('text/plain')).toBe('E2\nE3\nE4');
+    });
+  });
+});


### PR DESCRIPTION
### Context

The PR fixes the `modifyCopyableRange` hook's documentation and type, which were both incomplete. The JSDoc only said the hook is "fired to allow modifying the copyable range," without stating when it fires, the shape of the data it receives, or that its return value is used — even though `CopyPaste` (`copyPaste.ts:485`) already replaces `this.copyableRanges` with whatever the hook returns, and `Autofill` (`autofill.ts:223`) also fires it during a fill-handle drag. The TypeScript signature was also out of sync: it typed the callback as returning `void`, while runtime code has always consumed a returned `RangeType[]`.

### How has this been tested?

- Added a TypeScript regression case to `settings.types.ts` asserting the callback can return `RangeType[]`.
- Added `modifyCopyableRange.spec.js` (E2E): asserts the hook is called with the pending copyable ranges, and that returning a modified range actually narrows what lands in the clipboard.
- `npm run test:types --prefix handsontable`
- `npm run test:unit --prefix handsontable -- --testPathPattern=settings`
- `npm run test:e2e --prefix handsontable -- --testPathPattern=copyPaste/__tests__/hooks/modifyCopyableRange`
- `npm run eslint --prefix handsontable` on all changed files

No `.unit.js` was added — the changed behavior is clipboard integration with no isolable pure logic to unit-test; it's covered by the E2E spec plus the type regression test.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-844

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-844

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and typing only; runtime copy/paste logic is unchanged. E2E tests lock in existing hook behavior.
> 
> **Overview**
> Aligns **documentation and TypeScript** for `modifyCopyableRange` with behavior that already exists at runtime: CopyPaste replaces `copyableRanges` with the hook’s return value, and Autofill also uses this hook during fill-handle drags.
> 
> The **`GridSettings` signature** now allows returning `RangeType[] | void` instead of only `void`. Hook JSDoc in `constants.ts` is expanded with when the hook runs, the `startRow`/`startCol`/`endRow`/`endCol` payload, that an omitted return keeps the input ranges, and JS/React/Angular examples.
> 
> Adds a **type regression** in `settings.types.ts` and **CopyPaste E2E tests** that the hook receives the pending ranges and that returning a narrower range changes clipboard text. Includes a changelog entry for the type fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 577c89d22cae82f32323dde70f48161172fa81b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->