### PR TITLE
DEV-846: Document undoRedo done() with an example

### DIFF
--- a/docs/content/guides/accessories-and-menus/undo-redo/undo-redo.md
+++ b/docs/content/guides/accessories-and-menus/undo-redo/undo-redo.md
@@ -140,6 +140,38 @@ if (undoRedo.isRedoAvailable()) {
 undoRedo.clear();
 ```
 
+## Registering a custom undoable action
+
+Use [`done()`](@/api/undoRedo.md#done) to add an action to the undo stack that isn't tracked by default, such as a direct [`setCellMeta()`](@/api/core.md#setcellmeta) update.
+
+Call `done()` with a function that returns an action object. The action object needs an `undo()` method and a `redo()` method, each receiving the Handsontable instance and a callback to call once the operation finishes.
+
+```js
+function setCellBackgroundColor(row, col, className) {
+  const undoRedo = hot.getPlugin('undoRedo');
+  const previousClassName = hot.getCellMeta(row, col).className;
+
+  undoRedo.done(() => ({
+    actionType: 'cellBackgroundColor',
+    undo(instance, callback) {
+      instance.setCellMeta(row, col, 'className', previousClassName);
+      instance.render();
+      callback();
+    },
+    redo(instance, callback) {
+      instance.setCellMeta(row, col, 'className', className);
+      instance.render();
+      callback();
+    },
+  }), 'cellBackgroundColor');
+
+  hot.setCellMeta(row, col, 'className', className);
+  hot.render();
+}
+```
+
+After you call `setCellBackgroundColor()`, pressing <kbd>**Ctrl**</kbd>/<kbd>⌘</kbd>+<kbd>**Z**</kbd> reverts the color change, and pressing <kbd>**Ctrl**</kbd>/<kbd>⌘</kbd>+<kbd>**Y**</kbd> reapplies it.
+
 ## Known limitations
 
 UndoRedo does not record every possible operation.

--- a/handsontable/src/plugins/undoRedo/undoRedo.ts
+++ b/handsontable/src/plugins/undoRedo/undoRedo.ts
@@ -162,6 +162,32 @@ export class UndoRedo extends BasePlugin {
   /**
    * Stash information about performed actions.
    *
+   * @example
+   * ```js
+   * // Register a custom action, for example when setting cell metadata directly
+   * // (a change that UndoRedo doesn't track by default).
+   * function setCellBackgroundColor(row, col, className) {
+   *   const undoRedo = hot.getPlugin('undoRedo');
+   *   const previousClassName = hot.getCellMeta(row, col).className;
+   *
+   *   undoRedo.done(() => ({
+   *     actionType: 'cellBackgroundColor',
+   *     undo(instance, callback) {
+   *       instance.setCellMeta(row, col, 'className', previousClassName);
+   *       instance.render();
+   *       callback();
+   *     },
+   *     redo(instance, callback) {
+   *       instance.setCellMeta(row, col, 'className', className);
+   *       instance.render();
+   *       callback();
+   *     },
+   *   }), 'cellBackgroundColor');
+   *
+   *   hot.setCellMeta(row, col, 'className', className);
+   *   hot.render();
+   * }
+   * ```
    * @fires Hooks#beforeUndoStackChange
    * @fires Hooks#afterUndoStackChange
    * @fires Hooks#beforeRedoStackChange


### PR DESCRIPTION
### Context

The PR adds a usage example for the `UndoRedo` plugin's `done()` method, which was public but undocumented. `done()` lets a custom action register itself on the undo/redo stack (this is how built-in tracked actions like filtering already work internally), but the guide never demonstrated it, and the method had no `@example` in its JSDoc.

This adds:
- An `@example` block to `done()`'s JSDoc in `undoRedo.ts`, showing a custom action for a `setCellMeta()` change (something UndoRedo doesn't track by default).
- A new "Registering a custom undoable action" subsection in the undo-redo guide, using the same example, with a link to the `done()` API reference.

### How has this been tested?

- `npm --prefix handsontable run eslint` -- passes with no issues.
- No behavior change (JSDoc/documentation only), so no new unit/E2E tests are needed.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-846

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-846

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and JSDoc only; no runtime or API behavior changes.
> 
> **Overview**
> Documents how to register **custom undo/redo actions** with the public [`done()`](@/api/undoRedo.md#done) API, which was previously undocumented.
> 
> A new **"Registering a custom undoable action"** section in the undo-redo guide explains calling `done()` with a factory that returns an object with `actionType`, `undo()`, and `redo()`, using a `setCellMeta()` / cell background color example for changes UndoRedo does not track by default. The same example is added as an `@example` on `done()` in `undoRedo.ts`, linked from the guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb8e085a8c0b01f12815f2b0c09439e2838261d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->