### PR TITLE
DEV-842: Fix misleading allowEmpty JSDoc tip for text cell type

### DIFF
--- a/handsontable/src/dataMap/metaManager/metaSchema.ts
+++ b/handsontable/src/dataMap/metaManager/metaSchema.ts
@@ -202,7 +202,11 @@ export default (): Record<string, unknown> => {
      * | `false`          | - Don't accept `null`, `undefined` and `''` values<br>- Mark cells that contain `null`, `undefined` or `''` values with as `invalid` |
      *
      * ::: tip
-     * To use the [`allowEmpty`](#allowempty) option, you need to set the [`validator`](#validator) option (or the [`type`](#type) option).
+     * The [`allowEmpty`](#allowempty) option only takes effect when the cell has a [`validator`](#validator).
+     * You can set a validator directly, or use a [`type`](#type) that comes with a built-in validator,
+     * such as `numeric`, `date`, `time`, `autocomplete`, `dropdown`, or `multiSelect`.
+     * Types without a built-in validator, such as `text`, `checkbox`, `password`, and `handsontable`,
+     * ignore the `allowEmpty` option unless you also set a `validator`.
      * :::
      *
      * This option can be set at any level of the [cascading configuration](@/guides/getting-started/configuration-options/configuration-options.md#cascading-configuration):


### PR DESCRIPTION
### Context

The PR fixes a misleading `allowEmpty` JSDoc tip in `metaSchema.ts`. The tip claimed that setting the `type` option alone was enough to make `allowEmpty` work, but that's only true for types that ship a built-in `validator` (`numeric`, `date`, `time`, `autocomplete`, `dropdown`, `multiSelect`). Types without a built-in validator, such as `text`, `checkbox`, `password`, and `handsontable`, silently ignore `allowEmpty` unless a `validator` is also set. The tip now states this precisely.

DEV-842: https://app.clickup.com/t/9015210959/DEV-842

### How has this been tested?

- Docs-only JSDoc correction; no behavior change to verify.
- `npx eslint src/dataMap/metaManager/metaSchema.ts` — no issues.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-842

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-842

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change in metaSchema JSDoc; no runtime or API behavior changes.
> 
> **Overview**
> Updates the JSDoc tip for **`allowEmpty`** in `metaSchema.ts` so it no longer implies that setting **`type`** alone is enough.
> 
> The tip now states that **`allowEmpty` only applies when the cell has a `validator`**—either set explicitly or via a type with a built-in validator (`numeric`, `date`, `time`, `autocomplete`, `dropdown`, `multiSelect`). It also notes that types such as **`text`**, **`checkbox`**, **`password`**, and **`handsontable`** ignore **`allowEmpty`** unless a **`validator`** is configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32e842954ea3d923f32ba5337c453674588f21ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->