### PR TITLE
DEV-847: Document keyboard shortcuts for all cell types

### DIFF
--- a/docs/content/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md
+++ b/docs/content/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md
@@ -91,7 +91,7 @@ The [`trimDropdown`](@/api/options.md#trimdropdown) option controls the dropdown
 
 ## Autocomplete strict mode
 
-This is the same example as above, the difference being that `autocomplete` now runs in strict mode. In this mode, the autocomplete cells will only accept values that are defined in the source array. The mouse and keyboard bindings are identical to the `Handsontable` cell type but with the differences below:
+This is the same example as above, the difference being that `autocomplete` now runs in strict mode. In this mode, the autocomplete cells will only accept values that are defined in the source array. The mouse and keyboard bindings are identical to the [`handsontable` cell type](@/guides/cell-types/handsontable-cell-type/handsontable-cell-type.md) but with the differences below:
 
 - If there is at least one option visible, there always is a selection in HOT-in-HOT
 - When the first row is selected, pressing <kbd>**Arrow Up**</kbd> does not deselect HOT-in-HOT. Instead, it behaves as the <kbd>**Enter**</kbd> key but moves the selection in the main HOT upwards
@@ -496,6 +496,10 @@ The left column uses the default behavior (`allowHtml: false`) — HTML tags in 
 ## Result
 
 After configuring the autocomplete cell type, cells display a text input that shows matching suggestions as the user types. In strict mode, only values from the source list are accepted. In flexible mode, users can also enter custom values not in the list.
+
+## Keyboard shortcuts
+
+The autocomplete cell editor shares its keyboard shortcuts with the [`handsontable` editor](@/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md#handsontable-editor-keyboard-shortcuts). In strict mode, a few of these shortcuts behave differently -- see [Autocomplete strict mode](#autocomplete-strict-mode).
 
 ## Related articles
 

--- a/docs/content/guides/cell-types/checkbox-cell-type/checkbox-cell-type.md
+++ b/docs/content/guides/cell-types/checkbox-cell-type/checkbox-cell-type.md
@@ -246,6 +246,8 @@ After configuring the checkbox cell type, cells display an interactive checkbox.
 | <kbd>**Delete**</kbd>    | <kbd>**Delete**</kbd>    | Uncheck the checkbox          | &cross; | &check; |
 | <kbd>**Backspace**</kbd> | <kbd>**Backspace**</kbd> | Uncheck the checkbox          | &cross; | &check; |
 
+For the full list of default keyboard shortcuts, see [keyboard shortcuts](@/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md#checkbox-editor-keyboard-shortcuts).
+
 ## Related articles
 
 **Related guides**

--- a/docs/content/guides/cell-types/date-cell-type/date-cell-type.md
+++ b/docs/content/guides/cell-types/date-cell-type/date-cell-type.md
@@ -380,6 +380,10 @@ The [`dateFormat`](@/api/options.md#dateformat) option controls how dates are di
 
 After configuring the date cell type, cells display dates formatted according to your `dateFormat` configuration. Clicking an `intl-date` or `date` cell opens a native date picker. Source data is stored in ISO 8601 format (`YYYY-MM-DD`) regardless of the display format.
 
+## Keyboard shortcuts
+
+The `intl-date` and `date` cell editors open the browser's native date picker. Keyboard navigation inside the picker comes from the browser, so it varies between browsers and operating systems. Outside the picker, the standard [edition keyboard shortcuts](@/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md#edition-keyboard-shortcuts) apply.
+
 ## Related articles
 
 **Related guides**

--- a/docs/content/guides/cell-types/dropdown-cell-type/dropdown-cell-type.md
+++ b/docs/content/guides/cell-types/dropdown-cell-type/dropdown-cell-type.md
@@ -346,6 +346,10 @@ In the example below, the **Job title (default)** column uses the default height
 
 After configuring the dropdown cell type, cells display a button that opens a dropdown list of options. Users can search the list by typing. Only values from the source list are accepted. The selected value is stored in the data source.
 
+## Keyboard shortcuts
+
+The dropdown cell editor is an [autocomplete](@/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md) editor with strict mode always on, so it uses the same keyboard shortcuts as [Autocomplete strict mode](@/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md#autocomplete-strict-mode). See the [keyboard shortcuts](@/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md#dropdown-editor-keyboard-shortcuts) reference for details.
+
 ## Related articles
 
 **Related guides**

--- a/docs/content/guides/cell-types/handsontable-cell-type/handsontable-cell-type.md
+++ b/docs/content/guides/cell-types/handsontable-cell-type/handsontable-cell-type.md
@@ -90,6 +90,8 @@ The first column uses the handsontable cell type for a searchable manufacturer l
 | <kbd>**Arrow Right**</kbd> | Move text cursor in the text field to the left. If cursor was at start, behave as <kbd>**Enter**</kbd> but move main HOT selection to the left |
 | <kbd>**Arrow Left**</kbd> | Move text cursor in the text field to the right. If cursor was at end, behave as <kbd>**Tab**</kbd> |
 
+For the full list of default keyboard shortcuts, see [keyboard shortcuts](@/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md#handsontable-editor-keyboard-shortcuts).
+
 ## Result
 
 After configuring the Handsontable cell type, cells display a text input with a trigger icon. Activating the cell opens a second embedded grid that users can navigate and select from. The selected row value is written back to the parent cell.

--- a/docs/content/guides/cell-types/multiselect-cell-type/multiselect-cell-type.md
+++ b/docs/content/guides/cell-types/multiselect-cell-type/multiselect-cell-type.md
@@ -144,6 +144,8 @@ When the dropdown opens, the initial focus depends on the [**`searchInput`**](@/
 
 Each selection (or deselection) immediately updates the underlying cell data.
 
+For the full list of default keyboard shortcuts, see [keyboard shortcuts](@/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md#multiselect-editor-keyboard-shortcuts).
+
 ## Other options
 
 The MultiSelect cell type provides several configuration options to tailor its behavior:

--- a/docs/content/guides/cell-types/numeric-cell-type/numeric-cell-type.md
+++ b/docs/content/guides/cell-types/numeric-cell-type/numeric-cell-type.md
@@ -422,6 +422,10 @@ Two options control how the validator treats values:
 
 After configuring the numeric cell type, cells right-align their values and display them using the format you defined in `numericFormat`. Invalid (non-numeric) values are marked as invalid -- see [Validate numbers](#validate-numbers). The underlying data source stores the raw number.
 
+## Keyboard shortcuts
+
+The numeric cell editor is a text editor, so it uses the standard [edition keyboard shortcuts](@/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md#edition-keyboard-shortcuts). It has no numeric-specific key bindings. Type a period (`.`) or a comma (`,`) to enter a decimal separator -- see [Editor behavior](#editor-behavior).
+
 ## Related articles
 
 **Related guides**

--- a/docs/content/guides/cell-types/password-cell-type/password-cell-type.md
+++ b/docs/content/guides/cell-types/password-cell-type/password-cell-type.md
@@ -215,6 +215,10 @@ When `hashRevealDelay` is set, the editor switches from a native `<input type="p
 
 After configuring the password cell type, cells display asterisks instead of the actual value. The editor uses an `<input type="password">` field (or `<input type="text">` when `hashRevealDelay` is set). The actual data is stored in plain text in the data source and is not encrypted by Handsontable.
 
+## Keyboard shortcuts
+
+The password cell editor is a text editor, so it uses the standard [edition keyboard shortcuts](@/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md#edition-keyboard-shortcuts). It has no password-specific key bindings.
+
 ## Related articles
 
 **Related guides**

--- a/docs/content/guides/cell-types/time-cell-type/time-cell-type.md
+++ b/docs/content/guides/cell-types/time-cell-type/time-cell-type.md
@@ -403,6 +403,10 @@ The [`timeFormat`](@/api/options.md#timeformat) option controls how times are di
 
 After configuring the time cell type, cells display time values formatted according to your `timeFormat` configuration. Clicking an `intl-time` or `time` cell opens a native time picker. Source data is stored in 24-hour format (`HH:mm`, `HH:mm:ss`, or `HH:mm:ss.SSS`) regardless of the display format.
 
+## Keyboard shortcuts
+
+The `intl-time` and `time` cell editors open the browser's native time picker. Keyboard navigation inside the picker comes from the browser, so it varies between browsers and operating systems. Outside the picker, the standard [edition keyboard shortcuts](@/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md#edition-keyboard-shortcuts) apply.
+
 ## Related articles
 
 **Related guides**

--- a/docs/content/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md
+++ b/docs/content/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md
@@ -146,6 +146,42 @@ These keyboard shortcuts work in the [`select`](@/guides/cell-types/select-cell-
 | <kbd>**↑**</kbd> | <kbd>**↑**</kbd> | Select the previous option      | &cross; | &cross; |
 | <kbd>**↓**</kbd> | <kbd>**↓**</kbd> | Select the next option          | &cross; | &cross; |
 
+### Autocomplete editor keyboard shortcuts
+
+The [`autocomplete`](@/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md) cell editor uses the same keyboard shortcuts as the [`handsontable` editor](#handsontable-editor-keyboard-shortcuts). In strict mode, a few of these shortcuts behave differently -- see [Autocomplete strict mode](@/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md#autocomplete-strict-mode).
+
+### Dropdown editor keyboard shortcuts
+
+The [`dropdown`](@/guides/cell-types/dropdown-cell-type/dropdown-cell-type.md) cell editor is an [autocomplete editor](#autocomplete-editor-keyboard-shortcuts) with strict mode always on, so it uses the same keyboard shortcuts as [Autocomplete strict mode](@/guides/cell-types/autocomplete-cell-type/autocomplete-cell-type.md#autocomplete-strict-mode).
+
+### MultiSelect editor keyboard shortcuts
+
+These keyboard shortcuts work in the [`multiselect`](@/guides/cell-types/multiselect-cell-type/multiselect-cell-type.md) cell editor.
+
+| Windows                             | macOS                               | Action                                                                                                                                          |  Excel  | Sheets  |
+| ------------------------------------ | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ | :-----: | :-----: |
+| <kbd>**↑**</kbd> / <kbd>**↓**</kbd>  | <kbd>**↑**</kbd> / <kbd>**↓**</kbd>  | Move the focus between items in the dropdown list                                                                                                | &cross; | &cross; |
+| <kbd>**Space**</kbd>                 | <kbd>**Space**</kbd>                 | Toggle the selection of the focused item                                                                                                         | &cross; | &cross; |
+| <kbd>**Enter**</kbd>                 | <kbd>**Enter**</kbd>                 | Toggle the focused item's selection, or close the editor and commit the selection, depending on the [`enterCommits`](@/api/options.md#entercommits) option | &cross; | &cross; |
+
+For the full behavior, including how [`searchInput`](@/api/options.md#searchinput) affects initial focus, see [Keyboard navigation](@/guides/cell-types/multiselect-cell-type/multiselect-cell-type.md#keyboard-navigation).
+
+### Numeric editor keyboard shortcuts
+
+The [`numeric`](@/guides/cell-types/numeric-cell-type/numeric-cell-type.md) cell editor is a text editor, so it uses the standard [edition keyboard shortcuts](#edition-keyboard-shortcuts) above. It has no numeric-specific key bindings.
+
+### Date editor keyboard shortcuts
+
+The [`intl-date`/`date`](@/guides/cell-types/date-cell-type/date-cell-type.md) cell editor opens the browser's native date picker. Keyboard navigation inside the picker comes from the browser, so it varies between browsers and operating systems.
+
+### Time editor keyboard shortcuts
+
+The [`intl-time`/`time`](@/guides/cell-types/time-cell-type/time-cell-type.md) cell editor opens the browser's native time picker. Keyboard navigation inside the picker comes from the browser, so it varies between browsers and operating systems.
+
+### Password editor keyboard shortcuts
+
+The [`password`](@/guides/cell-types/password-cell-type/password-cell-type.md) cell editor is a text editor, so it uses the standard [edition keyboard shortcuts](#edition-keyboard-shortcuts) above. It has no password-specific key bindings.
+
 ## Plugin keyboard shortcuts
 
 These keyboard shortcuts work with particular plugins.


### PR DESCRIPTION
### Context

The PR adds missing keyboard-shortcut documentation for the remaining cell types and cross-links each cell-type guide with the general [keyboard shortcuts](https://handsontable.com/docs/javascript-data-grid/keyboard-shortcuts/) reference page.

Previously, only the checkbox, `handsontable`, and select cell types had keyboard-shortcut sections, and only the select page linked back to the general reference. This PR:

- Adds reciprocal links between the checkbox and `handsontable` cell-type pages and the general keyboard-shortcuts reference.
- Replaces the inline note on the autocomplete page with a proper "Keyboard shortcuts" section, and links its strict-mode note to the `handsontable` cell type page.
- Adds a "Keyboard shortcuts" section to the dropdown, numeric, date, time, and password cell-type pages (all previously missing any keyboard documentation).
- Notes that the date and time editors now use the browser's native date/time picker (Pikaday was removed in Handsontable 18.0), so keyboard navigation inside the picker is browser-dependent rather than a fixed key table.
- Adds matching subsections (Autocomplete, Dropdown, MultiSelect, Numeric, Date, Time, Password editors) to `keyboard-shortcuts.md`, including a full shortcut table for the MultiSelect editor.
- Bonus: links the MultiSelect cell-type page's existing "Keyboard navigation" section to a new reciprocal subsection on the reference page (same gap, found during the same pass).

### How has this been tested?

- Docs-only change; verified by reading the rendered Markdown and checking that all new anchor links (`#autocomplete-editor-keyboard-shortcuts`, `#dropdown-editor-keyboard-shortcuts`, `#multiselect-editor-keyboard-shortcuts`, `#numeric-editor-keyboard-shortcuts`, `#date-editor-keyboard-shortcuts`, `#time-editor-keyboard-shortcuts`, `#password-editor-keyboard-shortcuts`, `#edition-keyboard-shortcuts`) match the corresponding heading text.
- Cross-checked editor behavior against source (`handsontable/src/editors/`): confirmed `numericEditor` and `passwordEditor` extend `TextEditor` with no extra key bindings, `dropdownEditor` extends `autocompleteEditor` with `strict: true`, and `dateEditor`/`intlDateEditor`/`timeEditor`/`intlTimeEditor` use native browser inputs (Pikaday removed, see `dateEditor.ts:44`).

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-847

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-847

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no application code, data handling, or API modifications.
> 
> **Overview**
> **Documentation** fills gaps in keyboard-shortcut coverage for autocomplete, dropdown, multiselect, numeric, date, time, and password cell types, and ties each cell-type guide to the central [keyboard shortcuts](@/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md) page.
> 
> On **cell-type guides**, new or expanded **Keyboard shortcuts** sections explain editor behavior (e.g. autocomplete inherits `handsontable` keys with strict-mode exceptions; dropdown points at autocomplete strict mode; numeric/password defer to edition shortcuts). Checkbox and `handsontable` guides now link back to the reference anchors. Autocomplete strict mode now links to the `handsontable` cell type guide instead of a bare name.
> 
> On **`keyboard-shortcuts.md`**, new subsections document Autocomplete, Dropdown, MultiSelect (with a shortcut table), Numeric, Date, Time, and Password editors, including that date/time editors use the **native browser picker** (picker keys are OS/browser-dependent).
> 
> **Risk:** Low — Markdown and cross-links only; no runtime or API changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bccb0f8f16dbb72b3ae009eae49ed101b3c6fd94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->