### PR TITLE
DEV-858: Clarify registerCellType options

### DIFF
--- a/docs/content/guides/cell-types/cell-type/cell-type.md
+++ b/docs/content/guides/cell-types/cell-type/cell-type.md
@@ -250,7 +250,7 @@ This gives users a convenient way of defining which cell type should be used for
 To register your own alias use `Handsontable.cellTypes.registerCellType()` function. It takes two arguments:
 
 - `cellTypeName` - a string representing the cell type object
-- [`type`](@/api/options.md#type) - an object with keys [`editor`](@/api/options.md#editor), [`renderer`](@/api/options.md#renderer), and [`validator`](@/api/options.md#validator) that will be represented by `cellTypeName`
+- [`type`](@/api/options.md#type) - an object represented by `cellTypeName`. It can include cell behavior callbacks, such as [`editor`](@/api/options.md#editor), [`renderer`](@/api/options.md#renderer), and [`validator`](@/api/options.md#validator). It can also include Handsontable settings, such as [`readOnly`](@/api/options.md#readonly), [`className`](@/api/options.md#classname), and [`allowInvalid`](@/api/options.md#allowinvalid), or custom properties, such as `myCustomCellState`, available through `cellProperties`.
 
 If you'd like to register `copyablePasswordType` under alias `copyable-password`, you need to call:
 


### PR DESCRIPTION
### Context

The PR changes the Cell type guide for DEV-858. The `registerCellType()` argument description only mentioned `editor`, `renderer`, and `validator`, even though the registered cell type object can also include Handsontable settings and custom properties.

This updates the docs to mention settings such as `readOnly`, `className`, and `allowInvalid`, plus custom properties such as `myCustomCellState` available through `cellProperties`.

The old issue reference to `handsontable/types/cellTypes/base.d.ts` is obsolete. The `types/` directory no longer exists, and the current TypeScript source already accepts arbitrary cell type properties.

### How has this been tested?

- `ReadLints` for `docs/content/guides/cell-types/cell-type/cell-type.md` - no linter errors.
- `rtk npm --prefix docs run build` - attempted, but it fails on an unrelated `/angular-data-grid/disabled-cells` rendered HTML/cache route issue.
- `rtk rm -rf docs/.astro docs/dist && rtk npm --prefix docs run build` - attempted, same unrelated `/angular-data-grid/disabled-cells` failure.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-858

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-858

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change in the cell type guide; no runtime or API behavior changes.
> 
> **Overview**
> Updates the **Register custom cell type** section so the second `registerCellType()` argument is described as a full cell-type object, not only `editor`, `renderer`, and `validator`.
> 
> The bullet now states that the object may include **Handsontable settings** (e.g. `readOnly`, `className`, `allowInvalid`) and **custom properties** exposed on `cellProperties` (e.g. `myCustomCellState`), aligning the API list with the longer example later in the same guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17b2dc6a3c1b8c19091dd6fe348a8c26d3729fe8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->