### PR TITLE
DEV-854: Document manual resize setManualSize repainting

### DIFF
--- a/docs/content/guides/columns/column-width/column-width.md
+++ b/docs/content/guides/columns/column-width/column-width.md
@@ -243,6 +243,12 @@ Set the option [`manualColumnResize`](@/api/options.md#manualcolumnresize) to `t
 
 You can adjust the size of one or multiple columns simultaneously, even if the selected columns are not placed next to each other.
 
+::: tip
+
+When you set a column width programmatically with [`ManualColumnResize#setManualSize()`](@/api/manualColumnResize.md#setmanualsize), call `hot.render()` after the method call to repaint the grid. Values below `20px` are stored as `20px`.
+
+:::
+
 ::: only-for javascript
 
 ::: example #example4 --js 1 --ts 2

--- a/docs/content/guides/rows/row-height/row-height.md
+++ b/docs/content/guides/rows/row-height/row-height.md
@@ -186,6 +186,12 @@ Set the option [`manualRowResize`](@/api/options.md#manualrowresize) to `true` t
 
 You can adjust the size of one or multiple rows simultaneously, even if the selected rows are not placed next to each other.
 
+::: tip
+
+When you set a row height programmatically with [`ManualRowResize#setManualSize()`](@/api/manualRowResize.md#setmanualsize), call `hot.render()` after the method call to repaint the grid. Values below the theme's default row height are stored as the default row height.
+
+:::
+
 ::: only-for javascript
 
 ::: example #example4 --js 1 --ts 2

--- a/handsontable/src/plugins/manualColumnResize/manualColumnResize.ts
+++ b/handsontable/src/plugins/manualColumnResize/manualColumnResize.ts
@@ -244,7 +244,18 @@ export class ManualColumnResize extends BasePlugin {
   }
 
   /**
-   * Sets the new width for specified column index.
+   * Sets the new width for the specified visual column index.
+   *
+   * This method updates the plugin's internal width map. Call `render()` after `setManualSize()` to repaint the grid.
+   * Values lower than `20px` are saved as `20px`.
+   *
+   * @example
+   * ```js
+   * const resizePlugin = hot.getPlugin('manualColumnResize');
+   *
+   * resizePlugin.setManualSize(0, 120);
+   * hot.render();
+   * ```
    *
    * @param {number} column Visual column index.
    * @param {number} width Column width (no less than 20px).

--- a/handsontable/src/plugins/manualRowResize/manualRowResize.ts
+++ b/handsontable/src/plugins/manualRowResize/manualRowResize.ts
@@ -238,10 +238,21 @@ export class ManualRowResize extends BasePlugin {
   }
 
   /**
-   * Sets the new height for specified row index.
+   * Sets the new height for the specified visual row index.
+   *
+   * This method updates the plugin's internal height map. Call `render()` after `setManualSize()` to repaint the grid.
+   * Values lower than the theme's default row height are saved as the default row height.
+   *
+   * @example
+   * ```js
+   * const resizePlugin = hot.getPlugin('manualRowResize');
+   *
+   * resizePlugin.setManualSize(0, 40);
+   * hot.render();
+   * ```
    *
    * @param {number} row Visual row index.
-   * @param {number} height Row height.
+   * @param {number} height Row height (no less than the theme's default row height).
    * @returns {number} Returns new height.
    */
   setManualSize(row: number, height: number): number {


### PR DESCRIPTION
### Context

The PR fixes DEV-854 by clarifying how `setManualSize()` works for manual column and row resizing. The API docs now describe that the method updates the plugin's internal size map, requires `hot.render()` to repaint the grid, and clamps values below the supported minimum.

### How has this been tested?

- `rtk npm --prefix handsontable run build`
- `rtk npm --prefix docs run docs:api`
- `rtk npm --prefix handsontable run eslint`
- `rtk npm --prefix handsontable run stylelint`
- `ReadLints` on the changed source and docs files.
- `rtk git diff --check`

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-854

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-854

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and JSDoc only; no runtime logic changes.
> 
> **Overview**
> Clarifies **programmatic** column and row sizing via `ManualColumnResize#setManualSize()` and `ManualRowResize#setManualSize()` so callers know the method only updates the plugin’s internal size map and **`hot.render()`** is required to repaint the grid.
> 
> **JSDoc** on both plugins now states the repaint requirement, documents minimum stored sizes (**20px** for columns; theme default row height for rows), and adds usage examples. Matching **`::: tip`** blocks were added to the **column width** and **row height** guides under the manual resize sections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd34e8d0ecde6ee2aac446e3949f757e40cd7a14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->