### PR TITLE
DEV-904: Fix docs TOC keyboard navigation

### DIFF
--- a/docs/src/components/PageSidebar.astro
+++ b/docs/src/components/PageSidebar.astro
@@ -138,6 +138,23 @@ if (actions?.claude) {
 )}
 
 <script>
+  import { attachTocKeyboardNav } from '../scripts/a11y-utils';
+
+  function initDesktopTocKeyboardNav() {
+    const desktopToc = document.querySelector('.right-sidebar-panel starlight-toc') as HTMLElement | null;
+
+    if (!desktopToc || desktopToc.dataset.keyboardNavInitialized === 'true') return;
+
+    desktopToc.dataset.keyboardNavInitialized = 'true';
+    attachTocKeyboardNav(desktopToc);
+  }
+
+  customElements.whenDefined('starlight-toc').then(initDesktopTocKeyboardNav);
+  document.addEventListener('astro:page-load', initDesktopTocKeyboardNav);
+  window.addEventListener('load', initDesktopTocKeyboardNav);
+</script>
+
+<script>
   const copyButton = document.querySelector(
     '#copy-markdown'
   ) as HTMLButtonElement;

--- a/docs/src/components/__tests__/toc-keyboard-nav.test.mjs
+++ b/docs/src/components/__tests__/toc-keyboard-nav.test.mjs
@@ -1,0 +1,188 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+import ts from 'typescript';
+
+const utilsPath = fileURLToPath(new URL('../../scripts/a11y-utils.ts', import.meta.url));
+const utilsSource = readFileSync(utilsPath, 'utf8');
+const transpiledUtils = ts.transpileModule(utilsSource, {
+  compilerOptions: {
+    module: ts.ModuleKind.ES2022,
+    target: ts.ScriptTarget.ES2022,
+  },
+}).outputText;
+
+const { attachTocKeyboardNav } = await import(
+  `data:text/javascript;charset=utf-8,${encodeURIComponent(transpiledUtils)}`
+);
+
+class FakeEvent {
+  constructor(type, options = {}) {
+    this.type = type;
+    this.key = options.key;
+    this.target = options.target ?? null;
+    this.defaultPrevented = false;
+  }
+
+  preventDefault() {
+    this.defaultPrevented = true;
+  }
+}
+
+class FakeLink {
+  constructor(href) {
+    this.href = href;
+    this.visible = true;
+    this.focusOptions = [];
+    this.listeners = new Map();
+  }
+
+  get offsetParent() {
+    return this.visible ? {} : null;
+  }
+
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  dispatchEvent(event) {
+    event.target = event.target ?? this;
+    for (const listener of this.listeners.get(event.type) ?? []) {
+      listener(event);
+    }
+  }
+
+  focus(options) {
+    globalThis.document.activeElement = this;
+    this.focusOptions.push(options);
+  }
+
+  closest(selector) {
+    return selector === 'a[href^="#"]' && this.href.startsWith('#') ? this : null;
+  }
+}
+
+class FakeToc {
+  constructor(links) {
+    this.links = links;
+    this.listeners = new Map();
+  }
+
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  dispatchEvent(event) {
+    for (const listener of this.listeners.get(event.type) ?? []) {
+      listener(event);
+    }
+  }
+
+  querySelectorAll(selector) {
+    assert.equal(selector, 'a[href^="#"]');
+
+    return this.links;
+  }
+}
+
+function setup() {
+  const previousDocument = globalThis.document;
+  const previousRaf = globalThis.requestAnimationFrame;
+  const rafCallbacks = [];
+  const links = [
+    new FakeLink('#beforeundostackchange'),
+    new FakeLink('#beforeunhidecolumns'),
+    new FakeLink('#afterchange'),
+  ];
+  const toc = new FakeToc(links);
+
+  globalThis.document = { activeElement: null };
+  globalThis.requestAnimationFrame = (callback) => {
+    rafCallbacks.push(callback);
+    return rafCallbacks.length;
+  };
+
+  attachTocKeyboardNav(toc);
+
+  return {
+    links,
+    toc,
+    rafCallbacks,
+    cleanup() {
+      globalThis.document = previousDocument;
+      globalThis.requestAnimationFrame = previousRaf;
+    },
+  };
+}
+
+test('TOC ArrowDown and ArrowUp keys move focus between links with wrapping', () => {
+  const { links, toc, cleanup } = setup();
+
+  try {
+    links[0].focus();
+
+    const arrowDown = new FakeEvent('keydown', { key: 'ArrowDown', target: links[0] });
+    toc.dispatchEvent(arrowDown);
+
+    assert.equal(arrowDown.defaultPrevented, true);
+    assert.equal(globalThis.document.activeElement, links[1]);
+
+    const arrowUp = new FakeEvent('keydown', { key: 'ArrowUp', target: links[1] });
+    toc.dispatchEvent(arrowUp);
+
+    assert.equal(arrowUp.defaultPrevented, true);
+    assert.equal(globalThis.document.activeElement, links[0]);
+
+    const wrapUp = new FakeEvent('keydown', { key: 'ArrowUp', target: links[0] });
+    toc.dispatchEvent(wrapUp);
+
+    assert.equal(globalThis.document.activeElement, links[2]);
+  } finally {
+    cleanup();
+  }
+});
+
+test('TOC Home and End keys move focus to boundary links', () => {
+  const { links, toc, cleanup } = setup();
+
+  try {
+    links[1].focus();
+
+    const end = new FakeEvent('keydown', { key: 'End', target: links[1] });
+    toc.dispatchEvent(end);
+
+    assert.equal(end.defaultPrevented, true);
+    assert.equal(globalThis.document.activeElement, links[2]);
+
+    const home = new FakeEvent('keydown', { key: 'Home', target: links[2] });
+    toc.dispatchEvent(home);
+
+    assert.equal(home.defaultPrevented, true);
+    assert.equal(globalThis.document.activeElement, links[0]);
+  } finally {
+    cleanup();
+  }
+});
+
+test('TOC click restores focus to the clicked link without scrolling again', () => {
+  const { links, toc, rafCallbacks, cleanup } = setup();
+
+  try {
+    const click = new FakeEvent('click', { target: links[0] });
+    toc.dispatchEvent(click);
+
+    assert.equal(rafCallbacks.length, 1);
+
+    rafCallbacks[0]();
+
+    assert.equal(globalThis.document.activeElement, links[0]);
+    assert.deepEqual(links[0].focusOptions, [{ preventScroll: true }]);
+  } finally {
+    cleanup();
+  }
+});

--- a/docs/src/scripts/a11y-utils.ts
+++ b/docs/src/scripts/a11y-utils.ts
@@ -4,6 +4,8 @@
  * - createFocusTrap: traps Tab / Shift+Tab within a container.
  * - attachDropdownKeyboardNav: adds Arrow, Home/End, Enter, Escape to
  *   any trigger + menu dropdown pair.
+ * - attachTocKeyboardNav: keeps keyboard navigation inside the desktop
+ *   table of contents after hash-link clicks.
  */
 
 // ── Focus trap ──────────────────────────────────────────────────────────
@@ -163,6 +165,69 @@ export function attachDropdownKeyboardNav(
         trigger.focus();
         break;
       }
+    }
+  });
+}
+
+// ── Table of contents keyboard navigation ────────────────────────────────
+
+/**
+ * Attach keyboard navigation to a visible table of contents.
+ */
+export function attachTocKeyboardNav(toc: HTMLElement): void {
+  function getLinks(): HTMLAnchorElement[] {
+    return Array.from(toc.querySelectorAll<HTMLAnchorElement>('a[href^="#"]'))
+      .filter((link) => link.offsetParent !== null);
+  }
+
+  function focusLink(index: number) {
+    const links = getLinks();
+    if (links.length === 0) return;
+
+    const wrappedIndex = (index + links.length) % links.length;
+
+    links[wrappedIndex].focus();
+  }
+
+  function currentIndex(): number {
+    return getLinks().indexOf(document.activeElement as HTMLAnchorElement);
+  }
+
+  toc.addEventListener('click', (e: MouseEvent) => {
+    const link = (e.target as HTMLElement).closest<HTMLAnchorElement>('a[href^="#"]');
+
+    if (!link) return;
+
+    requestAnimationFrame(() => {
+      link.focus({ preventScroll: true });
+    });
+  });
+
+  toc.addEventListener('keydown', (e: KeyboardEvent) => {
+    const links = getLinks();
+    const idx = currentIndex();
+
+    if (links.length === 0 || idx === -1) return;
+
+    switch (e.key) {
+      case 'ArrowDown':
+      case 'Down':
+        e.preventDefault();
+        focusLink(idx + 1);
+        break;
+      case 'ArrowUp':
+      case 'Up':
+        e.preventDefault();
+        focusLink(idx - 1);
+        break;
+      case 'Home':
+        e.preventDefault();
+        focusLink(0);
+        break;
+      case 'End':
+        e.preventDefault();
+        focusLink(links.length - 1);
+        break;
     }
   });
 }

--- a/docs/tests/tocKeyboardNavigation.spec.ts
+++ b/docs/tests/tocKeyboardNavigation.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from '@playwright/test';
+
+const PAGE_PATH = '/docs/javascript-data-grid/events-and-hooks/';
+
+test.beforeEach(async ({ page, baseURL }) => {
+  const url = new URL(baseURL?.toString() || '');
+
+  await page.context().addCookies([
+    {
+      name: 'CookieConsent',
+      value: '-2',
+      domain: url.hostname,
+      path: '/',
+      expires: -1,
+      httpOnly: false,
+      secure: false,
+      sameSite: 'Lax',
+    },
+    {
+      name: '70d6d6e3-3a3e-4392-a095-5fe2a6b8bd70',
+      value: process.env.PASS_COOKIE ?? '',
+      domain: 'dev.handsontable.com',
+      path: '/',
+      expires: -1,
+      httpOnly: false,
+      secure: false,
+      sameSite: 'Lax',
+    },
+  ]);
+});
+
+test.describe('Right-side table of contents keyboard navigation', () => {
+  test('keeps focus in the TOC after clicking an entry', async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto(PAGE_PATH);
+
+    const toc = page.locator('.right-sidebar-panel starlight-toc');
+    const tocLinks = toc.locator('a[href^="#"]:visible');
+    const clickedLink = tocLinks.nth(0);
+    const nextLink = tocLinks.nth(1);
+    const thirdLink = tocLinks.nth(2);
+
+    await expect(clickedLink).toBeVisible();
+    await expect(nextLink).toBeVisible();
+    await expect(thirdLink).toBeVisible();
+
+    const clickedHref = await clickedLink.getAttribute('href');
+    const nextHref = await nextLink.getAttribute('href');
+    const thirdHref = await thirdLink.getAttribute('href');
+    const activeTocHref = () => page.evaluate(() =>
+      document.activeElement?.closest('.right-sidebar-panel starlight-toc a')?.getAttribute('href') ?? ''
+    );
+
+    await clickedLink.click();
+
+    await expect.poll(activeTocHref).toBe(clickedHref);
+
+    await page.keyboard.press('Tab');
+    await expect.poll(activeTocHref).toBe(nextHref);
+
+    await page.keyboard.press('ArrowDown');
+    await expect.poll(activeTocHref).toBe(thirdHref);
+
+    await page.keyboard.press('ArrowUp');
+    await expect.poll(activeTocHref).toBe(nextHref);
+  });
+});


### PR DESCRIPTION
### Context

The PR fixes DEV-904 by keeping keyboard focus in the desktop right-side table of contents after users click a TOC entry. Without this, the browser hash navigation can make the next Tab start from the target heading in the main content instead of the next TOC link.

The change also adds Arrow Up, Arrow Down, Home, and End navigation between desktop TOC links while keeping the TOC as a normal navigation landmark.

### How has this been tested?

- `rtk npm --prefix docs run docs:test:plugins`
- `rtk npm --prefix docs run docs:lint`
- `BASE_URL=http://127.0.0.1:4321/docs rtk npm --prefix docs run docs:visual-test -- tests/tocKeyboardNavigation.spec.ts`

`rtk npm --prefix docs run build` was attempted, but it failed on an unrelated docs generated-cache/middleware issue for `angular-data-grid/disabled-cells`.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-904

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`
- [x] Documentation site

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-904

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only accessibility behavior on the sidebar TOC; no auth, data, or core product runtime changes.
> 
> **Overview**
> Fixes **DEV-904** by improving keyboard behavior on the desktop right-side table of contents so focus stays in the TOC instead of jumping to in-page headings after a hash link click.
> 
> Adds **`attachTocKeyboardNav`** in `a11y-utils.ts`: after a TOC hash click it refocuses the clicked link with `preventScroll: true`, and supports **Arrow Up/Down** (with wrap), **Home**, and **End** among visible `#` links. **`PageSidebar.astro`** initializes this once on `.right-sidebar-panel starlight-toc` when the custom element is ready and on Astro page loads.
> 
> Coverage includes a **Node unit test** for the helper and a **Playwright** spec that clicks a TOC entry and asserts Tab/arrow keys move focus between TOC links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cdce1c9a84fa8e65fdd625e920b78a22de2a6ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->