### PR TITLE
DEV-931: Fix false code snippet scrollbars

### DIFF
--- a/docs/src/components/__tests__/code-scrollbars.test.mjs
+++ b/docs/src/components/__tests__/code-scrollbars.test.mjs
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const codeCss = readFileSync(join(__dirname, '../../styles/components/code.css'), 'utf8');
+const expressiveCodeBlock = codeCss.slice(
+  codeCss.indexOf('.expressive-code {'),
+  codeCss.indexOf('\n}\n\n.expressive-code figure.frame')
+);
+
+test('Expressive Code uses the current inline padding variable to avoid false scrollbars', () => {
+  assert.match(
+    expressiveCodeBlock,
+    /--ec-codePaddingInline:\s*(?:0\.85|1)rem;/,
+    'code blocks must reduce Expressive Code inline padding with --ec-codePaddingInline'
+  );
+});
+
+test('Expressive Code padding override does not use the obsolete shorthand variable', () => {
+  assert.doesNotMatch(
+    expressiveCodeBlock,
+    /--ec-codePadInl:/,
+    '--ec-codePadInl is not used by the installed Expressive Code version'
+  );
+});

--- a/docs/src/styles/components/code.css
+++ b/docs/src/styles/components/code.css
@@ -8,6 +8,8 @@
   --ec-codeBg: var(--sl-color-block-bg);
   --ec-codeFg: #e1e4e8;
   --ec-codeSelBg: #3392ff44;
+  /* Keep fitting lines from overflowing only because of Expressive Code's default padding. */
+  --ec-codePaddingInline: 0.85rem;
   /* Frame backgrounds */
   --ec-frm-edBg: var(--sl-color-block-bg);
   --ec-frm-termBg: var(--sl-color-block-bg);

--- a/docs/tests/codeSnippetScrollbars.spec.ts
+++ b/docs/tests/codeSnippetScrollbars.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect, type Locator } from '@playwright/test';
+
+const TOLERANCE_PX = 1;
+
+test.beforeEach(async({ page, baseURL }) => {
+  const url = new URL(baseURL?.toString() || '');
+  const extractedDomain = url.hostname;
+
+  await page.context().addCookies([
+    {
+      name: 'CookieConsent',
+      value: '-2',
+      domain: extractedDomain,
+      path: '/',
+      expires: -1,
+      httpOnly: false,
+      secure: false,
+      sameSite: 'Lax',
+    },
+    {
+      name: '70d6d6e3-3a3e-4392-a095-5fe2a6b8bd70',
+      value: process.env.PASS_COOKIE ? process.env.PASS_COOKIE : '',
+      domain: 'dev.handsontable.com',
+      path: '/',
+      expires: -1,
+      httpOnly: false,
+      secure: false,
+      sameSite: 'Lax',
+    },
+  ]);
+});
+
+async function expectNoFalseHorizontalOverflow(locator: Locator) {
+  await expect(locator).toBeVisible();
+
+  const overflow = await locator.evaluate((element) => ({
+    clientWidth: element.clientWidth,
+    scrollWidth: element.scrollWidth,
+  }));
+
+  expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.clientWidth + TOLERANCE_PX);
+}
+
+test('short API code snippets do not show false horizontal scrollbars', async({ page, baseURL }) => {
+  await page.goto(`${baseURL}/javascript-data-grid/api/options`);
+  await expect(page.getByText('Page not found (404)')).toHaveCount(0);
+  await expect(page.getByText('Password protected site')).toHaveCount(0);
+
+  const shortSnippet = page
+    .locator('.expressive-code pre')
+    .filter({ hasText: 'allowEmpty: true' })
+    .first();
+
+  await expectNoFalseHorizontalOverflow(shortSnippet);
+});
+
+test('interactive example source panels do not force horizontal scrollbars for fitting code', async({
+  page,
+  baseURL,
+}) => {
+  await page.goto(`${baseURL}/javascript-data-grid/column-menu`);
+  await expect(page.getByText('Page not found (404)')).toHaveCount(0);
+  await expect(page.getByText('Password protected site')).toHaveCount(0);
+  await expect(page.locator('.hot-example-preview--loading')).toHaveCount(0, { timeout: 30000 });
+
+  await page.locator('.hot-example-source-btn').first().click();
+
+  const visibleSourcePanel = page.locator('.hot-example-code:not([hidden])').first();
+
+  await expectNoFalseHorizontalOverflow(visibleSourcePanel);
+});


### PR DESCRIPTION
### Context

The PR fixes DEV-931 by preventing fitting docs code snippets from showing horizontal scrollbars caused only by Expressive Code's default inline padding.

The reported issue is still valid after the docs migration to Astro Starlight and Expressive Code, but the current CSS variable is `--ec-codePaddingInline` rather than the older shorthand name from the initial investigation.

[skip changelog]

### How has this been tested?

- `rtk npm --prefix docs run docs:lint`
- `rtk npm --prefix docs run docs:test:plugins`
- `rtk npx playwright test tests/codeSnippetScrollbars.spec.ts` against `npm --prefix docs run dev -- --host 127.0.0.1 --port 4321`
- rendered validation was completed with the docs dev server.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-931

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-931

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only styling and test additions with no impact on grid runtime, auth, or data handling.
> 
> **Overview**
> Fixes **DEV-931** by lowering Expressive Code inline padding so short lines that fit no longer trigger horizontal scrollbars from default padding alone.
> 
> In `code.css`, `.expressive-code` now sets **`--ec-codePaddingInline: 0.85rem`** (the current Expressive Code variable) instead of relying on library defaults.
> 
> **Regression coverage:** a Node test asserts the CSS block uses `--ec-codePaddingInline` and does not reference the obsolete `--ec-codePadInl`. Playwright checks API option snippets and interactive example source panels so `scrollWidth` stays within `clientWidth` for fitting code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a3de69aaaecef9fda610a44f2f04ad05a1f2a63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->