### PR TITLE
DEV-943: Differentiate docs button focus state

### DIFF
--- a/docs/src/styles/interactive-example.css
+++ b/docs/src/styles/interactive-example.css
@@ -201,6 +201,14 @@
   background: var(--sl-color-gray-4);
 }
 
+.example-controls-container button:focus-visible,
+.example-controls-container .button:focus-visible,
+.hot-example-preview > button:focus-visible,
+.ht-dialog__content button.hot-doc-dialog-html-button:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px var(--sl-color-accent);
+}
+
 /* Dialog guide: HTML `content` buttons sit below paragraph copy */
 .ht-dialog__content button.hot-doc-dialog-html-button {
   margin-top: 0.5rem;

--- a/docs/tests/exampleControlsFocus.spec.ts
+++ b/docs/tests/exampleControlsFocus.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test';
+
+const PAGE = '/javascript-data-grid/saving-data/';
+const THEMES = ['light', 'dark'] as const;
+
+test.beforeEach(async({ page, baseURL }) => {
+  const url = new URL(baseURL?.toString() || 'http://localhost');
+
+  await page.context().addCookies([
+    {
+      name: 'CookieConsent',
+      value: '-2',
+      domain: url.hostname,
+      path: '/',
+      expires: -1,
+      httpOnly: false,
+      secure: false,
+      sameSite: 'Lax',
+    },
+    {
+      name: '70d6d6e3-3a3e-4392-a095-5fe2a6b8bd70',
+      value: process.env.PASS_COOKIE ?? '',
+      domain: 'dev.handsontable.com',
+      path: '/',
+      expires: -1,
+      httpOnly: false,
+      secure: false,
+      sameSite: 'Lax',
+    },
+  ]);
+});
+
+THEMES.forEach((theme) => {
+  test(`example controls show an inset keyboard focus ring in ${theme} theme`, async({ page, baseURL }) => {
+    await page.goto(`${baseURL}${PAGE}`);
+    await expect(page.getByText('Page not found (404)')).toHaveCount(0);
+    await expect(page.getByText('Password protected site')).toHaveCount(0);
+    await page.locator('html').evaluate((html, selectedTheme) => {
+      html.setAttribute('data-theme', selectedTheme);
+    }, theme);
+    await expect(page.locator('.hot-example-preview--loading')).toHaveCount(0, { timeout: 30000 });
+
+    const preview = page.locator('.hot-example-preview').first();
+    const loadButton = preview.locator('#load');
+    const saveButton = preview.locator('#save');
+
+    await expect(loadButton).toBeVisible();
+    await loadButton.hover();
+    await loadButton.click();
+    await page.keyboard.press('Tab');
+
+    await expect(saveButton).toBeFocused();
+    const focusStyles = await saveButton.evaluate((button) => {
+      const styles = getComputedStyle(button);
+
+      return {
+        boxShadow: styles.boxShadow,
+        outlineStyle: styles.outlineStyle,
+      };
+    });
+
+    expect(focusStyles.outlineStyle).toBe('none');
+    expect(focusStyles.boxShadow).toContain('inset');
+  });
+});


### PR DESCRIPTION
### Context

The PR fixes DEV-943 by giving documentation example buttons a distinct keyboard focus state. The previous controls relied on the global external focus outline, which could be clipped by the example container and looked too close to the hover state.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-943

[skip changelog]

### How has this been tested?

- `rtk npm --prefix docs run docs:visual-test -- exampleControlsFocus.spec.ts`
- `rtk npm --prefix docs run docs:lint`
- Manual browser check on `/docs/javascript-data-grid/saving-data/`: clicked **Load data**, left the pointer on it, pressed `Tab`, and verified the focused **Save data** button shows an inset accent ring in light and dark themes.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-943

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`
- [x] Documentation

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only CSS and a visual regression test; no runtime product or data-handling changes.
> 
> **Overview**
> Documentation interactive example buttons (**Load/Save**, control strip, preview buttons, dialog HTML buttons) now get a dedicated **`:focus-visible`** style instead of relying on the global outline, which could clip inside the example container and look like hover.
> 
> Keyboard focus uses **`outline: none`** plus an **inset 2px accent `box-shadow`**, aligned with other example toolbar buttons in `interactive-example.css`.
> 
> A new Playwright spec on the saving-data page tabs from Load to Save and asserts the focused control has no outline and an inset box shadow in **light** and **dark** themes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb8efb0b0a31e60ab144603267af31a468166a7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->