### PR TITLE
DEV-942: Improve docs checkbox focus visibility

### DIFF
--- a/docs/src/styles/utilities.css
+++ b/docs/src/styles/utilities.css
@@ -77,6 +77,13 @@ html {
   border-color: var(--sl-color-accent);
 }
 
+.sl-markdown-content input[type="checkbox"]:checked:focus-visible:not(.htCheckboxRendererInput),
+.hot-example input[type="checkbox"]:checked:focus-visible:not(.handsontable input) {
+  outline: 2px solid var(--sl-color-bg);
+  outline-offset: 0;
+  box-shadow: 0 0 0 4px var(--sl-color-accent);
+}
+
 .sl-markdown-content input[type="checkbox"]:checked:not(.htCheckboxRendererInput)::after,
 .hot-example input[type="checkbox"]:checked:not(.handsontable input)::after {
   content: '';

--- a/docs/tests/checkboxFocusVisibility.spec.ts
+++ b/docs/tests/checkboxFocusVisibility.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from '@playwright/test';
+
+const PAGE = '/javascript-data-grid/saving-data/';
+const THEMES = ['light', 'dark'] as const;
+
+test.beforeEach(async({ page, baseURL }) => {
+  const url = new URL(baseURL?.toString() || 'http://localhost');
+
+  await page.context().addCookies([
+    {
+      name: 'CookieConsent',
+      value: '-2',
+      domain: url.hostname,
+      path: '/',
+      expires: -1,
+      httpOnly: false,
+      secure: false,
+      sameSite: 'Lax',
+    },
+    {
+      name: '70d6d6e3-3a3e-4392-a095-5fe2a6b8bd70',
+      value: process.env.PASS_COOKIE ?? '',
+      domain: 'dev.handsontable.com',
+      path: '/',
+      expires: -1,
+      httpOnly: false,
+      secure: false,
+      sameSite: 'Lax',
+    },
+  ]);
+});
+
+THEMES.forEach((theme) => {
+  test(`checked example checkbox shows a visible keyboard focus ring in ${theme} theme`, async({ page, baseURL }) => {
+    await page.goto(`${baseURL}${PAGE}`);
+    await expect(page.getByText('Page not found (404)')).toHaveCount(0);
+    await expect(page.getByText('Password protected site')).toHaveCount(0);
+    await page.locator('html').evaluate((html, selectedTheme) => {
+      html.setAttribute('data-theme', selectedTheme);
+    }, theme);
+    await expect(page.locator('.hot-example-preview--loading')).toHaveCount(0, { timeout: 30000 });
+
+    const preview = page.locator('.hot-example-preview').first();
+    const saveButton = preview.locator('#save');
+    const autosaveCheckbox = preview.locator('#autosave');
+
+    await expect(saveButton).toBeVisible();
+    await expect(autosaveCheckbox).toBeVisible();
+    await expect(preview.locator('.handsontable #autosave')).toHaveCount(0);
+
+    await autosaveCheckbox.check();
+    await saveButton.focus();
+    await page.keyboard.press('Tab');
+
+    await expect(autosaveCheckbox).toBeFocused();
+    const focusStyles = await autosaveCheckbox.evaluate((checkbox) => {
+      const styles = getComputedStyle(checkbox);
+
+      return {
+        boxShadow: styles.boxShadow,
+        outlineOffset: styles.outlineOffset,
+        outlineStyle: styles.outlineStyle,
+        outlineWidth: styles.outlineWidth,
+      };
+    });
+
+    expect(focusStyles.outlineStyle).toBe('solid');
+    expect(focusStyles.outlineWidth).toBe('2px');
+    expect(focusStyles.boxShadow).not.toBe('none');
+    expect(focusStyles.outlineOffset).toBe('0px');
+  });
+});


### PR DESCRIPTION
### Context

The PR fixes DEV-942 by making the keyboard focus state visible for checked checkboxes in documentation examples. The shared docs checkbox style used the same accent color for the checked background and the global focus outline, so the focus indicator was hard to see on the Saving data autosave checkbox and any other checked docs example checkbox.

This is related to the button-focus accessibility work in https://github.com/handsontable/handsontable/pull/13031, but it stays scoped to checkbox styling in `docs/src/styles/utilities.css`.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-942

[skip changelog]

### How has this been tested?

- `rtk npm --prefix docs run docs:visual-test -- checkboxFocusVisibility.spec.ts`
- Temporarily removed the new checkbox focus rule and confirmed `checkboxFocusVisibility.spec.ts` fails in both light and dark themes.
- Restored the rule and reran `rtk npm --prefix docs run docs:visual-test -- checkboxFocusVisibility.spec.ts`.
- `rtk npm --prefix docs run docs:lint`

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-942

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`
- [x] Documentation

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only CSS scoped to markdown/example checkboxes (excluding Handsontable internals) plus a regression test; no runtime grid or auth impact.
> 
> **Overview**
> Fixes **DEV-942** by giving **checked** documentation and `.hot-example` checkboxes a distinct keyboard focus treatment. When `:focus-visible` applies on a checked box, the style now uses a **background-colored inner outline** plus an **accent `box-shadow` ring** so the indicator stays visible against the accent fill (the global `:focus-visible` accent outline was effectively lost on checked states).
> 
> Adds a **Playwright** spec on the Saving data page that tabs to the autosave checkbox in **light and dark** themes and asserts outline and box-shadow are present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce382bc0f68ec893316092d044f8ad7893b975e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->