### PR TITLE
DEV-951: Improve docs copy button light mode styling

### DIFF
--- a/docs/src/components/__tests__/code-block-copy-button.test.mjs
+++ b/docs/src/components/__tests__/code-block-copy-button.test.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const codeCssPath = fileURLToPath(new URL('../../styles/components/code.css', import.meta.url));
+const codeCssSource = readFileSync(codeCssPath, 'utf8');
+
+function extractRule(selector) {
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const rulePattern = new RegExp(`${escapedSelector}\\s*\\{(?<body>[^}]+)\\}`);
+  const match = codeCssSource.match(rulePattern);
+
+  assert.ok(match?.groups?.body, `Expected ${selector} rule to exist`);
+
+  return match.groups.body;
+}
+
+test('light theme gives the code-block copy button a distinct resting surface', () => {
+  const lightCopyButtonRule = extractRule(":root[data-theme='light'] .expressive-code .copy button");
+
+  assert.match(lightCopyButtonRule, /background-color:\s*var\(--sl-color-gray-5\);/);
+  assert.match(lightCopyButtonRule, /border-color:\s*var\(--sl-color-gray-4\);/);
+});
+
+test('light theme gives the code-block copy button a distinct hover surface', () => {
+  const lightCopyButtonHoverRule = extractRule(":root[data-theme='light'] .expressive-code .copy button:hover");
+
+  assert.match(lightCopyButtonHoverRule, /background-color:\s*var\(--sl-color-gray-6\);/);
+  assert.match(lightCopyButtonHoverRule, /border-color:\s*var\(--sl-color-gray-3\);/);
+});
+
+test('copied code-block copy button stays visible after pointer leaves', () => {
+  const copiedRule = extractRule('.expressive-code .copy button.copied');
+
+  assert.match(copiedRule, /opacity:\s*1;/);
+});

--- a/docs/src/styles/components/code.css
+++ b/docs/src/styles/components/code.css
@@ -81,7 +81,13 @@
 }
 
 :root[data-theme='light'] .expressive-code .copy button {
+  background-color: var(--sl-color-gray-5);
+  border-color: var(--sl-color-gray-4);
+}
+
+:root[data-theme='light'] .expressive-code .copy button:hover {
   background-color: var(--sl-color-gray-6);
+  border-color: var(--sl-color-gray-3);
 }
 
 .expressive-code .ec-line .gutter {

--- a/docs/tests/codeBlockCopyButton.spec.ts
+++ b/docs/tests/codeBlockCopyButton.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+
+async function resolveCssColor(page, value: string): Promise<string> {
+  return page.evaluate((colorValue) => {
+    const element = document.createElement('div');
+
+    element.style.backgroundColor = colorValue;
+    document.body.appendChild(element);
+
+    const resolvedColor = getComputedStyle(element).backgroundColor;
+
+    element.remove();
+
+    return resolvedColor;
+  }, value);
+}
+
+test('code-block copy button has distinct light-theme hover and copied states', async({ page, baseURL }) => {
+  await page.goto(`${baseURL}/react-data-grid/bundle-size/`);
+  await page.evaluate(() => document.documentElement.setAttribute('data-theme', 'light'));
+  await page.waitForLoadState('domcontentloaded');
+
+  const codeBlock = page.locator('.expressive-code figure').first();
+  const copyButton = codeBlock.locator('.copy button');
+
+  await expect(codeBlock).toBeVisible();
+
+  const restingButtonBackground = await resolveCssColor(page, 'var(--sl-color-gray-5)');
+  const restingButtonBorder = await resolveCssColor(page, 'var(--sl-color-gray-4)');
+  const hoverButtonBackground = await resolveCssColor(page, 'var(--sl-color-gray-6)');
+  const hoverButtonBorder = await resolveCssColor(page, 'var(--sl-color-gray-3)');
+
+  await codeBlock.hover();
+  await expect(copyButton).toBeVisible();
+  await expect(copyButton).toHaveCSS('opacity', '1');
+  await expect(copyButton).toHaveCSS('background-color', restingButtonBackground);
+  await expect(copyButton).toHaveCSS('border-color', restingButtonBorder);
+
+  await copyButton.hover();
+  await expect(copyButton).toHaveCSS('background-color', hoverButtonBackground);
+  await expect(copyButton).toHaveCSS('border-color', hoverButtonBorder);
+
+  await copyButton.click();
+  await expect(copyButton).toHaveClass(/copied/);
+  await page.mouse.move(0, 0);
+  await expect(copyButton).toHaveCSS('opacity', '1');
+});


### PR DESCRIPTION
### Context

The PR fixes DEV-951 by improving the light-theme styling of the code-block **Copy to clipboard** hover control in the current Astro Starlight documentation site.

The original 2024 issue targeted the old VuePress docs implementation, which has since been replaced by Expressive Code. This change keeps the fix scoped to `.expressive-code .copy button` so it does not overlap with the separate docs button and checkbox accessibility work in #13031 and #13032.

[skip changelog]

### How has this been tested?

- `rtk node --test src/components/__tests__/code-block-copy-button.test.mjs`
- `rtk npx playwright test tests/codeBlockCopyButton.spec.ts --project=chromium`
- `rtk npm --prefix docs run docs:test:plugins`
- `rtk npm --prefix docs run docs:lint`

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-951

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`
- [x] Documentation

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-951

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only CSS and tests; no runtime product or auth/data paths affected.
> 
> **Overview**
> Improves **light theme** styling for Expressive Code **Copy to clipboard** controls in `code.css`, scoped to `.expressive-code .copy button`.
> 
> Light mode now sets explicit **resting** background (`--sl-color-gray-5`) and border (`--sl-color-gray-4`), and a separate **hover** rule with darker fill (`--sl-color-gray-6`) and border (`--sl-color-gray-3`) instead of folding hover background into the base light-theme selector.
> 
> Adds a **Node** test that parses `code.css` for those selectors and for `.copy button.copied` keeping `opacity: 1`, plus a **Playwright** test on a docs page in light theme that checks resolved colors on hover and after copy when the pointer leaves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 313c847ca13ff81d047f26f06244e5c1ba40b692. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->