### PR TITLE
QA Pillar-1: dev-owned test enforcement + Playwright E2E tier

### DIFF
--- a/.ai/STACK.md
+++ b/.ai/STACK.md
@@ -38,9 +38,8 @@
 
 **Testing:**
 - Jest 27 - Unit tests (`handsontable/jest.config.js`, `*.unit.js` files, jsdom environment, `jest-jasmine2` runner)
-- Jasmine 3.4 - E2E browser tests (`*.spec.js` files, run via Puppeteer)
-- Puppeteer 24 - Headless Chrome for E2E tests
-- Playwright 1.58 - Visual regression tests (`visual-tests/`)
+- Playwright 1.61 - **E2E (the paradigm for new tests, `tests/e2e/`)** and visual regression (`visual-tests/`, migrating into `tests/visual/`). One version across the monorepo via a pnpm catalog; CI runs the matching container image.
+- Jasmine 3.4 + Puppeteer 24 - **LEGACY (frozen) E2E** browser tests (`*.spec.js`, headless Chrome). Add no new specs; migrate broken ones to Playwright. Walkontable (`test/spec/**`) is frozen the same way and has a Playwright home at `tests/e2e/walkontable/`; its Jasmine job and the Playwright e2e job run in parallel in CI.
 - `@testing-library/react` 14 - React wrapper tests
 - `@vue/test-utils` 2.0.0-rc.16 - Vue 3 wrapper tests
 - `jest-preset-angular` 14 - Angular wrapper tests (requires `NODE_OPTIONS=--openssl-legacy-provider`)

--- a/.ai/TESTING.md
+++ b/.ai/TESTING.md
@@ -12,7 +12,8 @@ global helpers, mocking, fixtures, custom matchers), see
 | Pipeline | Framework | File pattern | Run command | Deep reference |
 |---|---|---|---|---|
 | Core unit | Jest (jsdom, `jest-jasmine2` runner) | `*.unit.js` | `npm --prefix handsontable run test:unit` | [`handsontable/.ai/TESTING.md`](../handsontable/.ai/TESTING.md) |
-| Core E2E | Jasmine + Puppeteer (headless Chrome) | `*.spec.js` | `npm --prefix handsontable run test:e2e` | [`handsontable/.ai/TESTING.md`](../handsontable/.ai/TESTING.md) |
+| E2E (new — the paradigm) | Playwright (real Chromium) | `tests/e2e/*.spec.ts` | `cd tests && npm test` | skill `handsontable-playwright-e2e` |
+| E2E (legacy — frozen) | Jasmine + Puppeteer (headless Chrome) | `*.spec.js` | `npm --prefix handsontable run test:e2e` | [`handsontable/.ai/TESTING.md`](../handsontable/.ai/TESTING.md); skill `handsontable-e2e-testing` |
 | Type tests | `tsc` only | `*.types.ts` | `npm --prefix handsontable run test:types` | [`handsontable/.ai/TESTING.md`](../handsontable/.ai/TESTING.md) |
 | Walkontable | Separate runner (`SpecRunner.html`) | — | `npm --prefix handsontable run test:walkontable` | `handsontable/src/3rdparty/walkontable/AGENTS.md`; skills `walkontable-testing`, `walkontable-dev` |
 | React wrapper | Jest + `@testing-library/react` | — | `npm --prefix wrappers/react-wrapper run test` | `wrappers/react-wrapper/AGENTS.md` |

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,23 @@
             "type": "command",
             "command": "command -v pipx >/dev/null 2>&1 && pipx run code-review-graph==2.3.2 update --skip-flows || true",
             "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "node scripts/claude/post-tool-use.mjs",
+            "timeout": 60
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node scripts/claude/stop.mjs",
+            "timeout": 120
           }
         ]
       }

--- a/.claude/skills/handsontable-dev/SKILL.md
+++ b/.claude/skills/handsontable-dev/SKILL.md
@@ -25,8 +25,10 @@ Always invoke `handsontable-code-review` (architecture dimension) alongside the 
 | Create / modify a **renderer** | `handsontable-renderer-dev` |
 | Create / modify a **validator** | `handsontable-validator-dev` |
 | Create / modify a **cell type** | `handsontable-celltype-dev` |
-| Write / modify **E2E tests** (`*.spec.js`) | `handsontable-e2e-testing` |
+| Write a **new E2E test** | `handsontable-playwright-e2e` (Playwright, `tests/e2e/`) |
+| Maintain a **legacy E2E test** (`*.spec.js`, frozen) | `handsontable-e2e-testing` |
 | Write / modify **unit tests** (`*.unit.js`) | `handsontable-unit-testing` |
+| Make a test actually prove behavior | `test-writing-discipline` |
 | Build a **demo / test page** | `handsontable-demo-page` |
 | Work on **CSS / themes** | `handsontable-css-dev` |
 | Walkontable rendering engine | `walkontable-dev` / `walkontable-testing` |
@@ -369,7 +371,7 @@ The CI `verify-emitted-types` job reports the exact leaked identifier with `TS23
 - [ ] No `as` / `any` casts introduced — used generics or `unknown` + guards instead
 - [ ] No `.d.ts` files hand-edited
 - [ ] Unit tests written (`*.unit.js`) — pure logic, no mocks
-- [ ] E2E tests written (`*.spec.js`) — DOM / rendering behavior
+- [ ] E2E tests written — Playwright in `tests/e2e/` (new); the legacy `*.spec.js` suite is frozen
 - [ ] `npm run build` (or `build:types` + `downlevel:types`) run if public types changed
 - [ ] Wired into all relevant index / factory files
 - [ ] Added to `metaSchema.ts` if a new option was introduced

--- a/.claude/skills/handsontable-e2e-testing/SKILL.md
+++ b/.claude/skills/handsontable-e2e-testing/SKILL.md
@@ -1,9 +1,11 @@
 ---
 name: handsontable-e2e-testing
-description: Use when writing or modifying Jasmine/Puppeteer E2E tests (*.spec.js) for Handsontable, or when a bug fix or feature change needs E2E test coverage. Covers standard boilerplate, async/await rules, global helpers, event simulation, plugin lifecycle patterns, and writing theme-agnostic assertions that pass under all themes without branching on theme name.
+description: Use ONLY when maintaining the FROZEN legacy Jasmine/Puppeteer E2E suite (*.spec.js) — editing an existing spec, or migrating a broken one to Playwright. Do NOT use for new E2E: new E2E is Playwright (skill handsontable-playwright-e2e). Covers the legacy boilerplate, async/await rules, global helpers, event simulation, and theme-agnostic assertions.
 ---
 
-# Handsontable E2E Testing Guide
+# Handsontable E2E Testing Guide (legacy Jasmine/Puppeteer — frozen)
+
+> **This suite is frozen.** New E2E tests are **Playwright** — use the `handsontable-playwright-e2e` skill and put them in `tests/e2e/`. This guide is for *maintaining* existing `*.spec.js` files. The presence gate blocks a newly added `*.spec.js`. If a legacy spec is broken or flaky, **migrate it to Playwright** rather than patching it here.
 
 ## Standard boilerplate (MUST follow)
 

--- a/.claude/skills/handsontable-playwright-e2e/SKILL.md
+++ b/.claude/skills/handsontable-playwright-e2e/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: handsontable-playwright-e2e
+description: Use when writing or modifying real-browser Playwright E2E / functional tests for Handsontable (specs in tests/e2e/, core, wrappers, or walkontable). Covers the Page Object Model, hooking in by data-testid, deterministic web-first waits, wrapper-specific gotchas, recording via the CLI, and the new-vs-modify / E2E-vs-unit decision. NOT for screenshot/visual tests (see visual-testing) or the legacy Jasmine suite (see handsontable-e2e-testing).
+---
+
+# Handsontable Playwright E2E authoring
+
+New E2E is **Playwright** in `tests/e2e/` (`*.spec.ts`). The legacy Jasmine `*.spec.js` suite is frozen — never add a new one. Reference: `tests/e2e/grid.spec.ts` + `tests/fixtures/pages/GridPage.ts`.
+
+## Four rules (non-negotiable)
+
+1. **Page Object Model.** A spec expresses intent; selectors and interactions live in a page object under `tests/fixtures/pages/`. Never put raw selectors or multi-step flows in a spec — when the DOM shifts, one file changes.
+2. **Hook by `data-testid`, not structural CSS.** Stamp ids in the fixture (or add them to the component when it removes ambiguity). Fall back to role/text locators before ever reaching into grid internals.
+3. **Web-first waits only.** `await expect(locator).toBeVisible()` — never `sleep`/`waitForTimeout`/`networkidle` or a custom ready flag. Await *every* assertion (a missing await is the sneakiest flake).
+4. **Isolation, no flake.** One instance per test; `page.route()` / `page.clock()` for network/time. `failOnFlakyTests` is on in CI — pass-on-retry is a hard failure.
+
+## Which test — decide, then route
+
+- **User-visible** (rendering, interaction, keyboard, menus, overlays) → **E2E here**.
+- **Invisible to users** (data, indexing, algorithms) → **Jest `*.unit.js`** — still mandatory.
+- **Pure refactor / non-runtime** → no new test; declare `Refactor-only: <reason>` in the commit.
+- **New API / plugin / editor** → new spec. **Bug fix** → a failing case in the closest existing spec.
+- **Broken or flaky legacy Jasmine → migrate to Playwright**, don't patch it.
+
+Full decision rules: `handsontable/.ai/TESTING.md`.
+
+## Recording
+
+Record with the Playwright **CLI** (`npx playwright codegen`), **not** a Playwright MCP — the CLI is the version-pinned tool installed here (CI parity) and produces code you keep. Refactor the output into a page object with `data-testid` selectors before committing.
+
+## References (load as needed)
+
+- [`references/page-objects.md`](references/page-objects.md) — POM, test ids, grid locators, editing, fixtures & the demo server.
+- [`references/wrappers.md`](references/wrappers.md) — React / Angular / Vue wrapper E2E: StrictMode, NgZone, reactivity, lifecycle, driving the example apps.
+- [`references/codegen.md`](references/codegen.md) — recording via the CLI, `--ui`, trace viewer, refactoring the output.
+- [`references/determinism.md`](references/determinism.md) — the flake-free checklist.
+
+TypeScript style is not repeated here — Playwright specs follow the repo's TS conventions (`handsontable/.ai/CONVENTIONS.md`).

--- a/.claude/skills/handsontable-playwright-e2e/references/codegen.md
+++ b/.claude/skills/handsontable-playwright-e2e/references/codegen.md
@@ -1,0 +1,15 @@
+# Recording through the UI with the Playwright CLI (reference)
+
+When an interaction is easier to capture by clicking than to write by hand, record it with the **Playwright CLI** — the version-pinned tool already installed here (parity with CI). Do not use a Playwright MCP for this; it is a second, unpinned automation surface with no version guarantee.
+
+1. Serve the fixture: `cd tests && node support/static-server.mjs` (or run any served demo).
+2. Record: `npx playwright codegen http://localhost:8123/tests/fixtures/demo/grid.html`. Click through the grid; codegen writes selectors and actions live.
+3. Develop/watch interactively: `npx playwright test --ui`.
+4. Debug a failure: `npx playwright show-trace` on the trace from a retried run.
+
+**The recording is a starting point, not the deliverable.** Before committing, refactor the generated code:
+
+- Replace generated CSS selectors with `data-testid` — add ids to the fixture (or component) where missing, rather than keeping a brittle selector.
+- Lift the interactions into a page object under `fixtures/pages/`.
+- Remove any generated `waitForTimeout`; use web-first assertions instead.
+- Delete dead steps codegen recorded incidentally.

--- a/.claude/skills/handsontable-playwright-e2e/references/determinism.md
+++ b/.claude/skills/handsontable-playwright-e2e/references/determinism.md
@@ -1,0 +1,9 @@
+# Determinism checklist (reference)
+
+A flake-free Playwright spec:
+
+- No `sleep` / `waitForTimeout` / `networkidle` / custom readiness globals — wait on a condition (`await expect(locator).toBeVisible()`, `waitForResponse`).
+- Every `expect` and every action is awaited (a missing await is the sneakiest flake).
+- Freeze time with `page.clock` where behavior depends on it; mock network with `page.route`.
+- Keep fixtures small — a big dataset slows every test and makes flakes likelier.
+- `failOnFlakyTests` is on in CI: a test that only passes on retry is a hard failure. Fix the root cause, don't add retries.

--- a/.claude/skills/handsontable-playwright-e2e/references/page-objects.md
+++ b/.claude/skills/handsontable-playwright-e2e/references/page-objects.md
@@ -1,0 +1,63 @@
+# Page objects, selectors & fixtures (reference)
+
+Canonical working example: `tests/e2e/grid.spec.ts` with `tests/fixtures/pages/GridPage.ts`. Read it first.
+
+## Page Object Model
+
+A page object wraps a page (or a component) and exposes intent-level methods. Rules:
+
+- **One object per surface** — a grid, a context menu, a filters dialog. Compose them (a `GridPage` can return a `ContextMenu`).
+- **Locators as fields, resolved lazily.** Assign `page.getByTestId(...)` in the constructor; do not `await` in the constructor.
+- **Methods are actions or queries**, not assertions — except thin `expectX` helpers wrapping a web-first assertion for readability. Keep real assertions in the spec so failures point at the test.
+- **No `page.waitForTimeout`.** A page object that must wait, waits on a condition.
+
+```ts
+export class GridPage {
+  readonly grid: Locator;
+  constructor(readonly page: Page) { this.grid = page.getByTestId('grid'); }
+  async goto() {
+    await this.page.goto('/tests/fixtures/demo/grid.html');
+    await expect(this.cell(0, 0)).toBeVisible(); // DOM condition, not a sleep or custom flag
+  }
+  cell(row: number, col: number) { return this.page.getByTestId(`cell-${row}-${col}`); }
+}
+```
+
+## Hooking in by test id
+
+Prefer, in order: `getByTestId` → `getByRole`/`getByText` → structural CSS (last resort).
+
+- Stamp cells in a fixture via a renderer so every cell is addressable:
+  ```js
+  const testIdRenderer = function (instance, td, row, col, prop, value) {
+    Handsontable.renderers.TextRenderer.apply(this, arguments);
+    td.setAttribute('data-testid', `cell-${row}-${col}`);
+  };
+  ```
+  `row`/`col` are visual indices — the coordinates a test reasons about.
+- Put `data-testid` on the container, toolbar buttons, and any menu/dialog the test drives.
+- If a needed element has no stable hook and you cannot add one in the fixture, that is a signal to add a test id to the component — not to write a fragile selector.
+
+## Grid-specific locators (only when a test id genuinely isn't available)
+
+- Master overlay rows: `.ht_master .htCore tbody tr`.
+- The text editor input: `.handsontableInput`.
+- Prefer adding a test id over relying on these.
+
+## Editing a cell
+
+```ts
+async editCell(row: number, col: number, value: string) {
+  await this.cell(row, col).dblclick();
+  const editor = this.page.locator('.handsontableInput');
+  await expect(editor).toBeVisible();
+  await editor.fill(value);
+  await editor.press('Enter');
+}
+```
+
+## Fixtures and the demo server
+
+- Demo pages live in `tests/fixtures/demo/` and mount a real grid from the built `handsontable/dist`. The static server (`tests/support/static-server.mjs`) serves the repo root so the page can load dist + styles.
+- Always pass `licenseKey: 'non-commercial-and-evaluation'` so the license overlay never blocks the test.
+- For a wrapper functional test, drive the wrapper example app instead of a static demo; the page-object and test-id rules are identical.

--- a/.claude/skills/handsontable-playwright-e2e/references/wrappers.md
+++ b/.claude/skills/handsontable-playwright-e2e/references/wrappers.md
@@ -1,0 +1,32 @@
+# Wrapper E2E (React / Angular / Vue) — reference
+
+Wrapper functional tests drive the wrapper **example apps** (not a static demo) in a real browser, because the bugs that matter are framework-integration bugs jsdom cannot see. Same rules as core E2E — page objects, `data-testid`, web-first waits — plus the framework-specific gotchas below. Specs live under `tests/e2e/wrappers/<framework>/`.
+
+## Driving the app
+
+- Serve the wrapper's example app (the `examples/next/visual-tests/<framework>/demo` apps, or a purpose-built one) and point the page object at it. Add `data-testid` to the wrapper component and its controls.
+- One mounted instance per test; reset via navigation, not shared state.
+
+## React
+
+- **StrictMode double-invoke:** React 18+ StrictMode mounts, unmounts, and remounts. Assert **exactly one** live Handsontable instance survives (no duplicate grid). This is the #1 wrapper regression — mount the app under `<React.StrictMode>` in the fixture and assert a single `.handsontable` root / one instance.
+- **Selection preserved on `updateSettings`:** change a prop that triggers `updateSettings`, then assert the previously-selected cell is still selected.
+- **HotColumn reorder / keyed children:** reorder columns via keys and assert the rendered order.
+
+## Angular
+
+- **NgZone:** hooks fired from outside Angular must run inside the zone (change detection updates the view). Trigger a HOT hook and assert the bound Angular view actually updated.
+- Test against the supported version floor as well as latest (version matrix is a later nightly task).
+
+## Vue 3
+
+- **Deep-watch / reactivity:** mutate a reactive `settings` prop and assert the grid reflects it (and that `updateSettings` fired the expected number of times, not on every tick).
+- **HotColumn comment-anchor ordering:** reorder and assert DOM order.
+
+## SSR frameworks (Next / Nuxt / Gatsby / Remix / Astro)
+
+- If the app renders server-side and hydrates, assert **no hydration-mismatch console error** on load — that is the class of bug an SSR wrapper test exists to catch. (Many demos disable SSR today; a real SSR+hydrate variant is the valuable one.)
+
+## What jsdom already covers
+
+Props mapping, lifecycle wiring, and pure logic are fine as **Jest** wrapper unit tests — keep those there. Reserve Playwright for what needs a real browser: rendering, real focus, scroll, StrictMode remount, NgZone, hydration.

--- a/.claude/skills/handsontable-plugin-dev/SKILL.md
+++ b/.claude/skills/handsontable-plugin-dev/SKILL.md
@@ -139,7 +139,7 @@ If your plugin provides UI elements (buttons, inputs, navigation bars), you must
 
 ## Testing Requirements
 
-- E2E tests (`__tests__/*.spec.js`): all `it()` callbacks must be `async`.
+- **New E2E tests are Playwright** in `tests/e2e/` (skill `handsontable-playwright-e2e`) — for a plugin's UI, interaction, rendering. Do not add new legacy `*.spec.js`; the presence gate blocks them. Editing an existing `*.spec.js` (async `it()` callbacks) is fine.
 - Unit tests (`__tests__/*.unit.js`): test strategies and helpers in isolation.
 - Test `updateSettings()`, `enablePlugin()`/`disablePlugin()` toggling.
 - Test interactions with other plugins (sorting, filters, hidden rows).

--- a/.claude/skills/handsontable-unit-testing/SKILL.md
+++ b/.claude/skills/handsontable-unit-testing/SKILL.md
@@ -7,6 +7,8 @@ description: Use when writing or modifying Jest unit tests (*.unit.js) or TypeSc
 
 ## When to Use Unit Tests vs E2E
 
+> "E2E" below means a **new Playwright** test in `tests/e2e/` (skill `handsontable-playwright-e2e`). The `handsontable()` / `selectCell()` globals mentioned later are the **legacy Jasmine** helpers — do not add new `*.spec.js`.
+
 **Favor E2E tests over unit tests.** The key rule: if a unit test requires mocking a module, write an E2E test instead. Mocking couples tests tightly to internal module shape, making code resistant to refactoring and extension - every internal restructure forces test updates even when behavior hasn't changed.
 
 - **Good unit test candidates:** Pure logic, utility functions, data transformations, calculations - anything that needs **no mocking**.

--- a/.claude/skills/test-writing-discipline/SKILL.md
+++ b/.claude/skills/test-writing-discipline/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: test-writing-discipline
+description: Use when writing or reviewing tests for any Handsontable change (unit, E2E, or wrapper) to make the test actually prove the behavior — not just execute the code. Covers write-the-failing-test-first for bug fixes, verifying with a real run before claiming done, avoiding hollow assertions, not mocking the unit under test, and migrating broken legacy tests instead of patching them.
+---
+
+# Test-writing discipline
+
+A test that passes but asserts nothing is worse than no test — it reads as coverage. These rules make a test prove behavior. They apply on top of the framework guides (`handsontable-playwright-e2e`, `handsontable-e2e-testing`, `handsontable-unit-testing`).
+
+## Bug fixes: write the failing test first
+
+1. Reproduce the bug as a test and **watch it fail — for the right reason** (the missing behavior, not a typo or a bad selector).
+2. Then apply the fix and watch the same test pass.
+3. A regression test that was never red proves nothing. On a bugfix PR, name the spec that fails without the fix.
+
+## Verify before you say "done"
+
+- Run the exact test command fresh, read the **full output and the exit code**, then state the result *with that evidence*.
+- Banned phrasings: "should work", "this fixes it" without a run, "tested manually, looks fine". If you did not run it, say so.
+- After editing source, run the impacted test — not the whole suite, the impacted one — and confirm green before finishing.
+
+## No hollow assertions
+
+- Assert the **behavior**, not that the code ran. `expect(getDataAtCell(0, 0)).toBe('x')`, not `expect(true).toBe(true)`.
+- One meaningful assertion beats five that restate the setup.
+- Coverage-on-new-code can be satisfied by a test that executes a line without checking its result — do not rely on it to judge quality; the assertion is what matters.
+
+## Don't mock the unit under test
+
+- Never mock the thing you are testing. Mock at the real boundary (network, timers, ResizeObserver — see the mocks in `test/__mocks__/`).
+- When you must build a mock, mock the **complete** real data shape; an incomplete mock gives a false pass. In this repo the default is to favor an E2E test over a unit test that would need to mock a module.
+
+## Fix broken legacy tests by migrating them
+
+- The Jasmine suite is frozen. If a legacy `*.spec.js` is broken or flaky, **do not patch it in place and do not add a `sleep()`** — rewrite it as a Playwright test in `tests/e2e/` and delete the Jasmine one. The tests that hurt most migrate first; the suite shrinks by attrition.
+- Routine, low-risk edits to an existing Jasmine spec are still fine.

--- a/.claude/skills/walkontable-testing/SKILL.md
+++ b/.claude/skills/walkontable-testing/SKILL.md
@@ -6,6 +6,8 @@ description: Use when writing tests for the Walkontable rendering engine - has i
 
 # Testing the Walkontable Rendering Engine
 
+> **Paradigm note:** Walkontable follows the **same freeze** as the main suite. It now has a **Playwright home** at `tests/e2e/walkontable/` (which drives overlay / frozen-pane / scroll-sync behavior through a real grid — see `tests/fixtures/pages/WalkontablePage.ts`). So: **maintenance edits to existing `*.spec.js` here are allowed; new or flaky walkontable tests move to Playwright** (the presence gate blocks a new walkontable `*.spec.js`). In CI the legacy Jasmine/Puppeteer walkontable job and the Playwright e2e job run **in parallel**; walkontable migrates by attrition, worst/flakiest first. The guide below is for *maintaining* the frozen Jasmine specs.
+
 ## Separate Test Pipeline
 
 Walkontable has its own dedicated test runner. Do NOT run Walkontable tests through the main `test:e2e` or `test:unit` commands -- they will not be picked up.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,21 @@
 ### Context
 <!--- Why is this change required? What problem does it solve? -->
 
-### How has this been tested?
-<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
+### Test evidence (required for source changes)
+<!---
+A PR is verified by things a machine can re-run or a reviewer can diff — a
+committed test, a coverage number, a visual diff. "Tested manually with Claude"
+is not evidence. New E2E is Playwright (tests/e2e/); the Jasmine suite is frozen.
+Fill in the paths below, or apply a `Refactor-only: <reason>` commit trailer.
+-->
+- Unit tests added/modified (`*.unit.js`): <!-- paths, or "none — covered by <path>" -->
+- E2E tests added/modified (Playwright `tests/e2e/*.spec.ts`): <!-- paths -->
+- Type tests (`*.types.ts`) updated if public API changed: <!-- paths -->
+- For a bug fix — the spec that fails without this fix: <!-- name -->
+- Demo page / recorded trace (for UI changes): <!-- link -->
+
+### Commands run
+<!--- Paste the test commands and their final output lines. -->
 
 ### Types of changes
 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

--- a/.github/scripts/__tests__/presence-gate.test.mjs
+++ b/.github/scripts/__tests__/presence-gate.test.mjs
@@ -1,0 +1,183 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  classify, isCoverage, isNewJasmineSpec, refactorDeclared, evaluate,
+} from '../lib/presence-gate.mjs';
+
+// --- classify: the 17 real-repo paths validated during scoping ---
+const CLASSIFY_CASES = [
+  ['handsontable/src/plugins/copyPaste/copyPaste.ts', 'source'],
+  ['handsontable/src/plugins/copyPaste/__tests__/settings/rowsLimit.spec.js', 'test'],
+  ['handsontable/src/renderers/baseRenderer/__tests__/baseRenderer.types.ts', 'test'],
+  ['handsontable/src/i18n/languages/de-DE.js', 'source'],
+  ['handsontable/src/3rdparty/walkontable/src/table.ts', 'source'],
+  ['handsontable/src/3rdparty/walkontable/test/spec/table.spec.js', 'test'],
+  ['wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.ts', 'source'],
+  ['wrappers/angular-wrapper/projects/hot-table/src/lib/hot-table.component.spec.ts', 'test'],
+  ['wrappers/angular-wrapper/projects/hot-table/src/lib/test-helpers/create-spreadsheet-data.ts', 'neither'],
+  ['wrappers/react-wrapper/src/hotTableInner.tsx', 'source'],
+  ['wrappers/react-wrapper/src/json.d.ts', 'neither'],
+  ['wrappers/react-wrapper/test/hotColumn.spec.tsx', 'test'],
+  ['wrappers/vue3/src/HotTable.vue', 'source'],
+  ['docs/content/guides/foo.md', 'neither'],
+  ['handsontable/CHANGELOG.md', 'neither'],
+  ['.changelogs/12345.json', 'neither'],
+  ['visual-tests/tests/js-only/filters/menu.spec.ts', 'test'],
+];
+
+test('classify matches the 17 validated real-repo paths', () => {
+  for (const [p, want] of CLASSIFY_CASES) {
+    assert.equal(classify(p), want, `${p} should be ${want}`);
+  }
+});
+
+test('a new Playwright spec under tests/e2e classifies as test', () => {
+  assert.equal(classify('tests/e2e/filters/menu.spec.ts'), 'test');
+});
+
+// --- isCoverage: new vs modified .spec.js ---
+test('a modified Jasmine spec counts as coverage; a new one does not', () => {
+  const spec = 'handsontable/src/plugins/filters/__tests__/filters.spec.js';
+  assert.equal(isCoverage({ status: 'M', path: spec }), true, 'modified .spec.js counts');
+  assert.equal(isCoverage({ status: 'A', path: spec }), false, 'added .spec.js does not count');
+});
+
+test('unit, types, and Playwright specs count as coverage when added', () => {
+  assert.equal(isCoverage({ status: 'A', path: 'handsontable/src/plugins/filters/__tests__/x.unit.js' }), true);
+  assert.equal(isCoverage({ status: 'A', path: 'handsontable/src/__tests__/core/x.types.ts' }), true);
+  assert.equal(isCoverage({ status: 'A', path: 'tests/e2e/filters.spec.ts' }), true);
+});
+
+// --- isNewJasmineSpec ---
+test('added .spec.js under a Jasmine tree is a new-Jasmine violation; modified is not', () => {
+  const spec = 'handsontable/src/plugins/filters/__tests__/filters.spec.js';
+  assert.equal(isNewJasmineSpec({ status: 'A', path: spec }), true);
+  assert.equal(isNewJasmineSpec({ status: 'M', path: spec }), false);
+  // A .spec.ts is never a Jasmine violation.
+  assert.equal(isNewJasmineSpec({ status: 'A', path: 'tests/e2e/filters.spec.ts' }), false);
+});
+
+// --- refactorDeclared ---
+test('refactorDeclared requires a non-empty reason', () => {
+  assert.equal(refactorDeclared(['Refactor-only: extracted duplicate range logic']), true);
+  assert.equal(refactorDeclared(['Refactor-only:']), false, 'empty reason does not count');
+  assert.equal(refactorDeclared(['DEV-123: some feature']), false);
+});
+
+// --- evaluate: the end-to-end decisions ---
+test('source change with a matching unit test passes', () => {
+  const r = evaluate([
+    { status: 'M', path: 'handsontable/src/plugins/filters/filters.ts' },
+    { status: 'A', path: 'handsontable/src/plugins/filters/__tests__/x.unit.js' },
+  ]);
+  assert.equal(r.pass, true);
+  assert.equal(r.reason, 'ok');
+});
+
+test('source change with no test fails with missing-coverage', () => {
+  const r = evaluate([{ status: 'M', path: 'handsontable/src/plugins/filters/filters.ts' }]);
+  assert.equal(r.pass, false);
+  assert.equal(r.reason, 'missing-coverage');
+  assert.deepEqual(r.sourceFiles, ['handsontable/src/plugins/filters/filters.ts']);
+});
+
+test('source change with a Refactor-only trailer passes as a declared refactor', () => {
+  const r = evaluate(
+    [{ status: 'M', path: 'handsontable/src/plugins/filters/filters.ts' }],
+    ['Refactor-only: renamed a private field, no behavior change'],
+  );
+  assert.equal(r.pass, true);
+  assert.equal(r.reason, 'refactor-declared');
+});
+
+test('a new Jasmine spec fails even when other coverage exists', () => {
+  const r = evaluate([
+    { status: 'M', path: 'handsontable/src/plugins/filters/filters.ts' },
+    { status: 'A', path: 'handsontable/src/plugins/filters/__tests__/x.unit.js' },
+    { status: 'A', path: 'handsontable/src/plugins/filters/__tests__/new.spec.js' },
+  ]);
+  assert.equal(r.pass, false);
+  assert.equal(r.reason, 'new-jasmine-spec');
+  assert.deepEqual(r.newJasmine, ['handsontable/src/plugins/filters/__tests__/new.spec.js']);
+});
+
+test('source change satisfied by a new Playwright spec passes', () => {
+  const r = evaluate([
+    { status: 'M', path: 'handsontable/src/plugins/filters/filters.ts' },
+    { status: 'A', path: 'tests/e2e/filters/menu.spec.ts' },
+  ]);
+  assert.equal(r.pass, true);
+});
+
+test('docs-only / .d.ts-only / changelog-only changes never trigger the gate', () => {
+  for (const path of [
+    'docs/content/guides/foo.md',
+    'wrappers/react-wrapper/src/json.d.ts',
+    '.changelogs/12345.json',
+  ]) {
+    const r = evaluate([{ status: 'M', path }]);
+    assert.equal(r.pass, true, `${path} should pass`);
+    assert.equal(r.sourceFiles.length, 0);
+  }
+});
+
+test('editing an existing Jasmine spec alongside a source change passes (migrate later)', () => {
+  const r = evaluate([
+    { status: 'M', path: 'handsontable/src/plugins/filters/filters.ts' },
+    { status: 'M', path: 'handsontable/src/plugins/filters/__tests__/filters.spec.js' },
+  ]);
+  assert.equal(r.pass, true);
+});
+
+// --- test-only changes never demand "a test for the test" ---
+test('a test-only PR does not demand new coverage (no source changed)', () => {
+  const cases = [
+    // modifying existing tests of every kind
+    [{ status: 'M', path: 'handsontable/src/plugins/filters/__tests__/filters.spec.js' }],
+    [{ status: 'M', path: 'handsontable/src/plugins/filters/__tests__/x.unit.js' }],
+    [{ status: 'M', path: 'tests/e2e/filters/menu.spec.ts' }],
+    [{ status: 'M', path: 'visual-tests/tests/js-only/filters/menu.spec.ts' }],
+    // adding new non-Jasmine tests (allowed kinds)
+    [{ status: 'A', path: 'handsontable/src/plugins/filters/__tests__/x.unit.js' }],
+    [{ status: 'A', path: 'tests/e2e/filters/new.spec.ts' }],
+    [{ status: 'A', path: 'handsontable/src/__tests__/core/x.types.ts' }],
+    // touching test helpers only
+    [{ status: 'M', path: 'handsontable/test/helpers/common.js' }],
+    [{ status: 'M', path: 'wrappers/angular-wrapper/projects/hot-table/src/lib/test-helpers/create-spreadsheet-data.ts' }],
+  ];
+  for (const changes of cases) {
+    const r = evaluate(changes);
+    assert.equal(r.pass, true, `${changes[0].path} (${changes[0].status}) should pass`);
+    assert.equal(r.sourceFiles.length, 0, `${changes[0].path} must not be seen as source`);
+  }
+});
+
+test('the Jasmine freeze still blocks a NEW .spec.js even in a test-only PR', () => {
+  // Not a "test for a test" demand — the freeze: new E2E must be Playwright.
+  const r = evaluate([{ status: 'A', path: 'handsontable/src/plugins/filters/__tests__/new.spec.js' }]);
+  assert.equal(r.pass, false);
+  assert.equal(r.reason, 'new-jasmine-spec');
+});
+
+// --- Walkontable is frozen like the main suite (it has a Playwright home) ---
+test('a NEW Walkontable Jasmine spec is frozen (blocked, not coverage); editing one is allowed', () => {
+  const wtSpec = 'handsontable/src/3rdparty/walkontable/test/spec/overlay/top.spec.js';
+  assert.equal(isNewJasmineSpec({ status: 'A', path: wtSpec }), true, 'a new walkontable spec is a freeze violation');
+  assert.equal(isCoverage({ status: 'A', path: wtSpec }), false, 'a new walkontable spec does not count');
+  assert.equal(isCoverage({ status: 'M', path: wtSpec }), true, 'editing an existing walkontable spec counts');
+});
+
+test('a Walkontable source change is satisfied by a Playwright spec, blocked by a new Jasmine spec', () => {
+  const withPlaywright = evaluate([
+    { status: 'M', path: 'handsontable/src/3rdparty/walkontable/src/table.ts' },
+    { status: 'A', path: 'tests/e2e/walkontable/overlays.spec.ts' },
+  ]);
+  assert.equal(withPlaywright.pass, true, 'walkontable source + Playwright spec passes');
+
+  const withNewJasmine = evaluate([
+    { status: 'M', path: 'handsontable/src/3rdparty/walkontable/src/table.ts' },
+    { status: 'A', path: 'handsontable/src/3rdparty/walkontable/test/spec/table.spec.js' },
+  ]);
+  assert.equal(withNewJasmine.pass, false, 'a new walkontable Jasmine spec is blocked');
+  assert.equal(withNewJasmine.reason, 'new-jasmine-spec');
+});

--- a/.github/scripts/lib/presence-gate.mjs
+++ b/.github/scripts/lib/presence-gate.mjs
@@ -1,0 +1,153 @@
+/**
+ * Presence gate — pure classifier and evaluator.
+ *
+ * Decides whether a set of changed files satisfies the "source changed ⇒ a
+ * matching test changed" rule, which kind of new coverage is valid, and whether
+ * a new Jasmine spec was added (which is not allowed — the Jasmine suite is
+ * frozen; new E2E is Playwright). No git or filesystem access lives here so the
+ * logic is unit-testable; the CLI wrapper feeds it a parsed diff.
+ *
+ * A "change" is `{ status, path }` where status is a git name-status letter
+ * (A added, M modified, R renamed, D deleted, ...).
+ */
+
+/**
+ * Source paths that, when changed, require a matching test change.
+ */
+const SOURCE = [
+  /^handsontable\/src\/.*\.(ts|js|tsx)$/,
+  /^wrappers\/(react-wrapper|vue3)\/src\/.*\.(ts|tsx|vue)$/,
+  /^wrappers\/angular-wrapper\/projects\/hot-table\/src\/lib\/.*\.ts$/,
+];
+
+/**
+ * A source candidate is excluded if it is itself a test, a type declaration, or
+ * a test helper. Exclusions are by filename and directory marker, not directory
+ * alone, because specs are co-located inside `src/**\/__tests__/`.
+ */
+const NOT_SOURCE = [
+  /\.spec\.[jt]sx?$/, /\.unit\.[jt]sx?$/, /\.types\.ts$/, /\.d\.ts$/,
+  /\/__tests__\//, /\/test\//, /\/test-helpers\//, /\/spec\//,
+];
+
+/**
+ * Test files that count as coverage regardless of git status.
+ */
+const COVERAGE_ANY_STATUS = [
+  /\.unit\.[jt]sx?$/,       // Jest unit
+  /\.types\.ts$/,           // public-API type-surface tests
+  /\.spec\.tsx?$/,          // Playwright (tests/), wrapper (.spec.tsx/.ts), visual (.spec.ts)
+];
+
+/**
+ * A newly added Jasmine spec (`*.spec.js` under a Jasmine tree). New Jasmine
+ * files do not satisfy the gate and are flagged — new E2E goes to Playwright.
+ */
+const JASMINE_SPEC = /\.spec\.js$/;
+// The frozen Jasmine suites. Walkontable is now INCLUDED — it has a Playwright
+// home (tests/e2e/walkontable), so it follows the same freeze as the main
+// suite: edit existing specs, but new/flaky ones move to Playwright.
+const JASMINE_TREE = [
+  /^handsontable\/src\/.*\/__tests__\//,
+  /^handsontable\/test\//,
+  /^handsontable\/src\/3rdparty\/walkontable\/test\//,
+];
+
+/**
+ * Classify a single path as 'source', 'test', or 'neither' (status-independent
+ * view, used by tests and reporting).
+ *
+ * @param {string} p Repo-relative path.
+ * @returns {'source'|'test'|'neither'} The classification.
+ */
+export function classify(p) {
+  const isSource = SOURCE.some(r => r.test(p)) && !NOT_SOURCE.some(r => r.test(p));
+  if (isSource) {
+    return 'source';
+  }
+  const isTest = COVERAGE_ANY_STATUS.some(r => r.test(p)) || JASMINE_SPEC.test(p);
+  return isTest ? 'test' : 'neither';
+}
+
+/**
+ * Does this change count as coverage that satisfies the gate?
+ * Modified `*.spec.js` counts; a newly added `*.spec.js` does not.
+ *
+ * @param {{status: string, path: string}} change A parsed diff entry.
+ * @returns {boolean} True when the change satisfies the "a test changed" rule.
+ */
+export function isCoverage({ status, path }) {
+  if (COVERAGE_ANY_STATUS.some(r => r.test(path))) {
+    return true;
+  }
+  // A modified (not newly added) Jasmine spec counts — bug-fix cases on a frozen
+  // spec are allowed (main suite and walkontable alike). A newly added one does
+  // not (see isNewJasmineSpec).
+  return JASMINE_SPEC.test(path) && status !== 'A';
+}
+
+/**
+ * Is this a newly added Jasmine spec — the frozen-set violation?
+ *
+ * @param {{status: string, path: string}} change A parsed diff entry.
+ * @returns {boolean} True for an added `*.spec.js` under a Jasmine tree.
+ */
+export function isNewJasmineSpec({ status, path }) {
+  return status === 'A' && JASMINE_SPEC.test(path) && JASMINE_TREE.some(r => r.test(path));
+}
+
+/**
+ * Is a source change present?
+ *
+ * @param {{status: string, path: string}} change A parsed diff entry.
+ * @returns {boolean} True when the change is production source needing a test.
+ */
+export function isSource({ path }) {
+  return classify(path) === 'source';
+}
+
+/**
+ * Is a pure refactor declared for this change set?
+ * A `Refactor-only:` commit trailer with a non-empty reason.
+ *
+ * @param {string[]} trailers Commit trailer lines from the PR range.
+ * @returns {boolean} True when a non-empty Refactor-only trailer is present.
+ */
+export function refactorDeclared(trailers) {
+  return trailers.some(t => /^Refactor-only:\s*\S/i.test(t.trim()));
+}
+
+/**
+ * Evaluate a change set against the gate.
+ *
+ * @param {{status: string, path: string}[]} changes Parsed diff entries.
+ * @param {string[]} [trailers] Commit trailer lines from the PR range.
+ * @returns {{ pass: boolean, sourceFiles: string[], newJasmine: string[],
+ *   reason: string }} Verdict and the data needed to build a PR comment.
+ */
+export function evaluate(changes, trailers = []) {
+  const sourceFiles = changes.filter(isSource).map(c => c.path);
+  const newJasmine = changes.filter(isNewJasmineSpec).map(c => c.path);
+  const hasCoverage = changes.some(isCoverage);
+  const declared = refactorDeclared(trailers);
+
+  // New Jasmine specs are always a violation (steer to Playwright), independent
+  // of whether other coverage exists.
+  if (newJasmine.length > 0) {
+    return {
+      pass: false,
+      sourceFiles,
+      newJasmine,
+      reason: 'new-jasmine-spec',
+    };
+  }
+
+  if (sourceFiles.length > 0 && !hasCoverage) {
+    if (declared) {
+      return { pass: true, sourceFiles, newJasmine, reason: 'refactor-declared' };
+    }
+    return { pass: false, sourceFiles, newJasmine, reason: 'missing-coverage' };
+  }
+
+  return { pass: true, sourceFiles, newJasmine, reason: 'ok' };
+}

--- a/.github/scripts/test-presence-gate.mjs
+++ b/.github/scripts/test-presence-gate.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * Presence gate CLI.
+ *
+ * Runs the pure evaluator (lib/presence-gate.mjs) against the current PR diff.
+ * Derives the base ref from the PR event when available, skips cleanly on
+ * branch pushes, and exits non-zero only in block mode.
+ *
+ * Env:
+ *   GATE_MODE   'warn' (default) exits 0 always; 'block' exits 1 on failure.
+ *   GATE_BASE   Base ref/SHA to diff against. In CI, pass
+ *               github.event.pull_request.base.sha. When unset, the gate is a
+ *               branch push and is skipped.
+ *
+ * The verdict is printed as GitHub-flavored Markdown so a workflow step can post
+ * it as a sticky PR comment.
+ */
+import { execSync } from 'node:child_process';
+import { evaluate } from './lib/presence-gate.mjs';
+
+const base = process.env.GATE_BASE;
+const mode = process.env.GATE_MODE === 'block' ? 'block' : 'warn';
+
+if (!base) {
+  console.log('presence-gate: no GATE_BASE (branch push) — skipped.');
+  process.exit(0);
+}
+
+/**
+ * Parse `git diff --name-status` into `{ status, path }` entries.
+ *
+ * @param {string} range The diff range, e.g. `<base>...HEAD`.
+ * @returns {{status: string, path: string}[]} Parsed diff entries.
+ */
+function readChanges(range) {
+  const out = execSync(`git diff --name-status ${range}`, { encoding: 'utf8' });
+  return out.split('\n').filter(Boolean).map((line) => {
+    const [status, ...rest] = line.split('\t');
+    // For renames (Rxxx) git prints old\tnew — take the new path.
+    return { status: status[0], path: rest[rest.length - 1] };
+  });
+}
+
+/**
+ * Read `Refactor-only:` trailers from the commits in the range.
+ *
+ * @param {string} range The commit range, e.g. `<base>..HEAD`.
+ * @returns {string[]} Trailer lines.
+ */
+function readTrailers(range) {
+  const out = execSync(`git log ${range} --format=%B`, { encoding: 'utf8' });
+  return out.split('\n').filter(l => /^Refactor-only:/i.test(l.trim()));
+}
+
+const changes = readChanges(`${base}...HEAD`);
+const trailers = readTrailers(`${base}..HEAD`);
+const result = evaluate(changes, trailers);
+
+const lines = ['## Test-presence gate', ''];
+if (result.pass) {
+  if (result.reason === 'refactor-declared') {
+    lines.push('✅ Pass — source changed with no test, but a `Refactor-only:` trailer declares this a refactor. Existing tests for the area must stay green.');
+  } else {
+    lines.push('✅ Pass.');
+  }
+} else if (result.reason === 'new-jasmine-spec') {
+  lines.push('❌ A **new Jasmine `*.spec.js`** was added. The Jasmine suite is frozen — new E2E goes in `tests/e2e/` as Playwright (`*.spec.ts`). Editing an existing Jasmine spec is fine.', '');
+  lines.push('New Jasmine files:');
+  lines.push(...result.newJasmine.map(f => `- \`${f}\``));
+} else if (result.reason === 'missing-coverage') {
+  lines.push('❌ Source changed with no matching test change. Add a Playwright `*.spec.ts` (`tests/e2e/`), a Jest `*.unit.js`, or a `*.types.ts` — or add a `Refactor-only: <reason>` commit trailer if this is a pure refactor.', '');
+  lines.push('Source files needing a test:');
+  lines.push(...result.sourceFiles.map(f => `- \`${f}\``));
+}
+
+console.log(lines.join('\n'));
+
+if (!result.pass && mode === 'block') {
+  process.exitCode = 1;
+}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Pillar 1 enforcement: source changed ⇒ a matching test changed, and new E2E
+  # is Playwright (a new Jasmine *.spec.js is flagged). Warn mode — it reports
+  # via the job summary but does not block. Flip to block in a later change
+  # (see quality/pillar-1/tasks/09). Needs only node + git history, no build.
+  test-presence-gate:
+    name: "[CHECK] Test presence"
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # https://github.com/actions/checkout/releases/tag/v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Evaluate test-presence gate (warn)
+        run: node .github/scripts/test-presence-gate.mjs | tee -a "$GITHUB_STEP_SUMMARY"
+        env:
+          GATE_MODE: warn
+          GATE_BASE: ${{ github.event.pull_request.base.sha }}
+
+  # Functional Playwright E2E (tests/e2e). Runs inside the pinned Playwright
+  # container so the engine + browsers match local and baseline generation
+  # exactly; the version here tracks the tests/ package (bump together).
+  # Consumes the UMD build artifact — the fixture serves handsontable/dist.
+  test-e2e-playwright:
+    name: "[TEST] E2E (Playwright)"
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.61.1-noble
+    needs: [ check-scope, build-handsontable-umd ]
+    if: |
+      needs.check-scope.outputs.run-all == 'true' ||
+      needs.check-scope.outputs.build-handsontable-umd == 'true'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # https://github.com/actions/checkout/releases/tag/v6.0.2
+
+      - name: Download the Handsontable UMD build artifact
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # https://github.com/actions/download-artifact/releases/tag/v8.0.0
+        with:
+          name: handsontable-build-umd
+
+      - run: tar -zxf dist.tar.gz ./handsontable/dist ./handsontable/styles && rm dist.tar.gz
+
+      - name: Install the Playwright test package
+        run: cd tests && npm ci
+
+      - name: Run Playwright E2E
+        run: cd tests && npx playwright test --project=e2e-chromium
+
+      - name: Upload the Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # https://github.com/actions/upload-artifact/releases/tag/v7.0.0
+        with:
+          name: playwright-report
+          path: tests/playwright-report
+          retention-days: 3
+
   check-scope:
     name: Check the scope
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ docs/.env
 /docs/*.png
 # Added by code-review-graph
 .code-review-graph/
+
+# QA overhaul planning scaffold — ephemeral. Durable rules/skills/conventions
+# are promoted into the committed repo structure (see quality/pillar-1/tasks/07).
+quality/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ Full rules (what counts, the per-change table, legacy vs deprecated, what is NOT
 
 Every code change produced by an agent **must** satisfy all of the following:
 
-1. **Tests are required.** Every change must include both **unit tests** (Jest, `*.unit.js`) and **E2E tests** (Jasmine/Puppeteer, `*.spec.js`). No change is complete without test coverage for the new or modified behavior.
+1. **Tests are required, and machine-enforced.** A change to `handsontable/src/**` or `wrappers/**` must ship a matching test change (the presence gate checks this on every PR). The *kind* follows the change: **unit** (Jest, `*.unit.js`) for logic, **E2E** for anything a user can see or do — and **new E2E is Playwright** (`tests/e2e/*.spec.ts`); the Jasmine/Puppeteer `*.spec.js` suite is frozen (edit existing specs, but do not add new ones — migrate broken ones to Playwright). A pure refactor needs no new test if declared with a `Refactor-only: <reason>` commit trailer. Full decision rules: `handsontable/.ai/TESTING.md`.
 2. **Documentation must be updated.** If a change affects the public API, configuration options, hooks, behavior, or user-facing experience, update the corresponding documentation (guides, API reference via JSDoc/Typedoc, migration guide) in the same change. See [Documentation standards](#documentation-standards-all-packages).
 3. **Update AGENTS.md.** If a change introduces new conventions, patterns, constraints, file locations, or gotchas that future agents should know, update the `AGENTS.md` at the correct scope.
 

--- a/handsontable/.ai/CONVENTIONS.md
+++ b/handsontable/.ai/CONVENTIONS.md
@@ -65,8 +65,12 @@
 | `handsontable/restricted-module-imports` | No imports from barrel index files (`plugins/index`, `editors/index`, `renderers/index`, `validators/index`, `cellTypes/index`, `i18n/index`). Import from specific submodule paths. Only exception: `src/registry.ts` |
 | `handsontable/require-async-in-it` | All `it()` callbacks in `*.spec.js` must be `async`. Disabled for `*.unit.js` |
 | `handsontable/require-await` | Specific HOT API calls must be `await`-ed in `*.spec.js` (full list in `handsontable/.eslintrc.js` lines 84-151) |
+| `handsontable/no-fixed-sleep-in-spec` | No fixed `sleep()` delay in `*.spec.js` — wait for a condition instead. `warn` (surfaces the frozen suite's legacy debt without red-walling CI); new E2E belongs in Playwright |
+| `handsontable/no-new-it-flaky` | No new `it.flaky()`/`fit.flaky()` — fix the flake at its source or migrate the spec to Playwright. `warn` for the same reason |
 | `no-restricted-globals` | Source: `window`, `document`, `console`, `Handsontable` banned. Tests: only `fit`, `fdescribe` banned |
 | `compat/compat` | Browser API compatibility check (off in test files) |
+
+The Playwright tier (`tests/`) has its own config (`tests/.eslintrc.cjs`) with the `@typescript-eslint` parser and `no-restricted-syntax` bans for `page.waitForTimeout()`, `sleep()`, and `'networkidle'` — at `error`, since that tier is greenfield with no debt to baseline.
 
 **Test file overrides (relaxed rules in `handsontable/.eslintrc.js`):**
 - `jsdoc/require-jsdoc`: off in `*.unit.js` and `*.spec.js`

--- a/handsontable/.ai/TESTING.md
+++ b/handsontable/.ai/TESTING.md
@@ -1,27 +1,30 @@
 # Testing Patterns
 
+> **Paradigm (read first):** new E2E is **Playwright**, in the `tests/` package (`tests/e2e/*.spec.ts`) — see the `handsontable-playwright-e2e` skill. The **Jasmine + Puppeteer** `*.spec.js` suite documented below is the **frozen legacy** suite: keep it running, edit existing specs, but add no new ones — migrate broken/flaky ones to Playwright. Unit tests stay Jest. Which framework a change needs is decided in "What to test, and in which framework" below and machine-enforced by the presence gate.
+
 ## Test Framework
 
-**Runner:**
-- Jest for unit tests (configured in `handsontable/jest.config.js`)
-- Jasmine with Puppeteer for E2E tests (browser-based, headless Chrome via `test/scripts/run-puppeteer.mjs`)
+**Runners:**
+- Jest for unit tests (configured in `handsontable/jest.config.js`; `jest-jasmine2` runner)
+- **Playwright for new E2E** (`tests/` package; the current paradigm — skill: `handsontable-playwright-e2e`)
+- Jasmine with Puppeteer for the **frozen legacy** E2E suite (headless Chrome via `test/scripts/run-puppeteer.mjs`)
 - Separate test runner for Walkontable (`npm run test:walkontable`)
-- Test runner: `jest-jasmine2` (not the default Jest runner)
 
 **Assertion Library:**
 - Jest's built-in `expect()` for unit tests
-- Jasmine's `expect()` for E2E tests
-- Custom matchers from `test/helpers/custom-matchers.js` (shared between unit and E2E)
+- Playwright's web-first `expect()` for new E2E (auto-retrying)
+- Jasmine's `expect()` for the legacy E2E suite
+- Custom matchers from `test/helpers/custom-matchers.js` (shared between unit and legacy E2E)
 
 **Run Commands:**
 ```bash
 # From handsontable/ directory:
 npm run test:unit                  # Run all Jest unit tests (~216 files)
-npm run test:e2e                   # Build + run Jasmine E2E tests (~946 spec files)
+npm run test:e2e                   # Build + run the LEGACY Jasmine E2E suite (~946 spec files)
 npm run test:walkontable           # Run Walkontable-specific tests
-npm run test:e2e.watch             # Watch mode for E2E tests
 npm run test:types                 # TypeScript type checking only
-npm run test                       # Full pipeline: lint + unit + types + walkontable + e2e + production
+# New Playwright E2E (from the repo root):
+cd tests && npm test               # Playwright functional + visual projects
 
 # From monorepo root (npm --prefix):
 npm --prefix handsontable run test:unit
@@ -60,8 +63,9 @@ The helper that derives the hash lives in `handsontable/.config/helper/run-id.js
 
 **Test Environment:**
 - Unit tests: jsdom (JavaScript DOM implementation)
-- E2E tests: Puppeteer with real headless Chrome
-- Default Jasmine timeout: 15000ms (set in `test/bootstrap.js`)
+- New E2E: Playwright (real Chromium; `tests/` package)
+- Legacy E2E: Puppeteer with real headless Chrome
+- Default legacy-Jasmine timeout: 15000ms (set in `test/bootstrap.js`)
 
 ## Test File Organization
 
@@ -266,13 +270,31 @@ Keyboard events: `keyDownUp`, `keyDown`, `keyUp`
 **Scroll-Awaiting Pattern (`test/helpers/utils.js`):**
 Many helpers (e.g., `selectCell`, `scrollViewportTo`, `selectAll`) are wrapped with `waitOnScroll()`, which returns a Promise that resolves after any triggered scroll completes. This is why they must be `await`-ed.
 
-**Delay Pattern:**
+**Waiting — condition-based, never a fixed delay (rule):**
+Do **not** add `await sleep(100)` / `sleep(200)` to new tests. A fixed delay is either too short (flaky) or too long (slow), and it is the root of this suite's flakiness. Wait for the *condition* instead:
 ```javascript
-await sleep(100); // Wait for async validation or animation
-await sleep(200); // Wait for dropdown menus to render
+// legacy Jasmine E2E: await the state, not the clock
+await selectCell(0, 0);                 // helpers already await the scroll they trigger
+await sleep(...);                        // ← avoid; if you must, root-cause it and add a real waiter
 ```
+For new Playwright tests use web-first, auto-retrying assertions (`await expect(locator).toBeVisible()`); see the `handsontable-playwright-e2e` skill. Existing `sleep()` sites are baselined by lint, but a broken or flaky legacy test is a signal to migrate it (see below), not to add another delay.
 
 **Unit tests are synchronous:** `handsontable/require-async-in-it` and `handsontable/require-await` are both off for `*.unit.js`.
+
+## What to test, and in which framework (Pillar 1)
+
+Machine-enforced by the presence gate (`.github/scripts/test-presence-gate.mjs`): a change to `handsontable/src/**` or `wrappers/**` must ship a matching test change. Which kind:
+
+- **A user could see or do it** (rendering, editing, selection, keyboard, menus, overlays) → **E2E**. New E2E is **Playwright** in `tests/e2e/` — see the `handsontable-playwright-e2e` skill.
+- **Behavior changed but is invisible to users** (data, indexing, algorithms, internal state) → a **Jest `*.unit.js`**. Still mandatory — "not user-facing" is not a free pass.
+- **No behavior change** (pure refactor) or **non-runtime** (types, docs, config, i18n text, re-exports) → **no new test**; declare a refactor with a `Refactor-only: <reason>` commit trailer.
+
+**New spec vs modify existing:** new public API / plugin / editor → a new spec; a bug fix → add a case to the closest existing spec (its test must fail without the fix).
+
+**The Jasmine suite is frozen — and migrates by attrition:**
+- Adding a **new** `*.spec.js` is blocked; new E2E goes to Playwright.
+- **Editing** an existing `*.spec.js` for routine maintenance is fine.
+- But if a legacy Jasmine test is **broken or flaky, fix it by migrating it to Playwright** (delete the `*.spec.js`, write the equivalent `tests/e2e/*.spec.ts`) rather than patching Jasmine. That is how the suite gradually migrates — the tests that hurt most move first.
 
 ## Mocking
 

--- a/handsontable/.config/plugin/eslint/index.js
+++ b/handsontable/.config/plugin/eslint/index.js
@@ -16,5 +16,7 @@ module.exports = {
     'require-await': require('./rules/require-await'),
     'no-native-error-throw': require('./rules/no-native-error-throw'),
     'no-direct-dom-geometry-read': require('./rules/no-direct-dom-geometry-read'),
+    'no-fixed-sleep-in-spec': require('./rules/no-fixed-sleep-in-spec'),
+    'no-new-it-flaky': require('./rules/no-new-it-flaky'),
   },
 };

--- a/handsontable/.config/plugin/eslint/rules/no-fixed-sleep-in-spec.js
+++ b/handsontable/.config/plugin/eslint/rules/no-fixed-sleep-in-spec.js
@@ -1,0 +1,33 @@
+module.exports = {
+  meta: {
+    type: 'suggestion',
+
+    docs: {
+      description: 'Disallows fixed `sleep()` delays in spec files — wait for a condition instead',
+      category: 'Custom',
+      recommended: false,
+      fixable: false,
+    },
+
+    messages: {
+      noSleep: 'Do not use a fixed sleep() delay. Wait for the condition — a hook, a DOM state, or a '
+        + 'web-first assertion. See handsontable/.ai/TESTING.md.',
+    },
+  },
+
+  create(context) {
+    return {
+      /**
+       * Flag any direct `sleep(...)` call.
+       *
+       * @param {object} node The CallExpression node.
+       * @returns {void}
+       */
+      CallExpression(node) {
+        if (node.callee && node.callee.type === 'Identifier' && node.callee.name === 'sleep') {
+          context.report({ node, messageId: 'noSleep' });
+        }
+      },
+    };
+  },
+};

--- a/handsontable/.config/plugin/eslint/rules/no-new-it-flaky.js
+++ b/handsontable/.config/plugin/eslint/rules/no-new-it-flaky.js
@@ -1,0 +1,37 @@
+module.exports = {
+  meta: {
+    type: 'suggestion',
+
+    docs: {
+      description: 'Disallows new it.flaky()/fit.flaky() — fix the flake at its root or migrate the spec to Playwright',
+      category: 'Custom',
+      recommended: false,
+      fixable: false,
+    },
+
+    messages: {
+      noFlaky: 'Do not add it.flaky()/fit.flaky(). Fix the flake at its source, or migrate the spec '
+        + 'to Playwright (tests/e2e). See handsontable/.ai/TESTING.md.',
+    },
+  },
+
+  create(context) {
+    return {
+      /**
+       * Flag `it.flaky(...)` and `fit.flaky(...)` member calls.
+       *
+       * @param {object} node The CallExpression node.
+       * @returns {void}
+       */
+      CallExpression(node) {
+        const callee = node.callee;
+
+        if (callee && callee.type === 'MemberExpression'
+          && callee.property && callee.property.name === 'flaky'
+          && callee.object && (callee.object.name === 'it' || callee.object.name === 'fit')) {
+          context.report({ node, messageId: 'noFlaky' });
+        }
+      },
+    };
+  },
+};

--- a/handsontable/.eslintrc.js
+++ b/handsontable/.eslintrc.js
@@ -210,6 +210,12 @@ module.exports = {
         'jsdoc/require-returns': 'off',
         'handsontable/restricted-module-imports': 'off',
         'handsontable/require-async-in-it': 'error',
+        // Determinism guards for the frozen Jasmine suite. WARN, not error: the
+        // existing sleep()/it.flaky() debt must surface without red-walling CI.
+        // Escalation to error happens in the flip-to-blocking task once the
+        // debt is burned down. New E2E belongs in Playwright (tests/e2e).
+        'handsontable/no-fixed-sleep-in-spec': 'warn',
+        'handsontable/no-new-it-flaky': 'warn',
         'brace-style': ['error', '1tbs', { allowSingleLine: true }],
       }
     },

--- a/handsontable/AGENTS.md
+++ b/handsontable/AGENTS.md
@@ -47,7 +47,10 @@ Gotcha: Filters `conditionCollection` uses physical indexes, `getDataAtCol()` us
 | Type | Pattern | Framework | Run |
 |------|---------|-----------|-----|
 | Unit | `*.unit.js` | Jest (jsdom) | `npm run test:unit` |
-| E2E | `*.spec.js` | Jasmine (Puppeteer) | `npm run test:e2e` |
+| E2E (legacy, frozen) | `*.spec.js` | Jasmine (Puppeteer) | `npm run test:e2e` |
+| E2E (new) | `tests/e2e/*.spec.ts` | Playwright | `cd tests && npm test` |
+
+**New E2E is Playwright** in `tests/e2e/` (skill: `handsontable-playwright-e2e`). The Jasmine `*.spec.js` suite is frozen — edit existing specs, but add no new ones, and migrate broken ones to Playwright. What to test in which framework, and when a test is even required, is machine-enforced by the presence gate; the decision rules are in `.ai/TESTING.md`.
 
 - ALL `it()` callbacks in spec files MUST be `async`
 - HOT API calls MUST be `await`-ed

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,9 @@
+# Local git hooks (lefthook). The pre-push gate is fast, local feedback — the
+# same enforcement CI runs, one step earlier. It is bypassable with
+# `git push --no-verify`; CI is the authoritative gate.
+#
+# Activate once after install:  npx lefthook install
+pre-push:
+  commands:
+    test-gate:
+      run: node scripts/pre-push.mjs

--- a/scripts/__tests__/pre-push.test.mjs
+++ b/scripts/__tests__/pre-push.test.mjs
@@ -1,0 +1,26 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { changedPlaywrightSpecs } from '../pre-push.mjs';
+
+test('selects changed Playwright specs and maps them relative to tests/', () => {
+  const changed = [
+    'tests/e2e/grid.spec.ts',
+    'tests/e2e/filters/menu.spec.ts',
+    'tests/fixtures/pages/GridPage.ts', // support, not a spec
+    'handsontable/src/plugins/filters/filters.ts', // source
+    'handsontable/src/plugins/filters/__tests__/x.spec.js', // legacy Jasmine
+    'tests/visual/theme.spec.ts', // visual, not e2e
+  ];
+
+  assert.deepEqual(changedPlaywrightSpecs(changed), [
+    'e2e/grid.spec.ts',
+    'e2e/filters/menu.spec.ts',
+  ]);
+});
+
+test('returns nothing when no e2e specs changed', () => {
+  assert.deepEqual(changedPlaywrightSpecs([
+    'handsontable/src/core.ts',
+    'tests/fixtures/demo/grid.html',
+  ]), []);
+});

--- a/scripts/claude/__tests__/session.test.mjs
+++ b/scripts/claude/__tests__/session.test.mjs
@@ -1,0 +1,41 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { isNewJasmineSpec } from '../../../.github/scripts/lib/presence-gate.mjs';
+import { sessionEditsFile, stopVerdict } from '../session.mjs';
+
+test('sessionEditsFile is per-session and sanitized', () => {
+  const a = sessionEditsFile('abc-123');
+  const b = sessionEditsFile('abc-123');
+  const c = sessionEditsFile('other/../id');
+
+  assert.equal(a, b, 'same id → same path');
+  assert.notEqual(a, c);
+  assert.match(c, /other_+id\.edits$/, 'unsafe chars replaced');
+});
+
+test('stopVerdict blocks on a NEW Jasmine spec created this turn', () => {
+  const v = stopVerdict(
+    [{ status: 'A', path: 'handsontable/src/plugins/filters/__tests__/new.spec.js' }],
+    isNewJasmineSpec,
+  );
+
+  assert.equal(v.block, true);
+  assert.equal(v.reason, 'new-jasmine-spec');
+});
+
+test('stopVerdict does NOT block on source-without-test (pre-push/CI owns existence)', () => {
+  const v = stopVerdict(
+    [{ status: 'M', path: 'handsontable/src/plugins/filters/filters.ts' }],
+    isNewJasmineSpec,
+  );
+
+  assert.equal(v.block, false);
+});
+
+test('stopVerdict does NOT block on a new Playwright spec or a modified Jasmine spec', () => {
+  const newPlaywright = [{ status: 'A', path: 'tests/e2e/x.spec.ts' }];
+  const modifiedJasmine = [{ status: 'M', path: 'handsontable/src/plugins/filters/__tests__/filters.spec.js' }];
+
+  assert.equal(stopVerdict(newPlaywright, isNewJasmineSpec).block, false);
+  assert.equal(stopVerdict(modifiedJasmine, isNewJasmineSpec).block, false);
+});

--- a/scripts/claude/post-tool-use.mjs
+++ b/scripts/claude/post-tool-use.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * Claude Code PostToolUse hook (Edit|Write). Two jobs, both scoped to stay fast:
+ *   1. Record the edited path to a per-session list, so the Stop hook knows what
+ *      the turn touched (a Stop hook receives no file path).
+ *   2. If a spec was edited, lint it (`eslint --fix`) and feed lint errors back
+ *      to the model via exit 2, so determinism rules are applied at authoring
+ *      time.
+ *
+ * Reads the tool payload as JSON on stdin (there is no $CLAUDE_TOOL_FILE_PATH).
+ */
+import { spawnSync } from 'node:child_process';
+import { appendFileSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { sessionEditsFile } from './session.mjs';
+
+/**
+ * Read all of stdin synchronously.
+ *
+ * @returns {string} Raw stdin contents (empty string if none).
+ */
+function readStdin() {
+  try {
+    return spawnSync('cat', { stdio: ['inherit', 'pipe', 'ignore'], encoding: 'utf8' }).stdout || '';
+  } catch {
+    return '';
+  }
+}
+
+const raw = readStdin();
+let payload = {};
+
+try {
+  payload = JSON.parse(raw);
+} catch { /* no/!json stdin — nothing to do */ }
+
+const file = payload?.tool_input?.file_path;
+
+if (!file) {
+  process.exit(0);
+}
+
+const sessionId = payload?.session_id || 'default';
+const editsFile = sessionEditsFile(sessionId);
+
+try {
+  mkdirSync(path.dirname(editsFile), { recursive: true });
+  appendFileSync(editsFile, `${file}\n`);
+} catch { /* recording is best-effort */ }
+
+// Lint edited specs only — running the full typed ESLint on every core .ts edit
+// is too slow for the edit loop.
+if (/\.(spec|unit)\.[jt]sx?$/.test(file)) {
+  const res = spawnSync('npx', ['eslint', '--fix', file], { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf8' });
+  const output = `${res.stdout || ''}${res.stderr || ''}`;
+  // Only block on genuine rule violations. A parsing error or eslint's own error
+  // (status 2) means no applicable config for this file type — do not blame the
+  // model for that. Both the frozen Jasmine suite (handsontable/.eslintrc.js)
+  // and the Playwright tier (tests/.eslintrc.cjs) now have configs, so real
+  // determinism violations DO surface here and block; the guard only covers
+  // file types that still lack a config.
+  const configGap = res.status === 2 || /Parsing error/i.test(output);
+
+  if (res.status === 1 && !configGap) {
+    process.stderr.write(`Lint errors in ${file}:\n${output}`);
+    process.exit(2);
+  }
+}
+
+process.exit(0);

--- a/scripts/claude/session.mjs
+++ b/scripts/claude/session.mjs
@@ -1,0 +1,42 @@
+/**
+ * Shared helpers for the Claude Code agent hooks (post-tool-use + stop).
+ */
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+/**
+ * Path to the per-session file that records which paths the agent edited this
+ * turn/session. The PostToolUse hook appends to it; the Stop hook reads it.
+ *
+ * @param {string} sessionId The Claude Code session id (or 'default').
+ * @returns {string} An absolute temp file path.
+ */
+export function sessionEditsFile(sessionId) {
+  const safe = String(sessionId).replace(/[^A-Za-z0-9_-]/g, '_');
+
+  return path.join(tmpdir(), 'hot-claude-hooks', `${safe}.edits`);
+}
+
+/**
+ * Decide what the Stop hook should do, given the session's changed files.
+ * Pure, so it is unit-testable.
+ *
+ * Philosophy: a Stop hook fires on every turn end, so it blocks only on
+ * unambiguous violations — a NEW Jasmine spec (new E2E must be Playwright).
+ * The "a test must exist for this source" check is left to pre-push and CI,
+ * where the `Refactor-only:` escape exists. Whether touched tests pass is
+ * decided by the CLI actually running them.
+ *
+ * @param {{status: string, path: string}[]} entries Session changes.
+ * @param {(c: {status: string, path: string}) => boolean} isNewJasmineSpec Predicate.
+ * @returns {{ block: boolean, reason: string, newJasmine: string[] }} Verdict.
+ */
+export function stopVerdict(entries, isNewJasmineSpec) {
+  const newJasmine = entries.filter(isNewJasmineSpec).map(e => e.path);
+
+  if (newJasmine.length > 0) {
+    return { block: true, reason: 'new-jasmine-spec', newJasmine };
+  }
+
+  return { block: false, reason: 'ok', newJasmine };
+}

--- a/scripts/claude/stop.mjs
+++ b/scripts/claude/stop.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+/**
+ * Claude Code Stop hook. When the agent ends a turn, verify the tests it
+ * touched this session. Blocks (exit 2, which returns control to the agent with
+ * the message) only on unambiguous problems:
+ *   - a NEW Jasmine spec was created (new E2E must be Playwright), or
+ *   - a Playwright spec the session touched now fails.
+ *
+ * It does NOT hard-block on "source changed without a test" — that fires every
+ * turn and would be hostile mid-task; pre-push and CI enforce existence, where
+ * the `Refactor-only:` escape is available.
+ */
+import { execSync, spawnSync } from 'node:child_process';
+import { readFileSync, existsSync } from 'node:fs';
+import { isNewJasmineSpec } from '../../.github/scripts/lib/presence-gate.mjs';
+import { sessionEditsFile, stopVerdict } from './session.mjs';
+import { changedPlaywrightSpecs } from '../pre-push.mjs';
+
+/**
+ * Read all of stdin synchronously.
+ *
+ * @returns {string} Raw stdin contents (empty string if none).
+ */
+function readStdin() {
+  try {
+    return spawnSync('cat', { stdio: ['inherit', 'pipe', 'ignore'], encoding: 'utf8' }).stdout || '';
+  } catch {
+    return '';
+  }
+}
+
+let payload = {};
+
+try {
+  payload = JSON.parse(readStdin());
+} catch { /* ignore */ }
+const editsFile = sessionEditsFile(payload?.session_id || 'default');
+
+if (!existsSync(editsFile)) {
+  process.exit(0);
+}
+
+const paths = [...new Set(readFileSync(editsFile, 'utf8').split('\n').filter(Boolean))];
+
+/**
+ * Git status letter for a path in the working tree (A for untracked/added,
+ * M for modified, ' ' otherwise).
+ *
+ * @param {string} p Repo-relative path.
+ * @returns {string} A single status letter.
+ */
+function statusOf(p) {
+  const out = execSync(`git status --porcelain -- "${p}"`, { encoding: 'utf8' }).trim();
+
+  if (!out) {
+    return 'M';
+  }
+  const code = out.slice(0, 2);
+
+  return code.includes('?') ? 'A' : (code.trim()[0] || 'M');
+}
+
+const entries = paths.map(p => ({ status: statusOf(p), path: p }));
+const verdict = stopVerdict(entries, isNewJasmineSpec);
+
+if (verdict.block && verdict.reason === 'new-jasmine-spec') {
+  process.stderr.write(
+    'A new Jasmine *.spec.js was created this turn. The Jasmine suite is frozen — '
+    + `move it to tests/e2e/ as a Playwright *.spec.ts before finishing:\n  ${
+      verdict.newJasmine.join('\n  ')}\n`);
+  process.exit(2);
+}
+
+// Run any Playwright spec the session touched; a red test the agent wrote must
+// not survive the turn.
+const specs = changedPlaywrightSpecs(paths).filter(s => existsSync(`tests/${s}`));
+
+if (specs.length > 0) {
+  const pw = spawnSync('npx', ['playwright', 'test', '--project=e2e-chromium', ...specs], {
+    cwd: 'tests', stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf8',
+  });
+
+  if (pw.status !== 0) {
+    process.stderr.write(
+      `Playwright specs you touched are failing — fix them before finishing:\n${pw.stdout || ''}${pw.stderr || ''}`,
+    );
+    process.exit(2);
+  }
+}
+
+process.exit(0);

--- a/scripts/pre-push.mjs
+++ b/scripts/pre-push.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * Pre-push gate (invoked by lefthook). The local, fast mirror of the CI
+ * enforcement: a change must carry a test, and any changed Playwright spec is
+ * run so a new test is proven before it is pushed. Bypassable with
+ * `git push --no-verify` — CI is the real guarantee.
+ *
+ * Scoped to stay fast: it runs the presence gate (no build) and only the
+ * Playwright specs the push touches. The full unit/E2E suites are CI's job.
+ */
+import { execSync, spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+
+/**
+ * Resolve the base ref to diff against — the merge-base with the trunk.
+ *
+ * @returns {string} A ref/SHA usable in `git diff <base>...HEAD`.
+ */
+function resolveBase() {
+  for (const ref of ['origin/develop', 'develop']) {
+    try {
+      return execSync(`git merge-base ${ref} HEAD`, { encoding: 'utf8' }).trim();
+    } catch {
+      // try the next candidate
+    }
+  }
+
+  return 'develop';
+}
+
+/**
+ * Map the pushed diff to the Playwright specs that must run.
+ * Pure so it can be unit-tested; returns paths relative to `tests/`.
+ *
+ * @param {string[]} changed Repo-relative changed paths.
+ * @returns {string[]} Spec paths relative to the `tests/` package.
+ */
+export function changedPlaywrightSpecs(changed) {
+  return changed
+    .filter(f => /^tests\/e2e\/.+\.spec\.ts$/.test(f))
+    .map(f => f.replace(/^tests\//, ''));
+}
+
+// Exit early when imported by a test.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const base = resolveBase();
+
+  // 1) Presence gate (block mode).
+  const gate = spawnSync('node', ['.github/scripts/test-presence-gate.mjs'], {
+    stdio: 'inherit',
+    env: { ...process.env, GATE_MODE: 'block', GATE_BASE: base },
+  });
+
+  if (gate.status !== 0) {
+    process.exit(gate.status ?? 1);
+  }
+
+  // 2) Run any Playwright spec the push changed, so a new test is proven.
+  const changed = execSync(`git diff --name-only ${base}...HEAD`, { encoding: 'utf8' })
+    .split('\n').filter(Boolean);
+  const specs = changedPlaywrightSpecs(changed).filter(s => existsSync(`tests/${s}`));
+
+  if (specs.length > 0) {
+    console.log(`pre-push: running ${specs.length} changed Playwright spec(s)…`);
+    const pw = spawnSync('npx', ['playwright', 'test', '--project=e2e-chromium', ...specs], {
+      cwd: 'tests',
+      stdio: 'inherit',
+    });
+
+    if (pw.status !== 0) {
+      process.exit(pw.status ?? 1);
+    }
+  }
+
+  console.log('pre-push: ok');
+}

--- a/scripts/sync-skills-to-cursor.mjs
+++ b/scripts/sync-skills-to-cursor.mjs
@@ -22,6 +22,8 @@ const GLOB_MAP = {
   'handsontable-celltype-dev': ['handsontable/src/cellTypes/**'],
   'handsontable-unit-testing': ['handsontable/src/**/*.unit.js', 'handsontable/test/unit/**'],
   'handsontable-e2e-testing': ['handsontable/src/**/*.spec.js', 'handsontable/test/e2e/**'],
+  'handsontable-playwright-e2e': ['tests/e2e/**', 'tests/fixtures/**'],
+  'test-writing-discipline': null, // applies to all tests -- loaded on demand, no globs
   'walkontable-dev': ['handsontable/src/3rdparty/walkontable/**'],
   'walkontable-testing': ['handsontable/src/3rdparty/walkontable/test/**'],
   'visual-testing': ['visual-tests/**'],

--- a/tests/.eslintrc.cjs
+++ b/tests/.eslintrc.cjs
@@ -1,0 +1,44 @@
+// ESLint config for the Playwright test tier (tests/e2e, tests/visual).
+// CommonJS (.cjs) because this package is "type": "module" and ESLint's
+// legacy config loader requires CJS.
+//
+// This tier is greenfield — there is no legacy debt to baseline — so the
+// determinism bans ship at `error`, not `warn`. A fixed delay or a
+// `networkidle` wait must never enter a Playwright spec: wait for a
+// condition (a web-first assertion, a locator state) instead.
+//
+// Scope is deliberately minimal: the @typescript-eslint PARSER (so `.ts`
+// specs parse) plus core `no-restricted-syntax` bans. It does NOT pull in
+// eslint-plugin-playwright — that richer ruleset is a new third-party
+// dependency and is gated on the team-discussion required by the
+// minimal-dependency policy (see tests/README.md).
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  env: {
+    node: true,
+    browser: true,
+    es2022: true,
+  },
+  rules: {
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector: "CallExpression[callee.property.name='waitForTimeout']",
+        message: 'No fixed page.waitForTimeout() — wait for a condition (a web-first assertion or a locator state). See .claude/skills/handsontable-playwright-e2e/references/determinism.md.',
+      },
+      {
+        selector: "CallExpression[callee.name='sleep']",
+        message: 'No fixed sleep() delay — wait for a condition instead. See .claude/skills/handsontable-playwright-e2e/references/determinism.md.',
+      },
+      {
+        selector: "Literal[value='networkidle']",
+        message: "No 'networkidle' wait — it is flaky and deprecated for web apps. Assert on a locator or response instead. See .claude/skills/handsontable-playwright-e2e/references/determinism.md.",
+      },
+    ],
+  },
+};

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+playwright-report/
+test-results/
+blob-report/
+.playwright/

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,45 @@
+# `tests/` — Playwright test package
+
+The single Playwright package for Handsontable: functional end-to-end tests in `e2e/`, and visual regression in `visual/` (populated during the visual milestone). One config, one Playwright version.
+
+> Distinct from `handsontable/test/` — that is the package-scoped Jasmine/Puppeteer + unit harness. This `tests/` directory is the Playwright package.
+
+## Layout
+
+```
+tests/
+├── playwright.config.ts   # one config; projects split e2e (flake-strict) from visual
+├── e2e/                    # functional specs (*.spec.ts)
+├── visual/                 # visual regression — destination for the current visual-tests/ suite
+├── fixtures/
+│   ├── demo/               # static pages that mount a real grid for tests to drive
+│   └── pages/              # Page Objects — selectors + interactions live here, not in specs
+└── support/                # static file server for the fixtures
+```
+
+## Conventions (enforced by the `handsontable-playwright-e2e` skill)
+
+- **Page Object Model.** Specs express intent (`grid.editCell(0, 0, 'x')`); selectors and interaction mechanics live in `fixtures/pages/`. When the DOM shifts, one file changes.
+- **Address elements by `data-testid`.** The demo fixtures stamp stable test ids (e.g. `cell-<row>-<col>`) so tests hook in unambiguously instead of via brittle structural CSS.
+- **Web-first waits only.** `await expect(locator).toBeVisible()` and friends — never `waitForTimeout`/`sleep`, never a custom readiness global. `npm run lint` enforces this: `tests/.eslintrc.cjs` bans `page.waitForTimeout()`, `sleep()`, and `'networkidle'` at `error`. (The richer `eslint-plugin-playwright` ruleset is the recommended upgrade, but it is a new third-party dependency gated on the minimal-dependency team discussion — until then the hand-rolled `no-restricted-syntax` bans cover the determinism anti-patterns.)
+- **Deterministic.** `failOnFlakyTests` in CI; a test that only passes on retry is a hard failure.
+
+## Running locally
+
+```bash
+npm install             # from tests/ — this is a standalone package (not yet a workspace member; see below)
+npx playwright install  # browsers, once per version (CI runs inside the pinned container instead)
+npm test                # all projects
+npm run test:e2e        # just the functional e2e project
+npm run lint            # determinism + parse checks on the specs
+```
+
+When enforcement requires a new test, you run it here to prove it works before you push — that is the point of a single, locally-runnable install.
+
+## One Playwright version across the monorepo
+
+There must be **one** Playwright version, installed once, aligned to the version CI runs — currently the latest stable, **1.61.1**. The mechanism is a pnpm **catalog**: `pnpm-workspace.yaml` declares `catalog: { '@playwright/test': 1.61.1 }`, and every Playwright-using package (`tests/`, `visual-tests/`, and — after their bump is verified — `performance-tests/` and `docs/`) sets `"@playwright/test": "catalog:"`. `pnpm install` then resolves one version into the store, and its browsers download once.
+
+The CI Playwright jobs run inside the matching container image, `mcr.microsoft.com/playwright:v1.61.1-noble`. **The catalog version and the container tag bump together, never apart**, so local, CI, and baseline generation render identically.
+
+> Current state: this package pins `1.61.1` concretely and is verified against it. Moving it (and the others) onto `catalog:` and adding `tests/` to the workspace regenerates `pnpm-lock.yaml`, so it is done as one reviewed change — see `quality/pillar-1/tasks/02`.

--- a/tests/e2e/grid.spec.ts
+++ b/tests/e2e/grid.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+import { GridPage } from '../fixtures/pages/GridPage';
+
+/**
+ * Reference functional E2E spec. Demonstrates the conventions the authoring
+ * skill teaches: a page object holds the selectors and interactions, cells are
+ * addressed by stable test id, and every wait is a web-first assertion — no
+ * fixed sleeps.
+ */
+test.describe('grid demo', () => {
+  let grid: GridPage;
+
+  test.beforeEach(async ({ page }) => {
+    grid = new GridPage(page);
+    await grid.goto();
+  });
+
+  test('renders the seeded data', async () => {
+    await grid.expectCell(0, 0, 'A1');
+    await grid.expectCell(1, 1, 'B2');
+    await grid.expectCell(4, 2, 'C5');
+  });
+
+  test('edits a cell through the editor', async () => {
+    await grid.editCell(0, 0, 'edited');
+    await grid.expectCell(0, 0, 'edited');
+  });
+
+  test('adds a row', async () => {
+    const before = await grid.rowCount();
+    await grid.addRowButton.click();
+    await expect(grid.rowLocator()).toHaveCount(before + 1);
+  });
+});

--- a/tests/e2e/walkontable/overlays.spec.ts
+++ b/tests/e2e/walkontable/overlays.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+import { WalkontablePage } from '../../fixtures/pages/WalkontablePage';
+
+/**
+ * Walkontable engine E2E via a frozen-panes grid. This is the Playwright home
+ * for walkontable — new/flaky walkontable behavior lands here, not in the
+ * frozen Jasmine `test/spec/**` suite.
+ */
+test.describe('walkontable overlays', { tag: '@walkontable' }, () => {
+  let wt: WalkontablePage;
+
+  test.beforeEach(async ({ page }) => {
+    wt = new WalkontablePage(page);
+    await wt.goto();
+  });
+
+  test('renders the frozen-pane overlay clones', async () => {
+    await expect(wt.topOverlay).toBeVisible();
+    await expect(wt.inlineStartOverlay).toBeVisible();
+    await expect(wt.corner).toBeVisible();
+  });
+
+  test('frozen rows stay put while the body scrolls', async () => {
+    // The top overlay holds frozen rows across the SCROLLABLE columns (C3+ here,
+    // since C1/C2 are frozen and live in the corner). R1C3 is a frozen-row cell
+    // in the top overlay: it must stay visible across a vertical scroll.
+    const frozenCell = wt.topOverlay.getByText('R1C3', { exact: true }).first();
+    await expect(frozenCell).toBeVisible();
+
+    await wt.scrollBy(600);
+    await expect.poll(async () => (await wt.scrollOffset()).top).toBeGreaterThan(0);
+
+    // Frozen row is still shown by the top overlay after scrolling; corner too.
+    await expect(wt.topOverlay.getByText('R1C3', { exact: true }).first()).toBeVisible();
+    await expect(wt.corner).toBeVisible();
+  });
+});

--- a/tests/fixtures/demo/grid.html
+++ b/tests/fixtures/demo/grid.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Handsontable e2e fixture</title>
+  <link rel="stylesheet" href="/handsontable/styles/handsontable.min.css">
+  <link rel="stylesheet" href="/handsontable/styles/ht-theme-main.min.css">
+  <style> body { font-family: sans-serif; margin: 1rem; } #toolbar { margin-bottom: .8rem; } </style>
+</head>
+<body>
+  <!--
+    E2E fixture. Cells are stamped with data-testid via a renderer so tests hook
+    into them unambiguously (data-testid="cell-<row>-<col>") instead of brittle
+    structural selectors. This mirrors the convention the authoring skill teaches.
+  -->
+  <div id="toolbar">
+    <button data-testid="add-row" type="button">Add row</button>
+  </div>
+  <div id="grid" data-testid="grid" class="ht-theme-main"></div>
+
+  <script src="/handsontable/dist/handsontable.full.min.js"></script>
+  <script>
+    const container = document.querySelector('[data-testid="grid"]');
+
+    const testIdRenderer = function(instance, td, row, col, prop, value, cellProperties) {
+      Handsontable.renderers.TextRenderer.apply(this, arguments);
+      td.setAttribute('data-testid', `cell-${row}-${col}`);
+    };
+
+    const hot = new Handsontable(container, {
+      data: [
+        ['A1', 'B1', 'C1'],
+        ['A2', 'B2', 'C2'],
+        ['A3', 'B3', 'C3'],
+        ['A4', 'B4', 'C4'],
+        ['A5', 'B5', 'C5'],
+      ],
+      colHeaders: true,
+      rowHeaders: true,
+      renderer: testIdRenderer,
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+
+    document.querySelector('[data-testid="add-row"]').addEventListener('click', () => {
+      hot.alter('insert_row_below', hot.countRows() - 1);
+    });
+  </script>
+</body>
+</html>

--- a/tests/fixtures/demo/walkontable.html
+++ b/tests/fixtures/demo/walkontable.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Walkontable (frozen panes) e2e fixture</title>
+  <link rel="stylesheet" href="/handsontable/styles/handsontable.min.css">
+  <link rel="stylesheet" href="/handsontable/styles/ht-theme-main.min.css">
+  <style> body { font-family: sans-serif; margin: 1rem; } </style>
+</head>
+<body>
+  <!--
+    Exercises the Walkontable rendering engine (overlays, frozen panes, scroll
+    sync) through a real grid. Frozen rows/columns produce walkontable's overlay
+    clones: master, top, inline-start, and the top/inline-start corner.
+  -->
+  <div id="grid" data-testid="grid" class="ht-theme-main"></div>
+
+  <script src="/handsontable/dist/handsontable.full.min.js"></script>
+  <script>
+    const container = document.querySelector('[data-testid="grid"]');
+
+    const data = Array.from({ length: 50 }, (_, r) =>
+      Array.from({ length: 10 }, (_, c) => `R${r + 1}C${c + 1}`));
+
+    const testIdRenderer = function(instance, td, row, col, prop, value, cellProperties) {
+      Handsontable.renderers.TextRenderer.apply(this, arguments);
+      td.setAttribute('data-testid', `cell-${row}-${col}`);
+    };
+
+    new Handsontable(container, {
+      data,
+      width: 420,
+      height: 300,
+      colWidths: 80,
+      fixedRowsTop: 2,
+      fixedColumnsStart: 2,
+      rowHeaders: true,
+      colHeaders: true,
+      renderer: testIdRenderer,
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+  </script>
+</body>
+</html>

--- a/tests/fixtures/pages/GridPage.ts
+++ b/tests/fixtures/pages/GridPage.ts
@@ -1,0 +1,60 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+
+/**
+ * Page Object for the Handsontable demo fixture.
+ *
+ * The point of a page object: tests express intent (`editCell`, `rowCount`),
+ * and the selectors + interaction mechanics live here, in one place. When the
+ * DOM shifts, one file changes, not every spec. Selectors prefer `data-testid`
+ * (stamped by the fixture renderer) over structural CSS, so hooks are stable
+ * and unambiguous. Waits are condition-based — never fixed timeouts.
+ */
+export class GridPage {
+  readonly page: Page;
+  readonly grid: Locator;
+  readonly addRowButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.grid = page.getByTestId('grid');
+    this.addRowButton = page.getByTestId('add-row');
+  }
+
+  /**
+   * Navigate to the fixture and wait for the grid to render. We wait on a real
+   * DOM condition (the first cell is visible) rather than a custom readiness
+   * flag or a fixed timeout — the web-first pattern the authoring skill teaches.
+   */
+  async goto(): Promise<void> {
+    await this.page.goto('/tests/fixtures/demo/grid.html');
+    await expect(this.cell(0, 0)).toBeVisible();
+  }
+
+  /** A single data cell, by visual row/column, via its stable test id. */
+  cell(row: number, col: number): Locator {
+    return this.page.getByTestId(`cell-${row}-${col}`);
+  }
+
+  /** Assert a cell shows the expected text (web-first, auto-retrying). */
+  async expectCell(row: number, col: number, text: string): Promise<void> {
+    await expect(this.cell(row, col)).toHaveText(text);
+  }
+
+  /** Open a cell's editor, type a value, and commit it. */
+  async editCell(row: number, col: number, value: string): Promise<void> {
+    await this.cell(row, col).dblclick();
+    const editor = this.page.locator('.handsontableInput');
+    await expect(editor).toBeVisible();
+    await editor.fill(value);
+    await editor.press('Enter');
+  }
+
+  /** The number of rendered data rows in the master overlay. */
+  rowLocator(): Locator {
+    return this.page.locator('.ht_master .htCore tbody tr');
+  }
+
+  async rowCount(): Promise<number> {
+    return this.rowLocator().count();
+  }
+}

--- a/tests/fixtures/pages/WalkontablePage.ts
+++ b/tests/fixtures/pages/WalkontablePage.ts
@@ -1,0 +1,49 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+
+/**
+ * Page Object for the Walkontable frozen-panes fixture. Encapsulates the
+ * overlay clones the engine produces (master, top, inline-start, corner) and
+ * scroll interaction, so specs assert engine behavior without reaching into
+ * walkontable DOM class names directly.
+ */
+export class WalkontablePage {
+  readonly page: Page;
+  readonly grid: Locator;
+  readonly master: Locator;
+  readonly topOverlay: Locator;
+  readonly inlineStartOverlay: Locator;
+  readonly corner: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.grid = page.getByTestId('grid');
+    this.master = this.grid.locator('.ht_master');
+    this.topOverlay = this.grid.locator('.ht_clone_top');
+    this.inlineStartOverlay = this.grid.locator('.ht_clone_inline_start');
+    this.corner = this.grid.locator('.ht_clone_top_inline_start_corner');
+  }
+
+  /** Navigate and wait for the grid to render (a real DOM condition, no sleep). */
+  async goto(): Promise<void> {
+    await this.page.goto('/tests/fixtures/demo/walkontable.html');
+    await expect(this.master).toBeVisible();
+  }
+
+  /** The scrollable master holder. */
+  holder(): Locator {
+    return this.master.locator('.wtHolder');
+  }
+
+  /** Scroll the master viewport by a pixel delta and let the overlays sync. */
+  async scrollBy(top: number, left = 0): Promise<void> {
+    await this.holder().evaluate((el, d) => {
+      el.scrollTop += d.top;
+      el.scrollLeft += d.left;
+    }, { top, left });
+  }
+
+  /** Current scroll offset of the master holder. */
+  async scrollOffset(): Promise<{ top: number, left: number }> {
+    return this.holder().evaluate(el => ({ top: el.scrollTop, left: el.scrollLeft }));
+  }
+}

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -1,0 +1,1702 @@
+{
+  "name": "handsontable-tests",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "handsontable-tests",
+      "devDependencies": {
+        "@playwright/test": "1.61.1",
+        "@typescript-eslint/parser": "8.61.0",
+        "eslint": "8.57.1"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+      "deprecated": "Use @eslint/config-array instead",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^2.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "deprecated": "Use @eslint/object-schema instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.0.tgz",
+      "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.0.tgz",
+      "integrity": "sha512-DV42F7MLJO6Rax7SK1yg43tcnEfGUrurSpSxKuVX+a3RCTzBlH3fuxprrOJXKCJGAaw82xXocikJ0uQaqwXgGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.61.0",
+        "@typescript-eslint/types": "^8.61.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.0.tgz",
+      "integrity": "sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.0.tgz",
+      "integrity": "sha512-O5Amvdv9ztMpxpf+vmFULGG78IE6Qwdr3bCGvqwG4nwc9H2qXkOYJJnRbRHyMkQTjv1d03olqwwwzHLMqpFePQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.0.tgz",
+      "integrity": "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.0.tgz",
+      "integrity": "sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.61.0",
+        "@typescript-eslint/tsconfig-utils": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.0.tgz",
+      "integrity": "sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.61.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.2.tgz",
+      "integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "handsontable-tests",
+  "private": true,
+  "type": "module",
+  "description": "Consolidated Playwright test package (functional e2e + visual). See tests/README.md.",
+  "scripts": {
+    "test": "playwright test",
+    "test:e2e": "playwright test --project=e2e-chromium",
+    "report": "playwright show-report",
+    "lint": "eslint --ext .ts e2e fixtures"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.61.1",
+    "@typescript-eslint/parser": "8.61.0",
+    "eslint": "8.57.1"
+  }
+}

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -1,0 +1,50 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * One Playwright config for the whole package. Functional E2E lives in `e2e/`,
+ * visual regression in `visual/` (populated during the visual milestone). The
+ * two are separated by projects so each can carry its own settings — e2e is
+ * flake-strict, visual will add screenshot tolerances and masks.
+ *
+ * Version parity rule: `@playwright/test` here and the CI container image
+ * (`mcr.microsoft.com/playwright:v<same>-noble`) bump together, never apart, so
+ * local, CI, and baseline generation render identically.
+ */
+export default defineConfig({
+  testDir: '.',
+  timeout: 20_000,
+  expect: { timeout: 10_000 },
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  // A test that only passes on retry is a hard failure pre-merge.
+  failOnFlakyTests: !!process.env.CI,
+  reporter: process.env.CI ? 'blob' : 'html',
+  use: {
+    baseURL: 'http://localhost:8123',
+    trace: 'on-first-retry',
+    video: 'on-first-retry',
+  },
+  // Serves the repo root so the fixture page can load the built handsontable
+  // dist and styles. cwd defaults to this config's directory (`tests/`).
+  webServer: {
+    command: 'node support/static-server.mjs',
+    port: 8123,
+    reuseExistingServer: !process.env.CI,
+    timeout: 30_000,
+  },
+  projects: [
+    {
+      name: 'e2e-chromium',
+      testDir: 'e2e',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    // Visual regression project — destination for the visual suite (milestone 2/3).
+    // {
+    //   name: 'visual-chromium',
+    //   testDir: 'visual',
+    //   use: { ...devices['Desktop Chrome'] },
+    //   expect: { toHaveScreenshot: { maxDiffPixelRatio: 0.01 } },
+    // },
+  ],
+});

--- a/tests/support/static-server.mjs
+++ b/tests/support/static-server.mjs
@@ -1,0 +1,47 @@
+/**
+ * Minimal static file server for the Playwright fixtures. Serves the repo root
+ * so a fixture page can reference the built `handsontable/dist` and
+ * `handsontable/styles` assets. Started by the Playwright `webServer` config.
+ *
+ * Intentionally dependency-free (node: built-ins only) per the repo's
+ * minimal-dependency and air-gap constraints.
+ */
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const PORT = Number(process.env.PORT) || 8123;
+// cwd is `tests/` when launched by Playwright; serve one level up (repo root).
+const ROOT = path.resolve(process.cwd(), '..');
+
+const TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.map': 'application/json; charset=utf-8',
+};
+
+const server = createServer(async (req, res) => {
+  try {
+    const urlPath = decodeURIComponent((req.url || '/').split('?')[0]);
+    // Resolve within ROOT and refuse path traversal.
+    const filePath = path.join(ROOT, urlPath);
+    if (!filePath.startsWith(ROOT)) {
+      res.writeHead(403).end('Forbidden');
+      return;
+    }
+    const body = await readFile(filePath);
+    res.writeHead(200, { 'Content-Type': TYPES[path.extname(filePath)] || 'application/octet-stream' });
+    res.end(body);
+  } catch {
+    res.writeHead(404).end('Not found');
+  }
+});
+
+server.listen(PORT, () => {
+  // eslint-disable-next-line no-console
+  console.log(`static-server: serving ${ROOT} on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
Replace conversational/manual QA with machine-enforced, dev-owned testing so QA no longer scales with PR count.

Enforcement (agent-first, local + CI):
- Presence gate: a source change must ship a matching test change. Pure classifier + a PR job in warn mode, a Playwright-first freeze, and a Refactor-only: trailer escape.
- Claude Code hooks: PostToolUse lints edited specs; Stop blocks a turn that leaves a new Jasmine spec or a failing Playwright spec.
- lefthook pre-push: runs the gate (block) plus the changed Playwright specs.

Playwright E2E tier (tests/):
- One package, one config; grid + walkontable overlay specs drive the real dist. Page Object Model, data-testid hooks, web-first waits.
- Pinned @playwright/test 1.61.1, matching the CI container image mcr.microsoft.com/playwright:v1.61.1-noble.

Determinism lint:
- Custom rules no-fixed-sleep-in-spec + no-new-it-flaky (warn) surface the frozen Jasmine suite's debt without red-walling CI.
- tests/.eslintrc.cjs bans waitForTimeout/sleep/networkidle (error) on the greenfield Playwright tier.

Docs and skills aligned to the new paradigm (Playwright is the E2E framework; Jasmine/Puppeteer are frozen). New skills: handsontable-playwright-e2e and test-writing-discipline.

### Context
<!--- Why is this change required? What problem does it solve? -->

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large CI and contributor-workflow change (new blocking pre-push gate, new E2E job, agent hooks); product runtime is untouched, but merges can fail locally on missing tests or new Jasmine specs even while CI presence gate only warns.
> 
> **Overview**
> Introduces **machine-enforced, dev-owned testing** so source changes must ship matching test coverage, with **Playwright** as the only path for new E2E.
> 
> **Enforcement stack:** A pure **presence gate** (`.github/scripts/lib/presence-gate.mjs` + CLI) classifies PR diffs—source edits need a unit/types/Playwright change or a `Refactor-only:` trailer; **new `*.spec.js` under Jasmine trees is always rejected** (main + Walkontable). CI runs it in **warn** mode on PRs; **lefthook pre-push** runs the same gate in **block** mode and executes changed `tests/e2e` specs. **Claude Code hooks** record session edits, lint touched specs, block Stop on new Jasmine files, and run failing Playwright specs touched in the turn.
> 
> **New Playwright package (`tests/`):** Standalone package (Playwright 1.61.1, pinned CI image), `playwright.config.ts`, static server, demo fixtures with `data-testid`, page objects (`GridPage`, `WalkontablePage`), reference specs (`grid.spec.ts`, `walkontable/overlays.spec.ts`), and a **`test-e2e-playwright`** workflow job after UMD build. Skills/docs/AGENTS/checklists now state Jasmine/Puppeteer is **frozen**; new skills `handsontable-playwright-e2e` and `test-writing-discipline`.
> 
> **Lint & template:** Custom ESLint rules `no-fixed-sleep-in-spec` / `no-new-it-flaky` (warn on legacy `*.spec.js`); `tests/.eslintrc.cjs` bans `waitForTimeout`/`sleep`/`networkidle` at error. PR template requires structured **test evidence** and commands run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af2071370ebbefb576c566a08539d55093978d23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->