### PR TITLE
DEV-1812: Fix invalid-state background and wrapped count in frozen summary row recipe

### DIFF
--- a/docs/content/recipes/rendering-styling/frozen-summary-row/angular/example1.css
+++ b/docs/content/recipes/rendering-styling/frozen-summary-row/angular/example1.css
@@ -1,4 +1,10 @@
 .htSummaryRow {
   font-weight: 600;
-  background-color: var(--ht-background-color-extra-light, #f2f3f5);
+}
+
+/* The summary row is always read-only, so Handsontable applies its built-in .htDimmed
+   background with `!important`. Match that specificity and add `!important` here too,
+   so this rule - not the default read-only style - decides the summary row's background. */
+.handsontable .htSummaryRow.htDimmed {
+  background-color: var(--ht-background-secondary-color, #f2f3f5) !important;
 }

--- a/docs/content/recipes/rendering-styling/frozen-summary-row/angular/example1.ts
+++ b/docs/content/recipes/rendering-styling/frozen-summary-row/angular/example1.ts
@@ -58,7 +58,7 @@ function formatSummary(prop: keyof Row): string {
   const sum = numbers.reduce((acc, n) => acc + n, 0);
   const avg = sum / numbers.length;
 
-  return `Sum: ${sum.toFixed(2)} · Avg: ${avg.toFixed(2)} · Count: ${numbers.length}`;
+  return `Sum: ${sum.toFixed(2)}\nAvg: ${avg.toFixed(2)}\nCount: ${numbers.length}`;
 }
 
 function refreshSummary(hot: Handsontable): void {
@@ -108,6 +108,7 @@ export class AppComponent {
 
       if (prop !== 'item') {
         meta['type'] = 'text';
+        meta['validator'] = undefined;
         meta['className'] = 'htSummaryRow htRight';
       }
 

--- a/docs/content/recipes/rendering-styling/frozen-summary-row/frozen-summary-row.md
+++ b/docs/content/recipes/rendering-styling/frozen-summary-row/frozen-summary-row.md
@@ -19,6 +19,7 @@ vue:
 searchCategory: Recipes
 category: Rendering and styling
 type: how-to
+menuTag: updated
 ---
 
 In this tutorial, you will pin a read-only totals row at the bottom of the grid. You will learn how to use `fixedRowsBottom`, recalculate aggregates on `afterChange`, and style the summary row with the `cells` callback.
@@ -95,6 +96,8 @@ For each column, compute:
 - **Avg** - sum divided by how many numeric values you counted.
 - **Count** - number of numeric values (not including blanks or non-numeric text).
 
+Join the three stats with a newline (`\n`) instead of a single line, so `Sum`, `Avg`, and `Count` each render on their own line inside the cell. The grid's default `white-space: pre-wrap` cell style turns that `\n` into a real line break, so the count never gets stranded mid-wrap next to the other stats.
+
 Write the formatted string into the summary cells with [`setDataAtRowProp`](@/api/core.md#setdataatrowprop).
 
 ## Step 4: Recalculate on load and on edits
@@ -111,8 +114,9 @@ Use the [`cells`](@/api/options.md#cells) callback (row, column, prop) to return
 - Set [`readOnly: true`](@/api/options.md#readonly) so users cannot edit totals.
 - Set [`className`](@/api/options.md#classname) (for example `htSummaryRow`, and `htRight` on numeric columns) and define those classes in a small CSS file.
 - For summary cells that display text aggregates, set [`type: 'text'`](@/api/options.md#type) so Handsontable does not run the numeric cell renderer on those strings.
+- Also set `validator: undefined` on those same cells. Overriding `type` on a cell whose column has a different `type` does not clear a property the column's type already set - the text cell type declares no `validator`, so the cell keeps inheriting the column's numeric validator. That validator then fails on the aggregate text and marks the cell invalid, which Handsontable renders with its built-in error background instead of your `htSummaryRow` style.
 
-Prefer Handsontable theme variables (for example `--ht-background-color-extra-light`) so the row still looks correct with different themes.
+A read-only cell also gets Handsontable's built-in `.htDimmed` background, applied with `!important`. Give your own background rule at least the same specificity and add `!important` too - for example `.handsontable .htSummaryRow.htDimmed { background-color: ...; }` - so it wins instead of silently losing to the default read-only style. Prefer Handsontable theme variables (for example `--ht-background-secondary-color`) so the row still looks correct with different themes.
 
 ## Related guides
 
@@ -124,7 +128,7 @@ Prefer Handsontable theme variables (for example `--ht-background-color-extra-li
 - How `fixedRowsBottom` pins the last N rows at the bottom of the grid so they stay visible during scrolling.
 - How to recalculate summary values in `afterChange` and `afterInit` and write them back with `hot.setDataAtRowProp()`.
 - How to use the `cells` callback to mark only the summary row as `readOnly` and apply a custom `className` for styling.
-- Why you should use Handsontable theme CSS variables (such as `--ht-background-color-extra-light`) in your summary row styles so the row stays visually consistent across themes.
+- Why you should use Handsontable theme CSS variables (such as `--ht-background-secondary-color`) in your summary row styles so the row stays visually consistent across themes, and why a custom background rule on a read-only row needs to match or exceed the specificity of Handsontable's built-in `.htDimmed` style to actually take effect.
 
 ## Next steps
 

--- a/docs/content/recipes/rendering-styling/frozen-summary-row/javascript/example1.css
+++ b/docs/content/recipes/rendering-styling/frozen-summary-row/javascript/example1.css
@@ -1,4 +1,10 @@
 .htSummaryRow {
   font-weight: 600;
-  background-color: var(--ht-background-color-extra-light, #f2f3f5);
+}
+
+/* The summary row is always read-only, so Handsontable applies its built-in .htDimmed
+   background with `!important`. Match that specificity and add `!important` here too,
+   so this rule - not the default read-only style - decides the summary row's background. */
+.handsontable .htSummaryRow.htDimmed {
+  background-color: var(--ht-background-secondary-color, #f2f3f5) !important;
 }

--- a/docs/content/recipes/rendering-styling/frozen-summary-row/javascript/example1.js
+++ b/docs/content/recipes/rendering-styling/frozen-summary-row/javascript/example1.js
@@ -37,7 +37,7 @@ function formatSummary(prop) {
     }
     const sum = numbers.reduce((acc, n) => acc + n, 0);
     const avg = sum / numbers.length;
-    return `Sum: ${sum.toFixed(2)} · Avg: ${avg.toFixed(2)} · Count: ${numbers.length}`;
+    return `Sum: ${sum.toFixed(2)}\nAvg: ${avg.toFixed(2)}\nCount: ${numbers.length}`;
 }
 function refreshSummary(hot) {
     hot.batch(() => {
@@ -73,6 +73,7 @@ const hot = new Handsontable(container, {
         };
         if (prop !== 'item') {
             meta.type = 'text';
+            meta.validator = undefined;
             meta.className = 'htSummaryRow htRight';
         }
         return meta;

--- a/docs/content/recipes/rendering-styling/frozen-summary-row/javascript/example1.ts
+++ b/docs/content/recipes/rendering-styling/frozen-summary-row/javascript/example1.ts
@@ -58,7 +58,7 @@ function formatSummary(prop: keyof Row): string {
   const sum = numbers.reduce((acc, n) => acc + n, 0);
   const avg = sum / numbers.length;
 
-  return `Sum: ${sum.toFixed(2)} · Avg: ${avg.toFixed(2)} · Count: ${numbers.length}`;
+  return `Sum: ${sum.toFixed(2)}\nAvg: ${avg.toFixed(2)}\nCount: ${numbers.length}`;
 }
 
 function refreshSummary(hot: Handsontable) {
@@ -100,6 +100,7 @@ const hot = new Handsontable(container, {
 
     if (prop !== 'item') {
       meta.type = 'text';
+      meta.validator = undefined;
       meta.className = 'htSummaryRow htRight';
     }
 

--- a/docs/content/recipes/rendering-styling/frozen-summary-row/react/example1.css
+++ b/docs/content/recipes/rendering-styling/frozen-summary-row/react/example1.css
@@ -1,4 +1,10 @@
 .htSummaryRow {
   font-weight: 600;
-  background-color: var(--ht-background-color-extra-light, #f2f3f5);
+}
+
+/* The summary row is always read-only, so Handsontable applies its built-in .htDimmed
+   background with `!important`. Match that specificity and add `!important` here too,
+   so this rule - not the default read-only style - decides the summary row's background. */
+.handsontable .htSummaryRow.htDimmed {
+  background-color: var(--ht-background-secondary-color, #f2f3f5) !important;
 }

--- a/docs/content/recipes/rendering-styling/frozen-summary-row/react/example1.jsx
+++ b/docs/content/recipes/rendering-styling/frozen-summary-row/react/example1.jsx
@@ -1,124 +1,87 @@
 import { HotTable } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
 import './example1.css';
-
 registerAllModules();
-
 const SUMMARY_SOURCE = 'updateSummary';
-
 function parseNumeric(value) {
-  if (typeof value === 'number' && Number.isFinite(value)) {
-    return value;
-  }
-
-  if (typeof value === 'string' && value.trim() !== '') {
-    const n = Number(value);
-
-    if (Number.isFinite(n)) {
-      return n;
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        return value;
     }
-  }
-
-  return null;
+    if (typeof value === 'string' && value.trim() !== '') {
+        const n = Number(value);
+        if (Number.isFinite(n)) {
+            return n;
+        }
+    }
+    return null;
 }
-
 const data = [
-  { item: 'Module A', units: 12, price: 49.5, tax: 5.2 },
-  { item: 'Module B', units: 8, price: 120, tax: 8 },
-  { item: 'Module C', units: 3, price: 200, tax: '\u2014' },
-  { item: 'Module D', units: 15, price: 35, tax: 4.1 },
-  { item: 'Module E', units: 0, price: 75, tax: 6 },
-  { item: '', units: '', price: '', tax: '' },
+    { item: 'Module A', units: 12, price: 49.5, tax: 5.2 },
+    { item: 'Module B', units: 8, price: 120, tax: 8 },
+    { item: 'Module C', units: 3, price: 200, tax: '\u2014' },
+    { item: 'Module D', units: 15, price: 35, tax: 4.1 },
+    { item: 'Module E', units: 0, price: 75, tax: 6 },
+    { item: '', units: '', price: '', tax: '' },
 ];
-
 const numericProps = ['units', 'price', 'tax'];
 const summaryRowIndex = data.length - 1;
-
 function formatSummary(prop) {
-  const numbers = [];
-
-  for (let row = 0; row < summaryRowIndex; row += 1) {
-    const n = parseNumeric(data[row][prop]);
-
-    if (n !== null) {
-      numbers.push(n);
+    const numbers = [];
+    for (let row = 0; row < summaryRowIndex; row += 1) {
+        const n = parseNumeric(data[row][prop]);
+        if (n !== null) {
+            numbers.push(n);
+        }
     }
-  }
-
-  if (numbers.length === 0) {
-    return '\u2014';
-  }
-
-  const sum = numbers.reduce((acc, n) => acc + n, 0);
-  const avg = sum / numbers.length;
-
-  return `Sum: ${sum.toFixed(2)} · Avg: ${avg.toFixed(2)} · Count: ${numbers.length}`;
+    if (numbers.length === 0) {
+        return '\u2014';
+    }
+    const sum = numbers.reduce((acc, n) => acc + n, 0);
+    const avg = sum / numbers.length;
+    return `Sum: ${sum.toFixed(2)}\nAvg: ${avg.toFixed(2)}\nCount: ${numbers.length}`;
 }
-
 function refreshSummary(hot) {
-  hot.batch(() => {
-    hot.setDataAtRowProp(summaryRowIndex, 'item', 'Totals', SUMMARY_SOURCE);
-
-    numericProps.forEach((prop) => {
-      hot.setDataAtRowProp(summaryRowIndex, prop, formatSummary(prop), SUMMARY_SOURCE);
+    hot.batch(() => {
+        hot.setDataAtRowProp(summaryRowIndex, 'item', 'Totals', SUMMARY_SOURCE);
+        numericProps.forEach((prop) => {
+            hot.setDataAtRowProp(summaryRowIndex, prop, formatSummary(prop), SUMMARY_SOURCE);
+        });
     });
-  });
 }
-
 const ExampleComponent = () => {
-  return (
-    <HotTable
-      data={data}
-      licenseKey="non-commercial-and-evaluation"
-      rowHeaders={true}
-      colHeaders={['Item', 'Units', 'Price', 'Tax']}
-      fixedRowsBottom={1}
-      height="auto"
-      width="100%"
-      columns={[
-        { data: 'item', type: 'text', readOnly: false },
-        { data: 'units', type: 'numeric', numericFormat: { maximumFractionDigits: 0 } },
-        { data: 'price', type: 'numeric', numericFormat: { minimumFractionDigits: 2, maximumFractionDigits: 2 } },
-        { data: 'tax', type: 'numeric', numericFormat: { minimumFractionDigits: 2, maximumFractionDigits: 2 } },
-      ]}
-      cells={function (row, _col, prop) {
-        if (row !== summaryRowIndex) {
-          return {};
-        }
-
-        const meta = {
-          readOnly: true,
-          className: 'htSummaryRow',
-        };
-
-        if (prop !== 'item') {
-          meta.type = 'text';
-          meta.className = 'htSummaryRow htRight';
-        }
-
-        return meta;
-      }}
-      afterInit={function () {
-        refreshSummary(this);
-      }}
-      afterChange={function (changes, source) {
-        if (!changes || source === SUMMARY_SOURCE) {
-          return;
-        }
-
-        if (changes.every(([row]) => row === summaryRowIndex)) {
-          return;
-        }
-
-        refreshSummary(this);
-      }}
-      beforeUndoStackChange={function (_doneActions, source) {
-        if (source === SUMMARY_SOURCE) {
-          return false;
-        }
-      }}
-    />
-  );
+    return (<HotTable data={data} licenseKey="non-commercial-and-evaluation" rowHeaders={true} colHeaders={['Item', 'Units', 'Price', 'Tax']} fixedRowsBottom={1} height="auto" width="100%" columns={[
+            { data: 'item', type: 'text', readOnly: false },
+            { data: 'units', type: 'numeric', numericFormat: { maximumFractionDigits: 0 } },
+            { data: 'price', type: 'numeric', numericFormat: { minimumFractionDigits: 2, maximumFractionDigits: 2 } },
+            { data: 'tax', type: 'numeric', numericFormat: { minimumFractionDigits: 2, maximumFractionDigits: 2 } },
+        ]} cells={function (row, _col, prop) {
+            if (row !== summaryRowIndex) {
+                return {};
+            }
+            const meta = {
+                readOnly: true,
+                className: 'htSummaryRow',
+            };
+            if (prop !== 'item') {
+                meta.type = 'text';
+                meta.validator = undefined;
+                meta.className = 'htSummaryRow htRight';
+            }
+            return meta;
+        }} afterInit={function () {
+            refreshSummary(this);
+        }} afterChange={function (changes, source) {
+            if (!changes || source === SUMMARY_SOURCE) {
+                return;
+            }
+            if (changes.every(([row]) => row === summaryRowIndex)) {
+                return;
+            }
+            refreshSummary(this);
+        }} beforeUndoStackChange={function (_doneActions, source) {
+            if (source === SUMMARY_SOURCE) {
+                return false;
+            }
+        }}/>);
 };
-
 export default ExampleComponent;

--- a/docs/content/recipes/rendering-styling/frozen-summary-row/react/example1.tsx
+++ b/docs/content/recipes/rendering-styling/frozen-summary-row/react/example1.tsx
@@ -60,7 +60,7 @@ function formatSummary(prop: keyof Row): string {
   const sum = numbers.reduce((acc, n) => acc + n, 0);
   const avg = sum / numbers.length;
 
-  return `Sum: ${sum.toFixed(2)} · Avg: ${avg.toFixed(2)} · Count: ${numbers.length}`;
+  return `Sum: ${sum.toFixed(2)}\nAvg: ${avg.toFixed(2)}\nCount: ${numbers.length}`;
 }
 
 function refreshSummary(hot: Handsontable): void {
@@ -106,6 +106,7 @@ const ExampleComponent = () => {
 
         if (prop !== 'item') {
           meta.type = 'text';
+          meta.validator = undefined;
           meta.className = 'htSummaryRow htRight';
         }
 


### PR DESCRIPTION
### Context

The PR fixes two visual bugs on the "Frozen summary row" recipe reported in [DEV-1812](https://app.clickup.com/t/9015210959/DEV-1812):

1. The summary ("Totals") row rendered with a **red background** that read as an error state. Root cause: the recipe's `cells()` callback switches summary cells to `type: 'text'` so the aggregate string renders correctly, but the `text` cell type declares no `validator` key, so the cell kept inheriting the column's `numeric` validator through the meta cascade. That validator ran `isNumeric()` against strings like `"Sum: 38.00 · Avg: 7.60 · Count: 5"`, failed, and Handsontable applied its built-in `htInvalid` error background — on every page load, with no user interaction needed. Fixed by explicitly setting `validator: undefined` on those cells.
2. The aggregate text wrapped awkwardly, stranding the count number alone on a second line. Fixed by joining `Sum`/`Avg`/`Count` with `\n` instead of a single line, so each stat renders on its own line (relies on the grid's default `white-space: pre-wrap`).

While verifying the background fix, found a third, previously-latent issue: the recipe's own `.htSummaryRow` background rule was silently masked by Handsontable's built-in `!important` read-only (`.htDimmed`) style, and it referenced `--ht-background-color-extra-light`, a CSS variable that doesn't exist anywhere in Handsontable's theme system (it only ever fell back to a hardcoded value). Fixed by matching `.htDimmed`'s specificity and swapping in the real theme token `--ht-background-secondary-color`.

Applied identically across the JS, React, and Angular example variants (the JS example is also reused for the Vue tab via `only-for javascript vue`), regenerated the `.js`/`.jsx` mirrors via `npm run docs:code-examples:generate-js`, and updated the recipe prose to explain both gotchas for readers adapting this pattern.

### How has this been tested?

- Manually verified in a headless browser against the local docs dev server, on all four framework tabs (JS, React, Angular, Vue):
  - No `htInvalid` class on the summary row; computed background comes from the recipe's own `.htSummaryRow.htDimmed` CSS rule (confirmed via matched CSS rules), not the default read-only style.
  - Each stat (`Sum:`, `Avg:`, `Count:`) renders on its own line, no mid-stat wrap.
- Edited a data cell (`Module A` units 12 → 20) and confirmed `afterChange` recalculates the summary correctly and the row still shows no error background afterward.
- `BASE_URL=http://localhost:4323/docs npx playwright test recipeConsoleErrors.spec.ts -g "frozen-summary-row"` — passes (no console/page errors on the recipe page).
- Confirmed `docs/content/recipes/**/*.ts` is excluded from `docs:lint` (`docs/.eslintrc.js` `ignorePatterns`), so there is no type-check/lint gate on these example files to run.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1812

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

(Docs-only change — no package source touched.)

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1812

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example-only changes; no Handsontable package or runtime library code is modified.
> 
> **Overview**
> Fixes visual issues in the **Frozen summary row** docs recipe (JS/React/Angular examples and prose).
> 
> Summary aggregate strings now use **newlines** between Sum, Avg, and Count so each stat sits on its own line instead of wrapping awkwardly. Summary numeric cells set **`validator: undefined`** alongside `type: 'text'` so inherited column numeric validators no longer mark aggregate text invalid (red error background).
> 
> **CSS** moves the summary background to `.handsontable .htSummaryRow.htDimmed` with `!important` so it overrides Handsontable’s read-only dimming, and switches the theme token to **`--ht-background-secondary-color`**. The recipe markdown is updated with the same guidance and tagged `menuTag: updated`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b497679a04f7348c2e0b26a4798a9ce0713e093. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->