### PR TITLE
DEV-1811: Use ContextMenu.SEPARATOR in the custom context menu recipe (+ type fix)

### DIFF
--- a/.changelogs/13037.json
+++ b/.changelogs/13037.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed the `ContextMenu.SEPARATOR` constant missing from the TypeScript type declarations.",
+  "type": "fixed",
+  "issueOrPR": 13037,
+  "breaking": false,
+  "framework": "none"
+}

--- a/docs/content/guides/accessories-and-menus/context-menu/angular/example3.ts
+++ b/docs/content/guides/accessories-and-menus/context-menu/angular/example3.ts
@@ -1,6 +1,7 @@
 /* file: app.component.ts */
 import { Component, OnInit } from '@angular/core';
 import Handsontable from 'handsontable';
+import { ContextMenu } from 'handsontable/plugins/contextMenu';
 import { GridSettings, HotTableModule } from '@handsontable/angular-wrapper';
 
 @Component({
@@ -40,10 +41,9 @@ export class AppComponent implements OnInit {
             return this.getSelectedLast()?.[0] === 0; // `this` === hot
           },
         },
-        // A separator line can also be added like this:
-        // 'sp1': '---------'
-        // and the key has to be unique
-        sp1: { name: '---------' },
+        // Use the dedicated separator constant to insert a separator line
+        // (the key has to be unique)
+        sp1: ContextMenu.SEPARATOR,
         row_below: {
           name: 'Click to add row below',
         },

--- a/docs/content/guides/accessories-and-menus/context-menu/context-menu.md
+++ b/docs/content/guides/accessories-and-menus/context-menu/context-menu.md
@@ -207,12 +207,14 @@ To see the context menu, right-click on a cell. On touch devices, long-press a c
 To fully customize the context menu, set `contextMenu` to an object with an `items` property. Each key in `items` identifies one menu entry. The value can be:
 
 - A predefined item key string such as `'row_above'` — includes the built-in item unchanged.
-- The string `'---------'` — inserts a horizontal separator line.
+- `ContextMenu.SEPARATOR` (imported from `handsontable/plugins/contextMenu`) — inserts a horizontal separator line.
 - A configuration object — defines a custom item or overrides a predefined one.
 
 This means you can freely mix built-in items with custom ones in the same menu:
 
 ```js
+import { ContextMenu } from 'handsontable/plugins/contextMenu';
+
 contextMenu: {
   // Optional: a shared callback fired on every item click.
   callback(key, selection, clickEvent) {
@@ -220,7 +222,7 @@ contextMenu: {
   },
   items: {
     row_above: {},                   // predefined item, unchanged
-    sp1: '---------',               // separator
+    sp1: ContextMenu.SEPARATOR,      // separator
     row_below: {
       name: 'Click to add row below', // override a predefined item's label
     },

--- a/docs/content/guides/accessories-and-menus/context-menu/javascript/example3.js
+++ b/docs/content/guides/accessories-and-menus/context-menu/javascript/example3.js
@@ -1,5 +1,6 @@
 import Handsontable from 'handsontable/base';
 import { registerAllModules } from 'handsontable/registry';
+import { ContextMenu } from 'handsontable/plugins/contextMenu';
 
 // Register all Handsontable's modules.
 registerAllModules();
@@ -17,10 +18,9 @@ const contextMenuSettings = {
         return this.getSelectedLast()?.[0] === 0; // `this` === hot
       },
     },
-    // A separator line can also be added like this:
-    // 'sp1': { name: '---------' }
-    // and the key has to be unique
-    sp1: '---------',
+    // Use the dedicated separator constant to insert a separator line
+    // (the key has to be unique)
+    sp1: ContextMenu.SEPARATOR,
     row_below: {
       name: 'Click to add row below', // Set custom text for predefined option
     },

--- a/docs/content/guides/accessories-and-menus/context-menu/javascript/example3.ts
+++ b/docs/content/guides/accessories-and-menus/context-menu/javascript/example3.ts
@@ -1,6 +1,6 @@
 import Handsontable from 'handsontable/base';
 import { registerAllModules } from 'handsontable/registry';
-import { DetailedSettings, MenuItemConfig } from 'handsontable/plugins/contextMenu';
+import { ContextMenu, DetailedSettings } from 'handsontable/plugins/contextMenu';
 
 // Register all Handsontable's modules.
 registerAllModules();
@@ -18,10 +18,9 @@ const contextMenuSettings: DetailedSettings = {
         return this.getSelectedLast()?.[0] === 0; // `this` === hot
       },
     },
-    // A separator line can also be added like this:
-    // 'sp1': { name: '---------' }
-    // and the key has to be unique
-    sp1: '---------' as MenuItemConfig,
+    // Use the dedicated separator constant to insert a separator line
+    // (the key has to be unique)
+    sp1: ContextMenu.SEPARATOR,
     row_below: {
       name: 'Click to add row below', // Set custom text for predefined option
     },

--- a/docs/content/guides/accessories-and-menus/context-menu/react/example3.jsx
+++ b/docs/content/guides/accessories-and-menus/context-menu/react/example3.jsx
@@ -1,5 +1,6 @@
 import { HotTable } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
+import { ContextMenu } from 'handsontable/plugins/contextMenu';
 
 // register Handsontable's modules
 registerAllModules();
@@ -17,10 +18,9 @@ const contextMenuSettings = {
         return this.getSelectedLast()?.[0] === 0; // `this` === hot
       },
     },
-    // A separator line can also be added like this:
-    // 'sp1': { name: '---------' }
-    // and the key has to be unique
-    sp1: '---------',
+    // Use the dedicated separator constant to insert a separator line
+    // (the key has to be unique)
+    sp1: ContextMenu.SEPARATOR,
     row_below: {
       name: 'Click to add row below', // Set custom text for predefined option
     },

--- a/docs/content/guides/accessories-and-menus/context-menu/react/example3.tsx
+++ b/docs/content/guides/accessories-and-menus/context-menu/react/example3.tsx
@@ -1,5 +1,5 @@
 import { HotTable } from '@handsontable/react-wrapper';
-import { DetailedSettings, MenuItemConfig } from 'handsontable/plugins/contextMenu';
+import { ContextMenu, DetailedSettings } from 'handsontable/plugins/contextMenu';
 import { registerAllModules } from 'handsontable/registry';
 
 // register Handsontable's modules
@@ -18,10 +18,9 @@ const contextMenuSettings: DetailedSettings = {
         return this.getSelectedLast()?.[0] === 0; // `this` === hot
       },
     },
-    // A separator line can also be added like this:
-    // 'sp1': { name: '---------' }
-    // and the key has to be unique
-    sp1: '---------' as MenuItemConfig,
+    // Use the dedicated separator constant to insert a separator line
+    // (the key has to be unique)
+    sp1: ContextMenu.SEPARATOR,
     row_below: {
       name: 'Click to add row below', // Set custom text for predefined option
     },

--- a/docs/content/guides/accessories-and-menus/context-menu/vue/example3.vue
+++ b/docs/content/guides/accessories-and-menus/context-menu/vue/example3.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { ref } from 'vue';
 import { HotTable } from '@handsontable/vue3';
-import type { DetailedSettings, MenuItemConfig } from 'handsontable/plugins/contextMenu';
+import { ContextMenu } from 'handsontable/plugins/contextMenu';
+import type { DetailedSettings } from 'handsontable/plugins/contextMenu';
 import { registerAllModules } from 'handsontable/registry';
 import type { GridSettings } from 'handsontable/settings';
 
@@ -17,7 +18,7 @@ const contextMenuSettings: DetailedSettings = {
         return this.getSelectedLast()?.[0] === 0;
       },
     },
-    sp1: '---------' as MenuItemConfig,
+    sp1: ContextMenu.SEPARATOR,
     row_below: {
       name: 'Click to add row below',
     },

--- a/handsontable/src/plugins/contextMenu/__tests__/contextMenu.types.ts
+++ b/handsontable/src/plugins/contextMenu/__tests__/contextMenu.types.ts
@@ -1,4 +1,6 @@
 import Handsontable from 'handsontable';
+import { ContextMenu } from 'handsontable/plugins/contextMenu';
+import type { MenuItemConfig } from 'handsontable/plugins/contextMenu';
 
 const hot = new Handsontable(document.createElement('div'), {
   contextMenu: true,
@@ -87,6 +89,17 @@ new Handsontable(document.createElement('div'), {
         hidden: false,
         disabled: false,
       }
+    }
+  }
+});
+
+const separator: MenuItemConfig = ContextMenu.SEPARATOR;
+
+new Handsontable(document.createElement('div'), {
+  contextMenu: {
+    items: {
+      sep1: ContextMenu.SEPARATOR,
+      row_above: 'row_above',
     }
   }
 });

--- a/handsontable/src/plugins/contextMenu/contextMenu.ts
+++ b/handsontable/src/plugins/contextMenu/contextMenu.ts
@@ -104,6 +104,16 @@ export class ContextMenu extends BasePlugin {
   }
 
   /**
+   * The item descriptor that identifies a menu separator. Use it as a value in a custom
+   * `items` configuration object to insert a separator line at that key.
+   *
+   * @returns {MenuItemConfig}
+   */
+  static get SEPARATOR(): MenuItemConfig {
+    return { name: SEPARATOR };
+  }
+
+  /**
    * Context menu default items order when `contextMenu` options is set as `true`.
    *
    * @returns {string[]}
@@ -477,7 +487,3 @@ export class ContextMenu extends BasePlugin {
     super.destroy();
   }
 }
-
-(ContextMenu as unknown as Record<string, unknown>).SEPARATOR = {
-  name: SEPARATOR
-};


### PR DESCRIPTION
### Context

The PR fixes an inconsistency in the "Context menu with a fully custom configuration" recipe (`example3`) on the [Context menu](https://handsontable.com/docs/javascript-data-grid/context-menu/) guide page. Across every framework variant (JavaScript, React, Angular, Vue), the separator entry was hand-rolled as a raw `'---------'` string (or, in the Angular variant, a manually spelled `{ name: '---------' }` object) instead of using the dedicated `ContextMenu.SEPARATOR` constant that Handsontable exposes for exactly this case.

This constant is already used correctly in the neighboring `example4` on the same page and in core's own test suite (`contextMenu.spec.js`), so `example3` was the odd one out. Each file's comment also inconsistently claimed "the other form" was the alternative, confirming the docs never settled on the recommended approach.

I verified live against a local docs dev server (right-clicking `example3` before and after the change, across all four framework tabs) that the separator renders identically either way — as a proper non-clickable `.htSeparator` line. So the docs change itself is a consistency/best-practice fix, not a functional bug fix: it brings the recipe in line with `example4` and removes the hand-typed dash string as a footgun (a single flipped character silently breaks the separator match).

**Follow-up core fix.** The CI's "Angular docs type-check" job failed on the `angular/example3.ts` change with `TS2339: Property 'SEPARATOR' does not exist on type 'typeof ContextMenu'`. It turns out `ContextMenu.SEPARATOR` was assigned outside the class body via `(ContextMenu as unknown as Record<string, unknown>).SEPARATOR = { name: SEPARATOR };` — a cast left over from the original JS-to-TS conversion that hides the property from the type checker entirely. The React and Vue recipe examples already used `ContextMenu.SEPARATOR` in TypeScript before this PR, but nothing type-checks those examples in CI, so the gap went unnoticed. I moved `SEPARATOR` into the class as a typed `static get` (matching the existing `PLUGIN_KEY`/`PLUGIN_PRIORITY`/`DEFAULT_ITEMS` getter pattern in the same file), so it's now part of the public type surface for every consumer, not just a runtime-only convenience.

### How has this been tested?

- Manual: ran `npm run start` in `docs/` and right-clicked a cell in `#example3` on the JavaScript, React, Angular, and Vue tabs, confirming the separator renders as a 1px non-clickable `.htSeparator` row (matching `example4`) both before and after the docs change.
- `npm run test:types --prefix handsontable` — passes, confirms `ContextMenu.SEPARATOR` now type-checks as `MenuItemConfig`.
- `npm run test:unit --prefix handsontable -- --testPathPattern=contextMenu` — passes.
- `npm run test:e2e --prefix handsontable -- --testPathPattern=contextMenu/__tests__/contextMenu.spec` — 132 specs, 0 failures (covers the existing `Handsontable.plugins.ContextMenu.SEPARATOR` usage in `contextMenu.spec.js`).
- `SKIP_LATEST=1 npm run typecheck --prefix docs/angular-type-check` (after rebuilding `handsontable/tmp` via `npm run build --prefix handsontable`) — 0 type errors, confirming the CI failure is resolved.
- Added a type regression test in `handsontable/src/plugins/contextMenu/__tests__/contextMenu.types.ts` asserting `ContextMenu.SEPARATOR` satisfies `MenuItemConfig` and can be used as an `items` value.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1811

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1811

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, non-breaking API surface fix plus documentation and type tests; runtime separator behavior is unchanged.
> 
> **Overview**
> **`ContextMenu.SEPARATOR`** is now a typed **`static get`** on the `ContextMenu` class (replacing a runtime-only post-class assignment), so TypeScript consumers can use it as a **`MenuItemConfig`** in custom `items` maps.
> 
> The context menu **example3** recipes and guide text are updated across JavaScript, React, Angular, and Vue to use **`ContextMenu.SEPARATOR`** instead of hand-typed `'---------'` strings or casts. A changelog entry and type regression coverage were added for the declaration fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d1c1bf387dd205d960975768a6e734d3c40fff6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->