### PR TITLE
DEV-841: Add Text cell type documentation page

### DIFF
--- a/docs/content/guides/cell-types/cell-type/cell-type.md
+++ b/docs/content/guides/cell-types/cell-type/cell-type.md
@@ -854,6 +854,7 @@ Empty cells may be treated differently in different contexts, for example, the [
 - [Numeric cell type](@/guides/cell-types/numeric-cell-type/numeric-cell-type.md)
 - [Password cell type](@/guides/cell-types/password-cell-type/password-cell-type.md)
 - [Select cell type](@/guides/cell-types/select-cell-type/select-cell-type.md)
+- [Text cell type](@/guides/cell-types/text-cell-type/text-cell-type.md)
 - [Time cell type](@/guides/cell-types/time-cell-type/time-cell-type.md)
 
 </div>

--- a/docs/content/guides/cell-types/text-cell-type/angular/example1.html
+++ b/docs/content/guides/cell-types/text-cell-type/angular/example1.html
@@ -1,0 +1,3 @@
+<div>
+  <example1-text-cell-type></example1-text-cell-type>
+</div>

--- a/docs/content/guides/cell-types/text-cell-type/angular/example1.ts
+++ b/docs/content/guides/cell-types/text-cell-type/angular/example1.ts
@@ -1,0 +1,57 @@
+/* file: app.component.ts */
+import { Component } from '@angular/core';
+import { GridSettings, HotTableModule} from '@handsontable/angular-wrapper';
+
+@Component({
+  selector: 'example1-text-cell-type',
+  standalone: true,
+  imports: [HotTableModule],
+  template: ` <div>
+    <hot-table [data]="data" [settings]="gridSettings"></hot-table>
+  </div>`,
+})
+export class AppComponent {
+
+  readonly data = [
+    { sku: '004821', category: '032', quantity: 142, unitPrice: 18.5 },
+    { sku: '000093', category: '032', quantity: 0, unitPrice: 42.0 },
+    { sku: '017640', category: '015', quantity: 67, unitPrice: 9.99 },
+    { sku: '002210', category: '015', quantity: 310, unitPrice: 4.25 },
+    { sku: '008875', category: '048', quantity: 24, unitPrice: 129.0 },
+  ];
+
+  readonly gridSettings: GridSettings = {
+    colHeaders: ['SKU', 'Category code', 'Quantity', 'Unit price ($)'],
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true,
+    columns: [
+      { data: 'sku', type: 'text' },
+      { data: 'category', type: 'text' },
+      { data: 'quantity', type: 'numeric' },
+      { data: 'unitPrice', type: 'numeric' },
+    ]
+  };
+}
+/* end-file */
+
+
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+/* end-file */

--- a/docs/content/guides/cell-types/text-cell-type/angular/example2.html
+++ b/docs/content/guides/cell-types/text-cell-type/angular/example2.html
@@ -1,0 +1,3 @@
+<div>
+  <example2-text-cell-type></example2-text-cell-type>
+</div>

--- a/docs/content/guides/cell-types/text-cell-type/angular/example2.ts
+++ b/docs/content/guides/cell-types/text-cell-type/angular/example2.ts
@@ -1,0 +1,60 @@
+/* file: app.component.ts */
+import { Component } from '@angular/core';
+import { GridSettings, HotTableModule} from '@handsontable/angular-wrapper';
+
+const skuValidator = (value: string, callback: (isValid: boolean) => void) => {
+  callback(/^\d{6}$/.test(value));
+};
+
+@Component({
+  selector: 'example2-text-cell-type',
+  standalone: true,
+  imports: [HotTableModule],
+  template: ` <div>
+    <hot-table [data]="data" [settings]="gridSettings"></hot-table>
+  </div>`,
+})
+export class AppComponent {
+
+  readonly data = [
+    { sku: '004821', supplier: 'Harbor Goods', quantity: 142 },
+    { sku: '000093', supplier: 'Alpine Supply Co.', quantity: 0 },
+    { sku: '017640', supplier: 'Harbor Goods', quantity: 67 },
+    { sku: '002210', supplier: 'Crestline Wholesale', quantity: 310 },
+    { sku: '008875', supplier: 'Alpine Supply Co.', quantity: 24 },
+  ];
+
+  readonly gridSettings: GridSettings = {
+    colHeaders: ['SKU', 'Supplier', 'Quantity'],
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true,
+    columns: [
+      { data: 'sku', type: 'text', validator: skuValidator, allowInvalid: false },
+      { data: 'supplier', type: 'text' },
+      { data: 'quantity', type: 'numeric' },
+    ]
+  };
+}
+/* end-file */
+
+
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+/* end-file */

--- a/docs/content/guides/cell-types/text-cell-type/javascript/example1.js
+++ b/docs/content/guides/cell-types/text-cell-type/javascript/example1.js
@@ -1,0 +1,25 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+// Register all Handsontable's modules.
+registerAllModules();
+const container = document.querySelector('#example1');
+new Handsontable(container, {
+    data: [
+        { sku: '004821', category: '032', quantity: 142, unitPrice: 18.5 },
+        { sku: '000093', category: '032', quantity: 0, unitPrice: 42.0 },
+        { sku: '017640', category: '015', quantity: 67, unitPrice: 9.99 },
+        { sku: '002210', category: '015', quantity: 310, unitPrice: 4.25 },
+        { sku: '008875', category: '048', quantity: 24, unitPrice: 129.0 },
+    ],
+    colHeaders: ['SKU', 'Category code', 'Quantity', 'Unit price ($)'],
+    height: 'auto',
+    licenseKey: 'non-commercial-and-evaluation',
+    columns: [
+        { data: 'sku', type: 'text' },
+        { data: 'category', type: 'text' },
+        { data: 'quantity', type: 'numeric' },
+        { data: 'unitPrice', type: 'numeric' },
+    ],
+    autoWrapRow: true,
+    autoWrapCol: true,
+});

--- a/docs/content/guides/cell-types/text-cell-type/javascript/example1.ts
+++ b/docs/content/guides/cell-types/text-cell-type/javascript/example1.ts
@@ -1,0 +1,28 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+// Register all Handsontable's modules.
+registerAllModules();
+
+const container = document.querySelector('#example1')!;
+
+new Handsontable(container, {
+  data: [
+    { sku: '004821', category: '032', quantity: 142, unitPrice: 18.5 },
+    { sku: '000093', category: '032', quantity: 0, unitPrice: 42.0 },
+    { sku: '017640', category: '015', quantity: 67, unitPrice: 9.99 },
+    { sku: '002210', category: '015', quantity: 310, unitPrice: 4.25 },
+    { sku: '008875', category: '048', quantity: 24, unitPrice: 129.0 },
+  ],
+  colHeaders: ['SKU', 'Category code', 'Quantity', 'Unit price ($)'],
+  height: 'auto',
+  licenseKey: 'non-commercial-and-evaluation',
+  columns: [
+    { data: 'sku', type: 'text' },
+    { data: 'category', type: 'text' },
+    { data: 'quantity', type: 'numeric' },
+    { data: 'unitPrice', type: 'numeric' },
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+});

--- a/docs/content/guides/cell-types/text-cell-type/javascript/example2.js
+++ b/docs/content/guides/cell-types/text-cell-type/javascript/example2.js
@@ -1,0 +1,27 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+// Register all Handsontable's modules.
+registerAllModules();
+const container = document.querySelector('#example2');
+const skuValidator = (value, callback) => {
+    callback(/^\d{6}$/.test(value));
+};
+new Handsontable(container, {
+    data: [
+        { sku: '004821', supplier: 'Harbor Goods', quantity: 142 },
+        { sku: '000093', supplier: 'Alpine Supply Co.', quantity: 0 },
+        { sku: '017640', supplier: 'Harbor Goods', quantity: 67 },
+        { sku: '002210', supplier: 'Crestline Wholesale', quantity: 310 },
+        { sku: '008875', supplier: 'Alpine Supply Co.', quantity: 24 },
+    ],
+    colHeaders: ['SKU', 'Supplier', 'Quantity'],
+    height: 'auto',
+    licenseKey: 'non-commercial-and-evaluation',
+    columns: [
+        { data: 'sku', type: 'text', validator: skuValidator, allowInvalid: false },
+        { data: 'supplier', type: 'text' },
+        { data: 'quantity', type: 'numeric' },
+    ],
+    autoWrapRow: true,
+    autoWrapCol: true,
+});

--- a/docs/content/guides/cell-types/text-cell-type/javascript/example2.ts
+++ b/docs/content/guides/cell-types/text-cell-type/javascript/example2.ts
@@ -1,0 +1,31 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+// Register all Handsontable's modules.
+registerAllModules();
+
+const container = document.querySelector('#example2')!;
+
+const skuValidator = (value: string, callback: (isValid: boolean) => void) => {
+  callback(/^\d{6}$/.test(value));
+};
+
+new Handsontable(container, {
+  data: [
+    { sku: '004821', supplier: 'Harbor Goods', quantity: 142 },
+    { sku: '000093', supplier: 'Alpine Supply Co.', quantity: 0 },
+    { sku: '017640', supplier: 'Harbor Goods', quantity: 67 },
+    { sku: '002210', supplier: 'Crestline Wholesale', quantity: 310 },
+    { sku: '008875', supplier: 'Alpine Supply Co.', quantity: 24 },
+  ],
+  colHeaders: ['SKU', 'Supplier', 'Quantity'],
+  height: 'auto',
+  licenseKey: 'non-commercial-and-evaluation',
+  columns: [
+    { data: 'sku', type: 'text', validator: skuValidator, allowInvalid: false },
+    { data: 'supplier', type: 'text' },
+    { data: 'quantity', type: 'numeric' },
+  ],
+  autoWrapRow: true,
+  autoWrapCol: true,
+});

--- a/docs/content/guides/cell-types/text-cell-type/react/example1.jsx
+++ b/docs/content/guides/cell-types/text-cell-type/react/example1.jsx
@@ -1,0 +1,19 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+// register Handsontable's modules
+registerAllModules();
+const ExampleComponent = () => {
+    return (<HotTable data={[
+            { sku: '004821', category: '032', quantity: 142, unitPrice: 18.5 },
+            { sku: '000093', category: '032', quantity: 0, unitPrice: 42.0 },
+            { sku: '017640', category: '015', quantity: 67, unitPrice: 9.99 },
+            { sku: '002210', category: '015', quantity: 310, unitPrice: 4.25 },
+            { sku: '008875', category: '048', quantity: 24, unitPrice: 129.0 },
+        ]} colHeaders={['SKU', 'Category code', 'Quantity', 'Unit price ($)']} height="auto" autoWrapRow={true} autoWrapCol={true} licenseKey="non-commercial-and-evaluation" columns={[
+            { data: 'sku', type: 'text' },
+            { data: 'category', type: 'text' },
+            { data: 'quantity', type: 'numeric' },
+            { data: 'unitPrice', type: 'numeric' },
+        ]}/>);
+};
+export default ExampleComponent;

--- a/docs/content/guides/cell-types/text-cell-type/react/example1.tsx
+++ b/docs/content/guides/cell-types/text-cell-type/react/example1.tsx
@@ -1,0 +1,32 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={[
+        { sku: '004821', category: '032', quantity: 142, unitPrice: 18.5 },
+        { sku: '000093', category: '032', quantity: 0, unitPrice: 42.0 },
+        { sku: '017640', category: '015', quantity: 67, unitPrice: 9.99 },
+        { sku: '002210', category: '015', quantity: 310, unitPrice: 4.25 },
+        { sku: '008875', category: '048', quantity: 24, unitPrice: 129.0 },
+      ]}
+      colHeaders={['SKU', 'Category code', 'Quantity', 'Unit price ($)']}
+      height="auto"
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+      columns={[
+        { data: 'sku', type: 'text' },
+        { data: 'category', type: 'text' },
+        { data: 'quantity', type: 'numeric' },
+        { data: 'unitPrice', type: 'numeric' },
+      ]}
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/cell-types/text-cell-type/react/example2.jsx
+++ b/docs/content/guides/cell-types/text-cell-type/react/example2.jsx
@@ -1,0 +1,21 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+// register Handsontable's modules
+registerAllModules();
+const skuValidator = (value, callback) => {
+    callback(/^\d{6}$/.test(value));
+};
+const ExampleComponent = () => {
+    return (<HotTable data={[
+            { sku: '004821', supplier: 'Harbor Goods', quantity: 142 },
+            { sku: '000093', supplier: 'Alpine Supply Co.', quantity: 0 },
+            { sku: '017640', supplier: 'Harbor Goods', quantity: 67 },
+            { sku: '002210', supplier: 'Crestline Wholesale', quantity: 310 },
+            { sku: '008875', supplier: 'Alpine Supply Co.', quantity: 24 },
+        ]} colHeaders={['SKU', 'Supplier', 'Quantity']} height="auto" autoWrapRow={true} autoWrapCol={true} licenseKey="non-commercial-and-evaluation" columns={[
+            { data: 'sku', type: 'text', validator: skuValidator, allowInvalid: false },
+            { data: 'supplier', type: 'text' },
+            { data: 'quantity', type: 'numeric' },
+        ]}/>);
+};
+export default ExampleComponent;

--- a/docs/content/guides/cell-types/text-cell-type/react/example2.tsx
+++ b/docs/content/guides/cell-types/text-cell-type/react/example2.tsx
@@ -1,0 +1,35 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const skuValidator = (value: string, callback: (isValid: boolean) => void) => {
+  callback(/^\d{6}$/.test(value));
+};
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={[
+        { sku: '004821', supplier: 'Harbor Goods', quantity: 142 },
+        { sku: '000093', supplier: 'Alpine Supply Co.', quantity: 0 },
+        { sku: '017640', supplier: 'Harbor Goods', quantity: 67 },
+        { sku: '002210', supplier: 'Crestline Wholesale', quantity: 310 },
+        { sku: '008875', supplier: 'Alpine Supply Co.', quantity: 24 },
+      ]}
+      colHeaders={['SKU', 'Supplier', 'Quantity']}
+      height="auto"
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+      columns={[
+        { data: 'sku', type: 'text', validator: skuValidator, allowInvalid: false },
+        { data: 'supplier', type: 'text' },
+        { data: 'quantity', type: 'numeric' },
+      ]}
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/cell-types/text-cell-type/text-cell-type.md
+++ b/docs/content/guides/cell-types/text-cell-type/text-cell-type.md
@@ -1,0 +1,174 @@
+---
+type: how-to
+title: Text cell type
+metaTitle: Text cell type - JavaScript Data Grid | Handsontable
+description: Use the text cell type, the default cell type in Handsontable, to display and edit plain text values.
+permalink: /text-cell-type
+canonicalUrl: /text-cell-type
+react:
+  metaTitle: Text cell type - React Data Grid | Handsontable
+angular:
+  metaTitle: Text cell type - Angular Data Grid | Handsontable
+vue:
+  metaTitle: Text cell type - Vue Data Grid | Handsontable
+searchCategory: Guides
+category: Cell types
+menuTag: new
+---
+Use the text cell type, the default cell type in Handsontable, to display and edit plain text values.
+
+[[toc]]
+
+## Overview
+
+The text cell type is the default [cell type](@/guides/cell-types/cell-type/cell-type.md) in Handsontable. It renders a cell's value as plain text and lets you edit it with a standard text input. It has no built-in validator.
+
+Because `text` is the default, you don't need to set `type: 'text'` for it to apply. Set it explicitly when you want to override a different type inherited from a higher configuration level, or when you want the configuration to state the type directly, for example to guard alphanumeric codes or values with leading zeros against being reformatted by another type.
+
+::: only-for javascript
+
+::: example #example1 --js 1 --ts 2
+
+@[code](@/content/guides/cell-types/text-cell-type/javascript/example1.js)
+@[code](@/content/guides/cell-types/text-cell-type/javascript/example1.ts)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #example1 :react --js 1 --ts 2
+
+@[code](@/content/guides/cell-types/text-cell-type/react/example1.jsx)
+@[code](@/content/guides/cell-types/text-cell-type/react/example1.tsx)
+
+:::
+
+:::
+
+::: only-for angular
+
+::: example #example1 :angular --ts 1 --html 2
+
+@[code](@/content/guides/cell-types/text-cell-type/angular/example1.ts)
+@[code](@/content/guides/cell-types/text-cell-type/angular/example1.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example1 :vue3
+
+@[code](@/content/guides/cell-types/text-cell-type/vue/example1.vue)
+
+:::
+
+:::
+
+In the example above, the `sku` and `category` columns use `type: 'text'` explicitly, even though it's the default. This makes the configuration self-documenting: values such as `'004821'` are alphanumeric codes with leading zeros, not numbers, and the explicit type states that intent even if a later change sets a different type at the grid or column level.
+
+## Adding a validator
+
+The text cell type ships without a built-in [validator](@/guides/cell-functions/cell-validator/cell-validator.md). To validate text values, combine `type: 'text'` with your own validator function, and set [`allowInvalid`](@/api/options.md#allowinvalid) to `false` to reject invalid entries.
+
+::: only-for javascript
+
+::: example #example2 --js 1 --ts 2
+
+@[code](@/content/guides/cell-types/text-cell-type/javascript/example2.js)
+@[code](@/content/guides/cell-types/text-cell-type/javascript/example2.ts)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #example2 :react --js 1 --ts 2
+
+@[code](@/content/guides/cell-types/text-cell-type/react/example2.jsx)
+@[code](@/content/guides/cell-types/text-cell-type/react/example2.tsx)
+
+:::
+
+:::
+
+::: only-for angular
+
+::: example #example2 :angular --ts 1 --html 2
+
+@[code](@/content/guides/cell-types/text-cell-type/angular/example2.ts)
+@[code](@/content/guides/cell-types/text-cell-type/angular/example2.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example2 :vue3
+
+@[code](@/content/guides/cell-types/text-cell-type/vue/example2.vue)
+
+:::
+
+:::
+
+## Result
+
+After configuring the text cell type, cells display and edit their value as plain text, with no formatting or masking applied. Combine it with a custom [`validator`](@/api/options.md#validator) to restrict which values a text cell accepts.
+
+## Keyboard shortcuts
+
+The text cell editor uses the standard [edition keyboard shortcuts](@/guides/navigation/keyboard-shortcuts/keyboard-shortcuts.md#edition-keyboard-shortcuts). It has no type-specific key bindings.
+
+## Related articles
+
+**Related guides**
+
+<div class="boxes-list">
+
+- [Cell type](@/guides/cell-types/cell-type/cell-type.md)
+- [Cell validator](@/guides/cell-functions/cell-validator/cell-validator.md)
+
+</div>
+
+**Configuration options**
+
+<div class="boxes-list">
+
+- [type](@/api/options.md#type)
+- [validator](@/api/options.md#validator)
+- [allowInvalid](@/api/options.md#allowinvalid)
+
+</div>
+
+**Core methods**
+
+<div class="boxes-list">
+
+- [getCellMeta()](@/api/core.md#getcellmeta)
+- [getCellMetaAtRow()](@/api/core.md#getcellmetaatrow)
+- [getCellsMeta()](@/api/core.md#getcellsmeta)
+- [getDataType()](@/api/core.md#getdatatype)
+- [setCellMeta()](@/api/core.md#setcellmeta)
+- [setCellMetaObject()](@/api/core.md#setcellmetaobject)
+- [removeCellMeta()](@/api/core.md#removecellmeta)
+
+</div>
+
+**Hooks**
+
+<div class="boxes-list">
+
+- [afterGetCellMeta](@/api/hooks.md#aftergetcellmeta)
+- [afterSetCellMeta](@/api/hooks.md#aftersetcellmeta)
+- [afterValidate](@/api/hooks.md#aftervalidate)
+- [beforeGetCellMeta](@/api/hooks.md#beforegetcellmeta)
+- [beforeSetCellMeta](@/api/hooks.md#beforesetcellmeta)
+- [beforeValidate](@/api/hooks.md#beforevalidate)
+
+</div>

--- a/docs/content/guides/cell-types/text-cell-type/text-cell-type.md
+++ b/docs/content/guides/cell-types/text-cell-type/text-cell-type.md
@@ -74,6 +74,8 @@ In the example above, the `sku` and `category` columns use `type: 'text'` explic
 
 The text cell type ships without a built-in [validator](@/guides/cell-functions/cell-validator/cell-validator.md). To validate text values, combine `type: 'text'` with your own validator function, and set [`allowInvalid`](@/api/options.md#allowinvalid) to `false` to reject invalid entries.
 
+With `allowInvalid: false`, the cell editor doesn't close on an invalid value. It stays open until you either enter a value that passes validation or press <kbd>**Esc**</kbd> to cancel the edit and restore the previous value. See [invalid cell commit semantics](@/guides/cell-functions/cell-validator/cell-validator.md#invalid-cell-commit-semantics-vs-visual-marking) for the full behavior, including how it differs from `allowInvalid: true`.
+
 ::: only-for javascript
 
 ::: example #example2 --js 1 --ts 2

--- a/docs/content/guides/cell-types/text-cell-type/vue/example1.vue
+++ b/docs/content/guides/cell-types/text-cell-type/vue/example1.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    { sku: '004821', category: '032', quantity: 142, unitPrice: 18.5 },
+    { sku: '000093', category: '032', quantity: 0, unitPrice: 42.0 },
+    { sku: '017640', category: '015', quantity: 67, unitPrice: 9.99 },
+    { sku: '002210', category: '015', quantity: 310, unitPrice: 4.25 },
+    { sku: '008875', category: '048', quantity: 24, unitPrice: 129.0 },
+  ],
+  colHeaders: ['SKU', 'Category code', 'Quantity', 'Unit price ($)'],
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  columns: [
+    { data: 'sku', type: 'text' },
+    { data: 'category', type: 'text' },
+    { data: 'quantity', type: 'numeric' },
+    { data: 'unitPrice', type: 'numeric' },
+  ],
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example1">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-types/text-cell-type/vue/example2.vue
+++ b/docs/content/guides/cell-types/text-cell-type/vue/example2.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+// register Handsontable's modules
+registerAllModules();
+
+const skuValidator = (value: string, callback: (isValid: boolean) => void) => {
+  callback(/^\d{6}$/.test(value));
+};
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    { sku: '004821', supplier: 'Harbor Goods', quantity: 142 },
+    { sku: '000093', supplier: 'Alpine Supply Co.', quantity: 0 },
+    { sku: '017640', supplier: 'Harbor Goods', quantity: 67 },
+    { sku: '002210', supplier: 'Crestline Wholesale', quantity: 310 },
+    { sku: '008875', supplier: 'Alpine Supply Co.', quantity: 24 },
+  ],
+  colHeaders: ['SKU', 'Supplier', 'Quantity'],
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  columns: [
+    { data: 'sku', type: 'text', validator: skuValidator, allowInvalid: false },
+    { data: 'supplier', type: 'text' },
+    { data: 'quantity', type: 'numeric' },
+  ],
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example2">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/sidebar.js
+++ b/docs/content/guides/sidebar.js
@@ -97,6 +97,7 @@ const cellFunctionsItems = [
 
 const cellTypesItems = [
   { path: 'guides/cell-types/cell-type/cell-type' },
+  { path: 'guides/cell-types/text-cell-type/text-cell-type' },
   { path: 'guides/cell-types/numeric-cell-type/numeric-cell-type' },
   { path: 'guides/cell-types/date-cell-type/date-cell-type' },
   { path: 'guides/cell-types/time-cell-type/time-cell-type' },


### PR DESCRIPTION
### Context

The PR adds the missing "Text cell type" documentation page. Every other built-in cell type (`autocomplete`, `checkbox`, `date`, `dropdown`, `handsontable`, `multiselect`, `numeric`, `password`, `select`, `time`) has its own guide page under `docs/content/guides/cell-types/`, but `text` — the default cell type — did not.

The new page explains that `text` is the default cell type (`TextEditor` + `textRenderer`, no built-in validator), shows when to set `type: 'text'` explicitly (to make configuration self-documenting for alphanumeric/leading-zero values), and shows how to combine it with a custom validator since it ships without one.

### How has this been tested?

- Verified the page renders for all four frameworks via the local docs dev server (`npm run dev` in `docs/`): `/docs/javascript-data-grid/text-cell-type`, `/docs/react-data-grid/text-cell-type`, `/docs/angular-data-grid/text-cell-type`, `/docs/vue-data-grid/text-cell-type` all return 200 with the expected content.
- Generated the JS/JSX variants from the TS/TSX sources with `npm run docs:code-examples:generate-js`.
- Ran `npx eslint` over the new example files and `sidebar.js` — no errors.
- Confirmed the Angular example's module-scope validator pattern matches the existing, live `cell-functions/cell-validator/angular/example1.ts` example.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-841

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-841

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to docs content and example snippets; no Handsontable runtime or wrapper package behavior is modified.
> 
> **Overview**
> Adds the missing **Text cell type** documentation so the default `text` type matches the other built-in cell type guides.
> 
> The new `text-cell-type` page covers when to set `type: 'text'` explicitly (including leading-zero / alphanumeric codes), that there is no built-in validator, and how to pair text columns with a custom validator and `allowInvalid: false`. It ships two live examples per stack (JavaScript, React, Angular, Vue).
> 
> Navigation is wired up by inserting the guide in `sidebar.js` under Cell types and adding a **Text cell type** link on the main cell type page’s related list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25ae594b89c82c82ff008610a477ecbdf33c7f95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->