### PR TITLE
DEV-2040: Replace docs-site :has() selectors with a stamped-class fallback

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -10,6 +10,7 @@ import { pluginCollapsibleSections } from '@expressive-code/plugin-collapsible-s
 import { vuepressPreprocessor } from './src/plugins/vuepress-preprocessor.mjs';
 import { rehypeTableWrapper } from './src/plugins/rehype-table-wrapper.mjs';
 import { rehypeMigrationSteps } from './src/plugins/rehype-migration-steps.mjs';
+import { replaceHasSelectors } from './src/plugins/replace-has-selectors.mjs';
 import { buildAllSidebars, buildAllValidUrls } from './src/sidebar.mjs';
 import { resolveHotVersion } from './src/lib/hot-version.mjs';
 import { resolve, dirname } from 'path';
@@ -687,6 +688,7 @@ export default defineConfig({
   compressHTML: true,
 
   integrations: [
+    replaceHasSelectors(),
     starlight({
       title: 'Handsontable',
       description:

--- a/docs/src/plugins/__tests__/replace-has-selectors.test.mjs
+++ b/docs/src/plugins/__tests__/replace-has-selectors.test.mjs
@@ -1,0 +1,108 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { rewriteHasSelectors } from '../replace-has-selectors.mjs';
+
+test('replaces a static :has() with a stamped class and emits a manifest', () => {
+  const { css, replaced, kept } = rewriteHasSelectors('.hot-example:has(.theme-dropdown) { color: red; }');
+
+  assert.equal(replaced, 1);
+  assert.equal(kept, 0);
+  assert.match(css, /\.hot-example:where\(\.ht-nohas-[a-z0-9]+\):not\(\._\)\s*\{/);
+  assert.match(css, /:root \{ --ht-nohas-[a-z0-9]+: "\.hot-example:has\(\.theme-dropdown\)"; \}/);
+  assert.ok(!css.split(':root')[0].includes(':has('));
+});
+
+test('keeps hover/focus-driven :has() selectors untouched', () => {
+  const input = '.sidebar-pane ul ul li:has(> a:not([aria-current="page"]):is(:hover, :focus-visible)) { border-color: red; }';
+  const { css, replaced, kept } = rewriteHasSelectors(input);
+
+  assert.equal(replaced, 0);
+  assert.equal(kept, 1);
+  assert.ok(css.includes(':has(> a:not([aria-current="page"]):is(:hover, :focus-visible))'));
+  assert.ok(!css.includes(':root'));
+});
+
+test('rewrites only the :has() items of a selector list', () => {
+  const { css, replaced } = rewriteHasSelectors('.a:has(.b), .c { color: red; }');
+
+  assert.equal(replaced, 1);
+  assert.match(css, /\.a:where\(\.ht-nohas-[a-z0-9]+\):not\(\._\), \.c \{/);
+});
+
+test('preserves the specificity of the dropped segments via padding', () => {
+  // :has(> a[aria-current='page']) contributes (0,1,1) -> one :not(._) and one :not(_)
+  const input = ".sidebar-pane ul ul li:has(> a[aria-current='page']) { border-color: red; }";
+  const { css } = rewriteHasSelectors(input);
+
+  assert.match(css, /li:where\(\.ht-nohas-[a-z0-9]+\):not\(\._\):not\(_\)\s*\{/);
+});
+
+test('handles a :has() anchor followed by a suffix', () => {
+  const { css } = rewriteHasSelectors('main:has(.not-found) .hot-footer { display: none; }');
+
+  assert.match(css, /main:where\(\.ht-nohas-[a-z0-9]+\):not\(\._\) \.hot-footer \{/);
+  assert.match(css, /--ht-nohas-[a-z0-9]+: "main:has\(\.not-found\)"/);
+});
+
+test('handles multiple :not(:has(...)) segments in one compound', () => {
+  const input = '.controls:not(:has(button:not([hidden]))):not(:has(input:not([hidden]))) { display: none; }';
+  const { css, replaced } = rewriteHasSelectors(input);
+
+  assert.equal(replaced, 1);
+  // each dropped :not(:has(...)) contributes (0,1,1) -> total (0,2,2)
+  assert.match(css, /\.controls:where\(\.ht-nohas-[a-z0-9]+\):not\(\._\):not\(\._\):not\(_\):not\(_\)\s*\{/);
+  assert.ok(!css.split(':root')[0].includes(':has('));
+});
+
+test('rewrites the Starlight markdown list rule (comment inside the selector)', () => {
+  const input = `.sl-markdown-content
+ :is(ol, ul):has(> li > :not(a, strong, em, del, span, input, code, br, script, ol, ul))
+ > li
+ > :is(
+    :last-child:not(a, strong, em, del, span, input, code, br, :where(.not-content *)),
+    /* comment inside the selector */
+    :not(script):has(~ script:last-child):not(:has(~ :not(script)))
+ ) { margin-bottom: 1.25rem; }`;
+  const { css, replaced } = rewriteHasSelectors(input);
+
+  assert.equal(replaced, 1);
+  assert.ok(!css.split(':root')[0].includes(':has('));
+  assert.ok(!css.includes('/* comment inside the selector */') || css.indexOf('/*') > css.indexOf('{'));
+
+  const anchors = [...css.matchAll(/--ht-nohas-[a-z0-9]+: "([^"]+)"/g)].map(m => m[1]);
+
+  assert.equal(anchors.length, 2);
+  assert.ok(anchors[0].startsWith('.sl-markdown-content :is(ol, ul):has('));
+  assert.ok(anchors[1].includes('> li > :is('));
+});
+
+test('resolves & against parent rules for the manifest anchor', () => {
+  const input = `ul ul li {
+  &:has(> a[aria-current='page']) { border-color: red; }
+}`;
+  const { css } = rewriteHasSelectors(input);
+
+  assert.match(css, /--ht-nohas-[a-z0-9]+: ":is\(ul ul li\):has\(> a\[aria-current='page'\]\)"/);
+  assert.match(css, /&:where\(\.ht-nohas-[a-z0-9]+\)/);
+});
+
+test('keeps an explicit & when the only & sat inside the dropped :has()', () => {
+  const input = `.search-dialog {
+  div:has(> &) { justify-content: center; }
+}`;
+  const { css } = rewriteHasSelectors(input);
+
+  assert.match(css, /div:where\(\.ht-nohas-[a-z0-9]+\)[^{]*:where\(&, :not\(&\)\)\s*\{/);
+  assert.match(css, /--ht-nohas-[a-z0-9]+: "div:has\(> :is\(\.search-dialog\)\)"/);
+});
+
+test('same anchor in different rules maps to the same class', () => {
+  const { css } = rewriteHasSelectors(
+    'main:has(.not-found) .a { color: red; } main:has(.not-found) .b { color: blue; }',
+  );
+  const classes = [...css.matchAll(/:where\(\.(ht-nohas-[a-z0-9]+)\)/g)].map(m => m[1]);
+
+  assert.equal(classes.length, 2);
+  assert.equal(classes[0], classes[1]);
+  assert.equal([...css.matchAll(/--ht-nohas-/g)].length, 1);
+});

--- a/docs/src/plugins/__tests__/replace-has-selectors.test.mjs
+++ b/docs/src/plugins/__tests__/replace-has-selectors.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { rewriteHasSelectors } from '../replace-has-selectors.mjs';
+import { rewriteHasSelectors, isStylesheetId } from '../replace-has-selectors.mjs';
 
 test('replaces a static :has() with a stamped class and emits a manifest', () => {
   const { css, replaced, kept } = rewriteHasSelectors('.hot-example:has(.theme-dropdown) { color: red; }');
@@ -105,4 +105,19 @@ test('same anchor in different rules maps to the same class', () => {
   assert.equal(classes.length, 2);
   assert.equal(classes[0], classes[1]);
   assert.equal([...css.matchAll(/--ht-nohas-/g)].length, 1);
+});
+
+test('treats plain stylesheets and astro/vue style blocks as CSS modules', () => {
+  assert.equal(isStylesheetId('/docs/src/styles/sidebar.css'), true);
+  assert.equal(isStylesheetId('/docs/src/pages/index.astro?astro&type=style&index=0&lang.css'), true);
+  assert.equal(isStylesheetId('/docs/src/components/Widget.vue?vue&type=style&index=0&lang.css'), true);
+});
+
+test('skips ?raw, ?url, and ?inline CSS imports (served as JavaScript, not stylesheets)', () => {
+  // The example runner imports example CSS with `?raw`; vite serves it as
+  // `export default "..."` - postcss parsing that failed the production build.
+  assert.equal(isStylesheetId('/docs/content/guides/navigation/focus-scopes/javascript/example1.css?raw'), false);
+  assert.equal(isStylesheetId('/docs/src/styles/anything.css?url'), false);
+  assert.equal(isStylesheetId('/docs/src/styles/anything.css?inline'), false);
+  assert.equal(isStylesheetId('/docs/src/components/module.mjs'), false);
 });

--- a/docs/src/plugins/has-fallback-runtime.mjs
+++ b/docs/src/plugins/has-fallback-runtime.mjs
@@ -1,0 +1,149 @@
+/**
+ * Client runtime for the `replace-has-selectors` Astro integration.
+ *
+ * The build-time transform rewrites static `:has()` selectors to
+ * `.ht-nohas-<hash>` classes and serves a manifest as CSS custom properties on
+ * `:root` (`--ht-nohas-<hash>: "<original selector>"`). This script reads that
+ * manifest and stamps the classes onto the elements the original selector
+ * matches, using `querySelectorAll` - which, unlike a stylesheet `:has()`
+ * rule, registers no style-invalidation hooks in the browser.
+ *
+ * Restamping runs on page load and after DOM mutations (rAF-debounced).
+ * Mutations inside a Handsontable grid (`.ht-root-wrapper`) are ignored: the
+ * grid mutates on scroll/resize and never contains stamped elements.
+ */
+(() => {
+  if (typeof window === 'undefined' || typeof MutationObserver === 'undefined') {
+    return;
+  }
+
+  const PROPERTY_PREFIX = '--ht-nohas-';
+  const GRID_SELECTOR = '.ht-root-wrapper';
+  let observer = null;
+  let scheduled = false;
+
+  /**
+   * Reads the stamped-class manifest out of the loaded stylesheets.
+   *
+   * @returns {Map<string, string>} className -> original selector.
+   */
+  const collectManifest = () => {
+    const manifest = new Map();
+    const walk = (rules) => {
+      for (const rule of rules) {
+        if (rule.style) {
+          for (const property of rule.style) {
+            if (property.startsWith(PROPERTY_PREFIX)) {
+              let value = rule.style.getPropertyValue(property).trim();
+
+              if (value.startsWith('"') && value.endsWith('"')) {
+                value = value.slice(1, -1).replace(/\\(["\\])/g, '$1');
+              }
+
+              manifest.set(`ht-nohas-${property.slice(PROPERTY_PREFIX.length)}`, value);
+            }
+          }
+        }
+
+        if (rule.cssRules && rule.cssRules.length > 0) {
+          walk(rule.cssRules);
+        }
+      }
+    };
+
+    for (const sheet of document.styleSheets) {
+      try {
+        walk(sheet.cssRules);
+      } catch (error) {
+        // cross-origin sheet - not ours, skip
+      }
+    }
+
+    return manifest;
+  };
+
+  const startObserver = () => {
+    observer.observe(document.documentElement, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+    });
+  };
+
+  /**
+   * Applies every manifest entry: adds the class to current matches, removes it
+   * from elements that no longer match. The observer is paused while stamping
+   * so our own class writes do not re-trigger it.
+   */
+  const stamp = () => {
+    if (observer) {
+      observer.disconnect();
+    }
+
+    for (const [className, selector] of collectManifest()) {
+      let matches;
+
+      try {
+        matches = document.querySelectorAll(selector);
+      } catch (error) {
+        continue;
+      }
+
+      const matchSet = new Set(matches);
+
+      for (const element of matches) {
+        element.classList.add(className);
+      }
+
+      for (const element of document.querySelectorAll(`.${className}`)) {
+        if (!matchSet.has(element)) {
+          element.classList.remove(className);
+        }
+      }
+    }
+
+    if (observer) {
+      startObserver();
+    }
+  };
+
+  const schedule = () => {
+    if (scheduled) {
+      return;
+    }
+
+    scheduled = true;
+    requestAnimationFrame(() => {
+      scheduled = false;
+      stamp();
+    });
+  };
+
+  observer = new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      let element = mutation.target;
+
+      if (element.nodeType !== Node.ELEMENT_NODE) {
+        element = element.parentElement;
+      }
+
+      if (element && element.closest && element.closest(GRID_SELECTOR)) {
+        continue;
+      }
+
+      schedule();
+
+      return;
+    }
+  });
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', stamp, { once: true });
+  } else {
+    stamp();
+  }
+
+  window.addEventListener('load', schedule);
+  document.addEventListener('astro:page-load', schedule);
+  startObserver();
+})();

--- a/docs/src/plugins/replace-has-selectors.mjs
+++ b/docs/src/plugins/replace-has-selectors.mjs
@@ -422,20 +422,31 @@ export function rewriteHasSelectors(css) {
 }
 
 /**
- * Returns `true` when a Vite module id points at a stylesheet: a plain
- * .css/.scss/.sass/.less file, or a compiled `<style>` block of an .astro/.vue
- * component (their ids carry an `astro&type=style` / `vue&type=style` query and
- * a `lang.css` marker).
+ * Returns `true` when a Vite module id points at a stylesheet served AS CSS: a
+ * plain .css/.scss/.sass/.less file, or a compiled `<style>` block of an
+ * .astro/.vue component (their ids carry an `astro&type=style` /
+ * `vue&type=style` query and a `lang.css` marker).
+ *
+ * A `?raw`, `?url`, or `?inline` query means the file is imported as a
+ * JavaScript module (`export default "..."`), not served as a stylesheet - the
+ * docs example runner imports example CSS this way. Those modules are not CSS
+ * at transform time and must be skipped (postcss cannot parse them, and in the
+ * production build this failed the whole `astro build`).
  *
  * @param {string} id The Vite module id.
  * @returns {boolean} Whether the id is a stylesheet module.
  */
-function isStylesheetId(id) {
+export function isStylesheetId(id) {
   if (id.includes('&type=style')) {
     return true;
   }
 
-  const cleanId = id.split('?')[0];
+  const [cleanId, query = ''] = id.split('?');
+  const params = new URLSearchParams(query);
+
+  if (params.has('raw') || params.has('url') || params.has('inline')) {
+    return false;
+  }
 
   return /\.(css|scss|sass|less)$/.test(cleanId);
 }
@@ -482,13 +493,24 @@ export function replaceHasSelectors() {
                     return null;
                   }
 
-                  const { css, replaced } = rewriteHasSelectors(code);
+                  let result;
 
-                  if (replaced === 0) {
+                  try {
+                    result = rewriteHasSelectors(code);
+                  } catch (error) {
+                    // A module that passed the id check but is not parseable CSS
+                    // (e.g. an import mode this plugin does not know about) must
+                    // never fail the whole build - serve it untouched and warn.
+                    this.warn(`replace-has-selectors: skipping unparseable stylesheet module "${id}": ${error.message}`);
+
                     return null;
                   }
 
-                  return { code: css, map: null };
+                  if (result.replaced === 0) {
+                    return null;
+                  }
+
+                  return { code: result.css, map: null };
                 },
               },
             ],

--- a/docs/src/plugins/replace-has-selectors.mjs
+++ b/docs/src/plugins/replace-has-selectors.mjs
@@ -1,0 +1,500 @@
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+// postcss is not a direct dependency of docs/ (pnpm keeps transitive deps out of
+// docs/node_modules), but vite is - and vite always ships postcss. Resolve it
+// through vite's own dependency chain.
+const postcss = require(require.resolve('postcss', { paths: [require.resolve('vite')] }));
+
+/**
+ * File-path fragments whose stylesheets must NOT be rewritten. Handsontable's own
+ * CSS is the library under test - rewriting its rules here would fake an
+ * engine-side fix at the docs level. `handsontable-import.css` is listed
+ * explicitly because vite inlines its `@import` of the built HT CSS into the
+ * docs module id before this transform runs.
+ */
+const EXCLUDED_ID_FRAGMENTS = [
+  'handsontable/tmp/',
+  'handsontable/styles/',
+  '@handsontable/',
+  'handsontable-import.css',
+];
+
+/**
+ * A selector that contains any of these is driven by live user interaction or
+ * runtime element state. Replacing its `:has()` with a JS-stamped class would
+ * need per-event restamping to look right, so such selectors are left alone.
+ * They are cheap to keep: hover/focus-driven `:has()` rules do not fire on
+ * scroll-driven DOM mutations.
+ */
+const DYNAMIC_STATE_PATTERN =
+  /:hover|:focus|:active\b|:checked|:target\b|:popover-open|:empty|:placeholder-shown|:autofill|\[open\]|:enabled|:disabled/;
+
+/**
+ * The class and CSS-custom-property prefix shared with the client runtime
+ * (`has-fallback-runtime.mjs`). A rewritten rule matches `.ht-nohas-<hash>`;
+ * the manifest entry that tells the runtime what to stamp is served as
+ * `--ht-nohas-<hash>: "<selector>"` on `:root`.
+ */
+const FALLBACK_PREFIX = 'ht-nohas-';
+
+/**
+ * Hashes a string into a short base36 token (djb2). Deterministic, so the same
+ * anchor selector always maps to the same stamped class, across files and runs.
+ *
+ * @param {string} input The string to hash.
+ * @returns {string} A short base36 hash.
+ */
+function hashString(input) {
+  let hash = 5381;
+
+  for (let i = 0; i < input.length; i++) {
+    hash = (((hash << 5) + hash) + input.charCodeAt(i)) >>> 0;
+  }
+
+  return hash.toString(36);
+}
+
+/**
+ * Removes CSS comments and collapses all whitespace runs to single spaces.
+ * Starlight writes block comments inside multi-line selectors; those are valid
+ * in a stylesheet but not in `querySelectorAll`.
+ *
+ * @param {string} selector The raw selector text.
+ * @returns {string} The cleaned selector.
+ */
+function cleanSelector(selector) {
+  return selector.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Splits a selector list on top-level commas (commas inside `()` or `[]` do not
+ * split).
+ *
+ * @param {string} selector The selector list.
+ * @returns {string[]} The individual selector items.
+ */
+function splitSelectorList(selector) {
+  const items = [];
+  let depth = 0;
+  let start = 0;
+
+  for (let i = 0; i < selector.length; i++) {
+    const char = selector[i];
+
+    if (char === '(' || char === '[') {
+      depth++;
+    } else if (char === ')' || char === ']') {
+      depth--;
+    } else if (char === ',' && depth === 0) {
+      items.push(selector.slice(start, i));
+      start = i + 1;
+    }
+  }
+
+  items.push(selector.slice(start));
+
+  return items.map(item => item.trim()).filter(item => item.length > 0);
+}
+
+/**
+ * Tokenizes one selector item into alternating compound and combinator tokens
+ * (starting and ending with a compound). Combinator tokens include their
+ * surrounding whitespace, so joining all tokens reproduces the item.
+ *
+ * @param {string} item A single (comma-free) selector.
+ * @returns {string[]} Alternating [compound, combinator, compound, ...] tokens.
+ */
+function tokenizeCompounds(item) {
+  const tokens = [];
+  let depth = 0;
+  let current = '';
+  let inCombinator = false;
+
+  for (let i = 0; i < item.length; i++) {
+    const char = item[i];
+
+    if (char === '(' || char === '[') {
+      depth++;
+    } else if (char === ')' || char === ']') {
+      depth--;
+    }
+
+    const isCombinatorChar = depth === 0 && (char === ' ' || char === '>' || char === '+' || char === '~');
+
+    if (isCombinatorChar !== inCombinator) {
+      tokens.push(current);
+      current = '';
+      inCombinator = isCombinatorChar;
+    }
+
+    current += char;
+  }
+
+  tokens.push(current);
+
+  return tokens;
+}
+
+/**
+ * Splits a compound selector into its simple-selector segments: a type name or
+ * `&`/`*`, `.class`, `#id`, `[attr]`, `:pseudo-class(...)`, `::pseudo-element`.
+ *
+ * @param {string} compound A compound selector (no top-level combinators).
+ * @returns {string[]} The segments, in order.
+ */
+function splitSegments(compound) {
+  const segments = [];
+  let i = 0;
+
+  while (i < compound.length) {
+    const start = i;
+    const char = compound[i];
+
+    if (char === '[') {
+      let depth = 0;
+
+      do {
+        if (compound[i] === '[') {
+          depth++;
+        } else if (compound[i] === ']') {
+          depth--;
+        }
+        i++;
+      } while (i < compound.length && depth > 0);
+
+    } else if (char === ':' || char === '.' || char === '#') {
+      i++;
+
+      if (char === ':' && compound[i] === ':') {
+        i++;
+      }
+
+      while (i < compound.length && /[\w\\-]/.test(compound[i])) {
+        i++;
+      }
+
+      if (compound[i] === '(') {
+        let depth = 0;
+
+        do {
+          if (compound[i] === '(') {
+            depth++;
+          } else if (compound[i] === ')') {
+            depth--;
+          }
+          i++;
+        } while (i < compound.length && depth > 0);
+      }
+
+    } else {
+      // type selector, `&`, `*`, or a namespaced name
+      i++;
+
+      while (i < compound.length && /[\w\\|*-]/.test(compound[i])) {
+        i++;
+      }
+    }
+
+    segments.push(compound.slice(start, i));
+  }
+
+  return segments;
+}
+
+/**
+ * Computes CSS specificity `[ids, classes, types]` for a selector string,
+ * following the same rules the browser uses: `:is()`, `:not()`, and `:has()`
+ * count as the highest specificity among their arguments; `:where()` counts as
+ * zero.
+ *
+ * @param {string} selector The selector (may contain combinators and commas).
+ * @returns {number[]} The `[a, b, c]` specificity triple.
+ */
+function specificity(selector) {
+  const max = (left, right) => {
+    for (let i = 0; i < 3; i++) {
+      if (left[i] !== right[i]) {
+        return left[i] > right[i] ? left : right;
+      }
+    }
+
+    return left;
+  };
+
+  let best = [0, 0, 0];
+
+  for (const item of splitSelectorList(selector)) {
+    const total = [0, 0, 0];
+    const tokens = tokenizeCompounds(item);
+
+    for (let t = 0; t < tokens.length; t += 2) {
+      for (const segment of splitSegments(tokens[t])) {
+        if (segment.startsWith('::')) {
+          total[2]++;
+        } else if (segment.startsWith(':')) {
+          const name = segment.slice(1).replace(/\(.*$/s, '').toLowerCase();
+          const argsMatch = segment.match(/^:[\w-]+\((.*)\)$/s);
+
+          if (name === 'where') {
+            // zero
+          } else if (argsMatch && ['is', 'not', 'has', 'matches'].includes(name)) {
+            const inner = specificity(argsMatch[1]);
+
+            total[0] += inner[0];
+            total[1] += inner[1];
+            total[2] += inner[2];
+          } else if (['before', 'after', 'first-line', 'first-letter'].includes(name)) {
+            total[2]++;
+          } else {
+            total[1]++;
+          }
+        } else if (segment.startsWith('.') || segment.startsWith('[')) {
+          total[1]++;
+        } else if (segment.startsWith('#')) {
+          total[0]++;
+        } else if (segment !== '*' && segment !== '&') {
+          total[2]++;
+        }
+      }
+    }
+
+    best = max(best, total);
+  }
+
+  return best;
+}
+
+/**
+ * Builds an always-true selector suffix whose specificity equals the given
+ * triple, so a rewritten rule keeps the exact cascade weight of the segments
+ * it dropped. `:not(#_)` adds one id, `:not(._)` one class, `:not(_)` one type;
+ * each matches every element on a real page.
+ *
+ * @param {number[]} spec The `[a, b, c]` specificity to reproduce.
+ * @returns {string} The padding suffix (may be empty).
+ */
+function specificityPadding(spec) {
+  return ':not(#_)'.repeat(spec[0]) + ':not(._)'.repeat(spec[1]) + ':not(_)'.repeat(spec[2]);
+}
+
+/**
+ * Resolves a (possibly nested) selector to an absolute one, per the CSS nesting
+ * model: `&` becomes `:is(<parent selector list>)`; a nested selector without
+ * `&` gets the parent prepended as a descendant context. At-rule ancestors
+ * (`@media`, `@layer`, ...) are skipped - they do not contribute selector text.
+ *
+ * @param {string} selector The selector item to resolve.
+ * @param {import('postcss').Rule} rule The rule the selector belongs to.
+ * @returns {string} An absolute selector usable with `querySelectorAll`.
+ */
+function resolveNested(selector, rule) {
+  let parent = rule.parent;
+
+  while (parent && parent.type !== 'root' && parent.type !== 'rule') {
+    parent = parent.parent;
+  }
+
+  if (!parent || parent.type !== 'rule') {
+    return selector;
+  }
+
+  const parentList = splitSelectorList(cleanSelector(parent.selector))
+    .map(item => resolveNested(item, parent))
+    .join(', ');
+  const parentRef = `:is(${parentList})`;
+
+  if (selector.includes('&')) {
+    return selector.replaceAll('&', parentRef);
+  }
+
+  return `${parentRef} ${selector}`;
+}
+
+/**
+ * Rewrites one selector item: every compound that contains `:has()` has those
+ * segments replaced by `:where(.ht-nohas-<hash>)` plus specificity padding.
+ * The hash is derived from the "anchor" - the original selector up to and
+ * including that compound - which is also what the client runtime evaluates
+ * (once, via `querySelectorAll`) to stamp the class on the matching elements.
+ *
+ * @param {string} item The selector item (comments stripped).
+ * @param {import('postcss').Rule} rule The owning rule (for nesting context).
+ * @param {Map<string, string>} manifest Accumulates className -> anchor pairs.
+ * @returns {string} The rewritten selector item.
+ */
+function rewriteSelectorItem(item, rule, manifest) {
+  const tokens = tokenizeCompounds(item);
+  const rewritten = [...tokens];
+  let lostAmpersand = false;
+
+  for (let t = 0; t < tokens.length; t += 2) {
+    if (!tokens[t].includes(':has(')) {
+      continue;
+    }
+
+    const anchorRaw = tokens.slice(0, t + 1).join('');
+    const anchor = cleanSelector(resolveNested(anchorRaw, rule));
+    const className = FALLBACK_PREFIX + hashString(anchor);
+    const segments = splitSegments(tokens[t]);
+    const kept = segments.filter(segment => !segment.includes(':has('));
+    const dropped = segments.filter(segment => segment.includes(':has('));
+
+    if (dropped.some(segment => segment.includes('&'))) {
+      lostAmpersand = true;
+    }
+
+    const droppedSpec = specificity(
+      dropped.map(segment => resolveNested(segment, rule)).join(''),
+    );
+
+    rewritten[t] = `${kept.join('')}:where(.${className})${specificityPadding(droppedSpec)}`;
+    manifest.set(className, anchor);
+  }
+
+  let result = rewritten.join('');
+
+  // A nested selector whose only `&` sat inside a dropped `:has()` (for example
+  // `div:has(> &)`) must keep an explicit `&`, otherwise the browser adds an
+  // implicit descendant scope that the original selector did not have.
+  if (lostAmpersand && item.includes('&') && !result.includes('&')) {
+    result += ':where(&, :not(&))';
+  }
+
+  return result;
+}
+
+/**
+ * Rewrites every statically-decidable `:has()` selector in a stylesheet to a
+ * stamped-class fallback, and appends a `:root` manifest block that maps each
+ * stamped class back to the original selector for the client runtime.
+ * Selectors gated on live interaction state (hover, focus, `[open]`, ...) are
+ * kept as `:has()` - they are not triggered by scroll-driven DOM mutations.
+ *
+ * @param {string} css The stylesheet source.
+ * @returns {{ css: string, replaced: number, kept: number }} The rewritten
+ * stylesheet and how many `:has()` selector items were replaced vs kept.
+ */
+export function rewriteHasSelectors(css) {
+  const root = postcss.parse(css);
+  const manifest = new Map();
+  let replaced = 0;
+  let kept = 0;
+
+  root.walkRules((rule) => {
+    if (!rule.selector.includes(':has(')) {
+      return;
+    }
+
+    const items = splitSelectorList(cleanSelector(rule.selector));
+    const output = items.map((item) => {
+      if (!item.includes(':has(')) {
+        return item;
+      }
+
+      if (DYNAMIC_STATE_PATTERN.test(item)) {
+        kept++;
+
+        return item;
+      }
+
+      replaced++;
+
+      return rewriteSelectorItem(item, rule, manifest);
+    });
+
+    rule.selector = output.join(', ');
+  });
+
+  let result = root.toString();
+
+  if (manifest.size > 0) {
+    const declarations = [...manifest.entries()]
+      .map(([className, anchor]) => `--${className}: "${anchor.replaceAll('\\', '\\\\').replaceAll('"', '\\"')}"`)
+      .join('; ');
+
+    result += `\n:root { ${declarations}; }\n`;
+  }
+
+  return { css: result, replaced, kept };
+}
+
+/**
+ * Returns `true` when a Vite module id points at a stylesheet: a plain
+ * .css/.scss/.sass/.less file, or a compiled `<style>` block of an .astro/.vue
+ * component (their ids carry an `astro&type=style` / `vue&type=style` query and
+ * a `lang.css` marker).
+ *
+ * @param {string} id The Vite module id.
+ * @returns {boolean} Whether the id is a stylesheet module.
+ */
+function isStylesheetId(id) {
+  if (id.includes('&type=style')) {
+    return true;
+  }
+
+  const cleanId = id.split('?')[0];
+
+  return /\.(css|scss|sass|less)$/.test(cleanId);
+}
+
+/**
+ * Astro integration that replaces statically-decidable `:has()` selectors in
+ * every served stylesheet with JS-stamped class fallbacks, and injects the
+ * client runtime that stamps those classes.
+ *
+ * Why: in Chrome, `:has()` rules in a stylesheet register document-global
+ * style-invalidation hooks - any structural DOM mutation then pays a
+ * host-page-scaled style recalculation. `querySelectorAll(':has(...)')` from
+ * JS registers nothing, so moving the matching from CSS to a one-off (plus
+ * mutation-observed) stamping pass keeps the pixels identical while removing
+ * the per-mutation cost. Hover/focus-driven rules stay as `:has()` in CSS;
+ * they measured ~zero scroll cost.
+ *
+ * Handsontable's own stylesheets are excluded on purpose - see
+ * {@link EXCLUDED_ID_FRAGMENTS}.
+ *
+ * @returns {import('astro').AstroIntegration} The integration.
+ */
+export function replaceHasSelectors() {
+  return {
+    name: 'replace-has-selectors',
+    hooks: {
+      'astro:config:setup': ({ updateConfig, injectScript }) => {
+        injectScript('page', readFileSync(new URL('./has-fallback-runtime.mjs', import.meta.url), 'utf8'));
+
+        updateConfig({
+          vite: {
+            plugins: [
+              {
+                // No `enforce`: a normal plugin's transform runs after vite:css
+                // (preprocessors compiled, @imports resolved - the code is plain
+                // CSS) and before vite:css-post (which wraps it for the browser).
+                name: 'replace-has-selectors',
+                transform(code, id) {
+                  if (!isStylesheetId(id) || !code.includes(':has(')) {
+                    return null;
+                  }
+
+                  if (EXCLUDED_ID_FRAGMENTS.some(fragment => id.includes(fragment))) {
+                    return null;
+                  }
+
+                  const { css, replaced } = rewriteHasSelectors(code);
+
+                  if (replaced === 0) {
+                    return null;
+                  }
+
+                  return { code: css, map: null };
+                },
+              },
+            ],
+          },
+        });
+      },
+    },
+  };
+}


### PR DESCRIPTION
### Context

The PR adds a docs-site Astro integration that removes `:has()` selectors from the CSS the docs pages serve, without changing how any page looks.

In Chrome, every `:has()` rule in a stylesheet registers a document-wide style-invalidation hook. Any DOM insert or remove on the page then pays a style-recalculation pass whose cost scales with the page. On the docs site, one Starlight package rule alone made a single DOM insertion near the page content cost ~14 ms of style recalculation. This affects every interaction that mutates the DOM near an embedded grid or the page content.

The integration (`docs/src/plugins/replace-has-selectors.mjs`) works at the CSS-serving layer, so it covers the docs' own CSS and third-party package CSS (Starlight, theme, plugins) alike:

- Each statically-decidable `:has()` selector is rewritten to a stamped class (`:where(.ht-nohas-<hash>)`) plus specificity padding, so the rewritten rule keeps the exact cascade weight of the original.
- The original selector ships to the browser as a `--ht-nohas-*` custom property on `:root`.
- A small injected client script (`has-fallback-runtime.mjs`) reads that manifest and stamps the classes via `querySelectorAll` — a JS selector query registers no invalidation hooks. It re-stamps after DOM mutations (one-frame debounce, Handsontable grid subtrees excluded).
- Selectors gated on live interaction state (`:hover`, `:focus`, `[open]`, `:empty`) are left as `:has()` — they measured ~zero cost and cannot be stamped statically.
- Handsontable's own stylesheets are excluded on purpose: the library must not have its CSS silently patched by the docs site.

Measured on the local docs "Grid size" page (Chrome, raw `performance.now()`, profiler off):

| Metric | Before | After |
| --- | --- | --- |
| `:has()` rules live on the page | 46 | 28 (all remaining are Handsontable-internal or hover/focus-gated) |
| Style-recalc cost of one DOM insertion near page content | ~13.6 ms | ~1.1 ms |
| Grid scroll janky frames (>24 ms per 120 steps) | 2–4 | 1–2 |

Visual output is unchanged: stamped-class matches were verified element-for-element against the original selectors (sidebar current-page marker, 404 page, Starlight markdown list rule), including an in-place CSSOM swap of the rewritten selector back to the original, which produced identical computed styles.

Related engine-side work: #13020 (DEV-2040) makes the grid itself immune to host-page `:has()` invalidation during scroll. This PR is the complementary docs-page hygiene: it lowers the `:has()` tax for all non-grid DOM activity on the docs pages.

`[skip changelog]` — docs-site-only change, no package source code affected.

### How has this been tested?

- Unit tests for the CSS transform (10 tests: selector-list splitting, dynamic-state skipping, specificity padding, CSS-nesting `&` resolution, the Starlight markdown rule with a comment inside the selector, manifest emission):
  `cd docs && node --test src/plugins/__tests__/replace-has-selectors.test.mjs`
- Live equivalence check on the dev server: for every manifest entry, the set of elements matching the original `:has()` selector equals the set carrying the stamped class (0 mismatches on the grid-size, installation, and 404 pages).
- Dynamically inserted content is re-stamped within one frame (MutationObserver path).
- Scroll and style-recalc measurements on `http://localhost:4321/docs/javascript-data-grid/grid-size/` (numbers above).

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2040 (related engine PR: #13020)

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

Documentation site (`docs/`) only.

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Docs-only, but the CSS rewrite and mutation-driven class stamping must stay equivalent to the original selectors; mis-rewrites could cause subtle layout bugs on all doc pages.
> 
> **Overview**
> Adds a **docs-only** Astro integration that cuts Chrome’s document-wide `:has()` style-invalidation cost on doc pages while keeping visuals the same.
> 
> At build time, **static** `:has()` rules in served stylesheets (Starlight, theme, docs CSS—not Handsontable’s own CSS) are rewritten to `:where(.ht-nohas-<hash>)` with specificity padding, and original selectors are published on `:root` as `--ht-nohas-*` custom properties. A **page script** reads that manifest, stamps matching elements via `querySelectorAll`, and re-stamps after DOM changes (rAF-debounced, ignoring mutations under `.ht-root-wrapper`). **Hover/focus/state-gated** `:has()` selectors stay in CSS; `?raw`/`?url`/`?inline` CSS modules are skipped so production builds don’t break.
> 
> `astro.config.mjs` registers `replaceHasSelectors()`; unit tests cover the PostCSS rewrite and `isStylesheetId` filtering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a692f7bbf80838a4a07d3d228884888a60a154e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->