### PR TITLE
DEV-641: Document context menu alignment and undo/redo tracking

### DIFF
--- a/docs/content/guides/accessories-and-menus/context-menu/context-menu.md
+++ b/docs/content/guides/accessories-and-menus/context-menu/context-menu.md
@@ -327,6 +327,7 @@ To see the context menu, right-click on a cell. On touch devices, long-press a c
 
 - [Adding comments via the context menu](@/guides/cell-features/comments/comments.md#add-comments-via-the-context-menu)
 - [Clipboard: Context menu](@/guides/cell-features/clipboard/clipboard.md#context-menu)
+- [Text alignment: Align cells using the context menu](@/guides/cell-features/text-alignment/text-alignment.md#align-cells-using-the-context-menu)
 - [Icon pack](@/guides/accessories-and-menus/icon-pack/icon-pack.md)
 ::: only-for javascript
 - [Custom context menu in React](@/react/guides/accessories-and-menus/context-menu/context-menu.md)

--- a/docs/content/guides/cell-features/text-alignment/text-alignment.md
+++ b/docs/content/guides/cell-features/text-alignment/text-alignment.md
@@ -5,6 +5,13 @@ metaTitle: Text alignment - JavaScript Data Grid | Handsontable
 description: "Align values within cells: horizontally (to the right, left, center, or by justifying them), and vertically (to the top, middle, or bottom of the cell)."
 permalink: /text-alignment
 canonicalUrl: /text-alignment
+tags:
+  - align
+  - alignment
+  - text-align
+  - horizontal-alignment
+  - vertical-alignment
+  - justify
 react:
   metaTitle: Text alignment - React Data Grid | Handsontable
 angular:
@@ -13,12 +20,23 @@ vue:
   metaTitle: Text alignment - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features
+menuTag: updated
 ---
 Align values within cells: horizontally (to the right, left, center, or by justifying them), and vertically (to the top, middle, or bottom of the cell).
 
 [[toc]]
 
 Apply text alignment to cells using CSS class names or the `className` configuration option.
+
+## Overview
+
+You can set cell alignment in two ways:
+
+| Configuration option<br>`className`/`cells` | Context menu<br>`alignment` item |
+|---|---|
+| Set programmatically, for the whole grid, a column, or individual cells | Set interactively, by the person using the grid |
+| Requires no additional plugin | Requires the [`ContextMenu`](@/guides/accessories-and-menus/context-menu/context-menu.md) plugin, with the `alignment` item enabled |
+| Not tracked by [`UndoRedo`](@/guides/accessories-and-menus/undo-redo/undo-redo.md) | Tracked by [`UndoRedo`](@/guides/accessories-and-menus/undo-redo/undo-redo.md) |
 
 ## To align a cell
 
@@ -66,6 +84,29 @@ const hotSettings = {
 ```
 
 :::
+
+## Align cells using the context menu
+
+Let the person using the grid set alignment interactively, through the [context menu](@/guides/accessories-and-menus/context-menu/context-menu.md).
+
+Enable the `ContextMenu` plugin and include the `alignment` item:
+
+```js
+contextMenu: ['alignment'],
+```
+
+Select one or more cells, right-click to open the context menu, and choose an option from the **Align** submenu:
+
+- Horizontal: **Left**, **Center**, **Right**, **Justify**
+- Vertical: **Top**, **Middle**, **Bottom**
+
+Each option sets the matching CSS class name (`htLeft`, `htCenter`, `htRight`, `htJustify`, `htTop`, `htMiddle`, `htBottom`) on the selected cells, and fires the [`beforeCellAlignment`](@/api/hooks.md#beforecellalignment) hook before applying the change.
+
+### Undo and redo alignment changes
+
+Alignment changes made through the context menu are tracked by the [`UndoRedo`](@/guides/accessories-and-menus/undo-redo/undo-redo.md) plugin. Press <kbd>**Ctrl**</kbd>/<kbd>⌘</kbd>+<kbd>**Z**</kbd> to undo an alignment change, and <kbd>**Ctrl**</kbd>/<kbd>⌘</kbd>+<kbd>**Y**</kbd> to redo it.
+
+Alignment changes made through the `className` or `cells` configuration options aren't tracked by `UndoRedo`.
 
 ## Basic example
 
@@ -125,6 +166,7 @@ Cells display the configured horizontal or vertical alignment. Global settings a
 <div class="boxes-list">
 
 - [className](@/api/options.md#classname)
+- [contextMenu](@/api/options.md#contextmenu)
 
 </div>
 
@@ -134,5 +176,14 @@ Cells display the configured horizontal or vertical alignment. Global settings a
 
 - [afterSetCellMeta](@/api/hooks.md#aftersetcellmeta)
 - [beforeCellAlignment](@/api/hooks.md#beforecellalignment)
+
+</div>
+
+**Plugins**
+
+<div class="boxes-list">
+
+- [ContextMenu](@/api/contextMenu.md)
+- [UndoRedo](@/api/undoRedo.md)
 
 </div>


### PR DESCRIPTION
### Context

The PR completes the outstanding part of DEV-641 ("Rewrite the 'Text alignment' page"). A previous Diátaxis restructure pass covered the format/structure of the page but only documented the declarative `className`/`cells` config-option path to alignment. It never covered the interactive path: the `ContextMenu` plugin's `alignment` predefined item (submenu of left/center/right/justify/top/middle/bottom), the `beforeCellAlignment` hook it fires, or its `UndoRedo` tracking. There was also no cross-link between `text-alignment.md` and `context-menu.md`.

This PR:
- Adds an `## Overview` section contrasting the config-option path and the context-menu path.
- Adds an `## Align cells using the context menu` section documenting the `alignment` predefined item and the `beforeCellAlignment` hook.
- Documents that context-menu alignment changes are tracked by `UndoRedo` (config-option changes aren't).
- Cross-links `text-alignment.md` ↔ `context-menu.md`.
- Adds `tags:` frontmatter and sets `menuTag: updated`.

### How has this been tested?

- Docs-only change; reviewed rendered Markdown structure and verified all internal links (`@/api/contextMenu.md`, `@/api/undoRedo.md`, `@/api/hooks.md#beforecellalignment`, `@/guides/accessories-and-menus/context-menu/context-menu.md`, `@/guides/accessories-and-menus/undo-redo/undo-redo.md`) resolve to existing anchors/pages.
- Verified the `alignment` ContextMenu item behavior and `beforeCellAlignment` hook usage against `handsontable/src/plugins/contextMenu/predefinedItems/alignment.ts` and `handsontable/src/plugins/undoRedo/actions/cellAlignment.ts`.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-641

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-641

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API behavior modifications.
> 
> **Overview**
> Completes DEV-641 documentation for the interactive alignment path that was missing after the earlier Text alignment page restructure.
> 
> The **Text alignment** guide now has an **Overview** table contrasting programmatic `className`/`cells` setup with the context menu **`alignment`** item (ContextMenu requirement and UndoRedo tracking). A new section explains enabling `contextMenu: ['alignment']`, the Align submenu options, CSS classes applied, and **`beforeCellAlignment`**. A subsection clarifies that only context-menu alignment is undoable/redoable, not config-driven changes.
> 
> Frontmatter adds search **tags** and **`menuTag: updated`**. Related API lists **`contextMenu`**, **ContextMenu**, and **UndoRedo**. The **Context menu** guide’s related links now point to the new alignment section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d28d05a554467ad0beb213f8ebec68f999cee453. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->