### PR TITLE
DEV-642: Rewrite Conditional formatting docs page

### DIFF
--- a/docs/content/guides/cell-features/conditional-formatting/angular/example1.ts
+++ b/docs/content/guides/cell-features/conditional-formatting/angular/example1.ts
@@ -24,7 +24,8 @@ const data = [
 }
 example1-conditional-formatting .handsontable td.loss {
     color: #d81e2c;
-    background: #fdecea;
+    background: var(--ht-cell-error-background-color, rgba(216, 30, 44, 0.14));
+    background: color-mix(in srgb, #d81e2c 16%, var(--ht-background-color, #ffffff));
 }
 example1-conditional-formatting .handsontable td.loss::before {
     content: "▼ ";
@@ -32,6 +33,13 @@ example1-conditional-formatting .handsontable td.loss::before {
 example1-conditional-formatting .handsontable td.strong-quarter {
     color: #157a3d;
     font-weight: 600;
+}
+html[data-theme="dark"] example1-conditional-formatting .handsontable td.loss {
+    color: #ff5c70;
+    background: color-mix(in srgb, #ff5c70 22%, var(--ht-background-color, #000000));
+}
+html[data-theme="dark"] example1-conditional-formatting .handsontable td.strong-quarter {
+    color: #22c55e;
 }
 `,
   encapsulation: ViewEncapsulation.None,

--- a/docs/content/guides/cell-features/conditional-formatting/angular/example1.ts
+++ b/docs/content/guides/cell-features/conditional-formatting/angular/example1.ts
@@ -10,17 +10,17 @@ import Handsontable from 'handsontable/base';
   template: ` <div>
     <hot-table [data]="data" [settings]="gridSettings"></hot-table>
   </div>`,
-  styles: `hot-table td.company-name {
+  styles: `example1-conditional-formatting .handsontable td.company-name {
     font-weight: 600;
 }
-hot-table td.loss {
+example1-conditional-formatting .handsontable td.loss {
     color: #d81e2c;
     background: #fdecea;
 }
-hot-table td.loss::before {
+example1-conditional-formatting .handsontable td.loss::before {
     content: "▼ ";
 }
-hot-table td.strong-quarter {
+example1-conditional-formatting .handsontable td.strong-quarter {
     color: #157a3d;
     font-weight: 600;
 }

--- a/docs/content/guides/cell-features/conditional-formatting/angular/example1.ts
+++ b/docs/content/guides/cell-features/conditional-formatting/angular/example1.ts
@@ -3,6 +3,15 @@ import { Component, ViewEncapsulation } from '@angular/core';
 import { GridSettings, HotTableModule } from '@handsontable/angular-wrapper';
 import Handsontable from 'handsontable/base';
 
+const data = [
+  ['Acme Corp', 4.2, 5.1, -1.3, 6.8],
+  ['Vertex Industries', 12.5, 11.9, 13.2, 14],
+  ['Harbor Analytics', -2.4, 0.8, 2.1, 3.5],
+  ['Summit Logistics', 8.7, -3.2, 4.4, 5.9],
+  ['Pioneer Foods', 1.1, 1.4, 0.9, -0.5],
+  ['Meridian Retail', 6, 7.3, 8.1, 9.4],
+];
+
 @Component({
   selector: 'example1-conditional-formatting',
   standalone: true,
@@ -29,14 +38,7 @@ example1-conditional-formatting .handsontable td.strong-quarter {
 })
 export class AppComponent {
 
-  readonly data = [
-    ['Acme Corp', 4.2, 5.1, -1.3, 6.8],
-    ['Vertex Industries', 12.5, 11.9, 13.2, 14],
-    ['Harbor Analytics', -2.4, 0.8, 2.1, 3.5],
-    ['Summit Logistics', 8.7, -3.2, 4.4, 5.9],
-    ['Pioneer Foods', 1.1, 1.4, 0.9, -0.5],
-    ['Meridian Retail', 6, 7.3, 8.1, 9.4],
-  ];
+  readonly data = data;
 
   readonly gridSettings: GridSettings = {
     colHeaders: ['Company', 'Q1', 'Q2', 'Q3', 'Q4'],
@@ -54,7 +56,7 @@ export class AppComponent {
       if (col > 0) {
         cellProperties.className = '';
 
-        const value = (this as any).instance.getDataAtCell(row, col);
+        const value = data[row]?.[col];
 
         if (typeof value === 'number' && value < 0) {
           cellProperties.className = 'loss';

--- a/docs/content/guides/cell-features/conditional-formatting/angular/example1.ts
+++ b/docs/content/guides/cell-features/conditional-formatting/angular/example1.ts
@@ -52,6 +52,8 @@ export class AppComponent {
       const cellProperties: Handsontable.CellMeta = {};
 
       if (col > 0) {
+        cellProperties.className = '';
+
         const value = (this as any).instance.getDataAtCell(row, col);
 
         if (typeof value === 'number' && value < 0) {

--- a/docs/content/guides/cell-features/conditional-formatting/angular/example2.html
+++ b/docs/content/guides/cell-features/conditional-formatting/angular/example2.html
@@ -1,0 +1,3 @@
+<div>
+  <example2-conditional-formatting></example2-conditional-formatting>
+</div>

--- a/docs/content/guides/cell-features/conditional-formatting/angular/example2.ts
+++ b/docs/content/guides/cell-features/conditional-formatting/angular/example2.ts
@@ -49,6 +49,9 @@ registerRenderer('profitRenderer', profitRenderer);
     color: #d81e2c;
     font-weight: 600;
 }
+html[data-theme="dark"] example2-conditional-formatting .handsontable td.loss-cell {
+    color: #ff5c70;
+}
 `,
   encapsulation: ViewEncapsulation.None,
 })

--- a/docs/content/guides/cell-features/conditional-formatting/angular/example2.ts
+++ b/docs/content/guides/cell-features/conditional-formatting/angular/example2.ts
@@ -17,6 +17,8 @@ const profitRenderer = (
 ) => {
   const amount = Number(value);
 
+  td.classList.remove('loss-cell');
+
   if (!Number.isFinite(amount)) {
     textRenderer(instance, td, row, col, prop, value, cellProperties);
 

--- a/docs/content/guides/cell-features/conditional-formatting/angular/example2.ts
+++ b/docs/content/guides/cell-features/conditional-formatting/angular/example2.ts
@@ -30,7 +30,7 @@ const profitRenderer = (
   textRenderer(instance, td, row, col, prop, formatted, cellProperties);
 
   if (amount < 0) {
-    td.className = 'loss-cell';
+    td.classList.add('loss-cell');
   }
 };
 
@@ -43,7 +43,7 @@ registerRenderer('profitRenderer', profitRenderer);
   template: ` <div>
     <hot-table [data]="data" [settings]="gridSettings"></hot-table>
   </div>`,
-  styles: `hot-table td.loss-cell {
+  styles: `example2-conditional-formatting .handsontable td.loss-cell {
     color: #d81e2c;
     font-weight: 600;
 }

--- a/docs/content/guides/cell-features/conditional-formatting/angular/example2.ts
+++ b/docs/content/guides/cell-features/conditional-formatting/angular/example2.ts
@@ -2,26 +2,49 @@
 import { Component, ViewEncapsulation } from '@angular/core';
 import { GridSettings, HotTableModule } from '@handsontable/angular-wrapper';
 import Handsontable from 'handsontable/base';
+import { registerRenderer } from 'handsontable/renderers';
+import { textRenderer } from 'handsontable/renderers/textRenderer';
+
+// display losses in an accounting format, so color is not the only signal
+const profitRenderer = (
+  instance: Handsontable,
+  td: HTMLTableCellElement,
+  row: number,
+  col: number,
+  prop: string | number,
+  value: Handsontable.CellValue,
+  cellProperties: Handsontable.CellProperties
+) => {
+  const amount = Number(value);
+
+  if (!Number.isFinite(amount)) {
+    textRenderer(instance, td, row, col, prop, value, cellProperties);
+
+    return;
+  }
+
+  const formatted = amount < 0
+    ? `($${Math.abs(amount).toFixed(1)}M)`
+    : `$${amount.toFixed(1)}M`;
+
+  textRenderer(instance, td, row, col, prop, formatted, cellProperties);
+
+  if (amount < 0) {
+    td.className = 'loss-cell';
+  }
+};
+
+registerRenderer('profitRenderer', profitRenderer);
 
 @Component({
-  selector: 'example1-conditional-formatting',
+  selector: 'example2-conditional-formatting',
   standalone: true,
   imports: [HotTableModule],
   template: ` <div>
     <hot-table [data]="data" [settings]="gridSettings"></hot-table>
   </div>`,
-  styles: `hot-table td.company-name {
-    font-weight: 600;
-}
-hot-table td.loss {
+  styles: `hot-table td.loss-cell {
     color: #d81e2c;
-    background: #fdecea;
-}
-hot-table td.loss::before {
-    content: "▼ ";
-}
-hot-table td.strong-quarter {
-    color: #157a3d;
     font-weight: 600;
 }
 `,
@@ -42,27 +65,12 @@ export class AppComponent {
     colHeaders: ['Company', 'Q1', 'Q2', 'Q3', 'Q4'],
     height: 'auto',
     columns: [
-      { className: 'company-name' },
-      { type: 'numeric' },
-      { type: 'numeric' },
-      { type: 'numeric' },
-      { type: 'numeric' },
+      {},
+      { renderer: 'profitRenderer' },
+      { renderer: 'profitRenderer' },
+      { renderer: 'profitRenderer' },
+      { renderer: 'profitRenderer' },
     ],
-    cells(row: number, col: number) {
-      const cellProperties: Handsontable.CellMeta = {};
-
-      if (col > 0) {
-        const value = (this as any).instance.getDataAtCell(row, col);
-
-        if (typeof value === 'number' && value < 0) {
-          cellProperties.className = 'loss';
-        } else if (typeof value === 'number' && value > 10) {
-          cellProperties.className = 'strong-quarter';
-        }
-      }
-
-      return cellProperties;
-    },
   };
 }
 /* end-file */

--- a/docs/content/guides/cell-features/conditional-formatting/angular/example3.html
+++ b/docs/content/guides/cell-features/conditional-formatting/angular/example3.html
@@ -1,0 +1,3 @@
+<div>
+  <example3-conditional-formatting></example3-conditional-formatting>
+</div>

--- a/docs/content/guides/cell-features/conditional-formatting/angular/example3.ts
+++ b/docs/content/guides/cell-features/conditional-formatting/angular/example3.ts
@@ -1,0 +1,89 @@
+/* file: app.component.ts */
+import { Component } from '@angular/core';
+import { GridSettings, HotTableModule } from '@handsontable/angular-wrapper';
+import Handsontable from 'handsontable/base';
+import { registerRenderer } from 'handsontable/renderers';
+import { textRenderer } from 'handsontable/renderers/textRenderer';
+
+const data = [
+  ['Acme Corp', 4.2, 5.1, -1.3, 6.8],
+  ['Vertex Industries', 12.5, 11.9, 13.2, 14],
+  ['Harbor Analytics', -2.4, 0.8, 2.1, 3.5],
+  ['Summit Logistics', 8.7, -3.2, 4.4, 5.9],
+  ['Pioneer Foods', 1.1, 1.4, 0.9, -0.5],
+  ['Meridian Retail', 6, 7.3, 8.1, 9.4],
+];
+
+const values = data.flatMap((row) => row.slice(1) as number[]);
+const min = Math.min(...values);
+const max = Math.max(...values);
+
+// shade the background from red (low) to green (high); the value stays visible
+const heatmapRenderer = (
+  instance: Handsontable,
+  td: HTMLTableCellElement,
+  row: number,
+  col: number,
+  prop: string | number,
+  value: Handsontable.CellValue,
+  cellProperties: Handsontable.CellProperties
+) => {
+  textRenderer(instance, td, row, col, prop, value, cellProperties);
+
+  const amount = Number(value);
+
+  if (Number.isFinite(amount)) {
+    const ratio = (amount - min) / (max - min);
+    const hue = Math.round(ratio * 120);
+
+    td.style.background = `hsl(${hue}, 75%, 85%)`;
+  }
+};
+
+registerRenderer('heatmapRenderer', heatmapRenderer);
+
+@Component({
+  selector: 'example3-conditional-formatting',
+  standalone: true,
+  imports: [HotTableModule],
+  template: ` <div>
+    <hot-table [data]="data" [settings]="gridSettings"></hot-table>
+  </div>`,
+})
+export class AppComponent {
+
+  readonly data = data;
+
+  readonly gridSettings: GridSettings = {
+    colHeaders: ['Company', 'Q1', 'Q2', 'Q3', 'Q4'],
+    height: 'auto',
+    columns: [
+      {},
+      { renderer: 'heatmapRenderer' },
+      { renderer: 'heatmapRenderer' },
+      { renderer: 'heatmapRenderer' },
+      { renderer: 'heatmapRenderer' },
+    ],
+  };
+}
+/* end-file */
+
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+/* end-file */

--- a/docs/content/guides/cell-features/conditional-formatting/angular/example3.ts
+++ b/docs/content/guides/cell-features/conditional-formatting/angular/example3.ts
@@ -37,6 +37,7 @@ const heatmapRenderer = (
     const hue = Math.round(ratio * 120);
 
     td.style.background = `hsl(${hue}, 75%, 85%)`;
+    td.style.color = '#1b1b1b';
   }
 };
 

--- a/docs/content/guides/cell-features/conditional-formatting/angular/example3.ts
+++ b/docs/content/guides/cell-features/conditional-formatting/angular/example3.ts
@@ -14,10 +14,6 @@ const data = [
   ['Meridian Retail', 6, 7.3, 8.1, 9.4],
 ];
 
-const values = data.flatMap((row) => row.slice(1) as number[]);
-const min = Math.min(...values);
-const max = Math.max(...values);
-
 // shade the background from red (low) to green (high); the value stays visible
 const heatmapRenderer = (
   instance: Handsontable,
@@ -33,7 +29,13 @@ const heatmapRenderer = (
   const amount = Number(value);
 
   if (Number.isFinite(amount)) {
-    const ratio = (amount - min) / (max - min);
+    const values = instance.getData()
+      .flatMap((rowData) => rowData.slice(1))
+      .map(Number)
+      .filter((cellValue) => Number.isFinite(cellValue));
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    const ratio = min === max ? 0.5 : (amount - min) / (max - min);
     const hue = Math.round(ratio * 120);
 
     td.style.background = `hsl(${hue}, 75%, 85%)`;

--- a/docs/content/guides/cell-features/conditional-formatting/conditional-formatting.md
+++ b/docs/content/guides/cell-features/conditional-formatting/conditional-formatting.md
@@ -1,8 +1,8 @@
 ---
-type: reference
+type: how-to
 title: Conditional formatting
 metaTitle: Conditional formatting - JavaScript Data Grid | Handsontable
-description: Format specified cells, based on dynamic conditions.
+description: Style cells dynamically based on their values, using CSS classes, custom renderers, or a color scale.
 permalink: /conditional-formatting
 canonicalUrl: /conditional-formatting
 react:
@@ -11,28 +11,42 @@ angular:
   metaTitle: Conditional formatting - Angular Data Grid | Handsontable
 vue:
   metaTitle: Conditional formatting - Vue Data Grid | Handsontable
+tags:
+  - conditional-formatting
+  - cell-styling
+  - className
+  - renderer
 searchCategory: Guides
 category: Cell features
 menuTag: updated
 ---
-Format specified cells, based on dynamic conditions.
+Style cells dynamically based on their values, so you can highlight outliers, flag errors, or visualize data ranges.
 
 [[toc]]
 
-Conditional formatting lets you apply custom styles to cells based on their values. Use it to highlight outliers, flag errors, or visualize data ranges.
-
 ## Overview
 
-Conditional formatting can be used to set the font, color, typeface, etc., for cell content and can also be used to format the style of a cell, all based on a predefined set of criteria.
+Conditional formatting changes a cell's appearance based on the data it holds. As values change, the formatting updates on the next render.
 
-## Example of conditional formatting
+Choose an approach based on your goal:
 
-This demo shows how to use the cell type renderer feature to make some conditional formatting:
+- Use [`className`](@/api/options.md#classname) with the [`cells`](@/api/options.md#cells) callback when you want reusable CSS classes driven by cell values. This is the recommended default.
+- Use the [`renderer`](@/api/options.md#renderer) option when you need inline styles or want to transform the displayed value.
+- Combine a `renderer` with a computed background color when you want a color scale that reflects each value's magnitude.
 
-1. The first row is read-only and formatted as bold green text.
-2. All cells in the Nissan column are formatted as italic text.
-3. Empty cells are formatted with a silver background.
-4. Negative numbers are formatted as red text.
+For static styling that does not depend on cell values, see [Formatting cells](@/guides/cell-features/formatting-cells/formatting-cells.md).
+
+## Prerequisites
+
+- A Handsontable instance with data loaded.
+- A stylesheet, if you format cells through custom CSS classes.
+- Familiarity with the cascading configuration model, where cell settings override column settings, which override global settings. See [Configuration options](@/guides/getting-started/configuration-options/configuration-options.md).
+
+## Highlight cells by value with a CSS class
+
+Return a [`className`](@/api/options.md#classname) from the [`cells`](@/api/options.md#cells) callback to style cells by value. The callback runs for every cell, so you can inspect the value and assign a class conditionally.
+
+This example uses the cascading model on two levels: the Company column sets a static `className` through its `columns` entry, while the [`cells`](@/api/options.md#cells) callback adds a `loss` class to negative quarters and a `strong-quarter` class to quarters above 10. The `loss` class pairs its red color with a leading marker, so the value stays readable without color.
 
 ::: only-for javascript
 
@@ -79,13 +93,115 @@ This demo shows how to use the cell type renderer feature to make some condition
 
 :::
 
+## Format cells with a custom renderer
+
+Use a [`renderer`](@/api/options.md#renderer) when a CSS class is not enough - for example, when you need to transform the displayed value or apply inline styles computed at render time.
+
+This renderer formats each quarter as a currency amount and shows losses in an accounting format, `($1.3M)`. The parentheses convey a loss on their own, so the red color is a secondary signal.
+
+::: only-for javascript
+
+::: example #example2 --css 1 --js 2 --ts 3
+
+@[code](@/content/guides/cell-features/conditional-formatting/javascript/example2.css)
+@[code](@/content/guides/cell-features/conditional-formatting/javascript/example2.js)
+@[code](@/content/guides/cell-features/conditional-formatting/javascript/example2.ts)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #example2 :react --css 1 --js 2 --ts 3
+
+@[code](@/content/guides/cell-features/conditional-formatting/react/example2.css)
+@[code](@/content/guides/cell-features/conditional-formatting/react/example2.jsx)
+@[code](@/content/guides/cell-features/conditional-formatting/react/example2.tsx)
+
+:::
+
+:::
+
+::: only-for angular
+
+::: example #example2 :angular --ts 1 --html 2
+
+@[code](@/content/guides/cell-features/conditional-formatting/angular/example2.ts)
+@[code](@/content/guides/cell-features/conditional-formatting/angular/example2.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example2 :vue3
+
+@[code](@/content/guides/cell-features/conditional-formatting/vue/example2.vue)
+
+:::
+
+:::
+
+## Build a color scale
+
+To visualize magnitude, compute a background color from each value and apply it in a [`renderer`](@/api/options.md#renderer). This example maps every quarter to a green-to-red scale based on the minimum and maximum across the data, producing a heatmap. The numeric value remains visible in each cell, so the color adds meaning rather than replacing it.
+
+::: only-for javascript
+
+::: example #example3 --js 1 --ts 2
+
+@[code](@/content/guides/cell-features/conditional-formatting/javascript/example3.js)
+@[code](@/content/guides/cell-features/conditional-formatting/javascript/example3.ts)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #example3 :react --js 1 --ts 2
+
+@[code](@/content/guides/cell-features/conditional-formatting/react/example3.jsx)
+@[code](@/content/guides/cell-features/conditional-formatting/react/example3.tsx)
+
+:::
+
+:::
+
+::: only-for angular
+
+::: example #example3 :angular --ts 1 --html 2
+
+@[code](@/content/guides/cell-features/conditional-formatting/angular/example3.ts)
+@[code](@/content/guides/cell-features/conditional-formatting/angular/example3.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example3 :vue3
+
+@[code](@/content/guides/cell-features/conditional-formatting/vue/example3.vue)
+
+:::
+
+:::
+
+## Make conditional formatting accessible
+
+Color alone does not meet [WCAG 2.1 AA](https://www.w3.org/WAI/WCAG21/quickref/#use-of-color). Readers with color vision deficiencies, or anyone viewing the grid in high-contrast mode, can miss a signal that relies only on color.
+
+- Pair color with a second cue: a symbol, text label, or font weight. In the first example, the `loss` class adds a marker; in the second, losses appear in parentheses.
+- In a color scale, keep the underlying value visible so the color stays supplementary.
+- Verify that text keeps a contrast ratio of at least 4.5:1 against the cell background you apply.
+
 ## Result
 
-Cells that match the defined conditions display the configured styles -- colors, fonts, or borders -- automatically updating as data changes.
-
-## Format negative numbers
-
-A frequent conditional-formatting task is styling negative numbers -- for example, showing them in red. The example above does this in its renderer: it checks whether the cell value is below zero and applies a CSS class for negative values. Use the same approach to flag any value that meets a numeric condition, such as amounts over a threshold.
+Cells that match your conditions display the configured styles - classes, inline styles, or a color scale - and update automatically as the data changes.
 
 ## Related articles
 
@@ -94,6 +210,8 @@ A frequent conditional-formatting task is styling negative numbers -- for exampl
 <div class="boxes-list">
 
 - [Formatting cells](@/guides/cell-features/formatting-cells/formatting-cells.md)
+- [Text alignment](@/guides/cell-features/text-alignment/text-alignment.md)
+- [Configuration options](@/guides/getting-started/configuration-options/configuration-options.md)
 
 </div>
 
@@ -101,26 +219,8 @@ A frequent conditional-formatting task is styling negative numbers -- for exampl
 
 <div class="boxes-list">
 
-- [activeHeaderClassName](@/api/options.md#activeheaderclassname)
 - [className](@/api/options.md#classname)
-- [commentedCellClassName](@/api/options.md#commentedcellclassname)
-- [currentColClassName](@/api/options.md#currentcolclassname)
-- [currentHeaderClassName](@/api/options.md#currentheaderclassname)
-- [currentRowClassName](@/api/options.md#currentrowclassname)
-- [customBorders](@/api/options.md#customborders)
-- [invalidCellClassName](@/api/options.md#invalidcellclassname)
-- [noWordWrapClassName](@/api/options.md#nowordwrapclassname)
-- [placeholder](@/api/options.md#placeholder)
-- [placeholderCellClassName](@/api/options.md#placeholdercellclassname)
-- [readOnlyCellClassName](@/api/options.md#readonlycellclassname)
-- [tableClassName](@/api/options.md#tableclassname)
-
-</div>
-
-**Plugins**
-
-<div class="boxes-list">
-
-- [CustomBorders](@/api/customBorders.md)
+- [cells](@/api/options.md#cells)
+- [renderer](@/api/options.md#renderer)
 
 </div>

--- a/docs/content/guides/cell-features/conditional-formatting/javascript/example1.css
+++ b/docs/content/guides/cell-features/conditional-formatting/javascript/example1.css
@@ -4,7 +4,8 @@
 
 #example1 .handsontable td.loss {
   color: #d81e2c;
-  background: #fdecea;
+  background: var(--ht-cell-error-background-color, rgba(216, 30, 44, 0.14));
+  background: color-mix(in srgb, #d81e2c 16%, var(--ht-background-color, #ffffff));
 }
 
 #example1 .handsontable td.loss::before {
@@ -14,4 +15,13 @@
 #example1 .handsontable td.strong-quarter {
   color: #157a3d;
   font-weight: 600;
+}
+
+html[data-theme="dark"] #example1 .handsontable td.loss {
+  color: #ff5c70;
+  background: color-mix(in srgb, #ff5c70 22%, var(--ht-background-color, #000000));
+}
+
+html[data-theme="dark"] #example1 .handsontable td.strong-quarter {
+  color: #22c55e;
 }

--- a/docs/content/guides/cell-features/conditional-formatting/javascript/example1.css
+++ b/docs/content/guides/cell-features/conditional-formatting/javascript/example1.css
@@ -1,3 +1,17 @@
-.make-me-red {
-  color: #FF5A12 !important;
+.company-name {
+  font-weight: 600;
+}
+
+.loss {
+  color: #d81e2c;
+  background: #fdecea;
+}
+
+.loss::before {
+  content: "▼ ";
+}
+
+.strong-quarter {
+  color: #157a3d;
+  font-weight: 600;
 }

--- a/docs/content/guides/cell-features/conditional-formatting/javascript/example1.css
+++ b/docs/content/guides/cell-features/conditional-formatting/javascript/example1.css
@@ -1,17 +1,17 @@
-.company-name {
+#example1 .handsontable td.company-name {
   font-weight: 600;
 }
 
-.loss {
+#example1 .handsontable td.loss {
   color: #d81e2c;
   background: #fdecea;
 }
 
-.loss::before {
+#example1 .handsontable td.loss::before {
   content: "▼ ";
 }
 
-.strong-quarter {
+#example1 .handsontable td.strong-quarter {
   color: #157a3d;
   font-weight: 600;
 }

--- a/docs/content/guides/cell-features/conditional-formatting/javascript/example1.js
+++ b/docs/content/guides/cell-features/conditional-formatting/javascript/example1.js
@@ -1,83 +1,39 @@
 import Handsontable from 'handsontable/base';
 import { registerAllModules } from 'handsontable/registry';
-import { textRenderer } from 'handsontable/renderers/textRenderer';
-import { registerRenderer } from 'handsontable/renderers';
-
-// Register all Handsontable's modules.
+// register Handsontable's modules
 registerAllModules();
-
 const data = [
-  ['', 'Tesla', 'Nissan', 'Toyota', 'Honda'],
-  ['2017', -5, '', 12, 13],
-  ['2018', '', -11, 14, 13],
-  ['2019', '', 15, -12, 'readOnly'],
+    ['Acme Corp', 4.2, 5.1, -1.3, 6.8],
+    ['Vertex Industries', 12.5, 11.9, 13.2, 14],
+    ['Harbor Analytics', -2.4, 0.8, 2.1, 3.5],
+    ['Summit Logistics', 8.7, -3.2, 4.4, 5.9],
+    ['Pioneer Foods', 1.1, 1.4, 0.9, -0.5],
+    ['Meridian Retail', 6, 7.3, 8.1, 9.4],
 ];
-
-const firstRowRenderer = (instance, td, ...rest) => {
-  textRenderer(instance, td, ...rest);
-  td.style.fontWeight = 'bold';
-  td.style.color = 'green';
-  td.style.background = '#CEC';
-};
-
-const negativeValueRenderer = (instance, td, row, col, prop, value, cellProperties) => {
-  textRenderer(instance, td, row, col, prop, value, cellProperties);
-
-  // if the row contains a negative number
-  if (parseInt(value, 10) < 0) {
-    // add class 'make-me-red'
-    td.className = 'make-me-red';
-  }
-
-  if (!value || value === '') {
-    td.style.background = 'rgb(238, 238, 238, 0.4)';
-  } else {
-    if (instance.getDataAtCell(0, col) === 'Nissan') {
-      td.style.fontStyle = 'italic';
-    }
-
-    td.style.background = '';
-  }
-};
-
-// maps function to a lookup string
-registerRenderer('negativeValueRenderer', negativeValueRenderer);
-
 const container = document.querySelector('#example1');
-
 new Handsontable(container, {
-  data,
-  licenseKey: 'non-commercial-and-evaluation',
-  height: 'auto',
-  afterSelection(_row, _col, row2, col2) {
-    const meta = this.getCellMeta(row2, col2);
-
-    if (meta.readOnly) {
-      this.updateSettings({
-        fillHandle: false,
-      });
-    } else {
-      this.updateSettings({
-        fillHandle: true,
-      });
-    }
-  },
-  cells(row, col) {
-    const cellProperties = {};
-    const data = this.instance.getData();
-
-    if (row === 0 || (data[row] && data[row][col] === 'readOnly')) {
-      cellProperties.readOnly = true; // make cell read-only if it is first row or the text reads 'readOnly'
-    }
-
-    if (row === 0) {
-      cellProperties.renderer = firstRowRenderer; // uses function directly
-    } else {
-      cellProperties.renderer = 'negativeValueRenderer'; // uses lookup map
-    }
-
-    return cellProperties;
-  },
-  autoWrapRow: true,
-  autoWrapCol: true,
+    data,
+    colHeaders: ['Company', 'Q1', 'Q2', 'Q3', 'Q4'],
+    licenseKey: 'non-commercial-and-evaluation',
+    height: 'auto',
+    columns: [
+        { className: 'company-name' },
+        { type: 'numeric' },
+        { type: 'numeric' },
+        { type: 'numeric' },
+        { type: 'numeric' },
+    ],
+    cells(row, col) {
+        const cellProperties = {};
+        if (col > 0) {
+            const value = this.instance.getDataAtCell(row, col);
+            if (typeof value === 'number' && value < 0) {
+                cellProperties.className = 'loss';
+            }
+            else if (typeof value === 'number' && value > 10) {
+                cellProperties.className = 'strong-quarter';
+            }
+        }
+        return cellProperties;
+    },
 });

--- a/docs/content/guides/cell-features/conditional-formatting/javascript/example1.js
+++ b/docs/content/guides/cell-features/conditional-formatting/javascript/example1.js
@@ -26,6 +26,7 @@ new Handsontable(container, {
     cells(row, col) {
         const cellProperties = {};
         if (col > 0) {
+            cellProperties.className = '';
             const value = this.instance.getDataAtCell(row, col);
             if (typeof value === 'number' && value < 0) {
                 cellProperties.className = 'loss';

--- a/docs/content/guides/cell-features/conditional-formatting/javascript/example1.js
+++ b/docs/content/guides/cell-features/conditional-formatting/javascript/example1.js
@@ -27,7 +27,7 @@ new Handsontable(container, {
         const cellProperties = {};
         if (col > 0) {
             cellProperties.className = '';
-            const value = this.instance.getDataAtCell(row, col);
+            const value = data[row]?.[col];
             if (typeof value === 'number' && value < 0) {
                 cellProperties.className = 'loss';
             }

--- a/docs/content/guides/cell-features/conditional-formatting/javascript/example1.ts
+++ b/docs/content/guides/cell-features/conditional-formatting/javascript/example1.ts
@@ -31,6 +31,8 @@ new Handsontable(container, {
     const cellProperties: Handsontable.CellMeta = {};
 
     if (col > 0) {
+      cellProperties.className = '';
+
       const value = this.instance.getDataAtCell(row, col);
 
       if (typeof value === 'number' && value < 0) {

--- a/docs/content/guides/cell-features/conditional-formatting/javascript/example1.ts
+++ b/docs/content/guides/cell-features/conditional-formatting/javascript/example1.ts
@@ -1,83 +1,45 @@
 import Handsontable from 'handsontable/base';
 import { registerAllModules } from 'handsontable/registry';
-import { BaseRenderer, registerRenderer } from 'handsontable/renderers';
-import { textRenderer } from 'handsontable/renderers/textRenderer';
 
-// Register all Handsontable's modules.
+// register Handsontable's modules
 registerAllModules();
 
-const data: (string | number)[][] = [
-  ['', 'Tesla', 'Nissan', 'Toyota', 'Honda'],
-  ['2017', -5, '', 12, 13],
-  ['2018', '', -11, 14, 13],
-  ['2019', '', 15, -12, 'readOnly'],
+const data = [
+  ['Acme Corp', 4.2, 5.1, -1.3, 6.8],
+  ['Vertex Industries', 12.5, 11.9, 13.2, 14],
+  ['Harbor Analytics', -2.4, 0.8, 2.1, 3.5],
+  ['Summit Logistics', 8.7, -3.2, 4.4, 5.9],
+  ['Pioneer Foods', 1.1, 1.4, 0.9, -0.5],
+  ['Meridian Retail', 6, 7.3, 8.1, 9.4],
 ];
-
-const firstRowRenderer: BaseRenderer = (instance, td, ...rest) => {
-  textRenderer(instance, td, ...rest);
-  td.style.fontWeight = 'bold';
-  td.style.color = 'green';
-  td.style.background = '#CEC';
-};
-
-const negativeValueRenderer: BaseRenderer = (instance, td, row, col, prop, value, cellProperties) => {
-  textRenderer(instance, td, row, col, prop, value, cellProperties);
-
-  // if the row contains a negative number
-  if (parseInt(value, 10) < 0) {
-    // add class 'make-me-red'
-    td.className = 'make-me-red';
-  }
-
-  if (!value || value === '') {
-    td.style.background = 'rgb(238, 238, 238, 0.4)';
-  } else {
-    if (instance.getDataAtCell(0, col) === 'Nissan') {
-      td.style.fontStyle = 'italic';
-    }
-
-    td.style.background = '';
-  }
-};
-
-// maps function to a lookup string
-registerRenderer('negativeValueRenderer', negativeValueRenderer);
 
 const container = document.querySelector('#example1')!;
 
 new Handsontable(container, {
   data,
+  colHeaders: ['Company', 'Q1', 'Q2', 'Q3', 'Q4'],
   licenseKey: 'non-commercial-and-evaluation',
   height: 'auto',
-  afterSelection(_row, _col, row2, col2) {
-    const meta = (this as unknown as Handsontable.Core).getCellMeta(row2, col2);
-
-    if (meta.readOnly) {
-      (this as unknown as Handsontable.Core).updateSettings({
-        fillHandle: false,
-      });
-    } else {
-      (this as unknown as Handsontable.Core).updateSettings({
-        fillHandle: true,
-      });
-    }
-  },
+  columns: [
+    { className: 'company-name' },
+    { type: 'numeric' },
+    { type: 'numeric' },
+    { type: 'numeric' },
+    { type: 'numeric' },
+  ],
   cells(row, col) {
     const cellProperties: Handsontable.CellMeta = {};
-    const data = this.instance.getData();
 
-    if (row === 0 || (data[row] && data[row][col] === 'readOnly')) {
-      cellProperties.readOnly = true; // make cell read-only if it is first row or the text reads 'readOnly'
-    }
+    if (col > 0) {
+      const value = this.instance.getDataAtCell(row, col);
 
-    if (row === 0) {
-      cellProperties.renderer = firstRowRenderer; // uses function directly
-    } else {
-      cellProperties.renderer = 'negativeValueRenderer'; // uses lookup map
+      if (typeof value === 'number' && value < 0) {
+        cellProperties.className = 'loss';
+      } else if (typeof value === 'number' && value > 10) {
+        cellProperties.className = 'strong-quarter';
+      }
     }
 
     return cellProperties;
   },
-  autoWrapRow: true,
-  autoWrapCol: true,
 });

--- a/docs/content/guides/cell-features/conditional-formatting/javascript/example1.ts
+++ b/docs/content/guides/cell-features/conditional-formatting/javascript/example1.ts
@@ -33,7 +33,7 @@ new Handsontable(container, {
     if (col > 0) {
       cellProperties.className = '';
 
-      const value = this.instance.getDataAtCell(row, col);
+      const value = data[row]?.[col];
 
       if (typeof value === 'number' && value < 0) {
         cellProperties.className = 'loss';

--- a/docs/content/guides/cell-features/conditional-formatting/javascript/example2.css
+++ b/docs/content/guides/cell-features/conditional-formatting/javascript/example2.css
@@ -1,4 +1,4 @@
-.loss-cell {
+#example2 .handsontable td.loss-cell {
   color: #d81e2c;
   font-weight: 600;
 }

--- a/docs/content/guides/cell-features/conditional-formatting/javascript/example2.css
+++ b/docs/content/guides/cell-features/conditional-formatting/javascript/example2.css
@@ -1,0 +1,4 @@
+.loss-cell {
+  color: #d81e2c;
+  font-weight: 600;
+}

--- a/docs/content/guides/cell-features/conditional-formatting/javascript/example2.css
+++ b/docs/content/guides/cell-features/conditional-formatting/javascript/example2.css
@@ -2,3 +2,7 @@
   color: #d81e2c;
   font-weight: 600;
 }
+
+html[data-theme="dark"] #example2 .handsontable td.loss-cell {
+  color: #ff5c70;
+}

--- a/docs/content/guides/cell-features/conditional-formatting/javascript/example2.js
+++ b/docs/content/guides/cell-features/conditional-formatting/javascript/example2.js
@@ -24,7 +24,7 @@ const profitRenderer = (instance, td, row, col, prop, value, cellProperties) => 
         : `$${amount.toFixed(1)}M`;
     textRenderer(instance, td, row, col, prop, formatted, cellProperties);
     if (amount < 0) {
-        td.className = 'loss-cell';
+        td.classList.add('loss-cell');
     }
 };
 registerRenderer('profitRenderer', profitRenderer);

--- a/docs/content/guides/cell-features/conditional-formatting/javascript/example2.js
+++ b/docs/content/guides/cell-features/conditional-formatting/javascript/example2.js
@@ -1,0 +1,44 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+import { registerRenderer } from 'handsontable/renderers';
+import { textRenderer } from 'handsontable/renderers/textRenderer';
+// register Handsontable's modules
+registerAllModules();
+const data = [
+    ['Acme Corp', 4.2, 5.1, -1.3, 6.8],
+    ['Vertex Industries', 12.5, 11.9, 13.2, 14],
+    ['Harbor Analytics', -2.4, 0.8, 2.1, 3.5],
+    ['Summit Logistics', 8.7, -3.2, 4.4, 5.9],
+    ['Pioneer Foods', 1.1, 1.4, 0.9, -0.5],
+    ['Meridian Retail', 6, 7.3, 8.1, 9.4],
+];
+// display losses in an accounting format, so color is not the only signal
+const profitRenderer = (instance, td, row, col, prop, value, cellProperties) => {
+    const amount = Number(value);
+    if (!Number.isFinite(amount)) {
+        textRenderer(instance, td, row, col, prop, value, cellProperties);
+        return;
+    }
+    const formatted = amount < 0
+        ? `($${Math.abs(amount).toFixed(1)}M)`
+        : `$${amount.toFixed(1)}M`;
+    textRenderer(instance, td, row, col, prop, formatted, cellProperties);
+    if (amount < 0) {
+        td.className = 'loss-cell';
+    }
+};
+registerRenderer('profitRenderer', profitRenderer);
+const container = document.querySelector('#example2');
+new Handsontable(container, {
+    data,
+    colHeaders: ['Company', 'Q1', 'Q2', 'Q3', 'Q4'],
+    licenseKey: 'non-commercial-and-evaluation',
+    height: 'auto',
+    columns: [
+        {},
+        { renderer: 'profitRenderer' },
+        { renderer: 'profitRenderer' },
+        { renderer: 'profitRenderer' },
+        { renderer: 'profitRenderer' },
+    ],
+});

--- a/docs/content/guides/cell-features/conditional-formatting/javascript/example2.js
+++ b/docs/content/guides/cell-features/conditional-formatting/javascript/example2.js
@@ -15,6 +15,7 @@ const data = [
 // display losses in an accounting format, so color is not the only signal
 const profitRenderer = (instance, td, row, col, prop, value, cellProperties) => {
     const amount = Number(value);
+    td.classList.remove('loss-cell');
     if (!Number.isFinite(amount)) {
         textRenderer(instance, td, row, col, prop, value, cellProperties);
         return;

--- a/docs/content/guides/cell-features/conditional-formatting/javascript/example2.ts
+++ b/docs/content/guides/cell-features/conditional-formatting/javascript/example2.ts
@@ -19,6 +19,8 @@ const data = [
 const profitRenderer: BaseRenderer = (instance, td, row, col, prop, value, cellProperties) => {
   const amount = Number(value);
 
+  td.classList.remove('loss-cell');
+
   if (!Number.isFinite(amount)) {
     textRenderer(instance, td, row, col, prop, value, cellProperties);
 

--- a/docs/content/guides/cell-features/conditional-formatting/javascript/example2.ts
+++ b/docs/content/guides/cell-features/conditional-formatting/javascript/example2.ts
@@ -32,7 +32,7 @@ const profitRenderer: BaseRenderer = (instance, td, row, col, prop, value, cellP
   textRenderer(instance, td, row, col, prop, formatted, cellProperties);
 
   if (amount < 0) {
-    td.className = 'loss-cell';
+    td.classList.add('loss-cell');
   }
 };
 

--- a/docs/content/guides/cell-features/conditional-formatting/javascript/example2.ts
+++ b/docs/content/guides/cell-features/conditional-formatting/javascript/example2.ts
@@ -1,0 +1,55 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+import { BaseRenderer, registerRenderer } from 'handsontable/renderers';
+import { textRenderer } from 'handsontable/renderers/textRenderer';
+
+// register Handsontable's modules
+registerAllModules();
+
+const data = [
+  ['Acme Corp', 4.2, 5.1, -1.3, 6.8],
+  ['Vertex Industries', 12.5, 11.9, 13.2, 14],
+  ['Harbor Analytics', -2.4, 0.8, 2.1, 3.5],
+  ['Summit Logistics', 8.7, -3.2, 4.4, 5.9],
+  ['Pioneer Foods', 1.1, 1.4, 0.9, -0.5],
+  ['Meridian Retail', 6, 7.3, 8.1, 9.4],
+];
+
+// display losses in an accounting format, so color is not the only signal
+const profitRenderer: BaseRenderer = (instance, td, row, col, prop, value, cellProperties) => {
+  const amount = Number(value);
+
+  if (!Number.isFinite(amount)) {
+    textRenderer(instance, td, row, col, prop, value, cellProperties);
+
+    return;
+  }
+
+  const formatted = amount < 0
+    ? `($${Math.abs(amount).toFixed(1)}M)`
+    : `$${amount.toFixed(1)}M`;
+
+  textRenderer(instance, td, row, col, prop, formatted, cellProperties);
+
+  if (amount < 0) {
+    td.className = 'loss-cell';
+  }
+};
+
+registerRenderer('profitRenderer', profitRenderer);
+
+const container = document.querySelector('#example2')!;
+
+new Handsontable(container, {
+  data,
+  colHeaders: ['Company', 'Q1', 'Q2', 'Q3', 'Q4'],
+  licenseKey: 'non-commercial-and-evaluation',
+  height: 'auto',
+  columns: [
+    {},
+    { renderer: 'profitRenderer' },
+    { renderer: 'profitRenderer' },
+    { renderer: 'profitRenderer' },
+    { renderer: 'profitRenderer' },
+  ],
+});

--- a/docs/content/guides/cell-features/conditional-formatting/javascript/example3.js
+++ b/docs/content/guides/cell-features/conditional-formatting/javascript/example3.js
@@ -1,0 +1,42 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+import { registerRenderer } from 'handsontable/renderers';
+import { textRenderer } from 'handsontable/renderers/textRenderer';
+// register Handsontable's modules
+registerAllModules();
+const data = [
+    ['Acme Corp', 4.2, 5.1, -1.3, 6.8],
+    ['Vertex Industries', 12.5, 11.9, 13.2, 14],
+    ['Harbor Analytics', -2.4, 0.8, 2.1, 3.5],
+    ['Summit Logistics', 8.7, -3.2, 4.4, 5.9],
+    ['Pioneer Foods', 1.1, 1.4, 0.9, -0.5],
+    ['Meridian Retail', 6, 7.3, 8.1, 9.4],
+];
+const values = data.flatMap((row) => row.slice(1));
+const min = Math.min(...values);
+const max = Math.max(...values);
+// shade the background from red (low) to green (high); the value stays visible
+const heatmapRenderer = (instance, td, row, col, prop, value, cellProperties) => {
+    textRenderer(instance, td, row, col, prop, value, cellProperties);
+    const amount = Number(value);
+    if (Number.isFinite(amount)) {
+        const ratio = (amount - min) / (max - min);
+        const hue = Math.round(ratio * 120);
+        td.style.background = `hsl(${hue}, 75%, 85%)`;
+    }
+};
+registerRenderer('heatmapRenderer', heatmapRenderer);
+const container = document.querySelector('#example3');
+new Handsontable(container, {
+    data,
+    colHeaders: ['Company', 'Q1', 'Q2', 'Q3', 'Q4'],
+    licenseKey: 'non-commercial-and-evaluation',
+    height: 'auto',
+    columns: [
+        {},
+        { renderer: 'heatmapRenderer' },
+        { renderer: 'heatmapRenderer' },
+        { renderer: 'heatmapRenderer' },
+        { renderer: 'heatmapRenderer' },
+    ],
+});

--- a/docs/content/guides/cell-features/conditional-formatting/javascript/example3.js
+++ b/docs/content/guides/cell-features/conditional-formatting/javascript/example3.js
@@ -12,15 +12,18 @@ const data = [
     ['Pioneer Foods', 1.1, 1.4, 0.9, -0.5],
     ['Meridian Retail', 6, 7.3, 8.1, 9.4],
 ];
-const values = data.flatMap((row) => row.slice(1));
-const min = Math.min(...values);
-const max = Math.max(...values);
 // shade the background from red (low) to green (high); the value stays visible
 const heatmapRenderer = (instance, td, row, col, prop, value, cellProperties) => {
     textRenderer(instance, td, row, col, prop, value, cellProperties);
     const amount = Number(value);
     if (Number.isFinite(amount)) {
-        const ratio = (amount - min) / (max - min);
+        const values = instance.getData()
+            .flatMap((rowData) => rowData.slice(1))
+            .map(Number)
+            .filter((cellValue) => Number.isFinite(cellValue));
+        const min = Math.min(...values);
+        const max = Math.max(...values);
+        const ratio = min === max ? 0.5 : (amount - min) / (max - min);
         const hue = Math.round(ratio * 120);
         td.style.background = `hsl(${hue}, 75%, 85%)`;
         td.style.color = '#1b1b1b';

--- a/docs/content/guides/cell-features/conditional-formatting/javascript/example3.js
+++ b/docs/content/guides/cell-features/conditional-formatting/javascript/example3.js
@@ -23,6 +23,7 @@ const heatmapRenderer = (instance, td, row, col, prop, value, cellProperties) =>
         const ratio = (amount - min) / (max - min);
         const hue = Math.round(ratio * 120);
         td.style.background = `hsl(${hue}, 75%, 85%)`;
+        td.style.color = '#1b1b1b';
     }
 };
 registerRenderer('heatmapRenderer', heatmapRenderer);

--- a/docs/content/guides/cell-features/conditional-formatting/javascript/example3.ts
+++ b/docs/content/guides/cell-features/conditional-formatting/javascript/example3.ts
@@ -15,10 +15,6 @@ const data = [
   ['Meridian Retail', 6, 7.3, 8.1, 9.4],
 ];
 
-const values = data.flatMap((row) => row.slice(1) as number[]);
-const min = Math.min(...values);
-const max = Math.max(...values);
-
 // shade the background from red (low) to green (high); the value stays visible
 const heatmapRenderer: BaseRenderer = (instance, td, row, col, prop, value, cellProperties) => {
   textRenderer(instance, td, row, col, prop, value, cellProperties);
@@ -26,7 +22,13 @@ const heatmapRenderer: BaseRenderer = (instance, td, row, col, prop, value, cell
   const amount = Number(value);
 
   if (Number.isFinite(amount)) {
-    const ratio = (amount - min) / (max - min);
+    const values = instance.getData()
+      .flatMap((rowData) => rowData.slice(1))
+      .map(Number)
+      .filter((cellValue) => Number.isFinite(cellValue));
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    const ratio = min === max ? 0.5 : (amount - min) / (max - min);
     const hue = Math.round(ratio * 120);
 
     td.style.background = `hsl(${hue}, 75%, 85%)`;

--- a/docs/content/guides/cell-features/conditional-formatting/javascript/example3.ts
+++ b/docs/content/guides/cell-features/conditional-formatting/javascript/example3.ts
@@ -30,6 +30,7 @@ const heatmapRenderer: BaseRenderer = (instance, td, row, col, prop, value, cell
     const hue = Math.round(ratio * 120);
 
     td.style.background = `hsl(${hue}, 75%, 85%)`;
+    td.style.color = '#1b1b1b';
   }
 };
 

--- a/docs/content/guides/cell-features/conditional-formatting/javascript/example3.ts
+++ b/docs/content/guides/cell-features/conditional-formatting/javascript/example3.ts
@@ -1,0 +1,52 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+import { BaseRenderer, registerRenderer } from 'handsontable/renderers';
+import { textRenderer } from 'handsontable/renderers/textRenderer';
+
+// register Handsontable's modules
+registerAllModules();
+
+const data = [
+  ['Acme Corp', 4.2, 5.1, -1.3, 6.8],
+  ['Vertex Industries', 12.5, 11.9, 13.2, 14],
+  ['Harbor Analytics', -2.4, 0.8, 2.1, 3.5],
+  ['Summit Logistics', 8.7, -3.2, 4.4, 5.9],
+  ['Pioneer Foods', 1.1, 1.4, 0.9, -0.5],
+  ['Meridian Retail', 6, 7.3, 8.1, 9.4],
+];
+
+const values = data.flatMap((row) => row.slice(1) as number[]);
+const min = Math.min(...values);
+const max = Math.max(...values);
+
+// shade the background from red (low) to green (high); the value stays visible
+const heatmapRenderer: BaseRenderer = (instance, td, row, col, prop, value, cellProperties) => {
+  textRenderer(instance, td, row, col, prop, value, cellProperties);
+
+  const amount = Number(value);
+
+  if (Number.isFinite(amount)) {
+    const ratio = (amount - min) / (max - min);
+    const hue = Math.round(ratio * 120);
+
+    td.style.background = `hsl(${hue}, 75%, 85%)`;
+  }
+};
+
+registerRenderer('heatmapRenderer', heatmapRenderer);
+
+const container = document.querySelector('#example3')!;
+
+new Handsontable(container, {
+  data,
+  colHeaders: ['Company', 'Q1', 'Q2', 'Q3', 'Q4'],
+  licenseKey: 'non-commercial-and-evaluation',
+  height: 'auto',
+  columns: [
+    {},
+    { renderer: 'heatmapRenderer' },
+    { renderer: 'heatmapRenderer' },
+    { renderer: 'heatmapRenderer' },
+    { renderer: 'heatmapRenderer' },
+  ],
+});

--- a/docs/content/guides/cell-features/conditional-formatting/react/example1.css
+++ b/docs/content/guides/cell-features/conditional-formatting/react/example1.css
@@ -4,7 +4,8 @@
 
 #example1 .handsontable td.loss {
   color: #d81e2c;
-  background: #fdecea;
+  background: var(--ht-cell-error-background-color, rgba(216, 30, 44, 0.14));
+  background: color-mix(in srgb, #d81e2c 16%, var(--ht-background-color, #ffffff));
 }
 
 #example1 .handsontable td.loss::before {
@@ -14,4 +15,13 @@
 #example1 .handsontable td.strong-quarter {
   color: #157a3d;
   font-weight: 600;
+}
+
+html[data-theme="dark"] #example1 .handsontable td.loss {
+  color: #ff5c70;
+  background: color-mix(in srgb, #ff5c70 22%, var(--ht-background-color, #000000));
+}
+
+html[data-theme="dark"] #example1 .handsontable td.strong-quarter {
+  color: #22c55e;
 }

--- a/docs/content/guides/cell-features/conditional-formatting/react/example1.css
+++ b/docs/content/guides/cell-features/conditional-formatting/react/example1.css
@@ -1,3 +1,17 @@
-.make-me-red {
-  color: #FF5A12 !important;
+.company-name {
+  font-weight: 600;
+}
+
+.loss {
+  color: #d81e2c;
+  background: #fdecea;
+}
+
+.loss::before {
+  content: "▼ ";
+}
+
+.strong-quarter {
+  color: #157a3d;
+  font-weight: 600;
 }

--- a/docs/content/guides/cell-features/conditional-formatting/react/example1.css
+++ b/docs/content/guides/cell-features/conditional-formatting/react/example1.css
@@ -1,17 +1,17 @@
-.company-name {
+#example1 .handsontable td.company-name {
   font-weight: 600;
 }
 
-.loss {
+#example1 .handsontable td.loss {
   color: #d81e2c;
   background: #fdecea;
 }
 
-.loss::before {
+#example1 .handsontable td.loss::before {
   content: "▼ ";
 }
 
-.strong-quarter {
+#example1 .handsontable td.strong-quarter {
   color: #157a3d;
   font-weight: 600;
 }

--- a/docs/content/guides/cell-features/conditional-formatting/react/example1.jsx
+++ b/docs/content/guides/cell-features/conditional-formatting/react/example1.jsx
@@ -20,6 +20,7 @@ const ExampleComponent = () => {
         ]} cells={function (row, col) {
             const cellProperties = {};
             if (col > 0) {
+                cellProperties.className = '';
                 const value = this.instance.getDataAtCell(row, col);
                 if (typeof value === 'number' && value < 0) {
                     cellProperties.className = 'loss';

--- a/docs/content/guides/cell-features/conditional-formatting/react/example1.jsx
+++ b/docs/content/guides/cell-features/conditional-formatting/react/example1.jsx
@@ -21,7 +21,7 @@ const ExampleComponent = () => {
             const cellProperties = {};
             if (col > 0) {
                 cellProperties.className = '';
-                const value = this.instance.getDataAtCell(row, col);
+                const value = data[row]?.[col];
                 if (typeof value === 'number' && value < 0) {
                     cellProperties.className = 'loss';
                 }

--- a/docs/content/guides/cell-features/conditional-formatting/react/example1.jsx
+++ b/docs/content/guides/cell-features/conditional-formatting/react/example1.jsx
@@ -1,88 +1,34 @@
 import { HotTable } from '@handsontable/react-wrapper';
-import Handsontable from 'handsontable/base';
 import { registerAllModules } from 'handsontable/registry';
-import { registerRenderer } from 'handsontable/renderers';
-import { textRenderer } from 'handsontable/renderers/textRenderer';
-
 // register Handsontable's modules
 registerAllModules();
-
+const data = [
+    ['Acme Corp', 4.2, 5.1, -1.3, 6.8],
+    ['Vertex Industries', 12.5, 11.9, 13.2, 14],
+    ['Harbor Analytics', -2.4, 0.8, 2.1, 3.5],
+    ['Summit Logistics', 8.7, -3.2, 4.4, 5.9],
+    ['Pioneer Foods', 1.1, 1.4, 0.9, -0.5],
+    ['Meridian Retail', 6, 7.3, 8.1, 9.4],
+];
 const ExampleComponent = () => {
-  const data = [
-    ['', 'Tesla', 'Nissan', 'Toyota', 'Honda'],
-    ['2017', -5, '', 12, 13],
-    ['2018', '', -11, 14, 13],
-    ['2019', '', 15, -12, 'readOnly'],
-  ];
-
-  const firstRowRenderer = (instance, td, ...rest) => {
-    textRenderer(instance, td, ...rest);
-    td.style.fontWeight = 'bold';
-    td.style.color = 'green';
-    td.style.background = '#CEC';
-  };
-
-  const negativeValueRenderer = (instance, td, row, col, prop, value, cellProperties) => {
-    textRenderer(instance, td, row, col, prop, value, cellProperties);
-
-    // if the row contains a negative number
-    if (parseInt(value, 10) < 0) {
-      // add class 'make-me-red'
-      td.className = 'make-me-red';
-    }
-
-    if (!value || value === '') {
-      td.style.background = 'rgb(238, 238, 238, 0.4)';
-    } else {
-      if (instance.getDataAtCell(0, col) === 'Nissan') {
-        td.style.fontStyle = 'italic';
-      }
-
-      td.style.background = '';
-    }
-  };
-
-  //  maps function to a lookup string
-  registerRenderer('negativeValueRenderer', negativeValueRenderer);
-
-  return (
-    <HotTable
-      data={data}
-      autoWrapRow={true}
-      autoWrapCol={true}
-      licenseKey="non-commercial-and-evaluation"
-      height="auto"
-      afterSelection={function (_row, _col, row2, col2) {
-        const meta = this.getCellMeta(row2, col2);
-
-        if (meta.readOnly) {
-          this.updateSettings({
-            fillHandle: false,
-          });
-        } else {
-          this.updateSettings({
-            fillHandle: true,
-          });
-        }
-      }}
-      cells={function (row, col) {
-        const cellProperties = {};
-        const data = this.instance.getData();
-
-        if (row === 0 || (data[row] && data[row][col] === 'readOnly')) {
-          cellProperties.readOnly = true; // make cell read-only if it is first row or the text reads 'readOnly'
-        }
-
-        if (row === 0) {
-          cellProperties.renderer = firstRowRenderer; // uses function directly
-        } else {
-          cellProperties.renderer = 'negativeValueRenderer'; // uses lookup map
-        }
-
-        return cellProperties;
-      }}
-    />
-  );
+    return (<HotTable data={data} colHeaders={['Company', 'Q1', 'Q2', 'Q3', 'Q4']} licenseKey="non-commercial-and-evaluation" height="auto" columns={[
+            { className: 'company-name' },
+            { type: 'numeric' },
+            { type: 'numeric' },
+            { type: 'numeric' },
+            { type: 'numeric' },
+        ]} cells={function (row, col) {
+            const cellProperties = {};
+            if (col > 0) {
+                const value = this.instance.getDataAtCell(row, col);
+                if (typeof value === 'number' && value < 0) {
+                    cellProperties.className = 'loss';
+                }
+                else if (typeof value === 'number' && value > 10) {
+                    cellProperties.className = 'strong-quarter';
+                }
+            }
+            return cellProperties;
+        }}/>);
 };
-
 export default ExampleComponent;

--- a/docs/content/guides/cell-features/conditional-formatting/react/example1.tsx
+++ b/docs/content/guides/cell-features/conditional-formatting/react/example1.tsx
@@ -32,6 +32,8 @@ const ExampleComponent = () => {
         const cellProperties: Handsontable.CellMeta = {};
 
         if (col > 0) {
+          cellProperties.className = '';
+
           const value = this.instance.getDataAtCell(row, col);
 
           if (typeof value === 'number' && value < 0) {

--- a/docs/content/guides/cell-features/conditional-formatting/react/example1.tsx
+++ b/docs/content/guides/cell-features/conditional-formatting/react/example1.tsx
@@ -1,82 +1,44 @@
 import { HotTable } from '@handsontable/react-wrapper';
 import Handsontable from 'handsontable/base';
 import { registerAllModules } from 'handsontable/registry';
-import { BaseRenderer, registerRenderer } from 'handsontable/renderers';
-import { textRenderer } from 'handsontable/renderers/textRenderer';
 
 // register Handsontable's modules
 registerAllModules();
 
+const data = [
+  ['Acme Corp', 4.2, 5.1, -1.3, 6.8],
+  ['Vertex Industries', 12.5, 11.9, 13.2, 14],
+  ['Harbor Analytics', -2.4, 0.8, 2.1, 3.5],
+  ['Summit Logistics', 8.7, -3.2, 4.4, 5.9],
+  ['Pioneer Foods', 1.1, 1.4, 0.9, -0.5],
+  ['Meridian Retail', 6, 7.3, 8.1, 9.4],
+];
+
 const ExampleComponent = () => {
-  const data = [
-    ['', 'Tesla', 'Nissan', 'Toyota', 'Honda'],
-    ['2017', -5, '', 12, 13],
-    ['2018', '', -11, 14, 13],
-    ['2019', '', 15, -12, 'readOnly'],
-  ];
-
-  const firstRowRenderer: BaseRenderer = (instance, td, ...rest) => {
-    textRenderer(instance, td, ...rest);
-    td.style.fontWeight = 'bold';
-    td.style.color = 'green';
-    td.style.background = '#CEC';
-  };
-
-  const negativeValueRenderer: BaseRenderer = (instance, td, row, col, prop, value, cellProperties) => {
-    textRenderer(instance, td, row, col, prop, value, cellProperties);
-
-    // if the row contains a negative number
-    if (parseInt(value, 10) < 0) {
-      // add class 'make-me-red'
-      td.className = 'make-me-red';
-    }
-
-    if (!value || value === '') {
-      td.style.background = 'rgb(238, 238, 238, 0.4)';
-    } else {
-      if (instance.getDataAtCell(0, col) === 'Nissan') {
-        td.style.fontStyle = 'italic';
-      }
-
-      td.style.background = '';
-    }
-  };
-
-  //  maps function to a lookup string
-  registerRenderer('negativeValueRenderer', negativeValueRenderer);
-
   return (
     <HotTable
       data={data}
-      autoWrapRow={true}
-      autoWrapCol={true}
+      colHeaders={['Company', 'Q1', 'Q2', 'Q3', 'Q4']}
       licenseKey="non-commercial-and-evaluation"
       height="auto"
-      afterSelection={function (this: Handsontable, _row, _col, row2, col2) {
-        const meta = this.getCellMeta(row2, col2);
-
-        if (meta.readOnly) {
-          this.updateSettings({
-            fillHandle: false,
-          });
-        } else {
-          this.updateSettings({
-            fillHandle: true,
-          });
-        }
-      }}
+      columns={[
+        { className: 'company-name' },
+        { type: 'numeric' },
+        { type: 'numeric' },
+        { type: 'numeric' },
+        { type: 'numeric' },
+      ]}
       cells={function (row, col) {
         const cellProperties: Handsontable.CellMeta = {};
-        const data = this.instance.getData();
 
-        if (row === 0 || (data[row] && data[row][col] === 'readOnly')) {
-          cellProperties.readOnly = true; // make cell read-only if it is first row or the text reads 'readOnly'
-        }
+        if (col > 0) {
+          const value = this.instance.getDataAtCell(row, col);
 
-        if (row === 0) {
-          cellProperties.renderer = firstRowRenderer; // uses function directly
-        } else {
-          cellProperties.renderer = 'negativeValueRenderer'; // uses lookup map
+          if (typeof value === 'number' && value < 0) {
+            cellProperties.className = 'loss';
+          } else if (typeof value === 'number' && value > 10) {
+            cellProperties.className = 'strong-quarter';
+          }
         }
 
         return cellProperties;

--- a/docs/content/guides/cell-features/conditional-formatting/react/example1.tsx
+++ b/docs/content/guides/cell-features/conditional-formatting/react/example1.tsx
@@ -34,7 +34,7 @@ const ExampleComponent = () => {
         if (col > 0) {
           cellProperties.className = '';
 
-          const value = this.instance.getDataAtCell(row, col);
+          const value = data[row]?.[col];
 
           if (typeof value === 'number' && value < 0) {
             cellProperties.className = 'loss';

--- a/docs/content/guides/cell-features/conditional-formatting/react/example2.css
+++ b/docs/content/guides/cell-features/conditional-formatting/react/example2.css
@@ -1,4 +1,4 @@
-.loss-cell {
+#example2 .handsontable td.loss-cell {
   color: #d81e2c;
   font-weight: 600;
 }

--- a/docs/content/guides/cell-features/conditional-formatting/react/example2.css
+++ b/docs/content/guides/cell-features/conditional-formatting/react/example2.css
@@ -1,0 +1,4 @@
+.loss-cell {
+  color: #d81e2c;
+  font-weight: 600;
+}

--- a/docs/content/guides/cell-features/conditional-formatting/react/example2.css
+++ b/docs/content/guides/cell-features/conditional-formatting/react/example2.css
@@ -2,3 +2,7 @@
   color: #d81e2c;
   font-weight: 600;
 }
+
+html[data-theme="dark"] #example2 .handsontable td.loss-cell {
+  color: #ff5c70;
+}

--- a/docs/content/guides/cell-features/conditional-formatting/react/example2.jsx
+++ b/docs/content/guides/cell-features/conditional-formatting/react/example2.jsx
@@ -24,7 +24,7 @@ const profitRenderer = (instance, td, row, col, prop, value, cellProperties) => 
         : `$${amount.toFixed(1)}M`;
     textRenderer(instance, td, row, col, prop, formatted, cellProperties);
     if (amount < 0) {
-        td.className = 'loss-cell';
+        td.classList.add('loss-cell');
     }
 };
 registerRenderer('profitRenderer', profitRenderer);

--- a/docs/content/guides/cell-features/conditional-formatting/react/example2.jsx
+++ b/docs/content/guides/cell-features/conditional-formatting/react/example2.jsx
@@ -15,6 +15,7 @@ const data = [
 // display losses in an accounting format, so color is not the only signal
 const profitRenderer = (instance, td, row, col, prop, value, cellProperties) => {
     const amount = Number(value);
+    td.classList.remove('loss-cell');
     if (!Number.isFinite(amount)) {
         textRenderer(instance, td, row, col, prop, value, cellProperties);
         return;

--- a/docs/content/guides/cell-features/conditional-formatting/react/example2.jsx
+++ b/docs/content/guides/cell-features/conditional-formatting/react/example2.jsx
@@ -1,0 +1,40 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import { registerRenderer } from 'handsontable/renderers';
+import { textRenderer } from 'handsontable/renderers/textRenderer';
+// register Handsontable's modules
+registerAllModules();
+const data = [
+    ['Acme Corp', 4.2, 5.1, -1.3, 6.8],
+    ['Vertex Industries', 12.5, 11.9, 13.2, 14],
+    ['Harbor Analytics', -2.4, 0.8, 2.1, 3.5],
+    ['Summit Logistics', 8.7, -3.2, 4.4, 5.9],
+    ['Pioneer Foods', 1.1, 1.4, 0.9, -0.5],
+    ['Meridian Retail', 6, 7.3, 8.1, 9.4],
+];
+// display losses in an accounting format, so color is not the only signal
+const profitRenderer = (instance, td, row, col, prop, value, cellProperties) => {
+    const amount = Number(value);
+    if (!Number.isFinite(amount)) {
+        textRenderer(instance, td, row, col, prop, value, cellProperties);
+        return;
+    }
+    const formatted = amount < 0
+        ? `($${Math.abs(amount).toFixed(1)}M)`
+        : `$${amount.toFixed(1)}M`;
+    textRenderer(instance, td, row, col, prop, formatted, cellProperties);
+    if (amount < 0) {
+        td.className = 'loss-cell';
+    }
+};
+registerRenderer('profitRenderer', profitRenderer);
+const ExampleComponent = () => {
+    return (<HotTable data={data} colHeaders={['Company', 'Q1', 'Q2', 'Q3', 'Q4']} licenseKey="non-commercial-and-evaluation" height="auto" columns={[
+            {},
+            { renderer: 'profitRenderer' },
+            { renderer: 'profitRenderer' },
+            { renderer: 'profitRenderer' },
+            { renderer: 'profitRenderer' },
+        ]}/>);
+};
+export default ExampleComponent;

--- a/docs/content/guides/cell-features/conditional-formatting/react/example2.tsx
+++ b/docs/content/guides/cell-features/conditional-formatting/react/example2.tsx
@@ -1,0 +1,59 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import { BaseRenderer, registerRenderer } from 'handsontable/renderers';
+import { textRenderer } from 'handsontable/renderers/textRenderer';
+
+// register Handsontable's modules
+registerAllModules();
+
+const data = [
+  ['Acme Corp', 4.2, 5.1, -1.3, 6.8],
+  ['Vertex Industries', 12.5, 11.9, 13.2, 14],
+  ['Harbor Analytics', -2.4, 0.8, 2.1, 3.5],
+  ['Summit Logistics', 8.7, -3.2, 4.4, 5.9],
+  ['Pioneer Foods', 1.1, 1.4, 0.9, -0.5],
+  ['Meridian Retail', 6, 7.3, 8.1, 9.4],
+];
+
+// display losses in an accounting format, so color is not the only signal
+const profitRenderer: BaseRenderer = (instance, td, row, col, prop, value, cellProperties) => {
+  const amount = Number(value);
+
+  if (!Number.isFinite(amount)) {
+    textRenderer(instance, td, row, col, prop, value, cellProperties);
+
+    return;
+  }
+
+  const formatted = amount < 0
+    ? `($${Math.abs(amount).toFixed(1)}M)`
+    : `$${amount.toFixed(1)}M`;
+
+  textRenderer(instance, td, row, col, prop, formatted, cellProperties);
+
+  if (amount < 0) {
+    td.className = 'loss-cell';
+  }
+};
+
+registerRenderer('profitRenderer', profitRenderer);
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={data}
+      colHeaders={['Company', 'Q1', 'Q2', 'Q3', 'Q4']}
+      licenseKey="non-commercial-and-evaluation"
+      height="auto"
+      columns={[
+        {},
+        { renderer: 'profitRenderer' },
+        { renderer: 'profitRenderer' },
+        { renderer: 'profitRenderer' },
+        { renderer: 'profitRenderer' },
+      ]}
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/cell-features/conditional-formatting/react/example2.tsx
+++ b/docs/content/guides/cell-features/conditional-formatting/react/example2.tsx
@@ -19,6 +19,8 @@ const data = [
 const profitRenderer: BaseRenderer = (instance, td, row, col, prop, value, cellProperties) => {
   const amount = Number(value);
 
+  td.classList.remove('loss-cell');
+
   if (!Number.isFinite(amount)) {
     textRenderer(instance, td, row, col, prop, value, cellProperties);
 

--- a/docs/content/guides/cell-features/conditional-formatting/react/example2.tsx
+++ b/docs/content/guides/cell-features/conditional-formatting/react/example2.tsx
@@ -32,7 +32,7 @@ const profitRenderer: BaseRenderer = (instance, td, row, col, prop, value, cellP
   textRenderer(instance, td, row, col, prop, formatted, cellProperties);
 
   if (amount < 0) {
-    td.className = 'loss-cell';
+    td.classList.add('loss-cell');
   }
 };
 

--- a/docs/content/guides/cell-features/conditional-formatting/react/example3.jsx
+++ b/docs/content/guides/cell-features/conditional-formatting/react/example3.jsx
@@ -12,15 +12,18 @@ const data = [
     ['Pioneer Foods', 1.1, 1.4, 0.9, -0.5],
     ['Meridian Retail', 6, 7.3, 8.1, 9.4],
 ];
-const values = data.flatMap((row) => row.slice(1));
-const min = Math.min(...values);
-const max = Math.max(...values);
 // shade the background from red (low) to green (high); the value stays visible
 const heatmapRenderer = (instance, td, row, col, prop, value, cellProperties) => {
     textRenderer(instance, td, row, col, prop, value, cellProperties);
     const amount = Number(value);
     if (Number.isFinite(amount)) {
-        const ratio = (amount - min) / (max - min);
+        const values = instance.getData()
+            .flatMap((rowData) => rowData.slice(1))
+            .map(Number)
+            .filter((cellValue) => Number.isFinite(cellValue));
+        const min = Math.min(...values);
+        const max = Math.max(...values);
+        const ratio = min === max ? 0.5 : (amount - min) / (max - min);
         const hue = Math.round(ratio * 120);
         td.style.background = `hsl(${hue}, 75%, 85%)`;
         td.style.color = '#1b1b1b';

--- a/docs/content/guides/cell-features/conditional-formatting/react/example3.jsx
+++ b/docs/content/guides/cell-features/conditional-formatting/react/example3.jsx
@@ -23,6 +23,7 @@ const heatmapRenderer = (instance, td, row, col, prop, value, cellProperties) =>
         const ratio = (amount - min) / (max - min);
         const hue = Math.round(ratio * 120);
         td.style.background = `hsl(${hue}, 75%, 85%)`;
+        td.style.color = '#1b1b1b';
     }
 };
 registerRenderer('heatmapRenderer', heatmapRenderer);

--- a/docs/content/guides/cell-features/conditional-formatting/react/example3.jsx
+++ b/docs/content/guides/cell-features/conditional-formatting/react/example3.jsx
@@ -1,0 +1,38 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import { registerRenderer } from 'handsontable/renderers';
+import { textRenderer } from 'handsontable/renderers/textRenderer';
+// register Handsontable's modules
+registerAllModules();
+const data = [
+    ['Acme Corp', 4.2, 5.1, -1.3, 6.8],
+    ['Vertex Industries', 12.5, 11.9, 13.2, 14],
+    ['Harbor Analytics', -2.4, 0.8, 2.1, 3.5],
+    ['Summit Logistics', 8.7, -3.2, 4.4, 5.9],
+    ['Pioneer Foods', 1.1, 1.4, 0.9, -0.5],
+    ['Meridian Retail', 6, 7.3, 8.1, 9.4],
+];
+const values = data.flatMap((row) => row.slice(1));
+const min = Math.min(...values);
+const max = Math.max(...values);
+// shade the background from red (low) to green (high); the value stays visible
+const heatmapRenderer = (instance, td, row, col, prop, value, cellProperties) => {
+    textRenderer(instance, td, row, col, prop, value, cellProperties);
+    const amount = Number(value);
+    if (Number.isFinite(amount)) {
+        const ratio = (amount - min) / (max - min);
+        const hue = Math.round(ratio * 120);
+        td.style.background = `hsl(${hue}, 75%, 85%)`;
+    }
+};
+registerRenderer('heatmapRenderer', heatmapRenderer);
+const ExampleComponent = () => {
+    return (<HotTable data={data} colHeaders={['Company', 'Q1', 'Q2', 'Q3', 'Q4']} licenseKey="non-commercial-and-evaluation" height="auto" columns={[
+            {},
+            { renderer: 'heatmapRenderer' },
+            { renderer: 'heatmapRenderer' },
+            { renderer: 'heatmapRenderer' },
+            { renderer: 'heatmapRenderer' },
+        ]}/>);
+};
+export default ExampleComponent;

--- a/docs/content/guides/cell-features/conditional-formatting/react/example3.tsx
+++ b/docs/content/guides/cell-features/conditional-formatting/react/example3.tsx
@@ -15,10 +15,6 @@ const data = [
   ['Meridian Retail', 6, 7.3, 8.1, 9.4],
 ];
 
-const values = data.flatMap((row) => row.slice(1) as number[]);
-const min = Math.min(...values);
-const max = Math.max(...values);
-
 // shade the background from red (low) to green (high); the value stays visible
 const heatmapRenderer: BaseRenderer = (instance, td, row, col, prop, value, cellProperties) => {
   textRenderer(instance, td, row, col, prop, value, cellProperties);
@@ -26,7 +22,13 @@ const heatmapRenderer: BaseRenderer = (instance, td, row, col, prop, value, cell
   const amount = Number(value);
 
   if (Number.isFinite(amount)) {
-    const ratio = (amount - min) / (max - min);
+    const values = instance.getData()
+      .flatMap((rowData) => rowData.slice(1))
+      .map(Number)
+      .filter((cellValue) => Number.isFinite(cellValue));
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    const ratio = min === max ? 0.5 : (amount - min) / (max - min);
     const hue = Math.round(ratio * 120);
 
     td.style.background = `hsl(${hue}, 75%, 85%)`;

--- a/docs/content/guides/cell-features/conditional-formatting/react/example3.tsx
+++ b/docs/content/guides/cell-features/conditional-formatting/react/example3.tsx
@@ -1,0 +1,56 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import { BaseRenderer, registerRenderer } from 'handsontable/renderers';
+import { textRenderer } from 'handsontable/renderers/textRenderer';
+
+// register Handsontable's modules
+registerAllModules();
+
+const data = [
+  ['Acme Corp', 4.2, 5.1, -1.3, 6.8],
+  ['Vertex Industries', 12.5, 11.9, 13.2, 14],
+  ['Harbor Analytics', -2.4, 0.8, 2.1, 3.5],
+  ['Summit Logistics', 8.7, -3.2, 4.4, 5.9],
+  ['Pioneer Foods', 1.1, 1.4, 0.9, -0.5],
+  ['Meridian Retail', 6, 7.3, 8.1, 9.4],
+];
+
+const values = data.flatMap((row) => row.slice(1) as number[]);
+const min = Math.min(...values);
+const max = Math.max(...values);
+
+// shade the background from red (low) to green (high); the value stays visible
+const heatmapRenderer: BaseRenderer = (instance, td, row, col, prop, value, cellProperties) => {
+  textRenderer(instance, td, row, col, prop, value, cellProperties);
+
+  const amount = Number(value);
+
+  if (Number.isFinite(amount)) {
+    const ratio = (amount - min) / (max - min);
+    const hue = Math.round(ratio * 120);
+
+    td.style.background = `hsl(${hue}, 75%, 85%)`;
+  }
+};
+
+registerRenderer('heatmapRenderer', heatmapRenderer);
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={data}
+      colHeaders={['Company', 'Q1', 'Q2', 'Q3', 'Q4']}
+      licenseKey="non-commercial-and-evaluation"
+      height="auto"
+      columns={[
+        {},
+        { renderer: 'heatmapRenderer' },
+        { renderer: 'heatmapRenderer' },
+        { renderer: 'heatmapRenderer' },
+        { renderer: 'heatmapRenderer' },
+      ]}
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/cell-features/conditional-formatting/react/example3.tsx
+++ b/docs/content/guides/cell-features/conditional-formatting/react/example3.tsx
@@ -30,6 +30,7 @@ const heatmapRenderer: BaseRenderer = (instance, td, row, col, prop, value, cell
     const hue = Math.round(ratio * 120);
 
     td.style.background = `hsl(${hue}, 75%, 85%)`;
+    td.style.color = '#1b1b1b';
   }
 };
 

--- a/docs/content/guides/cell-features/conditional-formatting/vue/example1.vue
+++ b/docs/content/guides/cell-features/conditional-formatting/vue/example1.vue
@@ -1,102 +1,71 @@
 <script setup lang="ts">
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
-import { registerRenderer } from 'handsontable/renderers';
-import type { BaseRenderer } from 'handsontable/renderers';
-import { textRenderer } from 'handsontable/renderers/textRenderer';
 import type { GridSettings } from 'handsontable/settings';
 import type Handsontable from 'handsontable/base';
-import { ref, useTemplateRef } from 'vue';
 
 registerAllModules();
 
-const data: (string | number)[][] = [
-  ['', 'Tesla', 'Nissan', 'Toyota', 'Honda'],
-  ['2017', -5, '', 12, 13],
-  ['2018', '', -11, 14, 13],
-  ['2019', '', 15, -12, 'readOnly'],
+const data = [
+  ['Acme Corp', 4.2, 5.1, -1.3, 6.8],
+  ['Vertex Industries', 12.5, 11.9, 13.2, 14],
+  ['Harbor Analytics', -2.4, 0.8, 2.1, 3.5],
+  ['Summit Logistics', 8.7, -3.2, 4.4, 5.9],
+  ['Pioneer Foods', 1.1, 1.4, 0.9, -0.5],
+  ['Meridian Retail', 6, 7.3, 8.1, 9.4],
 ];
-
-const firstRowRenderer: BaseRenderer = (instance, td, ...rest) => {
-  textRenderer(instance, td, ...rest);
-  td.style.fontWeight = 'bold';
-  td.style.color = 'green';
-  td.style.background = '#CEC';
-};
-
-const negativeValueRenderer: BaseRenderer = (instance, td, row, col, prop, value, cellProperties) => {
-  textRenderer(instance, td, row, col, prop, value, cellProperties);
-
-  if (parseInt(String(value), 10) < 0) {
-    td.className = 'make-me-red';
-  }
-
-  if (!value || value === '') {
-    td.style.background = 'rgb(238, 238, 238, 0.4)';
-  } else {
-    if (instance.getDataAtCell(0, col) === 'Nissan') {
-      td.style.fontStyle = 'italic';
-    }
-
-    td.style.background = '';
-  }
-};
-
-registerRenderer('negativeValueRenderer', negativeValueRenderer);
-
-const hotTableRef = useTemplateRef<InstanceType<typeof HotTable>>('hotTableRef');
 
 const hotSettings: GridSettings = {
   data,
+  colHeaders: ['Company', 'Q1', 'Q2', 'Q3', 'Q4'],
   licenseKey: 'non-commercial-and-evaluation',
   height: 'auto',
-  afterSelection(_row, _col, row2, col2) {
-    const hot = hotTableRef.value?.hotInstance;
-
-    if (!hot) {
-      return;
-    }
-
-    const meta = hot.getCellMeta(row2, col2);
-
-    if (meta.readOnly) {
-      hot.updateSettings({
-        fillHandle: false,
-      });
-    } else {
-      hot.updateSettings({
-        fillHandle: true,
-      });
-    }
-  },
+  columns: [
+    { className: 'company-name' },
+    { type: 'numeric' },
+    { type: 'numeric' },
+    { type: 'numeric' },
+    { type: 'numeric' },
+  ],
   cells(row, col) {
     const cellProperties: Handsontable.CellMeta = {};
+    const value = data[row]?.[col];
 
-    if (row === 0 || (data[row] && data[row][col] === 'readOnly')) {
-      cellProperties.readOnly = true;
-    }
-
-    if (row === 0) {
-      cellProperties.renderer = firstRowRenderer;
-    } else {
-      cellProperties.renderer = 'negativeValueRenderer';
+    if (col > 0) {
+      if (typeof value === 'number' && value < 0) {
+        cellProperties.className = 'loss';
+      } else if (typeof value === 'number' && value > 10) {
+        cellProperties.className = 'strong-quarter';
+      }
     }
 
     return cellProperties;
   },
-  autoWrapRow: true,
-  autoWrapCol: true,
 };
 </script>
 
 <template>
   <div id="example1">
-    <HotTable ref="hotTableRef" :settings="hotSettings" />
+    <HotTable :settings="hotSettings" />
   </div>
 </template>
 
 <style>
-.make-me-red {
-  color: #FF5A12 !important;
+.company-name {
+  font-weight: 600;
+}
+
+.loss {
+  color: #d81e2c;
+  background: #fdecea;
+}
+
+.loss::before {
+  content: "▼ ";
+}
+
+.strong-quarter {
+  color: #157a3d;
+  font-weight: 600;
 }
 </style>

--- a/docs/content/guides/cell-features/conditional-formatting/vue/example1.vue
+++ b/docs/content/guides/cell-features/conditional-formatting/vue/example1.vue
@@ -51,20 +51,20 @@ const hotSettings: GridSettings = {
 </template>
 
 <style>
-.company-name {
+#example1 .handsontable td.company-name {
   font-weight: 600;
 }
 
-.loss {
+#example1 .handsontable td.loss {
   color: #d81e2c;
   background: #fdecea;
 }
 
-.loss::before {
+#example1 .handsontable td.loss::before {
   content: "▼ ";
 }
 
-.strong-quarter {
+#example1 .handsontable td.strong-quarter {
   color: #157a3d;
   font-weight: 600;
 }

--- a/docs/content/guides/cell-features/conditional-formatting/vue/example1.vue
+++ b/docs/content/guides/cell-features/conditional-formatting/vue/example1.vue
@@ -59,7 +59,8 @@ const hotSettings: GridSettings = {
 
 #example1 .handsontable td.loss {
   color: #d81e2c;
-  background: #fdecea;
+  background: var(--ht-cell-error-background-color, rgba(216, 30, 44, 0.14));
+  background: color-mix(in srgb, #d81e2c 16%, var(--ht-background-color, #ffffff));
 }
 
 #example1 .handsontable td.loss::before {
@@ -69,5 +70,14 @@ const hotSettings: GridSettings = {
 #example1 .handsontable td.strong-quarter {
   color: #157a3d;
   font-weight: 600;
+}
+
+html[data-theme="dark"] #example1 .handsontable td.loss {
+  color: #ff5c70;
+  background: color-mix(in srgb, #ff5c70 22%, var(--ht-background-color, #000000));
+}
+
+html[data-theme="dark"] #example1 .handsontable td.strong-quarter {
+  color: #22c55e;
 }
 </style>

--- a/docs/content/guides/cell-features/conditional-formatting/vue/example1.vue
+++ b/docs/content/guides/cell-features/conditional-formatting/vue/example1.vue
@@ -32,6 +32,8 @@ const hotSettings: GridSettings = {
     const value = data[row]?.[col];
 
     if (col > 0) {
+      cellProperties.className = '';
+
       if (typeof value === 'number' && value < 0) {
         cellProperties.className = 'loss';
       } else if (typeof value === 'number' && value > 10) {

--- a/docs/content/guides/cell-features/conditional-formatting/vue/example2.vue
+++ b/docs/content/guides/cell-features/conditional-formatting/vue/example2.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import { registerRenderer } from 'handsontable/renderers';
+import type { BaseRenderer } from 'handsontable/renderers';
+import { textRenderer } from 'handsontable/renderers/textRenderer';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const data = [
+  ['Acme Corp', 4.2, 5.1, -1.3, 6.8],
+  ['Vertex Industries', 12.5, 11.9, 13.2, 14],
+  ['Harbor Analytics', -2.4, 0.8, 2.1, 3.5],
+  ['Summit Logistics', 8.7, -3.2, 4.4, 5.9],
+  ['Pioneer Foods', 1.1, 1.4, 0.9, -0.5],
+  ['Meridian Retail', 6, 7.3, 8.1, 9.4],
+];
+
+// display losses in an accounting format, so color is not the only signal
+const profitRenderer: BaseRenderer = (instance, td, row, col, prop, value, cellProperties) => {
+  const amount = Number(value);
+
+  if (!Number.isFinite(amount)) {
+    textRenderer(instance, td, row, col, prop, value, cellProperties);
+
+    return;
+  }
+
+  const formatted = amount < 0
+    ? `($${Math.abs(amount).toFixed(1)}M)`
+    : `$${amount.toFixed(1)}M`;
+
+  textRenderer(instance, td, row, col, prop, formatted, cellProperties);
+
+  if (amount < 0) {
+    td.className = 'loss-cell';
+  }
+};
+
+registerRenderer('profitRenderer', profitRenderer);
+
+const hotSettings: GridSettings = {
+  data,
+  colHeaders: ['Company', 'Q1', 'Q2', 'Q3', 'Q4'],
+  licenseKey: 'non-commercial-and-evaluation',
+  height: 'auto',
+  columns: [
+    {},
+    { renderer: 'profitRenderer' },
+    { renderer: 'profitRenderer' },
+    { renderer: 'profitRenderer' },
+    { renderer: 'profitRenderer' },
+  ],
+};
+</script>
+
+<template>
+  <div id="example2">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>
+
+<style>
+.loss-cell {
+  color: #d81e2c;
+  font-weight: 600;
+}
+</style>

--- a/docs/content/guides/cell-features/conditional-formatting/vue/example2.vue
+++ b/docs/content/guides/cell-features/conditional-formatting/vue/example2.vue
@@ -34,7 +34,7 @@ const profitRenderer: BaseRenderer = (instance, td, row, col, prop, value, cellP
   textRenderer(instance, td, row, col, prop, formatted, cellProperties);
 
   if (amount < 0) {
-    td.className = 'loss-cell';
+    td.classList.add('loss-cell');
   }
 };
 
@@ -62,7 +62,7 @@ const hotSettings: GridSettings = {
 </template>
 
 <style>
-.loss-cell {
+#example2 .handsontable td.loss-cell {
   color: #d81e2c;
   font-weight: 600;
 }

--- a/docs/content/guides/cell-features/conditional-formatting/vue/example2.vue
+++ b/docs/content/guides/cell-features/conditional-formatting/vue/example2.vue
@@ -21,6 +21,8 @@ const data = [
 const profitRenderer: BaseRenderer = (instance, td, row, col, prop, value, cellProperties) => {
   const amount = Number(value);
 
+  td.classList.remove('loss-cell');
+
   if (!Number.isFinite(amount)) {
     textRenderer(instance, td, row, col, prop, value, cellProperties);
 

--- a/docs/content/guides/cell-features/conditional-formatting/vue/example2.vue
+++ b/docs/content/guides/cell-features/conditional-formatting/vue/example2.vue
@@ -68,4 +68,8 @@ const hotSettings: GridSettings = {
   color: #d81e2c;
   font-weight: 600;
 }
+
+html[data-theme="dark"] #example2 .handsontable td.loss-cell {
+  color: #ff5c70;
+}
 </style>

--- a/docs/content/guides/cell-features/conditional-formatting/vue/example3.vue
+++ b/docs/content/guides/cell-features/conditional-formatting/vue/example3.vue
@@ -17,10 +17,6 @@ const data = [
   ['Meridian Retail', 6, 7.3, 8.1, 9.4],
 ];
 
-const values = data.flatMap((row) => row.slice(1) as number[]);
-const min = Math.min(...values);
-const max = Math.max(...values);
-
 // shade the background from red (low) to green (high); the value stays visible
 const heatmapRenderer: BaseRenderer = (instance, td, row, col, prop, value, cellProperties) => {
   textRenderer(instance, td, row, col, prop, value, cellProperties);
@@ -28,7 +24,13 @@ const heatmapRenderer: BaseRenderer = (instance, td, row, col, prop, value, cell
   const amount = Number(value);
 
   if (Number.isFinite(amount)) {
-    const ratio = (amount - min) / (max - min);
+    const values = instance.getData()
+      .flatMap((rowData) => rowData.slice(1))
+      .map(Number)
+      .filter((cellValue) => Number.isFinite(cellValue));
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    const ratio = min === max ? 0.5 : (amount - min) / (max - min);
     const hue = Math.round(ratio * 120);
 
     td.style.background = `hsl(${hue}, 75%, 85%)`;

--- a/docs/content/guides/cell-features/conditional-formatting/vue/example3.vue
+++ b/docs/content/guides/cell-features/conditional-formatting/vue/example3.vue
@@ -32,6 +32,7 @@ const heatmapRenderer: BaseRenderer = (instance, td, row, col, prop, value, cell
     const hue = Math.round(ratio * 120);
 
     td.style.background = `hsl(${hue}, 75%, 85%)`;
+    td.style.color = '#1b1b1b';
   }
 };
 

--- a/docs/content/guides/cell-features/conditional-formatting/vue/example3.vue
+++ b/docs/content/guides/cell-features/conditional-formatting/vue/example3.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import { registerRenderer } from 'handsontable/renderers';
+import type { BaseRenderer } from 'handsontable/renderers';
+import { textRenderer } from 'handsontable/renderers/textRenderer';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const data = [
+  ['Acme Corp', 4.2, 5.1, -1.3, 6.8],
+  ['Vertex Industries', 12.5, 11.9, 13.2, 14],
+  ['Harbor Analytics', -2.4, 0.8, 2.1, 3.5],
+  ['Summit Logistics', 8.7, -3.2, 4.4, 5.9],
+  ['Pioneer Foods', 1.1, 1.4, 0.9, -0.5],
+  ['Meridian Retail', 6, 7.3, 8.1, 9.4],
+];
+
+const values = data.flatMap((row) => row.slice(1) as number[]);
+const min = Math.min(...values);
+const max = Math.max(...values);
+
+// shade the background from red (low) to green (high); the value stays visible
+const heatmapRenderer: BaseRenderer = (instance, td, row, col, prop, value, cellProperties) => {
+  textRenderer(instance, td, row, col, prop, value, cellProperties);
+
+  const amount = Number(value);
+
+  if (Number.isFinite(amount)) {
+    const ratio = (amount - min) / (max - min);
+    const hue = Math.round(ratio * 120);
+
+    td.style.background = `hsl(${hue}, 75%, 85%)`;
+  }
+};
+
+registerRenderer('heatmapRenderer', heatmapRenderer);
+
+const hotSettings: GridSettings = {
+  data,
+  colHeaders: ['Company', 'Q1', 'Q2', 'Q3', 'Q4'],
+  licenseKey: 'non-commercial-and-evaluation',
+  height: 'auto',
+  columns: [
+    {},
+    { renderer: 'heatmapRenderer' },
+    { renderer: 'heatmapRenderer' },
+    { renderer: 'heatmapRenderer' },
+    { renderer: 'heatmapRenderer' },
+  ],
+};
+</script>
+
+<template>
+  <div id="example3">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>


### PR DESCRIPTION
### Context

The PR rewrites the [Conditional formatting](https://handsontable.com/docs/javascript-data-grid/conditional-formatting/) guide page (DEV-642). The page was only partially updated since 2023 - mechanical sweeps kept it building, but it never got the content rewrite the task asked for. Specifically, it was typed `reference` (every sibling `cell-features/*` page is `how-to`), demonstrated only a single custom-renderer technique, used non-compliant example data (empty column + car brands + bare year rows + a literal `'readOnly'` string, 3 rows), mixed in unrelated `fillHandle` logic, and had no accessibility guidance.

Changes:

- Retype the page to `how-to`, restructure it to the how-to template (add `Prerequisites`, keep `Result`), and trim `Related articles` so it no longer duplicates the `Formatting cells` page.
- Replace the single demo with three progressive, value-driven examples across all four frameworks:
  1. Declarative `className` via the `cells()` callback (highlights losses and strong quarters) - the recommended default.
  2. Custom `renderer` that shows losses in an accounting format `($1.3M)`.
  3. Color-scale heatmap driven by each value's magnitude.
- Use a domain-realistic financial dataset (6 companies x 4 quarters) and drop the unrelated selection/`fillHandle` code.
- Add a "Make conditional formatting accessible" section (WCAG 2.1 AA - never rely on color alone); examples 1 and 2 pair color with a non-color cue.

### How has this been tested?

Ran the docs dev server (`ASTRO_DEV_BACKGROUND=1 npm run dev` in `docs/`) and loaded `/conditional-formatting` for all four frameworks. Every framework renders all three grids with no Handsontable console errors:

- Example 1: 4 `loss` cells + 4 `strong-quarter` cells.
- Example 2: accounting format `($1.3M)` on losses + 4 loss cells.
- Example 3: 24 heatmap backgrounds applied.

JavaScript and React `.js`/`.jsx` variants were generated with `npm run docs:code-examples:generate-js` (not hand-edited).

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

Documentation-only change.

### Related issue(s):

1. DEV-642

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

Documentation only.

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] This change is to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-642

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to docs content and live examples; no library or runtime product code is modified.
> 
> **Overview**
> Rewrites the **Conditional formatting** docs page (DEV-642): retypes it from `reference` to **`how-to`**, adds **Prerequisites** and clearer guidance on when to use `className` + `cells`, custom `renderer`, or a color scale, plus a **WCAG 2.1 AA** accessibility section. **Related articles** is narrowed to `className`, `cells`, and `renderer` (and a few related guides).
> 
> **Example 1** is replaced across JS/React/Angular/Vue: drops custom renderers, read-only/`fillHandle` logic, and the old car-brand dataset in favor of a 6×4 quarterly financial grid styled via **`cells()`** and CSS (`loss`, `strong-quarter`, dark theme).
> 
> **Examples 2 and 3** are new everywhere: accounting-style **`profitRenderer`** for quarter columns, and a **`heatmapRenderer`** min–max color scale. Angular gains `example2`/`example3` shells and updated `example1` with `ViewEncapsulation.None` and component-scoped styles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a8ae85874cc8d419551ec03d335d1815c9f4537. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->