### PR TITLE
DEV-1803: Fix vanilla JS getting-started demo width mismatch

### DIFF
--- a/docs/content/guides/getting-started/demo/javascript/example.js
+++ b/docs/content/guides/getting-started/demo/javascript/example.js
@@ -134,6 +134,7 @@ const example = document.getElementById('example');
 new Handsontable(example, {
   data,
   height: 450,
+  width: '100%',
   colWidths: [180, 220, 140, 120, 120, 120, 140],
   colHeaders: ['Company Name', 'Name', 'Sell date', 'In stock', 'Quantity', 'Order ID', 'Country'],
   contextMenu: [

--- a/docs/content/guides/getting-started/demo/javascript/example.ts
+++ b/docs/content/guides/getting-started/demo/javascript/example.ts
@@ -143,6 +143,7 @@ const example = document.getElementById('example')!;
 new Handsontable(example, {
   data,
   height: 450,
+  width: '100%',
   colWidths: [180, 220, 140, 120, 120, 120, 140],
   colHeaders: ['Company Name', 'Name', 'Sell date', 'In stock', 'Quantity', 'Order ID', 'Country'],
   contextMenu: [


### PR DESCRIPTION
### Context

The PR fixes the getting-started demo size mismatch reported in DEV-1803.

The original fix (PR #12673) patched the old examples provider under `examples/prs/*`, but the getting-started demos are now rendered inline by the new self-hosted examples provider from `docs/content/guides/getting-started/demo/`. In that source the React, Angular, and Vue demos fill the container width (Vue sets `width: '100%'` explicitly; the framework wrappers fill the container), while the vanilla JavaScript demo had no `width` and sized itself to its column content — so it rendered noticeably narrower than the other three framework demos.

This change adds `width: '100%'` to the JavaScript demo (`example.js` and `example.ts`) so it matches the React, Angular, and Vue demos. No other framework demo is touched.

`[skip changelog]` — docs-example content only, no source-code change.

### How has this been tested?

- Confirmed all four getting-started demo configs (`javascript`, `react`, `angular`, `vue`) are otherwise identical (same `height: 450`, `colWidths`, `colHeaders`, and `columns`); the only remaining difference was the missing `width` on the JavaScript demo.
- Verified the JavaScript demo now carries `width: '100%'`, matching the width behavior of the other three framework demos.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1803

### Affected project(s):

- [x] `handsontable` (documentation examples only)
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1803

https://claude.ai/code/session_019TvUiBRsZ9NVL6ag84DxfQ


---
_Generated by [Claude Code](https://claude.ai/code/session_019TvUiBRsZ9NVL6ag84DxfQ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only example config tweak with no runtime product impact.
> 
> **Overview**
> Fixes **DEV-1803** by setting `width: '100%'` on the vanilla JavaScript getting-started Handsontable config in `example.js` and `example.ts`, so the grid fills the demo container like the React, Angular, and Vue tabs instead of sizing to column content and appearing narrower.
> 
> No library or framework wrapper code is changed—documentation demo content only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4588c2d0c41565e18239efcf99702eb626d65647. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->