### PR TITLE
DEV-2042: Fix doubled border under the Filters "Filter by value" list

### DIFF
--- a/.changelogs/13047.json
+++ b/.changelogs/13047.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed a doubled separator line under the \"Filter by value\" list in the dropdown menu.",
+  "type": "fixed",
+  "issueOrPR": 13047,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
+++ b/handsontable/src/plugins/filters/__tests__/filtersUI.spec.js
@@ -21,6 +21,27 @@ describe('Filters UI', () => {
     }
   });
 
+  it('should not draw the frame ring on the "Filter by value" list holder (its separator comes from the menu item)', async() => {
+    handsontable({
+      data: getDataForFilters(),
+      columns: getColumnsForFilters(),
+      filters: true,
+      dropdownMenu: true,
+      width: 500,
+      height: 300,
+    });
+
+    await dropdownMenu(1);
+
+    const embeddedHolder = document.querySelector('.htDropdownMenu .htUIMultipleSelect .ht_master .wtHolder');
+
+    // Without the override, the embedded value-list grid gets the base inset frame ring
+    // (box-shadow) because it has its own scrollbar; its bottom line then doubles with the
+    // `.htFiltersMenuValue` menu item's separator border right below it.
+    expect(embeddedHolder).not.toBe(null);
+    expect(getComputedStyle(embeddedHolder).boxShadow).toBe('none');
+  });
+
   it('should deselect all values in "Filter by value" after clicking "Clear" link', async() => {
     handsontable({
       data: getDataForFilters(),

--- a/handsontable/src/styles/components/plugins/_dropdown-menu.scss
+++ b/handsontable/src/styles/components/plugins/_dropdown-menu.scss
@@ -296,6 +296,13 @@
       background: transparent;
       border-radius: 0 !important;
 
+      // The "Filter by value" list is deliberately chrome-less - the `.htFiltersMenuValue`
+      // menu item draws the separator line below it. Without this override, the embedded
+      // grid's holder also gets the base inset frame ring (it has its own scrollbar), and
+      // the ring's bottom line doubles with that separator. `!important` because the base
+      // frame-ring selector carries more classes than this menu-scoped one.
+      box-shadow: none !important;
+
       .htCore {
         box-shadow: none;
       }


### PR DESCRIPTION
### Context

The PR fixes a doubled 1px line in the dropdown menu's Filters section, under the "Filter by value" list - a regression introduced with the 18.0 theme system (17.1 did not have it).

Since 18.0, grids that own their scrollbars draw their outer frame as an inset box-shadow ring on `.wtHolder` (`box-shadow: inset 0 0 0 1px var(--ht-border-color)` in `src/styles/base/_base.scss`). The "Filter by value" component embeds a small Handsontable instance for the value list, and that embedded grid's holder matches the same frame-ring rule (it has its own scrollbar). The ring's bottom line then renders directly above the `.htFiltersMenuValue` menu item's own separator border - two 1px lines, same color, one pixel apart.

The embedded value list is deliberately chrome-less: its holder already gets `background: transparent`, `border-radius: 0`, and `.htCore { box-shadow: none }` overrides in `_dropdown-menu.scss`. The frame ring was a leak into that set. The fix adds `box-shadow: none` next to those existing overrides, so the `.htFiltersMenuValue` separator is the single line below the list regardless of how many values the list holds. `!important` matches the neighboring declarations - the base frame-ring selector carries more classes than the menu-scoped one.

Root cause was verified in Chrome with a stacked-line detector (walking computed borders and inset shadows of every element in the open menu and reporting distinct sources within 2px): before the fix the pair was the embedded holder's ring + `td.htFiltersMenuValue` `border-bottom`; after the fix no stacked pairs remain in the menu.

#### v18
<img width="237" height="210" alt="image" src="https://github.com/user-attachments/assets/ca8831f8-2f50-4e23-ae80-c9bf368c8c14" />

### PR
<img width="237" height="198" alt="image" src="https://github.com/user-attachments/assets/08beb9a5-0ac3-4c01-9852-17e78eaf9cf9" />


Note: the same frame-ring mechanism also produces a doubled line at the main grid's bottom edge when scrolled fully down (last row's `border-bottom` + ring). That fix was prototyped but deliberately left out of this PR - it changes measured overlay heights (the bottom overlay gets 1px shorter), so it needs its own review round. This PR contains only the Filters fix, which has no layout impact.

### How has this been tested?

- New E2E test in `src/plugins/filters/__tests__/filtersUI.spec.js`: opens the dropdown menu and asserts the embedded value-list holder has no box-shadow.
  `npm run test:e2e --prefix handsontable --testPathPattern=filtersUI` - 68 specs, 0 failures.
- `npm run test:e2e --prefix handsontable --testPathPattern='core/resize'` - unaffected (8 specs, 0 failures).
- Full E2E suite, `eslint`, `stylelint` - green.
- Manual before/after on a local repro page (dropdown menu with Filters open, screenshots at high zoom).

Note on unit tests: the change is CSS-only (one SCSS declaration); the behavior is only observable in a rendered browser, so coverage is an E2E computed-style assertion rather than a Jest unit test.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2042

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/86canuuh2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped dropdown-menu styling and a visual regression test; no filter logic or layout measurement changes.
> 
> **Overview**
> Fixes a **18.0 theme regression** where two 1px lines appeared under the Filters **Filter by value** list in the column dropdown menu.
> 
> The embedded value-list grid’s `.wtHolder` was still getting the global scrollbar **inset frame ring** (`box-shadow`), which stacked on top of the `.htFiltersMenuValue` menu row separator. **`_dropdown-menu.scss`** now sets **`box-shadow: none !important`** on that holder (alongside existing chrome-less overrides) so only the menu item draws the bottom line.
> 
> Adds an E2E check in **`filtersUI.spec.js`** that the embedded holder’s computed `boxShadow` is `none`, plus a changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37cbdc07ae4bd40876986da08a598af160f84ad3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->