### PR TITLE
Fix Docker redirect for 2026 TestArmy certificate

### DIFF
--- a/docs/docker/redirects.conf
+++ b/docs/docker/redirects.conf
@@ -220,6 +220,7 @@ rewrite ^/docs/sitemap\.xml$ /docs/sitemap-index.xml permanent;
 #  * /testarmy-certificate.pdf
 #  * /testarmy-certificate-2024.pdf
 #  * /testarmy-certificate-2025.pdf
+#  * /testarmy-certificate-2026.pdf
 
-rewrite ^/docs/((?:\d+\.\d+|next)/)(?!(?:javascript|react|angular)-data-grid|redirect|assets/|data/|handsontable|@handsontable/|img/|scripts/|404\.html|sitemap[^/]*\.xml|securitum-certificate\.pdf|seqred-certificate\.pdf|testarmy-certificate\.pdf|testarmy-certificate-2024\.pdf|testarmy-certificate-2025\.pdf)(.+)$ /docs/$1$framework/$2 permanent;
-rewrite ^/docs/(?!\d+\.\d+|next\/)(?!(?:javascript|react|angular)-data-grid|redirect|assets/|data/|handsontable/|@handsontable/|img/|scripts/|404\.html|sitemap[^/]*\.xml|securitum-certificate\.pdf|seqred-certificate\.pdf|testarmy-certificate\.pdf|testarmy-certificate-2024\.pdf|testarmy-certificate-2025\.pdf)(.+)$ /docs/$framework/$1 permanent;
+rewrite ^/docs/((?:\d+\.\d+|next)/)(?!(?:javascript|react|angular)-data-grid|redirect|assets/|data/|handsontable|@handsontable/|img/|scripts/|404\.html|sitemap[^/]*\.xml|securitum-certificate\.pdf|seqred-certificate\.pdf|testarmy-certificate\.pdf|testarmy-certificate-2024\.pdf|testarmy-certificate-2025\.pdf|testarmy-certificate-2026\.pdf)(.+)$ /docs/$1$framework/$2 permanent;
+rewrite ^/docs/(?!\d+\.\d+|next\/)(?!(?:javascript|react|angular)-data-grid|redirect|assets/|data/|handsontable/|@handsontable/|img/|scripts/|404\.html|sitemap[^/]*\.xml|securitum-certificate\.pdf|seqred-certificate\.pdf|testarmy-certificate\.pdf|testarmy-certificate-2024\.pdf|testarmy-certificate-2025\.pdf|testarmy-certificate-2026\.pdf)(.+)$ /docs/$framework/$1 permanent;


### PR DESCRIPTION
### Context

This PR fixes the Docker/Nginx redirect configuration for the 2026 TestArmy certificate download.

The docs security guide links to `/docs/testarmy-certificate-2026.pdf`, but `docs/docker/redirects.conf` did not exclude that PDF from framework-prefix rewrites. Docker-served docs could therefore rewrite the certificate URL to a framework-prefixed path and break the download.

The change adds the 2026 certificate to the same exclusion list that already contains the 2023, 2024, and 2025 certificate PDFs.

### How has this been tested?

- Checked the resulting diff against `develop`.
- Checked linter diagnostics for `docs/docker/redirects.conf`.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. Follow-up to the production docs backport review in #13048.

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`
- [x] `handsontable-documentation`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file Nginx config change aligned with prior certificate exclusions; no auth, data, or application logic.
> 
> **Overview**
> **Fixes broken `/docs/testarmy-certificate-2026.pdf` downloads** when docs are served via Docker/Nginx.
> 
> The catch-all rules that prefix paths with `javascript-data-grid` (or cookie-selected framework) now **skip** `testarmy-certificate-2026.pdf`, matching the existing exclusions for the 2023–2025 certificate PDFs. A comment in `redirects.conf` documents the new exception.
> 
> Without this change, requests for the 2026 certificate URL could be rewritten to a framework-prefixed path and fail even though the security guide already links to the bare PDF path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9259661e8250481cd67d85919d9e51eb148efb1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->