### PR TITLE
DEV-697: Add valueFormatter demo for non-Intl symbols in cell renderer guide

### DIFF
--- a/docs/content/guides/cell-functions/cell-renderer/angular/example7.html
+++ b/docs/content/guides/cell-functions/cell-renderer/angular/example7.html
@@ -1,0 +1,3 @@
+<div>
+    <example7-cell-renderer></example7-cell-renderer>
+</div>

--- a/docs/content/guides/cell-functions/cell-renderer/angular/example7.ts
+++ b/docs/content/guides/cell-functions/cell-renderer/angular/example7.ts
@@ -1,0 +1,65 @@
+/* file: app.component.ts */
+import { Component } from '@angular/core';
+import { GridSettings, HotTableModule } from '@handsontable/angular-wrapper';
+
+@Component({
+  standalone: true,
+  imports: [HotTableModule],
+  selector: 'example7-cell-renderer',
+  template: `
+    <div>
+      <hot-table [settings]="gridSettings"></hot-table>
+    </div>
+  `,
+})
+export class AppComponent {
+  readonly data = [
+    { asset: 'Bitcoin', btcValue: 12.45, portfolioShare: 452 },
+    { asset: 'Ethereum', btcValue: 3.82, portfolioShare: 268 },
+    { asset: 'Solana', btcValue: 1.15, portfolioShare: 134 },
+    { asset: 'Cardano', btcValue: 0.47, portfolioShare: 81 },
+    { asset: 'Polkadot', btcValue: 0.29, portfolioShare: 65 },
+  ];
+
+  readonly gridSettings: GridSettings = {
+    data: this.data,
+    colHeaders: ['Asset', 'BTC-equivalent value', 'Portfolio share'],
+    columns: [
+      { data: 'asset' },
+      {
+        data: 'btcValue',
+        // Bitcoin (₿) isn't an ISO 4217 currency, so `numericFormat` can't format it.
+        // `valueFormatter` prepends the symbol instead.
+        valueFormatter(value: number) {
+          return `₿${value.toFixed(4)}`;
+        },
+      },
+      {
+        data: 'portfolioShare',
+        // Per mille (‰) isn't a unit sanctioned by `Intl.NumberFormat`, so `valueFormatter`
+        // appends the symbol manually.
+        valueFormatter(value: number) {
+          return `${value}‰`;
+        },
+      },
+    ],
+    height: 'auto',
+  };
+}
+/* end-file */
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    { provide: HOT_GLOBAL_CONFIG, useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig },
+  ],
+};
+/* end-file */

--- a/docs/content/guides/cell-functions/cell-renderer/cell-renderer.md
+++ b/docs/content/guides/cell-functions/cell-renderer/cell-renderer.md
@@ -770,6 +770,53 @@ settings = {
 
 In this example, `valueFormatter` adds the currency symbol and formatting, while `renderer` wraps it in a custom DOM structure with additional styling.
 
+#### Format symbols outside the `Intl` standard
+
+The `numeric` renderer's `numericFormat` option formats numbers through `Intl.NumberFormat`, which only recognizes ISO 4217 currency codes and a fixed list of ECMA-402 sanctioned units. Symbols outside that list, such as the Bitcoin symbol (₿) or per mille (‰), aren't available through `numericFormat`. Attach them with `valueFormatter` instead:
+
+::: only-for javascript
+
+::: example #example6 --js 1 --ts 2
+
+@[code](@/content/guides/cell-functions/cell-renderer/javascript/example6.js)
+@[code](@/content/guides/cell-functions/cell-renderer/javascript/example6.ts)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #example6 :react --js 1 --ts 2
+
+@[code](@/content/guides/cell-functions/cell-renderer/react/example6.jsx)
+@[code](@/content/guides/cell-functions/cell-renderer/react/example6.tsx)
+
+:::
+
+:::
+
+::: only-for angular
+
+::: example #example7 :angular --ts 1 --html 2
+
+@[code](@/content/guides/cell-functions/cell-renderer/angular/example7.ts)
+@[code](@/content/guides/cell-functions/cell-renderer/angular/example7.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example6 :vue3
+
+@[code](@/content/guides/cell-functions/cell-renderer/vue/example6.vue)
+
+:::
+
+:::
+
 ### Configuration options and API
 
 ::: only-for javascript

--- a/docs/content/guides/cell-functions/cell-renderer/javascript/example6.js
+++ b/docs/content/guides/cell-functions/cell-renderer/javascript/example6.js
@@ -1,0 +1,37 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+// Register all Handsontable's modules.
+registerAllModules();
+const data = [
+    { asset: 'Bitcoin', btcValue: 12.45, portfolioShare: 452 },
+    { asset: 'Ethereum', btcValue: 3.82, portfolioShare: 268 },
+    { asset: 'Solana', btcValue: 1.15, portfolioShare: 134 },
+    { asset: 'Cardano', btcValue: 0.47, portfolioShare: 81 },
+    { asset: 'Polkadot', btcValue: 0.29, portfolioShare: 65 },
+];
+const container = document.querySelector('#example6');
+new Handsontable(container, {
+    data,
+    colHeaders: ['Asset', 'BTC-equivalent value', 'Portfolio share'],
+    columns: [
+        { data: 'asset' },
+        {
+            data: 'btcValue',
+            // Bitcoin (₿) isn't an ISO 4217 currency, so `numericFormat` can't format it.
+            // `valueFormatter` prepends the symbol instead.
+            valueFormatter(value) {
+                return `₿${value.toFixed(4)}`;
+            },
+        },
+        {
+            data: 'portfolioShare',
+            // Per mille (‰) isn't a unit sanctioned by `Intl.NumberFormat`, so `valueFormatter`
+            // appends the symbol manually.
+            valueFormatter(value) {
+                return `${value}‰`;
+            },
+        },
+    ],
+    height: 'auto',
+    licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/cell-functions/cell-renderer/javascript/example6.ts
+++ b/docs/content/guides/cell-functions/cell-renderer/javascript/example6.ts
@@ -1,0 +1,47 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+// Register all Handsontable's modules.
+registerAllModules();
+
+interface Holding {
+  asset: string;
+  btcValue: number;
+  portfolioShare: number;
+}
+
+const data: Holding[] = [
+  { asset: 'Bitcoin', btcValue: 12.45, portfolioShare: 452 },
+  { asset: 'Ethereum', btcValue: 3.82, portfolioShare: 268 },
+  { asset: 'Solana', btcValue: 1.15, portfolioShare: 134 },
+  { asset: 'Cardano', btcValue: 0.47, portfolioShare: 81 },
+  { asset: 'Polkadot', btcValue: 0.29, portfolioShare: 65 },
+];
+
+const container = document.querySelector('#example6')!;
+
+new Handsontable(container, {
+  data,
+  colHeaders: ['Asset', 'BTC-equivalent value', 'Portfolio share'],
+  columns: [
+    { data: 'asset' },
+    {
+      data: 'btcValue',
+      // Bitcoin (₿) isn't an ISO 4217 currency, so `numericFormat` can't format it.
+      // `valueFormatter` prepends the symbol instead.
+      valueFormatter(value) {
+        return `₿${value.toFixed(4)}`;
+      },
+    },
+    {
+      data: 'portfolioShare',
+      // Per mille (‰) isn't a unit sanctioned by `Intl.NumberFormat`, so `valueFormatter`
+      // appends the symbol manually.
+      valueFormatter(value) {
+        return `${value}‰`;
+      },
+    },
+  ],
+  height: 'auto',
+  licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/cell-functions/cell-renderer/react/example6.jsx
+++ b/docs/content/guides/cell-functions/cell-renderer/react/example6.jsx
@@ -1,0 +1,33 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+// register Handsontable's modules
+registerAllModules();
+const ExampleComponent = () => {
+    const data = [
+        { asset: 'Bitcoin', btcValue: 12.45, portfolioShare: 452 },
+        { asset: 'Ethereum', btcValue: 3.82, portfolioShare: 268 },
+        { asset: 'Solana', btcValue: 1.15, portfolioShare: 134 },
+        { asset: 'Cardano', btcValue: 0.47, portfolioShare: 81 },
+        { asset: 'Polkadot', btcValue: 0.29, portfolioShare: 65 },
+    ];
+    return (<HotTable data={data} colHeaders={['Asset', 'BTC-equivalent value', 'Portfolio share']} columns={[
+            { data: 'asset' },
+            {
+                data: 'btcValue',
+                // Bitcoin (₿) isn't an ISO 4217 currency, so `numericFormat` can't format it.
+                // `valueFormatter` prepends the symbol instead.
+                valueFormatter(value) {
+                    return `₿${value.toFixed(4)}`;
+                },
+            },
+            {
+                data: 'portfolioShare',
+                // Per mille (‰) isn't a unit sanctioned by `Intl.NumberFormat`, so `valueFormatter`
+                // appends the symbol manually.
+                valueFormatter(value) {
+                    return `${value}‰`;
+                },
+            },
+        ]} height="auto" licenseKey="non-commercial-and-evaluation"/>);
+};
+export default ExampleComponent;

--- a/docs/content/guides/cell-functions/cell-renderer/react/example6.tsx
+++ b/docs/content/guides/cell-functions/cell-renderer/react/example6.tsx
@@ -1,0 +1,45 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const ExampleComponent = () => {
+  const data = [
+    { asset: 'Bitcoin', btcValue: 12.45, portfolioShare: 452 },
+    { asset: 'Ethereum', btcValue: 3.82, portfolioShare: 268 },
+    { asset: 'Solana', btcValue: 1.15, portfolioShare: 134 },
+    { asset: 'Cardano', btcValue: 0.47, portfolioShare: 81 },
+    { asset: 'Polkadot', btcValue: 0.29, portfolioShare: 65 },
+  ];
+
+  return (
+    <HotTable
+      data={data}
+      colHeaders={['Asset', 'BTC-equivalent value', 'Portfolio share']}
+      columns={[
+        { data: 'asset' },
+        {
+          data: 'btcValue',
+          // Bitcoin (₿) isn't an ISO 4217 currency, so `numericFormat` can't format it.
+          // `valueFormatter` prepends the symbol instead.
+          valueFormatter(value: number) {
+            return `₿${value.toFixed(4)}`;
+          },
+        },
+        {
+          data: 'portfolioShare',
+          // Per mille (‰) isn't a unit sanctioned by `Intl.NumberFormat`, so `valueFormatter`
+          // appends the symbol manually.
+          valueFormatter(value: number) {
+            return `${value}‰`;
+          },
+        },
+      ]}
+      height="auto"
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/cell-functions/cell-renderer/vue/example6.vue
+++ b/docs/content/guides/cell-functions/cell-renderer/vue/example6.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+interface Holding {
+  asset: string;
+  btcValue: number;
+  portfolioShare: number;
+}
+
+const data: Holding[] = [
+  { asset: 'Bitcoin', btcValue: 12.45, portfolioShare: 452 },
+  { asset: 'Ethereum', btcValue: 3.82, portfolioShare: 268 },
+  { asset: 'Solana', btcValue: 1.15, portfolioShare: 134 },
+  { asset: 'Cardano', btcValue: 0.47, portfolioShare: 81 },
+  { asset: 'Polkadot', btcValue: 0.29, portfolioShare: 65 },
+];
+
+const hotSettings = ref<GridSettings>({
+  data,
+  colHeaders: ['Asset', 'BTC-equivalent value', 'Portfolio share'],
+  columns: [
+    { data: 'asset' },
+    {
+      data: 'btcValue',
+      // Bitcoin (₿) isn't an ISO 4217 currency, so `numericFormat` can't format it.
+      // `valueFormatter` prepends the symbol instead.
+      valueFormatter(value: number) {
+        return `₿${value.toFixed(4)}`;
+      },
+    },
+    {
+      data: 'portfolioShare',
+      // Per mille (‰) isn't a unit sanctioned by `Intl.NumberFormat`, so `valueFormatter`
+      // appends the symbol manually.
+      valueFormatter(value: number) {
+        return `${value}‰`;
+      },
+    },
+  ],
+  height: 'auto',
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example6">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>


### PR DESCRIPTION
### Context

The PR closes the remaining gap in DEV-697. That 2023 ticket asked for four new demos in the "Rendering cells" guide (now `cell-renderer.md`): Bitcoin symbol, percentage, per mille, and Celsius symbol formatting. Percentage and Celsius are already covered natively via `numericFormat: { style: 'percent' | 'unit' }` since `numericFormat` migrated to `Intl.NumberFormat`. Bitcoin (₿) and per mille (‰) are not ISO 4217 currencies or ECMA-402 sanctioned units, so `numericFormat` can't format them — that part of the ticket was still open.

This adds a runnable example (JS, React, Angular, Vue) to the `renderer` vs `valueFormatter` section of the cell renderer guide, showing `valueFormatter` as the correct tool for attaching non-standard symbols to numeric values.

### How has this been tested?

- Ran the docs dev server (`ASTRO_DEV_BACKGROUND=1 npm run dev` from `docs/`) and verified the new example renders correctly (HTTP 200, correct content, no console/build errors) on all four framework pages: `/docs/javascript-data-grid/cell-renderer/`, `/docs/react-data-grid/cell-renderer/`, `/docs/angular-data-grid/cell-renderer/`, `/docs/vue-data-grid/cell-renderer/`.
- Generated the JS variant from TypeScript via `npm run docs:code-examples:generate-js -- content/guides/cell-functions/cell-renderer/javascript/example6.ts` (and the React `.tsx` equivalent).

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-697

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-697

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and example snippets only; no runtime library or API changes.
> 
> **Overview**
> Adds a **“Format symbols outside the `Intl` standard”** subsection to the cell renderer guide’s `renderer` vs `valueFormatter` section, explaining that `numericFormat` / `Intl.NumberFormat` cannot represent symbols like ₿ or ‰ and that **`valueFormatter`** is the right approach.
> 
> The change wires in new runnable **example6** demos (JS/TS, React, Vue) and **example7** for Angular (since example6 is already used elsewhere in that guide), all using the same crypto-portfolio grid with ₿ and ‰ formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ad4b96a0c6ea2e414ca8d2e9bf1d58952dd1f40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->