### PR TITLE
DEV-700: Add Comments guide demos for invalid cells and reading comments

### DIFF
--- a/docs/content/guides/cell-features/comments/angular/example5.html
+++ b/docs/content/guides/cell-features/comments/angular/example5.html
@@ -1,0 +1,3 @@
+<div>
+  <example5-comments></example5-comments>
+</div>

--- a/docs/content/guides/cell-features/comments/angular/example5.ts
+++ b/docs/content/guides/cell-features/comments/angular/example5.ts
@@ -1,0 +1,77 @@
+/* file: app.component.ts */
+import { Component } from '@angular/core';
+import Handsontable from 'handsontable/base';
+import { GridSettings, HotTableModule } from '@handsontable/angular-wrapper';
+
+@Component({
+  selector: 'example5-comments',
+  standalone: true,
+  imports: [HotTableModule],
+  template: ` <div>
+    <hot-table [data]="data" [settings]="gridSettings"></hot-table>
+  </div>`,
+})
+export class AppComponent {
+
+  readonly data = [
+    ['Wireless mouse', 142],
+    ['USB-C cable', 67],
+    ['Mechanical keyboard', -5],
+    ['Laptop stand', 38],
+    ['HDMI adapter', 210],
+  ];
+
+  readonly gridSettings: GridSettings = {
+    colHeaders: ['Product', 'Stock'],
+    rowHeaders: true,
+    comments: true,
+    columns: [
+      {},
+      {
+        type: 'numeric',
+        validator(value: any, callback: (valid: boolean) => void) {
+          callback(Number.isInteger(value) && value >= 0);
+        },
+      },
+    ],
+    // Attach a comment when a cell fails validation, and remove it once the cell is valid.
+    afterValidate(this: Handsontable, isValid: boolean, value: any, row: number, prop: string | number) {
+      const column = this.propToCol(prop);
+      const comments = this.getPlugin('comments');
+
+      if (!isValid) {
+        comments.setCommentAtCell(row, column, `"${value}" is not valid. Enter a whole number of 0 or more.`);
+      } else {
+        comments.removeCommentAtCell(row, column);
+      }
+    },
+    // Validate every cell on load so the pre-existing invalid value is flagged right away.
+    afterInit(this: Handsontable) {
+      this.validateCells();
+    },
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true
+  };
+}
+/* end-file */
+
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+/* end-file */

--- a/docs/content/guides/cell-features/comments/angular/example6.html
+++ b/docs/content/guides/cell-features/comments/angular/example6.html
@@ -1,0 +1,3 @@
+<div>
+  <example6-comments></example6-comments>
+</div>

--- a/docs/content/guides/cell-features/comments/angular/example6.ts
+++ b/docs/content/guides/cell-features/comments/angular/example6.ts
@@ -55,7 +55,7 @@ export class AppComponent {
     // `getCellMetaAtRow()` takes a physical row index (equal to the visual index here, with no sorting or trimming).
     for (let row = 0; row < hot.countRows(); row += 1) {
       hot.getCellMetaAtRow(row).forEach((cellMeta, col) => {
-        const comment = cellMeta.comment as { value?: string } | undefined;
+        const comment = cellMeta['comment'] as { value?: string } | undefined;
 
         if (comment?.value !== undefined) {
           found.push(`Row ${row + 1}, "${hot.getColHeader(col)}": ${comment.value}`);

--- a/docs/content/guides/cell-features/comments/angular/example6.ts
+++ b/docs/content/guides/cell-features/comments/angular/example6.ts
@@ -1,0 +1,89 @@
+/* file: app.component.ts */
+import { Component, ViewChild } from '@angular/core';
+import { GridSettings, HotTableComponent, HotTableModule } from '@handsontable/angular-wrapper';
+
+@Component({
+  selector: 'example6-comments',
+  standalone: true,
+  imports: [HotTableModule],
+  template: ` <div class="example-controls-container">
+      <div class="controls">
+        <button id="list-comments" (click)="listComments()">List all comments</button>
+      </div>
+    </div>
+    <div>
+      <hot-table [data]="data" [settings]="gridSettings"></hot-table>
+    </div>
+    <output class="comments-output" style="white-space: pre-wrap">{{ output }}</output>`,
+})
+export class AppComponent {
+  @ViewChild(HotTableComponent, { static: false }) readonly hotTable!: HotTableComponent;
+
+  readonly data = [
+    ['Update API docs', 'Ana García', 'In progress'],
+    ['Deploy hotfix', 'James Okafor', 'Blocked'],
+    ['Review pull requests', 'Li Wei', 'Done'],
+    ['Plan Q3 roadmap', 'Maria Santos', 'In progress'],
+    ['Refactor auth module', 'David Kim', 'In review'],
+  ];
+
+  readonly gridSettings: GridSettings = {
+    colHeaders: ['Task', 'Assignee', 'Status'],
+    rowHeaders: true,
+    comments: true,
+    cell: [
+      { row: 1, col: 2, comment: { value: 'Waiting on infrastructure approval.' } },
+      { row: 3, col: 1, comment: { value: 'Reassign if capacity is tight.' } },
+      { row: 4, col: 0, comment: { value: 'Blocked on the security review.' } },
+    ],
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true
+  };
+
+  output = '';
+
+  listComments(): void {
+    const hot = this.hotTable?.hotInstance;
+
+    if (!hot) {
+      return;
+    }
+
+    const found: string[] = [];
+
+    // `getCellMetaAtRow()` takes a physical row index (equal to the visual index here, with no sorting or trimming).
+    for (let row = 0; row < hot.countRows(); row += 1) {
+      hot.getCellMetaAtRow(row).forEach((cellMeta, col) => {
+        const comment = cellMeta.comment as { value?: string } | undefined;
+
+        if (comment?.value !== undefined) {
+          found.push(`Row ${row + 1}, "${hot.getColHeader(col)}": ${comment.value}`);
+        }
+      });
+    }
+
+    this.output = found.length > 0 ? found.join('\n') : 'No comments found.';
+  }
+}
+/* end-file */
+
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+/* end-file */

--- a/docs/content/guides/cell-features/comments/comments.md
+++ b/docs/content/guides/cell-features/comments/comments.md
@@ -15,6 +15,7 @@ vue:
   metaTitle: Comments - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell features
+menuTag: updated
 ---
 Add a comment (a note) to a cell, using the context menu, just like in Excel. Edit and delete comments. Make comments read-only.
 
@@ -328,6 +329,101 @@ To display comments after a pre-configured time delay, use the [`displayDelay`](
 ::: example #example4 :vue3
 
 @[code](@/content/guides/cell-features/comments/vue/example4.vue)
+
+:::
+
+:::
+
+## Flag invalid cells with a comment
+
+Combine comments with validation to explain data-entry errors. This example adds a comment to a cell when it fails validation and removes the comment once the value is valid. The [`afterValidate`](@/api/hooks.md#aftervalidate) hook drives the change, and [`setCommentAtCell()`](@/api/comments.md#setcommentatcell) writes the message. The grid validates on load, so the **Mechanical keyboard** row starts with an invalid stock value and shows its comment right away. Edit any **Stock** cell and enter a negative number or text to flag it, or enter a valid whole number to clear the flag.
+
+::: only-for javascript
+
+::: example #example5 --js 1 --ts 2
+
+@[code](@/content/guides/cell-features/comments/javascript/example5.js)
+@[code](@/content/guides/cell-features/comments/javascript/example5.ts)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #example5 :react --js 1 --ts 2
+
+@[code](@/content/guides/cell-features/comments/react/example5.jsx)
+@[code](@/content/guides/cell-features/comments/react/example5.tsx)
+
+:::
+
+:::
+
+::: only-for angular
+
+::: example #example5 :angular --ts 1 --html 2
+
+@[code](@/content/guides/cell-features/comments/angular/example5.ts)
+@[code](@/content/guides/cell-features/comments/angular/example5.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example5 :vue3
+
+@[code](@/content/guides/cell-features/comments/vue/example5.vue)
+
+:::
+
+:::
+
+## Read all comments programmatically
+
+To collect every comment in the grid, loop through the rows and read each cell's metadata with [`getCellMetaAtRow()`](@/api/core.md#getcellmetaatrow). Each returned cell-meta object stores its comment under the `comment` key. Click **List all comments** to print all comments below the grid.
+
+::: only-for javascript
+
+::: example #example6 --html 1 --js 2 --ts 3
+
+@[code](@/content/guides/cell-features/comments/javascript/example6.html)
+@[code](@/content/guides/cell-features/comments/javascript/example6.js)
+@[code](@/content/guides/cell-features/comments/javascript/example6.ts)
+
+:::
+
+:::
+
+::: only-for react
+
+::: example #example6 :react --js 1 --ts 2
+
+@[code](@/content/guides/cell-features/comments/react/example6.jsx)
+@[code](@/content/guides/cell-features/comments/react/example6.tsx)
+
+:::
+
+:::
+
+::: only-for angular
+
+::: example #example6 :angular --ts 1 --html 2
+
+@[code](@/content/guides/cell-features/comments/angular/example6.ts)
+@[code](@/content/guides/cell-features/comments/angular/example6.html)
+
+:::
+
+:::
+
+::: only-for vue
+
+::: example #example6 :vue3
+
+@[code](@/content/guides/cell-features/comments/vue/example6.vue)
 
 :::
 

--- a/docs/content/guides/cell-features/comments/javascript/example5.js
+++ b/docs/content/guides/cell-features/comments/javascript/example5.js
@@ -1,0 +1,45 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+// Register all Handsontable's modules.
+registerAllModules();
+const container = document.querySelector('#example5');
+new Handsontable(container, {
+    data: [
+        ['Wireless mouse', 142],
+        ['USB-C cable', 67],
+        ['Mechanical keyboard', -5],
+        ['Laptop stand', 38],
+        ['HDMI adapter', 210],
+    ],
+    colHeaders: ['Product', 'Stock'],
+    rowHeaders: true,
+    comments: true,
+    columns: [
+        {},
+        {
+            type: 'numeric',
+            validator(value, callback) {
+                callback(Number.isInteger(value) && value >= 0);
+            },
+        },
+    ],
+    // Attach a comment when a cell fails validation, and remove it once the cell is valid.
+    afterValidate(isValid, value, row, prop) {
+        const column = this.propToCol(prop);
+        const comments = this.getPlugin('comments');
+        if (!isValid) {
+            comments.setCommentAtCell(row, column, `"${value}" is not valid. Enter a whole number of 0 or more.`);
+        }
+        else {
+            comments.removeCommentAtCell(row, column);
+        }
+    },
+    // Validate every cell on load so the pre-existing invalid value is flagged right away.
+    afterInit() {
+        this.validateCells();
+    },
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true,
+    licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/cell-features/comments/javascript/example5.ts
+++ b/docs/content/guides/cell-features/comments/javascript/example5.ts
@@ -1,0 +1,48 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+// Register all Handsontable's modules.
+registerAllModules();
+
+const container = document.querySelector('#example5')!;
+
+new Handsontable(container, {
+  data: [
+    ['Wireless mouse', 142],
+    ['USB-C cable', 67],
+    ['Mechanical keyboard', -5],
+    ['Laptop stand', 38],
+    ['HDMI adapter', 210],
+  ],
+  colHeaders: ['Product', 'Stock'],
+  rowHeaders: true,
+  comments: true,
+  columns: [
+    {},
+    {
+      type: 'numeric',
+      validator(value: any, callback: (valid: boolean) => void) {
+        callback(Number.isInteger(value) && value >= 0);
+      },
+    },
+  ],
+  // Attach a comment when a cell fails validation, and remove it once the cell is valid.
+  afterValidate(isValid, value, row, prop) {
+    const column = this.propToCol(prop);
+    const comments = this.getPlugin('comments');
+
+    if (!isValid) {
+      comments.setCommentAtCell(row, column, `"${value}" is not valid. Enter a whole number of 0 or more.`);
+    } else {
+      comments.removeCommentAtCell(row, column);
+    }
+  },
+  // Validate every cell on load so the pre-existing invalid value is flagged right away.
+  afterInit() {
+    this.validateCells();
+  },
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/cell-features/comments/javascript/example6.html
+++ b/docs/content/guides/cell-features/comments/javascript/example6.html
@@ -1,0 +1,7 @@
+<div class="example-controls-container">
+  <div class="controls">
+    <button id="list-comments">List all comments</button>
+  </div>
+</div>
+<div id="example6"></div>
+<output id="comments-output" class="comments-output" style="white-space: pre-wrap;"></output>

--- a/docs/content/guides/cell-features/comments/javascript/example6.js
+++ b/docs/content/guides/cell-features/comments/javascript/example6.js
@@ -1,0 +1,41 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+// Register all Handsontable's modules.
+registerAllModules();
+const container = document.querySelector('#example6');
+const hot = new Handsontable(container, {
+    data: [
+        ['Update API docs', 'Ana García', 'In progress'],
+        ['Deploy hotfix', 'James Okafor', 'Blocked'],
+        ['Review pull requests', 'Li Wei', 'Done'],
+        ['Plan Q3 roadmap', 'Maria Santos', 'In progress'],
+        ['Refactor auth module', 'David Kim', 'In review'],
+    ],
+    colHeaders: ['Task', 'Assignee', 'Status'],
+    rowHeaders: true,
+    comments: true,
+    cell: [
+        { row: 1, col: 2, comment: { value: 'Waiting on infrastructure approval.' } },
+        { row: 3, col: 1, comment: { value: 'Reassign if capacity is tight.' } },
+        { row: 4, col: 0, comment: { value: 'Blocked on the security review.' } },
+    ],
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true,
+    licenseKey: 'non-commercial-and-evaluation',
+});
+const button = document.querySelector('#list-comments');
+const output = document.querySelector('#comments-output');
+button.addEventListener('click', () => {
+    const found = [];
+    // `getCellMetaAtRow()` takes a physical row index (equal to the visual index here, with no sorting or trimming).
+    for (let row = 0; row < hot.countRows(); row += 1) {
+        hot.getCellMetaAtRow(row).forEach((cellMeta, col) => {
+            const comment = cellMeta.comment;
+            if (comment?.value !== undefined) {
+                found.push(`Row ${row + 1}, "${hot.getColHeader(col)}": ${comment.value}`);
+            }
+        });
+    }
+    output.textContent = found.length > 0 ? found.join('\n') : 'No comments found.';
+});

--- a/docs/content/guides/cell-features/comments/javascript/example6.ts
+++ b/docs/content/guides/cell-features/comments/javascript/example6.ts
@@ -1,0 +1,49 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+// Register all Handsontable's modules.
+registerAllModules();
+
+const container = document.querySelector('#example6')!;
+
+const hot = new Handsontable(container, {
+  data: [
+    ['Update API docs', 'Ana García', 'In progress'],
+    ['Deploy hotfix', 'James Okafor', 'Blocked'],
+    ['Review pull requests', 'Li Wei', 'Done'],
+    ['Plan Q3 roadmap', 'Maria Santos', 'In progress'],
+    ['Refactor auth module', 'David Kim', 'In review'],
+  ],
+  colHeaders: ['Task', 'Assignee', 'Status'],
+  rowHeaders: true,
+  comments: true,
+  cell: [
+    { row: 1, col: 2, comment: { value: 'Waiting on infrastructure approval.' } },
+    { row: 3, col: 1, comment: { value: 'Reassign if capacity is tight.' } },
+    { row: 4, col: 0, comment: { value: 'Blocked on the security review.' } },
+  ],
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+const button = document.querySelector('#list-comments')!;
+const output = document.querySelector('#comments-output')!;
+
+button.addEventListener('click', () => {
+  const found: string[] = [];
+
+  // `getCellMetaAtRow()` takes a physical row index (equal to the visual index here, with no sorting or trimming).
+  for (let row = 0; row < hot.countRows(); row += 1) {
+    hot.getCellMetaAtRow(row).forEach((cellMeta, col) => {
+      const comment = cellMeta.comment as { value?: string } | undefined;
+
+      if (comment?.value !== undefined) {
+        found.push(`Row ${row + 1}, "${hot.getColHeader(col)}": ${comment.value}`);
+      }
+    });
+  }
+
+  output.textContent = found.length > 0 ? found.join('\n') : 'No comments found.';
+});

--- a/docs/content/guides/cell-features/comments/react/example5.jsx
+++ b/docs/content/guides/cell-features/comments/react/example5.jsx
@@ -1,0 +1,37 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+// register Handsontable's modules
+registerAllModules();
+const ExampleComponent = () => {
+    return (<HotTable data={[
+            ['Wireless mouse', 142],
+            ['USB-C cable', 67],
+            ['Mechanical keyboard', -5],
+            ['Laptop stand', 38],
+            ['HDMI adapter', 210],
+        ]} colHeaders={['Product', 'Stock']} rowHeaders={true} comments={true} columns={[
+            {},
+            {
+                type: 'numeric',
+                validator(value, callback) {
+                    callback(Number.isInteger(value) && value >= 0);
+                },
+            },
+        ]} 
+    // Attach a comment when a cell fails validation, and remove it once the cell is valid.
+    afterValidate={function (isValid, value, row, prop) {
+            const column = this.propToCol(prop);
+            const comments = this.getPlugin('comments');
+            if (!isValid) {
+                comments.setCommentAtCell(row, column, `"${value}" is not valid. Enter a whole number of 0 or more.`);
+            }
+            else {
+                comments.removeCommentAtCell(row, column);
+            }
+        }} 
+    // Validate every cell on load so the pre-existing invalid value is flagged right away.
+    afterInit={function () {
+            this.validateCells();
+        }} height="auto" autoWrapRow={true} autoWrapCol={true} licenseKey="non-commercial-and-evaluation"/>);
+};
+export default ExampleComponent;

--- a/docs/content/guides/cell-features/comments/react/example5.tsx
+++ b/docs/content/guides/cell-features/comments/react/example5.tsx
@@ -1,0 +1,53 @@
+import Handsontable from 'handsontable/base';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={[
+        ['Wireless mouse', 142],
+        ['USB-C cable', 67],
+        ['Mechanical keyboard', -5],
+        ['Laptop stand', 38],
+        ['HDMI adapter', 210],
+      ]}
+      colHeaders={['Product', 'Stock']}
+      rowHeaders={true}
+      comments={true}
+      columns={[
+        {},
+        {
+          type: 'numeric',
+          validator(value: any, callback: (valid: boolean) => void) {
+            callback(Number.isInteger(value) && value >= 0);
+          },
+        },
+      ]}
+      // Attach a comment when a cell fails validation, and remove it once the cell is valid.
+      afterValidate={function (this: Handsontable, isValid, value, row, prop) {
+        const column = this.propToCol(prop);
+        const comments = this.getPlugin('comments');
+
+        if (!isValid) {
+          comments.setCommentAtCell(row, column, `"${value}" is not valid. Enter a whole number of 0 or more.`);
+        } else {
+          comments.removeCommentAtCell(row, column);
+        }
+      }}
+      // Validate every cell on load so the pre-existing invalid value is flagged right away.
+      afterInit={function (this: Handsontable) {
+        this.validateCells();
+      }}
+      height="auto"
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/cell-features/comments/react/example6.jsx
+++ b/docs/content/guides/cell-features/comments/react/example6.jsx
@@ -1,0 +1,50 @@
+import { useRef, useState } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+// register Handsontable's modules
+registerAllModules();
+const ExampleComponent = () => {
+    const hotRef = useRef(null);
+    const [output, setOutput] = useState('');
+    const listComments = () => {
+        const hot = hotRef.current?.hotInstance;
+        if (!hot) {
+            return;
+        }
+        const found = [];
+        // `getCellMetaAtRow()` takes a physical row index (equal to the visual index here, with no sorting or trimming).
+        for (let row = 0; row < hot.countRows(); row += 1) {
+            hot.getCellMetaAtRow(row).forEach((cellMeta, col) => {
+                const comment = cellMeta.comment;
+                if (comment?.value !== undefined) {
+                    found.push(`Row ${row + 1}, "${hot.getColHeader(col)}": ${comment.value}`);
+                }
+            });
+        }
+        setOutput(found.length > 0 ? found.join('\n') : 'No comments found.');
+    };
+    return (<>
+      <div className="example-controls-container">
+        <div className="controls">
+          <button id="list-comments" onClick={() => listComments()}>
+            List all comments
+          </button>
+        </div>
+      </div>
+      <HotTable ref={hotRef} data={[
+            ['Update API docs', 'Ana García', 'In progress'],
+            ['Deploy hotfix', 'James Okafor', 'Blocked'],
+            ['Review pull requests', 'Li Wei', 'Done'],
+            ['Plan Q3 roadmap', 'Maria Santos', 'In progress'],
+            ['Refactor auth module', 'David Kim', 'In review'],
+        ]} colHeaders={['Task', 'Assignee', 'Status']} rowHeaders={true} comments={true} cell={[
+            { row: 1, col: 2, comment: { value: 'Waiting on infrastructure approval.' } },
+            { row: 3, col: 1, comment: { value: 'Reassign if capacity is tight.' } },
+            { row: 4, col: 0, comment: { value: 'Blocked on the security review.' } },
+        ]} height="auto" autoWrapRow={true} autoWrapCol={true} licenseKey="non-commercial-and-evaluation"/>
+      <output className="comments-output" style={{ whiteSpace: 'pre-wrap' }}>
+        {output}
+      </output>
+    </>);
+};
+export default ExampleComponent;

--- a/docs/content/guides/cell-features/comments/react/example6.tsx
+++ b/docs/content/guides/cell-features/comments/react/example6.tsx
@@ -1,0 +1,73 @@
+import { useRef, useState } from 'react';
+import { HotTable, HotTableRef } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const ExampleComponent = () => {
+  const hotRef = useRef<HotTableRef>(null);
+  const [output, setOutput] = useState('');
+
+  const listComments = () => {
+    const hot = hotRef.current?.hotInstance;
+
+    if (!hot) {
+      return;
+    }
+
+    const found: string[] = [];
+
+    // `getCellMetaAtRow()` takes a physical row index (equal to the visual index here, with no sorting or trimming).
+    for (let row = 0; row < hot.countRows(); row += 1) {
+      hot.getCellMetaAtRow(row).forEach((cellMeta, col) => {
+        const comment = cellMeta.comment as { value?: string } | undefined;
+
+        if (comment?.value !== undefined) {
+          found.push(`Row ${row + 1}, "${hot.getColHeader(col)}": ${comment.value}`);
+        }
+      });
+    }
+
+    setOutput(found.length > 0 ? found.join('\n') : 'No comments found.');
+  };
+
+  return (
+    <>
+      <div className="example-controls-container">
+        <div className="controls">
+          <button id="list-comments" onClick={() => listComments()}>
+            List all comments
+          </button>
+        </div>
+      </div>
+      <HotTable
+        ref={hotRef}
+        data={[
+          ['Update API docs', 'Ana García', 'In progress'],
+          ['Deploy hotfix', 'James Okafor', 'Blocked'],
+          ['Review pull requests', 'Li Wei', 'Done'],
+          ['Plan Q3 roadmap', 'Maria Santos', 'In progress'],
+          ['Refactor auth module', 'David Kim', 'In review'],
+        ]}
+        colHeaders={['Task', 'Assignee', 'Status']}
+        rowHeaders={true}
+        comments={true}
+        cell={[
+          { row: 1, col: 2, comment: { value: 'Waiting on infrastructure approval.' } },
+          { row: 3, col: 1, comment: { value: 'Reassign if capacity is tight.' } },
+          { row: 4, col: 0, comment: { value: 'Blocked on the security review.' } },
+        ]}
+        height="auto"
+        autoWrapRow={true}
+        autoWrapCol={true}
+        licenseKey="non-commercial-and-evaluation"
+      />
+      <output className="comments-output" style={{ whiteSpace: 'pre-wrap' }}>
+        {output}
+      </output>
+    </>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/cell-features/comments/vue/example5.vue
+++ b/docs/content/guides/cell-features/comments/vue/example5.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import Handsontable from 'handsontable/base';
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['Wireless mouse', 142],
+    ['USB-C cable', 67],
+    ['Mechanical keyboard', -5],
+    ['Laptop stand', 38],
+    ['HDMI adapter', 210],
+  ],
+  colHeaders: ['Product', 'Stock'],
+  rowHeaders: true,
+  comments: true,
+  columns: [
+    {},
+    {
+      type: 'numeric',
+      validator(value: any, callback: (valid: boolean) => void) {
+        callback(Number.isInteger(value) && value >= 0);
+      },
+    },
+  ],
+  // Attach a comment when a cell fails validation, and remove it once the cell is valid.
+  afterValidate(this: Handsontable, isValid: boolean, value: any, row: number, prop: string | number) {
+    const column = this.propToCol(prop);
+    const comments = this.getPlugin('comments');
+
+    if (!isValid) {
+      comments.setCommentAtCell(row, column, `"${value}" is not valid. Enter a whole number of 0 or more.`);
+    } else {
+      comments.removeCommentAtCell(row, column);
+    }
+  },
+  // Validate every cell on load so the pre-existing invalid value is flagged right away.
+  afterInit(this: Handsontable) {
+    this.validateCells();
+  },
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example5">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-features/comments/vue/example6.vue
+++ b/docs/content/guides/cell-features/comments/vue/example6.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import { ref, useTemplateRef } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const hotTableRef = useTemplateRef<InstanceType<typeof HotTable>>('hotTableRef');
+const output = ref('');
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['Update API docs', 'Ana García', 'In progress'],
+    ['Deploy hotfix', 'James Okafor', 'Blocked'],
+    ['Review pull requests', 'Li Wei', 'Done'],
+    ['Plan Q3 roadmap', 'Maria Santos', 'In progress'],
+    ['Refactor auth module', 'David Kim', 'In review'],
+  ],
+  colHeaders: ['Task', 'Assignee', 'Status'],
+  rowHeaders: true,
+  comments: true,
+  cell: [
+    { row: 1, col: 2, comment: { value: 'Waiting on infrastructure approval.' } },
+    { row: 3, col: 1, comment: { value: 'Reassign if capacity is tight.' } },
+    { row: 4, col: 0, comment: { value: 'Blocked on the security review.' } },
+  ],
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+
+const listComments = () => {
+  const hot = hotTableRef.value?.hotInstance;
+
+  if (!hot) {
+    return;
+  }
+
+  const found: string[] = [];
+
+  // `getCellMetaAtRow()` takes a physical row index (equal to the visual index here, with no sorting or trimming).
+  for (let row = 0; row < hot.countRows(); row += 1) {
+    hot.getCellMetaAtRow(row).forEach((cellMeta, col) => {
+      const comment = cellMeta.comment as { value?: string } | undefined;
+
+      if (comment?.value !== undefined) {
+        found.push(`Row ${row + 1}, "${hot.getColHeader(col)}": ${comment.value}`);
+      }
+    });
+  }
+
+  output.value = found.length > 0 ? found.join('\n') : 'No comments found.';
+};
+</script>
+
+<template>
+  <div id="example6">
+    <div class="example-controls-container">
+      <div class="controls">
+        <button id="list-comments" type="button" @click="listComments">List all comments</button>
+      </div>
+    </div>
+    <HotTable ref="hotTableRef" :settings="hotSettings" />
+    <output class="comments-output" style="white-space: pre-wrap">{{ output }}</output>
+  </div>
+</template>


### PR DESCRIPTION
### Context

The PR adds two example demos requested in DEV-700 to the Comments guide (`docs/content/guides/cell-features/comments/`), which previously had none for these use cases:

1. **Flag invalid cells with a comment** - uses the `afterValidate` hook with `setCommentAtCell()` / `removeCommentAtCell()` to attach a comment explaining a validation error and clear it once the value is valid. The grid validates on load, so the pre-seeded invalid row is flagged immediately.
2. **Read all comments programmatically** - loops the rows with `getCellMetaAtRow()`, reads each cell's `comment` metadata, and prints all comments to an on-page output area on button click.

Both demos ship JavaScript, React, Angular, and Vue variants to keep framework parity with the rest of the page. Domain-realistic data is used (inventory stock levels and project-management tasks).

`[skip changelog]` - docs-only change, no source code touched.

### How has this been tested?

- TypeScript sources type-checked against the built core types (`handsontable/tmp/*.d.ts`); JS/JSX variants generated via `npm run docs:code-examples:generate-js`.
- Verified live in the docs dev server for all four frameworks (`/docs/{javascript,react,angular,vue}-data-grid/comments/`):
  - Demo A renders and flags the invalid stock value with a comment on load.
  - Demo B lists all three comments on button click; output renders below the grid.
  - Browser console is clean on every variant.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-700

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-700

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example code only; no changes to Handsontable packages or runtime behavior.
> 
> **Overview**
> The **Comments** guide gains two new sections and live examples (**example5** / **example6**) for JavaScript, TypeScript, React, Angular, and Vue. Front matter now includes `menuTag: updated`.
> 
> **Flag invalid cells with a comment** documents pairing validation with the Comments plugin: `afterValidate` calls `setCommentAtCell()` / `removeCommentAtCell()`, and `afterInit` runs `validateCells()` so a pre-seeded invalid stock value is flagged on load.
> 
> **Read all comments programmatically** shows iterating rows with `getCellMetaAtRow()`, reading `comment` from cell meta, and printing results when **List all comments** is clicked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38b55ce98542540563d49dd549aaa29373c9ce40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->