### PR TITLE
DEV-701: Add clipboard metadata demos

### DIFF
--- a/docs/content/guides/cell-features/clipboard/angular/example4.html
+++ b/docs/content/guides/cell-features/clipboard/angular/example4.html
@@ -1,0 +1,3 @@
+<div>
+  <example4-clipboard></example4-clipboard>
+</div>

--- a/docs/content/guides/cell-features/clipboard/angular/example4.ts
+++ b/docs/content/guides/cell-features/clipboard/angular/example4.ts
@@ -61,6 +61,9 @@ export class AppComponent {
     afterCopy: (_data: unknown[][], coords: CopyRange[]) => {
       this.copiedClassNames = collectClassNames(this.hotTable.hotInstance!, coords);
     },
+    afterCut: (_data: unknown[][], coords: CopyRange[]) => {
+      this.copiedClassNames = collectClassNames(this.hotTable.hotInstance!, coords);
+    },
     afterPaste: (_data: unknown[][], coords: CopyRange[]) => {
       const target = coords[0];
       const hot = this.hotTable.hotInstance!;

--- a/docs/content/guides/cell-features/clipboard/angular/example4.ts
+++ b/docs/content/guides/cell-features/clipboard/angular/example4.ts
@@ -17,7 +17,7 @@ function collectClassNames(hot: Handsontable, coords: CopyRange[]): string[][] {
     const rowClassNames: string[] = [];
 
     for (let col = source.startCol; col <= source.endCol; col += 1) {
-      rowClassNames.push((hot.getCellMeta(row, col).className as string | undefined) ?? '');
+      rowClassNames.push((hot.getCellMeta(row, col)['className'] as string | undefined) ?? '');
     }
 
     classNames.push(rowClassNames);
@@ -58,12 +58,12 @@ export class AppComponent {
       { row: 2, col: 1, className: 'htRight htDimmed' },
       { row: 2, col: 2, className: 'htCenter htDimmed' },
     ],
-    afterCopy: (_data, coords) => {
-      this.copiedClassNames = collectClassNames(this.hotTable.hotInstance, coords as CopyRange[]);
+    afterCopy: (_data: unknown[][], coords: CopyRange[]) => {
+      this.copiedClassNames = collectClassNames(this.hotTable.hotInstance!, coords);
     },
-    afterPaste: (_data, coords) => {
-      const target = (coords as CopyRange[])[0];
-      const hot = this.hotTable.hotInstance;
+    afterPaste: (_data: unknown[][], coords: CopyRange[]) => {
+      const target = coords[0];
+      const hot = this.hotTable.hotInstance!;
 
       if (!target) {
         return;

--- a/docs/content/guides/cell-features/clipboard/angular/example4.ts
+++ b/docs/content/guides/cell-features/clipboard/angular/example4.ts
@@ -1,0 +1,107 @@
+/* file: app.component.ts */
+import { Component, ViewChild } from '@angular/core';
+import Handsontable from 'handsontable/base';
+import { GridSettings, HotTableComponent, HotTableModule } from '@handsontable/angular-wrapper';
+
+type CopyRange = { startRow: number; startCol: number; endRow: number; endCol: number };
+
+function collectClassNames(hot: Handsontable, coords: CopyRange[]): string[][] {
+  const source = coords[0];
+  const classNames: string[][] = [];
+
+  if (!source) {
+    return classNames;
+  }
+
+  for (let row = source.startRow; row <= source.endRow; row += 1) {
+    const rowClassNames: string[] = [];
+
+    for (let col = source.startCol; col <= source.endCol; col += 1) {
+      rowClassNames.push((hot.getCellMeta(row, col).className as string | undefined) ?? '');
+    }
+
+    classNames.push(rowClassNames);
+  }
+
+  return classNames;
+}
+
+@Component({
+  selector: 'example4-clipboard',
+  standalone: true,
+  imports: [HotTableModule],
+  template: `
+    <div>
+      <hot-table [data]="data" [settings]="gridSettings"></hot-table>
+    </div>`,
+})
+export class AppComponent {
+  @ViewChild(HotTableComponent, { static: false })
+  readonly hotTable!: HotTableComponent;
+
+  copiedClassNames: string[][] = [];
+
+  readonly data = [
+    ['Wireless mouse', 142, 'In stock'],
+    ['USB-C cable', 67, 'In stock'],
+    ['Mechanical keyboard', 0, 'Backordered'],
+    ['Laptop stand', 38, 'In stock'],
+    ['HDMI adapter', 210, 'In stock'],
+  ];
+
+  readonly gridSettings: GridSettings = {
+    colHeaders: ['Product', 'Stock', 'Status'],
+    rowHeaders: true,
+    cell: [
+      { row: 0, col: 1, className: 'htRight' },
+      { row: 0, col: 2, className: 'htCenter' },
+      { row: 2, col: 1, className: 'htRight htDimmed' },
+      { row: 2, col: 2, className: 'htCenter htDimmed' },
+    ],
+    afterCopy: (_data, coords) => {
+      this.copiedClassNames = collectClassNames(this.hotTable.hotInstance, coords as CopyRange[]);
+    },
+    afterPaste: (_data, coords) => {
+      const target = (coords as CopyRange[])[0];
+      const hot = this.hotTable.hotInstance;
+
+      if (!target) {
+        return;
+      }
+
+      hot.batch(() => {
+        this.copiedClassNames.forEach((rowClassNames, rowOffset) => {
+          rowClassNames.forEach((className, colOffset) => {
+            hot.setCellMeta(target.startRow + rowOffset, target.startCol + colOffset, 'className', className);
+          });
+        });
+      });
+
+      hot.render();
+    },
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true
+  };
+}
+/* end-file */
+
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+/* end-file */

--- a/docs/content/guides/cell-features/clipboard/angular/example5.html
+++ b/docs/content/guides/cell-features/clipboard/angular/example5.html
@@ -1,0 +1,3 @@
+<div>
+  <example5-clipboard></example5-clipboard>
+</div>

--- a/docs/content/guides/cell-features/clipboard/angular/example5.ts
+++ b/docs/content/guides/cell-features/clipboard/angular/example5.ts
@@ -62,6 +62,9 @@ export class AppComponent {
     afterCopy: (_data: unknown[][], coords: CopyRange[]) => {
       this.copiedComments = collectComments(this.hotTable.hotInstance!, coords);
     },
+    afterCut: (_data: unknown[][], coords: CopyRange[]) => {
+      this.copiedComments = collectComments(this.hotTable.hotInstance!, coords);
+    },
     afterPaste: (_data: unknown[][], coords: CopyRange[]) => {
       const target = coords[0];
       const hot = this.hotTable.hotInstance!;

--- a/docs/content/guides/cell-features/clipboard/angular/example5.ts
+++ b/docs/content/guides/cell-features/clipboard/angular/example5.ts
@@ -59,12 +59,12 @@ export class AppComponent {
       { row: 2, col: 1, comment: { value: 'Reorder request sent to Harbor Goods.' } },
       { row: 2, col: 2, comment: { value: 'Expected delivery is July 18.' } },
     ],
-    afterCopy: (_data, coords) => {
-      this.copiedComments = collectComments(this.hotTable.hotInstance, coords as CopyRange[]);
+    afterCopy: (_data: unknown[][], coords: CopyRange[]) => {
+      this.copiedComments = collectComments(this.hotTable.hotInstance!, coords);
     },
-    afterPaste: (_data, coords) => {
-      const target = (coords as CopyRange[])[0];
-      const hot = this.hotTable.hotInstance;
+    afterPaste: (_data: unknown[][], coords: CopyRange[]) => {
+      const target = coords[0];
+      const hot = this.hotTable.hotInstance!;
       const comments = hot.getPlugin('comments');
 
       if (!target) {

--- a/docs/content/guides/cell-features/clipboard/angular/example5.ts
+++ b/docs/content/guides/cell-features/clipboard/angular/example5.ts
@@ -1,0 +1,116 @@
+/* file: app.component.ts */
+import { Component, ViewChild } from '@angular/core';
+import Handsontable from 'handsontable/base';
+import { GridSettings, HotTableComponent, HotTableModule } from '@handsontable/angular-wrapper';
+
+type CopyRange = { startRow: number; startCol: number; endRow: number; endCol: number };
+
+function collectComments(hot: Handsontable, coords: CopyRange[]): (string | undefined)[][] {
+  const source = coords[0];
+  const comments = hot.getPlugin('comments');
+  const copied: (string | undefined)[][] = [];
+
+  if (!source) {
+    return copied;
+  }
+
+  for (let row = source.startRow; row <= source.endRow; row += 1) {
+    const rowComments: (string | undefined)[] = [];
+
+    for (let col = source.startCol; col <= source.endCol; col += 1) {
+      rowComments.push(comments.getCommentAtCell(row, col));
+    }
+
+    copied.push(rowComments);
+  }
+
+  return copied;
+}
+
+@Component({
+  selector: 'example5-clipboard',
+  standalone: true,
+  imports: [HotTableModule],
+  template: `
+    <div>
+      <hot-table [data]="data" [settings]="gridSettings"></hot-table>
+    </div>`,
+})
+export class AppComponent {
+  @ViewChild(HotTableComponent, { static: false })
+  readonly hotTable!: HotTableComponent;
+
+  copiedComments: (string | undefined)[][] = [];
+
+  readonly data = [
+    ['Wireless mouse', 142, 'In stock'],
+    ['USB-C cable', 67, 'In stock'],
+    ['Mechanical keyboard', 0, 'Backordered'],
+    ['Laptop stand', 38, 'In stock'],
+    ['HDMI adapter', 210, 'In stock'],
+  ];
+
+  readonly gridSettings: GridSettings = {
+    colHeaders: ['Product', 'Stock', 'Status'],
+    rowHeaders: true,
+    comments: true,
+    cell: [
+      { row: 0, col: 1, comment: { value: 'Counted during the July audit.' } },
+      { row: 2, col: 1, comment: { value: 'Reorder request sent to Harbor Goods.' } },
+      { row: 2, col: 2, comment: { value: 'Expected delivery is July 18.' } },
+    ],
+    afterCopy: (_data, coords) => {
+      this.copiedComments = collectComments(this.hotTable.hotInstance, coords as CopyRange[]);
+    },
+    afterPaste: (_data, coords) => {
+      const target = (coords as CopyRange[])[0];
+      const hot = this.hotTable.hotInstance;
+      const comments = hot.getPlugin('comments');
+
+      if (!target) {
+        return;
+      }
+
+      hot.batch(() => {
+        this.copiedComments.forEach((rowComments, rowOffset) => {
+          rowComments.forEach((comment, colOffset) => {
+            const row = target.startRow + rowOffset;
+            const col = target.startCol + colOffset;
+
+            if (comment) {
+              comments.setCommentAtCell(row, col, comment);
+            } else {
+              comments.removeCommentAtCell(row, col, false);
+            }
+          });
+        });
+      });
+
+      hot.render();
+    },
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true
+  };
+}
+/* end-file */
+
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+/* end-file */

--- a/docs/content/guides/cell-features/clipboard/clipboard.md
+++ b/docs/content/guides/cell-features/clipboard/clipboard.md
@@ -341,9 +341,9 @@ Examples of how to use them are provided in their descriptions.
 
 ### Copy cell appearance on paste
 
-The [`CopyPaste`](@/api/copyPaste.md) plugin copies cell values by default. To copy cell appearance, save each copied cell's `className` metadata in [`afterCopy`](@/api/hooks.md#aftercopy), and then apply it to the pasted range in [`afterPaste`](@/api/hooks.md#afterpaste).
+The [`CopyPaste`](@/api/copyPaste.md) plugin copies cell values by default. To copy cell appearance, save each copied or cut cell's `className` metadata in [`afterCopy`](@/api/hooks.md#aftercopy) and [`afterCut`](@/api/hooks.md#aftercut), and then apply it to the pasted range in [`afterPaste`](@/api/hooks.md#afterpaste).
 
-Copy a styled range from the grid, and paste it into another range to copy the cell values and appearance.
+Copy or cut a styled range from the grid, and paste it into another range to copy the cell values and appearance.
 
 ::: only-for javascript
 ::: example #example4 --js 1 --ts 2
@@ -382,9 +382,9 @@ Copy a styled range from the grid, and paste it into another range to copy the c
 
 ### Copy comments on paste
 
-To copy cell comments, enable the [`Comments`](@/api/comments.md) plugin. Then use [`getCommentAtCell()`](@/api/comments.md#getcommentatcell) in [`afterCopy`](@/api/hooks.md#aftercopy), and [`setCommentAtCell()`](@/api/comments.md#setcommentatcell) in [`afterPaste`](@/api/hooks.md#afterpaste).
+To copy cell comments, enable the [`Comments`](@/api/comments.md) plugin. Then use [`getCommentAtCell()`](@/api/comments.md#getcommentatcell) in [`afterCopy`](@/api/hooks.md#aftercopy) and [`afterCut`](@/api/hooks.md#aftercut), and [`setCommentAtCell()`](@/api/comments.md#setcommentatcell) in [`afterPaste`](@/api/hooks.md#afterpaste).
 
-Copy a commented range from the grid, and paste it into another range to copy the cell values and comments.
+Copy or cut a commented range from the grid, and paste it into another range to copy the cell values and comments.
 
 ::: only-for javascript
 ::: example #example5 --js 1 --ts 2

--- a/docs/content/guides/cell-features/clipboard/clipboard.md
+++ b/docs/content/guides/cell-features/clipboard/clipboard.md
@@ -339,9 +339,91 @@ The [`CopyPaste`](@/api/copyPaste.md) plugin exposes the following hooks to mani
 
 Examples of how to use them are provided in their descriptions.
 
+### Copy cell appearance on paste
+
+The [`CopyPaste`](@/api/copyPaste.md) plugin copies cell values by default. To copy cell appearance, save each copied cell's `className` metadata in [`afterCopy`](@/api/hooks.md#aftercopy), and then apply it to the pasted range in [`afterPaste`](@/api/hooks.md#afterpaste).
+
+Copy a styled range from the grid, and paste it into another range to copy the cell values and appearance.
+
+::: only-for javascript
+::: example #example4 --js 1 --ts 2
+
+@[code](@/content/guides/cell-features/clipboard/javascript/example4.js)
+@[code](@/content/guides/cell-features/clipboard/javascript/example4.ts)
+
+:::
+:::
+
+::: only-for react
+::: example #example4 :react --js 1 --ts 2
+
+@[code](@/content/guides/cell-features/clipboard/react/example4.jsx)
+@[code](@/content/guides/cell-features/clipboard/react/example4.tsx)
+
+:::
+:::
+
+::: only-for angular
+::: example #example4 :angular --ts 1 --html 2
+
+@[code](@/content/guides/cell-features/clipboard/angular/example4.ts)
+@[code](@/content/guides/cell-features/clipboard/angular/example4.html)
+
+:::
+:::
+
+::: only-for vue
+::: example #example4 :vue3
+
+@[code](@/content/guides/cell-features/clipboard/vue/example4.vue)
+
+:::
+:::
+
+### Copy comments on paste
+
+To copy cell comments, enable the [`Comments`](@/api/comments.md) plugin. Then use [`getCommentAtCell()`](@/api/comments.md#getcommentatcell) in [`afterCopy`](@/api/hooks.md#aftercopy), and [`setCommentAtCell()`](@/api/comments.md#setcommentatcell) in [`afterPaste`](@/api/hooks.md#afterpaste).
+
+Copy a commented range from the grid, and paste it into another range to copy the cell values and comments.
+
+::: only-for javascript
+::: example #example5 --js 1 --ts 2
+
+@[code](@/content/guides/cell-features/clipboard/javascript/example5.js)
+@[code](@/content/guides/cell-features/clipboard/javascript/example5.ts)
+
+:::
+:::
+
+::: only-for react
+::: example #example5 :react --js 1 --ts 2
+
+@[code](@/content/guides/cell-features/clipboard/react/example5.jsx)
+@[code](@/content/guides/cell-features/clipboard/react/example5.tsx)
+
+:::
+:::
+
+::: only-for angular
+::: example #example5 :angular --ts 1 --html 2
+
+@[code](@/content/guides/cell-features/clipboard/angular/example5.ts)
+@[code](@/content/guides/cell-features/clipboard/angular/example5.html)
+
+:::
+:::
+
+::: only-for vue
+::: example #example5 :vue3
+
+@[code](@/content/guides/cell-features/clipboard/vue/example5.vue)
+
+:::
+:::
+
 ## Known limitations
 
-1. The [`CopyPaste`](@/api/copyPaste.md) plugin doesn't copy, cut or paste cells' appearance.
+1. The [`CopyPaste`](@/api/copyPaste.md) plugin doesn't copy, cut or paste cells' appearance by default. To copy a cell's `className` metadata, see [Copy cell appearance on paste](#copy-cell-appearance-on-paste).
 2. The data copied from Handsontable will always remain as plain text. For example, if you copy a checked checkbox, the input will be kept as the value of `'true'`.
 3. `document.execCommand` can be called only during an immediate-execute event, such as a `MouseEvent` or a `KeyboardEvent`.
 4. Clipboard operations don’t work in Chrome 133+ with Handsontable 14.6.0, 14.6.1, or 15.0.0. Update to 14.6.2 or 15.0.1+. See the [incident announcement](https://handsontable.com/blog/incident-report-handsontable-14.6-15.0-clipboard-disruption-in-chrome-133) for details.

--- a/docs/content/guides/cell-features/clipboard/javascript/example4.js
+++ b/docs/content/guides/cell-features/clipboard/javascript/example4.js
@@ -1,0 +1,62 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+// Register all Handsontable's modules.
+registerAllModules();
+const container = document.querySelector('#example4');
+let copiedClassNames = [];
+function collectClassNames(hot, coords) {
+    const source = coords[0];
+    const classNames = [];
+    if (!source) {
+        return classNames;
+    }
+    for (let row = source.startRow; row <= source.endRow; row += 1) {
+        const rowClassNames = [];
+        for (let col = source.startCol; col <= source.endCol; col += 1) {
+            rowClassNames.push(hot.getCellMeta(row, col).className ?? '');
+        }
+        classNames.push(rowClassNames);
+    }
+    return classNames;
+}
+function applyClassNames(hot, coords) {
+    const target = coords[0];
+    if (!target) {
+        return;
+    }
+    hot.batch(() => {
+        copiedClassNames.forEach((rowClassNames, rowOffset) => {
+            rowClassNames.forEach((className, colOffset) => {
+                hot.setCellMeta(target.startRow + rowOffset, target.startCol + colOffset, 'className', className);
+            });
+        });
+    });
+    hot.render();
+}
+new Handsontable(container, {
+    data: [
+        ['Wireless mouse', 142, 'In stock'],
+        ['USB-C cable', 67, 'In stock'],
+        ['Mechanical keyboard', 0, 'Backordered'],
+        ['Laptop stand', 38, 'In stock'],
+        ['HDMI adapter', 210, 'In stock'],
+    ],
+    colHeaders: ['Product', 'Stock', 'Status'],
+    rowHeaders: true,
+    cell: [
+        { row: 0, col: 1, className: 'htRight' },
+        { row: 0, col: 2, className: 'htCenter' },
+        { row: 2, col: 1, className: 'htRight htDimmed' },
+        { row: 2, col: 2, className: 'htCenter htDimmed' },
+    ],
+    afterCopy(_data, coords) {
+        copiedClassNames = collectClassNames(this, coords);
+    },
+    afterPaste(_data, coords) {
+        applyClassNames(this, coords);
+    },
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true,
+    licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/cell-features/clipboard/javascript/example4.js
+++ b/docs/content/guides/cell-features/clipboard/javascript/example4.js
@@ -52,6 +52,9 @@ new Handsontable(container, {
     afterCopy(_data, coords) {
         copiedClassNames = collectClassNames(this, coords);
     },
+    afterCut(_data, coords) {
+        copiedClassNames = collectClassNames(this, coords);
+    },
     afterPaste(_data, coords) {
         applyClassNames(this, coords);
     },

--- a/docs/content/guides/cell-features/clipboard/javascript/example4.ts
+++ b/docs/content/guides/cell-features/clipboard/javascript/example4.ts
@@ -1,0 +1,77 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+type CopyRange = { startRow: number; startCol: number; endRow: number; endCol: number };
+
+// Register all Handsontable's modules.
+registerAllModules();
+
+const container = document.querySelector('#example4')!;
+let copiedClassNames: string[][] = [];
+
+function collectClassNames(hot: Handsontable, coords: CopyRange[]): string[][] {
+  const source = coords[0];
+  const classNames: string[][] = [];
+
+  if (!source) {
+    return classNames;
+  }
+
+  for (let row = source.startRow; row <= source.endRow; row += 1) {
+    const rowClassNames: string[] = [];
+
+    for (let col = source.startCol; col <= source.endCol; col += 1) {
+      rowClassNames.push((hot.getCellMeta(row, col).className as string | undefined) ?? '');
+    }
+
+    classNames.push(rowClassNames);
+  }
+
+  return classNames;
+}
+
+function applyClassNames(hot: Handsontable, coords: CopyRange[]): void {
+  const target = coords[0];
+
+  if (!target) {
+    return;
+  }
+
+  hot.batch(() => {
+    copiedClassNames.forEach((rowClassNames, rowOffset) => {
+      rowClassNames.forEach((className, colOffset) => {
+        hot.setCellMeta(target.startRow + rowOffset, target.startCol + colOffset, 'className', className);
+      });
+    });
+  });
+
+  hot.render();
+}
+
+new Handsontable(container, {
+  data: [
+    ['Wireless mouse', 142, 'In stock'],
+    ['USB-C cable', 67, 'In stock'],
+    ['Mechanical keyboard', 0, 'Backordered'],
+    ['Laptop stand', 38, 'In stock'],
+    ['HDMI adapter', 210, 'In stock'],
+  ],
+  colHeaders: ['Product', 'Stock', 'Status'],
+  rowHeaders: true,
+  cell: [
+    { row: 0, col: 1, className: 'htRight' },
+    { row: 0, col: 2, className: 'htCenter' },
+    { row: 2, col: 1, className: 'htRight htDimmed' },
+    { row: 2, col: 2, className: 'htCenter htDimmed' },
+  ],
+  afterCopy(_data, coords) {
+    copiedClassNames = collectClassNames(this, coords as CopyRange[]);
+  },
+  afterPaste(_data, coords) {
+    applyClassNames(this, coords as CopyRange[]);
+  },
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/cell-features/clipboard/javascript/example4.ts
+++ b/docs/content/guides/cell-features/clipboard/javascript/example4.ts
@@ -67,6 +67,9 @@ new Handsontable(container, {
   afterCopy(_data, coords) {
     copiedClassNames = collectClassNames(this, coords as CopyRange[]);
   },
+  afterCut(_data, coords) {
+    copiedClassNames = collectClassNames(this, coords as CopyRange[]);
+  },
   afterPaste(_data, coords) {
     applyClassNames(this, coords as CopyRange[]);
   },

--- a/docs/content/guides/cell-features/clipboard/javascript/example5.js
+++ b/docs/content/guides/cell-features/clipboard/javascript/example5.js
@@ -61,6 +61,9 @@ new Handsontable(container, {
     afterCopy(_data, coords) {
         copiedComments = collectComments(this, coords);
     },
+    afterCut(_data, coords) {
+        copiedComments = collectComments(this, coords);
+    },
     afterPaste(_data, coords) {
         applyComments(this, coords);
     },

--- a/docs/content/guides/cell-features/clipboard/javascript/example5.js
+++ b/docs/content/guides/cell-features/clipboard/javascript/example5.js
@@ -1,0 +1,71 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+// Register all Handsontable's modules.
+registerAllModules();
+const container = document.querySelector('#example5');
+let copiedComments = [];
+function collectComments(hot, coords) {
+    const source = coords[0];
+    const comments = hot.getPlugin('comments');
+    const copied = [];
+    if (!source) {
+        return copied;
+    }
+    for (let row = source.startRow; row <= source.endRow; row += 1) {
+        const rowComments = [];
+        for (let col = source.startCol; col <= source.endCol; col += 1) {
+            rowComments.push(comments.getCommentAtCell(row, col));
+        }
+        copied.push(rowComments);
+    }
+    return copied;
+}
+function applyComments(hot, coords) {
+    const target = coords[0];
+    const comments = hot.getPlugin('comments');
+    if (!target) {
+        return;
+    }
+    hot.batch(() => {
+        copiedComments.forEach((rowComments, rowOffset) => {
+            rowComments.forEach((comment, colOffset) => {
+                const row = target.startRow + rowOffset;
+                const col = target.startCol + colOffset;
+                if (comment) {
+                    comments.setCommentAtCell(row, col, comment);
+                }
+                else {
+                    comments.removeCommentAtCell(row, col, false);
+                }
+            });
+        });
+    });
+    hot.render();
+}
+new Handsontable(container, {
+    data: [
+        ['Wireless mouse', 142, 'In stock'],
+        ['USB-C cable', 67, 'In stock'],
+        ['Mechanical keyboard', 0, 'Backordered'],
+        ['Laptop stand', 38, 'In stock'],
+        ['HDMI adapter', 210, 'In stock'],
+    ],
+    colHeaders: ['Product', 'Stock', 'Status'],
+    rowHeaders: true,
+    comments: true,
+    cell: [
+        { row: 0, col: 1, comment: { value: 'Counted during the July audit.' } },
+        { row: 2, col: 1, comment: { value: 'Reorder request sent to Harbor Goods.' } },
+        { row: 2, col: 2, comment: { value: 'Expected delivery is July 18.' } },
+    ],
+    afterCopy(_data, coords) {
+        copiedComments = collectComments(this, coords);
+    },
+    afterPaste(_data, coords) {
+        applyComments(this, coords);
+    },
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true,
+    licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/cell-features/clipboard/javascript/example5.ts
+++ b/docs/content/guides/cell-features/clipboard/javascript/example5.ts
@@ -76,6 +76,9 @@ new Handsontable(container, {
   afterCopy(_data, coords) {
     copiedComments = collectComments(this, coords as CopyRange[]);
   },
+  afterCut(_data, coords) {
+    copiedComments = collectComments(this, coords as CopyRange[]);
+  },
   afterPaste(_data, coords) {
     applyComments(this, coords as CopyRange[]);
   },

--- a/docs/content/guides/cell-features/clipboard/javascript/example5.ts
+++ b/docs/content/guides/cell-features/clipboard/javascript/example5.ts
@@ -1,0 +1,86 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+type CopyRange = { startRow: number; startCol: number; endRow: number; endCol: number };
+
+// Register all Handsontable's modules.
+registerAllModules();
+
+const container = document.querySelector('#example5')!;
+let copiedComments: (string | undefined)[][] = [];
+
+function collectComments(hot: Handsontable, coords: CopyRange[]): (string | undefined)[][] {
+  const source = coords[0];
+  const comments = hot.getPlugin('comments');
+  const copied: (string | undefined)[][] = [];
+
+  if (!source) {
+    return copied;
+  }
+
+  for (let row = source.startRow; row <= source.endRow; row += 1) {
+    const rowComments: (string | undefined)[] = [];
+
+    for (let col = source.startCol; col <= source.endCol; col += 1) {
+      rowComments.push(comments.getCommentAtCell(row, col));
+    }
+
+    copied.push(rowComments);
+  }
+
+  return copied;
+}
+
+function applyComments(hot: Handsontable, coords: CopyRange[]): void {
+  const target = coords[0];
+  const comments = hot.getPlugin('comments');
+
+  if (!target) {
+    return;
+  }
+
+  hot.batch(() => {
+    copiedComments.forEach((rowComments, rowOffset) => {
+      rowComments.forEach((comment, colOffset) => {
+        const row = target.startRow + rowOffset;
+        const col = target.startCol + colOffset;
+
+        if (comment) {
+          comments.setCommentAtCell(row, col, comment);
+        } else {
+          comments.removeCommentAtCell(row, col, false);
+        }
+      });
+    });
+  });
+
+  hot.render();
+}
+
+new Handsontable(container, {
+  data: [
+    ['Wireless mouse', 142, 'In stock'],
+    ['USB-C cable', 67, 'In stock'],
+    ['Mechanical keyboard', 0, 'Backordered'],
+    ['Laptop stand', 38, 'In stock'],
+    ['HDMI adapter', 210, 'In stock'],
+  ],
+  colHeaders: ['Product', 'Stock', 'Status'],
+  rowHeaders: true,
+  comments: true,
+  cell: [
+    { row: 0, col: 1, comment: { value: 'Counted during the July audit.' } },
+    { row: 2, col: 1, comment: { value: 'Reorder request sent to Harbor Goods.' } },
+    { row: 2, col: 2, comment: { value: 'Expected delivery is July 18.' } },
+  ],
+  afterCopy(_data, coords) {
+    copiedComments = collectComments(this, coords as CopyRange[]);
+  },
+  afterPaste(_data, coords) {
+    applyComments(this, coords as CopyRange[]);
+  },
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/cell-features/clipboard/react/example4.jsx
+++ b/docs/content/guides/cell-features/clipboard/react/example4.jsx
@@ -1,0 +1,51 @@
+import { useRef } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+// register Handsontable's modules
+registerAllModules();
+function collectClassNames(hot, coords) {
+    const source = coords[0];
+    const classNames = [];
+    if (!source) {
+        return classNames;
+    }
+    for (let row = source.startRow; row <= source.endRow; row += 1) {
+        const rowClassNames = [];
+        for (let col = source.startCol; col <= source.endCol; col += 1) {
+            rowClassNames.push(hot.getCellMeta(row, col).className ?? '');
+        }
+        classNames.push(rowClassNames);
+    }
+    return classNames;
+}
+const ExampleComponent = () => {
+    const copiedClassNames = useRef([]);
+    return (<HotTable data={[
+            ['Wireless mouse', 142, 'In stock'],
+            ['USB-C cable', 67, 'In stock'],
+            ['Mechanical keyboard', 0, 'Backordered'],
+            ['Laptop stand', 38, 'In stock'],
+            ['HDMI adapter', 210, 'In stock'],
+        ]} colHeaders={['Product', 'Stock', 'Status']} rowHeaders={true} cell={[
+            { row: 0, col: 1, className: 'htRight' },
+            { row: 0, col: 2, className: 'htCenter' },
+            { row: 2, col: 1, className: 'htRight htDimmed' },
+            { row: 2, col: 2, className: 'htCenter htDimmed' },
+        ]} afterCopy={function (_data, coords) {
+            copiedClassNames.current = collectClassNames(this, coords);
+        }} afterPaste={function (_data, coords) {
+            const target = coords[0];
+            if (!target) {
+                return;
+            }
+            this.batch(() => {
+                copiedClassNames.current.forEach((rowClassNames, rowOffset) => {
+                    rowClassNames.forEach((className, colOffset) => {
+                        this.setCellMeta(target.startRow + rowOffset, target.startCol + colOffset, 'className', className);
+                    });
+                });
+            });
+            this.render();
+        }} height="auto" autoWrapRow={true} autoWrapCol={true} licenseKey="non-commercial-and-evaluation"/>);
+};
+export default ExampleComponent;

--- a/docs/content/guides/cell-features/clipboard/react/example4.jsx
+++ b/docs/content/guides/cell-features/clipboard/react/example4.jsx
@@ -33,6 +33,8 @@ const ExampleComponent = () => {
             { row: 2, col: 2, className: 'htCenter htDimmed' },
         ]} afterCopy={function (_data, coords) {
             copiedClassNames.current = collectClassNames(this, coords);
+        }} afterCut={function (_data, coords) {
+            copiedClassNames.current = collectClassNames(this, coords);
         }} afterPaste={function (_data, coords) {
             const target = coords[0];
             if (!target) {

--- a/docs/content/guides/cell-features/clipboard/react/example4.tsx
+++ b/docs/content/guides/cell-features/clipboard/react/example4.tsx
@@ -52,6 +52,9 @@ const ExampleComponent = () => {
       afterCopy={function (this: Handsontable, _data, coords) {
         copiedClassNames.current = collectClassNames(this, coords as CopyRange[]);
       }}
+      afterCut={function (this: Handsontable, _data, coords) {
+        copiedClassNames.current = collectClassNames(this, coords as CopyRange[]);
+      }}
       afterPaste={function (this: Handsontable, _data, coords) {
         const target = (coords as CopyRange[])[0];
 

--- a/docs/content/guides/cell-features/clipboard/react/example4.tsx
+++ b/docs/content/guides/cell-features/clipboard/react/example4.tsx
@@ -1,0 +1,80 @@
+import { useRef } from 'react';
+import Handsontable from 'handsontable/base';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+type CopyRange = { startRow: number; startCol: number; endRow: number; endCol: number };
+
+// register Handsontable's modules
+registerAllModules();
+
+function collectClassNames(hot: Handsontable, coords: CopyRange[]): string[][] {
+  const source = coords[0];
+  const classNames: string[][] = [];
+
+  if (!source) {
+    return classNames;
+  }
+
+  for (let row = source.startRow; row <= source.endRow; row += 1) {
+    const rowClassNames: string[] = [];
+
+    for (let col = source.startCol; col <= source.endCol; col += 1) {
+      rowClassNames.push((hot.getCellMeta(row, col).className as string | undefined) ?? '');
+    }
+
+    classNames.push(rowClassNames);
+  }
+
+  return classNames;
+}
+
+const ExampleComponent = () => {
+  const copiedClassNames = useRef<string[][]>([]);
+
+  return (
+    <HotTable
+      data={[
+        ['Wireless mouse', 142, 'In stock'],
+        ['USB-C cable', 67, 'In stock'],
+        ['Mechanical keyboard', 0, 'Backordered'],
+        ['Laptop stand', 38, 'In stock'],
+        ['HDMI adapter', 210, 'In stock'],
+      ]}
+      colHeaders={['Product', 'Stock', 'Status']}
+      rowHeaders={true}
+      cell={[
+        { row: 0, col: 1, className: 'htRight' },
+        { row: 0, col: 2, className: 'htCenter' },
+        { row: 2, col: 1, className: 'htRight htDimmed' },
+        { row: 2, col: 2, className: 'htCenter htDimmed' },
+      ]}
+      afterCopy={function (this: Handsontable, _data, coords) {
+        copiedClassNames.current = collectClassNames(this, coords as CopyRange[]);
+      }}
+      afterPaste={function (this: Handsontable, _data, coords) {
+        const target = (coords as CopyRange[])[0];
+
+        if (!target) {
+          return;
+        }
+
+        this.batch(() => {
+          copiedClassNames.current.forEach((rowClassNames, rowOffset) => {
+            rowClassNames.forEach((className, colOffset) => {
+              this.setCellMeta(target.startRow + rowOffset, target.startCol + colOffset, 'className', className);
+            });
+          });
+        });
+
+        this.render();
+      }}
+      height="auto"
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/cell-features/clipboard/react/example5.jsx
+++ b/docs/content/guides/cell-features/clipboard/react/example5.jsx
@@ -1,0 +1,59 @@
+import { useRef } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+// register Handsontable's modules
+registerAllModules();
+function collectComments(hot, coords) {
+    const source = coords[0];
+    const comments = hot.getPlugin('comments');
+    const copied = [];
+    if (!source) {
+        return copied;
+    }
+    for (let row = source.startRow; row <= source.endRow; row += 1) {
+        const rowComments = [];
+        for (let col = source.startCol; col <= source.endCol; col += 1) {
+            rowComments.push(comments.getCommentAtCell(row, col));
+        }
+        copied.push(rowComments);
+    }
+    return copied;
+}
+const ExampleComponent = () => {
+    const copiedComments = useRef([]);
+    return (<HotTable data={[
+            ['Wireless mouse', 142, 'In stock'],
+            ['USB-C cable', 67, 'In stock'],
+            ['Mechanical keyboard', 0, 'Backordered'],
+            ['Laptop stand', 38, 'In stock'],
+            ['HDMI adapter', 210, 'In stock'],
+        ]} colHeaders={['Product', 'Stock', 'Status']} rowHeaders={true} comments={true} cell={[
+            { row: 0, col: 1, comment: { value: 'Counted during the July audit.' } },
+            { row: 2, col: 1, comment: { value: 'Reorder request sent to Harbor Goods.' } },
+            { row: 2, col: 2, comment: { value: 'Expected delivery is July 18.' } },
+        ]} afterCopy={function (_data, coords) {
+            copiedComments.current = collectComments(this, coords);
+        }} afterPaste={function (_data, coords) {
+            const target = coords[0];
+            const comments = this.getPlugin('comments');
+            if (!target) {
+                return;
+            }
+            this.batch(() => {
+                copiedComments.current.forEach((rowComments, rowOffset) => {
+                    rowComments.forEach((comment, colOffset) => {
+                        const row = target.startRow + rowOffset;
+                        const col = target.startCol + colOffset;
+                        if (comment) {
+                            comments.setCommentAtCell(row, col, comment);
+                        }
+                        else {
+                            comments.removeCommentAtCell(row, col, false);
+                        }
+                    });
+                });
+            });
+            this.render();
+        }} height="auto" autoWrapRow={true} autoWrapCol={true} licenseKey="non-commercial-and-evaluation"/>);
+};
+export default ExampleComponent;

--- a/docs/content/guides/cell-features/clipboard/react/example5.jsx
+++ b/docs/content/guides/cell-features/clipboard/react/example5.jsx
@@ -33,6 +33,8 @@ const ExampleComponent = () => {
             { row: 2, col: 2, comment: { value: 'Expected delivery is July 18.' } },
         ]} afterCopy={function (_data, coords) {
             copiedComments.current = collectComments(this, coords);
+        }} afterCut={function (_data, coords) {
+            copiedComments.current = collectComments(this, coords);
         }} afterPaste={function (_data, coords) {
             const target = coords[0];
             const comments = this.getPlugin('comments');

--- a/docs/content/guides/cell-features/clipboard/react/example5.tsx
+++ b/docs/content/guides/cell-features/clipboard/react/example5.tsx
@@ -53,6 +53,9 @@ const ExampleComponent = () => {
       afterCopy={function (this: Handsontable, _data, coords) {
         copiedComments.current = collectComments(this, coords as CopyRange[]);
       }}
+      afterCut={function (this: Handsontable, _data, coords) {
+        copiedComments.current = collectComments(this, coords as CopyRange[]);
+      }}
       afterPaste={function (this: Handsontable, _data, coords) {
         const target = (coords as CopyRange[])[0];
         const comments = this.getPlugin('comments');

--- a/docs/content/guides/cell-features/clipboard/react/example5.tsx
+++ b/docs/content/guides/cell-features/clipboard/react/example5.tsx
@@ -1,0 +1,89 @@
+import { useRef } from 'react';
+import Handsontable from 'handsontable/base';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+type CopyRange = { startRow: number; startCol: number; endRow: number; endCol: number };
+
+// register Handsontable's modules
+registerAllModules();
+
+function collectComments(hot: Handsontable, coords: CopyRange[]): (string | undefined)[][] {
+  const source = coords[0];
+  const comments = hot.getPlugin('comments');
+  const copied: (string | undefined)[][] = [];
+
+  if (!source) {
+    return copied;
+  }
+
+  for (let row = source.startRow; row <= source.endRow; row += 1) {
+    const rowComments: (string | undefined)[] = [];
+
+    for (let col = source.startCol; col <= source.endCol; col += 1) {
+      rowComments.push(comments.getCommentAtCell(row, col));
+    }
+
+    copied.push(rowComments);
+  }
+
+  return copied;
+}
+
+const ExampleComponent = () => {
+  const copiedComments = useRef<(string | undefined)[][]>([]);
+
+  return (
+    <HotTable
+      data={[
+        ['Wireless mouse', 142, 'In stock'],
+        ['USB-C cable', 67, 'In stock'],
+        ['Mechanical keyboard', 0, 'Backordered'],
+        ['Laptop stand', 38, 'In stock'],
+        ['HDMI adapter', 210, 'In stock'],
+      ]}
+      colHeaders={['Product', 'Stock', 'Status']}
+      rowHeaders={true}
+      comments={true}
+      cell={[
+        { row: 0, col: 1, comment: { value: 'Counted during the July audit.' } },
+        { row: 2, col: 1, comment: { value: 'Reorder request sent to Harbor Goods.' } },
+        { row: 2, col: 2, comment: { value: 'Expected delivery is July 18.' } },
+      ]}
+      afterCopy={function (this: Handsontable, _data, coords) {
+        copiedComments.current = collectComments(this, coords as CopyRange[]);
+      }}
+      afterPaste={function (this: Handsontable, _data, coords) {
+        const target = (coords as CopyRange[])[0];
+        const comments = this.getPlugin('comments');
+
+        if (!target) {
+          return;
+        }
+
+        this.batch(() => {
+          copiedComments.current.forEach((rowComments, rowOffset) => {
+            rowComments.forEach((comment, colOffset) => {
+              const row = target.startRow + rowOffset;
+              const col = target.startCol + colOffset;
+
+              if (comment) {
+                comments.setCommentAtCell(row, col, comment);
+              } else {
+                comments.removeCommentAtCell(row, col, false);
+              }
+            });
+          });
+        });
+
+        this.render();
+      }}
+      height="auto"
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/cell-features/clipboard/vue/example4.vue
+++ b/docs/content/guides/cell-features/clipboard/vue/example4.vue
@@ -51,6 +51,9 @@ const hotSettings = ref<GridSettings>({
   afterCopy(this: Handsontable, _data, coords) {
     copiedClassNames.value = collectClassNames(this, coords as CopyRange[]);
   },
+  afterCut(this: Handsontable, _data, coords) {
+    copiedClassNames.value = collectClassNames(this, coords as CopyRange[]);
+  },
   afterPaste(this: Handsontable, _data, coords) {
     const target = (coords as CopyRange[])[0];
 

--- a/docs/content/guides/cell-features/clipboard/vue/example4.vue
+++ b/docs/content/guides/cell-features/clipboard/vue/example4.vue
@@ -1,0 +1,82 @@
+<script setup lang="ts">
+import Handsontable from 'handsontable/base';
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+type CopyRange = { startRow: number; startCol: number; endRow: number; endCol: number };
+
+registerAllModules();
+
+const copiedClassNames = ref<string[][]>([]);
+
+function collectClassNames(hot: Handsontable, coords: CopyRange[]): string[][] {
+  const source = coords[0];
+  const classNames: string[][] = [];
+
+  if (!source) {
+    return classNames;
+  }
+
+  for (let row = source.startRow; row <= source.endRow; row += 1) {
+    const rowClassNames: string[] = [];
+
+    for (let col = source.startCol; col <= source.endCol; col += 1) {
+      rowClassNames.push((hot.getCellMeta(row, col).className as string | undefined) ?? '');
+    }
+
+    classNames.push(rowClassNames);
+  }
+
+  return classNames;
+}
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['Wireless mouse', 142, 'In stock'],
+    ['USB-C cable', 67, 'In stock'],
+    ['Mechanical keyboard', 0, 'Backordered'],
+    ['Laptop stand', 38, 'In stock'],
+    ['HDMI adapter', 210, 'In stock'],
+  ],
+  colHeaders: ['Product', 'Stock', 'Status'],
+  rowHeaders: true,
+  cell: [
+    { row: 0, col: 1, className: 'htRight' },
+    { row: 0, col: 2, className: 'htCenter' },
+    { row: 2, col: 1, className: 'htRight htDimmed' },
+    { row: 2, col: 2, className: 'htCenter htDimmed' },
+  ],
+  afterCopy(this: Handsontable, _data, coords) {
+    copiedClassNames.value = collectClassNames(this, coords as CopyRange[]);
+  },
+  afterPaste(this: Handsontable, _data, coords) {
+    const target = (coords as CopyRange[])[0];
+
+    if (!target) {
+      return;
+    }
+
+    this.batch(() => {
+      copiedClassNames.value.forEach((rowClassNames, rowOffset) => {
+        rowClassNames.forEach((className, colOffset) => {
+          this.setCellMeta(target.startRow + rowOffset, target.startCol + colOffset, 'className', className);
+        });
+      });
+    });
+
+    this.render();
+  },
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example4">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-features/clipboard/vue/example5.vue
+++ b/docs/content/guides/cell-features/clipboard/vue/example5.vue
@@ -1,0 +1,91 @@
+<script setup lang="ts">
+import Handsontable from 'handsontable/base';
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+type CopyRange = { startRow: number; startCol: number; endRow: number; endCol: number };
+
+registerAllModules();
+
+const copiedComments = ref<(string | undefined)[][]>([]);
+
+function collectComments(hot: Handsontable, coords: CopyRange[]): (string | undefined)[][] {
+  const source = coords[0];
+  const comments = hot.getPlugin('comments');
+  const copied: (string | undefined)[][] = [];
+
+  if (!source) {
+    return copied;
+  }
+
+  for (let row = source.startRow; row <= source.endRow; row += 1) {
+    const rowComments: (string | undefined)[] = [];
+
+    for (let col = source.startCol; col <= source.endCol; col += 1) {
+      rowComments.push(comments.getCommentAtCell(row, col));
+    }
+
+    copied.push(rowComments);
+  }
+
+  return copied;
+}
+
+const hotSettings = ref<GridSettings>({
+  data: [
+    ['Wireless mouse', 142, 'In stock'],
+    ['USB-C cable', 67, 'In stock'],
+    ['Mechanical keyboard', 0, 'Backordered'],
+    ['Laptop stand', 38, 'In stock'],
+    ['HDMI adapter', 210, 'In stock'],
+  ],
+  colHeaders: ['Product', 'Stock', 'Status'],
+  rowHeaders: true,
+  comments: true,
+  cell: [
+    { row: 0, col: 1, comment: { value: 'Counted during the July audit.' } },
+    { row: 2, col: 1, comment: { value: 'Reorder request sent to Harbor Goods.' } },
+    { row: 2, col: 2, comment: { value: 'Expected delivery is July 18.' } },
+  ],
+  afterCopy(this: Handsontable, _data, coords) {
+    copiedComments.value = collectComments(this, coords as CopyRange[]);
+  },
+  afterPaste(this: Handsontable, _data, coords) {
+    const target = (coords as CopyRange[])[0];
+    const comments = this.getPlugin('comments');
+
+    if (!target) {
+      return;
+    }
+
+    this.batch(() => {
+      copiedComments.value.forEach((rowComments, rowOffset) => {
+        rowComments.forEach((comment, colOffset) => {
+          const row = target.startRow + rowOffset;
+          const col = target.startCol + colOffset;
+
+          if (comment) {
+            comments.setCommentAtCell(row, col, comment);
+          } else {
+            comments.removeCommentAtCell(row, col, false);
+          }
+        });
+      });
+    });
+
+    this.render();
+  },
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example5">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-features/clipboard/vue/example5.vue
+++ b/docs/content/guides/cell-features/clipboard/vue/example5.vue
@@ -52,6 +52,9 @@ const hotSettings = ref<GridSettings>({
   afterCopy(this: Handsontable, _data, coords) {
     copiedComments.value = collectComments(this, coords as CopyRange[]);
   },
+  afterCut(this: Handsontable, _data, coords) {
+    copiedComments.value = collectComments(this, coords as CopyRange[]);
+  },
   afterPaste(this: Handsontable, _data, coords) {
     const target = (coords as CopyRange[])[0];
     const comments = this.getPlugin('comments');


### PR DESCRIPTION
### Context

The PR adds missing Clipboard guide demos for DEV-701. The guide explains that CopyPaste does not copy cell appearance by default, but it did not show how to preserve related cell metadata during paste.

This change adds framework-parity examples for copying `className` appearance metadata and Comments plugin comments with `afterCopy` and `afterPaste`.

[skip changelog]

### How has this been tested?

- Generated JavaScript and JSX examples:
  - `npm run docs:code-examples:generate-js -- content/guides/cell-features/clipboard/javascript/example4.ts`
  - `npm run docs:code-examples:generate-js -- content/guides/cell-features/clipboard/javascript/example5.ts`
  - `npm run docs:code-examples:generate-js -- content/guides/cell-features/clipboard/react/example4.tsx`
  - `npm run docs:code-examples:generate-js -- content/guides/cell-features/clipboard/react/example5.tsx`
- `npm run docs:lint`
- Browser smoke-tested:
  - `/javascript-data-grid/basic-clipboard/`
  - `/react-data-grid/basic-clipboard/`
  - `/angular-data-grid/basic-clipboard/`
  - `/vue-data-grid/basic-clipboard/`
- Verified the JavaScript demos copy/paste `htRight` and `htCommentCell` metadata to target cells.
- `npm run build` was attempted after clearing `.astro`, then `.astro` and `dist`, but it still failed on the unrelated `/angular-data-grid/disabled-cells` rendered HTML cache error after `/angular-data-grid/basic-clipboard/` rendered.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-701

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-701

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and doc-site examples only; no changes to Handsontable core or wrapper packages.
> 
> **Overview**
> Expands the **Clipboard** guide with two new how-to sections and live **example4** / **example5** demos for JavaScript, TypeScript, React, Angular, and Vue.
> 
> **Copy cell appearance on paste** documents preserving `className` cell metadata by caching it in `afterCopy` / `afterCut` and reapplying with `setCellMeta` in `afterPaste`. **Copy comments on paste** shows the same hook pattern using the Comments plugin (`getCommentAtCell` on copy/cut, `setCommentAtCell` / `removeCommentAtCell` on paste).
> 
> The **Known limitations** list is updated so appearance is described as not copied *by default*, with a link to the new appearance section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0954eb1d1de5b4933821747410f110bcebe589a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->