### PR TITLE
DEV-702: Add decimal validator docs demo

### DIFF
--- a/docs/content/guides/cell-functions/cell-validator/angular/example2.html
+++ b/docs/content/guides/cell-functions/cell-validator/angular/example2.html
@@ -1,0 +1,3 @@
+<div>
+  <example2-cell-validator></example2-cell-validator>
+</div>

--- a/docs/content/guides/cell-functions/cell-validator/angular/example2.ts
+++ b/docs/content/guides/cell-functions/cell-validator/angular/example2.ts
@@ -10,9 +10,17 @@ const data = [
   ['Holiday Preview', 'Social', '9.25'],
 ];
 
-const decimalValidator = (value: string, callback: (valid: boolean) => void) => {
-  callback(/^\d+[.,]\d+$/.test(value));
-};
+type CellMeta = { allowEmpty?: boolean };
+
+function decimalValidator(this: CellMeta, value: unknown, callback: (valid: boolean) => void) {
+  if (this.allowEmpty && (value === null || value === undefined || value === '')) {
+    callback(true);
+
+    return;
+  }
+
+  callback(/^\d+[.,]\d+$/.test(String(value)));
+}
 
 @Component({
   selector: 'example2-cell-validator',

--- a/docs/content/guides/cell-functions/cell-validator/angular/example2.ts
+++ b/docs/content/guides/cell-functions/cell-validator/angular/example2.ts
@@ -1,0 +1,64 @@
+/* file: app.component.ts */
+import { Component } from '@angular/core';
+import { GridSettings, HotTableModule } from '@handsontable/angular-wrapper';
+
+const data = [
+  ['Spring Sale 2025', 'Email', '3.4'],
+  ['Brand Awareness Q3', 'Paid Search', '8,1'],
+  ['Retention Push', 'In-app', '12.0'],
+  ['Partner Webinar', 'Organic', '6,75'],
+  ['Holiday Preview', 'Social', '9.25'],
+];
+
+const decimalValidator = (value: string, callback: (valid: boolean) => void) => {
+  callback(/^\d+[.,]\d+$/.test(value));
+};
+
+@Component({
+  selector: 'example2-cell-validator',
+  standalone: true,
+  imports: [HotTableModule],
+  template: `
+    <hot-table [data]="data" [settings]="gridSettings"></hot-table>
+  `,
+})
+export class AppComponent {
+  readonly data = data;
+
+  readonly gridSettings: GridSettings = {
+    colHeaders: ['Campaign', 'Channel', 'Conversion rate'],
+    columns: [
+      {},
+      {},
+      {
+        validator: decimalValidator,
+        allowInvalid: false,
+      },
+    ],
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true,
+  };
+}
+/* end-file */
+
+
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+// register Handsontable's modules
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    {
+      provide: HOT_GLOBAL_CONFIG,
+      useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig,
+    },
+  ],
+};
+/* end-file */

--- a/docs/content/guides/cell-functions/cell-validator/cell-validator.md
+++ b/docs/content/guides/cell-functions/cell-validator/cell-validator.md
@@ -208,6 +208,53 @@ const hot = new Handsontable(container, {
 
 :::
 
+## Validate decimal numbers with dot or comma separators
+
+Use a custom validator when a column must accept decimal values with either `.` or `,` as the decimal separator. The following example validates campaign conversion rates. It accepts values such as `3.4` and `8,1`, and rejects values that do not match the decimal format.
+
+:::: only-for javascript
+
+:::: example #example2 --js 1 --ts 2
+
+@[code](@/content/guides/cell-functions/cell-validator/javascript/example2.js)
+@[code](@/content/guides/cell-functions/cell-validator/javascript/example2.ts)
+
+::::
+
+::::
+
+:::: only-for react
+
+:::: example #example2 :react --js 1 --ts 2
+
+@[code](@/content/guides/cell-functions/cell-validator/react/example2.jsx)
+@[code](@/content/guides/cell-functions/cell-validator/react/example2.tsx)
+
+::::
+
+::::
+
+:::: only-for angular
+
+:::: example #example2 :angular --ts 1 --html 2
+
+@[code](@/content/guides/cell-functions/cell-validator/angular/example2.ts)
+@[code](@/content/guides/cell-functions/cell-validator/angular/example2.html)
+
+::::
+
+::::
+
+:::: only-for vue
+
+:::: example #example2 :vue3
+
+@[code](@/content/guides/cell-functions/cell-validator/vue/example2.vue)
+
+::::
+
+::::
+
 ## Full featured example
 
 Use the validator method to easily validate synchronous or asynchronous changes to a cell. If you need more control, [`beforeValidate`](@/api/hooks.md#beforevalidate) and [`afterValidate`](@/api/hooks.md#aftervalidate) hooks are available. In the below example, `email_validator_fn` is an async validator that resolves after 1000 ms.

--- a/docs/content/guides/cell-functions/cell-validator/cell-validator.md
+++ b/docs/content/guides/cell-functions/cell-validator/cell-validator.md
@@ -214,44 +214,44 @@ Use a custom validator when a column must accept decimal values with either `.` 
 
 :::: only-for javascript
 
-:::: example #example2 --js 1 --ts 2
+::: example #example2 --js 1 --ts 2
 
 @[code](@/content/guides/cell-functions/cell-validator/javascript/example2.js)
 @[code](@/content/guides/cell-functions/cell-validator/javascript/example2.ts)
 
-::::
+:::
 
 ::::
 
 :::: only-for react
 
-:::: example #example2 :react --js 1 --ts 2
+::: example #example2 :react --js 1 --ts 2
 
 @[code](@/content/guides/cell-functions/cell-validator/react/example2.jsx)
 @[code](@/content/guides/cell-functions/cell-validator/react/example2.tsx)
 
-::::
+:::
 
 ::::
 
 :::: only-for angular
 
-:::: example #example2 :angular --ts 1 --html 2
+::: example #example2 :angular --ts 1 --html 2
 
 @[code](@/content/guides/cell-functions/cell-validator/angular/example2.ts)
 @[code](@/content/guides/cell-functions/cell-validator/angular/example2.html)
 
-::::
+:::
 
 ::::
 
 :::: only-for vue
 
-:::: example #example2 :vue3
+::: example #example2 :vue3
 
 @[code](@/content/guides/cell-functions/cell-validator/vue/example2.vue)
 
-::::
+:::
 
 ::::
 

--- a/docs/content/guides/cell-functions/cell-validator/javascript/example2.js
+++ b/docs/content/guides/cell-functions/cell-validator/javascript/example2.js
@@ -10,9 +10,13 @@ const data = [
     ['Partner Webinar', 'Organic', '6,75'],
     ['Holiday Preview', 'Social', '9.25'],
 ];
-const decimalValidator = (value, callback) => {
-    callback(/^\d+[.,]\d+$/.test(value));
-};
+function decimalValidator(value, callback) {
+    if (this.allowEmpty && (value === null || value === undefined || value === '')) {
+        callback(true);
+        return;
+    }
+    callback(/^\d+[.,]\d+$/.test(String(value)));
+}
 new Handsontable(container, {
     data,
     colHeaders: ['Campaign', 'Channel', 'Conversion rate'],

--- a/docs/content/guides/cell-functions/cell-validator/javascript/example2.js
+++ b/docs/content/guides/cell-functions/cell-validator/javascript/example2.js
@@ -1,0 +1,31 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+// Register all Handsontable's modules.
+registerAllModules();
+const container = document.querySelector('#example2');
+const data = [
+    ['Spring Sale 2025', 'Email', '3.4'],
+    ['Brand Awareness Q3', 'Paid Search', '8,1'],
+    ['Retention Push', 'In-app', '12.0'],
+    ['Partner Webinar', 'Organic', '6,75'],
+    ['Holiday Preview', 'Social', '9.25'],
+];
+const decimalValidator = (value, callback) => {
+    callback(/^\d+[.,]\d+$/.test(value));
+};
+new Handsontable(container, {
+    data,
+    colHeaders: ['Campaign', 'Channel', 'Conversion rate'],
+    columns: [
+        {},
+        {},
+        {
+            validator: decimalValidator,
+            allowInvalid: false,
+        },
+    ],
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true,
+    licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/cell-functions/cell-validator/javascript/example2.ts
+++ b/docs/content/guides/cell-functions/cell-validator/javascript/example2.ts
@@ -14,9 +14,17 @@ const data = [
   ['Holiday Preview', 'Social', '9.25'],
 ];
 
-const decimalValidator = (value: string, callback: (valid: boolean) => void) => {
-  callback(/^\d+[.,]\d+$/.test(value));
-};
+type CellMeta = { allowEmpty?: boolean };
+
+function decimalValidator(this: CellMeta, value: unknown, callback: (valid: boolean) => void) {
+  if (this.allowEmpty && (value === null || value === undefined || value === '')) {
+    callback(true);
+
+    return;
+  }
+
+  callback(/^\d+[.,]\d+$/.test(String(value)));
+}
 
 new Handsontable(container, {
   data,

--- a/docs/content/guides/cell-functions/cell-validator/javascript/example2.ts
+++ b/docs/content/guides/cell-functions/cell-validator/javascript/example2.ts
@@ -1,0 +1,36 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+// Register all Handsontable's modules.
+registerAllModules();
+
+const container = document.querySelector('#example2')!;
+
+const data = [
+  ['Spring Sale 2025', 'Email', '3.4'],
+  ['Brand Awareness Q3', 'Paid Search', '8,1'],
+  ['Retention Push', 'In-app', '12.0'],
+  ['Partner Webinar', 'Organic', '6,75'],
+  ['Holiday Preview', 'Social', '9.25'],
+];
+
+const decimalValidator = (value: string, callback: (valid: boolean) => void) => {
+  callback(/^\d+[.,]\d+$/.test(value));
+};
+
+new Handsontable(container, {
+  data,
+  colHeaders: ['Campaign', 'Channel', 'Conversion rate'],
+  columns: [
+    {},
+    {},
+    {
+      validator: decimalValidator,
+      allowInvalid: false,
+    },
+  ],
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/cell-functions/cell-validator/react/example2.jsx
+++ b/docs/content/guides/cell-functions/cell-validator/react/example2.jsx
@@ -1,0 +1,25 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+// register Handsontable's modules
+registerAllModules();
+const data = [
+    ['Spring Sale 2025', 'Email', '3.4'],
+    ['Brand Awareness Q3', 'Paid Search', '8,1'],
+    ['Retention Push', 'In-app', '12.0'],
+    ['Partner Webinar', 'Organic', '6,75'],
+    ['Holiday Preview', 'Social', '9.25'],
+];
+const decimalValidator = (value, callback) => {
+    callback(/^\d+[.,]\d+$/.test(value));
+};
+const ExampleComponent = () => {
+    return (<HotTable data={data} colHeaders={['Campaign', 'Channel', 'Conversion rate']} columns={[
+            {},
+            {},
+            {
+                validator: decimalValidator,
+                allowInvalid: false,
+            },
+        ]} height="auto" autoWrapRow={true} autoWrapCol={true} licenseKey="non-commercial-and-evaluation"/>);
+};
+export default ExampleComponent;

--- a/docs/content/guides/cell-functions/cell-validator/react/example2.jsx
+++ b/docs/content/guides/cell-functions/cell-validator/react/example2.jsx
@@ -9,9 +9,13 @@ const data = [
     ['Partner Webinar', 'Organic', '6,75'],
     ['Holiday Preview', 'Social', '9.25'],
 ];
-const decimalValidator = (value, callback) => {
-    callback(/^\d+[.,]\d+$/.test(value));
-};
+function decimalValidator(value, callback) {
+    if (this.allowEmpty && (value === null || value === undefined || value === '')) {
+        callback(true);
+        return;
+    }
+    callback(/^\d+[.,]\d+$/.test(String(value)));
+}
 const ExampleComponent = () => {
     return (<HotTable data={data} colHeaders={['Campaign', 'Channel', 'Conversion rate']} columns={[
             {},

--- a/docs/content/guides/cell-functions/cell-validator/react/example2.tsx
+++ b/docs/content/guides/cell-functions/cell-validator/react/example2.tsx
@@ -12,9 +12,17 @@ const data = [
   ['Holiday Preview', 'Social', '9.25'],
 ];
 
-const decimalValidator = (value: string, callback: (valid: boolean) => void) => {
-  callback(/^\d+[.,]\d+$/.test(value));
-};
+type CellMeta = { allowEmpty?: boolean };
+
+function decimalValidator(this: CellMeta, value: unknown, callback: (valid: boolean) => void) {
+  if (this.allowEmpty && (value === null || value === undefined || value === '')) {
+    callback(true);
+
+    return;
+  }
+
+  callback(/^\d+[.,]\d+$/.test(String(value)));
+}
 
 const ExampleComponent = () => {
   return (

--- a/docs/content/guides/cell-functions/cell-validator/react/example2.tsx
+++ b/docs/content/guides/cell-functions/cell-validator/react/example2.tsx
@@ -1,0 +1,40 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+// register Handsontable's modules
+registerAllModules();
+
+const data = [
+  ['Spring Sale 2025', 'Email', '3.4'],
+  ['Brand Awareness Q3', 'Paid Search', '8,1'],
+  ['Retention Push', 'In-app', '12.0'],
+  ['Partner Webinar', 'Organic', '6,75'],
+  ['Holiday Preview', 'Social', '9.25'],
+];
+
+const decimalValidator = (value: string, callback: (valid: boolean) => void) => {
+  callback(/^\d+[.,]\d+$/.test(value));
+};
+
+const ExampleComponent = () => {
+  return (
+    <HotTable
+      data={data}
+      colHeaders={['Campaign', 'Channel', 'Conversion rate']}
+      columns={[
+        {},
+        {},
+        {
+          validator: decimalValidator,
+          allowInvalid: false,
+        },
+      ]}
+      height="auto"
+      autoWrapRow={true}
+      autoWrapCol={true}
+      licenseKey="non-commercial-and-evaluation"
+    />
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/cell-functions/cell-validator/vue/example2.vue
+++ b/docs/content/guides/cell-functions/cell-validator/vue/example2.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const data = [
+  ['Spring Sale 2025', 'Email', '3.4'],
+  ['Brand Awareness Q3', 'Paid Search', '8,1'],
+  ['Retention Push', 'In-app', '12.0'],
+  ['Partner Webinar', 'Organic', '6,75'],
+  ['Holiday Preview', 'Social', '9.25'],
+];
+
+const decimalValidator = (value: string, callback: (valid: boolean) => void) => {
+  callback(/^\d+[.,]\d+$/.test(value));
+};
+
+const hotSettings = ref<GridSettings>({
+  data,
+  colHeaders: ['Campaign', 'Channel', 'Conversion rate'],
+  columns: [
+    {},
+    {},
+    {
+      validator: decimalValidator,
+      allowInvalid: false,
+    },
+  ],
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});
+</script>
+
+<template>
+  <div id="example2">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-functions/cell-validator/vue/example2.vue
+++ b/docs/content/guides/cell-functions/cell-validator/vue/example2.vue
@@ -14,9 +14,17 @@ const data = [
   ['Holiday Preview', 'Social', '9.25'],
 ];
 
-const decimalValidator = (value: string, callback: (valid: boolean) => void) => {
-  callback(/^\d+[.,]\d+$/.test(value));
-};
+type CellMeta = { allowEmpty?: boolean };
+
+function decimalValidator(this: CellMeta, value: unknown, callback: (valid: boolean) => void) {
+  if (this.allowEmpty && (value === null || value === undefined || value === '')) {
+    callback(true);
+
+    return;
+  }
+
+  callback(/^\d+[.,]\d+$/.test(String(value)));
+}
 
 const hotSettings = ref<GridSettings>({
   data,


### PR DESCRIPTION
### Context

The PR adds a Cell validator guide demo for DEV-702. The new example shows a custom regex validator for decimal values that accepts either `.` or `,` as the decimal separator.

[skip changelog]

### How has this been tested?

- `npm run docs:code-examples:generate-js -- content/guides/cell-functions/cell-validator/javascript/example2.ts`
- `npm run docs:code-examples:generate-js -- content/guides/cell-functions/cell-validator/react/example2.tsx`
- `npm run docs:lint`
- `npm run docs:validate-highlights`
- `git diff --check -- docs/content/guides/cell-functions/cell-validator`

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-702

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-702

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to docs and example code; no Handsontable library or wrapper runtime behavior is modified.
> 
> **Overview**
> Adds a new **Cell validator** guide section, *Validate decimal numbers with dot or comma separators*, placed before the existing full-featured example.
> 
> The docs introduce a `decimalValidator` that accepts values matching `^\d+[.,]\d+$` (e.g. `3.4`, `8,1`) on a campaign conversion-rate column with **`allowInvalid: false`**. Runnable **`#example2`** snippets are added for JavaScript/TypeScript, React, Angular, and Vue, following the same multi-framework pattern as other guide examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 246fc20544b4d3d2545a4e8fa8b2f053b8ed7d56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->