### PR TITLE
DEV-2049: Improve code-review-graph discoverability for AI agents, bump to 2.3.6

### DIFF
--- a/.ai/MCP.md
+++ b/.ai/MCP.md
@@ -85,7 +85,7 @@ A Tree-sitter knowledge graph over the full codebase (28k+ nodes, 419k+ edges). 
   - macOS: `brew install pipx && pipx ensurepath`
   - Linux: `python3 -m pip install --user pipx && pipx ensurepath`
 
-No manual `code-review-graph` install is required. The `.mcp.json` configuration invokes it via `pipx run code-review-graph==2.3.2 serve`, which fetches and caches the package on first use (~10s one-time download, instant on subsequent starts).
+No manual `code-review-graph` install is required. The `.mcp.json` configuration invokes it via `pipx run code-review-graph==2.3.6 serve`, which fetches and caches the package on first use (~10s one-time download, instant on subsequent starts).
 
 ### Verifying the setup
 
@@ -96,10 +96,10 @@ Run `/mcp` in Claude Code and confirm `code-review-graph` appears with status `c
 The graph is built against a specific git commit. After switching branches, rebuild so tools like `detect_changes` don't report function names from unrelated files:
 
 ```bash
-pipx run code-review-graph==2.3.2 build
+pipx run code-review-graph==2.3.6 build
 ```
 
-The `PostToolUse` hook in `.claude/settings.json` runs `pipx run code-review-graph==2.3.2 update --skip-flows` after each `Edit` or `Write` to keep the graph in sync during a session. The `--skip-flows` flag skips execution-flow re-analysis for speed -- flows are only re-indexed on a full `build`. A rebuild is only needed after `git checkout`, `git pull`, or large merges.
+The `PostToolUse` hook in `.claude/settings.json` runs `pipx run code-review-graph==2.3.6 update --skip-flows` after each `Edit` or `Write` to keep the graph in sync during a session. The `--skip-flows` flag skips execution-flow re-analysis for speed -- flows are only re-indexed on a full `build`. A rebuild is only needed after `git checkout`, `git pull`, or large merges.
 
 The hooks are guarded with `command -v pipx >/dev/null 2>&1 && ... || true` so machines without `pipx` installed (or air-gapped sessions where PyPI is unreachable) do not error on every session start or file edit.
 
@@ -107,9 +107,9 @@ The hooks are guarded with `command -v pipx >/dev/null 2>&1 && ... || true` so m
 
 | Symptom | Fix |
 |---|---|
-| `code-review-graph` not listed in `/mcp` | Check `pipx --version` is installed; run `pipx run code-review-graph==2.3.2 --version` manually to confirm |
+| `code-review-graph` not listed in `/mcp` | Check `pipx --version` is installed; run `pipx run code-review-graph==2.3.6 --version` manually to confirm |
 | First session is slow (~10s hang at start) | Expected -- pipx is downloading the package. Subsequent sessions use the cached venv |
-| `detect_changes` reports wrong function names | Graph is stale on the wrong branch. Run `pipx run code-review-graph==2.3.2 build` |
+| `detect_changes` reports wrong function names | Graph is stale on the wrong branch. Run `pipx run code-review-graph==2.3.6 build` |
 | `tests_for` returns 0 for files with known tests | Known limitation -- use grep for `.spec.js` / `.unit.js` files instead |
 | `get_architecture_overview` fails with token-limit error | Do not call this tool -- it produces 3.9M characters. Use `list_communities` + `get_community` for specific areas |
 

--- a/.ai/MCP.md
+++ b/.ai/MCP.md
@@ -85,7 +85,7 @@ A Tree-sitter knowledge graph over the full codebase (28k+ nodes, 419k+ edges). 
   - macOS: `brew install pipx && pipx ensurepath`
   - Linux: `python3 -m pip install --user pipx && pipx ensurepath`
 
-No manual `code-review-graph` install is required. The `.mcp.json` configuration invokes it via `pipx run code-review-graph==2.3.6 serve`, which fetches and caches the package on first use (~10s one-time download, instant on subsequent starts).
+No manual `code-review-graph` install is required. The `.mcp.json` configuration (Claude Code) and `.cursor/mcp.json` (Cursor) invoke it via `pipx run code-review-graph==2.3.6 serve`, which fetches and caches the package on first use (~10s one-time download, instant on subsequent starts).
 
 ### Verifying the setup
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,7 +11,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "command -v pipx >/dev/null 2>&1 && pipx run code-review-graph==2.3.2 update --skip-flows || true",
+            "command": "command -v pipx >/dev/null 2>&1 && pipx run code-review-graph==2.3.6 update --skip-flows || true",
             "timeout": 30
           }
         ]
@@ -23,7 +23,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "command -v pipx >/dev/null 2>&1 && pipx run code-review-graph==2.3.2 status || true",
+            "command": "command -v pipx >/dev/null 2>&1 && pipx run code-review-graph==2.3.6 status || true; echo 'Cross-file queries (who calls X, what imports Y, rename impact, blast radius): query the code-review-graph MCP before walking call chains with Grep+Read. Load schemas first via ToolSearch select:mcp__code-review-graph__query_graph_tool — full workflow in the code-graph skill.'",
             "timeout": 30
           }
         ]

--- a/.claude/skills/code-graph/SKILL.md
+++ b/.claude/skills/code-graph/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-graph
-description: Use the pre-built code-review-graph knowledge graph for ANY cross-file task in this monorepo — exploring code, debugging symptom→root-cause, planning a safe refactor/rename, or reviewing a branch/PR. Reach for this BEFORE manual Grep+Read of call chains; results are 2-6x cheaper. Trigger on "who calls X", "what imports Y", "where is X used", "dependency chain", "blast radius", "trace this bug", "rename X across the codebase", "find dead code", "what would break if I change", "review this PR" — or any question that spans multiple files, even when Grep seems enough.
+description: Query the pre-built code-review-graph knowledge graph (Tree-sitter, whole monorepo) instead of walking call chains with Grep+Read — 2-6x cheaper, and it catches dynamic dispatch that grep misses. Use for ANY task that spans multiple files, even when the user never mentions a graph or asks for it - fixing or tracing a bug ("fix this bug", "why does X happen", "trace this"), exploring unfamiliar code ("how does X work", "who calls X", "what imports Y", "where is X used or handled"), planning or doing a refactor ("rename X", "is it safe to change or remove X", "what would break", "blast radius", "find dead code"), or reviewing changes ("review this PR", "review this branch or diff"). If you are about to Grep for a symbol to find its callers, callees, or importers, stop and use this skill instead.
 ---
 
 # Code graph (code-review-graph MCP)
@@ -22,8 +22,8 @@ Comma-separate whichever tools the task needs. One cheap call unblocks every gra
 A graph built on another branch makes `detect_changes` report function names from unrelated files. Verify and rebuild when needed (the `PostToolUse` hook keeps it in sync after edits, so a manual rebuild is only needed after `git checkout` / `git pull` / large merges):
 
 ```
-pipx run code-review-graph==2.3.2 status
-pipx run code-review-graph==2.3.2 build
+pipx run code-review-graph==2.3.6 status
+pipx run code-review-graph==2.3.6 build
 ```
 
 ## Pick your mode

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -21,6 +21,10 @@
     "filesystem_docs": {
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-filesystem", "./docs/content"]
+    },
+    "code-review-graph": {
+      "command": "pipx",
+      "args": ["run", "code-review-graph==2.3.6", "serve"]
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -27,7 +27,7 @@
       "command": "pipx",
       "args": [
         "run",
-        "code-review-graph==2.3.2",
+        "code-review-graph==2.3.6",
         "serve"
       ],
       "type": "stdio"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ In every directory, `CLAUDE.md` is a symlink to its sibling `AGENTS.md`. Edit `A
 
 ### Cross-file code queries: use the code-review-graph MCP
 
-A pre-built Tree-sitter knowledge graph over the whole monorepo answers cross-file questions far more cheaply than walking call chains with Grep+Read. For any of: "who calls X", "what imports Y", "where is X used", rename impact, PR blast radius, or dead-code hunting — query the graph FIRST. Its tools are deferred at session start, so load the schemas with one `ToolSearch` call (e.g. `select:mcp__code-review-graph__query_graph_tool,mcp__code-review-graph__get_impact_radius_tool`), then query. Plain Grep stays the right tool for single-symbol, single-file lookups. Full workflow (modes, staleness, rebuild after branch switches): the `code-graph` skill and `.ai/MCP.md`.
+A pre-built Tree-sitter knowledge graph over the whole monorepo answers cross-file questions far more cheaply than walking call chains with Grep+Read. For any of: "who calls X", "what imports Y", "where is X used", rename impact, PR blast radius, or dead-code hunting — query the graph FIRST. In Claude Code, its tools are deferred at session start — load the schemas with one `ToolSearch` call (e.g. `select:mcp__code-review-graph__query_graph_tool,mcp__code-review-graph__get_impact_radius_tool`), then query. In agents without deferred tool loading (e.g. Cursor), skip that step — the graph tools are callable directly. Plain Grep stays the right tool for single-symbol, single-file lookups. Full workflow (modes, staleness, rebuild after branch switches): `.ai/MCP.md`, plus the `code-graph` skill in Claude Code.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,10 @@ Route to the lowest correct scope. `AGENTS.md` answers "what must I never get wr
 
 In every directory, `CLAUDE.md` is a symlink to its sibling `AGENTS.md`. Edit `AGENTS.md` — the symlink keeps Claude Code and Cursor reading the same single source.
 
+### Cross-file code queries: use the code-review-graph MCP
+
+A pre-built Tree-sitter knowledge graph over the whole monorepo answers cross-file questions far more cheaply than walking call chains with Grep+Read. For any of: "who calls X", "what imports Y", "where is X used", rename impact, PR blast radius, or dead-code hunting — query the graph FIRST. Its tools are deferred at session start, so load the schemas with one `ToolSearch` call (e.g. `select:mcp__code-review-graph__query_graph_tool,mcp__code-review-graph__get_impact_radius_tool`), then query. Plain Grep stays the right tool for single-symbol, single-file lookups. Full workflow (modes, staleness, rebuild after branch switches): the `code-graph` skill and `.ai/MCP.md`.
+
 ---
 
 ## Workspace packages

--- a/handsontable/AGENTS.md
+++ b/handsontable/AGENTS.md
@@ -164,7 +164,7 @@ Extra args after `--` flow through to tasks with `"passthrough": true` in `tasks
 ## For Deeper Guidance
 
 Use these skills for detailed workflow instructions:
-- Cross-file queries (who calls X, what imports Y, rename impact, blast radius): `code-graph` skill — query the pre-built code-review-graph MCP before walking call chains with Grep+Read
+- Cross-file queries (who calls X, what imports Y, rename impact, blast radius): query the pre-built code-review-graph MCP before walking call chains with Grep+Read — workflow in `.ai/MCP.md` and, in Claude Code, the `code-graph` skill
 - Plugin development: `handsontable-plugin-dev`
 - Editors/renderers/validators/cellTypes: `handsontable-editor-dev`, `handsontable-renderer-dev`, `handsontable-validator-dev`, `handsontable-celltype-dev`
 - Testing: `handsontable-unit-testing`, `handsontable-e2e-testing`

--- a/handsontable/AGENTS.md
+++ b/handsontable/AGENTS.md
@@ -164,6 +164,7 @@ Extra args after `--` flow through to tasks with `"passthrough": true` in `tasks
 ## For Deeper Guidance
 
 Use these skills for detailed workflow instructions:
+- Cross-file queries (who calls X, what imports Y, rename impact, blast radius): `code-graph` skill — query the pre-built code-review-graph MCP before walking call chains with Grep+Read
 - Plugin development: `handsontable-plugin-dev`
 - Editors/renderers/validators/cellTypes: `handsontable-editor-dev`, `handsontable-renderer-dev`, `handsontable-validator-dev`, `handsontable-celltype-dev`
 - Testing: `handsontable-unit-testing`, `handsontable-e2e-testing`

--- a/handsontable/src/3rdparty/walkontable/AGENTS.md
+++ b/handsontable/src/3rdparty/walkontable/AGENTS.md
@@ -51,9 +51,9 @@ For detailed guidance: use skills `walkontable-dev`, `walkontable-testing`
 
 A Tree-sitter knowledge graph (28k+ nodes, 419k+ edges) pre-built over the full codebase. Provides structured, function-level results for cross-file queries that would otherwise require many Grep+Read round-trips.
 
-**Prerequisite:** `pipx` must be installed. The MCP server starts automatically via `pipx run` on first use (one-time ~10s PyPI download, then cached). Rebuild after switching branches: `pipx run code-review-graph==2.3.2 build`.
+**Prerequisite:** `pipx` must be installed. The MCP server starts automatically via `pipx run` on first use (one-time ~10s PyPI download, then cached). Rebuild after switching branches: `pipx run code-review-graph==2.3.6 build`.
 
-**Maintainer note:** the pinned version `2.3.2` appears in `.mcp.json`, the two hook commands in `.claude/settings.json`, and the guidance tables below. Bumping requires updating all four locations in sync.
+**Maintainer note:** the pinned version `2.3.6` appears in `.mcp.json`, the two hook commands in `.claude/settings.json`, `.ai/MCP.md`, `.claude/skills/code-graph/SKILL.md`, and the guidance below. Bumping requires updating all locations in sync.
 
 ### First-call protocol - load schema before grep
 
@@ -91,7 +91,7 @@ The first tool call should be `ToolSearch` for the graph schema whenever the use
 
 1. **Always pass `detail_level: "minimal"`** - standard mode repeats the full absolute path per node and inflates token cost 6x.
 2. **Use fully qualified names**: `path/to/file.ts::ClassName.methodName`. Bare names return an "ambiguous" error.
-3. **Rebuild on branch switch**: `pipx run code-review-graph==2.3.2 build`. A stale graph causes `detect_changes` to report function names from unrelated files.
+3. **Rebuild on branch switch**: `pipx run code-review-graph==2.3.6 build`. A stale graph causes `detect_changes` to report function names from unrelated files.
 
 ### Reliable tools
 

--- a/handsontable/src/3rdparty/walkontable/AGENTS.md
+++ b/handsontable/src/3rdparty/walkontable/AGENTS.md
@@ -53,14 +53,16 @@ A Tree-sitter knowledge graph (28k+ nodes, 419k+ edges) pre-built over the full 
 
 **Prerequisite:** `pipx` must be installed. The MCP server starts automatically via `pipx run` on first use (one-time ~10s PyPI download, then cached). Rebuild after switching branches: `pipx run code-review-graph==2.3.6 build`.
 
-**Maintainer note:** the pinned version `2.3.6` appears in `.mcp.json`, the two hook commands in `.claude/settings.json`, `.ai/MCP.md`, `.claude/skills/code-graph/SKILL.md`, and the guidance below. Bumping requires updating all locations in sync.
+**Maintainer note:** the pinned version `2.3.6` appears in `.mcp.json`, `.cursor/mcp.json`, the two hook commands in `.claude/settings.json`, `.ai/MCP.md`, `.claude/skills/code-graph/SKILL.md`, and the guidance below. Bumping requires updating all locations in sync.
 
 ### First-call protocol - load schema before grep
 
-Graph MCP tools are **deferred** at session start; their schemas are not loaded. Calling them directly fails with `InputValidationError`. The sequence is always:
+In Claude Code, graph MCP tools are **deferred** at session start; their schemas are not loaded. Calling them directly fails with `InputValidationError`. The sequence is always:
 
 1. `ToolSearch` with `query: "select:mcp__code-review-graph__query_graph_tool"` to load the schema (comma-separate names to load several in one call).
 2. Call `mcp__code-review-graph__query_graph_tool` with `pattern` and `detail_level: "minimal"`.
+
+Agents without deferred tool loading (e.g. Cursor) skip step 1 — the graph tools are callable directly.
 
 If you reach for `grep -r "from.*foo"`, `grep -rn` for a symbol, or repeated `Read` calls to answer a cross-file question, **stop and load the graph tool first.** Grep produces 2-6x more tokens, lacks structural context, and misses dynamic dispatch.
 


### PR DESCRIPTION
### Context

The PR improves the discoverability of the `code-review-graph` MCP server for AI agents, and updates the pinned tool version from 2.3.2 to 2.3.6.

The graph server is configured and works, but agents almost never used it. The cause is low visibility, not misconfiguration:

- The graph MCP tools are deferred at session start. Agents only see the tool names in a long list, while the native Grep/Read tools are always loaded — so grep wins by habit.
- The usage instructions lived only in `handsontable/src/3rdparty/walkontable/AGENTS.md` and `.ai/MCP.md`. The root `AGENTS.md` and `handsontable/AGENTS.md` — the files always loaded into agent context — never mentioned the graph.
- The `code-graph` skill description triggered on analyst phrases ("blast radius", "dependency chain") that users rarely type.

Changes:

1. **Root `AGENTS.md`**: new "Cross-file code queries" section, so every agent session sees the pointer.
2. **`handsontable/AGENTS.md`**: a `code-graph` entry in the "For Deeper Guidance" skill list.
3. **`.claude/settings.json`**: the `SessionStart` hook now prints a one-line usage hint next to the graph stats, reminding agents to query the graph before walking call chains with Grep+Read.
4. **`.claude/skills/code-graph/SKILL.md`**: the skill description is rewritten to match real user phrasings ("fix this bug", "how does X work", "is it safe to remove X") and adds a self-correction cue ("if you are about to Grep for a symbol's callers, stop and use this skill").
5. **Version bump 2.3.2 → 2.3.6** in all pinned locations: `.mcp.json`, both hook commands in `.claude/settings.json`, `.ai/MCP.md`, the `code-graph` skill, and the walkontable `AGENTS.md` (its maintainer note now lists the complete set of pinned locations).

No package source code is changed — agent tooling and docs only.

[skip changelog]

### How has this been tested?

- Verified `code-review-graph==2.3.6` exists on PyPI and runs: `pipx run code-review-graph==2.3.6 --version`.
- Validated `.mcp.json` and `.claude/settings.json` parse as JSON after the hook change.
- Ran the updated incremental sync command (`pipx run code-review-graph==2.3.6 update --skip-flows`) against the existing graph — completes in ~0.6 s.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2049

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2049

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and MCP/agent configuration only; no runtime grid behavior or dependency changes in application code.
> 
> **Overview**
> Improves how AI agents are steered toward the **code-review-graph** MCP (no Handsontable package code changes).
> 
> **Discoverability:** Root `AGENTS.md` adds a **Cross-file code queries** section; `handsontable/AGENTS.md` links the graph in **For Deeper Guidance**. The Claude **`SessionStart`** hook now prints a one-line reminder to query the graph before Grep+Read chains. The **`code-graph`** skill description is rewritten for everyday prompts (bugs, exploration, refactors, PR review) and tells agents to stop if they are about to grep for callers/importers.
> 
> **Tooling parity:** **`code-review-graph`** is registered in **`.cursor/mcp.json`** (it was only in `.mcp.json` before). Walkontable `AGENTS.md` notes that deferred-tool loading applies to Claude Code, not Cursor.
> 
> **Version pin:** **`2.3.2` → `2.3.6`** everywhere it is pinned—`.mcp.json`, `.cursor/mcp.json`, `.claude/settings.json` hooks, `.ai/MCP.md`, `code-graph` skill, and walkontable maintainer docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e52e0fb1b01308e0da72f0af0479d62560782d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->