### PR TITLE
DEV-1928: Clarify updateSettings hook feedback loops

### DIFF
--- a/docs/content/guides/getting-started/events-and-hooks/events-and-hooks.md
+++ b/docs/content/guides/getting-started/events-and-hooks/events-and-hooks.md
@@ -367,6 +367,7 @@ It's worth mentioning that some Handsontable hooks are triggered from the Handso
 | `edit`                                             | Action triggered by Handsontable after the data has been changed, e.g., after an edit or using [`setDataAtCell()`](@/api/core.md#setdataatcell), [`setDataAtRowProp()`](@/api/core.md#setdataatrowprop), or [`setSourceDataAtCell()`](@/api/core.md#setsourcedataatcell) methods. |
 | `loadData`                                         | Action triggered by Handsontable after the [`loadData`](@/api/core.md#loaddata) method has been called with the [`data`](@/api/options.md#data) property.
 | `updateData`                                         | Action triggered by Handsontable after the [`updateData`](@/api/core.md#updatedata) method has been called; e.g., before or after a data change.                                                                                                     |
+| `updateSettings`                                   | Action triggered by [`updateSettings()`](@/api/core.md#updatesettings) when its settings object includes the [`data`](@/api/options.md#data) option. The [`beforeUpdateData`](@/api/hooks.md#beforeupdatedata) and [`afterUpdateData`](@/api/hooks.md#afterupdatedata) hooks receive this source. |
 | `populateFromArray`                                | Action triggered by Handsontable after the [`populateFromArray()`](@/api/core.md#populatefromarray) method has been called.                                                                                            |
 | `spliceCol`                                        | Action triggered by Handsontable after the [`spliceCol()`](@/api/core.md#splicecol) method has been called.                                                                                                            |
 | `spliceRow`                                        | Action triggered by Handsontable after the [`spliceRow()`](@/api/core.md#splicerow) method has been called.                                                                                                            |
@@ -388,6 +389,26 @@ It's worth mentioning that some Handsontable hooks are triggered from the Handso
 | [`ColumnSummary.set`](@/api/columnSummary.md)      | Action triggered by the ColumnSummary plugin after the calculation has been done.                                                                                                                                      |
 | [`ColumnSummary.reset`](@/api/columnSummary.md)    | Action triggered by the ColumnSummary plugin after the calculation has been reset.                                                                                                                                    |
 
+### Prevent feedback loops when replacing data
+
+After initialization, [`updateSettings()`](@/api/core.md#updatesettings) uses [`updateData()`](@/api/core.md#updatedata) internally when its settings object includes `data`. The [`beforeUpdateData`](@/api/hooks.md#beforeupdatedata) and [`afterUpdateData`](@/api/hooks.md#afterupdatedata) hooks receive `source === 'updateSettings'`. The resulting [`afterChange`](@/api/hooks.md#afterchange) hook receives `changes === null` and `source === 'updateData'`.
+
+Calling `updateSettings({ data })` inside `afterChange` triggers `afterChange` again. Check the source before replacing data to prevent a feedback loop. In this callback snippet, `nextData` contains the dataset supplied by your application:
+
+```javascript
+hot.addHook('afterChange', (changes, source) => {
+  if (source === 'updateData') {
+    return;
+  }
+
+  hot.updateSettings({
+    data: nextData,
+  });
+});
+```
+
+The [`beforeChange`](@/api/hooks.md#beforechange) hook doesn't run for whole-dataset replacements. Use [`beforeUpdateData`](@/api/hooks.md#beforeupdatedata) to intercept data passed through `updateSettings({ data })`.
+
 List of callbacks that operate on the `source` parameter:
 
 <div class="boxes-list">
@@ -399,6 +420,7 @@ List of callbacks that operate on the `source` parameter:
 - [afterSetDataAtCell](@/api/hooks.md#aftersetdataatcell)
 - [afterSetDataAtRowProp](@/api/hooks.md#aftersetdataatrowprop)
 - [afterSetSourceDataAtCell](@/api/hooks.md#aftersetsourcedataatcell)
+- [afterUpdateData](@/api/hooks.md#afterupdatedata)
 - [afterRemoveCol](@/api/hooks.md#afterremovecol)
 - [afterRemoveRow](@/api/hooks.md#afterremoverow)
 - [afterValidate](@/api/hooks.md#aftervalidate)
@@ -409,6 +431,7 @@ List of callbacks that operate on the `source` parameter:
 - [beforeLoadData](@/api/hooks.md#beforeloaddata)
 - [beforeRemoveCol](@/api/hooks.md#beforeremovecol)
 - [beforeRemoveRow](@/api/hooks.md#beforeremoverow)
+- [beforeUpdateData](@/api/hooks.md#beforeupdatedata)
 - [beforeValidate](@/api/hooks.md#beforevalidate)
 
 </div>

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -3154,6 +3154,13 @@ export default function Core(
    * Passing `columns` inside the `settings` object resets the states corresponding to rows and columns
    * (for example, row/column sequence, column width, row height, frozen columns etc.). Passing `data` does not reset these states.
    *
+   * After initialization, passing `data` calls [`updateData()`](@/api/core.md#updatedata) internally.
+   * The resulting [`beforeUpdateData`](@/api/hooks.md#beforeupdatedata) and
+   * [`afterUpdateData`](@/api/hooks.md#afterupdatedata) hooks receive `"updateSettings"` as their
+   * `source`, while [`afterChange`](@/api/hooks.md#afterchange) receives `null` as its `changes`
+   * argument and `"updateData"` as its `source`. If you call `updateSettings` with `data` inside
+   * `afterChange`, check the hook's `source` to prevent an infinite loop.
+   *
    * Cell meta set imperatively through [[setCellMeta]] (for example, by the user or the context menu) is preserved across
    * `updateSettings`, even when `settings` includes `cell`, `cells`, or `columns`. On a direct conflict, a value re-stated
    * through the declarative `cell` option takes precedence over the preserved imperative value.

--- a/handsontable/src/core/hooks/constants.ts
+++ b/handsontable/src/core/hooks/constants.ts
@@ -137,17 +137,23 @@ export const REGISTERED_HOOKS = [
    * Fired after one or more cells has been changed. The changes are triggered in any situation when the
    * value is entered using an editor or changed using API (e.q [`setDataAtCell`](@/api/core.md#setdataatcell) method).
    *
-   * __Note:__ For performance reasons, the `changes` array is null for `"loadData"` source.
+   * For performance reasons, the `changes` array is `null` when the `source` is `"loadData"` or `"updateData"`.
+   *
+   * Calling [`updateSettings()`](@/api/core.md#updatesettings) with the `data` option inside this hook
+   * triggers another `afterChange` call with the `"updateData"` source. Check the `source` argument
+   * to prevent an infinite loop.
    *
    * @event Hooks#afterChange
-   * @param {Array[]} changes 2D array containing information about each of the edited cells `[[row, prop, oldVal, newVal], ...]`.
-   *                          `row` is a visual row index. `prop` is a property name, a column index, or – when
-   *                          [`columns[].data`](@/api/options.md#columns) is a function – the column accessor function.
-   *                          To resolve a visual column index from `prop`, call [`propToCol()`](@/api/core.md#proptocol).
-   *                          Unlike [`beforeValidate`](@/api/hooks.md#beforevalidate) and
-   *                          [`afterValidate`](@/api/hooks.md#aftervalidate), this hook passes the accessor function
-   *                          as `prop` so the grid can write data back. Read more:
-   *                          [Binding to data: Identify changed columns in hooks](@/guides/getting-started/binding-to-data/binding-to-data.md#identify-changed-columns-in-hooks).
+   * @param {Array[]|null} changes 2D array containing information about each of the edited cells
+   *                               `[[row, prop, oldVal, newVal], ...]`, or `null` for the `"loadData"`
+   *                               and `"updateData"` sources. `row` is a visual row index. `prop` is a property name,
+   *                               a column index, or – when [`columns[].data`](@/api/options.md#columns) is a function –
+   *                               the column accessor function. To resolve a visual column index from `prop`, call
+   *                               [`propToCol()`](@/api/core.md#proptocol). Unlike
+   *                               [`beforeValidate`](@/api/hooks.md#beforevalidate) and
+   *                               [`afterValidate`](@/api/hooks.md#aftervalidate), this hook passes the accessor function
+   *                               as `prop` so the grid can write data back. Read more:
+   *                               [Binding to data: Identify changed columns in hooks](@/guides/getting-started/binding-to-data/binding-to-data.md#identify-changed-columns-in-hooks).
    * @param {string} [source] String that identifies source of hook call ([list of all available sources](@/guides/getting-started/events-and-hooks/events-and-hooks.md#definition-for-source-argument)).
    * @example
    * ::: only-for javascript
@@ -1395,6 +1401,12 @@ export const REGISTERED_HOOKS = [
    * Use this hook to silently alter the user's changes before Handsontable re-renders.
    *
    * To ignore the user's changes, use a nullified array or return `false`.
+   *
+   * This hook doesn't run when the entire data source is replaced through
+   * [`loadData()`](@/api/core.md#loaddata), [`updateData()`](@/api/core.md#updatedata), or
+   * [`updateSettings()`](@/api/core.md#updatesettings) with the `data` option. To intercept these
+   * replacements, use [`beforeLoadData`](@/api/hooks.md#beforeloaddata) or
+   * [`beforeUpdateData`](@/api/hooks.md#beforeupdatedata).
    *
    * @event Hooks#beforeChange
    * @param {Array[]} changes 2D array containing information about each of the edited cells `[[row, prop, oldVal, newVal], ...]`.


### PR DESCRIPTION
### Context

The PR fixes incomplete guidance about calling `updateSettings({ data })` from change hooks. Without checking the hook source, an `afterChange` callback can retrigger itself and create an infinite loop.

The API reference now documents the exact hook sequence and source values. The Events and hooks guide adds a guarded example and explains that whole-dataset replacement does not fire `beforeChange`.

### How has this been tested?

- `npm --prefix handsontable run eslint`
- `npm --prefix handsontable run build`
- `npm --prefix docs run docs:api`
- `npm --prefix docs run docs:lint`
- Manually rendered the Events and hooks guide for JavaScript, React, Angular, and Vue.
- Manually verified the Vue `beforeChange`, `afterChange`, and `updateSettings()` API sections and links.

The full docs build was attempted twice. It stops on the unrelated `angular-data-grid/disabled-cells` page because its generated HTML cache file is missing, including after clearing `docs/.astro`. Stylelint also cannot load the existing `stylelint-plugin-handsontable` package in this checkout; this PR changes no styles.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1928

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

### Docs PR checklist

- [x] Existing `type: explanation` frontmatter remains unchanged.
- [x] Existing page structure and title remain unchanged.
- [x] The new section uses active voice, second person, short sentences, and American English.
- [x] The callback snippet has a language tag and contains no banned placeholder data.
- [x] Heading hierarchy and internal links are valid.
- [x] The existing `menuTag: updated` remains in place.
- [x] No trademark notice is required.
- [x] No new page, sidebar entry, or generated JavaScript example is required.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1928

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No runtime or API behavior changes—only docs and JSDoc comments.
> 
> **Overview**
> Documents how **`updateSettings({ data })`** behaves after init: it routes through **`updateData()`**, which hook **`source`** values apply (`updateSettings` vs `updateData`), and why **`afterChange`** can recurse if you replace data from inside that hook.
> 
> The **Events and hooks** guide adds a **`updateSettings`** row to the `source` table, a **“Prevent feedback loops when replacing data”** section with a guarded **`afterChange`** example, and **`beforeUpdateData` / `afterUpdateData`** in the source-parameter hook list. **`beforeChange`** is called out as not running for full-dataset replacement.
> 
> JSDoc on **`updateSettings`**, **`afterChange`**, and **`beforeChange`** in `core.ts` and `hooks/constants.ts` is aligned with that behavior (including `changes === null` for `loadData` / `updateData` sources).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6175cd0829bf9a6ce6adc1bcf82ad2eae64da50d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->