### PR TITLE
DEV-704: Add conditional column moving demo

### DIFF
--- a/docs/content/guides/columns/column-moving/angular/example4.html
+++ b/docs/content/guides/columns/column-moving/angular/example4.html
@@ -1,0 +1,3 @@
+<div>
+  <example4-column-moving></example4-column-moving>
+</div>

--- a/docs/content/guides/columns/column-moving/angular/example4.ts
+++ b/docs/content/guides/columns/column-moving/angular/example4.ts
@@ -1,0 +1,61 @@
+/* file: app.component.ts */
+import { Component } from '@angular/core';
+import { GridSettings, HotTableModule } from '@handsontable/angular-wrapper';
+
+const data = [
+  ['SKU-4821', 'Wireless keyboard', 'Harbor Goods', 142],
+  ['SKU-0093', 'USB-C dock', 'Vertex Supply', 67],
+  ['SKU-3148', '27-inch monitor', 'Alpine Supply Co.', 24],
+  ['SKU-7720', 'Laptop stand', 'Northstar Wholesale', 89],
+  ['SKU-1056', 'Noise-canceling headset', 'Summit Distribution', 35],
+];
+
+@Component({
+  selector: 'example4-column-moving',
+  standalone: true,
+  imports: [HotTableModule],
+  template: `
+    <div class="example-controls-container">
+      <div class="controls">
+        <label>
+          <input type="checkbox" (change)="onAllowColumnMovingChange($event)" />
+          Allow column moving
+        </label>
+      </div>
+    </div>
+    <hot-table [data]="data" [settings]="gridSettings"></hot-table>
+  `,
+})
+
+export class AppComponent {
+  readonly data = data;
+  allowColumnMoving = false;
+  readonly gridSettings: GridSettings = {
+    colHeaders: ['SKU', 'Product', 'Supplier', 'Stock'],
+    rowHeaders: true,
+    manualColumnMove: true,
+    beforeColumnMove: () => this.allowColumnMoving,
+    stretchH: 'all',
+    height: 'auto',
+  };
+
+  onAllowColumnMovingChange(event: Event): void {
+    this.allowColumnMoving = (event.target as HTMLInputElement).checked;
+  }
+}
+/* end-file */
+
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
+registerAllModules();
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    { provide: HOT_GLOBAL_CONFIG, useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig },
+  ],
+};
+/* end-file */

--- a/docs/content/guides/columns/column-moving/column-moving.md
+++ b/docs/content/guides/columns/column-moving/column-moving.md
@@ -17,6 +17,7 @@ vue:
   metaTitle: Column moving - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Columns
+menuTag: updated
 ---
 Change the order of columns, either manually (dragging them to another location), or programmatically (using Handsontable's API methods).
 
@@ -180,9 +181,59 @@ This renders the columns in the following order:
 
 The array must contain all physical column indexes (its length must equal the total number of columns). After the initial render, users can still drag columns to change the order further.
 
+## Control column moving
+
+Use the [`beforeColumnMove`](@/api/hooks.md#beforecolumnmove) hook to decide whether each column move is allowed. Returning `false` cancels the move while keeping the [`manualColumnMove`](@/api/options.md#manualcolumnmove) plugin enabled.
+
+In the following example, select **Allow column moving** before you drag a column to a new position. Clear the checkbox to block column moving again.
+
+:::: only-for javascript
+
+::: example #example4 --html 1 --js 2 --ts 3
+
+@[code](@/content/guides/columns/column-moving/javascript/example4.html)
+@[code](@/content/guides/columns/column-moving/javascript/example4.js)
+@[code](@/content/guides/columns/column-moving/javascript/example4.ts)
+
+:::
+
+::::
+
+:::: only-for react
+
+::: example #example4 :react --jsx 1 --tsx 2
+
+@[code](@/content/guides/columns/column-moving/react/example4.jsx)
+@[code](@/content/guides/columns/column-moving/react/example4.tsx)
+
+:::
+
+::::
+
+:::: only-for angular
+
+::: example #example4 :angular --ts 1 --html 2
+
+@[code](@/content/guides/columns/column-moving/angular/example4.ts)
+@[code](@/content/guides/columns/column-moving/angular/example4.html)
+
+:::
+
+::::
+
+:::: only-for vue
+
+::: example #example4 :vue3
+
+@[code](@/content/guides/columns/column-moving/vue/example4.vue)
+
+:::
+
+::::
+
 ## Result
 
-After completing this guide, you can reorder columns by dragging them with the mouse or by calling `dragColumns()` and `moveColumns()` programmatically. You can also set a pre-defined column order at initialization.
+After completing this guide, you can reorder columns by dragging them with the mouse or by calling `dragColumns()` and `moveColumns()` programmatically. You can also set a pre-defined column order at initialization or use `beforeColumnMove` to block individual moves.
 
 ## Drag and move actions of the [`ManualColumnMove`](@/api/manualColumnMove.md) plugin
 

--- a/docs/content/guides/columns/column-moving/javascript/example4.html
+++ b/docs/content/guides/columns/column-moving/javascript/example4.html
@@ -1,0 +1,9 @@
+<div class="example-controls-container">
+  <div class="controls">
+    <label>
+      <input id="allow-column-moving" type="checkbox" />
+      Allow column moving
+    </label>
+  </div>
+</div>
+<div id="example4"></div>

--- a/docs/content/guides/columns/column-moving/javascript/example4.js
+++ b/docs/content/guides/columns/column-moving/javascript/example4.js
@@ -1,0 +1,31 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const data = [
+    ['SKU-4821', 'Wireless keyboard', 'Harbor Goods', 142],
+    ['SKU-0093', 'USB-C dock', 'Vertex Supply', 67],
+    ['SKU-3148', '27-inch monitor', 'Alpine Supply Co.', 24],
+    ['SKU-7720', 'Laptop stand', 'Northstar Wholesale', 89],
+    ['SKU-1056', 'Noise-canceling headset', 'Summit Distribution', 35],
+];
+
+const container = document.querySelector('#example4');
+const allowColumnMovingInput = document.querySelector('#allow-column-moving');
+let allowColumnMoving = false;
+
+allowColumnMovingInput.addEventListener('change', () => {
+    allowColumnMoving = allowColumnMovingInput.checked;
+});
+
+new Handsontable(container, {
+    data,
+    colHeaders: ['SKU', 'Product', 'Supplier', 'Stock'],
+    rowHeaders: true,
+    manualColumnMove: true,
+    beforeColumnMove: () => allowColumnMoving,
+    stretchH: 'all',
+    height: 'auto',
+    licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/columns/column-moving/javascript/example4.ts
+++ b/docs/content/guides/columns/column-moving/javascript/example4.ts
@@ -1,0 +1,31 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const data = [
+  ['SKU-4821', 'Wireless keyboard', 'Harbor Goods', 142],
+  ['SKU-0093', 'USB-C dock', 'Vertex Supply', 67],
+  ['SKU-3148', '27-inch monitor', 'Alpine Supply Co.', 24],
+  ['SKU-7720', 'Laptop stand', 'Northstar Wholesale', 89],
+  ['SKU-1056', 'Noise-canceling headset', 'Summit Distribution', 35],
+];
+
+const container = document.querySelector('#example4')!;
+const allowColumnMovingInput = document.querySelector<HTMLInputElement>('#allow-column-moving')!;
+let allowColumnMoving = false;
+
+allowColumnMovingInput.addEventListener('change', () => {
+  allowColumnMoving = allowColumnMovingInput.checked;
+});
+
+new Handsontable(container, {
+  data,
+  colHeaders: ['SKU', 'Product', 'Supplier', 'Stock'],
+  rowHeaders: true,
+  manualColumnMove: true,
+  beforeColumnMove: () => allowColumnMoving,
+  stretchH: 'all',
+  height: 'auto',
+  licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/columns/column-moving/react/example4.jsx
+++ b/docs/content/guides/columns/column-moving/react/example4.jsx
@@ -1,0 +1,35 @@
+import { useRef } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const data = [
+    ['SKU-4821', 'Wireless keyboard', 'Harbor Goods', 142],
+    ['SKU-0093', 'USB-C dock', 'Vertex Supply', 67],
+    ['SKU-3148', '27-inch monitor', 'Alpine Supply Co.', 24],
+    ['SKU-7720', 'Laptop stand', 'Northstar Wholesale', 89],
+    ['SKU-1056', 'Noise-canceling headset', 'Summit Distribution', 35],
+];
+
+const ExampleComponent = () => {
+    const allowColumnMoving = useRef(false);
+
+    const handleChange = (event) => {
+        allowColumnMoving.current = event.target.checked;
+    };
+
+    return (<div>
+      <div className="example-controls-container">
+        <div className="controls">
+          <label>
+            <input type="checkbox" onChange={handleChange}/>
+            Allow column moving
+          </label>
+        </div>
+      </div>
+      <HotTable data={data} colHeaders={['SKU', 'Product', 'Supplier', 'Stock']} rowHeaders={true} manualColumnMove={true} beforeColumnMove={() => allowColumnMoving.current} stretchH="all" height="auto" licenseKey="non-commercial-and-evaluation"/>
+    </div>);
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/columns/column-moving/react/example4.tsx
+++ b/docs/content/guides/columns/column-moving/react/example4.tsx
@@ -1,0 +1,47 @@
+import { useRef } from 'react';
+import type { ChangeEvent } from 'react';
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+
+registerAllModules();
+
+const data = [
+  ['SKU-4821', 'Wireless keyboard', 'Harbor Goods', 142],
+  ['SKU-0093', 'USB-C dock', 'Vertex Supply', 67],
+  ['SKU-3148', '27-inch monitor', 'Alpine Supply Co.', 24],
+  ['SKU-7720', 'Laptop stand', 'Northstar Wholesale', 89],
+  ['SKU-1056', 'Noise-canceling headset', 'Summit Distribution', 35],
+];
+
+const ExampleComponent = () => {
+  const allowColumnMoving = useRef(false);
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    allowColumnMoving.current = event.target.checked;
+  };
+
+  return (
+    <div>
+      <div className="example-controls-container">
+        <div className="controls">
+          <label>
+            <input type="checkbox" onChange={handleChange} />
+            Allow column moving
+          </label>
+        </div>
+      </div>
+      <HotTable
+        data={data}
+        colHeaders={['SKU', 'Product', 'Supplier', 'Stock']}
+        rowHeaders={true}
+        manualColumnMove={true}
+        beforeColumnMove={() => allowColumnMoving.current}
+        stretchH="all"
+        height="auto"
+        licenseKey="non-commercial-and-evaluation"
+      />
+    </div>
+  );
+};
+
+export default ExampleComponent;

--- a/docs/content/guides/columns/column-moving/vue/example4.vue
+++ b/docs/content/guides/columns/column-moving/vue/example4.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+
+const allowColumnMoving = ref(false);
+
+const hotSettings: GridSettings = {
+  data: [
+    ['SKU-4821', 'Wireless keyboard', 'Harbor Goods', 142],
+    ['SKU-0093', 'USB-C dock', 'Vertex Supply', 67],
+    ['SKU-3148', '27-inch monitor', 'Alpine Supply Co.', 24],
+    ['SKU-7720', 'Laptop stand', 'Northstar Wholesale', 89],
+    ['SKU-1056', 'Noise-canceling headset', 'Summit Distribution', 35],
+  ],
+  colHeaders: ['SKU', 'Product', 'Supplier', 'Stock'],
+  rowHeaders: true,
+  manualColumnMove: true,
+  beforeColumnMove: () => allowColumnMoving.value,
+  stretchH: 'all',
+  height: 'auto',
+  licenseKey: 'non-commercial-and-evaluation',
+};
+</script>
+
+<template>
+  <div id="example4">
+    <div class="example-controls-container">
+      <div class="controls">
+        <label>
+          <input v-model="allowColumnMoving" type="checkbox" />
+          Allow column moving
+        </label>
+      </div>
+    </div>
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>


### PR DESCRIPTION
### Context

The PR adds a runnable example showing how to conditionally allow column moving with the `beforeColumnMove` hook. The guide previously described the hook but did not demonstrate its cancellation behavior.

The example uses an external checkbox and covers JavaScript, React, Angular, and Vue.

### How has this been tested?

- Ran `npm --prefix docs run docs:lint`.
- Verified the example in JavaScript, React, Angular, and Vue: column moving is blocked while the checkbox is clear and allowed after selecting it.
- Attempted `npm --prefix docs run build` twice, including after clearing `docs/.astro`. The build remains blocked by the unrelated existing missing rendered HTML error for `angular-data-grid/disabled-cells`.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-704

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-704

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and docs examples only; no changes to Handsontable runtime or wrapper packages.
> 
> **Overview**
> Adds a **Control column moving** section to the column-moving guide with a new **example4** that gates drag-and-drop reordering via `beforeColumnMove` (return `false` to cancel moves while `manualColumnMove` stays on). An **Allow column moving** checkbox toggles whether the hook allows each move.
> 
> Runnable examples are added for JavaScript, React, Angular, and Vue. The guide is marked `menuTag: updated`, and the **Result** section now mentions blocking individual moves with `beforeColumnMove`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9878546bd4273e6509aab6f988dd7bd115f4f79b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->