### PR TITLE
DEV-706: Add mixed cell type documentation demo

### DIFF
--- a/docs/content/guides/cell-types/cell-type/angular/example3.html
+++ b/docs/content/guides/cell-types/cell-type/angular/example3.html
@@ -1,0 +1,3 @@
+<div>
+  <example3-cell-type></example3-cell-type>
+</div>

--- a/docs/content/guides/cell-types/cell-type/angular/example3.ts
+++ b/docs/content/guides/cell-types/cell-type/angular/example3.ts
@@ -1,0 +1,59 @@
+/* file: app.component.ts */
+import { Component } from '@angular/core';
+import { GridSettings, HotTableModule } from '@handsontable/angular-wrapper';
+import type { CellMeta } from 'handsontable/settings';
+const projectMembers = [['Ana García', 'Product Manager'], ['James Okafor', 'Senior Engineer'], ['Li Wei', 'UX Designer']];
+const valueCellMeta: CellMeta[] = [
+  { type: 'dropdown', source: ['Planning', 'In progress', 'Blocked'] },
+  { type: 'numeric', locale: 'en-US', numericFormat: { style: 'currency', currency: 'USD', maximumFractionDigits: 0 } },
+  { type: 'intl-date', locale: 'en-US', dateFormat: { year: 'numeric', month: 'short', day: 'numeric' } },
+  { type: 'checkbox' },
+  { type: 'text' },
+  {
+    type: 'handsontable',
+    handsontable: {
+      colHeaders: ['Name', 'Role'],
+      autoColumnSize: true,
+      data: projectMembers,
+      getValue() {
+        const selection = this.getSelectedLast();
+        return this.getSourceDataAtCell(Math.max(selection?.[0] ?? 0, 0), 0);
+      },
+    },
+  },
+  { type: 'password' },
+];
+@Component({
+  selector: 'example3-cell-type',
+  standalone: true, imports: [HotTableModule],
+  template: `<hot-table [data]="data" [settings]="gridSettings"></hot-table>`,
+})
+export class AppComponent {
+  readonly data = [
+    ['Status', 'In progress'], ['Budget', 250000],
+    ['Due date', '2026-09-30'], ['Approved', true],
+    ['Project name', 'Website redesign'], ['Owner', 'Ana García'],
+    ['Access code', 'release-2026'],
+  ];
+  readonly gridSettings: GridSettings = {
+    colHeaders: ['Setting', 'Value'],
+    columns: [{ readOnly: true }, {}],
+    cells: (row: number, col: number) => (col === 1 ? (valueCellMeta[row] ?? {}) : {}),
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true,
+  };
+}
+/* end-file */
+/* file: app.config.ts */
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { registerAllModules } from 'handsontable/registry';
+import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+registerAllModules();
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    { provide: HOT_GLOBAL_CONFIG, useValue: { license: NON_COMMERCIAL_LICENSE } as HotGlobalConfig },
+  ],
+};
+/* end-file */

--- a/docs/content/guides/cell-types/cell-type/angular/example3.ts
+++ b/docs/content/guides/cell-types/cell-type/angular/example3.ts
@@ -2,11 +2,25 @@
 import { Component } from '@angular/core';
 import { GridSettings, HotTableModule } from '@handsontable/angular-wrapper';
 import type { CellMeta } from 'handsontable/settings';
-const projectMembers = [['Ana García', 'Product Manager'], ['James Okafor', 'Senior Engineer'], ['Li Wei', 'UX Designer']];
+
+const projectMembers = [
+  ['Ana García', 'Product Manager'],
+  ['James Okafor', 'Senior Engineer'],
+  ['Li Wei', 'UX Designer'],
+];
+
 const valueCellMeta: CellMeta[] = [
   { type: 'dropdown', source: ['Planning', 'In progress', 'Blocked'] },
-  { type: 'numeric', locale: 'en-US', numericFormat: { style: 'currency', currency: 'USD', maximumFractionDigits: 0 } },
-  { type: 'intl-date', locale: 'en-US', dateFormat: { year: 'numeric', month: 'short', day: 'numeric' } },
+  {
+    type: 'numeric',
+    locale: 'en-US',
+    numericFormat: { style: 'currency', currency: 'USD', maximumFractionDigits: 0 },
+  },
+  {
+    type: 'intl-date',
+    locale: 'en-US',
+    dateFormat: { year: 'numeric', month: 'short', day: 'numeric' },
+  },
   { type: 'checkbox' },
   { type: 'text' },
   {
@@ -17,24 +31,31 @@ const valueCellMeta: CellMeta[] = [
       data: projectMembers,
       getValue() {
         const selection = this.getSelectedLast();
+
         return this.getSourceDataAtCell(Math.max(selection?.[0] ?? 0, 0), 0);
       },
     },
   },
   { type: 'password' },
 ];
+
 @Component({
   selector: 'example3-cell-type',
-  standalone: true, imports: [HotTableModule],
+  standalone: true,
+  imports: [HotTableModule],
   template: `<hot-table [data]="data" [settings]="gridSettings"></hot-table>`,
 })
 export class AppComponent {
   readonly data = [
-    ['Status', 'In progress'], ['Budget', 250000],
-    ['Due date', '2026-09-30'], ['Approved', true],
-    ['Project name', 'Website redesign'], ['Owner', 'Ana García'],
+    ['Status', 'In progress'],
+    ['Budget', 250000],
+    ['Due date', '2026-09-30'],
+    ['Approved', true],
+    ['Project name', 'Website redesign'],
+    ['Owner', 'Ana García'],
     ['Access code', 'release-2026'],
   ];
+
   readonly gridSettings: GridSettings = {
     colHeaders: ['Setting', 'Value'],
     columns: [{ readOnly: true }, {}],
@@ -45,11 +66,14 @@ export class AppComponent {
   };
 }
 /* end-file */
+
 /* file: app.config.ts */
 import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { registerAllModules } from 'handsontable/registry';
 import { HOT_GLOBAL_CONFIG, HotGlobalConfig, NON_COMMERCIAL_LICENSE } from '@handsontable/angular-wrapper';
+
 registerAllModules();
+
 export const appConfig: ApplicationConfig = {
   providers: [
     provideZoneChangeDetection({ eventCoalescing: true }),

--- a/docs/content/guides/cell-types/cell-type/cell-type.md
+++ b/docs/content/guides/cell-types/cell-type/cell-type.md
@@ -13,6 +13,7 @@ vue:
   metaTitle: Cell type - Vue Data Grid | Handsontable
 searchCategory: Guides
 category: Cell types
+menuTag: updated
 ---
 Use Handsontable's built-in cell types such as autocomplete, date, time, and more, for consistent UI across cell renderer, editor, and validator.
 
@@ -840,6 +841,53 @@ Please keep in mind that opening a cell with `undefined` and `null` values resul
 :::
 
 Empty cells may be treated differently in different contexts, for example, the [`ColumnSorting`](@/api/columnSorting.md) plugin has `sortEmptyCells` option which is responsible for establishing whether empty cells should be sorted like non-empty cells.
+
+## Set different cell types in one column
+
+Use the [`cells`](@/api/options.md#cells) option to assign a different cell type to each row in a column. The following example creates a project settings form with `dropdown`, `numeric`, `intl-date`, `checkbox`, `text`, `handsontable`, and `password` cell types.
+
+:::: only-for javascript
+
+::: example #example3 --js 1 --ts 2
+
+@[code](@/content/guides/cell-types/cell-type/javascript/example3.js)
+@[code](@/content/guides/cell-types/cell-type/javascript/example3.ts)
+
+:::
+
+::::
+
+:::: only-for react
+
+::: example #example3 :react --js 1 --ts 2
+
+@[code](@/content/guides/cell-types/cell-type/react/example3.jsx)
+@[code](@/content/guides/cell-types/cell-type/react/example3.tsx)
+
+:::
+
+::::
+
+:::: only-for angular
+
+::: example #example3 :angular --ts 1 --html 2
+
+@[code](@/content/guides/cell-types/cell-type/angular/example3.ts)
+@[code](@/content/guides/cell-types/cell-type/angular/example3.html)
+
+:::
+
+::::
+
+:::: only-for vue
+
+::: example #example3 :vue3
+
+@[code](@/content/guides/cell-types/cell-type/vue/example3.vue)
+
+:::
+
+::::
 
 ## Related
 

--- a/docs/content/guides/cell-types/cell-type/javascript/example3.js
+++ b/docs/content/guides/cell-types/cell-type/javascript/example3.js
@@ -2,7 +2,9 @@ import Handsontable from 'handsontable/base';
 import { registerAllModules } from 'handsontable/registry';
 registerAllModules();
 const projectMembers = [
-    ['Ana García', 'Product Manager'], ['James Okafor', 'Senior Engineer'], ['Li Wei', 'UX Designer'],
+    ['Ana García', 'Product Manager'],
+    ['James Okafor', 'Senior Engineer'],
+    ['Li Wei', 'UX Designer'],
 ];
 const valueCellMeta = [
     { type: 'dropdown', source: ['Planning', 'In progress', 'Blocked'] },

--- a/docs/content/guides/cell-types/cell-type/javascript/example3.js
+++ b/docs/content/guides/cell-types/cell-type/javascript/example3.js
@@ -1,53 +1,59 @@
 import Handsontable from 'handsontable/base';
 import { registerAllModules } from 'handsontable/registry';
+
 registerAllModules();
+
 const projectMembers = [
-    ['Ana García', 'Product Manager'],
-    ['James Okafor', 'Senior Engineer'],
-    ['Li Wei', 'UX Designer'],
+  ['Ana García', 'Product Manager'],
+  ['James Okafor', 'Senior Engineer'],
+  ['Li Wei', 'UX Designer'],
 ];
+
 const valueCellMeta = [
-    { type: 'dropdown', source: ['Planning', 'In progress', 'Blocked'] },
-    {
-        type: 'numeric',
-        locale: 'en-US',
-        numericFormat: { style: 'currency', currency: 'USD', maximumFractionDigits: 0 },
+  { type: 'dropdown', source: ['Planning', 'In progress', 'Blocked'] },
+  {
+    type: 'numeric',
+    locale: 'en-US',
+    numericFormat: { style: 'currency', currency: 'USD', maximumFractionDigits: 0 },
+  },
+  { type: 'intl-date', locale: 'en-US', dateFormat: { year: 'numeric', month: 'short', day: 'numeric' } },
+  { type: 'checkbox' },
+  { type: 'text' },
+  {
+    type: 'handsontable',
+    handsontable: {
+      colHeaders: ['Name', 'Role'],
+      autoColumnSize: true,
+      data: projectMembers,
+      getValue() {
+        const selection = this.getSelectedLast();
+
+        return this.getSourceDataAtCell(Math.max(selection?.[0] ?? 0, 0), 0);
+      },
     },
-    { type: 'intl-date', locale: 'en-US', dateFormat: { year: 'numeric', month: 'short', day: 'numeric' } },
-    { type: 'checkbox' },
-    { type: 'text' },
-    {
-        type: 'handsontable',
-        handsontable: {
-            colHeaders: ['Name', 'Role'],
-            autoColumnSize: true,
-            data: projectMembers,
-            getValue() {
-                const selection = this.getSelectedLast();
-                return this.getSourceDataAtCell(Math.max(selection?.[0] ?? 0, 0), 0);
-            },
-        },
-    },
-    { type: 'password' },
+  },
+  { type: 'password' },
 ];
+
 const container = document.querySelector('#example3');
+
 new Handsontable(container, {
-    data: [
-        ['Status', 'In progress'],
-        ['Budget', 250000],
-        ['Due date', '2026-09-30'],
-        ['Approved', true],
-        ['Project name', 'Website redesign'],
-        ['Owner', 'Ana García'],
-        ['Access code', 'release-2026'],
-    ],
-    colHeaders: ['Setting', 'Value'],
-    columns: [{ readOnly: true }, {}],
-    cells(row, col) {
-        return col === 1 ? (valueCellMeta[row] ?? {}) : {};
-    },
-    height: 'auto',
-    autoWrapRow: true,
-    autoWrapCol: true,
-    licenseKey: 'non-commercial-and-evaluation',
+  data: [
+    ['Status', 'In progress'],
+    ['Budget', 250000],
+    ['Due date', '2026-09-30'],
+    ['Approved', true],
+    ['Project name', 'Website redesign'],
+    ['Owner', 'Ana García'],
+    ['Access code', 'release-2026'],
+  ],
+  colHeaders: ['Setting', 'Value'],
+  columns: [{ readOnly: true }, {}],
+  cells(row, col) {
+    return col === 1 ? (valueCellMeta[row] ?? {}) : {};
+  },
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
 });

--- a/docs/content/guides/cell-types/cell-type/javascript/example3.js
+++ b/docs/content/guides/cell-types/cell-type/javascript/example3.js
@@ -1,0 +1,51 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+registerAllModules();
+const projectMembers = [
+    ['Ana García', 'Product Manager'], ['James Okafor', 'Senior Engineer'], ['Li Wei', 'UX Designer'],
+];
+const valueCellMeta = [
+    { type: 'dropdown', source: ['Planning', 'In progress', 'Blocked'] },
+    {
+        type: 'numeric',
+        locale: 'en-US',
+        numericFormat: { style: 'currency', currency: 'USD', maximumFractionDigits: 0 },
+    },
+    { type: 'intl-date', locale: 'en-US', dateFormat: { year: 'numeric', month: 'short', day: 'numeric' } },
+    { type: 'checkbox' },
+    { type: 'text' },
+    {
+        type: 'handsontable',
+        handsontable: {
+            colHeaders: ['Name', 'Role'],
+            autoColumnSize: true,
+            data: projectMembers,
+            getValue() {
+                const selection = this.getSelectedLast();
+                return this.getSourceDataAtCell(Math.max(selection?.[0] ?? 0, 0), 0);
+            },
+        },
+    },
+    { type: 'password' },
+];
+const container = document.querySelector('#example3');
+new Handsontable(container, {
+    data: [
+        ['Status', 'In progress'],
+        ['Budget', 250000],
+        ['Due date', '2026-09-30'],
+        ['Approved', true],
+        ['Project name', 'Website redesign'],
+        ['Owner', 'Ana García'],
+        ['Access code', 'release-2026'],
+    ],
+    colHeaders: ['Setting', 'Value'],
+    columns: [{ readOnly: true }, {}],
+    cells(row, col) {
+        return col === 1 ? (valueCellMeta[row] ?? {}) : {};
+    },
+    height: 'auto',
+    autoWrapRow: true,
+    autoWrapCol: true,
+    licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/cell-types/cell-type/javascript/example3.ts
+++ b/docs/content/guides/cell-types/cell-type/javascript/example3.ts
@@ -5,7 +5,9 @@ import type { CellMeta } from 'handsontable/settings';
 registerAllModules();
 
 const projectMembers = [
-  ['Ana García', 'Product Manager'], ['James Okafor', 'Senior Engineer'], ['Li Wei', 'UX Designer'],
+  ['Ana García', 'Product Manager'],
+  ['James Okafor', 'Senior Engineer'],
+  ['Li Wei', 'UX Designer'],
 ];
 
 const valueCellMeta: CellMeta[] = [

--- a/docs/content/guides/cell-types/cell-type/javascript/example3.ts
+++ b/docs/content/guides/cell-types/cell-type/javascript/example3.ts
@@ -1,0 +1,58 @@
+import Handsontable from 'handsontable/base';
+import { registerAllModules } from 'handsontable/registry';
+import type { CellMeta } from 'handsontable/settings';
+
+registerAllModules();
+
+const projectMembers = [
+  ['Ana García', 'Product Manager'], ['James Okafor', 'Senior Engineer'], ['Li Wei', 'UX Designer'],
+];
+
+const valueCellMeta: CellMeta[] = [
+  { type: 'dropdown', source: ['Planning', 'In progress', 'Blocked'] },
+  {
+    type: 'numeric',
+    locale: 'en-US',
+    numericFormat: { style: 'currency', currency: 'USD', maximumFractionDigits: 0 },
+  },
+  { type: 'intl-date', locale: 'en-US', dateFormat: { year: 'numeric', month: 'short', day: 'numeric' } },
+  { type: 'checkbox' },
+  { type: 'text' },
+  {
+    type: 'handsontable',
+    handsontable: {
+      colHeaders: ['Name', 'Role'],
+      autoColumnSize: true,
+      data: projectMembers,
+      getValue() {
+        const selection = this.getSelectedLast();
+
+        return this.getSourceDataAtCell(Math.max(selection?.[0] ?? 0, 0), 0);
+      },
+    },
+  },
+  { type: 'password' },
+];
+
+const container = document.querySelector('#example3')!;
+
+new Handsontable(container, {
+  data: [
+    ['Status', 'In progress'],
+    ['Budget', 250000],
+    ['Due date', '2026-09-30'],
+    ['Approved', true],
+    ['Project name', 'Website redesign'],
+    ['Owner', 'Ana García'],
+    ['Access code', 'release-2026'],
+  ],
+  colHeaders: ['Setting', 'Value'],
+  columns: [{ readOnly: true }, {}],
+  cells(row, col) {
+    return col === 1 ? (valueCellMeta[row] ?? {}) : {};
+  },
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+});

--- a/docs/content/guides/cell-types/cell-type/react/example3.jsx
+++ b/docs/content/guides/cell-types/cell-type/react/example3.jsx
@@ -2,7 +2,9 @@ import { HotTable } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
 registerAllModules();
 const projectMembers = [
-    ['Ana García', 'Product Manager'], ['James Okafor', 'Senior Engineer'], ['Li Wei', 'UX Designer'],
+    ['Ana García', 'Product Manager'],
+    ['James Okafor', 'Senior Engineer'],
+    ['Li Wei', 'UX Designer'],
 ];
 const valueCellMeta = [
     { type: 'dropdown', source: ['Planning', 'In progress', 'Blocked'] },

--- a/docs/content/guides/cell-types/cell-type/react/example3.jsx
+++ b/docs/content/guides/cell-types/cell-type/react/example3.jsx
@@ -1,43 +1,61 @@
 import { HotTable } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
+
 registerAllModules();
+
 const projectMembers = [
-    ['Ana García', 'Product Manager'],
-    ['James Okafor', 'Senior Engineer'],
-    ['Li Wei', 'UX Designer'],
+  ['Ana García', 'Product Manager'],
+  ['James Okafor', 'Senior Engineer'],
+  ['Li Wei', 'UX Designer'],
 ];
+
 const valueCellMeta = [
-    { type: 'dropdown', source: ['Planning', 'In progress', 'Blocked'] },
-    {
-        type: 'numeric',
-        locale: 'en-US',
-        numericFormat: { style: 'currency', currency: 'USD', maximumFractionDigits: 0 },
+  { type: 'dropdown', source: ['Planning', 'In progress', 'Blocked'] },
+  {
+    type: 'numeric',
+    locale: 'en-US',
+    numericFormat: { style: 'currency', currency: 'USD', maximumFractionDigits: 0 },
+  },
+  { type: 'intl-date', locale: 'en-US', dateFormat: { year: 'numeric', month: 'short', day: 'numeric' } },
+  { type: 'checkbox' },
+  { type: 'text' },
+  {
+    type: 'handsontable',
+    handsontable: {
+      colHeaders: ['Name', 'Role'],
+      autoColumnSize: true,
+      data: projectMembers,
+      getValue() {
+        const selection = this.getSelectedLast();
+
+        return this.getSourceDataAtCell(Math.max(selection?.[0] ?? 0, 0), 0);
+      },
     },
-    { type: 'intl-date', locale: 'en-US', dateFormat: { year: 'numeric', month: 'short', day: 'numeric' } },
-    { type: 'checkbox' },
-    { type: 'text' },
-    {
-        type: 'handsontable',
-        handsontable: {
-            colHeaders: ['Name', 'Role'],
-            autoColumnSize: true,
-            data: projectMembers,
-            getValue() {
-                const selection = this.getSelectedLast();
-                return this.getSourceDataAtCell(Math.max(selection?.[0] ?? 0, 0), 0);
-            },
-        },
-    },
-    { type: 'password' },
+  },
+  { type: 'password' },
 ];
+
 const data = [
-    ['Status', 'In progress'],
-    ['Budget', 250000],
-    ['Due date', '2026-09-30'],
-    ['Approved', true],
-    ['Project name', 'Website redesign'],
-    ['Owner', 'Ana García'],
-    ['Access code', 'release-2026'],
+  ['Status', 'In progress'],
+  ['Budget', 250000],
+  ['Due date', '2026-09-30'],
+  ['Approved', true],
+  ['Project name', 'Website redesign'],
+  ['Owner', 'Ana García'],
+  ['Access code', 'release-2026'],
 ];
-const ExampleComponent = () => (<HotTable data={data} colHeaders={['Setting', 'Value']} columns={[{ readOnly: true }, {}]} cells={(row, col) => (col === 1 ? (valueCellMeta[row] ?? {}) : {})} height="auto" autoWrapRow={true} autoWrapCol={true} licenseKey="non-commercial-and-evaluation"/>);
+
+const ExampleComponent = () => (
+  <HotTable
+    data={data}
+    colHeaders={['Setting', 'Value']}
+    columns={[{ readOnly: true }, {}]}
+    cells={(row, col) => (col === 1 ? (valueCellMeta[row] ?? {}) : {})}
+    height="auto"
+    autoWrapRow={true}
+    autoWrapCol={true}
+    licenseKey="non-commercial-and-evaluation"
+  />
+);
+
 export default ExampleComponent;

--- a/docs/content/guides/cell-types/cell-type/react/example3.jsx
+++ b/docs/content/guides/cell-types/cell-type/react/example3.jsx
@@ -1,0 +1,41 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+registerAllModules();
+const projectMembers = [
+    ['Ana García', 'Product Manager'], ['James Okafor', 'Senior Engineer'], ['Li Wei', 'UX Designer'],
+];
+const valueCellMeta = [
+    { type: 'dropdown', source: ['Planning', 'In progress', 'Blocked'] },
+    {
+        type: 'numeric',
+        locale: 'en-US',
+        numericFormat: { style: 'currency', currency: 'USD', maximumFractionDigits: 0 },
+    },
+    { type: 'intl-date', locale: 'en-US', dateFormat: { year: 'numeric', month: 'short', day: 'numeric' } },
+    { type: 'checkbox' },
+    { type: 'text' },
+    {
+        type: 'handsontable',
+        handsontable: {
+            colHeaders: ['Name', 'Role'],
+            autoColumnSize: true,
+            data: projectMembers,
+            getValue() {
+                const selection = this.getSelectedLast();
+                return this.getSourceDataAtCell(Math.max(selection?.[0] ?? 0, 0), 0);
+            },
+        },
+    },
+    { type: 'password' },
+];
+const data = [
+    ['Status', 'In progress'],
+    ['Budget', 250000],
+    ['Due date', '2026-09-30'],
+    ['Approved', true],
+    ['Project name', 'Website redesign'],
+    ['Owner', 'Ana García'],
+    ['Access code', 'release-2026'],
+];
+const ExampleComponent = () => (<HotTable data={data} colHeaders={['Setting', 'Value']} columns={[{ readOnly: true }, {}]} cells={(row, col) => (col === 1 ? (valueCellMeta[row] ?? {}) : {})} height="auto" autoWrapRow={true} autoWrapCol={true} licenseKey="non-commercial-and-evaluation"/>);
+export default ExampleComponent;

--- a/docs/content/guides/cell-types/cell-type/react/example3.tsx
+++ b/docs/content/guides/cell-types/cell-type/react/example3.tsx
@@ -5,7 +5,9 @@ import type { CellMeta } from 'handsontable/settings';
 registerAllModules();
 
 const projectMembers = [
-  ['Ana García', 'Product Manager'], ['James Okafor', 'Senior Engineer'], ['Li Wei', 'UX Designer'],
+  ['Ana García', 'Product Manager'],
+  ['James Okafor', 'Senior Engineer'],
+  ['Li Wei', 'UX Designer'],
 ];
 
 const valueCellMeta: CellMeta[] = [

--- a/docs/content/guides/cell-types/cell-type/react/example3.tsx
+++ b/docs/content/guides/cell-types/cell-type/react/example3.tsx
@@ -1,0 +1,60 @@
+import { HotTable } from '@handsontable/react-wrapper';
+import { registerAllModules } from 'handsontable/registry';
+import type { CellMeta } from 'handsontable/settings';
+
+registerAllModules();
+
+const projectMembers = [
+  ['Ana García', 'Product Manager'], ['James Okafor', 'Senior Engineer'], ['Li Wei', 'UX Designer'],
+];
+
+const valueCellMeta: CellMeta[] = [
+  { type: 'dropdown', source: ['Planning', 'In progress', 'Blocked'] },
+  {
+    type: 'numeric',
+    locale: 'en-US',
+    numericFormat: { style: 'currency', currency: 'USD', maximumFractionDigits: 0 },
+  },
+  { type: 'intl-date', locale: 'en-US', dateFormat: { year: 'numeric', month: 'short', day: 'numeric' } },
+  { type: 'checkbox' },
+  { type: 'text' },
+  {
+    type: 'handsontable',
+    handsontable: {
+      colHeaders: ['Name', 'Role'],
+      autoColumnSize: true,
+      data: projectMembers,
+      getValue() {
+        const selection = this.getSelectedLast();
+
+        return this.getSourceDataAtCell(Math.max(selection?.[0] ?? 0, 0), 0);
+      },
+    },
+  },
+  { type: 'password' },
+];
+
+const data = [
+  ['Status', 'In progress'],
+  ['Budget', 250000],
+  ['Due date', '2026-09-30'],
+  ['Approved', true],
+  ['Project name', 'Website redesign'],
+  ['Owner', 'Ana García'],
+  ['Access code', 'release-2026'],
+];
+
+const ExampleComponent = () => (
+  <HotTable
+    data={data}
+    colHeaders={['Setting', 'Value']}
+    columns={[{ readOnly: true }, {}]}
+    cells={(row, col) => (col === 1 ? (valueCellMeta[row] ?? {}) : {})}
+    height="auto"
+    autoWrapRow={true}
+    autoWrapCol={true}
+    licenseKey="non-commercial-and-evaluation"
+  />
+);
+
+export default ExampleComponent;

--- a/docs/content/guides/cell-types/cell-type/vue/example3.vue
+++ b/docs/content/guides/cell-types/cell-type/vue/example3.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import { HotTable } from '@handsontable/vue3';
+import { registerAllModules } from 'handsontable/registry';
+import type { CellMeta, GridSettings } from 'handsontable/settings';
+
+registerAllModules();
+const projectMembers = [
+  ['Ana García', 'Product Manager'], ['James Okafor', 'Senior Engineer'], ['Li Wei', 'UX Designer'],
+];
+const valueCellMeta: CellMeta[] = [
+  { type: 'dropdown', source: ['Planning', 'In progress', 'Blocked'] },
+  {
+    type: 'numeric',
+    locale: 'en-US',
+    numericFormat: { style: 'currency', currency: 'USD', maximumFractionDigits: 0 },
+  },
+  { type: 'intl-date', locale: 'en-US', dateFormat: { year: 'numeric', month: 'short', day: 'numeric' } },
+  { type: 'checkbox' },
+  { type: 'text' },
+  {
+    type: 'handsontable',
+    handsontable: {
+      colHeaders: ['Name', 'Role'],
+      autoColumnSize: true,
+      data: projectMembers,
+      getValue() {
+        const selection = this.getSelectedLast();
+
+        return this.getSourceDataAtCell(Math.max(selection?.[0] ?? 0, 0), 0);
+      },
+    },
+  },
+  { type: 'password' },
+];
+const hotSettings: GridSettings = {
+  data: [
+    ['Status', 'In progress'],
+    ['Budget', 250000],
+    ['Due date', '2026-09-30'],
+    ['Approved', true],
+    ['Project name', 'Website redesign'],
+    ['Owner', 'Ana García'],
+    ['Access code', 'release-2026'],
+  ],
+  colHeaders: ['Setting', 'Value'],
+  columns: [{ readOnly: true }, {}],
+  cells: (row, col) => (col === 1 ? (valueCellMeta[row] ?? {}) : {}),
+  height: 'auto',
+  autoWrapRow: true,
+  autoWrapCol: true,
+  licenseKey: 'non-commercial-and-evaluation',
+};
+</script>
+
+<template>
+  <div id="example3">
+    <HotTable :settings="hotSettings" />
+  </div>
+</template>

--- a/docs/content/guides/cell-types/cell-type/vue/example3.vue
+++ b/docs/content/guides/cell-types/cell-type/vue/example3.vue
@@ -4,9 +4,13 @@ import { registerAllModules } from 'handsontable/registry';
 import type { CellMeta, GridSettings } from 'handsontable/settings';
 
 registerAllModules();
+
 const projectMembers = [
-  ['Ana García', 'Product Manager'], ['James Okafor', 'Senior Engineer'], ['Li Wei', 'UX Designer'],
+  ['Ana García', 'Product Manager'],
+  ['James Okafor', 'Senior Engineer'],
+  ['Li Wei', 'UX Designer'],
 ];
+
 const valueCellMeta: CellMeta[] = [
   { type: 'dropdown', source: ['Planning', 'In progress', 'Blocked'] },
   {
@@ -32,6 +36,7 @@ const valueCellMeta: CellMeta[] = [
   },
   { type: 'password' },
 ];
+
 const hotSettings: GridSettings = {
   data: [
     ['Status', 'In progress'],


### PR DESCRIPTION
### Context

The PR adds a missing `cells` callback demo to the Cell type guide. It shows how to configure `dropdown`, `numeric`, `intl-date`, `checkbox`, `text`, `handsontable`, and `password` cell types within one column in JavaScript, React, Angular, and Vue.

### How has this been tested?

- `npm --prefix docs run docs:lint`
- `SKIP_LATEST=1 npm --prefix docs/angular-type-check run typecheck`
- `npm --prefix docs run build`
- Verified all seven cell types, editor registration, formatted output, checkbox interaction, nested editor sizing, and browser console output in the production build for JavaScript, React, Angular, and Vue.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-706

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-706

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and sample code only; no changes to the Handsontable library or wrappers.
> 
> **Overview**
> Adds a new **Cell type** guide section, **Set different cell types in one column**, with live **example3** demos for JavaScript, TypeScript, React, Angular, and Vue.
> 
> The examples use the [`cells`](@/api/options.md#cells) callback on a two-column “Setting / Value” grid so each value row gets its own type: `dropdown`, `numeric`, `intl-date`, `checkbox`, `text`, nested `handsontable` (owner picker), and `password`. The guide front matter gets `menuTag: updated`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b541f73eefcbb8dce5744a2b1f04f6be3984267. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->