### PR TITLE
DEV-1983: Auto-generate version-highlights scaffold on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -218,6 +218,9 @@ jobs:
           CHANGELOG_CONTENT: ${{ steps.changelog.outputs.content }}
         run: node .github/scripts/update-docs-changelog.mjs '${{ steps.version.outputs.rc-version }}'
 
+      - name: Generate version highlights scaffold
+        run: node docs/scripts/generate-version-highlights.mjs '${{ steps.version.outputs.rc-version }}'
+
       - name: Commit and push
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -674,6 +677,9 @@ jobs:
         env:
           CHANGELOG_CONTENT: ${{ steps.changelog.outputs.content }}
         run: node .github/scripts/update-docs-changelog.mjs '${{ steps.rc-version.outputs.rc-version }}'
+
+      - name: Generate version highlights scaffold
+        run: node docs/scripts/generate-version-highlights.mjs '${{ steps.rc-version.outputs.rc-version }}'
 
       - name: Commit and push
         env:

--- a/docs/README.md
+++ b/docs/README.md
@@ -86,6 +86,8 @@ The documentation branches are created and updated automatically by the `stable-
     * Update the docs changelog and generate API content via `npm run docs:api`;
     * Commit and push the changes to the origin;
 
+The first RC build of a release (see `first-rc-build` in `.github/workflows/publish.yml`) also auto-creates an empty version-highlights scaffold at `docs/content/data/version-highlights/<MAJOR.MINOR>.json` (`{ "version": "<MAJOR.MINOR>", "highlighted": [] }`) if one doesn't already exist. Before the docs release, an author fills in up to 5 `highlighted` entries (each keyed by `prNumber`, with editorial `tagline` and `whyItMatters` fields) to feature them on the "Changes between versions" page. The scaffolding step never overwrites an existing file, so it's safe across RC2+ builds and patch releases.
+
 The prod-docs/latest branch is automatically recreated by the CI/CD pipeline whenever a patch or release update is applied to the latest documentation version. This branch triggers a GitHub workflow that initiates a rebuild and deploys to Cloudflare Pages on each push or when a new branch `prod-docs/<MAJOR.MINOR>` is created.
 
 Committing directly to the Documentation production branch triggers GitHub workflow that deploys the changes to Cloudflare Pages. The exception is the `develop` branch that holds the changes for the "next" version. The staging version can be deployed only [manually](./README-DEPLOYMENT.md#deploying-the-documentation-to-the-staging-environment).

--- a/docs/scripts/generate-version-highlights.mjs
+++ b/docs/scripts/generate-version-highlights.mjs
@@ -1,6 +1,6 @@
 import { access, mkdir, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const DEFAULT_DIR = join(dirname(fileURLToPath(import.meta.url)), '../content/data/version-highlights');
 
@@ -46,7 +46,14 @@ export async function generateHighlightsScaffold(version, directory = DEFAULT_DI
   return { status: 'created', filePath };
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+// process.argv[1] is not resolved to an absolute path when the script is
+// invoked with a relative one (e.g. `node docs/scripts/generate-version-highlights.mjs`,
+// as publish.yml does), so comparing it to import.meta.url as a plain string
+// would never match. pathToFileURL() resolves it the same way Node resolves
+// import.meta.url, so the comparison works regardless of how the script is invoked.
+const isMainModule = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isMainModule) {
   const [version] = process.argv.slice(2);
 
   if (!version) {

--- a/docs/scripts/generate-version-highlights.mjs
+++ b/docs/scripts/generate-version-highlights.mjs
@@ -1,0 +1,67 @@
+import { access, mkdir, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DEFAULT_DIR = join(dirname(fileURLToPath(import.meta.url)), '../content/data/version-highlights');
+
+/**
+ * Extracts "<major>.<minor>" from a full version string (e.g. "18.1.0" or
+ * "18.1.0-rc1"). Returns null when the version doesn't match that shape.
+ */
+export function parseMajorMinor(version) {
+  const match = String(version ?? '').match(/^(\d+)\.(\d+)\.\d+(-rc\d+)?$/);
+
+  return match ? `${match[1]}.${match[2]}` : null;
+}
+
+/**
+ * Builds the minimal scaffold content for a version-highlights file.
+ */
+export function buildScaffold(majorMinor) {
+  return `${JSON.stringify({ version: majorMinor, highlighted: [] }, null, 2)}\n`;
+}
+
+/**
+ * Creates a minimal version-highlights scaffold for the given release version,
+ * unless a file for that major.minor already exists (idempotent - never
+ * overwrites highlights an author has already filled in).
+ */
+export async function generateHighlightsScaffold(version, directory = DEFAULT_DIR) {
+  const majorMinor = parseMajorMinor(version);
+
+  if (majorMinor === null) {
+    throw new Error(`Invalid version "${version}" — expected X.Y.Z or X.Y.Z-rcN`);
+  }
+
+  const filePath = join(directory, `${majorMinor}.json`);
+  const exists = await access(filePath).then(() => true, () => false);
+
+  if (exists) {
+    return { status: 'exists', filePath };
+  }
+
+  await mkdir(directory, { recursive: true });
+  await writeFile(filePath, buildScaffold(majorMinor), 'utf8');
+
+  return { status: 'created', filePath };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const [version] = process.argv.slice(2);
+
+  if (!version) {
+    process.stderr.write('Usage: node generate-version-highlights.mjs <version>\n');
+    process.exitCode = 1;
+  } else {
+    try {
+      const { status, filePath } = await generateHighlightsScaffold(version);
+
+      process.stdout.write(status === 'exists'
+        ? `Version highlights file already exists, skipping: ${filePath}\n`
+        : `Created version highlights scaffold: ${filePath}\n`);
+    } catch (err) {
+      process.stderr.write(`Error: ${err.message}\n`);
+      process.exitCode = 1;
+    }
+  }
+}

--- a/docs/src/plugins/__tests__/generate-version-highlights.test.mjs
+++ b/docs/src/plugins/__tests__/generate-version-highlights.test.mjs
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  buildScaffold,
+  generateHighlightsScaffold,
+  parseMajorMinor,
+} from '../../../scripts/generate-version-highlights.mjs';
+import { validateHighlightFile } from '../../../scripts/validate-version-highlights.mjs';
+
+async function withTempDir(fn) {
+  const dir = mkdtempSync(join(tmpdir(), 'vh-gen-'));
+
+  try {
+    await fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('creates a minimal scaffold for a stable version', async () => {
+  await withTempDir(async (dir) => {
+    const result = await generateHighlightsScaffold('18.1.0', dir);
+
+    assert.equal(result.status, 'created');
+    assert.equal(
+      readFileSync(join(dir, '18.1.json'), 'utf8'),
+      '{\n  "version": "18.1",\n  "highlighted": []\n}\n',
+    );
+  });
+});
+
+test('strips the -rc suffix when deriving major.minor', async () => {
+  await withTempDir(async (dir) => {
+    const rc1 = await generateHighlightsScaffold('18.1.0-rc1', dir);
+
+    assert.equal(rc1.status, 'created');
+    assert.equal(JSON.parse(readFileSync(join(dir, '18.1.json'), 'utf8')).version, '18.1');
+  });
+
+  await withTempDir(async (dir) => {
+    const rc12 = await generateHighlightsScaffold('18.1.0-rc12', dir);
+
+    assert.equal(rc12.status, 'created');
+    assert.equal(JSON.parse(readFileSync(join(dir, '18.1.json'), 'utf8')).version, '18.1');
+  });
+});
+
+test('does not overwrite an existing file (idempotent across RCs)', async () => {
+  await withTempDir(async (dir) => {
+    const customContent = JSON.stringify({
+      version: '18.1',
+      highlighted: [{ prNumber: 1, tagline: 't', whyItMatters: 'y' }],
+    });
+
+    writeFileSync(join(dir, '18.1.json'), customContent, 'utf8');
+
+    const result = await generateHighlightsScaffold('18.1.0-rc2', dir);
+
+    assert.equal(result.status, 'exists');
+    assert.equal(readFileSync(join(dir, '18.1.json'), 'utf8'), customContent);
+  });
+});
+
+test('does not overwrite an existing file on a patch release', async () => {
+  await withTempDir(async (dir) => {
+    const customContent = JSON.stringify({ version: '18.0', highlighted: [] });
+
+    writeFileSync(join(dir, '18.0.json'), customContent, 'utf8');
+
+    const result = await generateHighlightsScaffold('18.0.2', dir);
+
+    assert.equal(result.status, 'exists');
+    assert.equal(readFileSync(join(dir, '18.0.json'), 'utf8'), customContent);
+  });
+});
+
+test('rejects invalid version strings', async () => {
+  await withTempDir(async (dir) => {
+    for (const invalid of ['18.1', '18.1.0-beta1', 'x.y.z', '', undefined]) {
+      await assert.rejects(() => generateHighlightsScaffold(invalid, dir));
+    }
+  });
+});
+
+test('parseMajorMinor returns null for invalid input', () => {
+  assert.equal(parseMajorMinor('18.1'), null);
+  assert.equal(parseMajorMinor('18.1.0-beta1'), null);
+  assert.equal(parseMajorMinor(undefined), null);
+});
+
+test('the generated scaffold passes the highlights validator', () => {
+  const scaffold = JSON.parse(buildScaffold('18.1'));
+  const errors = validateHighlightFile('18.1.json', scaffold, new Set());
+
+  assert.deepEqual(errors, []);
+});


### PR DESCRIPTION
### Context

The PR adds automatic scaffolding for the per-release `version-highlights` file, following up on PR [#12922](https://github.com/handsontable/handsontable/pull/12922), which introduced `docs/content/data/version-highlights/<major>.<minor>.json` and required creating each file by hand.

This PR generates a minimal, valid scaffold (`{ "version": "<major>.<minor>", "highlighted": [] }`) during the release workflow, so an author only needs to fill in `highlighted` entries (editorial `tagline`/`whyItMatters`, keyed by `prNumber`) before the docs release — instead of creating the file from scratch.

Generation hooks into `.github/workflows/publish.yml`, right after the existing "Update docs changelog" step, in both the first-RC and subsequent-RC scenarios (the version is known there, and the existing "Commit and push" step already picks up docs changes on the release branch). The `docs-production.yml` workflow was **not** used for this, since it only builds/deploys and never commits back to the repository. The new script is idempotent — it skips silently if the file already exists — so it's safe across RC2+ builds, patch releases, and reruns, and it never overwrites an author's manually filled-in highlights.

### How has this been tested?

- Added unit tests: `docs/src/plugins/__tests__/generate-version-highlights.test.mjs` (happy path, `-rcN` suffix parsing, idempotency on rerun and on patch releases, invalid-version rejection, and integration with the existing highlights validator).
- Ran `npm run docs:test:plugins --prefix docs` — full 143-test suite passes.
- Ran `npm run docs:validate-highlights --prefix docs` with a generated scaffold present — passes.
- Manually exercised the CLI (`node docs/scripts/generate-version-highlights.mjs <version>`): creates the file, is a no-op on rerun, and errors on an invalid version string.
- Linted the new files (`npx eslint`) — no issues.
- Validated the modified `publish.yml` is syntactically valid YAML.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1983

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1983

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only scaffolding and CI wiring; no runtime product logic and existing files are never overwritten.
> 
> **Overview**
> Release RC builds now create an empty **version-highlights** JSON scaffold under `docs/content/data/version-highlights/<MAJOR.MINOR>.json` so authors only need to fill in `highlighted` entries before docs ship, instead of creating the file manually.
> 
> A new `docs/scripts/generate-version-highlights.mjs` script parses `X.Y.Z` or `X.Y.Z-rcN`, writes `{ "version": "<MAJOR.MINOR>", "highlighted": [] }`, and **skips** if the file already exists so filled-in highlights and reruns (RC2+, patches) are safe. **Publish** workflow runs it after "Update docs changelog" in both **first RC** and **subsequent RC** jobs, alongside the existing commit-and-push step. `docs/README.md` documents the behavior, and unit tests cover parsing, idempotency, invalid versions, and compatibility with `validate-version-highlights`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7461af764cfc3ee6806b02d2309d912d814f0b5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->