### PR TITLE
DEV-2068: Read bulk scans through transient cell meta across core and plugins

### DIFF
--- a/.changelogs/13068.json
+++ b/.changelogs/13068.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Improved memory usage of read-only cell settings lookups. The context menu, filters dropdown, formulas synchronization, data type detection, column summaries, and clearing large selections no longer permanently cache settings for every visited cell.",
+  "type": "changed",
+  "issueOrPR": 13068,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/__tests__/core/emptySelectedCells.spec.js
+++ b/handsontable/src/__tests__/core/emptySelectedCells.spec.js
@@ -154,6 +154,29 @@ describe('Core.emptySelectedCells', () => {
     expect(onBeforeChange).not.toHaveBeenCalled();
   });
 
+  it('should not permanently retain a cell meta object for every cleared cell', async() => {
+    const rows = [];
+
+    for (let i = 0; i < 200; i++) {
+      rows.push([1, 2, 3]);
+    }
+
+    const hot = handsontable({
+      data: rows,
+      width: 400,
+      height: 200,
+    });
+
+    await selectCells([[0, 0, 199, 2]]);
+
+    const retainedBefore = hot.getCellsMeta().length;
+
+    await emptySelectedCells(); // clears all 600 cells, mostly off-screen
+
+    expect(getDataAtCell(199, 0)).toBe(null);
+    expect(hot.getCellsMeta().length).toBe(retainedBefore);
+  });
+
   it('should override cleared values using `beforeChange` hook', async() => {
     handsontable({
       data: [

--- a/handsontable/src/__tests__/core/getDataType.spec.js
+++ b/handsontable/src/__tests__/core/getDataType.spec.js
@@ -35,12 +35,12 @@ describe('Core_getDataType', () => {
       data: arrayOfArrays()
     });
 
-    spyOn(hot, 'getCellMeta').and.callThrough();
+    spyOn(hot, 'getCellMetaTransient').and.callThrough();
 
     expect(getDataType(-1, -2, 2, 2)).toEqual('text');
-    expect(hot.getCellMeta.calls.count()).toBe(9);
-    expect(hot.getCellMeta.calls.first().args).toEqual([0, 0]);
-    expect(hot.getCellMeta.calls.mostRecent().args).toEqual([2, 2]);
+    expect(hot.getCellMetaTransient.calls.count()).toBe(9);
+    expect(hot.getCellMetaTransient.calls.first().args).toEqual([0, 0]);
+    expect(hot.getCellMetaTransient.calls.mostRecent().args).toEqual([2, 2]);
   });
 
   it('should return data type at specified range (type defined in columns)', async() => {
@@ -121,5 +121,19 @@ describe('Core_getDataType', () => {
     expect(getDataType(1, 1)).toEqual('date');
     expect(getDataType(1, 2)).toEqual('checkbox');
     expect(getDataType(0, 0, 1, 1)).toEqual('mixed');
+  });
+
+  it('should not permanently retain a cell meta object for every scanned cell', async() => {
+    const hot = handsontable({
+      data: createSpreadsheetData(200, 10),
+      width: 400,
+      height: 200,
+    });
+
+    const retainedBefore = hot.getCellsMeta().length;
+
+    getDataType(0, 0, 199, 9); // scans all 2,000 cells
+
+    expect(hot.getCellsMeta().length).toBe(retainedBefore);
   });
 });

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -2530,7 +2530,9 @@ export default function Core(
 
       const collectEmptyCellChanges = (row: number) => {
         rangeEach(fromColumn, toColumn, (column) => {
-          if (!this.getCellMeta(row, column).readOnly) {
+          // The transient read keeps clearing a large selection from permanently materializing
+          // one meta object per cell - only `readOnly` is read here.
+          if (!this.getCellMetaTransient(row, column).readOnly) {
             changes.push([row, column, null]);
           }
         });
@@ -4060,7 +4062,10 @@ export default function Core(
       const visualColumn = instance.toVisualColumn(changeProp as number);
 
       if (Number.isInteger(visualColumn)) {
-        return instance.getCellMeta(visualRow!, visualColumn as number);
+        // The transient read keeps a bulk source-data write from permanently materializing one
+        // meta object per changed cell - the meta only feeds the `valueSetter` and the
+        // source-data validator, both read-only.
+        return instance.getCellMetaTransient(visualRow!, visualColumn as number);
       }
 
       // If there's no requested visual column, we can use the table meta as the cell properties.
@@ -4199,7 +4204,7 @@ export default function Core(
       let isTypeEqual = true;
 
       rangeEach(Math.max(Math.min(columnStart, columnEnd), 0), Math.max(columnStart, columnEnd), (column) => {
-        const cellType = instance.getCellMeta(row, column);
+        const cellType = instance.getCellMetaTransient(row, column);
 
         currentType = (cellType.type as string | null | undefined) ?? null;
 

--- a/handsontable/src/plugins/columnSorting/columnSorting.ts
+++ b/handsontable/src/plugins/columnSorting/columnSorting.ts
@@ -576,7 +576,7 @@ export class ColumnSorting extends BasePlugin {
   getMergedPluginSettings(column: number): Record<string, unknown> {
     const pluginMainSettings = this.hot.getSettings()[this.pluginKey] as Record<string, unknown>;
     const storedColumnProperties = this.columnStatesManager?.getAllColumnsProperties() ?? {};
-    const cellMeta = this.hot.getCellMeta(0, column);
+    const cellMeta = this.hot.getCellMetaTransient(0, column);
     const columnMeta = Object.getPrototypeOf(cellMeta) as Record<string, unknown>;
 
     if (Array.isArray(columnMeta.columns)) {
@@ -602,7 +602,7 @@ export class ColumnSorting extends BasePlugin {
   // TODO: Workaround. Inheriting of non-primitive cell meta values doesn't work. Instead of getting properties from column meta we call this function.
   // TODO: Remove test named: "should not break the dataset when inserted new row" (#5431).
   getFirstCellSettings(column: number): Record<string, unknown> {
-    const cellMeta = this.hot.getCellMeta(0, column);
+    const cellMeta = this.hot.getCellMetaTransient(0, column);
 
     const cellMetaCopy = Object.create(cellMeta) as Record<string, unknown>;
 

--- a/handsontable/src/plugins/columnSummary/columnSummary.ts
+++ b/handsontable/src/plugins/columnSummary/columnSummary.ts
@@ -502,7 +502,7 @@ export class ColumnSummary extends BasePlugin {
     let cellClassName = '';
 
     if (visualRowIndex !== null) {
-      cellClassName = (this.hot.getCellMeta(visualRowIndex, col).className as string) || '';
+      cellClassName = (this.hot.getCellMetaTransient(visualRowIndex, col).className as string) || '';
     }
 
     if (cellClassName.indexOf('columnSummaryResult') > -1) {

--- a/handsontable/src/plugins/columnSummary/endpoints.ts
+++ b/handsontable/src/plugins/columnSummary/endpoints.ts
@@ -640,7 +640,7 @@ class Endpoints {
 
     if (destinationVisualRow !== null) {
       const destinationColumn = endpoint.destinationColumn!;
-      const cellMeta = this.hot.getCellMeta(destinationVisualRow, destinationColumn);
+      const cellMeta = this.hot.getCellMetaTransient(destinationVisualRow, destinationColumn);
 
       if (source === 'init' || cellMeta.readOnly !== endpoint.readOnly) {
         // Declarative writes (see `refreshCellMetas`) so the styling survives viewport meta eviction

--- a/handsontable/src/plugins/contextMenu/predefinedItems/alignment.ts
+++ b/handsontable/src/plugins/contextMenu/predefinedItems/alignment.ts
@@ -44,12 +44,12 @@ export default function alignmentItem() {
           callback(this: HotInstance) {
             const selectedRange = this.getSelectedRange() ?? [];
             const stateBefore = getAlignmentClasses(selectedRange,
-              (row: number, col: number) => this.getCellMeta(row, col).className as string);
+              (row: number, col: number) => this.getCellMetaTransient(row, col).className as string);
             const type = 'horizontal';
             const alignment = 'htLeft';
 
             this.runHooks('beforeCellAlignment', stateBefore, selectedRange, type, alignment);
-            align(selectedRange, type, alignment, (row: number, col: number) => this.getCellMeta(row, col),
+            align(selectedRange, type, alignment, (row: number, col: number) => this.getCellMetaTransient(row, col),
               (row: number, col: number, key: string, value: string) => this.setCellMeta(row, col, key, value));
             this.render();
           },
@@ -63,12 +63,12 @@ export default function alignmentItem() {
           callback(this: HotInstance) {
             const selectedRange = this.getSelectedRange() ?? [];
             const stateBefore = getAlignmentClasses(selectedRange,
-              (row: number, col: number) => this.getCellMeta(row, col).className as string);
+              (row: number, col: number) => this.getCellMetaTransient(row, col).className as string);
             const type = 'horizontal';
             const alignment = 'htCenter';
 
             this.runHooks('beforeCellAlignment', stateBefore, selectedRange, type, alignment);
-            align(selectedRange, type, alignment, (row: number, col: number) => this.getCellMeta(row, col),
+            align(selectedRange, type, alignment, (row: number, col: number) => this.getCellMetaTransient(row, col),
               (row: number, col: number, key: string, value: string) => this.setCellMeta(row, col, key, value));
             this.render();
           },
@@ -82,12 +82,12 @@ export default function alignmentItem() {
           callback(this: HotInstance) {
             const selectedRange = this.getSelectedRange() ?? [];
             const stateBefore = getAlignmentClasses(selectedRange,
-              (row: number, col: number) => this.getCellMeta(row, col).className as string);
+              (row: number, col: number) => this.getCellMetaTransient(row, col).className as string);
             const type = 'horizontal';
             const alignment = 'htRight';
 
             this.runHooks('beforeCellAlignment', stateBefore, selectedRange, type, alignment);
-            align(selectedRange, type, alignment, (row: number, col: number) => this.getCellMeta(row, col),
+            align(selectedRange, type, alignment, (row: number, col: number) => this.getCellMetaTransient(row, col),
               (row: number, col: number, key: string, value: string) => this.setCellMeta(row, col, key, value));
             this.render();
           },
@@ -101,12 +101,12 @@ export default function alignmentItem() {
           callback(this: HotInstance) {
             const selectedRange = this.getSelectedRange() ?? [];
             const stateBefore = getAlignmentClasses(selectedRange,
-              (row: number, col: number) => this.getCellMeta(row, col).className as string);
+              (row: number, col: number) => this.getCellMetaTransient(row, col).className as string);
             const type = 'horizontal';
             const alignment = 'htJustify';
 
             this.runHooks('beforeCellAlignment', stateBefore, selectedRange, type, alignment);
-            align(selectedRange, type, alignment, (row: number, col: number) => this.getCellMeta(row, col),
+            align(selectedRange, type, alignment, (row: number, col: number) => this.getCellMetaTransient(row, col),
               (row: number, col: number, key: string, value: string) => this.setCellMeta(row, col, key, value));
             this.render();
           },
@@ -123,12 +123,12 @@ export default function alignmentItem() {
           callback(this: HotInstance) {
             const selectedRange = this.getSelectedRange() ?? [];
             const stateBefore = getAlignmentClasses(selectedRange,
-              (row: number, col: number) => this.getCellMeta(row, col).className as string);
+              (row: number, col: number) => this.getCellMetaTransient(row, col).className as string);
             const type = 'vertical';
             const alignment = 'htTop';
 
             this.runHooks('beforeCellAlignment', stateBefore, selectedRange, type, alignment);
-            align(selectedRange, type, alignment, (row: number, col: number) => this.getCellMeta(row, col),
+            align(selectedRange, type, alignment, (row: number, col: number) => this.getCellMetaTransient(row, col),
               (row: number, col: number, key: string, value: string) => this.setCellMeta(row, col, key, value));
             this.render();
           },
@@ -142,12 +142,12 @@ export default function alignmentItem() {
           callback(this: HotInstance) {
             const selectedRange = this.getSelectedRange() ?? [];
             const stateBefore = getAlignmentClasses(selectedRange,
-              (row: number, col: number) => this.getCellMeta(row, col).className as string);
+              (row: number, col: number) => this.getCellMetaTransient(row, col).className as string);
             const type = 'vertical';
             const alignment = 'htMiddle';
 
             this.runHooks('beforeCellAlignment', stateBefore, selectedRange, type, alignment);
-            align(selectedRange, type, alignment, (row: number, col: number) => this.getCellMeta(row, col),
+            align(selectedRange, type, alignment, (row: number, col: number) => this.getCellMetaTransient(row, col),
               (row: number, col: number, key: string, value: string) => this.setCellMeta(row, col, key, value));
             this.render();
           },
@@ -161,12 +161,12 @@ export default function alignmentItem() {
           callback(this: HotInstance) {
             const selectedRange = this.getSelectedRange() ?? [];
             const stateBefore = getAlignmentClasses(selectedRange,
-              (row: number, col: number) => this.getCellMeta(row, col).className as string);
+              (row: number, col: number) => this.getCellMetaTransient(row, col).className as string);
             const type = 'vertical';
             const alignment = 'htBottom';
 
             this.runHooks('beforeCellAlignment', stateBefore, selectedRange, type, alignment);
-            align(selectedRange, type, alignment, (row: number, col: number) => this.getCellMeta(row, col),
+            align(selectedRange, type, alignment, (row: number, col: number) => this.getCellMetaTransient(row, col),
               (row: number, col: number, key: string, value: string) => this.setCellMeta(row, col, key, value));
             this.render();
           },

--- a/handsontable/src/plugins/contextMenu/predefinedItems/clearColumn.ts
+++ b/handsontable/src/plugins/contextMenu/predefinedItems/clearColumn.ts
@@ -40,7 +40,7 @@ export default function clearColumnItem() {
           return true;
         }
 
-        const { readOnly } = this.getCellMeta(row, col);
+        const { readOnly } = this.getCellMetaTransient(row, col);
 
         if (!readOnly) {
           atLeastOneNonReadOnly = true;

--- a/handsontable/src/plugins/contextMenu/predefinedItems/readOnly.ts
+++ b/handsontable/src/plugins/contextMenu/predefinedItems/readOnly.ts
@@ -14,7 +14,7 @@ export default function readOnlyItem() {
     ariaChecked(this: HotInstance) {
       const atLeastOneReadOnly = checkSelectionConsistency(
         this.getSelectedRange() ?? [],
-        (row: number, col: number) => Boolean(this.getCellMeta(row, col).readOnly)
+        (row: number, col: number) => Boolean(this.getCellMetaTransient(row, col).readOnly)
       );
 
       return atLeastOneReadOnly;
@@ -28,7 +28,7 @@ export default function readOnlyItem() {
       let label = this.getTranslatedPhrase(C.CONTEXTMENU_ITEMS_READ_ONLY) as string;
       const atLeastOneReadOnly = checkSelectionConsistency(
         this.getSelectedRange() ?? [],
-        (row: number, col: number) => Boolean(this.getCellMeta(row, col).readOnly)
+        (row: number, col: number) => Boolean(this.getCellMetaTransient(row, col).readOnly)
       );
 
       if (atLeastOneReadOnly) {
@@ -41,7 +41,7 @@ export default function readOnlyItem() {
       const ranges = this.getSelectedRange() ?? [];
       const atLeastOneReadOnly = checkSelectionConsistency(
         ranges,
-        (row: number, col: number) => Boolean(this.getCellMeta(row, col).readOnly)
+        (row: number, col: number) => Boolean(this.getCellMetaTransient(row, col).readOnly)
       );
 
       for (const range of ranges) {

--- a/handsontable/src/plugins/contextMenu/utils.ts
+++ b/handsontable/src/plugins/contextMenu/utils.ts
@@ -188,7 +188,7 @@ export function getDocumentOffsetByElement(elementToCheck: HTMLElement, baseDocu
  */
 export function getAlignmentComparatorByClass(htClassName: string) {
   return function(this: HotInstance, row: number, col: number): boolean {
-    const className = this.getCellMeta(row, col).className as string | string[] | undefined;
+    const className = this.getCellMetaTransient(row, col).className as string | string[] | undefined;
 
     return Boolean(className && className.indexOf(htClassName) !== -1);
   };

--- a/handsontable/src/plugins/dataProvider/__tests__/query/crud.unit.js
+++ b/handsontable/src/plugins/dataProvider/__tests__/query/crud.unit.js
@@ -53,7 +53,7 @@ describe('dataProvider crud', () => {
   describe('filterChangesForBatchedServerUpdate', () => {
     const hot = {
       propToCol: prop => (prop === 'bad' ? -1 : 0),
-      getCellMeta: (row, col) => ({ valid: row === 0 && col === 0 }),
+      getCellMetaTransient: (row, col) => ({ valid: row === 0 && col === 0 }),
     };
 
     it('should drop no-op edits and invalid cells', () => {
@@ -319,6 +319,7 @@ describe('dataProvider crud', () => {
         propToCol: () => 0,
         colToProp: () => 'name',
         getCellMeta: () => ({ allowInvalid: false }),
+        getCellMetaTransient: () => ({ allowInvalid: false }),
         getCellValidator: () => () => {},
         validateCell: (value, cellMeta, cb) => {
           cb(false);

--- a/handsontable/src/plugins/dataProvider/query/crud.ts
+++ b/handsontable/src/plugins/dataProvider/query/crud.ts
@@ -368,7 +368,7 @@ export function filterChangesForBatchedServerUpdate(
       return false;
     }
 
-    return hot.getCellMeta(c[0], col).valid !== false;
+    return hot.getCellMetaTransient(c[0], col).valid !== false;
   });
 }
 

--- a/handsontable/src/plugins/filters/__tests__/conditionCollection.unit.ts
+++ b/handsontable/src/plugins/filters/__tests__/conditionCollection.unit.ts
@@ -8,6 +8,7 @@ const hotMock = {
   toVisualColumn: column => column,
   columnIndexMapper: new IndexMapper(),
   getCellMeta: () => ({}),
+  getCellMetaTransient: () => ({}),
   addHook: () => {},
 };
 

--- a/handsontable/src/plugins/filters/component/value.ts
+++ b/handsontable/src/plugins/filters/component/value.ts
@@ -183,7 +183,7 @@ export class ValueComponent extends BaseComponent {
         const rowValues = arrayMap(filteredRows, row => row.value);
         const rowMetaMap = new Map(
           filteredRows.map((row: FilteredRow) =>
-            [row.value, this.hot?.getCellMeta(row.meta.visualRow, row.meta.visualCol)])
+            [row.value, this.hot?.getCellMetaTransient(row.meta.visualRow, row.meta.visualCol)])
         );
         const columnMeta = filteredRows[0]?.meta;
         const comparator = getSortComparatorForMeta(columnMeta);
@@ -209,7 +209,7 @@ export class ValueComponent extends BaseComponent {
 
         const column = stateInfo.editedConditionStack.column;
 
-        state.locale = this.hot?.getCellMeta(0, column).locale;
+        state.locale = this.hot?.getCellMetaTransient(0, column).locale;
         state.args = [selectedValues];
         state.command = getConditionDescriptor(CONDITION_BY_VALUE);
         state.itemsSnapshot = itemsSnapshot;
@@ -318,7 +318,8 @@ export class ValueComponent extends BaseComponent {
     const selectedColumn = this.hot?.getPlugin('filters').getSelectedColumn() ?? null;
 
     if (selectedColumn !== null) {
-      this.getMultipleSelectElement().setLocale(this.hot?.getCellMeta(0, selectedColumn.visualIndex).locale as string);
+      this.getMultipleSelectElement()
+        .setLocale(this.hot?.getCellMetaTransient(0, selectedColumn.visualIndex).locale as string);
     }
   }
 
@@ -386,7 +387,7 @@ export class ValueComponent extends BaseComponent {
     return arrayMap(this.hot?.getDataAtCol(selectedColumn.visualIndex) ?? [], (v, rowIndex) => {
       return {
         value: toEmptyString(v) as string,
-        meta: this.hot?.getCellMeta(rowIndex, selectedColumn.visualIndex) ?? {},
+        meta: this.hot?.getCellMetaTransient(rowIndex, selectedColumn.visualIndex) ?? {},
       };
     });
   }

--- a/handsontable/src/plugins/filters/conditionCollection.ts
+++ b/handsontable/src/plugins/filters/conditionCollection.ts
@@ -124,7 +124,7 @@ class ConditionCollection {
   addCondition(
     column: number, conditionDefinition: Record<string, unknown>, operation = OPERATION_AND, position?: number
   ) {
-    const localeForColumn = this.hot.getCellMeta(0, column).locale as string | undefined;
+    const localeForColumn = this.hot.getCellMetaTransient(0, column).locale as string | undefined;
     const args = (conditionDefinition.args as unknown[])
       .map((v: unknown) => (typeof v === 'string' ? localeLowerCase(v, localeForColumn) : v));
     const name = (conditionDefinition.name || (conditionDefinition.command as Record<string, unknown>).key) as string;

--- a/handsontable/src/plugins/filters/filters.ts
+++ b/handsontable/src/plugins/filters/filters.ts
@@ -1140,7 +1140,7 @@ export class Filters extends BasePlugin {
   updateValueComponentCondition(columnIndex: number) {
     const visualColumnIndex = this.hot.toVisualColumn(columnIndex);
     const dataAtCol = this.hot.getDataAtCol(visualColumnIndex);
-    const columnMeta = this.hot.countRows() > 0 ? this.hot.getCellMeta(0, visualColumnIndex) : null;
+    const columnMeta = this.hot.countRows() > 0 ? this.hot.getCellMetaTransient(0, visualColumnIndex) : null;
     const comparator = getSortComparatorForMeta(columnMeta);
     const selectedValues = unifyColumnValues(dataAtCol, comparator);
 

--- a/handsontable/src/plugins/formulas/formulas.ts
+++ b/handsontable/src/plugins/formulas/formulas.ts
@@ -169,7 +169,12 @@ export class Formulas extends BasePlugin {
       return change;
     }
 
-    const cellMeta = this.hot.getCellMeta(visualRow, visualColumn, { skipMetaExtension: true });
+    // The uncached read keeps the same no-extension semantics as the previous
+    // `skipMetaExtension` read, without permanently materializing the cell meta.
+    const cellMeta = this.hot._getMetaManager().getCellMetaUncached(
+      this.hot.toPhysicalRow(visualRow) ?? visualRow, this.hot.toPhysicalColumn(visualColumn) ?? visualColumn,
+      { visualRow, visualColumn },
+    );
     let newValue: unknown;
 
     if (cellMeta.type === 'date') {
@@ -768,7 +773,7 @@ export class Formulas extends BasePlugin {
       return;
     }
 
-    const cellMeta = this.hot.getCellMeta(row, column);
+    const cellMeta = this.hot.getCellMetaTransient(row, column);
 
     if (isDate(newValue, cellMeta.type)) {
       if (isDateValid(newValue)) {
@@ -797,7 +802,7 @@ export class Formulas extends BasePlugin {
     if (isObject(value) && value !== null) {
       const visualRow = this.hot.toVisualRow(row);
       const visualColumn = this.hot.toVisualColumn(column);
-      const cellMeta = this.hot.getCellMeta(visualRow, visualColumn);
+      const cellMeta = this.hot.getCellMetaTransient(visualRow, visualColumn);
 
       value = getValueGetterValue(value, cellMeta);
 
@@ -885,7 +890,7 @@ export class Formulas extends BasePlugin {
         sheet: this.sheetId,
       };
 
-      const cellMeta = this.hot.getCellMeta(visualRow, visualColumn);
+      const cellMeta = this.hot.getCellMetaTransient(visualRow, visualColumn);
       let cellValue = this.engine!.getCellValue(address); // Date as an integer (Excel-like date).
 
       if (cellMeta.type === 'date' && isNumeric(cellValue)) {
@@ -1047,7 +1052,12 @@ export class Formulas extends BasePlugin {
 
     sourceDataArray.forEach((rowData: unknown[], rowIndex: number) => {
       rowData.forEach((cellValue: unknown, columnIndex: number) => {
-        const cellMeta = this.hot.getCellMeta(rowIndex, columnIndex, { skipMetaExtension: true });
+        // The uncached read keeps this full source-data scan from permanently materializing
+        // one meta object per cell (same no-extension semantics as `skipMetaExtension`).
+        const cellMeta = this.hot._getMetaManager().getCellMetaUncached(
+          this.hot.toPhysicalRow(rowIndex) ?? rowIndex, this.hot.toPhysicalColumn(columnIndex) ?? columnIndex,
+          { visualRow: rowIndex, visualColumn: columnIndex },
+        );
 
         if (isDate(cellValue, cellMeta.type)) {
           if (isDateValid(cellValue)) {
@@ -1153,7 +1163,12 @@ export class Formulas extends BasePlugin {
     };
     let cellValue = this.engine!.getCellValue(address); // Date as an integer (Excel like date).
 
-    const cellMeta = this.hot.getCellMeta(visualRow, visualColumn, { skipMetaExtension: true });
+    // The uncached read matters here: this hook fires inside bulk data reads (for example, the
+    // filters column scan), so an eager read would materialize one meta per scanned cell.
+    const cellMeta = this.hot._getMetaManager().getCellMetaUncached(
+      this.hot.toPhysicalRow(visualRow) ?? visualRow, this.hot.toPhysicalColumn(visualColumn) ?? visualColumn,
+      { visualRow, visualColumn },
+    );
 
     if (cellMeta.type === 'date' && isNumeric(cellValue)) {
       cellValue = getDateFromExcelDate(cellValue);

--- a/handsontable/src/plugins/undoRedo/actions/cellAlignment.ts
+++ b/handsontable/src/plugins/undoRedo/actions/cellAlignment.ts
@@ -77,7 +77,7 @@ export class CellAlignmentAction extends BaseAction {
    * @param {function(): void} redoneCallback The callback to be called after the action is redone.
    */
   redo(hot: HotInstance, redoneCallback: HookCallback) {
-    align(this.range, this.type, this.alignment, (row: number, col: number) => hot.getCellMeta(row, col),
+    align(this.range, this.type, this.alignment, (row: number, col: number) => hot.getCellMetaTransient(row, col),
       (row: number, col: number, key: string, value: unknown) => hot.setCellMeta(row, col, key, value));
 
     hot.addHookOnce('afterViewRender', redoneCallback);

--- a/handsontable/src/renderers/checkboxRenderer/checkboxRenderer.ts
+++ b/handsontable/src/renderers/checkboxRenderer/checkboxRenderer.ts
@@ -399,7 +399,7 @@ export function checkboxRenderer(
 
       for (let visualRow = topLeft.row; visualRow <= bottomRight.row; visualRow++) {
         for (let visualColumn = topLeft.col; visualColumn <= bottomRight.col; visualColumn++) {
-          const cellMeta = hotInstance.getCellMeta(visualRow, visualColumn);
+          const cellMeta = hotInstance.getCellMetaTransient(visualRow, visualColumn);
 
           /* eslint-disable no-continue */
           if (cellMeta.readOnly) {
@@ -534,7 +534,7 @@ function onClick(event: Event, instance: HotInstance) {
 
   const row = Number.parseInt(target.getAttribute(ATTR_ROW)!, 10);
   const col = Number.parseInt(target.getAttribute(ATTR_COLUMN)!, 10);
-  const cellProperties = instance.getCellMeta(row, col);
+  const cellProperties = instance.getCellMetaTransient(row, col);
 
   if (cellProperties.readOnly) {
     event.preventDefault();
@@ -560,7 +560,7 @@ function onChange(event: Event, instance: HotInstance) {
 
   const row = Number.parseInt(target.getAttribute(ATTR_ROW)!, 10);
   const col = Number.parseInt(target.getAttribute(ATTR_COLUMN)!, 10);
-  const cellProperties = instance.getCellMeta(row, col);
+  const cellProperties = instance.getCellMetaTransient(row, col);
 
   if (!cellProperties.readOnly) {
     let newCheckboxValue = null;

--- a/handsontable/src/shortcuts/contexts/commands/populateSelectedCellsData.ts
+++ b/handsontable/src/shortcuts/contexts/commands/populateSelectedCellsData.ts
@@ -18,7 +18,7 @@ export const command = {
     for (let i = 0; i < selectedRange.length; i++) {
       selectedRange[i].forAll((row: number, column: number) => {
         if (row >= 0 && column >= 0 && (row !== highlightRow || column !== highlightColumn)) {
-          const { readOnly } = hot.getCellMeta(row, column);
+          const { readOnly } = hot.getCellMetaTransient(row, column);
 
           if (!readOnly) {
             cellValues.set(`${row}x${column}`, [row, column, valueToPopulate]);

--- a/handsontable/src/utils/__tests__/ghostTable.spec.js
+++ b/handsontable/src/utils/__tests__/ghostTable.spec.js
@@ -320,18 +320,18 @@ describe('GhostTable', () => {
 
     gt = new Handsontable.__GhostTable(hot);
 
-    spyOn(hot, 'getCellMeta').and.returnValue({
+    const cellMeta = {
       row: 3,
       col: 4,
       visualRow: 5,
       visualCol: 6,
       renderer: jasmine.createSpy('renderer'),
-    });
+    };
+
+    spyOn(hot, 'getCellMetaTransient').and.returnValue(cellMeta);
 
     gt.samples = new Map([[0, { strings: [{ col: 0, value: 'test' }] }]]);
     gt.createRow(0);
-
-    const cellMeta = getCellMeta(0, 0);
 
     expect(cellMeta.renderer).toHaveBeenCalledTimes(1);
     expect(cellMeta.row).toBe(3);
@@ -345,18 +345,18 @@ describe('GhostTable', () => {
 
     gt = new Handsontable.__GhostTable(hot);
 
-    spyOn(hot, 'getCellMeta').and.returnValue({
+    const cellMeta = {
       row: 3,
       col: 4,
       visualRow: 5,
       visualCol: 6,
       renderer: jasmine.createSpy('renderer'),
-    });
+    };
+
+    spyOn(hot, 'getCellMetaTransient').and.returnValue(cellMeta);
 
     gt.samples = new Map([[0, { strings: [{ row: 0, value: 'test' }] }]]);
     gt.createCol(0);
-
-    const cellMeta = getCellMeta(0, 0);
 
     expect(cellMeta.renderer).toHaveBeenCalledTimes(1);
     expect(cellMeta.row).toBe(3);

--- a/handsontable/src/utils/ghostTable.ts
+++ b/handsontable/src/utils/ghostTable.ts
@@ -322,7 +322,7 @@ class GhostTable {
     this.samples!.forEach((sample: SampleEntry) => {
       arrayEach(sample.strings, (string: SampleString) => {
         const column = string.col!;
-        const cellProperties = this.hot!.getCellMeta<CellProperties>(row, column);
+        const cellProperties = this.hot!.getCellMetaTransient<CellProperties>(row, column);
         const renderer = this.hot!.getCellRenderer(cellProperties);
         const td = rootDocument.createElement('td');
 
@@ -386,7 +386,7 @@ class GhostTable {
     this.samples!.forEach((sample: SampleEntry) => {
       arrayEach(sample.strings, (string: SampleString) => {
         const row = string.row!;
-        const cellProperties = this.hot!.getCellMeta<CellProperties>(row, column);
+        const cellProperties = this.hot!.getCellMetaTransient<CellProperties>(row, column);
         const renderer = this.hot!.getCellRenderer(cellProperties);
         const td = rootDocument.createElement('td');
         const tr = rootDocument.createElement('tr');
@@ -453,7 +453,7 @@ class GhostTable {
     let colspan = 0;
 
     if (row >= 0 && column >= 0) {
-      colspan = Number(this.hot!.getCellMeta(row, column).colspan);
+      colspan = Number(this.hot!.getCellMetaTransient(row, column).colspan);
     }
 
     let width = this.hot!.getColWidth(column);

--- a/handsontable/src/utils/parseTable.ts
+++ b/handsontable/src/utils/parseTable.ts
@@ -59,7 +59,7 @@ export function instanceToHTML(instance: HotInstance): string {
 
       } else {
         const cellData = data[row][column];
-        const { hidden, rowspan, colspan } = instance.getCellMeta(row - columnModifier, column - rowModifier);
+        const { hidden, rowspan, colspan } = instance.getCellMetaTransient(row - columnModifier, column - rowModifier);
 
         if (!hidden) {
           const attrs = [];


### PR DESCRIPTION
### Context

The PR converts every remaining read-only `getCellMeta` call site in the core and plugins to the no-retention reads introduced by DEV-2056 (#13063): `getCellMetaTransient` (full dynamic extension, nothing stored) or `getCellMetaUncached` (no extension, nothing stored — used where the site deliberately passed `skipMetaExtension: true`). After this change, bulk scans and one-shot reads no longer permanently materialize one cell meta object per visited cell.

**Base branch note: this PR is based on `feature/DEV-2056_Rewrite-LazyFactoryMap-to-native-Map` (#13063) and should be retargeted/rebased onto `develop` after #13063 merges.**

Every one of the 68 call sites was audited individually. 48 were converted; the rest stay eager by design:

- **Render path and public meta APIs** (`getCellMeta`, `getCellRenderer`/`getCellEditor`/`getCellValidator`) — their contract returns the stored, memoized meta.
- **Editor lifecycle** (`editorManager.prepareEditor`, `baseEditor.beginEditing`) — editors hold the meta object by reference; eviction explicitly protects the focused row.
- **Validation persistence** (`validateChanges` validator branch, `_validateCells`, dataProvider `validateRows`) — validation writes `valid` on the meta and that result must survive.
- **Undo stack capture** (`undoRedo/utils.ts` `getCellMetas`) — the meta objects themselves are stored and restored.
- **Search** — the default search callback persists `isSearchResult` by design.
- **Repeated tight-loop reads** (`formulas` autofill source cells) — eager memoization is cheaper than re-running extension per iteration.

Converted areas: context menu scans (alignment ×14, readOnly ×3, clearColumn, the alignment comparator), filters (value component ×4, condition locale reads ×2, comparator read), formulas (engine sync, full-source date scan, `modifyData` hook read, value getter, validate-hook read — the three `skipMetaExtension` sites use `getCellMetaUncached` to keep identical no-extension semantics), column sorting settings reads ×2, column summary ×2, checkbox event handlers ×3, ghost table sampling ×3, `parseTable` export, dataProvider server-update filter, `emptySelectedCells`, `setSourceDataAtCell`, `getDataType`, and the populate-selection shortcut.

### Measured results

Real Chrome, dev UMD builds of develop HEAD, the DEV-2056 branch HEAD (base), and this branch, fresh page per measurement, medians of 3. Grid shapes: 500k×1000 (sparse fill) and 1000×10k (full).

**The delta this PR adds (vs the DEV-2056 base):**

| Scenario | DEV-2056 base | this PR | Change |
|---|---:|---:|---|
| `getDataType` over 500k cells | 194.5 ms, retains 499,560 metas | 131.3 ms, retains 0 | 🟢 −33% time, −40 MB retained heap |
| Clear a 600k-cell selection (`emptySelectedCells`) | 682.8 ms, retains 599,520 metas | 797.8 ms, retains 0 | 🟡 +17% one-shot time, −38 MB retained heap (see trade-off note) |
| Init (500k×1000 / 1000×10k / autoColumnSize) | 141 / 87.4 / 72 ms | 135.4 / 89.2 / 73.1 ms | equal |
| Scrolling (vertical/horizontal, both shapes) — per draw | 9.4 / 6.7 / 9.2 / 10.2 ms | 9.3 / 6.7 / 9.3 / 10.1 ms | equal |
| Warm `getCellMeta` read (ns-level microbench) | 204 ms | 197 ms | equal (noise) |
| Row/column alters, with and without persisted metas | 74.6–288.6 ms | 75.1–288.7 ms | equal |
| `getData`/copy/validation/sort/filter bulk scenarios | — | — | equal (already converted in #13063) |

**Trade-off note (`emptySelectedCells`):** clearing N cells now runs the dynamic meta extension up to three times per cell (the readOnly scan, the `valueSetter` lookup, and the validator lookup each read a fresh transient), where the base materialized once and reused the stored object. That costs ~+115 ms per 600k-cell clear as a one-shot, in exchange for not permanently retaining 600k meta objects (~38 MB that previously never came back). Grids with viewport-sized selections see no measurable difference.

### How has this been tested?

- Full unit suite: 270 suites / 3,081 tests, 0 failures (three test fixtures that stubbed `getCellMeta` were retargeted to the method the code now calls; the assertions and intent are unchanged).
- Full E2E suite: 9,546 specs, 0 failures after fixture retargeting.
- New E2E retention specs: `getDataType` over 2,000 cells and `emptySelectedCells` over 600 cells must not grow `getCellsMeta()` beyond the viewport count.
- `npm run test:types` (incl. downlevel-dts) and ESLint — clean.
- Real-browser three-way A/B/C benchmark (develop / DEV-2056 base / this branch): init, scrolling, warm reads, row/column alters with and without persisted metas, `getData`, copy, validation, sorting, filtering, `getDataType`, and selection clearing (`perf-suite.html` + `perf-suite-runner.mjs`).

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2068

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2068

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide surface area across core data paths and many plugins; behavior should match prior reads but large clears may trade one-shot CPU for heap (documented ~+17% on 600k-cell clear vs retained meta).
> 
> **Overview**
> Read-only cell settings lookups across core and plugins now use **`getCellMetaTransient`** (or **`getCellMetaUncached`** where extension was skipped) instead of **`getCellMeta`**, so bulk scans no longer permanently materialize one meta object per visited cell.
> 
> **Core:** **`emptySelectedCells`**, **`setSourceDataAtCell`**, and **`getDataType`** only read settings like `readOnly` / `type` without growing **`getCellsMeta()`**. **Plugins and utilities** updated the same way for context menu (alignment, read-only, clear column), filters, formulas (uncached reads for full-source / hook paths), column sorting/summary, checkbox handlers, ghost table sampling, **`parseTable`**, data provider CRUD filtering, undo alignment, and populate-selection shortcuts. Writes still go through **`setCellMeta`** / declarative meta where behavior must persist.
> 
> Tests assert **`getCellsMeta().length`** stays stable after large **`getDataType`** scans and **`emptySelectedCells`** clears; changelog **13068** documents the memory improvement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b11f1cd575ce8463fb6a9f7943ccd1bd830a66d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->