### PR TITLE
DEV-2069: Fix remove_row stack overflow on grids with 125k+ rows

### DIFF
--- a/.changelogs/13070.json
+++ b/.changelogs/13070.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed removing rows throwing a \"Maximum call stack size exceeded\" error on grids with roughly 125,000 rows or more.",
+  "type": "fixed",
+  "issueOrPR": 13070,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/__tests__/core/removeRow.spec.js
+++ b/handsontable/src/__tests__/core/removeRow.spec.js
@@ -91,6 +91,23 @@ describe('Core.alter', () => {
         expect(getData().length).toBe(5);
       });
 
+      it('should remove a row from a grid with hundreds of thousands of rows', async() => {
+        const rows = [];
+
+        for (let i = 0; i < 200000; i++) {
+          rows.push([i]);
+        }
+
+        handsontable({
+          data: rows,
+        });
+
+        await alter('remove_row', 0, 1);
+
+        expect(countRows()).toBe(199999);
+        expect(getDataAtCell(0, 0)).toBe(1);
+      });
+
       it('should remove rows when index groups are passed as intersecting values (the second scenario)', async() => {
         handsontable({
           data: createSpreadsheetData(15, 5),

--- a/handsontable/src/dataMap/__tests__/dataMap.unit.js
+++ b/handsontable/src/dataMap/__tests__/dataMap.unit.js
@@ -1,0 +1,47 @@
+import DataMap from 'handsontable/dataMap/dataMap';
+
+describe('DataMap', () => {
+  describe('filterData', () => {
+    /**
+     * Builds the minimal context `filterData` needs: a hot mock whose `filterData` hook
+     * returns its first argument (the default hook behavior) and a data source array.
+     *
+     * @param {number} rowCount The number of single-cell rows to create in the data source.
+     * @returns {object}
+     */
+    function createFilterDataContext(rowCount) {
+      const dataSource = [];
+
+      for (let i = 0; i < rowCount; i++) {
+        dataSource.push([i]);
+      }
+
+      return {
+        hot: {
+          runHooks: (name, firstArg) => firstArg,
+        },
+        dataSource,
+      };
+    }
+
+    it('should remove the given physical rows from the data source', () => {
+      const context = createFilterDataContext(5);
+
+      DataMap.prototype.filterData.call(context, 1, 2, [1, 2]);
+
+      expect(context.dataSource).toEqual([[0], [3], [4]]);
+    });
+
+    it('should not overflow the call stack when the data source holds hundreds of thousands of rows', () => {
+      const context = createFilterDataContext(300000);
+
+      expect(() => {
+        DataMap.prototype.filterData.call(context, 0, 1, [0]);
+      }).not.toThrow();
+
+      expect(context.dataSource.length).toBe(299999);
+      expect(context.dataSource[0]).toEqual([1]);
+      expect(context.dataSource[299998]).toEqual([299999]);
+    });
+  });
+});

--- a/handsontable/src/dataMap/dataMap.ts
+++ b/handsontable/src/dataMap/dataMap.ts
@@ -800,7 +800,11 @@ class DataMap {
     }
 
     this.dataSource!.length = 0;
-    Array.prototype.push.apply(this.dataSource!, data as unknown[]);
+    // Pushing in a loop instead of `push.apply`, which passes one call argument per row and
+    // overflows the call stack on grids with roughly 125k rows or more (same pattern as #7840).
+    (data as unknown[]).forEach((row) => {
+      this.dataSource!.push(row as Record<string, unknown> | unknown[]);
+    });
   }
 
   /**


### PR DESCRIPTION
### Context

The PR fixes a crash: `alter('remove_row', ...)` throws `RangeError: Maximum call stack size exceeded` on grids with roughly 125,000 rows or more.

`DataMap.filterData` rebuilds the data source in place with `Array.prototype.push.apply(this.dataSource, data)`. `apply` passes one call argument per remaining row, and above ~125k arguments the engine runs out of call stack. The rebuild must stay in place (the user's data array is held by reference), so the fix replaces the single `apply` call with an element-by-element push - the same pattern already used a few lines above for the sibling spare-rows path (#7840).

Found during large-grid benchmarking of #13063/#13068: the crash reproduces identically on `develop` and both feature branches, on any row removal once the grid is large enough.

### How has this been tested?

- New unit test (`dataMap.unit.js`): `filterData` over a 300,000-row data source must not throw and must produce the correctly filtered array (this call overflowed the stack before the fix). A second test pins the basic filtering behavior.
- New E2E spec (`removeRow.spec.js`): `alter('remove_row', 0, 1)` on a 200,000-row grid removes the row and keeps the grid consistent (threw `RangeError` before the fix).
- Full unit suite green; full E2E suite: 9,536 specs, 0 failures.
- Real-browser check on a 500k×1000 grid (the benchmark scenario that originally exposed the bug): removing 10 rows now completes in ~107 ms; it previously threw on develop and both feature branches.
- ESLint clean.

Commands:

```
npm run test:unit --testPathPattern=dataMap
npm run test:e2e --testPathPattern=removeRow
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2069

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2069

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow bug fix in row-removal data rebuild with the same safe pattern already used in spliceData; behavior unchanged for normal grid sizes, with large-grid tests added.
> 
> **Overview**
> Fixes **`RangeError: Maximum call stack size exceeded`** when removing rows on grids with roughly **125,000+** rows (e.g. `alter('remove_row', ...)`).
> 
> In **`DataMap.filterData`**, rebuilding the in-place data source no longer uses **`Array.prototype.push.apply`**, which passes one argument per remaining row and blows the call stack at large sizes. It now **pushes rows one at a time** via **`forEach`**, matching the existing **`spliceData`** fix (#7840).
> 
> Coverage adds a **unit test** for `filterData` at **300k** rows, an **E2E** `remove_row` case at **200k** rows, and a **changelog** entry for #13070.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22474bb7c62e598ee9d4d7d0bddfb9bc3aa275f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->