### PR TITLE
Fix broken TypeScript examples on the TypeScript types docs page (#13072)

### DIFF
--- a/docs/content/guides/tools-and-building/typescript-types/typescript-types.md
+++ b/docs/content/guides/tools-and-building/typescript-types/typescript-types.md
@@ -267,9 +267,9 @@ const settings: GridSettings = {
 `Events` maps every hook name to its callback signature. Extract a specific callback type with `Events[hookName]`:
 
 ```typescript
-import type { Events } from 'handsontable';
+import type { Events, CellChange, ChangeSource } from 'handsontable';
 
-const onAfterChange: Events['afterChange'] = (changes, source) => {
+const onAfterChange: Events['afterChange'] = (changes: CellChange[] | null, source: ChangeSource) => {
   if (!changes) return;
   console.log(source, changes);
 };
@@ -294,7 +294,7 @@ function statusRenderer(
   value: string,
   cellProperties: CellProperties
 ): void {
-  Handsontable.renderers.TextRenderer.apply(this, [hotInstance, TD, row, col, prop, value, cellProperties]);
+  Handsontable.renderers.TextRenderer(hotInstance, TD, row, col, prop, value, cellProperties);
   TD.style.color = value === 'Active' ? 'green' : 'red';
 }
 ```
@@ -304,10 +304,10 @@ function statusRenderer(
 Extend `BaseEditorInstance` for full IDE support when writing custom editors:
 
 ```typescript
-import { BaseEditor } from 'handsontable/editors';
+import { TextEditor } from 'handsontable/editors';
 import type { GridSettings } from 'handsontable';
 
-class RatingEditor extends BaseEditor {
+class RatingEditor extends TextEditor {
   override getValue(): string {
     return this.TEXTAREA?.value ?? '';
   }
@@ -329,23 +329,29 @@ const settings: GridSettings = {
 
 ### Type the HOT instance in a React ref
 
+`HotTable` exposes its ref as `HotTableRef`, not `HotInstance` -- read the Handsontable instance through `hotRef.current?.hotInstance`. The wrapper takes grid options as individual props, so there's no `settings` prop -- type a reusable settings object as `HotTableProps` and spread it onto `<HotTable>`. See [React methods](@/guides/getting-started/react-methods/react-methods.md) for more on working with the instance ref.
+
 ```tsx
 import { useRef } from 'react';
 import { HotTable } from '@handsontable/react-wrapper';
-import type { HotInstance, GridSettings } from 'handsontable';
+import type { HotTableRef, HotTableProps } from '@handsontable/react-wrapper';
 
 export function Grid() {
-  const hotRef = useRef<HotInstance | null>(null);
+  const hotRef = useRef<HotTableRef>(null);
 
-  const settings: GridSettings = {
+  const settings: HotTableProps = {
     data: myData,
     licenseKey: 'non-commercial-and-evaluation',
+  };
+
+  const selectFirstCell = () => {
+    hotRef.current?.hotInstance?.selectCell(0, 0);
   };
 
   return (
     <HotTable
       ref={hotRef}
-      settings={settings}
+      {...settings}
     />
   );
 }
@@ -359,8 +365,7 @@ export function Grid() {
 
 ```typescript
 import { Component, ViewChild } from '@angular/core';
-import { HotTableComponent, HotTableModule } from '@handsontable/angular-wrapper';
-import type { GridSettings } from 'handsontable';
+import { HotTableComponent, HotTableModule, GridSettings } from '@handsontable/angular-wrapper';
 
 @Component({
   standalone: true,
@@ -376,6 +381,8 @@ export class GridComponent {
   };
 }
 ```
+
+Read the Handsontable instance through `hotTable.hotInstance`.
 
 :::
 


### PR DESCRIPTION
### Context

The PR fixes broken TypeScript code examples on the [TypeScript types](https://handsontable.com/docs/react-data-grid/typescript-types/) docs page.

[#13072](https://github.com/handsontable/handsontable/issues/13072) reported that the React example under "Type the HOT instance in a React ref" fails to build with `tsc`. The reporter's linked StackBlitz was just an empty Vite template with no Handsontable code, but the error reproduces directly from the docs snippet: it typed the ref as `HotInstance` instead of `HotTableRef` (the actual ref type exposed by `HotTable`, a `forwardRef<HotTableRef, HotTableProps>` since 14.1.0), and passed a `settings` prop that doesn't exist on the current `@handsontable/react-wrapper` API (that was the old `@handsontable/react` API — the current wrapper spreads grid options as individual props).

While fixing the reported snippet, I typechecked every code example on the page against the built `handsontable` types (`tsc --strict`) and found three more broken snippets:
- `Events['afterChange']` callback params inferred as implicit `any`
- The custom renderer example passes an implicit-`any` `this` to `.apply()`
- The custom editor example extends `BaseEditor`, but `TEXTAREA` is only declared on `TextEditor`

Also aligned the Angular example's `GridSettings` import with `@handsontable/angular-wrapper`, matching every other Angular docs page (it was importing from `handsontable` instead).

Note: the `Events['afterChange']` fix here is a docs-level workaround (explicit param types). The actual root cause is a core types bug — `GridSettings`'s index signature collapses the derived `Events` type — tracked separately in [DEV-2072](https://app.clickup.com/t/86caqyk2z).

### How has this been tested?

- Extracted every code snippet from the page into standalone `.ts`/`.tsx` files and ran `tsc --strict` against them with `paths` mapped to `handsontable/tmp` (built core types) and the react-wrapper's emitted `.d.ts` — all snippets now compile with exit code 0.
- Confirmed the original (unfixed) React snippet still reproduces the exact `TS2322` from the issue, as a negative control on the verification harness.
- Confirmed `GridSettings` and `hotInstance` are exported/typed as expected from the Angular wrapper's built `dist/hot-table/public-api.d.ts`.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. #13072
2. [DEV-2071](https://app.clickup.com/t/86caqyf4c)

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

Docs-only change (`docs/content/`).

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes in `docs/content/` with no runtime or library code impact.
> 
> **Overview**
> Updates the **TypeScript types** guide so every on-page snippet passes **`tsc --strict`**, fixing patterns that no longer match current wrapper APIs or strict typing.
> 
> Hook examples now **import `CellChange` and `ChangeSource`** and annotate `Events['afterChange']` parameters explicitly (workaround until core `Events` typing is fixed). The custom renderer sample calls **`TextRenderer` as a function** instead of `.apply(this, …)`. The custom editor sample **extends `TextEditor`** so `TEXTAREA` is typed.
> 
> The React section documents **`HotTableRef` / `HotTableProps`**, spreading props instead of a `settings` prop, and accessing the grid via **`hotRef.current?.hotInstance`**. The Angular snippet imports **`GridSettings` from `@handsontable/angular-wrapper`** and notes **`hotTable.hotInstance`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7831b1bd9b7eadcc4731395854a6dd5b8c3fc99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->