### PR TITLE
DEV-2075: Wire PositionCache into overlay scrollTo row-height sums

### DIFF
--- a/.changelogs/13075.json
+++ b/.changelogs/13075.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Improved scroll-to-row performance on large grids: keyboard navigation and `scrollViewportTo` near the bottom of the dataset now compute the scroll offset in constant time instead of summing every row height from the top.",
+  "type": "changed",
+  "issueOrPR": 13075,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/AGENTS.md
+++ b/handsontable/src/3rdparty/walkontable/AGENTS.md
@@ -37,6 +37,7 @@ Self-contained rendering engine for viewport calculation, DOM rendering, scroll 
 - Batch scroll events with requestAnimationFrame
 - Never `arr.push(...largeArray)` with 10k+ elements
 - Reuse DOM elements, minimize layout thrashing
+- **Row-height sums go through `Viewport#sumRowHeights`** (prefix-sum `PositionCache`, O(1)) — never add a new per-row summation loop. Two constraints it encodes: (1) the first rendered visible row reports a +1px border-top compensation (`StylesHandler#getDefaultRowHeight`, AutoRowSize), so `sumRowHeights` re-reads the build-time and current first-rendered rows live (`PositionCache#onBuildFn` records the build-time row) — bypassing this breaks totals by exactly 1px (AutoRowSize/Pagination specs catch it). (2) **Column-width sums must stay live walks** (`sumCellSizes` in `inlineStartOverlay`, `sumColumnWidths` in `workspaceSize`): stretched widths (`stretchH`) derive from the workspace width, which derives from the column sum — caching freezes that cycle and nothing invalidates the column cache on stretch (Core_init display-none and StretchColumns window-mode specs catch it).
 
 ## Testing
 

--- a/handsontable/src/3rdparty/walkontable/src/axisSizing/positionCache.ts
+++ b/handsontable/src/3rdparty/walkontable/src/axisSizing/positionCache.ts
@@ -3,6 +3,7 @@ export interface PositionCacheConfig {
   sizeFn: (index: number) => number;
   defaultSizeFn: () => number;
   isUniformFn?: () => boolean;
+  onBuildFn?: () => void;
 }
 
 /**
@@ -58,6 +59,14 @@ export class PositionCache {
    */
   readonly #isUniformFn?: () => boolean;
   /**
+   * Optional callback invoked whenever the cache is (re)built, in either mode. Lets the owner
+   * record the context the sizes were read in (e.g. which row carried the first-rendered-row
+   * border compensation at build time).
+   *
+   * @type {Function|undefined}
+   */
+  readonly #onBuildFn?: () => void;
+  /**
    * The shared size used when the cache is in uniform mode. `null` when the cache is in
    * prefix-sum mode (heterogeneous sizes) or not yet built.
    *
@@ -80,11 +89,12 @@ export class PositionCache {
    *   that return NaN/undefined.
    * @param {Function} [config.isUniformFn] Optional predicate; when `true`, all items share one size.
    */
-  constructor({ totalItemsFn, sizeFn, defaultSizeFn, isUniformFn }: PositionCacheConfig) {
+  constructor({ totalItemsFn, sizeFn, defaultSizeFn, isUniformFn, onBuildFn }: PositionCacheConfig) {
     this.#totalItemsFn = totalItemsFn;
     this.#sizeFn = sizeFn;
     this.#defaultSizeFn = defaultSizeFn;
     this.#isUniformFn = isUniformFn;
+    this.#onBuildFn = onBuildFn;
   }
 
   /**
@@ -99,6 +109,7 @@ export class PositionCache {
 
     this.totalItems = totalItems;
     this.#built = true;
+    this.#onBuildFn?.();
 
     if (this.#isUniformFn?.()) {
       // Sample the LAST item, never the first rendered one: `getDefaultRowHeight` adds a 1px

--- a/handsontable/src/3rdparty/walkontable/src/overlay/regions/bottomOverlay.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/regions/bottomOverlay.ts
@@ -160,28 +160,17 @@ export class BottomOverlay extends Overlay {
   }
 
   /**
-   * Calculates total sum cells height.
+   * Calculates total sum cells height. Delegates to the viewport's row-height prefix-sum cache
+   * (`Viewport#sumRowHeights`), so a call costs O(1) instead of walking every row in the
+   * `[from, to)` range — `scrollTo` passes ranges that start at row 0, which made keyboard
+   * navigation near the bottom of a large grid re-sum the whole dataset on every keypress.
    *
    * @param {number} from Row index which calculates started from.
    * @param {number} to Row index where calculation is finished.
    * @returns {number} Height sum.
    */
   sumCellSizes(from: number, to: number) {
-    const wtTable = this.deps.getWtTable();
-    const { wtSettings } = this;
-    const defaultRowHeight = wtSettings.getSetting('stylesHandler').getDefaultRowHeight();
-
-    let row = from;
-    let sum = 0;
-
-    while (row < to) {
-      const height = wtTable.getRowHeight(row);
-
-      sum += height === undefined ? defaultRowHeight : height;
-      row += 1;
-    }
-
-    return sum;
+    return this.deps.getWtViewport().sumRowHeights(from, to);
   }
 
   /**

--- a/handsontable/src/3rdparty/walkontable/src/overlay/regions/inlineStartOverlay.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/regions/inlineStartOverlay.ts
@@ -127,7 +127,11 @@ export class InlineStartOverlay extends Overlay {
   }
 
   /**
-   * Calculates total sum cells width.
+   * Calculates total sum cells width. Walks the columns live instead of reading the column-width
+   * prefix-sum cache: stretched widths (`stretchH`) are derived from the workspace width, which in
+   * turn depends on this sum — the live read resolves that cycle fresh on every call, while a
+   * cached read would freeze pre-stretch widths (nothing invalidates the cache when stretching
+   * recomputes). Column counts stay far below row counts, so this walk is not a scroll hotspot.
    *
    * @param {number} from Column index which calculates started from.
    * @param {number} to Column index where calculation is finished.

--- a/handsontable/src/3rdparty/walkontable/src/overlay/regions/topOverlay.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/regions/topOverlay.ts
@@ -148,26 +148,17 @@ export class TopOverlay extends Overlay {
   }
 
   /**
-   * Calculates total sum cells height.
+   * Calculates total sum cells height. Delegates to the viewport's row-height prefix-sum cache
+   * (`Viewport#sumRowHeights`), so a call costs O(1) instead of walking every row in the
+   * `[from, to)` range — `scrollTo` passes ranges that start at row 0, which made keyboard
+   * navigation near the bottom of a large grid re-sum the whole dataset on every keypress.
    *
    * @param {number} from Row index which calculates started from.
    * @param {number} to Row index where calculation is finished.
    * @returns {number} Height sum.
    */
   sumCellSizes(from: number, to: number) {
-    const stylesHandler = this.wtSettings.getSetting('stylesHandler');
-    const defaultRowHeight = stylesHandler.getDefaultRowHeight();
-    let row = from;
-    let sum = 0;
-
-    while (row < to) {
-      const height = this.deps.getWtTable().getRowHeight(row);
-
-      sum += height === undefined ? defaultRowHeight : height;
-      row += 1;
-    }
-
-    return sum;
+    return this.deps.getWtViewport().sumRowHeights(from, to);
   }
 
   /**

--- a/handsontable/src/3rdparty/walkontable/src/viewport/viewport.ts
+++ b/handsontable/src/3rdparty/walkontable/src/viewport/viewport.ts
@@ -16,7 +16,6 @@ import {
   RenderedRowsCalculationType,
 } from '../calculator';
 import { PositionCache } from '../axisSizing/positionCache';
-import { DEFAULT_COLUMN_WIDTH } from '../constants';
 import { workspaceSize, type WorkspaceSize } from './workspaceSize';
 import { calculatorFactory, type CalculatorFactory } from './calculatorFactory';
 import { createLayoutDeps, gatherLayoutInput, type LayoutDeps } from './boxLayout/gatherLayoutInput';
@@ -162,6 +161,16 @@ class Viewport {
    * @type {PositionCache}
    */
   declare columnWidthCache: PositionCache;
+  /**
+   * The row that was the first rendered row when `rowHeightCache` was last built, or `-1` when
+   * nothing was rendered at that moment. The first rendered visible row carries a 1px border-top
+   * compensation in its reported height (see `StylesHandler#getDefaultRowHeight`), so the cache
+   * holds a value for this row that stops being correct once the viewport scrolls.
+   * {@link Viewport#sumRowHeights} re-reads it (and the current first rendered row) live.
+   *
+   * @type {number}
+   */
+  #rowFirstRenderedAtBuild: number = -1;
 
   /**
    * Read-only access to the dependencies, for the `workspaceSize` / `calculatorFactory` mixins, which
@@ -226,6 +235,9 @@ class Viewport {
       // oversized rows. Any of these invalidates the cache, so the next build re-evaluates this.
       isUniformFn: () => rowSizeSource.isUniform() &&
         Object.keys(this.oversizedRows).length === 0,
+      onBuildFn: () => {
+        this.#rowFirstRenderedAtBuild = wtTable.getFirstRenderedRow();
+      },
     });
     /**
      * Cumulative column width prefix sum cache. Enables O(log n) scroll-to-column lookups
@@ -236,7 +248,10 @@ class Viewport {
     this.columnWidthCache = new PositionCache({
       totalItemsFn: () => wtSettings.getSetting<number>('totalColumns'),
       sizeFn: sourceCol => wtTable.getColumnWidth(sourceCol),
-      defaultSizeFn: () => DEFAULT_COLUMN_WIDTH,
+      // Read the default through the size source (the `defaultColumnWidth` setting) — the same
+      // fallback the overlays' `sumCellSizes` used before they delegated to this cache — so a
+      // consumer-overridden default keeps scroll offsets and calculators in agreement.
+      defaultSizeFn: () => columnSizeSource.getDefaultSize(),
       // Uniform fast path: every column is the default width only when the source reports it (no
       // per-column `colWidths`, no `modifyColWidth` hook — note `autoColumnSize` is on by default and
       // registers that hook, so this is true only when `colWidths` is set).
@@ -289,6 +304,39 @@ class Viewport {
    */
   invalidateLayout() {
     this.#layout = null;
+  }
+
+  /**
+   * Sums the heights of the `[from, to)` row range in O(1) using the row-height prefix-sum cache,
+   * with the exact semantics of a live per-row walk. Row heights are position-independent except
+   * for one row: the first rendered visible row reports a 1px border-top compensation
+   * (`StylesHandler#getDefaultRowHeight`, AutoRowSize). The cache holds the heights read at build
+   * time, so the row that carried the compensation then, and the row that carries it now, are
+   * re-read live and the cached values are replaced by the live ones.
+   *
+   * @param {number} from Start row index (inclusive).
+   * @param {number} to End row index (exclusive).
+   * @returns {number} The height sum in pixels.
+   */
+  sumRowHeights(from: number, to: number): number {
+    const cache = this.rowHeightCache;
+
+    cache.ensureBuilt();
+
+    let sum = cache.getOffset(to) - cache.getOffset(from);
+    const compensationRows = new Set([this.#rowFirstRenderedAtBuild, this.wtTable.getFirstRenderedRow()]);
+
+    compensationRows.forEach((row) => {
+      if (row >= 0 && row >= from && row < to && row < cache.totalItems) {
+        const liveHeight = this.wtTable.getRowHeight(row);
+        const resolvedLiveHeight = liveHeight === undefined
+          ? this.#deps.rowSizeSource.getDefaultSize() : liveHeight;
+
+        sum += resolvedLiveHeight - cache.getSizeAt(row);
+      }
+    });
+
+    return sum;
   }
 
   /**

--- a/handsontable/src/3rdparty/walkontable/src/viewport/workspaceSize.ts
+++ b/handsontable/src/3rdparty/walkontable/src/viewport/workspaceSize.ts
@@ -283,6 +283,10 @@ export const workspaceSize: WorkspaceSize = {
   },
 
   /**
+   * Sums the column widths live (no cache). Stretched widths (`stretchH`) are derived from the
+   * workspace width, which itself depends on this sum — the live walk resolves that cycle fresh
+   * on every call, while the column-width prefix-sum cache would freeze pre-stretch values.
+   *
    * @this Viewport
    * @param {number} from The visual column index from the width sum is start calculated.
    * @param {number} length The length of the column to traverse.

--- a/handsontable/src/3rdparty/walkontable/test/spec/overlay/sumCellSizes.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/overlay/sumCellSizes.spec.js
@@ -1,0 +1,141 @@
+describe('WalkontableOverlay', () => {
+  const OUTER_WIDTH = 200;
+  const OUTER_HEIGHT = 200;
+
+  beforeEach(function() {
+    this.$wrapper = $('<div></div>').addClass('handsontable').css({ overflow: 'hidden' });
+    this.$wrapper.width(OUTER_WIDTH).height(OUTER_HEIGHT);
+    this.$container = $('<div></div>');
+    this.$table = $('<table></table>').addClass('htCore');
+    this.$wrapper.append(this.$container);
+    this.$container.append(this.$table);
+    this.$wrapper.appendTo('body');
+
+    createDataArray(200, 200);
+  });
+
+  afterEach(function() {
+    this.$wrapper.remove();
+    this.wotInstance.destroy();
+  });
+
+  describe('sumCellSizes', () => {
+    /**
+     * Reference implementation: the live per-row walk that `sumCellSizes` used before it
+     * delegated to the row-height prefix-sum cache. The delegation must stay exactly equal to it.
+     *
+     * @param {Walkontable} wt The Walkontable instance.
+     * @param {number} from Start row index (inclusive).
+     * @param {number} to End row index (exclusive).
+     * @returns {number} The height sum in pixels.
+     */
+    function liveRowWalk(wt, from, to) {
+      const stylesHandler = wt.wtSettings.getSetting('stylesHandler');
+      const defaultRowHeight = stylesHandler.getDefaultRowHeight();
+      let sum = 0;
+
+      for (let row = from; row < to; row++) {
+        const height = wt.wtTable.getRowHeight(row);
+
+        sum += height === undefined ? defaultRowHeight : height;
+      }
+
+      return sum;
+    }
+
+    it('should equal a live per-row walk with default row heights', async() => {
+      const wt = walkontable({
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
+      });
+
+      wt.draw();
+
+      const topOverlay = wt.wtOverlays.topOverlay;
+
+      expect(topOverlay.sumCellSizes(0, getTotalRows())).toBe(liveRowWalk(wt, 0, getTotalRows()));
+      expect(topOverlay.sumCellSizes(0, 1)).toBe(liveRowWalk(wt, 0, 1));
+      expect(topOverlay.sumCellSizes(5, 42)).toBe(liveRowWalk(wt, 5, 42));
+    });
+
+    it('should equal a live per-row walk with varied row heights', async() => {
+      const wt = walkontable({
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
+        rowHeight: row => 20 + ((row % 7) * 4),
+      });
+
+      wt.draw();
+
+      const topOverlay = wt.wtOverlays.topOverlay;
+      const bottomOverlay = wt.wtOverlays.bottomOverlay;
+
+      expect(topOverlay.sumCellSizes(0, getTotalRows())).toBe(liveRowWalk(wt, 0, getTotalRows()));
+      expect(topOverlay.sumCellSizes(13, 177)).toBe(liveRowWalk(wt, 13, 177));
+      expect(bottomOverlay.sumCellSizes(0, 100)).toBe(liveRowWalk(wt, 0, 100));
+    });
+
+    it('should equal a live per-row walk after the viewport was scrolled', async() => {
+      const wt = walkontable({
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
+        rowHeight: row => 20 + ((row % 7) * 4),
+      });
+
+      wt.draw();
+      wt.scrollViewport(new Walkontable.CellCoords(150, 0));
+      wt.draw();
+
+      const topOverlay = wt.wtOverlays.topOverlay;
+
+      expect(topOverlay.sumCellSizes(0, getTotalRows())).toBe(liveRowWalk(wt, 0, getTotalRows()));
+      expect(topOverlay.sumCellSizes(140, 160)).toBe(liveRowWalk(wt, 140, 160));
+    });
+
+    it('should reflect changed row heights after the row-height cache is invalidated', async() => {
+      let heightOverride = null;
+      const wt = walkontable({
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
+        rowHeight: row => (heightOverride === null ? 25 : heightOverride[row] ?? 25),
+      });
+
+      wt.draw();
+
+      const topOverlay = wt.wtOverlays.topOverlay;
+
+      expect(topOverlay.sumCellSizes(0, 10)).toBe(liveRowWalk(wt, 0, 10));
+
+      heightOverride = { 3: 100, 7: 60 };
+      wt.wtViewport.invalidateRowHeightCache();
+
+      expect(topOverlay.sumCellSizes(0, 10)).toBe(liveRowWalk(wt, 0, 10));
+      expect(topOverlay.sumCellSizes(0, 10)).toBe((8 * 25) + 100 + 60);
+    });
+
+    it('should equal a live per-column walk for the inline-start overlay', async() => {
+      const wt = walkontable({
+        data: getData,
+        totalRows: getTotalRows,
+        totalColumns: getTotalColumns,
+        columnWidth: column => 40 + ((column % 5) * 10),
+      });
+
+      wt.draw();
+
+      const inlineStartOverlay = wt.wtOverlays.inlineStartOverlay;
+      const defaultColumnWidth = wt.wtSettings.getSetting('defaultColumnWidth');
+      let sum = 0;
+
+      for (let column = 0; column < getTotalColumns(); column++) {
+        sum += wt.wtTable.getColumnWidth(column) || defaultColumnWidth;
+      }
+
+      expect(inlineStartOverlay.sumCellSizes(0, getTotalColumns())).toBe(sum);
+    });
+  });
+});

--- a/handsontable/src/3rdparty/walkontable/test/unit/axisSizing/positionCache.unit.js
+++ b/handsontable/src/3rdparty/walkontable/test/unit/axisSizing/positionCache.unit.js
@@ -361,6 +361,67 @@ describe('PositionCache', () => {
     });
   });
 
+  describe('onBuildFn', () => {
+    it('should be called once per build, in both modes', () => {
+      const onBuildFn = jest.fn();
+      const heterogeneous = new PositionCache({
+        totalItemsFn: () => 3,
+        sizeFn: () => 10,
+        defaultSizeFn: () => 10,
+        onBuildFn,
+      });
+
+      heterogeneous.build();
+
+      expect(onBuildFn).toHaveBeenCalledTimes(1);
+
+      const onBuildFnUniform = jest.fn();
+      const uniform = new PositionCache({
+        totalItemsFn: () => 3,
+        sizeFn: () => 10,
+        defaultSizeFn: () => 10,
+        isUniformFn: () => true,
+        onBuildFn: onBuildFnUniform,
+      });
+
+      uniform.build();
+
+      expect(onBuildFnUniform).toHaveBeenCalledTimes(1);
+    });
+
+    it('should be called by ensureBuilt only when it actually rebuilds', () => {
+      const onBuildFn = jest.fn();
+      let totalItems = 3;
+      const cache = new PositionCache({
+        totalItemsFn: () => totalItems,
+        sizeFn: () => 10,
+        defaultSizeFn: () => 10,
+        onBuildFn,
+      });
+
+      cache.ensureBuilt();
+
+      expect(onBuildFn).toHaveBeenCalledTimes(1);
+
+      // no-op: already built, same item count
+      cache.ensureBuilt();
+
+      expect(onBuildFn).toHaveBeenCalledTimes(1);
+
+      // rebuild via invalidation
+      cache.invalidate();
+      cache.ensureBuilt();
+
+      expect(onBuildFn).toHaveBeenCalledTimes(2);
+
+      // rebuild via item-count change
+      totalItems = 5;
+      cache.ensureBuilt();
+
+      expect(onBuildFn).toHaveBeenCalledTimes(3);
+    });
+  });
+
   describe('isCurrent', () => {
     it('should be false before the cache is built', () => {
       const { cache } = createCache(3, () => 10, 10);

--- a/handsontable/src/__tests__/core/scrollViewportTo.spec.js
+++ b/handsontable/src/__tests__/core/scrollViewportTo.spec.js
@@ -1003,4 +1003,64 @@ describe('Core.scrollViewportTo', () => {
       expect(tableView().scrollViewport).toHaveBeenCalledWith(cellCoords(40, 45), 'end', 'bottom');
     });
   });
+
+  describe('large datasets (scroll offsets come from the row-height prefix-sum cache)', () => {
+    it('should scroll exactly to a distant row with default row heights', async() => {
+      handsontable({
+        data: createSpreadsheetData(50000, 5),
+        width: 300,
+        height: 300,
+      });
+
+      await scrollViewportTo({ row: 40000, col: 0, verticalSnap: 'top' });
+
+      expect(getFirstFullyVisibleRow()).toBe(40000);
+
+      await scrollViewportTo({ row: 12345, col: 0, verticalSnap: 'top' });
+
+      expect(getFirstFullyVisibleRow()).toBe(12345);
+    });
+
+    it('should scroll exactly to a distant row with varied row heights', async() => {
+      handsontable({
+        data: createSpreadsheetData(50000, 5),
+        rowHeights: row => 20 + ((row % 7) * 4),
+        width: 300,
+        height: 300,
+      });
+
+      await scrollViewportTo({ row: 40000, col: 0, verticalSnap: 'top' });
+
+      // For some target rows the first-rendered-row 1px border compensation leaves the target
+      // 1px shy of fully visible after a top snap (same on every release), so the exactness of
+      // the scroll offset is pinned through the partially-visible index.
+      expect(getFirstPartiallyVisibleRow()).toBe(40000);
+
+      await scrollViewportTo({ row: 33333, col: 0, verticalSnap: 'top' });
+
+      expect(getFirstPartiallyVisibleRow()).toBe(33333);
+      expect(getFirstFullyVisibleRow()).toBe(33333);
+    });
+
+    it('should keep a distant selected cell fully visible when navigating past the viewport edge', async() => {
+      handsontable({
+        data: createSpreadsheetData(50000, 5),
+        rowHeights: row => 20 + ((row % 7) * 4),
+        width: 300,
+        height: 300,
+      });
+
+      await selectCell(40000, 1);
+
+      expect(getLastFullyVisibleRow()).toBe(40000);
+
+      await selectCell(40001, 1);
+
+      expect(getLastFullyVisibleRow()).toBe(40001);
+
+      await selectCell(40002, 1);
+
+      expect(getLastFullyVisibleRow()).toBe(40002);
+    });
+  });
 });


### PR DESCRIPTION
### Context

The PR speeds up scroll-to-row on large grids. `TopOverlay#scrollTo` and `BottomOverlay#scrollTo` computed the target scroll offset with `sumCellSizes`, which walked every row from row 0 to the target row and resolved each height through the settings funnel (`rowHeight` callback, index-mapper translation, `modifyRowHeight` hooks). The cost grew linearly with the target row index: on a 1,000,000-row grid, one keyboard-navigation step near the bottom cost 50–150 ms, a <kbd>Ctrl</kbd>+<kbd>End</kbd> jump cost 200–420 ms, and holding <kbd>ArrowDown</kbd> dropped the grid to a few frames per second.

`sumCellSizes` in the top and bottom overlays now delegates to a new `Viewport#sumRowHeights`, backed by the viewport's existing row-height prefix-sum `PositionCache` — O(1) per call. Measured in Chrome on 1M rows × 10 columns:

| Scenario | before | after |
|---|---|---|
| One <kbd>ArrowDown</kbd> keypress at row 900k, uniform row heights | 92 ms | 1.9 ms |
| One <kbd>ArrowDown</kbd> keypress at row 900k, varied row heights | 149 ms | 2.9 ms |
| <kbd>Ctrl</kbd>+<kbd>End</kbd> jump to the last cell, uniform row heights | 207 ms | 7 ms |
| <kbd>Ctrl</kbd>+<kbd>End</kbd> jump to the last cell, varied row heights | 420 ms | 5 ms |

Per-keypress cost is now flat regardless of the target row index, and scroll positions match the previous implementation exactly (verified step-by-step against a develop build, uniform and varied heights, with frozen rows/columns and headers).

Two correctness details are covered explicitly:

- **First-rendered-row compensation.** The first rendered visible row reports a +1px border-top compensation (`StylesHandler#getDefaultRowHeight`, AutoRowSize), so row heights are position-dependent for exactly that one row. `PositionCache` gained an `onBuildFn` callback; the viewport records which row was first-rendered at build time, and `sumRowHeights` re-reads that row and the current first-rendered row live, replacing their cached values. This keeps the result identical to the old live walk in every scenario (the AutoRowSize hider-height and Pagination height specs pin this to the pixel).
- **Column-width sums intentionally stay live walks.** Stretched widths (`stretchH`) are derived from the workspace width, which in window-scroll mode is derived from the column-width sum — the live walk resolves that cycle fresh on every call. Column counts are small, so this path was never the hotspot. The constraint is documented in the code and in the Walkontable AGENTS.md.

ClickUp task: DEV-2075

### How has this been tested?

- New unit tests for `PositionCache#onBuildFn` (called once per build, on rebuilds only): `npm run test:unit --prefix handsontable -- --testPathPattern=positionCache`
- New Walkontable spec asserting `sumCellSizes` equals a live per-row walk (default heights, varied heights, after scrolling, after cache invalidation, and the column overlay): `npm run test:walkontable --prefix handsontable -- --testPathPattern=sumCellSizes`
- New E2E specs for exact deep scrolling on a 50k-row grid (default and varied heights, plus keyboard-navigation edge visibility): `npm run test:e2e --prefix handsontable -- --testPathPattern=scrollViewportTo`
- Full E2E suite: 9535 specs, 0 failures. Walkontable suite: 803 specs, 0 failures. `test:types`, ESLint, and Stylelint pass.
- Manual verification in Chrome: per-step scroll-position parity with develop across a 9-step navigation sequence (deep jumps, held arrow keys, <kbd>Ctrl</kbd>+<kbd>End</kbd>, mid-cell wheel scroll) with `fixedRowsTop`, `fixedRowsBottom`, `fixedColumnsStart`, and headers, on uniform and varied row heights, including overlay-alignment checks (frozen bands vs master, headers vs cells) and screenshot pixel diffs.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2075

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2075
