### PR TITLE
DEV-2077: Replace indexOf/includes membership scans with Set lookups

### DIFF
--- a/.changelogs/13077.json
+++ b/.changelogs/13077.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Improved performance of copy, autofill, bulk edits, header resize, and custom borders on large selections by replacing linear membership scans with set-based lookups.",
+  "type": "changed",
+  "issueOrPR": 13077,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/helpers/__tests__/array.unit.ts
+++ b/handsontable/src/helpers/__tests__/array.unit.ts
@@ -8,6 +8,7 @@ import {
   arrayMin,
   arrayReduce,
   arraySum,
+  arrayUnique,
   stringToArray,
   getDifferenceOfArrays,
   getIntersectionOfArrays,
@@ -278,6 +279,36 @@ describe('Array helper', () => {
       expect(arraySum([1, 1, 2, 3, 4])).toBe(11);
       expect(arraySum([1, 1, 0, 3.1, 4.2])).toBe(9.3);
       expect(arraySum(iterableObject)).toBe(12);
+    });
+  });
+
+  //
+  // Handsontable.helper.arrayUnique
+  //
+  describe('arrayUnique', () => {
+    it('should return a new array without duplicated values', () => {
+      expect(arrayUnique([1, 2, 2, 3, 1, 4])).toStrictEqual([1, 2, 3, 4]);
+      expect(arrayUnique(['a', 'b', 'a', 'c'])).toStrictEqual(['a', 'b', 'c']);
+    });
+
+    it('should keep the first-occurrence order of the values', () => {
+      expect(arrayUnique([3, 1, 3, 2, 1])).toStrictEqual([3, 1, 2]);
+    });
+
+    it('should compare values strictly (no type coercion)', () => {
+      expect(arrayUnique([1, '1', 1, '1'])).toStrictEqual([1, '1']);
+      expect(arrayUnique([0, false, '', null, undefined, 0, false])).toStrictEqual([0, false, '', null, undefined]);
+    });
+
+    it('should deduplicate objects by reference', () => {
+      const objectA = { id: 1 };
+      const objectB = { id: 1 };
+
+      expect(arrayUnique([objectA, objectB, objectA])).toStrictEqual([objectA, objectB]);
+    });
+
+    it('should return an empty array for an empty input', () => {
+      expect(arrayUnique([])).toStrictEqual([]);
     });
   });
 

--- a/handsontable/src/helpers/array.ts
+++ b/handsontable/src/helpers/array.ts
@@ -248,9 +248,11 @@ export function arrayFlatten(array: unknown[]): unknown[] {
  */
 export function arrayUnique<T = unknown>(array: T[]): T[] {
   const unique: T[] = [];
+  const seen = new Set<T>();
 
   arrayEach(array, (value: T) => {
-    if (unique.indexOf(value) === -1) {
+    if (!seen.has(value)) {
+      seen.add(value);
       unique.push(value);
     }
   });
@@ -269,7 +271,9 @@ export function getDifferenceOfArrays<T extends string | number>(...arrays: Arra
   let filteredFirstArray = first;
 
   arrayEach(rest, (array) => {
-    filteredFirstArray = filteredFirstArray.filter(value => !array.includes(value));
+    const lookup = new Set(array);
+
+    filteredFirstArray = filteredFirstArray.filter(value => !lookup.has(value));
   });
 
   return filteredFirstArray;
@@ -300,14 +304,18 @@ export function getIntersectionOfArrays(
     }
   });
 
-  const isMatch = comparator
-    ? (value: string | number, array: Array<string | number>) => array.some(item => comparator!(value, item))
-    : (value: string | number, array: Array<string | number>) => array.includes(value);
   const [first, ...rest] = arrays;
   let filteredFirstArray = first;
 
   arrayEach(rest, (array) => {
-    filteredFirstArray = filteredFirstArray.filter(value => isMatch(value, array));
+    if (comparator) {
+      filteredFirstArray = filteredFirstArray.filter(value => array.some(item => comparator!(value, item)));
+
+    } else {
+      const lookup = new Set(array);
+
+      filteredFirstArray = filteredFirstArray.filter(value => lookup.has(value));
+    }
   });
 
   return filteredFirstArray;

--- a/handsontable/src/helpers/moves.ts
+++ b/handsontable/src/helpers/moves.ts
@@ -8,8 +8,9 @@
  * @returns {number} Index informing where to move the first element.
  */
 function getMoveLine(movedIndexes: number[], finalIndex: number, numberOfIndexes: number) {
+  const movedIndexesLookup = new Set(movedIndexes);
   const notMovedElements = Array.from(Array(numberOfIndexes).keys())
-    .filter(index => movedIndexes.includes(index) === false);
+    .filter(index => movedIndexesLookup.has(index) === false);
 
   if (finalIndex === 0) {
     return notMovedElements[finalIndex] ?? 0; // Moving before the first dataset's element.

--- a/handsontable/src/plugins/autoRowSize/autoRowSize.ts
+++ b/handsontable/src/plugins/autoRowSize/autoRowSize.ts
@@ -790,17 +790,15 @@ export class AutoRowSize extends BasePlugin {
    * recalculated on the next render.
    */
   #onBeforeChange = (changes: unknown[][]) => {
-    const changedRows = changes.reduce<number[]>((acc, [row]: unknown[]) => {
-      const rowIndex = Number(row);
+    const changedRows = new Set<number>();
 
-      if (acc.indexOf(rowIndex) === -1) {
-        acc.push(rowIndex);
-      }
+    changes.forEach(([row]: unknown[]) => {
+      changedRows.add(Number(row));
+    });
 
-      return acc;
-    }, [] as number[]);
-
-    this.#visualRowsToRefresh.push(...changedRows);
+    changedRows.forEach((rowIndex) => {
+      this.#visualRowsToRefresh.push(rowIndex);
+    });
   };
 
   /**

--- a/handsontable/src/plugins/autofill/autofill.ts
+++ b/handsontable/src/plugins/autofill/autofill.ts
@@ -230,17 +230,21 @@ export class Autofill extends BasePlugin {
     }]);
     const copyableRows: number[] = [];
     const copyableColumns: number[] = [];
+    const seenRows = new Set<number>();
+    const seenColumns = new Set<number>();
     const data: unknown[][] = [];
 
     arrayEach(copyableRanges, (range) => {
       for (let visualRow = range.startRow; visualRow <= range.endRow; visualRow += 1) {
-        if (copyableRows.indexOf(visualRow) === -1) {
+        if (!seenRows.has(visualRow)) {
+          seenRows.add(visualRow);
           copyableRows.push(visualRow);
         }
       }
 
       for (let visualColumn = range.startCol; visualColumn <= range.endCol; visualColumn += 1) {
-        if (copyableColumns.indexOf(visualColumn) === -1) {
+        if (!seenColumns.has(visualColumn)) {
+          seenColumns.add(visualColumn);
           copyableColumns.push(visualColumn);
         }
       }

--- a/handsontable/src/plugins/copyPaste/copyableRanges.ts
+++ b/handsontable/src/plugins/copyPaste/copyableRanges.ts
@@ -202,6 +202,8 @@ export class CopyableRangesFactory {
 export function normalizeRanges(ranges: Record<string, number>[]) {
   const rows: number[] = [];
   const columns: number[] = [];
+  const seenRows = new Set<number>();
+  const seenColumns = new Set<number>();
 
   arrayEach(ranges, (range) => {
     const r = range as Record<string, number>;
@@ -209,7 +211,8 @@ export function normalizeRanges(ranges: Record<string, number>[]) {
     const maxRow = Math.max(r.startRow, r.endRow);
 
     rangeEach(minRow, maxRow, (row) => {
-      if (rows.indexOf(row) === -1) {
+      if (!seenRows.has(row)) {
+        seenRows.add(row);
         rows.push(row);
       }
     });
@@ -218,7 +221,8 @@ export function normalizeRanges(ranges: Record<string, number>[]) {
     const maxColumn = Math.max(r.startCol, r.endCol);
 
     rangeEach(minColumn, maxColumn, (column) => {
-      if (columns.indexOf(column) === -1) {
+      if (!seenColumns.has(column)) {
+        seenColumns.add(column);
         columns.push(column);
       }
     });

--- a/handsontable/src/plugins/customBorders/customBorders.ts
+++ b/handsontable/src/plugins/customBorders/customBorders.ts
@@ -3,7 +3,7 @@ import { throwWithCause } from '../../helpers/errors';
 import { hasOwnProperty, deepClone } from '../../helpers/object';
 import { warn } from '../../helpers/console';
 import { rangeEach } from '../../helpers/number';
-import { arrayEach, arrayReduce, arrayMap } from '../../helpers/array';
+import { arrayEach, arrayReduce } from '../../helpers/array';
 import * as C from '../../i18n/constants';
 import {
   top as menuItemTop,
@@ -28,6 +28,7 @@ import type { BorderSettings, BorderObject, CustomBorderConfig } from './utils';
 import { detectSelectionType, normalizeSelectionFactory } from '../../selection';
 import { isDefined } from '../../helpers/mixed';
 import type { HotInstance } from '../../core/types';
+import type VisualSelection from '../../selection/highlight/visualSelection';
 import type Selection from '../../3rdparty/walkontable/src/selection/selection';
 import type Border from '../../3rdparty/walkontable/src/selection/border/border';
 import type CellRange from '../../3rdparty/walkontable/src/cell/range';
@@ -161,6 +162,18 @@ export class CustomBorders extends BasePlugin {
    * @type {Array}
    */
   savedBorders: BorderObject[] = [];
+
+  /**
+   * Positions of the saved borders in the `savedBorders` array, keyed by the border id.
+   * Lets bulk border operations locate an existing border in O(1) instead of scanning the array.
+   */
+  #savedBordersIndex: Map<string, number> = new Map();
+
+  /**
+   * Cache of the plugin-created custom selections keyed by the border id.
+   * Rebuilt on demand when it goes out of sync with `hot.selection.highlight.customSelections`.
+   */
+  #customSelectionsCache: Map<string, VisualSelection> = new Map();
 
   /**
    * Checks if the plugin is enabled in the handsontable settings. This method is executed in {@link Hooks#beforeInit}
@@ -343,13 +356,16 @@ export class CustomBorders extends BasePlugin {
       this.setBorders(selectionRanges);
 
     } else {
+      const selectionsById = this.#customSelectionsById();
+
       arrayEach(this.savedBorders, (border) => {
-        this.clearBordersFromSelectionSettings(border.id);
-        this.clearNullCellRange();
+        selectionsById.get(border.id)?.clear();
         this.hot.removeCellMeta(border.row, border.col, 'borders');
       });
 
+      this.#clearNullCellRanges();
       this.savedBorders.length = 0;
+      this.#savedBordersIndex.clear();
     }
   }
 
@@ -365,6 +381,7 @@ export class CustomBorders extends BasePlugin {
 
     if (!hasSavedBorders) {
       this.savedBorders.push(border);
+      this.#savedBordersIndex.set(border.id, this.savedBorders.length - 1);
     }
 
     const borderCoords = this.hot._createCellCoords(border.row, border.col);
@@ -372,7 +389,10 @@ export class CustomBorders extends BasePlugin {
     const hasCustomSelections = this.checkCustomSelections(border, visualCellRange, place);
 
     if (!hasCustomSelections) {
+      const { customSelections } = this.hot.selection.highlight;
+
       this.hot.selection.highlight.addCustomSelection({ border, visualCellRange });
+      this.#customSelectionsCache.set(border.id, customSelections[customSelections.length - 1]);
     }
   }
 
@@ -666,13 +686,10 @@ export class CustomBorders extends BasePlugin {
    * @param {string} borderId Border id name as string.
    */
   clearBordersFromSelectionSettings(borderId: string) {
-    const index = arrayMap(
-      this.hot.selection.highlight.customSelections,
-      customSelection => customSelection.settings.id
-    ).indexOf(borderId);
+    const customSelection = this.#customSelectionsById().get(borderId);
 
-    if (index > -1) {
-      this.hot.selection.highlight.customSelections[index].clear();
+    if (customSelection) {
+      customSelection.clear();
     }
   }
 
@@ -684,12 +701,69 @@ export class CustomBorders extends BasePlugin {
   clearNullCellRange() {
     arrayEach(this.hot.selection.highlight.customSelections, (customSelection, index) => {
       if (customSelection.cellRange === null) {
+        const selectionId = customSelection.settings.id;
+
         customSelection.destroy();
         this.hot.selection.highlight.customSelections.splice(index, 1);
+
+        if (typeof selectionId === 'string') {
+          this.#customSelectionsCache.delete(selectionId);
+        }
 
         return false; // breaks forAll
       }
     });
+  }
+
+  /**
+   * Destroys and removes every custom selection whose cell range was cleared. Batched
+   * equivalent of calling `clearNullCellRange` once per cleared border.
+   */
+  #clearNullCellRanges() {
+    const { customSelections } = this.hot.selection.highlight;
+    const remainingSelections = customSelections.filter((customSelection) => {
+      if (customSelection.cellRange === null) {
+        customSelection.destroy();
+
+        return false;
+      }
+
+      return true;
+    });
+
+    if (remainingSelections.length !== customSelections.length) {
+      customSelections.length = 0;
+
+      arrayEach(remainingSelections, (customSelection) => {
+        customSelections.push(customSelection);
+      });
+
+      this.#customSelectionsCache.clear();
+    }
+  }
+
+  /**
+   * Returns the plugin-created custom selections keyed by the border id. The cached map is
+   * rebuilt when its size no longer matches the custom selections collection.
+   *
+   * @returns {Map<string, VisualSelection>}
+   */
+  #customSelectionsById(): Map<string, VisualSelection> {
+    const { customSelections } = this.hot.selection.highlight;
+
+    if (this.#customSelectionsCache.size !== customSelections.length) {
+      this.#customSelectionsCache.clear();
+
+      arrayEach(customSelections, (customSelection) => {
+        const selectionId = customSelection.settings.id;
+
+        if (typeof selectionId === 'string') {
+          this.#customSelectionsCache.set(selectionId, customSelection);
+        }
+      });
+    }
+
+    return this.#customSelectionsCache;
   }
 
   /**
@@ -698,10 +772,13 @@ export class CustomBorders extends BasePlugin {
    * @private
    */
   hideBorders() {
+    const selectionsById = this.#customSelectionsById();
+
     arrayEach(this.savedBorders, (border) => {
-      this.clearBordersFromSelectionSettings(border.id);
-      this.clearNullCellRange();
+      selectionsById.get(border.id)?.clear();
     });
+
+    this.#clearNullCellRanges();
   }
 
   /**
@@ -711,11 +788,23 @@ export class CustomBorders extends BasePlugin {
    * @param {string} borderId Border id name as string.
    */
   spliceBorder(borderId: string) {
-    const index = arrayMap(this.savedBorders, border => border.id).indexOf(borderId);
+    const index = this.#savedBordersIndex.get(borderId) ?? -1;
 
     if (index > -1) {
       this.savedBorders.splice(index, 1);
+      this.#rebuildSavedBordersIndex();
     }
+  }
+
+  /**
+   * Rebuilds the id-to-position index of the saved borders after positions have shifted.
+   */
+  #rebuildSavedBordersIndex() {
+    this.#savedBordersIndex.clear();
+
+    arrayEach(this.savedBorders, (border, index) => {
+      this.#savedBordersIndex.set(border.id, index);
+    });
   }
 
   /**
@@ -737,14 +826,12 @@ export class CustomBorders extends BasePlugin {
       check = true;
 
     } else {
-      arrayEach(this.savedBorders, (savedBorder, index) => {
-        if (border.id === savedBorder.id) {
-          this.savedBorders[index] = border;
-          check = true;
+      const index = this.#savedBordersIndex.get(border.id);
 
-          return false; // breaks forAll
-        }
-      });
+      if (index !== undefined) {
+        this.savedBorders[index] = border;
+        check = true;
+      }
     }
 
     return check;
@@ -763,25 +850,22 @@ export class CustomBorders extends BasePlugin {
    */
   checkCustomSelectionsFromContextMenu(border: Record<string, unknown>, place: string, remove: boolean | undefined) {
     let check = false;
+    const customSelection = typeof border.id === 'string'
+      ? this.#customSelectionsById().get(border.id)
+      : undefined;
 
-    const customSelections = this.hot.selection.highlight.customSelections as unknown as Selection[];
+    if (customSelection) {
+      const borders: Border[] = this.hot.view._wt.selectionManager
+        .getBorderInstances(customSelection as unknown as Selection) as Border[];
 
-    arrayEach(customSelections, (customSelection: Selection) => {
-      if (border.id === customSelection.settings.id) {
-        const borders: Border[] = this.hot.view._wt.selectionManager
-          .getBorderInstances(customSelection) as Border[];
-
-        if (isBorderSide(place)) {
-          arrayEach(borders, (borderObject: Border) => {
-            borderObject.toggleHiddenClass(place, remove ?? false);
-          });
-        }
-
-        check = true;
-
-        return false; // breaks forAll
+      if (isBorderSide(place)) {
+        arrayEach(borders, (borderObject: Border) => {
+          borderObject.toggleHiddenClass(place, remove ?? false);
+        });
       }
-    });
+
+      check = true;
+    }
 
     return check;
   }
@@ -805,25 +889,23 @@ export class CustomBorders extends BasePlugin {
       check = true;
 
     } else {
-      arrayEach(this.hot.selection.highlight.customSelections, (customSelection) => {
-        if (border.id === customSelection.settings.id) {
-          customSelection.visualCellRange = cellRange;
-          customSelection.commit();
+      const customSelection = this.#customSelectionsById().get(border.id);
 
-          if (place && isBorderSide(place)) {
-            const borders: Border[] = this.hot.view._wt.selectionManager
-              .getBorderInstances(customSelection as unknown as Selection) as Border[];
+      if (customSelection) {
+        customSelection.visualCellRange = cellRange;
+        customSelection.commit();
 
-            arrayEach(borders, (borderObject: Border) => {
-              borderObject.changeBorderStyle(place, border);
-            });
-          }
+        if (place && isBorderSide(place)) {
+          const borders: Border[] = this.hot.view._wt.selectionManager
+            .getBorderInstances(customSelection as unknown as Selection) as Border[];
 
-          check = true;
-
-          return false; // breaks forAll
+          arrayEach(borders, (borderObject: Border) => {
+            borderObject.changeBorderStyle(place, border);
+          });
         }
-      });
+
+        check = true;
+      }
     }
 
     return check;
@@ -844,6 +926,7 @@ export class CustomBorders extends BasePlugin {
 
       if (!bordersClone.length) {
         this.savedBorders = [];
+        this.#savedBordersIndex.clear();
       }
 
       this.createCustomBorders(bordersClone);

--- a/handsontable/src/plugins/hiddenColumns/contextMenuItem/showColumn.ts
+++ b/handsontable/src/plugins/hiddenColumns/contextMenuItem/showColumn.ts
@@ -89,9 +89,13 @@ export default function showColumnItem(hiddenColumnsPlugin: Record<string, Funct
         // Collect not trimmed columns if there are some hidden columns in the selection range.
         if (visualColumnsInRange > renderedColumnsInRange) {
           const physicalIndexesInRange = notTrimmedColumnIndexes.slice(visualStartColumn, visualEndColumn + 1);
+          const hiddenPhysicalColumnsLookup = new Set(hiddenPhysicalColumns);
 
-          physicalColumnIndexes.push(...physicalIndexesInRange
-            .filter((physicalIndex: number) => hiddenPhysicalColumns.includes(physicalIndex)));
+          physicalIndexesInRange.forEach((physicalIndex: number) => {
+            if (hiddenPhysicalColumnsLookup.has(physicalIndex)) {
+              physicalColumnIndexes.push(physicalIndex);
+            }
+          });
         }
 
       // Handled column is the first rendered index and there are some visual indexes before it.

--- a/handsontable/src/plugins/hiddenRows/contextMenuItem/showRow.ts
+++ b/handsontable/src/plugins/hiddenRows/contextMenuItem/showRow.ts
@@ -89,10 +89,13 @@ export default function showRowItem(hiddenRowsPlugin: Record<string, Function>) 
         // Collect not trimmed rows if there are some hidden rows in the selection range.
         if (visualRowsInRange > renderedRowsInRange) {
           const physicalIndexesInRange = notTrimmedRowIndexes.slice(visualStartRow, visualEndRow + 1);
+          const hiddenPhysicalRowsLookup = new Set(hiddenPhysicalRows);
 
-          physicalRowIndexes.push(
-            ...physicalIndexesInRange.filter((physicalIndex: number) => hiddenPhysicalRows.includes(physicalIndex))
-          );
+          physicalIndexesInRange.forEach((physicalIndex: number) => {
+            if (hiddenPhysicalRowsLookup.has(physicalIndex)) {
+              physicalRowIndexes.push(physicalIndex);
+            }
+          });
         }
 
         // Handled row is the first rendered index and there are some visual indexes before it.

--- a/handsontable/src/plugins/manualColumnResize/manualColumnResize.ts
+++ b/handsontable/src/plugins/manualColumnResize/manualColumnResize.ts
@@ -367,6 +367,7 @@ export class ManualColumnResize extends BasePlugin {
 
     if (this.hot.selection.isSelected() && isFullColumnSelected) {
       const selectionRanges = this.hot.getSelectedRange() ?? [];
+      const seenColumns = new Set<number>();
 
       arrayEach(selectionRanges, (selectionRange) => {
         const fromColumn = (selectionRange as CellRange).getTopStartCorner().col;
@@ -378,7 +379,8 @@ export class ManualColumnResize extends BasePlugin {
 
         // Add every selected column for resize action.
         rangeEach(fromColumn, toColumn, (columnIndex) => {
-          if (!this.#selectedCols.includes(columnIndex)) {
+          if (!seenColumns.has(columnIndex)) {
+            seenColumns.add(columnIndex);
             this.#selectedCols.push(columnIndex);
           }
         });

--- a/handsontable/src/plugins/manualRowResize/manualRowResize.ts
+++ b/handsontable/src/plugins/manualRowResize/manualRowResize.ts
@@ -342,6 +342,7 @@ export class ManualRowResize extends BasePlugin {
 
     if (this.hot.selection.isSelected() && isFullRowSelected) {
       const selectionRanges = this.hot.getSelectedRange() ?? [];
+      const seenRows = new Set<number>();
 
       arrayEach(selectionRanges, (selectionRange) => {
         const fromRow = (selectionRange as CellRange).getTopStartCorner().row;
@@ -353,7 +354,8 @@ export class ManualRowResize extends BasePlugin {
 
         // Add every selected row for resize action.
         rangeEach(fromRow, toRow, (rowIndex) => {
-          if (!this.#selectedRows.includes(rowIndex)) {
+          if (!seenRows.has(rowIndex)) {
+            seenRows.add(rowIndex);
             this.#selectedRows.push(rowIndex);
           }
         });


### PR DESCRIPTION
### Context

The PR removes the "array used as a set" pattern in ten places: `.indexOf()` / `.includes()` membership checks running inside data-scaled loops. Each check re-scanned a whole array, so bulk operations (copy, autofill, bulk `setDataAtCell`, header hover with select-all, applying custom borders to a range) became quadratic in the selection or grid size. The membership checks now use a `Set` (or an id-keyed `Map` in CustomBorders) while output arrays keep their original order, so behavior is unchanged.

Fixed sites:

- `helpers/array.ts` — `arrayUnique`, `getDifferenceOfArrays`, `getIntersectionOfArrays` (the comparator path of intersection is unchanged)
- `helpers/moves.ts` — `getMoveLine`
- `plugins/copyPaste/copyableRanges.ts` — `normalizeRanges`
- `plugins/autofill/autofill.ts` — `getSelectionData`
- `plugins/autoRowSize/autoRowSize.ts` — `#onBeforeChange` (also removes a `push(...spread)` stack-overflow risk on huge pastes)
- `plugins/manualRowResize` + `plugins/manualColumnResize` — `setupHandlePosition`
- `plugins/hiddenRows` + `plugins/hiddenColumns` — "Show rows/columns" context-menu items
- `plugins/customBorders` — id-keyed lookup maps for `savedBorders` and `customSelections`, batched cleanup of cleared selections

Measured in real Chrome (`performance.now()`, no profiler, 3 runs per cell, medians):

| Scenario | Before | After |
|---|---|---|
| Copy 50k rows × 5 cols (`getRangedData`) | 247 ms | 112 ms |
| Autofill data prep, 50k rows × 3 cols | 206 ms | 72 ms |
| AutoRowSize, 30k-cell `setDataAtCell` | 166 ms | 119 ms |
| ManualRowResize hover with 30k-row select-all | 56 ms | 8 ms |
| CustomBorders `setBorders` on 9k cells | 1570 ms | 855 ms |

The removed cost is quadratic, so the gains grow with grid size.

### How has this been tested?

- New unit tests for `arrayUnique` (dedup, first-occurrence order, strict equality, reference identity): `npm run test:unit --prefix handsontable -- --testPathPattern=helpers/__tests__/array`
- Full unit suite: 3112 passed — `npm run test:unit --prefix handsontable`
- Full E2E suite passed; targeted suites for all touched plugins (copyPaste, autofill, autoRowSize, manualRowResize, manualColumnResize, customBorders, hiddenRows, hiddenColumns, collapsibleColumns): 1449 specs, 0 failures — `npm run test:e2e --prefix handsontable`
- ESLint and `tsc --noEmit` clean
- Before/after benchmark in real Chrome via Puppeteer (fresh page per run)

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2077

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2077

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only refactors with preserved ordering and equality semantics; CustomBorders index maintenance on splice is the main area to watch, but behavior is intended to be unchanged and is covered by existing E2E.
> 
> **Overview**
> Replaces **O(n) array membership checks** inside loops with **`Set`/`Map` lookups** so copy, autofill, bulk edits, header resize, and custom borders scale better on large selections. Output order and semantics stay the same.
> 
> **Shared helpers:** `arrayUnique`, `getDifferenceOfArrays`, and the default path of `getIntersectionOfArrays` use a `Set`; `getMoveLine` uses a `Set` for moved indexes. New **unit tests** cover `arrayUnique`.
> 
> **Plugins:** Copy/paste `normalizeRanges`, autofill `getSelectionData`, and **AutoRowSize** `#onBeforeChange` dedupe row/column indexes with `Set`s (also avoids a large `push(...spread)` on huge pastes). **Manual row/column resize** dedupe multi-range header selections the same way. **Show hidden row/column** context menu items use a `Set` when filtering hidden physical indexes in a range.
> 
> **CustomBorders** adds id-keyed **`Map`s** for `savedBorders` positions and cached custom selections, plus batched `#clearNullCellRanges`, so bulk `setBorders`/`clearBorders` no longer scan arrays on every cell.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d18e0888a22ef6ebc17b736e7968136707c1a4d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->