### PR TITLE
DEV-2072: Fix Events type collapsing to any

### DIFF
--- a/.changelogs/13079.json
+++ b/.changelogs/13079.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed the `Events` type resolving every hook callback to `any`, so callbacks typed through `Events[hookName]` and `addHook` now get correct parameter types and autocomplete.",
+  "type": "fixed",
+  "issueOrPR": 13079,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/__tests__/core/settings.types.ts
+++ b/handsontable/src/__tests__/core/settings.types.ts
@@ -1,6 +1,8 @@
 import type Handsontable from 'handsontable';
 import HyperFormula from 'hyperformula';
-import type { CellProperties, CellCoords, RangeType, RemoveIndexSignature } from 'handsontable';
+import type {
+  CellProperties, CellCoords, RangeType, RemoveIndexSignature, Events, HotInstance, CellChange, ChangeSource,
+} from 'handsontable';
 
 // Helpers to verify multiple different settings and prevent TS control-flow from eliminating unreachable values
 declare function oneOf<T extends Array<string | number | boolean | undefined | null | object>>(...args: T): T[number];
@@ -463,6 +465,7 @@ const allSettings: Required<Handsontable.GridSettings> = {
   afterOnCellCornerMouseDown: (event) => {},
   afterOnCellMouseDown: (event, coords, TD) => {},
   afterOnCellMouseOver: (event, coords, TD) => {},
+  afterOnCellMouseOverOutside: (event, coords, TD) => {},
   afterOnCellMouseOut: (event, coords, TD) => {},
   afterOnCellMouseUp: (event, coords, TD) => {},
   afterPageChange(oldPage, newPage) {
@@ -640,6 +643,7 @@ const allSettings: Required<Handsontable.GridSettings> = {
   beforeOnCellMouseDown: (event, coords, TD, controller) => {},
   beforeOnCellMouseOut: (event, coords, TD) => {},
   beforeOnCellMouseOver: (event, coords, TD, controller) => {},
+  beforeOnCellMouseOverOutside: (event, coords, TD, controller) => {},
   beforeOnCellMouseUp: (event, coords, TD) => {},
   beforeDataProviderFetch: queryParameters => true,
   beforePageChange(oldPage, newPage) {
@@ -898,3 +902,38 @@ const _sourceDataValidatorBadReturn: Handsontable.GridSettings = {
   // @ts-expect-error the validator must return `boolean`, not `string`.
   sourceDataValidator: () => 'yes',
 };
+
+// DEV-2072 regression: `Events` is derived from `GridSettings` via `HookKey`. Without stripping
+// `GridSettings`'s index signature first, `HookKey` (and thus `Events`) collapsed to a bare index
+// signature, so every hook callback typed through `Events[hookName]` inferred its parameters as `any`.
+const _onAfterChange: Events['afterChange'] = (changes, source) => {
+  // These assignments only compile if the parameters keep their real, non-`any` types.
+  const _changes: CellChange[] | null = changes;
+  const _source: ChangeSource = source;
+};
+// Newly-documented hooks (previously missing from `GridSettings`) resolve to real callback types too.
+const _onBeforeOnCellMouseOverOutside: Events['beforeOnCellMouseOverOutside'] = (event, coords, TD, controller) => {
+  const _event: MouseEvent = event;
+  const _coords: CellCoords = coords;
+  const _TD: HTMLTableCellElement = TD;
+  const _controller: { row: boolean, column: boolean, cell: boolean } = controller;
+};
+
+// @ts-expect-error `notARealHook` is not a hook-shaped `GridSettings` property.
+type _NotAHook = Events['notARealHook'];
+// @ts-expect-error An arbitrary string is not a member of the now-finite `keyof Events` union.
+const _arbitraryHookKey: keyof Events = 'someArbitraryString';
+
+declare const hot: HotInstance;
+// Rung 1 of the `addHook` overload ladder: an unannotated arrow under a known hook name
+// gets full parameter inference from `Events[K]`.
+hot.addHook('afterChange', (changes, source) => {
+  const _changes: CellChange[] | null = changes;
+  const _source: ChangeSource = source;
+});
+// Rung 2: an explicitly-annotated callback that doesn't exactly match the declared hook
+// signature is still accepted under a known hook name (back-compat with pre-tightening code).
+hot.addHook('afterCreateRow', (index: number, amount: number, source: string) => {});
+// Rung 3: a dynamic/plugin-only hook name still compiles, including with a typed callback
+// (the `HookCallback` fallback is the sound function top type, not `(...args: unknown[])`).
+hot.addHook('someCustomPluginHook', (payload: { id: number }, flag: boolean) => {});

--- a/handsontable/src/core/hooks/bucket.ts
+++ b/handsontable/src/core/hooks/bucket.ts
@@ -1,6 +1,13 @@
 import { REGISTERED_HOOKS } from './constants';
 
-export type HookCallback = (...args: unknown[]) => unknown;
+/**
+ * The storage type for hook listeners. `(...args: never[]) => unknown` is the "top type" of
+ * functions: every function is assignable to it (parameter contravariance -- `never` is assignable
+ * to every type), yet it cannot be invoked without a deliberate cast. This lets the hooks system
+ * accept any correctly-typed listener without resorting to `any`, while confining the unavoidable
+ * dynamically-typed call to a single cast at the dispatch boundary (`fastCall`).
+ */
+export type HookCallback = (...args: never[]) => unknown;
 
 export interface HookEntry {
   callback: HookCallback;

--- a/handsontable/src/core/settings.ts
+++ b/handsontable/src/core/settings.ts
@@ -7,7 +7,9 @@ import type {
   CellCoords as WalkontableCellCoords,
   CellRange as WalkontableCellRange,
 } from '../3rdparty/walkontable/src';
-import type { CellChange, ChangeSource, RowObject, CellValue, CellProperties, ColumnSettings } from '../settings';
+import type {
+  CellChange, ChangeSource, RowObject, CellValue, CellProperties, ColumnSettings, RemoveIndexSignature,
+} from '../settings';
 import type { ColumnConditions } from '../plugins/filters';
 import type { LayoutConfig } from './layout';
 import type { PredefinedMenuItemKey, MenuItemConfig, ContextMenu } from '../plugins/contextMenu';
@@ -327,6 +329,7 @@ export interface GridSettings {
   afterOnCellMouseDown?: (event: MouseEvent, coords: WalkontableCellCoords, TD: HTMLTableCellElement) => void;
   afterOnCellMouseOut?: (event: MouseEvent, coords: WalkontableCellCoords, TD: HTMLTableCellElement) => void;
   afterOnCellMouseOver?: (event: MouseEvent, coords: WalkontableCellCoords, TD: HTMLTableCellElement) => void;
+  afterOnCellMouseOverOutside?: (event: MouseEvent, coords: WalkontableCellCoords, TD: HTMLTableCellElement) => void;
   afterOnCellMouseUp?: (event: MouseEvent, coords: WalkontableCellCoords, TD: HTMLTableCellElement) => void;
   afterPageChange?: (oldPage: number, newPage: number) => void;
   afterPageCounterVisibilityChange?: (isVisible: boolean) => void;
@@ -484,6 +487,8 @@ export interface GridSettings {
   beforeOnCellMouseOut?: (event: MouseEvent, coords: WalkontableCellCoords, TD: HTMLTableCellElement) => void;
   beforeOnCellMouseOver?: (event: MouseEvent, coords: WalkontableCellCoords, TD: HTMLTableCellElement,
     controller: { preventDefault: boolean }) => void;
+  beforeOnCellMouseOverOutside?: (event: MouseEvent, coords: WalkontableCellCoords, TD: HTMLTableCellElement,
+    controller: { row: boolean, column: boolean, cell: boolean }) => void;
   beforeOnCellMouseUp?: (event: MouseEvent, coords: WalkontableCellCoords, TD: HTMLTableCellElement) => void;
   beforePageChange?: (oldPage: number, newPage: number) => void | boolean;
   beforePageSizeChange?: (oldPageSize: number | 'auto', newPageSize: number | 'auto') => void | boolean;
@@ -579,10 +584,15 @@ export interface GridSettings {
 /**
  * Extracts all hook callback keys from GridSettings.
  * Used to derive the Events type for addHook/removeHook generics.
+ *
+ * Derived from `RemoveIndexSignature<GridSettings>` rather than `GridSettings` directly -- the raw
+ * type's `[key: string]: any` index signature makes `keyof GridSettings` include `string`, which
+ * collapses this mapped type to `string` and, in turn, collapses `Events` to `{ [key: string]: any }`.
  */
 type HookKey = {
-  [K in keyof GridSettings]-?: NonNullable<GridSettings[K]> extends (...args: any[]) => any ? K : never; // eslint-disable-line @typescript-eslint/no-explicit-any
-}[keyof GridSettings];
+  [K in keyof RemoveIndexSignature<GridSettings>]-?:
+    NonNullable<GridSettings[K]> extends (...args: never[]) => unknown ? K : never;
+}[keyof RemoveIndexSignature<GridSettings>];
 
 /**
  * Map of all Handsontable hook names to their typed callback signatures.

--- a/handsontable/src/core/types.ts
+++ b/handsontable/src/core/types.ts
@@ -62,14 +62,26 @@ export interface ViewportScrollerInstance {
 /**
  * Handsontable Core instance interface.
  * Provides type-safe access to the Core API without requiring circular imports.
+ *
+ * The `addHook`/`addHookOnce`/`removeHook` methods form a three-rung overload ladder:
+ * 1. Strict -- a known hook name with a callback typed as `Events[K]`. Unannotated inline arrow
+ *    functions get full parameter inference from this rung.
+ * 2. Lenient -- a known hook name with any explicitly-annotated callback. `HookCallback` is the
+ *    sound function "top type" (see `core/hooks/bucket.ts`), so a callback whose annotations don't
+ *    exactly match the declared hook signature is still accepted, matching the runtime behavior and
+ *    keeping previously-compiling listener code compiling.
+ * 3. Fallback -- any string, for dynamically-named and plugin-local hooks.
  */
 export interface HotInstance {
   // Lifecycle & hooks
   addHook<K extends keyof Events>(key: K, callback: Events[K] | Array<Events[K]>, orderIndex?: number): void;
+  addHook<K extends keyof Events>(key: K, callback: HookCallback | HookCallback[], orderIndex?: number): void;
   addHook(key: string, callback: HookCallback | HookCallback[], orderIndex?: number): void;
   addHookOnce<K extends keyof Events>(key: K, callback: Events[K] | Array<Events[K]>, orderIndex?: number): void;
+  addHookOnce<K extends keyof Events>(key: K, callback: HookCallback | HookCallback[], orderIndex?: number): void;
   addHookOnce(key: string, callback: HookCallback | HookCallback[], orderIndex?: number): void;
   removeHook<K extends keyof Events>(key: K, callback: Events[K]): void;
+  removeHook<K extends keyof Events>(key: K, callback: HookCallback): void;
   removeHook(key: string, callback: HookCallback): void;
   runHooks<R = unknown>(name: string, ...args: unknown[]): R;
   hasHook(name: string): boolean;

--- a/handsontable/src/helpers/function.ts
+++ b/handsontable/src/helpers/function.ts
@@ -285,8 +285,12 @@ export function curryRight(func: (...args: unknown[]) => unknown): (...args: unk
  * @returns {*}
  */
 export function fastCall(
-  func: (...args: unknown[]) => unknown, context: unknown,
+  dispatchedFunc: (...args: never[]) => unknown, context: unknown,
   arg1?: unknown, arg2?: unknown, arg3?: unknown, arg4?: unknown, arg5?: unknown, arg6?: unknown): unknown {
+  // This is the designated dynamic-dispatch boundary of the hooks system: listeners are stored as
+  // the uncallable function "top type" and must be cast to a callable shape exactly here.
+  const func = dispatchedFunc as (...args: unknown[]) => unknown;
+
   if (isDefined(arg6)) {
     return func.call(context, arg1, arg2, arg3, arg4, arg5, arg6);
 

--- a/handsontable/src/plugins/base/base.ts
+++ b/handsontable/src/plugins/base/base.ts
@@ -443,6 +443,15 @@ export class BasePlugin {
    */
   addHook<K extends keyof Events>(name: K, callback: Events[K], orderIndex?: number): void;
   /**
+   * Registers a hook listener under a known hook name, accepting any explicitly-annotated callback
+   * (see the overload-ladder description on `HotInstance` in `core/types.ts`).
+   */
+  addHook<K extends keyof Events>(name: K, callback: HookCallback, orderIndex?: number): void;
+  /**
+   * Registers a hook listener under a dynamically-named hook.
+   */
+  addHook(name: string, callback: HookCallback, orderIndex?: number): void;
+  /**
    * Registers a hook listener and tracks it so it can be removed automatically when the plugin is disabled.
    */
   addHook(name: string, callback: HookCallback, orderIndex?: number): void {


### PR DESCRIPTION
### Context

The PR fixes the exported `Events` type resolving every hook lookup to `any`.

`GridSettings` carries a `[key: string]: any` index signature (for plugin-specific keys), which makes `keyof GridSettings` include `string`. The `HookKey` helper that derives `Events` mapped over the raw `keyof GridSettings`, so it collapsed to `string`, and `Events = Required<Pick<GridSettings, HookKey>>` degraded to a bare `{ [key: string]: any }`. As a result, `Events['afterChange']` was `any`, callbacks typed through `Events[hookName]` had implicit-`any` parameters (failing users' strict builds — this is what broke the docs example investigated in #13072), and the typed `addHook` overloads provided no real checking or autocomplete.

**The fix** derives `HookKey` from `RemoveIndexSignature<GridSettings>` — the same helper the React wrapper already uses for exactly this index-signature-collapse problem.

Tightening `Events` surfaced that many internal `addHook` call sites have callback annotations that don't exactly match the declared hook signatures (previously unchecked because `Events[K]` was `any`). Rather than masking this with `any` or force-fixing ~90 call sites in one PR, the `addHook`/`addHookOnce`/`removeHook` methods now form a documented three-rung overload ladder, with no `any` anywhere:

1. **Strict** — known hook name, callback typed `Events[K]`. Unannotated inline arrows get full parameter inference from this rung.
2. **Lenient** — known hook name, any explicitly-annotated callback. `HookCallback` is now `(...args: never[]) => unknown` — the sound function "top type": every function is assignable to it (parameter contravariance), but it cannot be invoked without a deliberate cast. This keeps all previously-compiling listener code (internal and user) compiling.
3. **Fallback** — any string, for dynamically-named and plugin-local hooks. Because `HookCallback` is the top type, this rung now also accepts typed callbacks (previously the `(...args: unknown[])` fallback rejected any concretely-typed callback).

The single place listeners are dynamically invoked (`fastCall` in `helpers/function.ts`) carries the one deliberate, documented cast. No runtime behavior changes anywhere.

Also fixes a parity gap found during the audit: the documented `afterOnCellMouseOverOutside` / `beforeOnCellMouseOverOutside` hooks (`@since 17.2.0`) were missing from `GridSettings`, and `BasePlugin.addHook` was missing an explicit string-fallback overload declaration (only the typed overload was visible to callers).

**Not a breaking change**: type-level tightening of `Events` lookups only; the overload ladder keeps every previously-compiling `addHook` call compiling, and hook callbacks passed through the settings object were already strictly typed.

**Follow-up (out of scope here):** the strict rung exposed ~90 internal callback-annotation mismatches across 32 files, including a few genuinely wrong declarations (e.g. `afterContextMenuDefaultOptions` is declared to receive an items array but runtime passes `{ items: [...] }`) and suspected latent bugs (e.g. `beforeRowWrap` handlers annotate an object-listener parameter as `boolean`). These compile via the lenient rung and should be reconciled in a dedicated task.

### How has this been tested?

- New type regressions in `src/__tests__/core/settings.types.ts`: `Events['afterChange']` parameter inference, the newly-added hooks' signatures, `@ts-expect-error` rejection of bogus hook names and arbitrary `keyof Events` strings, and one test per overload-ladder rung.
- `npm run test:types` — compiles all 78 `*.types.ts` files against the rebuilt, downleveled `tmp/*.d.ts` (validates the published shape, not just source).
- Scratch verification against the emitted types: an `Events['afterChange']` callback with zero explicit annotations now infers `CellChange[] | null` / `ChangeSource` (fails with implicit-`any` errors before this change); proved the old and new `HookKey` matchers select the identical key set via a mutual-extension assertion.
- `npm run test:unit -- --testPathPattern=hooks` — 53/53 pass (hooks engine, bucket, mixins).
- React wrapper suite (consumes the built `tmp/` types): 75/75 pass.
- ESLint clean on all changed files.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2072
2. #13072 (the docs issue whose investigation uncovered this)

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/86caqyk2z

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only tightening with backward-compatible addHook overloads; runtime hook dispatch unchanged aside from documented fastCall cast.
> 
> **Overview**
> Fixes **`Events`** so hook lookups like `Events['afterChange']` infer real callback parameters instead of collapsing to **`any`**, by deriving **`HookKey`** from **`RemoveIndexSignature<GridSettings>`** rather than raw **`GridSettings`** (whose `[key: string]: any` index signature widened **`keyof`** to **`string`**).
> 
> **`HookCallback`** becomes `(...args: never[]) => unknown` as a sound function top type; dynamic invocation is isolated to a single cast in **`fastCall`**. **`HotInstance`**, **`BasePlugin`**, and related APIs gain a documented three-rung **`addHook`** / **`addHookOnce`** / **`removeHook`** overload ladder (strict **`Events[K]`**, lenient **`HookCallback`**, string fallback) so tightening types does not break existing listeners.
> 
> Adds missing **`afterOnCellMouseOverOutside`** / **`beforeOnCellMouseOverOutside`** entries on **`GridSettings`**, plus DEV-2072 type regressions in **`settings.types.ts`**. No runtime behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b3c89dc0101db936924a5c247c30043b4b47a79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->