### PR TITLE
DEV-2080: Add skipUnchangedWrites option to IndexMap for scalar-valued maps

### DIFF
--- a/.changelogs/13080.json
+++ b/.changelogs/13080.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Improved index-map performance: writing an unchanged value into scalar-valued index maps (hiding, trimming, order sequence, and the automatic or manual row/column size maps) no longer rebuilds the index caches.",
+  "type": "changed",
+  "issueOrPR": 13080,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/autoColumnSize/autoColumnSize.ts
+++ b/handsontable/src/plugins/autoColumnSize/autoColumnSize.ts
@@ -8,7 +8,7 @@ import { valueAccordingPercent, rangeEach } from '../../helpers/number';
 import SamplesGenerator from '../../utils/samplesGenerator';
 import { isPercentValue } from '../../helpers/string';
 import { DEFAULT_COLUMN_WIDTH } from '../../3rdparty/walkontable/src';
-import { PhysicalIndexToValueMap as IndexToValueMap } from '../../translations';
+import type { PhysicalIndexToValueMap as IndexToValueMap } from '../../translations';
 
 Hooks.getSingleton().register('modifyAutoColumnSizeSeed');
 
@@ -285,7 +285,7 @@ export class AutoColumnSize extends BasePlugin {
    * @private
    * @type {PhysicalIndexToValueMap}
    */
-  columnWidthsMap = new IndexToValueMap(null, { skipUnchangedWrites: true });
+  columnWidthsMap: IndexToValueMap;
   /**
    * `true` value indicates that the #onInit() function has been already called.
    *
@@ -317,7 +317,11 @@ export class AutoColumnSize extends BasePlugin {
    */
   constructor(hotInstance: HotInstance) {
     super(hotInstance);
-    this.hot.columnIndexMapper.registerMap(COLUMN_SIZE_MAP_NAME, this.columnWidthsMap);
+    // The map holds numbers only, so re-writing an unchanged width is a no-op that must not
+    // invalidate the column-width position cache (every render re-measures the visible columns).
+    this.columnWidthsMap = this.hot.columnIndexMapper.createAndRegisterIndexMap(
+      COLUMN_SIZE_MAP_NAME, 'physicalIndexToValue', null, { skipUnchangedWrites: true },
+    );
 
     // Leave the listener active to allow auto-sizing the columns when the plugin is disabled.
     // This is necessary for width recalculation for resize handler doubleclick (ManualColumnResize).

--- a/handsontable/src/plugins/autoColumnSize/autoColumnSize.ts
+++ b/handsontable/src/plugins/autoColumnSize/autoColumnSize.ts
@@ -285,7 +285,7 @@ export class AutoColumnSize extends BasePlugin {
    * @private
    * @type {PhysicalIndexToValueMap}
    */
-  columnWidthsMap = new IndexToValueMap();
+  columnWidthsMap = new IndexToValueMap(null, { skipUnchangedWrites: true });
   /**
    * `true` value indicates that the #onInit() function has been already called.
    *

--- a/handsontable/src/plugins/autoRowSize/autoRowSize.ts
+++ b/handsontable/src/plugins/autoRowSize/autoRowSize.ts
@@ -291,7 +291,7 @@ export class AutoRowSize extends BasePlugin {
    * @private
    * @type {PhysicalIndexToValueMap}
    */
-  rowHeightsMap = new IndexToValueMap();
+  rowHeightsMap = new IndexToValueMap(null, { skipUnchangedWrites: true });
   /**
    * An array of row indexes whose height will be recalculated.
    *

--- a/handsontable/src/plugins/autoRowSize/autoRowSize.ts
+++ b/handsontable/src/plugins/autoRowSize/autoRowSize.ts
@@ -6,7 +6,7 @@ import { isObject } from '../../helpers/object';
 import { valueAccordingPercent, rangeEach } from '../../helpers/number';
 import SamplesGenerator from '../../utils/samplesGenerator';
 import { isPercentValue } from '../../helpers/string';
-import { PhysicalIndexToValueMap as IndexToValueMap } from '../../translations';
+import type { PhysicalIndexToValueMap as IndexToValueMap } from '../../translations';
 import { addClass, removeClass } from '../../helpers/dom/element';
 
 export const PLUGIN_KEY = 'autoRowSize';
@@ -291,7 +291,7 @@ export class AutoRowSize extends BasePlugin {
    * @private
    * @type {PhysicalIndexToValueMap}
    */
-  rowHeightsMap = new IndexToValueMap(null, { skipUnchangedWrites: true });
+  rowHeightsMap: IndexToValueMap;
   /**
    * An array of row indexes whose height will be recalculated.
    *
@@ -316,7 +316,11 @@ export class AutoRowSize extends BasePlugin {
    */
   constructor(hotInstance: HotInstance) {
     super(hotInstance);
-    this.hot.rowIndexMapper.registerMap(ROW_WIDTHS_MAP_NAME, this.rowHeightsMap);
+    // The map holds numbers only, so re-writing an unchanged height is a no-op that must not
+    // invalidate the row-height position cache.
+    this.rowHeightsMap = this.hot.rowIndexMapper.createAndRegisterIndexMap(
+      ROW_WIDTHS_MAP_NAME, 'physicalIndexToValue', null, { skipUnchangedWrites: true },
+    );
 
     // Leave the listener active to allow auto-sizing the rows when the plugin is disabled.
     // This is necessary for height recalculation for resize handler doubleclick (ManualRowResize).

--- a/handsontable/src/plugins/columnSorting/columnSorting.ts
+++ b/handsontable/src/plugins/columnSorting/columnSorting.ts
@@ -11,7 +11,7 @@ import { isObject, isPlainObject } from '../../helpers/object';
 import { isFunction } from '../../helpers/function';
 import { arrayMap } from '../../helpers/array';
 import { BasePlugin } from '../base';
-import { IndexesSequence, PhysicalIndexToValueMap as IndexToValueMap } from '../../translations';
+import type { IndexesSequence, PhysicalIndexToValueMap as IndexToValueMap } from '../../translations';
 import { Hooks } from '../../core/hooks';
 import { ColumnStatesManager } from './columnStatesManager';
 import { EDITOR_EDIT_GROUP as SHORTCUTS_GROUP_EDITOR } from '../../shortcuts/contexts';
@@ -195,16 +195,19 @@ export class ColumnSorting extends BasePlugin {
     pluginConflictsState.set(this.hot, this.pluginKey);
 
     this.columnStatesManager = new ColumnStatesManager(this.hot, `${this.pluginKey}.sortingStates`);
-    this.columnMetaCache = new IndexToValueMap((physicalIndex: number) => {
-      let visualIndex: number = this.hot.toVisualColumn(physicalIndex);
+    this.columnMetaCache = this.hot.columnIndexMapper.createAndRegisterIndexMap(
+      `${this.pluginKey}.columnMeta`,
+      'physicalIndexToValue',
+      (physicalIndex: number) => {
+        let visualIndex: number = this.hot.toVisualColumn(physicalIndex);
 
-      if (visualIndex === null) {
-        visualIndex = physicalIndex;
-      }
+        if (visualIndex === null) {
+          visualIndex = physicalIndex;
+        }
 
-      return this.getMergedPluginSettings(visualIndex);
-    });
-    this.hot.columnIndexMapper.registerMap(`${this.pluginKey}.columnMeta`, this.columnMetaCache);
+        return this.getMergedPluginSettings(visualIndex);
+      },
+    );
 
     this.addHook('afterGetColHeader', this.#onAfterGetColHeader);
     this.addHook('beforeOnCellMouseDown', this.#onBeforeOnCellMouseDown);
@@ -348,7 +351,7 @@ export class ColumnSorting extends BasePlugin {
 
     if (currentSortConfig.length === 0 && this.indexesSequenceCache === null) {
       this.indexesSequenceCache =
-        this.hot.rowIndexMapper.registerMap(this.pluginKey, new IndexesSequence());
+        this.hot.rowIndexMapper.createAndRegisterIndexMap(this.pluginKey, 'indexesSequence');
       this.indexesSequenceCache.setValues(this.hot.rowIndexMapper.getIndexesSequence());
     }
 

--- a/handsontable/src/plugins/columnSorting/columnStatesManager.ts
+++ b/handsontable/src/plugins/columnSorting/columnStatesManager.ts
@@ -1,7 +1,6 @@
 import type { HotInstance } from '../../core/types';
 import { isObject, objectEach } from '../../helpers/object';
-import { LinkedPhysicalIndexToValueMap as IndexToValueMap } from '../../translations';
-import { isDefined } from '../../helpers/mixed';
+import type { LinkedPhysicalIndexToValueMap as IndexToValueMap } from '../../translations';
 
 const inheritedColumnProperties = ['sortEmptyCells', 'indicator', 'headerAction', 'compareFunctionFactory'];
 
@@ -27,7 +26,7 @@ export class ColumnStatesManager {
    *
    * @type {LinkedPhysicalIndexToValueMap}
    */
-  sortingStates = new IndexToValueMap();
+  sortingStates: IndexToValueMap;
   /**
    * Determines whether we should sort empty cells.
    *
@@ -63,7 +62,8 @@ export class ColumnStatesManager {
   constructor(hot: HotInstance, mapName: string) {
     this.hot = hot;
     this.mapName = mapName;
-    this.hot.columnIndexMapper.registerMap(mapName, this.sortingStates);
+    this.sortingStates = this.hot.columnIndexMapper
+      .createAndRegisterIndexMap(mapName, 'linkedPhysicalIndexToValue');
   }
 
   /**

--- a/handsontable/src/plugins/filters/component/_base.ts
+++ b/handsontable/src/plugins/filters/component/_base.ts
@@ -3,7 +3,6 @@ import { arrayEach } from '../../../helpers/array';
 import { throwWithCause } from '../../../helpers/errors';
 import { mixin } from '../../../helpers/object';
 import localHooks from '../../../mixins/localHooks';
-import { LinkedPhysicalIndexToValueMap as IndexToValueMap } from '../../../translations';
 
 /**
  * @private
@@ -54,7 +53,8 @@ export class BaseComponent {
     this.hot = hotInstance;
     this.id = id;
     this.stateId = `Filters.component.${this.id}`;
-    this.state = stateless ? null : this.hot.columnIndexMapper.registerMap(this.stateId, new IndexToValueMap());
+    this.state = stateless
+      ? null : this.hot.columnIndexMapper.createAndRegisterIndexMap(this.stateId, 'linkedPhysicalIndexToValue');
   }
 
   /**

--- a/handsontable/src/plugins/filters/conditionCollection.ts
+++ b/handsontable/src/plugins/filters/conditionCollection.ts
@@ -51,7 +51,7 @@ class ConditionCollection {
    *
    * @type {LinkedPhysicalIndexToValueMap}
    */
-  filteringStates = new IndexToValueMap();
+  filteringStates: IndexToValueMap;
 
   /**
    * Initializes the condition collection with the Handsontable instance, optionally registering the filtering states index map on the column index mapper.
@@ -61,9 +61,12 @@ class ConditionCollection {
     this.isMapRegistrable = isMapRegistrable;
 
     if (this.isMapRegistrable === true) {
-      this.hot.columnIndexMapper.registerMap(MAP_NAME, this.filteringStates);
+      this.filteringStates = this.hot.columnIndexMapper
+        .createAndRegisterIndexMap(MAP_NAME, 'linkedPhysicalIndexToValue');
 
     } else {
+      // A standalone (unregistered) map cannot go through the mapper factory.
+      this.filteringStates = new IndexToValueMap();
       this.filteringStates.init(this.hot.columnIndexMapper.getNumberOfIndexes());
     }
   }

--- a/handsontable/src/plugins/filters/filters.ts
+++ b/handsontable/src/plugins/filters/filters.ts
@@ -30,7 +30,7 @@ import {
   OPERATION_OR,
   OPERATION_OR_THEN_VARIABLE
 } from './constants';
-import { TrimmingMap } from '../../translations';
+import type { TrimmingMap } from '../../translations';
 import type { BaseComponent } from './component/_base';
 
 export type OperationType = 'conjunction' | 'disjunction' | 'disjunctionWithExtraCondition';
@@ -272,7 +272,7 @@ export class Filters extends BasePlugin {
 
     this.#isDataProviderActive = this.hot.runHooks('hasExternalDataSource') === true;
 
-    this.filtersRowsMap = this.hot.rowIndexMapper.registerMap(this.pluginName ?? '', new TrimmingMap()) as TrimmingMap;
+    this.filtersRowsMap = this.hot.rowIndexMapper.createAndRegisterIndexMap(this.pluginName ?? '', 'trimming');
     this.dropdownMenuPlugin = this.hot.getPlugin('dropdownMenu');
 
     const dropdownSettings = this.hot.getSettings().dropdownMenu;

--- a/handsontable/src/plugins/hiddenColumns/hiddenColumns.ts
+++ b/handsontable/src/plugins/hiddenColumns/hiddenColumns.ts
@@ -6,7 +6,7 @@ import { SEPARATOR } from '../contextMenu/predefinedItems';
 import { Hooks } from '../../core/hooks';
 import hideColumnItem from './contextMenuItem/hideColumn';
 import showColumnItem from './contextMenuItem/showColumn';
-import { HidingMap } from '../../translations';
+import type { HidingMap } from '../../translations';
 
 Hooks.getSingleton().register('beforeHideColumns');
 Hooks.getSingleton().register('afterHideColumns');
@@ -238,9 +238,14 @@ export class HiddenColumns extends BasePlugin {
       return;
     }
 
-    this.#hiddenColumnsMap = new HidingMap();
-    this.#hiddenColumnsMap!.addLocalHook('init', () => this.#onMapInit());
-    this.hot.columnIndexMapper.registerMap(this.pluginName ?? '', this.#hiddenColumnsMap);
+    this.#hiddenColumnsMap = this.hot.columnIndexMapper.createAndRegisterIndexMap(this.pluginName ?? '', 'hiding');
+    this.#hiddenColumnsMap.addLocalHook('init', () => this.#onMapInit());
+
+    // `createAndRegisterIndexMap` initializes the map synchronously when the dataset is already
+    // loaded (a plugin re-enable), before the hook above could attach - replay the init handler.
+    if (this.hot.columnIndexMapper.getNumberOfIndexes() > 0) {
+      this.#onMapInit();
+    }
 
     this.addHook('afterContextMenuDefaultOptions', this.#onAfterContextMenuDefaultOptions);
     this.addHook('afterGetCellMeta', this.#onAfterGetCellMeta);

--- a/handsontable/src/plugins/hiddenRows/hiddenRows.ts
+++ b/handsontable/src/plugins/hiddenRows/hiddenRows.ts
@@ -6,7 +6,7 @@ import { SEPARATOR } from '../contextMenu/predefinedItems';
 import { Hooks } from '../../core/hooks';
 import hideRowItem from './contextMenuItem/hideRow';
 import showRowItem from './contextMenuItem/showRow';
-import { HidingMap } from '../../translations';
+import type { HidingMap } from '../../translations';
 
 Hooks.getSingleton().register('beforeHideRows');
 Hooks.getSingleton().register('afterHideRows');
@@ -238,9 +238,14 @@ export class HiddenRows extends BasePlugin {
       return;
     }
 
-    this.#hiddenRowsMap = new HidingMap();
-    this.#hiddenRowsMap!.addLocalHook('init', () => this.#onMapInit());
-    this.hot.rowIndexMapper.registerMap(this.pluginName!, this.#hiddenRowsMap);
+    this.#hiddenRowsMap = this.hot.rowIndexMapper.createAndRegisterIndexMap(this.pluginName!, 'hiding');
+    this.#hiddenRowsMap.addLocalHook('init', () => this.#onMapInit());
+
+    // `createAndRegisterIndexMap` initializes the map synchronously when the dataset is already
+    // loaded (a plugin re-enable), before the hook above could attach - replay the init handler.
+    if (this.hot.rowIndexMapper.getNumberOfIndexes() > 0) {
+      this.#onMapInit();
+    }
 
     this.addHook('afterContextMenuDefaultOptions', this.#onAfterContextMenuDefaultOptions);
     this.addHook('afterGetCellMeta', this.#onAfterGetCellMeta);

--- a/handsontable/src/plugins/manualColumnResize/manualColumnResize.ts
+++ b/handsontable/src/plugins/manualColumnResize/manualColumnResize.ts
@@ -173,7 +173,7 @@ export class ManualColumnResize extends BasePlugin {
       return;
     }
 
-    this.#columnWidthsMap = new IndexToValueMap();
+    this.#columnWidthsMap = new IndexToValueMap(null, { skipUnchangedWrites: true });
     this.#columnWidthsMap.addLocalHook('init', () => this.#onMapInit());
     this.hot.columnIndexMapper.registerMap(this.pluginName!, this.#columnWidthsMap);
 

--- a/handsontable/src/plugins/manualColumnResize/manualColumnResize.ts
+++ b/handsontable/src/plugins/manualColumnResize/manualColumnResize.ts
@@ -14,7 +14,7 @@ import {
 import { arrayEach } from '../../helpers/array';
 import { rangeEach } from '../../helpers/number';
 import { deprecatedWarn } from '../../helpers/console';
-import { PhysicalIndexToValueMap as IndexToValueMap } from '../../translations';
+import type { PhysicalIndexToValueMap as IndexToValueMap } from '../../translations';
 import {
   getElementScaleFactor,
   normalizeVisualDelta,
@@ -173,9 +173,16 @@ export class ManualColumnResize extends BasePlugin {
       return;
     }
 
-    this.#columnWidthsMap = new IndexToValueMap(null, { skipUnchangedWrites: true });
+    this.#columnWidthsMap = this.hot.columnIndexMapper.createAndRegisterIndexMap(
+      this.pluginName!, 'physicalIndexToValue', null, { skipUnchangedWrites: true },
+    );
     this.#columnWidthsMap.addLocalHook('init', () => this.#onMapInit());
-    this.hot.columnIndexMapper.registerMap(this.pluginName!, this.#columnWidthsMap);
+
+    // `createAndRegisterIndexMap` initializes the map synchronously when the dataset is already
+    // loaded (a plugin re-enable), before the hook above could attach - replay the init handler.
+    if (this.hot.columnIndexMapper.getNumberOfIndexes() > 0) {
+      this.#onMapInit();
+    }
 
     this.#disposeMapObserver = this.hot.columnIndexMapper
       .observeMapChange(this.#columnWidthsMap, () => {

--- a/handsontable/src/plugins/manualRowResize/manualRowResize.ts
+++ b/handsontable/src/plugins/manualRowResize/manualRowResize.ts
@@ -14,7 +14,7 @@ import {
 import { arrayEach } from '../../helpers/array';
 import { rangeEach } from '../../helpers/number';
 import { deprecatedWarn } from '../../helpers/console';
-import { PhysicalIndexToValueMap as IndexToValueMap } from '../../translations';
+import type { PhysicalIndexToValueMap as IndexToValueMap } from '../../translations';
 import {
   getElementScaleFactor,
   normalizeVisualDelta,
@@ -168,9 +168,16 @@ export class ManualRowResize extends BasePlugin {
       return;
     }
 
-    this.#rowHeightsMap = new IndexToValueMap(null, { skipUnchangedWrites: true });
+    this.#rowHeightsMap = this.hot.rowIndexMapper.createAndRegisterIndexMap(
+      this.pluginName!, 'physicalIndexToValue', null, { skipUnchangedWrites: true },
+    );
     this.#rowHeightsMap.addLocalHook('init', () => this.#onMapInit());
-    this.hot.rowIndexMapper.registerMap(this.pluginName!, this.#rowHeightsMap);
+
+    // `createAndRegisterIndexMap` initializes the map synchronously when the dataset is already
+    // loaded (a plugin re-enable), before the hook above could attach - replay the init handler.
+    if (this.hot.rowIndexMapper.getNumberOfIndexes() > 0) {
+      this.#onMapInit();
+    }
 
     this.#disposeMapObserver = this.hot.rowIndexMapper
       .observeMapChange(this.#rowHeightsMap, () => {

--- a/handsontable/src/plugins/manualRowResize/manualRowResize.ts
+++ b/handsontable/src/plugins/manualRowResize/manualRowResize.ts
@@ -168,7 +168,7 @@ export class ManualRowResize extends BasePlugin {
       return;
     }
 
-    this.#rowHeightsMap = new IndexToValueMap();
+    this.#rowHeightsMap = new IndexToValueMap(null, { skipUnchangedWrites: true });
     this.#rowHeightsMap.addLocalHook('init', () => this.#onMapInit());
     this.hot.rowIndexMapper.registerMap(this.pluginName!, this.#rowHeightsMap);
 

--- a/handsontable/src/plugins/nestedRows/nestedRows.ts
+++ b/handsontable/src/plugins/nestedRows/nestedRows.ts
@@ -6,7 +6,7 @@ import HeadersUI from './ui/headers';
 import ContextMenuUI from './ui/contextMenu';
 import { isValidDataSource } from './utils/isValidDataSource';
 import { error } from '../../helpers/console';
-import { TrimmingMap } from '../../translations';
+import type { TrimmingMap } from '../../translations';
 import { EDITOR_EDIT_GROUP as SHORTCUTS_GROUP_EDITOR } from '../../shortcuts/contexts';
 import RowMoveController from './utils/rowMoveController';
 
@@ -121,7 +121,7 @@ export class NestedRows extends BasePlugin {
       return;
     }
 
-    this.collapsedRowsMap = this.hot.rowIndexMapper.registerMap('nestedRows', new TrimmingMap()) as TrimmingMap;
+    this.collapsedRowsMap = this.hot.rowIndexMapper.createAndRegisterIndexMap('nestedRows', 'trimming');
 
     this.dataManager = new DataManager(this, this.hot);
     this.collapsingUI = new CollapsingUI(this, this.hot);

--- a/handsontable/src/plugins/trimRows/trimRows.ts
+++ b/handsontable/src/plugins/trimRows/trimRows.ts
@@ -1,5 +1,5 @@
 import { BasePlugin } from '../base';
-import { TrimmingMap } from '../../translations';
+import type { TrimmingMap } from '../../translations';
 import { arrayEach, arrayReduce } from '../../helpers/array';
 
 export const PLUGIN_KEY = 'trimRows';
@@ -200,7 +200,7 @@ export class TrimRows extends BasePlugin {
       return;
     }
 
-    this.trimmedRowsMap = this.hot.rowIndexMapper.registerMap('trimRows', new TrimmingMap()) as TrimmingMap;
+    this.trimmedRowsMap = this.hot.rowIndexMapper.createAndRegisterIndexMap('trimRows', 'trimming');
     this.trimmedRowsMap!.addLocalHook('init', this.#onMapInit);
 
     super.enablePlugin();

--- a/handsontable/src/plugins/trimRows/trimRows.ts
+++ b/handsontable/src/plugins/trimRows/trimRows.ts
@@ -203,6 +203,12 @@ export class TrimRows extends BasePlugin {
     this.trimmedRowsMap = this.hot.rowIndexMapper.createAndRegisterIndexMap('trimRows', 'trimming');
     this.trimmedRowsMap!.addLocalHook('init', this.#onMapInit);
 
+    // `createAndRegisterIndexMap` initializes the map synchronously when the dataset is already
+    // loaded (a plugin re-enable), before the hook above could attach - replay the init handler.
+    if (this.hot.rowIndexMapper.getNumberOfIndexes() > 0) {
+      this.#onMapInit();
+    }
+
     super.enablePlugin();
   }
 

--- a/handsontable/src/tableView.ts
+++ b/handsontable/src/tableView.ts
@@ -1,6 +1,7 @@
 import type { HotInstance } from './core/types';
 import type { BaseRenderer } from './renderers/baseRenderer';
 import type { CellProperties } from './settings';
+import type { IndexMapper } from './translations';
 import type { WalkontableInstance } from './3rdparty/walkontable/src/types';
 import type { RowsCalculationType, ColumnsCalculationType } from './3rdparty/walkontable/src/calculator/viewportBase';
 import {
@@ -596,7 +597,7 @@ class TableView {
    *
    * @returns {number|*}
    */
-  countRenderableIndexes(indexMapper: import('./translations').IndexMapper, maxElements: number) {
+  countRenderableIndexes(indexMapper: IndexMapper, maxElements: number) {
     const consideredElements = Math.min(indexMapper.getNotTrimmedIndexesLength(), maxElements);
     // Don't take hidden indexes into account. We are looking just for renderable indexes.
     const firstNotHiddenIndex = indexMapper.getNearestNotHiddenIndex(consideredElements - 1, -1);
@@ -665,7 +666,7 @@ class TableView {
    */
   countNotHiddenIndexes(
     visualIndex: number, incrementBy: number,
-    indexMapper: import('./translations').IndexMapper, renderableIndexesCount: number
+    indexMapper: IndexMapper, renderableIndexesCount: number
   ) {
     if (isNaN(visualIndex) || visualIndex < 0) {
       return 0;

--- a/handsontable/src/translations/__tests__/indexMapper.unit.ts
+++ b/handsontable/src/translations/__tests__/indexMapper.unit.ts
@@ -2500,21 +2500,16 @@ describe('IndexMapper', () => {
 
       trimmingMap1.setValueAtIndex(0, false);
 
-      // Actions on the first collection. No real change. We rebuild cache anyway (`change` hook should be called?).
-      expect(notTrimmedIndexesCache).not.toBe(indexMapper.notTrimmedIndexesCache);
-      expect(notTrimmedIndexesCache).toEqual(indexMapper.notTrimmedIndexesCache);
-      expect(notHiddenIndexesCache).not.toBe(indexMapper.notHiddenIndexesCache);
-      expect(notHiddenIndexesCache).toEqual(indexMapper.notHiddenIndexesCache);
-      expect(flattenTrimmingResult).not.toBe(indexMapper.trimmingMapsCollection.mergedValuesCache);
-      expect(flattenTrimmingResult).toEqual(indexMapper.trimmingMapsCollection.mergedValuesCache);
-      expect(flattenHidingResult).not.toBe(indexMapper.hidingMapsCollection.mergedValuesCache);
-      expect(flattenHidingResult).toEqual(indexMapper.hidingMapsCollection.mergedValuesCache);
-      expect(renderablePhysicalIndexesCache).not.toBe(indexMapper.renderablePhysicalIndexesCache);
-      expect(renderablePhysicalIndexesCache).toEqual(indexMapper.renderablePhysicalIndexesCache);
+      // Actions on the first collection. No real change - the no-op write is skipped, so the caches stay valid.
+      expect(notTrimmedIndexesCache).toBe(indexMapper.notTrimmedIndexesCache);
+      expect(notHiddenIndexesCache).toBe(indexMapper.notHiddenIndexesCache);
+      expect(flattenTrimmingResult).toBe(indexMapper.trimmingMapsCollection.mergedValuesCache);
+      expect(flattenHidingResult).toBe(indexMapper.hidingMapsCollection.mergedValuesCache);
+      expect(renderablePhysicalIndexesCache).toBe(indexMapper.renderablePhysicalIndexesCache);
 
       expect(flattenTrimmingResult.length).toBe(10);
       expect(flattenHidingResult.length).toBe(0);
-      expect(cacheUpdatedCallback.calls.count()).toEqual(3);
+      expect(cacheUpdatedCallback.calls.count()).toEqual(2);
 
       notTrimmedIndexesCache = indexMapper.notTrimmedIndexesCache;
       notHiddenIndexesCache = indexMapper.notHiddenIndexesCache;
@@ -2532,7 +2527,7 @@ describe('IndexMapper', () => {
 
       expect(flattenTrimmingResult.length).toBe(10);
       expect(flattenHidingResult.length).toBe(0);
-      expect(cacheUpdatedCallback.calls.count()).toEqual(4);
+      expect(cacheUpdatedCallback.calls.count()).toEqual(3);
 
       notTrimmedIndexesCache = indexMapper.notTrimmedIndexesCache;
       notHiddenIndexesCache = indexMapper.notHiddenIndexesCache;
@@ -2541,6 +2536,37 @@ describe('IndexMapper', () => {
       renderablePhysicalIndexesCache = indexMapper.renderablePhysicalIndexesCache;
 
       trimmingMap1.setValueAtIndex(0, false);
+
+      expect(notTrimmedIndexesCache).not.toBe(indexMapper.notTrimmedIndexesCache);
+      expect(notHiddenIndexesCache).not.toBe(indexMapper.notHiddenIndexesCache);
+      expect(flattenTrimmingResult).not.toBe(indexMapper.trimmingMapsCollection.mergedValuesCache);
+      expect(flattenHidingResult).not.toBe(indexMapper.hidingMapsCollection.mergedValuesCache);
+      expect(renderablePhysicalIndexesCache).not.toBe(indexMapper.renderablePhysicalIndexesCache);
+
+      expect(flattenTrimmingResult.length).toBe(10);
+      expect(flattenHidingResult.length).toBe(0);
+      expect(cacheUpdatedCallback.calls.count()).toEqual(4);
+
+      notTrimmedIndexesCache = indexMapper.notTrimmedIndexesCache;
+      notHiddenIndexesCache = indexMapper.notHiddenIndexesCache;
+      flattenTrimmingResult = indexMapper.trimmingMapsCollection.mergedValuesCache;
+      flattenHidingResult = indexMapper.hidingMapsCollection.mergedValuesCache;
+      renderablePhysicalIndexesCache = indexMapper.renderablePhysicalIndexesCache;
+
+      trimmingMap2.setValueAtIndex(0, false);
+
+      // Actions on the second collection. No real change - the no-op write is skipped, so the caches stay valid.
+      expect(notTrimmedIndexesCache).toBe(indexMapper.notTrimmedIndexesCache);
+      expect(notHiddenIndexesCache).toBe(indexMapper.notHiddenIndexesCache);
+      expect(flattenTrimmingResult).toBe(indexMapper.trimmingMapsCollection.mergedValuesCache);
+      expect(flattenHidingResult).toBe(indexMapper.hidingMapsCollection.mergedValuesCache);
+      expect(renderablePhysicalIndexesCache).toBe(indexMapper.renderablePhysicalIndexesCache);
+
+      expect(flattenTrimmingResult.length).toBe(10);
+      expect(flattenHidingResult.length).toBe(0);
+      expect(cacheUpdatedCallback.calls.count()).toEqual(4);
+
+      trimmingMap2.setValueAtIndex(0, true);
 
       expect(notTrimmedIndexesCache).not.toBe(indexMapper.notTrimmedIndexesCache);
       expect(notHiddenIndexesCache).not.toBe(indexMapper.notHiddenIndexesCache);
@@ -2560,51 +2586,15 @@ describe('IndexMapper', () => {
 
       trimmingMap2.setValueAtIndex(0, false);
 
-      // Actions on the second collection. No real change.  We rebuild cache anyway (`change` hook should be called?).
       expect(notTrimmedIndexesCache).not.toBe(indexMapper.notTrimmedIndexesCache);
-      expect(notTrimmedIndexesCache).toEqual(indexMapper.notTrimmedIndexesCache);
       expect(notHiddenIndexesCache).not.toBe(indexMapper.notHiddenIndexesCache);
-      expect(notHiddenIndexesCache).toEqual(indexMapper.notHiddenIndexesCache);
       expect(flattenTrimmingResult).not.toBe(indexMapper.trimmingMapsCollection.mergedValuesCache);
-      expect(flattenTrimmingResult).toEqual(indexMapper.trimmingMapsCollection.mergedValuesCache);
       expect(flattenHidingResult).not.toBe(indexMapper.hidingMapsCollection.mergedValuesCache);
-      expect(flattenHidingResult).toEqual(indexMapper.hidingMapsCollection.mergedValuesCache);
       expect(renderablePhysicalIndexesCache).not.toBe(indexMapper.renderablePhysicalIndexesCache);
-      expect(renderablePhysicalIndexesCache).toEqual(indexMapper.renderablePhysicalIndexesCache);
 
       expect(flattenTrimmingResult.length).toBe(10);
       expect(flattenHidingResult.length).toBe(0);
       expect(cacheUpdatedCallback.calls.count()).toEqual(6);
-
-      trimmingMap2.setValueAtIndex(0, true);
-
-      expect(notTrimmedIndexesCache).not.toBe(indexMapper.notTrimmedIndexesCache);
-      expect(notHiddenIndexesCache).not.toBe(indexMapper.notHiddenIndexesCache);
-      expect(flattenTrimmingResult).not.toBe(indexMapper.trimmingMapsCollection.mergedValuesCache);
-      expect(flattenHidingResult).not.toBe(indexMapper.hidingMapsCollection.mergedValuesCache);
-      expect(renderablePhysicalIndexesCache).not.toBe(indexMapper.renderablePhysicalIndexesCache);
-
-      expect(flattenTrimmingResult.length).toBe(10);
-      expect(flattenHidingResult.length).toBe(0);
-      expect(cacheUpdatedCallback.calls.count()).toEqual(7);
-
-      notTrimmedIndexesCache = indexMapper.notTrimmedIndexesCache;
-      notHiddenIndexesCache = indexMapper.notHiddenIndexesCache;
-      flattenTrimmingResult = indexMapper.trimmingMapsCollection.mergedValuesCache;
-      flattenHidingResult = indexMapper.hidingMapsCollection.mergedValuesCache;
-      renderablePhysicalIndexesCache = indexMapper.renderablePhysicalIndexesCache;
-
-      trimmingMap2.setValueAtIndex(0, false);
-
-      expect(notTrimmedIndexesCache).not.toBe(indexMapper.notTrimmedIndexesCache);
-      expect(notHiddenIndexesCache).not.toBe(indexMapper.notHiddenIndexesCache);
-      expect(flattenTrimmingResult).not.toBe(indexMapper.trimmingMapsCollection.mergedValuesCache);
-      expect(flattenHidingResult).not.toBe(indexMapper.hidingMapsCollection.mergedValuesCache);
-      expect(renderablePhysicalIndexesCache).not.toBe(indexMapper.renderablePhysicalIndexesCache);
-
-      expect(flattenTrimmingResult.length).toBe(10);
-      expect(flattenHidingResult.length).toBe(0);
-      expect(cacheUpdatedCallback.calls.count()).toEqual(8);
     });
 
     it('should reset caches when any registered `HidingMap` is changed', () => {
@@ -2640,21 +2630,16 @@ describe('IndexMapper', () => {
 
       hidingMap1.setValueAtIndex(0, false);
 
-      // Actions on the first collection. No real change. We rebuild cache anyway (`change` hook should be called?).
-      expect(notTrimmedIndexesCache).not.toBe(indexMapper.notTrimmedIndexesCache);
-      expect(notTrimmedIndexesCache).toEqual(indexMapper.notTrimmedIndexesCache);
-      expect(notHiddenIndexesCache).not.toBe(indexMapper.notHiddenIndexesCache);
-      expect(notHiddenIndexesCache).toEqual(indexMapper.notHiddenIndexesCache);
-      expect(flattenTrimmingResult).not.toBe(indexMapper.trimmingMapsCollection.mergedValuesCache);
-      expect(flattenTrimmingResult).toEqual(indexMapper.trimmingMapsCollection.mergedValuesCache);
-      expect(flattenHidingResult).not.toBe(indexMapper.hidingMapsCollection.mergedValuesCache);
-      expect(flattenHidingResult).toEqual(indexMapper.hidingMapsCollection.mergedValuesCache);
-      expect(renderablePhysicalIndexesCache).not.toBe(indexMapper.renderablePhysicalIndexesCache);
-      expect(renderablePhysicalIndexesCache).toEqual(indexMapper.renderablePhysicalIndexesCache);
+      // Actions on the first collection. No real change - the no-op write is skipped, so the caches stay valid.
+      expect(notTrimmedIndexesCache).toBe(indexMapper.notTrimmedIndexesCache);
+      expect(notHiddenIndexesCache).toBe(indexMapper.notHiddenIndexesCache);
+      expect(flattenTrimmingResult).toBe(indexMapper.trimmingMapsCollection.mergedValuesCache);
+      expect(flattenHidingResult).toBe(indexMapper.hidingMapsCollection.mergedValuesCache);
+      expect(renderablePhysicalIndexesCache).toBe(indexMapper.renderablePhysicalIndexesCache);
 
       expect(flattenTrimmingResult.length).toBe(0);
       expect(flattenHidingResult.length).toBe(10);
-      expect(cacheUpdatedCallback.calls.count()).toEqual(3);
+      expect(cacheUpdatedCallback.calls.count()).toEqual(2);
 
       notTrimmedIndexesCache = indexMapper.notTrimmedIndexesCache;
       notHiddenIndexesCache = indexMapper.notHiddenIndexesCache;
@@ -2672,7 +2657,7 @@ describe('IndexMapper', () => {
 
       expect(flattenTrimmingResult.length).toBe(0);
       expect(flattenHidingResult.length).toBe(10);
-      expect(cacheUpdatedCallback.calls.count()).toEqual(4);
+      expect(cacheUpdatedCallback.calls.count()).toEqual(3);
 
       notTrimmedIndexesCache = indexMapper.notTrimmedIndexesCache;
       notHiddenIndexesCache = indexMapper.notHiddenIndexesCache;
@@ -2681,6 +2666,37 @@ describe('IndexMapper', () => {
       renderablePhysicalIndexesCache = indexMapper.renderablePhysicalIndexesCache;
 
       hidingMap1.setValueAtIndex(0, false);
+
+      expect(notTrimmedIndexesCache).not.toBe(indexMapper.notTrimmedIndexesCache);
+      expect(notHiddenIndexesCache).not.toBe(indexMapper.notHiddenIndexesCache);
+      expect(flattenTrimmingResult).not.toBe(indexMapper.trimmingMapsCollection.mergedValuesCache);
+      expect(flattenHidingResult).not.toBe(indexMapper.hidingMapsCollection.mergedValuesCache);
+      expect(renderablePhysicalIndexesCache).not.toBe(indexMapper.renderablePhysicalIndexesCache);
+
+      expect(flattenTrimmingResult.length).toBe(0);
+      expect(flattenHidingResult.length).toBe(10);
+      expect(cacheUpdatedCallback.calls.count()).toEqual(4);
+
+      notTrimmedIndexesCache = indexMapper.notTrimmedIndexesCache;
+      notHiddenIndexesCache = indexMapper.notHiddenIndexesCache;
+      flattenTrimmingResult = indexMapper.trimmingMapsCollection.mergedValuesCache;
+      flattenHidingResult = indexMapper.hidingMapsCollection.mergedValuesCache;
+      renderablePhysicalIndexesCache = indexMapper.renderablePhysicalIndexesCache;
+
+      hidingMap2.setValueAtIndex(0, false);
+
+      // Actions on the second collection. No real change - the no-op write is skipped, so the caches stay valid.
+      expect(notTrimmedIndexesCache).toBe(indexMapper.notTrimmedIndexesCache);
+      expect(notHiddenIndexesCache).toBe(indexMapper.notHiddenIndexesCache);
+      expect(flattenTrimmingResult).toBe(indexMapper.trimmingMapsCollection.mergedValuesCache);
+      expect(flattenHidingResult).toBe(indexMapper.hidingMapsCollection.mergedValuesCache);
+      expect(renderablePhysicalIndexesCache).toBe(indexMapper.renderablePhysicalIndexesCache);
+
+      expect(flattenTrimmingResult.length).toBe(0);
+      expect(flattenHidingResult.length).toBe(10);
+      expect(cacheUpdatedCallback.calls.count()).toEqual(4);
+
+      hidingMap2.setValueAtIndex(0, true);
 
       expect(notTrimmedIndexesCache).not.toBe(indexMapper.notTrimmedIndexesCache);
       expect(notHiddenIndexesCache).not.toBe(indexMapper.notHiddenIndexesCache);
@@ -2700,51 +2716,15 @@ describe('IndexMapper', () => {
 
       hidingMap2.setValueAtIndex(0, false);
 
-      // Actions on the second collection. No real change.  We rebuild cache anyway (`change` hook should be called?).
       expect(notTrimmedIndexesCache).not.toBe(indexMapper.notTrimmedIndexesCache);
-      expect(notTrimmedIndexesCache).toEqual(indexMapper.notTrimmedIndexesCache);
       expect(notHiddenIndexesCache).not.toBe(indexMapper.notHiddenIndexesCache);
-      expect(notHiddenIndexesCache).toEqual(indexMapper.notHiddenIndexesCache);
       expect(flattenTrimmingResult).not.toBe(indexMapper.trimmingMapsCollection.mergedValuesCache);
-      expect(flattenTrimmingResult).toEqual(indexMapper.trimmingMapsCollection.mergedValuesCache);
       expect(flattenHidingResult).not.toBe(indexMapper.hidingMapsCollection.mergedValuesCache);
-      expect(flattenHidingResult).toEqual(indexMapper.hidingMapsCollection.mergedValuesCache);
       expect(renderablePhysicalIndexesCache).not.toBe(indexMapper.renderablePhysicalIndexesCache);
-      expect(renderablePhysicalIndexesCache).toEqual(indexMapper.renderablePhysicalIndexesCache);
 
       expect(flattenTrimmingResult.length).toBe(0);
       expect(flattenHidingResult.length).toBe(10);
       expect(cacheUpdatedCallback.calls.count()).toEqual(6);
-
-      hidingMap2.setValueAtIndex(0, true);
-
-      expect(notTrimmedIndexesCache).not.toBe(indexMapper.notTrimmedIndexesCache);
-      expect(notHiddenIndexesCache).not.toBe(indexMapper.notHiddenIndexesCache);
-      expect(flattenTrimmingResult).not.toBe(indexMapper.trimmingMapsCollection.mergedValuesCache);
-      expect(flattenHidingResult).not.toBe(indexMapper.hidingMapsCollection.mergedValuesCache);
-      expect(renderablePhysicalIndexesCache).not.toBe(indexMapper.renderablePhysicalIndexesCache);
-
-      expect(flattenTrimmingResult.length).toBe(0);
-      expect(flattenHidingResult.length).toBe(10);
-      expect(cacheUpdatedCallback.calls.count()).toEqual(7);
-
-      notTrimmedIndexesCache = indexMapper.notTrimmedIndexesCache;
-      notHiddenIndexesCache = indexMapper.notHiddenIndexesCache;
-      flattenTrimmingResult = indexMapper.trimmingMapsCollection.mergedValuesCache;
-      flattenHidingResult = indexMapper.hidingMapsCollection.mergedValuesCache;
-      renderablePhysicalIndexesCache = indexMapper.renderablePhysicalIndexesCache;
-
-      hidingMap2.setValueAtIndex(0, false);
-
-      expect(notTrimmedIndexesCache).not.toBe(indexMapper.notTrimmedIndexesCache);
-      expect(notHiddenIndexesCache).not.toBe(indexMapper.notHiddenIndexesCache);
-      expect(flattenTrimmingResult).not.toBe(indexMapper.trimmingMapsCollection.mergedValuesCache);
-      expect(flattenHidingResult).not.toBe(indexMapper.hidingMapsCollection.mergedValuesCache);
-      expect(renderablePhysicalIndexesCache).not.toBe(indexMapper.renderablePhysicalIndexesCache);
-
-      expect(flattenTrimmingResult.length).toBe(0);
-      expect(flattenHidingResult.length).toBe(10);
-      expect(cacheUpdatedCallback.calls.count()).toEqual(8);
     });
 
     it('should not reset cache when any registered map inside various mappings collection is changed', () => {

--- a/handsontable/src/translations/__tests__/maps/IndexesSequence.unit.ts
+++ b/handsontable/src/translations/__tests__/maps/IndexesSequence.unit.ts
@@ -223,15 +223,22 @@ describe('IndexesSequence', () => {
       expect(changeCallback.calls.count()).toEqual(1);
     });
 
-    it('should trigger `change` hook on setting data which does not change value', () => {
+    it('should not trigger `change` hook on setting data which does not change value (skipUnchangedWrites)', () => {
       const indexesSequence = new IndexesSequence();
       const changeCallback = jasmine.createSpy('change');
 
       indexesSequence.init(10);
       indexesSequence.addLocalHook('change', changeCallback);
 
-      // Default value is `0` for index at position `0`. No real change, but hook is called anyway.
-      indexesSequence.setValueAtIndex(0, 0);
+      // Default value is `0` for index at position `0`. No real change, so the no-op write is
+      // skipped entirely - and the compact identity representation is preserved.
+      expect(indexesSequence.setValueAtIndex(0, 0)).toBe(true);
+
+      expect(changeCallback.calls.count()).toEqual(0);
+      expect(indexesSequence.getValues()).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+      // A genuine change still triggers the hook.
+      indexesSequence.setValueAtIndex(0, 5);
 
       expect(changeCallback.calls.count()).toEqual(1);
     });

--- a/handsontable/src/translations/__tests__/maps/hidingMap.unit.ts
+++ b/handsontable/src/translations/__tests__/maps/hidingMap.unit.ts
@@ -209,15 +209,25 @@ describe('HidingMap', () => {
       expect(changeCallback.calls.count()).toEqual(1);
     });
 
-    it('should trigger `change` hook on setting data which does not change value', () => {
+    it('should not trigger `change` hook on setting data which does not change value (skipUnchangedWrites)', () => {
       const hidingMap = new HidingMap();
       const changeCallback = jasmine.createSpy('change');
 
       hidingMap.init(10);
       hidingMap.addLocalHook('change', changeCallback);
 
-      // Default value is `false`. No real change, but hook is called anyway.
-      hidingMap.setValueAtIndex(0, false);
+      // Default value is `false`. No real change, so the no-op write is skipped entirely.
+      expect(hidingMap.setValueAtIndex(0, false)).toBe(true);
+
+      expect(changeCallback.calls.count()).toEqual(0);
+
+      // A genuine change still triggers the hook.
+      hidingMap.setValueAtIndex(0, true);
+
+      expect(changeCallback.calls.count()).toEqual(1);
+
+      // Re-writing the same non-default value is a no-op again.
+      hidingMap.setValueAtIndex(0, true);
 
       expect(changeCallback.calls.count()).toEqual(1);
     });

--- a/handsontable/src/translations/__tests__/maps/physicalIndexToValueMap.unit.ts
+++ b/handsontable/src/translations/__tests__/maps/physicalIndexToValueMap.unit.ts
@@ -154,4 +154,66 @@ describe('PhysicalIndexToValueMap', () => {
       expect(changeCallback.calls.count()).toEqual(1);
     });
   });
+
+  describe('`skipUnchangedWrites` option', () => {
+    it('should skip the write and the `change` hook when the set value is strictly equal to the stored one', () => {
+      const indexToValueMap = new IndexToValueMap(null, { skipUnchangedWrites: true });
+      const changeCallback = jasmine.createSpy('change');
+
+      indexToValueMap.init(3);
+      indexToValueMap.setValueAtIndex(1, 50);
+      indexToValueMap.addLocalHook('change', changeCallback);
+
+      expect(indexToValueMap.setValueAtIndex(1, 50)).toBe(true);
+      expect(changeCallback.calls.count()).toEqual(0);
+      expect(indexToValueMap.getValueAtIndex(1)).toEqual(50);
+    });
+
+    it('should write and trigger the `change` hook when the set value differs from the stored one', () => {
+      const indexToValueMap = new IndexToValueMap(null, { skipUnchangedWrites: true });
+      const changeCallback = jasmine.createSpy('change');
+
+      indexToValueMap.init(3);
+      indexToValueMap.setValueAtIndex(1, 50);
+      indexToValueMap.addLocalHook('change', changeCallback);
+
+      expect(indexToValueMap.setValueAtIndex(1, 51)).toBe(true);
+      expect(changeCallback.calls.count()).toEqual(1);
+      expect(indexToValueMap.getValueAtIndex(1)).toEqual(51);
+    });
+
+    it('should treat writing the initial value over an untouched index as unchanged', () => {
+      const indexToValueMap = new IndexToValueMap(null, { skipUnchangedWrites: true });
+      const changeCallback = jasmine.createSpy('change');
+
+      indexToValueMap.init(3);
+      indexToValueMap.addLocalHook('change', changeCallback);
+
+      expect(indexToValueMap.setValueAtIndex(2, null)).toBe(true);
+      expect(changeCallback.calls.count()).toEqual(0);
+    });
+
+    it('should keep returning `false` and not trigger the `change` hook for indexes beyond the map', () => {
+      const indexToValueMap = new IndexToValueMap(null, { skipUnchangedWrites: true });
+      const changeCallback = jasmine.createSpy('change');
+
+      indexToValueMap.init(3);
+      indexToValueMap.addLocalHook('change', changeCallback);
+
+      expect(indexToValueMap.setValueAtIndex(3, 50)).toBe(false);
+      expect(changeCallback.calls.count()).toEqual(0);
+    });
+
+    it('should keep the default behavior (write + `change` hook on equal values) when the option is off', () => {
+      const indexToValueMap = new IndexToValueMap();
+      const changeCallback = jasmine.createSpy('change');
+
+      indexToValueMap.init(3);
+      indexToValueMap.setValueAtIndex(1, 50);
+      indexToValueMap.addLocalHook('change', changeCallback);
+
+      expect(indexToValueMap.setValueAtIndex(1, 50)).toBe(true);
+      expect(changeCallback.calls.count()).toEqual(1);
+    });
+  });
 });

--- a/handsontable/src/translations/__tests__/maps/trimmingMap.unit.ts
+++ b/handsontable/src/translations/__tests__/maps/trimmingMap.unit.ts
@@ -115,15 +115,25 @@ describe('TrimmingMap', () => {
       expect(changeCallback.calls.count()).toEqual(1);
     });
 
-    it('should trigger `change` hook on setting data which does not change value', () => {
+    it('should not trigger `change` hook on setting data which does not change value (skipUnchangedWrites)', () => {
       const trimmingMap = new TrimmingMap();
       const changeCallback = jasmine.createSpy('change');
 
       trimmingMap.init(10);
       trimmingMap.addLocalHook('change', changeCallback);
 
-      // Default value is `false`. No real change, but hook is called anyway.
-      trimmingMap.setValueAtIndex(0, false);
+      // Default value is `false`. No real change, so the no-op write is skipped entirely.
+      expect(trimmingMap.setValueAtIndex(0, false)).toBe(true);
+
+      expect(changeCallback.calls.count()).toEqual(0);
+
+      // A genuine change still triggers the hook.
+      trimmingMap.setValueAtIndex(0, true);
+
+      expect(changeCallback.calls.count()).toEqual(1);
+
+      // Re-writing the same non-default value is a no-op again.
+      trimmingMap.setValueAtIndex(0, true);
 
       expect(changeCallback.calls.count()).toEqual(1);
     });

--- a/handsontable/src/translations/indexMapper.ts
+++ b/handsontable/src/translations/indexMapper.ts
@@ -7,7 +7,7 @@ import {
   IndexesSequence,
   TrimmingMap,
 } from './maps';
-import type { IndexMap } from './maps/indexMap';
+import type { IndexMap, IndexMapOptions } from './maps/indexMap';
 import type { LinkedPhysicalIndexToValueMap } from './maps/linkedPhysicalIndexToValueMap';
 import type { PhysicalIndexToValueMap } from './maps/physicalIndexToValueMap';
 import {
@@ -288,15 +288,20 @@ export class IndexMapper {
   createAndRegisterIndexMap(indexName: string, mapType: 'hiding', initValueOrFn?: unknown): HidingMap;
   /* eslint-disable jsdoc/require-jsdoc -- these overloads + the implementation share the JSDoc above */
   createAndRegisterIndexMap(indexName: string, mapType: 'trimming', initValueOrFn?: unknown): TrimmingMap;
+  createAndRegisterIndexMap(indexName: string, mapType: 'indexesSequence'): IndexesSequence;
   createAndRegisterIndexMap(
-    indexName: string, mapType: 'physicalIndexToValue', initValueOrFn?: unknown
+    indexName: string, mapType: 'physicalIndexToValue', initValueOrFn?: unknown, options?: IndexMapOptions
   ): PhysicalIndexToValueMap;
   createAndRegisterIndexMap(
     indexName: string, mapType: 'linkedPhysicalIndexToValue', initValueOrFn?: unknown
   ): LinkedPhysicalIndexToValueMap;
-  createAndRegisterIndexMap(indexName: string, mapType: string, initValueOrFn?: unknown): IndexMap;
-  createAndRegisterIndexMap(indexName: string, mapType: string, initValueOrFn?: unknown): IndexMap {
-    return this.registerMap(indexName, createIndexMap(mapType, initValueOrFn));
+  createAndRegisterIndexMap(
+    indexName: string, mapType: string, initValueOrFn?: unknown, options?: IndexMapOptions
+  ): IndexMap;
+  createAndRegisterIndexMap(
+    indexName: string, mapType: string, initValueOrFn?: unknown, options?: IndexMapOptions
+  ): IndexMap {
+    return this.registerMap(indexName, createIndexMap(mapType, initValueOrFn, options));
   }
   /* eslint-enable jsdoc/require-jsdoc */
 

--- a/handsontable/src/translations/maps/booleanMap.ts
+++ b/handsontable/src/translations/maps/booleanMap.ts
@@ -1,4 +1,4 @@
-import { IndexMap } from './indexMap';
+import { IndexMap, type IndexMapOptions } from './indexMap';
 
 /**
  * Map from a physical index to a boolean (hidden/trimmed flags).
@@ -54,8 +54,11 @@ export class BooleanMap extends IndexMap {
   /**
    * Initializes the boolean map with a default value or factory (defaults to `false`).
    */
-  constructor(initValueOrFn: boolean | ((index: number, ordinalNumber: number) => unknown) = false) {
-    super(initValueOrFn);
+  constructor(
+    initValueOrFn: boolean | ((index: number, ordinalNumber: number) => unknown) = false,
+    options: IndexMapOptions = {},
+  ) {
+    super(initValueOrFn, options);
     this.#defaultFn = typeof initValueOrFn === 'function' ? initValueOrFn : null;
     this.#defaultValue = initValueOrFn === true;
   }
@@ -167,12 +170,20 @@ export class BooleanMap extends IndexMap {
 
     if (this.#allDefault) {
       if (flag === this.#defaultValue) {
-        this.runLocalHooks('change');
+        // Writing the default into the compact (all-default) state is always a no-op for the
+        // stored data; with `skipUnchangedWrites` the `change` hook is skipped too.
+        if (!this.skipUnchangedWrites) {
+          this.runLocalHooks('change');
+        }
 
         return true;
       }
 
       this.#materialize();
+    }
+
+    if (this.skipUnchangedWrites && (this.#store as boolean[])[index] === flag) {
+      return true;
     }
 
     (this.#store as boolean[])[index] = flag;

--- a/handsontable/src/translations/maps/hidingMap.ts
+++ b/handsontable/src/translations/maps/hidingMap.ts
@@ -10,9 +10,12 @@ import { arrayReduce } from '../../helpers/array';
 export class HidingMap extends BooleanMap {
   /**
    * Initializes the hiding map with an optional default value, defaulting to `false` (not hidden).
+   *
+   * The map stores flags coerced to booleans, so a write of an unchanged flag is provably a no-op —
+   * `skipUnchangedWrites` is always on, keeping no-op writes from rebuilding the index caches.
    */
   constructor(initValueOrFn = false) {
-    super(initValueOrFn);
+    super(initValueOrFn, { skipUnchangedWrites: true });
   }
 
   /**

--- a/handsontable/src/translations/maps/index.ts
+++ b/handsontable/src/translations/maps/index.ts
@@ -1,5 +1,6 @@
 import { HidingMap } from './hidingMap';
-import { IndexMap } from './indexMap';
+import { IndexMap, type IndexMapOptions } from './indexMap';
+import { IndexesSequence } from './indexesSequence';
 import { LinkedPhysicalIndexToValueMap } from './linkedPhysicalIndexToValueMap';
 import { PhysicalIndexToValueMap } from './physicalIndexToValueMap';
 import { TrimmingMap } from './trimmingMap';
@@ -18,6 +19,7 @@ export {
 const availableIndexMapTypes = new Map<string, typeof IndexMap>([
   ['hiding', HidingMap],
   ['index', IndexMap],
+  ['indexesSequence', IndexesSequence],
   ['linkedPhysicalIndexToValue', LinkedPhysicalIndexToValueMap],
   ['physicalIndexToValue', PhysicalIndexToValueMap],
   ['trimming', TrimmingMap],
@@ -28,12 +30,15 @@ const availableIndexMapTypes = new Map<string, typeof IndexMap>([
  *
  * @param {string} mapType The type of the map.
  * @param {*} [initValueOrFn=null] Initial value or function for index map.
+ * @param {object} [options] Map behavior options (see {@link IndexMapOptions}), e.g.
+ *   `skipUnchangedWrites` for maps holding scalar values. The `hiding` and `trimming` types
+ *   enable that behavior themselves regardless of the passed options.
  * @returns {IndexMap}
  */
-export function createIndexMap(mapType: string, initValueOrFn: unknown = null) {
+export function createIndexMap(mapType: string, initValueOrFn: unknown = null, options: IndexMapOptions = {}) {
   if (!availableIndexMapTypes.has(mapType)) {
     throwWithCause(`The provided map type ("${mapType}") does not exist.`);
   }
 
-  return new (availableIndexMapTypes.get(mapType)!)(initValueOrFn);
+  return new (availableIndexMapTypes.get(mapType)!)(initValueOrFn, options);
 }

--- a/handsontable/src/translations/maps/indexMap.ts
+++ b/handsontable/src/translations/maps/indexMap.ts
@@ -3,6 +3,21 @@ import { isFunction } from '../../helpers/function';
 import localHooks from '../../mixins/localHooks';
 
 /**
+ * Configuration options for an {@link IndexMap}.
+ */
+export interface IndexMapOptions {
+  /**
+   * When `true`, `setValueAtIndex` treats a write of a strictly-equal (`===`) value as a no-op:
+   * nothing is stored and the `change` hook does not run. Opt in only for maps that hold scalar
+   * values (numbers, strings, booleans, `null`) — for maps holding objects, reference equality
+   * would swallow the change event of a caller that mutates the stored object and re-sets the
+   * same reference. The option is honored only by maps whose `setValueAtIndex` delegates to the
+   * `IndexMap` implementation.
+   */
+  skipUnchangedWrites?: boolean;
+}
+
+/**
  * Map for storing mappings from an index to a value.
  *
  * @class IndexMap
@@ -22,6 +37,13 @@ export class IndexMap {
    * @type {*}
    */
   initValueOrFn;
+  /**
+   * Whether `setValueAtIndex` skips the write and the `change` hook when the new value is
+   * strictly equal to the stored one. See {@link IndexMapOptions#skipUnchangedWrites}.
+   *
+   * @type {boolean}
+   */
+  readonly #skipUnchangedWrites: boolean;
 
   // Mixin declarations for localHooks (signature must match mixin for subclass assignability)
   /**
@@ -38,10 +60,23 @@ export class IndexMap {
   declare clearLocalHooks: () => void;
 
   /**
-   * Initializes the index map with an optional default value or factory function applied to each index.
+   * Initializes the index map with an optional default value or factory function applied to each
+   * index, and optional map behavior options.
    */
-  constructor(initValueOrFn: unknown = null) {
+  constructor(initValueOrFn: unknown = null, { skipUnchangedWrites = false }: IndexMapOptions = {}) {
     this.initValueOrFn = initValueOrFn;
+    this.#skipUnchangedWrites = skipUnchangedWrites;
+  }
+
+  /**
+   * Whether `setValueAtIndex` treats a write of a strictly-equal value as a no-op. Read-only;
+   * configured through the constructor. Exposed so subclasses that fully override
+   * `setValueAtIndex` (e.g. `BooleanMap`) can honor the same contract.
+   *
+   * @returns {boolean}
+   */
+  get skipUnchangedWrites(): boolean {
+    return this.#skipUnchangedWrites;
   }
 
   /**
@@ -95,6 +130,12 @@ export class IndexMap {
    */
   setValueAtIndex(index: number, value: unknown): boolean {
     if (index < this.indexedValues.length) {
+      // A no-op write on an opted-in scalar map: the postcondition already holds, so skip the
+      // store and the `change` hook (each `change` rebuilds consumer caches).
+      if (this.skipUnchangedWrites && this.indexedValues[index] === value) {
+        return true;
+      }
+
       this.indexedValues[index] = value;
 
       this.runLocalHooks('change');

--- a/handsontable/src/translations/maps/indexesSequence.ts
+++ b/handsontable/src/translations/maps/indexesSequence.ts
@@ -34,10 +34,14 @@ export class IndexesSequence extends IndexMap {
 
   /**
    * Initializes the sequence map with an identity function so each index maps to its own physical value.
+   *
+   * The sequence stores physical indexes (numbers), so a write of an unchanged index is provably a
+   * no-op — `skipUnchangedWrites` is always on, which also preserves the compact identity
+   * representation when an identity value is re-written.
    */
   constructor() {
     // Not handling custom init function or init value.
-    super((index: number) => index);
+    super((index: number) => index, { skipUnchangedWrites: true });
   }
 
   /**
@@ -114,6 +118,12 @@ export class IndexesSequence extends IndexMap {
    */
   setValueAtIndex(index: number, value: unknown): boolean {
     if (index < this.getLength()) {
+      // Check before materializing: re-writing the value the position already holds must not
+      // degrade the compact identity representation into a materialized array.
+      if (this.skipUnchangedWrites && this.getValueAtIndex(index) === value) {
+        return true;
+      }
+
       this.#materialize();
 
       return super.setValueAtIndex(index, value);

--- a/handsontable/src/translations/maps/trimmingMap.ts
+++ b/handsontable/src/translations/maps/trimmingMap.ts
@@ -10,9 +10,12 @@ import { arrayReduce } from '../../helpers/array';
 export class TrimmingMap extends BooleanMap {
   /**
    * Initializes the trimming map with an optional default value, defaulting to `false` (not trimmed).
+   *
+   * The map stores flags coerced to booleans, so a write of an unchanged flag is provably a no-op —
+   * `skipUnchangedWrites` is always on, keeping no-op writes from rebuilding the index caches.
    */
   constructor(initValueOrFn = false) {
-    super(initValueOrFn);
+    super(initValueOrFn, { skipUnchangedWrites: true });
   }
 
   /**


### PR DESCRIPTION
### Context

The PR adds a `skipUnchangedWrites` option to `IndexMap`: when enabled, `setValueAtIndex` with a strictly-equal (`===`) value is a no-op — nothing is stored and the `change` hook does not run. Every `change` event on a registered map invalidates consumer caches (an unbatched write triggers a full O(n) `IndexMapper` cache rebuild), so re-writing an unchanged value paid a large, avoidable cost.

The option is an **explicit opt-in**, not a base-class default, because reference equality is not a safe "unchanged" signal for object-valued maps: `LinkedPhysicalIndexToValueMap` consumers store mutable state objects (Filters' `filteringStates`, ColumnSorting's `sortingStates`) and the codebase mutates stored values by reference (`conditionCollection.ts`, "Add next condition ... (by reference)"). Those maps keep today's semantics.

Where it is enabled:

- **Always-on for value-enforced scalar classes** — their write path coerces values, so an unchanged write is provably a no-op:
  - `HidingMap`, `TrimmingMap` (flags coerced to booleans in `BooleanMap`),
  - `IndexesSequence` (physical indexes) — where the check runs before materialization, so re-writing an identity value also preserves the compact identity representation.
- **Per-instance for the numeric width/height maps**: AutoColumnSize `columnWidthsMap`, AutoRowSize `rowHeightsMap`, ManualColumnResize, ManualRowResize. For AutoColumnSize this stops every render of a wide grid from rebuilding the column-width position cache (each render re-measures visible columns and rewrote unchanged widths; each write's `change` event invalidated the cache — ~5 ms rebuild per render at 5,000 columns).

`IndexMapper.updateCache` is already dirty-flag aware, so a `batchExecution` whose writes were all skipped no longer rebuilds at `resumeOperations`.

Measured (200k rows; before = develop-equivalent, after = this PR; `demo-skipwrites-bench.html`):

| Scenario | before | after |
|---|---|---|
| 200 unbatched no-op `setValueAtIndex` on a registered `HidingMap` | 1.58 s (each write = full O(n) cache rebuild) | 0.2 ms 🟢  |
| `hideRows` repeat with the same 20k rows (batched no-ops) | 389 ms | 378 ms (the one batch rebuild skipped; the rest is per-row translation + render) |
| `trimRows` repeat with the same 10k rows | 363 ms | 353 ms |
| Sort / filter (bulk `setValues` paths — out of scope) | – | parity |

Correctness identical across bundles (hidden/trimmed/filtered counts match exactly).

With `autoRowSize: true` + default `autoColumnSize` (20k rows × 60 columns), where every render re-measures sizes through the ghost tables:

| Scenario | before | this PR | |
|---|---|---|---|
| `hot.render()` × 20 (median) | 96.0 ms | 91.5 ms | −4.7% 🟢 |
| Cell edit (commit → full render, median of 10) | 105.5 ms | 99.2 ms | −6.0% 🟢 |

The saving is the skipped invalidation tail; the dominant remaining cost is the ghost-table DOM re-measurement itself, which is out of scope here (follow-up candidate).

**Factory conversion.** `createIndexMap` / `createAndRegisterIndexMap` now accept `IndexMapOptions` (plus a new `'indexesSequence'` registry type), and 12 plugin call sites moved from imperative `new *Map()` + `registerMap()` to the factory (autoColumnSize, autoRowSize, manualColumnResize, manualRowResize, hiddenRows, hiddenColumns, trimRows, nestedRows, filters ×2, columnSorting ×2). Plugins that attach an `'init'` local hook replay the handler after factory registration, because `registerMap` initializes the map synchronously on a loaded grid (a plugin re-enable) — before the hook could attach. Still imperative by design: `conditionCollection`'s deliberately unregistered standalone map, `bindRowsWithHeaders`' custom `StrictBindsMap` (not a registry type), and the mapper's own internal `indexesSequence`.

Related: DEV-2079 / #13078 (stacked work in the same area; if #13078 merges first, its temporary AutoColumnSize call-site guard becomes redundant and this PR's map option replaces it — the guard hunk can be dropped in whichever lands second). Possible follow-ups: the same no-op detection for `setValues` (would cover the sorting/filtering bulk paths) and an options parameter for the `createAndRegisterIndexMap` factory (StretchColumns).

### How has this been tested?

- 5 new unit tests for the option contract in `physicalIndexToValueMap.unit.ts` (skip on equal value, write on different value, initial-value no-op, out-of-range unchanged, default-off behavior preserved).
- Updated the map-contract tests that documented the old behavior (each carried a "`change` hook should be called?" comment questioning it): `hidingMap.unit.ts`, `trimmingMap.unit.ts`, `IndexesSequence.unit.ts`, and the two `indexMapper.unit.ts` cache tests — no-op writes now assert the caches stay valid by reference.
- `npm run test:unit --prefix handsontable -- --testPathPattern=translations` — 230 passing.
- Targeted E2E over every map-consuming plugin (`hiddenRows|hiddenColumns|trimRows|pagination|collapsibleColumns|nestedRows|filters|columnSorting|manualColumnMove|manualRowMove|autoColumnSize|autoRowSize|manualColumnResize|manualRowResize`) — 2238 specs, 0 failures.
- Full unit suite and smoke E2E re-run after rebasing onto develop — green.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2080

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2080

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core index translation and many plugins; behavior change is intentional for scalar maps but linked object maps keep old semantics to avoid breaking in-place mutations.
> 
> **Overview**
> Adds **`skipUnchangedWrites`** on `IndexMap`: when enabled, `setValueAtIndex` with a `===`-equal value does not store and does not fire `change`, so `IndexMapper` caches are not rebuilt on no-op updates.
> 
> **Always on** for scalar/boolean maps (`HidingMap`, `TrimmingMap`, `IndexesSequence`) and in **`BooleanMap`** for compact all-default writes. **Opt-in** via `createAndRegisterIndexMap(..., { skipUnchangedWrites: true })` for auto/manual row and column size maps. **Not** enabled for `LinkedPhysicalIndexToValueMap` (object state mutated by reference).
> 
> Plugins that used `new *Map()` + `registerMap()` now use **`createAndRegisterIndexMap`** (new `'indexesSequence'` type). Hidden/trim/manual resize plugins **replay `#onMapInit`** when the grid is already loaded on re-enable, because factory registration can initialize the map before the `init` hook attaches.
> 
> Unit tests now expect no `change` and stable cache references on unchanged trimming/hiding writes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2554dcece13ebdd0727d0674a9e56f417d125454. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->