### PR TITLE
DEV-2073: Restrict Algolia search language to English to fix date/data ranking collision

### DIFF
--- a/docs/src/config/docsearch.ts
+++ b/docs/src/config/docsearch.ts
@@ -38,6 +38,16 @@ export default {
   appId: 'MMN6OTJMGX',
   apiKey: 'c2430302c91e0162df988d4b383c9d8b',
   indexName: 'handsontable',
+  // Restrict linguistic processing (plural matching) to English. Without
+  // this, Algolia applies plural dictionaries for all languages at once,
+  // and in Italian "date" is the plural of "data" -- so a query for "date"
+  // matched every "data" page with zero typos and ranked "Saving data" &co.
+  // above the date-related guides (DEV-2073). Set at query time so search
+  // is fixed even before the crawler's index-level settings are updated.
+  searchParameters: {
+    queryLanguages: ['en'],
+    ignorePlurals: ['en'],
+  },
   // Restricts search results to the framework of the current page. Read
   // fresh per query (not computed once) because the search widget persists
   // across Astro View Transitions (`transition:persist="docs-search"` in


### PR DESCRIPTION
### Context

The PR fixes Algolia doc search ranking "data" pages above "date" pages when searching for "date".

Root cause: the crawler's `ignorePlurals: true` setting had no language restriction, so Algolia applied plural dictionaries for every supported language. In Italian, "date" is the plural of "data", so the query "date" matched every "data" page (e.g. "Saving data", "Server-side data") with zero typos, tying every ranking criterion with the actual date-related guides and pushing them below "data" pages by position alone.

This PR adds a query-time `searchParameters` override in `docs/src/config/docsearch.ts` restricting `queryLanguages` and `ignorePlurals` to English, so the fix ships independently of the Algolia Crawler dashboard update (which restricts the same settings at index time).

### How has this been tested?

- Reproduced the bug and verified the fix directly against the production Algolia index (`handsontable`, app `MMN6OTJMGX`) using the existing public search-only API key, comparing `_rankingInfo` before/after the parameter change.
  - Before: query "date" -> top hits are "Server-side data", "Saving data", etc. (`nbTypos: 0`, tied ranking, "Date cell type" pushed down).
  - After (`queryLanguages: ['en']`, `ignorePlurals: ['en']`): top hits become "Moment.js-based date", "Date cell type", "Pikaday", "Flatpickr".
  - Sanity check: query "dates" (genuine English plural) still matches the same date pages, so plural matching for English is unaffected.
- `npx tsc --noEmit` in `docs/` passes with the new `searchParameters` field against `DocSearchClientOptions`.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2073

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2073

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only DocSearch config change; no auth, data, or product runtime impact.
> 
> **Overview**
> Fixes doc search ranking where queries for **"date"** surfaced **data**-themed pages (e.g. Saving data) above real date guides.
> 
> Adds **query-time** `searchParameters` on the DocSearch client in `docsearch.ts`: `queryLanguages` and `ignorePlurals` are limited to **English** so Algolia no longer treats Italian *date* (plural of *data*) as a zero-typo match on "data". English plural behavior (e.g. **"dates"**) stays the same. The override ships before matching crawler/index settings are updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d64bb51c1639ab6e416ffd08cf529c272dca5276. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->