### PR TITLE
DEV-2082: Make MergeCells scale with merge count, not grid or selection area

### DIFF
--- a/.changelogs/13083.json
+++ b/.changelogs/13083.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "public",
-  "title": "Improved the performance of merged-cell lookups so that scrolling and extending large selections with the keyboard stay fast when the MergeCells plugin is enabled.",
+  "title": "Improved the performance of the MergeCells plugin: scrolling, extending large selections, and moving the focus with the keyboard no longer slow down with the grid or selection size.",
   "type": "changed",
   "issueOrPR": 13083,
   "breaking": false,

--- a/.changelogs/13083.json
+++ b/.changelogs/13083.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Improved the performance of merged-cell lookups so that scrolling and extending large selections with the keyboard stay fast when the MergeCells plugin is enabled.",
+  "type": "changed",
+  "issueOrPR": 13083,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/mergeCells/__tests__/cellsCollection.unit.ts
+++ b/handsontable/src/plugins/mergeCells/__tests__/cellsCollection.unit.ts
@@ -564,6 +564,185 @@ describe('MergeCells', () => {
       });
     });
 
+    describe('`getWithinRange` method with partials', () => {
+      it('should return a merged cell overlapping the range partially only when `countPartials` is `true`', () => {
+        const mergedCellsCollection = new MergedCellsCollection({ hot: hotMock });
+
+        mergedCellsCollection.add({
+          row: 3,
+          col: 3,
+          rowspan: 4,
+          colspan: 4
+        });
+
+        const range = createCellRange(5, 5, 10, 10);
+
+        expect(mergedCellsCollection.getWithinRange(range, false)).toEqual([]);
+        expect(mergedCellsCollection.getWithinRange(range, true).length).toBe(1);
+        expect(mergedCellsCollection.getWithinRange(range, true)[0].row).toBe(3);
+      });
+
+      it('should return each merged cell exactly once, even when it spans multiple cells of the range', () => {
+        const mergedCellsCollection = new MergedCellsCollection({ hot: hotMock });
+
+        mergedCellsCollection.add({
+          row: 1,
+          col: 1,
+          rowspan: 5,
+          colspan: 5
+        });
+
+        const range = createCellRange(0, 0, 10, 10);
+
+        expect(mergedCellsCollection.getWithinRange(range, true).length).toBe(1);
+        expect(mergedCellsCollection.getWithinRange(range, false).length).toBe(1);
+      });
+
+      it('should return merged cells ordered by their first covered cell in row-major order, ' +
+        'regardless of the insertion order', () => {
+        const mergedCellsCollection = new MergedCellsCollection({ hot: hotMock });
+
+        mergedCellsCollection.add({ row: 20, col: 21, rowspan: 3, colspan: 4 });
+        mergedCellsCollection.add({ row: 0, col: 5, rowspan: 3, colspan: 4 });
+        mergedCellsCollection.add({ row: 0, col: 1, rowspan: 3, colspan: 4 });
+        mergedCellsCollection.add({ row: 10, col: 11, rowspan: 3, colspan: 4 });
+
+        const wantedCollections = mergedCellsCollection.getWithinRange(createCellRange(0, 0, 30, 30));
+
+        expect(wantedCollections.map(({ row, col }) => [row, col])).toEqual([
+          [0, 1], [0, 5], [10, 11], [20, 21],
+        ]);
+      });
+    });
+
+    describe('non-intersecting index lookups compared with the exhaustive cell-scan reference', () => {
+      /**
+       * The pre-optimization implementation: visits every cell of the range and gathers, per
+       * row/column line, the set of indexes the line's cells point at. Kept here as the source
+       * of truth the optimized implementation must agree with.
+       */
+      function referenceNonIntersectingIndexes(collection, range, axis, scanDirection) {
+        const indexes = new Map();
+        const from = scanDirection === 1 ? range.getTopStartCorner() : range.getBottomEndCorner();
+        const to = scanDirection === 1 ? range.getBottomEndCorner() : range.getTopStartCorner();
+
+        for (let row = from.row; scanDirection === 1 ? row <= to.row : row >= to.row; row += scanDirection) {
+          for (
+            let column = from.col;
+            scanDirection === 1 ? column <= to.col : column >= to.col;
+            column += scanDirection
+          ) {
+            const index = axis === 'row' ? row : column;
+            const mergedCell = collection.get(row, column);
+            let lastIndex = index;
+
+            if (mergedCell) {
+              lastIndex = scanDirection === 1 ? mergedCell[axis] + mergedCell[`${axis}span`] - 1 : mergedCell[axis];
+            }
+
+            if (!indexes.has(index)) {
+              indexes.set(index, new Set());
+            }
+
+            indexes.get(index).add(lastIndex);
+          }
+        }
+
+        return Array.from(
+          new Set(Array.from(indexes.entries())
+            .filter(([, set]) => set.size === 1)
+            .flatMap(([, set]) => Array.from(set)))
+        );
+      }
+
+      /**
+       * Replays the pre-optimization caller loop: the first emitted index at or past the
+       * provided visual index (in the scan direction) wins.
+       */
+      function referenceMostIndex(collection, range, axis, scanDirection, visualIndex) {
+        const indexes = referenceNonIntersectingIndexes(collection, range, axis, scanDirection);
+        let result = visualIndex;
+
+        for (let i = 0; i < indexes.length; i++) {
+          if (scanDirection === 1 ? indexes[i] >= visualIndex : indexes[i] <= visualIndex) {
+            result = indexes[i];
+            break;
+          }
+        }
+
+        return result;
+      }
+
+      /**
+       * Deterministic pseudo-random generator (Park-Miller), so failures are reproducible.
+       */
+      function createRandom(seed) {
+        let state = (seed % 2147483647) || 1;
+
+        return () => {
+          state = (state * 16807) % 2147483647;
+
+          return (state - 1) / 2147483646;
+        };
+      }
+
+      it('should agree with the reference implementation on randomized merge layouts', () => {
+        const random = createRandom(2026);
+        const randomInt = (min, max) => min + Math.floor(random() * (max - min + 1));
+
+        for (let round = 0; round < 30; round++) {
+          const mergedCellsCollection = new MergedCellsCollection({ hot: hotMock });
+
+          // Non-overlapping placement: one optional merge per 5x5 block of a 30x30 grid.
+          for (let blockRow = 0; blockRow < 6; blockRow++) {
+            for (let blockColumn = 0; blockColumn < 6; blockColumn++) {
+              if (random() < 0.4) {
+                const rowspan = randomInt(1, 5);
+                const colspan = randomInt(1, 5);
+
+                if (rowspan === 1 && colspan === 1) {
+                  continue;
+                }
+
+                mergedCellsCollection.add({
+                  row: (blockRow * 5) + randomInt(0, 5 - rowspan),
+                  col: (blockColumn * 5) + randomInt(0, 5 - colspan),
+                  rowspan,
+                  colspan,
+                });
+              }
+            }
+          }
+
+          for (let check = 0; check < 20; check++) {
+            const rowA = randomInt(0, 29);
+            const rowB = randomInt(0, 29);
+            const columnA = randomInt(0, 29);
+            const columnB = randomInt(0, 29);
+            const range = createCellRange(
+              Math.min(rowA, rowB), Math.min(columnA, columnB),
+              Math.max(rowA, rowB), Math.max(columnA, columnB)
+            );
+            const visualRow = randomInt(-2, 31);
+            const visualColumn = randomInt(-2, 31);
+            const context = `round ${round}, check ${check}, ` +
+              `range [${range.getTopStartCorner().row}, ${range.getTopStartCorner().col}, ` +
+              `${range.getBottomEndCorner().row}, ${range.getBottomEndCorner().col}], ` +
+              `visualRow ${visualRow}, visualColumn ${visualColumn}`;
+
+            expect({ context, value: mergedCellsCollection.getStartMostColumnIndex(range, visualColumn) })
+              .toEqual({ context, value: referenceMostIndex(mergedCellsCollection, range, 'col', -1, visualColumn) });
+            expect({ context, value: mergedCellsCollection.getEndMostColumnIndex(range, visualColumn) })
+              .toEqual({ context, value: referenceMostIndex(mergedCellsCollection, range, 'col', 1, visualColumn) });
+            expect({ context, value: mergedCellsCollection.getTopMostRowIndex(range, visualRow) })
+              .toEqual({ context, value: referenceMostIndex(mergedCellsCollection, range, 'row', -1, visualRow) });
+            expect({ context, value: mergedCellsCollection.getBottomMostRowIndex(range, visualRow) })
+              .toEqual({ context, value: referenceMostIndex(mergedCellsCollection, range, 'row', 1, visualRow) });
+          }
+        }
+      });
+    });
+
     describe('static `detectContiguousRuns` method', () => {
       it('should return an empty array for an empty input', () => {
         expect(MergedCellsCollection.detectContiguousRuns([])).toEqual([]);

--- a/handsontable/src/plugins/mergeCells/__tests__/focusOrder.unit.ts
+++ b/handsontable/src/plugins/mergeCells/__tests__/focusOrder.unit.ts
@@ -1,0 +1,397 @@
+import { FocusOrder } from '../focusOrder';
+
+describe('MergeCells', () => {
+  describe('FocusOrder', () => {
+    const GRID_SIZE = 30;
+
+    /**
+     * Creates a minimal IndexMapper mock backed by a set of hidden indexes.
+     */
+    function createMapperMock(hiddenIndexes) {
+      const hidden = new Set(hiddenIndexes);
+
+      return {
+        isHidden: index => hidden.has(index),
+        getNearestNotHiddenIndex: (fromIndex, direction) => {
+          for (let i = fromIndex; i >= 0 && i < GRID_SIZE; i += direction) {
+            if (!hidden.has(i)) {
+              return i;
+            }
+          }
+
+          return null;
+        },
+      };
+    }
+
+    /**
+     * Creates a minimal CellRange mock exposing only what FocusOrder consumes.
+     */
+    function createRangeMock(rowFrom, colFrom, rowTo, colTo, highlightRow, highlightCol) {
+      return {
+        getTopStartCorner: () => ({ row: rowFrom, col: colFrom }),
+        getBottomEndCorner: () => ({ row: rowTo, col: colTo }),
+        highlight: {
+          clone: () => ({
+            normalize: () => ({ row: highlightRow, col: highlightCol }),
+          }),
+        },
+      };
+    }
+
+    /**
+     * Builds a merged-cells getter from a list of merge rectangles.
+     */
+    function createMergedCellsGetter(merges) {
+      const matrix = new Map();
+
+      merges.forEach((merge) => {
+        for (let r = merge.row; r < merge.row + merge.rowspan; r++) {
+          if (!matrix.has(r)) {
+            matrix.set(r, new Map());
+          }
+
+          for (let c = merge.col; c < merge.col + merge.colspan; c++) {
+            matrix.get(r).set(c, merge);
+          }
+        }
+      });
+
+      return (row, column) => matrix.get(row)?.get(column) ?? false;
+    }
+
+    /**
+     * The pre-optimization algorithm: visits every cell of every selected range and materializes
+     * one node per visible non-merged cell plus one node per fully-contained merged cell. Kept
+     * here as the source of truth the lazy implementation must agree with.
+     */
+    function buildReferenceOrder(ranges, mergedCellsGetter, rowMapper, colMapper, orientation) {
+      const list = [];
+      let currentIndex = null;
+
+      ranges.forEach((range, selectionLayer) => {
+        const visited = new Set();
+        const topStart = range.getTopStartCorner();
+        const bottomEnd = range.getBottomEndCorner();
+        const highlight = range.highlight.clone().normalize();
+        const outerFrom = orientation === 'horizontal' ? topStart.row : topStart.col;
+        const outerTo = orientation === 'horizontal' ? bottomEnd.row : bottomEnd.col;
+        const innerFrom = orientation === 'horizontal' ? topStart.col : topStart.row;
+        const innerTo = orientation === 'horizontal' ? bottomEnd.col : bottomEnd.row;
+
+        for (let outer = outerFrom; outer <= outerTo; outer++) {
+          const outerMapper = orientation === 'horizontal' ? rowMapper : colMapper;
+
+          if (outerMapper.isHidden(outer)) {
+            continue; // eslint-disable-line no-continue
+          }
+
+          for (let inner = innerFrom; inner <= innerTo; inner++) {
+            const innerMapper = orientation === 'horizontal' ? colMapper : rowMapper;
+
+            if (innerMapper.isHidden(inner)) {
+              continue; // eslint-disable-line no-continue
+            }
+
+            const row = orientation === 'horizontal' ? outer : inner;
+            const column = orientation === 'horizontal' ? inner : outer;
+            const mergeParent = mergedCellsGetter(row, column);
+
+            if (mergeParent && visited.has(mergeParent)) {
+              continue; // eslint-disable-line no-continue
+            }
+
+            let node = { selectionLayer, colStart: column, colEnd: column, rowStart: row, rowEnd: row };
+
+            if (mergeParent) {
+              visited.add(mergeParent);
+
+              if (
+                mergeParent.row < topStart.row ||
+                mergeParent.row + mergeParent.rowspan - 1 > bottomEnd.row ||
+                mergeParent.col < topStart.col ||
+                mergeParent.col + mergeParent.colspan - 1 > bottomEnd.col
+              ) {
+                continue; // eslint-disable-line no-continue
+              }
+
+              node = {
+                selectionLayer,
+                colStart: mergeParent.col,
+                colEnd: mergeParent.col + mergeParent.colspan - 1,
+                rowStart: mergeParent.row,
+                rowEnd: mergeParent.row + mergeParent.rowspan - 1,
+              };
+            }
+
+            list.push(node);
+
+            if (
+              (row === highlight.row && column === highlight.col) ||
+              (mergeParent &&
+                highlight.row >= mergeParent.row &&
+                highlight.row <= mergeParent.row + mergeParent.rowspan - 1 &&
+                highlight.col >= mergeParent.col &&
+                highlight.col <= mergeParent.col + mergeParent.colspan - 1)
+            ) {
+              currentIndex = list.length - 1;
+            }
+          }
+        }
+      });
+
+      return { list, currentIndex };
+    }
+
+    /**
+     * Replays the pre-optimization `setActiveNode`: first node in list order that matches the
+     * layer and contains the point.
+     */
+    function referenceFindIndex(list, row, column, selectionLayerIndex) {
+      for (let i = 0; i < list.length; i++) {
+        const node = list[i];
+
+        if (
+          node.selectionLayer === selectionLayerIndex &&
+          row >= node.rowStart && row <= node.rowEnd &&
+          column >= node.colStart && column <= node.colEnd
+        ) {
+          return i;
+        }
+      }
+
+      return null;
+    }
+
+    /**
+     * Deterministic pseudo-random generator (Park-Miller), so failures are reproducible.
+     */
+    function createRandom(seed) {
+      let state = (seed % 2147483647) || 1;
+
+      return () => {
+        state = (state * 16807) % 2147483647;
+
+        return (state - 1) / 2147483646;
+      };
+    }
+
+    it('should walk a plain selection cell by cell in both orders', () => {
+      const rowMapper = createMapperMock([]);
+      const colMapper = createMapperMock([]);
+      const focusOrder = new FocusOrder({
+        mergedCellsGetter: createMergedCellsGetter([]),
+        rowIndexMapper: rowMapper,
+        columnIndexMapper: colMapper,
+      });
+
+      focusOrder.buildFocusOrder([createRangeMock(1, 1, 2, 2, 1, 1)]);
+
+      expect(focusOrder.getCurrentHorizontalNode())
+        .toEqual({ selectionLayer: 0, rowStart: 1, rowEnd: 1, colStart: 1, colEnd: 1 });
+      expect(focusOrder.getNextHorizontalNode())
+        .toEqual({ selectionLayer: 0, rowStart: 1, rowEnd: 1, colStart: 2, colEnd: 2 });
+      expect(focusOrder.getNextVerticalNode())
+        .toEqual({ selectionLayer: 0, rowStart: 2, rowEnd: 2, colStart: 1, colEnd: 1 });
+      expect(focusOrder.getPrevHorizontalNode())
+        .toEqual({ selectionLayer: 0, rowStart: 2, rowEnd: 2, colStart: 2, colEnd: 2 });
+      expect(focusOrder.getFirstHorizontalNode())
+        .toEqual({ selectionLayer: 0, rowStart: 1, rowEnd: 1, colStart: 1, colEnd: 1 });
+    });
+
+    it('should merge a fully-contained merged cell into a single focus stop', () => {
+      const merge = { row: 1, col: 1, rowspan: 2, colspan: 2 };
+      const focusOrder = new FocusOrder({
+        mergedCellsGetter: createMergedCellsGetter([merge]),
+        rowIndexMapper: createMapperMock([]),
+        columnIndexMapper: createMapperMock([]),
+      });
+
+      focusOrder.buildFocusOrder([createRangeMock(0, 0, 3, 3, 0, 0)]);
+
+      // walk the first row: (0,0) -> (0,1) -> (0,2) -> (0,3) -> merge (anchored at 1,1 after 1,0)
+      focusOrder.setNextNodeAsActive(); // -> (0,1) horizontally
+      expect(focusOrder.getCurrentHorizontalNode())
+        .toEqual({ selectionLayer: 0, rowStart: 0, rowEnd: 0, colStart: 1, colEnd: 1 });
+
+      focusOrder.setActiveNode(1, 0, 0);
+      expect(focusOrder.getNextHorizontalNode())
+        .toEqual({ selectionLayer: 0, rowStart: 1, rowEnd: 2, colStart: 1, colEnd: 2 });
+
+      // the merged cell occupies one stop; the next one after it is (1,3)
+      focusOrder.setNextNodeAsActive();
+      expect(focusOrder.getNextHorizontalNode())
+        .toEqual({ selectionLayer: 0, rowStart: 1, rowEnd: 1, colStart: 3, colEnd: 3 });
+    });
+
+    it('should produce no focus stop for a merged cell that sticks out of the selection', () => {
+      const merge = { row: 0, col: 0, rowspan: 3, colspan: 3 };
+      const focusOrder = new FocusOrder({
+        mergedCellsGetter: createMergedCellsGetter([merge]),
+        rowIndexMapper: createMapperMock([]),
+        columnIndexMapper: createMapperMock([]),
+      });
+
+      // the selection covers only part of the merge
+      focusOrder.buildFocusOrder([createRangeMock(1, 1, 3, 3, 3, 3)]);
+
+      // walking backward from (3,3) skips all cells of the partially-contained merge
+      expect(focusOrder.getPrevHorizontalNode())
+        .toEqual({ selectionLayer: 0, rowStart: 3, rowEnd: 3, colStart: 2, colEnd: 2 });
+
+      focusOrder.setActiveNode(3, 1, 0);
+      // previous in horizontal order: skips (2,2), (2,1) (merge body) and lands on (2,3)
+      expect(focusOrder.getPrevHorizontalNode())
+        .toEqual({ selectionLayer: 0, rowStart: 2, rowEnd: 2, colStart: 3, colEnd: 3 });
+    });
+
+    it('should agree with the reference implementation on randomized layouts', () => {
+      const random = createRandom(1984);
+      const randomInt = (min, max) => min + Math.floor(random() * (max - min + 1));
+
+      for (let round = 0; round < 40; round++) {
+        // non-overlapping placement: one optional merge per 5x5 block of the 30x30 grid
+        const merges = [];
+
+        for (let blockRow = 0; blockRow < 6; blockRow++) {
+          for (let blockColumn = 0; blockColumn < 6; blockColumn++) {
+            if (random() < 0.4) {
+              const rowspan = randomInt(1, 5);
+              const colspan = randomInt(1, 5);
+
+              if (rowspan === 1 && colspan === 1) {
+                continue; // eslint-disable-line no-continue
+              }
+
+              merges.push({
+                row: (blockRow * 5) + randomInt(0, 5 - rowspan),
+                col: (blockColumn * 5) + randomInt(0, 5 - colspan),
+                rowspan,
+                colspan,
+              });
+            }
+          }
+        }
+
+        const hiddenRows = new Set();
+        const hiddenColumns = new Set();
+
+        for (let i = randomInt(0, 3); i > 0; i--) {
+          hiddenRows.add(randomInt(0, GRID_SIZE - 1));
+        }
+        for (let i = randomInt(0, 3); i > 0; i--) {
+          hiddenColumns.add(randomInt(0, GRID_SIZE - 1));
+        }
+
+        const ranges = [];
+
+        for (let i = randomInt(1, 3); i > 0; i--) {
+          const rowA = randomInt(0, GRID_SIZE - 1);
+          const rowB = randomInt(0, GRID_SIZE - 1);
+          const colA = randomInt(0, GRID_SIZE - 1);
+          const colB = randomInt(0, GRID_SIZE - 1);
+          const rowFrom = Math.min(rowA, rowB);
+          const rowTo = Math.max(rowA, rowB);
+          const colFrom = Math.min(colA, colB);
+          const colTo = Math.max(colA, colB);
+
+          ranges.push(createRangeMock(
+            rowFrom, colFrom, rowTo, colTo,
+            randomInt(rowFrom, rowTo), randomInt(colFrom, colTo)
+          ));
+        }
+
+        const rowMapper = createMapperMock(hiddenRows);
+        const colMapper = createMapperMock(hiddenColumns);
+        const mergedCellsGetter = createMergedCellsGetter(merges);
+        const focusOrder = new FocusOrder({
+          mergedCellsGetter,
+          rowIndexMapper: rowMapper,
+          columnIndexMapper: colMapper,
+        });
+
+        focusOrder.buildFocusOrder(ranges);
+
+        const refH = buildReferenceOrder(ranges, mergedCellsGetter, rowMapper, colMapper, 'horizontal');
+        const refV = buildReferenceOrder(ranges, mergedCellsGetter, rowMapper, colMapper, 'vertical');
+        const context = `round ${round}`;
+
+        expect({ context, value: focusOrder.getFirstHorizontalNode() })
+          .toEqual({ context, value: refH.list[0] });
+        expect({ context, value: focusOrder.getFirstVerticalNode() })
+          .toEqual({ context, value: refV.list[0] });
+        expect({ context, value: focusOrder.getCurrentHorizontalNode() })
+          .toEqual({ context, value: refH.currentIndex === null ? undefined : refH.list[refH.currentIndex] });
+        expect({ context, value: focusOrder.getCurrentVerticalNode() })
+          .toEqual({ context, value: refV.currentIndex === null ? undefined : refV.list[refV.currentIndex] });
+
+        if (refH.currentIndex === null || refV.currentIndex === null) {
+          continue; // eslint-disable-line no-continue
+        }
+
+        // walk forward through the whole circular order and one step beyond
+        let hIndex = refH.currentIndex;
+        let vIndex = refV.currentIndex;
+        const steps = Math.min(refH.list.length + 2, 40);
+
+        for (let step = 0; step < steps; step++) {
+          const stepContext = `${context}, forward step ${step}`;
+
+          expect({ context: stepContext, value: focusOrder.getNextHorizontalNode() })
+            .toEqual({ context: stepContext, value: refH.list[(hIndex + 1) % refH.list.length] });
+          expect({ context: stepContext, value: focusOrder.getPrevHorizontalNode() })
+            .toEqual({
+              context: stepContext,
+              value: refH.list[(hIndex - 1 + refH.list.length) % refH.list.length],
+            });
+          expect({ context: stepContext, value: focusOrder.getNextVerticalNode() })
+            .toEqual({ context: stepContext, value: refV.list[(vIndex + 1) % refV.list.length] });
+          expect({ context: stepContext, value: focusOrder.getPrevVerticalNode() })
+            .toEqual({
+              context: stepContext,
+              value: refV.list[(vIndex - 1 + refV.list.length) % refV.list.length],
+            });
+
+          if (random() < 0.5) {
+            focusOrder.setNextNodeAsActive();
+            hIndex = (hIndex + 1) % refH.list.length;
+            vIndex = (vIndex + 1) % refV.list.length;
+          } else {
+            focusOrder.setPrevNodeAsActive();
+            hIndex = (hIndex - 1 + refH.list.length) % refH.list.length;
+            vIndex = (vIndex - 1 + refV.list.length) % refV.list.length;
+          }
+
+          expect({ context: stepContext, value: focusOrder.getCurrentHorizontalNode() })
+            .toEqual({ context: stepContext, value: refH.list[hIndex] });
+          expect({ context: stepContext, value: focusOrder.getCurrentVerticalNode() })
+            .toEqual({ context: stepContext, value: refV.list[vIndex] });
+        }
+
+        // randomized setActiveNode round-trips
+        for (let check = 0; check < 10; check++) {
+          const row = randomInt(0, GRID_SIZE - 1);
+          const column = randomInt(0, GRID_SIZE - 1);
+          const layer = randomInt(0, ranges.length - 1);
+          const foundH = referenceFindIndex(refH.list, row, column, layer);
+          const foundV = referenceFindIndex(refV.list, row, column, layer);
+          const checkContext = `${context}, setActiveNode(${row}, ${column}, ${layer})`;
+
+          focusOrder.setActiveNode(row, column, layer);
+
+          if (foundH !== null) {
+            hIndex = foundH;
+          }
+          if (foundV !== null) {
+            vIndex = foundV;
+          }
+
+          expect({ context: checkContext, value: focusOrder.getCurrentHorizontalNode() })
+            .toEqual({ context: checkContext, value: refH.list[hIndex] });
+          expect({ context: checkContext, value: focusOrder.getCurrentVerticalNode() })
+            .toEqual({ context: checkContext, value: refV.list[vIndex] });
+        }
+      }
+    });
+  });
+});

--- a/handsontable/src/plugins/mergeCells/cellsCollection.ts
+++ b/handsontable/src/plugins/mergeCells/cellsCollection.ts
@@ -165,11 +165,13 @@ class MergedCellsCollection {
   }
 
   /**
-   * Get a merged cell contained in the provided range.
+   * Get the merged cells contained in the provided range. Each merged cell is returned once, even
+   * when it spans multiple cells of the range. The cost scales with the number of merged cells in
+   * the collection, not with the area of the range.
    *
    * @param {CellRange} range The range to search merged cells in.
    * @param {boolean} [countPartials=false] If set to `true`, all the merged cells overlapping the range will be taken into calculation.
-   * @returns {MergedCellCoords[]} Array of found merged cells.
+   * @returns {MergedCellCoords[]} Array of found merged cells, ordered by their first covered cell in row-major order.
    */
   getWithinRange(range: CellRange, countPartials = false) {
     const { row: rowStart, col: columnStart } = range.getTopStartCorner();
@@ -179,20 +181,29 @@ class MergedCellsCollection {
       return [];
     }
 
-    const result = [];
+    const result: MergedCellCoords[] = [];
 
-    for (let row = rowStart; row <= rowEnd; row++) {
-      for (let column = columnStart; column <= columnEnd; column++) {
-        const mergedCell = this.get(row, column);
+    for (let i = 0; i < this.mergedCells.length; i++) {
+      const mergedCell = this.mergedCells[i];
+      const { row, col, rowspan, colspan } = mergedCell;
+      const isWithin = countPartials
+        ? row <= rowEnd && row + rowspan - 1 >= rowStart &&
+          col <= columnEnd && col + colspan - 1 >= columnStart
+        : row >= rowStart && row <= rowEnd && col >= columnStart && col <= columnEnd;
 
-        if (
-          mergedCell &&
-          (countPartials ||
-          !countPartials && mergedCell.row === row && mergedCell.col === column)
-        ) {
-          result.push(mergedCell);
-        }
+      // The lookup matrix is the authority on visibility: merges whose whole visible span is
+      // hidden are purged from the matrix while staying in the `mergedCells` list, and their
+      // visual coordinates may be stale.
+      if (isWithin && this.get(row, col) === mergedCell) {
+        result.push(mergedCell);
       }
+    }
+
+    if (result.length > 1) {
+      result.sort((cellA, cellB) => {
+        return (Math.max(cellA.row, rowStart) - Math.max(cellB.row, rowStart)) ||
+          (Math.max(cellA.col, columnStart) - Math.max(cellB.col, columnStart));
+      });
     }
 
     return result;
@@ -368,17 +379,7 @@ class MergedCellsCollection {
    * @returns {number}
    */
   getStartMostColumnIndex(range: CellRange, visualColumnIndex: number) {
-    const indexes = this.#getNonIntersectingIndexes(range, 'col', -1);
-    let startMostIndex = visualColumnIndex;
-
-    for (let i = 0; i < indexes.length; i++) {
-      if (indexes[i] <= visualColumnIndex) {
-        startMostIndex = indexes[i];
-        break;
-      }
-    }
-
-    return startMostIndex;
+    return this.#findNonIntersectingIndex(range, 'col', -1, visualColumnIndex);
   }
 
   /**
@@ -389,17 +390,7 @@ class MergedCellsCollection {
    * @returns {number}
    */
   getEndMostColumnIndex(range: CellRange, visualColumnIndex: number) {
-    const indexes = this.#getNonIntersectingIndexes(range, 'col', 1);
-    let endMostIndex = visualColumnIndex;
-
-    for (let i = 0; i < indexes.length; i++) {
-      if (indexes[i] >= visualColumnIndex) {
-        endMostIndex = indexes[i];
-        break;
-      }
-    }
-
-    return endMostIndex;
+    return this.#findNonIntersectingIndex(range, 'col', 1, visualColumnIndex);
   }
 
   /**
@@ -410,17 +401,7 @@ class MergedCellsCollection {
    * @returns {number}
    */
   getTopMostRowIndex(range: CellRange, visualRowIndex: number) {
-    const indexes = this.#getNonIntersectingIndexes(range, 'row', -1);
-    let topMostIndex = visualRowIndex;
-
-    for (let i = 0; i < indexes.length; i++) {
-      if (indexes[i] <= visualRowIndex) {
-        topMostIndex = indexes[i];
-        break;
-      }
-    }
-
-    return topMostIndex;
+    return this.#findNonIntersectingIndex(range, 'row', -1, visualRowIndex);
   }
 
   /**
@@ -431,67 +412,150 @@ class MergedCellsCollection {
    * @returns {number}
    */
   getBottomMostRowIndex(range: CellRange, visualRowIndex: number) {
-    const indexes = this.#getNonIntersectingIndexes(range, 'row', 1);
-    let bottomMostIndex = visualRowIndex;
-
-    for (let i = 0; i < indexes.length; i++) {
-      if (indexes[i] >= visualRowIndex) {
-        bottomMostIndex = indexes[i];
-        break;
-      }
-    }
-
-    return bottomMostIndex;
+    return this.#findNonIntersectingIndex(range, 'row', 1, visualRowIndex);
   }
 
   /**
-   * Gets the list of the indexes that do not intersect with other merged cells within the provided range.
+   * Collects, per range line along the provided axis, the contributions of the merged cells that
+   * intersect the provided range. A line is a single row (for the `row` axis) or a single column
+   * (for the `col` axis) of the range. Each merged cell contributes, to every line it covers, its
+   * scan extent along the axis (the last covered index when scanning forward, the first when
+   * scanning backward) and the number of range cells it covers within the line. Lines without any
+   * merged cell are absent from the returned map. Only merged cells present in the lookup matrix
+   * are considered — merges purged from the matrix (fully hidden) are skipped.
    *
    * @param {CellRange} range The range to search within.
    * @param {'row' | 'col'} axis The axis to search within.
-   * @param {number} scanDirection  The direction to scan the range. `1` for forward, `-1` for backward.
-   * @returns {number[]}
+   * @param {number} scanDirection The direction to scan the range. `1` for forward, `-1` for backward.
+   * @returns {Map<number, { extents: Set<number>, coveredCells: number }>} Map keyed by the line index.
    */
-  #getNonIntersectingIndexes(range: CellRange, axis: 'row' | 'col', scanDirection = 1) {
-    const indexes = new Map<number, Set<number>>();
-    const from = scanDirection === 1 ? range.getTopStartCorner() : range.getBottomEndCorner();
-    const to = scanDirection === 1 ? range.getBottomEndCorner() : range.getTopStartCorner();
-    const fromRow = from.row ?? 0;
-    const fromCol = from.col ?? 0;
-    const toRow = to.row ?? 0;
-    const toCol = to.col ?? 0;
+  #collectLineContributions(range: CellRange, axis: 'row' | 'col', scanDirection: number) {
+    const { row: rangeStartRow, col: rangeStartColumn } = range.getTopStartCorner();
+    const { row: rangeEndRow, col: rangeEndColumn } = range.getBottomEndCorner();
+    const startRow = rangeStartRow ?? 0;
+    const startColumn = rangeStartColumn ?? 0;
+    const endRow = rangeEndRow ?? 0;
+    const endColumn = rangeEndColumn ?? 0;
+    const isRowAxis = axis === 'row';
+    const lineStart = isRowAxis ? startRow : startColumn;
+    const lineEnd = isRowAxis ? endRow : endColumn;
+    const crossStart = isRowAxis ? startColumn : startRow;
+    const crossEnd = isRowAxis ? endColumn : endRow;
+    const lines = new Map<number, { extents: Set<number>, coveredCells: number }>();
 
-    for (
-      let row = fromRow;
-      scanDirection === 1 ? row <= toRow : row >= toRow;
-      row += scanDirection
-    ) {
-      for (
-        let column = fromCol;
-        scanDirection === 1 ? column <= toCol : column >= toCol;
-        column += scanDirection
+    for (let i = 0; i < this.mergedCells.length; i++) {
+      const mergedCell = this.mergedCells[i];
+      const mergeLineStart = isRowAxis ? mergedCell.row : mergedCell.col;
+      const mergeLineEnd = mergeLineStart + (isRowAxis ? mergedCell.rowspan : mergedCell.colspan) - 1;
+      const mergeCrossStart = isRowAxis ? mergedCell.col : mergedCell.row;
+      const mergeCrossEnd = mergeCrossStart + (isRowAxis ? mergedCell.colspan : mergedCell.rowspan) - 1;
+
+      if (
+        mergeLineEnd < lineStart || mergeLineStart > lineEnd ||
+        mergeCrossEnd < crossStart || mergeCrossStart > crossEnd ||
+        // The lookup matrix is the authority on visibility: merges purged from the matrix
+        // (fully hidden) keep stale visual coordinates in the `mergedCells` list.
+        this.get(mergedCell.row, mergedCell.col) !== mergedCell
       ) {
-        const index = axis === 'row' ? row : column;
-        const mergedCell = this.get(row, column);
-        let lastIndex = index;
+        continue;
+      }
 
-        if (mergedCell) {
-          lastIndex = scanDirection === 1 ? mergedCell[axis] + mergedCell[`${axis}span`] - 1 : mergedCell[axis];
+      const extent = scanDirection === 1 ? mergeLineEnd : mergeLineStart;
+      const coveredCells = Math.min(mergeCrossEnd, crossEnd) - Math.max(mergeCrossStart, crossStart) + 1;
+      const firstLine = Math.max(mergeLineStart, lineStart);
+      const lastLine = Math.min(mergeLineEnd, lineEnd);
+
+      for (let line = firstLine; line <= lastLine; line++) {
+        let entry = lines.get(line);
+
+        if (!entry) {
+          entry = { extents: new Set(), coveredCells: 0 };
+          lines.set(line, entry);
         }
 
-        if (!indexes.has(index)) {
-          indexes.set(index, new Set());
-        }
-
-        indexes.get(index)!.add(lastIndex);
+        entry.extents.add(extent);
+        entry.coveredCells += coveredCells;
       }
     }
 
-    return Array.from(
-      new Set(Array.from(indexes.entries())
-        .filter(([, set]) => set.size === 1)
-        .flatMap(([, set]) => Array.from(set)))
-    );
+    return lines;
+  }
+
+  /**
+   * Finds the nearest index along the provided axis that does not intersect with any merged cell
+   * within the provided range. The range's lines are conceptually scanned in the provided
+   * direction; a line emits a candidate index when all of its cells agree on a single index — its
+   * own index when no merged cell touches it, or the shared scan extent when merged cells cover
+   * it uniformly. The first emitted candidate located at or past `visualIndex` (in the scan
+   * direction) wins. The cost scales with the number of merged cells intersecting the range, not
+   * with the area of the range.
+   *
+   * @param {CellRange} range The range to search within.
+   * @param {'row' | 'col'} axis The axis to search within.
+   * @param {number} scanDirection The direction to scan the range. `1` for forward, `-1` for backward.
+   * @param {number} visualIndex The visual row/column index the search relates to.
+   * @returns {number} The found visual index, or `visualIndex` when every line intersects a merged cell.
+   */
+  #findNonIntersectingIndex(range: CellRange, axis: 'row' | 'col', scanDirection: number, visualIndex: number) {
+    const { row: rangeStartRow, col: rangeStartColumn } = range.getTopStartCorner();
+    const { row: rangeEndRow, col: rangeEndColumn } = range.getBottomEndCorner();
+    const isRowAxis = axis === 'row';
+    const lineStart = (isRowAxis ? rangeStartRow : rangeStartColumn) ?? 0;
+    const lineEnd = (isRowAxis ? rangeEndRow : rangeEndColumn) ?? 0;
+    const crossLength = isRowAxis
+      ? ((rangeEndColumn ?? 0) - (rangeStartColumn ?? 0) + 1)
+      : ((rangeEndRow ?? 0) - (rangeStartRow ?? 0) + 1);
+    const matches = (index: number) => (scanDirection === 1 ? index >= visualIndex : index <= visualIndex);
+    const lines = this.#collectLineContributions(range, axis, scanDirection);
+    const touchedLines = Array.from(lines.keys())
+      .sort((lineA, lineB) => (lineA - lineB) * scanDirection);
+
+    // The first merge-touched line (in scan order) whose cells all agree on a single index
+    // that lies at or past `visualIndex`.
+    let touchedMatchLine = null;
+    let touchedMatchIndex = 0;
+
+    for (let i = 0; i < touchedLines.length; i++) {
+      const line = touchedLines[i];
+      const { extents, coveredCells } = lines.get(line)!;
+
+      // Cells not covered by any merged cell contribute the line's own index.
+      if (coveredCells < crossLength) {
+        extents.add(line);
+      }
+
+      if (extents.size === 1) {
+        const candidate = extents.values().next().value!;
+
+        if (matches(candidate)) {
+          touchedMatchLine = line;
+          touchedMatchIndex = candidate;
+          break;
+        }
+      }
+    }
+
+    // The first merge-free line in scan order that lies at or past `visualIndex`; such a line
+    // always emits its own index.
+    let freeMatchLine = scanDirection === 1
+      ? Math.max(lineStart, visualIndex)
+      : Math.min(lineEnd, visualIndex);
+
+    while (freeMatchLine >= lineStart && freeMatchLine <= lineEnd && lines.has(freeMatchLine)) {
+      freeMatchLine += scanDirection;
+    }
+
+    const hasFreeMatch = freeMatchLine >= lineStart && freeMatchLine <= lineEnd;
+
+    if (touchedMatchLine === null) {
+      return hasFreeMatch ? freeMatchLine : visualIndex;
+    }
+
+    if (!hasFreeMatch || (touchedMatchLine - freeMatchLine) * scanDirection <= 0) {
+      return touchedMatchIndex;
+    }
+
+    return freeMatchLine;
   }
 
   /**

--- a/handsontable/src/plugins/mergeCells/cellsCollection.ts
+++ b/handsontable/src/plugins/mergeCells/cellsCollection.ts
@@ -111,6 +111,50 @@ class MergedCellsCollection {
   }
 
   /**
+   * Get the merged cells that cover any cell of the provided visual row. The cost scales with the
+   * number of merged cells covering the row, not with the number of table columns. Merges purged
+   * from the lookup matrix (fully hidden) are not returned.
+   *
+   * @param {number} row Visual row index.
+   * @returns {MergedCellCoords[]} Array of merged cells covering the row.
+   */
+  getByVisualRow(row: number) {
+    const rowEntries = this.mergedCellsMatrix.get(row);
+
+    if (!rowEntries) {
+      return [];
+    }
+
+    return Array.from(new Set(rowEntries.values()));
+  }
+
+  /**
+   * Get the merged cells that cover any cell of the provided visual column. The cost scales with
+   * the total number of merged cells, not with the number of table rows. Merges purged from the
+   * lookup matrix (fully hidden) are not returned.
+   *
+   * @param {number} column Visual column index.
+   * @returns {MergedCellCoords[]} Array of merged cells covering the column.
+   */
+  getByVisualColumn(column: number) {
+    const result: MergedCellCoords[] = [];
+
+    for (let i = 0; i < this.mergedCells.length; i++) {
+      const mergedCell = this.mergedCells[i];
+
+      if (
+        mergedCell.col <= column && column <= mergedCell.col + mergedCell.colspan - 1 &&
+        // The lookup matrix is the authority on visibility (see `getWithinRange`).
+        this.get(mergedCell.row, mergedCell.col) === mergedCell
+      ) {
+        result.push(mergedCell);
+      }
+    }
+
+    return result;
+  }
+
+  /**
    * Filters merge cells objects provided by users from overlapping cells.
    *
    * @param {{ row: number, col: number, rowspan: number, colspan: number }} mergedCellsInfo The merged cell information object.

--- a/handsontable/src/plugins/mergeCells/focusOrder.ts
+++ b/handsontable/src/plugins/mergeCells/focusOrder.ts
@@ -1,11 +1,9 @@
-import type { NodeStructure } from '../../utils/dataStructures/linkedList';
-import LinkedList from '../../utils/dataStructures/linkedList';
 import type { IndexMapper } from '../../translations';
 import type { default as CellRange } from '../../3rdparty/walkontable/src/cell/range';
 import type MergedCellCoords from './cellCoords';
 
 /**
- * Data shape for focus order linked list nodes.
+ * Data shape for focus order nodes.
  */
 export interface FocusNodeData {
   selectionLayer: number;
@@ -16,30 +14,57 @@ export interface FocusNodeData {
 }
 
 /**
+ * Geometry snapshot of a single selection layer, captured when the focus order is rebuilt.
+ * The focus order walks these bounds lazily instead of materializing a node per selected cell.
+ */
+interface LayerGeometry {
+  rowFrom: number;
+  rowTo: number;
+  colFrom: number;
+  colTo: number;
+  highlightRow: number;
+  highlightCol: number;
+}
+
+/**
+ * A cell position used while scanning a selection layer.
+ */
+interface ScanPosition {
+  row: number;
+  column: number;
+}
+
+/**
+ * The traversal order of the focus: `horizontal` walks the selection row by row,
+ * `vertical` walks it column by column.
+ */
+type FocusOrderDirection = 'horizontal' | 'vertical';
+
+/**
  * Class responsible for providing the correct focus order (vertical and horizontal) within a selection that
  * contains merged cells.
+ *
+ * The order is computed lazily. A focus stop ("node") is either a visible non-merged cell or a merged
+ * cell that is fully contained in the selection layer (anchored at its first visible cell in scan
+ * order). Cells covered by a merged cell that sticks out of the layer produce no focus stop. Each
+ * navigation step costs time relative to the merged cells it walks past — never to the selection area.
  *
  * @private
  */
 export class FocusOrder {
   /**
-   * The linked list of the all cells within the current selection in horizontal order. The list is
-   * recreated every time the selection is changed.
+   * Geometry snapshots of the selected ranges, one per selection layer. Recreated every time the
+   * selection is changed.
    */
-  #cellsHorizontalOrder = new LinkedList();
+  #layers: LayerGeometry[] = [];
   /**
-   * The linked list of the all cells within the current selection in vertical order. The list is
-   * recreated every time the selection is changed.
+   * The currently highlighted node within the horizontal focus order.
    */
-  #cellsVerticalOrder = new LinkedList();
+  #currentHorizontalNode: FocusNodeData | null = null;
   /**
-   * The currently highlighted cell within the horizontal linked list.
+   * The currently highlighted node within the vertical focus order.
    */
-  #currentHorizontalLinkedNode: NodeStructure | null = null;
-  /**
-   * The currently highlighted cell within the vertical linked list.
-   */
-  #currentVerticalLinkedNode: NodeStructure | null = null;
+  #currentVerticalNode: FocusNodeData | null = null;
   /**
    * The merged cells getter function.
    */
@@ -66,269 +91,143 @@ export class FocusOrder {
   }
 
   /**
-   * Gets the currently selected node data from the vertical focus order list.
+   * Gets the currently selected node data from the vertical focus order.
    *
-   * @returns {NodeStructure}
+   * @returns {FocusNodeData | undefined}
    */
   getCurrentVerticalNode() {
-    return this.#currentVerticalLinkedNode?.data;
+    return this.#currentVerticalNode ?? undefined;
   }
 
   /**
-   * Gets the first node data from the vertical focus order list.
+   * Gets the first node data from the vertical focus order.
    *
-   * @returns {NodeStructure}
+   * @returns {FocusNodeData | undefined}
    */
   getFirstVerticalNode() {
-    return this.#cellsVerticalOrder.first?.data;
+    return this.#findFirstNode('vertical');
   }
 
   /**
-   * Gets the next selected node data from the vertical focus order list.
+   * Gets the next selected node data from the vertical focus order.
    *
    * @returns {FocusNodeData}
    */
   getNextVerticalNode(): FocusNodeData {
-    return this.#currentVerticalLinkedNode?.next?.data as FocusNodeData;
+    // The cast mirrors the previous linked-list implementation: with no current node the method
+    // returns `undefined` at runtime and the callers rely on that behavior.
+    return this.#neighborNode(this.#currentVerticalNode, 'vertical', 1) as FocusNodeData;
   }
 
   /**
-   * Gets the previous selected node data from the vertical focus order list.
+   * Gets the previous selected node data from the vertical focus order.
    *
    * @returns {FocusNodeData}
    */
   getPrevVerticalNode(): FocusNodeData {
-    return this.#currentVerticalLinkedNode?.prev?.data as FocusNodeData;
+    // See `getNextVerticalNode` for why the cast is kept.
+    return this.#neighborNode(this.#currentVerticalNode, 'vertical', -1) as FocusNodeData;
   }
 
   /**
-   * Gets the currently selected node data from the horizontal focus order list.
+   * Gets the currently selected node data from the horizontal focus order.
    *
-   * @returns {NodeStructure}
+   * @returns {FocusNodeData | undefined}
    */
   getCurrentHorizontalNode() {
-    return this.#currentHorizontalLinkedNode?.data;
+    return this.#currentHorizontalNode ?? undefined;
   }
 
   /**
-   * Gets the first node data from the horizontal focus order list.
+   * Gets the first node data from the horizontal focus order.
    *
-   * @returns {NodeStructure}
+   * @returns {FocusNodeData | undefined}
    */
   getFirstHorizontalNode() {
-    return this.#cellsHorizontalOrder.first?.data;
+    return this.#findFirstNode('horizontal');
   }
 
   /**
-   * Gets the next selected node data from the horizontal focus order list.
+   * Gets the next selected node data from the horizontal focus order.
    *
    * @returns {FocusNodeData}
    */
   getNextHorizontalNode(): FocusNodeData {
-    return this.#currentHorizontalLinkedNode?.next?.data as FocusNodeData;
+    // See `getNextVerticalNode` for why the cast is kept.
+    return this.#neighborNode(this.#currentHorizontalNode, 'horizontal', 1) as FocusNodeData;
   }
 
   /**
-   * Gets the previous selected node data from the horizontal focus order list.
+   * Gets the previous selected node data from the horizontal focus order.
    *
    * @returns {FocusNodeData}
    */
   getPrevHorizontalNode(): FocusNodeData {
-    return this.#currentHorizontalLinkedNode?.prev?.data as FocusNodeData;
+    // See `getNextVerticalNode` for why the cast is kept.
+    return this.#neighborNode(this.#currentHorizontalNode, 'horizontal', -1) as FocusNodeData;
   }
 
   /**
-   * Sets the previous node from the vertical focus order list as active.
+   * Sets the previous node in both focus orders as active.
    */
   setPrevNodeAsActive() {
-    if (this.#currentVerticalLinkedNode) {
-      this.#currentVerticalLinkedNode = this.#currentVerticalLinkedNode.prev;
+    if (this.#currentVerticalNode) {
+      this.#currentVerticalNode = this.#findNeighborNode(this.#currentVerticalNode, 'vertical', -1);
     }
 
-    if (this.#currentHorizontalLinkedNode) {
-      this.#currentHorizontalLinkedNode = this.#currentHorizontalLinkedNode.prev;
+    if (this.#currentHorizontalNode) {
+      this.#currentHorizontalNode = this.#findNeighborNode(this.#currentHorizontalNode, 'horizontal', -1);
     }
   }
 
   /**
-   * Sets the previous node from the horizontal focus order list as active.
+   * Sets the next node in both focus orders as active.
    */
   setNextNodeAsActive() {
-    if (this.#currentVerticalLinkedNode) {
-      this.#currentVerticalLinkedNode = this.#currentVerticalLinkedNode.next;
+    if (this.#currentVerticalNode) {
+      this.#currentVerticalNode = this.#findNeighborNode(this.#currentVerticalNode, 'vertical', 1);
     }
 
-    if (this.#currentHorizontalLinkedNode) {
-      this.#currentHorizontalLinkedNode = this.#currentHorizontalLinkedNode.next;
+    if (this.#currentHorizontalNode) {
+      this.#currentHorizontalNode = this.#findNeighborNode(this.#currentHorizontalNode, 'horizontal', 1);
     }
   }
 
   /**
-   * Rebuilds the focus order list based on the provided selection.
+   * Rebuilds the focus order based on the provided selection. Only the layers' geometry is
+   * captured — the focus stops themselves are computed lazily during navigation.
    *
    * @param {CellRange[]} selectedRanges The selected ranges to build the focus order for.
    */
   buildFocusOrder(selectedRanges: CellRange[]) {
-    this.#cellsHorizontalOrder = new LinkedList();
-
-    selectedRanges.forEach((range: CellRange, selectionLayer: number) => {
-      const visitedHorizontalCells = new WeakSet();
+    this.#layers = selectedRanges.map((range) => {
       const topStart = range.getTopStartCorner();
       const bottomEnd = range.getBottomEndCorner();
-      const rowFrom = topStart.row ?? 0;
-      const rowTo = bottomEnd.row ?? 0;
-      const colFrom = topStart.col ?? 0;
-      const colTo = bottomEnd.col ?? 0;
+      const highlight = range.highlight.clone().normalize();
 
-      for (let r = rowFrom; r <= rowTo; r++) {
-        if (this.#rowIndexMapper.isHidden(r)) {
-          // eslint-disable-next-line no-continue
-          continue;
-        }
-
-        for (let c = colFrom; c <= colTo; c++) {
-          if (this.#columnIndexMapper.isHidden(c)) {
-            // eslint-disable-next-line no-continue
-            continue;
-          }
-
-          const node = this.#pushOrderNode({
-            selectedRange: range,
-            selectionLayer,
-            listOrder: this.#cellsHorizontalOrder,
-            mergeCellsVisitor: visitedHorizontalCells,
-            row: r,
-            column: c
-          });
-
-          if (node) {
-            this.#currentHorizontalLinkedNode = node;
-          }
-        }
-      }
+      return {
+        rowFrom: topStart.row ?? 0,
+        rowTo: bottomEnd.row ?? 0,
+        colFrom: topStart.col ?? 0,
+        colTo: bottomEnd.col ?? 0,
+        highlightRow: highlight.row ?? 0,
+        highlightCol: highlight.col ?? 0,
+      };
     });
 
-    // create circular linked list
-    if (this.#cellsHorizontalOrder.first && this.#cellsHorizontalOrder.last) {
-      this.#cellsHorizontalOrder.first.prev = this.#cellsHorizontalOrder.last;
-      this.#cellsHorizontalOrder.last.next = this.#cellsHorizontalOrder.first;
-    }
+    let highlightNode: FocusNodeData | null = null;
 
-    this.#cellsVerticalOrder = new LinkedList();
+    for (let selectionLayer = 0; selectionLayer < this.#layers.length; selectionLayer++) {
+      const { highlightRow, highlightCol } = this.#layers[selectionLayer];
+      const node = this.#getNodeAt(selectionLayer, highlightRow, highlightCol);
 
-    selectedRanges.forEach((range: CellRange, selectionLayer: number) => {
-      const visitedVerticalCells = new WeakSet();
-      const topStart = range.getTopStartCorner();
-      const bottomEnd = range.getBottomEndCorner();
-      const rowFrom = topStart.row ?? 0;
-      const rowTo = bottomEnd.row ?? 0;
-      const colFrom = topStart.col ?? 0;
-      const colTo = bottomEnd.col ?? 0;
-
-      for (let c = colFrom; c <= colTo; c++) {
-        if (this.#columnIndexMapper.isHidden(c)) {
-          // eslint-disable-next-line no-continue
-          continue;
-        }
-
-        for (let r = rowFrom; r <= rowTo; r++) {
-          if (this.#rowIndexMapper.isHidden(r)) {
-            // eslint-disable-next-line no-continue
-            continue;
-          }
-
-          const node = this.#pushOrderNode({
-            selectedRange: range,
-            selectionLayer,
-            listOrder: this.#cellsVerticalOrder,
-            mergeCellsVisitor: visitedVerticalCells,
-            row: r,
-            column: c
-          });
-
-          if (node) {
-            this.#currentVerticalLinkedNode = node;
-          }
-        }
+      if (node) {
+        highlightNode = node;
       }
-    });
-
-    // create circular linked list
-    if (this.#cellsVerticalOrder.first && this.#cellsVerticalOrder.last) {
-      this.#cellsVerticalOrder.first.prev = this.#cellsVerticalOrder.last;
-      this.#cellsVerticalOrder.last.next = this.#cellsVerticalOrder.first;
-    }
-  }
-
-  /**
-   * Pushes a new node to the provided list order.
-   *
-   * @param {object} options The options object.
-   * @param {CellRange} options.selectedRange The selected range to build the focus order for.
-   * @param {number} options.selectionLayer The selection layer index.
-   * @param {LinkedList} options.listOrder The list order to push the node to.
-   * @param {WeakSet} options.mergeCellsVisitor The set of visited cells.
-   * @param {number} options.row The visual row index.
-   * @param {number} options.column The visual column index.
-   * @returns {NodeStructure | null}
-   */
-  #pushOrderNode({ selectedRange, selectionLayer, listOrder, mergeCellsVisitor, row, column }: {
-    selectedRange: CellRange, selectionLayer: number, listOrder: LinkedList,
-    mergeCellsVisitor: WeakSet<object>, row: number, column: number
-  }) {
-    const topStart = selectedRange.getTopStartCorner();
-    const bottomEnd = selectedRange.getBottomEndCorner();
-    const topStartRow = topStart.row ?? 0;
-    const topStartCol = topStart.col ?? 0;
-    const bottomEndRow = bottomEnd.row ?? 0;
-    const bottomEndCol = bottomEnd.col ?? 0;
-    const highlight = selectedRange.highlight.clone().normalize();
-    const highlightRow = highlight.row ?? 0;
-    const highlightCol = highlight.col ?? 0;
-    const mergeParent = this.#mergedCellsGetter(row, column);
-
-    if (mergeParent && mergeCellsVisitor.has(mergeParent)) {
-      return null;
     }
 
-    const node = {
-      selectionLayer,
-      colStart: column,
-      colEnd: column,
-      rowStart: row,
-      rowEnd: row,
-    };
-
-    if (mergeParent) {
-      mergeCellsVisitor.add(mergeParent);
-
-      if (
-        mergeParent.row < topStartRow ||
-        mergeParent.row + mergeParent.rowspan - 1 > bottomEndRow ||
-        mergeParent.col < topStartCol ||
-        mergeParent.col + mergeParent.colspan - 1 > bottomEndCol
-      ) {
-        return null;
-      }
-
-      node.colStart = mergeParent.col;
-      node.colEnd = mergeParent.col + mergeParent.colspan - 1;
-      node.rowStart = mergeParent.row;
-      node.rowEnd = mergeParent.row + mergeParent.rowspan - 1;
-    }
-
-    const linkedNode = listOrder.push(node);
-
-    if (
-      row === highlightRow && column === highlightCol ||
-      mergeParent &&
-      (highlightRow >= mergeParent.row && highlightRow <= mergeParent.row + mergeParent.rowspan - 1 &&
-      highlightCol >= mergeParent.col && highlightCol <= mergeParent.col + mergeParent.colspan - 1)
-    ) {
-      return linkedNode;
-    }
-
-    return null;
+    this.#currentHorizontalNode = highlightNode;
+    this.#currentVerticalNode = highlightNode;
   }
 
   /**
@@ -340,44 +239,378 @@ export class FocusOrder {
    * @returns {FocusOrder}
    */
   setActiveNode(row: number, column: number, selectionLayerIndex?: number) {
-    this.#cellsHorizontalOrder.inorder((node: NodeStructure) => {
-      const {
-        selectionLayer,
-        rowStart,
-        rowEnd,
-        colStart,
-        colEnd,
-      } = node.data as Record<string, number>;
+    // Without a layer index no node can match — kept for compatibility with the previous
+    // implementation, which compared each node's layer against `undefined`.
+    if (selectionLayerIndex === undefined) {
+      return this;
+    }
 
-      if (
-        selectionLayer === selectionLayerIndex &&
-        row >= rowStart && row <= rowEnd && column >= colStart && column <= colEnd
-      ) {
-        this.#currentHorizontalLinkedNode = node;
+    const node = this.#getNodeAt(selectionLayerIndex, row, column);
 
-        return true;
-      }
-    });
-
-    this.#cellsVerticalOrder.inorder((node: NodeStructure) => {
-      const {
-        selectionLayer,
-        rowStart,
-        rowEnd,
-        colStart,
-        colEnd,
-      } = node.data as Record<string, number>;
-
-      if (
-        selectionLayer === selectionLayerIndex &&
-        row >= rowStart && row <= rowEnd && column >= colStart && column <= colEnd
-      ) {
-        this.#currentVerticalLinkedNode = node;
-
-        return true;
-      }
-    });
+    if (node) {
+      this.#currentHorizontalNode = node;
+      this.#currentVerticalNode = node;
+    }
 
     return this;
+  }
+
+  /**
+   * Gets the focus node that contains the provided cell within the provided selection layer, or
+   * `null` when the cell produces no focus stop (outside the layer, hidden, or covered by a merged
+   * cell that sticks out of the layer).
+   *
+   * @param {number} selectionLayer The selection layer index.
+   * @param {number} row The visual row index.
+   * @param {number} column The visual column index.
+   * @returns {FocusNodeData | null}
+   */
+  #getNodeAt(selectionLayer: number, row: number, column: number): FocusNodeData | null {
+    const layer = this.#layers[selectionLayer];
+
+    if (!layer) {
+      return null;
+    }
+
+    const mergeParent = this.#mergedCellsGetter(row, column);
+
+    if (mergeParent) {
+      return this.#createMergeNode(selectionLayer, mergeParent);
+    }
+
+    if (
+      row < layer.rowFrom || row > layer.rowTo ||
+      column < layer.colFrom || column > layer.colTo ||
+      this.#rowIndexMapper.isHidden(row) || this.#columnIndexMapper.isHidden(column)
+    ) {
+      return null;
+    }
+
+    return { selectionLayer, rowStart: row, rowEnd: row, colStart: column, colEnd: column };
+  }
+
+  /**
+   * Creates a focus node for the provided merged cell, or `null` when the merged cell produces no
+   * focus stop — it sticks out of the layer's bounds or has no visible cell to anchor at.
+   *
+   * @param {number} selectionLayer The selection layer index.
+   * @param {MergedCellCoords} mergeParent The merged cell to create the node for.
+   * @returns {FocusNodeData | null}
+   */
+  #createMergeNode(selectionLayer: number, mergeParent: MergedCellCoords): FocusNodeData | null {
+    const layer = this.#layers[selectionLayer];
+    const rowStart = mergeParent.row;
+    const rowEnd = mergeParent.row + mergeParent.rowspan - 1;
+    const colStart = mergeParent.col;
+    const colEnd = mergeParent.col + mergeParent.colspan - 1;
+
+    if (
+      rowStart < layer.rowFrom || rowEnd > layer.rowTo ||
+      colStart < layer.colFrom || colEnd > layer.colTo ||
+      this.#findAnchor(rowStart, rowEnd, colStart, colEnd) === null
+    ) {
+      return null;
+    }
+
+    return { selectionLayer, rowStart, rowEnd, colStart, colEnd };
+  }
+
+  /**
+   * Finds the anchor — the first visible cell in scan order — of the provided rectangle. Returns
+   * `null` when the rectangle has no visible row or column.
+   *
+   * @param {number} rowStart The first visual row index of the rectangle.
+   * @param {number} rowEnd The last visual row index of the rectangle.
+   * @param {number} colStart The first visual column index of the rectangle.
+   * @param {number} colEnd The last visual column index of the rectangle.
+   * @returns {ScanPosition | null}
+   */
+  #findAnchor(rowStart: number, rowEnd: number, colStart: number, colEnd: number): ScanPosition | null {
+    const row = this.#rowIndexMapper.getNearestNotHiddenIndex(rowStart, 1);
+    const column = this.#columnIndexMapper.getNearestNotHiddenIndex(colStart, 1);
+
+    if (row === null || row > rowEnd || column === null || column > colEnd) {
+      return null;
+    }
+
+    return { row, column };
+  }
+
+  /**
+   * Gets the position the lazy scan resumes from for the provided node — the node's anchor, or its
+   * top-start corner when the anchor cannot be resolved anymore (e.g. hidden in the meantime).
+   *
+   * @param {FocusNodeData} node The node to resolve the scan position for.
+   * @returns {ScanPosition}
+   */
+  #nodeScanPosition(node: FocusNodeData): ScanPosition {
+    return this.#findAnchor(node.rowStart, node.rowEnd, node.colStart, node.colEnd)
+      ?? { row: node.rowStart, column: node.colStart };
+  }
+
+  /**
+   * Computes the neighboring node data of the provided node, or `undefined` when there is no node.
+   *
+   * @param {FocusNodeData | null} node The node to start from.
+   * @param {FocusOrderDirection} order The traversal order.
+   * @param {number} direction The traversal direction. `1` for next, `-1` for previous.
+   * @returns {FocusNodeData | undefined}
+   */
+  #neighborNode(node: FocusNodeData | null, order: FocusOrderDirection, direction: 1 | -1) {
+    if (!node) {
+      return undefined;
+    }
+
+    return this.#findNeighborNode(node, order, direction) ?? undefined;
+  }
+
+  /**
+   * Finds the neighboring node of the provided node, walking the selection layers circularly —
+   * exactly like the previously materialized circular linked list did. When the provided node is
+   * the only focus stop, the node itself is returned.
+   *
+   * @param {FocusNodeData} node The node to start from.
+   * @param {FocusOrderDirection} order The traversal order.
+   * @param {number} direction The traversal direction. `1` for next, `-1` for previous.
+   * @returns {FocusNodeData | null}
+   */
+  #findNeighborNode(node: FocusNodeData, order: FocusOrderDirection, direction: 1 | -1): FocusNodeData | null {
+    const totalLayers = this.#layers.length;
+
+    if (totalLayers === 0) {
+      return null;
+    }
+
+    const startLayer = this.#layers[node.selectionLayer] ? node.selectionLayer : 0;
+    let foundNode = this.#findNodeInLayer(startLayer, this.#nodeScanPosition(node), order, direction);
+
+    for (let step = 1; foundNode === null && step <= totalLayers; step++) {
+      const rawLayer = (startLayer + (step * direction)) % totalLayers;
+      const layer = (rawLayer + totalLayers) % totalLayers;
+
+      foundNode = this.#findNodeInLayer(layer, null, order, direction);
+    }
+
+    return foundNode;
+  }
+
+  /**
+   * Finds the first node of the whole focus order, or `undefined` when the selection produces no
+   * focus stops.
+   *
+   * @param {FocusOrderDirection} order The traversal order.
+   * @returns {FocusNodeData | undefined}
+   */
+  #findFirstNode(order: FocusOrderDirection) {
+    for (let selectionLayer = 0; selectionLayer < this.#layers.length; selectionLayer++) {
+      const node = this.#findNodeInLayer(selectionLayer, null, order, 1);
+
+      if (node) {
+        return node;
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Finds the first focus node of the provided layer at or after the provided scan position
+   * (exclusive). Passing `null` as the position scans the layer from its edge (inclusive).
+   *
+   * @param {number} selectionLayer The selection layer index.
+   * @param {ScanPosition | null} fromPosition The position to start the scan from, or `null` to
+   * scan from the layer's edge.
+   * @param {FocusOrderDirection} order The traversal order.
+   * @param {number} direction The traversal direction. `1` for forward, `-1` for backward.
+   * @returns {FocusNodeData | null}
+   */
+  #findNodeInLayer(
+    selectionLayer: number,
+    fromPosition: ScanPosition | null,
+    order: FocusOrderDirection,
+    direction: 1 | -1,
+  ): FocusNodeData | null {
+    const layer = this.#layers[selectionLayer];
+
+    if (!layer) {
+      return null;
+    }
+
+    let position = fromPosition === null
+      ? this.#layerEdgePosition(layer, direction)
+      : this.#advance(layer, fromPosition, order, direction);
+
+    while (position !== null) {
+      const mergeParent = this.#mergedCellsGetter(position.row, position.column);
+
+      if (!mergeParent) {
+        return {
+          selectionLayer,
+          rowStart: position.row,
+          rowEnd: position.row,
+          colStart: position.column,
+          colEnd: position.column,
+        };
+      }
+
+      const mergeNode = this.#createMergeNode(selectionLayer, mergeParent);
+
+      if (mergeNode && this.#emitsMergeNodeAt(mergeNode, position, order, direction)) {
+        return mergeNode;
+      }
+
+      position = this.#skipMerge(layer, position, mergeParent, order, direction);
+    }
+
+    return null;
+  }
+
+  /**
+   * Checks whether the merged cell's node is emitted at the provided scan position. Scanning
+   * forward, a merged cell is emitted exactly at its anchor. Scanning backward, it is emitted as
+   * soon as the scan enters the anchor's row (horizontal order) or column (vertical order) — every
+   * cell between that position and the anchor belongs to the same merged cell.
+   *
+   * @param {FocusNodeData} mergeNode The merged cell's node.
+   * @param {ScanPosition} position The current scan position (a cell of the merged cell).
+   * @param {FocusOrderDirection} order The traversal order.
+   * @param {number} direction The traversal direction. `1` for forward, `-1` for backward.
+   * @returns {boolean}
+   */
+  #emitsMergeNodeAt(
+    mergeNode: FocusNodeData,
+    position: ScanPosition,
+    order: FocusOrderDirection,
+    direction: 1 | -1,
+  ): boolean {
+    const anchor = this.#findAnchor(mergeNode.rowStart, mergeNode.rowEnd, mergeNode.colStart, mergeNode.colEnd);
+
+    if (anchor === null) {
+      return false;
+    }
+
+    if (direction === 1) {
+      return anchor.row === position.row && anchor.column === position.column;
+    }
+
+    return order === 'horizontal' ? anchor.row === position.row : anchor.column === position.column;
+  }
+
+  /**
+   * Advances the scan position past the provided merged cell along the traversal order's inner
+   * axis, so the scan cost stays relative to the merged cells walked past — not to their area.
+   *
+   * @param {LayerGeometry} layer The layer geometry.
+   * @param {ScanPosition} position The current scan position (a cell of the merged cell).
+   * @param {MergedCellCoords} mergeParent The merged cell to skip.
+   * @param {FocusOrderDirection} order The traversal order.
+   * @param {number} direction The traversal direction. `1` for forward, `-1` for backward.
+   * @returns {ScanPosition | null}
+   */
+  #skipMerge(
+    layer: LayerGeometry,
+    position: ScanPosition,
+    mergeParent: MergedCellCoords,
+    order: FocusOrderDirection,
+    direction: 1 | -1,
+  ): ScanPosition | null {
+    if (order === 'horizontal') {
+      const column = direction === 1
+        ? Math.min(mergeParent.col + mergeParent.colspan - 1, layer.colTo)
+        : Math.max(mergeParent.col, layer.colFrom);
+
+      return this.#advance(layer, { row: position.row, column }, order, direction);
+    }
+
+    const row = direction === 1
+      ? Math.min(mergeParent.row + mergeParent.rowspan - 1, layer.rowTo)
+      : Math.max(mergeParent.row, layer.rowFrom);
+
+    return this.#advance(layer, { row, column: position.column }, order, direction);
+  }
+
+  /**
+   * Gets the first (forward) or last (backward) visible cell position of the provided layer, or
+   * `null` when the layer has no visible cell.
+   *
+   * @param {LayerGeometry} layer The layer geometry.
+   * @param {number} direction The traversal direction. `1` for forward, `-1` for backward.
+   * @returns {ScanPosition | null}
+   */
+  #layerEdgePosition(layer: LayerGeometry, direction: 1 | -1): ScanPosition | null {
+    const row = direction === 1
+      ? this.#rowIndexMapper.getNearestNotHiddenIndex(layer.rowFrom, 1)
+      : this.#rowIndexMapper.getNearestNotHiddenIndex(layer.rowTo, -1);
+    const column = direction === 1
+      ? this.#columnIndexMapper.getNearestNotHiddenIndex(layer.colFrom, 1)
+      : this.#columnIndexMapper.getNearestNotHiddenIndex(layer.colTo, -1);
+
+    if (
+      row === null || row < layer.rowFrom || row > layer.rowTo ||
+      column === null || column < layer.colFrom || column > layer.colTo
+    ) {
+      return null;
+    }
+
+    return { row, column };
+  }
+
+  /**
+   * Advances the scan position to the next (or previous) visible cell of the layer in the provided
+   * traversal order, or `null` when the layer's end is reached.
+   *
+   * @param {LayerGeometry} layer The layer geometry.
+   * @param {ScanPosition} position The current scan position.
+   * @param {FocusOrderDirection} order The traversal order.
+   * @param {number} direction The traversal direction. `1` for forward, `-1` for backward.
+   * @returns {ScanPosition | null}
+   */
+  #advance(
+    layer: LayerGeometry,
+    position: ScanPosition,
+    order: FocusOrderDirection,
+    direction: 1 | -1,
+  ): ScanPosition | null {
+    if (order === 'horizontal') {
+      const column = this.#columnIndexMapper.getNearestNotHiddenIndex(position.column + direction, direction);
+
+      if (column !== null && column >= layer.colFrom && column <= layer.colTo) {
+        return { row: position.row, column };
+      }
+
+      const row = this.#rowIndexMapper.getNearestNotHiddenIndex(position.row + direction, direction);
+      const edgeColumn = direction === 1
+        ? this.#columnIndexMapper.getNearestNotHiddenIndex(layer.colFrom, 1)
+        : this.#columnIndexMapper.getNearestNotHiddenIndex(layer.colTo, -1);
+
+      if (
+        row === null || row < layer.rowFrom || row > layer.rowTo ||
+        edgeColumn === null || edgeColumn < layer.colFrom || edgeColumn > layer.colTo
+      ) {
+        return null;
+      }
+
+      return { row, column: edgeColumn };
+    }
+
+    const row = this.#rowIndexMapper.getNearestNotHiddenIndex(position.row + direction, direction);
+
+    if (row !== null && row >= layer.rowFrom && row <= layer.rowTo) {
+      return { row, column: position.column };
+    }
+
+    const column = this.#columnIndexMapper.getNearestNotHiddenIndex(position.column + direction, direction);
+    const edgeRow = direction === 1
+      ? this.#rowIndexMapper.getNearestNotHiddenIndex(layer.rowFrom, 1)
+      : this.#rowIndexMapper.getNearestNotHiddenIndex(layer.rowTo, -1);
+
+    if (
+      column === null || column < layer.colFrom || column > layer.colTo ||
+      edgeRow === null || edgeRow < layer.rowFrom || edgeRow > layer.rowTo
+    ) {
+      return null;
+    }
+
+    return { row: edgeRow, column };
   }
 }

--- a/handsontable/src/plugins/mergeCells/mergeCells.ts
+++ b/handsontable/src/plugins/mergeCells/mergeCells.ts
@@ -1482,22 +1482,20 @@ export class MergeCells extends BasePlugin {
   modifyViewportRowStart(calc: { startRow: number, endRow: number }, nrOfColumns: number) {
     const rowMapper = this.hot.rowIndexMapper;
     const visualStartRow = rowMapper.getVisualFromRenderableIndex(calc.startRow) ?? 0;
+    const mergedCellsWithinRow = this.mergedCellsCollection.getByVisualRow(visualStartRow);
 
-    for (let visualColumnIndex = 0; visualColumnIndex < nrOfColumns; visualColumnIndex += 1) {
-      const mergeParentForViewportStart = this.mergedCellsCollection.get(visualStartRow, visualColumnIndex);
+    for (let i = 0; i < mergedCellsWithinRow.length; i += 1) {
+      const mergeParentForViewportStart = mergedCellsWithinRow[i];
+      const nearestNotHiddenRow = rowMapper.getNearestNotHiddenIndex(mergeParentForViewportStart.row, 1);
+      const renderableIndexAtMergeStart = nearestNotHiddenRow !== null
+        ? rowMapper.getRenderableFromVisualIndex(nearestNotHiddenRow)
+        : null;
 
-      if (mergeParentForViewportStart !== false) {
-        const nearestNotHiddenRow = rowMapper.getNearestNotHiddenIndex(mergeParentForViewportStart.row, 1);
-        const renderableIndexAtMergeStart = nearestNotHiddenRow !== null
-          ? rowMapper.getRenderableFromVisualIndex(nearestNotHiddenRow)
-          : null;
+      if (renderableIndexAtMergeStart !== null && renderableIndexAtMergeStart < calc.startRow) {
+        calc.startRow = renderableIndexAtMergeStart;
+        this.modifyViewportRowStart(calc, nrOfColumns);
 
-        if (renderableIndexAtMergeStart !== null && renderableIndexAtMergeStart < calc.startRow) {
-          calc.startRow = renderableIndexAtMergeStart;
-          this.modifyViewportRowStart(calc, nrOfColumns);
-
-          return;
-        }
+        return;
       }
     }
   }
@@ -1512,23 +1510,21 @@ export class MergeCells extends BasePlugin {
   modifyViewportRowEnd(calc: { startRow: number, endRow: number }, nrOfColumns: number) {
     const rowMapper = this.hot.rowIndexMapper;
     const visualEndRow = rowMapper.getVisualFromRenderableIndex(calc.endRow) ?? 0;
+    const mergedCellsWithinRow = this.mergedCellsCollection.getByVisualRow(visualEndRow);
 
-    for (let visualColumnIndex = 0; visualColumnIndex < nrOfColumns; visualColumnIndex += 1) {
-      const mergeParentForViewportEnd = this.mergedCellsCollection.get(visualEndRow, visualColumnIndex);
+    for (let i = 0; i < mergedCellsWithinRow.length; i += 1) {
+      const mergeParentForViewportEnd = mergedCellsWithinRow[i];
+      const mergeEnd = mergeParentForViewportEnd.row + mergeParentForViewportEnd.rowspan - 1;
+      const nearestRow = rowMapper.getNearestNotHiddenIndex(mergeEnd, -1);
 
-      if (mergeParentForViewportEnd !== false) {
-        const mergeEnd = mergeParentForViewportEnd.row + mergeParentForViewportEnd.rowspan - 1;
-        const nearestRow = rowMapper.getNearestNotHiddenIndex(mergeEnd, -1);
+      if (nearestRow !== null) {
+        const renderableIndexAtMergeEnd = rowMapper.getRenderableFromVisualIndex(nearestRow);
 
-        if (nearestRow !== null) {
-          const renderableIndexAtMergeEnd = rowMapper.getRenderableFromVisualIndex(nearestRow);
+        if (renderableIndexAtMergeEnd !== null && renderableIndexAtMergeEnd > calc.endRow) {
+          calc.endRow = renderableIndexAtMergeEnd;
+          this.modifyViewportRowEnd(calc, nrOfColumns);
 
-          if (renderableIndexAtMergeEnd !== null && renderableIndexAtMergeEnd > calc.endRow) {
-            calc.endRow = renderableIndexAtMergeEnd;
-            this.modifyViewportRowEnd(calc, nrOfColumns);
-
-            return;
-          }
+          return;
         }
       }
     }
@@ -1560,22 +1556,20 @@ export class MergeCells extends BasePlugin {
   modifyViewportColumnStart(calc: { startColumn: number, endColumn: number }, nrOfRows: number) {
     const columnMapper = this.hot.columnIndexMapper;
     const visualStartCol = columnMapper.getVisualFromRenderableIndex(calc.startColumn) ?? 0;
+    const mergedCellsWithinColumn = this.mergedCellsCollection.getByVisualColumn(visualStartCol);
 
-    for (let visualRowIndex = 0; visualRowIndex < nrOfRows; visualRowIndex += 1) {
-      const mergeParentForViewportStart = this.mergedCellsCollection.get(visualRowIndex, visualStartCol);
+    for (let i = 0; i < mergedCellsWithinColumn.length; i += 1) {
+      const mergeParentForViewportStart = mergedCellsWithinColumn[i];
+      const nearestCol = columnMapper.getNearestNotHiddenIndex(mergeParentForViewportStart.col, 1);
 
-      if (mergeParentForViewportStart !== false) {
-        const nearestCol = columnMapper.getNearestNotHiddenIndex(mergeParentForViewportStart.col, 1);
+      if (nearestCol !== null) {
+        const renderableIndexAtMergeStart = columnMapper.getRenderableFromVisualIndex(nearestCol);
 
-        if (nearestCol !== null) {
-          const renderableIndexAtMergeStart = columnMapper.getRenderableFromVisualIndex(nearestCol);
+        if (renderableIndexAtMergeStart !== null && renderableIndexAtMergeStart < calc.startColumn) {
+          calc.startColumn = renderableIndexAtMergeStart;
+          this.modifyViewportColumnStart(calc, nrOfRows);
 
-          if (renderableIndexAtMergeStart !== null && renderableIndexAtMergeStart < calc.startColumn) {
-            calc.startColumn = renderableIndexAtMergeStart;
-            this.modifyViewportColumnStart(calc, nrOfRows);
-
-            return;
-          }
+          return;
         }
       }
     }
@@ -1591,23 +1585,21 @@ export class MergeCells extends BasePlugin {
   modifyViewportColumnEnd(calc: { startColumn: number, endColumn: number }, nrOfRows: number) {
     const columnMapper = this.hot.columnIndexMapper;
     const visualEndCol = columnMapper.getVisualFromRenderableIndex(calc.endColumn) ?? 0;
+    const mergedCellsWithinColumn = this.mergedCellsCollection.getByVisualColumn(visualEndCol);
 
-    for (let visualRowIndex = 0; visualRowIndex < nrOfRows; visualRowIndex += 1) {
-      const mergeParentForViewportEnd = this.mergedCellsCollection.get(visualRowIndex, visualEndCol);
+    for (let i = 0; i < mergedCellsWithinColumn.length; i += 1) {
+      const mergeParentForViewportEnd = mergedCellsWithinColumn[i];
+      const mergeEnd = mergeParentForViewportEnd.col + mergeParentForViewportEnd.colspan - 1;
+      const nearestCol = columnMapper.getNearestNotHiddenIndex(mergeEnd, -1);
 
-      if (mergeParentForViewportEnd !== false) {
-        const mergeEnd = mergeParentForViewportEnd.col + mergeParentForViewportEnd.colspan - 1;
-        const nearestCol = columnMapper.getNearestNotHiddenIndex(mergeEnd, -1);
+      if (nearestCol !== null) {
+        const renderableIndexAtMergeEnd = columnMapper.getRenderableFromVisualIndex(nearestCol);
 
-        if (nearestCol !== null) {
-          const renderableIndexAtMergeEnd = columnMapper.getRenderableFromVisualIndex(nearestCol);
+        if (renderableIndexAtMergeEnd !== null && renderableIndexAtMergeEnd > calc.endColumn) {
+          calc.endColumn = renderableIndexAtMergeEnd;
+          this.modifyViewportColumnEnd(calc, nrOfRows);
 
-          if (renderableIndexAtMergeEnd !== null && renderableIndexAtMergeEnd > calc.endColumn) {
-            calc.endColumn = renderableIndexAtMergeEnd;
-            this.modifyViewportColumnEnd(calc, nrOfRows);
-
-            return;
-          }
+          return;
         }
       }
     }


### PR DESCRIPTION
### Context

The PR removes every place where the MergeCells plugin's cost scaled with the grid or selection **area** instead of the number of merged cells. All five hotspots were paid even when the table had zero merges — enabling the plugin was enough. Four hot paths were affected:

**1. Border draws while scrolling with a selection (`MergedCellsCollection.getWithinRange`).** Called from the `beforeDrawBorders` hook on every draw of every overlay while an area selection exists. With a select-all on a 100k×50 grid it performed ~5M lookup-matrix reads per call, 8–14 calls per scroll frame — the grid froze while scrolling with a large selection active. The same scan ran on `Ctrl+M` (unmerge) and on the autofill snap path. Now it iterates `mergedCells` with a rectangle-overlap test. The result keeps the previous row-major order; with `countPartials = true` each merged cell is now returned once (previously one duplicate per covered range cell — every caller audited, none depends on the duplicates).

**2. Extending the selection with Shift+arrow (`#getNonIntersectingIndexes`).** Backed the `getStartMost/EndMost/TopMost/BottomMost` index lookups that run on every `Shift+arrow` keypress. After `Ctrl+Shift+Down` on a 1M-row grid, each further keypress re-scanned the whole selection and allocated one `Set` per selected row (~538 ms per keypress). Replaced by `#findNonIntersectingIndex`, which produces the same answer from merge-touched lines and arithmetic only.

**3. Viewport calculation on every scroll frame (`modifyViewportRowStart/End`, `modifyViewportColumnStart/End`).** With the default `virtualized: false`, the column-axis hooks scanned **all table rows** (and the row-axis hooks all columns) once per draw — ~1M matrix probes per scroll frame at 500k rows. New collection methods `getByVisualRow` (reads the matrix's row map) and `getByVisualColumn` (guarded list scan) make the hooks iterate only the merges covering the boundary row/column.

**4. Selection end and focus navigation (`FocusOrder`).** `buildFocusOrder` materialized two circular linked lists with ~2 nodes per selected cell on every selection end: Ctrl+A on 100k×50 froze for ~800 ms and retained ~1 GB of heap; a 1M×1k selection crashed the tab. Every Tab/Enter focus move then scanned those lists linearly (~10–30 ms per keypress). The class now captures only the layers' geometry and computes focus stops lazily: a stop is a visible non-merged cell or a fully-contained merged cell anchored at its first visible cell; merged cells sticking out of the layer produce none — the exact node set, order, and circular wrap of the previous lists, computed per navigation step in time relative to the merged cells walked past.

All paths preserve the matrix-purge invariant: merges purged from `mergedCellsMatrix` (fully hidden spans) stay in the `mergedCells` list with stale visual coordinates, so every list-iteration candidate is checked against the matrix before use.

Measured (Node micro-benchmarks on audit-scale scenarios):

| Path | Before | After |
|---|---|---|
| `getWithinRange`, 1M×50 selection, 1,000 merges | ~251 ms/call | 0.12 ms |
| `getBottomMostRowIndex` (Shift+Down), same | ~1,125 ms/keypress | 0.20 ms |
| `buildFocusOrder`, Ctrl+A 100k×50, 1,000 merges | ~800 ms + ~1 GB heap | 0.003 ms + ~4 KB |
| Focus move inside that selection | ~10–30 ms/keypress | ~0.1 µs |

### How has this been tested?

- New randomized equivalence suites keep the pre-optimization algorithms in the tests as reference implementations:
  - `cellsCollection.unit.ts` — 2,400 comparisons of the four `get*MostIndex` methods against the old cell-scan algorithm, plus new directed tests for partial-overlap, single-occurrence, and ordering guarantees of `getWithinRange`.
  - `focusOrder.unit.ts` — 40 randomized layouts (merges, hidden rows/columns, multi-layer selections) comparing full forward/backward circular walks, `setActiveNode` round-trips, and first/current node resolution against the old linked-list algorithm, plus directed tests for merge stops and partially-contained merges.
- Full unit suite: 3,178 tests passed — `npm run test:unit --prefix handsontable`.
- Full E2E suite: 9,552 specs, 0 failures — `npm run test:e2e --prefix handsontable` (run twice: after the collection rewrite and after the viewport/focus-order rewrite).
- ESLint clean on all changed files.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2082

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2082

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large behavioral surface in selection, scrolling, and keyboard focus with subtle semantics (partial merges, hidden cells, matrix-purged merges); mitigated by extensive randomized equivalence tests but still easy to miss edge cases.
> 
> **Overview**
> **MergeCells** no longer ties work to grid or selection **area**; cost tracks how many merges are involved instead.
> 
> **`MergedCellsCollection`** rewrites the expensive lookups: **`getWithinRange`** walks the merge list with overlap tests (each merge once, row-major order; with **`countPartials`** partial overlaps included only when requested). **`getStartMost` / `getEndMost` / `getTopMost` / `getBottomMost`** drop the per-cell range scan in favor of **`#findNonIntersectingIndex`** / **`#collectLineContributions`**. New **`getByVisualRow`** and **`getByVisualColumn`** feed viewport hooks so they only consider merges on a boundary line.
> 
> **`FocusOrder`** stops building full horizontal/vertical linked lists on every selection change; it stores layer geometry and computes focus stops lazily on Tab/Enter-style navigation, with the same merge/hidden/partial-merge rules as before.
> 
> **`mergeCells.ts`** viewport adjusters use the new row/column merge queries instead of scanning every row or column at the viewport edge.
> 
> Equivalence is guarded by reference-algorithm tests in **`cellsCollection.unit.ts`** and **`focusOrder.unit.ts`**, plus a changelog entry for the user-facing performance improvement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbc6252c07f415f186e3a68797a870f685dea89a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->