### PR TITLE
DEV-2083: Restore horizon theme even row-header stripe

### DIFF
--- a/.changelogs/13084.json
+++ b/.changelogs/13084.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Restored the horizon theme alternating stripe on even row headers, which stopped showing after the even row header background was made to cascade from headerRowBackgroundColor.",
+  "type": "fixed",
+  "issueOrPR": 13084,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/themes/__tests__/release700.unit.js
+++ b/handsontable/src/themes/__tests__/release700.unit.js
@@ -128,8 +128,15 @@ describe('RELEASE-700: Theme Builder', () => {
       expect(horizonTokens.rowHeaderOddBackgroundColor).toBe('tokens.headerRowBackgroundColor');
     });
 
-    it('should define rowHeaderEvenBackgroundColor referencing headerRowBackgroundColor in horizon tokens', () => {
-      expect(horizonTokens.rowHeaderEvenBackgroundColor).toBe('tokens.headerRowBackgroundColor');
+    // Horizon keeps an independent even-row header value to preserve its intentional zebra stripe.
+    // See DEV-1189 / #12322 - collapsing this to headerRowBackgroundColor removes the stripe.
+    it('should define rowHeaderEvenBackgroundColor referencing backgroundSecondaryColor in horizon tokens', () => {
+      expect(horizonTokens.rowHeaderEvenBackgroundColor).toBe('tokens.backgroundSecondaryColor');
+    });
+
+    it('should keep horizon row header even and odd background tokens different to preserve the stripe', () => {
+      expect(horizonTokens.rowHeaderEvenBackgroundColor)
+        .not.toBe(horizonTokens.rowHeaderOddBackgroundColor);
     });
 
     it('should accept custom headerRowBackgroundColor value', () => {
@@ -152,22 +159,43 @@ describe('RELEASE-700: Theme Builder', () => {
     });
 
     describe('static CSS defaults', () => {
-      const themeCssFiles = [
+      // Main and classic are non-striped themes: even row headers cascade from the header row
+      // background so a custom header row color reaches them.
+      const cascadingThemeCssFiles = [
         'ht-theme-main.css',
         'ht-theme-main-no-icons.css',
         'ht-theme-classic.css',
         'ht-theme-classic-no-icons.css',
+      ];
+
+      // Horizon is a striped theme: its even row headers keep an independent
+      // background-secondary-color so the zebra stripe stays visible (DEV-1189 / #12322).
+      const stripedThemeCssFiles = [
         'ht-theme-horizon.css',
         'ht-theme-horizon-no-icons.css',
       ];
 
-      it.each(themeCssFiles)('should cascade --ht-row-header-even-background-color from ' +
+      it.each(cascadingThemeCssFiles)('should cascade --ht-row-header-even-background-color from ' +
         '--ht-header-row-background-color in %s', (fileName) => {
         const cssPath = path.join(__dirname, '../static/css/theme', fileName);
         const cssContent = fs.readFileSync(cssPath, 'utf8');
 
         expect(cssContent).toMatch(
           /--ht-row-header-even-background-color:\s*var\(--ht-header-row-background-color\);/
+        );
+      });
+
+      it.each(stripedThemeCssFiles)('should keep --ht-row-header-even-background-color referencing ' +
+        '--ht-background-secondary-color in %s to preserve the stripe', (fileName) => {
+        const cssPath = path.join(__dirname, '../static/css/theme', fileName);
+        const cssContent = fs.readFileSync(cssPath, 'utf8');
+
+        expect(cssContent).toMatch(
+          /--ht-row-header-even-background-color:\s*var\(--ht-background-secondary-color\);/
+        );
+        // Odd still cascades from the header row background, so the two differ (the stripe).
+        expect(cssContent).toMatch(
+          /--ht-row-header-odd-background-color:\s*var\(--ht-header-row-background-color\);/
         );
       });
     });

--- a/handsontable/src/themes/static/css/theme/ht-theme-horizon-no-icons.css
+++ b/handsontable/src/themes/static/css/theme/ht-theme-horizon-no-icons.css
@@ -124,7 +124,7 @@
   --ht-header-row-active-foreground-color: var(--ht-background-color);
   --ht-header-row-active-background-color: light-dark(var(--ht-colors-palette-950), var(--ht-colors-primary-200));
   --ht-row-header-odd-background-color: var(--ht-header-row-background-color);
-  --ht-row-header-even-background-color: var(--ht-header-row-background-color);
+  --ht-row-header-even-background-color: var(--ht-background-secondary-color);
   --ht-row-cell-odd-background-color: var(--ht-background-color);
   --ht-row-cell-even-background-color: var(--ht-background-secondary-color);
   --ht-button-border-radius: var(--ht-sizing-size-4);

--- a/handsontable/src/themes/static/css/theme/ht-theme-horizon.css
+++ b/handsontable/src/themes/static/css/theme/ht-theme-horizon.css
@@ -124,7 +124,7 @@
   --ht-header-row-active-foreground-color: var(--ht-background-color);
   --ht-header-row-active-background-color: light-dark(var(--ht-colors-palette-950), var(--ht-colors-primary-200));
   --ht-row-header-odd-background-color: var(--ht-header-row-background-color);
-  --ht-row-header-even-background-color: var(--ht-header-row-background-color);
+  --ht-row-header-even-background-color: var(--ht-background-secondary-color);
   --ht-row-cell-odd-background-color: var(--ht-background-color);
   --ht-row-cell-even-background-color: var(--ht-background-secondary-color);
   --ht-button-border-radius: var(--ht-sizing-size-4);

--- a/handsontable/src/themes/static/variables/tokens/horizon.ts
+++ b/handsontable/src/themes/static/variables/tokens/horizon.ts
@@ -79,10 +79,6 @@ const horizonTokens: ThemeTokensConfig = {
   headerRowActiveForegroundColor: 'tokens.backgroundColor',
   headerRowActiveBackgroundColor: ['colors.palette.950', 'colors.primary.200'],
   rowHeaderOddBackgroundColor: 'tokens.headerRowBackgroundColor',
-  // Horizon keeps an independent even-row header value to preserve its intentional zebra stripe on
-  // row headers. Odd headers derive from `headerRowBackgroundColor` (so a custom header row color
-  // cascades), while even headers use `backgroundSecondaryColor` to alternate. Do NOT collapse this
-  // to `headerRowBackgroundColor` — that removes the stripe (see DEV-1189 / #12322).
   rowHeaderEvenBackgroundColor: 'tokens.backgroundSecondaryColor',
   rowCellOddBackgroundColor: 'tokens.backgroundColor',
   rowCellEvenBackgroundColor: 'tokens.backgroundSecondaryColor',

--- a/handsontable/src/themes/static/variables/tokens/horizon.ts
+++ b/handsontable/src/themes/static/variables/tokens/horizon.ts
@@ -79,7 +79,11 @@ const horizonTokens: ThemeTokensConfig = {
   headerRowActiveForegroundColor: 'tokens.backgroundColor',
   headerRowActiveBackgroundColor: ['colors.palette.950', 'colors.primary.200'],
   rowHeaderOddBackgroundColor: 'tokens.headerRowBackgroundColor',
-  rowHeaderEvenBackgroundColor: 'tokens.headerRowBackgroundColor',
+  // Horizon keeps an independent even-row header value to preserve its intentional zebra stripe on
+  // row headers. Odd headers derive from `headerRowBackgroundColor` (so a custom header row color
+  // cascades), while even headers use `backgroundSecondaryColor` to alternate. Do NOT collapse this
+  // to `headerRowBackgroundColor` — that removes the stripe (see DEV-1189 / #12322).
+  rowHeaderEvenBackgroundColor: 'tokens.backgroundSecondaryColor',
   rowCellOddBackgroundColor: 'tokens.backgroundColor',
   rowCellEvenBackgroundColor: 'tokens.backgroundSecondaryColor',
   buttonBorderRadius: 'sizing.size_4',


### PR DESCRIPTION
### Context

The PR fixes a regression on the Horizon theme where the row headers (the row-number column) stopped showing their alternating (zebra) stripe. The data cells still striped, so an even row had a gray data area but a white row-header cell — an inconsistent, half-striped look. It was most visible on the docs Themes page (built fresh from source), while local builds looked fine because their compiled CSS was stale.

The even/odd `ht__row_even` / `ht__row_odd` classes are still present on the row `<tr>` elements — this is a CSS token regression, not a rendering one.

Commit 4de1675699 (RELEASE-700, #12908) changed Horizon's `rowHeaderEvenBackgroundColor` from `backgroundSecondaryColor` to `headerRowBackgroundColor`, making even and odd row headers identical. That undid a deliberate exception documented in #12322 (DEV-1189): for the Horizon theme, `rowHeaderEvenBackgroundColor` keeps its independent value (`tokens.backgroundSecondaryColor`) to preserve the intentional alternating stripe. Main and classic themes have no striping at all, so aligning Horizon's header token to them was incorrect for Horizon (whose cells still stripe).

This PR restores Horizon's `rowHeaderEvenBackgroundColor` to `tokens.backgroundSecondaryColor` across the theme layers: the JS token (`horizon.ts`) and the two static CSS defaults (`ht-theme-horizon.css`, `ht-theme-horizon-no-icons.css`). Odd headers still cascade from `headerRowBackgroundColor`, so a custom header-row color still reaches them while the stripe stays visible.

### How has this been tested?

- Updated `src/themes/__tests__/release700.unit.js`: split Horizon out of the "cascade from headerRowBackgroundColor" assertions (main/classic still cascade), corrected the Horizon expectation to `backgroundSecondaryColor`, and added a positive regression asserting Horizon's even and odd row-header tokens differ (both for the JS tokens and the static CSS files).
- `npm run test:unit --prefix handsontable --testPathPattern=themes` — 199 tests pass.
- `npm run eslint --prefix handsontable` on the changed files — clean.
- Manual: rebuilt the theme CSS and verified in a live browser under Horizon that the odd row header is `#fff` and the even row header is `#f7f7f9`, matching the data cells — the stripe is restored.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2083

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2083

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Theme-only CSS/token revert with targeted unit tests; no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes a **Horizon theme regression** where even row headers lost their alternating background and no longer matched striped data cells.
> 
> **Horizon** `rowHeaderEvenBackgroundColor` is set back to `tokens.backgroundSecondaryColor` in `horizon.ts` and in `ht-theme-horizon.css` / `ht-theme-horizon-no-icons.css` (`--ht-row-header-even-background-color` → `--ht-background-secondary-color`). Odd row headers still use `headerRowBackgroundColor`, so the zebra pattern returns. **Main** and **classic** themes are unchanged—they still cascade even row headers from the header row background.
> 
> Unit tests in `release700.unit.js` split cascading vs striped theme CSS expectations and add assertions that Horizon’s even/odd row-header tokens differ. A changelog entry documents the fix (#13084).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6669e26f0e7c354685f9d6829166d73eba46fd7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->