### PR TITLE
DEV-2085: Make Formulas index translations O(1) and batch engine row/column removals

### DIFF
--- a/.changelogs/13085.json
+++ b/.changelogs/13085.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Improved Formulas plugin performance on large grids: faster rendering and sorting through cached index translations, and bulk row/column removals now issue batched engine calls.",
+  "type": "changed",
+  "issueOrPR": 13085,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/formulas/__tests__/formulas.spec.js
+++ b/handsontable/src/plugins/formulas/__tests__/formulas.spec.js
@@ -754,9 +754,64 @@ describe('Formulas general', () => {
       spyOn(engine, 'removeRows').and.callThrough();
       await alter('remove_row', 9, 3);
 
-      expect(engine.removeRows.calls.argsFor(0)).toEqual([0, [11, 1]]);
-      expect(engine.removeRows.calls.argsFor(1)).toEqual([0, [10, 1]]);
-      expect(engine.removeRows.calls.argsFor(2)).toEqual([0, [9, 1]]);
+      expect(engine.removeRows.calls.count()).toBe(1);
+      expect(engine.removeRows.calls.argsFor(0)).toEqual([0, [9, 3]]);
+    });
+
+    it('should remove rows with non-contiguous engine indexes (trimmed rows in between) within a single engine call', async() => {
+      handsontable({
+        data: [
+          [1, null],
+          [2, null],
+          [3, null],
+          [4, null],
+          [5, null],
+          [6, '=SUM(A1:A6)'],
+        ],
+        trimRows: [2],
+        formulas: {
+          engine: HyperFormula,
+        },
+      });
+
+      const engine = getPlugin('formulas').engine;
+
+      spyOn(engine, 'removeRows').and.callThrough();
+
+      // Visual rows 0-3 map to physical (and engine) rows 0, 1, 3, 4 — the trimmed
+      // physical row 2 splits them into two spans.
+      await alter('remove_row', 0, 4);
+
+      expect(engine.removeRows.calls.count()).toBe(1);
+      expect(engine.removeRows.calls.argsFor(0)).toEqual([0, [0, 2], [3, 2]]);
+      expect(countRows()).toBe(1);
+      expect(getDataAtRow(0)).toEqual([6, 9]);
+    });
+
+    it('should restore values with a single undo after a coalesced multi-row removal', async() => {
+      handsontable({
+        data: [
+          [1, '=SUM(A1:A5)'],
+          [2, null],
+          [3, null],
+          [4, null],
+          [5, null],
+        ],
+        formulas: {
+          engine: HyperFormula,
+        },
+      });
+
+      await alter('remove_row', 1, 3);
+
+      expect(countRows()).toBe(2);
+      expect(getDataAtCell(0, 1)).toBe(6);
+
+      getPlugin('undoRedo').undo();
+
+      expect(countRows()).toBe(5);
+      expect(getDataAtCol(0)).toEqual([1, 2, 3, 4, 5]);
+      expect(getDataAtCell(0, 1)).toBe(15);
     });
 
     it('should not throw an error after removing all rows', async() => {
@@ -942,9 +997,8 @@ describe('Formulas general', () => {
       spyOn(engine, 'removeColumns').and.callThrough();
       await alter('remove_col', 9, 3);
 
-      expect(engine.removeColumns.calls.argsFor(0)).toEqual([0, [11, 1]]);
-      expect(engine.removeColumns.calls.argsFor(1)).toEqual([0, [10, 1]]);
-      expect(engine.removeColumns.calls.argsFor(2)).toEqual([0, [9, 1]]);
+      expect(engine.removeColumns.calls.count()).toBe(1);
+      expect(engine.removeColumns.calls.argsFor(0)).toEqual([0, [9, 3]]);
     });
 
     it('should recalculate table and replace coordinates in formula expressions into #REF! ' +

--- a/handsontable/src/plugins/formulas/__tests__/indexSyncer/axisSyncerInitialOrder.unit.js
+++ b/handsontable/src/plugins/formulas/__tests__/indexSyncer/axisSyncerInitialOrder.unit.js
@@ -5,6 +5,7 @@ function createMockIndexMapper(indexesSequence, notTrimmedIndexes = indexesSeque
     getIndexesSequence: () => indexesSequence,
     getNotTrimmedIndexes: () => notTrimmedIndexes,
     getNumberOfIndexes: () => indexesSequence.length,
+    addLocalHook: () => {},
   };
 }
 

--- a/handsontable/src/plugins/formulas/__tests__/indexSyncer/axisSyncerTranslations.unit.js
+++ b/handsontable/src/plugins/formulas/__tests__/indexSyncer/axisSyncerTranslations.unit.js
@@ -1,0 +1,177 @@
+import AxisSyncer from '../../indexSyncer/axisSyncer';
+
+function createMockIndexMapper(indexesSequence, notTrimmedIndexes = indexesSequence) {
+  const localHooks = {};
+  const calls = { getIndexesSequence: 0 };
+  const mapper = {
+    calls,
+    state: { indexesSequence, notTrimmedIndexes },
+    getIndexesSequence: () => {
+      calls.getIndexesSequence += 1;
+
+      return mapper.state.indexesSequence;
+    },
+    getNotTrimmedIndexes: () => mapper.state.notTrimmedIndexes,
+    getNumberOfIndexes: () => mapper.state.indexesSequence.length,
+    getVisualFromPhysicalIndex:
+      physicalIndex => (mapper.state.notTrimmedIndexes.includes(physicalIndex) ?
+        mapper.state.notTrimmedIndexes.indexOf(physicalIndex) : null),
+    addLocalHook: (key, callback) => {
+      localHooks[key] = localHooks[key] ?? [];
+      localHooks[key].push(callback);
+    },
+    runLocalHooks: (key, ...args) => {
+      (localHooks[key] ?? []).forEach(callback => callback(...args));
+    },
+  };
+
+  return mapper;
+}
+
+function createMockIndexSyncer() {
+  return {
+    getEngine: () => null,
+    getSheetId: () => 0,
+    isPerformingUndoRedo: () => false,
+    getPostponeAction: () => () => {},
+  };
+}
+
+describe('AxisSyncer index translations', () => {
+  describe('getHfIndexFromVisualIndex', () => {
+    it('should return the same index when the sequence is the identity and nothing is trimmed', () => {
+      const indexMapper = createMockIndexMapper([0, 1, 2, 3, 4]);
+      const axisSyncer = new AxisSyncer('row', indexMapper, createMockIndexSyncer());
+
+      expect(axisSyncer.getHfIndexFromVisualIndex(0)).toBe(0);
+      expect(axisSyncer.getHfIndexFromVisualIndex(2)).toBe(2);
+      expect(axisSyncer.getHfIndexFromVisualIndex(4)).toBe(4);
+    });
+
+    it('should return the position within the full sequence when some indexes are trimmed', () => {
+      // Physical indexes 1 and 3 are trimmed. Visual 0 -> physical 0 (HF 0),
+      // visual 1 -> physical 2 (HF 2), visual 2 -> physical 4 (HF 4).
+      const indexMapper = createMockIndexMapper([0, 1, 2, 3, 4], [0, 2, 4]);
+      const axisSyncer = new AxisSyncer('row', indexMapper, createMockIndexSyncer());
+
+      expect(axisSyncer.getHfIndexFromVisualIndex(0)).toBe(0);
+      expect(axisSyncer.getHfIndexFromVisualIndex(1)).toBe(2);
+      expect(axisSyncer.getHfIndexFromVisualIndex(2)).toBe(4);
+    });
+
+    it('should respect a reordered sequence combined with trimming', () => {
+      // Sequence [2, 0, 1] with physical 0 trimmed: visual 0 -> physical 2 (HF 0),
+      // visual 1 -> physical 1 (HF 2).
+      const indexMapper = createMockIndexMapper([2, 0, 1], [2, 1]);
+      const axisSyncer = new AxisSyncer('row', indexMapper, createMockIndexSyncer());
+
+      expect(axisSyncer.getHfIndexFromVisualIndex(0)).toBe(0);
+      expect(axisSyncer.getHfIndexFromVisualIndex(1)).toBe(2);
+    });
+
+    it('should return -1 for out-of-range and negative visual indexes', () => {
+      const indexMapper = createMockIndexMapper([0, 1, 2]);
+      const axisSyncer = new AxisSyncer('row', indexMapper, createMockIndexSyncer());
+
+      expect(axisSyncer.getHfIndexFromVisualIndex(3)).toBe(-1);
+      expect(axisSyncer.getHfIndexFromVisualIndex(100)).toBe(-1);
+      expect(axisSyncer.getHfIndexFromVisualIndex(-1)).toBe(-1);
+    });
+  });
+
+  describe('getVisualIndexFromHfIndex', () => {
+    it('should be the inverse of getHfIndexFromVisualIndex for not-trimmed indexes', () => {
+      const indexMapper = createMockIndexMapper([2, 0, 1], [2, 1]);
+      const axisSyncer = new AxisSyncer('row', indexMapper, createMockIndexSyncer());
+
+      expect(axisSyncer.getVisualIndexFromHfIndex(0)).toBe(0); // physical 2 -> visual 0
+      expect(axisSyncer.getVisualIndexFromHfIndex(2)).toBe(1); // physical 1 -> visual 1
+    });
+
+    it('should return -1 when the HF index points to a trimmed element', () => {
+      const indexMapper = createMockIndexMapper([0, 1, 2, 3, 4], [0, 2, 4]);
+      const axisSyncer = new AxisSyncer('row', indexMapper, createMockIndexSyncer());
+
+      expect(axisSyncer.getVisualIndexFromHfIndex(1)).toBe(-1);
+      expect(axisSyncer.getVisualIndexFromHfIndex(3)).toBe(-1);
+    });
+
+    it('should return -1 for out-of-range HF indexes', () => {
+      const indexMapper = createMockIndexMapper([0, 1, 2]);
+      const axisSyncer = new AxisSyncer('row', indexMapper, createMockIndexSyncer());
+
+      expect(axisSyncer.getVisualIndexFromHfIndex(3)).toBe(-1);
+      expect(axisSyncer.getVisualIndexFromHfIndex(-1)).toBe(-1);
+    });
+  });
+
+  describe('translation cache', () => {
+    it('should not rebuild the translation tables between calls when indexes do not change', () => {
+      const indexMapper = createMockIndexMapper([0, 1, 2, 3]);
+      const axisSyncer = new AxisSyncer('row', indexMapper, createMockIndexSyncer());
+
+      axisSyncer.getHfIndexFromVisualIndex(0);
+      axisSyncer.getHfIndexFromVisualIndex(1);
+      axisSyncer.getVisualIndexFromHfIndex(2);
+      axisSyncer.getVisualIndexFromHfIndex(3);
+
+      expect(indexMapper.calls.getIndexesSequence).toBe(1);
+    });
+
+    it('should rebuild the translation tables after the `indexesSequenceChange` hook fires', () => {
+      const indexMapper = createMockIndexMapper([0, 1, 2]);
+      const axisSyncer = new AxisSyncer('row', indexMapper, createMockIndexSyncer());
+
+      expect(axisSyncer.getHfIndexFromVisualIndex(0)).toBe(0);
+
+      indexMapper.state.indexesSequence = [2, 0, 1];
+      indexMapper.state.notTrimmedIndexes = [2, 0, 1];
+      indexMapper.runLocalHooks('indexesSequenceChange', 'update');
+
+      expect(axisSyncer.getHfIndexFromVisualIndex(0)).toBe(0); // physical 2 at HF position 0
+      expect(axisSyncer.getHfIndexFromVisualIndex(1)).toBe(1); // physical 0 at HF position 1
+      expect(axisSyncer.getVisualIndexFromHfIndex(2)).toBe(2); // physical 1 -> visual 2
+    });
+
+    it('should rebuild the translation tables after the `cacheUpdated` hook reports a trimming change', () => {
+      const indexMapper = createMockIndexMapper([0, 1, 2, 3]);
+      const axisSyncer = new AxisSyncer('row', indexMapper, createMockIndexSyncer());
+
+      expect(axisSyncer.getHfIndexFromVisualIndex(1)).toBe(1);
+
+      indexMapper.state.notTrimmedIndexes = [0, 2, 3];
+      indexMapper.runLocalHooks('cacheUpdated', { trimmedIndexesChanged: true });
+
+      expect(axisSyncer.getHfIndexFromVisualIndex(1)).toBe(2);
+      expect(axisSyncer.getVisualIndexFromHfIndex(1)).toBe(-1);
+    });
+
+    it('should keep the translation tables when the `cacheUpdated` hook reports no trimming change', () => {
+      const indexMapper = createMockIndexMapper([0, 1, 2, 3]);
+      const axisSyncer = new AxisSyncer('row', indexMapper, createMockIndexSyncer());
+
+      axisSyncer.getHfIndexFromVisualIndex(1);
+      indexMapper.runLocalHooks('cacheUpdated', { trimmedIndexesChanged: false });
+      axisSyncer.getHfIndexFromVisualIndex(2);
+
+      expect(indexMapper.calls.getIndexesSequence).toBe(1);
+    });
+  });
+
+  describe('setRemovedHfIndexes', () => {
+    it('should translate the removed physical indexes to HF indexes', () => {
+      const indexMapper = createMockIndexMapper([0, 1, 2, 3, 4]);
+      const axisSyncer = new AxisSyncer('row', indexMapper, createMockIndexSyncer());
+
+      expect(axisSyncer.setRemovedHfIndexes([1, 3])).toEqual([1, 3]);
+      expect(axisSyncer.getRemovedHfIndexes()).toEqual([1, 3]);
+    });
+
+    it('should translate removed physical indexes to -1 when they are trimmed', () => {
+      const indexMapper = createMockIndexMapper([0, 1, 2, 3, 4], [0, 2, 4]);
+      const axisSyncer = new AxisSyncer('row', indexMapper, createMockIndexSyncer());
+
+      expect(axisSyncer.setRemovedHfIndexes([1, 2])).toEqual([-1, 2]);
+    });
+  });
+});

--- a/handsontable/src/plugins/formulas/__tests__/utils.unit.ts
+++ b/handsontable/src/plugins/formulas/__tests__/utils.unit.ts
@@ -1,4 +1,5 @@
 import {
+  coalesceIndexesToSpans,
   isEscapedFormulaExpression,
   unescapeFormulaExpression,
   isDateValid,
@@ -144,6 +145,42 @@ describe('Formulas utils', () => {
       expect(normalizeValueForFormulaEngine(123)).toBe(123);
       expect(normalizeValueForFormulaEngine(null)).toBeNull();
       expect(normalizeValueForFormulaEngine(objectValue)).toBe(objectValue);
+    });
+  });
+
+  describe('coalesceIndexesToSpans', () => {
+    it('should return an empty list for an empty input', () => {
+      expect(coalesceIndexesToSpans([])).toEqual([]);
+    });
+
+    it('should wrap a single index in a single span', () => {
+      expect(coalesceIndexesToSpans([5])).toEqual([[5, 1]]);
+    });
+
+    it('should merge contiguous indexes into one span', () => {
+      expect(coalesceIndexesToSpans([2, 3, 4])).toEqual([[2, 3]]);
+    });
+
+    it('should keep non-contiguous indexes in separate ascending spans', () => {
+      expect(coalesceIndexesToSpans([0, 2, 4])).toEqual([[0, 1], [2, 1], [4, 1]]);
+    });
+
+    it('should sort unordered input before coalescing', () => {
+      expect(coalesceIndexesToSpans([5, 1, 2, 3, 9])).toEqual([[1, 3], [5, 1], [9, 1]]);
+      expect(coalesceIndexesToSpans([10, 9, 8, 0])).toEqual([[0, 1], [8, 3]]);
+    });
+
+    it('should count duplicate indexes once', () => {
+      expect(coalesceIndexesToSpans([1, 1, 2, 2, 3])).toEqual([[1, 3]]);
+      expect(coalesceIndexesToSpans([4, 4])).toEqual([[4, 1]]);
+    });
+
+    it('should not mutate the input list', () => {
+      const indexes = [3, 1, 2];
+
+      coalesceIndexesToSpans(indexes);
+
+      expect(indexes).toEqual([3, 1, 2]);
     });
   });
 });

--- a/handsontable/src/plugins/formulas/engine/types.ts
+++ b/handsontable/src/plugins/formulas/engine/types.ts
@@ -22,8 +22,8 @@ export interface HyperFormulaEngine {
   isItPossibleToRemoveColumns(sheetId: number | null, spec: [number, number]): boolean;
   addRows(sheetId: number | null, spec: [number, number]): unknown[];
   addColumns(sheetId: number | null, spec: [number, number]): unknown[];
-  removeRows(sheetId: number | null, spec: [number, number]): void;
-  removeColumns(sheetId: number | null, spec: [number, number]): void;
+  removeRows(sheetId: number | null, ...indexes: [number, number][]): void;
+  removeColumns(sheetId: number | null, ...indexes: [number, number][]): void;
   getFillRangeData(sourceRange: object, targetRange: object): unknown[][];
   batch(callback: () => void): unknown[];
   getConfig(): Record<string, unknown>;

--- a/handsontable/src/plugins/formulas/formulas.ts
+++ b/handsontable/src/plugins/formulas/formulas.ts
@@ -6,6 +6,7 @@ import { isObject } from '../../helpers/object';
 import { isDefined, isUndefined } from '../../helpers/mixed';
 import { getRegisteredHotInstances, setupEngine, setupSheet, unregisterEngine, } from './engine/register';
 import {
+  coalesceIndexesToSpans,
   getDateFromExcelDate,
   getDateInHfFormat,
   getDateInHotFormat,
@@ -94,6 +95,10 @@ Hooks.getSingleton().register('afterFormulasValuesUpdate');
 // instances of Handsontable and HyperFormula should be synced (number of actions should be the same).
 const isBlockedSource = (source: unknown) =>
   source === 'UndoRedo.undo' || source === 'UndoRedo.redo' || source === 'auto';
+
+// Maximum number of `[startIndex, amount]` spans passed to a single variadic engine
+// `removeRows`/`removeColumns` call. An unbounded argument spread could overflow the call stack.
+const REMOVAL_SPANS_CHUNK_SIZE = 1000;
 
 /**
  * This plugin allows you to perform Excel-like calculations in your business applications. It does it by an
@@ -1480,14 +1485,10 @@ export class Formulas extends BasePlugin {
       return;
     }
 
-    const descendingHfRows = this.rowAxisSyncer!
-      .getRemovedHfIndexes()
-      .sort((a: number, b: number) => b - a); // sort numeric values descending
+    const removedSpans = coalesceIndexesToSpans(this.rowAxisSyncer!.getRemovedHfIndexes());
 
     const changes = this.engine!.batch(() => {
-      descendingHfRows.forEach((hfRow: number) => {
-        this.engine!.removeRows(this.sheetId, [hfRow, 1]);
-      });
+      this.#removeSpansFromEngine(removedSpans, 'removeRows');
     });
 
     this.renderDependentSheets(changes);
@@ -1507,18 +1508,37 @@ export class Formulas extends BasePlugin {
       return;
     }
 
-    const descendingHfColumns = this.columnAxisSyncer!
-      .getRemovedHfIndexes()
-      .sort((a: number, b: number) => b - a); // sort numeric values descending
+    const removedSpans = coalesceIndexesToSpans(this.columnAxisSyncer!.getRemovedHfIndexes());
 
     const changes = this.engine!.batch(() => {
-      descendingHfColumns.forEach((hfColumn: number) => {
-        this.engine!.removeColumns(this.sheetId, [hfColumn, 1]);
-      });
+      this.#removeSpansFromEngine(removedSpans, 'removeColumns');
     });
 
     this.renderDependentSheets(changes);
   };
+
+  /**
+   * Removes the provided `[startIndex, amount]` spans from the engine in as few calls as possible.
+   * One call handles many spans, so the engine pays its dependency-graph remap once per call instead
+   * of once per removed row or column. The engine methods are variadic, so the spans are chunked to
+   * keep the argument spread within call-stack limits; chunks run from the highest spans down, which
+   * keeps the original coordinates of the not-yet-removed lower spans valid.
+   *
+   * @param {Array<Array<number>>} spans Ascending list of `[startIndex, amount]` spans to remove.
+   * @param {'removeRows'|'removeColumns'} engineMethodName The engine removal method to call.
+   */
+  #removeSpansFromEngine(spans: [number, number][], engineMethodName: 'removeRows' | 'removeColumns') {
+    for (let end = spans.length; end > 0; end -= REMOVAL_SPANS_CHUNK_SIZE) {
+      const chunk = spans.slice(Math.max(0, end - REMOVAL_SPANS_CHUNK_SIZE), end);
+
+      if (engineMethodName === 'removeRows') {
+        this.engine!.removeRows(this.sheetId, ...chunk);
+
+      } else {
+        this.engine!.removeColumns(this.sheetId, ...chunk);
+      }
+    }
+  }
 
   /**
    * `afterDetachChild` hook callback.

--- a/handsontable/src/plugins/formulas/indexSyncer/axisSyncer.ts
+++ b/handsontable/src/plugins/formulas/indexSyncer/axisSyncer.ts
@@ -7,6 +7,23 @@ interface AxisIndexMapper {
   getIndexesSequence(): number[];
   getNotTrimmedIndexes(): number[];
   getNumberOfIndexes(): number;
+  addLocalHook(key: string, callback: Function): unknown;
+}
+
+interface HfTranslationCache {
+  /**
+   * Snapshot of the physical indexes sequence. The position in this array is the HF index,
+   * the value is the physical index.
+   */
+  physicalIndexOfHf: number[];
+  /**
+   * Inverse of the sequence. The position in this array is the physical index, the value is the HF index.
+   */
+  hfIndexOfPhysical: number[];
+  /**
+   * Translation from a physical index to its visual index, or `-1` when the physical index is trimmed.
+   */
+  visualIndexOfPhysical: number[];
 }
 
 interface ParentIndexSyncer {
@@ -75,6 +92,16 @@ class AxisSyncer {
    * @type {Array<number>}
    */
   #removedIndexes: number[] = [];
+  /**
+   * Cached translation tables between physical, visual, and HF indexes. Built lazily on the first
+   * translation call and invalidated whenever the indexes sequence or the trimmed indexes change.
+   * Keeping the tables makes both translation methods O(1) per call — they are called for every
+   * rendered cell, so a per-call sequence scan would scale with the dataset size.
+   *
+   * @private
+   * @type {HfTranslationCache|null}
+   */
+  #translationCache: HfTranslationCache | null = null;
 
   /**
    * Initializes the axis syncer for the given axis with the corresponding index mapper and parent index syncer references.
@@ -83,6 +110,44 @@ class AxisSyncer {
     this.#axis = axis;
     this.#indexMapper = indexMapper;
     this.#indexSyncer = indexSyncer;
+
+    // The sequence hook fires synchronously on every sequence mutation (also mid-batch), the
+    // `cacheUpdated` hook fires when the mapper rebuilds its own `notTrimmedIndexes` cache — the
+    // same moment from which the translation methods would read the new trimming state.
+    this.#indexMapper.addLocalHook('indexesSequenceChange', () => {
+      this.#translationCache = null;
+    });
+    this.#indexMapper.addLocalHook('cacheUpdated', (changes: { trimmedIndexesChanged: boolean }) => {
+      if (changes.trimmedIndexesChanged) {
+        this.#translationCache = null;
+      }
+    });
+  }
+
+  /**
+   * Gets the cached translation tables between physical, visual, and HF indexes, building them when needed.
+   *
+   * @returns {HfTranslationCache}
+   */
+  #getTranslationCache(): HfTranslationCache {
+    if (this.#translationCache === null) {
+      const physicalIndexOfHf = this.#indexMapper.getIndexesSequence();
+      const notTrimmedIndexes = this.#indexMapper.getNotTrimmedIndexes();
+      const hfIndexOfPhysical: number[] = new Array<number>(physicalIndexOfHf.length);
+      const visualIndexOfPhysical: number[] = new Array<number>(physicalIndexOfHf.length).fill(-1);
+
+      for (let hfIndex = 0; hfIndex < physicalIndexOfHf.length; hfIndex += 1) {
+        hfIndexOfPhysical[physicalIndexOfHf[hfIndex]] = hfIndex;
+      }
+
+      for (let visualIndex = 0; visualIndex < notTrimmedIndexes.length; visualIndex += 1) {
+        visualIndexOfPhysical[notTrimmedIndexes[visualIndex]] = visualIndex;
+      }
+
+      this.#translationCache = { physicalIndexOfHf, hfIndexOfPhysical, visualIndexOfPhysical };
+    }
+
+    return this.#translationCache;
   }
 
   /**
@@ -118,13 +183,15 @@ class AxisSyncer {
    * @returns {number}
    */
   getHfIndexFromVisualIndex(visualIndex: number) {
-    const indexesSequence = this.#indexMapper.getIndexesSequence();
-    const notTrimmedIndexes = this.#indexMapper.getNotTrimmedIndexes();
+    const physicalIndex = this.#indexMapper.getNotTrimmedIndexes()[visualIndex];
 
-    // Optimization:
-    // notTrimmedIndexes is a subset of indexesSequence,
-    // so for every x indexesSequence.indexOf(x) is always >= notTrimmedIndexes.indexOf(x)
-    return indexesSequence.indexOf(notTrimmedIndexes[visualIndex], visualIndex);
+    if (physicalIndex === undefined) {
+      return -1;
+    }
+
+    // The `?? -1` covers a mid-batch state in which the mapper's not-trimmed cache still holds a
+    // physical index that is no longer part of the sequence.
+    return this.#getTranslationCache().hfIndexOfPhysical[physicalIndex] ?? -1;
   }
 
   /**
@@ -135,15 +202,14 @@ class AxisSyncer {
    * @returns {number}
    */
   getVisualIndexFromHfIndex(hfIndex: number) {
-    const indexesSequence = this.#indexMapper.getIndexesSequence();
-    const notTrimmedIndexes = this.#indexMapper.getNotTrimmedIndexes();
-    const physicalIndex = indexesSequence[hfIndex];
+    const { physicalIndexOfHf, visualIndexOfPhysical } = this.#getTranslationCache();
+    const physicalIndex = physicalIndexOfHf[hfIndex];
 
     if (physicalIndex === undefined) {
       return -1;
     }
 
-    return notTrimmedIndexes.indexOf(physicalIndex);
+    return visualIndexOfPhysical[physicalIndex];
   }
 
   /**
@@ -232,7 +298,15 @@ class AxisSyncer {
       const newSequence = this.#indexMapper.getIndexesSequence();
 
       if (source === 'update' && newSequence.length > 0) {
-        const relativeTransformation = this.#indexesSequence.map(index => newSequence.indexOf(index));
+        // One-pass inverse lookup instead of `newSequence.indexOf` per element, which would make
+        // every sort/unsort quadratic in the number of rows or columns.
+        const positionOfPhysical: number[] = new Array<number>(newSequence.length);
+
+        for (let position = 0; position < newSequence.length; position += 1) {
+          positionOfPhysical[newSequence[position]] = position;
+        }
+
+        const relativeTransformation = this.#indexesSequence.map(index => positionOfPhysical[index] ?? -1);
         const sheetDimensions = this.#indexSyncer.getEngine()!.getSheetDimensions(this.#indexSyncer.getSheetId()!);
         let sizeForAxis;
 
@@ -290,8 +364,13 @@ class AxisSyncer {
     const sizeForAxis = this.#axis === 'row' ? sheetDimensions.height : sheetDimensions.width;
     // HF currently holds data in physical order ([0..n-1] identity). The transformation tells HF where each
     // currently-held element should move to, so that HF's visual order matches HOT's visual order. For each
-    // current position `i`, the target position is the visual index of physical `i`, i.e. `sequence.indexOf(i)`.
-    const transformation = Array.from({ length: sequence.length }, (_, i) => sequence.indexOf(i));
+    // current position `i`, the target position is the visual index of physical `i` — that is, the inverse
+    // permutation of the sequence, built in one pass.
+    const transformation: number[] = new Array<number>(sequence.length);
+
+    for (let position = 0; position < sequence.length; position += 1) {
+      transformation[sequence[position]] = position;
+    }
 
     for (let i = transformation.length; i < sizeForAxis; i += 1) {
       transformation.push(i);

--- a/handsontable/src/plugins/formulas/utils.ts
+++ b/handsontable/src/plugins/formulas/utils.ts
@@ -113,6 +113,32 @@ export function getDateFromExcelDate(numericDate: unknown): string {
 }
 
 /**
+ * Coalesces a list of indexes into an ascending list of contiguous `[startIndex, amount]` spans.
+ * For example, `[5, 1, 2, 3, 9]` becomes `[[1, 3], [5, 1], [9, 1]]`. The input order does not
+ * matter and duplicate indexes are counted once.
+ *
+ * @param {number[]} indexes List of indexes to coalesce.
+ * @returns {Array<Array<number>>} Ascending list of `[startIndex, amount]` spans.
+ */
+export function coalesceIndexesToSpans(indexes: number[]): [number, number][] {
+  const sortedIndexes = [...indexes].sort((a, b) => a - b);
+  const spans: [number, number][] = [];
+
+  sortedIndexes.forEach((index) => {
+    const lastSpan = spans[spans.length - 1];
+
+    if (lastSpan === undefined || index > lastSpan[0] + lastSpan[1]) {
+      spans.push([index, 1]);
+
+    } else if (index === lastSpan[0] + lastSpan[1]) {
+      lastSpan[1] += 1;
+    }
+  });
+
+  return spans;
+}
+
+/**
  * Converts a Handsontable cell value to a value accepted by HyperFormula.
  * HyperFormula doesn't accept arrays as direct cell values, so they are converted to a
  * comma-separated string.


### PR DESCRIPTION
### Context

The PR fixes four algorithmic-complexity hotspots in the Formulas plugin, found by the 2026-07-15 complexity audit (findings #4 critical, #31, #32, #33 high). All four scaled with the total grid size instead of the work at hand:

1. **`AxisSyncer.getHfIndexFromVisualIndex` ran per rendered cell and materialized the full index sequence per call.** The formulas render path (`modifyData` → `getCellType`) calls it 2–4 times per cell, and `getIndexesSequence()` allocates a fresh n-element array on every call in the default identity state. At 100k rows that is tens of millions of array writes and hundreds of MB of garbage per draw.
2. **`getIndexesChangeSyncMethod` was O(n²) on every sort/unsort** — `.map` over the old sequence with `indexOf` over the new one. The same pattern lived in `#syncInitialOrder` (init-only).
3. **`getVisualIndexFromHfIndex` did an unhinted O(n) `indexOf` per engine-reported change.** Editing one precedent cell that feeds a whole formula column made this O(n²) per keystroke.
4. **`#onAfterRemoveRow`/`#onAfterRemoveCol` issued one `engine.removeRows` call per removed row.** HyperFormula pays a full dependency-graph and address-mapping remap per call (`batch()` defers recalculation only, not structural remaps), so deleting 10k rows meant 10k remaps.

The fix:

- `AxisSyncer` keeps lazily-built translation tables (physical→HF, HF→physical, physical→visual), invalidated by the IndexMapper's `indexesSequenceChange` and `cacheUpdated` (trimming) local hooks. Both translation methods are now O(1) per call. Edge semantics are preserved: `-1` for out-of-range/trimmed indexes, and mid-batch stale-cache states behave exactly as before (the tables read the same mapper caches the old code read).
- Sequence-change sync and initial-order sync build a one-pass inverse permutation instead of calling `indexOf` per element — O(n) per sort.
- Removed HF indexes are coalesced into contiguous `[start, amount]` spans (new `coalesceIndexesToSpans` util) and removed in one variadic engine call per 1000-span chunk. Chunks run from the highest spans down, so the original coordinates of lower spans stay valid, and the chunk cap keeps the argument spread inside call-stack limits. HyperFormula interprets multi-span calls in original coordinates (`normalizeRemovedIndexes`) and groups every operation inside `batch()` into a single undo entry, so undo behavior is unchanged.
- The `HyperFormulaEngine` type declarations now match HyperFormula's real variadic `removeRows`/`removeColumns` signature.

Measured (dev UMD builds, M-series MacBook, Chrome):

| Scenario | develop | this PR |
| --- | --- | --- |
| Scroll + render per draw (100k×10, formulas enabled) | 18.2 ms | 4.0 ms |
| Sort 100k rows | did not finish (frozen > 10 min) | 13.9 s (engine reorder dominates) |
| Sort / unsort 20k rows | 1.4 s / 5.0 s | 0.82 s / 0.82 s |
| Edit a precedent cell of a 20k-row formula column | 3.3 s | 0.22 s |
| Remove 10k of 50k rows | 54.4 s | 0.34 s |

### How has this been tested?

- New unit suite `axisSyncerTranslations.unit.js`: translation correctness (identity, reordered, trimmed, out-of-range/negative), cache invalidation through both local hooks, no rebuild between unchanged calls, `setRemovedHfIndexes` translation.
- New unit tests for `coalesceIndexesToSpans` (empty, single, contiguous, non-contiguous, unsorted, duplicates, input immutability).
- New E2E: removal across trimmed rows produces one engine call with two non-contiguous spans (`[0, [0, 2], [3, 2]]`); a single undo restores a coalesced multi-row removal. The `#dev-1841` tests updated to the new coalesced call shape.
- `npm run test:unit --prefix handsontable` — 3,190 passed.
- `npm run test:e2e --prefix handsontable` — full suite, 9,554 specs, 0 failures.
- `npm run build:types` + downlevel — clean emit.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2085

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/86carm6wc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Formulas index sync and structural engine updates on every render, sort, and bulk delete; semantics are heavily tested but regressions could affect formula coordinates, trimming, and undo.
> 
> **Overview**
> Improves **Formulas** performance on large grids by fixing index-mapping and engine-removal hotspots that previously scaled with total row/column count.
> 
> **`AxisSyncer`** now keeps lazily built translation tables (physical ↔ HF ↔ visual), invalidated on `indexesSequenceChange` and trimming-related `cacheUpdated` hooks, so `getHfIndexFromVisualIndex` / `getVisualIndexFromHfIndex` are **O(1)** per call instead of scanning sequences. Sort/unsort and initial-order sync build a **one-pass inverse permutation** instead of repeated `indexOf` (**O(n)** vs **O(n²)**).
> 
> Row/column removal no longer calls HyperFormula once per index: removed HF indexes are **coalesced** via new `coalesceIndexesToSpans`, then applied in **few variadic** `removeRows` / `removeColumns` calls (chunked at 1000 spans, highest spans first). Engine types now match HyperFormula’s variadic removal signature.
> 
> Tests and changelog updated; behavior (including undo for batched removals and trimmed-row span splitting) is covered by new unit/E2E specs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9999e1304d7677848b8089d35a5d59722412da35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->