### PR TITLE
DEV-2087: Create sort compare functions once per run and memoize sort keys

### DIFF
--- a/.changelogs/13087.json
+++ b/.changelogs/13087.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Improved sorting performance on large datasets: date and time columns no longer re-parse values on every comparison, and text columns no longer re-lowercase values on every comparison.",
+  "type": "changed",
+  "issueOrPR": 13087,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/columnSorting/__tests__/rootComparator.unit.ts
+++ b/handsontable/src/plugins/columnSorting/__tests__/rootComparator.unit.ts
@@ -1,0 +1,44 @@
+import { rootComparator } from 'handsontable/plugins/columnSorting/rootComparator';
+
+describe('columnSorting rootComparator', () => {
+  it('should invoke the compare function factory once per sort run, not once per comparison', () => {
+    const compareSpy = jest.fn((value: number, nextValue: number) => {
+      if (value === nextValue) {
+        return 0;
+      }
+
+      return value < nextValue ? -1 : 1;
+    });
+    const factorySpy = jest.fn(() => compareSpy);
+    const columnMeta = { columnSorting: { compareFunctionFactory: factorySpy } };
+
+    const comparator = rootComparator(['asc'], [columnMeta]);
+
+    expect(comparator([0, 2], [1, 1])).toBe(1);
+    expect(comparator([1, 1], [2, 3])).toBe(-1);
+    expect(comparator([2, 3], [3, 3])).toBe(0);
+
+    expect(factorySpy).toHaveBeenCalledTimes(1);
+    expect(factorySpy).toHaveBeenCalledWith('asc', columnMeta, columnMeta.columnSorting);
+    expect(compareSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it('should resolve the compare function from the column type when no custom factory is defined', () => {
+    const columnMeta = { type: 'numeric', columnSorting: {} };
+
+    const comparator = rootComparator(['asc'], [columnMeta]);
+
+    expect(comparator([0, 10], [1, 9])).toBe(1);
+    expect(comparator([0, '2'], [1, '10'])).toBe(-1);
+    expect(comparator([0, 5], [1, 5])).toBe(0);
+  });
+
+  it('should compare only the value stored right after the row index in the sorted tuples', () => {
+    const columnMeta = { type: 'numeric', columnSorting: {} };
+
+    const comparator = rootComparator(['asc'], [columnMeta]);
+
+    // Tuples are [rowIndex, value] — the row index (999 vs 1) must not affect the result.
+    expect(comparator([999, 1], [1, 2])).toBe(-1);
+  });
+});

--- a/handsontable/src/plugins/columnSorting/__tests__/sortFunction/default.unit.ts
+++ b/handsontable/src/plugins/columnSorting/__tests__/sortFunction/default.unit.ts
@@ -50,3 +50,34 @@ it('should sort case-insensitively and identically to the default Unicode mappin
   expect(compare('apple', 'Apple')).toBe(0);
   expect(compare('Apple', 'banana')).toBeLessThan(0);
 });
+
+it('should lowercase each distinct string once per created compare function', () => {
+  // eslint-disable-next-line global-require
+  const stringHelpers = require('handsontable/helpers/string');
+  const spy = jest.spyOn(stringHelpers, 'localeLowerCase');
+  const compare = defaultSort('asc', { locale: 'en-US' }, {});
+
+  expect(compare('Banana', 'apple')).toBe(1);
+  expect(compare('apple', 'Cherry')).toBe(-1);
+  expect(compare('Cherry', 'Banana')).toBe(1);
+  expect(compare('Banana', 'Cherry')).toBe(-1);
+
+  // 3 distinct strings across 8 sides — every repeat must hit the per-run cache.
+  expect(spy).toHaveBeenCalledTimes(3);
+
+  spy.mockRestore();
+});
+
+it('should not share the lowercase cache between separately created compare functions', () => {
+  // eslint-disable-next-line global-require
+  const stringHelpers = require('handsontable/helpers/string');
+  const spy = jest.spyOn(stringHelpers, 'localeLowerCase');
+
+  defaultSort('asc', { locale: 'en-US' }, {})('Apple', 'Banana');
+  defaultSort('asc', { locale: 'en-US' }, {})('Apple', 'Banana');
+
+  // Each compare function owns a fresh cache, so both runs lowercase both strings.
+  expect(spy).toHaveBeenCalledTimes(4);
+
+  spy.mockRestore();
+});

--- a/handsontable/src/plugins/columnSorting/__tests__/utils.unit.ts
+++ b/handsontable/src/plugins/columnSorting/__tests__/utils.unit.ts
@@ -2,9 +2,12 @@ import {
   areValidSortStates,
   ASC_SORT_STATE,
   DESC_SORT_STATE,
+  createIntlDateCompareFunction,
+  createIntlTimeCompareFunction,
   isFirstLevelColumnHeader,
   wasHeaderClickedProperly,
 } from 'handsontable/plugins/columnSorting/utils';
+import * as dateTimeHelpers from 'handsontable/helpers/dateTime';
 
 describe('ColumnSorting', () => {
   it('areValidSortStates', () => {
@@ -50,5 +53,54 @@ describe('ColumnSorting', () => {
 
     expect(wasHeaderClickedProperly(-2, 0, { button: 0, target: rowspannedHeader })).toBe(true);
     expect(wasHeaderClickedProperly(-2, 0, { button: 2, target: rowspannedHeader })).toBe(false);
+  });
+});
+
+describe('createIntlDateCompareFunction', () => {
+  it('should parse each distinct value once per created compare function', () => {
+    const spy = jest.spyOn(dateTimeHelpers, 'parseToLocalDate');
+    const compare = createIntlDateCompareFunction('asc', {});
+
+    expect(compare('2024-01-02', '2024-01-01')).toBe(1);
+    expect(compare('2024-01-01', '2024-01-03')).toBe(-1);
+    expect(compare('2024-01-03', '2024-01-02')).toBe(1);
+    expect(compare('2024-01-02', '2024-01-03')).toBe(-1);
+
+    // 3 distinct values across 8 sides — every repeat must hit the per-run cache.
+    expect(spy).toHaveBeenCalledTimes(3);
+
+    spy.mockRestore();
+  });
+
+  it('should return symmetric results for cached and freshly-parsed values', () => {
+    const compare = createIntlDateCompareFunction('asc', {});
+
+    expect(compare('2024-05-10', '2024-05-11')).toBe(-compare('2024-05-11', '2024-05-10'));
+    expect(compare('2024-05-10', '2024-05-10')).toBe(0);
+  });
+
+  it('should keep unparsable and empty value handling intact when values repeat', () => {
+    const compare = createIntlDateCompareFunction('asc', {});
+
+    expect(compare('not a date', '2024-05-10')).toBe(1);
+    expect(compare('2024-05-10', 'not a date')).toBe(-1);
+    expect(compare('not a date', '2024-05-10')).toBe(1);
+    expect(compare(null, '2024-05-10')).toBe(1);
+    expect(compare('2024-05-10', null)).toBe(-1);
+  });
+});
+
+describe('createIntlTimeCompareFunction', () => {
+  it('should parse each distinct value once per created compare function', () => {
+    const spy = jest.spyOn(dateTimeHelpers, 'parseToLocalTime');
+    const compare = createIntlTimeCompareFunction('asc', {});
+
+    expect(compare('10:30', '09:15')).toBe(1);
+    expect(compare('09:15', '11:45')).toBe(-1);
+    expect(compare('11:45', '10:30')).toBe(1);
+
+    expect(spy).toHaveBeenCalledTimes(3);
+
+    spy.mockRestore();
   });
 });

--- a/handsontable/src/plugins/columnSorting/rootComparator.ts
+++ b/handsontable/src/plugins/columnSorting/rootComparator.ts
@@ -1,5 +1,26 @@
 import { getCompareFunctionFactory } from './sortService';
 
+type CompareFn = (a: unknown, b: unknown) => number;
+type CompareFnFactory = (order: unknown, meta: unknown, settings: unknown) => CompareFn;
+
+/**
+ * Creates the compare function for a single sorted column. Resolved once per sort run — the
+ * factory result is reused for every comparison, so any per-run caching inside the returned
+ * compare function (e.g. normalized-value memoization) stays effective.
+ *
+ * @param {unknown} sortingOrder Sort order (`asc` for ascending, `desc` for descending).
+ * @param {unknown} columnMeta Column meta object.
+ * @returns {Function} The compare function.
+ */
+function createColumnCompareFunction(sortingOrder: unknown, columnMeta: unknown): CompareFn {
+  const typedMeta = columnMeta as { columnSorting?: { compareFunctionFactory?: CompareFnFactory }; type?: string };
+  const pluginSettings = typedMeta.columnSorting;
+  const compareFunctionFactory: CompareFnFactory = pluginSettings?.compareFunctionFactory ?
+    pluginSettings.compareFunctionFactory : getCompareFunctionFactory(typedMeta.type ?? '') as CompareFnFactory;
+
+  return compareFunctionFactory(sortingOrder, columnMeta, pluginSettings);
+}
+
 /**
  * Sort comparator handled by conventional sort algorithm.
  *
@@ -8,29 +29,14 @@ import { getCompareFunctionFactory } from './sortService';
  * @returns {Function}
  */
 export function rootComparator(sortingOrders: unknown[], columnMetas: unknown[]) {
+  // The compare function is created once per sort run, not once per comparison. Re-invoking the
+  // factory inside the comparator would allocate a fresh closure ~n*log(n) times and defeat the
+  // per-run value caches the built-in compare functions rely on.
+  const compareFunction = createColumnCompareFunction(sortingOrders[0], columnMetas[0]);
+
   return function(rowIndexWithValues: unknown[], nextRowIndexWithValues: unknown[]) {
-    // We sort array of arrays. Single array is in form [rowIndex, ...values].
-    // We compare just values, stored at second index of array.
-    const [, ...values] = rowIndexWithValues;
-    const [, ...nextValues] = nextRowIndexWithValues;
-
-    return (function getCompareResult(column): number {
-      const sortingOrder = sortingOrders[column];
-      const columnMeta = columnMetas[column];
-      const value = values[column];
-      const nextValue = nextValues[column];
-
-      type CompareFn = (a: unknown, b: unknown) => number;
-      type CompareFnFactory = (order: unknown, meta: unknown, settings: unknown) => CompareFn;
-      const typedMeta = columnMeta as { columnSorting?: { compareFunctionFactory?: CompareFnFactory }; type?: string };
-      const pluginSettings = typedMeta.columnSorting;
-      const compareFunctionFactory: CompareFnFactory = pluginSettings?.compareFunctionFactory ?
-        pluginSettings.compareFunctionFactory : getCompareFunctionFactory(typedMeta.type ?? '') as CompareFnFactory;
-      const compareResult: number = compareFunctionFactory(sortingOrder, columnMeta, pluginSettings)(value, nextValue);
-
-      // DIFF - MultiColumnSorting & ColumnSorting: removed iteration through next sorted columns.
-
-      return compareResult;
-    }(0));
+    // We sort array of arrays. Single array is in form [rowIndex, ...values],
+    // so the value of the only sorted column is stored at index 1.
+    return compareFunction(rowIndexWithValues[1], nextRowIndexWithValues[1]);
   };
 }

--- a/handsontable/src/plugins/columnSorting/sortFunction/checkbox.ts
+++ b/handsontable/src/plugins/columnSorting/sortFunction/checkbox.ts
@@ -34,16 +34,14 @@ function compareTemplateValues(
  * @param {boolean} isValueFromTemplate Whether the first value is from the template.
  * @param {boolean} isNextValueFromTemplate Whether the second value is from the template.
  * @param {string} sortOrder Sort order (`asc` for ascending, `desc` for descending).
- * @param {object} columnMeta Column meta object.
- * @param {object} columnPluginSettings Plugin settings for the column.
+ * @param {Function} compareDefaultValues Compare function used for two non-template values.
  * @param {unknown} value The first value.
  * @param {unknown} nextValue The second value.
  * @returns {number | null} The comparison result or null if both values are from template.
  */
 function compareBadValues(
   isValueFromTemplate: boolean, isNextValueFromTemplate: boolean,
-  sortOrder: string, columnMeta: Record<string, unknown>,
-  columnPluginSettings: Record<string, unknown>,
+  sortOrder: string, compareDefaultValues: (value: unknown, nextValue: unknown) => number,
   value: unknown, nextValue: unknown
 ): number | null {
   // 1st value === #BAD_VALUE#
@@ -59,7 +57,7 @@ function compareBadValues(
   // 1st value === #BAD_VALUE# && 2nd value === #BAD_VALUE#
   if (isValueFromTemplate === false && isNextValueFromTemplate === false) {
     // Sorting by values (not just by visual representation).
-    return defaultCompareFunctionFactory(sortOrder, columnMeta, columnPluginSettings)(value, nextValue);
+    return compareDefaultValues(value, nextValue);
   }
 
   return null;
@@ -79,6 +77,9 @@ export function compareFunctionFactory(
   const checkedTemplate = columnMeta.checkedTemplate;
   const uncheckedTemplate = columnMeta.uncheckedTemplate;
   const { sortEmptyCells } = columnPluginSettings;
+  // Created once per sort run so the default comparator's per-run caches stay effective when
+  // non-template ("bad") values fall back to value-based sorting.
+  const compareDefaultValues = defaultCompareFunctionFactory(sortOrder, columnMeta, columnPluginSettings);
 
   return function(value: unknown, nextValue: unknown) {
     const isEmptyValue = isEmpty(value);
@@ -101,7 +102,7 @@ export function compareFunctionFactory(
 
     const badValueResult = compareBadValues(
       isValueFromTemplate, isNextValueFromTemplate,
-      sortOrder, columnMeta, columnPluginSettings, value, nextValue
+      sortOrder, compareDefaultValues, value, nextValue
     );
 
     if (badValueResult !== null) {

--- a/handsontable/src/plugins/columnSorting/sortFunction/default.ts
+++ b/handsontable/src/plugins/columnSorting/sortFunction/default.ts
@@ -5,17 +5,29 @@ import { localeLowerCase } from '../../../helpers/string';
 /**
  * Normalizes a cell value for comparison by converting booleans to numbers and strings to lowercase.
  *
+ * Lowercased strings are memoized in the provided cache. The compare function is created once per
+ * sort run, so each distinct string pays the locale-aware lowercasing once instead of on every
+ * comparison (~2*log(n) times per row in a sort).
+ *
  * @param {unknown} value The value to normalize.
  * @param {string | undefined} locale The locale to use for string lowercasing.
+ * @param {Map} lowerCaseCache Per-sort-run cache mapping original strings to lowercased ones.
  * @returns {unknown} The normalized value.
  */
-function normalizeValue(value: unknown, locale: string | undefined): unknown {
+function normalizeValue(value: unknown, locale: string | undefined, lowerCaseCache: Map<string, string>): unknown {
   if (typeof value === 'boolean') {
     return Number(value);
   }
 
   if (typeof value === 'string') {
-    return localeLowerCase(value, locale);
+    let lowerCasedValue = lowerCaseCache.get(value);
+
+    if (lowerCasedValue === undefined) {
+      lowerCasedValue = localeLowerCase(value, locale);
+      lowerCaseCache.set(value, lowerCasedValue);
+    }
+
+    return lowerCasedValue;
   }
 
   return value;
@@ -75,12 +87,13 @@ export function compareFunctionFactory(
   sortOrder: string, columnMeta: Record<string, unknown>, columnPluginSettings: Record<string, unknown>
 ) {
   const locale = columnMeta.locale as string | undefined;
+  const lowerCaseCache = new Map<string, string>();
 
   return function(value: unknown, nextValue: unknown) {
     const { sortEmptyCells } = columnPluginSettings;
 
-    const normalizedValue = normalizeValue(value, locale);
-    const normalizedNextValue = normalizeValue(nextValue, locale);
+    const normalizedValue = normalizeValue(value, locale, lowerCaseCache);
+    const normalizedNextValue = normalizeValue(nextValue, locale, lowerCaseCache);
 
     if (normalizedValue === normalizedNextValue) {
       return DO_NOT_SWAP;

--- a/handsontable/src/plugins/columnSorting/utils.ts
+++ b/handsontable/src/plugins/columnSorting/utils.ts
@@ -115,16 +115,35 @@ export function wasHeaderClickedProperly(row: number, column: number, clickEvent
 }
 
 /**
- * Creates intl-date sorting compare function.
+ * Creates a date/time sorting compare function around the given parse function.
  *
+ * Parse results are memoized per sort run as epoch milliseconds (or `null` for unparsable input).
+ * The compare function is created once per sort run, so each distinct cell value pays the
+ * regex-and-`Date` parsing once instead of on every comparison (~2*log(n) times per row in a sort).
+ *
+ * @param {Function} parseValue Converts a raw cell value to a `Date` or `null` when unparsable.
  * @param {string} sortOrder Sort order (`asc` for ascending, `desc` for descending).
  * @param {object} columnPluginSettings Plugin settings for the column.
  * @returns {Function} The compare function.
  */
-export function createIntlDateCompareFunction(
+function createParsingCompareFunction(
+  parseValue: (value: unknown) => Date | null,
   sortOrder: string,
   columnPluginSettings: Record<string, unknown>
 ): (value: unknown, nextValue: unknown) => number {
+  const parseCache = new Map<unknown, number | null>();
+
+  const getParsedTime = (value: unknown): number | null => {
+    let parsedTime = parseCache.get(value);
+
+    if (parsedTime === undefined) {
+      parsedTime = parseValue(value)?.getTime() ?? null;
+      parseCache.set(value, parsedTime);
+    }
+
+    return parsedTime;
+  };
+
   return function(value: unknown, nextValue: unknown) {
     const { sortEmptyCells } = columnPluginSettings;
 
@@ -154,27 +173,41 @@ export function createIntlDateCompareFunction(
       return FIRST_BEFORE_SECOND;
     }
 
-    const firstDate = parseToLocalDate(value);
-    const nextDate = parseToLocalDate(nextValue);
+    const firstTime = getParsedTime(value);
+    const nextTime = getParsedTime(nextValue);
 
-    if (firstDate === null) {
+    if (firstTime === null) {
       return FIRST_AFTER_SECOND;
     }
 
-    if (nextDate === null) {
+    if (nextTime === null) {
       return FIRST_BEFORE_SECOND;
     }
 
-    if (nextDate > firstDate) {
+    if (nextTime > firstTime) {
       return sortOrder === 'asc' ? FIRST_BEFORE_SECOND : FIRST_AFTER_SECOND;
     }
 
-    if (nextDate < firstDate) {
+    if (nextTime < firstTime) {
       return sortOrder === 'asc' ? FIRST_AFTER_SECOND : FIRST_BEFORE_SECOND;
     }
 
     return DO_NOT_SWAP;
   };
+}
+
+/**
+ * Creates intl-date sorting compare function.
+ *
+ * @param {string} sortOrder Sort order (`asc` for ascending, `desc` for descending).
+ * @param {object} columnPluginSettings Plugin settings for the column.
+ * @returns {Function} The compare function.
+ */
+export function createIntlDateCompareFunction(
+  sortOrder: string,
+  columnPluginSettings: Record<string, unknown>
+): (value: unknown, nextValue: unknown) => number {
+  return createParsingCompareFunction(parseToLocalDate, sortOrder, columnPluginSettings);
 }
 
 /**
@@ -188,56 +221,7 @@ export function createIntlTimeCompareFunction(
   sortOrder: string,
   columnPluginSettings: Record<string, unknown>
 ): (value: unknown, nextValue: unknown) => number {
-  return function(value: unknown, nextValue: unknown) {
-    const { sortEmptyCells } = columnPluginSettings;
-
-    if (value === nextValue) {
-      return DO_NOT_SWAP;
-    }
-
-    if (isEmpty(value)) {
-      if (isEmpty(nextValue)) {
-        return DO_NOT_SWAP;
-      }
-
-      // Just fist value is empty and `sortEmptyCells` option was set
-      if (sortEmptyCells) {
-        return sortOrder === 'asc' ? FIRST_BEFORE_SECOND : FIRST_AFTER_SECOND;
-      }
-
-      return FIRST_AFTER_SECOND;
-    }
-
-    if (isEmpty(nextValue)) {
-      // Just second value is empty and `sortEmptyCells` option was set
-      if (sortEmptyCells) {
-        return sortOrder === 'asc' ? FIRST_AFTER_SECOND : FIRST_BEFORE_SECOND;
-      }
-
-      return FIRST_BEFORE_SECOND;
-    }
-
-    const firstDate = parseToLocalTime(value);
-    const nextDate = parseToLocalTime(nextValue);
-
-    if (firstDate === null) {
-      return FIRST_AFTER_SECOND;
-    }
-
-    if (nextDate === null) {
-      return FIRST_BEFORE_SECOND;
-    }
-
-    if (nextDate > firstDate) {
-      return sortOrder === 'asc' ? FIRST_BEFORE_SECOND : FIRST_AFTER_SECOND;
-    }
-
-    if (nextDate < firstDate) {
-      return sortOrder === 'asc' ? FIRST_AFTER_SECOND : FIRST_BEFORE_SECOND;
-    }
-
-    return DO_NOT_SWAP;
-  };
+  return createParsingCompareFunction(parseToLocalTime, sortOrder, columnPluginSettings);
 }
 
 /**

--- a/handsontable/src/plugins/multiColumnSorting/__tests__/rootComparator.unit.ts
+++ b/handsontable/src/plugins/multiColumnSorting/__tests__/rootComparator.unit.ts
@@ -1,0 +1,76 @@
+import { rootComparator } from 'handsontable/plugins/multiColumnSorting/rootComparator';
+
+/**
+ * Creates a numeric ascending/descending compare function for the tests.
+ *
+ * @param {string} sortOrder Sort order (`asc` for ascending, `desc` for descending).
+ * @returns {Function} The compare function.
+ */
+function createNumericCompare(sortOrder: string) {
+  return (value: number, nextValue: number) => {
+    if (value === nextValue) {
+      return 0;
+    }
+
+    const result = value < nextValue ? -1 : 1;
+
+    return sortOrder === 'asc' ? result : -result;
+  };
+}
+
+describe('multiColumnSorting rootComparator', () => {
+  it('should invoke each column compare function factory once per sort run, not once per comparison', () => {
+    const firstFactory = jest.fn(createNumericCompare);
+    const secondFactory = jest.fn(createNumericCompare);
+    const columnMetas = [
+      { multiColumnSorting: { compareFunctionFactory: firstFactory } },
+      { multiColumnSorting: { compareFunctionFactory: secondFactory } },
+    ];
+
+    const comparator = rootComparator(['asc', 'desc'], columnMetas);
+
+    comparator([0, 1, 5], [1, 2, 5]);
+    comparator([1, 2, 5], [2, 2, 6]);
+    comparator([2, 2, 6], [3, 3, 4]);
+
+    expect(firstFactory).toHaveBeenCalledTimes(1);
+    expect(firstFactory).toHaveBeenCalledWith('asc', columnMetas[0], columnMetas[0].multiColumnSorting);
+    expect(secondFactory).toHaveBeenCalledTimes(1);
+    expect(secondFactory).toHaveBeenCalledWith('desc', columnMetas[1], columnMetas[1].multiColumnSorting);
+  });
+
+  it('should consult later columns only when all previous columns compare as equal', () => {
+    const firstCompare = jest.fn(createNumericCompare('asc'));
+    const secondCompare = jest.fn(createNumericCompare('asc'));
+    const columnMetas = [
+      { multiColumnSorting: { compareFunctionFactory: () => firstCompare } },
+      { multiColumnSorting: { compareFunctionFactory: () => secondCompare } },
+    ];
+
+    const comparator = rootComparator(['asc', 'asc'], columnMetas);
+
+    // First column decides — the second column must not be consulted.
+    expect(comparator([0, 1, 9], [1, 2, 1])).toBe(-1);
+    expect(secondCompare).toHaveBeenCalledTimes(0);
+
+    // First column ties — the second column breaks the tie.
+    expect(comparator([0, 2, 9], [1, 2, 1])).toBe(1);
+    expect(secondCompare).toHaveBeenCalledTimes(1);
+
+    // Both columns tie — the rows keep their relative order.
+    expect(comparator([0, 2, 1], [1, 2, 1])).toBe(0);
+  });
+
+  it('should resolve the compare function from the column type when no custom factory is defined', () => {
+    const columnMetas = [
+      { type: 'numeric', multiColumnSorting: {} },
+      { type: 'numeric', multiColumnSorting: {} },
+    ];
+
+    const comparator = rootComparator(['asc', 'desc'], columnMetas);
+
+    expect(comparator([0, 1, 1], [1, 2, 1])).toBe(-1);
+    expect(comparator([0, 2, 1], [1, 2, 2])).toBe(1);
+    expect(comparator([0, 2, 1], [1, 2, 1])).toBe(0);
+  });
+});

--- a/handsontable/src/plugins/multiColumnSorting/rootComparator.ts
+++ b/handsontable/src/plugins/multiColumnSorting/rootComparator.ts
@@ -1,6 +1,26 @@
 import { getCompareFunctionFactory } from '../columnSorting/sortService/registry';
 import { DO_NOT_SWAP } from '../columnSorting/sortService/engine';
 
+type CompareFn = (a: unknown, b: unknown) => number;
+type CompareFnFactory = (order: unknown, meta: unknown, settings: unknown) => CompareFn;
+
+/**
+ * Creates the compare function for a single sorted column. Resolved once per sort run — the
+ * factory result is reused for every comparison, so any per-run caching inside the returned
+ * compare function (e.g. normalized-value memoization) stays effective.
+ *
+ * @param {string} sortingOrder Sort order (`asc` for ascending, `desc` for descending).
+ * @param {object} columnMeta Column meta object.
+ * @returns {Function} The compare function.
+ */
+function createColumnCompareFunction(sortingOrder: string, columnMeta: Record<string, unknown>): CompareFn {
+  const pluginSettings = columnMeta.multiColumnSorting as { compareFunctionFactory?: CompareFnFactory };
+  const compareFunctionFactory: CompareFnFactory = pluginSettings.compareFunctionFactory ?
+    pluginSettings.compareFunctionFactory : getCompareFunctionFactory(columnMeta.type as string) as CompareFnFactory;
+
+  return compareFunctionFactory(sortingOrder, columnMeta, pluginSettings);
+}
+
 /**
  * Sort comparator handled by conventional sort algorithm.
  *
@@ -9,35 +29,25 @@ import { DO_NOT_SWAP } from '../columnSorting/sortService/engine';
  * @returns {Function}
  */
 export function rootComparator(sortingOrders: string[], columnMetas: Record<string, unknown>[]) {
+  // One compare function per sorted column, created once per sort run, not once per comparison.
+  // Re-invoking the factories inside the comparator would allocate fresh closures ~n*log(n) times
+  // and defeat the per-run value caches the built-in compare functions rely on.
+  const compareFunctions = columnMetas.map(
+    (columnMeta, column) => createColumnCompareFunction(sortingOrders[column], columnMeta));
+
   return function(rowIndexWithValues: unknown[], nextRowIndexWithValues: unknown[]) {
-    // We sort array of arrays. Single array is in form [rowIndex, ...values].
-    // We compare just values, stored at second index of array.
-    const [, ...values] = rowIndexWithValues;
-    const [, ...nextValues] = nextRowIndexWithValues;
+    // We sort array of arrays. Single array is in form [rowIndex, ...values],
+    // so the value of sorted column N is stored at index N + 1. Columns after the first act as
+    // tie-breakers: they are consulted only while the previous columns compare as equal.
+    for (let column = 0; column < compareFunctions.length; column += 1) {
+      const compareResult = compareFunctions[column](
+        rowIndexWithValues[column + 1], nextRowIndexWithValues[column + 1]);
 
-    return (function getCompareResult(column) {
-      const sortingOrder = sortingOrders[column];
-      const columnMeta = columnMetas[column];
-      const value = values[column];
-      const nextValue = nextValues[column];
-      const pluginSettings = columnMeta.multiColumnSorting as Record<string, unknown>;
-
-      type CompareFnFactory = (...args: unknown[]) => (...args2: unknown[]) => number;
-      const compareFunctionFactory = (pluginSettings.compareFunctionFactory
-        ? pluginSettings.compareFunctionFactory
-        : getCompareFunctionFactory(columnMeta.type as string)
-      ) as CompareFnFactory;
-      const compareResult = compareFunctionFactory(sortingOrder, columnMeta, pluginSettings)(value, nextValue);
-
-      if (compareResult === DO_NOT_SWAP) {
-        const nextSortedColumn = column + 1;
-
-        if (typeof columnMetas[nextSortedColumn] !== 'undefined') {
-          return getCompareResult(nextSortedColumn);
-        }
+      if (compareResult !== DO_NOT_SWAP) {
+        return compareResult;
       }
+    }
 
-      return compareResult;
-    }(0));
+    return DO_NOT_SWAP;
   };
 }


### PR DESCRIPTION
### Context

The PR changes how the ColumnSorting and MultiColumnSorting plugins build and use their compare functions.

Two problems compounded on every sort:

1. Both `rootComparator`s re-resolved the compare-function factory and re-created the compare closure on **every comparison** — ~n·log(n) times per sort — plus two rest-destructure array copies per comparison. This also made any per-run caching inside the compare functions impossible, because each closure lived for exactly one comparison.
2. The per-value normalization work ran inside the comparator: the date/time comparators re-parsed both sides (regex + split + `new Date`) on every comparison, and the default comparator ran `localeLowerCase` on both sides on every comparison. Each row paid the normalization ~2·log(n) times (~36× at 300k rows) instead of once.

What changed:

- Both `rootComparator`s resolve each column's compare function **once per sort run** and index the `[rowIndex, ...values]` tuples directly. The multi-column tie-break chain (later columns consulted only on ties) is preserved. The public `compareFunctionFactory` API is unchanged — custom factories receive the same arguments and return the same shape as before.
- The default comparator memoizes locale-aware lowercasing per distinct string in a per-run `Map`.
- The two near-identical date/time compare factories in `columnSorting/utils.ts` are merged into one shared implementation that memoizes parse results as epoch milliseconds per distinct value. Empty-cell and unparsable-value ordering semantics are unchanged.
- The checkbox comparator creates its fallback default comparator once per run instead of once per bad-value comparison.

Measured at 300k rows (UMD builds, fresh page per run, identical result orderings verified by row fingerprints):

| Sort | develop | this branch |
| --- | --- | --- |
| date asc / desc | 5.21 s / 5.30 s | 1.13 s / 1.14 s (**4.6×**) |
| text asc, locale `tr-TR` (ICU lowercase path) | 13.3 s | 2.1 s (**6.2×**) |
| text asc / desc, locale `en-US` | 1.71 s / 1.76 s | 1.66 s / 1.63 s |
| numeric asc | 1.18 s | 0.87 s |
| multiColumnSorting date+numeric desc | 5.32 s | 1.25 s (**4.2×**) |

ClickUp task: DEV-2087.

### How has this been tested?

- New unit suites for both `rootComparator`s: the factory is invoked once per sort run (not per comparison), the multi-column tie-break order is preserved, and tuple values are read from the correct index.
- New unit tests for the memoization: distinct-value call counts for `localeLowerCase` / `parseToLocalDate` / `parseToLocalTime` spies, no cache sharing between separately created compare functions, symmetric compare results, and unchanged unparsable/empty-value handling.
- Full unit suite: 3,192 passed (`npm run test:unit --prefix handsontable`).
- Full E2E suite: 9,552 specs, 0 failures (`npm run test:e2e --prefix handsontable`).
- Benchmark page used for the measurements: `demo-sortkeys-bench.html` (local, not committed).

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2087

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2087

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Core sorting behavior is refactored across both plugins; semantics are intended to be identical and are heavily tested, but any subtle ordering edge case would affect all users who sort large grids.
> 
> **Overview**
> **ColumnSorting** and **MultiColumnSorting** now build each column’s compare function **once per sort run** in `rootComparator`, instead of re-invoking factories on every comparison (~n·log(n) times). Multi-column tie-breaking is unchanged: later columns run only when earlier ones tie. Tuple indexing is simplified to read values directly from `[rowIndex, …values]`.
> 
> Built-in comparators add **per-run memoization**: default text sorting caches `localeLowerCase` per distinct string; intl date/time share a new `createParsingCompareFunction` that caches parsed epoch ms per distinct value. Checkbox sorting reuses a single default comparator instance for non-template values.
> 
> Unit tests lock in factory call counts, cache behavior, tie-break order, and unchanged empty/unparsable ordering. A changelog entry documents the performance improvement on large datasets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb7d9a16885d10cf2331bbe230514940d8a825c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->