### PR TITLE
DEV-2089: Batch bulk-alter paths in DataMap and Core

### DIFF
--- a/.changelogs/13091.json
+++ b/.changelogs/13091.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Improved the performance of bulk grid alterations: removing many rows or columns, inserting multiple columns, pasting data that extends the grid, and edits with the `minSpareCols` or `minCols` options on large datasets.",
+  "type": "changed",
+  "issueOrPR": 13091,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/__tests__/core/insertColStart.spec.js
+++ b/handsontable/src/__tests__/core/insertColStart.spec.js
@@ -676,6 +676,23 @@ describe('Core.alter', () => {
         expect(getDataAtRow(0)).toEqual([null, 'E1', null, 'A1', 'B1', 'C1', 'D1', null]);
         expect(getSourceDataAtRow(0)).toEqual([null, 'A1', 'B1', 'C1', 'D1', null, 'E1', null]);
       });
+
+      it('should append the created cells at the end of source rows shorter than the insertion point', async() => {
+        handsontable({
+          data: [
+            ['a', 'b', 'c', 'd'],
+            ['a'],
+            [],
+          ],
+        });
+
+        await alter('insert_col_start', 2, 2);
+
+        expect(countCols()).toBe(6);
+        expect(getSourceDataAtRow(0)).toEqual(['a', 'b', null, null, 'c', 'd']);
+        expect(getSourceDataAtRow(1)).toEqual(['a', null, null]);
+        expect(getSourceDataAtRow(2)).toEqual([null, null]);
+      });
     });
   });
 });

--- a/handsontable/src/__tests__/core/removeCol.spec.js
+++ b/handsontable/src/__tests__/core/removeCol.spec.js
@@ -451,5 +451,55 @@ describe('Core.alter', () => {
         alter('remove_col', 0, 1);
       }).not.toThrow();
     });
+
+    describe('when the removed columns map to non-contiguous physical indexes', () => {
+      it('should remove the correct columns after the column order was changed', async() => {
+        handsontable({
+          data: createSpreadsheetData(3, 8),
+        });
+
+        // visual order: A, E, F, G, H, B, C, D
+        columnIndexMapper().setIndexesSequence([0, 4, 5, 6, 7, 1, 2, 3]);
+        await render();
+
+        // removes visual G, H, B -> physical 6, 7, 1 (non-contiguous)
+        await alter('remove_col', 3, 3);
+
+        expect(countCols()).toBe(5);
+        expect(getDataAtRow(0)).toEqual(['A1', 'E1', 'F1', 'C1', 'D1']);
+        expect(getSourceDataAtRow(0)).toEqual(['A1', 'C1', 'D1', 'E1', 'F1']);
+      });
+
+      it('should remove all columns when the whole reordered grid range is passed', async() => {
+        handsontable({
+          data: createSpreadsheetData(2, 3),
+        });
+
+        columnIndexMapper().setIndexesSequence([1, 0, 2]);
+        await render();
+
+        await alter('remove_col', 0, 3);
+
+        expect(countCols()).toBe(0);
+        expect(getSourceDataAtRow(0)).toEqual([]);
+      });
+
+      it('should mutate the source row arrays in place', async() => {
+        const data = createSpreadsheetData(2, 5);
+        const rowReference = data[0];
+
+        handsontable({ data });
+
+        columnIndexMapper().setIndexesSequence([0, 3, 1, 2, 4]);
+        await render();
+
+        // removes visual D, B -> physical 3, 1 (non-contiguous)
+        await alter('remove_col', 1, 2);
+
+        expect(getSourceDataAtRow(0)).toEqual(['A1', 'C1', 'E1']);
+        expect(data[0]).toBe(rowReference);
+        expect(rowReference).toEqual(['A1', 'C1', 'E1']);
+      });
+    });
   });
 });

--- a/handsontable/src/__tests__/core/setDataAtCell.spec.js
+++ b/handsontable/src/__tests__/core/setDataAtCell.spec.js
@@ -531,4 +531,62 @@ describe('Core.setDataAtCell', () => {
       expect(getData()).toEqual([['aaa']]);
     });
   });
+
+  describe('setting a value beyond the current grid size', () => {
+    it('should create all missing rows in one bulk `createRow` call', async() => {
+      const afterCreateRow = jasmine.createSpy('afterCreateRow');
+
+      handsontable({
+        data: createSpreadsheetData(3, 3),
+        afterCreateRow,
+      });
+
+      await setDataAtCell(9, 0, 'foo');
+
+      expect(countRows()).toBe(10);
+      expect(getDataAtCell(9, 0)).toBe('foo');
+      expect(afterCreateRow).toHaveBeenCalledTimes(1);
+      expect(afterCreateRow).toHaveBeenCalledWith(3, 7, 'auto');
+    });
+
+    it('should create all missing columns in one bulk `createCol` call', async() => {
+      const afterCreateCol = jasmine.createSpy('afterCreateCol');
+
+      handsontable({
+        data: createSpreadsheetData(3, 3),
+        afterCreateCol,
+      });
+
+      await setDataAtCell(0, 9, 'foo');
+
+      expect(countCols()).toBe(10);
+      expect(getDataAtCell(0, 9)).toBe('foo');
+      expect(afterCreateCol).toHaveBeenCalledTimes(1);
+      expect(afterCreateCol).toHaveBeenCalledWith(3, 7, 'auto');
+    });
+
+    it('should skip the change when `maxRows` prevents reaching the target row', async() => {
+      handsontable({
+        data: createSpreadsheetData(3, 3),
+        maxRows: 5,
+      });
+
+      await setDataAtCell(9, 0, 'foo');
+
+      expect(countRows()).toBe(5);
+      expect(getDataAtCell(4, 0)).toBe(null);
+    });
+
+    it('should skip the change when `maxCols` prevents reaching the target column', async() => {
+      handsontable({
+        data: createSpreadsheetData(3, 3),
+        maxCols: 5,
+      });
+
+      await setDataAtCell(0, 9, 'foo');
+
+      expect(countCols()).toBe(5);
+      expect(getDataAtCell(0, 4)).toBe(null);
+    });
+  });
 });

--- a/handsontable/src/__tests__/settings/minCols.spec.js
+++ b/handsontable/src/__tests__/settings/minCols.spec.js
@@ -154,5 +154,32 @@ describe('settings', () => {
         expect(getCellMeta(0, 6).test).toBeUndefined();
       });
     });
+
+    it('should not verify column emptiness when `minSpareCols` is not set', async() => {
+      const isEmptyCol = jasmine.createSpy('isEmptyCol').and.callFake(function(visualCol) {
+        for (let row = 0; row < this.countRows(); row++) {
+          if (this.getDataAtCell(row, visualCol) !== null) {
+            return false;
+          }
+        }
+
+        return true;
+      });
+
+      handsontable({
+        data: createSpreadsheetData(3, 3),
+        minCols: 5,
+        isEmptyCol,
+      });
+
+      expect(countCols()).toBe(5);
+
+      isEmptyCol.calls.reset();
+
+      await setDataAtCell(0, 0, 'x');
+
+      expect(countCols()).toBe(5);
+      expect(isEmptyCol).not.toHaveBeenCalled();
+    });
   });
 });

--- a/handsontable/src/__tests__/settings/minSpareCols.spec.js
+++ b/handsontable/src/__tests__/settings/minSpareCols.spec.js
@@ -234,5 +234,63 @@ describe('settings', () => {
         expect(getCellMeta(0, 6).test).toBeUndefined();
       });
     });
+
+    describe('trailing empty-column verification', () => {
+      it('should verify at most `minSpareCols` trailing columns after a change', async() => {
+        const isEmptyCol = jasmine.createSpy('isEmptyCol').and.callFake(function(visualCol) {
+          for (let row = 0; row < this.countRows(); row++) {
+            if (this.getDataAtCell(row, visualCol) !== null) {
+              return false;
+            }
+          }
+
+          return true;
+        });
+
+        handsontable({
+          data: createSpreadsheetData(3, 2),
+          minSpareCols: 2,
+          isEmptyCol,
+        });
+
+        expect(countCols()).toBe(4);
+
+        isEmptyCol.calls.reset();
+
+        await setDataAtCell(0, 0, 'x');
+
+        expect(countCols()).toBe(4);
+        expect(isEmptyCol.calls.count()).toBe(2);
+      });
+
+      it('should add the missing spare columns after typing in a spare column', async() => {
+        handsontable({
+          data: createSpreadsheetData(3, 2),
+          minSpareCols: 3,
+        });
+
+        expect(countCols()).toBe(5);
+
+        await setDataAtCell(0, 2, 'x');
+
+        expect(countCols()).toBe(6);
+      });
+
+      it('should not add spare columns when more empty columns than `minSpareCols` already exist', async() => {
+        handsontable({
+          data: [
+            ['x', null, null, null, null],
+            ['x', null, null, null, null],
+          ],
+          minSpareCols: 2,
+        });
+
+        expect(countCols()).toBe(5);
+
+        await setDataAtCell(0, 0, 'y');
+
+        expect(countCols()).toBe(5);
+      });
+    });
   });
 });

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -1182,10 +1182,25 @@ export default function Core(
       }
       {
         let emptyCols = 0;
+        const canCreateSpareCols = minSpareCols > 0 && !tableMeta.columns && instance.dataType === 'array';
 
-        // count currently empty cols
-        if (minCols || minSpareCols) {
-          emptyCols = instance.countEmptyCols(true);
+        // Count trailing empty columns, but only when the `minSpareCols` branch below can consume
+        // the result, and never beyond `minSpareCols` itself. Verifying that a column is empty
+        // scans every row of that column, and this method runs after every change batch - an
+        // uncapped count (the previous `countEmptyCols(true)` call) paid O(empty columns * rows)
+        // per edit and also ran when only `minCols` was set, where the result was never used.
+        if (canCreateSpareCols) {
+          for (let visualIndex = instance.countCols() - 1; visualIndex >= 0; visualIndex--) {
+            if (!instance.isEmptyCol(visualIndex)) {
+              break;
+            }
+
+            emptyCols += 1;
+
+            if (emptyCols >= minSpareCols) {
+              break;
+            }
+          }
         }
 
         let nrOfColumns = instance.countCols();
@@ -1201,9 +1216,7 @@ export default function Core(
           datamap.createCol(nrOfColumns, colsToCreate, { source: 'auto' });
         }
         // should I add empty cols to meet minSpareCols?
-        if (minSpareCols && !tableMeta.columns && instance.dataType === 'array' &&
-          emptyCols < minSpareCols) {
-
+        if (canCreateSpareCols && emptyCols < minSpareCols) {
           nrOfColumns = instance.countCols();
           const emptyColsMissing = minSpareCols - emptyCols;
           const colsToCreate = Math.min(emptyColsMissing, tableMeta.maxCols - nrOfColumns);
@@ -1866,10 +1879,15 @@ export default function Core(
       }
 
       if (tableMeta.allowInsertRow) {
+        // Create the whole missing range in one call - one index-mapper insert and one hook
+        // round instead of one per row. Creating row by row made a paste reaching far below
+        // the last row quadratic in the gap size. The loop re-checks the count so a partial
+        // creation (e.g. a `maxRows` clamp) is detected and the change is skipped.
         while (changes[i][0] > instance.countRows() - 1) {
+          const missingRows = changes[i][0] - (instance.countRows() - 1);
           const {
             delta: numberOfCreatedRows
-          } = datamap.createRow(undefined, undefined, { source: 'auto' });
+          } = datamap.createRow(undefined, missingRows, { source: 'auto' });
 
           if (numberOfCreatedRows === 0) {
             skipThisChange = true;
@@ -1881,9 +1899,11 @@ export default function Core(
       if (instance.dataType === 'array' && (!tableMeta.columns || tableMeta.columns.length === 0) &&
           tableMeta.allowInsertColumn) {
         while (Number(datamap.propToCol(changes[i][1] as string | number)) > instance.countCols() - 1) {
+          const missingColumns =
+            Number(datamap.propToCol(changes[i][1] as string | number)) - (instance.countCols() - 1);
           const {
             delta: numberOfCreatedColumns
-          } = datamap.createCol(undefined, undefined, { source: 'auto' });
+          } = datamap.createCol(undefined, missingColumns, { source: 'auto' });
 
           if (numberOfCreatedColumns === 0) {
             skipThisChange = true;

--- a/handsontable/src/dataMap/dataMap.ts
+++ b/handsontable/src/dataMap/dataMap.ts
@@ -14,7 +14,7 @@ import {
   isObject,
   objectEach
 } from '../helpers/object';
-import { extendArray, to2dArray } from '../helpers/array';
+import { extendArray, insertValuesInPlace, removeIndexesInPlace, to2dArray } from '../helpers/array';
 import { rangeEach, isUnsignedNumber } from '../helpers/number';
 import { isDefined } from '../helpers/mixed';
 import { getValueGetterValue } from '../utils/valueAccessors';
@@ -474,17 +474,14 @@ class DataMap {
     const firstNewPhysicalColumnIndex = (mode === 'end') ?
       Math.min(physicalColumnIndex + 1, numberOfSourceCols) : physicalColumnIndex;
 
-    let numberOfCreatedCols = 0;
+    const numberOfCreatedCols = Math.max(
+      0, Math.min(amount, (maxCols ?? Infinity) - numberOfVisualCols)
+    );
 
-    for (
-      let col = firstNewPhysicalColumnIndex;
-      numberOfCreatedCols < amount && numberOfVisualCols + numberOfCreatedCols < (maxCols ?? Infinity);
-      col++, numberOfCreatedCols++
-    ) {
-      this.#insertColumnIntoDataSource(
-        dataSource, col, visualColumnIndex, numberOfVisualCols + numberOfCreatedCols, numberOfSourceRows
-      );
-    }
+    this.#insertColumnsIntoDataSource(
+      dataSource, firstNewPhysicalColumnIndex, visualColumnIndex, numberOfVisualCols,
+      numberOfSourceRows, numberOfCreatedCols
+    );
 
     if (numberOfCreatedCols > 0) {
       if ((index === undefined || index === null)) {
@@ -511,6 +508,72 @@ class DataMap {
       delta: numberOfCreatedCols,
       startPhysicalIndex: firstNewPhysicalColumnIndex,
     };
+  }
+
+  /**
+   * Inserts the given amount of null columns into the data source in one pass over the rows.
+   * A middle insert shifts each row's tail once by `amount` (instead of once per created column),
+   * and an append pushes all nulls in one walk. The rare mixed case - a visual index that lies
+   * beyond the current visual column count but within the source column count (possible only
+   * with trimmed columns and an out-of-range index) - starts as an append and switches to a
+   * middle insert partway through, so it falls back to the per-column path.
+   *
+   * @param {Array} dataSource The data source array.
+   * @param {number} firstColumn The physical column index at which the first column is inserted.
+   * @param {number|undefined} visualColumnIndex The visual column index being inserted.
+   * @param {number} numberOfVisualCols The visual column count before the insertion.
+   * @param {number} numberOfSourceRows The number of source rows.
+   * @param {number} amount The number of columns to insert.
+   */
+  #insertColumnsIntoDataSource(
+    dataSource: (Record<string, unknown> | unknown[])[],
+    firstColumn: number,
+    visualColumnIndex: number | undefined,
+    numberOfVisualCols: number,
+    numberOfSourceRows: number,
+    amount: number
+  ) {
+    if (amount === 0) {
+      return;
+    }
+
+    if (typeof visualColumnIndex === 'number' && visualColumnIndex < numberOfVisualCols) {
+      // Middle insert: shift each row's tail right once by `amount` and fill the gap with nulls.
+      // The insertion index clamps to the row length, so rows shorter than the insertion point
+      // get the nulls appended at their end, matching what repeated `splice` calls did.
+      for (let row = 0; row < numberOfSourceRows; row++) {
+        insertValuesInPlace(dataSource[row] as unknown[], firstColumn, amount, null);
+      }
+
+      return;
+    }
+
+    if (typeof visualColumnIndex !== 'number' || visualColumnIndex >= numberOfVisualCols + amount - 1) {
+      // Pure append: every created column lands past the last visual column.
+      if (numberOfSourceRows > 0) {
+        for (let row = 0; row < numberOfSourceRows; row++) {
+          if (typeof dataSource[row] === 'undefined') {
+            dataSource[row] = [];
+          }
+
+          for (let i = 0; i < amount; i++) {
+            (dataSource[row] as unknown[]).push(null);
+          }
+        }
+      } else {
+        for (let i = 0; i < amount; i++) {
+          dataSource.push([null]);
+        }
+      }
+
+      return;
+    }
+
+    for (let i = 0; i < amount; i++) {
+      this.#insertColumnIntoDataSource(
+        dataSource, firstColumn + i, visualColumnIndex, numberOfVisualCols + i, numberOfSourceRows
+      );
+    }
   }
 
   /**
@@ -657,8 +720,9 @@ class DataMap {
   }
 
   /**
-   * Splices the removed physical columns from each row in the data source,
-   * updating the meta manager for the first row.
+   * Removes the given physical columns from each row in the data source and keeps
+   * the meta manager in sync. Rows are mutated in place so external references to
+   * the row arrays stay valid.
    *
    * @param {Array} data The data source array.
    * @param {boolean} isTableUniform Whether the removed columns form a contiguous range.
@@ -683,15 +747,19 @@ class DataMap {
       }
 
     } else {
-      const removedColumnsCount = descendingPhysicalColumns.length;
+      // One in-place compaction pass per row instead of one `splice` per removed column per row.
+      // The splice variant costs O(rows * removed columns * columns) after any column reorder;
+      // the compaction pass is O(rows * columns) regardless of how many columns are removed.
+      const removedColumns = new Set(removedPhysicalIndexes);
+      const numberOfSourceRows = this.hot!.countSourceRows();
 
-      for (let r = 0, rlen = this.hot!.countSourceRows(); r < rlen; r++) {
-        for (let c = 0; c < removedColumnsCount; c++) {
-          (data[r] as unknown[]).splice(descendingPhysicalColumns[c], 1);
+      for (let r = 0; r < numberOfSourceRows; r++) {
+        removeIndexesInPlace(data[r] as unknown[], removedColumns);
+      }
 
-          if (r === 0) {
-            this.metaManager!.removeColumn(descendingPhysicalColumns[c], 1);
-          }
+      if (numberOfSourceRows > 0) {
+        for (let c = 0, clen = descendingPhysicalColumns.length; c < clen; c++) {
+          this.metaManager!.removeColumn(descendingPhysicalColumns[c], 1);
         }
       }
     }
@@ -781,19 +849,22 @@ class DataMap {
    */
   filterData(index: number, amount: number, physicalRows: number[]) {
     // Custom data filtering (run as a consequence of calling the below hook) provide an array containing new data.
-    let data = this.hot!.runHooks('filterData', index, amount, physicalRows);
+    const data = this.hot!.runHooks('filterData', index, amount, physicalRows);
 
     // Hooks by default returns first argument (when there is no callback changing execution result).
-    if (Array.isArray(data) === false) {
-      data = this.dataSource!.filter((_row, rowIndex: number) => physicalRows.indexOf(rowIndex) === -1);
+    if (Array.isArray(data)) {
+      this.dataSource!.length = 0;
+      // Pushing in a loop instead of `push.apply`, which passes one call argument per row and
+      // overflows the call stack on grids with roughly 125k rows or more (same pattern as #7840).
+      (data as unknown[]).forEach((row) => {
+        this.dataSource!.push(row as Record<string, unknown> | unknown[]);
+      });
+    } else {
+      // One O(source rows) compaction pass with an O(1) Set membership test per row. The previous
+      // `filter` + `indexOf` variant cost O(source rows * removed rows) - a multi-second freeze
+      // when bulk-removing rows from a large grid - and copied the survivors back afterwards.
+      removeIndexesInPlace(this.dataSource!, new Set(physicalRows));
     }
-
-    this.dataSource!.length = 0;
-    // Pushing in a loop instead of `push.apply`, which passes one call argument per row and
-    // overflows the call stack on grids with roughly 125k rows or more (same pattern as #7840).
-    (data as unknown[]).forEach((row) => {
-      this.dataSource!.push(row as Record<string, unknown> | unknown[]);
-    });
   }
 
   /**

--- a/handsontable/src/dataMap/dataMap.ts
+++ b/handsontable/src/dataMap/dataMap.ts
@@ -511,12 +511,13 @@ class DataMap {
   }
 
   /**
-   * Inserts the given amount of null columns into the data source in one pass over the rows.
-   * A middle insert shifts each row's tail once by `amount` (instead of once per created column),
-   * and an append pushes all nulls in one walk. The rare mixed case - a visual index that lies
-   * beyond the current visual column count but within the source column count (possible only
-   * with trimmed columns and an out-of-range index) - starts as an append and switches to a
-   * middle insert partway through, so it falls back to the per-column path.
+   * Inserts the given amount of null columns into the data source in at most two passes over
+   * the rows, instead of one full pass per created column. The previous per-column loop chose
+   * between an append and a middle splice per iteration, based on the visual index against the
+   * growing column count; the same sequence collapses into two batched phases: the first
+   * `appendCount` iterations (while the visual index is at or past the current count) are
+   * end-of-row pushes, and the remaining iterations are single splices at consecutive ascending
+   * positions - which is exactly one block insert at the first of those positions.
    *
    * @param {Array} dataSource The data source array.
    * @param {number} firstColumn The physical column index at which the first column is inserted.
@@ -533,81 +534,42 @@ class DataMap {
     numberOfSourceRows: number,
     amount: number
   ) {
-    if (amount === 0) {
+    if (amount <= 0) {
       return;
     }
 
-    if (typeof visualColumnIndex === 'number' && visualColumnIndex < numberOfVisualCols) {
-      // Middle insert: shift each row's tail right once by `amount` and fill the gap with nulls.
-      // The insertion index clamps to the row length, so rows shorter than the insertion point
-      // get the nulls appended at their end, matching what repeated `splice` calls did.
-      for (let row = 0; row < numberOfSourceRows; row++) {
-        insertValuesInPlace(dataSource[row] as unknown[], firstColumn, amount, null);
-      }
+    let appendCount = amount;
 
-      return;
+    if (typeof visualColumnIndex === 'number') {
+      appendCount = Math.max(0, Math.min(amount, visualColumnIndex - numberOfVisualCols + 1));
     }
 
-    if (typeof visualColumnIndex !== 'number' || visualColumnIndex >= numberOfVisualCols + amount - 1) {
-      // Pure append: every created column lands past the last visual column.
+    const middleCount = amount - appendCount;
+
+    if (appendCount > 0) {
       if (numberOfSourceRows > 0) {
         for (let row = 0; row < numberOfSourceRows; row++) {
           if (typeof dataSource[row] === 'undefined') {
             dataSource[row] = [];
           }
 
-          for (let i = 0; i < amount; i++) {
+          for (let i = 0; i < appendCount; i++) {
             (dataSource[row] as unknown[]).push(null);
           }
         }
       } else {
-        for (let i = 0; i < amount; i++) {
+        for (let i = 0; i < appendCount; i++) {
           dataSource.push([null]);
         }
       }
-
-      return;
     }
 
-    for (let i = 0; i < amount; i++) {
-      this.#insertColumnIntoDataSource(
-        dataSource, firstColumn + i, visualColumnIndex, numberOfVisualCols + i, numberOfSourceRows
-      );
-    }
-  }
-
-  /**
-   * Inserts a single null column into the data source at the given physical column index.
-   *
-   * @param {Array} dataSource The data source array.
-   * @param {number} col The physical column index at which to splice.
-   * @param {number|undefined} visualColumnIndex The visual column index being inserted.
-   * @param {number} currentVisualColCount The current visual column count including already-created columns.
-   * @param {number} numberOfSourceRows The number of source rows.
-   */
-  #insertColumnIntoDataSource(
-    dataSource: (Record<string, unknown> | unknown[])[],
-    col: number,
-    visualColumnIndex: number | undefined,
-    currentVisualColCount: number,
-    numberOfSourceRows: number
-  ) {
-    if (typeof visualColumnIndex !== 'number' || visualColumnIndex >= currentVisualColCount) {
-      if (numberOfSourceRows > 0) {
-        for (let row = 0; row < numberOfSourceRows; row += 1) {
-          if (typeof dataSource[row] === 'undefined') {
-            dataSource[row] = [];
-          }
-
-          (dataSource[row] as unknown[]).push(null);
-        }
-      } else {
-        dataSource.push([null]);
-      }
-
-    } else {
+    if (middleCount > 0) {
+      // The insertion index clamps to the row length inside `insertValuesInPlace`, so rows
+      // shorter than the insertion point get the nulls appended at their end - matching what
+      // the previous repeated clamped `splice` calls did.
       for (let row = 0; row < numberOfSourceRows; row++) {
-        (dataSource[row] as unknown[]).splice(col, 0, null);
+        insertValuesInPlace(dataSource[row] as unknown[], firstColumn + appendCount, middleCount, null);
       }
     }
   }
@@ -656,8 +618,8 @@ class DataMap {
 
     const descendingPhysicalRows = removedPhysicalIndexes.slice(0).sort((a, b) => b - a);
 
-    descendingPhysicalRows.forEach((rowPhysicalIndex) => {
-      this.metaManager!.removeRow(rowPhysicalIndex, 1);
+    this.#eachDescendingRun(descendingPhysicalRows, (start, runLength) => {
+      this.metaManager!.removeRow(start, runLength);
     });
 
     this.hot!.runHooks('afterRemoveRow', rowIndex, numberOfRemovedIndexes, removedPhysicalIndexes, source);
@@ -758,9 +720,33 @@ class DataMap {
       }
 
       if (numberOfSourceRows > 0) {
-        for (let c = 0, clen = descendingPhysicalColumns.length; c < clen; c++) {
-          this.metaManager!.removeColumn(descendingPhysicalColumns[c], 1);
-        }
+        this.#eachDescendingRun(descendingPhysicalColumns, (start, runLength) => {
+          this.metaManager!.removeColumn(start, runLength);
+        });
+      }
+    }
+  }
+
+  /**
+   * Groups physical indexes sorted in descending order into contiguous runs and invokes the
+   * callback once per run with the run's lowest index and its length. A sequence of
+   * one-at-a-time removals at descending contiguous indexes equals one bulk removal at the
+   * run's lowest index, and each meta-layer removal call pays a fixed walk over the
+   * materialized entries - so collapsing runs removes that per-index constant.
+   *
+   * @param {number[]} descendingIndexes Physical indexes sorted in descending order.
+   * @param {Function} callback Called with `(start, amount)` once per contiguous run.
+   */
+  #eachDescendingRun(descendingIndexes: number[], callback: (start: number, amount: number) => void) {
+    let runStartPosition = 0;
+
+    for (let i = 0; i < descendingIndexes.length; i++) {
+      const isLastOfRun = i + 1 >= descendingIndexes.length ||
+        descendingIndexes[i + 1] !== descendingIndexes[i] - 1;
+
+      if (isLastOfRun) {
+        callback(descendingIndexes[i], i - runStartPosition + 1);
+        runStartPosition = i + 1;
       }
     }
   }

--- a/handsontable/src/helpers/__tests__/array.unit.ts
+++ b/handsontable/src/helpers/__tests__/array.unit.ts
@@ -9,6 +9,8 @@ import {
   arrayReduce,
   arraySum,
   arrayUnique,
+  insertValuesInPlace,
+  removeIndexesInPlace,
   stringToArray,
   getDifferenceOfArrays,
   getIntersectionOfArrays,
@@ -309,6 +311,90 @@ describe('Array helper', () => {
 
     it('should return an empty array for an empty input', () => {
       expect(arrayUnique([])).toStrictEqual([]);
+    });
+  });
+
+  //
+  // Handsontable.helper.removeIndexesInPlace
+  //
+  describe('removeIndexesInPlace', () => {
+    it('should remove the elements at the given indexes', () => {
+      expect(removeIndexesInPlace(['a', 'b', 'c', 'd', 'e'], new Set([1, 3]))).toStrictEqual(['a', 'c', 'e']);
+    });
+
+    it('should remove non-contiguous indexes in one pass', () => {
+      expect(removeIndexesInPlace([0, 1, 2, 3, 4, 5, 6, 7], new Set([0, 2, 5, 7]))).toStrictEqual([1, 3, 4, 6]);
+    });
+
+    it('should mutate the array in place and return the same reference', () => {
+      const array = ['a', 'b', 'c'];
+      const result = removeIndexesInPlace(array, new Set([1]));
+
+      expect(result).toBe(array);
+      expect(array).toStrictEqual(['a', 'c']);
+    });
+
+    it('should ignore indexes beyond the array length', () => {
+      expect(removeIndexesInPlace(['a', 'b'], new Set([1, 5, 100]))).toStrictEqual(['a']);
+    });
+
+    it('should empty the array when every index is removed', () => {
+      expect(removeIndexesInPlace(['a', 'b'], new Set([0, 1]))).toStrictEqual([]);
+    });
+
+    it('should not change the array when the index set is empty', () => {
+      expect(removeIndexesInPlace(['a', 'b'], new Set([]))).toStrictEqual(['a', 'b']);
+    });
+
+    it('should keep falsy elements that are not removed', () => {
+      expect(removeIndexesInPlace([null, undefined, 0, '', false], new Set([2])))
+        .toStrictEqual([null, undefined, 0, '', false].filter((_, i) => i !== 2));
+    });
+  });
+
+  //
+  // Handsontable.helper.insertValuesInPlace
+  //
+  describe('insertValuesInPlace', () => {
+    it('should insert the given amount of copies at the index', () => {
+      expect(insertValuesInPlace(['a', 'b', 'c'], 1, 2, null)).toStrictEqual(['a', null, null, 'b', 'c']);
+    });
+
+    it('should mutate the array in place and return the same reference', () => {
+      const array = ['a', 'b'];
+      const result = insertValuesInPlace(array, 0, 1, 'x');
+
+      expect(result).toBe(array);
+      expect(array).toStrictEqual(['x', 'a', 'b']);
+    });
+
+    it('should append the values when the index equals the array length', () => {
+      expect(insertValuesInPlace(['a', 'b'], 2, 2, null)).toStrictEqual(['a', 'b', null, null]);
+    });
+
+    it('should clamp an index greater than the array length to the length', () => {
+      expect(insertValuesInPlace(['a', 'b'], 10, 2, null)).toStrictEqual(['a', 'b', null, null]);
+    });
+
+    it('should insert at the start of the array', () => {
+      expect(insertValuesInPlace(['a', 'b'], 0, 3, 0)).toStrictEqual([0, 0, 0, 'a', 'b']);
+    });
+
+    it('should work on an empty array', () => {
+      expect(insertValuesInPlace([], 0, 2, null)).toStrictEqual([null, null]);
+    });
+
+    it('should not change the array when the amount is zero or negative', () => {
+      expect(insertValuesInPlace(['a', 'b'], 1, 0, null)).toStrictEqual(['a', 'b']);
+      expect(insertValuesInPlace(['a', 'b'], 1, -2, null)).toStrictEqual(['a', 'b']);
+    });
+
+    it('should produce the same result as the equivalent splice calls', () => {
+      const viaSplice = ['a', 'b', 'c', 'd'];
+
+      viaSplice.splice(2, 0, null, null, null);
+
+      expect(insertValuesInPlace(['a', 'b', 'c', 'd'], 2, 3, null)).toStrictEqual(viaSplice);
     });
   });
 

--- a/handsontable/src/helpers/array.ts
+++ b/handsontable/src/helpers/array.ts
@@ -241,6 +241,63 @@ export function arrayFlatten(array: unknown[]): unknown[] {
 }
 
 /**
+ * Removes the elements at the given indexes from the array. The array is compacted in one
+ * pass and mutated in place, so external references to it stay valid. Cost is O(array length)
+ * regardless of how many indexes are removed - unlike one `splice` call per removed index,
+ * which re-shifts the tail every time.
+ *
+ * @param {Array} array The array to mutate.
+ * @param {Set<number>} indexes The indexes of the elements to remove.
+ * @returns {Array} Returns the same, mutated array.
+ */
+export function removeIndexesInPlace<T>(array: T[], indexes: Set<number>): T[] {
+  let writeIndex = 0;
+
+  for (let readIndex = 0; readIndex < array.length; readIndex++) {
+    if (!indexes.has(readIndex)) {
+      array[writeIndex] = array[readIndex];
+      writeIndex += 1;
+    }
+  }
+
+  array.length = writeIndex;
+
+  return array;
+}
+
+/**
+ * Inserts `amount` copies of `value` into the array at the given index. The tail is shifted
+ * right once by `amount` and the array is mutated in place, so external references to it stay
+ * valid. An index greater than the array length is clamped to it (the values are appended),
+ * matching `Array.prototype.splice` semantics. Cost is O(array length + amount) regardless of
+ * `amount` - unlike one `splice` call per inserted value, which re-shifts the tail every time.
+ *
+ * @param {Array} array The array to mutate.
+ * @param {number} index The index at which to insert the values.
+ * @param {number} amount The number of copies to insert.
+ * @param {*} value The value to insert.
+ * @returns {Array} Returns the same, mutated array.
+ */
+export function insertValuesInPlace<T>(array: T[], index: number, amount: number, value: T): T[] {
+  if (amount <= 0) {
+    return array;
+  }
+
+  const oldLength = array.length;
+  const insertAt = Math.min(index, oldLength);
+
+  array.length = oldLength + amount;
+
+  for (let i = oldLength - 1; i >= insertAt; i--) {
+    array[i + amount] = array[i];
+  }
+
+  array.fill(value, insertAt, insertAt + amount);
+
+  return array;
+}
+
+/**
  * Unique values in the array.
  *
  * @param {Array} array The array to process.


### PR DESCRIPTION
### Context

The PR changes the bulk-alter paths in `DataMap` and `Core` so their cost scales with the size of the dataset once, not once per altered row or column.

The five hotspots, all the same shape (per-item O(n) work inside a loop over the alter batch):

1. **`applyChanges` grew the grid one row/column at a time.** A paste (or `setDataAtCell`) reaching k rows below the last row made k separate `createRow(amount: 1)` calls, each paying a full index-mapper insert and a `beforeCreateRow`/`afterCreateRow` hook round — O(k·R) and a multi-second hang for large pastes. Now the whole missing gap is created in one call per `while` iteration; the loop shape stays, so a `maxRows`/`maxCols` clamp is still detected and the change skipped exactly as before.
2. **`DataMap.filterData` ran `physicalRows.indexOf` inside a filter over the whole data source** — O(n·k) for removing k rows from an n-row grid, plus a full copy-back of the survivors. Now a `Set` membership test and one in-place compaction pass — O(n + k).
3. **`DataMap.#spliceRemovedColumns` (non-contiguous branch) spliced each source row once per removed column** — O(rows·k·cols) after any column reorder. Now one in-place compaction pass per row — O(rows·cols), independent of how many columns are removed. Row array references stay intact.
4. **`DataMap.createCol` walked all source rows once per created column** — O(k·rows·cols) for multi-column middle inserts (and their undo). The per-column pass collapses into at most two batched phases (end-of-row appends, then one block insert per row) that reproduce the old per-iteration append/middle branch choice exactly, including the clamped-splice behavior on rows shorter than the insertion point.
5. **`grid.adjustRowsAndCols` re-counted trailing empty columns after every change batch** with full O(rows) scans per column — even when only `minCols` was set and the result was never used. The count now runs only when the `minSpareCols` branch can consume it and stops at `minSpareCols` verified-empty columns. The consuming branch only ever compares the count against `minSpareCols`, so behavior is identical.

Supporting changes: new `removeIndexesInPlace` / `insertValuesInPlace` helpers in `helpers/array.ts`, and contiguous descending runs of removed rows/columns collapse into single bulk `metaManager.removeRow/removeColumn` calls.

**Measured** (fresh page per run, dev UMD builds; details in the task):

| Scenario | develop | this PR |
| --- | --- | --- |
| `setDataAtCell` 10k rows below the last row (10-row grid) | 3,021.7 ms | 9.5 ms (~318×) |
| `alter('remove_row')` 20k of 100k rows | 251.7 ms | 60.9 ms (4.1×) |
| `alter('insert_col_start')` 40 middle columns into 100, 50k rows | 187.2 ms | 25.3 ms (7.4×) |
| Edit with `minSpareCols: 2` and 20 extra trailing empty columns, 200k rows | 616.4 ms/edit | 66.6 ms/edit (9.3×) |
| Edit with only `minCols` set, 200k rows | 153.3 ms/edit | 2.4 ms/edit (64×) |
| `alter('remove_col')` 30 non-contiguous of 100 columns, 50k rows | 892.9 ms | 797.4 ms (the removed O(rows·k·cols) term was a minor share at this size; a pre-existing cost shared with `develop` dominates and is left as a follow-up) |

One observable behavior note (not breaking): a `setDataAtCell`/paste that creates k missing rows now fires `beforeCreateRow`/`afterCreateRow` once with `amount = k` instead of k times with `amount = 1`. This matches the long-standing `alter('insert_row_below', k)` semantics that every hook consumer already handles.

### How has this been tested?

- New unit tests for the helpers (15 specs): `npm run test:unit --prefix handsontable --testPathPattern=helpers/__tests__/array`
- New E2E specs: bulk `afterCreateRow`/`afterCreateCol` on `setDataAtCell` beyond the grid + `maxRows`/`maxCols` skip; non-contiguous `remove_col` after a column reorder (data correctness, remove-all, in-place row mutation); ragged-row multi-column insert; `minSpareCols` scan cap (spy on `isEmptyCol`), spare top-up, no-op with extra empties; `minCols`-only never verifies emptiness: `npm run test:e2e --prefix handsontable --testPathPattern='(removeCol|setDataAtCell|insertColStart|minSpareCols|minCols)'`
- Full unit suite: 3,223 passed. Full E2E suite: 9,567 specs, 0 failures. ESLint clean, `build:types` + downlevel clean.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2089

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/86carurmq

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core data-mutation and hook timing on auto grid expansion; behavior is covered by new tests but integrators that assumed per-row hook calls may need to handle bulk `amount`.
> 
> **Overview**
> Improves performance for large grids by batching work that used to run once per row or column during bulk alters, pastes, and post-edit grid sizing.
> 
> **Core** now creates the full missing row/column gap in a single `createRow` / `createCol` call when `applyChanges` extends the grid (e.g. `setDataAtCell` or paste far below/right of the data). **`adjustRowsAndCols`** only scans trailing empty columns when `minSpareCols` can add columns, and stops after at most `minSpareCols` checks instead of counting all trailing empties (including when only `minCols` is set).
> 
> **DataMap** batches multi-column inserts (`#insertColumnsIntoDataSource`), compacts source rows in one pass when removing many rows (`filterData` with a `Set`) or non-contiguous physical columns (`removeIndexesInPlace`), and collapses contiguous descending physical indexes into fewer `metaManager` remove calls.
> 
> New **`removeIndexesInPlace`** and **`insertValuesInPlace`** helpers in `helpers/array.ts` support in-place mutations so external references to row arrays stay valid.
> 
> **Note:** Auto row/column growth from edits now fires `beforeCreateRow` / `afterCreateRow` (and column hooks) **once** with `amount` equal to the full gap, not once per inserted row/column.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf9e13153b36a8e23ed707c7d55a41365982cfa7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->