### PR TITLE
DEV-2094: Replace Fluent UI theme recipe CodeSandbox demo and add source link

### DIFF
--- a/docs/content/recipes/themes/fluent-ui/fluent-ui.md
+++ b/docs/content/recipes/themes/fluent-ui/fluent-ui.md
@@ -22,14 +22,15 @@ type: how-to
 
 In this tutorial, you will integrate Handsontable into a React app with Fluent UI so your grid follows Fluent colors, typography, and spacing. You will learn how to map Fluent UI tokens to Handsontable theme parameters through the Theme API.
 
-<iframe src="https://codesandbox.io/embed/2y26vw?view=preview&module=%2Fsrc%2FApp.tsx"
+<iframe src="https://demos.handsontable.com/embed/3w4w5x6f54"
   style="width:100%; height: 500px; border:0; border-radius: 4px; overflow:hidden;"
   title="Handsontable with Fluent UI"
   allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
 ></iframe>
 
-[**Open in CodeSandbox**](https://codesandbox.io/p/sandbox/2y26vw)
+[**Open in sandbox**](https://demos.handsontable.com/?example=fluent-ui&v={{$currentReleaseVersion}})
+[**View source on GitHub**](https://github.com/handsontable/examples/tree/master/examples/fluent-ui)
 
 ## Overview
 


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->

Updates the embedded demo and "Open in sandbox" link for the Fluent UI theme recipe to use demos.handsontable.com. This aligns with other theme examples and improves consistency across the documentation. Also adds a direct link to the example's source code on GitHub.

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->
Manual test

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. [DEV-2094](https://app.clickup.com/t/9015210959/DEV-2094)

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only URL and link updates with no product or runtime behavior changes.
> 
> **Overview**
> The **Fluent UI** theme recipe doc now uses the same demo hosting pattern as other theme recipes instead of CodeSandbox.
> 
> The embedded iframe and **Open in sandbox** link target `demos.handsontable.com` (with `example=fluent-ui` and the current release version). A **View source on GitHub** link points at `handsontable/examples` under `examples/fluent-ui`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0da7a6f6f3b51fabc76b32ec4475e3a8342b7926. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->