### PR TITLE
chore(docs): flip prod widget to CF Worker (SU-633 go-live)

### DIFF
--- a/.github/workflows/docs-production.yml
+++ b/.github/workflows/docs-production.yml
@@ -60,6 +60,8 @@ jobs:
           npm run measure:module-sizes --prefix handsontable
 
       - name: Docker build
+        env:
+          PUBLIC_CHAT_API_URL: https://hot-docs-assistant.handsontable-sandbox.workers.dev
         run: |
           npm run docs:docker:build:production
 


### PR DESCRIPTION
## ✅ Ready to merge — go-live for the SU-633 prod cutover
Merging pushes to `prod-docs/18.0` → `docs-production.yml` rebuilds & redeploys prod docs with the widget pointed at the prod docs-assistant CF Worker. **All prerequisites verified (2026-07-16):**
- [x] Prod Worker secrets set (`wrangler secret put --env production`)
- [x] Prod Worker `SLACK_CHANNEL_ID=C0AENKW3RGA` deployed (docs-assistant#60 → promotion #61; green redeploy)
- [x] Full E2E on the prod Worker — real streamed `/api/chat` answer, `X-Thread-Id` + Slack tee, citation strip, PostHog message+categorized+usage, no stream errors
- [x] Prod `/docs` CSP allows the Worker host (handsontable#13088, live-verified)

## Summary
Adds `PUBLIC_CHAT_API_URL=https://hot-docs-assistant.handsontable-sandbox.workers.dev` as an `env:` on the **"Docker build"** step of `docs-production.yml`, so the prod docs widget calls the prod docs-assistant Cloudflare Worker instead of the Netlify proxy. Part of **SU-633**.

## Why this is a wiring change, not just a value
The widget backend URL is baked at `astro build` from `process.env.PUBLIC_CHAT_API_URL` (astro.config `define`). `docs-production.yml` never set it — only `docs-staging.yml` does (via the *dev-scoped* `secrets.PUBLIC_CHAT_API_URL`, pointing at the **dev** Worker) — so prod always fell back to the Netlify default. The prod build runs `astro build` host-side, so a step-level `env:` is enough (no Docker build-arg). Hardcoding the public URL is the minimal fix.

## Rollback
Revert this commit on `prod-docs/18.0` and re-push → rebuilds with the Netlify default. The Netlify proxy stays live throughout, so rollback is instant.

## Follow-up (separate)
`develop`'s `docs-production.yml` needs the same `env:` so `prod-docs/18.1+` inherit it.

[skip changelog]


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switches production chat traffic to a new backend endpoint at build time; misconfiguration or an unprepared Worker would break the in-docs assistant until rollback/rebuild.
> 
> **Overview**
> Production docs builds now set **`PUBLIC_CHAT_API_URL`** on the **Docker build** step in `docs-production.yml`, so the docs assistant widget is compiled against the **Cloudflare Worker** (`hot-docs-assistant.handsontable-sandbox.workers.dev`) instead of the previous **Netlify** default baked in when the variable was unset.
> 
> Staging already passed this through `docs-staging.yml`; prod did not, so this is a one-line CI wiring change for go-live (SU-633). Rollback is reverting the commit and rebuilding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1b522b5bc9c0df9743e8fe90ac75d4a2d8f5c80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
