### PR TITLE
docs: route docs-assistant widget via same-origin proxy (SU-664)

### DIFF
--- a/docs/src/components/DocsAssistant/constants.ts
+++ b/docs/src/components/DocsAssistant/constants.ts
@@ -22,9 +22,39 @@ export const WELCOME = {
   sub: 'I search the docs to answer questions about APIs, configuration, and usage. I say "I don\'t know" when the docs don\'t cover it.',
 };
 
-export const API_URL =
+/**
+ * Canonical docs hosts where the marketing worker proxies a stable same-origin
+ * path (`/docs-assistant/*`) through to the assistant backend (SU-664). On
+ * these hosts the widget talks to its own origin, so future backend rollovers
+ * need no docs-repo, CSP, or CORS change.
+ */
+const SAME_ORIGIN_DOCS_HOSTS = new Set(['handsontable.com', 'dev.handsontable.com']);
+
+/** Same-origin base proxied by the marketing worker on the canonical hosts. */
+const SAME_ORIGIN_BASE = '/docs-assistant';
+
+/**
+ * Absolute backend URL used everywhere the same-origin proxy does not exist —
+ * `*.pages.dev` deploy previews and local development. Baked at build time from
+ * `PUBLIC_CHAT_API_URL`, falling back to the Netlify deployment.
+ */
+const ABSOLUTE_API_URL =
   (import.meta.env.PUBLIC_CHAT_API_URL as string | undefined) ||
   'https://hot-docs-assistant.netlify.app';
+
+/**
+ * Resolve the backend base URL at runtime. The widget mounts client-side only
+ * (see `docs-assistant-bootstrap.ts`), so `window` is available — but the guard
+ * keeps the module safe to evaluate during SSR/build too.
+ */
+function resolveApiBase(): string {
+  if (typeof window !== 'undefined' && SAME_ORIGIN_DOCS_HOSTS.has(window.location.hostname)) {
+    return SAME_ORIGIN_BASE;
+  }
+  return ABSOLUTE_API_URL;
+}
+
+export const API_URL = resolveApiBase();
 
 export const CHAT_ENDPOINT = `${API_URL.replace(/\/$/, '')}/api/chat`;
 export const FEEDBACK_ENDPOINT = `${API_URL.replace(/\/$/, '')}/api/feedback`;


### PR DESCRIPTION
## Summary
- On `handsontable.com` and `dev.handsontable.com`, the docs-assistant widget now calls a stable same-origin path (`/docs-assistant/*`) that the marketing worker proxies to the assistant backend, instead of hardcoding the backend URL.
- This makes future backend rollovers a one-env-var change on the marketing worker — no docs-repo edit, CSP change, or CORS change (SU-664; follow-up to the SU-633 Cloudflare migration).
- Deploy previews (`*.pages.dev`) and localhost are unchanged: they still use the absolute `PUBLIC_CHAT_API_URL` (or the Netlify fallback), since the same-origin proxy only exists on the canonical hosts.
- Runtime hostname check, `typeof window`-guarded; the widget mounts client-side only.

## Test plan
- [x] Real browser on dev.handsontable.com: same-origin `POST /docs-assistant/api/chat` streams a full answer (`message_start` → `content_chunk` → `message_end`) with `X-Thread-Id`, and **no CSP/CORS console errors** under the live `connect-src 'self'` policy.
- [x] `POST /docs-assistant/api/feedback` routes through the proxy to the backend (JSON 400 on empty body, not a marketing 404).
- [ ] After merge + dev deploy: confirm the live widget on dev.handsontable.com sends via `/docs-assistant` and streams an answer.

## Note for promotion
Dev-only. Promoting to prod requires the marketing-worker prod route (`develop→master` in handsontable.com-v2) to be live **first**, otherwise the prod widget would call `/docs-assistant` with no route. This supersedes the direct `PUBLIC_CHAT_API_URL` flip on `chore/flip-docs-assistant-endpoint-18.0`.

## Changelog
`[skip changelog]` — documentation-site-only change (docs assistant widget); does not touch the `handsontable` library.