### PR TITLE
DEV-2096: Cache getColHeader columns-function index translation

### DIFF
--- a/.changelogs/13096.json
+++ b/.changelogs/13096.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Improved `getColHeader` performance: the index translation derived from the `columns` function is now cached instead of being rebuilt on every call, which also speeds up grid initialization and `updateSettings` on grids with many columns.",
+  "type": "changed",
+  "issueOrPR": 13096,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/__tests__/core/getColHeader.spec.js
+++ b/handsontable/src/__tests__/core/getColHeader.spec.js
@@ -241,4 +241,75 @@ describe('Core.getColHeader', () => {
     expect(getColHeader(3, -5)).toBe('default'); // header level is out of range
     expect(getColHeader(4, -4)).toBe('default'); // column index is out of range
   });
+
+  it('should return column titles when the `columns` option is defined as a function', async() => {
+    handsontable({
+      data: createSpreadsheetData(2, 4),
+      colHeaders: true,
+      columns(index) {
+        return { title: `Col ${index}` };
+      },
+    });
+
+    expect(getColHeader(0)).toBe('Col 0');
+    expect(getColHeader(1)).toBe('Col 1');
+    expect(getColHeader(3)).toBe('Col 3');
+    expect(getColHeader()).toEqual(['Col 0', 'Col 1', 'Col 2', 'Col 3']);
+  });
+
+  it('should return the current title when the `columns` function returns a changing title', async() => {
+    let title = 'Before';
+
+    handsontable({
+      data: createSpreadsheetData(2, 3),
+      colHeaders: true,
+      columns() {
+        return { title };
+      },
+    });
+
+    expect(getColHeader(1)).toBe('Before');
+
+    title = 'After';
+
+    expect(getColHeader(1)).toBe('After');
+  });
+
+  it('should return titles from the new `columns` function after `updateSettings`', async() => {
+    handsontable({
+      data: createSpreadsheetData(2, 3),
+      colHeaders: true,
+      columns(index) {
+        return { title: `Old ${index}` };
+      },
+    });
+
+    expect(getColHeader(1)).toBe('Old 1');
+    expect(getColHeader()).toEqual(['Old 0', 'Old 1', 'Old 2']);
+
+    await updateSettings({
+      columns(index) {
+        return { title: `New ${index}` };
+      },
+    });
+
+    expect(getColHeader(1)).toBe('New 1');
+    expect(getColHeader()).toEqual(['New 0', 'New 1', 'New 2']);
+  });
+
+  it('should return titles for all columns after loading wider data when the `columns` option is a function', async() => {
+    handsontable({
+      data: createSpreadsheetData(2, 2),
+      colHeaders: true,
+      columns(index) {
+        return { title: `Col ${index}` };
+      },
+    });
+
+    expect(getColHeader()).toEqual(['Col 0', 'Col 1']);
+
+    await loadData(createSpreadsheetData(2, 5));
+
+    expect(getColHeader()).toEqual(['Col 0', 'Col 1', 'Col 2', 'Col 3', 'Col 4']);
+  });
 });

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -3219,6 +3219,10 @@ export default function Core(
       throwWithCause('Since 8.0.0 the "ganttChart" setting is no longer supported.');
     }
 
+    // The `columns` option (or the state its function form reads) may change in this call - drop
+    // getColHeader's index translation cache so it rebuilds against the updated settings.
+    columnsSettingIndexes = null;
+
     if (isDefined(settings.rowHeights) && isDefined(settings.minRowHeights)) {
       warn('Both `rowHeights` and `minRowHeights` are defined in your configuration. ' +
         'As one is the alias of the other, only one of them can be used at a time. ' +
@@ -4833,6 +4837,19 @@ export default function Core(
   };
 
   /**
+   * Caches the index translation that `getColHeader` derives from the `columns` option when that
+   * option is a function: the source column indexes for which `columns(index)` returns a truthy
+   * settings object. Only the membership array is cached — titles are still read live from the
+   * `columns` function. Rebuilt when the function reference or the column count changes; cleared
+   * by `updateSettings`.
+   */
+  let columnsSettingIndexes: {
+    columns: (...args: unknown[]) => Record<string, unknown>;
+    columnsLen: number;
+    indexes: number[];
+  } | null = null;
+
+  /**
    * Gets the values of column headers (if column headers are [enabled](@/api/options.md#colheaders)).
    *
    * To get an array with the values of all
@@ -4889,31 +4906,34 @@ export default function Core(
 
     let result: unknown = tableMeta.colHeaders;
     const columns = tableMeta.columns;
+    const columnsFn = typeof columns === 'function' ? columns : null;
+    const physicalColumn = instance.toPhysicalColumn(columnIndex as number);
+    let columnSettings: Record<string, unknown> | null = null;
 
-    const translateVisualIndexToColumns = function(visualColumnIndex: number) {
-      const arr: number[] = [];
-
+    if (columnsFn !== null) {
       const columnsLen = instance.countCols();
-      let index = 0;
 
-      for (; index < columnsLen; index++) {
-        if (isFunction(columns) && columns(index)) {
-          arr.push(index);
+      if (columnsSettingIndexes === null || columnsSettingIndexes.columns !== columnsFn ||
+          columnsSettingIndexes.columnsLen !== columnsLen) {
+        const indexes: number[] = [];
+
+        for (let index = 0; index < columnsLen; index++) {
+          if (columnsFn(index)) {
+            indexes.push(index);
+          }
         }
+
+        columnsSettingIndexes = { columns: columnsFn, columnsLen, indexes };
       }
 
-      return arr[visualColumnIndex];
-    };
-
-    const physicalColumn = instance.toPhysicalColumn(columnIndex as number);
-    const prop = translateVisualIndexToColumns(physicalColumn!);
+      columnSettings = columnsFn(columnsSettingIndexes.indexes[physicalColumn!]) ?? null;
+    }
 
     if (tableMeta.colHeaders === false) {
       result = null;
 
-    } else if (columns && isFunction(columns) && columns(prop) &&
-               (columns(prop) as Record<string, unknown>).title) {
-      result = (columns(prop) as Record<string, unknown>).title;
+    } else if (columnSettings && columnSettings.title) {
+      result = columnSettings.title;
 
     } else if (columns && !isFunction(columns) && columns[physicalColumn!] &&
                columns[physicalColumn!].title) {


### PR DESCRIPTION
### Context

The PR fixes an O(columns²) hotspot in `Core.getColHeader`. On every call, `getColHeader(column)` rebuilt an index-translation array by looping over all columns:

- When the `columns` option is a **function**, that loop invoked the user callback once per column, per call. The no-arg `getColHeader()` — used by AutoColumnSize on every init and `updateSettings`, by copy-with-headers, and by ExportFile — therefore made `columns × columns` callback invocations: at 5,000 columns, ~25,000,000 `columns()` calls (~270 ms) per call site.
- When `columns` is **not** a function, the loop still ran on every call and its result was provably unused (the only branch consuming it requires `columns` to be a function).

The fix:

- Skips the translation entirely when `columns` is not a function (exact behavior match).
- When `columns` is a function, memoizes the membership array (source indexes for which `columns(index)` returns a truthy settings object). The cache is keyed by the function reference and the column count, and is cleared at the start of `updateSettings`. Only the membership is cached — header titles are still read live from the `columns` function on every call, so dynamically computed titles keep working (covered by a new test).
- Side cleanup: the duplicated `columns(prop)` invocation became a single call, and two `as Record<string, unknown>` casts were removed in favor of native `typeof` narrowing.

Measured (columns as a function, 100 rows, fresh page per run):

| Scenario | develop | this PR |
|---|---|---|
| No-arg `getColHeader()`, 5,000 cols | 271.5 ms | 0.7 ms (~390×) |
| Grid init, 5,000 cols (AutoColumnSize on) | 373 ms / 26.2M `columns()` calls | 89 ms / 25k calls |
| 1,000 single `getColHeader(i)` calls, 5,000 cols | 57.2 ms | 0.1 ms |
| No-arg `getColHeader()`, 1,000 cols | 7.0 ms | 0.2 ms |

### How has this been tested?

- 4 new E2E specs in `src/__tests__/core/getColHeader.spec.js`: titles from a `columns` function, live (uncached) title reads, `updateSettings` invalidation, and cache rebuild after loading wider data.
- `npm run test:e2e --testPathPattern=getColHeader` — 24 specs, 0 failures.
- `npm run test:e2e --testPathPattern="autoColumnSize|nestedHeaders|updateSettings|exportFile|copyPaste"` (the `getColHeader` consumers) — 789 specs, 0 failures.
- `npm run test:unit` — 3220 tests, 0 failures.
- `npm run test:e2e` (full suite) — 9558 specs, 0 failures.
- `npx eslint` on the changed files and `npm run build:types` — clean.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2096

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2096

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a hot core API path used by init, copy/export, and AutoColumnSize; behavior is intended to be unchanged but incorrect cache invalidation could surface wrong headers.
> 
> **Overview**
> **`getColHeader`** no longer rebuilds a full-column index translation on every call when **`columns`** is a function. It now **memoizes** which source column indexes have truthy settings (keyed by the function reference and column count), still reads **titles live** from **`columns()`**, and **skips** that work entirely when **`columns`** is not a function.
> 
> **`updateSettings`** clears the cache at the start so a changed **`columns`** callback or column layout is picked up; wider data after **`loadData`** is covered by rebuilding when the column count changes.
> 
> Four E2E specs lock in function-based titles, dynamic title reads, **`updateSettings`** invalidation, and wider data. A changelog entry documents the performance improvement for large column counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25482c114cd0fa9576fee89883494b36d2e9f27d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->