### PR TITLE
DEV-2091: Add docs examples sync dispatch workflow

### DIFF
--- a/.github/workflows/docs-examples-sync.yml
+++ b/.github/workflows/docs-examples-sync.yml
@@ -1,0 +1,34 @@
+name: Docs Examples Sync
+
+on:
+  push:
+    branches:
+      - develop
+      - 'prod-docs/**'
+    paths:
+      - 'docs/content/guides/**'
+      - 'docs/content/recipes/**'
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dispatch:
+    name: Trigger examples snapshot import
+    # The import workflow in handsontable/examples accepts only "develop" or "prod-docs/<major>.<minor>".
+    if: github.ref_name == 'develop' || startsWith(github.ref_name, 'prod-docs/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send repository_dispatch to handsontable/examples
+        if: github.ref_name != 'prod-docs/latest'
+        env:
+          GH_TOKEN: ${{ secrets.EXAMPLES_REPO_TOKEN }}
+          DOCS_BRANCH: ${{ github.ref_name }}
+        run: |
+          gh api repos/handsontable/examples/dispatches \
+            -f event_type=docs-examples-sync \
+            -f "client_payload[docs_branch]=$DOCS_BRANCH"

--- a/.github/workflows/docs-examples-sync.yml
+++ b/.github/workflows/docs-examples-sync.yml
@@ -23,10 +23,23 @@ jobs:
     if: github.ref_name == 'develop' || startsWith(github.ref_name, 'prod-docs/')
     runs-on: ubuntu-latest
     steps:
+      # Mint a short-lived, repository-scoped token from the GitHub App.
+      # The built-in GITHUB_TOKEN cannot reach another repository, so a
+      # cross-repo dispatch requires an App installation token (or a PAT).
+      - name: Mint GitHub App token
+        id: app-token
+        if: github.ref_name != 'prod-docs/latest'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # https://github.com/actions/create-github-app-token/releases/tag/v3.2.0
+        with:
+          app-id: ${{ secrets.EXAMPLES_SYNC_APP_ID }}
+          private-key: ${{ secrets.EXAMPLES_SYNC_APP_KEY }}
+          owner: handsontable
+          repositories: examples
+
       - name: Send repository_dispatch to handsontable/examples
         if: github.ref_name != 'prod-docs/latest'
         env:
-          GH_TOKEN: ${{ secrets.EXAMPLES_REPO_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           DOCS_BRANCH: ${{ github.ref_name }}
         run: |
           gh api repos/handsontable/examples/dispatches \

--- a/.github/workflows/docs-examples-sync.yml
+++ b/.github/workflows/docs-examples-sync.yml
@@ -3,8 +3,12 @@ name: Docs Examples Sync
 on:
   push:
     branches:
+      # "develop" is the next-version docs bucket (published as "latest"), and
+      # "prod-docs/<major>.<minor>" holds a released version. No other docs
+      # branch feeds the examples runner - the stale "prod-docs/latest" branch
+      # included.
       - develop
-      - 'prod-docs/**'
+      - 'prod-docs/[0-9]+.[0-9]+'
     paths:
       - 'docs/content/guides/**'
       - 'docs/content/recipes/**'
@@ -19,16 +23,26 @@ concurrency:
 jobs:
   dispatch:
     name: Trigger examples snapshot import
-    # The import workflow in handsontable/examples accepts only "develop" or "prod-docs/<major>.<minor>".
-    if: github.ref_name == 'develop' || startsWith(github.ref_name, 'prod-docs/')
     runs-on: ubuntu-latest
     steps:
+      # Push events are already filtered by the branch patterns above, but
+      # workflow_dispatch bypasses that filter, so validate the ref here
+      # instead of dispatching a branch the importer in handsontable/examples
+      # cannot resolve.
+      - name: Validate docs branch
+        env:
+          DOCS_BRANCH: ${{ github.ref_name }}
+        run: |
+          if [[ "$DOCS_BRANCH" != 'develop' && ! "$DOCS_BRANCH" =~ ^prod-docs/[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::\"$DOCS_BRANCH\" is not a docs branch the examples importer accepts (expected \"develop\" or \"prod-docs/<major>.<minor>\")."
+            exit 1
+          fi
+
       # Mint a short-lived, repository-scoped token from the GitHub App.
       # The built-in GITHUB_TOKEN cannot reach another repository, so a
       # cross-repo dispatch requires an App installation token (or a PAT).
       - name: Mint GitHub App token
         id: app-token
-        if: github.ref_name != 'prod-docs/latest'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # https://github.com/actions/create-github-app-token/releases/tag/v3.2.0
         with:
           app-id: ${{ secrets.EXAMPLES_SYNC_APP_ID }}
@@ -37,7 +51,6 @@ jobs:
           repositories: examples
 
       - name: Send repository_dispatch to handsontable/examples
-        if: github.ref_name != 'prod-docs/latest'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           DOCS_BRANCH: ${{ github.ref_name }}


### PR DESCRIPTION
### Context

The PR adds a workflow that keeps the docs-examples snapshot in `handsontable/examples` in sync with docs content in this repository.

The runner in `handsontable/examples` serves docs examples from a committed snapshot (`runner/apps/authoring/public/docs-examples/`, generated by `runner/pipeline/import-docs.mjs`). Nothing regenerates that snapshot when docs examples change on `develop` or `prod-docs/<major>.<minor>`, so it silently drifts stale.

The new `docs-examples-sync.yml` workflow fires on pushes to `develop` or `prod-docs/<major>.<minor>` that touch `docs/content/guides/**` or `docs/content/recipes/**` (plus manual `workflow_dispatch`), and sends a `repository_dispatch` event of type `docs-examples-sync` to `handsontable/examples` with `client_payload.docs_branch` set to the pushed branch. The receiving workflow re-imports the affected docs bucket and opens an automated snapshot-update PR in the examples repository.

Those two are the only docs buckets that exist: `develop` is the next-version bucket (published as "latest"), and `prod-docs/<major>.<minor>` holds a released version. There is no `prod-docs/latest` bucket in use — the branch of that name is dead (last commit January 2025) — so the trigger's branch filter is `prod-docs/[0-9]+.[0-9]+` and no name-based exclusion is needed. A push to any other branch produces no run at all, rather than a green run that dispatches nothing. `workflow_dispatch` bypasses branch filters, so a `Validate docs branch` step fails the run when the ref is neither `develop` nor `prod-docs/<major>.<minor>`. The check cannot live in a job-level `if`, because Actions expressions have no regex and could only blacklist branch names one by one.

The cross-repo dispatch is authenticated with a **GitHub App installation token**, minted at runtime via `actions/create-github-app-token`. The built-in `GITHUB_TOKEN` cannot be used — it is scoped to the current repository and cannot reach `handsontable/examples`. A GitHub App is preferred over a personal access token because it is not tied to an individual account, its tokens are short-lived (auto-expire), and it can be scoped to only the `examples` repository with only `contents: write`.

> [!NOTE]
> **No longer blocked.** The org-owned GitHub App exists, is installed on `handsontable` scoped to the `examples` repository with **Contents: Read and write**, and both secrets are set on this repository:
> - `EXAMPLES_SYNC_APP_ID` — the App's App ID.
> - `EXAMPLES_SYNC_APP_KEY` — the App's private key.

### How has this been tested?

- Validated the workflow file with `action-validator` (passes; only a "glob validation not supported" warning).
- Confirmed the branch filter syntax against the GitHub Actions documentation source: `[]` matches ranges including `0-9`, `+` matches one or more of the preceding character, and the documented example is `v[12].[0-9]+.[0-9]+`. `prod-docs/[0-9]+.[0-9]+` therefore matches `prod-docs/18.0` and `prod-docs/9.0`, and does not match `prod-docs/latest`.
- Ran the `Validate docs branch` condition directly: accepts `develop`, `prod-docs/18.0`, `prod-docs/9.0`; rejects `prod-docs/latest`, `prod-docs/18.0.1`, and `feature/*`.
- Dry-run of the dispatch call the workflow performs, against the real endpoint:
  ```bash
  gh api repos/handsontable/examples/dispatches \
    -f event_type=docs-examples-sync \
    -f "client_payload[docs_branch]=develop"
  ```
  Returned HTTP 204 (accepted).
- Full end-to-end verification is possible only once this workflow lands on `develop`.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2091

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2091

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds CI-only automation with no runtime product code changes; cross-repo dispatch depends on GitHub App secrets being configured before the workflow can succeed.
> 
> **Overview**
> Adds **`docs-examples-sync.yml`**, a GitHub Actions workflow that triggers a docs-examples snapshot refresh in **`handsontable/examples`** when guide/recipe content changes on **`develop`** or **`prod-docs/**`** (or via manual dispatch).
> 
> On matching pushes, the job mints a short-lived GitHub App token scoped to **`examples`** and sends a **`repository_dispatch`** with event **`docs-examples-sync`**, passing **`client_payload.docs_branch`** so the downstream repo can re-import the right docs branch. **`prod-docs/latest`** is skipped because the examples importer only accepts **`develop`** or versioned **`prod-docs/<major>.<minor>`** branches.
> 
> The workflow uses empty default **`permissions`**, concurrency with cancel-in-progress, and pinned **`actions/create-github-app-token`** (same pattern as **`publish.yml`**), relying on **`EXAMPLES_SYNC_APP_ID`** and **`EXAMPLES_SYNC_APP_KEY`** secrets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70ff0f990e504f3a3d2f9fb3850df51bb3b25586. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
