### PR TITLE
Fix Open in runner links to use in-progress build version

### DIFF
--- a/docs/content/recipes/themes/ant-design/ant-design.md
+++ b/docs/content/recipes/themes/ant-design/ant-design.md
@@ -32,7 +32,7 @@ In this tutorial, you will integrate Handsontable into a React app that uses Ant
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
 ></iframe>
 
-[**Open in sandbox**](https://demos.handsontable.com/?example=ant-design&v={{$currentReleaseVersion}})
+[**Open in sandbox**](https://demos.handsontable.com/?example=ant-design&v={{$currentVersion}})
 [**View source on GitHub**](https://github.com/handsontable/examples/tree/master/examples/ant-design)
 
 ## Overview

--- a/docs/content/recipes/themes/base-theme/base-theme.md
+++ b/docs/content/recipes/themes/base-theme/base-theme.md
@@ -33,7 +33,7 @@ This tutorial shows you how to integrate Handsontable into a React app that uses
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
 ></iframe>
 
-[**Open in sandbox**](https://demos.handsontable.com/?example=base-web&v={{$currentReleaseVersion}})
+[**Open in sandbox**](https://demos.handsontable.com/?example=base-web&v={{$currentVersion}})
 [**View source on GitHub**](https://github.com/handsontable/examples/tree/master/examples/base-web)
 
 ## Overview

--- a/docs/content/recipes/themes/custom-theme/custom-theme.md
+++ b/docs/content/recipes/themes/custom-theme/custom-theme.md
@@ -33,7 +33,7 @@ This tutorial shows you how to integrate Handsontable into a Next.js app that us
      sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
    ></iframe>
 
-[**Open in sandbox**](https://demos.handsontable.com/?example=next-shadcn.js&v={{$currentReleaseVersion}})
+[**Open in sandbox**](https://demos.handsontable.com/?example=next-shadcn.js&v={{$currentVersion}})
 [**View source on GitHub**](https://github.com/handsontable/examples/tree/master/examples/next-shadcn.js)
 
 ## Overview

--- a/docs/content/recipes/themes/fluent-ui/fluent-ui.md
+++ b/docs/content/recipes/themes/fluent-ui/fluent-ui.md
@@ -29,7 +29,7 @@ In this tutorial, you will integrate Handsontable into a React app with Fluent U
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
 ></iframe>
 
-[**Open in sandbox**](https://demos.handsontable.com/?example=fluent-ui&v={{$currentReleaseVersion}})
+[**Open in sandbox**](https://demos.handsontable.com/?example=fluent-ui&v={{$currentVersion}})
 [**View source on GitHub**](https://github.com/handsontable/examples/tree/master/examples/fluent-ui)
 
 ## Overview

--- a/docs/content/recipes/themes/mui-theme/mui-theme.md
+++ b/docs/content/recipes/themes/mui-theme/mui-theme.md
@@ -34,7 +34,7 @@ This tutorial shows you how to integrate Handsontable into a React app that uses
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
 ></iframe>
 
-[**Open in sandbox**](https://demos.handsontable.com/?example=mui&v={{$currentReleaseVersion}})
+[**Open in sandbox**](https://demos.handsontable.com/?example=mui&v={{$currentVersion}})
 [**View source on GitHub**](https://github.com/handsontable/examples/tree/master/examples/mui)
 
 ## Overview

--- a/docs/src/plugins/__tests__/framework-loader.test.mjs
+++ b/docs/src/plugins/__tests__/framework-loader.test.mjs
@@ -7,7 +7,7 @@ import { join } from 'node:path';
 import { frameworkLoader } from '../framework-loader.mjs';
 import { setRenderedHtmlDirForTests, readRenderedHtml } from '../rendered-html-store.mjs';
 import { LATEST_CHANGELOG_MAJOR } from '../changelog-parser.mjs';
-import { CURRENT_RELEASE_VERSION } from '../docs-version.mjs';
+import { CURRENT_DOCS_VERSION } from '../docs-version.mjs';
 
 // The loader writes each entry's rendered HTML to a file and stores only a
 // marker in the data store (see rendered-html-store.mjs) — keep test writes
@@ -490,8 +490,8 @@ test('vanilla JS/TS guide example gets a runner link that follows the active tab
 
     assert.ok(html.includes('class="hot-example-runner-btn"'), 'expected a runner link');
     assert.ok(
-      html.includes(`href="https://demos.handsontable.com/?docs=guides/intro/javascript/example1.js&amp;v=${CURRENT_RELEASE_VERSION}"`),
-      'runner href should point at the .js variant with the current release version'
+      html.includes(`href="https://demos.handsontable.com/?docs=guides/intro/javascript/example1.js&amp;v=${CURRENT_DOCS_VERSION}"`),
+      'runner href should point at the .js variant with the resolved docs version'
     );
     assert.ok(html.includes('data-docs-ts="guides/intro/javascript/example1.ts"'), 'expected the .ts variant path for the client-side tab rewrite');
     assert.ok(html.includes('data-runner-version="'), 'expected the version to be carried for the client-side rewrite');
@@ -517,7 +517,7 @@ test('React example links the runner to the .tsx variant, not .jsx, with no tab-
     const html = renderedHtmlOf(store, 'react-data-grid/intro');
 
     assert.ok(
-      html.includes(`href="https://demos.handsontable.com/?docs=guides/intro/react/example1.tsx&amp;v=${CURRENT_RELEASE_VERSION}"`),
+      html.includes(`href="https://demos.handsontable.com/?docs=guides/intro/react/example1.tsx&amp;v=${CURRENT_DOCS_VERSION}"`),
       'runner href should point at the .tsx variant even though .jsx is listed first'
     );
     assert.ok(!html.includes('data-docs-js'), 'React examples have no manifest-eligible JS variant to follow');
@@ -572,7 +572,7 @@ test('recipe examples (outside guides/) get a runner link too', async () => {
     const html = renderedHtmlOf(store, 'javascript-data-grid/recipes/themes/base-theme');
 
     assert.ok(
-      html.includes(`href="https://demos.handsontable.com/?docs=recipes/themes/base-theme/javascript/example1.js&amp;v=${CURRENT_RELEASE_VERSION}"`),
+      html.includes(`href="https://demos.handsontable.com/?docs=recipes/themes/base-theme/javascript/example1.js&amp;v=${CURRENT_DOCS_VERSION}"`),
       'recipe examples should link the runner the same way guide examples do'
     );
     assert.ok(html.includes('hot-example-stackblitz-btn'), 'StackBlitz button should still render');

--- a/docs/src/plugins/docs-version.mjs
+++ b/docs/src/plugins/docs-version.mjs
@@ -107,20 +107,6 @@ function computeDocsVersion() {
 export const CURRENT_DOCS_VERSION = computeDocsVersion();
 
 /**
- * The published Handsontable package version (e.g. "18.0.0"), read directly
- * from `handsontable/package.json` regardless of BUILD_MODE.
- *
- * Unlike CURRENT_DOCS_VERSION, this never resolves to a synthetic
- * "0.0.0-next-..." pre-release string in staging/dev builds. Use it for links
- * to external services that only understand published version numbers (e.g.
- * the "Open in sandbox" links on the theme recipe pages), as opposed to
- * CodeSandbox VM links, which intentionally target the in-progress build.
- *
- * @type {string}
- */
-export const CURRENT_RELEASE_VERSION = getPackageVersion() ?? CURRENT_DOCS_VERSION;
-
-/**
  * The GitHub branch path used for source-code links in documentation pages.
  *
  * Production builds produce a `prod-docs/X.Y` path (e.g. `prod-docs/17.1`)

--- a/docs/src/plugins/framework-loader.mjs
+++ b/docs/src/plugins/framework-loader.mjs
@@ -12,7 +12,7 @@ import { join, relative, dirname } from 'path';
 import { createRequire } from 'module';
 import { fileURLToPath } from 'url';
 import matter from 'gray-matter';
-import { CURRENT_DOCS_VERSION, CURRENT_DOCS_MINOR_VERSION, CURRENT_RELEASE_VERSION } from './docs-version.mjs';
+import { CURRENT_DOCS_VERSION, CURRENT_DOCS_MINOR_VERSION } from './docs-version.mjs';
 import { LATEST_CHANGELOG_MAJOR } from './changelog-parser.mjs';
 import { convertAsideBodyMarkdown } from './aside-inline-markdown.mjs';
 import { internEcTokenStyles } from './ec-token-styles.mjs';
@@ -281,7 +281,7 @@ function buildExampleHtml(id, directive, fileRefs, contentDir, fileMeta = {}, ex
   const runnerTsRef = jsRef ? (fileRefs.find(r => r.endsWith('.ts')) ?? null) : null;
   const isRunnerEligible = !!runnerRef;
   const runnerUrl = isRunnerEligible
-    ? `https://demos.handsontable.com/?docs=${runnerRef}&v=${CURRENT_RELEASE_VERSION}`
+    ? `https://demos.handsontable.com/?docs=${runnerRef}&v=${CURRENT_DOCS_VERSION}`
     : '';
 
   // ── StackBlitz data (embedded as JSON for the client-side handler) ─────────
@@ -376,7 +376,7 @@ function buildExampleHtml(id, directive, fileRefs, contentDir, fileMeta = {}, ex
     ${iconCode} Source code ${iconChevron}
   </button>
   <div class="hot-example-actions">
-    ${isRunnerEligible ? `<a class="hot-example-runner-btn" href="${escapeHtml(runnerUrl)}" target="_blank" rel="noopener noreferrer" title="Edit in sandbox" aria-label="Edit in sandbox"${runnerTsRef ? ` data-docs-js="${escapeHtml(jsRef)}" data-docs-ts="${escapeHtml(runnerTsRef)}" data-runner-version="${escapeHtml(CURRENT_RELEASE_VERSION)}"` : ''}>
+    ${isRunnerEligible ? `<a class="hot-example-runner-btn" href="${escapeHtml(runnerUrl)}" target="_blank" rel="noopener noreferrer" title="Edit in sandbox" aria-label="Edit in sandbox"${runnerTsRef ? ` data-docs-js="${escapeHtml(jsRef)}" data-docs-ts="${escapeHtml(runnerTsRef)}" data-runner-version="${escapeHtml(CURRENT_DOCS_VERSION)}"` : ''}>
       ${iconRunner}
     </a>` : ''}
     <button class="hot-example-stackblitz-btn" type="button" title="Edit on StackBlitz" aria-label="Edit on StackBlitz">
@@ -1271,12 +1271,6 @@ function applyVuepressPreprocessing(content, prefix, contentDir) {
   // Staging/dev builds use "0.0.0-next-{shortSHA}-{YYYYMMDD}" so that
   // CodeSandbox links resolve to the correct in-progress build artifact.
   result = result.replace(/\{\{\s*\$currentVersion\s*\}\}/g, CURRENT_DOCS_VERSION);
-
-  // Fix {{$currentReleaseVersion}} → published Handsontable package version.
-  // Always the version in handsontable/package.json (e.g. "18.0.0"), even in
-  // staging/dev builds — for links to services that don't understand the
-  // synthetic "0.0.0-next-..." pre-release string.
-  result = result.replace(/\{\{\s*\$currentReleaseVersion\s*\}\}/g, CURRENT_RELEASE_VERSION);
 
   // Fix {{$currentMinorVersion}} → GitHub branch path for source-code links.
   // Production builds produce "prod-docs/X.Y" (e.g. "prod-docs/17.1").

--- a/docs/src/plugins/vuepress-preprocessor.mjs
+++ b/docs/src/plugins/vuepress-preprocessor.mjs
@@ -12,13 +12,12 @@
  * - ::: source-code-link URL  (convert to <a> tag)
  * - $withBase('/path') → /path
  * - {{$currentVersion}} → resolved Handsontable version string (full semver, e.g. "17.1.0")
- * - {{$currentReleaseVersion}} → published Handsontable package version (e.g. "18.0.0"), never a synthetic pre-release string
  * - {{$currentMinorVersion}} → GitHub branch path for source-code links (e.g. "prod-docs/17.1" or "develop")
  * - @/framework/path links  → /path (cross-framework alias)
  * - <div class="boxes-list"> ... </div>  → Starlight-styled card grid HTML
  */
 
-import { CURRENT_DOCS_VERSION, CURRENT_DOCS_MINOR_VERSION, CURRENT_RELEASE_VERSION } from './docs-version.mjs';
+import { CURRENT_DOCS_VERSION, CURRENT_DOCS_MINOR_VERSION } from './docs-version.mjs';
 import { convertAsideInlineMarkdown } from './aside-inline-markdown.mjs';
 
 /**
@@ -93,12 +92,6 @@ function preprocessMarkdown(content, framework) {
   //     Staging/dev builds use "0.0.0-next-{shortSHA}-{YYYYMMDD}" so that
   //     CodeSandbox links resolve to the correct in-progress build artifact.
   result = result.replace(/\{\{\s*\$currentVersion\s*\}\}/g, CURRENT_DOCS_VERSION);
-
-  // 6c-2. Fix {{$currentReleaseVersion}} → published Handsontable package version.
-  //       Always the version in handsontable/package.json (e.g. "18.0.0"), even
-  //       in staging/dev builds — for links to services that don't understand
-  //       the synthetic "0.0.0-next-..." pre-release string.
-  result = result.replace(/\{\{\s*\$currentReleaseVersion\s*\}\}/g, CURRENT_RELEASE_VERSION);
 
   // 6d. Fix {{$currentMinorVersion}} → GitHub branch path for source-code links.
   //     Production builds produce "prod-docs/X.Y" (e.g. "prod-docs/17.1").


### PR DESCRIPTION
### Context

The PR fixes the "Open in runner" button next to docs code examples so it opens the in-progress build, not the last published major. The runner link (`https://demos.handsontable.com/?docs=<path>&v=<version>`) sourced its `v=` value from `$currentReleaseVersion`, which always resolved to `handsontable/package.json`'s version (e.g. `18.0.0`) regardless of build mode. On staging/dev/PR-preview builds, that meant the runner never reflected in-progress content changes.

The Introduction page's CodeSandbox-VM links already solve this correctly via `$currentVersion`, which resolves to a synthetic `0.0.0-next-{sha}-{date}` build in staging/dev and the real package version in production. This change collapses the runner link (and the theme recipes' "Open in sandbox" links, which had the same issue) onto `$currentVersion`, and removes `$currentReleaseVersion` / `CURRENT_RELEASE_VERSION` entirely since it no longer has any distinct callers.

### How has this been tested?

- `node --test src/plugins/__tests__/*.test.mjs` (run from `docs/`) — 94 tests pass, including the 3 updated runner-href assertions in `framework-loader.test.mjs`.
- `node --test scripts/__tests__/test-runner-links.test.mjs` (run from `docs/`) — 11 tests pass (unaffected, sanity check).
- Manually evaluated `docs-version.mjs` in dev mode and confirmed `CURRENT_DOCS_VERSION` resolves to `0.0.0-next-<sha>-<date>`, and that `CURRENT_RELEASE_VERSION` is no longer exported.
- `grep -rn "CURRENT_RELEASE_VERSION\|currentReleaseVersion" docs/src docs/content` — no matches.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

N/A

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation build and external demo URL query parameters only; production behavior matches published package version when `BUILD_MODE=production`.
> 
> **Overview**
> **Runner and sandbox links** now pass `v=` from **`CURRENT_DOCS_VERSION`** (via `{{$currentVersion}}`), so staging/dev/PR preview builds open demos with the in-progress `0.0.0-next-{sha}-{date}` artifact instead of always using the last published semver from `package.json`.
> 
> The **framework loader** updates generated **Edit in sandbox** hrefs and `data-runner-version` the same way. **Theme recipe** pages switch **Open in sandbox** from `{{$currentReleaseVersion}}` to `{{$currentVersion}}`.
> 
> **`CURRENT_RELEASE_VERSION`** and **`{{$currentReleaseVersion}}`** preprocessing are **removed** from `docs-version.mjs`, `framework-loader.mjs`, and `vuepress-preprocessor.mjs`; tests assert **`CURRENT_DOCS_VERSION`** in runner URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0a5d21a288ff5c42a9754a635bb7ad3eae07816. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->