### PR TITLE
DEV-2105: Add Persian RTL language support to documentation

### DIFF
--- a/.changelogs/13101.json
+++ b/.changelogs/13101.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Added Persian language RTL direction support.",
+  "type": "added",
+  "issueOrPR": 13101,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/i18n/languages/fa-IR.ts
+++ b/handsontable/src/i18n/languages/fa-IR.ts
@@ -9,6 +9,7 @@ import * as C from '../constants';
 
 const dictionary = {
   languageCode: 'fa-IR',
+  languageDirection: 'rtl',
 
   [C.OK]: 'تایید',
   [C.CANCEL]: 'لغو',


### PR DESCRIPTION
### Context

The PR adds Persian language RTL (right-to-left) support to match the existing Arabic implementation. Persian (`fa-IR`) language dictionary now includes the `languageDirection: 'rtl'` property, enabling automatic RTL layout detection for Persian users.

This aligns Persian with other RTL languages like Arabic and ensures proper UI rendering for RTL-speaking audiences.

**Related ClickUp task:** DEV-2105

### How has this been tested?

- Verified the change matches the Arabic (ar-AR) implementation pattern
- No new tests required — this is an i18n configuration entry that follows the existing registry pattern

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2105

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/86cau2dde

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata field on an existing locale file; no logic or security changes.
> 
> **Overview**
> Persian (`fa-IR`) now declares **`languageDirection: 'rtl'`** on its i18n dictionary, matching the existing Arabic pack so Handsontable can apply right-to-left layout when that locale is active.
> 
> A changelog entry records the addition as a non-breaking i18n update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffeb20be0fcc29a4d7d04a6b2302db034d6fccf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->