### PR TITLE
DEV-2113: Fix runner-links checker for per-version manifest buckets

### DIFF
--- a/docs/scripts/__tests__/test-runner-links.test.mjs
+++ b/docs/scripts/__tests__/test-runner-links.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { extractRunnerLinks, crossCheckManifest, planHeadlessChecks, parseArgs } from '../test-runner-links.mjs';
+import { extractRunnerLinks, crossCheckManifest, planHeadlessChecks, parseArgs, deriveManifestBucket, formatTimestamp } from '../test-runner-links.mjs';
 
 test('extractRunnerLinks finds a plain-& href with a version', () => {
   const html = '<a href="https://demos.handsontable.com/?docs=guides/foo/example1.js&v=18.0.0">Open</a>';
@@ -118,21 +118,37 @@ test('planHeadlessChecks checks every Tier-2 link when sample is "all"', () => {
   assert.equal(droppedTier2, 0);
 });
 
-test('parseArgs applies defaults and derives the manifest URL from runner-origin', () => {
+test('parseArgs applies defaults, defaulting version to "next" and deriving the bucketed manifest URL', () => {
   const args = parseArgs([]);
 
   assert.equal(args.dist, './dist');
   assert.equal(args.runnerOrigin, 'https://demos.handsontable.com');
-  assert.equal(args.manifest, 'https://demos.handsontable.com/docs-examples/manifest.json');
+  assert.equal(args.version, 'next');
+  assert.equal(args.manifest, 'https://demos.handsontable.com/docs-examples/next/manifest.json');
   assert.equal(args.staticOnly, false);
   assert.equal(args.tier2Sample, 10);
   assert.equal(args.concurrency, 4);
+  assert.match(args.json, /^\.\/tests\/test-artifacts\/runner-links\/runner-sweep-report-\d{8}-\d{6}\.json$/);
+});
+
+test('formatTimestamp renders YYYYMMDD-HHmmss', () => {
+  const date = new Date(2026, 6, 20, 9, 5, 3); // 2026-07-20 09:05:03 local time
+
+  assert.equal(formatTimestamp(date), '20260720-090503');
+});
+
+test('parseArgs derives the manifest bucket from a --version override', () => {
+  const args = parseArgs(['--version', '18.0.0']);
+
+  assert.equal(args.version, '18.0.0');
+  assert.equal(args.manifest, 'https://demos.handsontable.com/docs-examples/18.0/manifest.json');
 });
 
 test('parseArgs reads flags, including a custom manifest override and tier2Sample=all', () => {
   const args = parseArgs([
     '--dist', './build',
     '--runner-origin', 'https://runner.example.com',
+    '--version', '18.0.0',
     '--manifest', './local-manifest.json',
     '--static-only',
     '--tier2-sample', 'all',
@@ -143,10 +159,22 @@ test('parseArgs reads flags, including a custom manifest override and tier2Sampl
 
   assert.equal(args.dist, './build');
   assert.equal(args.runnerOrigin, 'https://runner.example.com');
+  assert.equal(args.version, '18.0.0');
+  // --manifest wins over the derived bucket URL when explicitly passed.
   assert.equal(args.manifest, './local-manifest.json');
   assert.equal(args.staticOnly, true);
   assert.equal(args.tier2Sample, 'all');
   assert.equal(args.concurrency, 8);
   assert.equal(args.filter, 'column-adding');
   assert.equal(args.json, './out/report.json');
+});
+
+test('deriveManifestBucket resolves "next" as-is and drops the patch segment from release versions', () => {
+  assert.equal(deriveManifestBucket('next'), 'next');
+  assert.equal(deriveManifestBucket('18.0.0'), '18.0');
+  assert.equal(deriveManifestBucket('18.0'), '18.0');
+});
+
+test('deriveManifestBucket maps the staging/dev pre-release stamp to the "next" bucket', () => {
+  assert.equal(deriveManifestBucket('0.0.0-next-64139ae-20260219'), 'next');
 });

--- a/docs/scripts/test-runner-links.mjs
+++ b/docs/scripts/test-runner-links.mjs
@@ -26,16 +26,33 @@ import { chromium } from '@playwright/test';
 // output — so every form must be accepted here.
 const RUNNER_LINK_RE = /href="(https:\/\/demos\.handsontable\.com\/\?docs=([^"&]+))(?:&(?:amp;|#x26;)?v=([^"&]+))?"/gi;
 
+/**
+ * Formats a Date as `YYYYMMDD-HHmmss` for use in a report filename, so
+ * repeated runs don't clobber each other's report.
+ *
+ * @param {Date} date
+ * @returns {string}
+ */
+export function formatTimestamp(date) {
+  const pad = n => String(n).padStart(2, '0');
+
+  return `${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(date.getDate())}-${pad(date.getHours())}${pad(date.getMinutes())}${pad(date.getSeconds())}`;
+}
+
 const HELP_TEXT = `Usage: node scripts/test-runner-links.mjs [options]
 
   --dist <dir>            built-HTML dir to scan (default: ./dist)
   --runner-origin <url>   runner origin (default: https://demos.handsontable.com)
-  --manifest <url|path>   manifest override (default: <runner-origin>/docs-examples/manifest.json)
+  --version <ver>         Handsontable version the dist was built with — resolves to a
+                           docs-examples bucket ("next", or "X.Y"/"X.Y.Z" -> "X.Y")
+                           (default: next — matches local/staging builds)
+  --manifest <url|path>   manifest override, bypasses --version bucket derivation
+                           (default: <runner-origin>/docs-examples/<bucket>/manifest.json)
   --static-only           skip the headless phase — link extraction + manifest cross-check only
   --tier2-sample <N|all>  how many Vue/Angular links to headless-check per framework (default: 10)
   --concurrency <N>       parallel Tier-1 pages, Tier-2 is capped at min(2, N) (default: 4)
   --filter <substring>    only check docs paths containing this substring
-  --json <path>           report output path (default: ./test-artifacts/runner-sweep-report.json)
+  --json <path>           report output path (default: ./tests/test-artifacts/runner-links/runner-sweep-report-<timestamp>.json)
   --help                  print this message and exit`;
 
 const TIER1_FRAMEWORKS = new Set(['javascript', 'typescript', 'react']);
@@ -111,16 +128,54 @@ export async function collectRunnerLinks(distDir) {
 }
 
 /**
+ * Resolves a Handsontable version string to the docs-examples bucket that
+ * hosts its manifest — mirrors `deriveDocsBucketCandidate` in the runner repo
+ * (handsontable/examples, runner/packages/runtime/src/docs-bucket.ts):
+ * the in-progress build uses the "next" bucket, every release uses "X.Y"
+ * (patch is dropped — the runner buckets examples per minor version).
+ *
+ * Local/staging docs builds stamp `CURRENT_DOCS_VERSION` (see
+ * docs/src/plugins/docs-version.mjs) as `0.0.0-next-{sha}-{date}`, not the
+ * literal string "next" — that pre-release form is also mapped to "next"
+ * here so a version straight out of a runner link resolves correctly.
+ *
+ * @param {string} version
+ * @returns {string}
+ */
+export function deriveManifestBucket(version) {
+  if (version === 'next' || /^0\.0\.0-next-/.test(version)) return 'next';
+
+  const match = String(version).match(/^(\d+)\.(\d+)/);
+
+  return match ? `${match[1]}.${match[2]}` : version;
+}
+
+/**
  * Fetches the runner manifest from an http(s) URL or a local file path.
  *
  * @param {string} manifestSource
  * @returns {Promise<Map<string, object>>} docsPath -> manifest entry
  */
 export async function fetchManifest(manifestSource) {
-  const raw = manifestSource.startsWith('http')
-    ? await (await fetch(manifestSource)).text()
-    : await readFile(manifestSource, 'utf-8');
-  const parsed = JSON.parse(raw);
+  let raw;
+
+  if (manifestSource.startsWith('http')) {
+    const res = await fetch(manifestSource);
+
+    if (!res.ok) throw new Error(`Failed to fetch manifest from ${manifestSource}: HTTP ${res.status}`);
+    raw = await res.text();
+  } else {
+    raw = await readFile(manifestSource, 'utf-8');
+  }
+
+  let parsed;
+
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`Manifest at ${manifestSource} is not valid JSON — check the version/bucket is correct.`);
+  }
+
   const examples = parsed.examples ?? parsed;
 
   return new Map(examples.map(entry => [entry.docsPath, entry]));
@@ -158,15 +213,19 @@ function isIgnoredConsoleMessage(message) {
 
 /**
  * Polls every frame in the page (the flattened tree includes nested Sandpack /
- * container iframes) until a rendered Handsontable grid is found or the
- * deadline passes.
+ * container iframes) until a rendered Handsontable grid is found, the
+ * deadline passes, or `shouldAbort` reports a fatal condition (e.g. a 404 on
+ * a runner-origin resource) that makes waiting out the full timeout pointless.
  *
  * @param {import('@playwright/test').Page} page
  * @param {number} deadline - epoch ms
+ * @param {() => boolean} [shouldAbort]
  * @returns {Promise<boolean>}
  */
-async function waitForGrid(page, deadline) {
+async function waitForGrid(page, deadline, shouldAbort) {
   while (Date.now() < deadline) {
+    if (shouldAbort?.()) return false;
+
     for (const frame of page.frames()) {
       const found = await frame
         .evaluate(() => !!document.querySelector('.ht_master .htCore tbody tr td'))
@@ -219,12 +278,21 @@ async function verifyLink(browser, docsPath, link, manifestEntry, progress) {
 
   const page = await browser.newPage();
   const consoleWarnings = [];
+  const notFoundUrls = [];
+  const runnerOrigin = new URL(link.url).origin;
 
   page.on('console', msg => {
     if (msg.type() === 'error' && !isIgnoredConsoleMessage(msg.text())) consoleWarnings.push(msg.text());
   });
   page.on('pageerror', err => {
     if (!isIgnoredConsoleMessage(String(err))) consoleWarnings.push(String(err));
+  });
+  // A 404 on a runner-origin resource (manifest, example JSON, bundle) means
+  // the example can never render — abort the grid wait early instead of
+  // burning the full per-framework timeout. Third-party hosts (Sandpack CDN,
+  // fonts) are excluded: their transient 404s don't imply a broken example.
+  page.on('response', res => {
+    if (res.status() === 404 && res.url().startsWith(runnerOrigin)) notFoundUrls.push(res.url());
   });
 
   const elapsed = () => `${((Date.now() - startedAt) / 1000).toFixed(1)}s`;
@@ -237,15 +305,27 @@ async function verifyLink(browser, docsPath, link, manifestEntry, progress) {
   try {
     const deadline = Date.now() + timeoutMs;
 
+    let mainResponse;
+
     try {
-      await page.goto(link.url, { waitUntil: 'domcontentloaded', timeout: timeoutMs });
+      mainResponse = await page.goto(link.url, { waitUntil: 'domcontentloaded', timeout: timeoutMs });
     } catch {
       return finish({ docsPath, url: link.url, framework: manifestEntry.framework, phase: 'load-timeout', reason: `page failed to load within ${timeoutMs}ms`, pages: link.pages, consoleWarnings });
     }
 
-    const gridFound = await waitForGrid(page, deadline);
+    if (mainResponse && mainResponse.status() >= 400) {
+      return finish({ docsPath, url: link.url, framework: manifestEntry.framework, phase: 'http-error', reason: `runner page responded with HTTP ${mainResponse.status()}`, pages: link.pages, consoleWarnings });
+    }
+
+    const gridFound = await waitForGrid(page, deadline, () => notFoundUrls.length > 0);
 
     if (!gridFound) {
+      // A runner-origin 404 is the more precise diagnosis than "no grid" —
+      // and it's what aborted the wait early in the first place.
+      if (notFoundUrls.length > 0) {
+        return finish({ docsPath, url: link.url, framework: manifestEntry.framework, phase: 'http-404', reason: `runner resource(s) returned 404: ${notFoundUrls.slice(0, 3).join(', ')}`, pages: link.pages, consoleWarnings });
+      }
+
       return finish({ docsPath, url: link.url, framework: manifestEntry.framework, phase: 'no-grid', reason: `no Handsontable grid rendered within ${timeoutMs}ms`, pages: link.pages, consoleWarnings });
     }
 
@@ -336,12 +416,13 @@ export function parseArgs(argv) {
   const args = {
     dist: './dist',
     runnerOrigin: 'https://demos.handsontable.com',
+    version: 'next',
     manifest: null,
     staticOnly: false,
     tier2Sample: 10,
     concurrency: 4,
     filter: null,
-    json: './test-artifacts/runner-sweep-report.json',
+    json: `./tests/test-artifacts/runner-links/runner-sweep-report-${formatTimestamp(new Date())}.json`,
     help: false,
   };
 
@@ -351,6 +432,7 @@ export function parseArgs(argv) {
 
     if (arg === '--dist') args.dist = next();
     else if (arg === '--runner-origin') args.runnerOrigin = next();
+    else if (arg === '--version') args.version = next();
     else if (arg === '--manifest') args.manifest = next();
     else if (arg === '--static-only') args.staticOnly = true;
     else if (arg === '--tier2-sample') { const v = next(); args.tier2Sample = v === 'all' ? 'all' : Number(v); }
@@ -360,7 +442,7 @@ export function parseArgs(argv) {
     else if (arg === '--help' || arg === '-h') args.help = true;
   }
 
-  if (!args.manifest) args.manifest = `${args.runnerOrigin}/docs-examples/manifest.json`;
+  if (!args.manifest) args.manifest = `${args.runnerOrigin}/docs-examples/${deriveManifestBucket(args.version)}/manifest.json`;
 
   return args;
 }
@@ -375,7 +457,7 @@ async function main(argv) {
   }
 
   console.log(
-    `Settings: dist=${args.dist} static-only=${args.staticOnly} tier2-sample=${args.tier2Sample} concurrency=${args.concurrency}${args.filter ? ` filter="${args.filter}"` : ''} (run with --help to see all options)`
+    `Settings: dist=${args.dist} version=${args.version} static-only=${args.staticOnly} tier2-sample=${args.tier2Sample} concurrency=${args.concurrency}${args.filter ? ` filter="${args.filter}"` : ''} (run with --help to see all options)`
   );
 
   console.log(`Walking ${args.dist} for runner links...`);


### PR DESCRIPTION
### Context

The PR fixes `pnpm docs:test:runner-links`, which failed for every link because it fetched the runner manifest from the old flat path `<runner-origin>/docs-examples/manifest.json`. Since handsontable/examples#66, manifests are nested per version bucket (`docs-examples/<bucket>/manifest.json`), and the old path returns the SPA HTML shell instead of JSON, crashing the script with a `JSON.parse` error.

Changes to `docs/scripts/test-runner-links.mjs`:

- New `--version <ver>` flag (default: `next`). A new `deriveManifestBucket()` helper mirrors the runner's `deriveDocsBucketCandidate` (`runner/packages/runtime/src/docs-bucket.ts` in handsontable/examples): `next` and `0.0.0-next-*` dev stamps resolve to the `next` bucket, release versions (`X.Y.Z`/`X.Y`) resolve to `X.Y`. The manifest is fetched from `<runner-origin>/docs-examples/<bucket>/manifest.json`; an explicit `--manifest` still overrides bucket derivation entirely.
- `fetchManifest()` now throws a clear error on a non-2xx or non-JSON response (e.g. a nonexistent bucket) instead of a cryptic `JSON.parse` crash.
- Headless phase fails fast on HTTP errors instead of burning the full per-framework timeout (60–240 s): a `>= 400` status on the main document fails immediately with phase `http-error`, and a 404 on any runner-origin resource aborts the grid wait with phase `http-404` (listing the 404'd URLs). Third-party CDN 404s are ignored, and a link still passes if the grid rendered despite a late ancillary 404.
- The report is written to its own directory with a timestamped filename — `./tests/test-artifacts/runner-links/runner-sweep-report-<YYYYMMDD-HHmmss>.json` — so repeated runs don't clobber each other and reports stay under the already-gitignored `docs/tests/test-artifacts/` tree.

### How has this been tested?

- Unit tests updated and extended in `docs/scripts/__tests__/test-runner-links.test.mjs` (bucket derivation, `--version` flag, default report path shape, timestamp formatting): `node --test scripts/__tests__/test-runner-links.test.mjs` — 15/15 passing.
- Verified live against `demos.handsontable.com`: default run resolves the `next` bucket and flags a nonexistent docs path; `--version 18.0.0` resolves to bucket `18.0` and a manifest-listed link passes the headless check in ~4 s; a bogus `--version` produces a clear error naming the derived bucket.
- `npx eslint --ext .mjs scripts/test-runner-links.mjs scripts/__tests__/test-runner-links.test.mjs` — clean.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2113

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2113

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the docs runner-links test script and its unit tests; no production runtime, auth, or data paths are affected.
> 
> **Overview**
> Fixes **`pnpm docs:test:runner-links`**, which broke when runner manifests moved from a flat URL to **per-version buckets** under `docs-examples/<bucket>/manifest.json` (the old path returned HTML and caused `JSON.parse` failures).
> 
> Adds **`--version`** (default **`next`**) and **`deriveManifestBucket()`** so the manifest URL matches the runner’s bucket rules: `next` and `0.0.0-next-*` staging stamps → `next`, releases `X.Y.Z` / `X.Y` → `X.Y`. **`--manifest`** still overrides derivation. **`fetchManifest()`** now fails clearly on non-OK HTTP or invalid JSON.
> 
> Headless checks **fail fast** on runner HTTP problems: main document **≥400** → `http-error`; **404** on runner-origin resources aborts the grid wait with **`http-404`** instead of waiting the full framework timeout (60–240s).
> 
> Default JSON output moves to **`./tests/test-artifacts/runner-links/runner-sweep-report-<YYYYMMDD-HHmmss>.json`** via new **`formatTimestamp()`**, so repeated runs don’t overwrite reports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1778f986e8487b96640437d3bf41220fccdaeb3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->