### PR TITLE
docs: route prod docs-assistant widget via same-origin proxy (SU-664)

### DIFF
--- a/docs/src/components/DocsAssistant/constants.ts
+++ b/docs/src/components/DocsAssistant/constants.ts
@@ -22,9 +22,39 @@ export const WELCOME = {
   sub: 'I search the docs to answer questions about APIs, configuration, and usage. I say "I don\'t know" when the docs don\'t cover it.',
 };
 
-export const API_URL =
+/**
+ * Canonical docs hosts where the marketing worker proxies a stable same-origin
+ * path (`/docs-assistant/*`) through to the assistant backend (SU-664). On
+ * these hosts the widget talks to its own origin, so future backend rollovers
+ * need no docs-repo, CSP, or CORS change.
+ */
+const SAME_ORIGIN_DOCS_HOSTS = new Set(['handsontable.com', 'dev.handsontable.com']);
+
+/** Same-origin base proxied by the marketing worker on the canonical hosts. */
+const SAME_ORIGIN_BASE = '/docs-assistant';
+
+/**
+ * Absolute backend URL used everywhere the same-origin proxy does not exist —
+ * `*.pages.dev` deploy previews and local development. Baked at build time from
+ * `PUBLIC_CHAT_API_URL`, falling back to the Netlify deployment.
+ */
+const ABSOLUTE_API_URL =
   (import.meta.env.PUBLIC_CHAT_API_URL as string | undefined) ||
   'https://hot-docs-assistant.netlify.app';
+
+/**
+ * Resolve the backend base URL at runtime. The widget mounts client-side only
+ * (see `docs-assistant-bootstrap.ts`), so `window` is available — but the guard
+ * keeps the module safe to evaluate during SSR/build too.
+ */
+function resolveApiBase(): string {
+  if (typeof window !== 'undefined' && SAME_ORIGIN_DOCS_HOSTS.has(window.location.hostname)) {
+    return SAME_ORIGIN_BASE;
+  }
+  return ABSOLUTE_API_URL;
+}
+
+export const API_URL = resolveApiBase();
 
 export const CHAT_ENDPOINT = `${API_URL.replace(/\/$/, '')}/api/chat`;
 export const FEEDBACK_ENDPOINT = `${API_URL.replace(/\/$/, '')}/api/feedback`;


### PR DESCRIPTION
## Summary
- Completes the **SU-664 same-origin cutover for production**: ports the widget endpoint resolution from #13095 (merged to `develop`) into the live `prod-docs/18.0` branch.
- `constants.ts` now resolves `API_URL` at runtime — the stable same-origin path `/docs-assistant` on `handsontable.com` / `dev.handsontable.com`, otherwise the absolute `PUBLIC_CHAT_API_URL` (Netlify fallback), unchanged for `*.pages.dev` previews and localhost.
- The marketing worker's production `/docs-assistant/*` route is already live, so merging this moves the prod docs widget onto the Cloudflare Worker via the same-origin proxy and off the direct Netlify URL. Future backend rollovers no longer need a docs-repo, CSP, or CORS change.

## Test plan
- [x] Prod route live — `OPTIONS https://handsontable.com/docs-assistant/api/chat` → `204` + CORS (`X-Thread-Id` exposed)
- [x] Prod proxied path streams end-to-end — `POST .../api/chat` → `200 text/event-stream`, `message_start` → `content_chunk` → `message_end`, `X-Thread-Id` returned, citations inline/stripped
- [ ] Post-merge (docs deploy): live widget on `handsontable.com/docs` POSTs same-origin, streams a full answer, thread continuity + feedback work, Slack tee + PostHog `$ip`/geo land

Only touches `docs/src/components/DocsAssistant/constants.ts` (widget endpoint resolution). Rollback = revert this PR (widget falls back to the Netlify URL).

[skip changelog]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file endpoint resolution for the docs widget; previews and localhost keep the prior absolute backend URL.
> 
> **Overview**
> **Docs Assistant API base URL is now chosen at runtime** instead of always using the build-time Netlify URL.
> 
> On `handsontable.com` and `dev.handsontable.com`, chat and feedback requests go to the same-origin path `/docs-assistant` (proxied by the marketing worker). On preview (`*.pages.dev`) and local dev, behavior is unchanged: `PUBLIC_CHAT_API_URL` or the Netlify fallback. `CHAT_ENDPOINT` / `FEEDBACK_ENDPOINT` still derive from `API_URL`; only how that base is resolved changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66dfce6797b8f4d4d1b9734b2c4b806c2311a453. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->