### PR TITLE
DEV-2114: Fix grid height collapse when width set and height omitted

### DIFF
--- a/.changelogs/13104.json
+++ b/.changelogs/13104.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed a grid configured with a `width` and no `height` collapsing vertically. Relative widths (`100%`, percentages, viewport units, `calc()` with them) keep scrolling horizontally with the window, while definite pixel/`em` widths clip to their box.",
+  "type": "fixed",
+  "issueOrPR": 13104,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/__tests__/settings/width.spec.js
+++ b/handsontable/src/__tests__/settings/width.spec.js
@@ -473,6 +473,22 @@ describe('settings', () => {
         expect(holder.getBoundingClientRect().height).toBeGreaterThan(0);
         expect(hot.view.isVerticallyScrollableByWindow()).toBe(true);
       });
+
+      it('should not clip horizontally when `width` is a percentage and `height` is omitted', async() => {
+        // A percentage width fills its container. Only a definite pixel width is clipped; a relative
+        // width lets content wider than the container scroll with the window (the page gains a
+        // horizontal scrollbar), so every column stays reachable instead of being clipped away.
+        const hot = handsontable({
+          data: createSpreadsheetData(8, 20),
+          rowHeaders: true,
+          colHeaders: true,
+          colWidths: 150,
+          width: '100%',
+        });
+
+        expect(window.getComputedStyle(hot.rootElement).overflowX).not.toBe('clip');
+        expect(hot.view.isHorizontallyScrollableByWindow()).toBe(true);
+      });
     });
   });
 });

--- a/handsontable/src/__tests__/settings/width.spec.js
+++ b/handsontable/src/__tests__/settings/width.spec.js
@@ -410,6 +410,46 @@ describe('settings', () => {
         expect(hot.rootElement.style.overflow).toBe('hidden');
         expect(hot.rootElement.style.overflowX).toBe('hidden');
       });
+
+      it('should not vertically collapse the grid when `width` is set and `height` is omitted', async() => {
+        // Regression guard: the width-clip block sets `overflow-x: clip` on the root. The trimming
+        // container lookup must not treat that horizontal-only clip as a vertical trimming
+        // container, or the master holder is pinned to `0px` and the fully rendered rows are
+        // clipped to an invisible grid (the table's content height is > 0 but nothing shows).
+        const hot = handsontable({
+          data: createSpreadsheetData(8, 6),
+          rowHeaders: true,
+          colHeaders: true,
+          width: '100%',
+        });
+
+        const holder = hot.rootElement.querySelector('.ht_master .wtHolder');
+        const table = hot.rootElement.querySelector('.ht_master .htCore');
+
+        // The holder must size to its content, not collapse to zero.
+        expect(holder.getBoundingClientRect().height).toBeGreaterThan(0);
+        expect(holder.getBoundingClientRect().height)
+          .toBeAroundValue(table.getBoundingClientRect().height, 2);
+      });
+
+      it('should stay window-scrollable when `width` is set and `height` is omitted', async() => {
+        // The horizontal-only `overflow-x: clip` must leave the vertical axis scrolling with the
+        // window. If the clipped root is picked as the trimming container, the overlays drop out of
+        // window-scroll mode: frozen rows stop pinning and vertical virtualization stops (every row
+        // renders into the DOM).
+        const hot = handsontable({
+          data: createSpreadsheetData(200, 6),
+          rowHeaders: true,
+          colHeaders: true,
+          fixedRowsTop: 2,
+          width: '100%',
+        });
+
+        expect(hot.view.isVerticallyScrollableByWindow()).toBe(true);
+        // Window-scroll viewport virtualizes: only a slice of the 200 rows is rendered.
+        expect(hot.rootElement.querySelectorAll('.ht_master .htCore tbody tr').length)
+          .toBeLessThan(200);
+      });
     });
   });
 });

--- a/handsontable/src/__tests__/settings/width.spec.js
+++ b/handsontable/src/__tests__/settings/width.spec.js
@@ -504,6 +504,20 @@ describe('settings', () => {
         expect(window.getComputedStyle(hot.rootElement).overflowX).not.toBe('clip');
       });
 
+      it('should not clip when `width` is a viewport unit (`vw`) and `height` is omitted', async() => {
+        // Viewport units resolve against the viewport, not a fixed box, so they are relative — the
+        // unit is preceded by digits (`100vw`), which must still be detected as relative (no clip).
+        const hot = handsontable({
+          data: createSpreadsheetData(8, 10),
+          rowHeaders: true,
+          colHeaders: true,
+          colWidths: 150,
+          width: '100vw',
+        });
+
+        expect(window.getComputedStyle(hot.rootElement).overflowX).not.toBe('clip');
+      });
+
       it('should clip when `width` is a definite non-pixel length (`em`) and `height` is omitted', async() => {
         // Absolute lengths other than `px` (em, rem, etc.) still establish a fixed box, so the table
         // must not visually overflow it — clip applies.

--- a/handsontable/src/__tests__/settings/width.spec.js
+++ b/handsontable/src/__tests__/settings/width.spec.js
@@ -489,6 +489,34 @@ describe('settings', () => {
         expect(window.getComputedStyle(hot.rootElement).overflowX).not.toBe('clip');
         expect(hot.view.isHorizontallyScrollableByWindow()).toBe(true);
       });
+
+      it('should not clip when `width` is a `calc()` that mixes in a percentage and `height` is omitted', async() => {
+        // A `calc()` referencing a percentage is container-driven even though it ends in `px`, so it
+        // must be treated as relative (no clip) rather than as a definite pixel width.
+        const hot = handsontable({
+          data: createSpreadsheetData(8, 10),
+          rowHeaders: true,
+          colHeaders: true,
+          colWidths: 150,
+          width: 'calc(100% - 20px)',
+        });
+
+        expect(window.getComputedStyle(hot.rootElement).overflowX).not.toBe('clip');
+      });
+
+      it('should clip when `width` is a definite non-pixel length (`em`) and `height` is omitted', async() => {
+        // Absolute lengths other than `px` (em, rem, etc.) still establish a fixed box, so the table
+        // must not visually overflow it — clip applies.
+        const hot = handsontable({
+          data: createSpreadsheetData(8, 10),
+          rowHeaders: true,
+          colHeaders: true,
+          colWidths: 150,
+          width: '20em',
+        });
+
+        expect(window.getComputedStyle(hot.rootElement).overflowX).toBe('clip');
+      });
     });
   });
 });

--- a/handsontable/src/__tests__/settings/width.spec.js
+++ b/handsontable/src/__tests__/settings/width.spec.js
@@ -450,6 +450,29 @@ describe('settings', () => {
         expect(hot.rootElement.querySelectorAll('.ht_master .htCore tbody tr').length)
           .toBeLessThan(200);
       });
+
+      it('should render vertically when `width` is narrower than the columns and `height` is omitted', async() => {
+        // A width-constrained grid whose columns are wider than the width renders at content height
+        // and scrolls vertically with the window (previously the whole grid collapsed to `0px`).
+        // Known limitation: the columns past the constrained width are clipped by the root's
+        // `overflow-x: clip` and are not reachable via a horizontal scrollbar — reaching them needs
+        // per-axis trimming (window vertical + element horizontal), tracked in a follow-up task.
+        const hot = handsontable({
+          data: createSpreadsheetData(8, 10),
+          rowHeaders: true,
+          colHeaders: true,
+          colWidths: 150,
+          width: 300,
+        });
+
+        const holder = hot.rootElement.querySelector('.ht_master .wtHolder');
+
+        expect($(hot.rootElement).width()).toBeAroundValue(300, 1);
+        expect(window.getComputedStyle(hot.rootElement).overflowX).toBe('clip');
+        // Not collapsed: the grid is visible and sizes vertically to its content.
+        expect(holder.getBoundingClientRect().height).toBeGreaterThan(0);
+        expect(hot.view.isVerticallyScrollableByWindow()).toBe(true);
+      });
     });
   });
 });

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -3515,15 +3515,21 @@ export default function Core(
     // width blocks ran) so partial updateSettings calls see the correct state.
     // When height IS set, the height block's `overflow: clip` shorthand handles both axes — leave
     // overflowX untouched to avoid breaking that shorthand.
-    // Only clip for a definite pixel width. A relative width (`100%`, percentages, viewport units)
-    // fills its container, and content wider than that scrolls with the window — matching the
-    // long-standing behavior where the page gains a horizontal scrollbar and every column stays
-    // reachable. Clipping those would silently hide the off-width columns with no scrollbar.
+    // Only clip for a definite width. A relative width (`100%`, other percentages, viewport units,
+    // or a `calc()` that mixes them in) fills its container, and content wider than that scrolls
+    // with the window — matching the long-standing behavior where the page gains a horizontal
+    // scrollbar and every column stays reachable. Clipping those would silently hide the off-width
+    // columns with no scrollbar. A definite width (`px`, `em`, `rem`, and other absolute lengths)
+    // establishes a fixed box the table must not visually overflow, so it is clipped.
     // Browser compatibility: `overflow-x: clip` requires Safari 16+. On Safari 14.1–15.x it silently
     // falls back to `visible` (graceful degradation — pre-existing behavior, not a new regression).
     if (typeof settings.height !== 'undefined' || typeof settings.width !== 'undefined') {
       const effectiveHeight = instance.rootElement.style.height;
       const effectiveWidth = instance.rootElement.style.width;
+      // Relative: percentages and viewport units resolve against an ancestor, so a `%` or `vw`/`vh`/
+      // `vmin`/`vmax` token anywhere (including inside `calc()`) marks the width as container-driven.
+      const isRelativeWidth = /%|\bv(?:w|h|min|max)\b/i.test(effectiveWidth);
+      const isDefiniteWidth = effectiveWidth !== '' && effectiveWidth !== 'auto' && !isRelativeWidth;
 
       if (!effectiveHeight) {
         const currentOverflowX = instance.rootElement.style.overflowX;
@@ -3533,7 +3539,7 @@ export default function Core(
         // by `clip`. Unlike `hidden`, `clip` creates no block formatting context and allows no
         // programmatic scroll.
         if (currentOverflowX === '' || currentOverflowX === 'clip') {
-          instance.rootElement.style.overflowX = /px$/.test(effectiveWidth) ? 'clip' : '';
+          instance.rootElement.style.overflowX = isDefiniteWidth ? 'clip' : '';
         }
       }
     }

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -3526,9 +3526,11 @@ export default function Core(
     if (typeof settings.height !== 'undefined' || typeof settings.width !== 'undefined') {
       const effectiveHeight = instance.rootElement.style.height;
       const effectiveWidth = instance.rootElement.style.width;
-      // Relative: percentages and viewport units resolve against an ancestor, so a `%` or `vw`/`vh`/
-      // `vmin`/`vmax` token anywhere (including inside `calc()`) marks the width as container-driven.
-      const isRelativeWidth = /%|\bv(?:w|h|min|max)\b/i.test(effectiveWidth);
+      // Relative: percentages and viewport units resolve against an ancestor, so a `%` or a viewport
+      // unit (`vw`/`vh`/`vmin`/`vmax`, and dynamic `dvh`/`svh`/`lvh` via the `vh` match) anywhere —
+      // including inside `calc()` — marks the width as container-driven. No word boundaries: the unit
+      // is preceded by digits (`100vw`), which are word characters, so `\bv` would never match.
+      const isRelativeWidth = /%|v(?:w|h|min|max)/i.test(effectiveWidth);
       const isDefiniteWidth = effectiveWidth !== '' && effectiveWidth !== 'auto' && !isRelativeWidth;
 
       if (!effectiveHeight) {

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -3515,6 +3515,10 @@ export default function Core(
     // width blocks ran) so partial updateSettings calls see the correct state.
     // When height IS set, the height block's `overflow: clip` shorthand handles both axes — leave
     // overflowX untouched to avoid breaking that shorthand.
+    // Only clip for a definite pixel width. A relative width (`100%`, percentages, viewport units)
+    // fills its container, and content wider than that scrolls with the window — matching the
+    // long-standing behavior where the page gains a horizontal scrollbar and every column stays
+    // reachable. Clipping those would silently hide the off-width columns with no scrollbar.
     // Browser compatibility: `overflow-x: clip` requires Safari 16+. On Safari 14.1–15.x it silently
     // falls back to `visible` (graceful degradation — pre-existing behavior, not a new regression).
     if (typeof settings.height !== 'undefined' || typeof settings.width !== 'undefined') {
@@ -3529,8 +3533,7 @@ export default function Core(
         // by `clip`. Unlike `hidden`, `clip` creates no block formatting context and allows no
         // programmatic scroll.
         if (currentOverflowX === '' || currentOverflowX === 'clip') {
-          instance.rootElement.style.overflowX =
-            (effectiveWidth && effectiveWidth !== 'auto') ? 'clip' : '';
+          instance.rootElement.style.overflowX = /px$/.test(effectiveWidth) ? 'clip' : '';
         }
       }
     }

--- a/handsontable/src/helpers/dom/__tests__/element.unit.ts
+++ b/handsontable/src/helpers/dom/__tests__/element.unit.ts
@@ -21,6 +21,7 @@ import {
   isShadowRoot,
   outerHeight,
   outerWidth,
+  getTrimmingContainer,
 } from 'handsontable/helpers/dom/element';
 import { setPlatformMeta } from 'handsontable/helpers/browser';
 
@@ -1118,6 +1119,76 @@ describe('DomElement helper', () => {
       getScrollbarWidth();
 
       expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getTrimmingContainer', () => {
+    let wrapper = null;
+    let base = null;
+
+    beforeEach(() => {
+      wrapper = document.createElement('div');
+      base = document.createElement('div');
+      wrapper.appendChild(base);
+      document.body.appendChild(wrapper);
+    });
+
+    afterEach(() => {
+      wrapper.parentNode.removeChild(wrapper);
+      wrapper = null;
+      base = null;
+    });
+
+    it('should return the window when no ancestor traps the element', () => {
+      expect(getTrimmingContainer(base)).toBe(window);
+    });
+
+    it('should return the window when an ancestor clips only the horizontal axis (`overflow-x: clip`)', () => {
+      // A width-constrained, window-scrolled grid sets `overflow-x: clip` on its root. That clip
+      // establishes no scroll port and leaves the vertical axis scrolling with the window, so the
+      // ancestor must NOT become the trimming container — otherwise the grid drops out of
+      // window-scroll mode (frozen rows stop pinning, vertical virtualization stops).
+      wrapper.style.overflowX = 'clip';
+      wrapper.style.overflowY = 'visible';
+
+      expect(getTrimmingContainer(base)).toBe(window);
+    });
+
+    it('should return the window when an ancestor clips only the vertical axis (`overflow-y: clip`)', () => {
+      wrapper.style.overflowX = 'visible';
+      wrapper.style.overflowY = 'clip';
+
+      expect(getTrimmingContainer(base)).toBe(window);
+    });
+
+    it('should return the ancestor when it is a real horizontal scroll container (`overflow-x: auto`)', () => {
+      // Only the non-scrolling `clip` value is exempt. A genuine single-axis scroll container
+      // (`auto`/`scroll`) still trims and must remain the trimming container.
+      wrapper.style.overflowX = 'auto';
+      wrapper.style.overflowY = 'visible';
+
+      expect(getTrimmingContainer(base)).toBe(wrapper);
+    });
+
+    it('should return the ancestor when it is a real vertical scroll container (`overflow-y: scroll`)', () => {
+      wrapper.style.overflowX = 'visible';
+      wrapper.style.overflowY = 'scroll';
+
+      expect(getTrimmingContainer(base)).toBe(wrapper);
+    });
+
+    it('should return the ancestor when it clips both axes (`overflow: clip`)', () => {
+      // Clipping both axes does trap the element on both axes, so it is a trimming container.
+      wrapper.style.overflowX = 'clip';
+      wrapper.style.overflowY = 'clip';
+
+      expect(getTrimmingContainer(base)).toBe(wrapper);
+    });
+
+    it('should return the ancestor when it hides overflow (`overflow: hidden`)', () => {
+      wrapper.style.overflow = 'hidden';
+
+      expect(getTrimmingContainer(base)).toBe(wrapper);
     });
   });
 });

--- a/handsontable/src/helpers/dom/__tests__/element.unit.ts
+++ b/handsontable/src/helpers/dom/__tests__/element.unit.ts
@@ -1218,5 +1218,14 @@ describe('DomElement helper', () => {
 
       expect(getTrimmingContainer(base)).toBe(wrapper);
     });
+
+    it('should defer to computed style for a global `overflow` keyword instead of reading it literally', () => {
+      // `inherit`/`initial`/`revert`/`unset` are not concrete overflow values. The inline keyword
+      // must not be treated as a (non-trimming) literal — the computed style resolves the real value
+      // (here it resolves to `visible`, so the element does not trim and the window is returned).
+      wrapper.style.overflow = 'inherit';
+
+      expect(getTrimmingContainer(base)).toBe(window);
+    });
   });
 });

--- a/handsontable/src/helpers/dom/__tests__/element.unit.ts
+++ b/handsontable/src/helpers/dom/__tests__/element.unit.ts
@@ -1190,5 +1190,33 @@ describe('DomElement helper', () => {
 
       expect(getTrimmingContainer(base)).toBe(wrapper);
     });
+
+    it('should return the window when the two-value `overflow` shorthand clips one axis (`clip visible`)', () => {
+      // The inline `overflow` shorthand can carry two values. `clip visible` means
+      // `overflow-x: clip; overflow-y: visible`, so the single-axis-clip rule must apply here too —
+      // the early inline path must not treat any non-`visible` shorthand as a trimming container.
+      wrapper.style.overflow = 'clip visible';
+
+      expect(getTrimmingContainer(base)).toBe(window);
+    });
+
+    it('should return the window when the two-value `overflow` shorthand clips the vertical axis (`visible clip`)', () => {
+      wrapper.style.overflow = 'visible clip';
+
+      expect(getTrimmingContainer(base)).toBe(window);
+    });
+
+    it('should return the ancestor when the `overflow` shorthand clips both axes (`clip`)', () => {
+      wrapper.style.overflow = 'clip';
+
+      expect(getTrimmingContainer(base)).toBe(wrapper);
+    });
+
+    it('should return the ancestor when the two-value `overflow` shorthand scrolls one axis (`auto visible`)', () => {
+      // A real single-axis scroll container via the shorthand still trims.
+      wrapper.style.overflow = 'auto visible';
+
+      expect(getTrimmingContainer(base)).toBe(wrapper);
+    });
   });
 });

--- a/handsontable/src/helpers/dom/element.ts
+++ b/handsontable/src/helpers/dom/element.ts
@@ -841,6 +841,7 @@ export function getMaximumScrollLeft(element: HTMLElement) {
 }
 
 const OVERFLOW_TRIMMING_VALUES = ['scroll', 'hidden', 'auto', 'clip'];
+const OVERFLOW_CONCRETE_VALUES = ['visible', 'clip', 'hidden', 'scroll', 'auto', 'overlay'];
 
 /**
  * Checks whether a single overflow axis traps the table on that axis.
@@ -866,8 +867,11 @@ function overflowAxisTraps(axis: string, perpendicular: string): boolean {
  *
  * The inline `overflow` shorthand can carry two values (`overflow: clip visible` → x, y). Some
  * engines (jsdom) neither split that shorthand into `overflowX`/`overflowY` nor reflect it in the
- * computed style, so the shorthand string is parsed directly. Inline values win over computed ones
- * so an inline single-axis clip is evaluated by the same `overflowAxisTraps` rule as a computed one.
+ * computed style, so the shorthand string is parsed directly. An inline value is only preferred when
+ * it is a concrete overflow keyword; a global keyword (`inherit`, `initial`, `revert`, `unset`) or
+ * any other non-concrete value falls back to the computed style, which resolves it to the real value
+ * (e.g. an inherited `auto`). Otherwise an inline `inherit` would be read literally and miss the
+ * scroll value it inherits.
  *
  * @param {HTMLElement} el The element to read overflow from.
  * @param {CSSStyleDeclaration} computedStyle The element's computed style.
@@ -876,10 +880,15 @@ function overflowAxisTraps(axis: string, perpendicular: string): boolean {
 function resolveOverflowAxes(el: HTMLElement, computedStyle: CSSStyleDeclaration): { x: string, y: string } {
   const shorthand = el.style.overflow.split(/\s+/).filter(Boolean);
   const [shorthandX = '', shorthandY = shorthandX] = shorthand;
+  const resolveAxis = (inlineAxis: string, shorthandAxis: string, computedProperty: string): string => {
+    const inline = inlineAxis || shorthandAxis;
+
+    return OVERFLOW_CONCRETE_VALUES.includes(inline) ? inline : computedStyle.getPropertyValue(computedProperty);
+  };
 
   return {
-    x: el.style.overflowX || shorthandX || computedStyle.getPropertyValue('overflow-x'),
-    y: el.style.overflowY || shorthandY || computedStyle.getPropertyValue('overflow-y'),
+    x: resolveAxis(el.style.overflowX, shorthandX, 'overflow-x'),
+    y: resolveAxis(el.style.overflowY, shorthandY, 'overflow-y'),
   };
 }
 

--- a/handsontable/src/helpers/dom/element.ts
+++ b/handsontable/src/helpers/dom/element.ts
@@ -862,6 +862,28 @@ function overflowAxisTraps(axis: string, perpendicular: string): boolean {
 }
 
 /**
+ * Resolves the effective `overflow-x`/`overflow-y` of an element, preferring inline styles.
+ *
+ * The inline `overflow` shorthand can carry two values (`overflow: clip visible` → x, y). Some
+ * engines (jsdom) neither split that shorthand into `overflowX`/`overflowY` nor reflect it in the
+ * computed style, so the shorthand string is parsed directly. Inline values win over computed ones
+ * so an inline single-axis clip is evaluated by the same `overflowAxisTraps` rule as a computed one.
+ *
+ * @param {HTMLElement} el The element to read overflow from.
+ * @param {CSSStyleDeclaration} computedStyle The element's computed style.
+ * @returns {{ x: string, y: string }}
+ */
+function resolveOverflowAxes(el: HTMLElement, computedStyle: CSSStyleDeclaration): { x: string, y: string } {
+  const shorthand = el.style.overflow.split(/\s+/).filter(Boolean);
+  const [shorthandX = '', shorthandY = shorthandX] = shorthand;
+
+  return {
+    x: el.style.overflowX || shorthandX || computedStyle.getPropertyValue('overflow-x'),
+    y: el.style.overflowY || shorthandY || computedStyle.getPropertyValue('overflow-y'),
+  };
+}
+
+/**
  * Returns a DOM element responsible for trimming the provided element.
  *
  * @param {HTMLElement} base Base element.
@@ -874,21 +896,14 @@ export function getTrimmingContainer(base: HTMLElement): HTMLElement | Window {
   let el: HTMLElement | null = base.parentElement;
 
   while (el && el.style && rootDocument.body !== el) {
-    if (el.style.overflow !== 'visible' && el.style.overflow !== '') {
-      return el;
-    }
-
     if (rootWindow) {
-      const computedStyle = rootWindow.getComputedStyle(el);
-      const property = computedStyle.getPropertyValue('overflow');
-      const propertyY = computedStyle.getPropertyValue('overflow-y');
-      const propertyX = computedStyle.getPropertyValue('overflow-x');
+      const { x, y } = resolveOverflowAxes(el, rootWindow.getComputedStyle(el));
 
-      if (OVERFLOW_TRIMMING_VALUES.includes(property) ||
-          overflowAxisTraps(propertyX, propertyY) ||
-          overflowAxisTraps(propertyY, propertyX)) {
+      if (overflowAxisTraps(x, y) || overflowAxisTraps(y, x)) {
         return el;
       }
+    } else if (el.style.overflow !== 'visible' && el.style.overflow !== '') {
+      return el;
     }
 
     el = el.parentElement;

--- a/handsontable/src/helpers/dom/element.ts
+++ b/handsontable/src/helpers/dom/element.ts
@@ -864,9 +864,18 @@ export function getTrimmingContainer(base: HTMLElement): HTMLElement | Window {
       const propertyY = computedStyle.getPropertyValue('overflow-y');
       const propertyX = computedStyle.getPropertyValue('overflow-x');
 
-      if (allowedProperties.includes(property) ||
-          allowedProperties.includes(propertyY) ||
-          allowedProperties.includes(propertyX)) {
+      // `overflow: clip` establishes no scroll port. When an element clips a single axis while the
+      // other axis stays `visible`, it does not trap the table's scroll — the table still scrolls
+      // with the window on the visible axis. A width-constrained, window-scrolled table sets
+      // `overflow-x: clip` on its root (see core.ts, DEV-1025); treating that root as the trimming
+      // container drops the overlays out of window-scroll mode (frozen rows stop pinning, vertical
+      // virtualization stops). Such a single-axis clip must not qualify the element as trimming.
+      const clipsHorizontallyOnly = propertyX === 'clip' && (propertyY === 'visible' || propertyY === '');
+      const clipsVerticallyOnly = propertyY === 'clip' && (propertyX === 'visible' || propertyX === '');
+      const trimsX = allowedProperties.includes(propertyX) && !clipsHorizontallyOnly;
+      const trimsY = allowedProperties.includes(propertyY) && !clipsVerticallyOnly;
+
+      if (allowedProperties.includes(property) || trimsX || trimsY) {
         return el;
       }
     }

--- a/handsontable/src/helpers/dom/element.ts
+++ b/handsontable/src/helpers/dom/element.ts
@@ -840,6 +840,27 @@ export function getMaximumScrollLeft(element: HTMLElement) {
   return element.scrollWidth - element.clientWidth;
 }
 
+const OVERFLOW_TRIMMING_VALUES = ['scroll', 'hidden', 'auto', 'clip'];
+
+/**
+ * Checks whether a single overflow axis traps the table on that axis.
+ *
+ * `overflow: clip` establishes no scroll port. When an axis is `clip` while the perpendicular axis
+ * stays `visible`, it does not trap the table's scroll — the table still scrolls with the window on
+ * the visible axis. A width-constrained, window-scrolled table sets `overflow-x: clip` on its root
+ * (see core.ts, DEV-1025); treating that root as the trimming container drops the overlays out of
+ * window-scroll mode (frozen rows stop pinning, vertical virtualization stops). Such a single-axis
+ * clip must not qualify the axis as trimming.
+ *
+ * @param {string} axis The `overflow-x`/`overflow-y` value of the axis being tested.
+ * @param {string} perpendicular The `overflow` value of the other axis.
+ * @returns {boolean}
+ */
+function overflowAxisTraps(axis: string, perpendicular: string): boolean {
+  return OVERFLOW_TRIMMING_VALUES.includes(axis) &&
+    !(axis === 'clip' && (perpendicular === 'visible' || perpendicular === ''));
+}
+
 /**
  * Returns a DOM element responsible for trimming the provided element.
  *
@@ -859,23 +880,13 @@ export function getTrimmingContainer(base: HTMLElement): HTMLElement | Window {
 
     if (rootWindow) {
       const computedStyle = rootWindow.getComputedStyle(el);
-      const allowedProperties = ['scroll', 'hidden', 'auto', 'clip'];
       const property = computedStyle.getPropertyValue('overflow');
       const propertyY = computedStyle.getPropertyValue('overflow-y');
       const propertyX = computedStyle.getPropertyValue('overflow-x');
 
-      // `overflow: clip` establishes no scroll port. When an element clips a single axis while the
-      // other axis stays `visible`, it does not trap the table's scroll — the table still scrolls
-      // with the window on the visible axis. A width-constrained, window-scrolled table sets
-      // `overflow-x: clip` on its root (see core.ts, DEV-1025); treating that root as the trimming
-      // container drops the overlays out of window-scroll mode (frozen rows stop pinning, vertical
-      // virtualization stops). Such a single-axis clip must not qualify the element as trimming.
-      const clipsHorizontallyOnly = propertyX === 'clip' && (propertyY === 'visible' || propertyY === '');
-      const clipsVerticallyOnly = propertyY === 'clip' && (propertyX === 'visible' || propertyX === '');
-      const trimsX = allowedProperties.includes(propertyX) && !clipsHorizontallyOnly;
-      const trimsY = allowedProperties.includes(propertyY) && !clipsVerticallyOnly;
-
-      if (allowedProperties.includes(property) || trimsX || trimsY) {
+      if (OVERFLOW_TRIMMING_VALUES.includes(property) ||
+          overflowAxisTraps(propertyX, propertyY) ||
+          overflowAxisTraps(propertyY, propertyX)) {
         return el;
       }
     }


### PR DESCRIPTION
### Context

The PR fixes a grid that collapses to zero height when `width` is set (for example `width: '100%'`) and `height` is omitted — a v18 regression versus 17.1.

**Root cause.** DEV-1025 added `overflow-x: clip` on the root wrapper for width-constrained, height-less tables. `getTrimmingContainer()` treats `clip` as a scroll/trimming container, so it selected the clipped wrapper instead of the window. The table then dropped out of window-scroll mode: the master `wtHolder` was pinned to `0px` (content rendered but clipped to an invisible grid), frozen rows stopped pinning, and vertical virtualization stopped.

**Fixes in this PR:**

1. `getTrimmingContainer()` no longer treats a single-axis `overflow: clip` (with the perpendicular axis `visible`) as a trimming container — such an element establishes no scroll port and the table still scrolls with the window on the visible axis. Extracted an `overflowAxisTraps()` helper.
2. The same rule is applied to the inline `overflow` shorthand (`overflow: clip visible`), not only to individual/computed properties — via `resolveOverflowAxes()`, which also handles engines (jsdom) that neither split the shorthand nor reflect it in computed style.
3. `overflow-x: clip` is applied only for **definite** widths. Relative widths (`100%`, percentages, viewport units, or a `calc()` mixing them in) keep scrolling horizontally with the window (page scrollbar, all columns reachable) — matching 17.1. Definite lengths (`px`, `em`, `rem`, …) clip to their box.

Remaining, out of scope: a fixed **pixel** width narrower than its columns with no `height` still lacks an in-box horizontal scrollbar (columns clipped). Tracked in DEV-2116.

### How has this been tested?

Added E2E regression guards in `settings/width.spec.js` and unit tests in `helpers/dom/__tests__/element.unit.ts` (single-axis clip, inline shorthand, percentage / `calc()` / `em` width handling, vertical non-collapse, preserved window-scroll).

```bash
npm run build --prefix handsontable
npm run test:e2e --prefix handsontable -- --testPathPattern="settings/width"                    # 31 specs, 0 failures
npm run test:unit --prefix handsontable -- --testPathPattern="dom/__tests__/element.unit"        # 97 tests, 0 failures
npm run test:walkontable --prefix handsontable                                                   # 808 specs, 0 failures
npm run test:e2e --prefix handsontable -- --testPathPattern="Core_scroll|fixedRows|fixedColumns|settings/height|Core_init"  # 0 failures
```

Manual: `width: '100%'` (and wider content) with no `height` renders at content height and matches released 17.1 — auto height, virtualized rows, frozen rows pinning, and a page horizontal scrollbar when content is wider than the viewport.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2114
2. Follow-up: DEV-2116 (in-box horizontal scroll for fixed-px widths narrower than content)

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2114

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core layout/scroll detection (`getTrimmingContainer` and root overflow rules) used by Walkontable overlays and virtualization; behavior differs by width type but is covered by new regression tests.
> 
> **Overview**
> Fixes a v18 regression where a grid with **`width` set and no `height`** collapsed to zero height (invisible table) while breaking window vertical scroll, frozen rows, and row virtualization.
> 
> **`getTrimmingContainer`** no longer treats an ancestor as the trimming container when only one axis uses **`overflow: clip`** and the other stays **`visible`** (including two-value shorthands like `clip visible`). Horizontal-only clip on the root no longer steals trimming from the window. Overflow is resolved via new **`overflowAxisTraps`** / **`resolveOverflowAxes`** helpers (inline shorthand, jsdom, non-concrete keywords like `inherit`).
> 
> **Width / overflow in `core`:** **`overflow-x: clip`** is applied only for **definite** widths (`px`, `em`, etc.). **Relative** widths (`%`, viewport units, `calc()` containing them) skip clip so wide content scrolls with the page like 17.1.
> 
> E2E and DOM helper unit tests cover non-collapse, window scroll, and width-type behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dd0b4078ae74d92604e4943126db9d8550616f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->