### PR TITLE
DEV-2115: Fix autofill row resolution near vertically merged cells

### DIFF
--- a/.changelogs/13105.json
+++ b/.changelogs/13105.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed autofill dragging near vertically merged cells — the fill handle can now target rows inside a merged band in a neighboring column instead of jumping past the whole merge.",
+  "type": "fixed",
+  "issueOrPR": 13105,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/helpers/dom/__tests__/cellCoords.unit.js
+++ b/handsontable/src/helpers/dom/__tests__/cellCoords.unit.js
@@ -399,4 +399,178 @@ describe('getCellCoordsFromMousePosition', () => {
       expect(coords.row).toBe(4);
     });
   });
+
+  describe('reference column selection with a horizontal merge present', () => {
+    // Regression guard: column 1 is a slave of a purely horizontal merge, so its cells report
+    // `hidden: true` while still rendering at their own single-row height. Column 0 holds a
+    // vertical merge (rows 0-2). The row lookup must not reject column 1 just because it is
+    // hidden — otherwise it falls back to the vertically merged column 0 and collapses the row.
+    const rowHeight = 30;
+    const colWidth = 80;
+    const mergeSpan = 3; // column 0 merged across rows 0-2
+
+    /**
+     * Builds a HOT stub: column 0 is a vertical merge (rows 0-2), column 1 is a hidden slave of
+     * a purely horizontal merge (single-row height per row).
+     *
+     * @returns {object} Stubbed HOT instance.
+     */
+    function buildHotWithHorizontalSlave() {
+      return {
+        rootWindow: { innerWidth: 1280, innerHeight: 720 },
+        rootElement: { getBoundingClientRect: () => ({ left: 0, top: 0, right: 160, bottom: 120 }) },
+        isRtl: () => false,
+        hasColHeaders: () => false,
+        hasRowHeaders: () => false,
+        getFirstPartiallyVisibleRow: () => 0,
+        getLastPartiallyVisibleRow: () => 3,
+        getFirstPartiallyVisibleColumn: () => 0,
+        getLastPartiallyVisibleColumn: () => 1,
+        countRows: () => 4,
+        countCols: () => 2,
+        getCell: (row, col) => {
+          const el = document.createElement('td');
+          const isVerticalMerge = col === 0 && row < mergeSpan;
+          const top = isVerticalMerge ? 0 : row * rowHeight;
+          const height = isVerticalMerge ? rowHeight * mergeSpan : rowHeight;
+
+          Object.defineProperty(el, 'offsetHeight', { get: () => height });
+          Object.defineProperty(el, 'offsetWidth', { get: () => colWidth });
+          el.getBoundingClientRect = () => ({
+            top,
+            left: col * colWidth,
+            bottom: top + height,
+            right: (col * colWidth) + colWidth,
+          });
+
+          return el;
+        },
+        getCellMeta: (row, col) => {
+          if (col === 0 && row === 0) {
+            return { rowspan: mergeSpan, colspan: 1 };
+          }
+          // Column 1 is a hidden slave of a horizontal merge, but not vertically spanned.
+          if (col === 1) {
+            return { rowspan: 1, colspan: 1, hidden: true };
+          }
+
+          return { rowspan: 1, colspan: 1 };
+        },
+        _createCellCoords: (row, col) => ({ row, col }),
+        columnIndexMapper: {
+          getVisualFromRenderableIndex: n => n,
+          getNearestNotHiddenIndex: n => n,
+        },
+        rowIndexMapper: {
+          getVisualFromRenderableIndex: n => n,
+          getNearestNotHiddenIndex: n => n,
+          getNotHiddenIndexesLength: () => 4,
+        },
+        view: {
+          isVerticallyScrollableByWindow: () => false,
+          isHorizontallyScrollableByWindow: () => false,
+          getViewportWidth: () => 160,
+          getViewportHeight: () => 120,
+          getColumnHeaderHeight: () => 0,
+          getRowHeaderWidth: () => 0,
+          countNotHiddenFixedColumnsStart: () => 0,
+          countNotHiddenFixedRowsTop: () => 0,
+          countNotHiddenFixedRowsBottom: () => 0,
+        },
+      };
+    }
+
+    it('does not reject a hidden horizontal-merge slave as the row reference', () => {
+      const hot = buildHotWithHorizontalSlave();
+      // Y at the centre of row 2 (60..90 → 75), inside column 0's vertical merge band.
+      // Column 1 (hidden horizontal slave) has real per-row heights, so the row must resolve
+      // to 2 - not collapse onto the merge anchor (row 0) via a fallback to column 0.
+      const coords = getCellCoordsFromMousePosition(hot, 100, 75);
+
+      expect(coords.row).toBe(2);
+    });
+  });
+
+  describe('vertical merge confined to the fixed (frozen) top rows', () => {
+    // Regression guard (DEV-2115 follow-up): a vertical merge that lives only in the frozen top
+    // rows must be detected when resolving a row inside the frozen overlay. The reference column
+    // is chosen per row-scan range, so the fixed-top walk sees the frozen merge even though the
+    // scrollable "partially visible" range starts below it.
+    const rowHeight = 30;
+    const colWidth = 80;
+
+    /**
+     * Builds a HOT stub with 3 fixed top rows; column 0 holds a vertical merge across the frozen
+     * rows 0-1, while the scrollable body (rows 10+) has no merges.
+     *
+     * @returns {object} Stubbed HOT instance.
+     */
+    function buildHotWithFrozenMerge() {
+      return {
+        rootWindow: { innerWidth: 1280, innerHeight: 720 },
+        rootElement: { getBoundingClientRect: () => ({ left: 0, top: 0, right: 400, bottom: 400 }) },
+        isRtl: () => false,
+        hasColHeaders: () => false,
+        hasRowHeaders: () => false,
+        // Scrollable body is scrolled down - the frozen rows (0-2) are outside this range.
+        getFirstPartiallyVisibleRow: () => 10,
+        getLastPartiallyVisibleRow: () => 20,
+        getFirstPartiallyVisibleColumn: () => 0,
+        getLastPartiallyVisibleColumn: () => 4,
+        countRows: () => 30,
+        countCols: () => 5,
+        getCell: (row, col) => {
+          const el = document.createElement('td');
+          const isFrozenMerge = col === 0 && row < 2; // A1:A2 vertical merge in frozen rows
+          const top = isFrozenMerge ? 0 : row * rowHeight;
+          const height = isFrozenMerge ? rowHeight * 2 : rowHeight;
+
+          Object.defineProperty(el, 'offsetHeight', { get: () => height });
+          Object.defineProperty(el, 'offsetWidth', { get: () => colWidth });
+          el.getBoundingClientRect = () => ({
+            top,
+            left: col * colWidth,
+            bottom: top + height,
+            right: (col * colWidth) + colWidth,
+          });
+
+          return el;
+        },
+        getCellMeta: (row, col) => (
+          col === 0 && row === 0 ? { rowspan: 2, colspan: 1 } : { rowspan: 1, colspan: 1 }
+        ),
+        _createCellCoords: (row, col) => ({ row, col }),
+        columnIndexMapper: {
+          getVisualFromRenderableIndex: n => n,
+          getNearestNotHiddenIndex: n => n,
+        },
+        rowIndexMapper: {
+          getVisualFromRenderableIndex: n => n,
+          getNearestNotHiddenIndex: n => n,
+          getNotHiddenIndexesLength: () => 30,
+        },
+        view: {
+          isVerticallyScrollableByWindow: () => false,
+          isHorizontallyScrollableByWindow: () => false,
+          getViewportWidth: () => 400,
+          getViewportHeight: () => 400,
+          getColumnHeaderHeight: () => 0,
+          getRowHeaderWidth: () => 0,
+          countNotHiddenFixedColumnsStart: () => 0,
+          countNotHiddenFixedRowsTop: () => 3,
+          countNotHiddenFixedRowsBottom: () => 0,
+        },
+      };
+    }
+
+    it('resolves a frozen row inside the merge band using a merge-free reference column', () => {
+      const hot = buildHotWithFrozenMerge();
+      // Y at the centre of frozen row 1 (30..60 → 45), inside column 0's frozen merge band.
+      // Pointer over column 1 (x 80-160). Must resolve to row 1, not the merge anchor (row 0).
+      const coords = getCellCoordsFromMousePosition(hot, 100, 45);
+
+      expect(coords.col).toBe(1);
+      expect(coords.row).toBe(1);
+    });
+  });
 });

--- a/handsontable/src/helpers/dom/__tests__/cellCoords.unit.js
+++ b/handsontable/src/helpers/dom/__tests__/cellCoords.unit.js
@@ -3,6 +3,11 @@ import { getCellCoordsFromMousePosition } from 'handsontable/helpers/dom/cellCoo
 /**
  * Builds a minimal HOT instance stub for getCellCoordsFromMousePosition tests.
  *
+ * Merges are described declaratively through `mergedCells`: only the anchor cell reports a
+ * `rowspan`/`colspan` in its meta (matching real Handsontable), and every rendered slave of a
+ * vertical merge resolves to the SAME cached `<td>` element — so a lookup can detect the merge by
+ * element identity even when the anchor sits outside the scanned range.
+ *
  * @param {object} opts
  * @param {boolean} opts.isWindowScrollV  Whether the table scrolls vertically via window.
  * @param {boolean} opts.isWindowScrollH  Whether the table scrolls horizontally via window.
@@ -17,6 +22,14 @@ import { getCellCoordsFromMousePosition } from 'handsontable/helpers/dom/cellCoo
  * @param {number}   opts.lastRow          Index of the last partially visible row.
  * @param {number}   opts.firstCol         Index of the first partially visible column.
  * @param {number}   opts.lastCol          Index of the last partially visible column.
+ * @param {number}   opts.totalRows        Total number of rows (defaults to lastRow + 1).
+ * @param {number}   opts.totalCols        Total number of columns (defaults to lastCol + 1).
+ * @param {number}   opts.fixedRowsTop     Count of frozen top rows.
+ * @param {number}   opts.fixedRowsBottom  Count of frozen bottom rows.
+ * @param {Array}    opts.mergedCells      Merge anchors as `{ row, col, rowspan?, colspan? }`.
+ * @param {number[]} opts.hiddenColumns    Columns that render no cell (`getCell` returns null).
+ * @param {number[]} opts.hiddenMetaColumns Columns that render but report `hidden: true` meta
+ *                                          (e.g. a horizontal-merge slave).
  * @param {boolean}  opts.isRtl            Whether the table is in RTL layout.
  * @param {number}   opts.rowHeight        Uniform row height in pixels.
  * @param {number}   opts.colWidth         Uniform column width in pixels.
@@ -37,15 +50,104 @@ function buildHot({
   lastRow = 9,
   firstCol = 0,
   lastCol = 4,
+  totalRows,
+  totalCols,
+  fixedRowsTop = 0,
+  fixedRowsBottom = 0,
+  mergedCells = [],
+  hiddenColumns = [],
+  hiddenMetaColumns = [],
   rowHeight = 23,
   colWidth = 80,
 } = {}) {
-  // Cell top for row r (viewport-relative, accounting for column header and table top).
-  const cellTop = r => tableRect.top + colHeaderHeight + ((r - firstRow) * rowHeight);
+  const rowCount = totalRows ?? (lastRow + 1);
+  const colCount = totalCols ?? (lastCol + 1);
+  const merges = mergedCells.map(m => ({ rowspan: 1, colspan: 1, ...m }));
+
+  // Returns the merge whose band covers (row, col), or null.
+  const findMerge = (row, col) => merges.find(m =>
+    row >= m.row && row < m.row + m.rowspan &&
+    col >= m.col && col < m.col + m.colspan) ?? null;
+
+  // Cell top for a row. Frozen top rows sit at the top edge, frozen bottom rows at the bottom
+  // edge, and scrollable rows are viewport-relative to the first partially visible row.
+  const cellTop = (row) => {
+    if (fixedRowsTop > 0 && row < fixedRowsTop) {
+      return tableRect.top + colHeaderHeight + (row * rowHeight);
+    }
+    if (fixedRowsBottom > 0 && row >= rowCount - fixedRowsBottom) {
+      return tableRect.top + colHeaderHeight + viewportHeight - ((rowCount - row) * rowHeight);
+    }
+
+    return tableRect.top + colHeaderHeight + ((row - firstRow) * rowHeight);
+  };
+  // Rendered left for a column, skipping the width of any hidden columns before it.
+  const cellLeft = (col) => {
+    let hiddenBefore = 0;
+
+    for (let c = firstCol; c < col; c++) {
+      if (hiddenColumns.includes(c)) {
+        hiddenBefore += 1;
+      }
+    }
+
+    return tableRect.left + rowHeaderWidth + ((col - firstCol - hiddenBefore) * colWidth);
+  };
   // Cell right for col c in RTL (columns grow leftward from the right edge of the viewport).
   const cellRight = c => tableRect.right - rowHeaderWidth - ((c - firstCol) * colWidth);
-  // Cell left for col c (viewport-relative, accounting for row header and table left).
-  const cellLeft = c => tableRect.left + rowHeaderWidth + ((c - firstCol) * colWidth);
+
+  const makeCell = (row, col, merge) => {
+    const el = document.createElement('td');
+    const anchorRow = merge ? merge.row : row;
+    const height = rowHeight * (merge ? merge.rowspan : 1);
+    const width = colWidth * (merge ? merge.colspan : 1);
+    const top = cellTop(anchorRow);
+    const rect = isRtl
+      ? { top, right: cellRight(col), bottom: top + height, left: cellRight(col) - width }
+      : { top, left: cellLeft(col), bottom: top + height, right: cellLeft(col) + width };
+
+    Object.defineProperty(el, 'offsetHeight', { get: () => height });
+    Object.defineProperty(el, 'offsetWidth', { get: () => width });
+    el.getBoundingClientRect = () => rect;
+
+    return el;
+  };
+
+  // Cache one element per vertical-merge band so its slaves share element identity.
+  const bandCache = new Map();
+
+  const getCell = (row, col) => {
+    if (hiddenColumns.includes(col)) {
+      return null;
+    }
+
+    const merge = findMerge(row, col);
+
+    if (merge && merge.rowspan > 1) {
+      const key = `${merge.row}:${merge.col}`;
+
+      if (!bandCache.has(key)) {
+        bandCache.set(key, makeCell(row, col, merge));
+      }
+
+      return bandCache.get(key);
+    }
+
+    return makeCell(row, col, merge);
+  };
+
+  const getCellMeta = (row, col) => {
+    const anchor = merges.find(m => m.row === row && m.col === col);
+    const meta = anchor
+      ? { rowspan: anchor.rowspan, colspan: anchor.colspan }
+      : { rowspan: 1, colspan: 1 };
+
+    if (hiddenMetaColumns.includes(col)) {
+      meta.hidden = true;
+    }
+
+    return meta;
+  };
 
   const hot = {
     rootWindow: { innerWidth, innerHeight },
@@ -59,31 +161,11 @@ function buildHot({
     getLastPartiallyVisibleRow: () => lastRow,
     getFirstPartiallyVisibleColumn: () => firstCol,
     getLastPartiallyVisibleColumn: () => lastCol,
-    countRows: () => lastRow + 1,
-    countCols: () => lastCol + 1,
-    getCell: (row, col) => {
-      const el = document.createElement('td');
-      const rect = isRtl
-        ? {
-          top: cellTop(row),
-          right: cellRight(col),
-          bottom: cellTop(row) + rowHeight,
-          left: cellRight(col) - colWidth,
-        }
-        : {
-          top: cellTop(row),
-          left: cellLeft(col),
-          bottom: cellTop(row) + rowHeight,
-          right: cellLeft(col) + colWidth,
-        };
-
-      Object.defineProperty(el, 'offsetHeight', { get: () => rowHeight });
-      Object.defineProperty(el, 'offsetWidth', { get: () => colWidth });
-      el.getBoundingClientRect = () => rect;
-
-      return el;
-    },
-    getCellMeta: () => ({ rowspan: 1, colspan: 1 }),
+    countRows: () => rowCount,
+    countCols: () => colCount,
+    getCell,
+    getCellMeta,
+    getCellMetaTransient: getCellMeta,
     _createCellCoords: (row, col) => ({ row, col }),
     columnIndexMapper: {
       getVisualFromRenderableIndex: n => n,
@@ -92,7 +174,7 @@ function buildHot({
     rowIndexMapper: {
       getVisualFromRenderableIndex: n => n,
       getNearestNotHiddenIndex: n => n,
-      getNotHiddenIndexesLength: () => lastRow + 1,
+      getNotHiddenIndexesLength: () => rowCount,
     },
     view: {
       isVerticallyScrollableByWindow: () => isWindowScrollV,
@@ -102,8 +184,8 @@ function buildHot({
       getColumnHeaderHeight: () => colHeaderHeight,
       getRowHeaderWidth: () => rowHeaderWidth,
       countNotHiddenFixedColumnsStart: () => 0,
-      countNotHiddenFixedRowsTop: () => 0,
-      countNotHiddenFixedRowsBottom: () => 0,
+      countNotHiddenFixedRowsTop: () => fixedRowsTop,
+      countNotHiddenFixedRowsBottom: () => fixedRowsBottom,
     },
   };
 
@@ -312,77 +394,21 @@ describe('getCellCoordsFromMousePosition', () => {
     // merge anchor (row 2). When the mouse is over a NON-merged column, the row must
     // resolve to the actual row under the pointer, independent of the other column's
     // merge.
-    const rowHeight = 30;
-    const colWidth = 80;
-    const mergeStart = 2;
-    const mergeSpan = 3; // rows 2, 3, 4 merged in column 0
-
-    /**
-     * Builds a HOT stub whose column 0 holds a rowspan-3 merge (rows 2-4).
-     *
-     * @returns {object} Stubbed HOT instance.
-     */
-    function buildHotWithMergedFirstColumn() {
-      return {
-        rootWindow: { innerWidth: 1280, innerHeight: 720 },
-        rootElement: { getBoundingClientRect: () => ({ left: 0, top: 0, right: 500, bottom: 180 }) },
-        isRtl: () => false,
-        hasColHeaders: () => false,
-        hasRowHeaders: () => false,
-        getFirstPartiallyVisibleRow: () => 0,
-        getLastPartiallyVisibleRow: () => 5,
-        getFirstPartiallyVisibleColumn: () => 0,
-        getLastPartiallyVisibleColumn: () => 4,
-        countRows: () => 6,
-        countCols: () => 5,
-        getCell: (row, col) => {
-          const el = document.createElement('td');
-          const isMerged = col === 0 && row >= mergeStart && row < mergeStart + mergeSpan;
-          const top = isMerged ? mergeStart * rowHeight : row * rowHeight;
-          const height = isMerged ? rowHeight * mergeSpan : rowHeight;
-
-          Object.defineProperty(el, 'offsetHeight', { get: () => height });
-          Object.defineProperty(el, 'offsetWidth', { get: () => colWidth });
-          el.getBoundingClientRect = () => ({
-            top,
-            left: col * colWidth,
-            bottom: top + height,
-            right: (col * colWidth) + colWidth,
-          });
-
-          return el;
-        },
-        getCellMeta: (row, col) => (
-          col === 0 && row === mergeStart
-            ? { rowspan: mergeSpan, colspan: 1 }
-            : { rowspan: 1, colspan: 1 }
-        ),
-        _createCellCoords: (row, col) => ({ row, col }),
-        columnIndexMapper: {
-          getVisualFromRenderableIndex: n => n,
-          getNearestNotHiddenIndex: n => n,
-        },
-        rowIndexMapper: {
-          getVisualFromRenderableIndex: n => n,
-          getNearestNotHiddenIndex: n => n,
-          getNotHiddenIndexesLength: () => 6,
-        },
-        view: {
-          isVerticallyScrollableByWindow: () => false,
-          isHorizontallyScrollableByWindow: () => false,
-          getViewportWidth: () => 500,
-          getViewportHeight: () => 180,
-          getColumnHeaderHeight: () => 0,
-          getRowHeaderWidth: () => 0,
-          countNotHiddenFixedColumnsStart: () => 0,
-          countNotHiddenFixedRowsTop: () => 0,
-          countNotHiddenFixedRowsBottom: () => 0,
-        },
-      };
-    }
+    const mergedFirstColumnGeometry = {
+      tableRect: { left: 0, top: 0, right: 500, bottom: 180 },
+      viewportWidth: 500,
+      viewportHeight: 180,
+      firstRow: 0,
+      lastRow: 5,
+      firstCol: 0,
+      lastCol: 4,
+      rowHeight: 30,
+      colWidth: 80,
+      mergedCells: [{ row: 2, col: 0, rowspan: 3 }], // rows 2-4 merged in column 0
+    };
 
     it('resolves the row under the mouse in a non-merged column, ignoring the merge in column 0', () => {
-      const hot = buildHotWithMergedFirstColumn();
+      const hot = buildHot(mergedFirstColumnGeometry);
       // Mouse over column 1 (x 80-160), Y at the centre of row 3 (90..120 → 105).
       const coords = getCellCoordsFromMousePosition(hot, 100, 105);
 
@@ -391,7 +417,7 @@ describe('getCellCoordsFromMousePosition', () => {
     });
 
     it('resolves the last merged-band row in a non-merged column', () => {
-      const hot = buildHotWithMergedFirstColumn();
+      const hot = buildHot(mergedFirstColumnGeometry);
       // Y at the centre of row 4 (120..150 → 135), still inside column 0's merged band.
       const coords = getCellCoordsFromMousePosition(hot, 100, 135);
 
@@ -405,83 +431,22 @@ describe('getCellCoordsFromMousePosition', () => {
     // `hidden: true` while still rendering at their own single-row height. Column 0 holds a
     // vertical merge (rows 0-2). The row lookup must not reject column 1 just because it is
     // hidden — otherwise it falls back to the vertically merged column 0 and collapses the row.
-    const rowHeight = 30;
-    const colWidth = 80;
-    const mergeSpan = 3; // column 0 merged across rows 0-2
-
-    /**
-     * Builds a HOT stub: column 0 is a vertical merge (rows 0-2), column 1 is a hidden slave of
-     * a purely horizontal merge (single-row height per row).
-     *
-     * @returns {object} Stubbed HOT instance.
-     */
-    function buildHotWithHorizontalSlave() {
-      return {
-        rootWindow: { innerWidth: 1280, innerHeight: 720 },
-        rootElement: { getBoundingClientRect: () => ({ left: 0, top: 0, right: 160, bottom: 120 }) },
-        isRtl: () => false,
-        hasColHeaders: () => false,
-        hasRowHeaders: () => false,
-        getFirstPartiallyVisibleRow: () => 0,
-        getLastPartiallyVisibleRow: () => 3,
-        getFirstPartiallyVisibleColumn: () => 0,
-        getLastPartiallyVisibleColumn: () => 1,
-        countRows: () => 4,
-        countCols: () => 2,
-        getCell: (row, col) => {
-          const el = document.createElement('td');
-          const isVerticalMerge = col === 0 && row < mergeSpan;
-          const top = isVerticalMerge ? 0 : row * rowHeight;
-          const height = isVerticalMerge ? rowHeight * mergeSpan : rowHeight;
-
-          Object.defineProperty(el, 'offsetHeight', { get: () => height });
-          Object.defineProperty(el, 'offsetWidth', { get: () => colWidth });
-          el.getBoundingClientRect = () => ({
-            top,
-            left: col * colWidth,
-            bottom: top + height,
-            right: (col * colWidth) + colWidth,
-          });
-
-          return el;
-        },
-        getCellMeta: (row, col) => {
-          if (col === 0 && row === 0) {
-            return { rowspan: mergeSpan, colspan: 1 };
-          }
-          // Column 1 is a hidden slave of a horizontal merge, but not vertically spanned.
-          if (col === 1) {
-            return { rowspan: 1, colspan: 1, hidden: true };
-          }
-
-          return { rowspan: 1, colspan: 1 };
-        },
-        _createCellCoords: (row, col) => ({ row, col }),
-        columnIndexMapper: {
-          getVisualFromRenderableIndex: n => n,
-          getNearestNotHiddenIndex: n => n,
-        },
-        rowIndexMapper: {
-          getVisualFromRenderableIndex: n => n,
-          getNearestNotHiddenIndex: n => n,
-          getNotHiddenIndexesLength: () => 4,
-        },
-        view: {
-          isVerticallyScrollableByWindow: () => false,
-          isHorizontallyScrollableByWindow: () => false,
-          getViewportWidth: () => 160,
-          getViewportHeight: () => 120,
-          getColumnHeaderHeight: () => 0,
-          getRowHeaderWidth: () => 0,
-          countNotHiddenFixedColumnsStart: () => 0,
-          countNotHiddenFixedRowsTop: () => 0,
-          countNotHiddenFixedRowsBottom: () => 0,
-        },
-      };
-    }
+    const horizontalSlaveGeometry = {
+      tableRect: { left: 0, top: 0, right: 160, bottom: 120 },
+      viewportWidth: 160,
+      viewportHeight: 120,
+      firstRow: 0,
+      lastRow: 3,
+      firstCol: 0,
+      lastCol: 1,
+      rowHeight: 30,
+      colWidth: 80,
+      mergedCells: [{ row: 0, col: 0, rowspan: 3 }], // column 0 merged across rows 0-2
+      hiddenMetaColumns: [1], // column 1 renders per-row but reports hidden: true (horizontal slave)
+    };
 
     it('does not reject a hidden horizontal-merge slave as the row reference', () => {
-      const hot = buildHotWithHorizontalSlave();
+      const hot = buildHot(horizontalSlaveGeometry);
       // Y at the centre of row 2 (60..90 → 75), inside column 0's vertical merge band.
       // Column 1 (hidden horizontal slave) has real per-row heights, so the row must resolve
       // to 2 - not collapse onto the merge anchor (row 0) via a fallback to column 0.
@@ -496,75 +461,24 @@ describe('getCellCoordsFromMousePosition', () => {
     // rows must be detected when resolving a row inside the frozen overlay. The reference column
     // is chosen per row-scan range, so the fixed-top walk sees the frozen merge even though the
     // scrollable "partially visible" range starts below it.
-    const rowHeight = 30;
-    const colWidth = 80;
-
-    /**
-     * Builds a HOT stub with 3 fixed top rows; column 0 holds a vertical merge across the frozen
-     * rows 0-1, while the scrollable body (rows 10+) has no merges.
-     *
-     * @returns {object} Stubbed HOT instance.
-     */
-    function buildHotWithFrozenMerge() {
-      return {
-        rootWindow: { innerWidth: 1280, innerHeight: 720 },
-        rootElement: { getBoundingClientRect: () => ({ left: 0, top: 0, right: 400, bottom: 400 }) },
-        isRtl: () => false,
-        hasColHeaders: () => false,
-        hasRowHeaders: () => false,
-        // Scrollable body is scrolled down - the frozen rows (0-2) are outside this range.
-        getFirstPartiallyVisibleRow: () => 10,
-        getLastPartiallyVisibleRow: () => 20,
-        getFirstPartiallyVisibleColumn: () => 0,
-        getLastPartiallyVisibleColumn: () => 4,
-        countRows: () => 30,
-        countCols: () => 5,
-        getCell: (row, col) => {
-          const el = document.createElement('td');
-          const isFrozenMerge = col === 0 && row < 2; // A1:A2 vertical merge in frozen rows
-          const top = isFrozenMerge ? 0 : row * rowHeight;
-          const height = isFrozenMerge ? rowHeight * 2 : rowHeight;
-
-          Object.defineProperty(el, 'offsetHeight', { get: () => height });
-          Object.defineProperty(el, 'offsetWidth', { get: () => colWidth });
-          el.getBoundingClientRect = () => ({
-            top,
-            left: col * colWidth,
-            bottom: top + height,
-            right: (col * colWidth) + colWidth,
-          });
-
-          return el;
-        },
-        getCellMeta: (row, col) => (
-          col === 0 && row === 0 ? { rowspan: 2, colspan: 1 } : { rowspan: 1, colspan: 1 }
-        ),
-        _createCellCoords: (row, col) => ({ row, col }),
-        columnIndexMapper: {
-          getVisualFromRenderableIndex: n => n,
-          getNearestNotHiddenIndex: n => n,
-        },
-        rowIndexMapper: {
-          getVisualFromRenderableIndex: n => n,
-          getNearestNotHiddenIndex: n => n,
-          getNotHiddenIndexesLength: () => 30,
-        },
-        view: {
-          isVerticallyScrollableByWindow: () => false,
-          isHorizontallyScrollableByWindow: () => false,
-          getViewportWidth: () => 400,
-          getViewportHeight: () => 400,
-          getColumnHeaderHeight: () => 0,
-          getRowHeaderWidth: () => 0,
-          countNotHiddenFixedColumnsStart: () => 0,
-          countNotHiddenFixedRowsTop: () => 3,
-          countNotHiddenFixedRowsBottom: () => 0,
-        },
-      };
-    }
+    const frozenTopMergeGeometry = {
+      tableRect: { left: 0, top: 0, right: 400, bottom: 400 },
+      viewportWidth: 400,
+      viewportHeight: 400,
+      // Scrollable body is scrolled down - the frozen rows (0-2) are outside this range.
+      firstRow: 10,
+      lastRow: 20,
+      firstCol: 0,
+      lastCol: 4,
+      totalRows: 30,
+      fixedRowsTop: 3,
+      rowHeight: 30,
+      colWidth: 80,
+      mergedCells: [{ row: 0, col: 0, rowspan: 2 }], // A1:A2 vertical merge in frozen rows
+    };
 
     it('resolves a frozen row inside the merge band using a merge-free reference column', () => {
-      const hot = buildHotWithFrozenMerge();
+      const hot = buildHot(frozenTopMergeGeometry);
       // Y at the centre of frozen row 1 (30..60 → 45), inside column 0's frozen merge band.
       // Pointer over column 1 (x 80-160). Must resolve to row 1, not the merge anchor (row 0).
       const coords = getCellCoordsFromMousePosition(hot, 100, 45);
@@ -574,87 +488,101 @@ describe('getCellCoordsFromMousePosition', () => {
     });
   });
 
+  describe('vertical merge confined to the fixed (frozen) bottom rows', () => {
+    // Regression guard (DEV-2115 follow-up): the fixed-bottom row-scan branch must pick a
+    // merge-free reference column exactly like the fixed-top and scrollable branches. A vertical
+    // merge inside the frozen bottom band would otherwise collapse the resolved row onto the
+    // merge anchor. This also pins the branch's row-scan arguments: passing them in the wrong
+    // order makes `findRowReferenceColumn` scan an empty range and hand back the merged column.
+    const frozenBottomMergeGeometry = {
+      tableRect: { left: 0, top: 0, right: 400, bottom: 400 },
+      viewportWidth: 400,
+      viewportHeight: 400,
+      // Scrollable body is scrolled to the middle - the frozen bottom rows (28-29) are below it.
+      firstRow: 10,
+      lastRow: 20,
+      firstCol: 0,
+      lastCol: 4,
+      totalRows: 30,
+      fixedRowsBottom: 2,
+      rowHeight: 30,
+      colWidth: 80,
+      mergedCells: [{ row: 28, col: 0, rowspan: 2 }], // A29:A30 vertical merge in frozen bottom rows
+    };
+
+    it('resolves a frozen bottom row inside the merge band using a merge-free reference column', () => {
+      const hot = buildHot(frozenBottomMergeGeometry);
+      // The frozen bottom band spans y 340..400 (rows 28-29). Y at the centre of row 29
+      // (370..400 → 385). Pointer over column 1. Must resolve to row 29, not the merge
+      // anchor (row 28).
+      const coords = getCellCoordsFromMousePosition(hot, 100, 385);
+
+      expect(coords.col).toBe(1);
+      expect(coords.row).toBe(29);
+    });
+  });
+
   describe('hidden column between the merged column and a usable one', () => {
     // Regression guard (DEV-2115 follow-up): column 0 is vertically merged (rows 0-2) and
     // column 1 is hidden (e.g. `hiddenColumns`), so it renders no cells. The reference-column
     // search must skip the hidden column (no renderable cell to measure) rather than pick it,
     // which would hand back a null start cell and collapse the row lookup.
-    const rowHeight = 30;
-    const colWidth = 80;
-    const mergeSpan = 3;
-
-    /**
-     * Builds a HOT stub: column 0 vertical merge (rows 0-2), column 1 hidden (no rendered cell),
-     * column 2 normal.
-     *
-     * @returns {object} Stubbed HOT instance.
-     */
-    function buildHotWithHiddenColumn() {
-      return {
-        rootWindow: { innerWidth: 1280, innerHeight: 720 },
-        rootElement: { getBoundingClientRect: () => ({ left: 0, top: 0, right: 240, bottom: 120 }) },
-        isRtl: () => false,
-        hasColHeaders: () => false,
-        hasRowHeaders: () => false,
-        getFirstPartiallyVisibleRow: () => 0,
-        getLastPartiallyVisibleRow: () => 3,
-        getFirstPartiallyVisibleColumn: () => 0,
-        getLastPartiallyVisibleColumn: () => 2,
-        countRows: () => 4,
-        countCols: () => 3,
-        getCell: (row, col) => {
-          if (col === 1) {
-            return null; // hidden column - renders no cell
-          }
-
-          const el = document.createElement('td');
-          const isVerticalMerge = col === 0 && row < mergeSpan;
-          const top = isVerticalMerge ? 0 : row * rowHeight;
-          const height = isVerticalMerge ? rowHeight * mergeSpan : rowHeight;
-          // Column 2 is visually the second rendered column (column 1 is hidden).
-          const left = col === 2 ? colWidth : 0;
-
-          Object.defineProperty(el, 'offsetHeight', { get: () => height });
-          Object.defineProperty(el, 'offsetWidth', { get: () => colWidth });
-          el.getBoundingClientRect = () => ({ top, left, bottom: top + height, right: left + colWidth });
-
-          return el;
-        },
-        getCellMeta: (row, col) => (
-          col === 0 && row === 0 ? { rowspan: mergeSpan, colspan: 1 } : { rowspan: 1, colspan: 1 }
-        ),
-        _createCellCoords: (row, col) => ({ row, col }),
-        columnIndexMapper: {
-          getVisualFromRenderableIndex: n => n,
-          getNearestNotHiddenIndex: n => n,
-        },
-        rowIndexMapper: {
-          getVisualFromRenderableIndex: n => n,
-          getNearestNotHiddenIndex: n => n,
-          getNotHiddenIndexesLength: () => 4,
-        },
-        view: {
-          isVerticallyScrollableByWindow: () => false,
-          isHorizontallyScrollableByWindow: () => false,
-          getViewportWidth: () => 240,
-          getViewportHeight: () => 120,
-          getColumnHeaderHeight: () => 0,
-          getRowHeaderWidth: () => 0,
-          countNotHiddenFixedColumnsStart: () => 0,
-          countNotHiddenFixedRowsTop: () => 0,
-          countNotHiddenFixedRowsBottom: () => 0,
-        },
-      };
-    }
+    const hiddenColumnGeometry = {
+      tableRect: { left: 0, top: 0, right: 240, bottom: 120 },
+      viewportWidth: 240,
+      viewportHeight: 120,
+      firstRow: 0,
+      lastRow: 3,
+      firstCol: 0,
+      lastCol: 2,
+      rowHeight: 30,
+      colWidth: 80,
+      mergedCells: [{ row: 0, col: 0, rowspan: 3 }], // column 0 merged across rows 0-2
+      hiddenColumns: [1], // column 1 renders no cell
+    };
 
     it('skips the hidden column and resolves the row against column 2', () => {
-      const hot = buildHotWithHiddenColumn();
+      const hot = buildHot(hiddenColumnGeometry);
       // Pointer over column 2 (x 80-160), Y at the centre of row 2 (60..90 → 75), inside
       // column 0's merged band. Must resolve to row 2 via column 2, not collapse onto row 0.
       const coords = getCellCoordsFromMousePosition(hot, 100, 75);
 
       expect(coords.col).toBe(2);
       expect(coords.row).toBe(2);
+    });
+  });
+
+  describe('vertical merge whose anchor sits above the scanned range', () => {
+    // Regression guard for the element-identity signal in findRowReferenceColumn: column 0 holds
+    // a vertical merge anchored at row 8 (rowspan 5, rows 8-12), but the scrollable range starts
+    // at row 10. None of the scanned slave rows (10-12) reports a rowspan - only the anchor does,
+    // and it is out of range. The merge is detectable ONLY because every slave resolves to the
+    // same rendered element. Without the identity check the row would collapse onto row 10.
+    const anchorAboveRangeGeometry = {
+      tableRect: { left: 0, top: 0, right: 400, bottom: 330 },
+      viewportWidth: 400,
+      viewportHeight: 330,
+      firstRow: 10,
+      lastRow: 20,
+      firstCol: 0,
+      lastCol: 4,
+      totalRows: 30,
+      rowHeight: 30,
+      colWidth: 80,
+      mergedCells: [{ row: 8, col: 0, rowspan: 5 }], // rows 8-12; anchor (row 8) is above the range
+    };
+
+    it('detects the merge by element identity and resolves the true row under the pointer', () => {
+      const hot = buildHot(anchorAboveRangeGeometry);
+      // Pointer over column 1 (x 80-160), Y at the centre of row 12 (60..90 → 75, viewport-
+      // relative to firstRow 10). Column 0's slaves 10-12 share one element, so column 0 is
+      // rejected and the row resolves via column 1 to row 12.
+      const coords = getCellCoordsFromMousePosition(hot, 100, 75);
+
+      expect(coords.col).toBe(1);
+      expect(coords.row).toBe(12);
+      // Guard: without the identity check the merged column 0 would be used and collapse to row 10.
+      expect(coords.row).not.toBe(10);
     });
   });
 });

--- a/handsontable/src/helpers/dom/__tests__/cellCoords.unit.js
+++ b/handsontable/src/helpers/dom/__tests__/cellCoords.unit.js
@@ -573,4 +573,88 @@ describe('getCellCoordsFromMousePosition', () => {
       expect(coords.row).toBe(1);
     });
   });
+
+  describe('hidden column between the merged column and a usable one', () => {
+    // Regression guard (DEV-2115 follow-up): column 0 is vertically merged (rows 0-2) and
+    // column 1 is hidden (e.g. `hiddenColumns`), so it renders no cells. The reference-column
+    // search must skip the hidden column (no renderable cell to measure) rather than pick it,
+    // which would hand back a null start cell and collapse the row lookup.
+    const rowHeight = 30;
+    const colWidth = 80;
+    const mergeSpan = 3;
+
+    /**
+     * Builds a HOT stub: column 0 vertical merge (rows 0-2), column 1 hidden (no rendered cell),
+     * column 2 normal.
+     *
+     * @returns {object} Stubbed HOT instance.
+     */
+    function buildHotWithHiddenColumn() {
+      return {
+        rootWindow: { innerWidth: 1280, innerHeight: 720 },
+        rootElement: { getBoundingClientRect: () => ({ left: 0, top: 0, right: 240, bottom: 120 }) },
+        isRtl: () => false,
+        hasColHeaders: () => false,
+        hasRowHeaders: () => false,
+        getFirstPartiallyVisibleRow: () => 0,
+        getLastPartiallyVisibleRow: () => 3,
+        getFirstPartiallyVisibleColumn: () => 0,
+        getLastPartiallyVisibleColumn: () => 2,
+        countRows: () => 4,
+        countCols: () => 3,
+        getCell: (row, col) => {
+          if (col === 1) {
+            return null; // hidden column - renders no cell
+          }
+
+          const el = document.createElement('td');
+          const isVerticalMerge = col === 0 && row < mergeSpan;
+          const top = isVerticalMerge ? 0 : row * rowHeight;
+          const height = isVerticalMerge ? rowHeight * mergeSpan : rowHeight;
+          // Column 2 is visually the second rendered column (column 1 is hidden).
+          const left = col === 2 ? colWidth : 0;
+
+          Object.defineProperty(el, 'offsetHeight', { get: () => height });
+          Object.defineProperty(el, 'offsetWidth', { get: () => colWidth });
+          el.getBoundingClientRect = () => ({ top, left, bottom: top + height, right: left + colWidth });
+
+          return el;
+        },
+        getCellMeta: (row, col) => (
+          col === 0 && row === 0 ? { rowspan: mergeSpan, colspan: 1 } : { rowspan: 1, colspan: 1 }
+        ),
+        _createCellCoords: (row, col) => ({ row, col }),
+        columnIndexMapper: {
+          getVisualFromRenderableIndex: n => n,
+          getNearestNotHiddenIndex: n => n,
+        },
+        rowIndexMapper: {
+          getVisualFromRenderableIndex: n => n,
+          getNearestNotHiddenIndex: n => n,
+          getNotHiddenIndexesLength: () => 4,
+        },
+        view: {
+          isVerticallyScrollableByWindow: () => false,
+          isHorizontallyScrollableByWindow: () => false,
+          getViewportWidth: () => 240,
+          getViewportHeight: () => 120,
+          getColumnHeaderHeight: () => 0,
+          getRowHeaderWidth: () => 0,
+          countNotHiddenFixedColumnsStart: () => 0,
+          countNotHiddenFixedRowsTop: () => 0,
+          countNotHiddenFixedRowsBottom: () => 0,
+        },
+      };
+    }
+
+    it('skips the hidden column and resolves the row against column 2', () => {
+      const hot = buildHotWithHiddenColumn();
+      // Pointer over column 2 (x 80-160), Y at the centre of row 2 (60..90 → 75), inside
+      // column 0's merged band. Must resolve to row 2 via column 2, not collapse onto row 0.
+      const coords = getCellCoordsFromMousePosition(hot, 100, 75);
+
+      expect(coords.col).toBe(2);
+      expect(coords.row).toBe(2);
+    });
+  });
 });

--- a/handsontable/src/helpers/dom/__tests__/cellCoords.unit.js
+++ b/handsontable/src/helpers/dom/__tests__/cellCoords.unit.js
@@ -304,4 +304,99 @@ describe('getCellCoordsFromMousePosition', () => {
       });
     });
   });
+
+  describe('vertical merge in a column other than the one under the mouse', () => {
+    // Reproduces DEV-2115: the first visible column (col 0) has a vertical merge
+    // spanning rows 2-4 (rowspan 3). The row lookup used to always measure against
+    // that first column, so any mouse Y inside the merged band collapsed onto the
+    // merge anchor (row 2). When the mouse is over a NON-merged column, the row must
+    // resolve to the actual row under the pointer, independent of the other column's
+    // merge.
+    const rowHeight = 30;
+    const colWidth = 80;
+    const mergeStart = 2;
+    const mergeSpan = 3; // rows 2, 3, 4 merged in column 0
+
+    /**
+     * Builds a HOT stub whose column 0 holds a rowspan-3 merge (rows 2-4).
+     *
+     * @returns {object} Stubbed HOT instance.
+     */
+    function buildHotWithMergedFirstColumn() {
+      return {
+        rootWindow: { innerWidth: 1280, innerHeight: 720 },
+        rootElement: { getBoundingClientRect: () => ({ left: 0, top: 0, right: 500, bottom: 180 }) },
+        isRtl: () => false,
+        hasColHeaders: () => false,
+        hasRowHeaders: () => false,
+        getFirstPartiallyVisibleRow: () => 0,
+        getLastPartiallyVisibleRow: () => 5,
+        getFirstPartiallyVisibleColumn: () => 0,
+        getLastPartiallyVisibleColumn: () => 4,
+        countRows: () => 6,
+        countCols: () => 5,
+        getCell: (row, col) => {
+          const el = document.createElement('td');
+          const isMerged = col === 0 && row >= mergeStart && row < mergeStart + mergeSpan;
+          const top = isMerged ? mergeStart * rowHeight : row * rowHeight;
+          const height = isMerged ? rowHeight * mergeSpan : rowHeight;
+
+          Object.defineProperty(el, 'offsetHeight', { get: () => height });
+          Object.defineProperty(el, 'offsetWidth', { get: () => colWidth });
+          el.getBoundingClientRect = () => ({
+            top,
+            left: col * colWidth,
+            bottom: top + height,
+            right: (col * colWidth) + colWidth,
+          });
+
+          return el;
+        },
+        getCellMeta: (row, col) => (
+          col === 0 && row === mergeStart
+            ? { rowspan: mergeSpan, colspan: 1 }
+            : { rowspan: 1, colspan: 1 }
+        ),
+        _createCellCoords: (row, col) => ({ row, col }),
+        columnIndexMapper: {
+          getVisualFromRenderableIndex: n => n,
+          getNearestNotHiddenIndex: n => n,
+        },
+        rowIndexMapper: {
+          getVisualFromRenderableIndex: n => n,
+          getNearestNotHiddenIndex: n => n,
+          getNotHiddenIndexesLength: () => 6,
+        },
+        view: {
+          isVerticallyScrollableByWindow: () => false,
+          isHorizontallyScrollableByWindow: () => false,
+          getViewportWidth: () => 500,
+          getViewportHeight: () => 180,
+          getColumnHeaderHeight: () => 0,
+          getRowHeaderWidth: () => 0,
+          countNotHiddenFixedColumnsStart: () => 0,
+          countNotHiddenFixedRowsTop: () => 0,
+          countNotHiddenFixedRowsBottom: () => 0,
+        },
+      };
+    }
+
+    it('resolves the row under the mouse in a non-merged column, ignoring the merge in column 0', () => {
+      const hot = buildHotWithMergedFirstColumn();
+      // Mouse over column 1 (x 80-160), Y at the centre of row 3 (90..120 → 105).
+      const coords = getCellCoordsFromMousePosition(hot, 100, 105);
+
+      expect(coords.col).toBe(1);
+      expect(coords.row).toBe(3);
+    });
+
+    it('resolves the last merged-band row in a non-merged column', () => {
+      const hot = buildHotWithMergedFirstColumn();
+      // Y at the centre of row 4 (120..150 → 135), still inside column 0's merged band.
+      const coords = getCellCoordsFromMousePosition(hot, 100, 135);
+
+      expect(coords.col).toBe(1);
+      expect(coords.row).toBe(4);
+    });
+  });
 });

--- a/handsontable/src/helpers/dom/cellCoords.ts
+++ b/handsontable/src/helpers/dom/cellCoords.ts
@@ -38,7 +38,7 @@ function findColumnAtX(
 
     accumulatedX += width;
 
-    const { colspan } = hotInstance.getCellMeta<{ colspan?: number }>(row, column);
+    const { colspan } = hotInstance.getCellMetaTransient<{ colspan?: number }>(row, column);
 
     if (colspan !== undefined && colspan > 1) {
       column += colspan - 1;
@@ -83,7 +83,7 @@ function findRowAtY(
 
     accumulatedY += height;
 
-    const { rowspan } = hotInstance.getCellMeta<{ rowspan?: number }>(row, column);
+    const { rowspan } = hotInstance.getCellMetaTransient<{ rowspan?: number }>(row, column);
 
     if (rowspan !== undefined && rowspan > 1) {
       row += rowspan - 1;
@@ -128,7 +128,7 @@ function findRowReferenceColumn(
 
     for (let row = startRow; row <= endRow; row++) {
       const cell = hotInstance.getCell(row, column, true);
-      const { rowspan } = hotInstance.getCellMeta<{ rowspan?: number }>(row, column);
+      const { rowspan } = hotInstance.getCellMetaTransient<{ rowspan?: number }>(row, column);
 
       // A vertically merged cell reports `rowspan > 1` on its anchor and resolves to the same
       // rendered element for every row it covers; either signal marks the column as distorting.
@@ -151,6 +151,10 @@ function findRowReferenceColumn(
     }
   }
 
+  // Best-effort fallback: every column in the scanned range is vertically merged (e.g. a grouped
+  // report grid whose visible columns all merge across the same band). No column is free of the
+  // distortion, so `findRowAtY` will still collapse the band onto its anchor — `startColumn` is
+  // simply the least-surprising choice. This is a known narrow case of DEV-2115, not a bug here.
   return startColumn;
 }
 
@@ -285,7 +289,12 @@ export function getCellCoordsFromMousePosition(
   // the pointer's column is universally safe (a merge can live in either), so each row-scan
   // branch picks the first column free of vertical merges within its own row range (DEV-2115).
   const rowReferenceColumnStart = firstPartiallyVisibleColumn ?? 0;
-  const rowReferenceColumnEnd = lastPartiallyVisibleColumn ?? (hotInstance.countCols() - 1);
+  // When the viewport query returns null nothing is rendered, so there is no cell to measure
+  // against. Keep the search inside the (empty) rendered range instead of opening it to every
+  // column in the grid — otherwise `findRowReferenceColumn` walks the full column x row product,
+  // calling `getCellMetaTransient` on each step, and a single held autofill/`dragToScroll` drag
+  // on a large off-screen grid locks the tab.
+  const rowReferenceColumnEnd = lastPartiallyVisibleColumn ?? rowReferenceColumnStart;
 
   let foundRow: number | null = null;
 
@@ -357,12 +366,17 @@ export function getCellCoordsFromMousePosition(
 
   // Check scrollable rows (main table)
   if (foundRow === null) {
+    const scrollRowScanStart = firstPartiallyVisibleRow ?? 0;
+    // Same null-viewport guard as the column bound above: clamp the row scan to the (empty)
+    // rendered range rather than `countRows()`, so the reference-column search cannot walk the
+    // whole grid when nothing is rendered.
+    const scrollRowScanEnd = lastPartiallyVisibleRow ?? scrollRowScanStart;
     const rowReferenceColumn = findRowReferenceColumn(
       hotInstance,
       rowReferenceColumnStart,
       rowReferenceColumnEnd,
-      firstPartiallyVisibleRow ?? 0,
-      lastPartiallyVisibleRow ?? (hotInstance.countRows() - 1),
+      scrollRowScanStart,
+      scrollRowScanEnd,
     );
     const scrollCell = hotInstance.getCell(firstPartiallyVisibleRow, rowReferenceColumn, true);
 

--- a/handsontable/src/helpers/dom/cellCoords.ts
+++ b/handsontable/src/helpers/dom/cellCoords.ts
@@ -94,6 +94,49 @@ function findRowAtY(
 }
 
 /**
+ * Finds a column suitable for mapping a Y coordinate to a row: the first column in the range
+ * whose cells across the scanned rows all render at their own single-row height. `findRowAtY`
+ * walks a single column's cell heights, so it is distorted by two kinds of merged cell:
+ * a vertical-merge anchor (`rowspan > 1`, whose cell spans and hides the rows below it) and any
+ * merge slave (`hidden`, whose cell is collapsed to zero height — this also covers the hidden
+ * columns of a purely horizontal merge). A merge in one column must not distort the row lookup
+ * used for other columns (DEV-2115).
+ *
+ * @param {Handsontable} hotInstance The Handsontable instance.
+ * @param {number} startColumn First column to consider.
+ * @param {number} endColumn Last column to consider (inclusive).
+ * @param {number} startRow First row of the scanned range.
+ * @param {number} endRow Last row of the scanned range (inclusive).
+ * @returns {number} A column index free of merge distortion, or `startColumn` if none qualifies.
+ */
+function findRowReferenceColumn(
+  hotInstance: HotInstance,
+  startColumn: number,
+  endColumn: number,
+  startRow: number,
+  endRow: number,
+): number {
+  for (let column = startColumn; column <= endColumn; column++) {
+    let isDistortedByMerge = false;
+
+    for (let row = startRow; row <= endRow; row++) {
+      const { rowspan, hidden } = hotInstance.getCellMeta<{ rowspan?: number, hidden?: boolean }>(row, column);
+
+      if (hidden === true || (rowspan !== undefined && rowspan > 1)) {
+        isDistortedByMerge = true;
+        break;
+      }
+    }
+
+    if (!isDistortedByMerge) {
+      return column;
+    }
+  }
+
+  return startColumn;
+}
+
+/**
  * Get the cell coordinates from the mouse position. When the mouse is outside of the table,
  * the nearest cell is returned.
  *
@@ -214,6 +257,23 @@ export function getCellCoordsFromMousePosition(
     }
   }
 
+  if (foundColumn === null) {
+    throwWithCause('Failed to resolve cell coordinates from mouse position.');
+  }
+
+  // Resolve the row against a column that has no vertical merge across the visible rows.
+  // `findRowAtY` skips a merged cell's spanned rows, so measuring against a vertically merged
+  // column collapses every Y inside the band onto the merge anchor. Neither a fixed column nor
+  // the pointer's column is universally safe (a merge can live in either), so pick the first
+  // visible column that is free of vertical merges in the scanned range (DEV-2115).
+  const rowReferenceColumn = findRowReferenceColumn(
+    hotInstance,
+    firstPartiallyVisibleColumn ?? 0,
+    lastPartiallyVisibleColumn ?? (hotInstance.countCols() - 1),
+    firstPartiallyVisibleRow ?? 0,
+    lastPartiallyVisibleRow ?? (hotInstance.countRows() - 1),
+  );
+
   let foundRow: number | null = null;
 
   // Check fixed top rows first
@@ -225,7 +285,7 @@ export function getCellCoordsFromMousePosition(
       : null;
 
     if (firstNonHiddenRow !== null && lastFixedRow !== null) {
-      const fixedCell = hotInstance.getCell(firstNonHiddenRow, firstPartiallyVisibleColumn, true);
+      const fixedCell = hotInstance.getCell(firstNonHiddenRow, rowReferenceColumn, true);
 
       if (fixedCell instanceof HTMLElement) {
         const fixedCellRect = fixedCell.getBoundingClientRect();
@@ -233,7 +293,7 @@ export function getCellCoordsFromMousePosition(
 
         foundRow = findRowAtY(
           hotInstance,
-          firstPartiallyVisibleColumn,
+          rowReferenceColumn,
           firstNonHiddenRow,
           lastFixedRow,
           fixedRelativeY,
@@ -255,7 +315,7 @@ export function getCellCoordsFromMousePosition(
       : null;
 
     if (bottomStartNonHiddenRow !== null && bottomEndNonHiddenRow !== null) {
-      const fixedBottomCell = hotInstance.getCell(bottomStartNonHiddenRow, firstPartiallyVisibleColumn, true);
+      const fixedBottomCell = hotInstance.getCell(bottomStartNonHiddenRow, rowReferenceColumn, true);
 
       if (fixedBottomCell instanceof HTMLElement) {
         const fixedBottomCellRect = fixedBottomCell.getBoundingClientRect();
@@ -264,7 +324,7 @@ export function getCellCoordsFromMousePosition(
         if (fixedBottomRelativeY >= 0) {
           foundRow = findRowAtY(
             hotInstance,
-            firstPartiallyVisibleColumn,
+            rowReferenceColumn,
             bottomStartNonHiddenRow,
             bottomEndNonHiddenRow,
             fixedBottomRelativeY
@@ -280,7 +340,7 @@ export function getCellCoordsFromMousePosition(
 
   // Check scrollable rows (main table)
   if (foundRow === null) {
-    const scrollCell = hotInstance.getCell(firstPartiallyVisibleRow, firstPartiallyVisibleColumn, true);
+    const scrollCell = hotInstance.getCell(firstPartiallyVisibleRow, rowReferenceColumn, true);
 
     if (scrollCell instanceof HTMLElement) {
       const scrollCellRect = scrollCell.getBoundingClientRect();
@@ -288,7 +348,7 @@ export function getCellCoordsFromMousePosition(
 
       foundRow = findRowAtY(
         hotInstance,
-        firstPartiallyVisibleColumn,
+        rowReferenceColumn,
         firstPartiallyVisibleRow,
         lastPartiallyVisibleRow,
         scrollRelativeY,
@@ -306,7 +366,7 @@ export function getCellCoordsFromMousePosition(
     }
   }
 
-  if (foundRow === null || foundColumn === null) {
+  if (foundRow === null) {
     throwWithCause('Failed to resolve cell coordinates from mouse position.');
   }
 

--- a/handsontable/src/helpers/dom/cellCoords.ts
+++ b/handsontable/src/helpers/dom/cellCoords.ts
@@ -123,6 +123,7 @@ function findRowReferenceColumn(
 ): number {
   for (let column = startColumn; column <= endColumn; column++) {
     let spansMultipleRows = false;
+    let hasRenderableCell = false;
     let previousCell: HTMLElement | null = null;
 
     for (let row = startRow; row <= endRow; row++) {
@@ -138,10 +139,14 @@ function findRowReferenceColumn(
 
       if (cell !== null) {
         previousCell = cell;
+        hasRenderableCell = true;
       }
     }
 
-    if (!spansMultipleRows) {
+    // A hidden column (e.g. `hiddenColumns`) renders no cells, so `findRowAtY` cannot measure
+    // against it. Require at least one renderable cell so a hidden column between the merged
+    // column and a usable one is skipped rather than picked as the reference.
+    if (!spansMultipleRows && hasRenderableCell) {
       return column;
     }
   }

--- a/handsontable/src/helpers/dom/cellCoords.ts
+++ b/handsontable/src/helpers/dom/cellCoords.ts
@@ -95,19 +95,24 @@ function findRowAtY(
 
 /**
  * Finds a column suitable for mapping a Y coordinate to a row: the first column in the range
- * whose cells across the scanned rows all render at their own single-row height. `findRowAtY`
- * walks a single column's cell heights, so it is distorted by two kinds of merged cell:
- * a vertical-merge anchor (`rowspan > 1`, whose cell spans and hides the rows below it) and any
- * merge slave (`hidden`, whose cell is collapsed to zero height — this also covers the hidden
- * columns of a purely horizontal merge). A merge in one column must not distort the row lookup
- * used for other columns (DEV-2115).
+ * whose cells across the scanned rows each occupy their own single row. `findRowAtY` walks one
+ * column's cell heights and skips a merged cell's spanned rows, so it is distorted by a cell
+ * that spans multiple rows — a vertical-merge anchor or any of its slaves. Such a column is
+ * detected two ways: `rowspan > 1` on the anchor's meta, and element identity, since every row
+ * inside a vertical merge resolves to the same rendered cell. A purely horizontal merge resolves
+ * to a distinct, single-row master cell per row, so its columns stay valid. A merge in one column
+ * must not distort the row lookup used for other columns (DEV-2115).
+ *
+ * The scanned row range must match the range the returned column will be walked over (the frozen
+ * overlays and the scrollable body are resolved separately), so a merge confined to frozen rows
+ * cannot leak into the body lookup or vice versa.
  *
  * @param {Handsontable} hotInstance The Handsontable instance.
  * @param {number} startColumn First column to consider.
  * @param {number} endColumn Last column to consider (inclusive).
  * @param {number} startRow First row of the scanned range.
  * @param {number} endRow Last row of the scanned range (inclusive).
- * @returns {number} A column index free of merge distortion, or `startColumn` if none qualifies.
+ * @returns {number} A column index free of vertical-merge distortion, or `startColumn` if none qualifies.
  */
 function findRowReferenceColumn(
   hotInstance: HotInstance,
@@ -117,18 +122,26 @@ function findRowReferenceColumn(
   endRow: number,
 ): number {
   for (let column = startColumn; column <= endColumn; column++) {
-    let isDistortedByMerge = false;
+    let spansMultipleRows = false;
+    let previousCell: HTMLElement | null = null;
 
     for (let row = startRow; row <= endRow; row++) {
-      const { rowspan, hidden } = hotInstance.getCellMeta<{ rowspan?: number, hidden?: boolean }>(row, column);
+      const cell = hotInstance.getCell(row, column, true);
+      const { rowspan } = hotInstance.getCellMeta<{ rowspan?: number }>(row, column);
 
-      if (hidden === true || (rowspan !== undefined && rowspan > 1)) {
-        isDistortedByMerge = true;
+      // A vertically merged cell reports `rowspan > 1` on its anchor and resolves to the same
+      // rendered element for every row it covers; either signal marks the column as distorting.
+      if ((rowspan !== undefined && rowspan > 1) || (cell !== null && cell === previousCell)) {
+        spansMultipleRows = true;
         break;
+      }
+
+      if (cell !== null) {
+        previousCell = cell;
       }
     }
 
-    if (!isDistortedByMerge) {
+    if (!spansMultipleRows) {
       return column;
     }
   }
@@ -261,18 +274,13 @@ export function getCellCoordsFromMousePosition(
     throwWithCause('Failed to resolve cell coordinates from mouse position.');
   }
 
-  // Resolve the row against a column that has no vertical merge across the visible rows.
+  // Resolve the row against a column that has no vertical merge across the rows being walked.
   // `findRowAtY` skips a merged cell's spanned rows, so measuring against a vertically merged
   // column collapses every Y inside the band onto the merge anchor. Neither a fixed column nor
-  // the pointer's column is universally safe (a merge can live in either), so pick the first
-  // visible column that is free of vertical merges in the scanned range (DEV-2115).
-  const rowReferenceColumn = findRowReferenceColumn(
-    hotInstance,
-    firstPartiallyVisibleColumn ?? 0,
-    lastPartiallyVisibleColumn ?? (hotInstance.countCols() - 1),
-    firstPartiallyVisibleRow ?? 0,
-    lastPartiallyVisibleRow ?? (hotInstance.countRows() - 1),
-  );
+  // the pointer's column is universally safe (a merge can live in either), so each row-scan
+  // branch picks the first column free of vertical merges within its own row range (DEV-2115).
+  const rowReferenceColumnStart = firstPartiallyVisibleColumn ?? 0;
+  const rowReferenceColumnEnd = lastPartiallyVisibleColumn ?? (hotInstance.countCols() - 1);
 
   let foundRow: number | null = null;
 
@@ -285,6 +293,8 @@ export function getCellCoordsFromMousePosition(
       : null;
 
     if (firstNonHiddenRow !== null && lastFixedRow !== null) {
+      const rowReferenceColumn = findRowReferenceColumn(
+        hotInstance, rowReferenceColumnStart, rowReferenceColumnEnd, firstNonHiddenRow, lastFixedRow);
       const fixedCell = hotInstance.getCell(firstNonHiddenRow, rowReferenceColumn, true);
 
       if (fixedCell instanceof HTMLElement) {
@@ -315,6 +325,8 @@ export function getCellCoordsFromMousePosition(
       : null;
 
     if (bottomStartNonHiddenRow !== null && bottomEndNonHiddenRow !== null) {
+      const rowReferenceColumn = findRowReferenceColumn(
+        hotInstance, rowReferenceColumnStart, rowReferenceColumnEnd, bottomStartNonHiddenRow, bottomEndNonHiddenRow);
       const fixedBottomCell = hotInstance.getCell(bottomStartNonHiddenRow, rowReferenceColumn, true);
 
       if (fixedBottomCell instanceof HTMLElement) {
@@ -340,6 +352,13 @@ export function getCellCoordsFromMousePosition(
 
   // Check scrollable rows (main table)
   if (foundRow === null) {
+    const rowReferenceColumn = findRowReferenceColumn(
+      hotInstance,
+      rowReferenceColumnStart,
+      rowReferenceColumnEnd,
+      firstPartiallyVisibleRow ?? 0,
+      lastPartiallyVisibleRow ?? (hotInstance.countRows() - 1),
+    );
     const scrollCell = hotInstance.getCell(firstPartiallyVisibleRow, rowReferenceColumn, true);
 
     if (scrollCell instanceof HTMLElement) {

--- a/handsontable/src/plugins/mergeCells/__tests__/autofill.spec.js
+++ b/handsontable/src/plugins/mergeCells/__tests__/autofill.spec.js
@@ -69,6 +69,25 @@ describe('MergeCells cooperation with autofill', () => {
     expect(getDataAtCell(5, 1)).toBe('B6'); // untouched - below the drag range
   });
 
+  it('should fill into a merged band when a hidden column sits between it and the dragged column (DEV-2115)', async() => {
+    handsontable({
+      data: createSpreadsheetData(10, 5),
+      hiddenColumns: { columns: [1] }, // hide column 1, between the merged column 0 and column 2
+      mergeCells: [
+        { row: 2, col: 0, rowspan: 3, colspan: 1 }, // A3:A5 vertical merge in column 0
+      ],
+    });
+
+    await selectCell(2, 2); // the first cell of column 2 within the merged band (column 1 hidden)
+
+    // Drag down one row. The reference-column search must skip the hidden column 1 (no rendered
+    // cell) instead of picking it, which would collapse the row lookup onto the merge anchor.
+    simulateFillHandleDrag(getCell(3, 2));
+
+    expect(getDataAtCell(3, 2)).toBe('C3'); // filled from the source
+    expect(getDataAtCell(4, 2)).toBe('C5'); // untouched - drag stopped one row down
+  });
+
   it('should populate merged cells data up', async() => {
     handsontable({
       data: createSpreadsheetData(10, 10),

--- a/handsontable/src/plugins/mergeCells/__tests__/autofill.spec.js
+++ b/handsontable/src/plugins/mergeCells/__tests__/autofill.spec.js
@@ -31,6 +31,44 @@ describe('MergeCells cooperation with autofill', () => {
     expect(getDataAtCell(5, 1)).toBe('B2');
   });
 
+  it('should fill a row that sits within a vertical merge belonging to a different column (DEV-2115)', async() => {
+    handsontable({
+      data: createSpreadsheetData(10, 10),
+      mergeCells: [
+        { row: 2, col: 0, rowspan: 3, colspan: 1 }, // A3:A5 - vertical merge in column 0 only
+      ],
+    });
+
+    await selectCell(2, 1); // B3 - normal cell next to the merged column
+
+    // Drag the fill handle down by a single row, to B4 - a row that lies inside column 0's
+    // merged band (rows 2-4). Regression: the mouse-to-row lookup measured against the merged
+    // column, so every Y inside the band collapsed onto the merge anchor (B3) and the fill
+    // jumped past the whole band instead of stopping at B4.
+    simulateFillHandleDrag(getCell(3, 1));
+
+    expect(getDataAtCell(3, 1)).toBe('B3'); // filled from the source
+    expect(getDataAtCell(4, 1)).toBe('B5'); // untouched - drag stopped at B4
+  });
+
+  it('should fill several rows within a vertical merge belonging to a different column (DEV-2115)', async() => {
+    handsontable({
+      data: createSpreadsheetData(10, 10),
+      mergeCells: [
+        { row: 2, col: 0, rowspan: 3, colspan: 1 }, // A3:A5 - vertical merge in column 0 only
+      ],
+    });
+
+    await selectCell(2, 1); // B3
+
+    // Drag down to B5 - the last row inside column 0's merged band.
+    simulateFillHandleDrag(getCell(4, 1));
+
+    expect(getDataAtCell(3, 1)).toBe('B3');
+    expect(getDataAtCell(4, 1)).toBe('B3');
+    expect(getDataAtCell(5, 1)).toBe('B6'); // untouched - below the drag range
+  });
+
   it('should populate merged cells data up', async() => {
     handsontable({
       data: createSpreadsheetData(10, 10),


### PR DESCRIPTION
### Context

The PR fixes a regression where the autofill fill handle cannot target rows that fall within a vertical merge located in another column.

`getCellCoordsFromMousePosition` maps a pointer Y coordinate to a row by walking a single reference column (the first visible column) and honoring that column's `rowspan`. When that column holds a vertical merge, `findRowAtY` skips the merged band's rows, collapsing every Y inside the band onto the merge anchor. As a result, dragging the fill handle in a neighboring column cannot stop on a row inside the band — the fill jumps past the whole merge.

Example: with a merge on `A3:A5`, dragging `B3`'s fill handle down one row to `B4` filled nothing and snapped straight to `B6`. In 17.1.0 the same drag filled `B4`.

This is a regression introduced in 18.0.0 by the TypeScript conversion (#12011), which added the pixel-based row lookup in `Autofill#onMouseMove` and the new `cellCoords.ts` helper. Before that, the fill target came from the actual hovered cell reported by Walkontable (`beforeOnCellMouseOver`), which was merge-aware.

The fix resolves the row against a column free of merge distortion, chosen by a new `findRowReferenceColumn`: the first visible column whose scanned cells are neither a vertical-merge anchor (`rowspan > 1`) nor a merge slave (`hidden`). This keeps the row lookup correct whether the merge lives in the dragged column, a neighboring column, or the source column.

### How has this been tested?

- Unit tests for the helper (a vertical merge in a column other than the one under the pointer):

  ```
  npm run test:unit --prefix handsontable --testPathPattern=cellCoords.unit
  ```

- E2E tests for autofill into a merged band belonging to another column, plus the existing autofill / mergeCells / dragToScroll suites (324 specs, 0 failures):

  ```
  npm run test:e2e --prefix handsontable --testPathPattern="mergeCells/__tests__/(mergeCells.spec|autofill)|plugins/autofill/__tests__|plugins/dragToScroll"
  ```

- Manual verification in a browser: dragging `B3`'s fill handle one row into the `A3:A5` merged band now fills `B4` (matching 17.1.0), instead of jumping to `B6`.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2115

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2115

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared pointer-to-cell coordinate logic used by autofill and drag-to-scroll across frozen rows, hidden columns, and merges; mitigated by extensive unit/e2e coverage but edge cases where every visible column is vertically merged still fall back to prior behavior.
> 
> **Overview**
> Fixes **autofill** (and other pointer-driven flows) when a **vertical merge lives in another column**: dragging the fill handle no longer skips rows inside that merged band.
> 
> **`getCellCoordsFromMousePosition`** no longer maps Y to a row using only the first visible column. It adds **`findRowReferenceColumn`**, which picks the first column in the visible range whose cells are not vertically merged (via `rowspan > 1` or repeated DOM element identity), then runs **`findRowAtY`** on that column—separately for frozen top, frozen bottom, and scrollable body. Hidden columns with no renderable cells are skipped; **`getCellMetaTransient`** is used for span metadata. Reference-column search is clamped to the rendered viewport so long drags on huge off-screen grids do not scan the full grid.
> 
> Unit and mergeCells/autofill e2e tests cover neighboring-column merges, frozen rows, hidden columns, and anchors above the scan range.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b04629e2c541af48b2647c6e27bbd24670fe6b95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->