### PR TITLE
DEV-2125: Add HyperFormula installation guide to Formulas docs

### DIFF
--- a/docs/content/guides/formulas/installation/installation.md
+++ b/docs/content/guides/formulas/installation/installation.md
@@ -140,14 +140,54 @@ pass it to `formulas.engine`. Handsontable builds the engine, applies the
 `'internal-use-in-handsontable'` license key, and manages the engine's lifecycle for you. Use this
 for a single grid, or for grids that each work on their own data.
 
+```js
+import { HyperFormula } from 'hyperformula';
+
+const hot = new Handsontable(container, {
+  formulas: {
+    engine: HyperFormula,
+  },
+  licenseKey: 'non-commercial-and-evaluation', // for non-commercial use only
+});
+```
+
 **Build a HyperFormula instance first, then pass it.** Create the engine yourself with
 `HyperFormula.buildEmpty()`, set the license key, and pass the instance to `formulas.engine`. This
 gives you direct access to the engine's API. It also lets several Handsontable instances share one
 engine, so formulas can reference cells across grids with cross-sheet references.
 
+```js
+import { HyperFormula } from 'hyperformula';
+
+const hyperformulaInstance = HyperFormula.buildEmpty({
+  licenseKey: 'internal-use-in-handsontable',
+});
+
+const hot = new Handsontable(container, {
+  formulas: {
+    engine: hyperformulaInstance,
+  },
+  licenseKey: 'non-commercial-and-evaluation', // for non-commercial use only
+});
+```
+
 **Pass an engine configuration object.** Instead of the bare class, pass an object with a
 `hyperformula` field (the class or an instance) alongside HyperFormula configuration options, such
 as `leapYear1900`. Use this to customize how the engine behaves.
+
+```js
+import { HyperFormula } from 'hyperformula';
+
+const hot = new Handsontable(container, {
+  formulas: {
+    engine: {
+      hyperformula: HyperFormula, // or a pre-built HyperFormula instance
+      leapYear1900: false,
+    },
+  },
+  licenseKey: 'non-commercial-and-evaluation', // for non-commercial use only
+});
+```
 
 For complete, framework-specific examples of each approach - including shared and external engines
 across multiple grids - see [Initialization methods](@/guides/formulas/formula-calculation/formula-calculation.md#initialization-methods).

--- a/docs/content/guides/formulas/installation/installation.md
+++ b/docs/content/guides/formulas/installation/installation.md
@@ -1,0 +1,165 @@
+---
+type: how-to
+title: Installation
+metaTitle: Install HyperFormula - JavaScript Data Grid | Handsontable
+description: Install HyperFormula as a separate dependency, license it, and import it to power the Formulas plugin in Handsontable 18.0 and later.
+permalink: /formulas-installation
+canonicalUrl: /formulas-installation
+tags:
+  - formulas
+  - hyperformula
+  - installation
+  - license
+react:
+  metaTitle: Install HyperFormula - React Data Grid | Handsontable
+angular:
+  metaTitle: Install HyperFormula - Angular Data Grid | Handsontable
+vue:
+  metaTitle: Install HyperFormula - Vue Data Grid | Handsontable
+searchCategory: Guides
+category: Formulas
+menuTag: new
+---
+
+The [`Formulas`](@/api/formulas.md) plugin runs on [HyperFormula](https://hyperformula.handsontable.com/),
+a calculation engine that you install separately. This guide shows how to install, license, and
+import HyperFormula so you can enable the plugin.
+
+Starting with Handsontable 18.0, HyperFormula is not bundled with Handsontable. You add it to your
+project yourself. In earlier versions, HyperFormula shipped as a Handsontable dependency and
+required no separate installation.
+
+[[toc]]
+
+## Prerequisites
+
+- Handsontable is installed in your project. See [Installation](@/guides/getting-started/installation/installation.md).
+
+## Install HyperFormula
+
+Install HyperFormula with your package manager:
+
+<code-group>
+  <code-block title="npm">
+
+  ```bash
+  npm install hyperformula
+  ```
+
+  </code-block>
+  <code-block title="Yarn">
+
+  ```bash
+  yarn add hyperformula
+  ```
+
+  </code-block>
+  <code-block title="pnpm">
+
+  ```bash
+  pnpm add hyperformula
+  ```
+
+  </code-block>
+</code-group>
+
+Install the HyperFormula version that matches your Handsontable version. For the compatible
+versions, see [HyperFormula version support](@/guides/formulas/formula-calculation/formula-calculation.md#hyperformula-version-support).
+
+To load HyperFormula from a CDN or as a UMD bundle instead, see the
+[HyperFormula installation docs](https://handsontable.github.io/hyperformula/guide/client-side-installation.html).
+
+## Import HyperFormula
+
+Import the `HyperFormula` class into the file where you configure the grid:
+
+```js
+import { HyperFormula } from 'hyperformula';
+```
+
+## License HyperFormula
+
+HyperFormula requires a license key. When HyperFormula runs inside Handsontable, use the
+`'internal-use-in-handsontable'` key. This key is free and covers any HyperFormula instance that is
+connected to a Handsontable instance.
+
+How you apply the key depends on how you create the engine:
+
+- If you pass the `HyperFormula` class to the `formulas.engine` option, Handsontable builds the
+  engine and applies the `'internal-use-in-handsontable'` key for you.
+- If you build the engine yourself with `HyperFormula.buildEmpty()`, set the key in the
+  configuration:
+
+```js
+const hyperformulaInstance = HyperFormula.buildEmpty({
+  licenseKey: 'internal-use-in-handsontable',
+});
+```
+
+To run HyperFormula on its own, outside a Handsontable instance (for example, on a server), you
+need a dedicated [HyperFormula license key](https://hyperformula.handsontable.com/guide/license-key.html).
+For details, [contact our Sales Team](https://handsontable.com/get-a-quote).
+
+## Enable the Formulas plugin
+
+Pass the `HyperFormula` class to the `formulas.engine` option. Handsontable builds the engine and
+applies the license key for you.
+
+```js
+import Handsontable from 'handsontable';
+import { HyperFormula } from 'hyperformula';
+
+const container = document.querySelector('#example');
+
+const hot = new Handsontable(container, {
+  data: [
+    ['Product', 'Price', 'Quantity', 'Total'],
+    ['Wireless mouse', 25, 4, '=B2*C2'],
+    ['Mechanical keyboard', 89, 2, '=B3*C3'],
+    ['USB-C hub', 45, 3, '=B4*C4'],
+  ],
+  colHeaders: true,
+  rowHeaders: true,
+  formulas: {
+    engine: HyperFormula,
+  },
+  licenseKey: 'non-commercial-and-evaluation', // for non-commercial use only
+});
+```
+
+This example passes the `HyperFormula` class, which is one of several ways to connect the engine.
+
+## Ways to pass HyperFormula
+
+You can connect HyperFormula to Handsontable in more than one way. The `formulas.engine` option
+accepts the `HyperFormula` class, a pre-built HyperFormula instance, or an engine configuration
+object. Choose the approach that fits your setup.
+
+**Pass the `HyperFormula` class.** This is the shortest path, shown above. You import the class and
+pass it to `formulas.engine`. Handsontable builds the engine, applies the
+`'internal-use-in-handsontable'` license key, and manages the engine's lifecycle for you. Use this
+for a single grid, or for grids that each work on their own data.
+
+**Build a HyperFormula instance first, then pass it.** Create the engine yourself with
+`HyperFormula.buildEmpty()`, set the license key, and pass the instance to `formulas.engine`. This
+gives you direct access to the engine's API. It also lets several Handsontable instances share one
+engine, so formulas can reference cells across grids with cross-sheet references.
+
+**Pass an engine configuration object.** Instead of the bare class, pass an object with a
+`hyperformula` field (the class or an instance) alongside HyperFormula configuration options, such
+as `leapYear1900`. Use this to customize how the engine behaves.
+
+For complete, framework-specific examples of each approach - including shared and external engines
+across multiple grids - see [Initialization methods](@/guides/formulas/formula-calculation/formula-calculation.md#initialization-methods).
+
+## Result
+
+HyperFormula is installed, licensed, and connected to Handsontable. The `Formulas` plugin evaluates
+any cell whose value starts with `=`, and it recalculates dependent cells as your data changes.
+
+## Related
+
+- [Formula calculation](@/guides/formulas/formula-calculation/formula-calculation.md) - use formulas, named expressions, custom functions, and cross-sheet references
+- [Installation](@/guides/getting-started/installation/installation.md) - install Handsontable
+- [`Formulas` plugin API](@/api/formulas.md)
+- [`formulas` option](@/api/options.md#formulas)

--- a/docs/content/guides/formulas/installation/installation.md
+++ b/docs/content/guides/formulas/installation/installation.md
@@ -135,7 +135,8 @@ You can connect HyperFormula to Handsontable in more than one way. The `formulas
 accepts the `HyperFormula` class, a pre-built HyperFormula instance, or an engine configuration
 object. Choose the approach that fits your setup.
 
-**Pass the `HyperFormula` class.** This is the shortest path, shown above. You import the class and
+### Pass the `HyperFormula` class
+This is the shortest path, shown above. You import the class and
 pass it to `formulas.engine`. Handsontable builds the engine, applies the
 `'internal-use-in-handsontable'` license key, and manages the engine's lifecycle for you. Use this
 for a single grid, or for grids that each work on their own data.
@@ -151,7 +152,8 @@ const hot = new Handsontable(container, {
 });
 ```
 
-**Build a HyperFormula instance first, then pass it.** Create the engine yourself with
+### Build a `HyperFormula` instance first, then pass it
+Create the engine yourself with
 `HyperFormula.buildEmpty()`, set the license key, and pass the instance to `formulas.engine`. This
 gives you direct access to the engine's API. It also lets several Handsontable instances share one
 engine, so formulas can reference cells across grids with cross-sheet references.
@@ -171,7 +173,8 @@ const hot = new Handsontable(container, {
 });
 ```
 
-**Pass an engine configuration object.** Instead of the bare class, pass an object with a
+### Pass an engine configuration object
+Instead of the bare class, pass an object with a
 `hyperformula` field (the class or an instance) alongside HyperFormula configuration options, such
 as `leapYear1900`. Use this to customize how the engine behaves.
 

--- a/docs/content/guides/sidebar.js
+++ b/docs/content/guides/sidebar.js
@@ -112,6 +112,7 @@ const cellTypesItems = [
 ];
 
 const formulasItems = [
+  { path: 'guides/formulas/installation/installation' },
   { path: 'guides/formulas/formula-calculation/formula-calculation' },
 ];
 

--- a/docs/content/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md
+++ b/docs/content/guides/upgrade-and-migration/migrating-from-16.2-to-17.0/migrating-from-16.2-to-17.0.md
@@ -1152,7 +1152,7 @@ The **Formulas** plugin uses [HyperFormula](https://hyperformula.handsontable.co
 1. Install HyperFormula in your project (e.g. `npm install hyperformula`).
 2. Import HyperFormula and pass it to the Formulas plugin with `licenseKey: 'internal-use-in-handsontable'`.
 
-See the [Formula calculation](@/guides/formulas/formula-calculation/formula-calculation.md) guide for configuration details.
+See the [Formulas installation](@/guides/formulas/installation/installation.md) guide to install and license HyperFormula, and the [Formula calculation](@/guides/formulas/formula-calculation/formula-calculation.md) guide for configuration details.
 
 ## Summary of breaking changes
 


### PR DESCRIPTION
### Context

The PR adds documentation for installing HyperFormula, which was missing after Handsontable 18.0.

In Handsontable 18.0.0, HyperFormula was removed from the package dependencies - it now ships only as a dev dependency for internal tests (see `CHANGELOG.md`: "Deprecated bundling HyperFormula as a Handsontable dependency. Starting from version 18.0, install and import it separately"). Users of the `Formulas` plugin must now install and import HyperFormula themselves, but the docs never explained how. The Formula calculation page only covers how formulas are used and assumes HyperFormula is already installed.

This PR adds a new **Installation** page under the **Formulas** category that covers:

- Installing HyperFormula as a separate dependency (npm / Yarn / pnpm, plus a CDN/UMD pointer).
- Importing the `HyperFormula` class.
- Licensing with the free `internal-use-in-handsontable` key (when Handsontable applies it for you vs. when you set it on `buildEmpty()`).
- Enabling the `Formulas` plugin.
- The different ways to pass HyperFormula to Handsontable (the class, a pre-built instance, or an engine configuration object), linking to the calculation page's *Initialization methods* for the full framework-specific examples.

It also registers the page in the sidebar (before *Formula calculation*) and points the 16.2 -> 17.0 migration guide's existing HyperFormula deprecation note at the new page.

The Formula calculation page is intentionally left unchanged - it documents formula usage, not installation.

`[skip changelog]` - documentation-only change, no source code touched.

### How has this been tested?

- Confirmed the new page's internal-link anchors resolve: `#hyperformula-version-support` and `#initialization-methods` on the Formula calculation page, plus the getting-started Installation guide and the `formulas` API references.
- Confirmed the sidebar path (`guides/formulas/installation/installation`) matches the new file location.
- Verified the Formula calculation page has no diff.
- ESLint on the modified `sidebar.js` reports no errors.

No unit or E2E tests apply (documentation-only).

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

Documentation-only change.

### Related issue(s):

1. DEV-2125

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

Documentation site only.

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

### Docs PR checklist

- [x] `type:` field added to frontmatter (how-to)
- [x] Page uses the correct Diataxis template for its type
- [x] Intro paragraph states what, for whom, and what outcome the reader gains
- [x] No banned placeholder data (foo, bar, A1, Column1, etc.)
- [x] All example data is domain-realistic and internally consistent
- [x] All code blocks have language tags
- [x] No `var` in code examples; uses `const` / `let`
- [x] All examples include `licenseKey: 'non-commercial-and-evaluation'`
- [x] Heading hierarchy is correct
- [x] Active voice and second person ("you") used throughout
- [x] No banned words: simply, just, easy, straightforward, note that, please
- [x] How-to has Prerequisites and Result sections
- [x] New page registered in `content/guides/sidebar.js`
- [x] `menuTag: new` set on the new page
- [x] `[skip changelog]` in PR body (docs changes don't need changelog entries)

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2125

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no library, API, or runtime behavior impact.
> 
> **Overview**
> Adds a **Formulas → Installation** how-to for Handsontable 18+, where HyperFormula is no longer bundled. The page covers installing via npm/Yarn/pnpm (with version compatibility and CDN pointers), importing `HyperFormula`, using the free `internal-use-in-handsontable` license key, enabling the `Formulas` plugin, and the three `formulas.engine` wiring patterns (class, pre-built instance, config object), with links to **Formula calculation** for deeper setup.
> 
> Navigation is updated by listing the new page first under **Formulas** in `sidebar.js` (`menuTag: new`). The 16.2→17.0 migration guide’s HyperFormula deprecation section now points readers at this installation guide alongside the existing calculation doc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcbd6db087eb7d1ed4cd7948ca61c9ec2c1141a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->