### PR TITLE
DEV-2057: a pipeline-only PR should not run the library test matrix, lint, or scans

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -163,10 +163,14 @@ jobs:
               - './handsontable/package.json'
               - './handsontable/tsconfig*.json'
               - './wrappers/angular-wrapper/**'
-              # Markdown never shapes public types; exclude it so an AGENTS.md /
-              # README edit under the trees above does not route docs-angular.
-              # Keep in sync with docs-angular-typecheck.yml's push paths.
-              - '!**/*.md'
+              # NOTE: markdown can't be excluded here. dorny/paths-filter runs with
+              # predicate-quantifier: some (OR), so a `!**/*.md` rule is NOT
+              # subtractive — it would fail to exclude .md under the trees above and
+              # would match any non-md file on its own. The markdown exclusion that
+              # matters (the reported bug) is on docs-angular-typecheck.yml's PUSH
+              # paths, where GitHub-native path filters ARE subtractive. On a PR an
+              # AGENTS.md edit sets this flag but is inert unless the docs job also
+              # runs (it needs the `docs` flag), so it never routes a typecheck alone.
             pkg-preview:
               - './handsontable/**'
               - './wrappers/**'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -177,16 +177,21 @@ jobs:
             docs:
               - './docs/**'
               - './handsontable/package.json'
-            # True when the PR changes anything OUTSIDE the CI pipeline itself
-            # (./.github/**). Lint + the code-quality scans (Sonar/CodeQL/FOSSA/
-            # audit) gate on this so a pipeline-only PR (e.g. adding or editing a
-            # workflow) skips them — there is no library source to lint or scan,
-            # and a workflow's own YAML is validated by actionlint, not these jobs.
-            # NOTE: dorny/paths-filter negation is OR-based — a `!x` rule matches
-            # every file NOT under x. So this is a negation-ONLY rule: adding a
-            # positive like `**` would make it match everything (`**` alone is true).
+            # True when the PR changes anything that ESLint/scans can act on —
+            # i.e. NOT confined to the YAML pipeline definitions. Lint + the
+            # code-quality scans (Sonar/CodeQL/FOSSA/audit) gate on this so a
+            # workflow/action-only PR skips them (a YAML pipeline change is
+            # validated by the pipeline running itself + actionlint, not ESLint).
+            # Excludes ONLY the YAML CI dirs (workflows + actions), NOT
+            # `.github/scripts/**` — those are `.mjs` the root ESLint config
+            # targets and the local hooks defer to CI, so a scripts-only PR MUST
+            # still lint.
+            # NOTE: dorny/paths-filter negation is OR-based (predicate-quantifier:
+            # some) — a `!x` rule matches every file NOT under x. So this must be a
+            # single negation-only rule; a second `!y` (or a positive `**`) would
+            # make it match nearly everything.
             outside-ci:
-              - '!./.github/**'
+              - '!./.github/{workflows,actions}/**'
 
       # Build the Integration wrapper matrix from the scope flags (run-all → all
       # three). Emitting it here means the wrapper job fans out with no extra

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -78,7 +78,11 @@ jobs:
               - './handsontable/babel.config.js'
               # The bundler entry (rspack runs from the handsontable/ cwd).
               - './handsontable/rspack.config.js'
-              - './.github/workflows/**'
+              # NOTE: `.github/workflows/**` is deliberately NOT here. A pipeline
+              # (workflow) change must not route the library build/unit/e2e/wrapper/
+              # perf matrix — a PR that only edits a workflow (e.g. adding an unrelated
+              # workflow) previously ran the entire suite. A CI change is validated by
+              # the pipeline running itself, not by re-running library tests.
               - './visual-tests/playwright.config.ts'
               - './visual-tests/playwright-cross-browser.config.ts'
             hot-definition-files: &hot-definition-files
@@ -135,10 +139,11 @@ jobs:
               - './examples/next/visual-tests/**'
               - './visual-tests/**'
             test-performance:
-              # config-files (deps in package.json, babel/hot.config, workflows) can
-              # shift bundle perf — run the suite on the PR for those too, not just
+              # config-files (deps in package.json, babel/hot.config, bundler config)
+              # can shift bundle perf — run the suite on the PR for those too, not just
               # src changes. Otherwise a config-driven slowdown skips the PR run and
               # is then recorded as the new golden baseline on the develop push.
+              # (Workflow changes are intentionally excluded — see the config-files note.)
               - *config-files
               - './handsontable/src/**'
               - './performance-tests/**'
@@ -154,6 +159,10 @@ jobs:
               - './handsontable/package.json'
               - './handsontable/tsconfig*.json'
               - './wrappers/angular-wrapper/**'
+              # Markdown never shapes public types; exclude it so an AGENTS.md /
+              # README edit under the trees above does not route docs-angular.
+              # Keep in sync with docs-angular-typecheck.yml's push paths.
+              - '!**/*.md'
             pkg-preview:
               - './handsontable/**'
               - './wrappers/**'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -32,6 +32,9 @@ on:
       docs-angular: { value: '${{ jobs.scope.outputs.docs-angular }}' }
       pkg-preview: { value: '${{ jobs.scope.outputs.pkg-preview }}' }
       docs: { value: '${{ jobs.scope.outputs.docs }}' }
+      # True when the PR touches anything outside the CI pipeline (.github/**).
+      # Lint + the code-quality scans gate on it, so a pipeline-only PR skips them.
+      outside-ci: { value: '${{ jobs.scope.outputs.outside-ci }}' }
       # Precomputed here so the Integration wrapper matrix fans out with NO
       # per-module setup job (matrix context is illegal in a job-level if).
       wrapper-matrix: { value: '${{ jobs.scope.outputs.wrapper-matrix }}' }
@@ -58,6 +61,7 @@ jobs:
       docs-angular: ${{ steps.path-filter.outputs.docs-angular }}
       pkg-preview: ${{ steps.path-filter.outputs.pkg-preview }}
       docs: ${{ steps.path-filter.outputs.docs }}
+      outside-ci: ${{ steps.path-filter.outputs.outside-ci }}
       wrapper-matrix: ${{ steps.wrappers.outputs.list }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # https://github.com/actions/checkout/releases/tag/v6.0.2
@@ -169,6 +173,14 @@ jobs:
             docs:
               - './docs/**'
               - './handsontable/package.json'
+            # True when the PR changes anything OUTSIDE the CI pipeline itself
+            # (./.github/**). Lint + the code-quality scans (Sonar/CodeQL/FOSSA/
+            # audit) gate on this so a pipeline-only PR (e.g. adding or editing a
+            # workflow) skips them — there is no library source to lint or scan,
+            # and a workflow's own YAML is validated by actionlint, not these jobs.
+            outside-ci:
+              - '**'
+              - '!.github/**'
 
       # Build the Integration wrapper matrix from the scope flags (run-all → all
       # three). Emitting it here means the wrapper job fans out with no extra

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -178,9 +178,11 @@ jobs:
             # audit) gate on this so a pipeline-only PR (e.g. adding or editing a
             # workflow) skips them — there is no library source to lint or scan,
             # and a workflow's own YAML is validated by actionlint, not these jobs.
+            # NOTE: dorny/paths-filter negation is OR-based — a `!x` rule matches
+            # every file NOT under x. So this is a negation-ONLY rule: adding a
+            # positive like `**` would make it match everything (`**` alone is true).
             outside-ci:
-              - '**'
-              - '!.github/**'
+              - '!./.github/**'
 
       # Build the Integration wrapper matrix from the scope flags (run-all → all
       # three). Emitting it here means the wrapper job fans out with no extra

--- a/.github/workflows/docs-angular-typecheck.yml
+++ b/.github/workflows/docs-angular-typecheck.yml
@@ -21,6 +21,11 @@ on:
       - 'handsontable/package.json'
       - 'handsontable/tsconfig*.json'
       - 'wrappers/angular-wrapper/**'
+      # Markdown can never change the emitted public types, but AGENTS.md /
+      # README files live under the src and wrapper trees above and were
+      # triggering a full typecheck (e.g. an edit to
+      # wrappers/angular-wrapper/AGENTS.md). Exclude all markdown.
+      - '!**/*.md'
   workflow_call:
 
 concurrency:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -201,3 +201,50 @@ jobs:
       run-angular: ${{ needs.checks.outputs.docs-angular == 'true' }}
       is-pr: ${{ github.event_name == 'pull_request' }}
     secrets: inherit
+
+  # ── Single merge gate ──────────────────────────────────────────────────────
+  # THE one status check to pin in branch protection. Every other job here is
+  # conditional (scope-gated) or matrix-expanded, so pinning individual names is
+  # fragile: a scope-skipped matrix job never emits its per-leg check runs, which
+  # then sit as "Expected — waiting for status to be reported" and block the PR
+  # forever. This job instead ALWAYS runs (so it always reports one stable name)
+  # and derives a single verdict from every other job's result: it fails if any
+  # job that actually ran failed or was cancelled, and passes when everything
+  # else succeeded or was legitimately scope-skipped. Branch protection should
+  # require ONLY "CI Gate" and unpin every individual/matrix check name.
+  ci-gate:
+    name: CI Gate
+    if: ${{ always() }}
+    needs:
+      - checks
+      - manual-qa
+      - lint
+      - code-quality
+      - unit
+      - types
+      - build
+      - walkontable
+      - e2e
+      - integration
+      - emitted-types
+      - performance
+      - visual
+      - docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify every pipeline job passed or was scope-skipped
+        run: |
+          results="${{ join(needs.*.result, ',') }}"
+          echo "Upstream job results: $results"
+          failed=0
+          IFS=',' read -ra arr <<< "$results"
+          for r in "${arr[@]}"; do
+            case "$r" in
+              success|skipped) ;;
+              *) echo "::error::Pipeline job result '$r' — merge blocked."; failed=1 ;;
+            esac
+          done
+          if [ "$failed" -ne 0 ]; then
+            exit 1
+          fi
+          echo "All pipeline jobs passed or were legitimately scope-skipped."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,9 @@ jobs:
   lint:
     name: Lint
     needs: [ checks ]
-    if: ${{ !failure() && !cancelled() && github.event_name == 'pull_request' }}
+    # Skip on a pipeline-only PR (only .github/** changed) — there is no library
+    # source to lint. `outside-ci` is false in that case; run-all keeps trunk/full runs.
+    if: ${{ !failure() && !cancelled() && github.event_name == 'pull_request' && (needs.checks.outputs.run-all == 'true' || needs.checks.outputs.outside-ci == 'true') }}
     uses: ./.github/workflows/lint.yml
     with:
       run-visual: ${{ needs.checks.outputs.run-all == 'true' || needs.checks.outputs.test-visual == 'true' }}
@@ -71,7 +73,12 @@ jobs:
   code-quality:
     name: Code Quality
     needs: [ checks ]
-    if: ${{ !failure() && !cancelled() && github.event_name == 'pull_request' }}
+    # Skip the scans (Sonar/CodeQL/FOSSA/audit) on a pipeline-only PR — nothing in
+    # the library changed to scan. See `outside-ci` in checks.yml. NOTE: this also
+    # skips CodeQL's Actions-workflow analysis on a workflow-only PR; the nightly
+    # baseline scan still covers trunk. Carve CodeQL out at the job level if PR-time
+    # workflow-injection scanning is wanted.
+    if: ${{ !failure() && !cancelled() && github.event_name == 'pull_request' && (needs.checks.outputs.run-all == 'true' || needs.checks.outputs.outside-ci == 'true') }}
     uses: ./.github/workflows/code-quality.yml
     secrets: inherit
 


### PR DESCRIPTION
### Context

Two related problems surfaced right after the DEV-2055 merge (DEV-2057 §1):

**A. A pipeline-only PR ran the whole library suite.** [#13098](https://github.com/handsontable/handsontable/pull/13098) added one unrelated workflow yet [ran the full build/test/scan matrix](https://github.com/handsontable/handsontable/actions/runs/29915627687).

**B. Conditional/matrix jobs + required-named branch-protection checks = permanent block.** A scope-skipped **matrix** job never emits its per-leg check runs, so required names like `E2E / UMD (theme: main)` sit as **"Expected — waiting for status to be reported"** forever — currently blocking develop merges.

### Fixes (all in `.github/workflows/`)

1. **Test matrix scope.** Removed `./.github/workflows/**` from the shared `config-files` anchor in `checks.yml` — a workflow edit no longer flips every build/test flag.
2. **Lint + Code Quality scope.** Added an `outside-ci` flag; `lint` and `code-quality` (Sonar/CodeQL/FOSSA/audit) now skip a **workflow/action-only** PR. The flag excludes only the YAML CI dirs (`.github/{workflows,actions}`), **not** `.github/scripts/**` (`.mjs` that ESLint targets), so a scripts change still lints. (dorny `predicate-quantifier: some` → single negation-only rule.)
3. **docs-angular markdown.** Excluded `**/*.md` from the `docs-angular-typecheck.yml` **push** paths (GitHub-native filters are subtractive) so an `AGENTS.md`/README edit no longer triggers the Angular typecheck. (The dorny-side exclusion was reverted — non-subtractive under `some`; flagged by Bugbot.)
4. **`CI Gate` — single merge gate.** A job that **always runs** (so it always reports one stable check name) and `needs:` every other job; it fails if any job that ran failed/was cancelled and passes when everything else succeeded or was scope-skipped. This is the fix for problem B and the `tests-passed` rollup from DEV-2059.

`[skip changelog]` — CI/tooling only.

### Verification
- **Simulated** the real scope filters (dorny OR semantics, picomatch) across workflow-only / action-only / scripts / docs-md / docs-angular / core-src / wrapper change-sets — correct in every case (no over-skip, no over-run).
- **Live:** a workflow-only run skips the entire matrix + lint + scans and runs only the tier-0 gates; **`CI Gate` runs and passes** on that run (proves it reports green when everything is legitimately skipped).
- Bugbot: both findings ("Markdown exclude breaks scope filter" High, "Lint skips CI script changes" Medium) fixed and resolved.

### Required follow-up: branch protection (repo admin)
`CI Gate` only helps once develop requires it. Recommended sequence:
1. **Now (unblocks stuck PRs immediately):** in develop protection, remove every required check that a scope-skipped PR leaves as "Expected — waiting" (all build/test/matrix names). Keep review + the lightweight always-reporting checks.
2. **After this PR merges:** require **only `CI Gate`** (plus `cla/signed`, and `Cursor Bugbot` if desired — those are external, not covered by the gate) and unpin all individual/matrix names. Open PRs merge develop to pick up the gate job.

### Related
- DEV-2057 (trunk/release pipeline unification); the single-rollup requirement is DEV-2059's plan.