### PR TITLE
DEV-2113: Reduce false failures in the docs runner-links sweep

### DIFF
--- a/docs/scripts/__tests__/test-runner-links.test.mjs
+++ b/docs/scripts/__tests__/test-runner-links.test.mjs
@@ -149,6 +149,31 @@ test('planHeadlessChecks checks every Tier-2 link when sample is "all"', () => {
   assert.equal(droppedTier2, 0);
 });
 
+test('planHeadlessChecks skips the first tier2Offset links per framework before sampling', () => {
+  const { matched, manifestByDocsPath } = buildMatched({ vue: 6, angular: 6 });
+
+  // Skip the first 2 per framework, then keep the next 3: the 3rd-5th per framework.
+  const { toCheck, droppedTier2 } = planHeadlessChecks(matched, manifestByDocsPath, 0, 3, 0, 2);
+  const vue = toCheck.filter(item => item.manifestEntry.framework === 'vue').map(item => item.docsPath);
+
+  assert.deepEqual(vue, [
+    'guides/g/vue/example2.vue',
+    'guides/g/vue/example3.vue',
+    'guides/g/vue/example4.vue',
+  ], 'the offset skips example0-1 and the sample keeps the next three');
+  // 6 per framework, 3 kept each -> 3 dropped each (2 skipped by offset + 1 beyond sample).
+  assert.equal(droppedTier2, 6);
+});
+
+test('planHeadlessChecks with an offset and sample "all" keeps every link from the offset on', () => {
+  const { matched, manifestByDocsPath } = buildMatched({ vue: 5 });
+
+  const { toCheck, droppedTier2 } = planHeadlessChecks(matched, manifestByDocsPath, 0, 'all', 0, 2);
+
+  assert.equal(toCheck.length, 3, 'example2-4 remain after skipping example0-1');
+  assert.equal(droppedTier2, 2, 'only the offset-skipped prefix is dropped');
+});
+
 test('parseArgs applies defaults, leaving version null (auto-detected later) and no manifest override', () => {
   const args = parseArgs([]);
 
@@ -159,6 +184,8 @@ test('parseArgs applies defaults, leaving version null (auto-detected later) and
   assert.equal(args.staticOnly, false);
   assert.equal(args.tier1Sample, 'all');
   assert.equal(args.tier2Sample, 10);
+  assert.equal(args.tier1Offset, 0);
+  assert.equal(args.tier2Offset, 0);
   assert.equal(args.tier1Concurrency, 4);
   assert.equal(args.tier2Concurrency, 1);
   assert.equal(args.tier1Retries, 0);
@@ -186,6 +213,8 @@ test('parseArgs reads every flag, including tier1/tier2 samples, concurrency, an
     '--static-only',
     '--tier1-sample', '5',
     '--tier2-sample', 'all',
+    '--tier1-offset', '2',
+    '--tier2-offset', '15',
     '--tier1-concurrency', '8',
     '--tier2-concurrency', '3',
     '--tier1-retries', '2',
@@ -200,6 +229,8 @@ test('parseArgs reads every flag, including tier1/tier2 samples, concurrency, an
   assert.equal(args.staticOnly, true);
   assert.equal(args.tier1Sample, 5);
   assert.equal(args.tier2Sample, 'all');
+  assert.equal(args.tier1Offset, 2);
+  assert.equal(args.tier2Offset, 15);
   assert.equal(args.tier1Concurrency, 8);
   assert.equal(args.tier2Concurrency, 3);
   assert.equal(args.tier1Retries, 2);

--- a/docs/scripts/__tests__/test-runner-links.test.mjs
+++ b/docs/scripts/__tests__/test-runner-links.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { extractRunnerLinks, crossCheckManifest, planHeadlessChecks, parseArgs, deriveManifestBucket, formatTimestamp } from '../test-runner-links.mjs';
+import { extractRunnerLinks, crossCheckManifest, planHeadlessChecks, parseArgs, deriveManifestBucket, formatTimestamp, isIgnoredConsoleMessage, matchesExpectedContent, matchesSetupFailure, interactiveMarkerFor } from '../test-runner-links.mjs';
 
 test('extractRunnerLinks finds a plain-& href with a version', () => {
   const html = '<a href="https://demos.handsontable.com/?docs=guides/foo/example1.js&v=18.0.0">Open</a>';
@@ -177,4 +177,50 @@ test('deriveManifestBucket resolves "next" as-is and drops the patch segment fro
 
 test('deriveManifestBucket maps the staging/dev pre-release stamp to the "next" bucket', () => {
   assert.equal(deriveManifestBucket('0.0.0-next-64139ae-20260219'), 'next');
+});
+
+test('isIgnoredConsoleMessage filters benign infra noise on the first line', () => {
+  assert.equal(isIgnoredConsoleMessage('Failed to load resource: net::ERR_CONNECTION_TIMED_OUT @ https://col.csbops.io/data/sandpack'), true);
+  assert.equal(isIgnoredConsoleMessage('[vite] failed to connect to websocket.'), true);
+  assert.equal(isIgnoredConsoleMessage("WebSocket connection to 'wss://localhost:5173/' failed"), true);
+});
+
+test('isIgnoredConsoleMessage does NOT swallow a real error whose stack points at codesandbox.io', () => {
+  // A genuine SyntaxError/TypeError carries a multi-line stack with codesandbox.io frames;
+  // matching the whole string would hide the exact failures this sweep must catch.
+  const syntaxError = [
+    'SyntaxError: /index.js: Unexpected token (70:17)',
+    '    at J.raise (https://2-19-8-sandpack.codesandbox.io/static/js/babel.6.26.min.js:7:5751)',
+  ].join('\n');
+  const typeError = [
+    "TypeError: Cannot read properties of undefined (reading 'show')",
+    '    at eval (https://2-19-8-sandpack.codesandbox.io/src/App.tsx:145:36)',
+  ].join('\n');
+
+  assert.equal(isIgnoredConsoleMessage(syntaxError), false);
+  assert.equal(isIgnoredConsoleMessage(typeError), false);
+});
+
+test('matchesExpectedContent compares titles case-insensitively', () => {
+  const entry = { guideTitle: 'Cell functions', exampleTitle: 'Standard example' };
+
+  // Runner header title-cases the guide segment; the manifest stores sentence case.
+  assert.equal(matchesExpectedContent('Cell Functions · Standard example', entry), true);
+  assert.equal(matchesExpectedContent('Row hiding · Standard example', entry), false);
+});
+
+test('matchesSetupFailure detects the runner build-failure banner', () => {
+  assert.equal(matchesSetupFailure('Error: Setup failed'), true);
+  assert.equal(matchesSetupFailure('Cell Functions · Standard example'), false);
+});
+
+test('interactiveMarkerFor returns a marker for interactive examples and null otherwise', () => {
+  const marker = interactiveMarkerFor('recipes/import-export/import-csv-excel/javascript/example1.js');
+
+  assert.ok(marker instanceof RegExp);
+  assert.equal(marker.test('Load sample data'), true);
+  // Same interactive example, React variant.
+  assert.ok(interactiveMarkerFor('recipes/import-export/import-csv-excel/react/example1.tsx') instanceof RegExp);
+  // A normal grid-rendering example has no marker.
+  assert.equal(interactiveMarkerFor('guides/rows/row-hiding/javascript/example1.js'), null);
 });

--- a/docs/scripts/__tests__/test-runner-links.test.mjs
+++ b/docs/scripts/__tests__/test-runner-links.test.mjs
@@ -187,7 +187,7 @@ test('parseArgs applies defaults, leaving version null (auto-detected later) and
   assert.equal(args.tier1Offset, 0);
   assert.equal(args.tier2Offset, 0);
   assert.equal(args.tier1Concurrency, 4);
-  assert.equal(args.tier2Concurrency, 1);
+  assert.equal(args.tier2Concurrency, 2);
   assert.equal(args.tier1Retries, 0);
   assert.equal(args.tier2Retries, 1);
   assert.match(args.json, /^\.\/tests\/test-artifacts\/runner-links\/runner-sweep-report-\d{8}-\d{6}\.json$/);

--- a/docs/scripts/__tests__/test-runner-links.test.mjs
+++ b/docs/scripts/__tests__/test-runner-links.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { extractRunnerLinks, crossCheckManifest, planHeadlessChecks, parseArgs, deriveManifestBucket, formatTimestamp, isIgnoredConsoleMessage, matchesExpectedContent, matchesSetupFailure, interactiveMarkerFor } from '../test-runner-links.mjs';
+import { extractRunnerLinks, crossCheckManifest, planHeadlessChecks, parseArgs, deriveManifestBucket, resolveManifestSource, formatTimestamp, isIgnoredConsoleMessage, matchesExpectedContent, matchesSetupFailure, interactiveMarkerFor } from '../test-runner-links.mjs';
 
 test('extractRunnerLinks finds a plain-& href with a version', () => {
   const html = '<a href="https://demos.handsontable.com/?docs=guides/foo/example1.js&v=18.0.0">Open</a>';
@@ -77,57 +77,91 @@ test('crossCheckManifest reports no missing links when every docs path is covere
   assert.equal(missing.length, 0);
 });
 
-test('planHeadlessChecks checks all Tier-1 links and samples Tier-2 per framework', () => {
+/**
+ * Builds a matched-links array + manifest for `counts` per framework, e.g.
+ * { react: 3, vue: 5 }. The docs file extension follows the framework so paths
+ * stay realistic, though only `framework` matters to planHeadlessChecks.
+ */
+function buildMatched(counts) {
+  const ext = { javascript: 'js', typescript: 'ts', react: 'tsx', vue: 'vue', angular: 'ts' };
   const manifestByDocsPath = new Map();
   const matched = [];
 
-  for (let i = 0; i < 3; i++) {
-    const docsPath = `guides/g/react/example${i}.tsx`;
+  for (const [framework, count] of Object.entries(counts)) {
+    for (let i = 0; i < count; i++) {
+      const docsPath = `guides/g/${framework}/example${i}.${ext[framework]}`;
 
-    matched.push({ docsPath, url: docsPath, pages: [] });
-    manifestByDocsPath.set(docsPath, { docsPath, framework: 'react' });
+      matched.push({ docsPath, url: docsPath, pages: [] });
+      manifestByDocsPath.set(docsPath, { docsPath, framework });
+    }
   }
 
-  for (let i = 0; i < 5; i++) {
-    const docsPath = `guides/g/vue/example${i}.vue`;
+  return { matched, manifestByDocsPath };
+}
 
-    matched.push({ docsPath, url: docsPath, pages: [] });
-    manifestByDocsPath.set(docsPath, { docsPath, framework: 'vue' });
-  }
+test('planHeadlessChecks checks all Tier-1 links (sample "all") and samples Tier-2 per framework', () => {
+  const { matched, manifestByDocsPath } = buildMatched({ react: 3, vue: 5 });
 
-  const { toCheck, droppedTier2 } = planHeadlessChecks(matched, manifestByDocsPath, 2);
+  const { toCheck, droppedTier1, droppedTier2 } = planHeadlessChecks(matched, manifestByDocsPath, 'all', 2);
 
   const checkedReact = toCheck.filter(item => item.manifestEntry.framework === 'react');
   const checkedVue = toCheck.filter(item => item.manifestEntry.framework === 'vue');
 
-  assert.equal(checkedReact.length, 3, 'all Tier-1 links are checked');
+  assert.equal(checkedReact.length, 3, 'all Tier-1 links are checked when tier1Sample is "all"');
   assert.equal(checkedVue.length, 2, 'Tier-2 is sampled down to the requested count');
+  assert.equal(droppedTier1, 0);
   assert.equal(droppedTier2, 3, 'the remaining Tier-2 links are reported as dropped, not silently discarded');
 });
 
-test('planHeadlessChecks checks every Tier-2 link when sample is "all"', () => {
-  const manifestByDocsPath = new Map([
-    ['guides/g/angular/example1.ts', { docsPath: 'guides/g/angular/example1.ts', framework: 'angular' }],
-    ['guides/g/angular/example2.ts', { docsPath: 'guides/g/angular/example2.ts', framework: 'angular' }],
-  ]);
-  const matched = [...manifestByDocsPath.keys()].map(docsPath => ({ docsPath, url: docsPath, pages: [] }));
+test('planHeadlessChecks samples Tier-1 per framework and reports droppedTier1', () => {
+  const { matched, manifestByDocsPath } = buildMatched({ javascript: 4, react: 4, vue: 3 });
 
-  const { toCheck, droppedTier2 } = planHeadlessChecks(matched, manifestByDocsPath, 'all');
+  const { toCheck, droppedTier1, droppedTier2 } = planHeadlessChecks(matched, manifestByDocsPath, 2, 'all');
+
+  const checkedJs = toCheck.filter(item => item.manifestEntry.framework === 'javascript');
+  const checkedReact = toCheck.filter(item => item.manifestEntry.framework === 'react');
+  const checkedVue = toCheck.filter(item => item.manifestEntry.framework === 'vue');
+
+  assert.equal(checkedJs.length, 2, 'Tier-1 js is sampled to the requested count per framework');
+  assert.equal(checkedReact.length, 2, 'Tier-1 react is sampled to the requested count per framework');
+  assert.equal(checkedVue.length, 3, 'Tier-2 is untouched by tier1Sample');
+  assert.equal(droppedTier1, 4, 'droppedTier1 sums the per-framework Tier-1 drops (2 js + 2 react)');
+  assert.equal(droppedTier2, 0);
+});
+
+test('planHeadlessChecks with sample 0 skips a whole tier', () => {
+  const { matched, manifestByDocsPath } = buildMatched({ react: 3, vue: 4 });
+
+  const { toCheck, droppedTier1, droppedTier2 } = planHeadlessChecks(matched, manifestByDocsPath, 0, 'all');
+
+  assert.equal(toCheck.every(item => item.manifestEntry.framework === 'vue'), true, 'Tier-1 is skipped entirely');
+  assert.equal(toCheck.length, 4);
+  assert.equal(droppedTier1, 3, 'all Tier-1 links are reported dropped');
+  assert.equal(droppedTier2, 0);
+});
+
+test('planHeadlessChecks checks every Tier-2 link when sample is "all"', () => {
+  const { matched, manifestByDocsPath } = buildMatched({ angular: 2 });
+
+  const { toCheck, droppedTier2 } = planHeadlessChecks(matched, manifestByDocsPath, 'all', 'all');
 
   assert.equal(toCheck.length, 2);
   assert.equal(droppedTier2, 0);
 });
 
-test('parseArgs applies defaults, defaulting version to "next" and deriving the bucketed manifest URL', () => {
+test('parseArgs applies defaults, leaving version null (auto-detected later) and no manifest override', () => {
   const args = parseArgs([]);
 
   assert.equal(args.dist, './dist');
   assert.equal(args.runnerOrigin, 'https://demos.handsontable.com');
-  assert.equal(args.version, 'next');
-  assert.equal(args.manifest, 'https://demos.handsontable.com/docs-examples/next/manifest.json');
+  assert.equal(args.version, null);
+  assert.equal(args.manifest, undefined, 'the --manifest override no longer exists');
   assert.equal(args.staticOnly, false);
+  assert.equal(args.tier1Sample, 'all');
   assert.equal(args.tier2Sample, 10);
-  assert.equal(args.concurrency, 4);
+  assert.equal(args.tier1Concurrency, 4);
+  assert.equal(args.tier1Retries, 0);
+  assert.equal(args.tier2Retries, 1);
   assert.match(args.json, /^\.\/tests\/test-artifacts\/runner-links\/runner-sweep-report-\d{8}-\d{6}\.json$/);
 });
 
@@ -137,22 +171,23 @@ test('formatTimestamp renders YYYYMMDD-HHmmss', () => {
   assert.equal(formatTimestamp(date), '20260720-090503');
 });
 
-test('parseArgs derives the manifest bucket from a --version override', () => {
+test('parseArgs records an explicit --version override', () => {
   const args = parseArgs(['--version', '18.0.0']);
 
   assert.equal(args.version, '18.0.0');
-  assert.equal(args.manifest, 'https://demos.handsontable.com/docs-examples/18.0/manifest.json');
 });
 
-test('parseArgs reads flags, including a custom manifest override and tier2Sample=all', () => {
+test('parseArgs reads every flag, including tier1/tier2 samples, concurrency, and retries', () => {
   const args = parseArgs([
     '--dist', './build',
     '--runner-origin', 'https://runner.example.com',
     '--version', '18.0.0',
-    '--manifest', './local-manifest.json',
     '--static-only',
+    '--tier1-sample', '5',
     '--tier2-sample', 'all',
-    '--concurrency', '8',
+    '--tier1-concurrency', '8',
+    '--tier1-retries', '2',
+    '--tier2-retries', '3',
     '--filter', 'column-adding',
     '--json', './out/report.json',
   ]);
@@ -160,11 +195,12 @@ test('parseArgs reads flags, including a custom manifest override and tier2Sampl
   assert.equal(args.dist, './build');
   assert.equal(args.runnerOrigin, 'https://runner.example.com');
   assert.equal(args.version, '18.0.0');
-  // --manifest wins over the derived bucket URL when explicitly passed.
-  assert.equal(args.manifest, './local-manifest.json');
   assert.equal(args.staticOnly, true);
+  assert.equal(args.tier1Sample, 5);
   assert.equal(args.tier2Sample, 'all');
-  assert.equal(args.concurrency, 8);
+  assert.equal(args.tier1Concurrency, 8);
+  assert.equal(args.tier1Retries, 2);
+  assert.equal(args.tier2Retries, 3);
   assert.equal(args.filter, 'column-adding');
   assert.equal(args.json, './out/report.json');
 });
@@ -177,6 +213,51 @@ test('deriveManifestBucket resolves "next" as-is and drops the patch segment fro
 
 test('deriveManifestBucket maps the staging/dev pre-release stamp to the "next" bucket', () => {
   assert.equal(deriveManifestBucket('0.0.0-next-64139ae-20260219'), 'next');
+});
+
+test('resolveManifestSource auto-detects the version stamped into the links', () => {
+  const links = new Map([
+    ['guides/a/example1.js', { version: '18.0.0' }],
+    ['guides/b/example1.tsx', { version: '18.0.0' }],
+  ]);
+
+  const resolved = resolveManifestSource({ explicitVersion: null, runnerOrigin: 'https://demos.handsontable.com', links });
+
+  assert.equal(resolved.version, '18.0.0');
+  assert.equal(resolved.bucket, '18.0');
+  assert.equal(resolved.source, 'auto-detected from links');
+  assert.equal(resolved.url, 'https://demos.handsontable.com/docs-examples/18.0/manifest.json');
+});
+
+test('resolveManifestSource lets an explicit --version override the links', () => {
+  const links = new Map([['guides/a/example1.js', { version: '18.0.0' }]]);
+
+  const resolved = resolveManifestSource({ explicitVersion: '17.0.5', runnerOrigin: 'https://demos.handsontable.com', links });
+
+  assert.equal(resolved.version, '17.0.5');
+  assert.equal(resolved.bucket, '17.0');
+  assert.equal(resolved.source, 'from --version override');
+  assert.equal(resolved.url, 'https://demos.handsontable.com/docs-examples/17.0/manifest.json');
+});
+
+test('resolveManifestSource falls back to the "next" bucket when no link carries a version', () => {
+  const links = new Map([['guides/a/example1.js', { version: null }]]);
+
+  const resolved = resolveManifestSource({ explicitVersion: null, runnerOrigin: 'https://demos.handsontable.com', links });
+
+  assert.equal(resolved.version, 'next');
+  assert.equal(resolved.bucket, 'next');
+  assert.equal(resolved.source, 'default "next" (links carry no version)');
+  assert.equal(resolved.url, 'https://demos.handsontable.com/docs-examples/next/manifest.json');
+});
+
+test('resolveManifestSource maps the dev pre-release link stamp to the "next" bucket', () => {
+  const links = new Map([['guides/a/example1.js', { version: '0.0.0-next-64139ae-20260219' }]]);
+
+  const resolved = resolveManifestSource({ explicitVersion: null, runnerOrigin: 'https://demos.handsontable.com', links });
+
+  assert.equal(resolved.bucket, 'next');
+  assert.equal(resolved.source, 'auto-detected from links');
 });
 
 test('isIgnoredConsoleMessage filters benign infra noise on the first line', () => {

--- a/docs/scripts/__tests__/test-runner-links.test.mjs
+++ b/docs/scripts/__tests__/test-runner-links.test.mjs
@@ -160,6 +160,7 @@ test('parseArgs applies defaults, leaving version null (auto-detected later) and
   assert.equal(args.tier1Sample, 'all');
   assert.equal(args.tier2Sample, 10);
   assert.equal(args.tier1Concurrency, 4);
+  assert.equal(args.tier2Concurrency, 1);
   assert.equal(args.tier1Retries, 0);
   assert.equal(args.tier2Retries, 1);
   assert.match(args.json, /^\.\/tests\/test-artifacts\/runner-links\/runner-sweep-report-\d{8}-\d{6}\.json$/);
@@ -186,6 +187,7 @@ test('parseArgs reads every flag, including tier1/tier2 samples, concurrency, an
     '--tier1-sample', '5',
     '--tier2-sample', 'all',
     '--tier1-concurrency', '8',
+    '--tier2-concurrency', '3',
     '--tier1-retries', '2',
     '--tier2-retries', '3',
     '--filter', 'column-adding',
@@ -199,6 +201,7 @@ test('parseArgs reads every flag, including tier1/tier2 samples, concurrency, an
   assert.equal(args.tier1Sample, 5);
   assert.equal(args.tier2Sample, 'all');
   assert.equal(args.tier1Concurrency, 8);
+  assert.equal(args.tier2Concurrency, 3);
   assert.equal(args.tier1Retries, 2);
   assert.equal(args.tier2Retries, 3);
   assert.equal(args.filter, 'column-adding');

--- a/docs/scripts/test-runner-links.mjs
+++ b/docs/scripts/test-runner-links.mjs
@@ -506,11 +506,17 @@ async function verifyLink(browser, docsPath, link, manifestEntry, progress) {
 
     return finish(null);
   } finally {
-    // Navigating away fires pagehide, which makes the runner app tear down its
-    // Tier-2 container session (DELETE /api/session/:id, keepalive fetch) —
-    // page.close() alone does not reliably fire pagehide, and a leaked session
-    // squats one of the 5 prod container slots until the idle timeout.
+    // Navigate away so the old document fires pagehide, which makes the runner
+    // tear down its Tier-2 container session (a keepalive DELETE /api/session/:id);
+    // page.close() alone does not reliably fire pagehide. Then, for tier-2 only,
+    // settle briefly BEFORE closing the page: closing it immediately drops the
+    // still-in-flight keepalive DELETE, so the session leaks and squats one of the
+    // 5 prod container slots until its idle timeout (verified against the live
+    // runner — an immediate close leaves the session alive 15s+, a ~1s settle
+    // tears it down, HTTP 410). Tier-1 uses Sandpack and has no such container
+    // session, so it needs no settle (avoids adding a second to every tier-1 page).
     await page.goto('about:blank', { timeout: 5000 }).catch(() => {});
+    if (TIER2_FRAMEWORKS.has(manifestEntry.framework)) await page.waitForTimeout(1000);
     await page.close();
   }
 }
@@ -741,9 +747,6 @@ async function main(argv) {
       loaded = tier1Items.length + tier2Items.length;
       failures.push(...[...tier1Results, ...tier2Results].filter(Boolean));
     } finally {
-      // Give the last page's keepalive DELETE a moment to leave the wire before
-      // the browser process is torn down.
-      await new Promise(r => setTimeout(r, 1000));
       await browser.close();
     }
   }

--- a/docs/scripts/test-runner-links.mjs
+++ b/docs/scripts/test-runner-links.mjs
@@ -12,6 +12,12 @@
 //    own guideTitle + exampleTitle from the manifest — a guard against the runner
 //    loading a different example than the link intended.
 //
+// Run this AFTER building the docs: it scans the built HTML under --dist (default
+// ./dist) and fails loudly if that directory is absent. The build stamps the
+// Handsontable version into every runner link, and the sweep auto-detects that
+// version to pick the matching manifest bucket — so no --version flag is needed for
+// a normal run.
+//
 // Usage: node scripts/test-runner-links.mjs [options] — see --help for the full option list.
 
 import { readdir, readFile, mkdir, writeFile } from 'node:fs/promises';
@@ -40,21 +46,31 @@ export function formatTimestamp(date) {
 
 const HELP_TEXT = `Usage: node scripts/test-runner-links.mjs [options]
 
-  --dist <dir>            built-HTML dir to scan (default: ./dist)
-  --runner-origin <url>   runner origin (default: https://demos.handsontable.com)
-  --version <ver>         Handsontable version the dist was built with — resolves to a
-                           docs-examples bucket ("next", or "X.Y"/"X.Y.Z" -> "X.Y")
-                           (default: next — matches local/staging builds)
-  --manifest <url|path>   manifest override, bypasses --version bucket derivation
-                           (default: <runner-origin>/docs-examples/<bucket>/manifest.json)
-  --static-only           skip the headless phase — link extraction + manifest cross-check only
-  --tier2-sample <N|all>  how many Vue/Angular links to headless-check per framework (default: 10)
-  --concurrency <N>       parallel Tier-1 pages; Tier-2 (vue/angular) always runs serially
-                           to avoid cloud-container contention, retrying transient
-                           failures once (default: 4)
-  --filter <substring>    only check docs paths containing this substring
-  --json <path>           report output path (default: ./tests/test-artifacts/runner-links/runner-sweep-report-<timestamp>.json)
-  --help                  print this message and exit`;
+  Run after building the docs — the sweep scans the built HTML under --dist.
+
+  --dist <dir>              built-HTML dir to scan (default: ./dist)
+  --runner-origin <url>     runner origin (default: https://demos.handsontable.com)
+  --version <ver>           OVERRIDE the manifest bucket. Normally unneeded: the sweep
+                             auto-detects the version the docs were built with from the
+                             runner links themselves. Pass this only to force a bucket
+                             ("next", or "X.Y"/"X.Y.Z" -> "X.Y"), e.g. when the links
+                             carry no version. Does NOT affect the docs build.
+  --static-only             skip ALL headless rendering (Tier-1 and Tier-2) — do only link
+                             extraction + manifest cross-check. Never launches a browser, so
+                             it runs even without Playwright's Chromium installed.
+  --tier1-sample <N|all>    how many JS/TS/React links to headless-check per framework;
+                             0 skips Tier-1 entirely (default: all)
+  --tier2-sample <N|all>    how many Vue/Angular links to headless-check per framework;
+                             0 skips Tier-2 entirely (default: 10)
+  --tier1-concurrency <N>   parallel Tier-1 pages. Does NOT affect Tier-2, which always
+                             runs serially to avoid cloud-container contention (default: 4)
+  --tier1-retries <N>       retry a transient Tier-1 failure (no-grid/load-timeout) up to
+                             N times (default: 0 — Tier-1 sandboxes are cheap and reliable)
+  --tier2-retries <N>       retry a transient Tier-2 failure up to N times (default: 1 —
+                             a cloud container sometimes fails to provision under load)
+  --filter <substring>      only check docs paths containing this substring
+  --json <path>             report output path (default: ./tests/test-artifacts/runner-links/runner-sweep-report-<timestamp>.json)
+  --help                    print this message and exit`;
 
 const TIER1_FRAMEWORKS = new Set(['javascript', 'typescript', 'react']);
 const TIER2_FRAMEWORKS = new Set(['vue', 'angular']);
@@ -65,10 +81,11 @@ const TIER_TIMEOUTS_MS = { javascript: 60_000, typescript: 60_000, react: 60_000
 
 // A tier-2 cloud container sometimes fails to provision under load — a transient
 // no-grid/load-timeout rather than a broken example (the same link boots fine when
-// run alone). Retry these phases once before recording a failure. Tier-1 is excluded:
-// its sandboxes are cheap and reliable, and it has hundreds of links to re-run.
+// run alone). Only these phases are retried; a `setup-failed` (build/transpile error)
+// is deterministic and never retried. How many times each tier retries is set per run
+// via --tier1-retries / --tier2-retries (tier-1 defaults to 0 — its sandboxes are cheap
+// and reliable and it has hundreds of links; tier-2 defaults to 1).
 const RETRYABLE_PHASES = new Set(['no-grid', 'load-timeout']);
-const TIER2_RETRIES = 1;
 
 // Some examples build their grid only after a user action (drop a file, click a
 // button), so no `.ht_master .htCore` exists at load and the plain grid check
@@ -187,6 +204,31 @@ export function deriveManifestBucket(version) {
   const match = String(version).match(/^(\d+)\.(\d+)/);
 
   return match ? `${match[1]}.${match[2]}` : version;
+}
+
+/**
+ * Resolves which manifest to cross-check against. The version is taken from,
+ * in priority order: an explicit --version override, the version the docs build
+ * stamped into the runner links (framework-loader emits `v=<CURRENT_DOCS_VERSION>`
+ * on every link — see docs/src/plugins/framework-loader.mjs), or the literal
+ * "next" when links carry no version at all. The manifest URL is always derived
+ * from the runner origin and the version's bucket — there is no separate manifest
+ * flag to keep in sync.
+ *
+ * @param {{ explicitVersion: string | null, runnerOrigin: string, links: Map<string, { version: string | null }> }} params
+ * @returns {{ version: string, bucket: string, source: string, url: string }}
+ */
+export function resolveManifestSource({ explicitVersion, runnerOrigin, links }) {
+  const versionFromLinks = [...links.values()].find(link => link.version)?.version ?? null;
+  const version = explicitVersion ?? versionFromLinks ?? 'next';
+  const source = explicitVersion
+    ? 'from --version override'
+    : versionFromLinks
+      ? 'auto-detected from links'
+      : 'default "next" (links carry no version)';
+  const bucket = deriveManifestBucket(version);
+
+  return { version, bucket, source, url: `${runnerOrigin}/docs-examples/${bucket}/manifest.json` };
 }
 
 /**
@@ -488,44 +530,64 @@ async function runPool(items, limit, worker) {
 }
 
 /**
- * Splits manifest-matched links into Tier-1 (checked exhaustively) and a
- * deterministic per-framework sample of Tier-2 (slow cloud-container boots).
+ * Deterministically samples per-framework buckets down to `sample` links each.
+ * `'all'` keeps every link; `0` drops every link (skips the whole group); a
+ * positive N keeps the first N per framework after a stable docsPath sort.
+ *
+ * @param {Map<string, object[]>} byFramework
+ * @param {number | 'all'} sample
+ * @returns {{ kept: object[], dropped: number }}
+ */
+function sampleByFramework(byFramework, sample) {
+  let dropped = 0;
+  const kept = [];
+
+  for (const bucket of byFramework.values()) {
+    bucket.sort((a, b) => a.docsPath.localeCompare(b.docsPath));
+
+    const sampled = sample === 'all' ? bucket : bucket.slice(0, sample);
+
+    dropped += bucket.length - sampled.length;
+    kept.push(...sampled);
+  }
+
+  return { kept, dropped };
+}
+
+/**
+ * Splits manifest-matched links into a deterministic per-framework sample of
+ * Tier-1 (fast JS/TS/React sandboxes) and Tier-2 (slow Vue/Angular cloud-container
+ * boots). Each tier samples independently: `'all'` checks every link, `0` skips the
+ * tier entirely, and a positive N keeps the first N links per framework.
  *
  * @param {{ docsPath: string, url: string, pages: string[] }[]} matched
  * @param {Map<string, object>} manifestByDocsPath
+ * @param {number | 'all'} tier1Sample
  * @param {number | 'all'} tier2Sample
- * @returns {{ toCheck: object[], droppedTier2: number }}
+ * @returns {{ toCheck: object[], droppedTier1: number, droppedTier2: number }}
  */
-export function planHeadlessChecks(matched, manifestByDocsPath, tier2Sample) {
-  const tier1 = [];
+export function planHeadlessChecks(matched, manifestByDocsPath, tier1Sample, tier2Sample) {
+  const tier1ByFramework = new Map();
   const tier2ByFramework = new Map();
 
   for (const item of matched) {
     const manifestEntry = manifestByDocsPath.get(item.docsPath);
+    const target = TIER1_FRAMEWORKS.has(manifestEntry.framework) ? tier1ByFramework
+      : TIER2_FRAMEWORKS.has(manifestEntry.framework) ? tier2ByFramework
+        : null;
 
-    if (TIER1_FRAMEWORKS.has(manifestEntry.framework)) {
-      tier1.push({ ...item, manifestEntry });
-    } else if (TIER2_FRAMEWORKS.has(manifestEntry.framework)) {
-      const bucket = tier2ByFramework.get(manifestEntry.framework) ?? [];
+    if (!target) continue;
 
-      bucket.push({ ...item, manifestEntry });
-      tier2ByFramework.set(manifestEntry.framework, bucket);
-    }
+    const bucket = target.get(manifestEntry.framework) ?? [];
+
+    bucket.push({ ...item, manifestEntry });
+    target.set(manifestEntry.framework, bucket);
   }
 
-  let droppedTier2 = 0;
-  const tier2 = [];
+  const tier1 = sampleByFramework(tier1ByFramework, tier1Sample);
+  const tier2 = sampleByFramework(tier2ByFramework, tier2Sample);
 
-  for (const bucket of tier2ByFramework.values()) {
-    bucket.sort((a, b) => a.docsPath.localeCompare(b.docsPath));
-
-    const sampled = tier2Sample === 'all' ? bucket : bucket.slice(0, tier2Sample);
-
-    droppedTier2 += bucket.length - sampled.length;
-    tier2.push(...sampled);
-  }
-
-  return { toCheck: [...tier1, ...tier2], droppedTier2 };
+  return { toCheck: [...tier1.kept, ...tier2.kept], droppedTier1: tier1.dropped, droppedTier2: tier2.dropped };
 }
 
 /**
@@ -536,11 +598,15 @@ export function parseArgs(argv) {
   const args = {
     dist: './dist',
     runnerOrigin: 'https://demos.handsontable.com',
-    version: 'next',
-    manifest: null,
+    // null = no override; the manifest bucket is auto-detected from the links
+    // (resolveManifestSource). An explicit --version forces the bucket instead.
+    version: null,
     staticOnly: false,
+    tier1Sample: 'all',
     tier2Sample: 10,
-    concurrency: 4,
+    tier1Concurrency: 4,
+    tier1Retries: 0,
+    tier2Retries: 1,
     filter: null,
     json: `./tests/test-artifacts/runner-links/runner-sweep-report-${formatTimestamp(new Date())}.json`,
     help: false,
@@ -553,25 +619,27 @@ export function parseArgs(argv) {
     if (arg === '--dist') args.dist = next();
     else if (arg === '--runner-origin') args.runnerOrigin = next();
     else if (arg === '--version') args.version = next();
-    else if (arg === '--manifest') args.manifest = next();
     else if (arg === '--static-only') args.staticOnly = true;
+    else if (arg === '--tier1-sample') { const v = next(); args.tier1Sample = v === 'all' ? 'all' : Number(v); }
     else if (arg === '--tier2-sample') { const v = next(); args.tier2Sample = v === 'all' ? 'all' : Number(v); }
-    else if (arg === '--concurrency') args.concurrency = Number(next());
+    else if (arg === '--tier1-concurrency') args.tier1Concurrency = Number(next());
+    else if (arg === '--tier1-retries') args.tier1Retries = Number(next());
+    else if (arg === '--tier2-retries') args.tier2Retries = Number(next());
     else if (arg === '--filter') args.filter = next();
     else if (arg === '--json') args.json = next();
     else if (arg === '--help' || arg === '-h') args.help = true;
   }
-
-  if (!args.manifest) args.manifest = `${args.runnerOrigin}/docs-examples/${deriveManifestBucket(args.version)}/manifest.json`;
 
   return args;
 }
 
 /**
  * Runs verifyLink, retrying up to `retries` times while the result is a
- * retryable transient (a tier-2 container that failed to provision under load).
- * verifyLink logs its own start/finish line per attempt, so a retry is visible
- * in the output as a repeated load of the same docs path.
+ * retryable transient (a no-grid/load-timeout — e.g. a cloud container that
+ * failed to provision under load). Used by both tiers; `retries` is 0 for
+ * tier-1 by default (single attempt) and 1 for tier-2. verifyLink logs its own
+ * start/finish line per attempt, so a retry is visible in the output as a
+ * repeated load of the same docs path.
  *
  * @param {import('@playwright/test').Browser} browser
  * @param {{ docsPath: string, manifestEntry: object }} item
@@ -600,7 +668,7 @@ async function main(argv) {
   }
 
   console.log(
-    `Settings: dist=${args.dist} version=${args.version} static-only=${args.staticOnly} tier2-sample=${args.tier2Sample} concurrency=${args.concurrency}${args.filter ? ` filter="${args.filter}"` : ''} (run with --help to see all options)`
+    `Settings: dist=${args.dist} static-only=${args.staticOnly} tier1-sample=${args.tier1Sample} tier2-sample=${args.tier2Sample} tier1-concurrency=${args.tier1Concurrency} tier1-retries=${args.tier1Retries} tier2-retries=${args.tier2Retries}${args.filter ? ` filter="${args.filter}"` : ''} (run with --help to see all options)`
   );
 
   console.log(`Walking ${args.dist} for runner links...`);
@@ -611,8 +679,13 @@ async function main(argv) {
 
   console.log(`Found ${links.size} distinct runner link(s)${args.filter ? ` matching "${args.filter}"` : ''} (${allLinks.size} total).`);
 
-  console.log(`Fetching manifest from ${args.manifest}...`);
-  const manifestByDocsPath = await fetchManifest(args.manifest);
+  // Detect the version from the links the build stamped, so the manifest bucket
+  // matches the dist under test without a hand-passed --version.
+  const manifest = resolveManifestSource({ explicitVersion: args.version, runnerOrigin: args.runnerOrigin, links: allLinks });
+
+  console.log(`Version: ${manifest.version} (${manifest.source}) -> bucket ${manifest.bucket}`);
+  console.log(`Fetching manifest from ${manifest.url}...`);
+  const manifestByDocsPath = await fetchManifest(manifest.url);
   const { missing, reverseDiffCount } = crossCheckManifest(links, manifestByDocsPath);
 
   console.log(`Manifest cross-check: ${missing.length} missing, ${reverseDiffCount} manifest-only path(s) (expected, informational).`);
@@ -621,13 +694,17 @@ async function main(argv) {
 
   const matched = [...links].filter(([docsPath]) => manifestByDocsPath.has(docsPath)).map(([docsPath, link]) => ({ docsPath, ...link }));
   let loaded = 0;
+  let droppedTier1 = 0;
   let droppedTier2 = 0;
 
   if (!args.staticOnly) {
-    const { toCheck, droppedTier2: dropped } = planHeadlessChecks(matched, manifestByDocsPath, args.tier2Sample);
+    const plan = planHeadlessChecks(matched, manifestByDocsPath, args.tier1Sample, args.tier2Sample);
+    const { toCheck } = plan;
 
-    droppedTier2 = dropped;
-    if (droppedTier2 > 0) console.log(`Sampling Tier-2 (vue/angular): checking ${toCheck.length}, skipping ${droppedTier2} (use --tier2-sample all to check every one).`);
+    droppedTier1 = plan.droppedTier1;
+    droppedTier2 = plan.droppedTier2;
+    if (droppedTier1 > 0) console.log(`Sampling Tier-1 (js/ts/react): skipping ${droppedTier1} (use --tier1-sample all to check every one).`);
+    if (droppedTier2 > 0) console.log(`Sampling Tier-2 (vue/angular): skipping ${droppedTier2} (use --tier2-sample all to check every one).`);
 
     const browser = await chromium.launch({ headless: true });
 
@@ -641,10 +718,10 @@ async function main(argv) {
       // links boot fine in isolation, so tier-2 is given the machine to itself.
       const tier2Concurrency = 1;
 
-      console.log(`Checking ${tier1Items.length} Tier-1 link(s) (concurrency ${args.concurrency}), then ${tier2Items.length} Tier-2 link(s) (serial, isolated, retry ${TIER2_RETRIES}x on transient failures)...`);
+      console.log(`Checking ${tier1Items.length} Tier-1 link(s) (concurrency ${args.tier1Concurrency}, retry ${args.tier1Retries}x), then ${tier2Items.length} Tier-2 link(s) (serial, isolated, retry ${args.tier2Retries}x)...`);
 
-      const tier1Results = await runPool(tier1Items, args.concurrency, (item, i) => verifyLink(browser, item.docsPath, item, item.manifestEntry, { label: 'tier1', index: i + 1, total: tier1Items.length }));
-      const tier2Results = await runPool(tier2Items, tier2Concurrency, (item, i) => verifyWithRetry(browser, item, { label: 'tier2', index: i + 1, total: tier2Items.length }, TIER2_RETRIES));
+      const tier1Results = await runPool(tier1Items, args.tier1Concurrency, (item, i) => verifyWithRetry(browser, item, { label: 'tier1', index: i + 1, total: tier1Items.length }, args.tier1Retries));
+      const tier2Results = await runPool(tier2Items, tier2Concurrency, (item, i) => verifyWithRetry(browser, item, { label: 'tier2', index: i + 1, total: tier2Items.length }, args.tier2Retries));
 
       loaded = tier1Items.length + tier2Items.length;
       failures.push(...[...tier1Results, ...tier2Results].filter(Boolean));
@@ -656,6 +733,8 @@ async function main(argv) {
   const report = {
     generatedAt: new Date().toISOString(),
     runnerOrigin: args.runnerOrigin,
+    version: manifest.version,
+    manifestUrl: manifest.url,
     distDir: args.dist,
     totals: {
       extracted: links.size,
@@ -663,7 +742,7 @@ async function main(argv) {
       loaded,
       passed: loaded - failures.filter(f => f.phase !== 'manifest').length,
       failed: failures.length,
-      tier2Sampled: args.staticOnly ? 0 : loaded,
+      tier1Dropped: droppedTier1,
       tier2Dropped: droppedTier2,
     },
     failures,
@@ -685,7 +764,9 @@ async function main(argv) {
   console.log('Summary:');
   console.log(`  Runner links found:   ${report.totals.extracted}`);
   console.log(`  Manifest cross-check: ${report.totals.extracted - report.totals.manifestMissing} present, ${report.totals.manifestMissing} missing`);
-  console.log(`  Headless render:      ${report.totals.passed} passed, ${headlessFailed} failed (of ${loaded} checked)${droppedTier2 ? `, ${droppedTier2} tier-2 skipped` : ''}`);
+  const skipped = [droppedTier1 ? `${droppedTier1} tier-1` : null, droppedTier2 ? `${droppedTier2} tier-2` : null].filter(Boolean).join(', ');
+
+  console.log(`  Headless render:      ${report.totals.passed} passed, ${headlessFailed} failed (of ${loaded} checked)${skipped ? `, ${skipped} skipped` : ''}`);
   console.log(`  Total failures:       ${report.totals.failed}`);
 
   console.log(`Report written to ${args.json}. ${report.totals.failed} failure(s).`);

--- a/docs/scripts/test-runner-links.mjs
+++ b/docs/scripts/test-runner-links.mjs
@@ -62,6 +62,12 @@ const HELP_TEXT = `Usage: node scripts/test-runner-links.mjs [options]
                              0 skips Tier-1 entirely (default: all)
   --tier2-sample <N|all>    how many Vue/Angular links to headless-check per framework;
                              0 skips Tier-2 entirely (default: 10)
+  --tier1-offset <N>        skip the first N JS/TS/React links per framework before
+                             sampling (default: 0)
+  --tier2-offset <N>        skip the first N Vue/Angular links per framework before
+                             sampling -- resume past links already checked, e.g.
+                             --tier2-offset 15 --tier2-sample 35 checks the 16th-50th
+                             per framework (default: 0)
   --tier1-concurrency <N>   parallel Tier-1 pages (default: 4)
   --tier2-concurrency <N>   parallel Tier-2 pages. Kept at 1 by default: a Vue/Angular cloud
                              dev-server container needs ~1 min to cold-boot, booting several
@@ -548,22 +554,29 @@ async function runPool(items, limit, worker) {
 }
 
 /**
- * Deterministically samples per-framework buckets down to `sample` links each.
- * `'all'` keeps every link; `0` drops every link (skips the whole group); a
- * positive N keeps the first N per framework after a stable docsPath sort.
+ * Deterministically samples per-framework buckets down to `sample` links each,
+ * after skipping the first `offset` per framework. `'all'` keeps every link
+ * (from `offset` on); `0` drops every link (skips the whole group); a positive N
+ * keeps N per framework after a stable docsPath sort. `offset` lets a run resume
+ * past links already checked in a previous run (e.g. `--tier2-offset 15
+ * --tier2-sample 35` checks the 16th-50th per framework). Anything not kept --
+ * both the offset-skipped prefix and links beyond the sample -- counts as
+ * dropped.
  *
  * @param {Map<string, object[]>} byFramework
  * @param {number | 'all'} sample
+ * @param {number} [offset]
  * @returns {{ kept: object[], dropped: number }}
  */
-function sampleByFramework(byFramework, sample) {
+function sampleByFramework(byFramework, sample, offset = 0) {
   let dropped = 0;
   const kept = [];
 
   for (const bucket of byFramework.values()) {
     bucket.sort((a, b) => a.docsPath.localeCompare(b.docsPath));
 
-    const sampled = sample === 'all' ? bucket : bucket.slice(0, sample);
+    const afterOffset = bucket.slice(offset);
+    const sampled = sample === 'all' ? afterOffset : afterOffset.slice(0, sample);
 
     dropped += bucket.length - sampled.length;
     kept.push(...sampled);
@@ -582,9 +595,11 @@ function sampleByFramework(byFramework, sample) {
  * @param {Map<string, object>} manifestByDocsPath
  * @param {number | 'all'} tier1Sample
  * @param {number | 'all'} tier2Sample
+ * @param {number} [tier1Offset] - skip this many per framework before sampling Tier-1
+ * @param {number} [tier2Offset] - skip this many per framework before sampling Tier-2
  * @returns {{ toCheck: object[], droppedTier1: number, droppedTier2: number }}
  */
-export function planHeadlessChecks(matched, manifestByDocsPath, tier1Sample, tier2Sample) {
+export function planHeadlessChecks(matched, manifestByDocsPath, tier1Sample, tier2Sample, tier1Offset = 0, tier2Offset = 0) {
   const tier1ByFramework = new Map();
   const tier2ByFramework = new Map();
 
@@ -602,8 +617,8 @@ export function planHeadlessChecks(matched, manifestByDocsPath, tier1Sample, tie
     target.set(manifestEntry.framework, bucket);
   }
 
-  const tier1 = sampleByFramework(tier1ByFramework, tier1Sample);
-  const tier2 = sampleByFramework(tier2ByFramework, tier2Sample);
+  const tier1 = sampleByFramework(tier1ByFramework, tier1Sample, tier1Offset);
+  const tier2 = sampleByFramework(tier2ByFramework, tier2Sample, tier2Offset);
 
   return { toCheck: [...tier1.kept, ...tier2.kept], droppedTier1: tier1.dropped, droppedTier2: tier2.dropped };
 }
@@ -622,6 +637,8 @@ export function parseArgs(argv) {
     staticOnly: false,
     tier1Sample: 'all',
     tier2Sample: 10,
+    tier1Offset: 0,
+    tier2Offset: 0,
     tier1Concurrency: 4,
     tier2Concurrency: 1,
     tier1Retries: 0,
@@ -641,6 +658,8 @@ export function parseArgs(argv) {
     else if (arg === '--static-only') args.staticOnly = true;
     else if (arg === '--tier1-sample') { const v = next(); args.tier1Sample = v === 'all' ? 'all' : Number(v); }
     else if (arg === '--tier2-sample') { const v = next(); args.tier2Sample = v === 'all' ? 'all' : Number(v); }
+    else if (arg === '--tier1-offset') args.tier1Offset = Number(next());
+    else if (arg === '--tier2-offset') args.tier2Offset = Number(next());
     else if (arg === '--tier1-concurrency') args.tier1Concurrency = Number(next());
     else if (arg === '--tier2-concurrency') args.tier2Concurrency = Number(next());
     else if (arg === '--tier1-retries') args.tier1Retries = Number(next());
@@ -688,7 +707,7 @@ async function main(argv) {
   }
 
   console.log(
-    `Settings: dist=${args.dist} static-only=${args.staticOnly} tier1-sample=${args.tier1Sample} tier2-sample=${args.tier2Sample} tier1-concurrency=${args.tier1Concurrency} tier2-concurrency=${args.tier2Concurrency} tier1-retries=${args.tier1Retries} tier2-retries=${args.tier2Retries}${args.filter ? ` filter="${args.filter}"` : ''} (run with --help to see all options)`
+    `Settings: dist=${args.dist} static-only=${args.staticOnly} tier1-sample=${args.tier1Sample} tier2-sample=${args.tier2Sample} tier1-offset=${args.tier1Offset} tier2-offset=${args.tier2Offset} tier1-concurrency=${args.tier1Concurrency} tier2-concurrency=${args.tier2Concurrency} tier1-retries=${args.tier1Retries} tier2-retries=${args.tier2Retries}${args.filter ? ` filter="${args.filter}"` : ''} (run with --help to see all options)`
   );
 
   console.log(`Walking ${args.dist} for runner links...`);
@@ -718,7 +737,7 @@ async function main(argv) {
   let droppedTier2 = 0;
 
   if (!args.staticOnly) {
-    const plan = planHeadlessChecks(matched, manifestByDocsPath, args.tier1Sample, args.tier2Sample);
+    const plan = planHeadlessChecks(matched, manifestByDocsPath, args.tier1Sample, args.tier2Sample, args.tier1Offset, args.tier2Offset);
     const { toCheck } = plan;
 
     droppedTier1 = plan.droppedTier1;

--- a/docs/scripts/test-runner-links.mjs
+++ b/docs/scripts/test-runner-links.mjs
@@ -69,10 +69,7 @@ const HELP_TEXT = `Usage: node scripts/test-runner-links.mjs [options]
                              --tier2-offset 15 --tier2-sample 35 checks the 16th-50th
                              per framework (default: 0)
   --tier1-concurrency <N>   parallel Tier-1 pages (default: 4)
-  --tier2-concurrency <N>   parallel Tier-2 pages. Kept at 1 by default: a Vue/Angular cloud
-                             dev-server container needs ~1 min to cold-boot, booting several
-                             at once can starve each past the timeout, and prod caps
-                             concurrent containers at 5 (default: 1)
+  --tier2-concurrency <N>   parallel Tier-2 pages (default: 2)
   --tier1-retries <N>       retry a transient Tier-1 failure (no-grid/load-timeout) up to
                              N times (default: 0 — Tier-1 sandboxes are cheap and reliable)
   --tier2-retries <N>       retry a transient Tier-2 failure up to N times (default: 1 —
@@ -640,7 +637,7 @@ export function parseArgs(argv) {
     tier1Offset: 0,
     tier2Offset: 0,
     tier1Concurrency: 4,
-    tier2Concurrency: 1,
+    tier2Concurrency: 2,
     tier1Retries: 0,
     tier2Retries: 1,
     filter: null,
@@ -750,12 +747,12 @@ async function main(argv) {
     try {
       const tier1Items = toCheck.filter(item => TIER1_FRAMEWORKS.has(item.manifestEntry.framework));
       const tier2Items = toCheck.filter(item => TIER2_FRAMEWORKS.has(item.manifestEntry.framework));
-      // Tier-2 runs only after tier-1 finishes, not overlapped with it, and
-      // serially by default (--tier2-concurrency 1). A Vue/Angular cloud
-      // dev-server container needs ~1 min to boot; running several at once, or
-      // alongside the tier-1 page pool, can starve those boots past the timeout
-      // and produce false no-grid failures, and prod caps concurrent containers
-      // at 5.
+      // Tier-2 runs only after tier-1 finishes, not overlapped with it: a
+      // Vue/Angular cloud dev-server container needs ~1 min to boot, and running
+      // it alongside the tier-1 page pool starves that boot. It defaults to
+      // --tier2-concurrency 2 (prod caps concurrent containers at 5); each page
+      // frees its container slot on close (see verifyLink), so 2 boots stay well
+      // under the cap.
       const tier2Concurrency = args.tier2Concurrency;
 
       console.log(`Checking ${tier1Items.length} Tier-1 link(s) (concurrency ${args.tier1Concurrency}, retry ${args.tier1Retries}x), then ${tier2Items.length} Tier-2 link(s) (concurrency ${tier2Concurrency}, isolated, retry ${args.tier2Retries}x)...`);

--- a/docs/scripts/test-runner-links.mjs
+++ b/docs/scripts/test-runner-links.mjs
@@ -352,6 +352,17 @@ async function waitForGrid(page, deadline, shouldAbort, readyMarker = null) {
   while (Date.now() < deadline) {
     if (shouldAbort?.()) return 'aborted';
 
+    // Check the terminal "Setup failed" banner BEFORE the per-frame grid/marker
+    // scan. A build/transpile failure is terminal, so an interactive example's
+    // ready marker must never mask it: mid-boot the marker can appear in the
+    // Sandpack preview frame while the runner also puts up the banner, and a
+    // marker-first order would report that broken example as interactive-ready.
+    // A rendered grid and the banner cannot coexist, so checking the banner
+    // first never suppresses a real grid.
+    const topText = await page.evaluate(() => document.body?.innerText ?? '').catch(() => '');
+
+    if (matchesSetupFailure(topText)) return 'setup-failed';
+
     for (const frame of page.frames()) {
       const found = await frame
         .evaluate(() => !!document.querySelector('.ht_master .htCore'))
@@ -367,13 +378,6 @@ async function waitForGrid(page, deadline, shouldAbort, readyMarker = null) {
         if (readyMarker.test(frameText)) return 'interactive-ready';
       }
     }
-
-    // No grid yet — if the runner has instead put up its terminal "Setup failed"
-    // banner the example can never render, so end the wait now rather than
-    // polling until the deadline.
-    const topText = await page.evaluate(() => document.body?.innerText ?? '').catch(() => '');
-
-    if (matchesSetupFailure(topText)) return 'setup-failed';
 
     await page.waitForTimeout(500);
   }

--- a/docs/scripts/test-runner-links.mjs
+++ b/docs/scripts/test-runner-links.mjs
@@ -4,14 +4,13 @@
 // Two phases:
 // 1. Static: walk the built dist/ HTML, extract every runner href, and cross-check
 //    each docs path against the runner's manifest.json. A path missing from the
-//    manifest is a guaranteed failure — the runner silently falls back to a
-//    generic starter project for unknown paths instead of erroring, so this is
-//    the only fast, deterministic way to catch that.
-// 2. Headless (skipped with --static-only): load each link in Chromium and
-//    confirm a Handsontable grid actually rendered. A rendered grid alone isn't
-//    proof of correctness — the fallback starter also renders a (different,
-//    generic) grid — so this also asserts the page displays the example's own
-//    guideTitle + exampleTitle from the manifest, which the fallback never does.
+//    manifest is a guaranteed failure — the runner has no such example and renders
+//    an "Example not found" page, so this is the fast, deterministic way to catch a
+//    dead runner link.
+// 2. Headless (skipped with --static-only): load each link in Chromium and confirm a
+//    Handsontable grid actually rendered, then assert the page displays the example's
+//    own guideTitle + exampleTitle from the manifest — a guard against the runner
+//    loading a different example than the link intended.
 //
 // Usage: node scripts/test-runner-links.mjs [options] — see --help for the full option list.
 
@@ -50,15 +49,52 @@ const HELP_TEXT = `Usage: node scripts/test-runner-links.mjs [options]
                            (default: <runner-origin>/docs-examples/<bucket>/manifest.json)
   --static-only           skip the headless phase — link extraction + manifest cross-check only
   --tier2-sample <N|all>  how many Vue/Angular links to headless-check per framework (default: 10)
-  --concurrency <N>       parallel Tier-1 pages, Tier-2 is capped at min(2, N) (default: 4)
+  --concurrency <N>       parallel Tier-1 pages; Tier-2 (vue/angular) always runs serially
+                           to avoid cloud-container contention, retrying transient
+                           failures once (default: 4)
   --filter <substring>    only check docs paths containing this substring
   --json <path>           report output path (default: ./tests/test-artifacts/runner-links/runner-sweep-report-<timestamp>.json)
   --help                  print this message and exit`;
 
 const TIER1_FRAMEWORKS = new Set(['javascript', 'typescript', 'react']);
 const TIER2_FRAMEWORKS = new Set(['vue', 'angular']);
-const TIER_TIMEOUTS_MS = { javascript: 60_000, typescript: 60_000, react: 60_000, vue: 120_000, angular: 240_000 };
+// Vue/Angular boot a full cloud dev-server (Vite) container; under concurrent load the
+// cold boot routinely runs past two minutes, so the caps are generous — a shorter cap
+// reports a slow-but-working example as a false "no-grid" failure.
+const TIER_TIMEOUTS_MS = { javascript: 60_000, typescript: 60_000, react: 60_000, vue: 240_000, angular: 240_000 };
 
+// A tier-2 cloud container sometimes fails to provision under load — a transient
+// no-grid/load-timeout rather than a broken example (the same link boots fine when
+// run alone). Retry these phases once before recording a failure. Tier-1 is excluded:
+// its sandboxes are cheap and reliable, and it has hundreds of links to re-run.
+const RETRYABLE_PHASES = new Set(['no-grid', 'load-timeout']);
+const TIER2_RETRIES = 1;
+
+// Some examples build their grid only after a user action (drop a file, click a
+// button), so no `.ht_master .htCore` exists at load and the plain grid check
+// reports a false no-grid. For these, the sweep instead asserts the example
+// rendered its own pre-interaction UI (a "ready marker"), which confirms it
+// loaded and is not the blank/failed sandbox. Keyed by docsPath substring.
+const INTERACTIVE_EXAMPLES = [
+  { match: 'import-export/import-csv-excel', marker: /Load sample data|No data loaded yet/i },
+];
+
+/**
+ * Returns the ready-marker regex for an interactive example, or null if the
+ * example is expected to render a grid on its own.
+ *
+ * @param {string} docsPath
+ * @returns {RegExp | null}
+ */
+export function interactiveMarkerFor(docsPath) {
+  return INTERACTIVE_EXAMPLES.find(entry => docsPath.includes(entry.match))?.marker ?? null;
+}
+
+// Benign console noise the runner/sandbox emit even on a healthy example: network churn
+// while Sandpack reboots its preview, and Vite HMR websocket chatter from the tier-2
+// dev-server containers. These are matched against the message's FIRST LINE only (see
+// isIgnoredConsoleMessage) so a genuine SyntaxError/TypeError — whose multi-line stack
+// happens to contain a codesandbox.io URL — is still captured rather than swallowed.
 const IGNORED_CONSOLE_PATTERNS = [
   /net::ERR_/i,
   /Failed to load resource/i,
@@ -68,6 +104,9 @@ const IGNORED_CONSOLE_PATTERNS = [
   /Outdated Optimize Dep/i,
   /csb\.app/i,
   /codesandbox\.io/i,
+  /WebSocket connection to/i,
+  /\[vite\]/i,
+  /@vite\/client/i,
 ];
 
 /**
@@ -183,8 +222,9 @@ export async function fetchManifest(manifestSource) {
 
 /**
  * Flags every extracted runner link whose docs path is absent from the
- * manifest — the deterministic, no-browser-needed catch for the silent
- * default-starter fallback (typo'd path, renamed guide, recipe path, etc.).
+ * manifest — the deterministic, no-browser-needed catch for a dead runner link
+ * (typo'd path, renamed guide, recipe path, etc.); the runner renders an
+ * "Example not found" page for an unknown docs path.
  *
  * @param {Map<string, { url: string, pages: string[] }>} links
  * @param {Map<string, object>} manifestByDocsPath
@@ -207,8 +247,36 @@ export function crossCheckManifest(links, manifestByDocsPath) {
   return { missing, reverseDiffCount };
 }
 
-function isIgnoredConsoleMessage(message) {
-  return IGNORED_CONSOLE_PATTERNS.some(pattern => pattern.test(message));
+/**
+ * Reports whether a console/page-error message is benign infrastructure noise.
+ *
+ * Only the FIRST LINE is matched: a real error (e.g. `SyntaxError: Unexpected
+ * token`) carries a multi-line stack whose frames point at codesandbox.io, and
+ * matching the whole string against the `/codesandbox\.io/i` pattern would
+ * silently swallow the very failures this sweep exists to catch. The first line
+ * of a genuine error is the error itself; the first line of infra noise is the
+ * noise ("Failed to load resource ...", "[vite] ...").
+ *
+ * @param {string} message
+ * @returns {boolean}
+ */
+export function isIgnoredConsoleMessage(message) {
+  const firstLine = String(message).split('\n', 1)[0];
+
+  return IGNORED_CONSOLE_PATTERNS.some(pattern => pattern.test(firstLine));
+}
+
+/**
+ * Reports whether page text shows the runner's terminal "Setup failed" banner.
+ * The sandbox renders it when the example fails to build/transpile (for
+ * example, syntax its compiler can't parse). It never recovers, so the sweep
+ * stops waiting and reports it immediately instead of burning the full timeout.
+ *
+ * @param {string} text
+ * @returns {boolean}
+ */
+export function matchesSetupFailure(text) {
+  return /setup failed/i.test(text);
 }
 
 /**
@@ -217,34 +285,80 @@ function isIgnoredConsoleMessage(message) {
  * deadline passes, or `shouldAbort` reports a fatal condition (e.g. a 404 on
  * a runner-origin resource) that makes waiting out the full timeout pointless.
  *
+ * The presence signal is the rendered master table (`.ht_master .htCore`), NOT a
+ * data cell: an intentionally empty example (empty-data-state, a "load data on
+ * click" demo, `data={[]}`) renders a valid grid with headers but zero `<td>`
+ * cells, and keying on a `<td>` reports those working examples as false "no-grid"
+ * failures. The runner renders no `.htCore` at all on its "Example not found" page,
+ * so table presence alone remains a reliable real-grid signal.
+ *
+ * Returns a status: 'grid' (rendered), 'interactive-ready' (no grid yet, but the
+ * example rendered its `readyMarker` pre-interaction UI), 'setup-failed' (runner
+ * build/transpile failure — terminal), 'aborted' (shouldAbort fired, e.g. a
+ * runner-origin 404), or 'timeout' (deadline reached with none of the above).
+ *
  * @param {import('@playwright/test').Page} page
  * @param {number} deadline - epoch ms
  * @param {() => boolean} [shouldAbort]
- * @returns {Promise<boolean>}
+ * @param {RegExp | null} [readyMarker] - for interactive examples, page text that counts as loaded
+ * @returns {Promise<'grid'|'interactive-ready'|'setup-failed'|'aborted'|'timeout'>}
  */
-async function waitForGrid(page, deadline, shouldAbort) {
+async function waitForGrid(page, deadline, shouldAbort, readyMarker = null) {
   while (Date.now() < deadline) {
-    if (shouldAbort?.()) return false;
+    if (shouldAbort?.()) return 'aborted';
 
     for (const frame of page.frames()) {
       const found = await frame
-        .evaluate(() => !!document.querySelector('.ht_master .htCore tbody tr td'))
+        .evaluate(() => !!document.querySelector('.ht_master .htCore'))
         .catch(() => false); // frames can detach mid-poll while Sandpack reboots its preview
 
-      if (found) return true;
+      if (found) return 'grid';
+
+      // A rendered grid always wins; for an interactive example that has none
+      // yet, its own pre-interaction UI (the ready marker) counts as loaded.
+      if (readyMarker) {
+        const frameText = await frame.evaluate(() => document.body?.innerText ?? '').catch(() => '');
+
+        if (readyMarker.test(frameText)) return 'interactive-ready';
+      }
     }
+
+    // No grid yet — if the runner has instead put up its terminal "Setup failed"
+    // banner the example can never render, so end the wait now rather than
+    // polling until the deadline.
+    const topText = await page.evaluate(() => document.body?.innerText ?? '').catch(() => '');
+
+    if (matchesSetupFailure(topText)) return 'setup-failed';
 
     await page.waitForTimeout(500);
   }
 
-  return false;
+  return 'timeout';
 }
 
 /**
- * Confirms the page displays this example's own title, not the generic
- * fallback starter's. The runner header renders "<guideTitle> · <exampleTitle>"
- * for a manifest hit; an unknown docs path shows a generic starter name
- * instead (e.g. "React (Vite, TS)") with neither string present.
+ * Tests whether page text contains both of an example's manifest titles.
+ *
+ * The comparison is case-insensitive: the runner header title-cases the guide
+ * segment ("Cell Functions"), while the manifest stores it in sentence case
+ * ("Cell functions"), and a case-sensitive check reported that mismatch as a
+ * false "wrong-content" failure.
+ *
+ * @param {string} text
+ * @param {object} manifestEntry
+ * @returns {boolean}
+ */
+export function matchesExpectedContent(text, manifestEntry) {
+  const haystack = text.toLowerCase();
+
+  return haystack.includes(String(manifestEntry.guideTitle).toLowerCase())
+    && haystack.includes(String(manifestEntry.exampleTitle).toLowerCase());
+}
+
+/**
+ * Confirms the runner header displays this example's own "<guideTitle> ·
+ * <exampleTitle>", guarding against the runner loading a different example than
+ * the link intended.
  *
  * @param {import('@playwright/test').Page} page
  * @param {object} manifestEntry
@@ -253,7 +367,7 @@ async function waitForGrid(page, deadline, shouldAbort) {
 async function hasExpectedContent(page, manifestEntry) {
   const text = await page.evaluate(() => document.body.innerText).catch(() => '');
 
-  return text.includes(manifestEntry.guideTitle) && text.includes(manifestEntry.exampleTitle);
+  return matchesExpectedContent(text, manifestEntry);
 }
 
 /**
@@ -317,9 +431,15 @@ async function verifyLink(browser, docsPath, link, manifestEntry, progress) {
       return finish({ docsPath, url: link.url, framework: manifestEntry.framework, phase: 'http-error', reason: `runner page responded with HTTP ${mainResponse.status()}`, pages: link.pages, consoleWarnings });
     }
 
-    const gridFound = await waitForGrid(page, deadline, () => notFoundUrls.length > 0);
+    const gridState = await waitForGrid(page, deadline, () => notFoundUrls.length > 0, interactiveMarkerFor(docsPath));
 
-    if (!gridFound) {
+    if (gridState !== 'grid' && gridState !== 'interactive-ready') {
+      // The runner's "Setup failed" banner is a terminal build/transpile error —
+      // report it precisely (and fast; the wait ended as soon as it appeared).
+      if (gridState === 'setup-failed') {
+        return finish({ docsPath, url: link.url, framework: manifestEntry.framework, phase: 'setup-failed', reason: 'runner reported "Setup failed" — the example sandbox failed to build (often unsupported JS syntax)', pages: link.pages, consoleWarnings });
+      }
+
       // A runner-origin 404 is the more precise diagnosis than "no grid" —
       // and it's what aborted the wait early in the first place.
       if (notFoundUrls.length > 0) {
@@ -332,7 +452,7 @@ async function verifyLink(browser, docsPath, link, manifestEntry, progress) {
     const contentOk = await hasExpectedContent(page, manifestEntry);
 
     if (!contentOk) {
-      return finish({ docsPath, url: link.url, framework: manifestEntry.framework, phase: 'wrong-content', reason: `page does not display "${manifestEntry.guideTitle}" / "${manifestEntry.exampleTitle}" — likely the default fallback starter`, pages: link.pages, consoleWarnings });
+      return finish({ docsPath, url: link.url, framework: manifestEntry.framework, phase: 'wrong-content', reason: `page does not display "${manifestEntry.guideTitle}" / "${manifestEntry.exampleTitle}" — the runner rendered a different example than the link intended`, pages: link.pages, consoleWarnings });
     }
 
     return finish(null);
@@ -447,6 +567,29 @@ export function parseArgs(argv) {
   return args;
 }
 
+/**
+ * Runs verifyLink, retrying up to `retries` times while the result is a
+ * retryable transient (a tier-2 container that failed to provision under load).
+ * verifyLink logs its own start/finish line per attempt, so a retry is visible
+ * in the output as a repeated load of the same docs path.
+ *
+ * @param {import('@playwright/test').Browser} browser
+ * @param {{ docsPath: string, manifestEntry: object }} item
+ * @param {{ label: string, index: number, total: number }} progress
+ * @param {number} retries
+ * @returns {Promise<object|null>} failure record, or null on success
+ */
+async function verifyWithRetry(browser, item, progress, retries) {
+  let result = await verifyLink(browser, item.docsPath, item, item.manifestEntry, progress);
+
+  for (let attempt = 1; attempt <= retries && result && RETRYABLE_PHASES.has(result.phase); attempt++) {
+    console.log(`[${progress.label} ${progress.index}/${progress.total}] retrying ${item.docsPath} after ${result.phase} (attempt ${attempt + 1})...`);
+    result = await verifyLink(browser, item.docsPath, item, item.manifestEntry, progress);
+  }
+
+  return result;
+}
+
 async function main(argv) {
   const args = parseArgs(argv);
 
@@ -474,7 +617,7 @@ async function main(argv) {
 
   console.log(`Manifest cross-check: ${missing.length} missing, ${reverseDiffCount} manifest-only path(s) (expected, informational).`);
 
-  const failures = missing.map(m => ({ ...m, phase: 'manifest', reason: 'docs path is not in the runner manifest — would silently render the default fallback starter', framework: null, consoleWarnings: [] }));
+  const failures = missing.map(m => ({ ...m, phase: 'manifest', reason: 'docs path is not in the runner manifest — the runner renders an "Example not found" page (dead link)', framework: null, consoleWarnings: [] }));
 
   const matched = [...links].filter(([docsPath]) => manifestByDocsPath.has(docsPath)).map(([docsPath, link]) => ({ docsPath, ...link }));
   let loaded = 0;
@@ -491,14 +634,17 @@ async function main(argv) {
     try {
       const tier1Items = toCheck.filter(item => TIER1_FRAMEWORKS.has(item.manifestEntry.framework));
       const tier2Items = toCheck.filter(item => TIER2_FRAMEWORKS.has(item.manifestEntry.framework));
-      const tier2Concurrency = Math.min(2, args.concurrency);
+      // Tier-2 runs serially (concurrency 1) AND only after tier-1 finishes, not
+      // overlapped with it. A Vue/Angular cloud dev-server container needs ~1 min
+      // to boot; running two at once, or alongside the tier-1 page pool, starves
+      // that boot past the timeout and produces false no-grid failures. The same
+      // links boot fine in isolation, so tier-2 is given the machine to itself.
+      const tier2Concurrency = 1;
 
-      console.log(`Checking ${tier1Items.length} Tier-1 link(s) (concurrency ${args.concurrency}) and ${tier2Items.length} Tier-2 link(s) (concurrency ${tier2Concurrency})...`);
+      console.log(`Checking ${tier1Items.length} Tier-1 link(s) (concurrency ${args.concurrency}), then ${tier2Items.length} Tier-2 link(s) (serial, isolated, retry ${TIER2_RETRIES}x on transient failures)...`);
 
-      const [tier1Results, tier2Results] = await Promise.all([
-        runPool(tier1Items, args.concurrency, (item, i) => verifyLink(browser, item.docsPath, item, item.manifestEntry, { label: 'tier1', index: i + 1, total: tier1Items.length })),
-        runPool(tier2Items, tier2Concurrency, (item, i) => verifyLink(browser, item.docsPath, item, item.manifestEntry, { label: 'tier2', index: i + 1, total: tier2Items.length })),
-      ]);
+      const tier1Results = await runPool(tier1Items, args.concurrency, (item, i) => verifyLink(browser, item.docsPath, item, item.manifestEntry, { label: 'tier1', index: i + 1, total: tier1Items.length }));
+      const tier2Results = await runPool(tier2Items, tier2Concurrency, (item, i) => verifyWithRetry(browser, item, { label: 'tier2', index: i + 1, total: tier2Items.length }, TIER2_RETRIES));
 
       loaded = tier1Items.length + tier2Items.length;
       failures.push(...[...tier1Results, ...tier2Results].filter(Boolean));
@@ -527,7 +673,9 @@ async function main(argv) {
   await writeFile(args.json, JSON.stringify(report, null, 2));
 
   if (failures.length > 0) {
-    console.table(failures.map(f => ({ docsPath: f.docsPath, phase: f.phase, reason: f.reason })));
+    // `url` is the runner sandbox link — printed so a failure can be opened and
+    // eyeballed straight from the table without cross-referencing the JSON report.
+    console.table(failures.map(f => ({ docsPath: f.docsPath, phase: f.phase, url: f.url, reason: f.reason })));
   }
 
   console.log(`Report written to ${args.json}. ${report.totals.failed} failure(s).`);

--- a/docs/scripts/test-runner-links.mjs
+++ b/docs/scripts/test-runner-links.mjs
@@ -62,8 +62,11 @@ const HELP_TEXT = `Usage: node scripts/test-runner-links.mjs [options]
                              0 skips Tier-1 entirely (default: all)
   --tier2-sample <N|all>    how many Vue/Angular links to headless-check per framework;
                              0 skips Tier-2 entirely (default: 10)
-  --tier1-concurrency <N>   parallel Tier-1 pages. Does NOT affect Tier-2, which always
-                             runs serially to avoid cloud-container contention (default: 4)
+  --tier1-concurrency <N>   parallel Tier-1 pages (default: 4)
+  --tier2-concurrency <N>   parallel Tier-2 pages. Kept at 1 by default: a Vue/Angular cloud
+                             dev-server container needs ~1 min to cold-boot, booting several
+                             at once can starve each past the timeout, and prod caps
+                             concurrent containers at 5 (default: 1)
   --tier1-retries <N>       retry a transient Tier-1 failure (no-grid/load-timeout) up to
                              N times (default: 0 — Tier-1 sandboxes are cheap and reliable)
   --tier2-retries <N>       retry a transient Tier-2 failure up to N times (default: 1 —
@@ -610,6 +613,7 @@ export function parseArgs(argv) {
     tier1Sample: 'all',
     tier2Sample: 10,
     tier1Concurrency: 4,
+    tier2Concurrency: 1,
     tier1Retries: 0,
     tier2Retries: 1,
     filter: null,
@@ -628,6 +632,7 @@ export function parseArgs(argv) {
     else if (arg === '--tier1-sample') { const v = next(); args.tier1Sample = v === 'all' ? 'all' : Number(v); }
     else if (arg === '--tier2-sample') { const v = next(); args.tier2Sample = v === 'all' ? 'all' : Number(v); }
     else if (arg === '--tier1-concurrency') args.tier1Concurrency = Number(next());
+    else if (arg === '--tier2-concurrency') args.tier2Concurrency = Number(next());
     else if (arg === '--tier1-retries') args.tier1Retries = Number(next());
     else if (arg === '--tier2-retries') args.tier2Retries = Number(next());
     else if (arg === '--filter') args.filter = next();
@@ -673,7 +678,7 @@ async function main(argv) {
   }
 
   console.log(
-    `Settings: dist=${args.dist} static-only=${args.staticOnly} tier1-sample=${args.tier1Sample} tier2-sample=${args.tier2Sample} tier1-concurrency=${args.tier1Concurrency} tier1-retries=${args.tier1Retries} tier2-retries=${args.tier2Retries}${args.filter ? ` filter="${args.filter}"` : ''} (run with --help to see all options)`
+    `Settings: dist=${args.dist} static-only=${args.staticOnly} tier1-sample=${args.tier1Sample} tier2-sample=${args.tier2Sample} tier1-concurrency=${args.tier1Concurrency} tier2-concurrency=${args.tier2Concurrency} tier1-retries=${args.tier1Retries} tier2-retries=${args.tier2Retries}${args.filter ? ` filter="${args.filter}"` : ''} (run with --help to see all options)`
   );
 
   console.log(`Walking ${args.dist} for runner links...`);
@@ -716,14 +721,15 @@ async function main(argv) {
     try {
       const tier1Items = toCheck.filter(item => TIER1_FRAMEWORKS.has(item.manifestEntry.framework));
       const tier2Items = toCheck.filter(item => TIER2_FRAMEWORKS.has(item.manifestEntry.framework));
-      // Tier-2 runs serially (concurrency 1) AND only after tier-1 finishes, not
-      // overlapped with it. A Vue/Angular cloud dev-server container needs ~1 min
-      // to boot; running two at once, or alongside the tier-1 page pool, starves
-      // that boot past the timeout and produces false no-grid failures. The same
-      // links boot fine in isolation, so tier-2 is given the machine to itself.
-      const tier2Concurrency = 1;
+      // Tier-2 runs only after tier-1 finishes, not overlapped with it, and
+      // serially by default (--tier2-concurrency 1). A Vue/Angular cloud
+      // dev-server container needs ~1 min to boot; running several at once, or
+      // alongside the tier-1 page pool, can starve those boots past the timeout
+      // and produce false no-grid failures, and prod caps concurrent containers
+      // at 5.
+      const tier2Concurrency = args.tier2Concurrency;
 
-      console.log(`Checking ${tier1Items.length} Tier-1 link(s) (concurrency ${args.tier1Concurrency}, retry ${args.tier1Retries}x), then ${tier2Items.length} Tier-2 link(s) (serial, isolated, retry ${args.tier2Retries}x)...`);
+      console.log(`Checking ${tier1Items.length} Tier-1 link(s) (concurrency ${args.tier1Concurrency}, retry ${args.tier1Retries}x), then ${tier2Items.length} Tier-2 link(s) (concurrency ${tier2Concurrency}, isolated, retry ${args.tier2Retries}x)...`);
 
       const tier1Results = await runPool(tier1Items, args.tier1Concurrency, (item, i) => verifyWithRetry(browser, item, { label: 'tier1', index: i + 1, total: tier1Items.length }, args.tier1Retries));
       const tier2Results = await runPool(tier2Items, tier2Concurrency, (item, i) => verifyWithRetry(browser, item, { label: 'tier2', index: i + 1, total: tier2Items.length }, args.tier2Retries));

--- a/docs/scripts/test-runner-links.mjs
+++ b/docs/scripts/test-runner-links.mjs
@@ -678,6 +678,16 @@ async function main(argv) {
     console.table(failures.map(f => ({ docsPath: f.docsPath, phase: f.phase, url: f.url, reason: f.reason })));
   }
 
+  // A pass/fail tally so a run's outcome is legible without scrolling the log or
+  // opening the JSON report — the failure table only ever shows the failures.
+  const headlessFailed = failures.filter(f => f.phase !== 'manifest').length;
+
+  console.log('Summary:');
+  console.log(`  Runner links found:   ${report.totals.extracted}`);
+  console.log(`  Manifest cross-check: ${report.totals.extracted - report.totals.manifestMissing} present, ${report.totals.manifestMissing} missing`);
+  console.log(`  Headless render:      ${report.totals.passed} passed, ${headlessFailed} failed (of ${loaded} checked)${droppedTier2 ? `, ${droppedTier2} tier-2 skipped` : ''}`);
+  console.log(`  Total failures:       ${report.totals.failed}`);
+
   console.log(`Report written to ${args.json}. ${report.totals.failed} failure(s).`);
 
   return report;

--- a/docs/scripts/test-runner-links.mjs
+++ b/docs/scripts/test-runner-links.mjs
@@ -499,6 +499,11 @@ async function verifyLink(browser, docsPath, link, manifestEntry, progress) {
 
     return finish(null);
   } finally {
+    // Navigating away fires pagehide, which makes the runner app tear down its
+    // Tier-2 container session (DELETE /api/session/:id, keepalive fetch) —
+    // page.close() alone does not reliably fire pagehide, and a leaked session
+    // squats one of the 5 prod container slots until the idle timeout.
+    await page.goto('about:blank', { timeout: 5000 }).catch(() => {});
     await page.close();
   }
 }
@@ -726,6 +731,9 @@ async function main(argv) {
       loaded = tier1Items.length + tier2Items.length;
       failures.push(...[...tier1Results, ...tier2Results].filter(Boolean));
     } finally {
+      // Give the last page's keepalive DELETE a moment to leave the wire before
+      // the browser process is torn down.
+      await new Promise(r => setTimeout(r, 1000));
       await browser.close();
     }
   }


### PR DESCRIPTION
### Context

The PR hardens the docs runner-links sweep (`docs/scripts/test-runner-links.mjs`), which verifies every "Open in runner" link the docs emit to demos.handsontable.com. A full run reported ~79 failures, but manual verification on the runner showed most were false negatives caused by the sweep itself, not broken examples. This change removes those false failures, so the real runner bugs stand out and adds run controls, version auto-detection, clearer output, and Tier-2 container cleanup.

#### False-failure fixes

Each fix was confirmed by manually loading the flagged examples on demos.handsontable.com:

- **Empty-grid detection.** The grid check keyed on a data `<td>`, so intentionally empty examples (empty-data-state, "load data on click", `data={[]}`) were reported as `no-grid`. It now keys on the rendered master table (`.ht_master .htCore`), which an empty grid still has and the runner's "Example not found" page never does.
- **Interactive examples.** Some examples build their grid only after a user action (import-csv-excel renders a file-drop UI first). An allowlist (keyed by docs path) asserts the example's own pre-interaction UI ("ready marker") instead of a grid.
- **Case-insensitive content check.** The runner title-cases the guide segment ("Cell Functions") while the manifest stores sentence case ("Cell functions"), which produced false `wrong-content` failures.
- **Console filter.** `IGNORED_CONSOLE_PATTERNS` matched the whole message, so a real `SyntaxError`/`TypeError` whose stack contains a codesandbox.io URL was swallowed. It now matches the first line only, and Vite HMR noise patterns were added.
- **Fast-fail on build errors.** When the runner shows its terminal "Setup failed" banner, the sweep ends the wait immediately with a `setup-failed` phase instead of burning the full timeout (non-retryable -- deterministic).
- **Tier-2 (vue/angular) contention.** Timeouts raised to 240s; tier-2 runs serially and isolated from the tier-1 page pool (sequential, not overlapped) so a cloud dev-server container can boot without starvation; transient `no-grid`/`load-timeout` failures retry once.
- **Report table.** Adds the runner sandbox URL column so a failure can be opened and eyeballed straight from the output.
- **Stale copy.** The runner now serves an "Example not found" page for an unknown docs path rather than a silent fallback starter; reason text and comments updated.

#### Sweep controls, output, and cleanup

- **Version auto-detection.** The sweep auto-detects the Handsontable version stamped into the runner links and picks the matching manifest bucket (`next` or `X.Y`), so a normal run needs no `--version` flag; `--version` still forces a bucket when needed.
- **Granular run controls.** Per-framework sampling (`--tier1-sample`/`--tier2-sample`), `--tier1-concurrency`, per-tier retries (`--tier1-retries`/`--tier2-retries`), `--filter`, and `--static-only` (link extraction + manifest cross-check with no browser).
- **Pass/fail summary.** The run ends with a legible pass/fail tally so a run's outcome is clear without scrolling the log or opening the JSON report.
- **Tier-2 container teardown.** Each page navigates to `about:blank` before `page.close()`, firing `pagehide` so the runner app tears down its Tier-2 sandbox session (`DELETE /api/session/:id`, keepalive fetch) and frees one of the 5 prod container slots, instead of leaking it until the idle timeout. `page.close()` alone does not reliably fire `pagehide`. A 1s settle before `browser.close()` lets the last page's keepalive DELETE leave the wire.
- **Configurable Tier-2 concurrency.** `--tier2-concurrency` (default 1, behavior unchanged) so Tier-2 parallelism can be raised once the runner is confirmed to free container slots promptly on page close.

### How has this been tested?

- Unit tests for the extracted pure helpers (first-line console filtering, real-error capture, case-insensitive title matching, setup-failure detection, interactive-example allowlist, version-bucket derivation, manifest-source resolution, arg parsing):

  ```shell
  node --test docs/scripts/__tests__/test-runner-links.test.mjs
  ```

  26/26 passing.
- End-to-end filtered run confirming the interactive examples now pass:

  ```shell
  node docs/scripts/test-runner-links.mjs --filter import-csv-excel
  ```

  `import-csv-excel` javascript + react both pass (~6.8s).
- Full `pnpm docs:test:runner-links` runs before/after: the empty-data-state, cell-function, and interactive false failures cleared; tier-2 vue/angular timeouts cleared; the remaining failures are only the genuine runner bugs, tracked in separate follow-up tickets.
- Tier-2 container teardown verified against the deployed runner: each page's `about:blank` navigation fires the `pagehide` teardown, but `page.close()` had to be delayed briefly so the keepalive `DELETE /api/session/:id` reaches the wire -- an immediate close leaves the session alive (HTTP 200) 15s+, a short settle tears it down (HTTP 410). With that in place a `--tier2-concurrency 2` sweep of 30 vue/angular links passed 30/30 with no container-slot starvation and no retries (previously ~half hit the 240s no-grid timeout and only passed on retry).

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2113

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

Docs tooling only (`docs/scripts/`); no package source changed.

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog] -- test/tooling-only change (`docs/scripts/`), no package source affected.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2113

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only Playwright sweep tooling under `docs/scripts/`; no library or production runtime changes. Behavior changes affect how CI classifies runner link health, not shipped product code.
> 
> **Overview**
> **Hardens the docs runner-links sweep** (`test-runner-links.mjs`) so CI failures reflect real broken examples instead of flaky or overly strict checks.
> 
> **Detection fixes:** Grid presence now uses `.ht_master .htCore` (not data cells), so empty grids pass. Interactive examples (e.g. import-csv-excel) can pass via a **ready-marker** allowlist. Title checks are **case-insensitive**. Console noise is filtered on the **first line only** so real `SyntaxError`/`TypeError` stacks are not swallowed; Vite/WebSocket patterns were added. **Setup failed** is detected early as a non-retryable `setup-failed` phase. Vue/Angular timeouts go to **240s**; tier-2 runs **after** tier-1 with separate concurrency and **retries** for transient `no-grid`/`load-timeout`.
> 
> **Run controls:** Manifest bucket is **auto-detected** from link `v=` stamps via `resolveManifestSource` (`--manifest` removed; `--version` is override-only). New flags: tier1/tier2 **sample**, **offset**, **concurrency**, and **retries**. `planHeadlessChecks` samples both tiers and reports `droppedTier1`/`droppedTier2`.
> 
> **Ops/output:** Tier-2 pages navigate to `about:blank` plus a 1s settle before close to free cloud container slots. Failure `console.table` includes runner **URL**; run ends with a **summary** tally. Copy updated for “Example not found” vs old fallback-starter wording. Unit tests expanded for the new helpers and planning/args behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 735ceb7a1ae10f86c7ab38fde01c572a7ccc36ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

