### PR TITLE
DEV-2130: Fix blank runner preview for the React getting-started demo

### DIFF
--- a/docs/content/guides/getting-started/demo/demo.md
+++ b/docs/content/guides/getting-started/demo/demo.md
@@ -34,6 +34,7 @@ Explore Handsontable core features in this interactive demo. Click cells, sort c
 @[code](@/content/guides/getting-started/demo/react/example2.html)
 @[code](@/content/guides/getting-started/demo/react/example2.css)
 @[code](@/content/guides/getting-started/demo/react/example2.jsx)
+@[code](@/content/guides/getting-started/demo/react/example2.tsx)
 :::
 :::
 


### PR DESCRIPTION
### Context

The PR fixes a blank preview in the docs-examples runner (demos.handsontable.com) for the React getting-started demo (DEV-2130, task 1).

`docs/content/guides/getting-started/demo/react/example2.jsx` was the only React docs example referenced solely as `.jsx` in a markdown `@[code]` directive. The runner's importer classifies React examples with a TypeScript project config (entry: `/src/main.tsx`), while its file wrapper honors the source language and emits `src/main.jsx` — so the generated sandbox points at a file that doesn't exist and the preview renders blank.

The matching `example2.tsx` has existed in the repo since DEV-1778 (#12636) and is in sync with the `.jsx` variant, but the importer discovers files only through markdown directives, so it was never picked up. This PR adds the `.tsx` file to the `#example2` directive in `demo.md`, matching the convention used by every other React docs example. The docs-site example loader (`framework-loader.mjs`) already prefers `.tsx` for the runner link when both are listed, and keeps using the first-listed `.jsx` for the on-page live preview, so the docs page itself is unaffected.

Note: the runnable example's identity changes from `?docs=guides/getting-started/demo/react/example2.jsx` to `...example2.tsx`. The runner manifest will not contain the new path until the `handsontable/examples` repo re-imports docs content, so the `docs:test:runner-links` sweep flags this link as manifest-missing until that import runs.

[skip changelog]

### How has this been tested?

- Verified on the local docs dev server (`npm run dev` in `docs/`) with headless Chromium against `http://localhost:4321/docs/react-data-grid/demo/`:
  - The "Edit in sandbox" link now points at `https://demos.handsontable.com/?docs=guides/getting-started/demo/react/example2.tsx&v=...` (previously `.jsx`).
  - The on-page live preview still mounts the grid (80 cells rendered, correct data) with no related console errors.
- Confirmed `example2.tsx` and `example2.jsx` differ only in type annotations and the `handsontable/base` type import (`diff`).

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2130

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2130

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single documentation directive change with no runtime library impact; the only caveat is a temporary runner-manifest mismatch until examples are re-imported.
> 
> **Overview**
> Fixes a **blank docs-examples runner preview** for the React getting-started demo by registering the existing `example2.tsx` in the `#example2` `@[code]` block in `demo.md`, **after** `example2.jsx`.
> 
> That matches how other React guides list both `.jsx` and `.tsx`, so the importer can build a sandbox whose entry aligns with the TypeScript runner config (`main.tsx`) instead of pointing at a missing `main.jsx`. The on-page live preview should still use the first-listed `.jsx`; only the **Edit in sandbox** URL shifts from `example2.jsx` to `example2.tsx` until the examples repo re-imports docs content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3f7e089aefd6403ad7a9d724e7b5600c237fd91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->