### PR TITLE
DEV-2129: Import Handsontable in the React pagination i18n example

### DIFF
--- a/docs/content/guides/rows/rows-pagination/react/example6.jsx
+++ b/docs/content/guides/rows/rows-pagination/react/example6.jsx
@@ -1,3 +1,4 @@
+import Handsontable from 'handsontable/base';
 import { HotTable, HotColumn } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
 

--- a/docs/content/guides/rows/rows-pagination/react/example6.tsx
+++ b/docs/content/guides/rows/rows-pagination/react/example6.tsx
@@ -1,3 +1,4 @@
+import Handsontable from 'handsontable/base';
 import { HotTable, HotColumn } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
 


### PR DESCRIPTION
### Context
`docs/content/guides/rows/rows-pagination/react/example6.{tsx,jsx}` call `Handsontable.languages.getLanguageDictionary` / `dictionaryKeys` / `registerLanguageDictionary` but never import `Handsontable`. Every other framework variant of this example (javascript `.js`/`.ts`, vue, angular) has the import. On the demo runner (a real module sandbox — no page global) the example throws `ReferenceError: Handsontable is not defined` and the preview shows "Setup failed".

Live repro: https://demos.handsontable.com/?docs=guides%2Frows%2Frows-pagination%2Freact%2Fexample6.tsx

Fix: add `import Handsontable from 'handsontable/base';` (same style as the javascript variants) to both React files. `handsontable/base` carries the `languages` static (`src/base.ts:282`).

Docs-content-only change — no source code touched.

### Test evidence (required for source changes)
- Unit tests added/modified (`*.unit.js`): none — docs example content only
- E2E tests added/modified (Playwright `tests/e2e/*.spec.ts`): none — covered by the runner's live E2E suite (handsontable/examples `runner/e2e/docs-examples.spec.ts`, `E2E_LIVE=1`)
- Type tests (`*.types.ts`) updated if public API changed: n/a
- For a bug fix — the spec that fails without this fix: n/a (docs content)
- Demo page / recorded trace (for UI changes): patched artifact verified against the runner locally — example renders "Live", pagination bar present, zero console errors

### Commands run
Verified in handsontable/examples runner with the patched example source:
```
[status] Live
[pagination bar] 2
[errors] []
```

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1. DEV-2129

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
- [ ] This change needs a manual QA pass

After merge: dispatch the runner's import-docs workflow (handsontable/examples) so the `next` bucket regenerates with the fixed source. Backport to `prod-docs/18.0`: #13116.

[skip changelog]