### PR TITLE
Fix broken import path in the cell renderer guide

### DIFF
--- a/docs/content/guides/cell-functions/cell-renderer/cell-renderer.md
+++ b/docs/content/guides/cell-functions/cell-renderer/cell-renderer.md
@@ -230,7 +230,7 @@ All the sections below describe how to utilize the features available for the Ha
 
 ## Register custom cell renderer
 
-To register your own alias use `registerRenderer()` function from the `@handsontable/renderers` package. It takes two arguments:
+To register your own alias use `registerRenderer()` function from the `handsontable/renderers` module. It takes two arguments:
 
 - `rendererName` - a string representing a renderer function
 - `renderer` - a renderer function that will be represented by `rendererName`
@@ -238,7 +238,7 @@ To register your own alias use `registerRenderer()` function from the `@handsont
 If you'd like to register `asteriskDecoratorRenderer` under alias `asterisk` you have to call:
 
 ```js
-import { registerRenderer } from "@handsontable/renderers";
+import { registerRenderer } from "handsontable/renderers";
 
 registerRenderer("asterisk", asteriskDecoratorRenderer);
 ```
@@ -256,7 +256,7 @@ When using `registerRenderer()`, remember to call it at startup (e.g. in `main.t
 Choose aliases wisely. If you register your renderer under name that is already registered, the target function will be overwritten:
 
 ```js
-import { registerRenderer } from "@handsontable/renderers";
+import { registerRenderer } from "handsontable/renderers";
 
 registerRenderer("text", asteriskDecoratorRenderer);
 ```
@@ -266,7 +266,7 @@ Now `"text"` alias points to `asteriskDecoratorRenderer` function, not the built
 So, unless you intentionally want to overwrite an existing alias, try to choose a unique name. A good practice is prefixing your aliases with some custom name (for example your GitHub username) to minimize the possibility of name collisions. This is especially important if you want to publish your renderer, because you never know aliases has been registered by the user who uses your renderer.
 
 ```js
-import { registerRenderer } from "@handsontable/renderers";
+import { registerRenderer } from "handsontable/renderers";
 
 registerRenderer("asterisk", asteriskDecoratorRenderer);
 ```
@@ -274,7 +274,7 @@ registerRenderer("asterisk", asteriskDecoratorRenderer);
 Someone might already registered such alias
 
 ```js
-import { registerRenderer } from "@handsontable/renderers";
+import { registerRenderer } from "handsontable/renderers";
 
 registerRenderer("my.asterisk", asteriskDecoratorRenderer);
 ```
@@ -288,7 +288,7 @@ The final touch is to use registered aliases. That way users can easily refer to
 To sum up, a well prepared renderer function should look like this:
 
 ```js
-import { registerRenderer } from "@handsontable/renderers";
+import { registerRenderer } from "handsontable/renderers";
 
 function customRenderer(
   hotInstance,


### PR DESCRIPTION
## Summary

The cell renderer guide ([live page](https://handsontable.com/docs/react-data-grid/cell-renderer/)) tells readers to import `registerRenderer` from `@handsontable/renderers` — a scoped package that does not exist on npm (the registry returns 404). Anyone copying the snippets gets a module-not-found error.

This PR replaces all six occurrences in `docs/content/guides/cell-functions/cell-renderer/cell-renderer.md` (five import statements and one prose mention) with the correct subpath export, `handsontable/renderers`, matching every other example in the docs and the `renderers/index.d.ts` shipped in the `handsontable` package.

## Test plan

- `grep -rn "@handsontable/renderers" docs/content` returns no matches after the change (the remaining `@handsontable/*` references in the file are the real `react-wrapper`/`angular-wrapper` packages).
- Verified `registerRenderer` is exported via the `handsontable/renderers` subpath (`handsontable/src/renderers/registry.ts`).

[skip changelog]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only import path corrections with no runtime or API changes.
> 
> **Overview**
> The **cell renderer** guide incorrectly told readers to import `registerRenderer` from `@handsontable/renderers`, a package that is not published on npm. This PR updates **six** spots in `cell-renderer.md`—one prose reference to the `@handsontable/renderers` package and **five** code snippets—to use the supported subpath **`handsontable/renderers`**, consistent with the rest of the docs and the package’s type exports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e527d156cd98abdb82876a03f0aedeae44a16d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->