### PR TITLE
DEV-2057: path-aware changelog gate — required for source changes, auto-pass otherwise

### DIFF
--- a/.changelogs/README.md
+++ b/.changelogs/README.md
@@ -5,17 +5,17 @@ This directory includes temporary changelog entries, in the form of simple `.jso
 
 ## Mandatory PR check
 
-Every pull request in this repository requires a new changelog entry to be created in this directory, asserted by a GitHub actions workflow. The commit workflow will fail in any PR that does not have a new `.changelogs/*.json` file added. If a pushed commit does not have a PR associated with it, the check is skipped entirely.
+A changelog entry is required — and asserted by a GitHub Actions workflow — when a PR changes **shippable source**: anything under `handsontable/src/**` or `wrappers/**` except test files and markdown. The check fails when such a PR does not add a new `.changelogs/*.json` file.
 
-Changelog entries are expected only for source-code changes to the library core or the wrappers. Documentation-only, test-only, and CI/tooling PRs should disable the check instead.
+Documentation-only, test-only, and CI/tooling PRs **pass automatically** — no entry and no opt-out needed. If a pushed commit does not have a PR associated with it, the check is skipped entirely.
 
-**To disable this check**, simply add the following string to the **PR description**:
+**To skip the requirement on a source change** (rare — e.g. an internal change with no user-visible effect), add the following string to the **PR description**, outside any HTML comment (a commented mention, like the hint in the PR template, is deliberately inert):
 
 ```
 [skip changelog]
 ```
 
-...and re-run the failed **Changelog** check from the PR's checks tab (or push any new commit — `git commit --allow-empty` works). The check reads the PR body at run time; editing the description alone does not re-trigger it.
+...and re-run the failed **Changelog** check from the PR's checks tab (or push any new commit — `git commit --allow-empty` works). The check reads the PR body at run time; editing the description alone does not re-trigger it. The override is logged together with the source files it waves through, so reviewers can judge it.
 
 
 ## Changelog helper

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,15 @@ Fill in the paths below, or apply a `Refactor-only: <reason>` commit trailer.
 - For a bug fix — the spec that fails without this fix: <!-- name -->
 - Demo page / recorded trace (for UI changes): <!-- link -->
 
+<!--
+Changelog: a change under handsontable/src/** or wrappers/** (tests and .md
+excluded) requires a new .changelogs/*.json entry — run `npm run changelog
+entry` AFTER opening the PR (the file is named after the PR number). Docs-,
+test-, and CI/tooling-only PRs pass the check automatically. To deliberately
+skip it on a source change, write [skip changelog] in this description OUTSIDE
+any HTML comment — here, inside a comment, it is inert.
+-->
+
 ### Commands run
 <!--- Paste the test commands and their final output lines. -->
 

--- a/.github/scripts/__tests__/changelog-gate.test.mjs
+++ b/.github/scripts/__tests__/changelog-gate.test.mjs
@@ -51,6 +51,21 @@ test('stripHtmlComments removes single and multiline comment blocks', () => {
   assert.equal(stripped.includes('tail'), true);
 });
 
+test('a comment reassembled around a removed match cannot smuggle the marker', () => {
+  // Single-pass stripping of the inner comment would reconstruct
+  // `<!-- [skip changelog] -->` and match the marker; the fixed-point loop
+  // removes the reconstruction too (CodeQL js/incomplete-multi-character-sanitization).
+  const body = `<!-<!-- x -->- ${SKIP_MARKER} -->`;
+
+  assert.equal(stripHtmlComments(body).includes(SKIP_MARKER), false);
+});
+
+test('an unterminated trailing comment hides the marker (comment-to-EOF)', () => {
+  assert.equal(stripHtmlComments(`text <!-- dangling ${SKIP_MARKER}`).includes(SKIP_MARKER), false);
+  // ...but a marker BEFORE the dangling comment stays visible and active.
+  assert.equal(stripHtmlComments(`${SKIP_MARKER} <!-- dangling`).includes(SKIP_MARKER), true);
+});
+
 // --- evaluateChangelogGate ---
 const src = { status: 'modified', filename: 'handsontable/src/core.ts' };
 const scss = { status: 'modified', filename: 'handsontable/src/styles/themes/main.scss' };

--- a/.github/scripts/__tests__/changelog-gate.test.mjs
+++ b/.github/scripts/__tests__/changelog-gate.test.mjs
@@ -1,0 +1,127 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  SKIP_MARKER, requiresChangelog, stripHtmlComments, evaluateChangelogGate,
+} from '../lib/changelog-gate.mjs';
+
+// --- requiresChangelog: shippable-source classification ---
+const REQUIRES_CASES = [
+  // Core source ships → entry required.
+  ['handsontable/src/core.ts', true],
+  ['handsontable/src/plugins/copyPaste/copyPaste.ts', true],
+  ['handsontable/src/i18n/languages/de-DE.js', true],
+  // Styling under src ships (broader than the presence gate's testable set).
+  ['handsontable/src/styles/themes/main.scss', true],
+  // Wrapper source and manifests ship.
+  ['wrappers/react-wrapper/src/hotTableInner.tsx', true],
+  ['wrappers/vue3/src/HotTable.vue', true],
+  ['wrappers/react-wrapper/package.json', true],
+  // Tests never demand an entry — by file kind or by directory marker.
+  ['handsontable/src/plugins/copyPaste/__tests__/copyPaste.unit.js', false],
+  ['handsontable/src/plugins/copyPaste/__tests__/settings/rowsLimit.spec.js', false],
+  ['handsontable/src/plugins/copyPaste/__tests__/helpers/setup.js', false],
+  ['wrappers/react-wrapper/test/hotColumn.spec.tsx', false],
+  ['wrappers/angular-wrapper/projects/hot-table/src/lib/test-helpers/create-spreadsheet-data.ts', false],
+  // Markdown never demands an entry.
+  ['wrappers/angular-wrapper/AGENTS.md', false],
+  ['handsontable/src/plugins/contextMenu/AGENTS.md', false],
+  // Outside the trees: docs, CI, tooling, root files.
+  ['docs/content/guides/foo/foo.md', false],
+  ['.github/workflows/test.yml', false],
+  ['scripts/pre-push.mjs', false],
+  ['handsontable/test/e2e/keyboardShortcuts.spec.js', false],
+  ['CONTRIBUTING.md', false],
+  ['.changelogs/13110.json', false],
+];
+
+test('requiresChangelog classifies shippable source', () => {
+  for (const [path, want] of REQUIRES_CASES) {
+    assert.equal(requiresChangelog(path), want, `${path} should be ${want}`);
+  }
+});
+
+// --- stripHtmlComments ---
+test('stripHtmlComments removes single and multiline comment blocks', () => {
+  const body = `real text <!-- hidden ${SKIP_MARKER} --> more\n<!--\nmultiline ${SKIP_MARKER}\n-->tail`;
+
+  const stripped = stripHtmlComments(body);
+
+  assert.equal(stripped.includes(SKIP_MARKER), false);
+  assert.equal(stripped.includes('real text'), true);
+  assert.equal(stripped.includes('tail'), true);
+});
+
+// --- evaluateChangelogGate ---
+const src = { status: 'modified', filename: 'handsontable/src/core.ts' };
+const scss = { status: 'modified', filename: 'handsontable/src/styles/themes/main.scss' };
+const entry = { status: 'added', filename: '.changelogs/13200.json' };
+const doc = { status: 'modified', filename: 'docs/content/guides/foo/foo.md' };
+const workflow = { status: 'added', filename: '.github/workflows/develop.yml' };
+const wrapperTest = { status: 'modified', filename: 'wrappers/react-wrapper/test/hotColumn.spec.tsx' };
+
+test('an added entry passes, whatever else changed', () => {
+  const verdict = evaluateChangelogGate({ body: '', files: [src, entry] });
+
+  assert.deepEqual(verdict, { pass: true, reason: 'entry-added', sourceFiles: [src.filename] });
+});
+
+test('a MODIFIED changelog file is not a new entry', () => {
+  // Editing an existing entry (no source change) passes via no-source-change,
+  // not via entry-added.
+  const verdict = evaluateChangelogGate({
+    body: '',
+    files: [{ status: 'modified', filename: '.changelogs/13100.json' }],
+  });
+
+  assert.equal(verdict.reason, 'no-source-change');
+});
+
+test('docs/CI/test-only PRs pass automatically with no entry and no marker', () => {
+  for (const files of [[doc], [workflow], [wrapperTest], [doc, workflow, wrapperTest]]) {
+    const verdict = evaluateChangelogGate({ body: '', files });
+
+    assert.equal(verdict.pass, true);
+    assert.equal(verdict.reason, 'no-source-change');
+  }
+});
+
+test('a source change with no entry and no marker fails', () => {
+  const verdict = evaluateChangelogGate({ body: 'regular description', files: [src, doc] });
+
+  assert.deepEqual(verdict, { pass: false, reason: 'missing-entry', sourceFiles: [src.filename] });
+});
+
+test('a styling change under src is a source change', () => {
+  const verdict = evaluateChangelogGate({ body: '', files: [scss] });
+
+  assert.equal(verdict.reason, 'missing-entry');
+});
+
+test('removed and renamed source files count as source changes', () => {
+  for (const status of ['removed', 'renamed']) {
+    const verdict = evaluateChangelogGate({
+      body: '',
+      files: [{ status, filename: 'handsontable/src/plugins/oldPlugin/oldPlugin.ts' }],
+    });
+
+    assert.equal(verdict.reason, 'missing-entry', `status=${status}`);
+  }
+});
+
+test('the marker in the description overrides a source change', () => {
+  const verdict = evaluateChangelogGate({ body: `Tooling only.\n${SKIP_MARKER}`, files: [src] });
+
+  assert.deepEqual(verdict, { pass: true, reason: 'skipped-explicitly', sourceFiles: [src.filename] });
+});
+
+test('the marker inside an HTML comment is inert', () => {
+  const templateHint = `### Context\n<!-- To skip, write ${SKIP_MARKER} outside a comment. -->`;
+
+  assert.equal(evaluateChangelogGate({ body: templateHint, files: [src] }).reason, 'missing-entry');
+  assert.equal(evaluateChangelogGate({ body: templateHint, files: [doc] }).reason, 'no-source-change');
+});
+
+test('a missing body does not crash the gate', () => {
+  assert.equal(evaluateChangelogGate({ body: undefined, files: [doc] }).pass, true);
+  assert.equal(evaluateChangelogGate({ body: null, files: [src] }).reason, 'missing-entry');
+});

--- a/.github/scripts/check-changelog.js
+++ b/.github/scripts/check-changelog.js
@@ -18,6 +18,9 @@ const { owner, repo } = github.context.repo;
 const octokit = github.getOctokit(token);
 
 const run = async() => {
+  // The extension is mandatory here: ESM resolution (dynamic import from CJS)
+  // does not add `.mjs` the way require() adds `.js`.
+  // eslint-disable-next-line import/extensions
   const { evaluateChangelogGate, SKIP_MARKER } = await import('./lib/changelog-gate.mjs');
   const pr = github.context.payload.pull_request;
 
@@ -66,10 +69,14 @@ const run = async() => {
       console.log('Found new changelog(s), success!');
       break;
     case 'no-source-change':
-      console.log('No shippable source change (handsontable/src/** or wrappers/**) — a changelog entry is not required.');
+      console.log(
+        'No shippable source change (handsontable/src/** or wrappers/**) — a changelog entry is not required.'
+      );
       break;
     case 'skipped-explicitly':
-      console.log(`The PR description opts out via \`${SKIP_MARKER}\`. Source files waved through without a changelog entry:`);
+      console.log(
+        `The PR description opts out via \`${SKIP_MARKER}\`. Source files waved through without a changelog entry:`
+      );
       sourceFiles.forEach(file => console.log(`  - ${file}`));
       break;
     default:

--- a/.github/scripts/check-changelog.js
+++ b/.github/scripts/check-changelog.js
@@ -1,22 +1,24 @@
 /* eslint-disable no-console, no-restricted-globals */
 
-// Ensures that a new changelog entry was added in the current PR, if there
-// exists a PR associated with the current commit. If multiple PR's are
-// found, the first one returned from the API will be used for the check.
+// Path-aware changelog gate. A PR must add a `.changelogs/*.json` entry when
+// it changes shippable source (handsontable/src/** or wrappers/**, tests and
+// markdown excluded); docs-, test-, and CI/tooling-only PRs pass
+// automatically. `[skip changelog]` in the PR description — outside HTML
+// comments — overrides the requirement on a source change; the override is
+// logged with the source files it waves through. The decision logic lives in
+// lib/changelog-gate.mjs (pure, unit-tested); this wrapper only talks to the
+// GitHub API.
 
 const core = require('@actions/core');
 const github = require('@actions/github');
 
 const token = process.env.TOKEN;
 
-const skipCheckString = '[skip changelog]';
-
-const changelogsPath = '.changelogs/';
-
 const { owner, repo } = github.context.repo;
 const octokit = github.getOctokit(token);
 
 const run = async() => {
+  const { evaluateChangelogGate, SKIP_MARKER } = await import('./lib/changelog-gate.mjs');
   const pr = github.context.payload.pull_request;
 
   if (pr === undefined) {
@@ -34,11 +36,12 @@ const run = async() => {
   }
 
   // Read the LIVE PR body over the API rather than trusting
-  // `github.context.payload.pull_request.body`, which is frozen at the event that
-  // triggered the run and stays stale across "Re-run failed jobs". Reading it live
-  // lets an author add `[skip changelog]` to the description and re-run this job to
-  // clear the check — no empty commit, and no `edited` trigger re-running the whole
-  // pipeline. Falls back to the payload body if the fetch is unavailable.
+  // `github.context.payload.pull_request.body`, which is frozen at the event
+  // that triggered the run and stays stale across "Re-run failed jobs". Reading
+  // it live lets an author add the skip marker to the description and re-run
+  // this job to clear the check — no empty commit, and no `edited` trigger
+  // re-running the whole pipeline. Falls back to the payload body if the fetch
+  // is unavailable.
   let body = pr.body || '';
 
   try {
@@ -49,11 +52,6 @@ const run = async() => {
     console.log(`Could not fetch the live PR body, falling back to the event payload: ${error.message}`);
   }
 
-  if (body.includes(skipCheckString)) {
-    console.log('The PR body (description) includes a string to disable this check, exiting.');
-    process.exit(0);
-  }
-
   // https://octokit.github.io/rest.js/v18#pagination
   const files = await octokit.paginate(listPullFiles, {
     owner,
@@ -61,24 +59,26 @@ const run = async() => {
     pull_number: pr.number
   });
 
-  const newChangelogFileAddedwasAdded = files.some(file =>
-    file.status === 'added' && file.filename.startsWith(changelogsPath) && file.filename.endsWith('.json')
-  );
+  const { reason, sourceFiles } = evaluateChangelogGate({ body, files });
 
-  if (newChangelogFileAddedwasAdded) {
-    console.log('Found new changelog(s), success!');
-  } else {
-    console.log('Added files:');
-    console.log(
-      files
-        .filter(({ status }) => status === 'added')
-        .map(({ filename }) => `${filename}\n`)
-    );
-
-    core.setFailed(
-      // eslint-disable-next-line max-len
-      'Expected a new changelog file to be added in this PR. See instructions in .changelogs/README.md for information on how to do that and instructions on how to mute this error.'
-    );
+  switch (reason) {
+    case 'entry-added':
+      console.log('Found new changelog(s), success!');
+      break;
+    case 'no-source-change':
+      console.log('No shippable source change (handsontable/src/** or wrappers/**) — a changelog entry is not required.');
+      break;
+    case 'skipped-explicitly':
+      console.log(`The PR description opts out via \`${SKIP_MARKER}\`. Source files waved through without a changelog entry:`);
+      sourceFiles.forEach(file => console.log(`  - ${file}`));
+      break;
+    default:
+      console.log('Shippable source changed in this PR:');
+      sourceFiles.forEach(file => console.log(`  - ${file}`));
+      core.setFailed(
+        // eslint-disable-next-line max-len
+        `This PR changes shippable source but adds no changelog entry. Create one with \`npm run changelog entry\` (see .changelogs/README.md), or — when a source change genuinely warrants no entry — write \`${SKIP_MARKER}\` in the PR description (outside HTML comments) and re-run this check.`
+      );
   }
 };
 

--- a/.github/scripts/lib/changelog-gate.mjs
+++ b/.github/scripts/lib/changelog-gate.mjs
@@ -1,0 +1,100 @@
+/**
+ * Changelog gate — pure decision logic.
+ *
+ * A PR must add a `.changelogs/*.json` entry when it changes shippable source:
+ * anything under `handsontable/src/**` or `wrappers/**` that is not a test
+ * file, a test directory, or markdown. Documentation-, test-, and CI/tooling-
+ * only PRs pass automatically. `[skip changelog]` in the PR description —
+ * outside HTML comments — overrides the requirement on a source change; the
+ * override is surfaced together with the files it waves through so a reviewer
+ * can judge it.
+ *
+ * No network or filesystem access lives here so the logic is unit-testable;
+ * the CLI wrapper (`../check-changelog.js`) feeds it the live PR body and the
+ * changed-file list from the GitHub API.
+ */
+
+import { classify } from './presence-gate.mjs';
+
+/**
+ * The opt-out marker recognized in a PR description.
+ */
+export const SKIP_MARKER = '[skip changelog]';
+
+/**
+ * Trees whose changes ship in the npm packages and therefore warrant a
+ * changelog entry. Deliberately broader than the presence gate's SOURCE set
+ * (which targets testable code files): styling/theme files under
+ * `handsontable/src` and wrapper manifests are user-facing too.
+ */
+const CHANGELOG_TREES = [
+  /^handsontable\/src\//,
+  /^wrappers\//,
+];
+
+/**
+ * Never changelog-relevant, even inside the trees above: markdown, and the
+ * test-tree directory markers (mirrors the presence gate's NOT_SOURCE
+ * exclusions — helpers in test dirs classify as 'neither', not 'test').
+ */
+const EXCLUDED = [
+  /\.md$/i,
+  /\/__tests__\//,
+  /\/test\//,
+  /\/test-helpers\//,
+  /\/spec\//,
+];
+
+/**
+ * Does a change to this path warrant a changelog entry?
+ *
+ * @param {string} path Repo-relative path.
+ * @returns {boolean} True for shippable source under the changelog trees.
+ */
+export function requiresChangelog(path) {
+  return CHANGELOG_TREES.some(r => r.test(path))
+    && !EXCLUDED.some(r => r.test(path))
+    && classify(path) !== 'test';
+}
+
+/**
+ * Strip HTML comments, so a commented mention of the skip marker (e.g. the PR
+ * template documenting it) can never activate the opt-out.
+ *
+ * @param {string} body The PR description.
+ * @returns {string} The description without `<!-- ... -->` blocks.
+ */
+export function stripHtmlComments(body) {
+  return body.replace(/<!--[\s\S]*?-->/g, '');
+}
+
+/**
+ * Evaluate the gate for a PR.
+ *
+ * @param {object} pr The gate's inputs.
+ * @param {string} pr.body The PR description (live, not the frozen payload).
+ * @param {{status: string, filename: string}[]} pr.files The PR's changed
+ *   files, as returned by the GitHub "list pull request files" API.
+ * @returns {{pass: boolean, reason: string, sourceFiles: string[]}} The
+ *   verdict; `reason` is one of 'entry-added', 'no-source-change',
+ *   'skipped-explicitly', or 'missing-entry'.
+ */
+export function evaluateChangelogGate({ body, files }) {
+  const hasEntry = files.some(f => f.status === 'added'
+    && f.filename.startsWith('.changelogs/')
+    && f.filename.endsWith('.json'));
+  const sourceFiles = files.map(f => f.filename).filter(requiresChangelog);
+  const skipped = stripHtmlComments(body || '').includes(SKIP_MARKER);
+
+  if (hasEntry) {
+    return { pass: true, reason: 'entry-added', sourceFiles };
+  }
+  if (sourceFiles.length === 0) {
+    return { pass: true, reason: 'no-source-change', sourceFiles };
+  }
+  if (skipped) {
+    return { pass: true, reason: 'skipped-explicitly', sourceFiles };
+  }
+
+  return { pass: false, reason: 'missing-entry', sourceFiles };
+}

--- a/.github/scripts/lib/changelog-gate.mjs
+++ b/.github/scripts/lib/changelog-gate.mjs
@@ -61,11 +61,26 @@ export function requiresChangelog(path) {
  * Strip HTML comments, so a commented mention of the skip marker (e.g. the PR
  * template documenting it) can never activate the opt-out.
  *
+ * Stripping repeats until a fixed point: a single pass can reassemble a new
+ * `<!-- ... -->` from the text around a removed match (CodeQL
+ * js/incomplete-multi-character-sanitization). Any unterminated trailing
+ * `<!--` is dropped too, mirroring how renderers hide comment-to-EOF. Both
+ * choices bias the gate toward NOT recognizing an ambiguous marker — the safe
+ * failure mode is demanding an entry, never silently skipping.
+ *
  * @param {string} body The PR description.
  * @returns {string} The description without `<!-- ... -->` blocks.
  */
 export function stripHtmlComments(body) {
-  return body.replace(/<!--[\s\S]*?-->/g, '');
+  let stripped = body;
+  let previous;
+
+  do {
+    previous = stripped;
+    stripped = previous.replace(/<!--[\s\S]*?-->/g, '');
+  } while (stripped !== previous);
+
+  return stripped.replace(/<!--[\s\S]*$/, '');
 }
 
 /**

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -237,8 +237,12 @@ jobs:
   changelog:
     name: changelog
     runs-on: ubuntu-latest
-    # PR-only. Deliberately NOT re-run on `edited`: re-run the failed job after
-    # adding an entry or `[skip changelog]`.
+    # PR-only, and path-aware: an entry is required only when shippable source
+    # changed (handsontable/src/** or wrappers/**, tests + markdown excluded) —
+    # docs/test/CI-only PRs pass automatically, and `[skip changelog]` (outside
+    # HTML comments) overrides on a source change. Deliberately NOT re-run on
+    # `edited`: re-run the failed job after adding an entry or the marker (the
+    # script reads the live PR body).
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # https://github.com/actions/checkout/releases/tag/v6.0.2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,7 +160,7 @@ These standards apply to **all** documentation across the monorepo — guides, t
 ### PR requirements
 
 - Every PR that changes package source code must include a changelog entry. Use the `changelog-creation` and `pr-creation` skills for the entry format and PR flow.
-- To skip changelog (for non-source-code changes only), write `[skip changelog]` in the PR description.
+- The changelog gate is path-aware: docs-, test-, and CI/tooling-only PRs pass it automatically. To skip it on a genuine source change (`handsontable/src/**` or `wrappers/**`), write `[skip changelog]` in the PR description — outside HTML comments; a commented mention (like the PR template's hint) is inert.
 - PRs are merged using **"Squash and merge"** in the GitHub UI by the PR author after full approval.
 - The PR author addresses reviewer comments. The reviewer confirms resolution by clicking **Resolve conversation**.
 


### PR DESCRIPTION
### Context

The PR makes the changelog gate **path-aware**: an entry is required by default when a PR changes **shippable source** (`handsontable/src/**` or `wrappers/**`, tests and markdown excluded), while docs-, test-, and CI/tooling-only PRs **pass automatically** — no entry, no `[skip changelog]` ceremony. The marker remains as a deliberate override on source changes, and the override is logged together with the source files it waves through, so reviewers can judge it.

Previously the gate was path-blind — every PR needed an entry or the skip string, and nothing verified the skip string was justified. Enforcement now matches the policy `.changelogs/README.md` and `AGENTS.md` always stated ("entries are expected only for source-code changes to the library core or the wrappers").

Two supporting changes:

1. **HTML comments are stripped before matching the marker** — so the PR template can now safely *document* `[skip changelog]` in a comment without activating it on every PR (previously `body.includes(...)` matched even commented mentions, which is why the template never mentioned it).
2. **The template now carries a commented changelog hint** (entry required for source changes, `npm run changelog entry` after opening the PR, auto-pass for non-source PRs, how to skip).

The decision logic lives in a **pure, unit-tested lib** (`.github/scripts/lib/changelog-gate.mjs`) reusing the presence gate's `classify()` — one source of truth for "is this a test file". The classification is deliberately broader than the presence gate's testable-code set: styling/themes under `handsontable/src` and wrapper manifests ship, so they demand an entry.

This PR contains no skip marker (outside comments) — its own green `Checks / changelog` run **is** the feature demonstrating itself on a CI-only diff.

### How has this been tested?

- `node --test .github/scripts/__tests__/changelog-gate.test.mjs` — 11/11: shippable-source classification (core src, scss themes, wrapper src/manifests → required; unit/spec/test-helpers/markdown/docs/CI → not), entry-added pass, modified-entry ≠ new entry, removed/renamed source counts, marker override + logging, **marker-in-comment is inert**, missing/null body safety.
- `npm run test:tooling` — 80/80 (no regressions across the enforcement machinery).
- Self-demonstration: this PR's `Checks / changelog` passes via `no-source-change` with no entry and no marker.

### Commands run

```
node --test .github/scripts/__tests__/changelog-gate.test.mjs   # 11/11
npm run test:tooling                                            # 80/80
node --check .github/scripts/check-changelog.js                 # OK
```

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality) — CI gate behavior
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2057 (pipeline hardening; pairs with quality task 13 — changelog auto-generation, which reuses the same classifier)

### Affected project(s):

- [x] `handsontable` <!-- CI gate + docs; no shippable src -->
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1) <!-- internal change -->
- [x] My change requires a change to the documentation. <!-- .changelogs/README.md, PR template, AGENTS.md updated in this PR -->

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2057

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/docs/tooling only; no library runtime or release artifact behavior changes, with conservative defaults when skip-marker parsing is ambiguous.
> 
> **Overview**
> **Path-aware changelog enforcement** replaces the old rule that every PR needed a `.changelogs/*.json` entry or `[skip changelog]`. The gate now fails only when changed files include **shippable source** (`handsontable/src/**` or `wrappers/**`, excluding tests, test dirs, and markdown); docs-, test-, and CI/tooling-only PRs pass with no entry.
> 
> Decision logic moves into **`changelog-gate.mjs`** (pure functions + `evaluateChangelogGate`), reused from the presence gate’s `classify()` for test files. **`check-changelog.js`** dynamic-imports that module and branches on verdict reasons (`entry-added`, `no-source-change`, `skipped-explicitly`, `missing-entry`), listing source paths on skip or failure.
> 
> **`[skip changelog]`** is matched only after **`stripHtmlComments`** (fixed-point loop + comment-to-EOF stripping) so template hints in HTML comments cannot opt out; explicit skips log the waved-through source files.
> 
> **`.changelogs/README.md`**, **PR template**, **`AGENTS.md`**, and **`checks.yml`** comments document the new policy; **`changelog-gate.test.mjs`** adds 11 unit tests for classification, comment stripping, and gate outcomes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0320f8de436e0878b3f54d5d23e1a95f87894e24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->