### PR TITLE
DEV-2132: Fix HyperFormula type imports in custom-function docs examples

### DIFF
--- a/docs/angular-type-check/check.mjs
+++ b/docs/angular-type-check/check.mjs
@@ -163,7 +163,6 @@ function runCheck({ label, htDir }) {
       paths: {
         handsontable: [htDir],
         'handsontable/*': [`${htDir}/*`],
-        'hyperformula/typings/*': ['node_modules/hyperformula/typings/*'],
       },
     },
     include: ['./.tmp/**/*.ts', './types/**/*.d.ts'],

--- a/docs/content/guides/formulas/formula-calculation/angular/example-custom-functions.html
+++ b/docs/content/guides/formulas/formula-calculation/angular/example-custom-functions.html
@@ -1,0 +1,3 @@
+<div>
+  <app-example-custom-functions></app-example-custom-functions>
+</div>

--- a/docs/content/guides/formulas/formula-calculation/angular/example-custom-functions.ts
+++ b/docs/content/guides/formulas/formula-calculation/angular/example-custom-functions.ts
@@ -2,9 +2,14 @@
 import { Component } from '@angular/core';
 import { GridSettings, HotTableModule } from '@handsontable/angular-wrapper';
 import { FunctionArgumentType, FunctionPlugin, HyperFormula } from 'hyperformula';
-import type { ProcedureAst } from 'hyperformula/typings/parser/Ast';
-import type { InterpreterState } from 'hyperformula/typings/interpreter/InterpreterState';
-import type { InterpreterValue } from 'hyperformula/typings/interpreter/InterpreterValue';
+
+// HyperFormula does not export its parser and interpreter types from the package
+// entry point, so derive them from the inherited `runFunction` signature.
+type RunFunction = FunctionPlugin['runFunction'];
+type Ast = Parameters<RunFunction>[0][number];
+type ProcedureAst = Extract<Ast, { procedureName: string }>;
+type InterpreterState = Parameters<RunFunction>[1];
+type InterpreterValue = ReturnType<Parameters<RunFunction>[3]>;
 
 class CommissionPlugin extends FunctionPlugin {
   commission(ast: ProcedureAst, state: InterpreterState): InterpreterValue {
@@ -34,7 +39,7 @@ HyperFormula.registerFunctionPlugin(CommissionPlugin, {
 @Component({
   standalone: true,
   imports: [HotTableModule],
-  selector: 'app-example5',
+  selector: 'app-example-custom-functions',
   template: `
     <hot-table [settings]="gridSettings" [data]="data"></hot-table>
   `,

--- a/docs/content/guides/formulas/formula-calculation/angular/example5.html
+++ b/docs/content/guides/formulas/formula-calculation/angular/example5.html
@@ -1,3 +1,0 @@
-<div>
-  <app-example5></app-example5>
-</div>

--- a/docs/content/guides/formulas/formula-calculation/formula-calculation.md
+++ b/docs/content/guides/formulas/formula-calculation/formula-calculation.md
@@ -979,10 +979,10 @@ each sales representative's commission amount.
 
 ::: only-for angular
 
-::: example #example5 :angular --ts 1 --html 2
+::: example #example-custom-functions :angular --ts 1 --html 2
 
-@[code](@/content/guides/formulas/formula-calculation/angular/example5.ts)
-@[code](@/content/guides/formulas/formula-calculation/angular/example5.html)
+@[code](@/content/guides/formulas/formula-calculation/angular/example-custom-functions.ts)
+@[code](@/content/guides/formulas/formula-calculation/angular/example-custom-functions.html)
 
 :::
 

--- a/docs/content/guides/formulas/formula-calculation/javascript/example-custom-functions.ts
+++ b/docs/content/guides/formulas/formula-calculation/javascript/example-custom-functions.ts
@@ -1,9 +1,14 @@
 import Handsontable from 'handsontable/base';
 import { registerAllModules } from 'handsontable/registry';
 import { FunctionArgumentType, FunctionPlugin, HyperFormula } from 'hyperformula';
-import type { ProcedureAst } from 'hyperformula/typings/parser/Ast';
-import type { InterpreterState } from 'hyperformula/typings/interpreter/InterpreterState';
-import type { InterpreterValue } from 'hyperformula/typings/interpreter/InterpreterValue';
+
+// HyperFormula does not export its parser and interpreter types from the package
+// entry point, so derive them from the inherited `runFunction` signature.
+type RunFunction = FunctionPlugin['runFunction'];
+type Ast = Parameters<RunFunction>[0][number];
+type ProcedureAst = Extract<Ast, { procedureName: string }>;
+type InterpreterState = Parameters<RunFunction>[1];
+type InterpreterValue = ReturnType<Parameters<RunFunction>[3]>;
 
 // Register all Handsontable's modules.
 registerAllModules();

--- a/docs/content/guides/formulas/formula-calculation/react/example-custom-functions.tsx
+++ b/docs/content/guides/formulas/formula-calculation/react/example-custom-functions.tsx
@@ -1,10 +1,15 @@
 import { FunctionArgumentType, FunctionPlugin, HyperFormula } from 'hyperformula';
-import type { ProcedureAst } from 'hyperformula/typings/parser/Ast';
-import type { InterpreterState } from 'hyperformula/typings/interpreter/InterpreterState';
-import type { InterpreterValue } from 'hyperformula/typings/interpreter/InterpreterValue';
 import { HotTable } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
 import type { DetailedSettings } from 'handsontable/plugins/formulas';
+
+// HyperFormula does not export its parser and interpreter types from the package
+// entry point, so derive them from the inherited `runFunction` signature.
+type RunFunction = FunctionPlugin['runFunction'];
+type Ast = Parameters<RunFunction>[0][number];
+type ProcedureAst = Extract<Ast, { procedureName: string }>;
+type InterpreterState = Parameters<RunFunction>[1];
+type InterpreterValue = ReturnType<Parameters<RunFunction>[3]>;
 
 // register Handsontable's modules
 registerAllModules();

--- a/docs/content/guides/formulas/formula-calculation/vue/example-custom-functions.vue
+++ b/docs/content/guides/formulas/formula-calculation/vue/example-custom-functions.vue
@@ -3,11 +3,16 @@ import { ref, markRaw } from 'vue';
 import { HotTable } from '@handsontable/vue3';
 import { registerAllModules } from 'handsontable/registry';
 import { FunctionArgumentType, FunctionPlugin, HyperFormula } from 'hyperformula';
-import type { ProcedureAst } from 'hyperformula/typings/parser/Ast';
-import type { InterpreterState } from 'hyperformula/typings/interpreter/InterpreterState';
-import type { InterpreterValue } from 'hyperformula/typings/interpreter/InterpreterValue';
 import type { GridSettings } from 'handsontable/settings';
 import type { DetailedSettings } from 'handsontable/plugins/formulas';
+
+// HyperFormula does not export its parser and interpreter types from the package
+// entry point, so derive them from the inherited `runFunction` signature.
+type RunFunction = FunctionPlugin['runFunction'];
+type Ast = Parameters<RunFunction>[0][number];
+type ProcedureAst = Extract<Ast, { procedureName: string }>;
+type InterpreterState = Parameters<RunFunction>[1];
+type InterpreterValue = ReturnType<Parameters<RunFunction>[3]>;
 
 // register Handsontable's modules
 registerAllModules();


### PR DESCRIPTION
### Context

The PR fixes the Angular custom-function example on the **Formula calculation** page, which never rendered a grid in the docs example runner (the sweep reported `no-grid` after 240 s).

All four framework variants of that example imported HyperFormula's internal types through deep paths:

```ts
import type { ProcedureAst } from 'hyperformula/typings/parser/Ast';
import type { InterpreterState } from 'hyperformula/typings/interpreter/InterpreterState';
import type { InterpreterValue } from 'hyperformula/typings/interpreter/InterpreterValue';
```

`hyperformula@3.3.0` declares an `exports` map that exposes only `.` and `./i18n/languages/*`, so `./typings/*` is unresolvable under `moduleResolution: bundler` (the Angular 17+ default) even though the files exist on disk. `tsc` confirms it: `bundler` fails with `TS2307`, legacy `node10` resolves. The runner compiles Angular examples with real type checking, so the compile failed and no grid mounted. `ProcedureAst`, `InterpreterState` and `InterpreterValue` are not re-exported from the HyperFormula package root, and HyperFormula is not changed here.

The types are now derived from the inherited `runFunction` signature — no deep imports, no `any`, no suppressions:

```ts
type RunFunction = FunctionPlugin['runFunction'];
type Ast = Parameters<RunFunction>[0][number];
type ProcedureAst = Extract<Ast, { procedureName: string }>;
type InterpreterState = Parameters<RunFunction>[1];
type InterpreterValue = ReturnType<Parameters<RunFunction>[3]>;
```

Both derivations are exact. `procedureName` occurs once in the whole `Ast` union, and `Parameters<RunFunction>[3]` is `runFunction`'s `functionImplementation` argument, typed `(...arg: any) => InterpreterValue`. The `commission()` signature the guide teaches is unchanged.

Two related changes:

1. `angular/example5.{ts,html}` is renamed to `angular/example-custom-functions.{ts,html}`, so the Angular variant sits in the same named group as the JavaScript, React and Vue variants. Its code-preview container id (`#example5` to `#example-custom-functions`) and component selector are aligned with it. This changes the public runner URL for that example; the runner's own manifest is generated in the `handsontable/examples` repo and picks the new path up on its next regeneration.
2. `docs/angular-type-check/check.mjs` no longer injects a `hyperformula/typings/*` mapping into the `paths` of the tsconfig it generates. That mapping made the deep imports resolvable inside the harness only, which is why CI stayed green while the example runner failed. It was added by the same commit that added these examples.

### How has this been tested?

Angular docs type-check harness, with the `paths` override removed:

```bash
npm run build --prefix handsontable
npm run build --prefix wrappers/angular-wrapper
SKIP_LATEST=1 npm run typecheck --prefix docs/angular-type-check
```

`STATUS: TRUE`, zero errors.

Negative control on the same harness — one deep import temporarily re-added, then reverted:

```
[LOCAL-ONLY] guides/formulas/formula-calculation/angular/example-custom-functions.ts:4:58
  TS2307: Cannot find module 'hyperformula/typings/parser/Ast' ...
STATUS: FALSE - 1 type error(s) failed the run
```

The harness now rejects what it previously masked.

Docs loader unit tests:

```bash
node --test docs/src/plugins/__tests__/*.test.mjs
# 94 pass, 0 fail
```

Manual browser check against `npm run dev --prefix docs`, on all four framework variants of `guides/formulas/formula-calculation`:

- The custom-function grid mounts and column D computes 3600, 6200, 3040, 8520 and 2030 - no `#NAME?`, no empty container.
- On the Angular page all five examples still mount, the container id is `example-custom-functions`, and the rendered HTML contains no `File not found` marker and no `example5` reference.

Two limits worth stating:

- Nothing in this repository type-checks the `javascript/`, `react/` or `vue/` examples (`docs/tsconfig.json` excludes `content`, and the harness only collects files under `angular/`). Those three variants are covered here by the browser render plus the shared type derivation, not by a compiler run.
- The runner sweep (`docs/scripts/test-runner-links.mjs`) cannot verify the renamed path until the docs deploy and the external runner manifest regenerate.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2132

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

Documentation only.

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog]

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2132

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example-only TypeScript changes plus a test-harness tweak; no product library or runtime API changes.
> 
> **Overview**
> Fixes the **Formula calculation** custom-function docs examples (Angular, JS, React, Vue) that failed to compile or render because they imported `ProcedureAst`, `InterpreterState`, and `InterpreterValue` from `hyperformula/typings/*`, which HyperFormula 3.3’s `exports` map does not expose under `moduleResolution: bundler`.
> 
> Those types are now **derived from `FunctionPlugin['runFunction']`** instead of deep imports, with a short comment explaining why. Runtime behavior of the `COMMISSION` demo is unchanged.
> 
> The Angular variant is **renamed** from `example5` to `example-custom-functions` (files, `#example-custom-functions` anchor, and `app-example-custom-functions` selector) so it matches the other frameworks; `formula-calculation.md` embeds are updated accordingly.
> 
> The Angular docs type-check harness (`check.mjs`) **drops** the `hyperformula/typings/*` `paths` override so CI no longer masks the same resolution failure the live example runner hit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55745b783b09d3837c96aa1fb16c6fbafe3dde32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->