### PR TITLE
DEV-2059: gate-metrics report — the data behind the warn→block decision

### DIFF
--- a/scripts/__tests__/gate-metrics.test.mjs
+++ b/scripts/__tests__/gate-metrics.test.mjs
@@ -1,0 +1,74 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { analyzePr, median, summarize } from '../lib/gate-metrics.mjs';
+
+const srcFile = { status: 'modified', filename: 'handsontable/src/core.ts', additions: 100 };
+const unitFile = { status: 'added', filename: 'handsontable/src/__tests__/core.unit.js', additions: 40 };
+const docFile = { status: 'modified', filename: 'docs/content/guides/foo/foo.md', additions: 10 };
+const entryFile = { status: 'added', filename: '.changelogs/13200.json', additions: 5 };
+
+test('a source PR with a test computes the ratio and passes', () => {
+  const row = analyzePr({
+    number: 1, title: 't', body: '', files: [srcFile, unitFile, entryFile], commitMessages: ['DEV-1: change'],
+  });
+
+  assert.equal(row.pass, true);
+  assert.equal(row.verdict, 'ok');
+  assert.equal(row.sourceAdded, 100);
+  assert.equal(row.testAdded, 40);
+  assert.equal(row.ratio, 0.4);
+  assert.equal(row.changelogEntry, true);
+});
+
+test('a source PR with no test and no trailer would block', () => {
+  const row = analyzePr({
+    number: 2, title: 't', body: '', files: [srcFile], commitMessages: ['DEV-2: change'],
+  });
+
+  assert.equal(row.pass, false);
+  assert.equal(row.verdict, 'missing-coverage');
+});
+
+test('a Refactor-only trailer converts the block into a declared pass', () => {
+  const row = analyzePr({
+    number: 3, title: 't', body: '', files: [srcFile], commitMessages: ['DEV-3: x\n\nRefactor-only: renames'],
+  });
+
+  assert.equal(row.pass, true);
+  assert.equal(row.refactorTrailer, true);
+});
+
+test('docs-only PRs have no source signal and detect the skip marker', () => {
+  const row = analyzePr({
+    number: 4, title: 't', body: 'docs\n[skip changelog]', files: [docFile], commitMessages: ['docs'],
+  });
+
+  assert.equal(row.sourceFiles, 0);
+  assert.equal(row.ratio, null);
+  assert.equal(row.changelogSkipped, true);
+});
+
+test('median handles odd, even, and empty lists', () => {
+  assert.equal(median([3, 1, 2]), 2);
+  assert.equal(median([1, 2, 3, 4]), 2.5);
+  assert.equal(median([]), null);
+});
+
+test('summarize aggregates verdicts, escapes, and the would-block list', () => {
+  const rows = [
+    analyzePr({ number: 1, title: 'a', body: '', files: [srcFile, unitFile], commitMessages: [''] }),
+    analyzePr({ number: 2, title: 'b', body: '', files: [srcFile], commitMessages: [''] }),
+    analyzePr({ number: 3, title: 'c', body: '[skip changelog]', files: [docFile], commitMessages: [''] }),
+  ];
+  const s = summarize(rows);
+
+  assert.equal(s.totalPrs, 3);
+  assert.equal(s.sourcePrs, 2);
+  assert.equal(s.byVerdict.ok, 2);
+  assert.equal(s.byVerdict['missing-coverage'], 1);
+  assert.deepEqual(s.wouldBlock.map(r => r.number), [2]);
+  assert.equal(s.changelogSkips, 1);
+  // The test-less source PR's 0 ratio counts — dragging the median down IS the
+  // signal (median of [0.4, 0]).
+  assert.equal(s.medianRatio, 0.2);
+});

--- a/scripts/gate-metrics.mjs
+++ b/scripts/gate-metrics.mjs
@@ -1,0 +1,125 @@
+/**
+ * Gate metrics CLI — sweep merged PRs and report enforcement-gate health.
+ *
+ * The recurring health report behind the DEV-2059 warn→block decision:
+ * recomputes the presence-gate verdict for every merged PR (final state),
+ * measures implementation:test added-line ratios, counts escape-hatch usage,
+ * and (with --ci-history) how often the CI presence gate went red on the way.
+ *
+ * Usage:
+ *   node scripts/gate-metrics.mjs --since 2026-07-21 [--ci-history]
+ *
+ * Requires an authenticated `gh` CLI. Read-only.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { analyzePr, summarize } from './lib/gate-metrics.mjs';
+
+const args = process.argv.slice(2);
+const since = args[args.indexOf('--since') + 1];
+const ciHistory = args.includes('--ci-history');
+
+if (!args.includes('--since') || !since) {
+  console.error('Usage: node scripts/gate-metrics.mjs --since YYYY-MM-DD [--ci-history]');
+  process.exit(1);
+}
+
+/**
+ * Call the GitHub API through the gh CLI.
+ *
+ * @param {string} path API path (`:owner/:repo` placeholders allowed).
+ * @param {string} [jq] Optional jq filter.
+ * @param {boolean} [paginate] Paginate the endpoint.
+ * @returns {any} Parsed JSON.
+ */
+function ghApi(path, jq, paginate = false) {
+  const cliArgs = ['api', ...(paginate ? ['--paginate'] : []), path, ...(jq ? ['--jq', jq] : [])];
+  const out = execFileSync('gh', cliArgs, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+
+  if (!paginate) {
+    return JSON.parse(out);
+  }
+
+  // With --paginate, a --jq filter emits one JSON document PER PAGE
+  // (newline-separated) — parse each and flatten (gh's --slurp is not
+  // combinable with --jq in all gh versions).
+  return out.trim().split('\n').filter(Boolean).map(line => JSON.parse(line)).flat();
+}
+
+const mergedPrs = ghApi(
+  'repos/:owner/:repo/pulls?state=closed&base=develop&sort=updated&direction=desc&per_page=100',
+  `[.[] | select(.merged_at != null and .merged_at >= "${since}")
+     | {number, title, body, merged_at, head: .head.ref}]`
+);
+
+console.error(`Analyzing ${mergedPrs.length} PRs merged to develop since ${since}...`);
+
+const rows = [];
+
+for (const pr of mergedPrs) {
+  const files = ghApi(`repos/:owner/:repo/pulls/${pr.number}/files?per_page=100`,
+    '[.[] | {status, filename, additions}]', true);
+  const commitMessages = ghApi(`repos/:owner/:repo/pulls/${pr.number}/commits?per_page=100`,
+    '[.[].commit.message]', true);
+  const row = analyzePr({ ...pr, files, commitMessages });
+
+  if (ciHistory) {
+    // How often did the CI presence gate go red on this PR's branch? A red
+    // that later turned green means the gate prompted a test (worked); a
+    // never-red PR needed no prompting.
+    try {
+      const branch = encodeURIComponent(pr.head);
+      const runs = ghApi(
+        `repos/:owner/:repo/actions/workflows/test.yml/runs?event=pull_request&branch=${branch}&per_page=8`,
+        '[.workflow_runs[].id]'
+      );
+
+      row.presenceReds = 0;
+
+      for (const runId of runs) {
+        const conclusions = ghApi(`repos/:owner/:repo/actions/runs/${runId}/jobs?per_page=100`,
+          '[.jobs[] | select(.name == "Checks / test presence") | .conclusion]', true);
+
+        row.presenceReds += conclusions.filter(c => c === 'failure').length;
+      }
+    } catch {
+      row.presenceReds = null;
+    }
+  }
+
+  rows.push(row);
+  console.error(`  #${pr.number} ${row.verdict}`);
+}
+
+const s = summarize(rows);
+const fmtRatio = r => (r === null ? '—' : r.toFixed(2));
+
+console.log(`\n## Gate metrics — PRs merged to develop since ${since}\n`);
+console.log('| PR | Title | Src files | +src | +test | ratio | Verdict | Escapes | CI reds |');
+console.log('|---|---|---|---|---|---|---|---|---|');
+
+for (const r of rows) {
+  const escapes = [
+    r.refactorTrailer ? 'refactor-trailer' : '',
+    r.changelogSkipped ? 'skip-changelog' : '',
+  ].filter(Boolean).join(', ') || '—';
+
+  console.log(`| #${r.number} | ${r.title.slice(0, 48)} | ${r.sourceFiles} | ${r.sourceAdded} | ${r.testAdded} `
+    + `| ${fmtRatio(r.ratio)} | ${r.verdict} | ${escapes} | ${r.presenceReds ?? '—'} |`);
+}
+
+console.log('\n### Summary');
+console.log(`- PRs merged: **${s.totalPrs}** (source-changing: **${s.sourcePrs}**)`);
+console.log(`- Presence verdicts: ${Object.entries(s.byVerdict).map(([k, v]) => `${k}: **${v}**`).join(' · ')}`);
+console.log(`- Median test:impl added-line ratio (source PRs): **${fmtRatio(s.medianRatio)}**`);
+console.log(`- Escapes: Refactor-only trailers: **${s.refactorTrailers}** · [skip changelog]: **${s.changelogSkips}**`);
+
+if (s.wouldBlock.length > 0) {
+  console.log(`- **Would block under enforcement (${s.wouldBlock.length})** — judge each: real gap or false block?`);
+
+  for (const r of s.wouldBlock) {
+    console.log(`  - #${r.number} ${r.title.slice(0, 60)} (+${r.sourceAdded} src, +${r.testAdded} test)`);
+  }
+} else {
+  console.log('- Would block under enforcement: **none** 🎉');
+}

--- a/scripts/lib/gate-metrics.mjs
+++ b/scripts/lib/gate-metrics.mjs
@@ -1,0 +1,104 @@
+/**
+ * Gate metrics — pure analysis of merged PRs against the enforcement gates.
+ *
+ * Feeds the DEV-2059 warn→block decision with data: per-PR presence-gate
+ * verdicts (recomputed from the merged file set, not scraped from logs),
+ * implementation:test line ratios, and escape-hatch usage (`Refactor-only:`
+ * trailers, `[skip changelog]` markers). No network access lives here; the CLI
+ * wrapper (../gate-metrics.mjs) feeds it GitHub API data.
+ */
+
+import { evaluate, isSource, isCoverage } from '../../.github/scripts/lib/presence-gate.mjs';
+
+/**
+ * GitHub "list PR files" status words → git name-status letters, which the
+ * presence-gate classifier expects.
+ */
+const STATUS_LETTER = {
+  added: 'A',
+  modified: 'M',
+  removed: 'D',
+  renamed: 'R',
+  copied: 'C',
+  changed: 'M',
+};
+
+/**
+ * Analyze one merged PR.
+ *
+ * @param {object} pr The PR's raw data.
+ * @param {number} pr.number PR number.
+ * @param {string} pr.title PR title.
+ * @param {string} pr.body PR description.
+ * @param {{status: string, filename: string, additions: number}[]} pr.files
+ *   Changed files from the "list PR files" API.
+ * @param {string[]} pr.commitMessages Full commit messages of the PR.
+ * @returns {object} The per-PR metrics row.
+ */
+export function analyzePr({ number, title, body, files, commitMessages }) {
+  const changes = files
+    .filter(f => f.status !== 'unchanged')
+    .map(f => ({ status: STATUS_LETTER[f.status] ?? 'M', path: f.filename, additions: f.additions ?? 0 }));
+
+  const trailerLines = commitMessages.flatMap(m => String(m).split('\n'));
+  const verdict = evaluate(changes.map(({ status, path }) => ({ status, path })), trailerLines);
+
+  const sourceAdded = changes.filter(isSource).reduce((sum, c) => sum + c.additions, 0);
+  const testAdded = changes.filter(isCoverage).reduce((sum, c) => sum + c.additions, 0);
+
+  return {
+    number,
+    title,
+    sourceFiles: verdict.sourceFiles.length,
+    sourceAdded,
+    testAdded,
+    ratio: sourceAdded > 0 ? testAdded / sourceAdded : null,
+    verdict: verdict.reason,
+    pass: verdict.pass,
+    refactorTrailer: verdict.reason === 'refactor-declared',
+    changelogEntry: changes.some(c => c.status === 'A'
+      && c.path.startsWith('.changelogs/') && c.path.endsWith('.json')),
+    changelogSkipped: /\[skip changelog\]/.test(body || ''),
+  };
+}
+
+/**
+ * The median of a numeric list.
+ *
+ * @param {number[]} values The values.
+ * @returns {number|null} The median, or null for an empty list.
+ */
+export function median(values) {
+  if (values.length === 0) {
+    return null;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+/**
+ * Aggregate per-PR rows into the report summary.
+ *
+ * @param {object[]} rows Rows from analyzePr.
+ * @returns {object} Aggregate metrics.
+ */
+export function summarize(rows) {
+  const sourcePrs = rows.filter(r => r.sourceFiles > 0);
+  const byVerdict = {};
+
+  for (const r of rows) {
+    byVerdict[r.verdict] = (byVerdict[r.verdict] ?? 0) + 1;
+  }
+
+  return {
+    totalPrs: rows.length,
+    sourcePrs: sourcePrs.length,
+    byVerdict,
+    wouldBlock: rows.filter(r => !r.pass),
+    refactorTrailers: rows.filter(r => r.refactorTrailer).length,
+    changelogSkips: rows.filter(r => r.changelogSkipped).length,
+    medianRatio: median(sourcePrs.filter(r => r.ratio !== null).map(r => r.ratio)),
+  };
+}


### PR DESCRIPTION
### Context

The PR adds `scripts/gate-metrics.mjs` — the recurring health report behind the **DEV-2059 warn→block decision** (risks doc R3: flip only with real-PR data). It sweeps merged PRs and reports, per PR: the presence-gate verdict **recomputed from the merged file set** (via the tested presence-gate lib — no log scraping), implementation:test added-line ratios, escape-hatch usage (`Refactor-only:` trailers, `[skip changelog]`), and — with `--ci-history` — how often the CI presence gate went red on the way to merge.

```
node scripts/gate-metrics.mjs --since 2026-07-21 [--ci-history]
```

First run (week of Jul 21–28): 16 merged PRs, 3 source-changing, **0 would-block**, median test:impl ratio **3.46**, 0 `Refactor-only` trailers, 0 CI presence reds.

`[skip changelog]` — tooling only, no shippable source. <!-- and under the new path-aware gate this line is belt-and-braces -->

### How has this been tested?

- `node --test scripts/__tests__/gate-metrics.test.mjs` — 6/6 (ratio math including the zero-ratio drag, verdict mapping, trailer detection, skip-marker detection, median edge cases, aggregation).
- Live run over the real week of merged PRs (`--since 2026-07-21 --ci-history`) — output sane, cross-checked against known PRs.
- Root `npm run eslint` clean.

### Known limitation (noted for the next iteration)

The `[skip changelog]` counter is a naive substring match — it counts markers mentioned in prose/HTML comments too (one false positive in the first run: a PR *about* the marker). Once this branch rebases over #13123's `changelog-gate.mjs`, the tool should reuse its comment-stripping matcher.

### Types of changes

- [x] New feature or improvement (non-breaking change which adds functionality) — maintainer tooling

### Related issue(s):

1. DEV-2059 (branch-protection cutover + warn→block — this is its measurement pre-work)

### Affected project(s):

- [x] `handsontable` <!-- scripts/ tooling only -->
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1) <!-- internal -->
- [ ] My change requires a change to the documentation. <!-- maintainer tool; usage in the file header -->

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2059
