### PR TITLE
DEV-1790: Fix Starlight TOC :has() crash by wrapping init per instance

### DIFF
--- a/docs/src/components/Head.astro
+++ b/docs/src/components/Head.astro
@@ -29,23 +29,52 @@ import Default from '@astrojs/starlight/components/Head.astro';
 </script>
 
 <script is:inline>
-  // Patch StarlightTOC to silently handle browsers that don't support :has() (Chrome < 105,
-  // e.g. Chrome Mobile 75 on Android 6.0). The TOC uses :has() inside querySelectorAll which
-  // throws a DOMException named "SyntaxError" in those browsers. Catching it degrades gracefully: the TOC renders
-  // but doesn't highlight the active section while scrolling.
-  customElements.whenDefined('starlight-toc').then(function () {
-    var StarlightTOC = customElements.get('starlight-toc');
-    if (!StarlightTOC || !StarlightTOC.prototype.init) return;
-    var _originalInit = StarlightTOC.prototype.init;
-    StarlightTOC.prototype.init = function () {
-      try {
-        _originalInit.call(this);
-      } catch (e) {
-        if (e instanceof DOMException && e.name === 'SyntaxError') return;
-        throw e;
+  // Patch Starlight's table-of-contents elements to silently handle browsers without :has()
+  // support (Chrome < 105, e.g. Chrome Mobile 75 on Android 6.0; Safari < 15.4). Their init
+  // passes :has() to querySelectorAll, which throws a DOMException named "SyntaxError" there
+  // and surfaces as an uncaught page error (Sentry HANDSONTABLE-DOCS-1GA). Catching it
+  // degrades gracefully: the TOC renders but doesn't highlight the active section on scroll.
+  //
+  // Starlight assigns init as an own instance field inside the constructor, so a patch on
+  // StarlightTOC.prototype.init never applies - the instance field shadows it. Wrap init per
+  // instance instead, by subclassing the constructor as it is registered. This inline script
+  // runs during head parsing, before the deferred module that defines the elements.
+  (function () {
+    var guardedTags = ['starlight-toc', 'mobile-starlight-toc'];
+    var originalDefine = customElements.define;
+
+    customElements.define = function (name, constructor, options) {
+      if (guardedTags.indexOf(name) === -1 || typeof constructor !== 'function') {
+        return originalDefine.call(customElements, name, constructor, options);
       }
+
+      var GuardedElement = class extends constructor {
+        constructor() {
+          super();
+
+          var originalInit = this.init;
+
+          if (typeof originalInit !== 'function') {
+            return;
+          }
+
+          this.init = function () {
+            try {
+              return originalInit.apply(this, arguments);
+            } catch (error) {
+              if (error instanceof DOMException && error.name === 'SyntaxError') {
+                return undefined;
+              }
+
+              throw error;
+            }
+          };
+        }
+      };
+
+      return originalDefine.call(customElements, name, GuardedElement, options);
     };
-  });
+  })();
 </script>
 
 <script>

--- a/docs/src/components/__tests__/head-starlight-toc-has-guard.test.mjs
+++ b/docs/src/components/__tests__/head-starlight-toc-has-guard.test.mjs
@@ -1,0 +1,161 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const headPath = fileURLToPath(new URL('../Head.astro', import.meta.url));
+const headSource = readFileSync(headPath, 'utf8');
+
+/**
+ * Extracts the inline head script that guards Starlight's table-of-contents custom elements
+ * against the `:has()` SyntaxError.
+ *
+ * @returns {string} The script body, without the surrounding `<script>` tags.
+ */
+function readTocGuardScript() {
+  const blocks = headSource.match(/<script is:inline>[\s\S]*?<\/script>/g) ?? [];
+  const guardBlocks = blocks.filter((block) => block.includes('starlight-toc'));
+
+  assert.equal(guardBlocks.length, 1, 'Head.astro must contain exactly one starlight-toc guard script');
+
+  return guardBlocks[0].replace(/^<script is:inline>/, '').replace(/<\/script>$/, '');
+}
+
+class FakeHTMLElement {}
+
+/**
+ * Builds a stand-in for `window.customElements` that records definitions and resolves
+ * `whenDefined()` promises, so the guard script can run outside a browser.
+ *
+ * @returns {object} The fake registry.
+ */
+function createRegistry() {
+  const definitions = new Map();
+  const waiters = new Map();
+
+  return {
+    define(name, constructor) {
+      definitions.set(name, constructor);
+
+      for (const resolve of waiters.get(name) ?? []) {
+        resolve(constructor);
+      }
+
+      waiters.delete(name);
+    },
+    get(name) {
+      return definitions.get(name);
+    },
+    whenDefined(name) {
+      if (definitions.has(name)) {
+        return Promise.resolve(definitions.get(name));
+      }
+
+      return new Promise((resolve) => {
+        waiters.set(name, [...(waiters.get(name) ?? []), resolve]);
+      });
+    },
+  };
+}
+
+/**
+ * Mirrors the shape of Starlight's TOC element: `init` is an own instance field assigned in
+ * the constructor, never a prototype method. A prototype-level patch cannot intercept it.
+ *
+ * @param {Error|undefined} errorToThrow Error the original `init` throws, if any.
+ * @returns {Function} The class to register.
+ */
+function createStarlightTocClass(errorToThrow) {
+  return class extends FakeHTMLElement {
+    constructor() {
+      super();
+
+      this.originalInitCallCount = 0;
+
+      this.init = () => {
+        this.originalInitCallCount += 1;
+
+        if (errorToThrow) {
+          throw errorToThrow;
+        }
+
+        return 'initialized';
+      };
+    }
+  };
+}
+
+/**
+ * Runs the guard script against a fresh registry, then registers a Starlight-shaped class
+ * under `tagName` and returns an instance built from whatever the registry ended up holding.
+ *
+ * @param {object} options Test setup options.
+ * @param {string} options.tagName Custom element name to register.
+ * @param {Error} [options.errorToThrow] Error the original `init` throws.
+ * @returns {Promise<object>} The constructed instance.
+ */
+async function setUpGuardedElement({ tagName, errorToThrow }) {
+  const customElements = createRegistry();
+  const runGuardScript = new Function('customElements', 'DOMException', readTocGuardScript());
+
+  runGuardScript(customElements, DOMException);
+
+  customElements.define(tagName, createStarlightTocClass(errorToThrow));
+
+  // The pre-fix patch waited on `customElements.whenDefined()`, so let its microtasks settle
+  // before the element is constructed.
+  await Promise.resolve();
+  await Promise.resolve();
+
+  const RegisteredClass = customElements.get(tagName);
+
+  return new RegisteredClass();
+}
+
+for (const tagName of ['starlight-toc', 'mobile-starlight-toc']) {
+  test(`<${tagName}> swallows the :has() SyntaxError thrown by Starlight's init`, async () => {
+    // Regression guard for HANDSONTABLE-DOCS-1GA: browsers without :has() support (Chrome < 105,
+    // Safari < 15.4) throw a DOMException named "SyntaxError" from the querySelectorAll call in
+    // Starlight's TOC init, which reaches window.onerror as an uncaught page error.
+    const element = await setUpGuardedElement({
+      tagName,
+      errorToThrow: new DOMException('is not a valid selector', 'SyntaxError'),
+    });
+
+    assert.doesNotThrow(() => element.init());
+    assert.equal(
+      element.originalInitCallCount,
+      1,
+      "the guard must call Starlight's original init, not replace it with a no-op"
+    );
+  });
+
+  test(`<${tagName}> still runs init normally when :has() is supported`, async () => {
+    const element = await setUpGuardedElement({ tagName });
+
+    assert.equal(element.init(), 'initialized');
+    assert.equal(element.originalInitCallCount, 1);
+  });
+
+  test(`<${tagName}> rethrows errors unrelated to selector support`, async () => {
+    const element = await setUpGuardedElement({
+      tagName,
+      errorToThrow: new TypeError('something else broke'),
+    });
+
+    assert.throws(() => element.init(), TypeError);
+  });
+}
+
+test('the guard leaves unrelated custom element definitions untouched', () => {
+  const customElements = createRegistry();
+  const runGuardScript = new Function('customElements', 'DOMException', readTocGuardScript());
+
+  runGuardScript(customElements, DOMException);
+
+  class UnrelatedElement extends FakeHTMLElement {}
+
+  customElements.define('hot-version-switcher', UnrelatedElement);
+
+  assert.equal(customElements.get('hot-version-switcher'), UnrelatedElement);
+});


### PR DESCRIPTION
### Context

The PR fixes the uncaught `SyntaxError: Failed to execute 'querySelectorAll' on 'Document'` thrown by Starlight's table-of-contents script on browsers without `:has()` support (Chrome < 105 — the top reporter is Chrome Mobile 75 on Android 6.0 — and Safari < 15.4). Sentry: HANDSONTABLE-DOCS-1GA, 170 events, 14 users, still collecting.

The issue was previously marked fixed, but the patch in `docs/src/components/Head.astro` never took effect. It wrapped `StarlightTOC.prototype.init`, while Starlight assigns `init` as an **own instance field inside the constructor**:

```js
class H extends HTMLElement{constructor(){super(), ... this.init=()=>{ ... }, this.onIdle(()=>this.init())}
```

So `prototype.init` is `undefined`, the patch's own guard `if (!StarlightTOC.prototype.init) return;` bailed out, and nothing was ever wrapped. Verified on live production:

```
ctorFound: true, protoInitType: "undefined", patchGuardBailsOut: true
instanceOwnInit: true, ownProps: [_current, minH, maxH, tocHeadingSelector, onIdle, init]
```

A prototype-level patch cannot work here — the instance field shadows it. This PR wraps `init` per instance instead, by intercepting `customElements.define` and subclassing the constructor. The wrap lands in the subclass constructor right after `super()`, which runs before the `onIdle` macrotask that calls `init()`. It also covers `mobile-starlight-toc`, which extends the same class and threw the same error — the old patch targeted only `starlight-toc`.

Behavior on affected browsers is unchanged apart from the crash: the TOC renders, it just does not highlight the active section while scrolling. Errors that are not a `DOMException` named `SyntaxError` still propagate.

Note for the follow-up cherry-pick: production is served from `prod-docs/18.0`, so this fix does not reach users until it is cherry-picked there.

### How has this been tested?

New regression test `docs/src/components/__tests__/head-starlight-toc-has-guard.test.mjs` (7 cases). It extracts the inline guard script from `Head.astro` and runs it against a harness that mimics Starlight's shape (own-instance arrow `init`), for both `starlight-toc` and `mobile-starlight-toc`. It asserts that the original `init` actually ran (`originalInitCallCount === 1`), so a no-op stub cannot pass it; plus the normal-path return value, rethrow of non-`SyntaxError` errors, and passthrough for unrelated custom elements.

The test was confirmed red against the old patch (both `swallows the :has() SyntaxError` cases failed) before the fix was applied.

```bash
npm --prefix docs run docs:test:plugins
```

Result: 185/185 passing.

Real-browser check against the live production page with `:has()` failure simulated (`Document.prototype.querySelectorAll` throwing a `DOMException` named `SyntaxError` for the TOC's own selector), run in two contexts — production code as-is, then with this guard installed:

```
baselineNoGuard: tocSelectorSeen 2, guardSwallowed 0, pageErrors: 4 (2x SyntaxError + 2x uncaught)
withNewGuard:    tocSelectorSeen 2, guardSwallowed 2, pageErrors: 0
```

The baseline reproduces the reported Sentry error on current production code, so the simulation is not vacuous. `tocSelectorSeen: 2` confirms both TOC elements hit the failing selector.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-1790

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

Documentation site only (`docs/`).

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog] — docs-site source only, no package source change.

Fixes HANDSONTABLE-DOCS-1GA

ClickUp task: https://app.clickup.com/t/9015210959/DEV-1790

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-site inline script only; behavior change is limited to catching a known `:has()` SyntaxError on legacy browsers without affecting modern TOC highlighting.
> 
> **Overview**
> Fixes **uncaught page errors** on older browsers (Chrome &lt; 105, Safari &lt; 15.4) where Starlight’s table-of-contents `init` uses `:has()` in `querySelectorAll` and throws a `DOMException` named `SyntaxError` (Sentry HANDSONTABLE-DOCS-1GA).
> 
> The previous **prototype `init` patch in `Head.astro` never ran** because Starlight assigns `init` as an own instance field in the constructor, so it shadows `prototype.init`. This PR **wraps `customElements.define`** for `starlight-toc` and `mobile-starlight-toc`, subclasses the registered constructor, and **wraps each instance’s `init`** in a try/catch that swallows only that selector `SyntaxError`. Other errors still propagate; the TOC still renders but active-section highlighting may be missing on unsupported browsers.
> 
> Adds **`head-starlight-toc-has-guard.test.mjs`** to extract the inline guard from `Head.astro` and assert swallow/normal/rethrow behavior for both TOC tags plus passthrough for unrelated custom elements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f812f2b806653580d8208583542453a9c2226f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->