### PR TITLE
DEV-2137: Guard docs storage reads in opaque-origin documents

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -731,6 +731,24 @@ export default defineConfig({
       ],
 
       head: [
+        // Opaque-origin storage guard — MUST stay the first head entry (Sentry
+        // HANDSONTABLE-DOCS-206). Headless crawlers render the page with
+        // `page.setContent()`, which leaves the document at about:blank with an opaque
+        // origin (`location.origin === 'null'`); sandboxed and srcdoc iframes behave the
+        // same. There, `window.localStorage` is an own accessor that throws SecurityError
+        // on read, so `typeof localStorage !== 'undefined'` throws instead of
+        // short-circuiting. That kills Starlight's inline ThemeProvider script (no theme
+        // applied, `window.StarlightThemeProvider` never defined, cascading
+        // ReferenceErrors), plus ThemeSelect, SidebarPersister, and our own
+        // DocsAssistant storage reads. Running first means every later script — ours or
+        // third-party — sees a working storage object.
+        {
+          tag: 'script',
+          content: readFileSync(
+            resolve(__dirname, 'src', 'scripts', 'opaque-origin-storage-guard.js'),
+            'utf8'
+          ),
+        },
         {
           tag: 'script',
           attrs: { src: '/docs/example-tabs.js', defer: true },
@@ -761,6 +779,12 @@ export default defineConfig({
         //      but the check only tests for presence so any truthy value works). These
         //      are intentional developer-feedback errors (e.g. ColumnSummary data-type
         //      errors in demo examples) and should not be forwarded to Sentry.
+        //
+        //   3. Errors from documents whose URL is `about:blank` or another `about:` page.
+        //      No real visitor browses there; these come from headless crawlers that
+        //      inject the fetched HTML with `page.setContent()`. Every stack frame reads
+        //      `about:blank:<line>:<col>`, so the events are unattributable to a page and
+        //      the storage guard above already fixes the behavior for such contexts.
         {
           tag: 'script',
           content: `window.sentryOnLoad = function () {
@@ -775,6 +799,11 @@ export default defineConfig({
         var url = (event.request && event.request.url) || '';
 
         if (isDemoHttpError && url.indexOf('/recipes/data-management/server-side') !== -1) {
+          return null;
+        }
+
+        // Drop crawler noise from opaque-origin renders (about:blank and friends).
+        if (url.indexOf('about:') === 0) {
           return null;
         }
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,7 @@
     "docs:code-examples:generate-js": "node scripts/transpile-doc-example.mjs",
     "build": "npm run docs:api && npm run docs:validate-highlights && astro build",
     "preview": "astro preview",
-    "docs:test:plugins": "node --test src/plugins/__tests__/*.test.mjs src/lib/__tests__/*.test.mjs src/components/__tests__/*.test.mjs cloudflare/__tests__/*.test.mjs deploy/__tests__/*.test.mjs scripts/__tests__/*.test.mjs scripts/jsdoc-convert/renderer/preProcessors/__tests__/*.test.mjs",
+    "docs:test:plugins": "node --test src/plugins/__tests__/*.test.mjs src/lib/__tests__/*.test.mjs src/components/__tests__/*.test.mjs src/scripts/__tests__/*.test.mjs cloudflare/__tests__/*.test.mjs deploy/__tests__/*.test.mjs scripts/__tests__/*.test.mjs scripts/jsdoc-convert/renderer/preProcessors/__tests__/*.test.mjs",
     "docs:test:runner-links": "node scripts/test-runner-links.mjs",
     "docs:validate-highlights": "node scripts/validate-version-highlights.mjs",
     "docs:lint": "eslint --ext .js,.mjs,.ts,.astro src content",

--- a/docs/src/scripts/__tests__/opaque-origin-storage-guard.test.mjs
+++ b/docs/src/scripts/__tests__/opaque-origin-storage-guard.test.mjs
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+import vm from 'node:vm';
+
+const guardPath = fileURLToPath(new URL('../opaque-origin-storage-guard.js', import.meta.url));
+const guardSource = readFileSync(guardPath, 'utf8');
+
+const STORAGE_NAMES = ['localStorage', 'sessionStorage'];
+
+/**
+ * Runs the guard against a stand-in `window`, the way the inlined head script runs it.
+ */
+function runGuard(window) {
+  vm.runInContext(guardSource, vm.createContext({ window }));
+
+  return window;
+}
+
+/**
+ * Builds a `window` that reproduces an opaque-origin document: reading the storage
+ * property throws SecurityError instead of returning undefined.
+ */
+function opaqueOriginWindow({ configurable = true } = {}) {
+  const window = {};
+
+  STORAGE_NAMES.forEach((name) => {
+    Object.defineProperty(window, name, {
+      configurable,
+      get() {
+        throw new Error(
+          `Failed to read the '${name}' property from 'Window': Access is denied for this document.`
+        );
+      },
+    });
+  });
+
+  return window;
+}
+
+test('installs a working storage stand-in when the property read throws', () => {
+  const window = runGuard(opaqueOriginWindow());
+
+  STORAGE_NAMES.forEach((name) => {
+    const storage = window[name];
+
+    assert.equal(typeof storage, 'object', `${name} must be readable after the guard runs`);
+    assert.equal(storage.getItem('starlight-theme'), null);
+
+    storage.setItem('starlight-theme', 'light');
+    assert.equal(storage.getItem('starlight-theme'), 'light');
+    assert.equal(storage.length, 1);
+    assert.equal(storage.key(0), 'starlight-theme');
+
+    storage.setItem('sl-sidebar-state', 1);
+    assert.equal(storage.getItem('sl-sidebar-state'), '1', 'values are coerced to strings');
+
+    storage.removeItem('starlight-theme');
+    assert.equal(storage.getItem('starlight-theme'), null);
+    assert.equal(storage.length, 1);
+
+    storage.clear();
+    assert.equal(storage.length, 0);
+    assert.equal(storage.key(0), null);
+  });
+});
+
+test('the stand-in survives the guard used by Starlight without throwing', () => {
+  const window = runGuard(opaqueOriginWindow());
+
+  // Verbatim shape of @astrojs/starlight ThemeProvider / ThemeSelect, which throws on an
+  // unguarded opaque-origin window because `typeof` still triggers the property getter.
+  const readTheme = () =>
+    typeof window.localStorage !== 'undefined' && window.localStorage.getItem('starlight-theme');
+
+  assert.doesNotThrow(readTheme);
+  assert.equal(readTheme(), null);
+});
+
+test('leaves native storage untouched in a normal document', () => {
+  const nativeLocal = { getItem: () => 'dark' };
+  const nativeSession = { getItem: () => '1' };
+  const window = runGuard({ localStorage: nativeLocal, sessionStorage: nativeSession });
+
+  assert.equal(window.localStorage, nativeLocal, 'persistent storage must not be replaced');
+  assert.equal(window.sessionStorage, nativeSession, 'persistent storage must not be replaced');
+});
+
+test('does not throw when the storage property cannot be redefined', () => {
+  const window = opaqueOriginWindow({ configurable: false });
+
+  assert.doesNotThrow(() => runGuard(window));
+});

--- a/docs/src/scripts/__tests__/sentry-before-send.test.mjs
+++ b/docs/src/scripts/__tests__/sentry-before-send.test.mjs
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+import vm from 'node:vm';
+
+const configPath = fileURLToPath(new URL('../../../astro.config.mjs', import.meta.url));
+const configSource = readFileSync(configPath, 'utf8');
+
+const loaderScript = configSource.match(/content: `(window\.sentryOnLoad[\s\S]*?)`,\n/);
+
+assert.ok(loaderScript, 'astro.config.mjs must inline a window.sentryOnLoad Sentry Loader hook');
+
+/**
+ * Runs the inlined Sentry Loader hook and returns the `beforeSend` it registers.
+ */
+function loadBeforeSend() {
+  const window = {};
+  let options = null;
+  const context = vm.createContext({
+    window,
+    Sentry: {
+      init(initOptions) {
+        options = initOptions;
+      },
+    },
+  });
+
+  // The hook is authored inside a template literal, so the source read from disk still
+  // carries its escapes (`\\d{3}`). Evaluating it as a template literal yields the exact
+  // script the browser receives.
+  const script = vm.runInContext(`\`${loaderScript[1]}\``, context);
+
+  vm.runInContext(script, context);
+  window.sentryOnLoad();
+
+  assert.ok(options && typeof options.beforeSend === 'function');
+
+  return options.beforeSend;
+}
+
+const beforeSend = loadBeforeSend();
+
+/**
+ * Minimal shape of the fields `beforeSend` reads off an error event.
+ */
+function errorEvent(url, message) {
+  return { request: { url }, exception: { values: [{ value: message }] } };
+}
+
+test('drops errors from opaque-origin documents (about:blank crawler renders)', () => {
+  // Sentry HANDSONTABLE-DOCS-206: headless crawlers inject the page with
+  // `page.setContent()`, leaving every frame at about:blank.
+  const event = errorEvent(
+    'about:blank',
+    "Failed to read the 'localStorage' property from 'Window': Access is denied for this document."
+  );
+
+  assert.equal(beforeSend(event, {}), null);
+});
+
+test('keeps errors from real documentation pages', () => {
+  const event = errorEvent(
+    'https://handsontable.com/docs/javascript-data-grid/',
+    "Cannot read properties of undefined (reading 'getPlugin')"
+  );
+
+  assert.equal(beforeSend(event, {}), event);
+});
+
+test('drops expected HTTP errors from the server-side data recipe pages', () => {
+  const event = errorEvent(
+    'https://handsontable.com/docs/javascript-data-grid/recipes/data-management/server-side-data/',
+    'HTTP 404'
+  );
+
+  assert.equal(beforeSend(event, {}), null);
+});
+
+test('keeps HTTP errors raised outside the server-side data recipe pages', () => {
+  const event = errorEvent('https://handsontable.com/docs/javascript-data-grid/', 'HTTP 404');
+
+  assert.equal(beforeSend(event, {}), event);
+});
+
+test('drops errors thrown by Handsontable throwWithCause()', () => {
+  const url = 'https://handsontable.com/docs/javascript-data-grid/column-summary/';
+  const event = errorEvent(url, 'The provided data is not suitable for the column summary.');
+  const hint = { originalException: { cause: { handsontable: true } } };
+
+  assert.equal(beforeSend(event, hint), null);
+});

--- a/docs/src/scripts/opaque-origin-storage-guard.js
+++ b/docs/src/scripts/opaque-origin-storage-guard.js
@@ -1,0 +1,69 @@
+/**
+ * Opaque-origin storage guard (Sentry HANDSONTABLE-DOCS-206).
+ *
+ * In a document with an opaque origin -- about:blank, sandboxed iframes, srcdoc frames --
+ * reading `window.localStorage` throws SecurityError instead of returning undefined, so the
+ * usual `typeof localStorage !== 'undefined'` guard throws as well. Starlight's ThemeProvider,
+ * ThemeSelect, and SidebarPersister all rely on that guard, and the throw aborts the rest of
+ * their inline scripts.
+ *
+ * Each storage is probed once, and an in-memory stand-in is installed only when the read
+ * throws. Real browsers keep native persistent storage untouched.
+ *
+ * Inlined as the first <head> entry by astro.config.mjs -- keep it ES5 and dependency-free.
+ */
+(function () {
+  function createMemoryStorage() {
+    var data = {};
+
+    return {
+      getItem: function (key) {
+        var name = String(key);
+
+        return Object.prototype.hasOwnProperty.call(data, name) ? data[name] : null;
+      },
+      setItem: function (key, value) {
+        data[String(key)] = String(value);
+      },
+      removeItem: function (key) {
+        delete data[String(key)];
+      },
+      clear: function () {
+        data = {};
+      },
+      key: function (index) {
+        var keys = Object.keys(data);
+
+        return index >= 0 && index < keys.length ? keys[index] : null;
+      },
+      get length() {
+        return Object.keys(data).length;
+      },
+    };
+  }
+
+  function isReadable(name) {
+    try {
+      return !!window[name];
+    } catch (error) {
+      return false;
+    }
+  }
+
+  var names = ['localStorage', 'sessionStorage'];
+
+  for (var i = 0; i < names.length; i++) {
+    if (isReadable(names[i])) {
+      continue;
+    }
+
+    try {
+      Object.defineProperty(window, names[i], {
+        value: createMemoryStorage(),
+        configurable: true,
+      });
+    } catch (error) {
+      // A browser that refuses the redefinition keeps its own behavior; nothing else to do.
+    }
+  }
+})();


### PR DESCRIPTION
### Context

The PR fixes Sentry [HANDSONTABLE-DOCS-206](https://handsoncode.sentry.io/issues/HANDSONTABLE-DOCS-206): `SecurityError: Failed to read the 'localStorage' property from 'Window': Access is denied for this document.` (64 events, `url: about:blank`).

In a document with an opaque origin (`location.origin === 'null'`) reading `window.localStorage` throws `SecurityError` instead of returning `undefined`. `localStorage` is an own accessor on `window`, so even `typeof localStorage` fires the getter and throws. Starlight guards its storage reads with exactly the pattern that breaks:

```js
typeof localStorage !== 'undefined' && localStorage.getItem('starlight-theme')
```

That line is in `ThemeProvider`, `ThemeSelect`, and `SidebarPersister` (`sessionStorage`); our `DocsAssistant` reads storage unguarded too.

Every one of the 64 events comes from `HeadlessChrome 148` at `about:blank` - crawlers that fetch the page HTML and inject it with `page.setContent()`, which leaves the document URL at `about:blank`. Sandboxed and `srcdoc` iframes reach the same state.

The changes:

1. New `docs/src/scripts/opaque-origin-storage-guard.js` - probes `localStorage` and `sessionStorage`, and installs an in-memory stand-in **only when the read throws**. ES5, dependency-free.
2. `docs/astro.config.mjs` - inlines the guard as the **first** `head:` entry, so every later script (ours and third-party) sees a working storage object.
3. `docs/astro.config.mjs` - `beforeSend` drops events whose `request.url` starts with `about:`; those frames report as `about:blank:<line>:<col>` and are not attributable to any page.
4. `docs/package.json` - `docs:test:plugins` also runs `src/scripts/__tests__/*.test.mjs`.

Two notes for reviewers:

- `prod-docs/18.0` contains no `window.sentryOnLoad` block, so the existing `beforeSend` filters (DEV-1912, #12791) are not live in production either. The filter half of this PR starts working after the next prod-docs cherry-pick; the storage guard ships with the page HTML.
- With storage working, empty storage falls through to `prefers-color-scheme`, so headless renders now get `data-theme="light"` instead of the previously forced `dark`.
- Cookiebot's `document.cookie` `SecurityError` still throws in opaque-origin renders (third-party, out of scope). The `about:` filter suppresses its report.

### How has this been tested?

Unit tests (9 new, 187/187 in the docs suite):

```shell
npm --prefix docs run docs:test:plugins
```

- `opaque-origin-storage-guard.test.mjs` runs the guard source in a `window` whose storage getters throw, and asserts the stand-in round-trips, that `typeof localStorage !== 'undefined' && ...` no longer throws, that native storage is left in place in a normal document, and that a non-configurable property does not make the guard throw.
- `sentry-before-send.test.mjs` executes the `beforeSend` hook inlined in `astro.config.mjs` and covers all branches: `about:blank` dropped, real page kept, demo `HTTP 404` on the server-side recipe dropped, `HTTP 404` elsewhere kept, `throwWithCause` errors dropped.

Real-browser verification: the deployed docs HTML was loaded via `page.setContent()` (reproducing the crawler path, URL stays `about:blank`) and instrumented for page errors and Sentry ingest requests.

| Run | storage errors | `StarlightThemeProvider` errors | error envelopes sent |
|---|---|---|---|
| deployed HTML | 4 | 3 | 2 |
| + storage guard | 0 | 0 | 1 |
| + guard and `about:` filter | 0 | 0 | 0 |

Negative case on a real `https` origin with the guard active: `localStorage instanceof Storage === true`, the stored theme survives a reload, and the theme is applied - native persistent storage is untouched.

Also ran `npx eslint` on the changed files and `node --check astro.config.mjs`.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2137

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog] - docs-site only, no package source touched.

ClickUp task: https://app.clickup.com/t/86caxupvu

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-site-only head scripts and Sentry filtering; no product package changes, with unit tests and no replacement of real browser storage when reads succeed.
> 
> **Overview**
> Fixes **Sentry HANDSONTABLE-DOCS-206**: headless crawlers that inject docs HTML at `about:blank` hit `SecurityError` on `localStorage`/`sessionStorage` reads, which breaks Starlight theme/sidebar scripts and pollutes error reporting.
> 
> Adds **`opaque-origin-storage-guard.js`**, inlined as the **first** `<head>` script in `astro.config.mjs`. When storage accessors throw, it installs an in-memory `localStorage`/`sessionStorage` stand-in; normal pages keep native storage.
> 
> Extends the inlined Sentry **`beforeSend`** hook to drop events whose `request.url` starts with `about:` (unattributable crawler frames). **`docs:test:plugins`** now runs `src/scripts/__tests__/*.test.mjs`, covering the guard and all `beforeSend` branches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09fae1d73b7ef5ca9f8021c6cd67e2f5c26e3848. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->