### PR TITLE
DEV-2139: Guard viewport counters when the grid is not initialized

### DIFF
--- a/.changelogs/13131.json
+++ b/.changelogs/13131.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed an error thrown on every focus change when the grid's initialization did not finish — the row and column counting methods now report -1 instead of throwing.",
+  "type": "fixed",
+  "issueOrPR": 13131,
+  "breaking": false,
+  "framework": "none"
+}

--- a/.changelogs/13131.json
+++ b/.changelogs/13131.json
@@ -1,6 +1,6 @@
 {
   "issuesOrigin": "private",
-  "title": "Fixed an error thrown on every focus change when the grid's initialization did not finish — the row and column counting methods now report -1 instead of throwing.",
+  "title": "Fixed an error thrown on every focus change when the grid failed to initialize.",
   "type": "fixed",
   "issueOrPR": 13131,
   "breaking": false,

--- a/handsontable/src/__tests__/core/core.unit.js
+++ b/handsontable/src/__tests__/core/core.unit.js
@@ -102,6 +102,17 @@ describe('Core', () => {
     expect(columnCacheUpdatedCallback.calls.count()).toEqual(1);
   });
 
+  it('should return -1 from the rendered/visible counting methods when the instance is not initialized yet', () => {
+    const core = new Core(container, {
+      data: [['a'], ['b'], ['c']],
+    });
+
+    expect(core.countRenderedRows()).toBe(-1);
+    expect(core.countRenderedCols()).toBe(-1);
+    expect(core.countVisibleRows()).toBe(-1);
+    expect(core.countVisibleCols()).toBe(-1);
+  });
+
   it('should clear the DI container collection after destroy', () => {
     const core = new Core(container, {
       data: [['a'], ['b'], ['c']],

--- a/handsontable/src/core.ts
+++ b/handsontable/src/core.ts
@@ -5183,9 +5183,9 @@ export default function Core(
    * @returns {number} Returns -1 if table is not visible.
    */
   this.countRenderedRows = function(): number {
-    const view = instance.view as TableView;
+    const view = instance.view as TableView | undefined;
 
-    return view._wt.drawn ? view._wt.wtTable.getRenderedRowsCount() as number : -1;
+    return view?._wt.drawn ? view._wt.wtTable.getRenderedRowsCount() as number : -1;
   };
 
   /**
@@ -5197,9 +5197,9 @@ export default function Core(
    * @returns {number} Number of visible rows or -1.
    */
   this.countVisibleRows = function(): number {
-    const view = instance.view as TableView;
+    const view = instance.view as TableView | undefined;
 
-    return view._wt.drawn ? view._wt.wtTable.getVisibleRowsCount() as number : -1;
+    return view?._wt.drawn ? view._wt.wtTable.getVisibleRowsCount() as number : -1;
   };
 
   /**
@@ -5211,9 +5211,9 @@ export default function Core(
    * @returns {number} Returns -1 if table is not visible.
    */
   this.countRenderedCols = function(): number {
-    const view = instance.view as TableView;
+    const view = instance.view as TableView | undefined;
 
-    return view._wt.drawn ? view._wt.wtTable.getRenderedColumnsCount() as number : -1;
+    return view?._wt.drawn ? view._wt.wtTable.getRenderedColumnsCount() as number : -1;
   };
 
   /**
@@ -5225,9 +5225,9 @@ export default function Core(
    * @returns {number} Number of visible columns or -1.
    */
   this.countVisibleCols = function(): number {
-    const view = instance.view as TableView;
+    const view = instance.view as TableView | undefined;
 
-    return view._wt.drawn ? view._wt.wtTable.getVisibleColumnsCount() as number : -1;
+    return view?._wt.drawn ? view._wt.wtTable.getVisibleColumnsCount() as number : -1;
   };
 
   /**


### PR DESCRIPTION
### Context

The PR fixes an uncaught `TypeError: Cannot read property '_wt' of undefined` thrown from `Core#countRenderedRows` (Sentry `HANDSONTABLE-DOCS-1GP`, 42 events / 4 users on the documentation site).

The reported error is a *secondary* crash:

1. The `Core` constructor registers focus scopes (`registerAllFocusScopes`) **before** `init()` runs.
2. `init()` throws before `this.view = new TableView(this)` — in the reported sessions because the page script calls `Array.prototype.toSorted` / `Array.prototype.at` on Chrome Mobile 75 (Android 6), which those browsers do not support. The instance is left half-built with `instance.view === undefined`.
3. Any later `focusin` runs `FocusScopeManager#processScopes`, which calls every registered scope's `runOnlyIf()`.
4. The grid scope's `runOnlyIf` (`focusManager/scopes/grid.ts`) calls `hot.countRenderedRows()`, which dereferenced `view._wt` without a guard — so every focus move on the page threw.

Four viewport counters dereferenced `instance.view` unguarded, while their siblings `countRowHeaders` and `countColHeaders` already guarded against a missing view. This PR applies the same guard to:

- `countRenderedRows`
- `countVisibleRows`
- `countRenderedCols`
- `countVisibleCols`

They now return `-1` when the view does not exist yet, which matches their documented contract ("Returns -1 if table is not visible"). There is no behavior change when the view exists — that path previously threw, so no working code path changes. Downstream readers stay inert without a view: the grid focus scope's `runOnlyIf` returns `false`, `TableView#isVerticallyScrollableByWindow`'s `> fixedAllRows` comparison is `false`, and the Comments context-menu items cannot be reached without a rendered table.

Out of scope: the primary `toSorted` / `at` failures are an unsupported-browser symptom (Chrome Mobile 75 / Android 6). Deciding whether to transpile or polyfill those methods, or to declare the supported browser matrix, is tracked separately.

### How has this been tested?

New unit test in `handsontable/src/__tests__/core/core.unit.js` — it constructs `Core` without calling `init()` and asserts `-1` from all four counters. Verified red before the fix (`Cannot read properties of undefined (reading '_wt')`) and green after.

```bash
# the new test plus every other core unit suite
npm run test:unit --prefix handsontable -- --testPathPattern='core'
# → Test Suites: 8 passed, Tests: 101 passed

# published types still compile
npm run test:types --prefix handsontable
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2139

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2139

Sentry issue: https://handsoncode.sentry.io/issues/7505817638/?project=4506654085087232

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow defensive fix in public count APIs; behavior only changes for previously broken (uninitialized) instances, with a targeted unit test.
> 
> **Overview**
> Fixes a **secondary crash** when `Core` never finishes `init()` (e.g. `init()` throws before `TableView` is created): focus handling and other code could call viewport counters and hit `Cannot read property '_wt' of undefined`.
> 
> `countRenderedRows`, `countVisibleRows`, `countRenderedCols`, and `countVisibleCols` now treat `instance.view` as optional and use optional chaining on `_wt`, returning **-1** when there is no drawn view—aligned with their docs and with how `countRowHeaders` / `countColHeaders` already behaved. Initialized grids are unchanged on the success path.
> 
> Adds a unit test that constructs `Core` without `init()` and asserts all four methods return `-1`, plus a changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d997a34c346844fe9f8f5b6ac5a567f880006fc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->