### PR TITLE
ci: get the branch name to the slugifier via env instead of interpolating it

### DIFF
--- a/.github/actions/performance-run/action.yml
+++ b/.github/actions/performance-run/action.yml
@@ -57,8 +57,10 @@ runs:
       id: report-url
       if: github.event_name == 'pull_request'
       shell: bash
+      env:
+        HEAD_REF: ${{ github.head_ref }}
       run: |
-        BRANCH_SLUG=$(echo "${{ github.head_ref }}" | sed 's/[^a-zA-Z0-9._-]/-/g')
+        BRANCH_SLUG=$(echo "$HEAD_REF" | sed 's/[^a-zA-Z0-9._-]/-/g')
         PAGES_URL="https://handsontable.github.io/handsontable/performance-reports/${BRANCH_SLUG}/"
         echo "branch_slug=${BRANCH_SLUG}" >> "$GITHUB_OUTPUT"
         echo "pages_url=${PAGES_URL}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -80,8 +80,10 @@ jobs:
       - name: Compute report URL
         id: report-url
         if: github.event_name == 'pull_request'
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
-          BRANCH_SLUG=$(echo "${{ github.head_ref }}" | sed 's/[^a-zA-Z0-9._-]/-/g')
+          BRANCH_SLUG=$(echo "$HEAD_REF" | sed 's/[^a-zA-Z0-9._-]/-/g')
           PAGES_URL="https://handsontable.github.io/handsontable/performance-reports/${BRANCH_SLUG}/"
           echo "branch_slug=${BRANCH_SLUG}" >> "$GITHUB_OUTPUT"
           echo "pages_url=${PAGES_URL}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Hi, and thanks for Handsontable.

In `.github/workflows/performance-tests.yml`, the "Compute report URL" step slugifies the branch name:

```yaml
run: |
  BRANCH_SLUG=$(echo "${{ github.head_ref }}" | sed 's/[^a-zA-Z0-9._-]/-/g')
```

The `sed` is doing exactly the right thing — it strips everything outside `[a-zA-Z0-9._-]`. The problem is only one of ordering: Actions expands `${{ ... }}` into the script text before bash runs, so the branch name is already part of the command by the time `sed` gets a chance to clean it. Git allows `$`, `(`, `)` and backticks in branch names, and `$(...)` runs inside double quotes, so a fork PR on a branch named something like `x$(id)` would execute that before the slugifier ever sees the value.

Scope, so I do not overstate it: this is a `pull_request` workflow, so a fork PR carries a read-only token and no secrets. I am raising it as hardening.

The fix keeps your slugifier exactly as it is and just gets the value to it safely:

```yaml
env:
  HEAD_REF: ${{ github.head_ref }}
run: |
  BRANCH_SLUG=$(echo "$HEAD_REF" | sed 's/[^a-zA-Z0-9._-]/-/g')
```

`BRANCH_SLUG`, `PAGES_URL` and both `$GITHUB_OUTPUT` writes are unchanged, so report URLs come out identical. Two lines added, one changed.

Disclosure: I used AI assistance to help spot this and prepare the change, and I read the workflow and its trigger myself.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CI-only hardening of how a branch name is passed into bash; no product, auth, or data-handling changes. The workflow remains pull_request-scoped.
> 
> **Overview**
> Hardens the performance-report URL step so the PR branch name is not interpolated into the bash script before slugification.
> 
> `github.head_ref` is now passed as `HEAD_REF` via `env` in both `performance-tests.yml` and the `performance-run` composite action, then slugified from `"$HEAD_REF"`. Report URLs and outputs are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b8a4739a8f15083ec2f7f884e4f28529cbdb88b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->