### PR TITLE
DEV-2141: Stop DataProvider internal refetches floating rejections

### DIFF
--- a/.changelogs/13133.json
+++ b/.changelogs/13133.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed a failed `fetchRows` call in the `dataProvider` plugin surfacing as an unhandled promise rejection.",
+  "type": "fixed",
+  "issueOrPR": 13133,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/dataProvider/AGENTS.md
+++ b/handsontable/src/plugins/dataProvider/AGENTS.md
@@ -8,6 +8,14 @@ The `dataProvider` plugin backs the grid with a remote source via `fetchRows` an
 - **Fetch-failure toasts include a Refetch button** that calls `fetchData()` again. The toast uses `duration: 0`, so it stays until dismissed or Refetch is clicked.
 - **For custom error UI when Notification is disabled**, hook `afterDataProviderFetchError` and `afterRowsMutationError` instead of relying on the built-in toasts.
 
+## Who is allowed to let `fetchData()` reject
+
+`fetchData()` fires `afterDataProviderFetchError` and shows the error toast, then rethrows. That rethrow is public API — a caller awaiting `fetchData()` still gets the rejection.
+
+- **Internal fire-and-forget refetches must go through `#fetchDataSilently()`**: the initial load (`afterInit`), `updatePlugin()`, the sort ctx, the filter ctx, and the Refetch toast action. The wrapper logs `Data fetch failed:` and resolves `null`. `void this.fetchData()` does NOT work — `void` discards the value, not the rejection, so a failing `fetchRows` reaches the page as an `unhandledrejection` (Sentry HANDSONTABLE-DOCS-20B / 1JN).
+- **`#commitRowsUpdate`'s ctx (`fetchData: () => this.fetchData({ skipLoading: true })`) must keep rejecting.** `query/crud.ts` catches it to revert the optimistic cell values and log `Data reload failed:`. Do not "consistency-fix" this one to the silent wrapper.
+- **Pagination ctx callbacks stay rejecting too** — `query/pagination.ts` catches them to revert the page or page size.
+
 ## Where to look next
 
 - Plugin source: `dataProvider.ts`.

--- a/handsontable/src/plugins/dataProvider/__tests__/dataProvider.spec.js
+++ b/handsontable/src/plugins/dataProvider/__tests__/dataProvider.spec.js
@@ -357,4 +357,161 @@ describe('DataProvider', () => {
     expect(plugin.getRowId(0)).toBe('x-1');
     expect(getDataAtCell(0, 1)).toBe('First');
   });
+
+  describe('internal refetch failures', () => {
+    let unhandledRejections = [];
+    let onUnhandledRejection = null;
+
+    beforeEach(() => {
+      unhandledRejections = [];
+      onUnhandledRejection = (event) => {
+        unhandledRejections.push(event.reason);
+        event.preventDefault();
+      };
+
+      window.addEventListener('unhandledrejection', onUnhandledRejection);
+    });
+
+    afterEach(() => {
+      window.removeEventListener('unhandledrejection', onUnhandledRejection);
+      onUnhandledRejection = null;
+    });
+
+    /**
+     * Replaces `fetchRows` with a rejecting one on the already-initialized instance.
+     *
+     * @param {Error} err Error the new `fetchRows` rejects with.
+     * @returns {void}
+     */
+    function makeFetchRowsReject(err) {
+      spec().$container.handsontable('getInstance').getSettings().dataProvider.fetchRows = () => Promise.reject(err);
+    }
+
+    it('should not leave an unhandled rejection when the initial fetch fails', async() => {
+      spyOn(console, 'error');
+
+      handsontable({
+        data: [],
+        columns: [{ data: 'id' }, { data: 'name' }],
+        dataProvider: createDataProviderConfig({
+          fetchRows: () => Promise.reject(new Error('network down')),
+        }),
+      });
+
+      await sleep(100);
+
+      expect(unhandledRejections).toEqual([]);
+      // eslint-disable-next-line no-console
+      expect(console.error).toHaveBeenCalledWith('Data fetch failed:', jasmine.any(Error));
+    });
+
+    it('should not leave an unhandled rejection when the refetch after updateSettings fails', async() => {
+      spyOn(console, 'error');
+
+      handsontable({
+        data: [],
+        columns: [{ data: 'id' }, { data: 'name' }],
+        dataProvider: createDataProviderConfig({
+          fetchRows: () => Promise.resolve({ rows: [], totalRows: 0 }),
+        }),
+      });
+
+      await sleep(50);
+
+      await updateSettings({
+        dataProvider: createDataProviderConfig({
+          fetchRows: () => Promise.reject(new Error('network down')),
+        }),
+      });
+
+      await sleep(100);
+
+      expect(unhandledRejections).toEqual([]);
+    });
+
+    it('should not leave an unhandled rejection when the refetch after sorting fails', async() => {
+      spyOn(console, 'error');
+
+      handsontable({
+        data: [],
+        colHeaders: true,
+        columnSorting: true,
+        columns: [{ data: 'id' }, { data: 'name' }],
+        dataProvider: createDataProviderConfig({
+          fetchRows: () => Promise.resolve({ rows: [{ id: 1, name: 'Alice' }], totalRows: 1 }),
+        }),
+      });
+
+      await sleep(50);
+
+      makeFetchRowsReject(new Error('network down'));
+
+      getPlugin('columnSorting').sort({ column: 0, sortOrder: 'asc' });
+
+      await sleep(100);
+
+      expect(unhandledRejections).toEqual([]);
+    });
+
+    it('should not leave an unhandled rejection when the refetch after filtering fails', async() => {
+      spyOn(console, 'error');
+
+      handsontable({
+        data: [],
+        colHeaders: true,
+        filters: true,
+        dropdownMenu: true,
+        columns: [{ data: 'id' }, { data: 'name' }],
+        dataProvider: createDataProviderConfig({
+          fetchRows: () => Promise.resolve({ rows: [{ id: 1, name: 'Alice' }], totalRows: 1 }),
+        }),
+      });
+
+      await sleep(50);
+
+      makeFetchRowsReject(new Error('network down'));
+
+      const filters = getPlugin('filters');
+
+      filters.addCondition(1, 'contains', ['Al']);
+      filters.filter();
+
+      await sleep(100);
+
+      expect(unhandledRejections).toEqual([]);
+    });
+
+    it('should not leave an unhandled rejection when the Refetch notification action fails', async() => {
+      spyOn(console, 'error');
+
+      handsontable({
+        data: [],
+        columns: [{ data: 'id' }, { data: 'name' }],
+        notification: true,
+        dataProvider: createDataProviderConfig({
+          fetchRows: () => Promise.resolve({ rows: [], totalRows: 0 }),
+        }),
+      });
+
+      await sleep(50);
+
+      const notificationPlugin = getPlugin('notification');
+
+      spyOn(notificationPlugin, 'showMessage').and.callThrough();
+
+      makeFetchRowsReject(new Error('network down'));
+
+      try {
+        await getPlugin('dataProvider').fetchData();
+      } catch (e) {
+        // `fetchData()` is public API and keeps rethrowing for its direct callers.
+      }
+
+      notificationPlugin.showMessage.calls.mostRecent().args[0].actions[0].callback();
+
+      await sleep(100);
+
+      expect(unhandledRejections).toEqual([]);
+    });
+  });
 });

--- a/handsontable/src/plugins/dataProvider/dataProvider.ts
+++ b/handsontable/src/plugins/dataProvider/dataProvider.ts
@@ -308,7 +308,7 @@ export class DataProvider extends BasePlugin {
     this.enablePlugin();
 
     if (this.hot.view) {
-      void this.fetchData();
+      void this.#fetchDataSilently();
     }
 
     super.updatePlugin();
@@ -765,7 +765,7 @@ export class DataProvider extends BasePlugin {
               notificationPlugin.hide(toastId);
             }
 
-            void this.fetchData();
+            void this.#fetchDataSilently();
           },
         },
       ];
@@ -822,6 +822,26 @@ export class DataProvider extends BasePlugin {
   }
 
   /**
+   * Runs [[#fetchData]] for internal fire-and-forget refetches (initial load, `updatePlugin`, sort, filter, and the
+   * Refetch notification action). [[#fetchData]] already surfaces the failure – it fires
+   * [[Hooks#afterDataProviderFetchError]] and shows the error notification – before rethrowing for its public callers,
+   * so here the rejection is only logged and settled. Without this, `fetchRows` failures reach the page as
+   * `unhandledrejection` events.
+   *
+   * @param {object} [overrides] Partial query overrides passed to [[#fetchData]].
+   * @returns {Promise<{ rows: Array<*>, totalRows: number }|null>} Resolves to `null` when the fetch fails.
+   */
+  #fetchDataSilently(
+    overrides: DataProviderFetchDataOverrides = {}
+  ): Promise<{ rows: unknown[]; totalRows: number } | null> {
+    return this.fetchData(overrides).catch((err) => {
+      logError('Data fetch failed:', err);
+
+      return null;
+    });
+  }
+
+  /**
    * Default handler for [[Hooks#hasExternalDataSource]]: `true` when this instance has a complete server-backed
    * `dataProvider` configuration. Registered in the constructor (early lifecycle) and in `enablePlugin()` after each
    * `disablePlugin()` clears `addHook` listeners.
@@ -834,7 +854,7 @@ export class DataProvider extends BasePlugin {
    * @returns {void}
    */
   readonly #onAfterInit = () => {
-    void this.fetchData();
+    void this.#fetchDataSilently();
   };
 
   /**
@@ -896,7 +916,7 @@ export class DataProvider extends BasePlugin {
       applyFiltersAndRefetch: (filtersForProvider) => {
         this.#queryParameters.filters = filtersForProvider ?? null;
         this.#queryParameters.page = 1;
-        void this.fetchData();
+        void this.#fetchDataSilently();
       },
     },
     conditionsStack
@@ -915,7 +935,7 @@ export class DataProvider extends BasePlugin {
       hot: this.hot,
       hasFetchFn: () => isFunction(this.#getFetchFn()),
       applyQueryParametersFromPlugins: () => this.#applyQueryParametersFromPlugins(),
-      fetchData: overrides => this.fetchData(overrides),
+      fetchData: overrides => this.#fetchDataSilently(overrides),
     },
     currentSortConfig,
     destinationSortConfigs,


### PR DESCRIPTION
### Context

The PR fixes DataProvider leaking `unhandledrejection` events to the page whenever `fetchRows` fails.

`DataProvider.fetchData()` fires `afterDataProviderFetchError`, shows the error toast, and then rethrows. The rethrow is correct — it is public API, and a caller awaiting `fetchData()` should get the rejection. The bug is on the internal side: five fire-and-forget callers used `void this.fetchData()`. `void` discards the *value*, not the rejection, so every failed `fetchRows` escaped as an `unhandledrejection` in the user's console and in error trackers, even though the plugin had already handled the error.

Affected sites in `handsontable/src/plugins/dataProvider/`:

- `dataProvider.ts:311` — `updatePlugin()` refetch
- `dataProvider.ts:768` — Refetch action on the error toast
- `dataProvider.ts:837` — `#onAfterInit`, the initial load
- `dataProvider.ts:899` — filter refetch
- `dataProvider.ts:918` — sort ctx, whose only consumer is `query/sorting.ts:229`

The fix adds one private wrapper, `#fetchDataSilently()`, that catches, logs `Data fetch failed:` through `helpers/console`, and resolves `null`. This mirrors the idiom already used in `query/crud.ts` (`Data reload failed:`), so a failed fetch still leaves a console trail for anyone debugging without `notification` enabled or without an `afterDataProviderFetchError` hook.

Three paths deliberately keep rejecting, and this is now documented in `src/plugins/dataProvider/AGENTS.md`:

- `fetchData()` itself — changing the rethrow would be a breaking change.
- `#commitRowsUpdate`'s ctx — `query/crud.ts` catches it to revert optimistic cell values.
- The pagination ctx callbacks — `query/pagination.ts` catches them to revert the page or page size.

Reported through Sentry as `HANDSONTABLE-DOCS-20B` (13 events, 8 users). It surfaced on the current Angular REST-API recipe page, but the docs are not at fault: the demo endpoint is healthy and the page is the unversioned, current one. The fetch fails on the reader's own network — corporate proxy, content blocker, offline — which is exactly the condition a customer's own API hits in production.

The same defect was also reported as `HANDSONTABLE-DOCS-209` (10 events, 7 users, JavaScript variant of the current REST-API recipe), `HANDSONTABLE-DOCS-20A` (3 events, 3 users, React variant of the same recipe), and `HANDSONTABLE-DOCS-20N` (3 events, 1 user, Angular variant of the same page). All land on `dataProvider.ts:837`, the `#onAfterInit` initial load.

### How has this been tested?

Five specs added to `handsontable/src/plugins/dataProvider/__tests__/dataProvider.spec.js`, one per affected site. Each attaches a `window` `unhandledrejection` listener, drives the path with a rejecting `fetchRows`, and asserts nothing was captured.

Verified red first — on unmodified source all five failed with `Unhandled promise rejection: Error: network down`. Green after the fix.

```bash
npm run test:e2e --prefix handsontable --testPathPattern='dataProvider'
# 136 specs, 0 failures

npm run test:unit --prefix handsontable --testPathPattern='dataProvider'
# 85 passed

npm run test:e2e --prefix handsontable --testPathPattern='dataProvider|emptyDataState|pagination|filters|columnSorting'
# 919 specs, 2 failures
```

The 2 failures in the last command are pre-existing cross-suite interference in the Pagination Tab-focus specs — the identical 2 failures reproduce on a clean `develop` with the same pattern, and `pagination` alone is 205 specs / 0 failures on both.

`npx eslint src/plugins/dataProvider/dataProvider.ts` and `npx tsc --noEmit` are clean.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2141

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2141

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted promise-handling fix in dataProvider with preserved public API and explicit exceptions for CRUD/pagination; covered by new regression tests.
> 
> **Overview**
> Fixes **`dataProvider`** leaking **`unhandledrejection`** when **`fetchRows`** fails on paths that already handle the error via hooks and notifications. **`fetchData()`** still rethrows for direct callers; the bug was **`void this.fetchData()`**, which does not absorb promise rejections.
> 
> Adds private **`#fetchDataSilently()`** (catch, log **`Data fetch failed:`**, resolve **`null`**) and routes internal refetches through it: initial load, **`updatePlugin()`**, server sort/filter refetches, and the error toast **Refetch** action. CRUD reload and pagination callbacks keep using rejecting **`fetchData()`** so optimistic revert logic in **`query/crud.ts`** and **`query/pagination.ts`** is unchanged.
> 
> Documents the contract in **`AGENTS.md`**, adds a changelog entry, and adds five e2e specs that assert no **`unhandledrejection`** on those paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29df5c63a63b08ddb0c6506f7b471b274412cac8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

