### PR TITLE
DEV-2142: Filter legacy-engine script-parse errors out of docs Sentry

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -767,7 +767,7 @@ export default defineConfig({
         // DSN and any dashboard-enabled integrations (Performance/Replay) are applied
         // automatically, so adding `beforeSend` does not disturb the rest of the setup.
         //
-        // Two classes of expected errors are dropped:
+        // Four classes of expected errors are dropped:
         //
         //   1. HTTP <status> errors from server-side data recipe examples.
         //      The docs site has no `/api/products` backend, so fetchRows() correctly
@@ -785,9 +785,39 @@ export default defineConfig({
         //      inject the fetched HTML with `page.setContent()`. Every stack frame reads
         //      `about:blank:<line>:<col>`, so the events are unattributable to a page and
         //      the storage guard above already fixes the behavior for such contexts.
+        //
+        //   4. `SyntaxError: Unexpected token …` script-parse failures reported by
+        //      browser engines that predate the ES2020 syntax every bundle on this site
+        //      ships (optional chaining, nullish coalescing). Chrome WebView 57 and the
+        //      Android in-app browsers that spoof a modern Chrome UA cannot parse those
+        //      bundles at all, so each page load files one issue per bundle -- and the
+        //      same clients also fail on third-party code we do not build (Cloudflare's
+        //      `beacon.min.js`). The site's supported range is `browserslist` in
+        //      docs/package.json ("last 2 versions"), so these clients are out of scope
+        //      and nothing in our source can fix them.
+        //
+        //      The filter is gated on a runtime feature test, not on the message alone:
+        //      an engine that CAN parse `?.`/`??` still reports its parse errors, so a
+        //      real build regression on a supported browser keeps reaching Sentry.
+        //      Matching `^Unexpected token` also keeps genuine
+        //      `SyntaxError: Failed to execute 'querySelectorAll'` bugs (the Starlight
+        //      TOC `:has()` defect) visible.
         {
           tag: 'script',
           content: `window.sentryOnLoad = function () {
+  var supportsModernSyntax = (function () {
+    try {
+      new Function('var o = {}; return o?.a ?? 1');
+
+      return true;
+    } catch (e) {
+      // Only a SyntaxError means the engine cannot parse the syntax. A CSP that
+      // blocks \`new Function\` throws EvalError instead -- treat that as a supported
+      // engine so real parse errors keep reaching Sentry.
+      return !(e instanceof SyntaxError);
+    }
+  })();
+
   Sentry.init({
     beforeSend: function (event, hint) {
       try {
@@ -814,6 +844,18 @@ export default defineConfig({
 
         if (error && error.cause && 'handsontable' in error.cause) {
           return null;
+        }
+
+        // Drop script-parse failures from engines too old to parse our bundles.
+        if (!supportsModernSyntax) {
+          var isParseError = values.some(function (value) {
+            return value && value.type === 'SyntaxError' &&
+              typeof value.value === 'string' && /^Unexpected token/.test(value.value);
+          });
+
+          if (isParseError) {
+            return null;
+          }
         }
       } catch (e) {
         // never let the filter break error reporting


### PR DESCRIPTION
### Context

The PR stops a family of unactionable Sentry issues in the `handsontable-docs` project. About 20 near-identical groups titled `SyntaxError: Unexpected token ?` / `.` / `=` exist today (HANDSONTABLE-DOCS-20Z, 21B, 1G1, 1GY, 1GW, 1H0, 1GX, 216-218, 21K, 20Y and more) - one per Astro bundle (`page`, `base`, `preload-helper`, `Head`, `starlight-toc`, `a11y-utils`, `DocSearch`, `TableOfContents`, `VersionsDropdown`, `PageTitle`). Every deploy rotates the bundle hashes, so the set keeps regrowing.

**Root cause: the client engine, not our build.** These are browser engines that predate ES2020 and cannot parse the optional chaining and nullish coalescing that every bundle on the site ships. The cohort is Chrome Mobile WebView 57 (Android 8.1) plus Android in-app browsers reporting a Chrome 89/91 UA on Chinese devices (Huawei P30, vivo V2055A). `??` landed in Chrome 80.

The decisive evidence is HANDSONTABLE-DOCS-20R: the same `SyntaxError` inside Cloudflare's own `beacon.min.js`, which we do not build. The docs site's supported range is `browserslist` in `docs/package.json` ("last 2 versions"), so these clients are out of scope and no source change can fix them.

Two alternatives were considered and rejected:

- Rewriting `?? ''` to `|| ''` in `PageTitle.astro` - fixes 1 of ~20 groups, and new bundle hashes reappear with the same syntax on the next deploy.
- Lowering the Vite build target - costs every real user bundle size, cannot fix third-party scripts (`beacon.min.js`, Cookiebot), and the grid demos would not run on WebView 57 anyway.

**What this PR does.** It adds a third rule to the existing `beforeSend` filter in `docs/astro.config.mjs`, gated on a runtime feature test rather than on the message text alone:

- `new Function('var o = {}; return o?.a ?? 1')` decides whether the engine can parse what we ship. Only then are `SyntaxError` values matching `^Unexpected token` dropped, so a genuine build regression on a supported browser still reaches Sentry.
- The test fails open: a CSP that blocks `new Function` throws `EvalError`, not `SyntaxError`, and that is treated as a supported engine.
- Matching `^Unexpected token` keeps real `SyntaxError: Failed to execute 'querySelectorAll'` bugs visible (1GA, 1HP, 21Y - the Starlight TOC `:has()` defect). A bare `SyntaxError` predicate would have hidden them.

**Known limitation, called out for the reviewer.** `prod-docs/18.0` carries the Sentry loader `<script>` tag but has no `sentryOnLoad` block at all, so the whole `beforeSend` filter has never run in production. Every event in this family came from `handsontable.com/docs/*`. This change is therefore forward-looking: it suppresses nothing live until it is cherry-picked to the prod-docs branch, or a new prod-docs branch is cut from develop. The live backlog is being cleared Sentry-side instead (12 siblings are already ignored).

### How has this been tested?

Docs-site-only change; no core, wrapper, or example code is touched, so the core lint/build/test suites do not apply.

- Syntax check of the edited config: `npx acorn --ecma2022 --module docs/astro.config.mjs` - parses clean.
- Filter behavior verified against real event shapes taken from HANDSONTABLE-DOCS-20Z and HANDSONTABLE-DOCS-1GA, by extracting the inlined `sentryOnLoad` script and running its `beforeSend` in a `node:vm` context with a stubbed `Sentry.init`, under three engine conditions:
  - legacy engine (`new Function` throws `SyntaxError`) - `Unexpected token ?` and `Unexpected token '='` are dropped;
  - supported engine - the same events are kept, so a real build regression is still reported;
  - CSP blocks `new Function` (`EvalError`) - the events are kept;
  - `SyntaxError: Failed to execute 'querySelectorAll'` is kept under every condition;
  - the pre-existing `HTTP <status>` recipe rule and `error.cause.handsontable` rule behave exactly as before, and a malformed event passes through untouched.
- Confirmed from the served loader script (`https://js.sentry-cdn.com/611b4dbe630c4a434fe1367b98ba3644.min.js`) that pre-init `error` events are buffered and replayed through `window.onerror` **after** `sentryOnLoad`/`Sentry.init` runs. Script-parse failures therefore do pass through the SDK capture pipeline, so `beforeSend` applies to them.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2142

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

[skip changelog] - docs-site tooling only, no package source change.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2142

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only Sentry client filtering with a feature-gated drop rule; no auth, data, or product runtime paths change, and supported browsers retain full error reporting.
> 
> **Overview**
> **Adds a fourth Sentry drop rule** for unactionable `SyntaxError: Unexpected token …` noise from browsers that cannot parse ES2020 (`?.` / `??`) in the docs bundles—clients outside the site’s `browserslist` support, not regressions in our build.
> 
> The inlined `window.sentryOnLoad` hook now runs a **runtime syntax probe** (`new Function('var o = {}; return o?.a ?? 1')`) once at init. Only when that probe fails with `SyntaxError` does `beforeSend` discard exception values that are `SyntaxError` messages matching `^Unexpected token`. Supported browsers still report those errors; CSP blocking `new Function` yields `EvalError` and is treated as supported so real parse failures keep reaching Sentry. The `^Unexpected token` prefix is chosen so unrelated issues like `SyntaxError: Failed to execute 'querySelectorAll'` stay visible.
> 
> Inline comments document the new behavior alongside the existing HTTP demo, `handsontable` cause, and `about:` URL filters—unchanged except for the expanded explanation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b26d61c5d32a0036257261cb0a45606e8d4ec02d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->