### PR TITLE
DEV-2144: Document the Starlight class-field trap and extend the TOC guard tests

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -508,3 +508,22 @@ The custom loader (`src/plugins/framework-loader.mjs`) renders every source page
 - **A framework runtime (`react`, `vue`, `zone.js`, `@angular/compiler`) must only be imported inside `loadRuntime()`.** A bare `await import(...)` there escapes every try/catch as an unhandled rejection and leaves each example of that framework stuck on its loading shimmer forever. `loadRuntime()` returns `null` on failure, and the group is marked with `markFailed()` - the only place that shows a reader-visible notice (`.hot-example-error`). Per-example failures keep the silent `markLoaded()` degradation, because some examples render nothing by design.
 
 Guards for both rules live in `src/lib/__tests__/example-error-reporting.test.mjs` (run by `npm run docs:test:plugins`).
+
+---
+
+## 2.14 Patching Starlight's Custom Elements
+
+Starlight's custom elements assign their methods as **class fields** (`private init = (): void => {...}`), not as prototype methods. An own instance property never reaches the prototype, so `customElements.get('starlight-toc').prototype.init` is `undefined` and any prototype patch silently no-ops. A guard written that way looks correct in review, passes locally, and fixes nothing in production - that is exactly how the `:has()` table-of-contents guard stayed dead for two months (Sentry HANDSONTABLE-DOCS-1GA).
+
+To patch such an element, intercept `customElements.define` in an `is:inline` head script and wrap the method on `this` right after `super()`. Two rules:
+
+- **Cover every registered name.** `mobile-starlight-toc` (`components/MobileTableOfContents.astro`) extends the same `StarlightTOC` class but registers separately, so it needs its own wrap.
+- **Subclass with `class extends`,** which keeps statics reachable through the prototype chain and keeps `instanceof` true for the original constructor. The browser reads `observedAttributes` off whatever constructor the registry holds, and it upgrades elements against it.
+
+Wrapping after `super()` works because the base constructor only *schedules* the method through `requestIdleCallback`, and that callback reads `this.init` when it fires.
+
+The install does not need a re-entry flag today. The site does not use `<ClientRouter />`, and Astro's swap logic keys executed scripts by `textContent` (`detectScriptExecuted()` in `astro/dist/transitions/swap-functions.js`), so an unchanged inline head script never runs twice. Add one if either of those stops holding.
+
+The live guard is in `src/components/Head.astro`; its regression test is `src/components/__tests__/head-starlight-toc-has-guard.test.mjs`, which extracts the shipped script, asserts `Head.astro` holds exactly one guard script, and runs the guard against a double that replicates the class-field shape. It runs under `npm run docs:test:plugins`. Any claim that such a patch works needs a browser check of the *instance* property, not just the absence of a local error.
+
+Unrelated to this: `src/plugins/replace-has-selectors.mjs` and `src/plugins/has-fallback-runtime.mjs` rewrite `:has()` in **stylesheets** for performance. They do not touch selector strings passed to `querySelectorAll` inside third-party bundles.

--- a/docs/src/components/__tests__/head-starlight-toc-has-guard.test.mjs
+++ b/docs/src/components/__tests__/head-starlight-toc-has-guard.test.mjs
@@ -67,6 +67,10 @@ function createRegistry() {
  */
 function createStarlightTocClass(errorToThrow) {
   return class extends FakeHTMLElement {
+    // The browser reads observedAttributes off the constructor the registry holds, so the
+    // guard has to keep statics reachable from whatever it registers in place of this class.
+    static observedAttributes = ['data-min-h', 'data-max-h'];
+
     constructor() {
       super();
 
@@ -146,6 +150,63 @@ for (const tagName of ['starlight-toc', 'mobile-starlight-toc']) {
     assert.throws(() => element.init(), TypeError);
   });
 }
+
+test('Starlight keeps init as an own instance property, so a prototype patch cannot attach', () => {
+  // This is the defect the guard exists for (Sentry HANDSONTABLE-DOCS-1GA, 21Y). The fix that
+  // shipped before it patched `customElements.get('starlight-toc').prototype.init`, which is
+  // undefined, so the patch attached to nothing and the error kept reaching window.onerror.
+  const StarlightTocClass = createStarlightTocClass();
+
+  assert.equal(StarlightTocClass.prototype.init, undefined);
+
+  const instance = new StarlightTocClass();
+
+  assert.ok(Object.hasOwn(instance, 'init'), 'init must be an own property of the instance');
+});
+
+test('the shipped guard does not rely on prototype.init', () => {
+  // Comments are stripped first: the guard's own comment explains why the prototype approach
+  // fails, so matching the raw source would flag the explanation instead of the code.
+  const guardCode = readTocGuardScript().replace(/^\s*\/\/.*$/gm, '');
+
+  assert.doesNotMatch(
+    guardCode,
+    /prototype\.init/,
+    'init is a class field, so prototype.init is always undefined - wrap per instance instead'
+  );
+  assert.doesNotMatch(
+    guardCode,
+    /whenDefined/,
+    'whenDefined resolves after the element class is registered, which is too late to reach an instance field'
+  );
+});
+
+test('an error named SyntaxError that is not a DOMException still propagates', async () => {
+  // The guard checks `instanceof DOMException` as well as the name. A plain SyntaxError means a
+  // parse failure in code the site owns, and hiding it would hide a real regression.
+  const element = await setUpGuardedElement({
+    tagName: 'starlight-toc',
+    errorToThrow: new SyntaxError('a real parse error'),
+  });
+
+  assert.throws(() => element.init(), { name: 'SyntaxError' });
+});
+
+test('the registered constructor keeps instanceof and static members intact', async () => {
+  const customElements = createRegistry();
+  const runGuardScript = new Function('customElements', 'DOMException', readTocGuardScript());
+
+  runGuardScript(customElements, DOMException);
+
+  const StarlightTocClass = createStarlightTocClass();
+
+  customElements.define('starlight-toc', StarlightTocClass);
+
+  const RegisteredClass = customElements.get('starlight-toc');
+
+  assert.ok(new RegisteredClass() instanceof StarlightTocClass, 'the browser upgrades elements against the registered class');
+  assert.deepEqual(RegisteredClass.observedAttributes, ['data-min-h', 'data-max-h']);
+});
 
 test('the guard leaves unrelated custom element definitions untouched', () => {
   const customElements = createRegistry();


### PR DESCRIPTION
### Context

Follow-up to #13128, which landed the per-instance table-of-contents guard and fixed the reported Sentry events ([HANDSONTABLE-DOCS-1GA](https://handsoncode.sentry.io/issues/HANDSONTABLE-DOCS-1GA/), 21Y). This PR carries **no behavior change** - `Head.astro` is byte-identical to `develop`.

It adds `docs/AGENTS.md` §2.14 recording why the patch that preceded #13128 was dead code. Starlight declares the throwing method as a class field (`private init = (): void => {...}`), so it is an own property of every instance and never reaches the prototype. `customElements.get('starlight-toc').prototype.init` is therefore always `undefined`, and a guard written against it reviews clean, passes locally, and fixes nothing in production. That is how the `:has()` guard stayed dead for two months while the issue kept collecting events.

The section also records why the install needs no re-entry flag today, with the reference that decides it: the docs site does not use `<ClientRouter />`, and Astro keys executed scripts by `textContent` (`detectScriptExecuted()` in `astro/dist/transitions/swap-functions.js`), so an unchanged inline head script never runs twice. Add a flag if either of those stops holding.

Finally, it extends the guard's regression suite from 7 tests to 11 with the cases that would have caught the dead patch:

- the instance-property shape - `prototype.init` is `undefined` and `init` is an own property of the instance;
- the absence of any `prototype.init` or `whenDefined` dependency in the shipped script (comments stripped first, since the guard's own comment explains why that approach fails);
- propagation of a `SyntaxError` that is not a `DOMException`, which is a real parse failure in code the site owns;
- preservation of `instanceof` and statics through the subclass wrapper, which is what `class extends` buys.

### How has this been tested?

Docs-site-only change. No core, wrapper, or example code is touched, so the core lint, build, and test suites do not apply.

```bash
node --test docs/src/components/__tests__/head-starlight-toc-has-guard.test.mjs
# tests 11 / # pass 11 / # fail 0

npx eslint docs/src/components/__tests__/head-starlight-toc-has-guard.test.mjs
# ESLint: No issues found
```

Negative control for the new `instanceof`/statics test: severing the guard's static inheritance in `Head.astro` (`Object.setPrototypeOf(GuardedElement, Object.prototype)`) turns that test red, together with the six behavior tests - `class extends` carries the static link and `super()` through the same chain. Reverted after the check; `Head.astro` is unchanged in this PR.

The suite runs in CI under `npm run docs:test:plugins`, which globs `src/components/__tests__/*.test.mjs`.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

Documentation and test coverage only.

### Related issue(s):

1. DEV-2144

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

[skip changelog] - agent documentation and tests only, no package source change.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2144
