### PR TITLE
DEV-2145: Add an error boundary around the DocsAssistant renderers

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -70,6 +70,8 @@
     "@octokit/rest": "^18.6.7",
     "@playwright/test": "1.45.x",
     "@types/node": "^20.11.27",
+    "@types/react": "^18.3.31",
+    "@types/react-dom": "^18.3.7",
     "@vitejs/plugin-vue": "^6.0.7",
     "@vue/compiler-sfc": "^3.5.35",
     "broken-link-checker": "^0.7.8",

--- a/docs/src/components/DocsAssistant/DocsAssistant.css
+++ b/docs/src/components/DocsAssistant/DocsAssistant.css
@@ -265,6 +265,12 @@
   color: var(--sl-color-text);
 }
 
+/* Plain-text fallback shown when a lazy markdown-renderer chunk fails to load. */
+.da-markdown-plain {
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
 /* Headings */
 .da-assistant-body :is(h1, h2, h3, h4, h5, h6) {
   font-weight: 500;

--- a/docs/src/components/DocsAssistant/MarkdownRenderer.tsx
+++ b/docs/src/components/DocsAssistant/MarkdownRenderer.tsx
@@ -1,4 +1,5 @@
-import { lazy, Suspense } from 'react';
+import { Component, lazy, Suspense } from 'react';
+import type { ReactNode } from 'react';
 import { supportsModernRegex } from '../../lib/supports-modern-regex.mjs';
 
 interface Props {
@@ -17,12 +18,48 @@ function MarkdownFallback() {
   return <div className="da-markdown" aria-hidden="true" />;
 }
 
+interface BoundaryProps {
+  content: string;
+  children: ReactNode;
+}
+
+interface BoundaryState {
+  failed: boolean;
+}
+
+/**
+ * Keeps a failed renderer chunk from destroying the whole assistant root.
+ *
+ * Both renderers are lazy, so a chunk that does not load - stale deployment, offline, blocked
+ * request - rejects during render. Without a boundary React unmounts the widget and rethrows to
+ * window.onerror, which takes the launcher and the panel down with it. The fallback renders plain
+ * text inline and never another lazy component, because a boundary cannot catch a throw raised
+ * inside its own fallback.
+ */
+class MarkdownBoundary extends Component<BoundaryProps, BoundaryState> {
+  state: BoundaryState = { failed: false };
+
+  static getDerivedStateFromError(): BoundaryState {
+    return { failed: true };
+  }
+
+  render(): ReactNode {
+    if (this.state.failed) {
+      return <div className="da-markdown da-markdown-plain">{this.props.content}</div>;
+    }
+
+    return this.props.children;
+  }
+}
+
 export function MarkdownRenderer({ content }: Props) {
   const Renderer = supportsModernRegex() ? MarkdownRendererFull : MarkdownRendererSimple;
 
   return (
-    <Suspense fallback={<MarkdownFallback />}>
-      <Renderer content={content} />
-    </Suspense>
+    <MarkdownBoundary content={content}>
+      <Suspense fallback={<MarkdownFallback />}>
+        <Renderer content={content} />
+      </Suspense>
+    </MarkdownBoundary>
   );
 }

--- a/docs/src/components/__tests__/docs-assistant-markdown-boundary.test.mjs
+++ b/docs/src/components/__tests__/docs-assistant-markdown-boundary.test.mjs
@@ -1,0 +1,152 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+import React from 'react';
+import ts from 'typescript';
+
+const rendererPath = fileURLToPath(
+  new URL('../DocsAssistant/MarkdownRenderer.tsx', import.meta.url)
+);
+const rendererSource = readFileSync(rendererPath, 'utf8');
+const cssPath = fileURLToPath(new URL('../DocsAssistant/DocsAssistant.css', import.meta.url));
+const cssSource = readFileSync(cssPath, 'utf8');
+
+const transpiled = ts.transpileModule(rendererSource, {
+  compilerOptions: {
+    module: ts.ModuleKind.ES2022,
+    target: ts.ScriptTarget.ES2022,
+    jsx: ts.JsxEmit.React,
+  },
+}).outputText;
+
+/**
+ * A data: URL module cannot resolve bare or relative specifiers, so the two static imports are
+ * swapped for globals. The lazy `import()` calls stay untouched - they are never invoked here,
+ * which is exactly the condition under test.
+ */
+const shimmed = transpiled
+  .replace(
+    /^import \{[^}]*\} from ["']react["'];$/m,
+    'const { Component, lazy, Suspense } = globalThis.__hotTestReact;'
+  )
+  .replace(
+    /^import \{ supportsModernRegex \} from ["'][^"']*["'];$/m,
+    'const supportsModernRegex = () => true;'
+  );
+
+assert.doesNotMatch(
+  shimmed,
+  /^import [^(]/m,
+  'Expected every static import to be shimmed before loading the module'
+);
+
+globalThis.__hotTestReact = React;
+
+const { MarkdownRenderer } = await import(
+  `data:text/javascript;charset=utf-8,${encodeURIComponent(`const React = globalThis.__hotTestReact;\n${shimmed}`)}`
+);
+
+const LAZY_TYPE = Symbol.for('react.lazy');
+
+function collectElementTypes(node, types = []) {
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      collectElementTypes(child, types);
+    }
+
+    return types;
+  }
+
+  if (node === null || typeof node !== 'object') {
+    return types;
+  }
+
+  if (node.$$typeof === Symbol.for('react.element')) {
+    types.push(node.type);
+    collectElementTypes(node.props?.children, types);
+  }
+
+  return types;
+}
+
+function renderMarkdown(content) {
+  const tree = MarkdownRenderer({ content });
+  const Boundary = tree.type;
+
+  return { tree, Boundary };
+}
+
+test('the error boundary wraps the Suspense tree that loads the lazy renderers', () => {
+  const { tree, Boundary } = renderMarkdown('Set `autoWrapRow` to `true`.');
+
+  assert.equal(typeof Boundary.getDerivedStateFromError, 'function');
+  assert.equal(tree.props.content, 'Set `autoWrapRow` to `true`.');
+  assert.equal(tree.props.children.type, React.Suspense);
+  assert.equal(collectElementTypes(tree.props.children.props.children).length, 1);
+});
+
+test('the boundary renders its children untouched until a renderer chunk fails', () => {
+  const { tree, Boundary } = renderMarkdown('Call `updateSettings()` once.');
+  const boundary = new Boundary(tree.props);
+
+  assert.deepEqual(boundary.state, { failed: false });
+  assert.equal(boundary.render(), tree.props.children);
+});
+
+test('a failed renderer chunk keeps the assistant mounted and shows the message text', () => {
+  const content = 'Register the plugin with `registerPlugin()`.';
+  const { tree, Boundary } = renderMarkdown(content);
+  const boundary = new Boundary(tree.props);
+
+  boundary.state = Boundary.getDerivedStateFromError(
+    new TypeError('Failed to fetch dynamically imported module: /docs/_astro/MarkdownRendererFull.js')
+  );
+
+  const fallback = boundary.render();
+
+  assert.deepEqual(boundary.state, { failed: true });
+  assert.equal(fallback.type, 'div');
+  assert.match(fallback.props.className, /\bda-markdown-plain\b/);
+  assert.equal(fallback.props.children, content);
+});
+
+test('the failure fallback renders no lazy component of its own', () => {
+  const { tree, Boundary } = renderMarkdown('The `afterChange` hook fires once per edit.');
+  const boundary = new Boundary(tree.props);
+
+  boundary.state = Boundary.getDerivedStateFromError(new TypeError('chunk load failure'));
+
+  const types = collectElementTypes(boundary.render());
+
+  assert.ok(types.length > 0);
+
+  for (const type of types) {
+    assert.notEqual(
+      type?.$$typeof,
+      LAZY_TYPE,
+      'A boundary cannot catch a throw raised inside its own fallback, so the fallback must not be lazy'
+    );
+    assert.notEqual(type, React.Suspense);
+  }
+});
+
+test('the failure fallback reads live props so streamed message text keeps updating', () => {
+  const { tree, Boundary } = renderMarkdown('Partial ans');
+  const boundary = new Boundary(tree.props);
+
+  boundary.state = Boundary.getDerivedStateFromError(new TypeError('chunk load failure'));
+
+  assert.equal(boundary.render().props.children, 'Partial ans');
+
+  boundary.props = { ...boundary.props, content: 'Partial answer, now complete.' };
+
+  assert.equal(boundary.render().props.children, 'Partial answer, now complete.');
+});
+
+test('the plain-text fallback keeps markdown line breaks readable', () => {
+  const match = cssSource.match(/\.da-markdown-plain\s*\{(?<body>[^}]+)\}/);
+
+  assert.ok(match?.groups?.body, 'Expected a .da-markdown-plain rule');
+  assert.match(match.groups.body, /white-space:\s*pre-wrap;/);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,6 +298,12 @@ importers:
       '@types/node':
         specifier: ^20.11.27
         version: 20.19.42
+      '@types/react':
+        specifier: ^18.3.31
+        version: 18.3.31
+      '@types/react-dom':
+        specifier: ^18.3.7
+        version: 18.3.7(@types/react@18.3.31)
       '@vitejs/plugin-vue':
         specifier: ^6.0.7
         version: 6.0.7(vite@7.3.5(@types/node@20.19.42)(jiti@1.21.7)(less@4.6.4)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.48.0))(vue@3.5.35(typescript@5.8.3))


### PR DESCRIPTION
### Context

The PR fixes the docs-assistant widget disappearing entirely when one of its lazy chunks fails to load. Sentry: [HANDSONTABLE-DOCS-20G](https://handsoncode.sentry.io/issues/HANDSONTABLE-DOCS-20G/), reproduced live on production.

`docs/src/components/DocsAssistant/MarkdownRenderer.tsx` mounts two `React.lazy()` renderers inside `<Suspense>`, and there is no error boundary anywhere in `docs/src`. A rejected chunk import throws during render, so React unmounts the whole `#docs-assistant-root` and rethrows to `window.onerror` — the reader loses the assistant, not just the formatting.

This PR adds a small class error boundary around that `<Suspense>`. `getDerivedStateFromError` flips one boolean and the failure branch renders non-lazy inline plain text, reading live props so a streaming message keeps updating.

`MarkdownRendererSimple` cannot serve as the fallback: it is `lazy()` too, the same CDN or stale-deploy condition rejects its chunk, and a boundary cannot catch a throw raised inside its own fallback. That reasoning is in a JSDoc block on the class so it does not get "simplified" later. No dependency was added — `react-error-boundary` was deliberately avoided.

The PR also adds `@types/react` and `@types/react-dom` to `docs/package.json`. Without them the base `Component` resolves to `any`, `this.props` is unresolvable, and the class fails the JSX-component check. These are types-only packages for `react`/`react-dom`, which the docs site already ships.

Accepted trade-off worth flagging in review: after this fix the failure degrades to plain text **silently** and stops producing a Sentry event on this path. That is acceptable because the loud version of the same trigger is a separate, much larger group (1DQ, 223 events / 193 users) which stays visible.

### How has this been tested?

New Node test-runner guard, `docs/src/components/__tests__/docs-assistant-markdown-boundary.test.mjs` (6 tests):

```bash
cd docs && node --test src/components/__tests__/docs-assistant-markdown-boundary.test.mjs
# tests 6 / # pass 6 / # fail 0
```

All docs component tests:

```bash
cd docs && node --test src/components/__tests__/*.test.mjs
# tests 18 / # pass 18 / # fail 0
```

Type-check, which is the reason for the new devDependencies:

```bash
cd docs && npx tsc --noEmit
# TypeScript: No errors found
```

Current source was confirmed byte-identical to the unguarded 28-line version the triage described before editing, so the change applies to the state that is actually deployed.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2145

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2145

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-site UI resilience only; degrades formatting silently without touching auth, data, or core Handsontable packages.
> 
> **Overview**
> Fixes the Docs Assistant **vanishing entirely** when a lazy markdown renderer chunk fails to load (stale deploy, offline, blocked request). Previously a rejected `React.lazy()` import during render unmounted the whole widget.
> 
> `MarkdownRenderer` now wraps the existing `<Suspense>` + lazy renderer tree in a small **`MarkdownBoundary`** class error boundary. On failure it shows **plain text** from live `content` props (so streaming still updates) via `.da-markdown-plain` styling—**not** another lazy renderer, which the boundary could not recover from.
> 
> Adds **`@types/react`** / **`@types/react-dom`** for the class component typings and a **Node test suite** that guards boundary structure, fallback behavior, and CSS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b0b47c2edd0d066828ec583b225f4a901f9e3e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->