### PR TITLE
DEV-2146: Guard changeNamedExpression in the named-expressions demo

### DIFF
--- a/docs/content/guides/formulas/formula-calculation/angular/example3.ts
+++ b/docs/content/guides/formulas/formula-calculation/angular/example3.ts
@@ -14,6 +14,7 @@ import {HyperFormula} from 'hyperformula';
         <input [formControl]="namedExpressionsControl" type="text" />&nbsp;
         <button (click)="applyNamedExpression()">Calculate the price</button>
       </div>
+      <output [class.is-error]="errorMessage">{{ errorMessage }}</output>
     </div>
 
     <hot-table
@@ -26,6 +27,8 @@ export class AppComponent {
   @ViewChild(HotTableComponent, {static: false}) hotTable!: HotTableComponent;
 
   namedExpressionsControl = new FormControl('=10 * Sheet1!$A$2');
+
+  errorMessage = '';
 
   readonly hotData = [
     ['Travel ID', 'Destination', 'Base price', 'Price with extra cost'],
@@ -54,7 +57,16 @@ export class AppComponent {
   applyNamedExpression() {
     const formulasPlugin = this.hotTable.hotInstance!.getPlugin('formulas');
 
-    (formulasPlugin.engine as any)?.changeNamedExpression('ADDITIONAL_COST', this.namedExpressionsControl.value);
+    try {
+      (formulasPlugin.engine as any)?.changeNamedExpression('ADDITIONAL_COST', this.namedExpressionsControl.value);
+    } catch (error) {
+      // HyperFormula rejects some expressions, for example relative references such as `Sheet1!A2`.
+      this.errorMessage = error instanceof Error ? error.message : String(error);
+
+      return;
+    }
+
+    this.errorMessage = '';
     this.hotTable.hotInstance!.render();
   }
 }

--- a/docs/content/guides/formulas/formula-calculation/formula-calculation.md
+++ b/docs/content/guides/formulas/formula-calculation/formula-calculation.md
@@ -804,7 +804,8 @@ for the full naming rules and supported expression types.
 
 The example below registers `ADDITIONAL_COST` as a plain number. Cell formulas in column D add that
 constant to each base price. The input below the grid lets you replace the expression at runtime
-using `changeNamedExpression()`.
+using `changeNamedExpression()`. If HyperFormula rejects the expression - for example when you use a
+relative reference such as `Sheet1!A2` - the demo shows the error message below the input.
 
 ::: only-for javascript
 

--- a/docs/content/guides/formulas/formula-calculation/javascript/example-named-expressions1.html
+++ b/docs/content/guides/formulas/formula-calculation/javascript/example-named-expressions1.html
@@ -3,5 +3,6 @@
     <input id="named-expressions-input" type="text" value="=10 * Sheet1!$A$2" />
     <button id="named-expressions-button">Calculate the price</button>
   </div>
+  <output id="named-expressions-status"></output>
 </div>
 <div id="example-named-expressions1"></div>

--- a/docs/content/guides/formulas/formula-calculation/javascript/example-named-expressions1.js
+++ b/docs/content/guides/formulas/formula-calculation/javascript/example-named-expressions1.js
@@ -35,8 +35,20 @@ const hot = new Handsontable(container, {
 const input = document.getElementById('named-expressions-input');
 const formulasPlugin = hot.getPlugin('formulas');
 const button = document.getElementById('named-expressions-button');
+const statusOutput = document.getElementById('named-expressions-status');
 
 button.addEventListener('click', () => {
-  formulasPlugin.engine?.changeNamedExpression('ADDITIONAL_COST', input.value);
+  try {
+    formulasPlugin.engine?.changeNamedExpression('ADDITIONAL_COST', input.value);
+  } catch (error) {
+    // HyperFormula rejects some expressions, for example relative references such as `Sheet1!A2`.
+    statusOutput.textContent = error instanceof Error ? error.message : String(error);
+    statusOutput.classList.add('is-error');
+
+    return;
+  }
+
+  statusOutput.textContent = '';
+  statusOutput.classList.remove('is-error');
   hot.render();
 });

--- a/docs/content/guides/formulas/formula-calculation/javascript/example-named-expressions1.ts
+++ b/docs/content/guides/formulas/formula-calculation/javascript/example-named-expressions1.ts
@@ -38,8 +38,20 @@ const hot = new Handsontable(container, {
 const input = document.getElementById('named-expressions-input')!;
 const formulasPlugin: Formulas = hot.getPlugin('formulas');
 const button = document.getElementById('named-expressions-button')!;
+const statusOutput = document.getElementById('named-expressions-status')!;
 
 button!.addEventListener('click', () => {
-  formulasPlugin.engine?.changeNamedExpression('ADDITIONAL_COST', (input as HTMLInputElement).value);
+  try {
+    formulasPlugin.engine?.changeNamedExpression('ADDITIONAL_COST', (input as HTMLInputElement).value);
+  } catch (error) {
+    // HyperFormula rejects some expressions, for example relative references such as `Sheet1!A2`.
+    statusOutput.textContent = error instanceof Error ? error.message : String(error);
+    statusOutput.classList.add('is-error');
+
+    return;
+  }
+
+  statusOutput.textContent = '';
+  statusOutput.classList.remove('is-error');
   hot.render();
 });

--- a/docs/content/guides/formulas/formula-calculation/react/example-named-expressions1.jsx
+++ b/docs/content/guides/formulas/formula-calculation/react/example-named-expressions1.jsx
@@ -9,6 +9,7 @@ registerAllModules();
 const ExampleComponent = () => {
   const hotNamedExpressionsRef = useRef(null);
   const [namedExpressionValue, setNamedExpressionValue] = useState('=10 * Sheet1!$A$2');
+  const [errorMessage, setErrorMessage] = useState('');
   const data = [
     ['Travel ID', 'Destination', 'Base price', 'Price with extra cost'],
     ['154', 'Rome', 400, '=ROUND(ADDITIONAL_COST+C2,0)'],
@@ -24,7 +25,16 @@ const ExampleComponent = () => {
     const hotNamedExpressions = hotNamedExpressionsRef.current?.hotInstance;
     const formulasPlugin = hotNamedExpressions?.getPlugin('formulas');
 
-    formulasPlugin?.engine?.changeNamedExpression('ADDITIONAL_COST', namedExpressionValue);
+    try {
+      formulasPlugin?.engine?.changeNamedExpression('ADDITIONAL_COST', namedExpressionValue);
+    } catch (error) {
+      // HyperFormula rejects some expressions, for example relative references such as `Sheet1!A2`.
+      setErrorMessage(error instanceof Error ? error.message : String(error));
+
+      return;
+    }
+
+    setErrorMessage('');
     hotNamedExpressions?.render();
   };
 
@@ -42,6 +52,7 @@ const ExampleComponent = () => {
             Calculate the price
           </button>
         </div>
+        <output className={errorMessage ? 'is-error' : undefined}>{errorMessage}</output>
       </div>
       <HotTable
         ref={hotNamedExpressionsRef}

--- a/docs/content/guides/formulas/formula-calculation/react/example-named-expressions1.tsx
+++ b/docs/content/guides/formulas/formula-calculation/react/example-named-expressions1.tsx
@@ -10,6 +10,7 @@ registerAllModules();
 const ExampleComponent = () => {
   const hotNamedExpressionsRef = useRef<HotTableRef>(null);
   const [namedExpressionValue, setNamedExpressionValue] = useState('=10 * Sheet1!$A$2');
+  const [errorMessage, setErrorMessage] = useState('');
 
   const data = [
     ['Travel ID', 'Destination', 'Base price', 'Price with extra cost'],
@@ -26,8 +27,16 @@ const ExampleComponent = () => {
     const hotNamedExpressions = hotNamedExpressionsRef.current?.hotInstance;
     const formulasPlugin = hotNamedExpressions?.getPlugin('formulas');
 
-    formulasPlugin?.engine?.changeNamedExpression('ADDITIONAL_COST', namedExpressionValue);
+    try {
+      formulasPlugin?.engine?.changeNamedExpression('ADDITIONAL_COST', namedExpressionValue);
+    } catch (error) {
+      // HyperFormula rejects some expressions, for example relative references such as `Sheet1!A2`.
+      setErrorMessage(error instanceof Error ? error.message : String(error));
 
+      return;
+    }
+
+    setErrorMessage('');
     hotNamedExpressions?.render();
   };
 
@@ -45,6 +54,7 @@ const ExampleComponent = () => {
             Calculate the price
           </button>
         </div>
+        <output className={errorMessage ? 'is-error' : undefined}>{errorMessage}</output>
       </div>
       <HotTable
         ref={hotNamedExpressionsRef}

--- a/docs/content/guides/formulas/formula-calculation/vue/example-named-expressions1.vue
+++ b/docs/content/guides/formulas/formula-calculation/vue/example-named-expressions1.vue
@@ -11,6 +11,7 @@ registerAllModules();
 
 const hotRef = useTemplateRef<InstanceType<typeof HotTable>>('hotRef');
 const namedExpressionValue = ref('=10 * Sheet1!$A$2');
+const errorMessage = ref('');
 
 const data = [
   ['Travel ID', 'Destination', 'Base price', 'Price with extra cost'],
@@ -46,8 +47,16 @@ function buttonClickCallback() {
   const hotInstance = hotRef.value?.hotInstance;
   const formulasPlugin = hotInstance?.getPlugin('formulas');
 
-  formulasPlugin?.engine?.changeNamedExpression('ADDITIONAL_COST', namedExpressionValue.value);
+  try {
+    formulasPlugin?.engine?.changeNamedExpression('ADDITIONAL_COST', namedExpressionValue.value);
+  } catch (error) {
+    // HyperFormula rejects some expressions, for example relative references such as `Sheet1!A2`.
+    errorMessage.value = error instanceof Error ? error.message : String(error);
 
+    return;
+  }
+
+  errorMessage.value = '';
   hotInstance?.render();
 }
 </script>
@@ -66,6 +75,7 @@ function buttonClickCallback() {
           Calculate the price
         </button>
       </div>
+      <output :class="{ 'is-error': errorMessage }">{{ errorMessage }}</output>
     </div>
     <HotTable ref="hotRef" :settings="hotSettings" />
   </div>


### PR DESCRIPTION
### Context

The PR fixes an uncaught exception a reader can trigger by typing in the named-expressions demo on the formula-calculation page. Sentry: [HANDSONTABLE-DOCS-1BZ](https://handsoncode.sentry.io/issues/HANDSONTABLE-DOCS-1BZ/) — 4 events / 2 users, still firing.

The "plain-value named expression" demo passes the reader's raw input straight into HyperFormula's `changeNamedExpression()`. The input is prefilled with an absolute address (`=10 * Sheet1!$A$2`), so dropping a single `$` makes HyperFormula throw `Relative addresses not allowed in named expressions.` with nothing catching it — the reader gets no feedback and the error reaches `window.onerror`.

Verified against the installed hyperformula 3.3.0: a relative address throws, while a malformed formula does **not** (it is accepted and evaluates to an error value). So a `try`/`catch` around this one call is sufficient — no input validation needed.

The fix wraps the call in all six framework variants and shows the engine's own message in an `<output>` under the input, then skips `render()` because nothing in the engine changed and a re-render would be misleading. Inline feedback rather than a console warning or a silent revert: readers of a docs page are looking at the page, not devtools, and the message HyperFormula produces is exactly what the surrounding tip about absolute notation is teaching. Reverting the input would hide which expression was rejected.

Two things reviewers may want to know. One of the four Sentry events comes from the frozen `/docs/15.3/` archive and **cannot** be fixed from this repo — that residual needs Sentry-side suppression. And production docs are served from `prod-docs/18.0`, where this demo is live and still unguarded, so this needs a cherry-pick to reach the readers who are hitting it.

### How has this been tested?

Node-level reproduction of the edited handler body against the installed hyperformula 3.3.0, with the demo's own sheet and a stubbed status element:

```
PASS  unguarded handler throws on a relative address — Relative addresses not allowed in named expressions.
PASS  relative address "=10 * Sheet1!A2" is caught — {"message":"Relative addresses not allowed in named expressions.","isError":true,"rendered":0}
PASS  absolute address "=10 * Sheet1!$A$2" succeeds — {"message":"","isError":false,"rendered":1}
```

The first line is the negative control: the pre-fix handler body still throws in the same harness, so the test is not vacuous.

All six variants were re-read against current `develop` before editing; the line numbers from triage all matched (js:40, ts:43, jsx:27, tsx:29, vue:49, angular/example3.ts:57), so nothing was applied to stale code.

Files changed:

- `docs/content/guides/formulas/formula-calculation/javascript/example-named-expressions1.{js,ts,html}`
- `docs/content/guides/formulas/formula-calculation/react/example-named-expressions1.{jsx,tsx}`
- `docs/content/guides/formulas/formula-calculation/vue/example-named-expressions1.vue`
- `docs/content/guides/formulas/formula-calculation/angular/example3.ts`
- `docs/content/guides/formulas/formula-calculation/formula-calculation.md`

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2146

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2146

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and interactive examples only; no product library or runtime behavior changes.
> 
> **Overview**
> Fixes uncaught exceptions on the **plain-value named expression** demo when readers submit expressions HyperFormula rejects (e.g. relative sheet references like `Sheet1!A2`).
> 
> All six framework examples now wrap `changeNamedExpression()` in **try/catch**, surface the engine message in an `<output>` under the input (with `is-error` on failure), and **skip `render()`** when the update fails. The formula-calculation guide text notes this inline error behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 444572d592993a2c6a920951acbf45278ce04de8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->