### PR TITLE
DEV-2147: Stop the valueFormatter demo throwing on non-numeric input

### DIFF
--- a/docs/content/guides/cell-functions/cell-renderer/angular/example7.ts
+++ b/docs/content/guides/cell-functions/cell-renderer/angular/example7.ts
@@ -28,10 +28,17 @@ export class AppComponent {
       { data: 'asset' },
       {
         data: 'btcValue',
+        type: 'numeric',
         // Bitcoin (₿) isn't an ISO 4217 currency, so `numericFormat` can't format it.
         // `valueFormatter` prepends the symbol instead.
         valueFormatter(value: unknown) {
-          return `₿${(value as number).toFixed(4)}`;
+          // `type: 'numeric'` turns numeric input into a number, but invalid input
+          // stays a string, so check the type before calling `toFixed()`.
+          if (typeof value !== 'number') {
+            return value;
+          }
+
+          return `₿${value.toFixed(4)}`;
         },
       },
       {

--- a/docs/content/guides/cell-functions/cell-renderer/javascript/example6.js
+++ b/docs/content/guides/cell-functions/cell-renderer/javascript/example6.js
@@ -17,9 +17,15 @@ new Handsontable(container, {
         { data: 'asset' },
         {
             data: 'btcValue',
+            type: 'numeric',
             // Bitcoin (₿) isn't an ISO 4217 currency, so `numericFormat` can't format it.
             // `valueFormatter` prepends the symbol instead.
             valueFormatter(value) {
+                // `type: 'numeric'` turns numeric input into a number, but invalid input
+                // stays a string, so check the type before calling `toFixed()`.
+                if (typeof value !== 'number') {
+                    return value;
+                }
                 return `₿${value.toFixed(4)}`;
             },
         },

--- a/docs/content/guides/cell-functions/cell-renderer/javascript/example6.ts
+++ b/docs/content/guides/cell-functions/cell-renderer/javascript/example6.ts
@@ -27,9 +27,16 @@ new Handsontable(container, {
     { data: 'asset' },
     {
       data: 'btcValue',
+      type: 'numeric',
       // Bitcoin (₿) isn't an ISO 4217 currency, so `numericFormat` can't format it.
       // `valueFormatter` prepends the symbol instead.
       valueFormatter(value) {
+        // `type: 'numeric'` turns numeric input into a number, but invalid input
+        // stays a string, so check the type before calling `toFixed()`.
+        if (typeof value !== 'number') {
+          return value;
+        }
+
         return `₿${value.toFixed(4)}`;
       },
     },

--- a/docs/content/guides/cell-functions/cell-renderer/react/example6.jsx
+++ b/docs/content/guides/cell-functions/cell-renderer/react/example6.jsx
@@ -14,9 +14,15 @@ const ExampleComponent = () => {
             { data: 'asset' },
             {
                 data: 'btcValue',
+                type: 'numeric',
                 // Bitcoin (₿) isn't an ISO 4217 currency, so `numericFormat` can't format it.
                 // `valueFormatter` prepends the symbol instead.
                 valueFormatter(value) {
+                    // `type: 'numeric'` turns numeric input into a number, but invalid input
+                    // stays a string, so check the type before calling `toFixed()`.
+                    if (typeof value !== 'number') {
+                        return value;
+                    }
                     return `₿${value.toFixed(4)}`;
                 },
             },

--- a/docs/content/guides/cell-functions/cell-renderer/react/example6.tsx
+++ b/docs/content/guides/cell-functions/cell-renderer/react/example6.tsx
@@ -21,9 +21,16 @@ const ExampleComponent = () => {
         { data: 'asset' },
         {
           data: 'btcValue',
+          type: 'numeric',
           // Bitcoin (₿) isn't an ISO 4217 currency, so `numericFormat` can't format it.
           // `valueFormatter` prepends the symbol instead.
-          valueFormatter(value: number) {
+          valueFormatter(value: unknown) {
+            // `type: 'numeric'` turns numeric input into a number, but invalid input
+            // stays a string, so check the type before calling `toFixed()`.
+            if (typeof value !== 'number') {
+              return value;
+            }
+
             return `₿${value.toFixed(4)}`;
           },
         },
@@ -31,7 +38,7 @@ const ExampleComponent = () => {
           data: 'portfolioShare',
           // Per mille (‰) isn't a unit sanctioned by `Intl.NumberFormat`, so `valueFormatter`
           // appends the symbol manually.
-          valueFormatter(value: number) {
+          valueFormatter(value: unknown) {
             return `${value}‰`;
           },
         },

--- a/docs/content/guides/cell-functions/cell-renderer/vue/example6.vue
+++ b/docs/content/guides/cell-functions/cell-renderer/vue/example6.vue
@@ -27,9 +27,16 @@ const hotSettings = ref<GridSettings>({
     { data: 'asset' },
     {
       data: 'btcValue',
+      type: 'numeric',
       // Bitcoin (₿) isn't an ISO 4217 currency, so `numericFormat` can't format it.
       // `valueFormatter` prepends the symbol instead.
-      valueFormatter(value: number) {
+      valueFormatter(value: unknown) {
+        // `type: 'numeric'` turns numeric input into a number, but invalid input
+        // stays a string, so check the type before calling `toFixed()`.
+        if (typeof value !== 'number') {
+          return value;
+        }
+
         return `₿${value.toFixed(4)}`;
       },
     },
@@ -37,7 +44,7 @@ const hotSettings = ref<GridSettings>({
       data: 'portfolioShare',
       // Per mille (‰) isn't a unit sanctioned by `Intl.NumberFormat`, so `valueFormatter`
       // appends the symbol manually.
-      valueFormatter(value: number) {
+      valueFormatter(value: unknown) {
         return `${value}‰`;
       },
     },


### PR DESCRIPTION
### Context

The PR fixes the `valueFormatter` demo in the cell-renderer guide, which throws on **every** edit of its BTC column — including a perfectly valid number. Sentry: [HANDSONTABLE-DOCS-219](https://handsoncode.sentry.io/issues/HANDSONTABLE-DOCS-219/).

The formatter calls `.toFixed()` on whatever the editor produces. The column has no `type`, so the text editor yields a string, and `'5'.toFixed` is `undefined` — the first edit throws regardless of what the reader types.

Both halves of the fix are required, and the matrix was re-derived in a browser rather than assumed:

- `type: 'numeric'` alone — coerces `5` to a number, but leaves `abc` a string, so invalid text still throws.
- The `typeof value !== 'number'` guard alone — stops the throw, but the column loses its ₿ formatting on every edit, because the text editor never produces a number.
- Both together — a valid edit renders `₿5.0000`, invalid text renders raw with `htInvalid`.

`type: 'numeric'` also makes the example match the prose it sits under, which frames it as the case the numeric renderer's `numericFormat` cannot express. The PR also removes the `value: number` annotations (and the Angular `as number` cast) that hid this mismatch from the type checker.

Two side effects reviewers should look at, both cosmetic: the numeric renderer adds `htRight htNumeric`, so the BTC column is now right-aligned while the neighbouring formatter column stays left; and invalid text now paints `htInvalid` in this demo, which is arguably the desired teaching but is new UI here. Initial render is byte-identical to before.

No cherry-pick needed — the example is merged on `develop` but verifiably absent from production, which is why the Sentry group has a single event. That also means this must land before the next docs deploy ships the example to readers.

### How has this been tested?

No harness in the repo covers `docs/content/` examples, so three real gates plus negative controls were used.

Angular compile gate — the same `ngc` invocation `docs/angular-type-check` runs in CI, with `strict` and `strictTemplates`:

```bash
node split.mjs .../angular/example7.ts src && ./node_modules/.bin/ngc --project tsconfig.json
# ngc_exit=0
```

Negative control on that harness: reintroducing the removed `as number` cast makes it fail, so the gate is not vacuous.

Browser verification of the behaviour matrix (valid number, invalid text, initial render) for the JS, React and Vue variants, confirming `₿5.0000` on a valid edit, raw text plus `htInvalid` on `abc`, and an unchanged first paint.

All six variants were checked against current `develop` before editing; the triage line numbers matched exactly.

Files changed:

- `docs/content/guides/cell-functions/cell-renderer/javascript/example6.{js,ts}`
- `docs/content/guides/cell-functions/cell-renderer/react/example6.{jsx,tsx}`
- `docs/content/guides/cell-functions/cell-renderer/vue/example6.vue`
- `docs/content/guides/cell-functions/cell-renderer/angular/example7.ts`

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2147

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2147

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation example-only changes with no library or runtime product impact.
> 
> **Overview**
> Fixes the cell-renderer guide **valueFormatter** demos (JS/TS, React, Vue, Angular) so editing the BTC column no longer throws when `.toFixed()` runs on string editor output.
> 
> The **btcValue** column now sets **`type: 'numeric'`** so valid edits are numbers and keep **₿** formatting, and **`valueFormatter`** guards with **`typeof value !== 'number'`** before formatting so invalid text is returned as-is instead of crashing. Typed examples drop **`number`** annotations / **`as number`** casts in favor of **`unknown`** so the mismatch is visible to the type checker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b57fcf4863fe3f14a02a5d1c24fd79d3fa9d8f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->