### PR TITLE
DEV-2149: Report swallowed example failures and guard runtime imports

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -497,3 +497,14 @@ The custom loader (`src/plugins/framework-loader.mjs`) renders every source page
 - Both `.astro/data-store.json` and `.astro/rendered-html/` are derived caches — reset them together with `rm -rf .astro`. Never delete one without the other.
 - `npm run dev` must work with the default Node heap. Do not add `NODE_OPTIONS=--max-old-space-size` workarounds; shrink the data store instead.
 - Plugin unit tests run with `node --test src/plugins/__tests__/*.test.mjs`.
+
+---
+
+## 2.13 Example-Runner Error Handling
+
+`src/scripts/example-runner.ts` catches every example failure so one broken example cannot take a page down. Two rules keep that from hiding real crashes (Sentry HANDSONTABLE-DOCS-20K) or leaking unhandled rejections (HANDSONTABLE-DOCS-1FX):
+
+- **Every caught example failure goes through `reportExampleError()`** from `src/lib/example-error-reporting.mjs`. That module owns the drop list - failed chunk fetches, errors carrying `cause.handsontable` (core `throwWithCause()`), the expected `HTTP <status>` of the server-side data examples - plus deduplication by message and a cap of three forwarded failures per page load. Widen or narrow the drop list there, never at the call site. Sentry reaches the runner through the Loader Script (`window.Sentry`), whose deferred `<script>` tag precedes the bundled Head scripts, so the queueing stub exists by the time the runner runs; a blocked CDN request degrades to no report.
+- **A framework runtime (`react`, `vue`, `zone.js`, `@angular/compiler`) must only be imported inside `loadRuntime()`.** A bare `await import(...)` there escapes every try/catch as an unhandled rejection and leaves each example of that framework stuck on its loading shimmer forever. `loadRuntime()` returns `null` on failure, and the group is marked with `markFailed()` - the only place that shows a reader-visible notice (`.hot-example-error`). Per-example failures keep the silent `markLoaded()` degradation, because some examples render nothing by design.
+
+Guards for both rules live in `src/lib/__tests__/example-error-reporting.test.mjs` (run by `npm run docs:test:plugins`).

--- a/docs/src/lib/__tests__/example-error-reporting.test.mjs
+++ b/docs/src/lib/__tests__/example-error-reporting.test.mjs
@@ -1,0 +1,302 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+import {
+  createExampleErrorReporter,
+  isChunkLoadError,
+  isExpectedDemoHttpError,
+  isIntentionalHandsontableError,
+} from '../example-error-reporting.mjs';
+
+/**
+ * Collects the arguments the reporter passes to Sentry.
+ */
+function createSentryStub() {
+  const calls = [];
+
+  return {
+    calls,
+    sentry: {
+      captureException(err, hint) {
+        calls.push({ err, hint });
+      },
+    },
+  };
+}
+
+function createReporter(overrides = {}) {
+  const { calls, sentry } = createSentryStub();
+  const report = createExampleErrorReporter({ getSentry: () => sentry, ...overrides });
+
+  return { calls, report };
+}
+
+const jsContext = { framework: 'javascript', phase: 'example-init', source: '/content/example.js' };
+
+test('reports a real example failure to Sentry with framework and phase tags', () => {
+  const { calls, report } = createReporter();
+  // The failure class that produced zero Sentry events before this module existed
+  // (HANDSONTABLE-DOCS-20K): a method the reader's engine does not implement.
+  const err = new TypeError('hooks.toSorted is not a function');
+
+  assert.equal(report(err, jsContext), 'reported');
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].err, err);
+  assert.deepEqual(calls[0].hint.tags, {
+    hot_example: 'javascript',
+    hot_example_phase: 'example-init',
+  });
+  assert.equal(calls[0].hint.extra.source, '/content/example.js');
+});
+
+test('does not report failed dynamic imports in any browser wording', () => {
+  const { calls, report } = createReporter();
+  const messages = [
+    'Failed to fetch dynamically imported module: https://handsontable.com/docs/_astro/example2.js',
+    'error loading dynamically imported module: https://handsontable.com/docs/_astro/vue.js',
+    'Importing a module script failed.',
+  ];
+
+  for (const message of messages) {
+    assert.equal(report(new TypeError(message), jsContext), 'skipped-chunk-load');
+  }
+
+  assert.equal(calls.length, 0);
+});
+
+test('does not report errors Handsontable throws on purpose', () => {
+  const { calls, report } = createReporter();
+  const err = new Error('The provided data type is not supported', { cause: { handsontable: true } });
+
+  assert.equal(report(err, jsContext), 'skipped-intentional');
+  assert.equal(calls.length, 0);
+});
+
+test('does not report the expected HTTP status of the server-side data examples', () => {
+  const { calls, report } = createReporter();
+
+  assert.equal(report(new Error('HTTP 404'), jsContext), 'skipped-demo-http');
+  assert.equal(calls.length, 0);
+});
+
+test('reports each distinct failure once per page load', () => {
+  const { calls, report } = createReporter();
+
+  assert.equal(report(new TypeError('boom'), jsContext), 'reported');
+  assert.equal(report(new TypeError('boom'), jsContext), 'skipped-duplicate');
+  assert.equal(report(new TypeError('boom'), { ...jsContext, source: '/content/other.js' }), 'skipped-duplicate');
+  assert.equal(report(new TypeError('different'), jsContext), 'reported');
+  assert.equal(calls.length, 2);
+});
+
+test('caps the number of forwarded failures per page load', () => {
+  const { calls, report } = createReporter({ maxReports: 2 });
+
+  assert.equal(report(new TypeError('one'), jsContext), 'reported');
+  assert.equal(report(new TypeError('two'), jsContext), 'reported');
+  assert.equal(report(new TypeError('three'), jsContext), 'skipped-limit');
+  assert.equal(calls.length, 2);
+});
+
+test('the same message under a different framework or phase is a separate failure', () => {
+  const { calls, report } = createReporter();
+
+  assert.equal(report(new TypeError('boom'), jsContext), 'reported');
+  assert.equal(report(new TypeError('boom'), { framework: 'vue', phase: 'runtime-import' }), 'reported');
+  assert.equal(calls.length, 2);
+});
+
+test('never throws when Sentry is missing or broken', () => {
+  const missing = createExampleErrorReporter({ getSentry: () => undefined });
+
+  assert.equal(missing(new TypeError('boom'), jsContext), 'skipped-unavailable');
+
+  const blocked = createExampleErrorReporter({ getSentry: () => ({}) });
+
+  assert.equal(blocked(new TypeError('boom'), jsContext), 'skipped-unavailable');
+
+  const broken = createExampleErrorReporter({
+    getSentry: () => ({
+      captureException() {
+        throw new Error('SDK not loaded');
+      },
+    }),
+  });
+
+  assert.equal(broken(new TypeError('boom'), jsContext), 'skipped-sentry-error');
+});
+
+test('handles non-Error rejection values', () => {
+  const { calls, report } = createReporter();
+
+  assert.equal(report('plain string failure', jsContext), 'reported');
+  assert.equal(report('plain string failure', jsContext), 'skipped-duplicate');
+  assert.equal(report(undefined, jsContext), 'reported');
+  assert.equal(calls.length, 2);
+});
+
+test('predicates are individually correct', () => {
+  assert.equal(isChunkLoadError(new Error('Failed to fetch dynamically imported module: x')), false);
+  assert.equal(isChunkLoadError(new TypeError('Failed to fetch')), false);
+  assert.equal(isIntentionalHandsontableError(new Error('boom')), false);
+  assert.equal(isIntentionalHandsontableError(new Error('boom', { cause: new Error('inner') })), false);
+  assert.equal(isExpectedDemoHttpError(new Error('HTTP 4040')), false);
+  assert.equal(isExpectedDemoHttpError(new Error('HTTP 503')), true);
+});
+
+// ── Regression guard on the runner itself ──────────────────────────────────
+// Sentry HANDSONTABLE-DOCS-1FX: the shared framework-runtime imports used to sit outside every
+// try/catch, so one failed chunk escaped as an unhandled rejection and left every example of that
+// framework stuck on its loading shimmer. They must stay inside loadRuntime().
+
+const runnerFile = readFileSync(
+  fileURLToPath(new URL('../../scripts/example-runner.ts', import.meta.url)),
+  'utf8'
+);
+
+// Comments discuss the very imports these tests look for, so scan executable source only.
+// The runner contains no string literal with `//` or `/*` in it, which keeps this strip safe.
+const runnerSource = runnerFile
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  .replace(/\/\/[^\n]*/g, '');
+
+/**
+ * Returns the source spans of every `loadRuntime(...)` call, paren-balanced so nested calls and
+ * arrow-function bodies are included.
+ */
+function loadRuntimeSpans(source) {
+  const spans = [];
+  let from = 0;
+
+  for (;;) {
+    const start = source.indexOf('loadRuntime(', from);
+
+    if (start === -1) break;
+
+    let depth = 0;
+    let end = source.indexOf('(', start);
+
+    for (let i = end; i < source.length; i += 1) {
+      if (source[i] === '(') depth += 1;
+      if (source[i] === ')') {
+        depth -= 1;
+
+        if (depth === 0) {
+          end = i;
+          break;
+        }
+      }
+    }
+
+    spans.push([start, end]);
+    from = end + 1;
+  }
+
+  return spans;
+}
+
+const guardedSpans = loadRuntimeSpans(runnerSource);
+
+/**
+ * Returns every index at which `needle` occurs in the runner source.
+ */
+function occurrences(needle) {
+  const found = [];
+  let from = 0;
+
+  for (;;) {
+    const at = runnerSource.indexOf(needle, from);
+
+    if (at === -1) break;
+
+    found.push(at);
+    from = at + needle.length;
+  }
+
+  return found;
+}
+
+test('loadRuntime() spans are found in the runner source', () => {
+  assert.equal(guardedSpans.length, 3, 'expected one loadRuntime() call per framework group');
+});
+
+for (const specifier of ['react-dom/client', 'react', 'vue', '@angular/compiler']) {
+  test(`import('${specifier}') only runs inside a loadRuntime() call`, () => {
+    const found = occurrences(`import('${specifier}')`);
+
+    assert.ok(found.length > 0, `expected import('${specifier}') in example-runner.ts`);
+
+    for (const at of found) {
+      assert.ok(
+        guardedSpans.some(([start, end]) => at > start && at < end),
+        `import('${specifier}') at index ${at} escapes loadRuntime(); a failed chunk would become an unhandled rejection`
+      );
+    }
+  });
+}
+
+test("import('zone.js') runs inside ensureZone(), which only runs inside loadRuntime()", () => {
+  const zoneBodyStart = runnerSource.indexOf('async function ensureZone()');
+  const zoneBodyEnd = runnerSource.indexOf('\n}', zoneBodyStart);
+
+  assert.ok(zoneBodyStart > -1 && zoneBodyEnd > zoneBodyStart, 'expected an ensureZone() declaration');
+
+  for (const at of occurrences("import('zone.js')")) {
+    assert.ok(at > zoneBodyStart && at < zoneBodyEnd, "import('zone.js') must stay inside ensureZone()");
+  }
+
+  const calls = occurrences('ensureZone()').filter(at => at !== zoneBodyStart + 'async function '.length);
+
+  assert.ok(calls.length > 0, 'expected at least one ensureZone() call');
+
+  for (const at of calls) {
+    assert.ok(
+      guardedSpans.some(([start, end]) => at > start && at < end),
+      'ensureZone() must be called inside loadRuntime()'
+    );
+  }
+});
+
+test('ensureZone() marks zone.js as loaded only after the import resolves', () => {
+  const zoneBodyStart = runnerSource.indexOf('async function ensureZone()');
+  const body = runnerSource.slice(zoneBodyStart, runnerSource.indexOf('\n}', zoneBodyStart));
+
+  assert.ok(
+    body.indexOf("import('zone.js')") < body.indexOf('zoneLoaded = true'),
+    'setting the flag before awaiting the import makes a failed load unretryable'
+  );
+});
+
+test('every framework runtime is loaded through loadRuntime()', () => {
+  for (const framework of ['react', 'vue', 'angular']) {
+    assert.match(
+      runnerSource,
+      new RegExp(`loadRuntime\\('${framework}'`),
+      `expected loadRuntime('${framework}', ...) in example-runner.ts`
+    );
+  }
+});
+
+test('every framework loop skips an unresolvable module instead of reporting it', () => {
+  // A src that matches no glob is a build-time mistake, not a runtime failure worth an event per
+  // reader. Each loop must warn and continue before it calls the loader.
+  for (const label of ['JS', 'JSX', 'Vue', 'Angular']) {
+    assert.match(
+      runnerSource,
+      new RegExp(`if \\(!loader\\) \\{\\s*console\\.warn\\('\\[hot-example\\] No ${label} module for:'`),
+      `expected a !loader early-out in the ${label} loop`
+    );
+  }
+});
+
+test('every per-example catch reports to Sentry', () => {
+  const catches = runnerSource.match(/} catch \(err\) \{[\s\S]*?\n {4,6}}/g) ?? [];
+  const exampleCatches = catches.filter(block => /console\.error\('\[hot-example\] (JS|JSX|Vue|Angular) failed/.test(block));
+
+  assert.equal(exampleCatches.length, 4, 'expected the JS, JSX, Vue, and Angular example catch blocks');
+
+  for (const block of exampleCatches) {
+    assert.match(block, /reportExampleError\(err, \{/);
+  }
+});

--- a/docs/src/lib/example-error-reporting.mjs
+++ b/docs/src/lib/example-error-reporting.mjs
@@ -1,0 +1,147 @@
+/**
+ * Failure reporting for the docs example runner.
+ *
+ * The runner catches every example failure so one broken example cannot take the whole page down.
+ * Until now that also meant a genuine crash - a Handsontable call that an older browser engine
+ * does not support, for instance - produced a console message and nothing else, so no Sentry event
+ * ever arrived (HANDSONTABLE-DOCS-20K: a 90-day `message:"toSorted" level:error` search returns
+ * nothing even though grids were dying).
+ *
+ * This module forwards those failures to Sentry while keeping the volume bounded: a reader on a
+ * flaky network, or a page whose examples all fail the same way, must not turn into an event storm.
+ */
+
+/**
+ * Distinct failures forwarded per page load. A page can embed a dozen examples; the first few
+ * failures carry all the diagnostic value, and the rest only inflate the event count.
+ */
+const MAX_REPORTS_PER_PAGE = 3;
+
+/**
+ * Returns true when the error is a failed dynamic import: a stale deployment (the browser holds
+ * cached HTML pointing at content-hashed chunks that no longer exist), an offline reader, or a
+ * blocked request. Browsers word it differently. None of it says anything about our code, so these
+ * failures stay out of Sentry.
+ *
+ * `docs-assistant-bootstrap.ts` carries the same check for its own mount path. It is duplicated
+ * here on purpose: importing that module registers listeners and mounts the chat widget.
+ */
+export function isChunkLoadError(err) {
+  if (!(err instanceof TypeError)) {
+    return false;
+  }
+
+  const message = String(err.message);
+
+  return (
+    message.includes('Failed to fetch dynamically imported module') || // Chrome
+    message.includes('error loading dynamically imported module') || // Firefox
+    message.includes('Importing a module script failed') // Safari
+  );
+}
+
+/**
+ * Returns true for errors Handsontable throws on purpose as developer feedback. They all carry
+ * `cause.handsontable`, set by the core `throwWithCause()` helper.
+ *
+ * The Sentry `beforeSend` hook in `astro.config.mjs` drops these as well, but that hook only runs
+ * on deployments built from a branch that has it, so the reporter repeats the check. Presence of
+ * the property is the test, matching `beforeSend` - the value is `true` today and may change.
+ */
+export function isIntentionalHandsontableError(err) {
+  const cause = err && typeof err === 'object' ? err.cause : null;
+
+  return !!cause && typeof cause === 'object' && 'handsontable' in cause;
+}
+
+/**
+ * Returns true for the `HTTP <status>` errors the server-side data examples throw. The docs site
+ * serves no `/api/*` backend, so those requests correctly fail here. That is expected on this site,
+ * not a product defect.
+ */
+export function isExpectedDemoHttpError(err) {
+  const message = err && typeof err === 'object' ? err.message : err;
+
+  return /^HTTP \d{3}$/.test(String(message ?? ''));
+}
+
+/**
+ * Builds the message key used for deduplication.
+ */
+function failureKey(err, context) {
+  const message = err && typeof err === 'object' && err.message ? err.message : String(err);
+
+  return `${context.framework}|${context.phase}|${message}`;
+}
+
+/**
+ * Creates the reporter the example runner uses for caught failures.
+ *
+ * The returned function never throws and returns the outcome as a string, which is what the unit
+ * test asserts on: `'reported'`, or a `'skipped-*'` reason.
+ *
+ * @param {object} [options] Test seams.
+ * @param {() => ({ captureException?: Function } | undefined)} [options.getSentry] Reads the Sentry
+ *   global. The docs site loads Sentry through the Loader Script, so `window.Sentry` is a queueing
+ *   stub - present as soon as that deferred script runs, absent when an ad blocker or a CSP drops
+ *   the CDN request.
+ * @param {number} [options.maxReports] Cap on forwarded failures per page load.
+ * @returns {(err: unknown, context: { framework: string, phase: string, source?: string }) => string}
+ */
+export function createExampleErrorReporter({
+  getSentry = () => globalThis.Sentry,
+  maxReports = MAX_REPORTS_PER_PAGE,
+} = {}) {
+  const seen = new Set();
+  let reports = 0;
+
+  return function reportExampleError(err, context) {
+    if (isChunkLoadError(err)) {
+      return 'skipped-chunk-load';
+    }
+
+    if (isIntentionalHandsontableError(err)) {
+      return 'skipped-intentional';
+    }
+
+    if (isExpectedDemoHttpError(err)) {
+      return 'skipped-demo-http';
+    }
+
+    const key = failureKey(err, context);
+
+    if (seen.has(key)) {
+      return 'skipped-duplicate';
+    }
+
+    seen.add(key);
+
+    if (reports >= maxReports) {
+      return 'skipped-limit';
+    }
+
+    const sentry = getSentry();
+
+    if (!sentry || typeof sentry.captureException !== 'function') {
+      return 'skipped-unavailable';
+    }
+
+    reports += 1;
+
+    try {
+      sentry.captureException(err, {
+        tags: {
+          hot_example: context.framework,
+          hot_example_phase: context.phase,
+        },
+        extra: {
+          source: context.source,
+        },
+      });
+    } catch {
+      return 'skipped-sentry-error';
+    }
+
+    return 'reported';
+  };
+}

--- a/docs/src/scripts/example-runner.ts
+++ b/docs/src/scripts/example-runner.ts
@@ -12,6 +12,15 @@
  *   - Modern standalone: export class AppComponent {} + export const appConfig  (bootstrapped via bootstrapApplication)
  */
 
+import { createExampleErrorReporter } from '../lib/example-error-reporting.mjs';
+
+/**
+ * Forwards caught example failures to Sentry, minus the classes that carry no signal (failed chunk
+ * fetches, errors Handsontable throws on purpose, the expected `HTTP <status>` of the server-side
+ * data examples), deduplicated and capped per page load. See the module for the full rationale.
+ */
+const reportExampleError = createExampleErrorReporter();
+
 // ── Glob maps resolved by Vite at build time ──────────────────────────────
 const jsModules       = import.meta.glob('/content/**/example*.js');
 const jsxModules      = import.meta.glob('/content/**/example*.jsx');
@@ -26,8 +35,9 @@ let zoneLoaded = false;
 
 async function ensureZone(): Promise<void> {
   if (zoneLoaded) return;
-  zoneLoaded = true;
+  // Flag set after the import resolves, so a failed load does not mark zone.js as present.
   await import('zone.js');
+  zoneLoaded = true;
 }
 
 // ── Angular bootstrap helper (NgModule + standalone) ─────────────────────
@@ -61,6 +71,52 @@ async function bootstrapAngular(mod: Record<string, unknown>): Promise<void> {
 /** Removes the loading shimmer from the preview section of an example element. */
 function markLoaded(el: Element): void {
   el.querySelector('.hot-example-preview')?.classList.remove('hot-example-preview--loading');
+}
+
+/**
+ * Stops the shimmer and tells the reader the example is not coming.
+ *
+ * Used only where nothing can possibly mount - the shared framework runtime failed to load, so
+ * every example of that framework on the page is dead. A per-example failure keeps the plain
+ * markLoaded() degradation: some examples render nothing by design, and a notice there would be
+ * wrong more often than right.
+ */
+function markFailed(el: Element): void {
+  markLoaded(el);
+
+  const preview = el.querySelector('.hot-example-preview');
+
+  if (!preview || preview.querySelector('.hot-example-error')) return;
+
+  const notice = document.createElement('p');
+
+  notice.className = 'hot-example-error';
+  notice.textContent = 'This example could not be loaded. Reload the page to try again.';
+  preview.appendChild(notice);
+}
+
+/**
+ * Loads a framework runtime that a whole group of examples depends on.
+ *
+ * These imports used to sit outside every try/catch, so a single failed chunk escaped as an
+ * unhandled rejection (Sentry HANDSONTABLE-DOCS-1FX for `import('vue')`) and left every example of
+ * that framework stuck on its loading shimmer. Returns `null` when the runtime is unavailable, in
+ * which case the group is marked as failed and skipped.
+ */
+async function loadRuntime<T>(
+  framework: string,
+  els: Element[],
+  load: () => Promise<T>
+): Promise<T | null> {
+  try {
+    return await load();
+  } catch (err) {
+    console.error(`[hot-example] ${framework} runtime failed to load:`, err);
+    reportExampleError(err, { framework, phase: 'runtime-import' });
+    els.forEach(markFailed);
+
+    return null;
+  }
 }
 
 /** Frame budget guarding each RAF wait loop (~1s at 60fps) against a never-met condition. */
@@ -196,6 +252,8 @@ async function runExamples(): Promise<void> {
         style.textContent = cssText;
         document.head.appendChild(style);
       } catch (err) {
+        // Not forwarded to Sentry: a missing stylesheet leaves the example working, and the only
+        // realistic cause is the chunk-fetch failure the reporter drops anyway.
         console.error('[hot-example] CSS failed:', src, err);
       }
     }
@@ -218,6 +276,7 @@ async function runExamples(): Promise<void> {
       renderInstances(el);
     } catch (err) {
       console.error('[hot-example] JS failed:', src, err);
+      reportExampleError(err, { framework: 'javascript', phase: 'example-init', source: src });
       markLoaded(el);
     }
   }
@@ -225,11 +284,15 @@ async function runExamples(): Promise<void> {
   // ── React JSX examples ─────────────────────────────────────────────────
   const jsxEls = [...document.querySelectorAll('[data-example-jsx]')] as HTMLElement[];
 
-  if (jsxEls.length > 0) {
-    const [{ createRoot }, { createElement }] = await Promise.all([
+  const react = jsxEls.length > 0
+    ? await loadRuntime('react', jsxEls, () => Promise.all([
       import('react-dom/client'),
       import('react'),
-    ]);
+    ]))
+    : null;
+
+  if (react) {
+    const [{ createRoot }, { createElement }] = react;
 
     for (const el of jsxEls) {
       const src = el.dataset.exampleJsx!;
@@ -260,6 +323,7 @@ async function runExamples(): Promise<void> {
         renderInstances(el);
       } catch (err) {
         console.error('[hot-example] JSX failed:', src, err);
+        reportExampleError(err, { framework: 'react', phase: 'example-init', source: src });
         markLoaded(el);
       }
     }
@@ -268,12 +332,26 @@ async function runExamples(): Promise<void> {
   // ── Vue 3 examples ────────────────────────────────────────────────────
   const vueEls = [...document.querySelectorAll('[data-example-vue]')] as HTMLElement[];
 
-  if (vueEls.length > 0) {
-    const { createApp } = await import('vue');
+  const vue = vueEls.length > 0
+    ? await loadRuntime('vue', vueEls, () => import('vue'))
+    : null;
+
+  if (vue) {
+    const { createApp } = vue;
 
     for (const el of vueEls) {
       const src = el.dataset.exampleVue!;
       const id  = el.dataset.exampleId;
+      const loader = vueModules[src] ?? vueJsModules[src];
+
+      // Same early-out as the other frameworks. Without it a src that matches neither glob - a
+      // .vue file moved out of a vue/ directory, say - would throw "loader is not a function" for
+      // every reader of that page, and the reporter has no reason to treat that as noise.
+      if (!loader) {
+        console.warn('[hot-example] No Vue module for:', src);
+        markLoaded(el);
+        continue;
+      }
 
       const container = id ? document.getElementById(id) : null;
 
@@ -295,7 +373,6 @@ async function runExamples(): Promise<void> {
           }
         }
 
-        const loader = vueModules[src] ?? vueJsModules[src];
         const mod = await loader() as { default: any };
         const mountTarget = container.querySelector('[id]') ?? container;
         const app = createApp(mod.default);
@@ -305,6 +382,7 @@ async function runExamples(): Promise<void> {
         renderInstances(el);
       } catch (err) {
         console.error('[hot-example] Vue failed:', src, err);
+        reportExampleError(err, { framework: 'vue', phase: 'example-init', source: src });
         markLoaded(el);
       }
     }
@@ -313,14 +391,20 @@ async function runExamples(): Promise<void> {
   // ── Angular examples ───────────────────────────────────────────────────
   const ngEls = [...document.querySelectorAll('[data-example-angular]')] as HTMLElement[];
 
-  if (ngEls.length > 0) {
-    await ensureZone();
+  const angularReady = ngEls.length > 0
+    ? await loadRuntime('angular', ngEls, async () => {
+      await ensureZone();
 
-    // @angular/compiler must be imported before platformBrowserDynamic.
-    // Vite tree-shakes it out of production bundles unless explicitly imported,
-    // causing "JIT compiler not available" errors for partially-compiled libraries.
-    await import('@angular/compiler');
+      // @angular/compiler must be imported before platformBrowserDynamic.
+      // Vite tree-shakes it out of production bundles unless explicitly imported,
+      // causing "JIT compiler not available" errors for partially-compiled libraries.
+      await import('@angular/compiler');
 
+      return true;
+    })
+    : null;
+
+  if (angularReady) {
     for (const el of ngEls) {
       const src     = el.dataset.exampleAngular!;
       const htmlSrc = el.dataset.exampleHtml;
@@ -356,6 +440,7 @@ async function runExamples(): Promise<void> {
         renderInstances(el);
       } catch (err) {
         console.error('[hot-example] Angular failed:', src, err);
+        reportExampleError(err, { framework: 'angular', phase: 'example-init', source: src });
         markLoaded(el);
       }
     }
@@ -363,8 +448,19 @@ async function runExamples(): Promise<void> {
 
 }
 
+/**
+ * Last-resort guard: `runExamples()` is async, so anything that escapes its inner handlers would
+ * surface as an unhandled rejection with no page context. Report it once and keep the page alive.
+ */
+function startExamples(): void {
+  runExamples().catch((err) => {
+    console.error('[hot-example] runner failed:', err);
+    reportExampleError(err, { framework: 'runner', phase: 'run-examples' });
+  });
+}
+
 if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', runExamples);
+  document.addEventListener('DOMContentLoaded', startExamples);
 } else {
-  runExamples();
+  startExamples();
 }

--- a/docs/src/styles/interactive-example.css
+++ b/docs/src/styles/interactive-example.css
@@ -81,6 +81,14 @@
   display: none;
 }
 
+/* Failure notice added by example-runner.ts when a framework runtime cannot load, so the reader
+   sees why the example is missing instead of an empty box. */
+.hot-example-error {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--sl-color-gray-2);
+}
+
 /* Keep the mount container invisible while loading to avoid a flash of
    unstyled content (Handsontable sets its own dimensions after mount). */
 .hot-example-preview--loading #\31 ,


### PR DESCRIPTION
### Context

The PR fixes two opposite error-handling defects in `docs/src/scripts/example-runner.ts`.

**It swallowed too much.** Per-example init failures were turned into `console.error` and nothing else, so an error that kills every grid on a page produced **zero** Sentry events. This is measurable: a 90-day `message:"toSorted" level:error` search over the docs project returns nothing, even though that method demonstrably ships in the bundles. Any reasoning about docs error volume was therefore systematically understating init-time failures.

**It guarded too little.** The shared framework imports sat *outside* every per-example `try`/`catch`: `import('vue')`, `import('zone.js')`, `import('@angular/compiler')`, and `import('react-dom/client')` / `import('react')`. When one rejected, it escaped as an unhandled rejection and the affected examples were left showing a shimmer forever. Sentry [HANDSONTABLE-DOCS-1FX](https://handsoncode.sentry.io/issues/HANDSONTABLE-DOCS-1FX/) (10 events / 7 users) is almost certainly the `vue` one — attribution by frame shape, not a reproduction, so a recurrence after deploy would mean the mapping was wrong.

Changes:

- New `docs/src/lib/example-error-reporting.mjs` exporting `createExampleErrorReporter()`. It owns the noise policy — a per-load cap, message dedupe, and a drop list — and reports through the Sentry Loader Script global, guarded so a blocked CDN request degrades silently instead of throwing inside the error path.
- The runner calls `reportExampleError(err, {framework, phase, source})` from all four per-example catches, from the framework-runtime guard, and from a new top-level `runExamples().catch()`.
- New `loadRuntime(framework, els, load)` wraps the previously unguarded shared imports. On failure it logs, reports, and calls `markFailed()` on every element in that group: shimmer stopped, plus a reader-visible message instead of a permanent skeleton.

Two things reviewers should weigh. This **raises** Sentry volume by design — bounded (capped per page load, deduped by message), but non-zero, so the first day of events after deploy is worth a look; a demo that throws intentionally belongs in the drop list in the `.mjs`, not silenced at the call site. And on branches that have the `beforeSend` hook, `captureException` fires before it, so both filters apply — harmless, but worth knowing when tracing why an event did or did not arrive.

### How has this been tested?

New test file, `docs/src/lib/__tests__/example-error-reporting.test.mjs`:

```bash
cd docs && node --test src/lib/__tests__/example-error-reporting.test.mjs
# tests 20 / # pass 20 / # fail 0
```

Mutation checks, each reverted immediately and the file re-verified green afterwards — these prove the structural assertions are not vacuous:

```
reverted vue to `? await import('vue')`  ->  not ok 11 - loadRuntime() spans are found
                                            not ok 14 - import('vue') only runs inside a loadRuntime() call
```

The suite asserts the structural invariants directly: `@angular/compiler` is imported only inside `loadRuntime()`, `zone.js` only inside `ensureZone()`, and every previously bare import is now inside a guarded span.

All line numbers were re-verified against current `develop` before editing.

Files changed:

- `docs/src/scripts/example-runner.ts`
- `docs/src/lib/example-error-reporting.mjs` (new)
- `docs/src/lib/__tests__/example-error-reporting.test.mjs` (new)
- `docs/src/styles/interactive-example.css`
- `docs/AGENTS.md`

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2149

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2149

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only client error handling and observability; bounded Sentry volume and no changes to Handsontable product APIs.
> 
> **Overview**
> Fixes two opposite problems in the docs **example runner**: per-example failures were only logged (no Sentry), while shared React/Vue/Angular runtime `import()` calls sat outside `try/catch` and could reject as unhandled failures with examples stuck on the loading shimmer.
> 
> Adds **`example-error-reporting.mjs`** with `createExampleErrorReporter()` — forwards real failures to Sentry with framework/phase tags, while filtering chunk-load errors, intentional Handsontable `cause.handsontable` errors, and expected demo `HTTP ###` messages, plus dedupe and a cap of three reports per page. **`example-runner.ts`** wires that reporter through per-example catches, runtime load failures, and a top-level `runExamples().catch()`.
> 
> Wraps framework runtimes in **`loadRuntime()`**; on failure it reports, calls **`markFailed()`** (reader-visible `.hot-example-error` message), and skips the group. **`ensureZone()`** now sets `zoneLoaded` only after `zone.js` resolves. Vue gains the same missing-module early-out as other frameworks. **`AGENTS.md`** documents the rules; unit tests include static checks that runtime imports stay inside `loadRuntime()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae0506184fb0956916d1539c88fc33d1b3bd7790. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->