### PR TITLE
DEV-2150: Keep the rendered row band consistent when a draw is skipped

### DIFF
--- a/.changelogs/13141.json
+++ b/.changelogs/13141.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed an `Error: TR was expected to be rendered but is not` thrown when a `beforeDraw` hook cancels a render after the rendered row range has already advanced.",
+  "type": "fixed",
+  "issueOrPR": 13141,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/3rdparty/walkontable/.ai/RENDERING-LIFECYCLE.md
+++ b/handsontable/src/3rdparty/walkontable/.ai/RENDERING-LIFECYCLE.md
@@ -215,6 +215,16 @@ All line numbers are in `table.ts` unless noted. "Master only" = guarded by `thi
 - Master: `alignOverlaysWithTrimmingContainer()` (`557`; overridden in `MasterTable`).
 - Master: fire the `beforeDraw` setting (`560`) → the **public `beforeViewRender` hook**. It can set
   `skipRender`, which gates Phase E (`performRedraw`, `561`).
+- **When that gate cancels the render, the master restores the pre-draw rendered state**
+  (`restoreRenderedState` in `table/drawCycle.ts`): `wtViewport.rowsRenderCalculator` /
+  `columnsRenderCalculator` and `table.rowFilter` / `columnFilter` all go back to the values they held
+  before this draw. Rationale: `Table#getCell` *gates* on the rendered bands but *resolves* the element
+  through the filters + `TBODY.childNodes`, so a band advanced past a DOM that was never re-rendered
+  makes the two disagree and `getCell` throws `TR was expected to be rendered but is not` — including
+  from the engine's own selection render in Phase G of the very same draw. A skipped render leaves the
+  screen unchanged, so the rendered state stays unchanged too, exactly like a fast draw. The
+  fully/partially-**visible** calculators are deliberately NOT restored: they describe the scroll
+  position, not the DOM contents.
 
 ### Phase E — Full path: cell + header render (`table.ts:564–585`, only if `performRedraw`)
 - `setHeaderContentRenderers(...)` (`565`); bottom / bottom-corner clones do not render column headers
@@ -282,7 +292,8 @@ Key facts to keep:
 - `beforeViewRender` / `afterViewRender` fire only on a full draw, only on the master, and
   `afterViewRender` fires mid-draw (before fixed-position finalization), not last.
 - `beforeViewRender` receives the `skipRender` object; `skipRender.skipRender = true` cancels the cell
-  render for that draw.
+  render for that draw — and the master then rolls the rendered bands + render filters back to their
+  pre-draw values, so `getCell` keeps describing the DOM that is actually on screen (see Phase D).
 - **The render-size probe reconcile (§7) must NOT fire these hooks** — it runs a hook-free WoT-internal
   reconcile, never `hot.render()`, so hook-count expectations hold.
 

--- a/handsontable/src/3rdparty/walkontable/.ai/RENDERING-LIFECYCLE.md
+++ b/handsontable/src/3rdparty/walkontable/.ai/RENDERING-LIFECYCLE.md
@@ -215,16 +215,28 @@ All line numbers are in `table.ts` unless noted. "Master only" = guarded by `thi
 - Master: `alignOverlaysWithTrimmingContainer()` (`557`; overridden in `MasterTable`).
 - Master: fire the `beforeDraw` setting (`560`) → the **public `beforeViewRender` hook**. It can set
   `skipRender`, which gates Phase E (`performRedraw`, `561`).
-- **When that gate cancels the render, the master restores the pre-draw rendered state**
-  (`restoreRenderedState` in `table/drawCycle.ts`): `wtViewport.rowsRenderCalculator` /
-  `columnsRenderCalculator` and `table.rowFilter` / `columnFilter` all go back to the values they held
-  before this draw. Rationale: `Table#getCell` *gates* on the rendered bands but *resolves* the element
-  through the filters + `TBODY.childNodes`, so a band advanced past a DOM that was never re-rendered
-  makes the two disagree and `getCell` throws `TR was expected to be rendered but is not` — including
-  from the engine's own selection render in Phase G of the very same draw. A skipped render leaves the
-  screen unchanged, so the rendered state stays unchanged too, exactly like a fast draw. The
-  fully/partially-**visible** calculators are deliberately NOT restored: they describe the scroll
-  position, not the DOM contents.
+- **When that gate cancels the render, the master restores the pre-draw rendered state — when
+  provably safe** (`restoreRenderedStateIfSafe` in `table/drawCycle.ts`):
+  `wtViewport.rowsRenderCalculator` / `columnsRenderCalculator` and `table.rowFilter` /
+  `columnFilter` go back to the values they held before this draw. Rationale: `Table#getCell`
+  *gates* on the rendered bands but *resolves* the element through the filters + `TBODY.childNodes`,
+  so a band advanced past a DOM that was never re-rendered makes the two disagree and `getCell`
+  throws `TR was expected to be rendered but is not` — including from the engine's own selection
+  render in Phase G of the very same draw. Guards (a blocked rollback keeps the this-draw state,
+  i.e. the pre-rollback engine behavior): (1) `Viewport#renderCycleSeq` — bumped by every
+  `renderCellBand` (master or clone; the clones share the master's Viewport) — must not have moved
+  since the pre-draw capture, so a hook that rendered a newer band (nested `draw()`, clone draws)
+  is never rolled back under; (2) the captured filters' build-time `total`s must match the current
+  `totalRows`/`totalColumns`, so a skip right after a dataset shrink (NestedRows removes rows, then
+  cancels the follow-up render) keeps the fresh band capped at the new totals instead of restoring
+  a band that names removed rows. Asymmetries: the filters are restored only when the captured ones
+  are non-null (a skipped FIRST draw keeps the just-built filters — several consumers read
+  `rowFilter!` unguarded once the table is drawn), and the fully/partially-**visible** calculators
+  are deliberately NOT restored: they describe the scroll position, not the DOM contents — so after
+  a skipped draw the visible band may extend past the rendered band (unlike a fast draw), and
+  `getCell` answers those rows with exit codes. A skipped render also never runs the Phase F 1px
+  `positionChanged` reconciliation (`refreshAll`) — gated on `performRedraw`, because the rolled-back
+  band would fail the nested draw's fast-draw check and escalate it to a full render.
 
 ### Phase E — Full path: cell + header render (`table.ts:564–585`, only if `performRedraw`)
 - `setHeaderContentRenderers(...)` (`565`); bottom / bottom-corner clones do not render column headers
@@ -293,7 +305,8 @@ Key facts to keep:
   `afterViewRender` fires mid-draw (before fixed-position finalization), not last.
 - `beforeViewRender` receives the `skipRender` object; `skipRender.skipRender = true` cancels the cell
   render for that draw — and the master then rolls the rendered bands + render filters back to their
-  pre-draw values, so `getCell` keeps describing the DOM that is actually on screen (see Phase D).
+  pre-draw values when that is provably safe (no render and no totals change since the pre-draw
+  capture — see Phase D), so `getCell` keeps describing the DOM that is actually on screen.
 - **The render-size probe reconcile (§7) must NOT fire these hooks** — it runs a hook-free WoT-internal
   reconcile, never `hot.render()`, so hook-count expectations hold.
 

--- a/handsontable/src/3rdparty/walkontable/.ai/RENDERING-LIFECYCLE.md
+++ b/handsontable/src/3rdparty/walkontable/.ai/RENDERING-LIFECYCLE.md
@@ -225,18 +225,25 @@ All line numbers are in `table.ts` unless noted. "Master only" = guarded by `thi
   render in Phase G of the very same draw. Guards (a blocked rollback keeps the this-draw state,
   i.e. the pre-rollback engine behavior): (1) `Viewport#renderCycleSeq` — bumped by every
   `renderCellBand` (master or clone; the clones share the master's Viewport) — must not have moved
-  since the pre-draw capture, so a hook that rendered a newer band (nested `draw()`, clone draws)
-  is never rolled back under; (2) the captured filters' build-time `total`s must match the current
-  `totalRows`/`totalColumns`, so a skip right after a dataset shrink (NestedRows removes rows, then
-  cancels the follow-up render) keeps the fresh band capped at the new totals instead of restoring
-  a band that names removed rows. Asymmetries: the filters are restored only when the captured ones
-  are non-null (a skipped FIRST draw keeps the just-built filters — several consumers read
-  `rowFilter!` unguarded once the table is drawn), and the fully/partially-**visible** calculators
-  are deliberately NOT restored: they describe the scroll position, not the DOM contents — so after
-  a skipped draw the visible band may extend past the rendered band (unlike a fast draw), and
-  `getCell` answers those rows with exit codes. A skipped render also never runs the Phase F 1px
-  `positionChanged` reconciliation (`refreshAll`) — gated on `performRedraw`, because the rolled-back
-  band would fail the nested draw's fast-draw check and escalate it to a full render.
+  since it was read right before the `beforeDraw` hook fired, so a hook that rendered a newer band
+  (nested `draw()`, clone draws) is never rolled back under; (2) **per axis**, the captured filter's
+  build-time `total` must match the current `totalRows`/`totalColumns`, so a skip right after a
+  dataset shrink (NestedRows removes rows, then cancels the follow-up render) keeps the fresh band
+  capped at the new totals instead of restoring a band that names removed rows — and a column-count
+  change never blocks the row rollback (or vice versa). Asymmetries: the filters are restored only
+  when the captured ones are non-null (a skipped FIRST draw keeps the just-built filters — several
+  consumers read `rowFilter!` unguarded once the table is drawn; the overlays' `applyToDOM` treats
+  the restored `null` calculators as the nothing-rendered spreader offset instead of throwing);
+  `correctHeaderWidth` is restored whenever no render happened, regardless of the totals gates (the
+  DOM header width did not change, and an advanced flag would suppress the corrective full draw);
+  and the fully/partially-**visible** calculators are deliberately NOT restored: they describe the
+  scroll position, not the DOM contents — so after a skipped draw the visible band may extend past
+  the rendered band (unlike a fast draw), and `getCell` answers those rows with exit codes. A
+  skipped render also never runs the Phase F 1px `positionChanged` reconciliation via `refreshAll`
+  (the rolled-back band would fail the nested draw's fast-draw check and escalate it to a full
+  render); instead it reruns the fixed-position pass against the post-toggle layout (which
+  converges), renders the active selections, and still runs the master `adjustElementsSize()` so
+  the hider/scrollbar size stays current.
 
 ### Phase E — Full path: cell + header render (`table.ts:564–585`, only if `performRedraw`)
 - `setHeaderContentRenderers(...)` (`565`); bottom / bottom-corner clones do not render column headers

--- a/handsontable/src/3rdparty/walkontable/src/overlay/regions/bottomOverlay.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/regions/bottomOverlay.ts
@@ -252,8 +252,9 @@ export class BottomOverlay extends Overlay {
     if (typeof rowsRenderCalculator?.startPosition === 'number') {
       this.spreader.style.top = `${rowsRenderCalculator.startPosition}px`;
 
-    } else if (total === 0) {
-      // can happen if there are 0 rows
+    } else if (total === 0 || rowsRenderCalculator === null) {
+      // 0 rows, or nothing rendered yet — a `null` calculator is the drawn-but-never-rendered state
+      // a skipped first draw leaves behind (see `restoreRenderedStateIfSafe` in `table/drawCycle.ts`).
       this.spreader.style.top = '0';
 
     } else {

--- a/handsontable/src/3rdparty/walkontable/src/overlay/regions/inlineStartOverlay.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/regions/inlineStartOverlay.ts
@@ -240,7 +240,9 @@ export class InlineStartOverlay extends Overlay {
     if (typeof columnsRenderCalculator?.startPosition === 'number') {
       this.spreader.style[styleProperty] = `${columnsRenderCalculator.startPosition}px`;
 
-    } else if (total === 0) {
+    } else if (total === 0 || columnsRenderCalculator === null) {
+      // 0 columns, or nothing rendered yet — a `null` calculator is the drawn-but-never-rendered state
+      // a skipped first draw leaves behind (see `restoreRenderedStateIfSafe` in `table/drawCycle.ts`).
       this.spreader.style[styleProperty] = '0';
 
     } else {

--- a/handsontable/src/3rdparty/walkontable/src/overlay/regions/topOverlay.ts
+++ b/handsontable/src/3rdparty/walkontable/src/overlay/regions/topOverlay.ts
@@ -287,8 +287,9 @@ export class TopOverlay extends Overlay {
     if (typeof rowsRenderCalculator?.startPosition === 'number') {
       this.spreader.style.top = `${rowsRenderCalculator.startPosition}px`;
 
-    } else if (total === 0) {
-      // can happen if there are 0 rows
+    } else if (total === 0 || rowsRenderCalculator === null) {
+      // 0 rows, or nothing rendered yet — a `null` calculator is the drawn-but-never-rendered state
+      // a skipped first draw leaves behind (see `restoreRenderedStateIfSafe` in `table/drawCycle.ts`).
       this.spreader.style.top = '0';
 
     } else {

--- a/handsontable/src/3rdparty/walkontable/src/table/drawCycle.ts
+++ b/handsontable/src/3rdparty/walkontable/src/table/drawCycle.ts
@@ -17,16 +17,17 @@ import type { ColumnsCalculationType, RowsCalculationType } from '../calculator/
 
 /**
  * The state that describes what is actually rendered in the TBODY/THEAD right now: the rendered
- * row/column bands (held by the viewport) and the render filters derived from them, plus the
- * render-cycle sequence number at capture time. Captured before the draw resolves the new band, so
- * the master's `skipRender` gate can put it back — see {@link restoreRenderedStateIfSafe}.
+ * row/column bands (held by the viewport), the render filters derived from them, and the
+ * `correctHeaderWidth` flag that describes the row-header width the DOM was rendered with. Captured
+ * before the draw resolves the new band, so the master's `skipRender` gate can put it back — see
+ * {@link restoreRenderedStateIfSafe}.
  */
 interface RenderedState {
   rowsRenderCalculator: RowsCalculationType | null;
   columnsRenderCalculator: ColumnsCalculationType | null;
   rowFilter: RowFilter | null;
   columnFilter: ColumnFilter | null;
-  renderCycleSeq: number;
+  correctHeaderWidth: boolean;
 }
 
 /**
@@ -164,6 +165,10 @@ function runMasterDrawCycle(table: Table, ctx: DrawContext): void {
 
     table.alignOverlaysWithTrimmingContainer(); // todo It calls method from child class (MasterTable).
     const skipRender: { skipRender?: boolean } = {};
+    // Read the counter as late as possible — right before the hook fires — so the guard in
+    // `restoreRenderedStateIfSafe` asks exactly "did the HOOK render?", and a hypothetical engine-
+    // internal render earlier in this draw cannot silently disable a rollback that is still safe.
+    const renderCycleSeqBeforeHook = wtViewport.renderCycleSeq;
 
     wtSettings.getSetting('beforeDraw', true, skipRender);
     ctx.performRedraw = skipRender.skipRender !== true;
@@ -176,7 +181,7 @@ function runMasterDrawCycle(table: Table, ctx: DrawContext): void {
       // disagree: `getCell` then throws "TR was expected to be rendered but is not" for every row past
       // the end of the stale DOM. Put the pre-draw state back when doing so is provably safe — the
       // guard conditions and the deliberate fallbacks are documented on the helper.
-      restoreRenderedStateIfSafe(table, wtViewport, renderedStateBeforeDraw);
+      restoreRenderedStateIfSafe(table, wtViewport, renderedStateBeforeDraw, renderCycleSeqBeforeHook);
     } else {
       renderCellBand(
         table,
@@ -216,16 +221,29 @@ function runMasterDrawCycle(table: Table, ctx: DrawContext): void {
 
   placeFixedOverlays(table, ctx);
 
-  if (ctx.positionChanged && ctx.performRedraw) {
-    // It refreshes the cells borders caused by a 1px shift (introduced by overlays which add or
-    // remove `innerBorderTop` and `innerBorderInlineStart` CSS classes to the DOM element. This happens
-    // when there is a switch between rendering from 0 to N rows/columns and vice versa).
-    // Gated on `performRedraw`: a draw whose render was skipped must not run this nested draw — the
-    // rolled-back band would fail the nested draw's fast-draw check, downgrading the cheap reposition
-    // to a full render that fires `beforeDraw` a second time and renders the cells the hook just
-    // cancelled. The per-overlay `adjustElementsSize()` calls inside `placeFixedOverlays` already ran,
-    // and nothing rendered, so the master spreader-size pass below has nothing new to apply either.
-    wtOverlays.refreshAll(); // `refreshAll()` internally already calls `refreshSelections()` method
+  if (ctx.positionChanged) {
+    if (ctx.performRedraw) {
+      // It refreshes the cells borders caused by a 1px shift (introduced by overlays which add or
+      // remove `innerBorderTop` and `innerBorderInlineStart` CSS classes to the DOM element. This happens
+      // when there is a switch between rendering from 0 to N rows/columns and vice versa).
+      wtOverlays.refreshAll(); // `refreshAll()` internally already calls `refreshSelections()` method
+    } else {
+      // A skipped render must not run the nested reconciliation draw above (`refreshAll` is
+      // `wot.draw(true)`): the rolled-back band would fail its fast-draw check and escalate it to a
+      // full render that fires `beforeDraw` a second time and renders the cells the hook just
+      // cancelled. But the `innerBorder*` toggle has already shifted the layout by 1px AFTER the
+      // overlay positions were computed, so rerun the fixed-position pass against the post-toggle
+      // layout — it converges, because the second border-state check finds the class already in
+      // place — and render the selections that `refreshAll` would have refreshed.
+      placeFixedOverlays(table, ctx);
+      renderActiveSelections(table, ctx.runFastDraw);
+    }
+
+    // Outside the render gate on purpose: the master hider/spreader size is written ONLY here on the
+    // 1px-shift path (the per-overlay `adjustElementsSize()` calls inside `placeFixedOverlays` size
+    // the clone roots, not the master hider), and the bands it reads are current whether or not the
+    // cell render ran — a skipped draw would otherwise keep a stale scrollbar until an unrelated
+    // full draw.
     wtOverlays.adjustElementsSize();
   } else {
     renderActiveSelections(table, ctx.runFastDraw);
@@ -298,9 +316,9 @@ function buildRenderFilters(table: Table, ctx: DrawContext): { rowFilter: RowFil
 }
 
 /**
- * Captures the rendered row/column bands and the render filters, i.e. everything that describes which
- * source rows and columns the current DOM holds, plus the render-cycle sequence number the viewport
- * reports at this moment. Master-only: the `skipRender` gate it serves is master-only.
+ * Captures the rendered row/column bands, the render filters, and the `correctHeaderWidth` flag,
+ * i.e. everything that describes which source rows and columns the current DOM holds and how it was
+ * rendered. Master-only: the `skipRender` gate it serves is master-only.
  *
  * @param {Table} table The master table.
  * @param {Viewport} wtViewport The viewport that owns the rendered bands.
@@ -312,7 +330,7 @@ function captureRenderedState(table: Table, wtViewport: Viewport): RenderedState
     columnsRenderCalculator: wtViewport.columnsRenderCalculator,
     rowFilter: table.rowFilter,
     columnFilter: table.columnFilter,
-    renderCycleSeq: wtViewport.renderCycleSeq,
+    correctHeaderWidth: table.correctHeaderWidth,
   };
 }
 
@@ -323,24 +341,31 @@ function captureRenderedState(table: Table, wtViewport: Viewport): RenderedState
  * a blocked rollback is never worse than what shipped before the rollback existed.
  *
  * The guards:
- * - The viewport's render-cycle counter must not have moved since the pre-draw capture. A hook that
- *   renders (a nested master `draw()`, or a draw of any overlay clone — the clones share this
- *   viewport) has put a NEWER band into the DOM; rolling the shared band back under it would create
- *   the very band/DOM divergence this rollback exists to prevent.
- * - The captured filters' build-time totals must still match the current `totalRows`/`totalColumns`.
- *   When the dataset shrank before the skipped draw (NestedRows cancels the render right after its
- *   row removal), the captured band names rows that no longer exist — the this-draw band, capped at
- *   the new totals, is the correct description. (A dataset that GREW before a skipped draw keeps the
- *   this-draw band too; that band can then overhang the stale DOM — a pre-existing edge of the
- *   skip contract, unchanged here.)
+ * - The viewport's render-cycle counter must not have moved since it was read right before the
+ *   `beforeDraw` hook fired. A hook that renders (a nested master `draw()`, or a draw of any overlay
+ *   clone — the clones share this viewport) has put a NEWER band into the DOM; rolling the shared
+ *   band back under it would create the very band/DOM divergence this rollback exists to prevent.
+ * - Per axis, the captured filter's build-time total must still match the current
+ *   `totalRows`/`totalColumns`. When the dataset shrank before the skipped draw (NestedRows cancels
+ *   the render right after its row removal), the captured band names rows that no longer exist — the
+ *   this-draw band, capped at the new totals, is the correct description. Each axis decides
+ *   independently, so a column-count change never blocks the row rollback (and vice versa); the
+ *   axes never disagree inside `getCell`, which gates and resolves each axis on its own pair.
+ *   (A dataset that GREW before a skipped draw keeps the this-draw band too; that band can then
+ *   overhang the stale DOM — a pre-existing edge of the skip contract, unchanged here.)
  *
  * The restore itself is asymmetric by design:
- * - The render calculators are restored unconditionally — `null` on a skipped first draw correctly
- *   reports "nothing rendered", so `Table#getCell` answers with its out-of-viewport exit codes.
+ * - The render calculators are restored — `null` on a skipped first draw correctly reports
+ *   "nothing rendered", so `Table#getCell` answers with its out-of-viewport exit codes (and the
+ *   overlays' `applyToDOM` treats a `null` calculator as the nothing-rendered spreader offset).
  * - The filters are restored only when the captured ones are non-null; on a skipped first draw the
  *   just-built filters are kept instead, because filter consumers (`getRowHeader`, `getTrForRow`,
  *   the selection scanner's header loop) read `rowFilter!` unguarded and must never see `null`
  *   after a completed draw.
+ * - `correctHeaderWidth` is restored whenever no render happened, regardless of the totals gates:
+ *   the flag describes the row-header width the DOM was rendered with, and that DOM did not change.
+ *   Leaving it advanced would make the next draw see "no change" and never re-render the corrected
+ *   header width.
  * - The visible-row/column calculators are deliberately NOT restored: they describe what the user
  *   can see (scroll position), not what the DOM holds. After a skipped draw the visible band may
  *   therefore extend past the rendered band — unlike a fast draw, which guarantees the visible band
@@ -349,24 +374,37 @@ function captureRenderedState(table: Table, wtViewport: Viewport): RenderedState
  * @param {Table} table The master table.
  * @param {Viewport} wtViewport The viewport that owns the rendered bands.
  * @param {RenderedState} state The state captured before the draw.
+ * @param {number} renderCycleSeqBeforeHook The render-cycle counter read right before the
+ *   `beforeDraw` hook fired.
  */
-function restoreRenderedStateIfSafe(table: Table, wtViewport: Viewport, state: RenderedState): void {
+function restoreRenderedStateIfSafe(
+  table: Table,
+  wtViewport: Viewport,
+  state: RenderedState,
+  renderCycleSeqBeforeHook: number,
+): void {
   const { wtSettings } = table;
-  const renderHappenedSinceCapture = wtViewport.renderCycleSeq !== state.renderCycleSeq;
-  const totalsChangedSinceCapture =
-    (state.rowFilter !== null && state.rowFilter.total !== wtSettings.getSetting<number>('totalRows')) ||
-    (state.columnFilter !== null && state.columnFilter.total !== wtSettings.getSetting<number>('totalColumns'));
 
-  if (renderHappenedSinceCapture || totalsChangedSinceCapture) {
+  if (wtViewport.renderCycleSeq !== renderCycleSeqBeforeHook) {
     return;
   }
 
-  wtViewport.rowsRenderCalculator = state.rowsRenderCalculator;
-  wtViewport.columnsRenderCalculator = state.columnsRenderCalculator;
+  table.correctHeaderWidth = state.correctHeaderWidth;
 
-  if (state.rowFilter !== null && state.columnFilter !== null) {
-    table.rowFilter = state.rowFilter;
-    table.columnFilter = state.columnFilter;
+  if (state.rowFilter === null || state.rowFilter.total === wtSettings.getSetting<number>('totalRows')) {
+    wtViewport.rowsRenderCalculator = state.rowsRenderCalculator;
+
+    if (state.rowFilter !== null) {
+      table.rowFilter = state.rowFilter;
+    }
+  }
+
+  if (state.columnFilter === null || state.columnFilter.total === wtSettings.getSetting<number>('totalColumns')) {
+    wtViewport.columnsRenderCalculator = state.columnsRenderCalculator;
+
+    if (state.columnFilter !== null) {
+      table.columnFilter = state.columnFilter;
+    }
   }
 }
 

--- a/handsontable/src/3rdparty/walkontable/src/table/drawCycle.ts
+++ b/handsontable/src/3rdparty/walkontable/src/table/drawCycle.ts
@@ -17,15 +17,16 @@ import type { ColumnsCalculationType, RowsCalculationType } from '../calculator/
 
 /**
  * The state that describes what is actually rendered in the TBODY/THEAD right now: the rendered
- * row/column bands (held by the viewport) and the render filters derived from them. Captured before
- * the draw resolves the new band, so the master's `skipRender` gate can put it back — see
- * {@link restoreRenderedState}.
+ * row/column bands (held by the viewport) and the render filters derived from them, plus the
+ * render-cycle sequence number at capture time. Captured before the draw resolves the new band, so
+ * the master's `skipRender` gate can put it back — see {@link restoreRenderedStateIfSafe}.
  */
 interface RenderedState {
   rowsRenderCalculator: RowsCalculationType | null;
   columnsRenderCalculator: ColumnsCalculationType | null;
   rowFilter: RowFilter | null;
   columnFilter: ColumnFilter | null;
+  renderCycleSeq: number;
 }
 
 /**
@@ -93,8 +94,8 @@ function runMasterDrawCycle(table: Table, ctx: DrawContext): void {
   const { wtSettings } = table;
   const wtOverlays = table.deps.getWtOverlays();
   const wtViewport = table.deps.getWtViewport();
-  // What is on the screen before this draw touches anything. Restored verbatim if the `beforeDraw`
-  // hook cancels the cell render below.
+  // What is on the screen before this draw touches anything. Restored (when safe — see
+  // `restoreRenderedStateIfSafe`) if the `beforeDraw` hook cancels the cell render below.
   const renderedStateBeforeDraw = captureRenderedState(table, wtViewport);
 
   // Record whether this master draw was entered as a fast/scroll draw, BEFORE `createCalculators`
@@ -160,8 +161,6 @@ function runMasterDrawCycle(table: Table, ctx: DrawContext): void {
     table.tableOffset = table.deps.geometryReader.offset(table.TABLE);
 
     const filters = buildRenderFilters(table, ctx);
-    // The band + filters this draw resolved, i.e. what the render below is about to put in the DOM.
-    const renderedStateThisDraw = captureRenderedState(table, wtViewport);
 
     table.alignOverlaysWithTrimmingContainer(); // todo It calls method from child class (MasterTable).
     const skipRender: { skipRender?: boolean } = {};
@@ -175,15 +174,9 @@ function runMasterDrawCycle(table: Table, ctx: DrawContext): void {
       // index (`Table#getCell` and, through it, the selection render below) gates on the bands but
       // reads the element through the filters and the TBODY, so leaving them advanced makes those two
       // disagree: `getCell` then throws "TR was expected to be rendered but is not" for every row past
-      // the end of the stale DOM. Put the pre-draw state back - a skipped render leaves the screen
-      // unchanged, so the rendered state must stay unchanged too, exactly like a fast draw.
-      // Guarded on the state still being the one THIS draw resolved: a `beforeViewRender` hook that
-      // renders (a nested `draw()`) has already put a matching band and DOM in place, and rolling that
-      // back would create the very divergence this rollback exists to prevent.
-      if (isSameRenderedState(captureRenderedState(table, wtViewport), renderedStateThisDraw)) {
-        restoreRenderedState(table, wtViewport, renderedStateBeforeDraw);
-      }
-
+      // the end of the stale DOM. Put the pre-draw state back when doing so is provably safe — the
+      // guard conditions and the deliberate fallbacks are documented on the helper.
+      restoreRenderedStateIfSafe(table, wtViewport, renderedStateBeforeDraw);
     } else {
       renderCellBand(
         table,
@@ -223,10 +216,15 @@ function runMasterDrawCycle(table: Table, ctx: DrawContext): void {
 
   placeFixedOverlays(table, ctx);
 
-  if (ctx.positionChanged) {
+  if (ctx.positionChanged && ctx.performRedraw) {
     // It refreshes the cells borders caused by a 1px shift (introduced by overlays which add or
     // remove `innerBorderTop` and `innerBorderInlineStart` CSS classes to the DOM element. This happens
     // when there is a switch between rendering from 0 to N rows/columns and vice versa).
+    // Gated on `performRedraw`: a draw whose render was skipped must not run this nested draw — the
+    // rolled-back band would fail the nested draw's fast-draw check, downgrading the cheap reposition
+    // to a full render that fires `beforeDraw` a second time and renders the cells the hook just
+    // cancelled. The per-overlay `adjustElementsSize()` calls inside `placeFixedOverlays` already ran,
+    // and nothing rendered, so the master spreader-size pass below has nothing new to apply either.
     wtOverlays.refreshAll(); // `refreshAll()` internally already calls `refreshSelections()` method
     wtOverlays.adjustElementsSize();
   } else {
@@ -280,7 +278,7 @@ function runCloneDrawCycle(table: Table, ctx: DrawContext): void {
  * `alignOverlaysWithTrimmingContainer` before it) may read the filters for the band about to render.
  * The filters and the rendered bands are the pair that `Table#getCell` resolves an element with, so
  * when that gate cancels the render the master puts BOTH back to their pre-draw values — see
- * `restoreRenderedState` in {@link runMasterDrawCycle}.
+ * {@link restoreRenderedStateIfSafe}.
  *
  * @param {Table} table The table (master or clone).
  * @param {DrawContext} ctx The per-draw scratch (supplies the pre-hook header counts).
@@ -301,8 +299,8 @@ function buildRenderFilters(table: Table, ctx: DrawContext): { rowFilter: RowFil
 
 /**
  * Captures the rendered row/column bands and the render filters, i.e. everything that describes which
- * source rows and columns the current DOM holds. Master-only: the `skipRender` gate it serves is
- * master-only.
+ * source rows and columns the current DOM holds, plus the render-cycle sequence number the viewport
+ * reports at this moment. Master-only: the `skipRender` gate it serves is master-only.
  *
  * @param {Table} table The master table.
  * @param {Viewport} wtViewport The viewport that owns the rendered bands.
@@ -314,40 +312,62 @@ function captureRenderedState(table: Table, wtViewport: Viewport): RenderedState
     columnsRenderCalculator: wtViewport.columnsRenderCalculator,
     rowFilter: table.rowFilter,
     columnFilter: table.columnFilter,
+    renderCycleSeq: wtViewport.renderCycleSeq,
   };
 }
 
 /**
- * Compares two captured rendered states by identity. The bands and the filters are replaced with fresh
- * objects on every full draw, so reference equality is exactly the "nothing has replaced them since"
- * question the `skipRender` rollback needs to answer.
+ * Puts the pre-draw rendered state back, undoing the band and filter advance of a draw whose render
+ * the `beforeDraw` hook cancelled — but only when the rollback is provably safe. When any guard
+ * fails, the this-draw state is kept, which is exactly the pre-rollback behavior of the engine, so
+ * a blocked rollback is never worse than what shipped before the rollback existed.
  *
- * @param {RenderedState} state The state to compare.
- * @param {RenderedState} otherState The state to compare it against.
- * @returns {boolean}
- */
-function isSameRenderedState(state: RenderedState, otherState: RenderedState): boolean {
-  return state.rowsRenderCalculator === otherState.rowsRenderCalculator &&
-    state.columnsRenderCalculator === otherState.columnsRenderCalculator &&
-    state.rowFilter === otherState.rowFilter &&
-    state.columnFilter === otherState.columnFilter;
-}
-
-/**
- * Puts a captured rendered state back, undoing the band and filter advance of a draw that ended up
- * rendering nothing. The visible-row/column calculators are deliberately NOT restored: they describe
- * what the user can see (scroll position), not what the DOM holds, and they are recomputed on every
- * draw regardless of the render gate.
+ * The guards:
+ * - The viewport's render-cycle counter must not have moved since the pre-draw capture. A hook that
+ *   renders (a nested master `draw()`, or a draw of any overlay clone — the clones share this
+ *   viewport) has put a NEWER band into the DOM; rolling the shared band back under it would create
+ *   the very band/DOM divergence this rollback exists to prevent.
+ * - The captured filters' build-time totals must still match the current `totalRows`/`totalColumns`.
+ *   When the dataset shrank before the skipped draw (NestedRows cancels the render right after its
+ *   row removal), the captured band names rows that no longer exist — the this-draw band, capped at
+ *   the new totals, is the correct description. (A dataset that GREW before a skipped draw keeps the
+ *   this-draw band too; that band can then overhang the stale DOM — a pre-existing edge of the
+ *   skip contract, unchanged here.)
+ *
+ * The restore itself is asymmetric by design:
+ * - The render calculators are restored unconditionally — `null` on a skipped first draw correctly
+ *   reports "nothing rendered", so `Table#getCell` answers with its out-of-viewport exit codes.
+ * - The filters are restored only when the captured ones are non-null; on a skipped first draw the
+ *   just-built filters are kept instead, because filter consumers (`getRowHeader`, `getTrForRow`,
+ *   the selection scanner's header loop) read `rowFilter!` unguarded and must never see `null`
+ *   after a completed draw.
+ * - The visible-row/column calculators are deliberately NOT restored: they describe what the user
+ *   can see (scroll position), not what the DOM holds. After a skipped draw the visible band may
+ *   therefore extend past the rendered band — unlike a fast draw, which guarantees the visible band
+ *   sits inside the rendered one — and `getCell` answers those rows with exit codes.
  *
  * @param {Table} table The master table.
  * @param {Viewport} wtViewport The viewport that owns the rendered bands.
  * @param {RenderedState} state The state captured before the draw.
  */
-function restoreRenderedState(table: Table, wtViewport: Viewport, state: RenderedState): void {
+function restoreRenderedStateIfSafe(table: Table, wtViewport: Viewport, state: RenderedState): void {
+  const { wtSettings } = table;
+  const renderHappenedSinceCapture = wtViewport.renderCycleSeq !== state.renderCycleSeq;
+  const totalsChangedSinceCapture =
+    (state.rowFilter !== null && state.rowFilter.total !== wtSettings.getSetting<number>('totalRows')) ||
+    (state.columnFilter !== null && state.columnFilter.total !== wtSettings.getSetting<number>('totalColumns'));
+
+  if (renderHappenedSinceCapture || totalsChangedSinceCapture) {
+    return;
+  }
+
   wtViewport.rowsRenderCalculator = state.rowsRenderCalculator;
   wtViewport.columnsRenderCalculator = state.columnsRenderCalculator;
-  table.rowFilter = state.rowFilter;
-  table.columnFilter = state.columnFilter;
+
+  if (state.rowFilter !== null && state.columnFilter !== null) {
+    table.rowFilter = state.rowFilter;
+    table.columnFilter = state.columnFilter;
+  }
 }
 
 /**
@@ -404,6 +424,11 @@ function renderCellBand(
     .setViewportSize(table.getRenderedRowsCount(), table.getRenderedColumnsCount())
     .setFilters(filters.rowFilter, filters.columnFilter)
     .render();
+
+  // Mark that a cell band reached the DOM. The viewport is shared by the master and all overlay
+  // clones, so this advances one counter no matter which table rendered — the signal the master's
+  // `skipRender` rollback guards on (see `restoreRenderedStateIfSafe`).
+  table.deps.getWtViewport().renderCycleSeq += 1;
 
   adjustColumnHeaderHeights(table);
 

--- a/handsontable/src/3rdparty/walkontable/src/table/drawCycle.ts
+++ b/handsontable/src/3rdparty/walkontable/src/table/drawCycle.ts
@@ -12,6 +12,21 @@ import {
 } from '../axisSizing/oversizedRows';
 import type Table from './baseTable';
 import type { default as Overlays } from '../overlay/overlays';
+import type Viewport from '../viewport/viewport';
+import type { ColumnsCalculationType, RowsCalculationType } from '../calculator/viewportBase';
+
+/**
+ * The state that describes what is actually rendered in the TBODY/THEAD right now: the rendered
+ * row/column bands (held by the viewport) and the render filters derived from them. Captured before
+ * the draw resolves the new band, so the master's `skipRender` gate can put it back — see
+ * {@link restoreRenderedState}.
+ */
+interface RenderedState {
+  rowsRenderCalculator: RowsCalculationType | null;
+  columnsRenderCalculator: ColumnsCalculationType | null;
+  rowFilter: RowFilter | null;
+  columnFilter: ColumnFilter | null;
+}
 
 /**
  * Per-draw mutable scratch shared by the phase functions of a single draw. It also captures the
@@ -78,6 +93,9 @@ function runMasterDrawCycle(table: Table, ctx: DrawContext): void {
   const { wtSettings } = table;
   const wtOverlays = table.deps.getWtOverlays();
   const wtViewport = table.deps.getWtViewport();
+  // What is on the screen before this draw touches anything. Restored verbatim if the `beforeDraw`
+  // hook cancels the cell render below.
+  const renderedStateBeforeDraw = captureRenderedState(table, wtViewport);
 
   // Record whether this master draw was entered as a fast/scroll draw, BEFORE `createCalculators`
   // below can downgrade `ctx.runFastDraw`. A `forceFullRender` (`hot.render()`) enters as `draw(false)`,
@@ -142,6 +160,8 @@ function runMasterDrawCycle(table: Table, ctx: DrawContext): void {
     table.tableOffset = table.deps.geometryReader.offset(table.TABLE);
 
     const filters = buildRenderFilters(table, ctx);
+    // The band + filters this draw resolved, i.e. what the render below is about to put in the DOM.
+    const renderedStateThisDraw = captureRenderedState(table, wtViewport);
 
     table.alignOverlaysWithTrimmingContainer(); // todo It calls method from child class (MasterTable).
     const skipRender: { skipRender?: boolean } = {};
@@ -149,7 +169,22 @@ function runMasterDrawCycle(table: Table, ctx: DrawContext): void {
     wtSettings.getSetting('beforeDraw', true, skipRender);
     ctx.performRedraw = skipRender.skipRender !== true;
 
-    if (ctx.performRedraw) {
+    if (!ctx.performRedraw) {
+      // The cells are not rendered on this draw, so the rendered bands and the filters resolved above
+      // describe a band that never reached the DOM. Everything that resolves an element from a source
+      // index (`Table#getCell` and, through it, the selection render below) gates on the bands but
+      // reads the element through the filters and the TBODY, so leaving them advanced makes those two
+      // disagree: `getCell` then throws "TR was expected to be rendered but is not" for every row past
+      // the end of the stale DOM. Put the pre-draw state back - a skipped render leaves the screen
+      // unchanged, so the rendered state must stay unchanged too, exactly like a fast draw.
+      // Guarded on the state still being the one THIS draw resolved: a `beforeViewRender` hook that
+      // renders (a nested `draw()`) has already put a matching band and DOM in place, and rolling that
+      // back would create the very divergence this rollback exists to prevent.
+      if (isSameRenderedState(captureRenderedState(table, wtViewport), renderedStateThisDraw)) {
+        restoreRenderedState(table, wtViewport, renderedStateBeforeDraw);
+      }
+
+    } else {
       renderCellBand(
         table,
         ctx,
@@ -241,10 +276,11 @@ function runCloneDrawCycle(table: Table, ctx: DrawContext): void {
 
 /**
  * Rebuilds the row/column render filters from the current first-rendered row/column. Shared by both
- * cycles and kept SEPARATE from `renderCellBand`, called BEFORE the master `beforeDraw` gate:
- * filters are rebuilt on the full path even when `skipRender` is true, and both the selection render
- * and the range-query mixins read them. Folding it into `renderCellBand` would stop the master
- * rebuilding filters on the skip-render path — a behavior break.
+ * cycles and called BEFORE the master `beforeDraw` gate, because the hook (and
+ * `alignOverlaysWithTrimmingContainer` before it) may read the filters for the band about to render.
+ * The filters and the rendered bands are the pair that `Table#getCell` resolves an element with, so
+ * when that gate cancels the render the master puts BOTH back to their pre-draw values — see
+ * `restoreRenderedState` in {@link runMasterDrawCycle}.
  *
  * @param {Table} table The table (master or clone).
  * @param {DrawContext} ctx The per-draw scratch (supplies the pre-hook header counts).
@@ -261,6 +297,57 @@ function buildRenderFilters(table: Table, ctx: DrawContext): { rowFilter: RowFil
   table.columnFilter = columnFilter;
 
   return { rowFilter, columnFilter };
+}
+
+/**
+ * Captures the rendered row/column bands and the render filters, i.e. everything that describes which
+ * source rows and columns the current DOM holds. Master-only: the `skipRender` gate it serves is
+ * master-only.
+ *
+ * @param {Table} table The master table.
+ * @param {Viewport} wtViewport The viewport that owns the rendered bands.
+ * @returns {RenderedState}
+ */
+function captureRenderedState(table: Table, wtViewport: Viewport): RenderedState {
+  return {
+    rowsRenderCalculator: wtViewport.rowsRenderCalculator,
+    columnsRenderCalculator: wtViewport.columnsRenderCalculator,
+    rowFilter: table.rowFilter,
+    columnFilter: table.columnFilter,
+  };
+}
+
+/**
+ * Compares two captured rendered states by identity. The bands and the filters are replaced with fresh
+ * objects on every full draw, so reference equality is exactly the "nothing has replaced them since"
+ * question the `skipRender` rollback needs to answer.
+ *
+ * @param {RenderedState} state The state to compare.
+ * @param {RenderedState} otherState The state to compare it against.
+ * @returns {boolean}
+ */
+function isSameRenderedState(state: RenderedState, otherState: RenderedState): boolean {
+  return state.rowsRenderCalculator === otherState.rowsRenderCalculator &&
+    state.columnsRenderCalculator === otherState.columnsRenderCalculator &&
+    state.rowFilter === otherState.rowFilter &&
+    state.columnFilter === otherState.columnFilter;
+}
+
+/**
+ * Puts a captured rendered state back, undoing the band and filter advance of a draw that ended up
+ * rendering nothing. The visible-row/column calculators are deliberately NOT restored: they describe
+ * what the user can see (scroll position), not what the DOM holds, and they are recomputed on every
+ * draw regardless of the render gate.
+ *
+ * @param {Table} table The master table.
+ * @param {Viewport} wtViewport The viewport that owns the rendered bands.
+ * @param {RenderedState} state The state captured before the draw.
+ */
+function restoreRenderedState(table: Table, wtViewport: Viewport, state: RenderedState): void {
+  wtViewport.rowsRenderCalculator = state.rowsRenderCalculator;
+  wtViewport.columnsRenderCalculator = state.columnsRenderCalculator;
+  table.rowFilter = state.rowFilter;
+  table.columnFilter = state.columnFilter;
 }
 
 /**

--- a/handsontable/src/3rdparty/walkontable/src/viewport/viewport.ts
+++ b/handsontable/src/3rdparty/walkontable/src/viewport/viewport.ts
@@ -149,8 +149,9 @@ class Viewport {
    * Monotonic counter of cell-band renders, bumped by every `renderCellBand` call (see
    * `table/drawCycle.ts`). Overlay clones share the master's Viewport instance, so a render by ANY
    * table of this Walkontable — the master or any clone, nested inside a hook or not — advances it.
-   * The master's `skipRender` rollback compares it against the value captured before the draw to
-   * answer "has any DOM cell band been (re)rendered since?" — see `restoreRenderedStateIfSafe`.
+   * The master's `skipRender` rollback compares it against the value read right before the
+   * `beforeDraw` hook fired to answer "did the hook render a DOM cell band?" — see
+   * `restoreRenderedStateIfSafe`.
    *
    * @type {number}
    */
@@ -210,6 +211,10 @@ class Viewport {
     this.rowHeaderWidth = NaN;
     this.rowsVisibleCalculator = null;
     this.columnsVisibleCalculator = null;
+    // Before the first render these must be `null` (the declared type), not `undefined` — the
+    // `skipRender` rollback captures/restores them and the overlays' `applyToDOM` null-checks them.
+    this.rowsRenderCalculator = null;
+    this.columnsRenderCalculator = null;
     type CalcTypeFactory = () => CalculationTypeLike;
 
     this.rowsCalculatorTypes = new Map<string, CalcTypeFactory>([

--- a/handsontable/src/3rdparty/walkontable/src/viewport/viewport.ts
+++ b/handsontable/src/3rdparty/walkontable/src/viewport/viewport.ts
@@ -146,6 +146,16 @@ class Viewport {
    */
   declare columnsRenderCalculator: ColumnsCalculationType | null;
   /**
+   * Monotonic counter of cell-band renders, bumped by every `renderCellBand` call (see
+   * `table/drawCycle.ts`). Overlay clones share the master's Viewport instance, so a render by ANY
+   * table of this Walkontable — the master or any clone, nested inside a hook or not — advances it.
+   * The master's `skipRender` rollback compares it against the value captured before the draw to
+   * answer "has any DOM cell band been (re)rendered since?" — see `restoreRenderedStateIfSafe`.
+   *
+   * @type {number}
+   */
+  renderCycleSeq: number = 0;
+  /**
    * @type {RowsCalculationType | null}
    */
   declare rowsPartiallyVisibleCalculator: RowsCalculationType | null;

--- a/handsontable/src/3rdparty/walkontable/test/spec/table/drawCycleHooks.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/table/drawCycleHooks.spec.js
@@ -64,6 +64,102 @@ describe('Table.draw() lifecycle hooks (characterization for the drawCycle refac
     expect(onDraw).toHaveBeenCalledTimes(0);
   });
 
+  it('should keep the rendered row band consistent with the rendered DOM when `beforeDraw` skips the render', async() => {
+    let skipNextRender = false;
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      beforeDraw: (force, skip) => {
+        if (skipNextRender) {
+          skip.skipRender = true;
+        }
+      },
+    });
+
+    wt.draw();
+
+    const renderedRows = wt.wtTable.TBODY.childNodes.length;
+
+    expect(renderedRows).toBe(wt.wtTable.getRenderedRowsCount());
+
+    skipNextRender = true;
+    wt.scrollViewportVertically(60);
+    wt.draw();
+
+    // The render was skipped, so the TBODY still holds the previously rendered rows. The rendered-row
+    // band and the row filter must keep describing that DOM - otherwise `getCell` resolves a row that
+    // the calculators claim is rendered against a TBODY that does not have it.
+    expect(wt.wtTable.TBODY.childNodes.length).toBe(renderedRows);
+    expect(wt.wtTable.getRenderedRowsCount()).toBe(renderedRows);
+    expect(wt.wtTable.rowFilter.offset).toBe(wt.wtTable.getFirstRenderedRow());
+    expect(wt.wtTable.getLastRenderedRow() - wt.wtTable.getFirstRenderedRow() + 1).toBe(renderedRows);
+
+    // Every row the calculators report as rendered must resolve to an element (no exit code, no throw).
+    for (let row = wt.wtTable.getFirstRenderedRow(); row <= wt.wtTable.getLastRenderedRow(); row++) {
+      expect(wt.wtTable.getCell(new Walkontable.CellCoords(row, 0)) instanceof HTMLElement).toBe(true);
+    }
+  });
+
+  it('should not throw while rendering the active selection on a draw whose render was skipped', async() => {
+    let skipNextRender = false;
+    const selections = createSelectionController();
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      selections,
+      beforeDraw: (force, skip) => {
+        if (skipNextRender) {
+          skip.skipRender = true;
+        }
+      },
+    });
+
+    selections.getFocus().add(new Walkontable.CellCoords(61, 0));
+    wt.draw();
+
+    skipNextRender = true;
+    wt.scrollViewportVertically(60);
+
+    expect(() => wt.draw()).not.toThrow();
+  });
+
+  it('should keep the rendered band consistent when `beforeDraw` renders and then skips the outer render', async() => {
+    let mode = 'idle';
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      beforeDraw: (force, skip) => {
+        if (mode !== 'nest') {
+          return;
+        }
+
+        // A nested draw renders the new band, so the outer draw's `skipRender` must NOT roll the
+        // rendered state back to what was on the screen before the outer draw started.
+        mode = 'nested';
+        wt.draw();
+        skip.skipRender = true;
+      },
+    });
+
+    wt.draw();
+
+    mode = 'nest';
+    wt.scrollViewportVertically(60);
+    wt.draw();
+
+    expect(wt.wtTable.TBODY.childNodes.length).toBe(wt.wtTable.getRenderedRowsCount());
+    expect(wt.wtTable.rowFilter.offset).toBe(wt.wtTable.getFirstRenderedRow());
+    expect(wt.wtTable.getLastRenderedRow() - wt.wtTable.getFirstRenderedRow() + 1)
+      .toBe(wt.wtTable.TBODY.childNodes.length);
+
+    for (let row = wt.wtTable.getFirstRenderedRow(); row <= wt.wtTable.getLastRenderedRow(); row++) {
+      expect(wt.wtTable.getCell(new Walkontable.CellCoords(row, 0)) instanceof HTMLElement).toBe(true);
+    }
+  });
+
   it('should fire `beforeDraw` but SKIP `onDraw` when beforeDraw sets skipRender', async() => {
     const beforeDraw = jasmine.createSpy('beforeDraw').and.callFake((_, skip) => {
       skip.skipRender = true;

--- a/handsontable/src/3rdparty/walkontable/test/spec/table/drawCycleHooks.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/table/drawCycleHooks.spec.js
@@ -160,6 +160,105 @@ describe('Table.draw() lifecycle hooks (characterization for the drawCycle refac
     }
   });
 
+  it('should not run the nested reconciliation draw (double `beforeDraw`) when the render is skipped', async() => {
+    let skipNextRender = false;
+    const beforeDraw = jasmine.createSpy('beforeDraw').and.callFake((force, skip) => {
+      if (skipNextRender) {
+        skip.skipRender = true;
+      }
+    });
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      columnHeaders: [(col, TH) => {
+        TH.innerHTML = col + 1;
+      }],
+      // The legacy (measured) layout path applies the `innerBorderTop` class only AFTER the render,
+      // via `resetFixedPosition` - so a scroll away from offset 0 flips `positionChanged` to `true`
+      // on the very draw whose render is skipped, which is the scenario under test.
+      singlePassLayout: false,
+      beforeDraw,
+    });
+
+    wt.draw();
+
+    beforeDraw.calls.reset();
+    skipNextRender = true;
+    wt.scrollViewportVertically(60);
+    wt.draw();
+
+    // The `innerBorderTop` flip must have happened on the skipped draw - otherwise this spec
+    // does not exercise the `positionChanged` reconciliation path at all.
+    expect(wt.wtTable.holder.parentNode.classList.contains('innerBorderTop')).toBe(true);
+
+    // The 1px-shift reconciliation (`refreshAll`) must not run for a skipped render: with the
+    // rendered band rolled back it degrades to a nested FULL draw, firing `beforeDraw` a second
+    // time within one `draw()` call and rendering the cells the hook just cancelled.
+    expect(beforeDraw).toHaveBeenCalledTimes(1);
+  });
+
+  it('should keep the table safe when the very first render is skipped', async() => {
+    const selections = createSelectionController();
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      columnHeaders: [(col, TH) => {
+        TH.innerHTML = col + 1;
+      }],
+      selections,
+      beforeDraw: (force, skip) => {
+        skip.skipRender = true;
+      },
+    });
+
+    selections.getFocus().add(new Walkontable.CellCoords(0, 0));
+
+    // Before the draw completes there was never a render, so the rendered state must describe an
+    // empty DOM without leaving the filters `null` (several consumers read `rowFilter` unguarded
+    // once the table reports itself as drawn).
+    expect(() => wt.draw()).not.toThrow();
+    expect(wt.wtTable.rowFilter).not.toBe(null);
+    expect(wt.wtTable.columnFilter).not.toBe(null);
+    expect(wt.wtTable.getRenderedRowsCount()).toBe(0);
+    expect(wt.wtTable.getCell(new Walkontable.CellCoords(0, 0))).toBe(-2);
+  });
+
+  it('should not restore a rendered band built for a larger dataset when the skip follows a row removal', async() => {
+    let skipNextRender = false;
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      beforeDraw: (force, skip) => {
+        if (skipNextRender) {
+          skip.skipRender = true;
+        }
+      },
+    });
+
+    wt.draw();
+
+    const renderedRowsBeforeRemoval = wt.wtTable.TBODY.childNodes.length;
+
+    // Shrink the dataset below the rendered band, then skip the follow-up draw - the NestedRows
+    // scenario (`skipRender` set right after its row removal). The pre-draw band was built for the
+    // old totals and names rows that no longer exist, so it must NOT be restored; the freshly
+    // resolved band, capped at the new totals, stays in place.
+    createDataArray(5, 4);
+    skipNextRender = true;
+    wt.draw();
+
+    // The render was really skipped - the TBODY still holds the stale rows.
+    expect(wt.wtTable.TBODY.childNodes.length).toBe(renderedRowsBeforeRemoval);
+    // The rendered state describes the new dataset, not the pre-removal one.
+    expect(wt.wtTable.rowFilter.total).toBe(getTotalRows());
+    expect(wt.wtTable.getLastRenderedRow()).toBeLessThan(getTotalRows());
+    // A removed row resolves to an out-of-viewport exit code, not to its stale TR.
+    expect(wt.wtTable.getCell(new Walkontable.CellCoords(8, 0))).toBe(-2);
+  });
+
   it('should fire `beforeDraw` but SKIP `onDraw` when beforeDraw sets skipRender', async() => {
     const beforeDraw = jasmine.createSpy('beforeDraw').and.callFake((_, skip) => {
       skip.skipRender = true;

--- a/handsontable/src/3rdparty/walkontable/test/spec/table/drawCycleHooks.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/table/drawCycleHooks.spec.js
@@ -196,6 +196,23 @@ describe('Table.draw() lifecycle hooks (characterization for the drawCycle refac
     // rendered band rolled back it degrades to a nested FULL draw, firing `beforeDraw` a second
     // time within one `draw()` call and rendering the cells the hook just cancelled.
     expect(beforeDraw).toHaveBeenCalledTimes(1);
+
+    // The border toggle shifts the layout by 1px AFTER the overlay positions were computed, so the
+    // skipped draw must rerun the fixed-position pass against the post-toggle layout (in element
+    // mode the reposition is a transform reset, so the observable contract is the rerun itself).
+    const resetFixedPosition = spyOn(wt.wtOverlays.topOverlay, 'resetFixedPosition').and.callThrough();
+
+    skipNextRender = false;
+    wt.scrollViewportVertically(0);
+    wt.draw(); // full draw back at offset 0 - removes `innerBorderTop` again
+    resetFixedPosition.calls.reset();
+
+    skipNextRender = true;
+    wt.scrollViewportVertically(60);
+    wt.draw();
+
+    // Once from the regular fixed-position pass + once from the skipped-draw reconciliation rerun.
+    expect(resetFixedPosition).toHaveBeenCalledTimes(2);
   });
 
   it('should keep the table safe when the very first render is skipped', async() => {
@@ -223,6 +240,9 @@ describe('Table.draw() lifecycle hooks (characterization for the drawCycle refac
     expect(wt.wtTable.columnFilter).not.toBe(null);
     expect(wt.wtTable.getRenderedRowsCount()).toBe(0);
     expect(wt.wtTable.getCell(new Walkontable.CellCoords(0, 0))).toBe(-2);
+    // The overlays' spreader positioning must survive the drawn-but-never-rendered state too - the
+    // sticky-scroll deactivation calls it directly, outside any draw.
+    expect(() => wt.wtOverlays.applyToDOM()).not.toThrow();
   });
 
   it('should not restore a rendered band built for a larger dataset when the skip follows a row removal', async() => {
@@ -257,6 +277,68 @@ describe('Table.draw() lifecycle hooks (characterization for the drawCycle refac
     expect(wt.wtTable.getLastRenderedRow()).toBeLessThan(getTotalRows());
     // A removed row resolves to an out-of-viewport exit code, not to its stale TR.
     expect(wt.wtTable.getCell(new Walkontable.CellCoords(8, 0))).toBe(-2);
+  });
+
+  it('should keep the row rollback when only the column count changed before the skipped draw', async() => {
+    let skipNextRender = false;
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      beforeDraw: (force, skip) => {
+        if (skipNextRender) {
+          skip.skipRender = true;
+        }
+      },
+    });
+
+    wt.draw();
+
+    // Shrink COLUMNS only, scroll rows, then skip the draw. The totals gates are per axis: the
+    // column change keeps the fresh column state (capped at the new total), but must NOT block the
+    // row rollback - `totalRows` never moved, and without the rollback the advanced row band points
+    // past the stale DOM and `getCell` throws.
+    createDataArray(100, 2);
+    skipNextRender = true;
+    wt.scrollViewportVertically(60);
+    wt.draw();
+
+    expect(wt.wtTable.columnFilter.total).toBe(getTotalColumns());
+    expect(wt.wtTable.rowFilter.offset).toBe(wt.wtTable.getFirstRenderedRow());
+
+    for (let row = wt.wtTable.getFirstRenderedRow(); row <= wt.wtTable.getLastRenderedRow(); row++) {
+      expect(wt.wtTable.getCell(new Walkontable.CellCoords(row, 0)) instanceof HTMLElement).toBe(true);
+    }
+  });
+
+  it('should restore the `correctHeaderWidth` flag when the render is skipped', async() => {
+    let skipNextRender = false;
+    const wt = walkontable({
+      data: getData,
+      totalRows: getTotalRows,
+      totalColumns: getTotalColumns,
+      rowHeaders: [(row, TH) => {
+        TH.innerHTML = row + 1;
+      }],
+      beforeDraw: (force, skip) => {
+        if (skipNextRender) {
+          skip.skipRender = true;
+        }
+      },
+    });
+
+    wt.draw();
+
+    expect(wt.wtTable.correctHeaderWidth).toBe(false);
+
+    // The flag flips before the `beforeDraw` gate, but the header it describes never re-renders on
+    // a skipped draw. Left advanced, the next draw would see "no change" and keep the stale header
+    // width forever - so the rollback must put the flag back with the rest of the rendered state.
+    skipNextRender = true;
+    wt.scrollViewportHorizontally(3, 'end');
+    wt.draw();
+
+    expect(wt.wtTable.correctHeaderWidth).toBe(false);
   });
 
   it('should fire `beforeDraw` but SKIP `onDraw` when beforeDraw sets skipRender', async() => {

--- a/handsontable/src/3rdparty/walkontable/test/spec/viewport.spec.js
+++ b/handsontable/src/3rdparty/walkontable/test/spec/viewport.spec.js
@@ -524,11 +524,12 @@ describe('WalkontableViewport', () => {
         totalColumns: getTotalColumns,
       });
 
-      // draw() is interrupted — rowsRenderCalculator and columnsRenderCalculator stay undefined
+      // draw() is interrupted — rowsRenderCalculator and columnsRenderCalculator keep their
+      // initial `null` (never rendered)
       wt.draw();
 
-      expect(wt.wtViewport.rowsRenderCalculator).toBeUndefined();
-      expect(wt.wtViewport.columnsRenderCalculator).toBeUndefined();
+      expect(wt.wtViewport.rowsRenderCalculator).toBeNull();
+      expect(wt.wtViewport.columnsRenderCalculator).toBeNull();
 
       // Simulate accordion/tab opening: container becomes visible
       spec().$wrapper.css('display', '');


### PR DESCRIPTION
### Context

The PR closes a window in walkontable's draw cycle where the rendered row band and the DOM disagree, which makes `getCell()` throw `Error: TR was expected to be rendered but is not`.

A full draw advances `rowsRenderCalculator` and `rowFilter` to the new band **before** the `beforeDraw` / `skipRender` gate runs. When the gate cancels the render, the band and filter describe rows that were never rendered, while the TBODY still holds the previous ones. `getCell()` then gates on the new band but resolves the element through the new filter against the old TBODY.

Measured on a master table after a `skipRender` draw:

```
before {first:0,  last:8,  count:9,  trs:9, offset:0}
after  {first:52, last:61, count:10, trs:9, offset:52}
```

`getCell(61)` passes the band check and then finds no TR. With an active selection the throw comes from **inside** `wt.draw()` via `SelectionScanner`, which is the frame shape seen in production.

The fix captures the rendered state and restores it on the skip path — `restoreRenderedState` runs only when `performRedraw === false`, so no other draw path changes behavior. Every full master draw pays one four-property object literal twice, which is the whole cost.

The other candidate window was **ruled out**, not just left alone: `tableView.ts` fast draw is safe because `viewport/calculatorFactory.ts` gates `this.rowsRenderCalculator = renderedRows` behind `!fastDraw`, so a fast draw leaves band, filter and TBODY stale-*consistent*. That was verified byte-identical in the 16.0.1 build that actually produced the reported events.

**What this PR does not do.** The two Sentry events that started this — [HANDSONTABLE-DOCS-21E](https://handsoncode.sentry.io/issues/HANDSONTABLE-DOCS-21E/) and its duplicate [HANDSONTABLE-DOCS-21F](https://handsoncode.sentry.io/issues/HANDSONTABLE-DOCS-21F/) — remain **unreproduced**. They share one trace and one mousedown 30 ms apart and reach the same throw site, but the trigger is unidentified, and their page is a frozen `/docs/16.0/` archive pulling a floating jsDelivr tag, so no release retires them. This fixes a proven instance of the same defect at its source; it is not a claim about those events.

That distinction matters here because the naive fix — returning the `-2` / `-4` sentinels `tableView.ts` already understands — would have silenced a genuinely inconsistent grid state instead of fixing it. Precedent: PR #11555 fixed the equivalent divergence at its source, and the build that threw already contained it.

Two further findings were recorded in `.ai/RENDERING-LIFECYCLE.md` and deliberately left unactioned: a sticky-clone live-band-vs-snapshot divergence, and a `renderedRows.ts` off-by-one.

### How has this been tested?

Test-first, with the failure observed before the fix existed:

```bash
# fix NOT yet applied
npm --prefix handsontable run test:walkontable -- --testPathPattern=drawCycleHooks
# 7 specs, 2 failures
#   Expected 10 to be 9  +  Error: TR was expected to be rendered but is not at MasterTable.getCell
#   Expected function not to throw, but it threw Error: TR was expected to be rendered but is not
#     (thrown from inside wt.draw())
```

Both specs are green with the fix. The second one is the one that matters: it reproduces the production frame shape, where the throw originates inside `wt.draw()` through `SelectionScanner` rather than from an external `getCell()` call.

Regression scope for the only `skipRender` consumer in core:

```bash
npm --prefix handsontable run test:walkontable
npm --prefix handsontable run test:e2e -- --testPathPattern=nestedRows
# green
```

Files changed:

- `handsontable/src/3rdparty/walkontable/src/table/drawCycle.ts`
- `handsontable/src/3rdparty/walkontable/test/spec/table/drawCycleHooks.spec.js`
- `handsontable/src/3rdparty/walkontable/.ai/RENDERING-LIFECYCLE.md`

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2150

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2150

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the master draw cycle, viewport band state, overlay positioning, and `getCell`/selection paths; behavior is gated and heavily tested but errors here affect core grid rendering.
> 
> **Overview**
> Fixes **`Error: TR was expected to be rendered but is not`** when a full master draw advances the rendered row/column band and filters before **`beforeDraw` / `skipRender`** cancels the cell pass, leaving **`getCell`** and selection rendering out of sync with the TBODY.
> 
> On **`performRedraw === false`**, the master now captures pre-draw state and runs **`restoreRenderedStateIfSafe`**: it rolls back render calculators, filters (when safe), and **`correctHeaderWidth`** unless **`renderCycleSeq`** moved (nested **`draw()`** or clone render) or per-axis row/column totals changed (e.g. NestedRows shrink). **`renderCycleSeq`** is incremented on each **`renderCellBand`**; viewport calculators start as **`null`**; overlays treat **`null`** calculators like “nothing rendered” for spreader offset.
> 
> Skipped draws no longer trigger **`refreshAll`** on the 1px border-shift path (which would re-enter **`beforeDraw`**); they re-run fixed-position overlay placement, render selections, and still **`adjustElementsSize`**. Lifecycle docs and **`drawCycleHooks`** specs cover rollback, first-draw skip, and dataset/column edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3ab4a3055c7c5c4dab083a47d8e1882173c878f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->