### PR TITLE
DEV-2153: Fix presence gate frozen-Jasmine tree path scope

### DIFF
--- a/.github/scripts/__tests__/presence-gate.test.mjs
+++ b/.github/scripts/__tests__/presence-gate.test.mjs
@@ -181,3 +181,15 @@ test('a Walkontable source change is satisfied by a Playwright spec, blocked by 
   assert.equal(withNewJasmine.pass, false, 'a new walkontable Jasmine spec is blocked');
   assert.equal(withNewJasmine.reason, 'new-jasmine-spec');
 });
+
+// --- specs directly under src/__tests__/ (no intermediate directory) ---
+test('a spec under src/__tests__/ with no intermediate directory is inside the frozen tree', () => {
+  // `handsontable/src/__tests__/` holds the bulk of the frozen suite (core/,
+  // hooks/, settings/, ...). The tree pattern must not require an intermediate
+  // directory between `src/` and `__tests__/`.
+  const spec = 'handsontable/src/__tests__/settings/rowHeights.spec.js';
+  assert.equal(isNewJasmineSpec({ status: 'A', path: spec }), true, 'a new spec there is a freeze violation');
+  assert.equal(isNewJasmineSpec({ status: 'M', path: spec }), false, 'editing one is not a violation');
+  assert.equal(isCoverage({ status: 'M', path: spec }), true, 'editing an existing spec there counts as coverage');
+  assert.equal(isCoverage({ status: 'A', path: spec }), false, 'a new spec there does not count as coverage');
+});

--- a/.github/scripts/lib/presence-gate.mjs
+++ b/.github/scripts/lib/presence-gate.mjs
@@ -48,7 +48,9 @@ const JASMINE_SPEC = /\.spec\.js$/;
 // home (tests/e2e/walkontable), so it follows the same freeze as the main
 // suite: edit existing specs, but new/flaky ones move to Playwright.
 const JASMINE_TREE = [
-  /^handsontable\/src\/.*\/__tests__\//,
+  // The intermediate directory is optional — specs live both at
+  // `src/__tests__/` and at `src/<any>/.../__tests__/`.
+  /^handsontable\/src\/(.*\/)?__tests__\//,
   /^handsontable\/test\//,
   /^handsontable\/src\/3rdparty\/walkontable\/test\//,
 ];


### PR DESCRIPTION
### Context

The PR fixes a path-scope bug in the test-presence gate's frozen-Jasmine detection.

`.github/scripts/lib/presence-gate.mjs` declared the first frozen Jasmine tree as `/^handsontable\/src\/.*\/__tests__\//`. The `.*\/` requires at least one **intermediate** directory between `src/` and `__tests__/`, because the slash after `src` is already consumed by the literal prefix. So `handsontable/src/__tests__/**/*.spec.js` never matched `JASMINE_TREE`, `isNewJasmineSpec()` returned `false` for it, and a newly added Jasmine spec in that directory passed the gate silently.

This is not a hypothetical gap. `handsontable/src/__tests__/` holds 268 `*.spec.js` files on `develop` (`core/` 136, `hooks/` 57, `settings/` 51, plus others), so it is a heavily used location and exactly where someone would add a new spec.

Reproduce on `develop`:

```bash
node --input-type=module -e "
import {isNewJasmineSpec} from './.github/scripts/lib/presence-gate.mjs';
for (const p of [
  'handsontable/src/__tests__/settings/foo.spec.js',
  'handsontable/src/plugins/formulas/__tests__/foo.spec.js',
]) console.log(isNewJasmineSpec({status:'A', path:p}), p);
"
# => false handsontable/src/__tests__/settings/foo.spec.js   <-- bug
# => true  handsontable/src/plugins/formulas/__tests__/foo.spec.js
```

The fix makes the intermediate directory optional: `/^handsontable\/src\/(.*\/)?__tests__\//`. The new pattern is a strict superset of the old one — the old pattern is just its non-empty branch — so nothing that was previously flagged stops being flagged. The other two entries in `JASMINE_TREE` are plain prefixes and do not have the same shape problem. `.github/scripts/lib/changelog-gate.mjs` uses a bare `/\/__tests__\//` marker with no `src/` prefix, so it never had the bug.

Scope is one regex plus its regression test. `presence-gate.mjs` stays a pure classifier with no git or filesystem access, and `SOURCE`, `NOT_SOURCE`, and `COVERAGE_ANY_STATUS` are untouched.

This is a CI/tooling-only change, so the presence gate and the changelog gate both pass it automatically — no changelog entry is needed.

### How has this been tested?

- Added a regression test to `.github/scripts/__tests__/presence-gate.test.mjs` covering `handsontable/src/__tests__/settings/rowHeights.spec.js` for both `isNewJasmineSpec` (status `A` => `true`, status `M` => `false`) and `isCoverage` (status `M` => `true`, status `A` => `false`), so the "modified frozen spec still counts as coverage" behavior is pinned too.
- Confirmed the test is red before the fix and green after. Against the unmodified classifier, exactly one assertion fails — the `isNewJasmineSpec` status `A` case. `isCoverage` never consults `JASMINE_TREE`, so its assertions hold either way; they are there to pin the behavior, not to prove the fix.

```bash
npm run test:tooling
# => # tests 83 / # pass 83 / # fail 0
```

```bash
npx eslint .github/scripts/
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2153

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2153

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI tooling only; tightens frozen-Jasmine detection without changing product code or weakening existing matches.
> 
> **Overview**
> Fixes a **regex scope bug** in the CI presence gate so `handsontable/src/__tests__/**` is treated as part of the frozen Jasmine suite.
> 
> The first `JASMINE_TREE` pattern required at least one directory between `src/` and `__tests__/`, so newly added `*.spec.js` files under `handsontable/src/__tests__/` were not flagged by `isNewJasmineSpec()`. The pattern is now `/^handsontable\/src\/(.*\/)?__tests__\//`, making that intermediate segment optional (a strict superset of the old rule).
> 
> A regression test in `presence-gate.test.mjs` pins `handsontable/src/__tests__/settings/rowHeights.spec.js` for new-Jasmine violations and modified-spec coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbac2f82f7ff4da9dc13ff909f08da4a31f47807. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->