### PR TITLE
Fix `afterSelectionEnd` firing twice on header drag (#7133)

### DIFF
--- a/.changelogs/7133.json
+++ b/.changelogs/7133.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "public",
+  "title": "Fixed a bug where the `afterSelectionEnd` and `afterSelectionEndByProp` hooks fired twice when selecting rows or columns by dragging over their headers.",
+  "type": "fixed",
+  "issueOrPR": 7133,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/selection/__tests__/mouseInteraction/selection.spec.js
+++ b/handsontable/src/selection/__tests__/mouseInteraction/selection.spec.js
@@ -686,6 +686,50 @@ describe('Selection using mouse interaction', () => {
     expect(tickEnd).toEqual(1);
   });
 
+  it('should call `afterSelectionEnd` only once when the user selects columns by dragging over column headers (#7133)', async() => {
+    let tickEnd = 0;
+
+    handsontable({
+      rowHeaders: true,
+      colHeaders: true,
+      startRows: 5,
+      startCols: 5,
+      afterSelectionEnd() {
+        tickEnd += 1;
+      }
+    });
+
+    spec().$container.find('.ht_clone_top tr:eq(0) th:eq(1)').simulate('mousedown'); // Header "A"
+    spec().$container.find('.ht_clone_top tr:eq(0) th:eq(2)').simulate('mouseover'); // Header "B"
+    spec().$container.find('.ht_clone_top tr:eq(0) th:eq(3)').simulate('mouseover'); // Header "C"
+    spec().$container.find('.ht_clone_top tr:eq(0) th:eq(3)').simulate('mouseup'); // Header "C"
+
+    expect(getSelected()).toEqual([[-1, 0, 4, 2]]);
+    expect(tickEnd).toEqual(1);
+  });
+
+  it('should call `afterSelectionEnd` only once when the user selects rows by dragging over row headers (#7133)', async() => {
+    let tickEnd = 0;
+
+    handsontable({
+      rowHeaders: true,
+      colHeaders: true,
+      startRows: 5,
+      startCols: 5,
+      afterSelectionEnd() {
+        tickEnd += 1;
+      }
+    });
+
+    spec().$container.find('.ht_clone_inline_start tbody tr:eq(0) th').simulate('mousedown'); // Header "1"
+    spec().$container.find('.ht_clone_inline_start tbody tr:eq(1) th').simulate('mouseover'); // Header "2"
+    spec().$container.find('.ht_clone_inline_start tbody tr:eq(2) th').simulate('mouseover'); // Header "3"
+    spec().$container.find('.ht_clone_inline_start tbody tr:eq(2) th').simulate('mouseup'); // Header "3"
+
+    expect(getSelected()).toEqual([[0, -1, 2, 4]]);
+    expect(tickEnd).toEqual(1);
+  });
+
   it('should properly select columns, when the user moves the cursor over column headers across two overlays', async() => {
     handsontable({
       rowHeaders: true,

--- a/handsontable/src/selection/selection.ts
+++ b/handsontable/src/selection/selection.ts
@@ -1327,7 +1327,13 @@ class Selection {
       this.selectedByColumnHeader.add(this.getLayerLevel());
       this.setRangeEnd(to);
       this.runLocalHooks('afterSelectColumns', from, to, highlight);
-      this.finish();
+
+      // For mouse-driven selection the process is finished by the document-level `mouseup`/`touchend`
+      // handler once the user releases the button. Finishing here as well would fire `afterSelectionEnd`
+      // prematurely on the initial `mousedown`, causing it to run twice for a header drag (#7133).
+      if (this.getSelectionSource() !== 'mouse') {
+        this.finish();
+      }
     }
 
     return isValid;
@@ -1385,7 +1391,13 @@ class Selection {
       this.selectedByRowHeader.add(this.getLayerLevel());
       this.setRangeEnd(to);
       this.runLocalHooks('afterSelectRows', from, to, highlight);
-      this.finish();
+
+      // For mouse-driven selection the process is finished by the document-level `mouseup`/`touchend`
+      // handler once the user releases the button. Finishing here as well would fire `afterSelectionEnd`
+      // prematurely on the initial `mousedown`, causing it to run twice for a header drag (#7133).
+      if (this.getSelectionSource() !== 'mouse') {
+        this.finish();
+      }
     }
 
     return isValid;


### PR DESCRIPTION
## Context

Fixes #7133.

When a user selects rows or columns by **dragging over their headers**, the `afterSelectionEnd` (and `afterSelectionEndByProp`) hook fired **twice** — once on the initial `mousedown`, then again on release. Selecting cells by dragging correctly fires it once. The bug has been present since the issue was reported (v7.4.2) and still reproduces on `develop` (verified in a real browser).

## Root cause

`selectColumns()` and `selectRows()` in `src/selection/selection.ts` unconditionally called `this.finish()`, which triggers `afterSelectionEnd`. These methods are used both programmatically (`hot.selectColumns(1, 3)`) and by the mouse handler (header `mousedown` → `mouseEventHandler.mouseDown` → `selectColumns`).

On a mouse-driven header selection, `finish()` ran prematurely on the initial `mousedown`. The subsequent `mouseover` (drag) calls `setRangeEnd()` → `begin()`, re-setting `inProgress = true`, so the document-level `mouseup` handler (`tableView.ts`) called `finish()` a second time. Cell selection avoids this because its `mousedown` path (`setRangeStart`) never calls `finish()` — only the document `mouseup` does.

## Fix

Skip the eager `finish()` in `selectColumns`/`selectRows` when the selection source is `mouse` (the document-level `mouseup`/`touchend` handler finishes it once on release), using the existing `getSelectionSource()` mechanism. Programmatic calls (source `unknown`) still finish immediately, so their behavior is unchanged.

## Tests

Added two regression tests in `mouseInteraction/selection.spec.js` (next to the existing cell-drag equivalent) asserting `afterSelectionEnd` fires exactly once for a column-header drag and a row-header drag. Both fail before the fix (`Expected 2 to equal 1`) and pass after.

Verified with no regressions:
- `mouseInteraction/selection` — 42/42
- broader selection suites (`selectColumns`, `selectRows`, `selectCells`, `refresh`, `general`) — 188/188
- full `selection/__tests__` — 912/912
- header-heavy plugins (`columnSorting`, `nestedHeaders`, `hiddenColumns`) — 524/524
- ESLint + `test:types` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change in selection completion timing; programmatic API behavior is preserved and tests cover the mouse header-drag case.
> 
> **Overview**
> Fixes **double `afterSelectionEnd` / `afterSelectionEndByProp`** when users drag across row or column headers (#7133).
> 
> In `selection.ts`, **`selectColumns` and `selectRows` no longer call `finish()` when the selection source is `mouse`**, so completion (and the end hooks) happens only from the document **`mouseup`/`touchend`** handler, matching cell drag behavior. **Programmatic** selection still calls `finish()` immediately when the source is not `mouse`.
> 
> Adds **regression tests** for column- and row-header drags and a **changelog** entry for the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a91150db382def17a72fb141155e8e9722aecf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->