### PR TITLE
Fix the Formulas plugin leaving its redo state active after a redo

### DIFF
--- a/.changelogs/13148.json
+++ b/.changelogs/13148.json
@@ -1,0 +1,8 @@
+{
+  "issuesOrigin": "private",
+  "title": "Fixed the `Formulas` plugin leaving its internal redo state active after a redo operation, which made the plugin treat subsequent operations as undo/redo replay.",
+  "type": "fixed",
+  "issueOrPR": 13148,
+  "breaking": false,
+  "framework": "none"
+}

--- a/handsontable/src/plugins/formulas/__tests__/redoState.unit.js
+++ b/handsontable/src/plugins/formulas/__tests__/redoState.unit.js
@@ -1,0 +1,85 @@
+import { HyperFormula } from 'hyperformula';
+import Handsontable from '../../../base';
+import { registerPlugin } from '../../registry';
+import { Formulas } from '../formulas';
+import { UndoRedo } from '../../undoRedo';
+
+/**
+ * The plugin registered its redo-state reset on `afterUndo` (twice) instead of `afterRedo`, so
+ * `setPerformRedo(false)` never ran after a redo and the flag leaked until the next undo — for
+ * every action type. While leaked, `isPerformingUndoRedo()` stays `true`, which makes the plugin
+ * treat subsequent operations as undo/redo replay (those paths skip engine work that normal
+ * operations must perform).
+ */
+describe('Formulas redo state', () => {
+  let container;
+  let hot;
+
+  beforeAll(() => {
+    registerPlugin(Formulas);
+    registerPlugin(UndoRedo);
+  });
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    hot?.destroy();
+    hot = null;
+    container.remove();
+  });
+
+  /**
+   * Builds a small grid with the formulas and undoRedo plugins on.
+   *
+   * @returns {object} The Handsontable instance.
+   */
+  function build() {
+    hot = new Handsontable(container, {
+      data: [
+        [1, '=A1+10'],
+        [2, null],
+      ],
+      formulas: {
+        engine: HyperFormula,
+      },
+      undoRedo: true,
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+
+    return hot;
+  }
+
+  it('clears the undo/redo state after an undo', () => {
+    build();
+
+    hot.setDataAtCell(1, 0, 5);
+    hot.getPlugin('undoRedo').undo();
+
+    expect(hot.getPlugin('formulas').indexSyncer.isPerformingUndoRedo()).toBe(false);
+  });
+
+  it('clears the undo/redo state after a redo', () => {
+    build();
+
+    hot.setDataAtCell(1, 0, 5);
+    hot.getPlugin('undoRedo').undo();
+    hot.getPlugin('undoRedo').redo();
+
+    expect(hot.getPlugin('formulas').indexSyncer.isPerformingUndoRedo()).toBe(false);
+  });
+
+  it('redoes the data change correctly', () => {
+    // Sanity companion: the redo itself must still apply, in both the grid and the engine.
+    build();
+
+    hot.setDataAtCell(1, 0, 5);
+    hot.getPlugin('undoRedo').undo();
+    hot.getPlugin('undoRedo').redo();
+
+    expect(hot.getDataAtCell(1, 0)).toBe(5);
+    expect(hot.getDataAtCell(0, 1)).toBe(11);
+  });
+});

--- a/handsontable/src/plugins/formulas/__tests__/redoState.unit.js
+++ b/handsontable/src/plugins/formulas/__tests__/redoState.unit.js
@@ -3,6 +3,7 @@ import Handsontable from '../../../base';
 import { registerPlugin } from '../../registry';
 import { Formulas } from '../formulas';
 import { UndoRedo } from '../../undoRedo';
+import { ManualRowMove } from '../../manualRowMove';
 
 /**
  * The plugin registered its redo-state reset on `afterUndo` (twice) instead of `afterRedo`, so
@@ -18,6 +19,7 @@ describe('Formulas redo state', () => {
   beforeAll(() => {
     registerPlugin(Formulas);
     registerPlugin(UndoRedo);
+    registerPlugin(ManualRowMove);
   });
 
   beforeEach(() => {
@@ -81,5 +83,55 @@ describe('Formulas redo state', () => {
 
     expect(hot.getDataAtCell(1, 0)).toBe(5);
     expect(hot.getDataAtCell(0, 1)).toBe(11);
+  });
+
+  it('keeps a row move performed right after a redo synchronized with the engine', () => {
+    // The behavioral consequence of the leaked flag: the axis syncer treats every operation
+    // between a redo and the next undo as undo/redo replay and skips syncing row moves to the
+    // engine, so a formula entered afterwards resolves its address against a stale row order.
+    hot = new Handsontable(container, {
+      data: [
+        [1, null],
+        [2, null],
+        [3, null],
+      ],
+      formulas: {
+        engine: HyperFormula,
+      },
+      undoRedo: true,
+      manualRowMove: true,
+      licenseKey: 'non-commercial-and-evaluation',
+    });
+
+    hot.setDataAtCell(0, 1, 100);
+    hot.getPlugin('undoRedo').undo();
+    hot.getPlugin('undoRedo').redo();
+
+    // Move the last row to the top: visual order is now 3, 1, 2.
+    hot.getPlugin('manualRowMove').moveRow(2, 0);
+    hot.render();
+
+    // A formula referencing A1 written after the move must see the moved row's value.
+    hot.setDataAtCell(1, 1, '=A1');
+
+    expect(hot.getDataAtCell(1, 1)).toBe(3);
+  });
+
+  it('clears the redo state after a redo cancelled by a beforeRedo listener', () => {
+    // A cancelled redo never fires `afterRedo`, so the reset must also happen on `afterUndo` —
+    // otherwise the flag set in `beforeRedo` would leak until the next successful redo.
+    build();
+
+    // Two done actions: the cancelled redo consumes one from the undone stack, and the final
+    // `undo()` must still be a REAL undo (its `afterUndo` hook performs the reset under test).
+    hot.setDataAtCell(1, 0, 5);
+    hot.setDataAtCell(1, 1, 9);
+    hot.getPlugin('undoRedo').undo();
+
+    hot.addHook('beforeRedo', () => false);
+    hot.getPlugin('undoRedo').redo();
+    hot.getPlugin('undoRedo').undo();
+
+    expect(hot.getPlugin('formulas').indexSyncer.isPerformingUndoRedo()).toBe(false);
   });
 });

--- a/handsontable/src/plugins/formulas/formulas.ts
+++ b/handsontable/src/plugins/formulas/formulas.ts
@@ -471,6 +471,10 @@ export class Formulas extends BasePlugin {
 
     this.addHook('afterUndo', () => {
       this.indexSyncer!.setPerformUndo(false);
+      // Also clears the redo flag: a redo cancelled by a `beforeRedo` listener never fires
+      // `afterRedo`, so without this reset the flag set in `beforeRedo` would leak until the
+      // next successful redo.
+      this.indexSyncer!.setPerformRedo(false);
     });
 
     this.addHook('afterRedo', () => {

--- a/handsontable/src/plugins/formulas/formulas.ts
+++ b/handsontable/src/plugins/formulas/formulas.ts
@@ -473,7 +473,7 @@ export class Formulas extends BasePlugin {
       this.indexSyncer!.setPerformUndo(false);
     });
 
-    this.addHook('afterUndo', () => {
+    this.addHook('afterRedo', () => {
       this.indexSyncer!.setPerformRedo(false);
     });
 


### PR DESCRIPTION
### Context

The PR fixes the `Formulas` plugin leaving its internal redo state active after a redo operation. The plugin registered its redo-state reset (`indexSyncer.setPerformRedo(false)`) on a **second `afterUndo` hook** instead of `afterRedo`, so the flag never reset after a redo and leaked until the next undo — for every action type. While leaked, `indexSyncer.isPerformingUndoRedo()` stays `true`, which makes the plugin treat subsequent operations as undo/redo replay (those code paths skip engine work that normal operations must perform).

Extracted from the review of #13076, where the leak surfaced because the new `moveCells` redo path depends on the flag being correct. The fix itself is independent of that feature and applies to `develop` as-is.

### How has this been tested?

- New unit suite `handsontable/src/plugins/formulas/__tests__/redoState.unit.js` (real HyperFormula in jsdom): the redo-state flag is `false` after an undo and — the regression — after a redo, plus a sanity case asserting the redo still applies in both the grid and the engine. The redo-flag test fails without the fix.
- `npm run test:unit --testPathPattern=formulas` (43 tests) and the legacy `npm run test:e2e --testPathPattern=formulas` suite (328 specs) pass.

Commands:

```bash
npm --prefix handsontable run test:unit -- --testPathPattern=redoState
```

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. Extracted from #13076 review feedback.

### Affected project(s):

- [x] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Formulas undo/redo hook wiring that gates HyperFormula index sync; scope is small but affects formula grids using undo/redo.
> 
> **Overview**
> Fixes a bug where the **Formulas** plugin left its internal redo flag set after **redo**, because `indexSyncer.setPerformRedo(false)` was wired to a **second `afterUndo` hook** instead of **`afterRedo`**. After redo, `isPerformingUndoRedo()` could stay true until the next undo, so later edits (e.g. **manual row move** + formulas) were treated as undo/redo replay and **HyperFormula** index sync was skipped.
> 
> The hook now resets the redo flag on **`afterRedo`**, and **`afterUndo`** also calls **`setPerformRedo(false)`** so a redo blocked by **`beforeRedo`** (no `afterRedo`) does not leak the flag. Adds **`redoState.unit.js`** regression tests and a changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9486cd7880550059bd27a35c1fe9a6ece024200e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->