### PR TITLE
DEV-2177: Migrate cell-type recipes to Intl-based numericFormat options and restore the Pikaday picker styles

### DIFF
--- a/docs/content/recipes/cell-types/moment-date/angular/example1.ts
+++ b/docs/content/recipes/cell-types/moment-date/angular/example1.ts
@@ -12,6 +12,9 @@ import '@handsontable/pikaday/css/pikaday.css';
 
 const DATE_FORMAT = 'YYYY-MM-DD';
 
+// `useMoment()` exists at runtime but is missing from the Pikaday type definitions.
+type PikadayWithMoment = Pikaday & { useMoment(momentFunction: typeof moment): void };
+
 @Component({
   standalone: true,
   selector: 'example1-moment-date-editor',
@@ -19,11 +22,12 @@ const DATE_FORMAT = 'YYYY-MM-DD';
   styles: [
     `
     :host { display: block; }
-    .pikaday-container { min-height: 250px; }
+    .pikaday-container { width: 290px; }
   `,
   ],
 })
 export class MomentDateEditorComponent extends HotCellEditorAdvancedComponent<string> {
+  override position = 'portal' as const;
   @ViewChild('container', { static: true }) container!: ElementRef;
   private pikaday: Pikaday | null = null;
 
@@ -44,11 +48,13 @@ export class MomentDateEditorComponent extends HotCellEditorAdvancedComponent<st
       },
     });
 
+    (this.pikaday as PikadayWithMoment).useMoment(moment);
+
     if (this.value) {
       const m = moment(this.value, DATE_FORMAT, true);
 
       if (m.isValid()) {
-        (this.pikaday as any).setMoment?.(m);
+        this.pikaday.setMoment(m, true);
       }
     } else {
       this.pikaday.gotoToday();

--- a/docs/content/recipes/cell-types/moment-date/angular/example1.ts
+++ b/docs/content/recipes/cell-types/moment-date/angular/example1.ts
@@ -157,9 +157,11 @@ export class AppComponent {
         type: 'numeric',
         width: 120,
         className: 'htRight',
+        locale: 'en-US',
         numericFormat: {
-          pattern: '$0,0.00',
-          culture: 'en-US',
+          style: 'currency',
+          currency: 'USD',
+          minimumFractionDigits: 2,
         },
       },
     ],

--- a/docs/content/recipes/cell-types/moment-date/angular/example1.ts
+++ b/docs/content/recipes/cell-types/moment-date/angular/example1.ts
@@ -8,6 +8,7 @@ import {
 } from '@handsontable/angular-wrapper';
 import moment from 'moment';
 import Pikaday from '@handsontable/pikaday';
+import '@handsontable/pikaday/css/pikaday.css';
 
 const DATE_FORMAT = 'YYYY-MM-DD';
 

--- a/docs/content/recipes/cell-types/moment-date/javascript/example1.js
+++ b/docs/content/recipes/cell-types/moment-date/javascript/example1.js
@@ -388,9 +388,11 @@ const hotOptions = {
       type: 'numeric',
       width: 120,
       className: 'htRight',
+      locale: 'en-US',
       numericFormat: {
-        pattern: '$0,0.00',
-        culture: 'en-US',
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: 2,
       },
     },
   ],

--- a/docs/content/recipes/cell-types/moment-date/javascript/example1.js
+++ b/docs/content/recipes/cell-types/moment-date/javascript/example1.js
@@ -5,6 +5,7 @@ import { editorFactory } from 'handsontable/editors';
 import { registerCellType } from 'handsontable/cellTypes';
 import moment from 'moment';
 import Pikaday from '@handsontable/pikaday';
+import '@handsontable/pikaday/css/pikaday.css';
 
 // Register all Handsontable's modules.
 registerAllModules();

--- a/docs/content/recipes/cell-types/moment-date/javascript/example1.ts
+++ b/docs/content/recipes/cell-types/moment-date/javascript/example1.ts
@@ -386,9 +386,11 @@ const hotOptions: Handsontable.GridSettings = {
       type: 'numeric',
       width: 120,
       className: 'htRight',
+      locale: 'en-US',
       numericFormat: {
-        pattern: '$0,0.00',
-        culture: 'en-US',
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: 2,
       },
     },
   ],

--- a/docs/content/recipes/cell-types/moment-date/javascript/example1.ts
+++ b/docs/content/recipes/cell-types/moment-date/javascript/example1.ts
@@ -5,6 +5,7 @@ import { editorFactory } from 'handsontable/editors';
 import { registerCellType } from 'handsontable/cellTypes';
 import moment from 'moment';
 import Pikaday from '@handsontable/pikaday';
+import '@handsontable/pikaday/css/pikaday.css';
 
 // Register all Handsontable's modules.
 registerAllModules();

--- a/docs/content/recipes/cell-types/moment-date/moment-date.md
+++ b/docs/content/recipes/cell-types/moment-date/moment-date.md
@@ -90,6 +90,7 @@ import { editorFactory } from 'handsontable/editors';
 import { registerCellType } from 'handsontable/cellTypes';
 import moment from 'moment';
 import Pikaday from '@handsontable/pikaday';
+import '@handsontable/pikaday/css/pikaday.css';
 
 registerAllModules();
 ```

--- a/docs/content/recipes/cell-types/moment-date/moment-date.md
+++ b/docs/content/recipes/cell-types/moment-date/moment-date.md
@@ -98,6 +98,7 @@ registerAllModules();
 **Why this matters:**
 - `moment` handles date parsing, validation, and formatting
 - `Pikaday` provides the calendar date picker UI
+- `@handsontable/pikaday/css/pikaday.css` provides the calendar panel styling
 - `editorFactory` creates a portal-based editor that overlays the cell
 - `registerCellType` registers the custom cell type for use in column config
 

--- a/docs/content/recipes/cell-types/moment-date/moment-date.md
+++ b/docs/content/recipes/cell-types/moment-date/moment-date.md
@@ -336,9 +336,11 @@ const hotOptions: Handsontable.GridSettings = {
       type: 'numeric',
       width: 120,
       className: 'htRight',
+      locale: 'en-US',
       numericFormat: {
-        pattern: '$0,0.00',
-        culture: 'en-US',
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: 2,
       },
     },
   ],

--- a/docs/content/recipes/cell-types/moment-date/react/example1.jsx
+++ b/docs/content/recipes/cell-types/moment-date/react/example1.jsx
@@ -379,7 +379,8 @@ const ExampleComponent = () => {
         type="numeric"
         width={120}
         className="htRight"
-        numericFormat={{ pattern: '$0,0.00', culture: 'en-US' }}
+        locale="en-US"
+        numericFormat={{ style: 'currency', currency: 'USD', minimumFractionDigits: 2 }}
       />
     </HotTable>
   );

--- a/docs/content/recipes/cell-types/moment-date/react/example1.jsx
+++ b/docs/content/recipes/cell-types/moment-date/react/example1.jsx
@@ -5,6 +5,7 @@ import { editorFactory } from 'handsontable/editors';
 import { registerCellType } from 'handsontable/cellTypes';
 import moment from 'moment';
 import Pikaday from '@handsontable/pikaday';
+import '@handsontable/pikaday/css/pikaday.css';
 import Handsontable from 'handsontable/base';
 import './example1.css';
 

--- a/docs/content/recipes/cell-types/moment-date/react/example1.tsx
+++ b/docs/content/recipes/cell-types/moment-date/react/example1.tsx
@@ -407,7 +407,8 @@ const ExampleComponent = () => {
         type="numeric"
         width={120}
         className="htRight"
-        numericFormat={{ pattern: '$0,0.00', culture: 'en-US' }}
+        locale="en-US"
+        numericFormat={{ style: 'currency', currency: 'USD', minimumFractionDigits: 2 }}
       />
     </HotTable>
   );

--- a/docs/content/recipes/cell-types/moment-date/react/example1.tsx
+++ b/docs/content/recipes/cell-types/moment-date/react/example1.tsx
@@ -5,6 +5,7 @@ import { editorFactory } from 'handsontable/editors';
 import { registerCellType } from 'handsontable/cellTypes';
 import moment from 'moment';
 import Pikaday from '@handsontable/pikaday';
+import '@handsontable/pikaday/css/pikaday.css';
 import Handsontable from 'handsontable/base';
 import './example1.css';
 

--- a/docs/content/recipes/cell-types/moment-time/angular/example1.ts
+++ b/docs/content/recipes/cell-types/moment-time/angular/example1.ts
@@ -143,9 +143,11 @@ export class AppComponent {
         type: 'numeric',
         width: 120,
         className: 'htRight',
+        locale: 'en-US',
         numericFormat: {
-          pattern: '$0,0.00',
-          culture: 'en-US',
+          style: 'currency',
+          currency: 'USD',
+          minimumFractionDigits: 2,
         },
       },
     ],

--- a/docs/content/recipes/cell-types/moment-time/javascript/example1.js
+++ b/docs/content/recipes/cell-types/moment-time/javascript/example1.js
@@ -208,9 +208,11 @@ const hotOptions = {
       type: 'numeric',
       width: 120,
       className: 'htRight',
+      locale: 'en-US',
       numericFormat: {
-        pattern: '$0,0.00',
-        culture: 'en-US',
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: 2,
       },
     },
   ],

--- a/docs/content/recipes/cell-types/moment-time/javascript/example1.ts
+++ b/docs/content/recipes/cell-types/moment-time/javascript/example1.ts
@@ -199,9 +199,11 @@ const hotOptions: Handsontable.GridSettings = {
       type: 'numeric',
       width: 120,
       className: 'htRight',
+      locale: 'en-US',
       numericFormat: {
-        pattern: '$0,0.00',
-        culture: 'en-US',
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: 2,
       },
     },
   ],

--- a/docs/content/recipes/cell-types/moment-time/moment-time.md
+++ b/docs/content/recipes/cell-types/moment-time/moment-time.md
@@ -226,9 +226,11 @@ const hotOptions: Handsontable.GridSettings = {
       type: 'numeric',
       width: 120,
       className: 'htRight',
+      locale: 'en-US',
       numericFormat: {
-        pattern: '$0,0.00',
-        culture: 'en-US',
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: 2,
       },
     },
   ],

--- a/docs/content/recipes/cell-types/moment-time/react/example1.jsx
+++ b/docs/content/recipes/cell-types/moment-time/react/example1.jsx
@@ -206,7 +206,8 @@ const ExampleComponent = () => {
         type="numeric"
         width={120}
         className="htRight"
-        numericFormat={{ pattern: '$0,0.00', culture: 'en-US' }}
+        locale="en-US"
+        numericFormat={{ style: 'currency', currency: 'USD', minimumFractionDigits: 2 }}
       />
     </HotTable>
   );

--- a/docs/content/recipes/cell-types/moment-time/react/example1.tsx
+++ b/docs/content/recipes/cell-types/moment-time/react/example1.tsx
@@ -224,7 +224,8 @@ const ExampleComponent = () => {
         type="numeric"
         width={120}
         className="htRight"
-        numericFormat={{ pattern: '$0,0.00', culture: 'en-US' }}
+        locale="en-US"
+        numericFormat={{ style: 'currency', currency: 'USD', minimumFractionDigits: 2 }}
       />
     </HotTable>
   );

--- a/docs/content/recipes/cell-types/pikaday/angular/example1.ts
+++ b/docs/content/recipes/cell-types/pikaday/angular/example1.ts
@@ -12,6 +12,9 @@ import '@handsontable/pikaday/css/pikaday.css';
 
 const DATE_FORMAT_US = 'MM/DD/YYYY';
 
+// `useMoment()` exists at runtime but is missing from the Pikaday type definitions.
+type PikadayWithMoment = Pikaday & { useMoment(momentFunction: typeof moment): void };
+
 @Component({
   standalone: true,
   selector: 'example1-pikaday-editor',
@@ -19,11 +22,12 @@ const DATE_FORMAT_US = 'MM/DD/YYYY';
   styles: [
     `
     :host { display: block; }
-    .pikaday-container { min-height: 250px; }
+    .pikaday-container { width: 250px; }
   `,
   ],
 })
 export class PikadayEditorComponent extends HotCellEditorAdvancedComponent<string> {
+  override position = 'portal' as const;
   @ViewChild('container', { static: true }) container!: ElementRef;
   private pikaday: Pikaday | null = null;
 
@@ -43,11 +47,13 @@ export class PikadayEditorComponent extends HotCellEditorAdvancedComponent<strin
       },
     });
 
+    (this.pikaday as PikadayWithMoment).useMoment(moment);
+
     if (this.value) {
       const m = moment(this.value, FORMAT, true);
 
       if (m.isValid()) {
-        (this.pikaday as any).setMoment?.(m);
+        this.pikaday.setMoment(m, true);
       }
     }
 

--- a/docs/content/recipes/cell-types/pikaday/angular/example1.ts
+++ b/docs/content/recipes/cell-types/pikaday/angular/example1.ts
@@ -8,6 +8,7 @@ import {
 } from '@handsontable/angular-wrapper';
 import moment from 'moment';
 import Pikaday from '@handsontable/pikaday';
+import '@handsontable/pikaday/css/pikaday.css';
 
 const DATE_FORMAT_US = 'MM/DD/YYYY';
 

--- a/docs/content/recipes/cell-types/pikaday/angular/example1.ts
+++ b/docs/content/recipes/cell-types/pikaday/angular/example1.ts
@@ -154,9 +154,11 @@ export class AppComponent {
         type: 'numeric',
         width: 120,
         className: 'htRight',
+        locale: 'en-US',
         numericFormat: {
-          pattern: '$0,0.00',
-          culture: 'en-US',
+          style: 'currency',
+          currency: 'USD',
+          minimumFractionDigits: 2,
         },
       },
     ],

--- a/docs/content/recipes/cell-types/pikaday/javascript/example1.js
+++ b/docs/content/recipes/cell-types/pikaday/javascript/example1.js
@@ -419,9 +419,11 @@ const hotOptions = {
       type: 'numeric',
       width: 120,
       className: 'htRight',
+      locale: 'en-US',
       numericFormat: {
-        pattern: '$0,0.00',
-        culture: 'en-US',
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: 2,
       },
     },
   ],

--- a/docs/content/recipes/cell-types/pikaday/javascript/example1.js
+++ b/docs/content/recipes/cell-types/pikaday/javascript/example1.js
@@ -2,6 +2,7 @@ import Handsontable from 'handsontable/base';
 import { registerAllModules } from 'handsontable/registry';
 import moment from 'moment';
 import Pikaday from '@handsontable/pikaday';
+import '@handsontable/pikaday/css/pikaday.css';
 import { editorFactory } from 'handsontable/editors';
 import { rendererFactory } from 'handsontable/renderers';
 

--- a/docs/content/recipes/cell-types/pikaday/javascript/example1.ts
+++ b/docs/content/recipes/cell-types/pikaday/javascript/example1.ts
@@ -466,9 +466,11 @@ const hotOptions: Handsontable.GridSettings = {
       type: "numeric",
       width: 120,
       className: "htRight",
+      locale: "en-US",
       numericFormat: {
-        pattern: "$0,0.00",
-        culture: "en-US",
+        style: "currency",
+        currency: "USD",
+        minimumFractionDigits: 2,
       },
     },
   ],

--- a/docs/content/recipes/cell-types/pikaday/javascript/example1.ts
+++ b/docs/content/recipes/cell-types/pikaday/javascript/example1.ts
@@ -2,6 +2,7 @@ import Handsontable from "handsontable/base";
 import { registerAllModules } from "handsontable/registry";
 import moment from "moment";
 import Pikaday from "@handsontable/pikaday";
+import "@handsontable/pikaday/css/pikaday.css";
 import { CellProperties } from "handsontable/settings";
 import { editorFactory } from "handsontable/editors";
 import { rendererFactory } from "handsontable/renderers";

--- a/docs/content/recipes/cell-types/pikaday/pikaday.md
+++ b/docs/content/recipes/cell-types/pikaday/pikaday.md
@@ -669,9 +669,11 @@ const hotOptions: Handsontable.GridSettings = {
       type: 'numeric',
       width: 120,
       className: 'htRight',
+      locale: 'en-US',
       numericFormat: {
-        pattern: '$0,0.00',
-        culture: 'en-US',
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: 2,
       },
     },
   ],

--- a/docs/content/recipes/cell-types/pikaday/pikaday.md
+++ b/docs/content/recipes/cell-types/pikaday/pikaday.md
@@ -90,6 +90,7 @@ import Handsontable from 'handsontable/base';
 import { registerAllModules } from 'handsontable/registry';
 import moment from 'moment';
 import Pikaday from '@handsontable/pikaday';
+import '@handsontable/pikaday/css/pikaday.css';
 import { CellProperties } from 'handsontable/settings';
 import { editorFactory } from 'handsontable/editors';
 import { rendererFactory } from 'handsontable/renderers';
@@ -789,7 +790,7 @@ options.format = 'MM/DD/YYYY'; // Pikaday format string
 ### 4. Localization
 
 ```typescript
-import 'pikaday/css/pikaday.css';
+import '@handsontable/pikaday/css/pikaday.css';
 import moment from 'moment';
 import 'moment/locale/fr';
 

--- a/docs/content/recipes/cell-types/pikaday/pikaday.md
+++ b/docs/content/recipes/cell-types/pikaday/pikaday.md
@@ -102,6 +102,7 @@ registerAllModules();
 - Handsontable core and styles
 - `editorFactory` and `rendererFactory` for creating custom cell type components
 - Pikaday for date picker functionality
+- `@handsontable/pikaday/css/pikaday.css` for the calendar panel styling
 - Moment for date formatting and parsing
 
 ## Step 2: Define Date Formats

--- a/docs/content/recipes/cell-types/pikaday/react/example1.jsx
+++ b/docs/content/recipes/cell-types/pikaday/react/example1.jsx
@@ -403,7 +403,8 @@ const ExampleComponent = () => {
         type="numeric"
         width={120}
         className="htRight"
-        numericFormat={{ pattern: '$0,0.00', culture: 'en-US' }}
+        locale="en-US"
+        numericFormat={{ style: 'currency', currency: 'USD', minimumFractionDigits: 2 }}
       />
     </HotTable>
   );

--- a/docs/content/recipes/cell-types/pikaday/react/example1.jsx
+++ b/docs/content/recipes/cell-types/pikaday/react/example1.jsx
@@ -2,6 +2,7 @@ import { HotTable, HotColumn } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
 import moment from 'moment';
 import Pikaday from '@handsontable/pikaday';
+import '@handsontable/pikaday/css/pikaday.css';
 import { editorFactory } from 'handsontable/editors';
 import { rendererFactory } from 'handsontable/renderers';
 import Handsontable from 'handsontable/base';

--- a/docs/content/recipes/cell-types/pikaday/react/example1.tsx
+++ b/docs/content/recipes/cell-types/pikaday/react/example1.tsx
@@ -431,7 +431,8 @@ const ExampleComponent = () => {
         type="numeric"
         width={120}
         className="htRight"
-        numericFormat={{ pattern: '$0,0.00', culture: 'en-US' }}
+        locale="en-US"
+        numericFormat={{ style: 'currency', currency: 'USD', minimumFractionDigits: 2 }}
       />
     </HotTable>
   );

--- a/docs/content/recipes/cell-types/pikaday/react/example1.tsx
+++ b/docs/content/recipes/cell-types/pikaday/react/example1.tsx
@@ -2,6 +2,7 @@ import { HotTable, HotColumn } from '@handsontable/react-wrapper';
 import { registerAllModules } from 'handsontable/registry';
 import moment from 'moment';
 import Pikaday from '@handsontable/pikaday';
+import '@handsontable/pikaday/css/pikaday.css';
 import { editorFactory } from 'handsontable/editors';
 import { rendererFactory } from 'handsontable/renderers';
 import Handsontable from 'handsontable/base';


### PR DESCRIPTION
### Context

The PR fixes three regressions in the cell-type recipe pages that surfaced after PRO-986 (#12689) removed numbro, moment, and pikaday from Handsontable core:

1. **Removed numbro-style `numericFormat` options.** The pikaday, moment-date, and moment-time recipes still configured their Cost column with `numericFormat: { pattern: '$0,0.00', culture: 'en-US' }`. Every render logged the console warning "The numericFormat.pattern and numericFormat.culture options are not supported. Use Intl.NumberFormat options instead (numericFormat: { style, currency, ... })." and the column rendered unformatted. The PR migrates all framework variants and the walkthrough snippets to the supported shape: `locale: 'en-US'` as a separate cell-meta option plus `numericFormat: { style: 'currency', currency: 'USD', minimumFractionDigits: 2 }`.
2. **Unstyled Pikaday date picker.** PRO-986 also removed the `.pika-single` calendar styles that Handsontable used to ship in its own CSS, so the pikaday and moment-date recipes opened an unstyled calendar. The PR adds `import '@handsontable/pikaday/css/pikaday.css';` to every code variant and walkthrough of both recipes — the same pattern the flatpickr and color-picker recipes already use — and corrects a wrong package path in the pikaday page's localization snippet (bare `pikaday/css/pikaday.css` → `@handsontable/pikaday/css/pikaday.css`).
3. **Broken Pikaday calendar in the Angular variants.** With the stylesheet restored, the Angular examples of both recipes still rendered a broken calendar — but the cause was not CSS. `.pika-single` had its styles all along. Two Angular-only defects were behind it, neither present in the JavaScript and React variants:
   - The editor components never set `position`, so `HotCellEditorAdvancedComponent`'s default `'container'` applied. Core then appends the editor container to `hot.rootElement` and clamps it to the cell rect, so the calendar rendered 150px wide inside a 30px-tall box and was clipped at the column edge. Fixed with `override position = 'portal' as const;`, which is what the JavaScript and React variants already do through `editorFactory({ position: 'portal' })`.
   - `pikaday.setMoment()` is a no-op unless `useMoment(moment)` registered Moment.js first, and the examples never called it — so the calendar always opened on the current month instead of the cell's date, with no day highlighted. The `?.` in `(this.pikaday as any).setMoment?.(m)` hid the failure. Fixed by calling `useMoment(moment)` before `setMoment(m, true)`; `useMoment` is missing from `pikaday.d.ts`, so a local `PikadayWithMoment` intersection type keeps the call typed without a `@ts-ignore`.
   - The editor container's `min-height: 250px` is replaced with an explicit `width` (250px for pikaday, 290px for moment-date, which enables `showWeekNumber` and therefore renders an eighth column).

The numbro recipe is intentionally untouched: its custom `numbro` cell type consumes `pattern`/`culture` in its own renderer, so the core `numericRenderer` (and its warning) never runs there.

The recipes crash reported in the same Slack thread ("You need to define the shortcut's group.") is tracked separately in DEV-2138 and already fixed in #13130.

Two related gaps are out of scope here and left for a follow-up: in the Angular variants, clicking a day does not auto-commit the value (Enter is required — this predates the PR and behaves the same with `position: 'container'`), and the recipe walkthrough prose is written against the vanilla `editorFactory` API, so Angular readers see steps that do not match their example.

[skip changelog]

### How has this been tested?

- Browser-verified on the local docs dev server (`npm run dev` in `docs/`, examples resolved against a fresh `handsontable/tmp/` build):
  - pikaday, moment-date, and moment-time recipe pages load with a clean console — the `numericFormat.pattern`/`culture` warning is gone.
  - The Cost column renders as currency (`$350,000.00`) on all three pages.
  - The Pikaday calendar opens fully styled (panel, border, month grid) on the pikaday and moment-date pages, and the editor opens without errors.
  - Angular variants of the pikaday and moment-date pages: the calendar mounts under `.ht-portal` instead of the clipped in-grid container, opens on the cell's own month with that day highlighted (August 2025, day 1), and its table fits inside the panel in both the 7-column and the 8-column (week-number) layout. Selecting day 15 and pressing Enter commits `08/15/2025` and `2025-08-15` respectively.
  - Regression check: the numbro recipe page still renders its numbro-formatted columns with a clean console.
- Angular example type-check: `SKIP_LATEST=1 node check.mjs` in `docs/angular-type-check` — `STATUS: TRUE`, 0 errors across 622 prepared files.
- Grep sweeps: zero `pattern:`/`culture:` occurrences remain in the three migrated recipe directories; all `pikaday/css/pikaday.css` references carry the `@handsontable/` prefix.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):

1. DEV-2177

### Affected project(s):

- [ ] `handsontable`
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2177
