### PR TITLE
DEV-2059: CI Gate canary — deliberately red, DO NOT MERGE

### DIFF
--- a/handsontable/src/__tests__/ciGateCanary.unit.js
+++ b/handsontable/src/__tests__/ciGateCanary.unit.js
@@ -1,0 +1,5 @@
+describe('CI Gate canary (DEV-2059)', () => {
+  it('deliberately fails so the pipeline proves a red CI Gate blocks the merge', () => {
+    expect('merge').toBe('blocked by CI Gate');
+  });
+});


### PR DESCRIPTION
### Context

**DO NOT MERGE — deliberate-failure canary.** The PR is DEV-2059 step 3: the branch-protection cutover replaced the pinned per-job required checks with the single `CI Gate` rollup, but in two weeks of organic PRs the gate has never gone red (0 CI reds in the gate-metrics sweep), so the blocking path has never been exercised. This PR adds one deliberately failing unit test to prove that:

1. a failing pipeline job turns `CI Gate` red, and
2. GitHub reports `CI Gate` as a **required** check that blocks the merge.

The PR will be closed (never merged) once both are confirmed, and the branch deleted.

`[skip changelog]` — throwaway CI verification, nothing ships.

### How has this been tested?

- This PR **is** the test. Expected result: `Unit` job fails → `CI Gate` fails → merge blocked.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or improvement (non-breaking change which adds functionality) — CI verification canary

### Related issue(s):

1. DEV-2059

### Affected project(s):

- [x] `handsontable` <!-- one throwaway test file, never to merge -->
- [ ] `@handsontable/angular-wrapper`
- [ ] `@handsontable/react-wrapper`
- [ ] `@handsontable/vue3`

### Checklist:

- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [ ] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1) <!-- internal -->
- [ ] My change requires a change to the documentation.

ClickUp task: https://app.clickup.com/t/9015210959/DEV-2059
